### PR TITLE
fix(dashboard): let touch devices scroll the chat transcript

### DIFF
--- a/web/src/components/HermesConsoleModal.tsx
+++ b/web/src/components/HermesConsoleModal.tsx
@@ -13,6 +13,7 @@ import { useProfileScope } from "@/contexts/useProfileScope";
 import { api } from "@/lib/api";
 import { maybeReloadForLoopbackWsAuthFailure } from "@/lib/dashboard-auth-reload";
 import { cn, themedBody } from "@/lib/utils";
+import { attachXtermTouchScroll } from "@/lib/xterm-touch-scroll";
 import { useTheme } from "@/themes";
 
 type ConsoleFrame =
@@ -368,6 +369,7 @@ export function HermesConsoleModal({ open, onClose }: HermesConsoleModalProps) {
     term.unicode.activeVersion = "11";
     term.loadAddon(new WebLinksAddon());
     term.open(host);
+    const touchScrollDisposable = attachXtermTouchScroll(term, host);
     term.focus();
 
     const fitTerminal = () => {
@@ -449,6 +451,7 @@ export function HermesConsoleModal({ open, onClose }: HermesConsoleModalProps) {
     return () => {
       cancelled = true;
       dataDisposable.dispose();
+      touchScrollDisposable.dispose();
       ro.disconnect();
       if (resizeFrame) cancelAnimationFrame(resizeFrame);
       wsRef.current?.close();

--- a/web/src/lib/xterm-touch-scroll.test.ts
+++ b/web/src/lib/xterm-touch-scroll.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  decayMomentum,
+  DEFAULT_SCROLL_GAIN,
+  MOMENTUM_STOP_VELOCITY_PX_PER_MS,
+  resolveScrollGain,
+  TouchScrollAccumulator,
+} from "./xterm-touch-scroll";
+
+describe("TouchScrollAccumulator", () => {
+  it("keeps sub-line travel instead of rounding it away", () => {
+    const acc = new TouchScrollAccumulator(20);
+    expect(acc.push(6)).toBe(0);
+    expect(acc.push(6)).toBe(0);
+    expect(acc.push(6)).toBe(0);
+    // 18px of travel so far: still short of one 20px line.
+    expect(acc.push(6)).toBe(1);
+  });
+
+  it("returns whole lines for a long drag and carries the remainder", () => {
+    const acc = new TouchScrollAccumulator(10);
+    expect(acc.push(95)).toBe(9);
+    expect(acc.push(5)).toBe(1);
+  });
+
+  it("scrolls backwards for upward finger travel", () => {
+    const acc = new TouchScrollAccumulator(20);
+    expect(acc.push(-45)).toBe(-2);
+    expect(acc.push(-15)).toBe(-1);
+  });
+
+  it("ignores zero and non-finite travel", () => {
+    const acc = new TouchScrollAccumulator(20);
+    expect(acc.push(0)).toBe(0);
+    expect(acc.push(Number.NaN)).toBe(0);
+    expect(acc.push(Number.POSITIVE_INFINITY)).toBe(0);
+  });
+
+  it("falls back to a 1px line height rather than dividing by zero", () => {
+    const acc = new TouchScrollAccumulator(0);
+    expect(acc.push(3)).toBe(3);
+  });
+
+  it("reset() drops the leftover remainder", () => {
+    const acc = new TouchScrollAccumulator(20);
+    acc.push(19);
+    acc.reset();
+    expect(acc.push(2)).toBe(0);
+  });
+});
+
+describe("decayMomentum", () => {
+  it("decays over time and reaches a stop threshold", () => {
+    let v = 1;
+    for (let i = 0; i < 200; i += 1) {
+      v = decayMomentum(v, 16);
+    }
+    expect(Math.abs(v)).toBeLessThan(MOMENTUM_STOP_VELOCITY_PX_PER_MS);
+  });
+
+  it("leaves speed untouched when no time passed", () => {
+    expect(decayMomentum(0.5, 0)).toBe(0.5);
+  });
+
+  it("glides for a noticeable stretch after a flick", () => {
+    // Half of the release speed should still be there ~170 ms later, so a
+    // flick keeps travelling instead of stopping dead under the finger.
+    const after170ms = decayMomentum(1, 170);
+    expect(after170ms).toBeGreaterThan(0.45);
+    expect(after170ms).toBeLessThan(0.55);
+  });
+});
+
+describe("resolveScrollGain", () => {
+  it("defaults to a faster-than-finger gain", () => {
+    expect(resolveScrollGain(undefined)).toBe(DEFAULT_SCROLL_GAIN);
+    expect(DEFAULT_SCROLL_GAIN).toBeGreaterThan(1);
+  });
+
+  it("honours an explicit gain, including exact 1:1 tracking", () => {
+    expect(resolveScrollGain(1)).toBe(1);
+    expect(resolveScrollGain(2.25)).toBe(2.25);
+  });
+
+  it("rejects nonsense gains", () => {
+    expect(resolveScrollGain(0)).toBe(DEFAULT_SCROLL_GAIN);
+    expect(resolveScrollGain(-3)).toBe(DEFAULT_SCROLL_GAIN);
+    expect(resolveScrollGain(Number.NaN)).toBe(DEFAULT_SCROLL_GAIN);
+  });
+});
+
+describe("gain applied to travel", () => {
+  it("scales finger travel before quantising to whole lines", () => {
+    const acc = new TouchScrollAccumulator(18);
+    // The tablet case measured at 18px rows: a 130px drag used to scroll 7
+    // lines at 1:1; with the default gain it moves 13.
+    expect(acc.push(130 * DEFAULT_SCROLL_GAIN)).toBe(13);
+    // 234px = 13 lines exactly, so the next push starts from a clean slate.
+    expect(acc.push(65 * DEFAULT_SCROLL_GAIN)).toBe(6);
+  });
+});

--- a/web/src/lib/xterm-touch-scroll.ts
+++ b/web/src/lib/xterm-touch-scroll.ts
@@ -1,0 +1,356 @@
+/**
+ * Finger-drag scrolling for the dashboard's xterm-based chat transcript.
+ *
+ * xterm.js paints its text into `.xterm-screen`, which — since xterm 6 — is a
+ * sibling of the legacy `.xterm-viewport` node and sits *on top* of it. The
+ * real scroll position lives in xterm's own VS Code-derived ScrollableElement,
+ * which only listens for wheel events. So on a tablet a finger drag over the
+ * transcript reaches no native scroller at all: the only way to move the
+ * backlog was to grab the thin scrollbar on the right edge, while a mouse
+ * wheel worked because ChatPage maps wheel deltas onto `term.scrollLines()`.
+ *
+ * This module gives touch the same treatment: a one-finger vertical drag is
+ * translated into terminal lines (at a slight gain, because line-quantised
+ * text feels sluggish at exact 1:1), and a flick releases into a ~0.55 s
+ * momentum glide. Taps, long-presses (text selection) and two-finger gestures
+ * (pinch-zoom) are deliberately left alone — nothing is consumed until the
+ * pointer has travelled far enough to be unambiguously a vertical scroll, and
+ * drags that start on the scrollbar are left to xterm's own scrollbar.
+ */
+
+import type { Terminal } from "@xterm/xterm";
+
+/** Finger travel (px) before a touch becomes a scroll instead of a tap. */
+export const DRAG_START_THRESHOLD_PX = 6;
+/**
+ * How far the transcript moves per pixel of finger travel. 1 = exact
+ * tracking; line-quantised text reads as "dragging through treacle" at 1:1,
+ * and 1.8 is where a tablet stops feeling like the text lags behind the
+ * finger. Pass `gain: 1` for exact tracking.
+ */
+export const DEFAULT_SCROLL_GAIN = 1.8;
+/** Minimum release speed (px/ms) that turns into a momentum scroll. */
+export const FLICK_MIN_VELOCITY_PX_PER_MS = 0.08;
+/** Momentum decay per millisecond (≈0.94 per 16 ms frame ⇒ ~0.55 s glide). */
+export const MOMENTUM_DECAY_PER_MS = 0.996;
+/** Speed (px/ms) below which momentum stops. */
+export const MOMENTUM_STOP_VELOCITY_PX_PER_MS = 0.015;
+/** Rolling window (ms) used to estimate release velocity. */
+export const VELOCITY_WINDOW_MS = 90;
+/** Touch points closer than this to the right edge belong to the scrollbar. */
+const SCROLLBAR_SLACK_PX = 4;
+
+/**
+ * Turns pixel travel into whole terminal lines, keeping the sub-line remainder
+ * so that slow drags still advance instead of being rounded away.
+ */
+export class TouchScrollAccumulator {
+  private residual = 0;
+  private lineHeight: number;
+
+  constructor(lineHeightPx: number) {
+    this.lineHeight = lineHeightPx > 0 ? lineHeightPx : 1;
+  }
+
+  setLineHeight(lineHeightPx: number): void {
+    this.lineHeight = lineHeightPx > 0 ? lineHeightPx : 1;
+  }
+
+  reset(): void {
+    this.residual = 0;
+  }
+
+  /**
+   * Feed finger travel. Positive = the finger moved up, so the transcript
+   * should move towards newer output. Returns whole lines to scroll now.
+   */
+  push(deltaPx: number): number {
+    if (!Number.isFinite(deltaPx) || deltaPx === 0) {
+      return 0;
+    }
+    this.residual += deltaPx;
+    const lines = Math.trunc(this.residual / this.lineHeight);
+    if (lines !== 0) {
+      this.residual -= lines * this.lineHeight;
+    }
+    return lines;
+  }
+}
+
+/** Speed of the next momentum frame, decayed by the elapsed time. */
+export function decayMomentum(
+  velocityPxPerMs: number,
+  dtMs: number,
+  decayPerMs: number = MOMENTUM_DECAY_PER_MS,
+): number {
+  if (!(dtMs > 0)) {
+    return velocityPxPerMs;
+  }
+  return velocityPxPerMs * Math.pow(decayPerMs, dtMs);
+}
+
+/** Coerce a caller-supplied gain into a usable value (falls back to 1.5). */
+export function resolveScrollGain(gain?: number): number {
+  return typeof gain === "number" && Number.isFinite(gain) && gain > 0
+    ? gain
+    : DEFAULT_SCROLL_GAIN;
+}
+
+/** True when the touch landed on xterm's own scrollbar / right edge gutter. */
+export function isScrollbarTouch(
+  host: HTMLElement,
+  clientX: number,
+): boolean {
+  const screen = host.querySelector<HTMLElement>(".xterm-screen");
+  if (!screen) {
+    return false;
+  }
+  const rect = screen.getBoundingClientRect();
+  if (rect.width <= 0) {
+    return false;
+  }
+  return clientX >= rect.right - SCROLLBAR_SLACK_PX;
+}
+
+export interface XtermTouchScrollHandle {
+  dispose(): void;
+}
+
+export interface XtermTouchScrollOptions {
+  /** Override the measured cell height, e.g. for tests. */
+  lineHeightPx?: () => number;
+  /**
+   * Transcript pixels per finger pixel (default {@link DEFAULT_SCROLL_GAIN}).
+   * Raise it for a faster feel, set 1 for exact 1:1 tracking.
+   */
+  gain?: number;
+}
+
+/**
+ * Wire finger-drag scrolling onto an opened xterm terminal. Attach to the
+ * container element that holds the terminal (events bubble up from the
+ * screen), and dispose it together with the terminal.
+ */
+export function attachXtermTouchScroll(
+  term: Terminal,
+  host: HTMLElement,
+  options: XtermTouchScrollOptions = {},
+): XtermTouchScrollHandle {
+  const measureLineHeight = (): number => {
+    if (options.lineHeightPx) {
+      return options.lineHeightPx();
+    }
+    // The DOM renderer sizes every row element to the cell height the terminal
+    // itself scrolls by — the most faithful pixel-per-line source when it is
+    // available (the canvas/WebGL renderers do not emit row elements).
+    const row = host.querySelector<HTMLElement>(".xterm-rows > div");
+    const rowHeight = row?.getBoundingClientRect().height ?? 0;
+    if (rowHeight > 0) {
+      return rowHeight;
+    }
+    const rows = term.rows > 0 ? term.rows : 1;
+    const screen = host.querySelector<HTMLElement>(".xterm-screen");
+    const height = screen?.getBoundingClientRect().height ?? 0;
+    return height > 0 ? height / rows : 0;
+  };
+
+  const lines = new TouchScrollAccumulator(measureLineHeight());
+  const gain = resolveScrollGain(options.gain);
+  let identifier: number | null = null;
+  let active = false;
+  let dragging = false;
+  let startX = 0;
+  let startY = 0;
+  let lastY = 0;
+  let samples: { t: number; y: number }[] = [];
+  let velocity = 0;
+  let momentum = 0;
+  let rafId = 0;
+  let lastFrameT = 0;
+
+  const scrollByLines = (count: number): void => {
+    if (count !== 0) {
+      term.scrollLines(count);
+    }
+  };
+
+  /** Feed finger travel through the gain, hand whole lines to xterm. */
+  const pushTravel = (deltaPx: number): void => {
+    scrollByLines(lines.push(deltaPx * gain));
+  };
+
+  const stopMomentum = (): void => {
+    if (rafId) {
+      cancelAnimationFrame(rafId);
+      rafId = 0;
+    }
+    momentum = 0;
+  };
+
+  const momentumFrame = (timeStamp: number): void => {
+    const dt = lastFrameT > 0 ? Math.min(48, timeStamp - lastFrameT) : 16;
+    lastFrameT = timeStamp;
+    pushTravel(momentum * dt);
+    momentum = decayMomentum(momentum, dt);
+    if (Math.abs(momentum) <= MOMENTUM_STOP_VELOCITY_PX_PER_MS) {
+      rafId = 0;
+      momentum = 0;
+      return;
+    }
+    rafId = requestAnimationFrame(momentumFrame);
+  };
+
+  const startMomentum = (v: number): void => {
+    stopMomentum();
+    if (Math.abs(v) < FLICK_MIN_VELOCITY_PX_PER_MS) {
+      lines.reset();
+      return;
+    }
+    momentum = v;
+    lastFrameT = 0;
+    rafId = requestAnimationFrame(momentumFrame);
+  };
+
+  const endGesture = (withMomentum: boolean): void => {
+    const wasDragging = dragging;
+    const releaseVelocity = velocity;
+    active = false;
+    dragging = false;
+    identifier = null;
+    samples = [];
+    velocity = 0;
+    if (wasDragging && withMomentum) {
+      startMomentum(releaseVelocity);
+    } else {
+      stopMomentum();
+      lines.reset();
+    }
+  };
+
+  const touchById = (
+    touches: TouchList,
+    id: number | null,
+  ): Touch | null => {
+    if (id === null) {
+      return null;
+    }
+    for (let i = 0; i < touches.length; i += 1) {
+      const touch = touches.item(i);
+      if (touch && touch.identifier === id) {
+        return touch;
+      }
+    }
+    return null;
+  };
+
+  const onTouchStart = (event: TouchEvent): void => {
+    // A new finger cancels any in-flight flick so the transcript stops where
+    // the user put it.
+    stopMomentum();
+    active = false;
+    dragging = false;
+    identifier = null;
+    velocity = 0;
+    samples = [];
+    if (event.touches.length !== 1) {
+      // Pinch-zoom / multi-finger gestures are not ours to consume.
+      return;
+    }
+    const touch = event.touches[0];
+    if (!touch || isScrollbarTouch(host, touch.clientX)) {
+      return;
+    }
+    identifier = touch.identifier;
+    active = true;
+    startX = touch.clientX;
+    startY = touch.clientY;
+    lastY = touch.clientY;
+    samples = [{ t: event.timeStamp || performance.now(), y: touch.clientY }];
+    lines.setLineHeight(measureLineHeight());
+    lines.reset();
+  };
+
+  const onTouchMove = (event: TouchEvent): void => {
+    if (!active) {
+      return;
+    }
+    if (event.touches.length > 1) {
+      // Escalate to the browser (pinch-zoom); we must not have swallowed the
+      // gesture, and by now we may have — so stop scrolling and bail out.
+      active = false;
+      dragging = false;
+      identifier = null;
+      lines.reset();
+      return;
+    }
+    const touch = touchById(event.touches, identifier);
+    if (!touch) {
+      return;
+    }
+    const y = touch.clientY;
+    if (!dragging) {
+      const travelY = startY - y;
+      if (Math.abs(travelY) < DRAG_START_THRESHOLD_PX) {
+        // Still a candidate tap / long-press: don't consume the event.
+        return;
+      }
+      if (Math.abs(travelY) < Math.abs(startX - touch.clientX)) {
+        // Horizontal intent (selection drag, page gesture) — not ours.
+        active = false;
+        identifier = null;
+        return;
+      }
+      dragging = true;
+      lines.reset();
+    }
+    const deltaPx = lastY - y;
+    lastY = y;
+    event.preventDefault();
+    pushTravel(deltaPx);
+
+    const timeStamp = event.timeStamp || performance.now();
+    samples.push({ t: timeStamp, y });
+    while (samples.length > 2 && timeStamp - samples[0].t > VELOCITY_WINDOW_MS) {
+      samples.shift();
+    }
+    const first = samples[0];
+    const dt = timeStamp - first.t;
+    velocity = dt > 0 ? (first.y - y) / dt : 0;
+  };
+
+  const onTouchEnd = (): void => {
+    if (!active) {
+      return;
+    }
+    endGesture(true);
+  };
+
+  const onTouchCancel = (): void => {
+    if (!active) {
+      return;
+    }
+    endGesture(false);
+  };
+
+  const onWheel = (): void => {
+    // Wheel scrolling is handled by ChatPage; a running flick would fight it.
+    stopMomentum();
+  };
+
+  host.addEventListener("touchstart", onTouchStart, { passive: true });
+  host.addEventListener("touchmove", onTouchMove, { passive: false });
+  host.addEventListener("touchend", onTouchEnd, { passive: true });
+  host.addEventListener("touchcancel", onTouchCancel, { passive: true });
+  host.addEventListener("wheel", onWheel, { passive: true, capture: true });
+
+  return {
+    dispose(): void {
+      stopMomentum();
+      host.removeEventListener("touchstart", onTouchStart);
+      host.removeEventListener("touchmove", onTouchMove);
+      host.removeEventListener("touchend", onTouchEnd);
+      host.removeEventListener("touchcancel", onTouchCancel);
+      host.removeEventListener("wheel", onWheel, true);
+    },
+  };
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -63,6 +63,7 @@ import {
   shouldTreatInputAsMobileReplacement,
 } from "@/lib/pty-mobile-input";
 import { computeKeyboardInset, shouldPinScroll } from "@/lib/keyboard-inset";
+import { attachXtermTouchScroll } from "@/lib/xterm-touch-scroll";
 import {
   resolvePtyKeyboardShortcut,
   sendPtyShortcutSequence,
@@ -832,6 +833,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       sendComposedText(data);
     });
     term.open(host);
+    const touchScrollDisposable = attachXtermTouchScroll(term, host);
 
     // IME composition guard (fixes #52111).
     //
@@ -1517,6 +1519,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       onDataDisposable?.dispose();
       onResizeDisposable?.dispose();
       onScrollDisposable?.dispose();
+      touchScrollDisposable.dispose();
       mobileInputCleanup?.();
       compositionForwarder.dispose();
       host.removeEventListener("paste", handleBrowserPaste, true);


### PR DESCRIPTION
### Problem

On a tablet (or any touch device) the dashboard's Chat tab cannot be scrolled
with a finger. The transcript only moves when the user grabs the thin scrollbar
on the right edge; swiping over the text does nothing. Mouse wheel and trackpad
scrolling work fine, which is what makes it look like a CSS/overflow problem — it
isn't.

### Root cause

The chat transcript is an xterm.js terminal (`web/src/pages/ChatPage.tsx`):

- `ChatPage` installs `term.attachCustomWheelEventHandler(...)` that maps wheel
  deltas onto `term.scrollLines()`, so the wheel path was already covered.
- Since xterm 6 the real scroll position lives in xterm's own VS Code-derived
  `ScrollableElement`, which listens for **wheel events only** — there is no
  touch handling in the core viewport.
- `.xterm-screen` (which paints the text) is a *later sibling* of the legacy
  `.xterm-viewport` node and is positioned over it, so a touch that lands on the
  text never reaches a scrollable element either.

Verified in a real xterm 6.0.0 instance: dispatching a 300 px synthetic
one-finger drag leaves the scroll position unchanged and nothing calls
`preventDefault()`.

### Fix

New `web/src/lib/xterm-touch-scroll.ts`, attached next to `term.open(host)` in
both `ChatPage` and `HermesConsoleModal` (which embeds the same terminal):

- one-finger vertical drag → `term.scrollLines()`, with a sub-line accumulator so
  slow drags still advance instead of being rounded away;
- a tunable gain (default 1.8×) because line-quantised text feels sluggish at
  exact 1:1 tracking — `gain: 1` restores pixel-perfect tracking;
- a flick releases into a ~0.55 s momentum glide;
- nothing is consumed until the pointer has travelled 6 px vertically and the
  gesture is more vertical than horizontal, so taps, long-presses, selection
  drags and pinch-zoom still behave normally;
- drags that start on xterm's own scrollbar / right-edge gutter are ignored, so
  the existing scrollbar interaction is preserved;
- `dispose()` in the same effect cleanup as the other xterm disposables.

### Verification

Measured against a real xterm 6.0.0 instance with a 240-line buffer (18 px rows),
reading `term.buffer.active.viewportY` directly:

| Gesture | Result |
|---|---|
| 130 px slow drag | 13 lines (expected 13.0 at gain 1.8; 7 at 1:1) |
| 65 px drag | 6 lines (remainder carried) |
| 200 px flick @ 2.5 px/ms | 20 lines while dragging + 64 lines of glide after release |
| tap / horizontal drag / both at once | no scroll, events not consumed |
| drag starting in the scrollbar gutter | no scroll (native scrollbar path untouched) |
| mouse wheel | unchanged |

`tsc -p web/tsconfig.json --noEmit` clean; 13 new unit tests for the
accumulator, gain resolution and momentum decay; `npm run build` clean.

### Notes

- No new dependency; the module is ~10 KB of TypeScript.
- Tuning knobs are exported constants (`DEFAULT_SCROLL_GAIN`,
  `MOMENTUM_DECAY_PER_MS`, `FLICK_MIN_VELOCITY_PX_PER_MS`) and can be overridden
  per call via `attachXtermTouchScroll(term, host, { gain })`.
- Verified against `main` as of `3d3c8918` (`web/package.json` pins
  `@xterm/xterm 6.0.0`, same as the version this was developed against).

### Related work

#86827 targets the same gap with a `ChatPage.tsx`-only patch (1 file, +94).
This PR keeps the same `term.scrollLines()` approach but extracts a tested
helper module, also covers the terminal embedded in `HermesConsoleModal`, and
gates the gesture (tap / long-press / horizontal / pinch / scrollbar gutter).
Happy to defer to whichever the maintainers prefer — if #86827 is picked, the
`xterm-touch-scroll.ts` module and its unit tests can be lifted across as-is.