### PR TITLE
fix(computer_use): attach element_token via live input schema, not the SDK-dropped capabilities array

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -2227,6 +2227,73 @@ class TestElementTokenAttachment:
         # The matching token rode along — cua-driver will prefer it.
         assert args["element_token"] == "s0001:5"
 
+    def _backend_with_schema_session(self, schemas):
+        """Session double modeling MCP SDK 2.x behavior: the driver's top-level `capabilities`
+        array is DROPPED by the pydantic Tool model (supports_capability always False), while the
+        input schema survives (supports_input_property reads it). Regression shape of #108355."""
+        from unittest.mock import MagicMock
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        backend = CuaDriverBackend()
+        backend._session = MagicMock()
+        backend._session.call_tool.return_value = {
+            "data": "ok", "images": [], "image_mime_types": [],
+            "structuredContent": None, "isError": False,
+        }
+        backend._session.supports_capability = lambda cap, tool=None: False  # SDK dropped the array
+        backend._session.supports_input_property = (
+            lambda tool, prop: prop in (schemas.get(tool, {}).get("properties") or {}))
+        backend._active_pid = 111
+        backend._active_window_id = 222
+        return backend
+
+    def test_token_attached_from_live_schema_when_capabilities_dropped(self):
+        """#108355: driver 0.28.0 advertises element_token in its click inputSchema but MCP SDK 2.x
+        drops the top-level capabilities array, so the capability-only gate never fired and every
+        element click degraded to a bare element_index (driver refuses: snapshot_id_required)."""
+        backend = self._backend_with_schema_session({
+            "click": {"properties": {"element_index": {}, "element_token": {}, "x": {}, "y": {}}},
+        })
+        backend._snapshot_tokens = {5: "s0001:5"}
+        backend.click(element=5, button="left")
+        name, args = backend._session.call_tool.call_args.args
+        assert name == "click"
+        assert args["element_index"] == 5
+        assert args["element_token"] == "s0001:5"
+
+    def test_token_withheld_when_schema_lacks_element_token(self):
+        """Fail-closed for older drivers: no element_token in the schema and no capability advertised
+        -> never send it (additionalProperties:false would reject the call)."""
+        backend = self._backend_with_schema_session({
+            "click": {"properties": {"element_index": {}, "x": {}, "y": {}}},
+        })
+        backend._snapshot_tokens = {5: "s0001:5"}
+        backend.click(element=5, button="left")
+        name, args = backend._session.call_tool.call_args.args
+        assert name == "click"
+        assert args["element_index"] == 5
+        assert "element_token" not in args
+
+    def test_scroll_coordinates_from_live_schema_when_capabilities_dropped(self):
+        """Same SDK-drop regression on the scroll x/y gate: schema says x is accepted -> coordinates ride."""
+        backend = self._backend_with_schema_session({
+            "scroll": {"properties": {"direction": {}, "amount": {}, "x": {}, "y": {}}},
+        })
+        backend.scroll(direction="down", amount=2, x=40, y=60)
+        name, args = backend._session.call_tool.call_args.args
+        assert name == "scroll"
+        assert args["x"] == 40 and args["y"] == 60
+
+    def test_scroll_coordinates_withheld_when_schema_lacks_xy(self):
+        """Schema without x/y (old driver) -> no coordinates sent; the window still scrolls via window_id."""
+        backend = self._backend_with_schema_session({
+            "scroll": {"properties": {"direction": {}, "amount": {}}},
+        })
+        backend.scroll(direction="down", amount=2, x=40, y=60)
+        name, args = backend._session.call_tool.call_args.args
+        assert name == "scroll"
+        assert "x" not in args and "y" not in args
+
 
     def test_capture_refreshes_snapshot_tokens(self):
         """A fresh capture should overwrite any stale tokens from a
@@ -2512,6 +2579,10 @@ class TestBoundsSpaceNote:
         note = _bounds_space_note(elems, 1455, 791)
         assert note is not None
         assert "native desktop coordinates" in note
+        # #108355 (px rung): the note must state the driver's contract — coordinate= clicks
+        # are SCREENSHOT pixels, never native bounds passed through (lands ~scale× off on HiDPI).
+        assert "SCREENSHOT pixels" in note
+        assert "never pass native" in note
 
     def test_no_note_when_spaces_match(self):
         from tools.computer_use.backend import UIElement

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -354,10 +354,16 @@ class CuaDriverBackend(_CaptureMixin, _InputMixin, ComputerUseBackend):
 
     def _action(self, name: str, args: Dict[str, Any], *, inject_session: bool = True) -> ActionResult:
         # Attach the snapshot's `element_token` to an `element_index` call so a superseded snapshot yields an explicit
-        # 'stale' error. Gated on the per-tool capability: older drivers (`additionalProperties: false`) must never see it.
+        # 'stale' error. Gated on the LIVE INPUT SCHEMA: MCP SDK 2.x pydantic models silently drop the driver's
+        # non-standard top-level `capabilities` array (model_extra is None), so the capability-token gate read False
+        # on every modern driver and element clicks degraded to bare element_index — which 0.17+ refuses with
+        # `snapshot_id_required` (NousResearch/hermes-agent#108355). The schema (`additionalProperties: false`) is the
+        # same fail-closed guarantee: a driver that doesn't accept element_token doesn't list it, and the capability
+        # check stays as an OR-branch for SDKs that do preserve the array.
         idx = args.get("element_index")
         token = self._snapshot_tokens.get(idx) if isinstance(idx, int) else None
-        if token and self._session.supports_capability("accessibility.element_tokens", tool=name):
+        if token and (self._session.supports_input_property(name, "element_token")
+                      or self._session.supports_capability("accessibility.element_tokens", tool=name)):
             args["element_token"] = token
         if inject_session:  # setdefault preserves any explicit session a caller already supplied
             args.setdefault("session", self._session_id)

--- a/tools/computer_use/cua_backend_input.py
+++ b/tools/computer_use/cua_backend_input.py
@@ -134,10 +134,12 @@ class _InputMixin:
         args.update(direction=direction, amount=max(1, min(50, amount)))
         # An element without a known window_id is not an addressing form here; scrolling then falls through
         # to the coordinate form or the bare window. Some driver schemas reject x/y on scroll: only send
-        # coordinates when the driver advertises support; otherwise it scrolls the targeted window
-        # (window_id is still sent for routing).
+        # coordinates when the live schema accepts them (capability token as OR-branch — MCP SDK 2.x drops
+        # the driver's top-level `capabilities` array, same gate fix as #108355); otherwise it scrolls the
+        # targeted window (window_id is still sent for routing).
         xy = lambda: ({"x": x, "y": y}  # noqa: E731
-                      if self._session.supports_capability("input.scroll.coordinates", tool="scroll") else {})
+                      if (self._session.supports_input_property("scroll", "x")
+                          or self._session.supports_capability("input.scroll.coordinates", tool="scroll")) else {})
         refusal = self._pointer_args("scroll", args, (
             ("element scroll", {"element_index": element}
              if element is not None and self._active_window_id is not None else None),

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -489,8 +489,10 @@ def _bounds_hints(elements: List[UIElement], image_width: int, image_height: int
     if max_x <= image_width * 1.05 and max_y <= image_height * 1.05:
         return None, None
     note = (f"element bounds are in native desktop coordinates (extend to ~{max_x}x{max_y}), "
-            f"NOT screenshot pixels ({image_width}x{image_height}). coordinate= clicks expect the native "
-            "space — derive click points from element bounds, or scale screenshot positions up accordingly")
+            f"NOT screenshot pixels ({image_width}x{image_height}). coordinate= clicks are sent to the "
+            f"driver as SCREENSHOT pixels (the driver reverses Retina/downscale itself) — never pass native "
+            f"bounds through directly: read the pixel off the screenshot, or divide the native bound by the "
+            f"estimated scale below")
     return round(max(max_x / image_width, max_y / image_height), 2), note
 
 _bounds_scale = lambda elements, image_width, image_height: _bounds_hints(elements, image_width, image_height)[0]  # noqa: E731


### PR DESCRIPTION
Fixes #108355.

## The bug

cua-driver 0.28.0 advertises `element_token` support **two ways** on every `tools/list` entry:

1. a non-standard top-level `capabilities` array (e.g. `["input.pointer.click", "accessibility.element_tokens", ...]`), and
2. the `element_token` property inside the tool's `inputSchema`.

`_populate_capabilities()` reads only route 1. But MCP SDK 2.x parses each tool into a pydantic `Tool` model that has **no `capabilities` field** and drops unknown top-level keys (`Tool.model_extra` is `None`) — so the map is populated with an **empty set per tool** and `supports_capability("accessibility.element_tokens")` returns `False` on every modern driver.

Consequence: the token-attach gate in `_action()` never fires, so every `click(element=N)` reaches the driver as a **bare `element_index`** — which cua-driver 0.17+ fail-closes with `snapshot_id_required` ("bare element_index is not accepted; pass element_token, or snapshot_id together with element_index"). Element-addressed input was structurally dead, and the model-facing schema exposes no `snapshot_id`/`element_token` to work around it. The **same dropped-capability bug** silently disabled scroll-by-coordinate (the `input.scroll.coordinates` gate).

This was verified live on macOS 27 / cua-driver 0.28.0: raw MCP `tools/list` carries the `capabilities` array and a `element_token` on all 284 snapshot elements; through the SDK, `Tool.model_validate(raw)` keeps neither (`hasattr(tool, 'capabilities')` → `False`, `model_extra` → `None`).

## The fix

Gate on the **live input schema** (`supports_input_property`, which reads the preserved `inputSchema`), keeping the capability token as an OR-branch for SDKs that do preserve the array:

```python
if token and (self._session.supports_input_property(name, "element_token")
              or self._session.supports_capability("accessibility.element_tokens", tool=name)):
    args["element_token"] = token
```

`additionalProperties: false` still guards old drivers — a driver that rejects `element_token` doesn't list it in its schema, so the attach stays **fail-closed**. The scroll x/y gate gets the same treatment.

Also corrects `_bounds_hints()`'s HiDPI note, which told the model the opposite of the driver contract ("coordinate= clicks expect the native space"). cua-driver's px path takes **screenshot pixels** and reverses Retina/downscale itself (`x`: "X in screenshot pixels … The driver reverses Retina backing scale and any window-image downscale"), so passing native bounds through lands ~scale× off target (≈1.7–1.9× on this machine). The note now states the real contract.

## Verification

- **Live E2E (the decisive test):** `click(element=N)` through the patched wrapper against cua-driver 0.28.0 on Finder's disclosure triangle returns `route: "accessibility"`, `✅ Performed AXPress`, and **verifiably mutates the AX tree** (278 → 282 elements on expand, collapsed back after). Unpatched, the same call returns `snapshot_id_required`.
- **Tests:** 4 new regression tests plus an extended bounds-note test, using a session double that models the SDK-2.x capability drop (schema preserved, capability array gone). The two attach tests are **red on base, green with the fix**; the two fail-closed tests pin old-driver behavior (no `element_token` in schema → never sent). Full `tests/tools/test_computer_use*.py` suite: **157/157 green**.

## Notes for maintainers

- The deeper issue is route 1 being unreadable under MCP SDK 2.x for any driver that uses the non-standard top-level `capabilities` array. This PR makes the wrapper rely on the schema (the SDK-preserved, spec-standard source of truth) instead. If the capability vocabulary is meant to be load-bearing, that's a separate conversation with trycua about moving it into `_meta` or `annotations` where the SDK preserves it.
- `drag` on 0.28.0 is pixel-only (`from_x/from_y/to_x/to_y`, no `*_element_*`); the wrapper's `drag(from_element=…)` is a separate pre-existing mismatch, out of scope here.
