### PR TITLE
fix(gateway): recover secondary profiles after secret helper failures

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -114,6 +114,10 @@ def _hydrate_profile_secret_sources(home: Path) -> dict[str, str]:
     if home_key in _APPLIED_HOMES:
         return get_secret_source_values(home)
 
+    # A retry must not keep serving a partial result after the source is removed, disabled, or can no
+    # longer be evaluated. Publish only the snapshot established by this attempt.
+    _SECRET_SOURCE_VALUES_BY_HOME.pop(home_key, None)
+
     try:
         cfg = _load_secrets_config(home)
     except Exception:  # noqa: BLE001 — external sources must not block routing

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -155,8 +155,7 @@ def _hydrate_profile_secret_sources(home: Path) -> dict[str, str]:
             continue
         _SECRET_SOURCES[name] = applied.source
         values[name] = value
-    if values:
-        _SECRET_SOURCE_VALUES_BY_HOME[home_key] = values
+    _SECRET_SOURCE_VALUES_BY_HOME[home_key] = values
     return dict(values)
 
 

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -143,7 +143,11 @@ def _hydrate_profile_secret_sources(home: Path) -> dict[str, str]:
     if not report.sources:
         return {}
 
-    _APPLIED_HOMES.add(home_key)
+    # Routed profiles have no runtime reset path. Keep a failed source retryable so correcting its
+    # profile-local bootstrap credentials takes effect on the next turn; successful sources from a
+    # mixed report are still snapshotted below and can be used while the failed source recovers.
+    if all(src.result.ok for src in report.sources):
+        _APPLIED_HOMES.add(home_key)
     values: dict[str, str] = {}
     for name, applied in report.provenance.items():
         value = local_env.get(name)

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -325,6 +325,58 @@ def test_cold_profile_hydration_dotenv_wins_over_op_env(tmp_path, monkeypatch):
     assert seen_env.get("OP_SERVICE_ACCOUNT_TOKEN") == "ops_from-dotenv"
 
 
+def test_cold_profile_hydration_retries_failed_source(tmp_path, monkeypatch):
+    """A failed routed-profile fetch must not make its empty snapshot process-lifetime state."""
+    from agent.secret_sources.base import ErrorKind, FetchResult
+    from agent.secret_sources.registry import AppliedVar, ApplyReport, SourceReport
+    from agent.secret_sources import registry as reg_module
+
+    (tmp_path / "config.yaml").write_text(
+        "secrets:\n  command:\n    enabled: true\n", encoding="utf-8"
+    )
+    attempts = 0
+
+    def _apply_after_credentials_are_fixed(_cfg, _home_path, environ=None):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            failed = FetchResult().fail("helper exited 1", ErrorKind.AUTH_FAILED)
+            return ApplyReport(
+                sources=[SourceReport(name="command", label="command", result=failed)]
+            )
+
+        environ["OPENAI_API_KEY"] = "recovered-key"
+        return ApplyReport(
+            sources=[
+                SourceReport(
+                    name="command",
+                    label="command",
+                    result=FetchResult(secrets={"OPENAI_API_KEY": "recovered-key"}),
+                    applied=["OPENAI_API_KEY"],
+                )
+            ],
+            provenance={
+                "OPENAI_API_KEY": AppliedVar(
+                    name="OPENAI_API_KEY",
+                    source="command",
+                    shape="bulk",
+                    overrode_env=False,
+                )
+            },
+        )
+
+    monkeypatch.setattr(reg_module, "apply_all", _apply_after_credentials_are_fixed)
+
+    assert env_loader.hydrate_profile_secret_sources(tmp_path) == {}
+    assert env_loader.hydrate_profile_secret_sources(tmp_path) == {
+        "OPENAI_API_KEY": "recovered-key"
+    }
+    assert env_loader.hydrate_profile_secret_sources(tmp_path) == {
+        "OPENAI_API_KEY": "recovered-key"
+    }
+    assert attempts == 2
+
+
 def test_apply_external_secret_sources_noop_when_disabled(tmp_path, monkeypatch):
     """Disabled Bitwarden config must not touch the source map."""
 

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -377,6 +377,64 @@ def test_cold_profile_hydration_retries_failed_source(tmp_path, monkeypatch):
     assert attempts == 2
 
 
+def test_cold_profile_hydration_replaces_partial_snapshot_after_failed_retry(
+    tmp_path, monkeypatch
+):
+    """Each retry replaces the prior profile snapshot, including with an empty result."""
+    from agent.secret_sources.base import ErrorKind, FetchResult
+    from agent.secret_sources.registry import AppliedVar, ApplyReport, SourceReport
+    from agent.secret_sources import registry as reg_module
+
+    (tmp_path / "config.yaml").write_text(
+        "secrets:\n  command:\n    enabled: true\n", encoding="utf-8"
+    )
+    attempts = 0
+
+    def _apply_with_stale_partial_value(_cfg, _home_path, environ=None):
+        nonlocal attempts
+        attempts += 1
+        failed = FetchResult().fail("helper exited 1", ErrorKind.AUTH_FAILED)
+        if attempts == 1:
+            environ["OPENAI_API_KEY"] = "first-value"
+            return ApplyReport(
+                sources=[
+                    SourceReport(
+                        name="onepassword",
+                        label="1Password",
+                        result=FetchResult(secrets={"OPENAI_API_KEY": "first-value"}),
+                        applied=["OPENAI_API_KEY"],
+                    ),
+                    SourceReport(name="command", label="command", result=failed),
+                ],
+                provenance={
+                    "OPENAI_API_KEY": AppliedVar(
+                        name="OPENAI_API_KEY",
+                        source="onepassword",
+                        shape="bulk",
+                        overrode_env=False,
+                    )
+                },
+            )
+        return ApplyReport(
+            sources=[
+                SourceReport(name="onepassword", label="1Password", result=failed),
+                SourceReport(name="command", label="command", result=failed),
+            ]
+        )
+
+    monkeypatch.setattr(reg_module, "apply_all", _apply_with_stale_partial_value)
+
+    assert env_loader.hydrate_profile_secret_sources(tmp_path) == {
+        "OPENAI_API_KEY": "first-value"
+    }
+    assert env_loader.get_secret_source_values(tmp_path) == {
+        "OPENAI_API_KEY": "first-value"
+    }
+    assert env_loader.hydrate_profile_secret_sources(tmp_path) == {}
+    assert env_loader.get_secret_source_values(tmp_path) == {}
+    assert attempts == 2
+
+
 def test_apply_external_secret_sources_noop_when_disabled(tmp_path, monkeypatch):
     """Disabled Bitwarden config must not touch the source map."""
 

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -435,6 +435,57 @@ def test_cold_profile_hydration_replaces_partial_snapshot_after_failed_retry(
     assert attempts == 2
 
 
+def test_cold_profile_hydration_clears_partial_snapshot_when_sources_are_removed(
+    tmp_path, monkeypatch
+):
+    """Removing secret sources during a retry must revoke values from a partial snapshot."""
+    from agent.secret_scope import build_profile_secret_scope
+    from agent.secret_sources.base import ErrorKind, FetchResult
+    from agent.secret_sources.registry import AppliedVar, ApplyReport, SourceReport
+    from agent.secret_sources import registry as reg_module
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "secrets:\n  command:\n    enabled: true\n", encoding="utf-8"
+    )
+    failed = FetchResult().fail("helper exited 1", ErrorKind.AUTH_FAILED)
+
+    def _apply_partial_result(_cfg, _home_path, environ=None):
+        environ["OPENAI_API_KEY"] = "partial-key"
+        return ApplyReport(
+            sources=[
+                SourceReport(
+                    name="onepassword",
+                    label="1Password",
+                    result=FetchResult(secrets={"OPENAI_API_KEY": "partial-key"}),
+                    applied=["OPENAI_API_KEY"],
+                ),
+                SourceReport(name="command", label="command", result=failed),
+            ],
+            provenance={
+                "OPENAI_API_KEY": AppliedVar(
+                    name="OPENAI_API_KEY",
+                    source="onepassword",
+                    shape="bulk",
+                    overrode_env=False,
+                )
+            },
+        )
+
+    monkeypatch.setattr(reg_module, "apply_all", _apply_partial_result)
+
+    assert env_loader.hydrate_profile_secret_sources(tmp_path) == {
+        "OPENAI_API_KEY": "partial-key"
+    }
+    assert build_profile_secret_scope(tmp_path)["OPENAI_API_KEY"] == "partial-key"
+
+    config_path.write_text("{}\n", encoding="utf-8")
+
+    assert env_loader.hydrate_profile_secret_sources(tmp_path) == {}
+    assert env_loader.get_secret_source_values(tmp_path) == {}
+    assert "OPENAI_API_KEY" not in build_profile_secret_scope(tmp_path)
+
+
 def test_apply_external_secret_sources_noop_when_disabled(tmp_path, monkeypatch):
     """Disabled Bitwarden config must not touch the source map."""
 


### PR DESCRIPTION
## What does this PR do?

Multiplex gateways can now recover a secondary profile on the next turn after its external secret helper fails and the operator fixes the profile-local bootstrap credentials. Failed routed-profile hydration remains retryable, while successful hydration keeps the existing once-per-home deduplication.

### Symptom

A secondary profile whose `secrets.command` helper fails on its first routed turn keeps an empty external-secret snapshot for the gateway process lifetime. Correcting that profile's `.env` does not restore its provider key, so subsequent turns continue failing authentication until the gateway restarts.

### Impact

Long-running multiplex gateways cannot recover an affected secondary profile without a process restart. Provider requests for that profile continue without the externally resolved key and fail with authentication errors.

### Bug Cause

**Trigger:** `hermes_cli/env_loader.py:146` in `_hydrate_profile_secret_sources`, after an enabled external source returns an error.

**Causal chain:**
1. A routed secondary profile invokes an external secret helper before its profile-local bootstrap credentials are valid.
2. `apply_all` reports the failed source with no applied values, but `_hydrate_profile_secret_sources` still adds the profile home to `_APPLIED_HOMES`.
3. Later turns return the cached empty snapshot without re-running the helper, even after the credentials are corrected.

**Why it is wrong:** The routed-profile path has no runtime cache-reset entry point, so treating a failed fetch as completed turns a recoverable configuration error into process-lifetime state.

**Working sibling / contrast:** Config parsing failures, missing source configuration, and calls with no enabled source already return before `_APPLIED_HOMES` is updated, so those conditions remain retryable.

**Ruled out:** The profile secret-scope builder is not dropping a successfully hydrated value. An explicit `reset_secret_source_cache()` restores hydration, which isolates the defect to the applied-home cache decision.

### Fix

Only mark routed-profile hydration complete when every attempted source reports success. A mixed result still snapshots and returns values from successful sources, while leaving the profile retryable so failed sources can recover on a later turn. Each retry replaces the prior per-profile snapshot, including with an empty result, so credentials from an earlier partial success cannot remain active after every source fails. The regression tests cover failed-to-successful recovery, deduplication after success, and stale partial-snapshot clearing.

## Related Issue

Fixes #108441

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/env_loader.py` - keep routed-profile source failures retryable without discarding successful values.
- `tests/test_env_loader_secret_sources.py` - verify failed hydration retries, recovers, deduplicates, and clears stale partial snapshots.

## How to Test

1. Run the focused secret-source loader tests:

```bash
scripts/run_tests.sh tests/test_env_loader_secret_sources.py
```

2. Confirmed: the new regression test fails on `main`, while this branch passes all 24 tests in the file.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/test_env_loader_secret_sources.py` and all 24 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)

### Documentation & Housekeeping

- [x] Documentation update is N/A; this changes recovery behavior without changing configuration or user-facing APIs.
- [x] `cli-config.yaml.example` update is N/A; no config keys changed.
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no architecture or workflow changed.
- [x] I've considered cross-platform impact; the cache decision and test are host-independent.
- [x] Tool description/schema updates are N/A; no tool schema changed.
