### PR TITLE
fix(gateway): tag auto-TTS audio filenames with the originating conversation

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -180,7 +180,7 @@ def should_send_media_as_audio(platform, ext: str, is_voice: bool = False) -> bo
     return is_voice or normalized_ext in _TELEGRAM_AUDIO_ATTACHMENT_EXTS
 
 
-def build_auto_tts_output_path(platform) -> str:
+def build_auto_tts_output_path(platform, session_id: "Optional[str]" = None) -> str:
     """Unique temp output path for gateway auto-TTS: ``.ogg`` for ``OPUS_VOICE_PLATFORMS``
     (the tool's ``_repair_ogg_container`` then guarantees real Opus bytes), else ``.mp3``.
     Platform-awareness lives HERE because ``_clear_session_env`` wipes the TTS tool's
@@ -190,11 +190,22 @@ def build_auto_tts_output_path(platform) -> str:
     single source of truth) get an explicit ``.ogg`` path; the tool's central container repair
     (``_repair_ogg_container``) then guarantees real Ogg/Opus bytes for every provider, including MP3-only
     backends like Edge TTS. Everything else keeps the MP3 default. See #36685, #57049.
+
+    *session_id*, when given, is embedded in the filename. One gateway serves many
+    concurrent sessions into one shared directory, so an anonymous ``tts_reply_<uuid>``
+    cannot be attributed after the fact: log correlation, cleanup of a specific session's
+    leftovers, and external tooling that watches this directory all have to guess, and a
+    watcher guessing by mtime alone can pick up another session's audio. The uuid is kept
+    so uniqueness never depends on the session id being present or distinct.
     """
     from tools.tts_tool import OPUS_VOICE_PLATFORMS
     ext = "ogg" if _platform_name(platform) in OPUS_VOICE_PLATFORMS else "mp3"
-    audio_path = os.path.join(
-        tempfile.gettempdir(), "hermes_voice", f"tts_reply_{uuid.uuid4().hex[:12]}.{ext}")
+    # Session ids are internally generated, but this value becomes a path segment, so
+    # constrain it rather than trusting the shape: filesystem-safe chars only, bounded
+    # length, and an empty result degrades to the plain uuid form.
+    tag = re.sub(r"[^\w.-]", "_", session_id)[:64].strip("._-") if session_id else ""
+    stem = f"tts_reply_{tag}_{uuid.uuid4().hex[:12]}" if tag else f"tts_reply_{uuid.uuid4().hex[:12]}"
+    audio_path = os.path.join(tempfile.gettempdir(), "hermes_voice", f"{stem}.{ext}")
     os.makedirs(os.path.dirname(audio_path), exist_ok=True)
     return audio_path
 
@@ -3639,10 +3650,12 @@ class BasePlatformAdapter(ABC):
             hi = _or_default(lambda: int(os.getenv("HERMES_HUMAN_DELAY_MAX_MS", str(hi))), hi)
         return random.uniform(lo / 1000.0, hi / 1000.0)
 
-    async def _synthesize_auto_tts(self, text_content: str) -> Tuple[List[str], Optional[str]]:
+    async def _synthesize_auto_tts(self, text_content: str,
+                                   session_key: "Optional[str]" = None) -> Tuple[List[str], Optional[str]]:
         """Synthesize auto-TTS audio -> ``(existing_paths, requested_path)``; empty/None on failure
         (logged, never raised). Path built platform-aware HERE: HERMES_SESSION_PLATFORM is cleared
-        post-handler."""
+        post-handler. *session_key* tags the filename so concurrent sessions sharing the
+        ``hermes_voice`` directory stay attributable."""
         paths: List[str] = []
         requested_path = None
         try:
@@ -3652,7 +3665,7 @@ class BasePlatformAdapter(ABC):
                 speech_text = self.prepare_tts_text(text_content)
                 if not speech_text:
                     raise ValueError("Empty text after markdown cleanup")
-                requested_path = build_auto_tts_output_path(self.platform)
+                requested_path = build_auto_tts_output_path(self.platform, session_key)
                 tts_data = _json.loads(await asyncio.to_thread(
                     text_to_speech_tool, text=speech_text, output_path=requested_path))
                 if tts_data.get("success", True):
@@ -4018,7 +4031,8 @@ class BasePlatformAdapter(ABC):
                 _tts_paths, _tts_requested_path = [], None
                 if self._wants_auto_tts(
                         event, session_key, interrupt_event, text_content, media_files):
-                    _tts_paths, _tts_requested_path = await self._synthesize_auto_tts(text_content)
+                    _tts_paths, _tts_requested_path = await self._synthesize_auto_tts(
+                        text_content, session_key)
                 # TTS plays before text; generated files are removed afterwards.
                 _tts_caption_delivered = False
                 for _tts_index, _tts_path in enumerate(_tts_paths):

--- a/gateway/run_voice.py
+++ b/gateway/run_voice.py
@@ -327,7 +327,13 @@ class GatewayVoiceMixin:
                 return
             # Platforms whose native voice bubbles require Ogg/Opus (OPUS_VOICE_PLATFORMS) get an
             # explicit .ogg path; the TTS tool's container repair guarantees real Ogg/Opus bytes.
-            audio_path = build_auto_tts_output_path(event.source.platform)
+            # The (platform, chat) pair tags the filename so concurrent conversations writing into
+            # the shared hermes_voice directory stay attributable. Derived from the event rather
+            # than the session store: this path must not gain a collaborator it does not otherwise
+            # need, and the artifact is per-conversation, not per-session-row.
+            audio_path = build_auto_tts_output_path(
+                event.source.platform,
+                f"{event.source.platform.value}_{event.source.chat_id}")
             raw = await asyncio.to_thread(text_to_speech_tool, text=tts_text,
                                           output_path=audio_path)
             try:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -998,6 +998,10 @@ DEFAULT_CONFIG = {
         # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" |
         # "gemini" | "deepinfra" | "neutts" (local) | "kittentts" (local) | "piper" (local)
         "provider": "edge",
+        # Seconds to wait for a provider's HTTP response. Generation time scales
+        # with script length, so long-form speech can exceed the 60s default and
+        # fail with "Read timed out" after the provider already did the work.
+        "request_timeout": 60,
         "edge": {
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural
             "voice": "en-US-AriaNeural",

--- a/tests/gateway/test_auto_tts_session_tag.py
+++ b/tests/gateway/test_auto_tts_session_tag.py
@@ -1,0 +1,53 @@
+"""Behaviour contract for session tagging in auto-TTS output paths.
+
+One gateway serves many concurrent sessions, and every auto-TTS artifact lands
+in one shared ``hermes_voice`` directory. Without a session tag in the filename
+an artifact cannot be attributed after the fact — log correlation, per-session
+cleanup, and any external tooling watching the directory have to guess, and a
+watcher guessing by mtime can pick up another session's audio.
+
+The value becomes a path segment, so these tests also pin that a hostile or
+malformed session key cannot escape the directory.
+"""
+
+import os
+
+from gateway.platforms.base import build_auto_tts_output_path
+
+
+class _Platform:
+    """Minimal stand-in: only the platform NAME is read for the extension."""
+
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+
+def test_session_tag_appears_and_paths_stay_unique():
+    """The tag is in the filename, and two calls never collide."""
+    key = "agent:main:discord:thread:123:123"
+    first = os.path.basename(build_auto_tts_output_path(_Platform("discord"), key))
+    second = os.path.basename(build_auto_tts_output_path(_Platform("discord"), key))
+
+    assert "discord" in first and "123" in first
+    assert first != second, "uuid must still guarantee uniqueness within a session"
+
+
+def test_untagged_path_still_works():
+    """Omitting the session key keeps the original anonymous form."""
+    name = os.path.basename(build_auto_tts_output_path(_Platform("discord")))
+    assert name.startswith("tts_reply_") and name.endswith(".mp3")
+
+
+def test_hostile_session_keys_cannot_escape_the_directory():
+    """A session key is data, not a path fragment.
+
+    ``..`` traversal, separators and an over-long key must all resolve to a
+    plain filename inside the intended directory.
+    """
+    for key in ("../../etc/passwd", "a/b/c", "..", "." * 300, "x" * 500, "", "   "):
+        path = build_auto_tts_output_path(_Platform("discord"), key)
+        directory, name = os.path.split(path)
+        assert os.path.basename(directory) == "hermes_voice"
+        assert ".." not in name and os.sep not in name
+        assert name.startswith("tts_reply_")
+        assert len(name) < 200

--- a/tests/tools/test_tts_request_timeout.py
+++ b/tests/tools/test_tts_request_timeout.py
@@ -1,0 +1,31 @@
+"""Behaviour contract for ``tts.request_timeout``.
+
+Generation time scales with script length, so long-form speech can exceed a
+fixed 60s read timeout and fail with ``Read timed out`` *after* the provider has
+already done (and billed) the work. The timeout must therefore be configurable —
+and must stay enabled when the config value is nonsense, since a disabled
+timeout hangs a turn forever.
+"""
+
+from tools.tts_tool_providers import (
+    DEFAULT_TTS_REQUEST_TIMEOUT,
+    _resolve_request_timeout,
+)
+
+
+def test_configured_timeout_reaches_the_request():
+    """A positive ``tts.request_timeout`` overrides the default."""
+    assert _resolve_request_timeout({"request_timeout": 180}) == 180
+    assert _resolve_request_timeout({}) == DEFAULT_TTS_REQUEST_TIMEOUT
+
+
+def test_unusable_values_keep_a_live_timeout():
+    """Garbage must fall back to the default, never to "no timeout".
+
+    ``True`` is included deliberately: ``isinstance(True, int)`` is True in
+    Python, so a bare int check would accept it and set a 1-second timeout.
+    """
+    for bad in (0, -5, True, "180", None, 1.5):
+        resolved = _resolve_request_timeout({"request_timeout": bad})
+        assert resolved == DEFAULT_TTS_REQUEST_TIMEOUT, bad
+        assert resolved > 0

--- a/tools/tts_tool_providers.py
+++ b/tools/tts_tool_providers.py
@@ -149,10 +149,31 @@ def _write_bytes(output_path: str, audio_bytes: bytes) -> str:
     return output_path
 
 
-def _post_json(url: str, payload: Dict[str, Any], headers: Dict[str, str], **extra: Any):
-    """Streaming ``requests.post`` with the shared 60s timeout (body read via the bounded readers)."""
+DEFAULT_TTS_REQUEST_TIMEOUT = 60
+
+
+def _resolve_request_timeout(tts_config: Optional[Dict[str, Any]] = None) -> int:
+    """Read timeout for a TTS HTTP request: ``tts.request_timeout``, else 60s.
+
+    Generation time scales with script length, so a legitimately long reply can
+    exceed a fixed 60s and fail with ``Read timed out`` after the provider has
+    already been billed for the work. Configurable so long-form speech is a
+    setting rather than a rebuild. Non-positive / non-int values fall through to
+    the default so a broken config cannot disable the timeout entirely.
+    """
+    value = (tts_config or {}).get("request_timeout")
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        return value
+    return DEFAULT_TTS_REQUEST_TIMEOUT
+
+
+def _post_json(url: str, payload: Dict[str, Any], headers: Dict[str, str],
+               *, timeout: Optional[int] = None, **extra: Any):
+    """Streaming ``requests.post`` (body read via the bounded readers)."""
     import requests
-    return requests.post(url, headers=headers, json=payload, timeout=60, stream=True, **extra)
+    return requests.post(url, headers=headers, json=payload,
+                         timeout=timeout or DEFAULT_TTS_REQUEST_TIMEOUT,
+                         stream=True, **extra)
 
 
 # --- Auxiliary-model speech-tag rewrites ---
@@ -335,7 +356,8 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
         payload["text_normalization"] = True
     response = _post_json(f"{base_url}/tts", payload, {
         "Authorization": f"Bearer {api_key}", "Content-Type": "application/json",
-        "User-Agent": hermes_xai_user_agent()})
+        "User-Agent": hermes_xai_user_agent()},
+        timeout=_resolve_request_timeout(tts_config))
     response.raise_for_status()
     return _write_bytes(output_path, _read_tts_response_bytes(response, label="xAI TTS"))
 
@@ -419,7 +441,8 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
     else:
         payload = {"model": model, "text": text, "voice_id": voice_id}
     response = _post_json(base_url, payload, {
-        "Content-Type": "application/json", "Authorization": f"Bearer {runtime.api_key}"})
+        "Content-Type": "application/json", "Authorization": f"Bearer {runtime.api_key}"},
+        timeout=_resolve_request_timeout(tts_config))
     if is_t2a_v2:
         response.raise_for_status()
         result = _read_tts_response_json(response, label="MiniMax TTS")
@@ -595,7 +618,8 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         except Exception:
             version = "0.0.0"
         headers["X-Goog-Api-Client"] = f"hermes-agent/{version}"  # partner-integration guidance
-    response = _post_json(f"{base_url}/models/{model}:generateContent", payload, headers, params={"key": api_key})
+    response = _post_json(f"{base_url}/models/{model}:generateContent", payload, headers,
+                          timeout=_resolve_request_timeout(tts_config), params={"key": api_key})
     if response.status_code != 200:
         raise RuntimeError(f"Gemini TTS API error (HTTP {response.status_code}): {_gemini_error_detail(response)}")
     try:


### PR DESCRIPTION
> **Stacks on #108378.** That PR's commit is the first of the two here; review this one's diff as `6875b29` alone, or merge #108378 first and this rebases to a single commit.

## The bug

`build_auto_tts_output_path` names every artifact `tts_reply_<uuid4hex>.mp3`. One gateway serves many concurrent conversations, and all of them write into one shared `$TMPDIR/hermes_voice` directory, so an artifact cannot be attributed after it exists:

- log correlation has nothing to join on
- cleaning up one conversation's leftovers means guessing
- anything watching that directory — the gateway's own delivery path is not the only consumer — has to pick by mtime, and under concurrency mtime can select **another conversation's audio**

The last one is not theoretical. A `post_llm_call` hook that adopts the gateway's attachment (to avoid synthesizing the same text twice) has no way to tell whose file it found; with two sessions replying at once it can play the wrong reply while the right one is deleted unheard.

## The fix

`build_auto_tts_output_path(platform, tag=None)` embeds the tag in the filename, wired through both call sites — `GatewayRunner._send_voice_reply` and `BasePlatformAdapter._synthesize_auto_tts`.

```
before:  tts_reply_a1b2c3d4e5f6.mp3
after:   tts_reply_discord_1539294104293474436_a1b2c3d4e5f6.mp3
```

The uuid stays, so uniqueness never depends on the tag being present or distinct, and **omitting the tag reproduces the previous name exactly** — the anonymous form is still valid for any caller that has no conversation context.

## Why the tag is sanitized

It becomes a path segment. The values passed today are internally generated, but "internally generated" is how traversal bugs ship — so it is treated as data: word characters only, bounded to 64, and an empty result falls back to the plain uuid form rather than producing a stray separator.

```
../../etc/passwd  ->  tts_reply_etc_passwd_99f1a9a172b2.mp3
"." * 300        ->  tts_reply_fda8b7485f86.mp3
```

## Why the tag is (platform, chat_id) and not a session key

My first version called `session_store._generate_session_key(event.source)`, which gave `_send_voice_reply` a collaborator it otherwise does not need — and broke four existing tests in `test_auto_voice_reply_format.py` that construct a bare runner with no session store. The tests were right: the artifact is per-conversation, not per-session-row, and the event already carries everything required.

## Tests

`tests/gateway/test_auto_tts_session_tag.py` — three invariant tests: the tag appears while paths stay unique; the untagged form still works; hostile and malformed tags cannot escape the directory. They assert relationships (tagged vs untagged, inside vs outside `hermes_voice`), not literal filenames.

```
scripts/run_tests.sh tests/gateway/test_auto_tts_session_tag.py
  3 passed

scripts/run_tests.sh tests/gateway/ -k "tts or voice"
  824 files, 232 passed, 0 failed, 1 skipped
```