### PR TITLE
fix(aux): send the OpenCode session header on post-turn auxiliary calls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2881,7 +2881,15 @@ def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optiona
 
 
 _MAIN_RUNTIME_FIELDS = ("provider", "model", "base_url", "api_key", "api_mode", "auth_mode")
-_MAIN_RUNTIME_CONTEXT_FIELDS = _MAIN_RUNTIME_FIELDS + ("requested_provider",)
+# ``session_id``/``cache_scope`` ride the context-local runtime only: ``set_runtime_main`` already
+# stores them, but they were missing here, so ``_normalize_main_runtime`` dropped them from any
+# *explicitly scoped* bind (``scoped_runtime_main`` / ``main_runtime=``). Callers that re-bind a
+# finished turn's session — post-turn auxiliary work such as the goal judge — therefore lost the
+# OpenCode relay's session affinity and got HTTP 400 MissingSessionID. They stay out of the legacy
+# mirrors (``_RUNTIME_MAIN_FIELDS``) on purpose: globals are shared across concurrent sessions.
+_MAIN_RUNTIME_CONTEXT_FIELDS = _MAIN_RUNTIME_FIELDS + (
+    "requested_provider", "session_id", "cache_scope",
+)
 
 
 def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str, Any]:

--- a/agent/opencode_affinity.py
+++ b/agent/opencode_affinity.py
@@ -17,9 +17,16 @@ so the header cannot drift per code path.
 
 from __future__ import annotations
 
+import uuid
 from typing import Any, Optional
 
 OPENCODE_SESSION_HEADER = "x-opencode-session"
+
+# Last-resort key for auxiliary calls that run with no ambient runtime at all — post-turn work such
+# as the /loop and kanban goal judges, which have no session of their own to re-bind. The relay
+# rejects a request WITHOUT the header (400 "MissingSessionID"), so sending a stable per-process key
+# beats sending none: those calls route consistently for the life of the process.
+_FALLBACK_SESSION_KEY = f"hermes-aux-{uuid.uuid4().hex}"
 
 
 def is_opencode_target(provider: Optional[str], base_url: Optional[str]) -> bool:
@@ -72,6 +79,8 @@ def opencode_session_headers(
         )
     except Exception:
         key = str(session_id or "")
+    if not key:
+        key = _FALLBACK_SESSION_KEY
     return {OPENCODE_SESSION_HEADER: key} if key else {}
 
 

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -851,16 +851,28 @@ def _render_background_block(background_processes: Optional[List[Dict[str, Any]]
     return JUDGE_BACKGROUND_BLOCK_TEMPLATE.format(background_lines="\n".join(lines))
 
 
-def _call_goal_judge_llm(call_llm, system_prompt: str, user_prompt: str, timeout: Optional[float]) -> str:
+def _call_goal_judge_llm(
+    call_llm, system_prompt: str, user_prompt: str, timeout: Optional[float],
+    session_id: Optional[str] = None,
+) -> str:
     """Route through call_llm so auxiliary.goal_judge.* config (provider/model, extra_body,
-    reasoning_effort, retries) all apply. Returns the raw reply text."""
+    reasoning_effort, retries) all apply. Returns the raw reply text.
+
+    ``session_id`` re-binds the finished turn's runtime scope. The judge runs *after* the turn tore
+    its runtime context down, so an unscoped call carries no session id — and the OpenCode relay
+    rejects a request without ``x-opencode-session`` (HTTP 400 MissingSessionID), which parked every
+    goal after 7 transport failures. See agent/opencode_affinity.py.
+    """
     # See #35566.
     # Route through call_llm — same #35566 fix as the judge call above.
-    resp = call_llm(
-        task="goal_judge",
-        messages=[{"role": "system", "content": system_prompt}, {"role": "user", "content": user_prompt}],
-        temperature=0, max_tokens=_goal_judge_max_tokens(), timeout=timeout,
-    )
+    from agent.auxiliary_client import scoped_runtime_main
+
+    with scoped_runtime_main({"session_id": session_id} if session_id else None):
+        resp = call_llm(
+            task="goal_judge",
+            messages=[{"role": "system", "content": system_prompt}, {"role": "user", "content": user_prompt}],
+            temperature=0, max_tokens=_goal_judge_max_tokens(), timeout=timeout,
+        )
     try:
         return resp.choices[0].message.content or ""
     except Exception:
@@ -872,6 +884,7 @@ def judge_goal(
     last_response: str,
     *,
     timeout: Optional[float] = None,
+    session_id: Optional[str] = None,
     subgoals: Optional[List[str]] = None,
     background_processes: Optional[List[Dict[str, Any]]] = None,
     contract: Optional[GoalContract] = None,
@@ -918,7 +931,7 @@ def judge_goal(
         prompt = JUDGE_USER_PROMPT_TEMPLATE.format(**common)
 
     try:
-        raw = _call_goal_judge_llm(call_llm, JUDGE_SYSTEM_PROMPT, prompt, timeout)
+        raw = _call_goal_judge_llm(call_llm, JUDGE_SYSTEM_PROMPT, prompt, timeout, session_id=session_id)
     except Exception as exc:
         logger.info("goal judge: API call failed (%s) — falling through to continue", exc)
         return "continue", f"judge error: {type(exc).__name__}", False, None, True
@@ -1011,7 +1024,8 @@ def gather_background_processes(task_id: Optional[str] = None, *, owner_task_id:
     return running
 
 
-def draft_contract(objective: str, *, timeout: Optional[float] = None) -> Optional[GoalContract]:
+def draft_contract(objective: str, *, timeout: Optional[float] = None,
+                   session_id: Optional[str] = None) -> Optional[GoalContract]:
     """Expand a plain-language objective into a completion contract via the ``goal_judge`` auxiliary
     task (a side LLM call, not a conversation turn). None when unavailable or unparseable."""
     objective = (objective or "").strip()
@@ -1030,7 +1044,7 @@ def draft_contract(objective: str, *, timeout: Optional[float] = None) -> Option
         return None
 
     try:
-        raw = _call_goal_judge_llm(call_llm, DRAFT_CONTRACT_SYSTEM_PROMPT, f"Objective:\n{_truncate(objective, 4000)}", timeout)
+        raw = _call_goal_judge_llm(call_llm, DRAFT_CONTRACT_SYSTEM_PROMPT, f"Objective:\n{_truncate(objective, 4000)}", timeout, session_id=session_id)
     except Exception as exc:
         logger.info("goal draft: API call failed (%s)", exc)
         return None
@@ -1462,7 +1476,8 @@ class GoalManager:
             return gate_decision
 
         verdict, reason, parse_failed, wait_directive, transport_failed = judge_goal(
-            state.goal, last_response, subgoals=state.subgoals or None, background_processes=background_processes,
+            state.goal, last_response, session_id=self.session_id,
+            subgoals=state.subgoals or None, background_processes=background_processes,
             contract=state.contract if state.has_contract() else None, active_delegations=active_delegations,
         )
         state.last_verdict = verdict

--- a/hermes_cli/loops.py
+++ b/hermes_cli/loops.py
@@ -558,7 +558,7 @@ class LoopManager:
             try:
                 from hermes_cli.goals import judge_goal
 
-                verdict, reason, _pf, _wait, _tf = judge_goal(s.until, last_response)
+                verdict, reason, _pf, _wait, _tf = judge_goal(s.until, last_response, session_id=self.session_id)
             except Exception as exc:
                 verdict, reason = "continue", f"judge unavailable: {type(exc).__name__}"
             if verdict == "done":

--- a/tests/agent/test_opencode_session_affinity.py
+++ b/tests/agent/test_opencode_session_affinity.py
@@ -60,3 +60,23 @@ def test_auxiliary_calls_share_the_main_turn_session_key():
         assert "x-opencode-session" not in (other.get("extra_headers") or {})
     finally:
         aux._RUNTIME_MAIN_CONTEXT.reset(token)
+
+
+def test_scoped_runtime_main_keeps_the_session_key():
+    """Post-turn callers re-bind a finished turn's session so their auxiliary calls stay on the same
+    relay backend. Regression: ``session_id`` was missing from ``_MAIN_RUNTIME_CONTEXT_FIELDS``, so
+    ``_normalize_main_runtime`` dropped it and every scoped call went out without the header."""
+    with aux.scoped_runtime_main({"session_id": "sess-affinity-1"}):
+        kwargs = aux._build_call_kwargs("opencode-go", "glm-5", _MSGS, base_url="https://opencode.ai/zen/go/v1")
+        assert kwargs["extra_headers"]["x-opencode-session"] == "sess-affinity-1"
+
+
+def test_a_call_with_no_runtime_at_all_still_sends_the_header():
+    """Callers with no session to re-bind (the kanban/loop judges) must still satisfy the relay:
+    a missing header is a hard 400, a stable per-process fallback key is not."""
+    from agent.opencode_affinity import _FALLBACK_SESSION_KEY
+
+    aux.clear_runtime_main()
+    kwargs = aux._build_call_kwargs("opencode-go", "glm-5", _MSGS, base_url="https://opencode.ai/zen/go/v1")
+    assert kwargs["extra_headers"]["x-opencode-session"] == _FALLBACK_SESSION_KEY
+    assert _FALLBACK_SESSION_KEY  # never empty — an empty key still 400s

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -96,6 +96,42 @@ class TestJudgeGoal:
         assert verdict == "done"
         assert reason == "achieved"
 
+    def test_judge_rebinds_the_session_scope_for_its_aux_call(self):
+        """The judge runs *after* the turn tore its runtime context down. Without an explicit
+        re-bind the auxiliary call carries no session id, the OpenCode relay answers 400
+        MissingSessionID, and the goal parks after 7 transport failures."""
+        from hermes_cli import goals
+        from agent.auxiliary_client import _runtime_main_value
+
+        seen = {}
+
+        def _capture(**_kwargs):
+            seen["session_id"] = _runtime_main_value("session_id")
+            return MagicMock(choices=[MagicMock(message=MagicMock(content='{"done": true, "reason": "ok"}'))])
+
+        with patch("agent.auxiliary_client.call_llm", side_effect=_capture):
+            goals.judge_goal("goal", "agent response", session_id="sess-judge-1")
+
+        assert seen["session_id"] == "sess-judge-1"
+
+    def test_judge_without_a_session_leaves_the_scope_alone(self):
+        """Callers with no session of their own (kanban/loop judges) must not invent one —
+        agent.opencode_affinity supplies its own fallback key instead."""
+        from hermes_cli import goals
+        from agent import auxiliary_client as aux
+
+        seen = {}
+
+        def _capture(**_kwargs):
+            seen["session_id"] = aux._runtime_main_value("session_id")
+            return MagicMock(choices=[MagicMock(message=MagicMock(content='{"done": true, "reason": "ok"}'))])
+
+        aux.clear_runtime_main()
+        with patch("agent.auxiliary_client.call_llm", side_effect=_capture):
+            goals.judge_goal("goal", "agent response")
+
+        assert seen["session_id"] == ""
+
 
 # ──────────────────────────────────────────────────────────────────────
 # GoalManager lifecycle + persistence


### PR DESCRIPTION
# Post-turn auxiliary calls lose the OpenCode session header → every `/goal` parks

## Summary

On the OpenCode relay, an auxiliary request without `x-opencode-session` is rejected
outright (`HTTP 400 MissingSessionID`). The goal judge runs *after* the turn tore its
runtime context down, so it had no session to derive the header from. Result: every
judge call failed, the goal auto-paused after 7 consecutive transport failures, and
`/goal resume` parked again on the next turn. A goal could never be judged complete.

Two defects, both fixed here.

## Defect 1 — a scoped runtime silently drops `session_id`

`set_runtime_main()` stores `session_id`/`cache_scope` in the context-local runtime dict,
but `_MAIN_RUNTIME_CONTEXT_FIELDS` did not list them, so `_normalize_main_runtime()`
stripped them from any *explicitly scoped* bind:

```python
_MAIN_RUNTIME_FIELDS = ("provider", "model", "base_url", "api_key", "api_mode", "auth_mode")
_MAIN_RUNTIME_CONTEXT_FIELDS = _MAIN_RUNTIME_FIELDS + ("requested_provider",)
```

```console
$ python -c "from agent.auxiliary_client import _normalize_main_runtime as n; print(n({'session_id':'x'}))"
{}                                  # pre-fix
{'session_id': 'x'}                 # post-fix
```

That is exactly why main turns worked and post-turn calls did not: the turn path calls
`set_runtime_main(...)`, everything else has to re-bind via `scoped_runtime_main(...)`,
and that path threw the session away.

The two fields stay out of the legacy mirrors (`_MAIN_RUNTIME_FIELDS`) on purpose —
those globals are shared across concurrent gateway sessions.

## Defect 2 — the judge was never given the session

`judge_goal()` had no `session_id` parameter, so even a correct scope could not be built.
It now accepts one and re-binds it around the auxiliary call. `GoalManager` (via
`self.session_id`), `LoopManager` (the `/loop` `--until` judge) and `draft_contract()`
pass theirs.

`agent/opencode_affinity.py` also falls back to a stable per-process key for callers that
genuinely have no session (the kanban judge). An absent header is a hard 400; a
per-process key only costs relay affinity for those side calls. If a reviewer would
rather keep the blast radius to the goal path, that part is an isolated hunk and can be
dropped — the goal judge is fixed by defects 1 + 2 alone.

## Reproduction

Needs a reachable OpenCode relay and a key:

```console
$ python - <<'PY'
import agent.opencode_affinity as oa
oa._FALLBACK_SESSION_KEY = ""            # isolate: only the scope may supply the header
from agent.auxiliary_client import call_llm
from hermes_cli import goals
msgs = 'Reply exactly: {"verdict":"done","reason":"ok"}'

print(goals._call_goal_judge_llm(call_llm, "judge", msgs, 60.0, session_id="sess-1"))
PY
```

```console
pre-fix:  Error code: 400 - {'type': 'error', 'error': {'type': 'MissingSessionID', ...}}
post-fix: {"verdict":"done","reason":"ok"}
```

The same call *without* `session_id` still 400s post-fix, which confirms the fallback —
not the scope — is what covers the session-less callers.

## Tests

`scripts/run_tests.sh tests/agent/test_opencode_session_affinity.py tests/hermes_cli/test_goals.py`

```
tests/agent/test_opencode_session_affinity.py   8 passed  (2 new)
tests/hermes_cli/test_goals.py                 42 passed  (2 new)
2 files, 50 tests passed, 0 failed
```

New coverage: a scoped runtime must survive normalization and reach the header; a call
with no runtime at all must still send one; `judge_goal(session_id=...)` must expose that
session to `call_llm`; and a session-less caller must leave the scope untouched rather
than invent a session.

Note for reviewers: `tests/gateway/test_goal_*.py` cannot run in this environment — the
venv here has no `pytest_asyncio`, so the async gateway goal tests error out
(`PytestUnknownMarkWarning: Unknown pytest.mark.asyncio`). The failure set is identical on
an untouched `origin/main` checkout: 16 failed across 6 files, same names, same counts.
Pre-existing and unrelated to this change.
