### PR TITLE
fix(doctor): flag named profiles whose provider has no credential

### DIFF
--- a/hermes_cli/doctor_state.py
+++ b/hermes_cli/doctor_state.py
@@ -3,6 +3,7 @@ Split out of ``hermes_cli/doctor.py``, which re-exports every name so ``hermes_c
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 from hermes_cli.doctor_report import (
@@ -404,6 +405,89 @@ def _check_memory_provider(should_fix: bool, f: Finding) -> None:
         check_warn(f"{label} check failed", str(_e))
 
 
+def _profile_env_keys(profile_dir: Path) -> set:
+    """Env var names given a non-empty value in a profile's own .env.
+
+    Read straight from the file: doctor must not mutate the process env (or HERMES_HOME) to
+    resolve another profile's keys.
+    """
+    keys: set = set()
+    env_path = profile_dir / ".env"
+    if not env_path.is_file():
+        return keys
+    try:
+        text = env_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        text = env_path.read_text(encoding="latin-1")
+    except OSError:
+        return keys
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        name, _, value = line.partition("=")
+        name = name.strip()
+        if name.startswith("export "):
+            name = name[len("export "):].strip()
+        if name and value.strip().strip('"').strip("'"):
+            keys.add(name)
+    return keys
+
+
+def _profile_auth_pool_providers(profile_dir: Path) -> set:
+    """Providers holding at least one credential in a profile's own auth.json pool."""
+    providers: set = set()
+    auth_path = profile_dir / "auth.json"
+    if not auth_path.is_file():
+        return providers
+    try:
+        data = json.loads(auth_path.read_text(encoding="utf-8"))
+    except Exception:
+        return providers
+    pool = data.get("credential_pool") if isinstance(data, dict) else None
+    if isinstance(pool, dict):
+        providers.update(str(k).strip().lower() for k in pool if str(k).strip())
+    return providers
+
+
+def _profile_provider_credential_problem(p) -> str:
+    """Reason string when a named profile's provider has no usable credential, else "".
+
+    Profiles are independent islands: a credential that works for the default profile proves
+    nothing about a named one, which resolves keys from its own .env / auth.json. A profile
+    pinned to a provider whose credential is gone (unset, blanked, never added) otherwise shows
+    a green tick here and only fails later at request time behind a generic provider error.
+
+    Static and offline by design — doctor must not issue a network request per profile. That
+    covers the "provider set, credential absent" class; a present-but-invalid key needs live
+    verification and is deliberately out of scope.
+    """
+    try:
+        provider = str(getattr(p, "provider", "") or "").strip().lower()
+        if not provider or provider in {"auto", "custom"} or provider.startswith("custom:"):
+            return ""
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        pconfig = PROVIDER_REGISTRY.get(provider)
+        if pconfig is None:
+            return f"model.provider '{provider}' is not a recognised provider"
+        if str(getattr(pconfig, "auth_type", "") or "") != "api_key":
+            return ""  # OAuth / cloud-SDK providers run their own checks
+        env_names = {str(n) for n in (getattr(pconfig, "api_key_env_vars", ()) or ()) if str(n)}
+        if provider == "openrouter":
+            env_names |= {"OPENROUTER_API_KEY", "OPENAI_API_KEY"}
+        if not env_names:
+            return ""
+        if env_names & _profile_env_keys(p.path):
+            return ""
+        if provider in _profile_auth_pool_providers(p.path):
+            return ""
+        checked = ", ".join(sorted(env_names))
+        return (f"model.provider '{provider}' is set but no credential is configured for this "
+                f"profile (checked {checked} in its .env and auth.json)")
+    except Exception:
+        return ""
+
+
 @doctor_check("")  # best-effort: profile enumeration must never break doctor
 def _check_profiles(should_fix: bool, f: Finding) -> None:
     from hermes_cli.profiles import list_profiles, _get_wrapper_dir, profile_exists
@@ -419,7 +503,13 @@ def _check_profiles(should_fix: bool, f: Finding) -> None:
             (p.gateway_running, "gateway running"), (p.model, (p.model or "")[:30]),
             (not (p.path / "config.yaml").exists(), "⚠ missing config"), (not (p.path / ".env").exists(), "no .env"),
             (not (wrapper_dir / p.name).exists(), "no alias")) if cond]
-        check_ok(f"  {p.name}: {', '.join(parts) if parts else 'configured'}")
+        label = f"  {p.name}: {', '.join(parts) if parts else 'configured'}"
+        problem = _profile_provider_credential_problem(p)
+        if problem:
+            check_warn(label, f"({problem})")
+            f.issues.append(f"Profile '{p.name}': {problem}")
+        else:
+            check_ok(label)
     # Orphan wrappers
     if wrapper_dir.is_dir():
         for wrapper in wrapper_dir.iterdir():

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -26,6 +26,55 @@ from hermes_cli import doctor_config
 from tools import browser_tool_install as bt_install
 
 
+class TestDoctorProfileProviderCredentials:
+    """A named profile pinned to a provider with no credential must not report healthy.
+
+    Profiles are independent islands — the default profile's key proves nothing about a named
+    one, which resolves its own keys from its own .env / auth.json. Before this check, doctor
+    ticked every profile green regardless of whether its configured provider had any credential
+    at all, so a fleet parked on a dead provider read as fully healthy.
+    """
+
+    @staticmethod
+    def _profile(tmp_path, name: str, provider: str, env_text: str):
+        from hermes_cli.profiles import ProfileInfo
+        path = tmp_path / "profiles" / name
+        path.mkdir(parents=True)
+        (path / "config.yaml").write_text(f"model:\n  provider: {provider}\n  default: some/model\n")
+        (path / ".env").write_text(env_text)
+        return ProfileInfo(name=name, path=path, is_default=False, gateway_running=False,
+                           model="some/model", provider=provider, has_env=True)
+
+    @staticmethod
+    def _run(monkeypatch, tmp_path, profile):
+        from hermes_cli.doctor_report import Finding
+        monkeypatch.setattr("hermes_cli.profiles.list_profiles", lambda: [profile])
+        monkeypatch.setattr("hermes_cli.profiles._get_wrapper_dir", lambda: tmp_path / "wrappers")
+        # _check_profiles is wrapped by @doctor_check, whose signature is (should_fix) -> Finding.
+        # Call the undecorated body so this test owns the Finding it inspects (wraps() stores it
+        # on __wrapped__); getattr keeps static checkers happy about the attribute.
+        body = getattr(doctor_state._check_profiles, "__wrapped__")
+        finding = Finding()
+        body(False, finding)
+        return finding
+
+    def test_provider_without_credential_is_flagged(self, tmp_path, monkeypatch, capsys):
+        profile = self._profile(tmp_path, "devops", "ollama-cloud", "UNRELATED_KEY=1\n")
+        finding = self._run(monkeypatch, tmp_path, profile)
+        out = capsys.readouterr().out
+
+        assert "no credential is configured" in out
+        assert any("devops" in issue for issue in finding.issues)
+
+    def test_provider_with_its_own_credential_is_not_flagged(self, tmp_path, monkeypatch, capsys):
+        profile = self._profile(tmp_path, "devops", "ollama-cloud", "OLLAMA_API_KEY=present\n")
+        finding = self._run(monkeypatch, tmp_path, profile)
+        out = capsys.readouterr().out
+
+        assert "no credential is configured" not in out
+        assert not any("devops" in issue for issue in finding.issues)
+
+
 class TestDoctorPlatformHints:
     def test_termux_package_hint(self, monkeypatch):
         monkeypatch.setenv("TERMUX_VERSION", "0.118.3")


### PR DESCRIPTION
## Symptom

`hermes doctor` reports a clean profile section while named profiles are broken:

```
◆ Profiles
  ✓ 6 profile(s) found
  ✓   chief-of-staff: gateway running, deepseek/deepseek-v4.1-flash
  ✓   devops: glm-5.3-flash
  ✓   sysadmin: glm-5.3-flash
```

`devops` was still pinned to a provider whose credential had been removed, and `sysadmin`'s
provider key was failing. Both returned `HTTP 401: Missing Authentication header` on every
request. Doctor's verdict for the same run was "Found 2 issue(s)" — both npm vulnerabilities,
nothing about the fleet. The operator has no signal that six profiles are dead.

## Where it manifests

`hermes_cli/doctor_state.py::_check_profiles` (main @ ad03f20):

```python
for p in named_profiles:
    parts = [text for cond, text in (
        (p.gateway_running, "gateway running"), (p.model, (p.model or "")[:30]),
        (not (p.path / "config.yaml").exists(), "⚠ missing config"), (not (p.path / ".env").exists(), "no .env"),
        (not (wrapper_dir / p.name).exists(), "no alias")) if cond]
    check_ok(f"  {p.name}: {', '.join(parts) if parts else 'configured'}")
```

Every profile is reported with `check_ok` unconditionally. The `parts` list is descriptive
only, and `ProfileInfo.provider` — already populated — is never consulted. There is no
`check_warn`/`check_fail` branch for a broken profile.

The credential check itself already exists, but only for the **active** profile:
`doctor_config.py::_validate_model_config` fails with
`model.provider 'X' is set but no API key is configured`. It is never applied to the others.

## Why this bites

Profiles are independent islands by design — `--clone` copies `.env`/`auth.json` at creation
and there is no live inheritance. A named profile therefore resolves provider keys from its
own files, so a profile pinned to a provider whose key was removed, blanked, or never added
looks configured until its first request, then fails behind a generic provider error. This is
easy to hit at fleet scale: rotate the root key after cloning, and every existing profile keeps
the stale copy.

## Fix

Validate each named profile's own `model.provider` against the credential it actually
resolves. `PROVIDER_REGISTRY` api_key providers are checked against that profile's `.env` and
`auth.json`; OAuth / cloud-SDK providers keep their own existing checks.

Deliberately **static and offline** — doctor must not issue a network request per profile.
That covers the "provider set, credential absent" class (the one above). A present-but-invalid
key needs live verification and is out of scope on purpose; scope is stated in the docstring.

## Tests

`tests/hermes_cli/test_doctor.py::TestDoctorProfileProviderCredentials` — 2 invariant tests
(behaviour contract: flagged when the credential is absent, not flagged when present).

Proven red on base via `git stash push -- hermes_cli/doctor_state.py`:

```
assert "no credential is configured" in out
E  AssertionError: assert 'no credential is configured' in
   '\n◆ Profiles\n  ✓ 1 profile(s) found\n  ✓   devops: some/model, no alias\n'
```

That green tick next to a credential-less profile is the bug. With the fix the full file
passes: `73 tests passed, 0 failed`.
