### PR TITLE
fix(mcp-oauth): let Desktop authenticate with RFC 9207 servers

### DIFF
--- a/apps/desktop/electron/mcp-oauth-callback-ipc.test.ts
+++ b/apps/desktop/electron/mcp-oauth-callback-ipc.test.ts
@@ -41,10 +41,11 @@ test('listen binds a loopback listener and wait resolves with the redirect param
   const waitPromise = invoke('hermes:mcp-oauth:wait', id, 5000) as Promise<{
     code: null | string
     error: null | string
+    iss: null | string
     state: null | string
   }>
 
-  const res = await fetch(`${redirectUri}?code=abc123&state=st-1`)
+  const res = await fetch(`${redirectUri}?code=abc123&state=st-1&iss=https%3A%2F%2Fidp.example`)
 
   assert.equal(res.status, 200)
   assert.match(await res.text(), /return to Hermes/)
@@ -54,6 +55,7 @@ test('listen binds a loopback listener and wait resolves with the redirect param
   assert.equal(result.code, 'abc123')
   assert.equal(result.state, 'st-1')
   assert.equal(result.error, null)
+  assert.equal(result.iss, 'https://idp.example')
 
   // Listener is one-shot: the port must be closed after the callback.
   await assert.rejects(fetch(`${redirectUri}?code=again&state=st-1`))

--- a/apps/desktop/electron/mcp-oauth-callback-ipc.ts
+++ b/apps/desktop/electron/mcp-oauth-callback-ipc.ts
@@ -11,13 +11,13 @@
  * login uses (native-oauth-login.ts): bind an ephemeral one-shot listener
  * on the USER'S loopback, hand its URL to the gateway as the OAuth
  * redirect_uri (`client_redirect_uri` on oauth.start), and resolve with the
- * redirect's `code`/`state` so the renderer can relay them via
+ * redirect's `code`/`state`/`iss` so the renderer can relay them via
  * `mcp.servers.oauth.callback`.
  *
  * Security posture:
  *   - binds 127.0.0.1 on an ephemeral port; closes on first callback,
  *     cancel, or timeout — no long-lived listener;
- *   - the listener only ever RECEIVES `code`/`state` query params and
+ *   - the listener only ever RECEIVES authorization response query params and
  *     forwards them to the renderer; no tokens are exchanged here — the
  *     gateway verifies `state` (constant-time) before redeeming anything;
  *   - the browser sees only a minimal "return to Hermes" page.
@@ -41,6 +41,7 @@ const DONE_HTML =
 interface CallbackResult {
   code: null | string
   error: null | string
+  iss: null | string
   state: null | string
 }
 
@@ -83,7 +84,7 @@ function dispose(id: string) {
   }
 
   if (!entry.settled) {
-    settle(id, { code: null, error: 'cancelled', state: null })
+    settle(id, { code: null, error: 'cancelled', iss: null, state: null })
   }
 
   pending.delete(id)
@@ -112,6 +113,7 @@ export function registerMcpOauthCallbackIpc() {
       let code: null | string = null
       let state: null | string = null
       let error: null | string = null
+      let iss: null | string = null
 
       try {
         const parsed = new URL(url, 'http://127.0.0.1')
@@ -119,11 +121,12 @@ export function registerMcpOauthCallbackIpc() {
         code = parsed.searchParams.get('code')
         state = parsed.searchParams.get('state')
         error = parsed.searchParams.get('error')
+        iss = parsed.searchParams.get('iss')
       } catch {
         error = 'unparseable callback URL'
       }
 
-      settle(id, { code, error, state })
+      settle(id, { code, error, iss, state })
     })
 
     await new Promise<void>((resolve, reject) => {
@@ -143,7 +146,7 @@ export function registerMcpOauthCallbackIpc() {
     const entry = pending.get(String(id || ''))
 
     if (!entry) {
-      return { code: null, error: 'listener not found', state: null }
+      return { code: null, error: 'listener not found', iss: null, state: null }
     }
 
     if (entry.result) {
@@ -158,7 +161,7 @@ export function registerMcpOauthCallbackIpc() {
 
     const result = await new Promise<CallbackResult>(resolve => {
       const timer = setTimeout(() => {
-        settle(String(id), { code: null, error: 'timeout waiting for OAuth callback', state: null })
+        settle(String(id), { code: null, error: 'timeout waiting for OAuth callback', iss: null, state: null })
       }, timeout)
 
       entry.waiters.push(value => {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -308,7 +308,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   mcpOauth: {
     // One-shot loopback listener for MCP OAuth against remote backends: bind
     // on this machine, hand redirectUri to mcp.servers.oauth.start, then wait
-    // for the provider redirect and relay code/state via oauth.callback.
+    // for the provider redirect and relay code/state/iss via oauth.callback.
     listen: () => ipcRenderer.invoke('hermes:mcp-oauth:listen'),
     wait: (id, timeoutMs) => ipcRenderer.invoke('hermes:mcp-oauth:wait', id, timeoutMs),
     cancel: id => ipcRenderer.invoke('hermes:mcp-oauth:cancel', id)

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -364,13 +364,13 @@ declare global {
       /** One-shot loopback callback listener for MCP OAuth against remote
        *  backends (electron/mcp-oauth-callback-ipc.ts): bind on THIS machine,
        *  pass redirectUri as client_redirect_uri to mcp.servers.oauth.start,
-       *  await the provider redirect, relay code/state via oauth.callback. */
+       *  await the provider redirect, relay code/state/iss via oauth.callback. */
       mcpOauth?: {
         listen: () => Promise<{ id: string; redirectUri: string }>
         wait: (
           id: string,
           timeoutMs?: number
-        ) => Promise<{ code: null | string; error: null | string; state: null | string }>
+        ) => Promise<{ code: null | string; error: null | string; iss: null | string; state: null | string }>
         cancel: (id: string) => Promise<boolean>
       }
       openPreviewInBrowser?: (url: string) => Promise<void>

--- a/apps/desktop/src/lib/mcp-dashboard-oauth.test.ts
+++ b/apps/desktop/src/lib/mcp-dashboard-oauth.test.ts
@@ -80,7 +80,9 @@ describe('Desktop MCP client callback lifecycle', () => {
       const { bridge, api, openExternal, rpc } = harness()
       setApiRequestConnection(connectionId)
       setApiRequestProfile('origin-profile')
-      const callbackResult = { code: 'code-1', state: 'expected', error: null }
+      const callbackResult = {
+        code: 'code-1', state: 'expected', error: null, iss: 'https://idp.example'
+      }
       bridge.wait.mockResolvedValue(callbackResult)
       openExternal.mockImplementation(async () => {
         setApiRequestConnection('other-gateway')

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -276,6 +276,7 @@ async def mcp_oauth_callback(
     code: Optional[str] = None,
     state: Optional[str] = None,
     error: Optional[str] = None,
+    iss: Optional[str] = None,
 ):
     _gc_mcp_oauth_flows()
     with _mcp_oauth_flows_lock:
@@ -291,7 +292,7 @@ async def mcp_oauth_callback(
     if flow is None:
         return HTMLResponse("<h1>OAuth flow expired</h1><p>Return to Hermes and try again.</p>", status_code=404)
     try:
-        flow.deliver_callback(code=code, state=state, error=error)
+        flow.deliver_callback(code=code, state=state, error=error, iss=iss)
     except ValueError as exc:
         return HTMLResponse(
             "<h1>OAuth callback rejected</h1><p>The callback was invalid or already used.</p>",

--- a/tests/hermes_cli/test_mcp_dashboard_oauth.py
+++ b/tests/hermes_cli/test_mcp_dashboard_oauth.py
@@ -81,11 +81,11 @@ def test_hosted_callback_bypasses_gated_cookie_auth(monkeypatch):
     monkeypatch.setattr(web_server.app.state, "auth_required", True, raising=False)
 
     response = TestClient(web_server.app).get(
-        "/api/mcp/oauth/callback/reports?code=abc&state=expected"
+        "/api/mcp/oauth/callback/reports?code=abc&state=expected&iss=https%3A%2F%2Fidp.example"
     )
 
     assert response.status_code == 200
-    assert flow._callback == ("abc", "expected")
+    assert flow._callback == ("abc", "expected", "https://idp.example")
 
 
 def test_hosted_auth_allows_same_server_name_in_different_profiles(tmp_path, monkeypatch):
@@ -132,7 +132,7 @@ def test_flow_status_does_not_expose_authorization_code():
     )
     flow.authorization_url = "https://idp.example/authorize"
     flow.status = "approved"
-    flow._callback = ("secret-code", "secret-state")
+    flow._callback = ("secret-code", "secret-state", "https://idp.example")
     _web_server_mcp._mcp_oauth_flows[flow.flow_id] = flow
 
     response = _client().get("/api/mcp/oauth/flows/flow-status")

--- a/tests/tools/test_mcp_dashboard_oauth.py
+++ b/tests/tools/test_mcp_dashboard_oauth.py
@@ -26,8 +26,8 @@ def test_dashboard_flow_exposes_authorization_url_and_accepts_callback():
         "error": None,
     }
 
-    flow.deliver_callback(code="code-1", state="s1", error=None)
-    assert asyncio.run(flow.wait_for_callback()) == ("code-1", "s1")
+    flow.deliver_callback(code="code-1", state="s1", error=None, iss="https://idp.example")
+    assert asyncio.run(flow.wait_for_callback()) == ("code-1", "s1", "https://idp.example")
 
 
 def test_dashboard_flow_accepts_only_one_concurrent_callback():
@@ -91,11 +91,13 @@ def test_mcp_oauth_helpers_use_dashboard_flow_without_loopback_port():
                 "https://idp.example/authorize?state=state-4"
             )
         )
-        flow.deliver_callback(code="code-4", state="state-4", error=None)
+        flow.deliver_callback(
+            code="code-4", state="state-4", error=None, iss="https://idp.example")
         # mcp 2.0's callback_handler contract returns an
         # AuthorizationCodeResult, not the legacy (code, state) tuple.
         result = asyncio.run(_make_callback_waiter(0)())
-        assert (result.code, result.state) == ("code-4", "state-4")
+        assert (result.code, result.state, result.iss) == (
+            "code-4", "state-4", "https://idp.example")
 
     assert flow.authorization_url == "https://idp.example/authorize?state=state-4"
 

--- a/tests/tui_gateway/test_mcp_oauth_client_callback.py
+++ b/tests/tui_gateway/test_mcp_oauth_client_callback.py
@@ -183,10 +183,17 @@ def teardown_function(_fn):
 
 
 def test_deliver_callback_accepts_matching_state():
+    from tui_gateway import server
+
     flow = _make_session()
-    out = deliver_callback_flow(
-        "sess-relay-1", "hosp", code="abc", state="s3cr3tstate",
-        iss="https://as.example.com")
+    response = server._methods["mcp.servers.oauth.callback"](
+        1,
+        {
+            "session_id": "sess-relay-1", "name": "hosp", "code": "abc",
+            "state": "s3cr3tstate", "iss": "https://as.example.com",
+        },
+    )
+    out = response["result"]
     assert out == {"ok": True, "session_id": "sess-relay-1"}
     assert flow._callback == ("abc", "s3cr3tstate", "https://as.example.com")
 

--- a/tests/tui_gateway/test_mcp_oauth_client_callback.py
+++ b/tests/tui_gateway/test_mcp_oauth_client_callback.py
@@ -7,7 +7,7 @@ Covers the three seams added for remote Desktop backends:
     never pins an attacker-controlled redirect into a DCR registration);
   - start_flow(client_redirect_uri=...): no gateway-side listener is bound and
     the flow's redirect_uri is pinned to the client's listener;
-  - deliver_callback_flow: relays a client-captured code/state into the flow
+  - deliver_callback_flow: relays client-captured code/state/iss into the flow
     with the SAME state verification as the loopback path (wrong state
     rejected, replay rejected, unknown session rejected).
 """
@@ -184,9 +184,11 @@ def teardown_function(_fn):
 
 def test_deliver_callback_accepts_matching_state():
     flow = _make_session()
-    out = deliver_callback_flow("sess-relay-1", "hosp", code="abc", state="s3cr3tstate")
+    out = deliver_callback_flow(
+        "sess-relay-1", "hosp", code="abc", state="s3cr3tstate",
+        iss="https://as.example.com")
     assert out == {"ok": True, "session_id": "sess-relay-1"}
-    assert flow._callback == ("abc", "s3cr3tstate")
+    assert flow._callback == ("abc", "s3cr3tstate", "https://as.example.com")
 
 
 def test_deliver_callback_rejects_state_mismatch():

--- a/tools/mcp_dashboard_oauth.py
+++ b/tools/mcp_dashboard_oauth.py
@@ -43,7 +43,7 @@ class DashboardOAuthFlow:
     error: str | None = None
     tools: list[dict] = field(default_factory=list)
     expected_state: str | None = field(default=None, init=False)
-    _callback: tuple[str, str | None] | None = field(default=None, init=False, repr=False)
+    _callback: tuple[str, str | None, str | None] | None = field(default=None, init=False, repr=False)
     _callback_error: str | None = field(default=None, init=False, repr=False)
     _authorization_ready: threading.Event = _event_field()
     _callback_ready: threading.Event = _event_field()
@@ -70,7 +70,10 @@ class DashboardOAuthFlow:
             raise RuntimeError(self.error or "MCP OAuth flow ended before authorization")
         return self.authorization_url
 
-    def deliver_callback(self, *, code: str | None, state: str | None, error: str | None) -> None:
+    def deliver_callback(
+        self, *, code: str | None, state: str | None, error: str | None,
+        iss: str | None = None,
+    ) -> None:
         """Hand the browser redirect to the waiting flow; ``state`` must match exactly."""
         with self._lock:
             if self._callback_ready.is_set():
@@ -80,12 +83,14 @@ class DashboardOAuthFlow:
             if error:
                 self._callback_error = error
             elif code:
-                self._callback = (code, state)
+                self._callback = (code, state, iss)
             else:
                 self._callback_error = "OAuth callback did not include code or error"
             self._callback_ready.set()
 
-    async def wait_for_callback(self, timeout: float = 300.0) -> tuple[str, str | None]:
+    async def wait_for_callback(
+        self, timeout: float = 300.0,
+    ) -> tuple[str, str | None, str | None]:
         if not await asyncio.to_thread(self._callback_ready.wait, timeout):
             raise TimeoutError("Timed out waiting for MCP OAuth callback")
         if self._callback_error:

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -646,7 +646,7 @@ def _make_callback_waiter(port: int, cimd_url: str | None = None, timeout: float
     async def _wait():
         dashboard_flow = get_dashboard_oauth_flow()
         if dashboard_flow is not None:
-            # Dashboard flow speaks the legacy tuple; normalize to one shape.
+            # Dashboard flow returns the redirect fields as a tuple; normalize to the SDK shape.
             return _authorization_code_result(*await dashboard_flow.wait_for_callback())
         # The SDK entered the authorization-code flow, so any cached token is unusable. Reject BEFORE
         # binding: binding would block for the full timeout and collide with the TIME_WAIT port on retry.

--- a/tui_gateway/mcp_oauth_sessions.py
+++ b/tui_gateway/mcp_oauth_sessions.py
@@ -61,7 +61,7 @@ def _start_loopback_listener(flow) -> "http.server.HTTPServer":
             status = 200
             try:
                 flow.deliver_callback(
-                    **{k: (qs.get(k) or [None])[0] for k in ("code", "state", "error")})
+                    **{k: (qs.get(k) or [None])[0] for k in ("code", "state", "error", "iss")})
             except Exception:
                 body = b"<h1>OAuth callback rejected</h1><p>The callback was invalid or already used.</p>"
                 status = 400
@@ -255,7 +255,7 @@ def cancel_flow(session_id: str, server_name: str, hermes_home: str) -> Dict[str
 
 def deliver_callback_flow(
     session_id: str, server_name: str, *, code: Optional[str], state: Optional[str],
-    error: Optional[str] = None) -> Dict[str, Any]:
+    error: Optional[str] = None, iss: Optional[str] = None) -> Dict[str, Any]:
     """Relay a client-captured OAuth redirect into a session's flow (remote-backend companion
     to ``start_flow(client_redirect_uri=...)``); ``deliver_callback`` still verifies ``state``
     and rejects replays. Returns ``{ok: true}`` or ``{ok: false, error_message}``."""
@@ -263,7 +263,7 @@ def deliver_callback_flow(
     if rec is None:
         return {"ok": False, "error_message": err}
     try:
-        rec["flow"].deliver_callback(code=code, state=state, error=error)
+        rec["flow"].deliver_callback(code=code, state=state, error=error, iss=iss)
     except ValueError as exc:
         return {"ok": False, "error_message": str(exc)}
     return {"ok": True, "session_id": session_id}

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1336,11 +1336,13 @@ def _(rid, params: dict) -> dict:
 
 @_mcp_rpc("oauth.callback", _NAME_SESSION)
 def _(rid, params: dict) -> dict:
-    """Relay a client-captured redirect (``code``/``state``/``error``) into a ``client_redirect_uri`` flow."""
-    code, state, error = (str(params.get(k) or "") or None for k in ("code", "state", "error"))
+    """Relay a client-captured redirect into a ``client_redirect_uri`` flow."""
+    code, state, error, iss = (
+        str(params.get(k) or "") or None for k in ("code", "state", "error", "iss"))
     deliver = _tools_mod("tui_gateway.mcp_oauth_sessions").deliver_callback_flow
     return _ok(rid, deliver(
-        _str_arg(params, "session_id"), _str_arg(params, "name"), code=code, state=state, error=error))
+        _str_arg(params, "session_id"), _str_arg(params, "name"),
+        code=code, state=state, error=error, iss=iss))
 
 
 # ─── Plugins ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Desktop and dashboard MCP authentication now preserve the RFC 9207 `iss` authorization response parameter from the browser callback through the bridge and into the MCP SDK. Without this field, compliant authorization servers that advertise issuer identification reject otherwise valid callback responses.

### Symptom

Desktop MCP authentication fails with `Authorization response missing iss parameter advertised by the authorization server` even when the authorization redirect includes `iss`. The same server can authenticate through `hermes mcp login`.

### Impact

Users cannot authenticate MCP servers backed by authorization servers that require RFC 9207 issuer identification through Desktop or the hosted dashboard callback paths.

### Bug Cause

**Trigger:** `tools/mcp_dashboard_oauth.py:DashboardOAuthFlow.deliver_callback` receives an OAuth redirect from a server that includes `iss`.

**Causal chain:**
1. The authorization server redirects with `code`, `state`, and RFC 9207 `iss`.
2. The dashboard bridge stores only `code` and `state`; the dashboard route, gateway listener, JSON-RPC callback, and Electron listener also omit `iss`.
3. `_make_callback_waiter` constructs `AuthorizationCodeResult` without an issuer, so the MCP SDK rejects the callback when server metadata requires issuer identification.

**Why it is wrong:** RFC 9207 makes `iss` part of the authorization response when advertised. Dropping it changes a valid response before SDK validation.

**Working sibling / contrast:** The CLI loopback callback parser already preserves `iss` and passes it to `_authorization_code_result`, so terminal authentication succeeds.

**Ruled out:** State validation is not the failure. `DashboardOAuthFlow.deliver_callback` already compares the callback state in constant time before accepting the response.

### Fix

Extend the shared dashboard callback tuple with `iss`, preserve it in the hosted dashboard and gateway loopback listeners, relay it through `mcp.servers.oauth.callback`, and include it in the Electron callback result. Existing renderer spread behavior then forwards the complete callback object to the backend, where `_authorization_code_result` passes the issuer to the MCP SDK for validation.

## Related Issue

Closes #108450

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_dashboard_oauth.py` and `tools/mcp_oauth.py` - carry the issuer into `AuthorizationCodeResult`.
- `tui_gateway/mcp_oauth_sessions.py` and `tui_gateway/methods_tools.py` - preserve issuer data across gateway-hosted and client-relayed callbacks.
- `hermes_cli/web_routers/mcp.py` - accept the issuer from hosted dashboard callback URLs.
- `apps/desktop/electron/mcp-oauth-callback-ipc.ts` and renderer types - capture and relay the issuer from Desktop loopback callbacks.
- Existing Python and TypeScript callback contract tests - assert issuer preservation at each bridge boundary.

## How to Test

1. Run the focused Python callback bridge tests.
2. Run the Desktop Electron and renderer callback tests.
3. Authenticate against an MCP authorization server that advertises `authorization_response_iss_parameter_supported: true` and returns `iss` in the redirect.

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I have added tests for my changes
- [x] I have tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant inline protocol documentation is updated
- [x] Config example changes are N/A because no config keys changed
- [x] Architecture documentation changes are N/A because no workflow changed
- [x] Cross-platform impact is limited to preserving an OAuth response field across existing transports
- [x] Tool description/schema changes are N/A because no model tool contract changed

## Screenshots / Logs

N/A - this fixes protocol field propagation without changing the UI.