### PR TITLE
feat: add fail-closed Max Telegram material ingress

### DIFF
--- a/gateway/max_material_ingress.py
+++ b/gateway/max_material_ingress.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -16,6 +17,9 @@ class IngressDispatchResult:
     status: str
 
 
+_TELEGRAM_IDENTIFIER = re.compile(r"[A-Za-z0-9_-]{1,128}\Z")
+
+
 def dispatch(*, settings: object, chat_id: str, user_id: str, message_ids: list[str],
              media_group_id: str | None, cached_paths: list[str]) -> IngressDispatchResult:
     """Stage one authorized JPEG/PNG batch and invoke no configurable shell."""
@@ -25,6 +29,11 @@ def dispatch(*, settings: object, chat_id: str, user_id: str, message_ids: list[
         return IngressDispatchResult(False, "unauthorized")
     root_value = settings.get("staging_root")
     if not isinstance(root_value, str) or not message_ids or len(message_ids) != len(cached_paths):
+        return IngressDispatchResult(True, "failed")
+    if (not all(isinstance(message_id, str) and _TELEGRAM_IDENTIFIER.fullmatch(message_id)
+                for message_id in message_ids)
+            or media_group_id is not None
+            and (not isinstance(media_group_id, str) or not _TELEGRAM_IDENTIFIER.fullmatch(media_group_id))):
         return IngressDispatchResult(True, "failed")
     root = Path(root_value)
     try:

--- a/gateway/max_material_ingress.py
+++ b/gateway/max_material_ingress.py
@@ -1,0 +1,64 @@
+"""Fail-closed ingress bridge for the fixed Max English material wrapper."""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class IngressDispatchResult:
+    handled: bool
+    status: str
+
+
+def dispatch(*, settings: object, chat_id: str, user_id: str, message_ids: list[str],
+             media_group_id: str | None, cached_paths: list[str]) -> IngressDispatchResult:
+    """Stage one authorized JPEG/PNG batch and invoke no configurable shell."""
+    if not isinstance(settings, dict) or settings.get("enabled") is not True:
+        return IngressDispatchResult(False, "disabled")
+    if str(settings.get("chat_id")) != chat_id or str(settings.get("user_id")) != user_id:
+        return IngressDispatchResult(False, "unauthorized")
+    root_value = settings.get("staging_root")
+    if not isinstance(root_value, str) or not message_ids or len(message_ids) != len(cached_paths):
+        return IngressDispatchResult(True, "failed")
+    root = Path(root_value)
+    try:
+        root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if root.stat().st_mode & 0o077:
+            return IngressDispatchResult(True, "failed")
+        batch = root / ("album-" + media_group_id if media_group_id else "single-" + message_ids[0])
+        batch.mkdir(mode=0o700, exist_ok=True)
+        files = []
+        for position, (message_id, raw) in enumerate(zip(message_ids, cached_paths)):
+            source = Path(raw)
+            if not source.is_file() or source.suffix.lower() not in {".jpg", ".png"}:
+                return IngressDispatchResult(True, "needs_resubmission")
+            target = batch / f"{position:02d}{source.suffix.lower()}"
+            if not target.exists():
+                shutil.copy2(source, target)
+                os.chmod(target, 0o600)
+            files.append({"message_id": message_id, "staged_path": str(target.relative_to(root))})
+        key = f"max:album:{media_group_id}" if media_group_id else f"max:single:{message_ids[0]}"
+        payload = {"ingress_key": key, "media_group_id": media_group_id, "files": files}
+        fd, temporary = tempfile.mkstemp(prefix="receipt-", suffix=".json", dir=batch)
+        try:
+            os.write(fd, json.dumps(payload, separators=(",", ":")).encode())
+        finally:
+            os.close(fd)
+        manifest = Path(temporary); os.chmod(manifest, 0o600)
+        wrapper = "/home/alan/.hermes/profiles/max/skills/max-english-learning/bin/receive-telegram-material"
+        completed = subprocess.run([wrapper], stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+                                   stderr=subprocess.DEVNULL, text=True, timeout=30,
+                                   env={"PATH": os.defpath, "HOME": "/home/alan", "LANG": "C.UTF-8",
+                                        "HERMES_ENGLISH_TELEGRAM_MANIFEST": str(manifest)})
+        if completed.returncode:
+            return IngressDispatchResult(True, "retrying")
+        result = json.loads(completed.stdout)
+        return IngressDispatchResult(True, str(result.get("status", "failed")))
+    except Exception:
+        return IngressDispatchResult(True, "failed")

--- a/hermes_cli/send_cmd.py
+++ b/hermes_cli/send_cmd.py
@@ -190,9 +190,39 @@ def _load_hermes_env() -> None:
             os.environ[key] = str(val)
 
 
+def _send_material_review_card(args: argparse.Namespace) -> int:
+    """Send one native card to the fixed review lane without starting a gateway."""
+    if any(getattr(args, key, None) is not None for key in ("message", "file", "subject")) or args.list_targets:
+        return _emit_result(json.dumps({"error": "--material-review-card cannot be mixed with text or --list"}),
+                            json_mode=args.json, quiet=args.quiet)
+    try:
+        import asyncio
+        from gateway.config import Platform, load_gateway_config
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+        from telegram import Bot
+        config = load_gateway_config().platforms.get(Platform.TELEGRAM)
+        if config is None or not config.enabled or not config.token:
+            raise ValueError
+        adapter = TelegramAdapter(config)
+        payload = json.loads(Path(args.material_review_card).read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError
+        async def send():
+            async with Bot(token=config.token) as bot:
+                adapter._bot = bot
+                result = await adapter.send_material_review_card(payload)
+                return {"success": result.success, "message_id": result.message_id, "error": result.error}
+        result = asyncio.run(send())
+    except Exception:
+        result = {"error": "Material review card delivery failed"}
+    return _emit_result(json.dumps(result), json_mode=args.json, quiet=args.quiet)
+
+
 def cmd_send(args: argparse.Namespace) -> None:
     """Entry point wired into the top-level argparse dispatcher."""
     _load_hermes_env()  # the downstream gateway config loader reads credentials from os.environ
+    if getattr(args, "material_review_card", None) is not None:
+        sys.exit(_send_material_review_card(args))
     if getattr(args, "list_targets", False):  # --list short-circuits everything else
         # `hermes send --list telegram` lands "telegram" in the `message` positional.
         exit_code = _list_targets(getattr(args, "message", None), json_mode=getattr(args, "json", False))
@@ -239,6 +269,8 @@ _SEND_ARGUMENTS = (
         "Read message body from PATH (text only). Use '-' to force stdin. "
         "To send an image/document as an attachment, use MEDIA:<path> in the message text instead."))),
     (("-s", "--subject"), dict(metavar="LINE", default=None, help="Prepend a subject/header line before the message body.")),
+    (("--material-review-card",), dict(metavar="FILE", default=None,
+                                         help="Send a material-review JSON card to the configured Telegram review lane.")),
     (("-l", "--list"), dict(dest="list_targets", action="store_true", default=False,
                             help="List available targets. Optional positional filter: `hermes send --list telegram`.")),
     (("-q", "--quiet"), dict(action="store_true", default=False, help="Suppress stdout on success (exit code only).")),

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3811,6 +3811,51 @@ class TelegramAdapter(TelegramWisdomMixin, BasePlatformAdapter):
     def _ea_escape(self, text: str) -> str:
         return _html.escape(text)
 
+    def material_review_target(self) -> tuple[int, int, int | None]:
+        """Return the explicitly configured Alan review lane."""
+        settings = self.config.extra.get("material_review", {})
+        if not isinstance(settings, dict):
+            raise ValueError("Material review is not configured")
+        reviewer_id, chat_id, thread_id = (settings.get(key) for key in ("reviewer_id", "chat_id", "thread_id"))
+        if (type(reviewer_id) is not int or type(chat_id) is not int or reviewer_id <= 0 or chat_id == 0
+                or (chat_id < 0 and (type(thread_id) is not int or thread_id <= 1))
+                or (chat_id > 0 and thread_id is not None)):
+            raise ValueError("Material review requires numeric reviewer and chat IDs")
+        if chat_id > 0 and chat_id != reviewer_id:
+            raise ValueError("Private material review must use the reviewer's direct chat")
+        return reviewer_id, chat_id, thread_id
+
+    async def send_material_review_card(self, payload: dict) -> SendResult:
+        """Send a bounded, plain-text Alan review card with opaque buttons."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        try:
+            _, chat_id, thread_id = self.material_review_target()
+            approve_id, reject_id = payload["approve_action_id"], payload["reject_action_id"]
+            if (not all(isinstance(value, str) and re.fullmatch(r"[A-Za-z0-9_-]{1,59}", value)
+                        for value in (approve_id, reject_id)) or approve_id == reject_id):
+                raise ValueError("Invalid material review action IDs")
+            candidates = payload["candidates"]
+            confidence = payload.get("confidence")
+            score = "未知" if confidence is None else f"{confidence:.0%}"
+            lines = [f"教材待審核 {payload.get('profile', '')}", str(payload["title"])[:200],
+                     f"檔案：{str(payload['filename'])[:128]}", f"OCR 信心：{score}",
+                     f"候選單字（{payload.get('candidate_count', len(candidates))}）"]
+            lines.extend(f"• {item['term'][:80]}：{item['definition'][:160]}" for item in candidates[:20])
+            text = "\n".join(lines).encode("utf-16-le")[:7000].decode("utf-16-le", errors="ignore")
+            message = await self._bot.send_message(
+                chat_id=chat_id, message_thread_id=thread_id, text=text,
+                reply_markup=InlineKeyboardMarkup([[
+                    InlineKeyboardButton("批准", callback_data=f"mr:{approve_id}:a"),
+                    InlineKeyboardButton("退回", callback_data=f"mr:{reject_id}:r"),
+                ]]), **self._link_preview_kwargs())
+            return SendResult(success=True, message_id=str(message.message_id))
+        except (ValueError, TypeError, KeyError):
+            return SendResult(success=False, error="Invalid material review payload or configuration")
+        except Exception:
+            logger.warning("[%s] Material review card delivery failed", self.name)
+            return SendResult(success=False, error="Material review card delivery failed")
+
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str, description: str = "dangerous command",
         metadata: Optional[Dict[str, Any]] = None, allow_permanent: bool = True, allow_session: bool = True,
@@ -4263,6 +4308,9 @@ class TelegramAdapter(TelegramWisdomMixin, BasePlatformAdapter):
             return
         data = query.data
         cb = self._callback_ctx(query)
+        if isinstance(data, str) and data.startswith("mr:"):
+            await self.handle_material_review_callback(update)
+            return
         if data.startswith("wa:"):
             await self._handle_wisdom_agent_callback(query, data)
             return
@@ -4288,6 +4336,53 @@ class TelegramAdapter(TelegramWisdomMixin, BasePlatformAdapter):
             if data.startswith(prefix):
                 await handler(query, data, cb)
                 return
+
+    async def _run_material_review_action(self, action_id: str, decision: str, reviewer_id: int) -> dict:
+        child = await asyncio.create_subprocess_exec(
+            "/home/alan/.hermes/skills/alan-english-review/bin/english-material-review-action",
+            decision, action_id, str(reviewer_id), stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.DEVNULL,
+            cwd="/home/alan/.hermes", env={"PATH": os.defpath, "HOME": "/home/alan", "LANG": "C.UTF-8"})
+        try:
+            stdout, _ = await asyncio.wait_for(child.communicate(), timeout=30)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            with contextlib.suppress(ProcessLookupError):
+                child.kill()
+            await child.wait()
+            raise
+        if child.returncode != 0:
+            raise ValueError("Material review action failed")
+        result = json.loads(stdout)
+        if not isinstance(result, dict) or result.get("action_id") != action_id or result.get("status") not in ("approved", "rejected"):
+            raise ValueError("Invalid material review result")
+        return result
+
+    async def handle_material_review_callback(self, update: "Update") -> None:
+        query = update.callback_query
+        if query is None:
+            return
+        match = re.fullmatch(r"mr:([A-Za-z0-9_-]{1,59}):([ar])", query.data if isinstance(query.data, str) else "")
+        try:
+            target = self.material_review_target()
+        except ValueError:
+            target = None
+        message = getattr(query, "message", None)
+        actual = (getattr(getattr(query, "from_user", None), "id", None), getattr(message, "chat_id", None),
+                  getattr(message, "message_thread_id", None))
+        if not match or actual != target:
+            await query.answer(text="無效的教材按鈕或未授權的審核位置。")
+            return
+        await query.answer(text="正在處理教材審核…")
+        action_id, code = match.groups()
+        try:
+            result = await self._run_material_review_action(action_id, "approve" if code == "a" else "reject", target[0])
+        except Exception:
+            logger.warning("[%s] Material review action failed", self.name)
+            return
+        try:
+            await query.edit_message_text(text=f"教材{'已批准' if result['status'] == 'approved' else '已退回'}。", reply_markup=None)
+        except Exception:
+            logger.warning("[%s] Material review completed but card edit failed", self.name)
 
     async def _claim_callback_state(self, query, cb: Dict[str, Any], state: dict, key, denial: str, resolved: str, *, pop: bool = True):
         """Auth-gate a button tap, then claim its pending entry; None (after answering) when refused or expired."""
@@ -5823,7 +5918,8 @@ class TelegramAdapter(TelegramWisdomMixin, BasePlatformAdapter):
             return
         super()._enqueue_text_event(event)
 
-    async def _flush_buffered(self, pending: dict, tasks: dict, key: str, delay: float, where: str, log_fn=None) -> None:
+    async def _flush_buffered(self, pending: dict, tasks: dict, key: str, delay: float, where: str,
+                              log_fn=None, dispatch=None) -> None:
         """Shared delayed-flush body: sleep, pop, hold if teardown started, else dispatch. A cancel after
         the pop but before durable dispatch re-holds the event (never lose it)."""
         current_task = asyncio.current_task()
@@ -5835,6 +5931,9 @@ class TelegramAdapter(TelegramWisdomMixin, BasePlatformAdapter):
                 return
             if self._should_drop_delayed_delivery():
                 self._hold_inbound_event(event, where=f"{where}-flush")
+                event = None
+                return
+            if dispatch is not None and await dispatch(event):
                 event = None
                 return
             if log_fn is not None:
@@ -5884,16 +5983,19 @@ class TelegramAdapter(TelegramWisdomMixin, BasePlatformAdapter):
         """Send a buffered photo burst/album as a single MessageEvent."""
         await self._flush_buffered(
             self._pending_photo_batches, self._pending_photo_batch_tasks, batch_key, self._media_batch_delay_seconds, "photo",
-            lambda ev: logger.info("[Telegram] Flushing photo batch %s with %d image(s)", batch_key, len(ev.media_urls)))
+            lambda ev: logger.info("[Telegram] Flushing photo batch %s with %d image(s)", batch_key, len(ev.media_urls)),
+            lambda ev: self._maybe_dispatch_max_material(ev, None))
 
     def _merge_into_pending(self, pending: dict, key: str, event: MessageEvent) -> None:
         """Merge ``event`` into ``pending[key]`` (media + caption) or seed it."""
         existing = pending.get(key)
         if existing is None:
+            event._max_material_message_ids = [str(event.message_id)]
             pending[key] = event
             return
         existing.media_urls.extend(event.media_urls)
         existing.media_types.extend(event.media_types)
+        existing._max_material_message_ids.append(str(event.message_id))
         if event.text:
             existing.text = self._merge_caption(existing.text, event.text)
 
@@ -6118,7 +6220,51 @@ class TelegramAdapter(TelegramWisdomMixin, BasePlatformAdapter):
 
     async def _flush_media_group_event(self, media_group_id: str) -> None:
         await self._flush_buffered(
-            self._media_group_events, self._media_group_tasks, media_group_id, self.MEDIA_GROUP_WAIT_SECONDS, "media-group")
+            self._media_group_events, self._media_group_tasks, media_group_id, self.MEDIA_GROUP_WAIT_SECONDS, "media-group",
+            dispatch=lambda ev: self._maybe_dispatch_max_material(ev, media_group_id))
+
+    async def _maybe_dispatch_max_material(self, event: MessageEvent, media_group_id: str | None) -> bool:
+        """Consume an authorized Max JPG/PNG batch before normal agent routing."""
+        result = await asyncio.to_thread(
+            self._dispatch_max_material_ingress, event, media_group_id,
+            list(getattr(event, "_max_material_message_ids", [str(event.message_id)])),
+        )
+        if result is None:
+            return False
+        await self._send_max_material_receipt(event, result.status)
+        return True
+
+    def _dispatch_max_material_ingress(self, event: MessageEvent, media_group_id: str | None,
+                                       message_ids: list[str]):
+        settings = self.config.extra.get("max_material_ingress", {})
+        if not isinstance(settings, dict) or settings.get("enabled") is not True:
+            return None
+        try:
+            from gateway.max_material_ingress import dispatch
+            result = dispatch(settings=settings, chat_id=str(event.source.chat_id),
+                              user_id=str(event.source.user_id), message_ids=message_ids,
+                              media_group_id=media_group_id, cached_paths=list(event.media_urls))
+            return result if result.handled else None
+        except Exception:
+            logger.exception("[%s] Max material ingress dispatch failed", self.name)
+            from gateway.max_material_ingress import IngressDispatchResult
+            return IngressDispatchResult(True, "failed")
+
+    async def _send_max_material_receipt(self, event: MessageEvent, status: str) -> None:
+        if not self._bot:
+            logger.error("[%s] Max material %s but Telegram receipt cannot be sent", self.name, status)
+            return
+        messages = {
+            "received": "教材圖片已收到，正在處理，尚未加入題庫。",
+            "pending_review": "教材已送交審核，尚未加入題庫。",
+            "needs_resubmission": "這批圖片無法使用，請重新傳送清楚的 JPG 或 PNG；管理者已收到通知。",
+            "retrying": "教材處理暫時失敗，系統會重試；管理者已收到通知。",
+            "failed": "教材處理未完成，管理者已收到通知。",
+        }
+        try:
+            await self._bot.send_message(chat_id=int(event.source.chat_id), text=messages.get(status, messages["failed"]))
+        except Exception:
+            logger.exception("[%s] Max material receipt delivery failed", self.name)
 
     async def _handle_sticker(self, msg: Message, event: "MessageEvent") -> None:
         """Describe a sticker via vision, cached by file_unique_id; animated/video stickers get an emoji placeholder."""

--- a/tests/gateway/test_max_material_ingress.py
+++ b/tests/gateway/test_max_material_ingress.py
@@ -1,0 +1,51 @@
+"""Max material ingress rejects unsafe Telegram identifiers before staging."""
+
+import importlib.util
+from pathlib import Path
+import sys
+from unittest.mock import Mock
+
+
+MODULE = Path(__file__).parents[2] / "gateway" / "max_material_ingress.py"
+SPEC = importlib.util.spec_from_file_location("max_material_ingress_under_test", MODULE)
+assert SPEC is not None and SPEC.loader is not None
+INGRESS = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = INGRESS
+SPEC.loader.exec_module(INGRESS)
+
+
+def test_unsafe_media_group_identifier_never_creates_a_staging_path(tmp_path, monkeypatch):
+    run = Mock()
+    monkeypatch.setattr(INGRESS.subprocess, "run", run)
+    image = tmp_path / "word.jpg"
+    image.write_bytes(b"image")
+    staging = tmp_path / "staging"
+
+    result = INGRESS.dispatch(
+        settings={"enabled": True, "chat_id": "1", "user_id": "2", "staging_root": str(staging)},
+        chat_id="1", user_id="2", message_ids=["123"], media_group_id="../../outside",
+        cached_paths=[str(image)],
+    )
+
+    assert result.handled is True
+    assert result.status == "failed"
+    assert not staging.exists()
+    run.assert_not_called()
+
+
+def test_safe_telegram_identifiers_reach_the_fixed_wrapper(tmp_path, monkeypatch):
+    run = Mock(return_value=Mock(returncode=1))
+    monkeypatch.setattr(INGRESS.subprocess, "run", run)
+    image = tmp_path / "word.jpg"
+    image.write_bytes(b"image")
+    staging = tmp_path / "staging"
+
+    result = INGRESS.dispatch(
+        settings={"enabled": True, "chat_id": "1", "user_id": "2", "staging_root": str(staging)},
+        chat_id="1", user_id="2", message_ids=["123"], media_group_id="album_456-7",
+        cached_paths=[str(image)],
+    )
+
+    assert result.status == "retrying"
+    assert (staging / "album-album_456-7").is_dir()
+    run.assert_called_once()

--- a/tests/gateway/test_telegram_material_review_buttons.py
+++ b/tests/gateway/test_telegram_material_review_buttons.py
@@ -1,0 +1,201 @@
+"""Stateless material buttons authorize the reviewer before a fixed command."""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+PAYLOAD = {
+    "profile": "max", "title": "Unit 3", "filename": "unit-3.jpg",
+    "confidence": 0.94, "summary": "候選單字（2）", "candidate_count": 2,
+    "candidates": [{"term": "arrive", "definition": "抵達"},
+                   {"term": "borrow", "definition": "借入"}],
+    "approve_action_id": "opaque_a1", "reject_action_id": "opaque_r1",
+}
+
+
+def make_adapter(settings=None):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token", extra={
+        "material_review": settings if settings is not None else {
+            "reviewer_id": 12345, "chat_id": -10099, "thread_id": 37,
+        },
+    }))
+    adapter._bot = AsyncMock()
+    adapter._bot.send_message.return_value = SimpleNamespace(message_id=42)
+    adapter._message_handler = AsyncMock()
+    return adapter
+
+
+def callback(data="mr:opaque_a1:a", *, user=12345, chat=-10099, thread=37):
+    query = SimpleNamespace(
+        data=data, from_user=SimpleNamespace(id=user),
+        message=SimpleNamespace(chat_id=chat, message_thread_id=thread,
+                                message_id=42, chat=SimpleNamespace(type="supergroup")),
+        answer=AsyncMock(), edit_message_text=AsyncMock(),
+    )
+    return SimpleNamespace(callback_query=query)
+
+
+def process(monkeypatch, *, result=None, code=0):
+    child = SimpleNamespace(
+        returncode=code,
+        communicate=AsyncMock(return_value=(json.dumps(result if result is not None else {
+            "action_id": "opaque_a1", "decision": "approve", "status": "approved",
+        }).encode(), b"")),
+        kill=Mock(), wait=AsyncMock(),
+    )
+    launch = AsyncMock(return_value=child)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", launch)
+    return child, launch
+
+
+@pytest.mark.asyncio
+async def test_card_sends_plain_text_and_only_opaque_decision_buttons(monkeypatch):
+    monkeypatch.setattr("plugins.platforms.telegram.adapter.InlineKeyboardButton",
+                        lambda text, callback_data: SimpleNamespace(text=text, callback_data=callback_data))
+    monkeypatch.setattr("plugins.platforms.telegram.adapter.InlineKeyboardMarkup",
+                        lambda rows: SimpleNamespace(inline_keyboard=rows))
+    adapter = make_adapter()
+    result = await adapter.send_material_review_card(PAYLOAD)
+    assert result.success and result.message_id == "42"
+    sent = adapter._bot.send_message.call_args.kwargs
+    assert sent["chat_id"] == -10099 and sent["message_thread_id"] == 37
+    assert "arrive" in sent["text"] and "94%" in sent["text"]
+    assert sent.get("parse_mode") is None
+    buttons = sent["reply_markup"].inline_keyboard[0]
+    assert [(button.text, button.callback_data) for button in buttons] == [
+        ("批准", "mr:opaque_a1:a"), ("退回", "mr:opaque_r1:r"),
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("code,decision,status,label", [
+    ("a", "approve", "approved", "已批准"),
+    ("r", "reject", "rejected", "已退回"),
+])
+async def test_callback_after_restart_answers_before_fixed_command_then_edits(
+        monkeypatch, code, decision, status, label):
+    adapter = make_adapter()  # No card/send state exists in this instance.
+    update = callback(f"mr:opaque_a1:{code}")
+    child, launch = process(monkeypatch, result={"action_id": "opaque_a1", "status": status})
+
+    async def invoke(*args, **kwargs):
+        assert update.callback_query.answer.await_count == 1
+        return child
+
+    launch.side_effect = invoke
+    monkeypatch.setenv("HERMES_ENGLISH_LEARNING_ENV_FILE", "/wrong/profile.env")
+    await adapter._handle_callback_query(update, None)
+    assert launch.call_args.args == (
+        "/home/alan/.hermes/skills/alan-english-review/bin/english-material-review-action",
+        decision, "opaque_a1", "12345",
+    )
+    assert "HERMES_ENGLISH_LEARNING_ENV_FILE" not in launch.call_args.kwargs["env"]
+    assert label in update.callback_query.edit_message_text.call_args.kwargs["text"]
+    assert update.callback_query.edit_message_text.call_args.kwargs["reply_markup"] is None
+    assert adapter._message_handler.await_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kwargs", [
+    {"user": 777}, {"chat": -10088}, {"thread": 38}, {"thread": None},
+    {"user": None}, {"user": "12345"}, {"user": True},
+    {"chat": "-10099"}, {"thread": "37"},
+])
+async def test_wrong_identity_never_executes_even_with_allow_all(kwargs, monkeypatch):
+    adapter = make_adapter()
+    _, launch = process(monkeypatch)
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+    update = callback(**kwargs)
+    await adapter._handle_callback_query(update, None)
+    assert update.callback_query.answer.await_count == 1
+    assert launch.await_count == 0
+    assert update.callback_query.edit_message_text.await_count == 0
+    assert adapter._message_handler.await_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("data", [
+    "mr::a", "mr:opaque_a1:approve", "mr:opaque_a1:a:extra", "mr:../db:a",
+    "mr:" + "a" * 60 + ":a", "mr:單字:a", "mr:opaque_a1:a\n", "mr:a1:;",
+])
+async def test_malformed_callback_is_answered_without_execution(data, monkeypatch):
+    adapter = make_adapter()
+    _, launch = process(monkeypatch)
+    update = callback(data)
+    await adapter._handle_callback_query(update, None)
+    assert update.callback_query.answer.await_count == 1
+    assert launch.await_count == 0
+    assert adapter._message_handler.await_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("settings", [{}, {"reviewer_id": 12345, "chat_id": -10099},
+    {"reviewer_id": "12345", "chat_id": -10099, "thread_id": 37}])
+async def test_missing_or_invalid_config_fails_closed(settings, monkeypatch):
+    adapter = make_adapter(settings)
+    _, launch = process(monkeypatch)
+    update = callback()
+    await adapter._handle_callback_query(update, None)
+    assert update.callback_query.answer.await_count == 1
+    assert launch.await_count == 0
+    assert not (await adapter.send_material_review_card(PAYLOAD)).success
+    assert adapter._bot.send_message.await_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("result,code", [
+    ({"action_id": "opaque_a1", "status": "approved"}, 1),
+    ({"action_id": "other", "status": "approved"}, 0),
+    ({"action_id": "opaque_a1", "status": "pending"}, 0),
+    (["approved"], 0),
+])
+async def test_failed_or_invalid_dispatcher_result_keeps_card(result, code, monkeypatch):
+    adapter = make_adapter()
+    process(monkeypatch, result=result, code=code)
+    update = callback()
+    await adapter._handle_callback_query(update, None)
+    assert update.callback_query.answer.await_count == 1
+    assert update.callback_query.edit_message_text.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_repeated_click_uses_durable_dispatcher_result_after_edit_failure(monkeypatch):
+    process(monkeypatch, result={"action_id": "opaque_r1", "status": "approved"})
+    first = callback("mr:opaque_r1:r")
+    first.callback_query.edit_message_text.side_effect = RuntimeError("network")
+    await make_adapter()._handle_callback_query(first, None)
+    replay = callback("mr:opaque_r1:r")
+    await make_adapter()._handle_callback_query(replay, None)
+    assert first.callback_query.answer.await_count == 1
+    assert replay.callback_query.answer.await_count == 1
+    assert "已批准" in replay.callback_query.edit_message_text.call_args.kwargs["text"]
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_timeout_kills_child_and_keeps_buttons(monkeypatch):
+    child, _ = process(monkeypatch)
+    child.communicate.side_effect = asyncio.TimeoutError
+    update = callback()
+    await make_adapter()._handle_callback_query(update, None)
+    assert child.kill.call_count == 1 and child.wait.await_count == 1
+    assert update.callback_query.answer.await_count == 1
+    assert update.callback_query.edit_message_text.await_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("payload", [
+    {}, {**PAYLOAD, "approve_action_id": "../db"},
+    {**PAYLOAD, "reject_action_id": "opaque_a1"},
+])
+async def test_invalid_card_payload_is_not_sent(payload):
+    adapter = make_adapter()
+    result = await adapter.send_material_review_card(payload)
+    assert not result.success
+    assert adapter._bot.send_message.await_count == 0

--- a/tests/hermes_cli/test_send_cmd.py
+++ b/tests/hermes_cli/test_send_cmd.py
@@ -15,6 +15,80 @@ import pytest
 from hermes_cli import send_cmd
 
 
+def test_material_review_card_cli_uses_native_adapter_without_connecting(tmp_path, monkeypatch, capsys):
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+    from gateway.config import Platform, PlatformConfig
+    import telegram
+    import gateway.config
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    payload = {
+        "profile": "max", "title": "Unit 3", "filename": "unit.jpg",
+        "confidence": 0.94, "summary": "候選單字（1）", "candidate_count": 1,
+        "candidates": [{"term": "arrive", "definition": "抵達"}],
+        "approve_action_id": "opaque_a1", "reject_action_id": "opaque_r1",
+    }
+    config = PlatformConfig(enabled=True, token="fake-token", extra={
+        "material_review": {"reviewer_id": 12345, "chat_id": -10099, "thread_id": 37},
+    })
+    monkeypatch.setattr(gateway.config, "load_gateway_config", lambda: SimpleNamespace(
+        platforms={Platform.TELEGRAM: config},
+    ))
+    monkeypatch.setattr(send_cmd, "_load_hermes_env", lambda: None)
+    bot = AsyncMock()
+    bot.__aenter__.return_value = bot
+    bot.send_message.return_value = SimpleNamespace(message_id=42)
+    monkeypatch.setattr(telegram, "Bot", lambda **kwargs: bot)
+    connect = AsyncMock(side_effect=AssertionError("sender must not start a poller"))
+    monkeypatch.setattr(TelegramAdapter, "connect", connect)
+    card = tmp_path / "card.json"
+    card.write_text(json.dumps(payload), encoding="utf-8")
+    args = _parse(["--to", "telegram:-10099:37", "--material-review-card", str(card), "--json"])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+    assert exc.value.code == 0
+    assert json.loads(capsys.readouterr().out)["message_id"] == "42"
+    assert bot.send_message.call_args.kwargs["reply_markup"] is not None
+    assert bot.send_message.call_args.kwargs["message_thread_id"] == 37
+    assert connect.await_count == 0
+
+
+@pytest.mark.parametrize("extra", [["message"], ["--file", "text.txt"], ["--subject", "subject"], ["--list"]])
+def test_material_review_card_rejects_mixed_text_options(extra, monkeypatch):
+    monkeypatch.setattr(send_cmd, "_load_hermes_env", lambda: None)
+    args = _parse(["--to", "telegram", "--material-review-card", "card.json", *extra])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+    assert exc.value.code == 2
+
+
+@pytest.mark.parametrize("target", ["telegram", "telegram:-10099", "telegram:-10088:37",
+                                    "telegram:-10099:38", "discord:-10099:37"])
+def test_material_review_card_rejects_other_targets_before_opening_bot(target, monkeypatch, tmp_path):
+    from types import SimpleNamespace
+    from gateway.config import Platform, PlatformConfig
+    import gateway.config
+    import telegram
+
+    config = PlatformConfig(enabled=True, token="fake-token", extra={
+        "material_review": {"reviewer_id": 12345, "chat_id": -10099, "thread_id": 37},
+    })
+    monkeypatch.setattr(gateway.config, "load_gateway_config", lambda: SimpleNamespace(
+        platforms={Platform.TELEGRAM: config},
+    ))
+    monkeypatch.setattr(send_cmd, "_load_hermes_env", lambda: None)
+    def unexpected_bot(**kwargs):
+        pytest.fail("Mismatched review targets must not open a bot")
+    monkeypatch.setattr(telegram, "Bot", unexpected_bot)
+    card = tmp_path / "card.json"
+    card.write_text("{}")
+    args = _parse(["--to", target, "--material-review-card", str(card), "--json"])
+    with pytest.raises(SystemExit) as exc:
+        send_cmd.cmd_send(args)
+    assert exc.value.code == 2
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements the Max-only Telegram JPG/PNG material ingress and Alan review path.

- stages only authorized Max uploads into a private manifest
- uses the fixed Max ingestion wrapper and fixed receipts
- keeps material pending until Alan review
- rejects unsafe Telegram identifiers before staging

Validation: targeted ingress regression tests and Python compilation passed locally.