### PR TITLE
feat(security): harden the agent process at startup (security.process_hardening)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5197,8 +5197,9 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # Set here (not at import) so incidental gateway.run imports from CLI code don't poison it.
     os.environ["HERMES_EXEC_ASK"] = "1"
 
-    from hermes_cli.resource_limits import apply_nofile_soft_limit
+    from hermes_cli.resource_limits import apply_nofile_soft_limit, apply_process_hardening
     apply_nofile_soft_limit()
+    apply_process_hardening()
 
     # Snapshot the revision while sys.modules matches disk so a later `git pull` is detected safely.
     from gateway.code_skew import record_boot_fingerprint

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1620,6 +1620,12 @@ DEFAULT_CONFIG = {
     "security": {  # Security: pre-exec scanning via tirith plus related guards.
         "allow_private_urls": False,  # allow requests to private/internal IPs (OpenWrt, VPNs)
         "redact_secrets": True,
+        # Hardening the agent process applies to itself at startup: "core-only" (default) drops
+        # the core-dump limit so a crash cannot write in-memory provider credentials to disk;
+        # "full" additionally refuses debugger attach (Linux PR_SET_DUMPABLE=0, macOS
+        # PT_DENY_ATTACH) and is opt-in because it breaks gdb/lldb attach; "off" disables.
+        # Applied by hermes_cli/resource_limits.py next to the RLIMIT_NOFILE floor.
+        "process_hardening": "core-only",
         # Persisted acknowledgement for unattended model overrides whose tier lets the vendor train
         # on prompts. The startup guard still warns every run; cost guards are unaffected.
         "allow_data_training_tiers_noninteractive": False,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2556,9 +2556,10 @@ def cmd_dashboard(args):
     # named-profile re-exec could leak that profile's higher limit into the
     # machine/default dashboard, whose lower policy intentionally cannot undo it.
     # This also covers Desktop SSH's isolated `serve` child, which does not route.
-    from hermes_cli.resource_limits import apply_nofile_soft_limit
+    from hermes_cli.resource_limits import apply_nofile_soft_limit, apply_process_hardening
 
     apply_nofile_soft_limit()
+    apply_process_hardening()
 
     _ssh_session_token = _read_ssh_session_token_file(_token_file) if _token_file else None
     _mcp_discovery_after_bind = _dashboard_prepare_runtime(args, _headless_backend)

--- a/hermes_cli/resource_limits.py
+++ b/hermes_cli/resource_limits.py
@@ -16,15 +16,27 @@ except (ImportError, ModuleNotFoundError):  # pragma: no cover - Windows only
 logger = logging.getLogger(__name__)
 
 DEFAULT_NOFILE_SOFT_LIMIT = int(DEFAULT_CONFIG["runtime"]["nofile_soft_limit"])
+DEFAULT_PROCESS_HARDENING = str(DEFAULT_CONFIG["security"]["process_hardening"])
 _MISSING = object()
 
+# ``security.process_hardening`` modes. ``core-only`` keeps the cheapest, least observable
+# guarantee: a crash can never spill the credentials the process holds in memory onto disk.
+# ``full`` adds debugger refusal, which is opt-in because it breaks gdb/lldb attach.
+_HARDENING_MODES = ("core-only", "full")
+_DISABLED_ALIASES = frozenset({"", "0", "false", "no", "none", "off", "disabled"})
+_ENABLED_ALIASES = frozenset({"1", "true", "yes", "on", "enabled"})
+# Linux: clear the process's dumpable attribute (man 2 prctl) — blocks ptrace/PROC_MEM reads by
+# unprivileged peers and core dumps. Darwin: refuse external debugger attachment (sys/ptrace.h).
+_PR_SET_DUMPABLE = 4
+_PT_DENY_ATTACH = 31
 
-def configured_nofile_soft_limit(config: Mapping[str, Any] | None = None) -> int | None:
-    """``runtime.nofile_soft_limit`` from a loaded config, or ``None`` when disabled/unresolvable.
 
-    Missing key → default. Explicit ``0``/``false``/``null`` disable; other non-int or negative
-    values are ignored (caller fails open). Shared by the in-process floor and service-definition
-    generators (launchd plist) so both use one knob.
+def configured_process_hardening(config: Mapping[str, Any] | None = None) -> str | None:
+    """``security.process_hardening`` from a loaded config, or ``None`` when disabled/unresolvable.
+
+    Missing key → :data:`DEFAULT_PROCESS_HARDENING`. Explicit ``"off"``/``false``/``0``/``null``
+    disable; unrecognized values are ignored (caller fails open). Accepts the boolean and string
+    spellings of both, so `hermes config set security.process_hardening off` and `false` agree.
     """
     if config is None:
         try:
@@ -32,21 +44,85 @@ def configured_nofile_soft_limit(config: Mapping[str, Any] | None = None) -> int
             from hermes_cli.config import load_config_readonly
             config = load_config_readonly()
         except Exception:
-            logger.debug("Could not load config for RLIMIT_NOFILE", exc_info=True)
+            logger.debug("Could not load config for process hardening", exc_info=True)
             return None
     if not isinstance(config, Mapping):
         return None
-    runtime = config.get("runtime", _MISSING)
-    if runtime is _MISSING:
-        return DEFAULT_NOFILE_SOFT_LIMIT
-    if not isinstance(runtime, Mapping):
+    security = config.get("security", _MISSING)
+    if security is _MISSING:
+        return DEFAULT_PROCESS_HARDENING
+    if not isinstance(security, Mapping):
         return None
-    raw_value = runtime.get("nofile_soft_limit", _MISSING)
+    raw_value = security.get("process_hardening", _MISSING)
     if raw_value is _MISSING:
-        return DEFAULT_NOFILE_SOFT_LIMIT
-    if isinstance(raw_value, bool) or not isinstance(raw_value, int) or raw_value <= 0:
+        return DEFAULT_PROCESS_HARDENING
+    if isinstance(raw_value, bool):
+        return DEFAULT_PROCESS_HARDENING if raw_value else None
+    if not isinstance(raw_value, str):
         return None
-    return raw_value
+    mode = raw_value.strip().lower()
+    if mode in _DISABLED_ALIASES:
+        return None
+    if mode in _ENABLED_ALIASES:
+        return DEFAULT_PROCESS_HARDENING
+    if mode in _HARDENING_MODES:
+        return mode
+    return None
+
+
+def _disable_core_dumps() -> bool:
+    """Drop this process's core-dump limit; ``True`` when the limit was lowered. Never raises."""
+    try:
+        _resource.setrlimit(_resource.RLIMIT_CORE, (0, 0))
+        return True
+    except Exception:
+        logger.debug("Could not disable core dumps", exc_info=True)
+        return False
+
+
+def _disable_debugger_attach() -> bool:
+    """Refuse debugger attach where the kernel supports it; ``False`` elsewhere. Never raises.
+
+    Linux ``PR_SET_DUMPABLE=0`` and Darwin ``PT_DENY_ATTACH`` are the two portable-ish levers;
+    Windows has no equivalent, and denied/unsupported calls are a no-op rather than an error.
+    """
+    try:
+        import ctypes
+        import platform
+
+        system = platform.system()
+        libc = ctypes.CDLL(None, use_errno=True)
+        if system == "Linux":
+            return libc.prctl(_PR_SET_DUMPABLE, 0, 0, 0, 0) == 0
+        if system == "Darwin":
+            return libc.ptrace(_PT_DENY_ATTACH, 0, None, 0) == 0
+    except Exception:
+        logger.debug("Could not refuse debugger attach", exc_info=True)
+    return False
+
+
+def apply_process_hardening(config: Mapping[str, Any] | None = None) -> str:
+    """Best-effort hardening of this process's own kernel surface; returns the mode requested.
+
+    ``"core-only"`` (the default) lowers ``RLIMIT_CORE`` to zero so a crash cannot write the
+    provider credentials held in memory to disk; ``"full"`` additionally refuses debugger attach.
+    Returns ``"off"`` when disabled or unsupported (Windows). Every step is best-effort: an
+    unsupported platform, a malformed setting, or a denied ``setrlimit``/``prctl`` must never
+    prevent a service from starting (fail open, never raises). Also inherited by children, so
+    workers spawned after this call can neither dump core nor be attached to unprivileged.
+    """
+    if _resource is None:
+        return "off"
+    mode = configured_process_hardening(config)
+    if mode is None:
+        return "off"
+    try:
+        _disable_core_dumps()
+        if mode == "full":
+            _disable_debugger_attach()
+    except Exception:  # a service must still start even if a lever misbehaves
+        logger.debug("Could not apply process hardening", exc_info=True)
+    return mode
 
 
 def apply_nofile_soft_limit(config: Mapping[str, Any] | None = None) -> bool:
@@ -79,4 +155,41 @@ def apply_nofile_soft_limit(config: Mapping[str, Any] | None = None) -> bool:
         return False
 
 
-__all__ = ["DEFAULT_NOFILE_SOFT_LIMIT", "apply_nofile_soft_limit", "configured_nofile_soft_limit"]
+def configured_nofile_soft_limit(config: Mapping[str, Any] | None = None) -> int | None:
+    """``runtime.nofile_soft_limit`` from a loaded config, or ``None`` when disabled/unresolvable.
+
+    Missing key → default. Explicit ``0``/``false``/``null`` disable; other non-int or negative
+    values are ignored (caller fails open). Shared by the in-process floor and service-definition
+    generators (launchd plist) so both use one knob.
+    """
+    if config is None:
+        try:
+            # Profile-aware loader (applies managed-scope overlays and defaults).
+            from hermes_cli.config import load_config_readonly
+            config = load_config_readonly()
+        except Exception:
+            logger.debug("Could not load config for RLIMIT_NOFILE", exc_info=True)
+            return None
+    if not isinstance(config, Mapping):
+        return None
+    runtime = config.get("runtime", _MISSING)
+    if runtime is _MISSING:
+        return DEFAULT_NOFILE_SOFT_LIMIT
+    if not isinstance(runtime, Mapping):
+        return None
+    raw_value = runtime.get("nofile_soft_limit", _MISSING)
+    if raw_value is _MISSING:
+        return DEFAULT_NOFILE_SOFT_LIMIT
+    if isinstance(raw_value, bool) or not isinstance(raw_value, int) or raw_value <= 0:
+        return None
+    return raw_value
+
+
+__all__ = [
+    "DEFAULT_NOFILE_SOFT_LIMIT",
+    "DEFAULT_PROCESS_HARDENING",
+    "apply_nofile_soft_limit",
+    "apply_process_hardening",
+    "configured_nofile_soft_limit",
+    "configured_process_hardening",
+]

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1388,10 +1388,12 @@ def start_server(
     _apply_ssh_owner_nonce(ssh_owner_nonce)
 
     # Dashboard-mode starts don't route through main.py's `serve` path, which
-    # applies the same RLIMIT_NOFILE floor (policy in resource_limits, #81547).
-    from hermes_cli.resource_limits import apply_nofile_soft_limit
+    # applies the same RLIMIT_NOFILE floor and process hardening (policy in
+    # resource_limits, #81547).
+    from hermes_cli.resource_limits import apply_nofile_soft_limit, apply_process_hardening
 
     apply_nofile_soft_limit()
+    apply_process_hardening()
 
     import uvicorn  # noqa: F401 — fail fast (before any side effects) when the dashboard extra is missing
 

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -1,4 +1,4 @@
-"""Tests for configurable RLIMIT_NOFILE startup handling."""
+"""Tests for configurable startup resource limits (RLIMIT_NOFILE) and process hardening."""
 
 from __future__ import annotations
 
@@ -17,19 +17,26 @@ from hermes_cli import main_dashboard
 
 class _FakeResource:
     RLIMIT_NOFILE = 7
+    RLIMIT_CORE = 4
     RLIM_INFINITY = 2**63 - 1
 
     def __init__(self, soft: int, hard: int) -> None:
-        self.limits = (soft, hard)
+        self.limits = (soft, hard)  # RLIMIT_NOFILE — the tuple the nofile tests assert on
+        self.core_limits = (-1, -1)
         self.set_calls: list[tuple[int, tuple[int, int]]] = []
 
     def getrlimit(self, resource: int) -> tuple[int, int]:
+        if resource == self.RLIMIT_CORE:
+            return self.core_limits
         assert resource == self.RLIMIT_NOFILE
         return self.limits
 
     def setrlimit(self, resource: int, limits: tuple[int, int]) -> None:
-        assert resource == self.RLIMIT_NOFILE
         self.set_calls.append((resource, limits))
+        if resource == self.RLIMIT_CORE:
+            self.core_limits = limits
+            return
+        assert resource == self.RLIMIT_NOFILE
         self.limits = limits
 
 
@@ -187,6 +194,11 @@ async def test_gateway_startup_applies_limit_before_gateway_initialization(monke
         "apply_nofile_soft_limit",
         lambda: calls.append("limit"),
     )
+    monkeypatch.setattr(
+        resource_limits,
+        "apply_process_hardening",
+        lambda: calls.append("hardening"),
+    )
 
     class _StopStartup(Exception):
         pass
@@ -200,7 +212,7 @@ async def test_gateway_startup_applies_limit_before_gateway_initialization(monke
     with pytest.raises(_StopStartup):
         await gateway_run.start_gateway()
 
-    assert calls == ["limit", "gateway-init"]
+    assert calls == ["limit", "hardening", "gateway-init"]
 
 
 def test_serve_startup_applies_limit_before_web_server(monkeypatch):
@@ -221,6 +233,11 @@ def test_serve_startup_applies_limit_before_web_server(monkeypatch):
         resource_limits,
         "apply_nofile_soft_limit",
         lambda: calls.append("limit"),
+    )
+    monkeypatch.setattr(
+        resource_limits,
+        "apply_process_hardening",
+        lambda: calls.append("hardening"),
     )
     monkeypatch.setattr(cli_main, "_sync_bundled_skills_quietly", lambda: None)
     monkeypatch.setattr(cli_main, "_build_web_ui", lambda *args, **kwargs: True)
@@ -250,7 +267,7 @@ def test_serve_startup_applies_limit_before_web_server(monkeypatch):
 
     cli_main.cmd_dashboard(args)
 
-    assert calls == ["limit", "server"]
+    assert calls == ["limit", "hardening", "server"]
 
 
 def test_named_profile_reroute_defers_limit_to_final_process(monkeypatch, tmp_path):
@@ -268,6 +285,11 @@ def test_named_profile_reroute_defers_limit_to_final_process(monkeypatch, tmp_pa
         resource_limits,
         "apply_nofile_soft_limit",
         lambda: calls.append("limit"),
+    )
+    monkeypatch.setattr(
+        resource_limits,
+        "apply_process_hardening",
+        lambda: calls.append("hardening"),
     )
     monkeypatch.setattr(
         hermes_cli.profiles,
@@ -330,6 +352,11 @@ def test_dashboard_lifecycle_flags_skip_limit_adjustment(monkeypatch, lifecycle_
         "apply_nofile_soft_limit",
         lambda: calls.append("limit"),
     )
+    monkeypatch.setattr(
+        resource_limits,
+        "apply_process_hardening",
+        lambda: calls.append("hardening"),
+    )
     monkeypatch.setattr(dashboard_procs, "_scan_dashboard_processes", lambda: [])
     monkeypatch.setattr(cli_main, "_find_stale_dashboard_pids", lambda: [])
     monkeypatch.setattr(hermes_cli_main_dashboard, "_find_stale_dashboard_pids", lambda: [])
@@ -353,3 +380,181 @@ def test_dashboard_lifecycle_flags_skip_limit_adjustment(monkeypatch, lifecycle_
         cli_main.cmd_dashboard(args)
 
     assert calls == []
+
+
+# --------------------------------------------------------------------------- #
+# security.process_hardening — best-effort startup hardening
+# --------------------------------------------------------------------------- #
+
+
+def test_default_hardening_drops_core_dumps(monkeypatch):
+    """The default closes the credential-to-disk path a crash would otherwise open."""
+    fake_resource = _FakeResource(soft=256, hard=4096)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_process_hardening({}) == "core-only"
+    assert fake_resource.set_calls == [(fake_resource.RLIMIT_CORE, (0, 0))]
+    assert fake_resource.core_limits == (0, 0)
+    assert fake_resource.limits == (256, 4096)
+
+
+def test_missing_security_section_falls_back_to_the_default(monkeypatch):
+    fake_resource = _FakeResource(soft=256, hard=4096)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_process_hardening({"security": {}}) == "core-only"
+    assert fake_resource.core_limits == (0, 0)
+
+
+@pytest.mark.parametrize("disabled", ["off", "none", "disabled", "false", "", False, 0, None])
+def test_disabled_values_are_noops(monkeypatch, disabled):
+    fake_resource = _FakeResource(soft=256, hard=4096)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+    monkeypatch.setattr(
+        resource_limits,
+        "_disable_debugger_attach",
+        lambda: pytest.fail("disabled hardening must not touch debugger attach"),
+    )
+
+    assert resource_limits.apply_process_hardening(
+        {"security": {"process_hardening": disabled}}
+    ) == "off"
+    assert fake_resource.set_calls == []
+
+
+@pytest.mark.parametrize("enabled", [True, "on", "true", "1", "yes"])
+def test_affirmative_spellings_use_the_default_mode(monkeypatch, enabled):
+    fake_resource = _FakeResource(soft=256, hard=4096)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_process_hardening(
+        {"security": {"process_hardening": enabled}}
+    ) == "core-only"
+    assert fake_resource.core_limits == (0, 0)
+
+
+@pytest.mark.parametrize("invalid", ["banana", 42, 4096.0, [], {}])
+def test_unrecognized_values_fail_open(monkeypatch, invalid):
+    fake_resource = _FakeResource(soft=256, hard=4096)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_process_hardening(
+        {"security": {"process_hardening": invalid}}
+    ) == "off"
+    assert fake_resource.set_calls == []
+
+
+def test_malformed_security_section_is_a_safe_noop(monkeypatch):
+    fake_resource = _FakeResource(soft=256, hard=4096)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_process_hardening({"security": "nope"}) == "off"
+    assert fake_resource.set_calls == []
+
+
+def test_full_mode_also_refuses_debugger_attach(monkeypatch):
+    fake_resource = _FakeResource(soft=256, hard=4096)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+    attach_calls: list[str] = []
+    monkeypatch.setattr(
+        resource_limits,
+        "_disable_debugger_attach",
+        lambda: attach_calls.append("attach") or True,
+    )
+
+    assert resource_limits.apply_process_hardening(
+        {"security": {"process_hardening": "full"}}
+    ) == "full"
+    assert attach_calls == ["attach"]
+    assert fake_resource.core_limits == (0, 0)
+
+
+def test_core_only_leaves_debugger_attach_alone(monkeypatch):
+    """core-only is the mode that must stay compatible with gdb/lldb attach."""
+    fake_resource = _FakeResource(soft=256, hard=4096)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+    monkeypatch.setattr(
+        resource_limits,
+        "_disable_debugger_attach",
+        lambda: pytest.fail("core-only must not refuse debugger attach"),
+    )
+
+    assert resource_limits.apply_process_hardening({"security": {}}) == "core-only"
+    assert fake_resource.core_limits == (0, 0)
+
+
+def test_unsupported_platform_is_a_safe_noop(monkeypatch):
+    monkeypatch.setattr(resource_limits, "_resource", None)
+
+    assert resource_limits.apply_process_hardening({}) == "off"
+
+
+def test_denied_setrlimit_does_not_block_startup(monkeypatch):
+    class _DeniedResource(_FakeResource):
+        def setrlimit(self, resource: int, limits: tuple[int, int]) -> None:
+            raise PermissionError("simulated EPERM")
+
+    fake_resource = _DeniedResource(soft=256, hard=4096)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    assert resource_limits.apply_process_hardening({}) == "core-only"
+    assert fake_resource.core_limits == (-1, -1)
+
+
+def test_internal_failure_never_escapes(monkeypatch):
+    fake_resource = _FakeResource(soft=256, hard=4096)
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+
+    def _boom() -> bool:
+        raise RuntimeError("simulated")
+
+    monkeypatch.setattr(resource_limits, "_disable_core_dumps", _boom)
+
+    assert resource_limits.apply_process_hardening({}) == "core-only"
+
+
+def test_real_config_loader_reads_process_hardening_setting(monkeypatch, tmp_path):
+    """The helper uses the canonical config loader, not a second YAML parser."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "security:\n  process_hardening: full\n",
+        encoding="utf-8",
+    )
+    fake_resource = _FakeResource(soft=256, hard=4096)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(resource_limits, "_resource", fake_resource)
+    monkeypatch.setattr(resource_limits, "_disable_debugger_attach", lambda: True)
+
+    assert resource_limits.apply_process_hardening() == "full"
+    assert fake_resource.core_limits == (0, 0)
+
+
+def test_fresh_process_without_posix_resource_keeps_hardening_off():
+    code = textwrap.dedent(
+        """
+        import importlib.util
+        import pathlib
+        import sys
+
+        sys.modules["resource"] = None
+        module_path = pathlib.Path(sys.argv[1])
+        spec = importlib.util.spec_from_file_location(
+            "hermes_cli._resource_limits_hardening_without_posix_resource",
+            module_path,
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        assert module.apply_process_hardening({}) == "off"
+        """
+    )
+
+    subprocess.run(
+        [sys.executable, "-c", code, resource_limits.__file__],
+        check=True,
+        cwd=Path(resource_limits.__file__).resolve().parents[1],
+        capture_output=True,
+        text=True,
+    )
+

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -87,6 +87,26 @@ sandboxes
 where the limit cannot be changed, startup continues without changing the
 limit.
 
+### Process hardening
+
+The same startup surfaces also harden the process's own kernel surface, so a
+crash cannot leak the provider credentials held in memory:
+
+```yaml
+security:
+  process_hardening: core-only   # core-only | full | off
+```
+
+- `core-only` (default) drops the core-dump limit (`RLIMIT_CORE = 0`).
+- `full` additionally refuses debugger attach — Linux `PR_SET_DUMPABLE=0`,
+  macOS `PT_DENY_ATTACH`. Opt-in, because it breaks `gdb`/`lldb` attach.
+- `off` disables the step; `0`, `false`, and `null` are accepted spellings.
+
+Every step is best-effort: Windows, a kernel that refuses the calls, or a
+malformed value all leave startup unchanged (fail open), and processes spawned
+afterwards inherit the result. The lever itself lives in
+`hermes_cli/resource_limits.py` next to the `RLIMIT_NOFILE` floor.
+
 ## Database Settings
 
 The `database:` section controls how Hermes opens its SQLite state database


### PR DESCRIPTION
## Summary

Adds a best-effort process-hardening step to the long-running service surfaces, right next to the existing `RLIMIT_NOFILE` floor: `security.process_hardening`, default `core-only`.

The agent process holds every resolved provider credential in memory for the life of the session, and `hermes_cli/resource_limits.py` already exists as the home for "adjust this process's own limits at startup". This closes the one path a crash still has to spill those credentials onto disk.

Fixes #108399

## Modes

- `core-only` (default) — `RLIMIT_CORE = 0`: a crash can no longer write the process's memory to disk.
- `full` — `core-only` plus refusing debugger attach: Linux `prctl(PR_SET_DUMPABLE, 0)`, macOS `ptrace(PT_DENY_ATTACH)`.
- `off` — no-op. `0`, `false`, `null`, `none`, `disabled` are accepted spellings, so `hermes config set security.process_hardening off` and `false` agree.

`full` is opt-in because refusing attach breaks `gdb`/`lldb` (the debugger conflict the issue asks to document); `core-only` is the default because it is invisible to normal debugging.

## Where it is applied

Alongside `apply_nofile_soft_limit()`, in the same three long-running surfaces:

- `gateway/run.py::start_gateway`
- `hermes_cli/main.py` (`hermes serve` / dashboard, after named-profile routing)
- `hermes_cli/web_server.py::start_server` (dashboard-mode starts that don't route through `main.py`)

Children inherit both the lowered `RLIMIT_CORE` and the dumpable attribute, so anything spawned afterwards (cron workers, terminal subprocesses) is covered too.

**Deliberately not in `hermes_bootstrap.py`.** That import runs before the config is loaded, so resolving the knob there would add config I/O to *every* entry point — including `hermes --version`. Measured on this branch:

```
hermes_bootstrap import:          1.8 ms
+ hermes_cli.resource_limits:     8.4 ms
+ load_config_readonly() (cold): 93.4 ms
```

At the three call sites the config module is already imported, so the knob resolves from the loader cache (0.1 ms).

## Fail-open contract

Never raises, never blocks startup: unsupported platform (Windows has no equivalent for either lever), unrecognized setting, malformed `security` section, denied `setrlimit`, or a failing `prctl`/`ptrace` all leave the process exactly as it was. `test_internal_failure_never_escapes` and `test_denied_setrlimit_does_not_block_startup` pin that contract.

## Tests

`tests/test_resource_limits.py` — **49 passed (22 new)**:

- Unit: default, missing section, `full`, `off` plus every accepted spelling, unrecognized values fail open, malformed section, unsupported platform, denied `setrlimit`, internal failure, and a cold-process import with `resource` unavailable.
- Integration (extended; these assert ordering): `test_gateway_startup_applies_limit_before_gateway_initialization` now expects `["limit", "hardening", "gateway-init"]`; the serve test expects `["limit", "hardening", "server"]`; the named-profile re-routing and `--status`/`--stop` tests additionally assert hardening is *not* run on those paths.
- Neighbouring suites re-run green: `tests/gateway/test_runner_startup_failures.py`, `tests/hermes_cli/test_gateway.py`, `tests/test_89315_replace_ownership_guard.py`, `tests/gateway/test_startup_restart_race.py`, `tests/gateway/test_replace_child_reap.py` — 80 passed, 0 failed, 3 skipped.

Real Linux run, no mocks, against a live profile config:

```
RLIMIT_CORE before     : (0, -1)
configured mode (live) : core-only
apply_process_hardening: core-only
RLIMIT_CORE after      : (0, 0)
with hardening off     : off
```

Docs: `website/docs/user-guide/configuration.md`, new subsection under Runtime Limits. No `_config_version` bump — new keys deep-merge.

Honest caveat: I had no macOS host to exercise `PT_DENY_ATTACH`; that branch is guarded and best-effort, but unverified on real hardware.
