### PR TITLE
fix(gateway,tools): multiplexed profiles keep their own max_turns, fallback chain, hooks, auth, caches and paths (salvage #56315 #56508 #63962, fixes #95685)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -910,6 +910,15 @@ _NOUS_MODEL = "google/gemini-3.6-flash"
 _NOUS_DEFAULT_BASE_URL = "https://inference-api.nousresearch.com/v1"
 _ANTHROPIC_DEFAULT_BASE_URL = "https://api.anthropic.com"
 _AUTH_JSON_PATH = get_hermes_home() / "auth.json"
+_AUTH_JSON_PATH_AT_IMPORT = _AUTH_JSON_PATH
+
+
+def _auth_json_path():
+    """Active profile's ``auth.json`` at call time (a patched ``_AUTH_JSON_PATH`` still wins). The
+    import-time constant is the LAUNCH profile's; under multiplexing a secondary's auxiliary calls
+    would otherwise authenticate to Nous with the default profile's token."""
+    from hermes_cli.auth import _auth_file_path
+    return _AUTH_JSON_PATH if _AUTH_JSON_PATH != _AUTH_JSON_PATH_AT_IMPORT else _auth_file_path()
 
 # Hosts exposing BOTH ``…/anthropic`` and a sibling OpenAI ``…/v1``. Matched on the URL *host*
 # only: unconditional rewrites break Anthropic-only gateways.
@@ -1859,9 +1868,10 @@ def _read_nous_auth() -> Optional[dict]:
             "source": "pool",
         }
     try:
-        if not _AUTH_JSON_PATH.is_file():
+        auth_path = _auth_json_path()
+        if not auth_path.is_file():
             return None
-        data = json.loads(_AUTH_JSON_PATH.read_text(encoding="utf-8-sig"))
+        data = json.loads(auth_path.read_text(encoding="utf-8-sig"))
         if data.get("active_provider") != "nous":
             return None
         provider = data.get("providers", {}).get("nous", {})

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -83,11 +83,14 @@ def _payload_fields(kwargs: Dict[str, Any]) -> Dict[str, Any]:
         cwd = str(Path.cwd())
     except OSError:
         cwd = ""
+    from hermes_cli.profiles import get_active_profile_name
     return {
         "tool_name": kwargs.get("tool_name"),
         "tool_input": kwargs.get("args") if isinstance(kwargs.get("args"), dict) else None,
         "session_id": kwargs.get("session_id") or kwargs.get("parent_session_id") or "",
         "cwd": cwd,
+        # Resolved at fire time: a multiplexed gateway's hook script must know which profile fired it.
+        "profile": get_active_profile_name(),
         "extra": {k: v for k, v in kwargs.items() if k not in _TOP_LEVEL_PAYLOAD_KEYS},
     }
 
@@ -301,11 +304,15 @@ def _spawn(spec: ShellHookSpec, stdin_json: str) -> Dict[str, Any]:
     # Own process group on POSIX so a timed-out hook's descendants are reaped with it (Windows: kill_process_tree
     # / taskkill /T). Hooks that finish in time keep detached helpers alive.
     popen_kwargs: Dict[str, Any] = {"creationflags": windows_hide_flags()} if IS_WINDOWS else {"process_group": 0}
-    from agent.delegation_context import delegated_child_subprocess_env
+    # HERMES_HOME follows the routed profile (the import-time environ holds the launch profile's), and
+    # under multiplexing os.environ carries the DEFAULT profile's secrets, which a secondary's hook
+    # script must not inherit; single-profile runs keep the process env byte-for-byte as before.
+    from agent.secret_scope import is_multiplex_active
+    from tools.environments.local import build_subprocess_env
     try:
         proc = subprocess.Popen(argv, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                                 text=True, encoding='utf-8', errors='replace', shell=False,
-                                env=delegated_child_subprocess_env(), **popen_kwargs)
+                                env=build_subprocess_env(scrub_secrets=is_multiplex_active()), **popen_kwargs)
     except Exception as exc:
         return failed(next((msg for cls, msg in _POPEN_ERRORS if isinstance(exc, cls)), str(exc)))
     try:

--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -21,6 +21,17 @@ from hermes_cli.config import get_hermes_home
 
 
 HOOKS_DIR = get_hermes_home() / "hooks"
+_HOOKS_DIR_AT_IMPORT = HOOKS_DIR
+
+
+def _resolve_hooks_dir() -> Path:
+    """Active profile's hooks dir at call time: the patched ``HOOKS_DIR`` when a test changed it,
+    else ``get_hermes_home()/hooks``. The import-time constant is the LAUNCH profile's; under
+    ``gateway.multiplex_profiles`` every served profile has its own ``hooks/``, and a registry
+    loaded from the launch home would run the default profile's handlers (arbitrary Python) on
+    every other profile's messages, responses and user ids."""
+    configured = Path(HOOKS_DIR)
+    return configured if configured != _HOOKS_DIR_AT_IMPORT else get_hermes_home() / "hooks"
 
 
 def _skip(name: str, reason: str) -> None:
@@ -74,11 +85,12 @@ class HookRegistry:
         """Extension point for always-on built-in hooks; currently none shipped."""
 
     def discover_and_load(self) -> None:
-        """Register built-in hooks, then load every valid hook dir under HOOKS_DIR."""
+        """Register built-in hooks, then load every valid hook dir under the active profile's ``hooks/``."""
         self._register_builtin_hooks()
-        if not HOOKS_DIR.exists():
+        hooks_dir = _resolve_hooks_dir()
+        if not hooks_dir.exists():
             return
-        for hook_dir in sorted(HOOKS_DIR.iterdir()):
+        for hook_dir in sorted(hooks_dir.iterdir()):
             if not hook_dir.is_dir():
                 continue
             try:

--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -12,12 +12,14 @@ model, provider.  Forum follow-ups pass ``message_thread_id=int(thread_id)``.
 import asyncio
 import importlib.util
 import sys
+import threading
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 import yaml
 
 from hermes_cli.config import get_hermes_home
+from hermes_constants import hermes_home_key
 
 
 HOOKS_DIR = get_hermes_home() / "hooks"
@@ -135,3 +137,45 @@ class HookRegistry:
             except Exception as e:
                 print(f"[hooks] Error in handler for '{event_type}': {e}", flush=True)
         return results
+
+
+class ProfileHookRegistries:
+    """``HookRegistry`` per served profile home, picked at emit time from the active HERMES_HOME.
+
+    The gateway holds ONE of these. Every hook emit already runs inside the routed profile's
+    ``_profile_runtime_scope`` (message handlers, /new, turn wiring), so resolving the registry by
+    ``get_hermes_home()`` there gives each profile its own ``hooks/`` and keeps the default
+    profile's handlers from seeing other profiles' messages. Each home's registry is loaded on its
+    first emit, i.e. inside that profile's scope (handler imports see its HERMES_HOME); multiplexing off
+    means a single entry for the launch home, i.e. exactly the old behaviour.
+    """
+
+    def __init__(self):
+        self._by_home: Dict[str, HookRegistry] = {}
+        self._lock = threading.Lock()
+
+    def _active(self) -> HookRegistry:
+        key = hermes_home_key(get_hermes_home())
+        registry = self._by_home.get(key)
+        if registry is None:
+            with self._lock:
+                registry = self._by_home.get(key)
+                if registry is None:
+                    registry = HookRegistry()
+                    registry.discover_and_load()
+                    self._by_home[key] = registry
+        return registry
+
+    @property
+    def loaded_hooks(self) -> List[dict]:
+        return self._active().loaded_hooks
+
+    def discover_and_load(self) -> None:
+        """Load the active home's hooks now (startup, or a secondary profile's scoped startup)."""
+        self._active()
+
+    async def emit(self, event_type: str, context: Optional[Dict[str, Any]] = None) -> None:
+        await self._active().emit(event_type, context)
+
+    async def emit_collect(self, event_type: str, context: Optional[Dict[str, Any]] = None) -> List[Any]:
+        return await self._active().emit_collect(event_type, context)

--- a/gateway/media_fetch.py
+++ b/gateway/media_fetch.py
@@ -26,8 +26,7 @@ from pathlib import Path, PurePosixPath
 from typing import Optional
 
 from gateway.platforms.base import (
-    _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS, _MEDIA_DELIVERY_DENIED_PREFIXES, _ROOT_CREDENTIAL_PATHS,
-    _TRUTHY, MEDIA_DELIVERY_STRICT_ENV)
+    _MEDIA_DELIVERY_DENIED_HOME_SUBPATHS, _MEDIA_DELIVERY_DENIED_PREFIXES, _ROOT_CREDENTIAL_PATHS)
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +78,8 @@ def _active_remote_env():
 def fetch_remote_media(path: str) -> Optional[str]:
     """Host path of a validated copy of sandbox file ``path``, or None (never raises). Only fires
     when a remote backend is active; the caller has already failed local validation."""
-    if os.environ.get(MEDIA_DELIVERY_STRICT_ENV, "0").strip().lower() in _TRUTHY:
+    from gateway.media_policy import media_delivery_strict
+    if media_delivery_strict():
         return None
     env = _active_remote_env()
     if env is None:

--- a/gateway/media_policy.py
+++ b/gateway/media_policy.py
@@ -19,6 +19,55 @@ logger = logging.getLogger(__name__)
 
 _FLAG_ENVS = (("strict", "HERMES_MEDIA_DELIVERY_STRICT"), ("trust_recent_files", "HERMES_MEDIA_TRUST_RECENT_FILES"))
 _ALLOW_DIRS_ENV = "HERMES_MEDIA_ALLOW_DIRS"
+_TRUST_RECENT_SECONDS_ENV = "HERMES_MEDIA_TRUST_RECENT_SECONDS"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _routed_gateway_cfg() -> Optional[Dict[str, Any]]:
+    """``gateway`` section of the ROUTED profile's config when a HERMES_HOME override is active
+    (multiplexed turn), else None. The env bridge is one process-wide copy of the launch profile's
+    policy, so a secondary's deliveries must read their own config instead of ``os.environ``."""
+    from hermes_constants import get_hermes_home_override
+    if not get_hermes_home_override():
+        return None
+    try:
+        from hermes_cli.config import load_config_readonly
+        gateway_cfg = load_config_readonly().get("gateway")
+    except Exception:
+        return {}
+    return gateway_cfg if isinstance(gateway_cfg, dict) else {}
+
+
+def media_delivery_strict() -> bool:
+    cfg = _routed_gateway_cfg()
+    if cfg is not None:
+        return bool(cfg.get("strict", False))
+    return os.environ.get(_FLAG_ENVS[0][1], "0").strip().lower() in _TRUTHY
+
+
+def media_delivery_allow_dirs() -> str:
+    """Operator allowlist as the ``os.pathsep``-joined string the validator splits."""
+    cfg = _routed_gateway_cfg()
+    if cfg is not None:
+        return _allow_dirs_str(cfg.get("media_delivery_allow_dirs"))
+    return os.environ.get(_ALLOW_DIRS_ENV, "")
+
+
+def media_delivery_trust_recent() -> bool:
+    cfg = _routed_gateway_cfg()
+    if cfg is not None:
+        return bool(cfg.get("trust_recent_files", True))
+    return os.environ.get(_FLAG_ENVS[1][1], "1").strip().lower() not in ("0", "false", "no", "off", "")
+
+
+def media_delivery_trust_recent_seconds() -> str:
+    """Raw recency window (``""`` = validator default); the caller parses/floors it."""
+    cfg = _routed_gateway_cfg()
+    if cfg is not None:
+        raw = cfg.get("trust_recent_files_seconds")
+        return "" if raw is None else str(raw)
+    return os.environ.get(_TRUST_RECENT_SECONDS_ENV, "")
+
 
 
 def _load_gateway_cfg(config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -844,8 +844,9 @@ def _kanban_attachment_roots() -> List[Path]:
 
 def _media_delivery_allowed_roots() -> List[Path]:
     """Return roots from which model-emitted local media may be delivered."""
+    from gateway.media_policy import media_delivery_allow_dirs
     operator_roots = (
-        root for chunk in os.environ.get(MEDIA_DELIVERY_ALLOW_DIRS_ENV, "").split(os.pathsep)
+        root for chunk in media_delivery_allow_dirs().split(os.pathsep)
         for raw_root in chunk.split(",")
         if (root := Path(os.path.expanduser(raw_root.strip()))).is_absolute())
     return [*map(Path, MEDIA_DELIVERY_SAFE_ROOTS), *_profile_cache_roots(),
@@ -854,10 +855,10 @@ def _media_delivery_allowed_roots() -> List[Path]:
 
 def _media_delivery_recency_seconds() -> float:
     """Recency window (seconds) for trusting fresh files; 0 = pure-allowlist mode."""
-    raw = os.environ.get(MEDIA_DELIVERY_TRUST_RECENT_ENV, "1").strip().lower()
-    if raw in ("0", "false", "no", "off", ""):
+    from gateway.media_policy import media_delivery_trust_recent, media_delivery_trust_recent_seconds
+    if not media_delivery_trust_recent():
         return 0.0
-    custom = os.environ.get(MEDIA_DELIVERY_TRUST_RECENT_SECONDS_ENV, "").strip()
+    custom = media_delivery_trust_recent_seconds().strip()
     default = float(_MEDIA_DELIVERY_TRUST_RECENT_DEFAULT_SECONDS)
     return _or_default(lambda: max(0.0, float(custom)) if custom else default, default)
 
@@ -1125,7 +1126,8 @@ def validate_media_delivery_path(path: str, session_key: str = "") -> Optional[s
         if resolved_root is not None and _path_is_within(resolved, resolved_root):
             return str(resolved)
     # Non-strict (default): anything not denylisted (/etc, /proc, ~/.ssh, Hermes-root secrets).
-    if os.environ.get(MEDIA_DELIVERY_STRICT_ENV, "0").strip().lower() not in _TRUTHY:
+    from gateway.media_policy import media_delivery_strict
+    if not media_delivery_strict():
         return None if _path_under_denied_prefix(resolved) else str(resolved)
     # Strict: recency trust for fresh files (pandoc -o /tmp/x.pdf); denylist still applies.
     window = _media_delivery_recency_seconds()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1620,9 +1620,20 @@ def _bridge_max_turns_from_config(home: "Path") -> None:
 def _current_max_iterations() -> int:
     """Return the per-turn iteration budget after runtime env refresh; ``resolve_turn_limit`` maps
     ``agent.max_turns: none``/``unlimited`` (bridged as a string) to the unlimited sentinel, not an
-    ``int()`` crash."""
+    ``int()`` crash. A routed profile (HERMES_HOME override, multiplexed turns) reads ITS
+    ``agent.max_turns`` straight from config: the ``HERMES_MAX_ITERATIONS`` bridge is one process-wide
+    slot holding the launch profile's value, so every secondary would inherit the default's budget."""
     _reload_runtime_env_preserving_config_authority()
     from hermes_cli.config import resolve_turn_limit as _resolve_turn_limit
+    override = get_hermes_home_override()
+    if override:
+        config_path = Path(override) / 'config.yaml'
+        try:
+            cfg = _load_bridge_config(config_path) if config_path.exists() else {}
+        except Exception:
+            cfg = {}
+        agent_cfg = cfg.get("agent")
+        return _resolve_turn_limit(agent_cfg.get("max_turns") if isinstance(agent_cfg, dict) else None)
     return _resolve_turn_limit(os.getenv("HERMES_MAX_ITERATIONS"))
 
 
@@ -3671,10 +3682,11 @@ class GatewayRunner(
         # ``pairing_store``: global/default store (CLI, callers without profile context); ``pairing_stores``:
         # per-profile map ``authz_mixin._is_user_authorized`` routes through (one whitelist per profile).
         from gateway.pairing import PairingStore
-        from gateway.hooks import HookRegistry
+        from gateway.hooks import ProfileHookRegistries
         self.pairing_store = PairingStore()
         self.pairing_stores: Dict[str, "PairingStore"] = {}
-        self.hooks = HookRegistry()
+        # One HookRegistry per served profile home, resolved from the active scope at emit time.
+        self.hooks = ProfileHookRegistries()
         # Per-chat voice reply mode: "off" | "voice_only" | "all"
         self._voice_mode: Dict[str, str] = self._load_voice_modes()
         # Per-(guild,user) transcript dedup: the voice/STT pipeline can emit one utterance twice.

--- a/gateway/run_config_loaders.py
+++ b/gateway/run_config_loaders.py
@@ -60,7 +60,7 @@ class GatewayConfigLoadersMixin:
         HERMES_PREFILL_MESSAGES_FILE env wins, then top-level prefill_messages_file in config.yaml,
         then legacy agent.prefill_messages_file. Relative paths resolve from ~/.hermes/.
         """
-        from gateway.run import _hermes_home, _load_gateway_runtime_config
+        from gateway.run import _gateway_config_home, _load_gateway_runtime_config
         file_path = os.getenv("HERMES_PREFILL_MESSAGES_FILE", "")
         if not file_path:
             cfg = _load_gateway_runtime_config()
@@ -71,7 +71,7 @@ class GatewayConfigLoadersMixin:
             return []
         path = Path(file_path).expanduser()
         if not path.is_absolute():
-            path = _hermes_home / path
+            path = _gateway_config_home() / path
         if not path.exists():
             logger.warning("Prefill messages file not found: %s", path)
             return []
@@ -426,13 +426,23 @@ class GatewayConfigLoadersMixin:
         ``self._fallback_model`` at process start, so a chain configured (or changed) after ``hermes
         gateway`` was running never reached messaging sessions even though the same process's cron jobs fell
         back correctly. Fixes #60955.
+
+        Reads the ACTIVE gateway home (the routed profile under multiplexing, else the launch home)
+        and keeps one last-known-good chain per home: a single runner-wide slot filled from the launch
+        home handed every secondary profile the default profile's fallback chain.
         """
-        from gateway.run import _hermes_home
+        from gateway.run import _gateway_config_home
+        from hermes_constants import hermes_home_key
+        home = _gateway_config_home()
+        by_home = getattr(self, "_fallback_model_by_home", None)
+        if by_home is None:
+            by_home = self._fallback_model_by_home = {}
+        home_key = hermes_home_key(home)
         try:
             from hermes_cli.config import read_user_config_raw
-            cfg_path = _hermes_home / "config.yaml"
+            cfg_path = home / "config.yaml"
             if not cfg_path.exists():
-                self._fallback_model = None
+                by_home[home_key] = self._fallback_model = None
                 return self._fallback_model
             # Raw primitive (raises on parse failure) is required here: the canonical fail-open
             # loader would return {} on a torn mid-edit write and WIPE the last known-good chain.
@@ -448,8 +458,9 @@ class GatewayConfigLoadersMixin:
                     cfg = expanded
         except Exception:
             logger.debug("fallback_providers refresh: config.yaml read failed; keeping last known-good chain", exc_info=True)
+            self._fallback_model = by_home.get(home_key, self._fallback_model)
             return self._fallback_model
-        self._fallback_model = get_fallback_chain(cfg) or None
+        by_home[home_key] = self._fallback_model = get_fallback_chain(cfg) or None
         return self._fallback_model
 
     @staticmethod

--- a/gateway/sticker_cache.py
+++ b/gateway/sticker_cache.py
@@ -6,12 +6,21 @@ Stickers are described via the vision tool once and cached by file_unique_id
 
 import json
 import time
+from pathlib import Path
 from typing import Optional
 
 from hermes_cli.config import get_hermes_home
 from utils import atomic_json_write
 
 CACHE_PATH = get_hermes_home() / "sticker_cache.json"
+_CACHE_PATH_AT_IMPORT = CACHE_PATH
+
+
+def _resolve_cache_path() -> Path:
+    """Active profile's cache file at call time: the patched ``CACHE_PATH`` when a test changed
+    it, else live profile-scoped HERMES_HOME — under the multiplexed gateway one process serves
+    every profile, so the import-time constant would pin every profile to the launch home."""
+    return CACHE_PATH if CACHE_PATH != _CACHE_PATH_AT_IMPORT else get_hermes_home() / "sticker_cache.json"
 
 # Kept concise to save tokens.
 STICKER_VISION_PROMPT = (
@@ -22,13 +31,13 @@ STICKER_VISION_PROMPT = (
 
 def _load_cache() -> dict:
     try:
-        return json.loads(CACHE_PATH.read_text(encoding="utf-8"))
+        return json.loads(_resolve_cache_path().read_text(encoding="utf-8"))
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         return {}
 
 
 def _save_cache(cache: dict) -> None:
-    atomic_json_write(CACHE_PATH, cache)
+    atomic_json_write(_resolve_cache_path(), cache)
 
 
 def get_cached_description(file_unique_id: str) -> Optional[dict]:

--- a/hermes_time.py
+++ b/hermes_time.py
@@ -26,14 +26,25 @@ _cache_lock = threading.Lock()
 _tz_cache: Dict[Tuple[str, str], Tuple[str, Optional[ZoneInfo]]] = {}
 
 
+def _env_timezone() -> str:
+    """``HERMES_TIMEZONE`` when it may speak for the active profile. Under the multiplexed
+    gateway the env var holds only the DEFAULT profile's value (bridged from its config.yaml at
+    startup), so every routed profile must read its own config.yaml instead."""
+    from agent.secret_scope import is_multiplex_active  # lazy: secret_scope pulls in more than a clock needs
+
+    if is_multiplex_active():
+        return ""
+    return os.getenv("HERMES_TIMEZONE", "").strip()
+
+
 def _timezone_cache_identity() -> Tuple[str, str]:
-    tz_env = os.getenv("HERMES_TIMEZONE", "").strip()
+    tz_env = _env_timezone()
     return ("environment", tz_env) if tz_env else ("config", str(get_config_path()))
 
 
 def _resolve_timezone_name() -> str:
     """Read the configured IANA timezone string (or ``""``). Does file I/O — callers cache."""
-    tz_env = os.getenv("HERMES_TIMEZONE", "").strip()
+    tz_env = _env_timezone()
     if tz_env:
         return tz_env
     try:
@@ -61,13 +72,13 @@ def _resolve_timezone_name() -> str:
     return ""
 
 
-def get_timezone() -> Optional[ZoneInfo]:
-    """Return the active profile's configured ZoneInfo, or None (server-local)."""
+def _timezone_entry() -> Tuple[str, Optional[ZoneInfo]]:
+    """Cached ``(configured name, ZoneInfo | None)`` for the active profile."""
     cache_identity = _timezone_cache_identity()
     with _cache_lock:
         entry = _tz_cache.get(cache_identity)
         if entry is not None:
-            return entry[1]
+            return entry
     # Resolve outside the lock (config file I/O); first writer wins so concurrent resolvers of the
     # same identity converge on one ZoneInfo object.
     name = _resolve_timezone_name()
@@ -78,7 +89,18 @@ def get_timezone() -> Optional[ZoneInfo]:
         except Exception as exc:
             logger.warning("Invalid timezone '%s': %s. Falling back to server local time.", name, exc)
     with _cache_lock:
-        return _tz_cache.setdefault(cache_identity, (name, tz))[1]
+        return _tz_cache.setdefault(cache_identity, (name, tz))
+
+
+def get_timezone() -> Optional[ZoneInfo]:
+    """Return the active profile's configured ZoneInfo, or None (server-local)."""
+    return _timezone_entry()[1]
+
+
+def get_timezone_name() -> str:
+    """The active profile's configured IANA timezone string, or ``""`` (server-local). Same
+    resolution and cache as :func:`get_timezone`; for handing ``TZ`` to sandboxed children."""
+    return _timezone_entry()[0]
 
 
 def reset_cache() -> None:

--- a/plugins/platforms/feishu/feishu_comment_rules.py
+++ b/plugins/platforms/feishu/feishu_comment_rules.py
@@ -10,16 +10,26 @@ import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
 
-# Resolved at import time: this module is lazy-imported by the comment event handler,
-# long after profile/HERMES_HOME overrides have been applied, so freezing is safe.
 RULES_FILE = get_hermes_home() / "feishu_comment_rules.json"
 PAIRING_FILE = get_hermes_home() / "feishu_comment_pairing.json"
+_RULES_FILE_AT_IMPORT, _PAIRING_FILE_AT_IMPORT = RULES_FILE, PAIRING_FILE
+
+
+def _rules_file() -> Path:
+    """Active profile's rules file at call time: the patched ``RULES_FILE`` when a test changed
+    it, else live profile-scoped HERMES_HOME — the multiplexed gateway serves every profile from
+    one process, so the import-time constant would apply the launch profile's rules everywhere."""
+    return RULES_FILE if RULES_FILE != _RULES_FILE_AT_IMPORT else get_hermes_home() / "feishu_comment_rules.json"
+
+
+def _pairing_file() -> Path:
+    return PAIRING_FILE if PAIRING_FILE != _PAIRING_FILE_AT_IMPORT else get_hermes_home() / "feishu_comment_pairing.json"
 
 _VALID_POLICIES = ("allowlist", "pairing")
 
@@ -51,31 +61,40 @@ class ResolvedCommentRule:
 
 
 class _MtimeCache:
-    """Mtime-based JSON file cache: ``stat()`` per access, re-read only on change."""
+    """Mtime-based JSON file cache: ``stat()`` per access, re-read only on change. ``path`` is a
+    ``Path`` or a zero-arg callable resolving one; state is keyed per resolved path so profiles
+    routed through one multiplexed process never share a slot."""
 
-    def __init__(self, path: Path):
-        self._path, self._mtime, self._data = path, 0.0, None
+    def __init__(self, path: Path | Callable[[], Path]):
+        self._resolve = path if callable(path) else (lambda: path)
+        self._entries: Dict[Path, tuple[float, dict]] = {}
+
+    def invalidate(self) -> None:
+        self._entries.pop(self._resolve(), None)
 
     def load(self) -> dict:
+        path = self._resolve()
         try:
-            mtime = self._path.stat().st_mtime
+            mtime = path.stat().st_mtime
         except FileNotFoundError:
-            self._mtime, self._data = 0.0, {}
+            self._entries.pop(path, None)
             return {}
-        if mtime == self._mtime and self._data is not None:
-            return self._data
+        cached = self._entries.get(path)
+        if cached is not None and cached[0] == mtime:
+            return cached[1]
         try:
-            with open(self._path, "r", encoding="utf-8") as f:
+            with open(path, "r", encoding="utf-8") as f:
                 data = json.load(f)
         except (json.JSONDecodeError, OSError):
-            logger.warning("[Feishu-Rules] Failed to read %s, using empty config", self._path)
+            logger.warning("[Feishu-Rules] Failed to read %s, using empty config", path)
             data = {}
-        self._mtime, self._data = mtime, (data if isinstance(data, dict) else {})
-        return self._data
+        data = data if isinstance(data, dict) else {}
+        self._entries[path] = (mtime, data)
+        return data
 
 
-_rules_cache = _MtimeCache(RULES_FILE)
-_pairing_cache = _MtimeCache(PAIRING_FILE)
+_rules_cache = _MtimeCache(_rules_file)
+_pairing_cache = _MtimeCache(_pairing_file)
 
 
 def _parse_frozenset(raw: Any) -> Optional[frozenset]:
@@ -137,11 +156,12 @@ def _load_pairing_approved() -> set:
 
 
 def _save_pairing(data: dict) -> None:
-    PAIRING_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with open(PAIRING_FILE.with_suffix(".tmp"), "w", encoding="utf-8") as f:
+    pairing_file = _pairing_file()
+    pairing_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(pairing_file.with_suffix(".tmp"), "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, ensure_ascii=False)
-    PAIRING_FILE.with_suffix(".tmp").replace(PAIRING_FILE)
-    _pairing_cache._mtime, _pairing_cache._data = 0.0, None  # invalidate so the next load re-reads
+    pairing_file.with_suffix(".tmp").replace(pairing_file)
+    _pairing_cache.invalidate()  # same-second rewrite can keep the mtime; force the next load to re-read
 
 
 def _mutate_pairing(user_open_id: str, add: bool) -> bool:
@@ -186,7 +206,8 @@ def _fmt_allow(allow_from) -> str:
 
 def _print_status() -> None:
     cfg = load_config()
-    print(f"Rules file: {RULES_FILE}\n  exists: {RULES_FILE.exists()}\nPairing file: {PAIRING_FILE}\n  exists: {PAIRING_FILE.exists()}\n")
+    rules_file, pairing_file = _rules_file(), _pairing_file()
+    print(f"Rules file: {rules_file}\n  exists: {rules_file.exists()}\nPairing file: {pairing_file}\n  exists: {pairing_file.exists()}\n")
     print(f"Top-level:\n  enabled:    {cfg.enabled}\n  policy:     {cfg.policy}\n  allow_from: {_fmt_allow(cfg.allow_from)}\n")
     print(f"Document rules ({len(cfg.documents)}):" if cfg.documents else "Document rules: (none)")
     for key, rule in sorted(cfg.documents.items()):
@@ -242,7 +263,7 @@ Commands:
   pairing remove <user_open_id>        Remove user from pairing-approved list
   pairing list                         List pairing-approved users
 
-Rules config file: {RULES_FILE}
+Rules config file: {_rules_file()}
   Edit this JSON file directly to configure policies and document rules.
   Changes take effect on the next comment event (no restart needed).
 """

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -737,3 +737,36 @@ class TestFailSemanticsEndToEnd:
         assert result["timed_out"] is True
         assert result["parsed"]["action"] == "block"
         assert "failed closed" in result["parsed"]["message"]
+
+
+# ── multiplexed profiles ──────────────────────────────────────────────────
+
+
+class TestRoutedProfileEnv:
+    @pytest.mark.linux_only
+    def test_hook_child_sees_routed_profile_home_and_no_default_secrets(self, tmp_path, monkeypatch):
+        """Under multiplexing the child gets the ROUTED HERMES_HOME, the default profile's secrets
+        stay out of its env, and the payload names the firing profile."""
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        launch, routed = tmp_path / "launch", tmp_path / "routed"
+        launch.mkdir(); routed.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(launch))
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-default-profile")
+        monkeypatch.setattr("agent.secret_scope.is_multiplex_active", lambda: True)
+        script = _write_script(
+            tmp_path, "env_dump.sh",
+            "#!/usr/bin/env bash\ncat > /dev/null\n"
+            'printf \'{"home": "%s", "key": "%s"}\\n\' "$HERMES_HOME" "${OPENAI_API_KEY:-}"\n',
+        )
+        spec = shell_hooks.ShellHookSpec(event="pre_tool_call", command=str(script))
+        token = set_hermes_home_override(str(routed))
+        try:
+            result = shell_hooks._spawn(spec, shell_hooks._serialize_payload("pre_tool_call", {"tool_name": "terminal"}))
+            payload = json.loads(shell_hooks._serialize_payload("pre_tool_call", {"tool_name": "terminal"}))
+        finally:
+            reset_hermes_home_override(token)
+        seen = json.loads(result["stdout"])
+        assert seen["home"] == str(routed)
+        assert seen["key"] == ""
+        assert "profile" in payload

--- a/tests/gateway/test_feishu_comment_rules.py
+++ b/tests/gateway/test_feishu_comment_rules.py
@@ -154,5 +154,34 @@ class TestPairingStore(unittest.TestCase):
         self.assertIn("ou_new", approved)
 
 
+class TestRulesFollowActiveProfile(unittest.TestCase):
+    """The multiplexed gateway serves every profile from one process: the rules/pairing files and
+    their mtime caches must follow the context-local HERMES_HOME override, one slot per profile."""
+
+    def test_rules_and_pairing_follow_home_override(self):
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from plugins.platforms.feishu import feishu_comment_rules as fcr
+
+        def under(home, fn):
+            token = set_hermes_home_override(str(home))
+            try:
+                return fn()
+            finally:
+                reset_hermes_home_override(token)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            prof_a, prof_b = Path(tmp) / "A", Path(tmp) / "B"
+            for home, enabled in ((prof_a, True), (prof_b, False)):
+                home.mkdir()
+                (home / "feishu_comment_rules.json").write_text(json.dumps({"enabled": enabled}))
+            self.assertTrue(under(prof_a, fcr.load_config).enabled)  # warm A's slot
+            self.assertFalse(under(prof_b, fcr.load_config).enabled)
+            self.assertTrue(under(prof_a, fcr.load_config).enabled)  # A's slot survives B
+            self.assertTrue(under(prof_b, lambda: fcr.pairing_add("ou_b")))
+            self.assertTrue((prof_b / "feishu_comment_pairing.json").exists())
+            self.assertFalse((prof_a / "feishu_comment_pairing.json").exists())
+            self.assertNotIn("ou_b", under(prof_a, fcr.pairing_list))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/gateway/test_multiplex_process_memo_scope.py
+++ b/tests/gateway/test_multiplex_process_memo_scope.py
@@ -1,0 +1,123 @@
+"""Multiplexed-gateway invariants: per-turn config, credentials and hooks follow the ROUTED profile
+(HERMES_HOME override), not the launch home the module constants were frozen from."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+@pytest.fixture
+def two_homes(tmp_path, monkeypatch):
+    """Launch home A (HERMES_HOME) and a routed profile B with different config everywhere."""
+    a = tmp_path / ".hermes"
+    b = a / "profiles" / "b"
+    b.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(a))
+    monkeypatch.delenv("HERMES_MAX_ITERATIONS", raising=False)
+    for home, turns, model in ((a, 7, "A/fallback"), (b, 99, "B/fallback")):
+        (home / "config.yaml").write_text(yaml.safe_dump({
+            "agent": {"max_turns": turns},
+            "fallback_providers": [{"provider": "openrouter", "model": model}],
+        }), encoding="utf-8")
+    return a, b
+
+
+def _under(home: Path, fn):
+    token = set_hermes_home_override(str(home))
+    try:
+        return fn()
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_max_turns_and_fallback_chain_follow_routed_profile(two_homes, monkeypatch):
+    a, b = two_homes
+    from gateway import run as gateway_run
+    from gateway.run import GatewayRunner
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", a)
+    monkeypatch.setattr("agent.secret_scope.is_multiplex_active", lambda: True)
+    runner = SimpleNamespace(_fallback_model=None)
+    refresh = GatewayRunner._refresh_fallback_model.__get__(runner)
+
+    # Default profile turn warms the process-wide bridge/slot with A's values...
+    assert gateway_run._current_max_iterations() == 7
+    assert refresh() == [{"provider": "openrouter", "model": "A/fallback"}]
+    # ...and a routed turn for B must still see B's config, not the launch home's.
+    assert _under(b, gateway_run._current_max_iterations) == 99
+    assert _under(b, refresh) == [{"provider": "openrouter", "model": "B/fallback"}]
+    # Back on the default profile the chain is A's again (per-home last-known-good, not last writer).
+    assert refresh() == [{"provider": "openrouter", "model": "A/fallback"}]
+
+
+def test_aux_nous_auth_reads_routed_profile_auth_json(two_homes, monkeypatch):
+    a, b = two_homes
+    import agent.auxiliary_client as aux
+
+    for home, token in ((a, "TOKEN_A"), (b, "TOKEN_B")):
+        (home / "auth.json").write_text(json.dumps({
+            "version": 1, "active_provider": "nous",
+            "providers": {"nous": {"agent_key": token, "access_token": token}},
+        }), encoding="utf-8")
+    monkeypatch.setattr(aux, "_select_pool_entry", lambda _provider: (False, None))
+
+    assert (aux._read_nous_auth() or {}).get("access_token") == "TOKEN_A"
+    assert (_under(b, aux._read_nous_auth) or {}).get("access_token") == "TOKEN_B"
+
+
+def _write_hook(home: Path, name: str) -> None:
+    hook_dir = home / "hooks" / name
+    hook_dir.mkdir(parents=True)
+    (hook_dir / "HOOK.yaml").write_text(f"name: {name}\nevents: ['agent:start']\n", encoding="utf-8")
+    (hook_dir / "handler.py").write_text(
+        "def handle(event_type, context):\n    context.setdefault('seen', []).append(__name__)\n",
+        encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_gateway_hooks_fire_per_routed_profile(two_homes):
+    """Profile B's hooks/ runs for B's turns and A's handlers never see B's context (and vice versa)."""
+    a, b = two_homes
+    _write_hook(a, "hook-a")
+    _write_hook(b, "hook-b")
+    from gateway.hooks import ProfileHookRegistries
+
+    hooks = ProfileHookRegistries()
+    ctx_a: dict = {}
+    await hooks.emit("agent:start", ctx_a)
+    token = set_hermes_home_override(str(b))
+    try:
+        ctx_b: dict = {}
+        await hooks.emit("agent:start", ctx_b)
+        assert [h["name"] for h in hooks.loaded_hooks] == ["hook-b"]
+    finally:
+        reset_hermes_home_override(token)
+    assert ctx_a.get("seen") == ["hermes_hook_hook-a"]
+    assert ctx_b.get("seen") == ["hermes_hook_hook-b"]
+
+
+def test_media_policy_reads_routed_profile_config_not_env(two_homes, monkeypatch):
+    a, b = two_homes
+    from gateway import media_policy
+
+    (a / "config.yaml").write_text(yaml.safe_dump(
+        {"gateway": {"strict": True, "media_delivery_allow_dirs": ["/srv/a"]}}), encoding="utf-8")
+    (b / "config.yaml").write_text(yaml.safe_dump(
+        {"gateway": {"strict": False, "media_delivery_allow_dirs": ["/srv/b"]}}), encoding="utf-8")
+    # Gateway startup bridges the LAUNCH profile's policy into the process env.
+    for var in ("HERMES_MEDIA_DELIVERY_STRICT", "HERMES_MEDIA_ALLOW_DIRS"):
+        monkeypatch.delenv(var, raising=False)
+    from hermes_cli.config import load_config
+    media_policy.apply_media_policy_env(load_config())
+    assert media_policy.media_delivery_strict() is True
+    assert media_policy.media_delivery_allow_dirs() == "/srv/a"
+
+    assert _under(b, media_policy.media_delivery_strict) is False
+    assert _under(b, media_policy.media_delivery_allow_dirs) == "/srv/b"

--- a/tests/hermes_cli/test_hooks_cli.py
+++ b/tests/hermes_cli/test_hooks_cli.py
@@ -102,7 +102,7 @@ class TestHooksTest:
         # Same top-level keys _serialize_payload produces at runtime
         assert set(seen.keys()) == {
             "hook_event_name", "tool_name", "tool_input",
-            "session_id", "cwd", "extra",
+            "session_id", "cwd", "extra", "profile",
         }
         # parent_session_id was routed to top-level session_id (matches runtime)
         assert seen["session_id"] == "parent-sess"

--- a/tests/test_profile_isolation_runtime.py
+++ b/tests/test_profile_isolation_runtime.py
@@ -156,6 +156,47 @@ class TestGatewayHooksDirResolution:
         assert "only-in-b" in b_hooks
 
 
+class TestCheckpointManagerPathResolution:
+    """tools/checkpoint_manager.py's checkpoint store root must honor the
+    active profile — otherwise one profile's CheckpointManager instance can
+    read/write code-edit checkpoints into a different profile's store under
+    the multiplexed gateway."""
+
+    def test_checkpoint_base_follows_override(self, two_profiles):
+        prof_a, prof_b = two_profiles
+        import tools.checkpoint_manager as cm
+
+        a_seen = _under_override(prof_a, lambda: cm._resolve_checkpoint_base())
+        b_seen = _under_override(prof_b, lambda: cm._resolve_checkpoint_base())
+
+        assert a_seen == prof_a / "checkpoints"
+        assert b_seen == prof_b / "checkpoints"
+        assert a_seen != b_seen
+
+    def test_store_path_follows_override(self, two_profiles):
+        prof_a, prof_b = two_profiles
+        import tools.checkpoint_manager as cm
+
+        b_seen = _under_override(prof_b, lambda: cm._store_path())
+        assert b_seen == prof_b / "checkpoints" / "store"
+
+
+class TestStickerCachePathResolution:
+    """gateway/sticker_cache.py's cache file must honor the active profile —
+    otherwise one profile's Telegram sticker-description cache leaks into a
+    different profile's under the multiplexed gateway."""
+
+    def test_cache_path_follows_override(self, two_profiles):
+        prof_a, prof_b = two_profiles
+        import gateway.sticker_cache as sc
+
+        a_seen = _under_override(prof_a, lambda: sc._resolve_cache_path())
+        b_seen = _under_override(prof_b, lambda: sc._resolve_cache_path())
+
+        assert a_seen == prof_a / "sticker_cache.json"
+        assert b_seen == prof_b / "sticker_cache.json"
+        assert a_seen != b_seen
+
 
 # ---------------------------------------------------------------------------
 # M2 — thread / executor context propagation

--- a/tests/test_profile_isolation_runtime.py
+++ b/tests/test_profile_isolation_runtime.py
@@ -111,6 +111,52 @@ class TestRichSentStorePathResolution:
         assert b_seen.endswith("state/rich_sent_index.json")
 
 
+class TestGatewayHooksDirResolution:
+    """gateway/hooks.py's HookRegistry must discover hooks from the active
+    profile's directory — otherwise one profile's HookRegistry loads and
+    executes a DIFFERENT profile's hook handlers (arbitrary Python) against
+    its own live event context under the multiplexed gateway."""
+
+    def test_hooks_dir_follows_override(self, two_profiles):
+        prof_a, prof_b = two_profiles
+        import gateway.hooks as gh
+
+        a_seen = _under_override(prof_a, lambda: gh._resolve_hooks_dir())
+        b_seen = _under_override(prof_b, lambda: gh._resolve_hooks_dir())
+
+        assert a_seen == prof_a / "hooks"
+        assert b_seen == prof_b / "hooks"
+        assert a_seen != b_seen
+
+    def test_discover_and_load_uses_active_profile_hooks_dir(self, two_profiles):
+        """End-to-end: a hook that only exists under profile B's hooks dir
+        must not be discovered when profile A's override is active, and vice
+        versa — proving the registry doesn't fall back to a frozen profile."""
+        prof_a, prof_b = two_profiles
+        import gateway.hooks as gh
+
+        b_hook_dir = prof_b / "hooks" / "only-in-b"
+        b_hook_dir.mkdir(parents=True)
+        (b_hook_dir / "HOOK.yaml").write_text(
+            "name: only-in-b\nevents: [\"agent:start\"]\n", encoding="utf-8",
+        )
+        (b_hook_dir / "handler.py").write_text(
+            "async def handle(event_type, context):\n    pass\n", encoding="utf-8",
+        )
+
+        def _load_and_names():
+            reg = gh.HookRegistry()
+            reg.discover_and_load()
+            return [h["name"] for h in reg.loaded_hooks]
+
+        a_hooks = _under_override(prof_a, _load_and_names)
+        b_hooks = _under_override(prof_b, _load_and_names)
+
+        assert "only-in-b" not in a_hooks
+        assert "only-in-b" in b_hooks
+
+
+
 # ---------------------------------------------------------------------------
 # M2 — thread / executor context propagation
 # ---------------------------------------------------------------------------

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -108,6 +108,35 @@ class TestGetTimezone:
         monkeypatch.setenv("HERMES_HOME", str(first_home))
         assert str(hermes_time.get_timezone()) == "Asia/Tokyo"
 
+    def test_multiplex_prefers_routed_profile_config_over_env(self, tmp_path, monkeypatch):
+        """Under the multiplexed gateway HERMES_TIMEZONE holds only the DEFAULT profile's value
+        (bridged at startup), so a routed profile must resolve from its own config.yaml."""
+        from agent.secret_scope import set_multiplex_active
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+        default_home, routed_home = tmp_path / "default", tmp_path / "routed"
+        default_home.mkdir()
+        routed_home.mkdir()
+        (default_home / "config.yaml").write_text("timezone: America/New_York\n", encoding="utf-8")
+        (routed_home / "config.yaml").write_text("timezone: Asia/Tokyo\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(default_home))
+        monkeypatch.setenv("HERMES_TIMEZONE", "America/New_York")
+
+        # Single-profile process: env stays authoritative.
+        assert hermes_time.get_timezone_name() == "America/New_York"
+
+        set_multiplex_active(True)
+        try:
+            assert hermes_time.get_timezone_name() == "America/New_York"  # default profile turn
+            token = set_hermes_home_override(str(routed_home))
+            try:
+                assert hermes_time.get_timezone_name() == "Asia/Tokyo"
+                assert str(hermes_time.get_timezone()) == "Asia/Tokyo"
+            finally:
+                reset_hermes_home_override(token)
+        finally:
+            set_multiplex_active(False)
+
     def test_concurrent_profile_resolution_never_mixes_zones(
         self, tmp_path, monkeypatch
     ):

--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -720,17 +720,12 @@ class TestConfigOverride(unittest.TestCase):
 
     def setUp(self):
         _read_tracker.clear()
-        # Reset the cached value so each test gets a fresh lookup
-        import tools.file_tools as _ft
-        _ft._max_read_chars_cached = None
 
     def tearDown(self):
         _read_tracker.clear()
-        import tools.file_tools as _ft
-        _ft._max_read_chars_cached = None
 
     @patch("tools.file_tools._get_file_ops")
-    @patch("hermes_cli.config.load_config", return_value={"file_read_max_chars": 50})
+    @patch("hermes_cli.config.load_config_readonly", return_value={"file_read_max_chars": 50})
     def test_custom_config_lowers_limit(self, _mock_cfg, mock_ops):
         """A config value of 50 should trigger truncation for reads over 50 chars,
         with the configured limit reflected in the continuation hint."""
@@ -743,7 +738,7 @@ class TestConfigOverride(unittest.TestCase):
         self.assertLessEqual(len(result["content"]), 50)
 
     @patch("tools.file_tools._get_file_ops")
-    @patch("hermes_cli.config.load_config", return_value={"file_read_max_chars": 500_000})
+    @patch("hermes_cli.config.load_config_readonly", return_value={"file_read_max_chars": 500_000})
     def test_custom_config_raises_limit(self, _mock_cfg, mock_ops):
         """A config value of 500K should allow reads up to 500K chars."""
         # 200K chars would be rejected at the default 100K but passes at 500K

--- a/tests/tools/test_multiplex_tool_memo_scope.py
+++ b/tests/tools/test_multiplex_tool_memo_scope.py
@@ -1,0 +1,89 @@
+"""Under ``gateway.multiplex_profiles`` one process serves every profile; each routed turn runs with
+a context-local HERMES_HOME override. Tool-side state resolved once at import, or cached in a
+single unkeyed slot, would hand the launch profile's paths/limits to every other profile.
+
+Each test warms the site under profile A, flips the override to profile B with different
+config, and asserts B sees its own values (real temp homes, real config.yaml, no mocks).
+"""
+
+import json
+
+import pytest
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+@pytest.fixture
+def two_profiles(tmp_path, monkeypatch):
+    prof_a, prof_b = tmp_path / "profA", tmp_path / "profB"
+    for home, limits in ((prof_a, (222, 33, 3300)), (prof_b, (888, 77, 7700))):
+        home.mkdir()
+        max_bytes, timeout, threshold = limits
+        (home / "config.yaml").write_text(
+            f"file_read_max_chars: {max_bytes}\ntool_output:\n  max_bytes: {max_bytes}\n"
+            f"browser:\n  command_timeout: {timeout}\n  snapshot_threshold: {threshold}\n",
+            encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(prof_a))
+    return prof_a, prof_b
+
+
+def _under(home, fn):
+    token = set_hermes_home_override(str(home))
+    try:
+        return fn()
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_checkpoint_and_snapshot_paths_follow_active_profile(two_profiles):
+    import tools.process_registry as pr
+    from tools.environments import modal, singularity
+
+    prof_a, prof_b = two_profiles
+    _under(prof_a, pr._checkpoint_path)  # warm under A
+    assert _under(prof_b, pr._checkpoint_path) == prof_b / "processes.json"
+    assert _under(prof_b, modal._snapshot_store) == prof_b / "modal_snapshots.json"
+    assert _under(prof_b, singularity._snapshot_store) == prof_b / "singularity_snapshots.json"
+    assert _under(prof_a, pr._checkpoint_path) == prof_a / "processes.json"
+
+
+def test_config_caches_are_keyed_by_profile(two_profiles):
+    import tools.browser_camofox as cam
+    import tools.browser_tool as bt
+    import tools.file_tools as ft
+    import tools.tool_output_limits as tol
+    from tools.browser_tool_lifecycle import cleanup_all_browsers
+
+    prof_a, prof_b = two_profiles
+    tol._reset_tool_output_limits_cache()
+    cleanup_all_browsers()
+    cam._cmd_timeout_resolved, cam._cached_cmd_timeout = False, None
+
+    def read_all():
+        return (tol.get_tool_output_limits()["max_bytes"], ft._get_max_read_chars(),
+                bt._get_command_timeout(), bt.get_browser_snapshot_threshold(), cam._get_command_timeout())
+
+    assert _under(prof_a, read_all) == (222, 222, 33, 3300, 33)
+    assert _under(prof_b, read_all) == (888, 888, 77, 7700, 77)
+    # Per-profile slots stay hot — switching back is not a single-slot ping-pong.
+    assert _under(prof_a, read_all) == (222, 222, 33, 3300, 33)
+
+
+def test_schema_path_hints_follow_active_profile(two_profiles):
+    import tools.cronjob_tools  # noqa: F401  (registers cronjob_manage)
+    import tools.skill_manager_tool  # noqa: F401
+    import tools.tts_tool  # noqa: F401
+    from tools.registry import registry
+
+    prof_a, prof_b = two_profiles
+    names = {"cronjob_manage", "text_to_speech", "skill_manage"}
+
+    def definitions():
+        return json.dumps(registry.get_definitions(names, quiet=True))
+
+    for_a, for_b = _under(prof_a, definitions), _under(prof_b, definitions)
+    assert "profA" in for_a and "profB" not in for_a
+    assert "profB" in for_b and "profA" not in for_b
+    for fn in json.loads(for_b):
+        name, text = fn["function"]["name"], json.dumps(fn["function"])
+        assert name in names and "profB" in text, name

--- a/tests/tools/test_terminal_truncation_spill.py
+++ b/tests/tools/test_terminal_truncation_spill.py
@@ -12,10 +12,11 @@ from tools.terminal_tool import terminal_tool
 @pytest.fixture
 def small_cap(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    from hermes_constants import hermes_home_key
     import tools.tool_output_limits as lim
-    monkeypatch.setattr(lim, "_cached_limits", {
+    monkeypatch.setattr(lim, "_cached_limits", {hermes_home_key(): {
         "max_bytes": 2000, "max_lines": 2000, "max_line_length": 2000,
-    })
+    }})
     return tmp_path
 
 

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -25,6 +25,7 @@ import requests
 
 from agent.secret_scope import get_secret
 from hermes_cli.config import cfg_get, load_config, read_raw_config
+from hermes_constants import hermes_home_key
 from tools.browser_camofox_state import get_camofox_identity
 from tools.registry import tool_error
 
@@ -36,24 +37,30 @@ _DEFAULT_TIMEOUT = 30  # fallback when config is unreadable
 _NO_SESSION_ERROR = "No browser session. Call browser_navigate first."
 _vnc_url: Optional[str] = None  # cached from /health response
 _vnc_url_checked = False  # only probe once per process
-_cached_cmd_timeout: Optional[int] = None  # browser.command_timeout, resolved lazily like browser_tool
+# browser.command_timeout, resolved lazily like browser_tool; keyed by profile home because the
+# multiplexed gateway serves every profile from one process.
+_cached_cmd_timeout: Optional[Dict[str, int]] = None
 _cmd_timeout_resolved = False
 
 
 def _get_command_timeout() -> int:
-    """``browser.command_timeout`` (floor 5s, default 30s), cached after first read."""
+    """``browser.command_timeout`` (floor 5s, default 30s), cached per profile home after first read."""
     global _cached_cmd_timeout, _cmd_timeout_resolved
-    if _cmd_timeout_resolved:
-        return _cached_cmd_timeout  # type: ignore[return-value]
-    _cmd_timeout_resolved = True
-    _cached_cmd_timeout = _DEFAULT_TIMEOUT
+    home = hermes_home_key()
+    if _cached_cmd_timeout is None:
+        _cached_cmd_timeout = {}
+    if _cmd_timeout_resolved and home in _cached_cmd_timeout:
+        return _cached_cmd_timeout[home]
+    timeout = _DEFAULT_TIMEOUT
     try:
         val = cfg_get(read_raw_config(), "browser", "command_timeout")
         if val is not None:
-            _cached_cmd_timeout = max(int(val), 5)
+            timeout = max(int(val), 5)
     except Exception as exc:
         logger.debug("Could not read browser.command_timeout: %s", exc)
-    return _cached_cmd_timeout
+    _cached_cmd_timeout[home] = timeout
+    _cmd_timeout_resolved = True
+    return timeout
 
 
 def _auth_headers() -> Dict[str, str]:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -20,7 +20,7 @@ import time
 from typing import Dict, Any, Optional, Union
 from pathlib import Path
 from agent.redact import redact_cdp_url
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, hermes_home_key
 from utils import env_int
 from hermes_cli.config import DEFAULT_CONFIG, cfg_get
 
@@ -125,11 +125,14 @@ AGENT_BROWSER_NPX_SPEC = "agent-browser@^0.26.0"
 
 # Process caches (``_cached_X`` + ``_X_resolved`` pairs) for config-derived lookups;
 # reset by ``cleanup_all_browsers``. Written/read by the sibling modules via ``browser_tool_origin``.
-_cached_command_timeout: Optional[int] = None
+# The config-derived ones are keyed by profile home (``hermes_home_key()``): the multiplexed
+# gateway serves every profile from one process, so a single slot would hand the launch
+# profile's browser settings to every other profile.
+_cached_command_timeout: Optional[Dict[str, int]] = None
 # Flip the resolved flag BEFORE nulling the cache so a concurrent reader never sees ``resolved=True`` with
 # ``cache=None`` (#14331).
 _command_timeout_resolved = False
-_cached_snapshot_threshold: Optional[int] = None
+_cached_snapshot_threshold: Optional[Dict[str, int]] = None
 _snapshot_threshold_resolved = False
 _cached_cloud_provider: Optional[BrowserProvider] = None
 _cloud_provider_resolved = False
@@ -167,14 +170,18 @@ def _browser_cfg(key: str, default, parse, log_label: str):
 
 
 def _cached_browser_cfg(cache_name: str, flag_name: str, key: str, default, parse, log_label: str):
-    """Process-cached ``_browser_cfg`` read (cleared by ``cleanup_all_browsers``). The value is
-    stored BEFORE the resolved flag flips so a concurrent reader never sees ``resolved=True``
-    with a ``None`` cache."""
+    """Process-cached ``_browser_cfg`` read, one slot per profile home (cleared by
+    ``cleanup_all_browsers``). The value is stored BEFORE the resolved flag flips so a
+    concurrent reader never sees ``resolved=True`` with an empty cache."""
     g = globals()
-    if g[flag_name] and g[cache_name] is not None:
-        return g[cache_name]
+    home = hermes_home_key()
+    cache = g[cache_name]
+    if cache is None:
+        cache = g[cache_name] = {}
+    if g[flag_name] and cache.get(home) is not None:
+        return cache[home]
     result = _browser_cfg(key, default, parse, log_label)
-    g[cache_name] = result
+    cache[home] = result
     g[flag_name] = True
     return result
 

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -31,6 +31,15 @@ from utils import env_int
 logger = logging.getLogger(__name__)
 
 CHECKPOINT_BASE = get_hermes_home() / "checkpoints"
+_CHECKPOINT_BASE_AT_IMPORT = CHECKPOINT_BASE
+
+
+def _resolve_checkpoint_base() -> Path:
+    """Active profile's checkpoint root at call time: the patched ``CHECKPOINT_BASE`` when a test
+    changed it, else live profile-scoped HERMES_HOME — under the multiplexed gateway one process
+    serves every profile, so the import-time constant would write every profile's code-edit
+    checkpoints into the launch profile's store."""
+    return CHECKPOINT_BASE if CHECKPOINT_BASE != _CHECKPOINT_BASE_AT_IMPORT else get_hermes_home() / "checkpoints"
 
 _STORE_DIRNAME, _INDEXES_DIRNAME, _PROJECTS_DIRNAME, _LEDGERS_DIRNAME = "store", "indexes", "projects", "ledgers"
 _REFS_PREFIX, _LEGACY_PREFIX, _PRUNE_MARKER_NAME = "refs/hermes", "legacy-", ".last_prune"
@@ -104,7 +113,7 @@ def _project_hash(working_dir: str) -> str:
 
 
 def _store_path(base: Optional[Path] = None) -> Path:
-    return (base or CHECKPOINT_BASE) / _STORE_DIRNAME
+    return (base or _resolve_checkpoint_base()) / _STORE_DIRNAME
 
 
 def _store_has_head(store: Path) -> bool:
@@ -516,7 +525,7 @@ class _ProjectRefs(NamedTuple):
 
 def _project_refs(working_dir: str) -> _ProjectRefs:
     abs_dir = str(_normalize_path(working_dir))
-    store, dir_hash = _store_path(CHECKPOINT_BASE), _project_hash(abs_dir)
+    store, dir_hash = _store_path(), _project_hash(abs_dir)
     return _ProjectRefs(abs_dir, store, dir_hash, _index_path(store, dir_hash), _ref_name(dir_hash))
 
 
@@ -591,7 +600,7 @@ class CheckpointManager:
             digest = _hash_file(path)
             if digest is None:
                 return
-            store, dir_hash = _store_path(CHECKPOINT_BASE), _project_hash(self.get_working_dir_for_path(str(path)))
+            store, dir_hash = _store_path(), _project_hash(self.get_working_dir_for_path(str(path)))
             _save_ledger(store, dir_hash, {**_load_ledger(store, dir_hash), str(path): {"sha256": digest, "ts": time.time()}})
         except Exception as exc:
             logger.debug("record_agent_write failed for %s: %s", file_path, exc)
@@ -674,7 +683,7 @@ class CheckpointManager:
         Each entry carries the extra ``workdir`` key so callers can label which project a checkpoint belongs
         to.
         """
-        store = _store_path(CHECKPOINT_BASE)
+        store = _store_path()
         if not _store_has_head(store):
             return []
         results = [{**entry, "workdir": workdir}
@@ -1062,7 +1071,7 @@ def prune_checkpoints(retention_days: int = 7, delete_orphans: bool = True, chec
     ``str``) binds orphan deletion to exactly what a ``store_status()`` preview showed — a project
     orphaned after the preview is skipped; ``None`` deletes every current orphan (``--force``,
     unattended).  ``max_total_size_mb > 0`` drops the oldest commit per project until the store fits."""
-    base = checkpoint_base or CHECKPOINT_BASE
+    base = checkpoint_base or _resolve_checkpoint_base()
     result = _empty_prune_result()
     if not base.exists():
         return result
@@ -1087,7 +1096,7 @@ def maybe_auto_prune_checkpoints(retention_days: int = 7, min_interval_hours: in
     """Idempotent wrapper around ``prune_checkpoints`` for startup hooks: writes
     ``CHECKPOINT_BASE/.last_prune`` so calls within ``min_interval_hours`` short-circuit.
     Returns ``{"skipped": bool, "result": prune dict, "error": optional str}``."""
-    base = checkpoint_base or CHECKPOINT_BASE
+    base = checkpoint_base or _resolve_checkpoint_base()
     out: Dict[str, object] = {"skipped": False}
     try:
         if not base.exists():
@@ -1125,7 +1134,7 @@ def store_status(checkpoint_base: Optional[Path] = None) -> Dict:
     ``pre_v2_projects`` are repos still on the pre-v2 layout, distinct from the migrated
     ``legacy_archives``; an orphan-deletion preview must include both ``projects`` and
     ``pre_v2_projects`` since ``prune_checkpoints`` sweeps both."""
-    base = checkpoint_base or CHECKPOINT_BASE
+    base = checkpoint_base or _resolve_checkpoint_base()
     out: Dict = {"base": str(base), "store_size_bytes": 0, "legacy_size_bytes": 0, "total_size_bytes": 0,
                  "project_count": 0, "projects": [], "pre_v2_projects": [], "legacy_archives": []}
     if not base.exists():
@@ -1155,7 +1164,7 @@ def store_status(checkpoint_base: Optional[Path] = None) -> Dict:
 def clear_all(checkpoint_base: Optional[Path] = None) -> Dict[str, int]:
     """Nuke the entire checkpoint base (store + legacy).  Irreversible.
     Returns ``{"bytes_freed": N, "deleted": bool}``."""
-    base = checkpoint_base or CHECKPOINT_BASE
+    base = checkpoint_base or _resolve_checkpoint_base()
     out = {"bytes_freed": 0, "deleted": False}
     if not base.exists():
         return out
@@ -1170,7 +1179,7 @@ def clear_all(checkpoint_base: Optional[Path] = None) -> Dict[str, int]:
 
 def clear_legacy(checkpoint_base: Optional[Path] = None) -> Dict[str, int]:
     """Delete all ``legacy-*`` archive directories.  Returns ``{"bytes_freed": N, "deleted": count}``."""
-    base = checkpoint_base or CHECKPOINT_BASE
+    base = checkpoint_base or _resolve_checkpoint_base()
     out = {"bytes_freed": 0, "deleted": 0}
     if not base.exists():
         return out

--- a/tools/code_execution_env.py
+++ b/tools/code_execution_env.py
@@ -121,8 +121,11 @@ def _build_child_env(*, rpc_endpoint: str, rpc_token: str, tmpdir: str,
     # code page (cp1252) and print("→") raises; harmless under a C/POSIX locale (containers).
     child_env["PYTHONIOENCODING"] = "utf-8"
     child_env["PYTHONUTF8"] = "1"
-    # Only TZ reaches the child; HERMES_TIMEZONE is an internal setting.
-    _tz_name = os.getenv("HERMES_TIMEZONE", "").strip()
+    # Only TZ reaches the child; HERMES_TIMEZONE is an internal setting (and under the multiplexed
+    # gateway holds only the default profile's value — hermes_time resolves the routed profile's).
+    from hermes_time import get_timezone_name
+
+    _tz_name = get_timezone_name()
     if _tz_name:
         child_env["TZ"] = _tz_name
     child_env.pop("HERMES_TIMEZONE", None)

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -28,6 +28,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from tools.thread_context import propagate_context_to_thread
 from tools.registry import registry, tool_error
 
+from hermes_time import get_timezone_name
 from tools.code_execution_env import _resolve_child_cwd, _resolve_child_python
 from tools.code_execution_rpc import _rpc_poll_loop
 
@@ -578,7 +579,7 @@ def _run_remote_per_call(env, env_type: str, code: str, effective_task_id: str,
         rpc_thread.start()
         env_prefix = (f"HERMES_RPC_DIR={quoted_rpc_dir} HERMES_RPC_TOKEN={shlex.quote(rpc_token)} "
                       "PYTHONDONTWRITEBYTECODE=1")
-        tz = os.getenv("HERMES_TIMEZONE", "").strip()
+        tz = get_timezone_name()  # routed profile's timezone, not the bridged default's
         if tz:
             env_prefix += f" TZ={shlex.quote(tz)}"
         logger.info("Executing code on %s backend (task %s)...", env_type, effective_task_id[:8])

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -10,6 +10,8 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
+import copy
+
 from hermes_constants import display_hermes_home
 
 logger = logging.getLogger(__name__)
@@ -904,6 +906,21 @@ def cronjob(
         return tool_error(str(e), success=False)
 
 
+def _script_description(home: str) -> str:
+    return (f"Optional script run each tick; stdout is injected into the agent's prompt as context (with no_agent=True "
+            f"the script IS the job). Relative paths resolve under {home}/scripts/; .sh/.bash via bash, else Python. "
+            "On update, '' clears.")
+
+
+def _cronjob_schema_overrides() -> dict:
+    """Rebuild the ``script`` path hint from the ACTIVE profile at every get_definitions(): the
+    static schema is built once per process, but the multiplexed gateway serves every profile from
+    that process, so a path baked in at import would name the launch profile's home (#95685)."""
+    params = copy.deepcopy(CRONJOB_SCHEMA["parameters"])
+    params["properties"]["script"]["description"] = _script_description(display_hermes_home())
+    return {"parameters": params}
+
+
 CRONJOB_SCHEMA = {
     "name": "cronjob_manage",
     "description": """Manage scheduled cron jobs: action='create' schedules a job from a prompt and/or skills; 'list' inspects jobs; 'update'/'pause'/'resume'/'remove' manage one by job_id (always list first — never guess job IDs); 'run' fires a job immediately in the BACKGROUND (returns a handle at once, outcome re-enters the conversation when done — do not wait or poll; optional 'prompt' adds transient context for that fire only).
@@ -954,7 +971,7 @@ Jobs run in a fresh session with no current-chat context, so prompts must be sel
             },
             "script": {
                 "type": "string",
-                "description": f"Optional script run each tick; stdout is injected into the agent's prompt as context (with no_agent=True the script IS the job). Relative paths resolve under {display_hermes_home()}/scripts/; .sh/.bash via bash, else Python. On update, '' clears."
+                "description": _script_description("the profile HERMES_HOME")
             },
             "monitor": {
                 "type": "string",
@@ -1037,6 +1054,7 @@ registry.register(
     handler=_cronjob_handler,
     check_fn=check_cronjob_requirements,
     emoji="⏰",
+    dynamic_schema_overrides=_cronjob_schema_overrides,
 )
 
 

--- a/tools/environments/modal.py
+++ b/tools/environments/modal.py
@@ -21,15 +21,18 @@ from tools.environments.remote_common import bash_argv, ensure_lazy_dep
 
 logger = logging.getLogger(__name__)
 
-_SNAPSHOT_STORE = get_hermes_home() / "modal_snapshots.json"
+def _snapshot_store() -> Path:
+    # Resolved per call: the multiplexed gateway serves every profile from one process, so an
+    # import-time path would keep every profile's snapshots in the launch profile's home.
+    return get_hermes_home() / "modal_snapshots.json"
 
 
 def _load_snapshots() -> dict:
-    return _load_json_store(_SNAPSHOT_STORE)
+    return _load_json_store(_snapshot_store())
 
 
 def _save_snapshots(data: dict) -> None:
-    _save_json_store(_SNAPSHOT_STORE, data)
+    _save_json_store(_snapshot_store(), data)
 
 
 def _get_snapshot_restore_candidate(task_id: str) -> tuple[str | None, bool]:

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -21,7 +21,10 @@ from tools.environments.remote_common import bash_argv, run_capture
 
 logger = logging.getLogger(__name__)
 
-_SNAPSHOT_STORE = get_hermes_home() / "singularity_snapshots.json"
+def _snapshot_store() -> Path:
+    # Resolved per call: the multiplexed gateway serves every profile from one process, so an
+    # import-time path would keep every profile's snapshots in the launch profile's home.
+    return get_hermes_home() / "singularity_snapshots.json"
 
 
 def _find_singularity_executable() -> str:
@@ -51,11 +54,11 @@ def _ensure_singularity_available() -> str:
 
 
 def _load_snapshots() -> dict:
-    return _load_json_store(_SNAPSHOT_STORE)
+    return _load_json_store(_snapshot_store())
 
 
 def _save_snapshots(data: dict) -> None:
-    _save_json_store(_SNAPSHOT_STORE, data)
+    _save_json_store(_snapshot_store(), data)
 
 
 def _get_scratch_dir() -> Path:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -45,21 +45,17 @@ _EXPECTED_WRITE_ERRNOS = {errno.EACCES, errno.EPERM, errno.EROFS}
 # Read-size guard. Model-agnostic, so characters proxy tokens: 100K chars is
 # ~25-35K tokens across typical tokenisers. Configurable: file_read_max_chars.
 _DEFAULT_MAX_READ_CHARS = 100_000
-_max_read_chars_cached: int | None = None
-
-
 def _get_max_read_chars() -> int:
-    """Return ``file_read_max_chars`` from config.yaml (cached per process; default on missing/invalid)."""
-    global _max_read_chars_cached
-    if _max_read_chars_cached is None:
-        try:
-            from hermes_cli.config import load_config
-            val = load_config().get("file_read_max_chars")
-        except Exception:
-            val = None
-        valid = isinstance(val, (int, float)) and val > 0
-        _max_read_chars_cached = int(val) if valid else _DEFAULT_MAX_READ_CHARS
-    return _max_read_chars_cached
+    """Return ``file_read_max_chars`` from config.yaml (default on missing/invalid). No module
+    cache: ``load_config_readonly`` is already mtime+path cached, and a process-lifetime slot
+    would pin the launch profile's value under the multiplexed gateway."""
+    try:
+        from hermes_cli.config import load_config_readonly
+        val = load_config_readonly().get("file_read_max_chars")
+    except Exception:
+        val = None
+    valid = isinstance(val, (int, float)) and val > 0
+    return int(val) if valid else _DEFAULT_MAX_READ_CHARS
 
 
 def _truncate_to_char_budget(content: str, max_chars: int) -> tuple[str, int, bool]:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -39,6 +39,15 @@ logger = logging.getLogger(__name__)
 
 # Crash-recovery checkpoint (gateway only)
 CHECKPOINT_PATH = get_hermes_home() / "processes.json"
+_CHECKPOINT_PATH_AT_IMPORT = CHECKPOINT_PATH
+
+
+def _checkpoint_path() -> Path:
+    """Active profile's checkpoint file at call time: the patched ``CHECKPOINT_PATH`` when a test
+    changed it, else live profile-scoped HERMES_HOME — the multiplexed gateway serves every
+    profile from one process, so the import-time constant would pin every profile's process
+    checkpoint to the launch home."""
+    return CHECKPOINT_PATH if CHECKPOINT_PATH != _CHECKPOINT_PATH_AT_IMPORT else get_hermes_home() / "processes.json"
 
 MAX_OUTPUT_CHARS = 200_000      # rolling output buffer
 FINISHED_TTL_SECONDS = 1800     # keep finished processes 30 minutes

--- a/tools/process_registry_checkpoint.py
+++ b/tools/process_registry_checkpoint.py
@@ -15,7 +15,7 @@ class ProcessCheckpointMixin:
 
     def _write_checkpoint(self, extra_entries: Optional[List[Dict[str, Any]]] = None):
         """Write running process metadata to the checkpoint file atomically."""
-        from tools.process_registry import CHECKPOINT_PATH, _CHECKPOINT_FIELDS
+        from tools.process_registry import _checkpoint_path, _CHECKPOINT_FIELDS
 
         try:
             with self._lock:
@@ -39,7 +39,7 @@ class ProcessCheckpointMixin:
                     tracked_ids = {item.get("session_id") for item in entries}
                     entries.extend(item for item in extra_entries if item.get("session_id") not in tracked_ids)
             from utils import atomic_json_write
-            atomic_json_write(CHECKPOINT_PATH, entries)
+            atomic_json_write(_checkpoint_path(), entries)
         except Exception as e:
             logger.debug("Failed to write checkpoint file: %s", e, exc_info=True)
 
@@ -47,14 +47,15 @@ class ProcessCheckpointMixin:
         """On gateway startup, probe PIDs from the checkpoint file; returns how many
         were recovered as detached sessions."""
         from tools.process_registry import (
-            CHECKPOINT_PATH, ProcessSession, _CHECKPOINT_FIELDS,
+            ProcessSession, _CHECKPOINT_FIELDS, _checkpoint_path,
             _CHECKPOINT_DEFAULTS, _WATCHER_ROUTE_KEYS, _stop_systemd_unit,
         )
 
-        if not CHECKPOINT_PATH.exists():
+        checkpoint_path = _checkpoint_path()
+        if not checkpoint_path.exists():
             return 0
         try:
-            entries = json.loads(CHECKPOINT_PATH.read_text(encoding="utf-8"))
+            entries = json.loads(checkpoint_path.read_text(encoding="utf-8"))
         except Exception:
             return 0
         recovered = 0

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -779,17 +779,13 @@ def skill_manage(
 
 # --- OpenAI Function-Calling Schema -------------------------------------------
 
-SKILL_MANAGE_SCHEMA = {
-    "name": "skill_manage",
-    # ONE advertised call shape (memory-tool pattern): the call IS an operations
-    # array. The legacy flat shape (top-level action/name/content/...) is still
-    # ACCEPTED for old transcripts and staged-write replay, but not advertised.
-    "description": (
+def _skill_manage_description(create_dir: str) -> str:
+    return (
         "Create, update, or delete skills — your procedural memory for "
         "recurring task types. The call is an operations array (a single "
         "edit is a list of one); it applies atomically — any failure rolls "
         "every touched skill back. Ops: create (full SKILL.md; lands in "
-        f"{_display_create_dir()}; must precede that skill's other "
+        f"{create_dir}; must precede that skill's other "
         "ops), patch (targeted old_string/new_string fix — preferred; "
         "content alone REPLACES the whole file, read it via skill_view() "
         "first), write_file/remove_file (supporting files), delete (sole "
@@ -799,7 +795,22 @@ SKILL_MANAGE_SCHEMA = {
         "imperative rule + why, no PR numbers/dates/incident narration, one "
         "rule per lesson, references/ named by topic (extend before adding). "
         "skill_view() shows format conventions."
-    ),
+    )
+
+
+def _skill_manage_schema_overrides() -> dict:
+    """Rebuild the create-dir hint from the ACTIVE profile at every get_definitions(): the
+    multiplexed gateway serves every profile from one process, so a path baked in at import
+    would name the launch profile's skills dir for everyone else (#95685)."""
+    return {"description": _skill_manage_description(_display_create_dir())}
+
+
+SKILL_MANAGE_SCHEMA = {
+    "name": "skill_manage",
+    # ONE advertised call shape (memory-tool pattern): the call IS an operations
+    # array. The legacy flat shape (top-level action/name/content/...) is still
+    # ACCEPTED for old transcripts and staged-write replay, but not advertised.
+    "description": _skill_manage_description("the profile's skills.create_dir"),
     "parameters": {
         "type": "object",
         "properties": {
@@ -881,7 +892,8 @@ from tools.registry import registry, tool_error
 registry.register(
     name="skill_manage", toolset="skills", schema=SKILL_MANAGE_SCHEMA, emoji="📝",
     handler=lambda args, **kw: _skill_manage_from(
-        args, task_id=kw.get("task_id"), session_id=kw.get("session_id")))
+        args, task_id=kw.get("task_id"), session_id=kw.get("session_id")),
+    dynamic_schema_overrides=_skill_manage_schema_overrides)
 
 
 # ---- BEGIN PLUGIN-COMPAT (revert-scheduled; see COMPAT_MANIFEST.md) ----

--- a/tools/tool_output_limits.py
+++ b/tools/tool_output_limits.py
@@ -8,10 +8,14 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+from hermes_constants import hermes_home_key
+
 DEFAULT_MAX_BYTES = 50_000       # terminal_tool.MAX_OUTPUT_CHARS
 DEFAULT_MAX_LINES = 2000         # file_operations.MAX_LINES
 DEFAULT_MAX_LINE_LENGTH = 2000   # file_operations.MAX_LINE_LENGTH
-_cached_limits: dict | None = None  # process-lifetime: no config.yaml re-read per tool call
+# Keyed by profile home: the multiplexed gateway serves every profile from one process, so a
+# single slot would hand the launch profile's limits to every other profile.
+_cached_limits: Dict[str, Dict[str, int]] = {}
 
 
 def _coerce_int(value: Any, default: int, minimum: int) -> int:
@@ -28,11 +32,12 @@ def _coerce_positive_int(value: Any, default: int) -> int:
 
 
 def get_tool_output_limits() -> Dict[str, int]:
-    """Resolved ``{max_bytes, max_lines, max_line_length}``; never raises. Cached for the
-    process — ``_reset_tool_output_limits_cache()`` forces a fresh read."""
-    global _cached_limits
-    if _cached_limits is not None:
-        return _cached_limits
+    """Resolved ``{max_bytes, max_lines, max_line_length}``; never raises. Cached per profile
+    home for the process — ``_reset_tool_output_limits_cache()`` forces a fresh read."""
+    key = hermes_home_key()
+    cached = _cached_limits.get(key)
+    if cached is not None:
+        return cached
     try:
         from hermes_cli.config import load_config
         cfg = load_config() or {}
@@ -41,18 +46,17 @@ def get_tool_output_limits() -> Dict[str, int]:
         section = None
     if not isinstance(section, dict):
         section = {}
-    _cached_limits = {
+    _cached_limits[key] = limits = {
         "max_bytes": _coerce_positive_int(section.get("max_bytes"), DEFAULT_MAX_BYTES),
         "max_lines": _coerce_positive_int(section.get("max_lines"), DEFAULT_MAX_LINES),
         "max_line_length": _coerce_positive_int(
             section.get("max_line_length"), DEFAULT_MAX_LINE_LENGTH)}
-    return _cached_limits
+    return limits
 
 
 def _reset_tool_output_limits_cache() -> None:
     """Reset the cached limits — for tests or after config hot-reload."""
-    global _cached_limits
-    _cached_limits = None
+    _cached_limits.clear()
 
 
 def get_max_bytes() -> int: return get_tool_output_limits()["max_bytes"]

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -19,6 +19,8 @@ import tempfile
 from pathlib import Path
 from typing import Callable, Dict, Any, List, Optional
 
+import copy
+
 from hermes_constants import display_hermes_home
 
 logger = logging.getLogger(__name__)
@@ -522,6 +524,19 @@ def check_tts_requirements() -> bool:
 # --- Registry ---
 from tools.registry import registry, tool_error
 
+def _output_path_description(home: str) -> str:
+    return f"Optional custom file path to save the audio. Defaults to {home}/audio_cache/<timestamp>.mp3"
+
+
+def _tts_schema_overrides() -> dict:
+    """Rebuild the ``output_path`` default hint from the ACTIVE profile at every get_definitions():
+    the multiplexed gateway serves every profile from one process, so a path baked in at import
+    would name the launch profile's home for everyone else (#95685)."""
+    params = copy.deepcopy(TTS_SCHEMA["parameters"])
+    params["properties"]["output_path"]["description"] = _output_path_description(display_hermes_home())
+    return {"parameters": params}
+
+
 TTS_SCHEMA = {
     "name": "text_to_speech",
     "description": "Convert text to speech audio. Returns a MEDIA: path that the platform delivers as native audio. Compatible providers render as a voice bubble on Telegram; otherwise audio is sent as a regular attachment. In CLI mode, saves to ~/voice-memos/. Voice and provider are user-configured (built-in providers like edge/openai or custom command providers under tts.providers.<name>), not model-selected.",
@@ -534,7 +549,7 @@ TTS_SCHEMA = {
             },
             "output_path": {
                 "type": "string",
-                "description": f"Optional custom file path to save the audio. Defaults to {display_hermes_home()}/audio_cache/<timestamp>.mp3"
+                "description": _output_path_description("the profile HERMES_HOME")
             },
             "speed": {
                 "type": "number",
@@ -572,7 +587,8 @@ registry.register(
         text=args.get("text", ""),
         **{k: args.get(k) for k in ("output_path", "speed", "instructions", "provider")}),
     check_fn=check_tts_requirements,
-    emoji="🔊")
+    emoji="🔊",
+    dynamic_schema_overrides=_tts_schema_overrides)
 
 
 # ---- BEGIN PLUGIN-COMPAT (revert-scheduled; see COMPAT_MANIFEST.md) ----

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -1633,11 +1633,14 @@ Each time the event fires, Hermes spawns a subprocess for every matching hook (m
   "tool_input":      {"command": "rm -rf /"},
   "session_id":      "sess_abc123",
   "cwd":             "/home/user/project",
+  "profile":         "default",
   "extra":           {"task_id": "...", "tool_call_id": "..."}
 }
 ```
 
-`tool_name` and `tool_input` are `null` for non-tool events (`pre_llm_call`, `subagent_stop`, session lifecycle). The `extra` dict carries all event-specific kwargs (`user_message`, `conversation_history`, `child_role`, `duration_ms`, …). Unserialisable values are stringified rather than omitted.
+`profile` names the Hermes profile that fired the hook (`"default"` outside profiles), so one
+script can serve every profile behind a multiplexed gateway; the subprocess also runs with that
+profile's `HERMES_HOME`. `tool_name` and `tool_input` are `null` for non-tool events (`pre_llm_call`, `subagent_stop`, session lifecycle). The `extra` dict carries all event-specific kwargs (`user_message`, `conversation_history`, `child_role`, `duration_ms`, …). Unserialisable values are stringified rather than omitted.
 
 **stdout — optional response:**
 

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -306,6 +306,19 @@ sent to another profile's proxy or self-hosted server. `WEIXIN_HOME_CHANNEL`,
 likewise per profile, and end-of-session memory extraction for an evicted
 secondary session runs under that profile's scope.
 
+Per-turn runtime settings follow the routed profile as well: `agent.max_turns`,
+`fallback_providers`, `file_read_max_chars`, `tool_output.*`, `browser.*`
+timeouts, `timezone` (including the `TZ` handed to `execute_code` sandboxes),
+the media-delivery policy (`gateway.strict`, `media_delivery_allow_dirs`,
+`trust_recent_files*`) and the Nous `auth.json` used for auxiliary calls are all
+read from the profile serving the turn, never from the profile the gateway was
+launched under. The same holds for per-profile state files (`processes.json`,
+`checkpoints/`, sandbox snapshot stores, Feishu comment rules/pairing) and for
+gateway hooks: each profile's `hooks/` directory is loaded on its own and fires
+only for that profile's events. Shell hooks run with the routed profile's
+`HERMES_HOME`, without the default profile's secrets in their environment, and
+their stdin payload carries a `profile` field naming the profile that fired them.
+
 ### Serving selected profiles
 
 By default, `gateway.multiplex_profiles: true` serves every valid named profile


### PR DESCRIPTION
Under `gateway.multiplex_profiles`, a secondary profile's turns now run with **its own** `agent.max_turns`, fallback chain, gateway hooks, Nous `auth.json`, media-delivery policy, checkpoint/snapshot stores, tool limits, browser timeouts, sandbox timezone and tool-schema paths — instead of the launch profile's values frozen into module constants and process caches at import.

## Changes

**Gateway / agent side** (`fix(gateway)`)
- `gateway/run.py::_current_max_iterations` — a routed turn (HERMES_HOME override) reads `agent.max_turns` from its own config instead of the process-wide `HERMES_MAX_ITERATIONS` bridge filled from `_hermes_home`.
- `gateway/run_config_loaders.py::_refresh_fallback_model` — reads the active gateway home and keeps a last-known-good chain **per home** (was one runner-wide slot from the launch home); `_load_prefill_messages` relative paths likewise.
- `agent/auxiliary_client.py` — `_AUTH_JSON_PATH` resolved per call via `hermes_cli.auth._auth_file_path()`; a secondary's compression/title/vision calls stop authenticating with the default profile's Nous token.
- `gateway/hooks.py` — `HOOKS_DIR` resolved per call (salvaged from #56508, @srojk34's commit kept) and a new `ProfileHookRegistries` holds one `HookRegistry` per served home, picked from the active scope at emit time. Secondaries' `hooks/` now fire; the default's handlers no longer see other profiles' messages/responses/user ids.
- `agent/shell_hooks.py::_spawn` — child env via `build_subprocess_env(scrub_secrets=is_multiplex_active())`: routed `HERMES_HOME`, default-profile secrets scrubbed under multiplexing; stdin payload gains `profile`. Single-profile runs keep the process env byte-for-byte.
- `gateway/media_policy.py` (+ `platforms/base.py`, `media_fetch.py`) — `media_delivery_strict/allow_dirs/trust_recent*` read the routed profile's config under an override; the env bridge remains the contract when no override is active.

**Tools side** (`fix(tools)`, + cherry-picked #56315 by @srojk34)
- `tools/process_registry.py::_checkpoint_path`, `tools/checkpoint_manager.py::_resolve_checkpoint_base`, `gateway/sticker_cache.py::_resolve_cache_path`, modal/singularity `_snapshot_store()` — resolved per call; existing `monkeypatch.setattr(<CONSTANT>)` test seams preserved (`*_AT_IMPORT` pattern from `tools/skills_tool._skills_dir`).
- `plugins/platforms/feishu/feishu_comment_rules.py` — `_MtimeCache` is path-keyed with `invalidate()`; `_rules_file()`/`_pairing_file()` follow the routed profile (second half of #63962, credit @nateEc).
- `tools/tool_output_limits.py`, `tools/browser_tool.py`, `tools/browser_camofox.py` — caches keyed by `hermes_home_key()`; `tools/file_tools.py` drops its private `file_read_max_chars` memo for the already path+mtime-cached `load_config_readonly()`.
- `hermes_time.py::get_timezone_name` — under multiplexing the routed profile's `timezone` beats the env `HERMES_TIMEZONE` bridged from the default; both `execute_code` sandbox `TZ` sites use it.
- `tools/cronjob_tools.py`, `tools/tts_tool.py`, `tools/skill_manager_tool.py` — static schema text is profile-neutral; `dynamic_schema_overrides` rebuilds the `display_hermes_home()` path per `get_definitions()` (#95685).

Docs: `multi-profile-gateways.md` (what follows the routed profile) and `hooks.md` (`profile` payload field).

## Validation

**Live repro** (`/tmp/mux_audit/fix-process-memo/repro.py`: temp HERMES_HOME A + `profiles/B` with different values everywhere; warm every cache under A, then `set_hermes_home_override(B)`):

| check (B's turn) | before | after |
|---|---|---|
| `_current_max_iterations()` | 7 (A) | 99 |
| `_refresh_fallback_model()` | `A/fallback` | `B/fallback` |
| aux `_read_nous_auth()` token | `TOKEN_A` | `TOKEN_B` |
| gateway hooks loaded | `hook_A` | `hook_B` |
| `processes.json` / `checkpoints/` / snapshot stores | `A/…` | `profiles/B/…` |
| feishu rules `enabled` | A's | B's |
| `tool_output.max_bytes` / `file_read_max_chars` | 222 / 111 | 888 / 999 |
| browser / camofox `command_timeout` | 33 | 77 |
| sandbox `TZ` / `hermes_time` | `America/New_York` | `Asia/Tokyo` |
| media strict / allow dirs | A's | B's |
| cronjob / tts / skill_manage schema path | A's home | `profiles/B` |

21 FAIL → 0 FAIL.

Tests: `tests/gateway/test_multiplex_process_memo_scope.py` (4, red on base), `tests/agent/test_shell_hooks.py::TestRoutedProfileEnv`, `tests/tools/test_multiplex_tool_memo_scope.py` (3), feishu/timezone invariants, salvaged `tests/test_profile_isolation_runtime.py` classes trimmed to ≤2 each. `scripts/run_tests.sh tests/gateway tests/agent tests/tools tests/plugins`: all green except pre-existing failures also red on `origin/main` in this environment (`test_modal_snapshot_isolation` ×2 — lazy-install gate, `test_web_tools_config` ×2, `test_execution_flag_detection` ×1) and one unrelated retry-flake (`test_compression_stall_fallback_78981`).

Root cause: the multiplexer runs every profile in one process whose module-level `get_hermes_home()` constants, `os.environ` bridges and unkeyed caches were populated once from the launch profile.

Audit refs: `/tmp/mux_audit/audit-memo` F3, F4, F6 (auth.json half), F7, F9, F10, F12; `audit-startup` F9.

Credits: @srojk34 — earliest fixes for hooks dir (#56508) and checkpoint/sticker paths (#56315), both cherry-picked; @nateEc (Nathan Shan) — Feishu comment-rules half of #63962, co-authored; @rawnets — reporter of #95685.

Fixes #95685. Addresses #56315, #56508, #63962.

## Infographic

![One gateway, many profiles](https://v3b.fal.media/files/b/0aaa05e1/nXacoBPygKg3BiaXbpmmM_xCrOOfnJ.png)
