### PR TITLE
fix(agent): keep runtime notices out of user-authored history

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2120,10 +2120,11 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     summary_api_request_id = f"iteration-summary:{uuid.uuid4()}"
     summary_call_outcome = "failed"
 
-    # Shared constant so compaction recognizers can identify this runtime nudge by its stable
-    # content after SessionDB projection strips metadata flags.
+    # Keep the stable text for legacy transcript recognition, but emit new
+    # notifications through a structurally-attributed virtual tool.
     from agent.context_compressor import MAX_ITERATIONS_SUMMARY_REQUEST
-    append_message(messages, {"role": "user", "content": MAX_ITERATIONS_SUMMARY_REQUEST})
+    from agent.message_metadata import append_runtime_notification
+    append_runtime_notification(messages, MAX_ITERATIONS_SUMMARY_REQUEST)
 
     try:
         api_messages = _iteration_summary_api_messages(agent, messages)

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -257,7 +257,8 @@ _LEGACY_COMPRESSION_CONTINUATION_USER_CONTENT = (
     "Continue from the compressed conversation context above. This marker exists because the compacted "
     "transcript contained no preserved user turn."
 )
-# Content string is the authoritative marker: SessionDB drops ``_``-metadata.
+# Legacy content markers remain readable for transcripts emitted before runtime
+# notifications gained structural virtual-tool provenance.
 MAX_ITERATIONS_SUMMARY_REQUEST = (
     "You've reached the maximum number of tool-calling iterations allowed. Please provide a final response "
     "summarizing what you've found and accomplished so far, without calling any more tools."

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2083,7 +2083,9 @@ def _merge_anchor_into_user_message(target: dict, anchor: dict) -> None:
         target.pop(flag, None)
 
 
-CompressedUserTurnOutcome = Literal["inserted", "merged", "already_present", "placeholder_appended"]
+CompressedUserTurnOutcome = Literal[
+    "inserted", "merged", "already_present", "runtime_notification_appended",
+]
 
 
 def _insert_real_user_anchor(messages: list, anchor: dict) -> CompressedUserTurnOutcome:
@@ -2148,9 +2150,9 @@ def _ensure_compressed_has_user_turn(original_messages: list, compressed: list) 
         steer_text = _extract_steer_text_from_message(message)
         if steer_text:
             return _insert_real_user_anchor(compressed, {"role": "user", "content": steer_text})
-    from agent.message_metadata import append_message
-    append_message(compressed, {"role": "user", "content": COMPRESSION_CONTINUATION_USER_CONTENT})
-    return "placeholder_appended"
+    from agent.message_metadata import append_runtime_notification
+    append_runtime_notification(compressed, COMPRESSION_CONTINUATION_USER_CONTENT)
+    return "runtime_notification_appended"
 
 
 def _messages_match_scoped_identity(left: Any, right: Any) -> bool:

--- a/agent/message_metadata.py
+++ b/agent/message_metadata.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 from time import time as wall_time
 from typing import Any, MutableMapping, Optional, TypeVar
+from uuid import uuid4
 
 
 # These fields describe Hermes' durable record, not provider-visible message
 # content. They must not influence context-pressure decisions.
 PERSISTENCE_ONLY_MESSAGE_FIELDS = frozenset({"timestamp"})
+
+RUNTIME_NOTIFICATION_TOOL_NAME = "__runtime_notification__"
 
 _Message = TypeVar("_Message", bound=MutableMapping[str, Any])
 
@@ -37,3 +40,38 @@ def append_message(
     """Stamp and append one live transcript message."""
     messages.append(stamp_message_timestamp(message, timestamp=timestamp))
     return message
+
+
+def append_runtime_notification(
+    messages: list[Any], content: Any, *, call_id: Optional[str] = None,
+) -> MutableMapping[str, Any]:
+    """Append a provider-valid virtual-tool result authored by the runtime.
+
+    The assistant tool-call envelope is protocol scaffolding; the durable tool
+    row carries the source structurally through ``tool_name`` and
+    ``tool_call_id`` instead of forging a user turn or sniffing its content.
+    """
+    call_id = call_id or f"runtime-notification-{uuid4().hex}"
+    tool_call = {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": RUNTIME_NOTIFICATION_TOOL_NAME, "arguments": "{}"},
+    }
+    tail = messages[-1] if messages and isinstance(messages[-1], MutableMapping) else None
+    if tail is not None and tail.get("role") == "assistant" and not tail.get("tool_calls"):
+        tail["tool_calls"] = [tool_call]
+    else:
+        append_message(messages, {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [tool_call],
+            "_runtime_notification_scaffold": True,
+        })
+    return append_message(messages, {
+        "role": "tool",
+        "name": RUNTIME_NOTIFICATION_TOOL_NAME,
+        "tool_name": RUNTIME_NOTIFICATION_TOOL_NAME,
+        "content": content,
+        "tool_call_id": call_id,
+        "_runtime_notification": True,
+    })

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -886,6 +886,13 @@ class TestMaxIterationsSummaryReplay:
             m for m in captured["messages"] if m.get("role") == "user"
         ]
         assert sent_users[0]["content"] == "q1\n\nPLUGIN-CTX"
+        assert len(sent_users) == 1
+        runtime_results = [
+            m for m in captured["messages"]
+            if m.get("role") == "tool" and m.get("tool_call_id", "").startswith("runtime-notification-")
+        ]
+        assert len(runtime_results) == 1
+        assert runtime_results[0]["content"].startswith("You've reached the maximum number")
         for m in captured["messages"]:
             assert "api_content" not in m
         # The live history dict is never mutated.

--- a/tests/agent/test_compression_rotation_state.py
+++ b/tests/agent/test_compression_rotation_state.py
@@ -939,7 +939,7 @@ class TestRotationChildFlushDedup:
         )
 
     def test_no_real_user_anchor_guard_not_entered(self, tmp_path: Path):
-        """Negative regression: placeholder_appended/already_present must not
+        """Negative regression: runtime-notification/already-present must not
         enter the anchor-source guard branch — no exception, rotation happens,
         no live row outside the handoff carries the marker."""
         db = SessionDB(db_path=tmp_path / "state.db")

--- a/tests/agent/test_context_compressor_zero_user_provenance.py
+++ b/tests/agent/test_context_compressor_zero_user_provenance.py
@@ -205,12 +205,13 @@ def test_zero_user_provenance_survives_iterative_compaction(compressor):
     assert second_handoffs[0][COMPRESSED_SUMMARY_HAS_USER_TURN_KEY] is False
 
 
-def test_max_iterations_nudge_is_synthetic_not_actionable():
-    """#78580: the max-iteration runtime nudge is runtime scaffolding, not a
-    human turn. It is appended as ``role="user"`` and persisted verbatim in
-    state.db (metadata flags do not survive projection), so recognition must be
-    content-based — exactly like the continuation/todo markers."""
-    # The projected form: a bare role/content row with no internal metadata.
+def test_legacy_max_iterations_user_nudge_is_synthetic_not_actionable():
+    """Transcripts emitted before structural provenance remain resumable.
+
+    Those releases persisted the runtime nudge as a bare user row, so legacy
+    recognition must remain content-based like the continuation/todo markers.
+    """
+    # The legacy projected form has no internal provenance metadata.
     nudge = {"role": "user", "content": MAX_ITERATIONS_SUMMARY_REQUEST}
 
     assert ContextCompressor._is_synthetic_compression_user_turn(nudge) is True
@@ -233,6 +234,28 @@ def test_zero_user_compaction_continue_uses_runtime_tool_provenance():
     assert compressed[-1]["tool_name"] == RUNTIME_NOTIFICATION_TOOL_NAME
     assert compressed[-1]["tool_call_id"] == compressed[-2]["tool_calls"][0]["id"]
     assert compressed[-1]["content"] == COMPRESSION_CONTINUATION_USER_CONTENT
+
+
+def test_runtime_notification_provenance_survives_session_db_round_trip(tmp_path):
+    compressed = [{"role": "assistant", "content": "compressed history"}]
+    _ensure_compressed_has_user_turn([], compressed)
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "runtime-notification-round-trip"
+    db.create_session(session_id, source="test")
+    try:
+        db.append_messages_batch(session_id, compressed)
+        restored = db.get_messages_as_conversation(session_id)
+    finally:
+        db.close()
+
+    assert not any(message.get("role") == "user" for message in restored)
+    assistant_call = restored[-2]["tool_calls"][0]
+    tool_result = restored[-1]
+    assert assistant_call["function"]["name"] == RUNTIME_NOTIFICATION_TOOL_NAME
+    assert tool_result["tool_call_id"] == assistant_call["id"]
+    assert tool_result["tool_name"] == RUNTIME_NOTIFICATION_TOOL_NAME
+    assert tool_result["content"] == COMPRESSION_CONTINUATION_USER_CONTENT
 
 
 def test_real_task_wins_over_trailing_max_iterations_nudge(compressor):

--- a/tests/agent/test_context_compressor_zero_user_provenance.py
+++ b/tests/agent/test_context_compressor_zero_user_provenance.py
@@ -20,6 +20,7 @@ from agent.conversation_compression import (
     _ensure_compressed_has_user_turn,
     compress_context,
 )
+from agent.message_metadata import RUNTIME_NOTIFICATION_TOOL_NAME
 from hermes_state import SessionDB
 from tools.process_registry_notifications import format_process_notification
 from tools.todo_tool import TODO_INJECTION_HEADER
@@ -218,6 +219,20 @@ def test_max_iterations_nudge_is_synthetic_not_actionable():
     assert ContextCompressor._is_synthetic_compression_user_turn(human) is False
     assert ContextCompressor._transcript_has_real_user_turn([nudge]) is False
     assert ContextCompressor._transcript_has_real_user_turn([human, nudge]) is True
+
+
+def test_zero_user_compaction_continue_uses_runtime_tool_provenance():
+    compressed = [{"role": "assistant", "content": "compressed history"}]
+
+    outcome = _ensure_compressed_has_user_turn([], compressed)
+
+    assert outcome == "runtime_notification_appended"
+    assert not any(message.get("role") == "user" for message in compressed)
+    assert compressed[-2]["tool_calls"][0]["function"]["name"] == RUNTIME_NOTIFICATION_TOOL_NAME
+    assert compressed[-1]["role"] == "tool"
+    assert compressed[-1]["tool_name"] == RUNTIME_NOTIFICATION_TOOL_NAME
+    assert compressed[-1]["tool_call_id"] == compressed[-2]["tool_calls"][0]["id"]
+    assert compressed[-1]["content"] == COMPRESSION_CONTINUATION_USER_CONTENT
 
 
 def test_real_task_wins_over_trailing_max_iterations_nudge(compressor):


### PR DESCRIPTION
## What does this PR do?

Runtime-generated max-iteration and zero-user compaction prompts no longer appear in durable history as messages authored by the user. They now use a reserved virtual-tool exchange, so replay and session search retain machine provenance through `role`, `tool_name`, and `tool_call_id` without changing previously cached messages.

### Symptom

A session that reached its tool-iteration ceiling or continued after zero-user compaction stored the runtime prompt with `role: "user"`. Transcript readers could not distinguish that row from human input without exact text matching.

### Impact

Persisted transcripts, replay, and session search could attribute runtime control flow to the human. A human message matching the marker text could also be classified as runtime scaffolding.

### Bug Cause

**Trigger:** `agent/chat_completion_helpers.py:handle_max_iterations` and `agent/conversation_compression.py:_ensure_compressed_has_user_turn`

**Causal chain:**
1. The loop needs a non-terminal prompt to request a final summary or continue from compressed context.
2. Both paths appended that prompt as a synthetic `user` message.
3. SessionDB persisted the role verbatim, while downstream compression logic relied on exact-string recognition to recover the real author.

**Why it is wrong:** The message role claimed human authorship for runtime-generated control flow, and content matching is not reliable provenance.

**Working sibling / contrast:** Tool results already carry machine-domain provenance through a paired assistant tool call, `role: "tool"`, `tool_name`, and `tool_call_id`.

**Ruled out:** Prompt caching did not require the user role. These notifications append at the active tail or at a compaction boundary, so no cached historical message needs to be rebuilt.

### Fix

Add one virtual runtime-notification tool helper and use it at both reported emission sites. The helper emits a provider-valid assistant tool-call envelope plus a paired tool result named `__runtime_notification__`. Legacy string recognizers remain in place so transcripts written by older releases still replay correctly.

## Related Issue

Closes #108452

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/message_metadata.py` - add the structurally attributed runtime-notification message builder.
- `agent/chat_completion_helpers.py` - request iteration-limit summaries through the virtual tool channel.
- `agent/conversation_compression.py` - continue zero-user compacted sessions through the same virtual tool channel.
- `agent/context_compressor.py` - document the retained marker as legacy transcript compatibility.
- `tests/agent/` - cover max-iteration and compaction message provenance.

## How to Test

Automated verification passed: 88 tests across the affected agent test files.

```bash
scripts/run_tests.sh tests/agent/test_api_content_sidecar.py tests/agent/test_context_compressor_zero_user_provenance.py tests/agent/test_compression_rotation_state.py
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I ran the repository test wrapper on the affected tests and all 88 tests passed
- [x] I've added tests for my changes
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; behavior and compatibility are documented in code
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no workflow changed
- [x] Cross-platform impact was considered; the message protocol is platform-independent
- [x] Tool description/schema update is N/A; no model-callable tool was added
