### PR TITLE
fix(tests): heavy view imports are paid at collection, not the first test's timeout budget

### DIFF
--- a/apps/desktop/src/app/messaging/index.test.tsx
+++ b/apps/desktop/src/app/messaging/index.test.tsx
@@ -95,8 +95,14 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
+// Import at module scope (after the hoisted vi.mock calls) so the heavy
+// component-tree transform is paid during collection, not billed against the
+// first test's testTimeout — inside a test body it exceeded the budget on
+// loaded CI runners and cascaded the whole file (main runs 34599517793,
+// 34600757569, 34601269252). Same pattern as chat/index.test.tsx.
+const { MessagingView } = await import('./index')
+
 async function renderMessaging() {
-  const { MessagingView } = await import('./index')
   let result: ReturnType<typeof render>
   await act(async () => {
     result = render(

--- a/apps/desktop/src/app/skills/index.test.tsx
+++ b/apps/desktop/src/app/skills/index.test.tsx
@@ -62,6 +62,11 @@ vi.mock('react-router', async importOriginal => ({
   useNavigate: () => navigateSpy
 }))
 
+// Import at module scope (after the hoisted vi.mock calls) so the heavy
+// component-tree transform is paid during collection, not billed against the
+// first test's testTimeout — same flake class as messaging/index.test.tsx.
+const { SkillsView } = await import('./index')
+
 function toolset(overrides: Record<string, unknown> = {}) {
   return {
     name: 'web',
@@ -76,7 +81,6 @@ function toolset(overrides: Record<string, unknown> = {}) {
 }
 
 async function renderSkills() {
-  const { SkillsView } = await import('./index')
   let result: ReturnType<typeof render>
   await act(async () => {
     result = render(
@@ -116,11 +120,11 @@ afterEach(() => {
   queryClient.clear()
 })
 
-// SkillsView is a heavy module: the first test pays the whole dynamic-import
-// cost, and the file legitimately runs ~14s on CI runners — right against the
-// global 15s per-test budget, so slow runners cascade-fail all 11 tests
-// (2× in a row on PR #93612, plus a main run the same hour). Give this file
-// headroom; the tests are not slow individually.
+// SkillsView is a heavy module (import cost now paid at module scope above,
+// during collection) but the file still legitimately runs ~14s on CI runners —
+// right against the global 15s per-test budget, so slow runners cascade-fail
+// all 11 tests (2× in a row on PR #93612, plus a main run the same hour).
+// Give this file headroom; the tests are not slow individually.
 describe('SkillsView toolset management', { timeout: 60_000 }, () => {
   it('renders a switch for each toolset and toggles it off', async () => {
     await renderSkills()
@@ -173,8 +177,7 @@ describe('SkillsView toolset management', { timeout: 60_000 }, () => {
       ]
     })
 
-    const { SkillsView } = await import('./index')
-    await act(async () => {
+      await act(async () => {
       render(
         <QueryClientProvider client={queryClient}>
           <MemoryRouter initialEntries={['/skills?tab=toolsets']}>
@@ -219,8 +222,7 @@ describe('SkillsView toolset management', { timeout: 60_000 }, () => {
       }
     ])
 
-    const { SkillsView } = await import('./index')
-    await act(async () => {
+      await act(async () => {
       render(
         <QueryClientProvider client={queryClient}>
           <MemoryRouter initialEntries={['/skills?tab=skills']}>
@@ -263,8 +265,7 @@ describe('SkillsView toolset management', { timeout: 60_000 }, () => {
       }
     ])
 
-    const { SkillsView } = await import('./index')
-    await act(async () => {
+      await act(async () => {
       render(
         <QueryClientProvider client={queryClient}>
           <MemoryRouter initialEntries={['/skills?tab=skills']}>
@@ -319,8 +320,7 @@ describe('SkillsView toolset management', { timeout: 60_000 }, () => {
 
     // Embedded mode drives tabs through local state (the route hooks are
     // mocked here), starting on Skills: the picker mounts with the tab.
-    const { SkillsView } = await import('./index')
-    await act(async () => {
+      await act(async () => {
       render(
         <QueryClientProvider client={queryClient}>
           <MemoryRouter initialEntries={['/skills']}>
@@ -378,8 +378,7 @@ describe('SkillsView toolset management', { timeout: 60_000 }, () => {
     // the live surface pointed at ITS backend — the reads must carry the
     // (connection, profile) pin, not a bare profile name that would resolve
     // against the ACTIVE gateway (the wrong-machine bug).
-    const { SkillsView } = await import('./index')
-    await act(async () => {
+      await act(async () => {
       render(
         <QueryClientProvider client={queryClient}>
           <MemoryRouter initialEntries={['/skills']}>
@@ -492,8 +491,7 @@ describe('SkillsView toolset management', { timeout: 60_000 }, () => {
       ]
     })
 
-    const { SkillsView } = await import('./index')
-    await act(async () => {
+      await act(async () => {
       render(
         <QueryClientProvider client={queryClient}>
           <MemoryRouter initialEntries={['/skills?tab=skills']}>

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -20,5 +20,11 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.{ts,tsx}"],
+    // The first test in a file pays env init + full module transform, and page
+    // suites (SessionsPage) legitimately run 3.5-4.5s on green CI runners —
+    // right against vitest's 5s default, so a loaded runner tips them into a
+    // timeout (main run 34600757569: 5079ms). Same headroom rationale as
+    // apps/desktop/vitest.config.ts; genuinely hung tests still fail.
+    testTimeout: 15_000,
   },
 });


### PR DESCRIPTION
Three CI test files no longer flake when a loaded runner makes their one-time module-import cost blow a fixed per-test timeout.

## Symptom

Three main-branch CI reds today (2026-09-11) with the same signature — a heavy view's first test times out, then every later test in the file fails on an unmounted DOM:

| Run (main) | Failure |
|---|---|
| [34599517793](https://github.com/NousResearch/hermes-agent/actions/runs/34599517793) | `apps/desktop` `messaging/index.test.tsx`: first test `Error: Test timed out in 15000ms`, 8-9 cascade failures |
| [34601269252](https://github.com/NousResearch/hermes-agent/actions/runs/34601269252) | same file, same cascade |
| [34600757569](https://github.com/NousResearch/hermes-agent/actions/runs/34600757569) | same file **plus** `web` `SessionsPage.test.tsx` per-row routing test at 5079ms vs vitest's 5s default |

## Root cause

One-time cost billed to the wrong clock. `renderMessaging()` did `await import('./index')` inside the test body, so the **first** test paid the entire MessagingView component-tree transform against its own `testTimeout`. On a green main run the whole file already takes **15.7s** — the moment CI contention lands that cost inside one test, the 15s budget is gone. `skills/index.test.tsx` had the identical pattern at 9 call sites (18.6s on a green run; previously band-aided with a 60s describe-timeout). The web vitest project never got the desktop's 15s `testTimeout` and still ran page suites that legitimately take 3.6-4.6s green against vitest's 5s default.

## Changes

- `apps/desktop/src/app/messaging/index.test.tsx` — move `await import('./index')` to module scope (after the hoisted `vi.mock` calls), where vitest bills it to collection; same pattern `chat/index.test.tsx` already uses.
- `apps/desktop/src/app/skills/index.test.tsx` — deduplicate 9 in-test dynamic imports into one module-scope import; the existing 60s describe-timeout stays for the legitimately slow tests.
- `web/vitest.config.ts` — `testTimeout: 15_000` with the same rationale comment the desktop config carries; genuinely hung tests still fail.

## Validation

| Check | Result |
|---|---|
| `messaging` + `skills` files, 5 consecutive runs | 30/30 green each run |
| Same two files pinned to **1 CPU core** (worst-case contention) | green, 17.4s wall |
| `SessionsPage.test.tsx` ×3 | green |
| Full desktop `--project ui` suite | 801 files / 7622 tests green |
| `tsc -p . --noEmit` (desktop + web) | clean |
| `eslint` touched files | 0 errors |

**Live repro:** before — the exact timeout signature on the three main runs above (not reproducible locally even on 1 core; it needs CI-grade contention, which is the definition of this flake class). After — import cost visibly moved out of the first test (its runtime drops to 48ms with the transform now in the import phase), so no per-test budget can be exceeded by collection work.

Found by the Flaky Test Scout (Tue/Fri cron).

## Infographic

![infographic](https://v3b.fal.media/files/b/0aaa04f2/Jkpmnt7FTWXyR-oWM26aK_LqTNsHio.png)
