### PR TITLE
fix(computer-use): disclose standalone doctor runtime

### DIFF
--- a/tests/computer_use/test_doctor.py
+++ b/tests/computer_use/test_doctor.py
@@ -429,3 +429,62 @@ class TestDoctorVersionIdentity:
         payload = json.loads(out.getvalue())
         assert payload["hermes_identity"]["version_mismatch"] is False
 
+
+@pytest.mark.parametrize("configured,expected_mode", [
+    ("standard", "standard"),
+    ("bounded", "bounded"),
+    ("unrestricted", "standard"),  # unrestricted is a session toggle, not a config mode
+])
+def test_json_discloses_standalone_scope_with_real_config(
+    configured, expected_mode, tmp_path, monkeypatch, capsys,
+):
+    from tools.computer_use import doctor
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        f"computer_use:\n  permission_mode: {configured}\n", encoding="utf-8",
+    )
+    report = _ok_report()
+    proc = _fake_proc_with_responses(
+        {"jsonrpc": "2.0", "id": 1, "result": {}},
+        {"jsonrpc": "2.0", "id": 2, "result": {"structuredContent": report}},
+    )
+    with patch("shutil.which", return_value="/fake/cua-driver"), \
+         patch("subprocess.Popen", return_value=proc) as spawn:
+        assert doctor.run_doctor(json_output=True) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    scope = payload["hermes_runtime"]
+    assert scope["kind"] == "standalone"
+    assert scope["connection"] == "stdio_mcp"
+    assert scope["configured_permission_mode"] == expected_mode
+    assert scope["session_runtime_checked"] is False
+    assert "private" in scope["warning"] and "not checked" in scope["warning"]
+    assert {key: payload[key] for key in report} == report
+    assert spawn.call_count == 1
+    assert spawn.call_args.args[0] == ["/fake/cua-driver", "mcp"]
+
+
+@pytest.mark.parametrize("configured", ["standard", "bounded"])
+def test_text_discloses_unchecked_private_sessions(
+    configured, tmp_path, monkeypatch, capsys,
+):
+    from tools.computer_use import doctor
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        f"computer_use:\n  permission_mode: {configured}\n", encoding="utf-8",
+    )
+    proc = _fake_proc_with_responses(
+        {"jsonrpc": "2.0", "id": 1, "result": {}},
+        {"jsonrpc": "2.0", "id": 2, "result": {"structuredContent": _ok_report()}},
+    )
+    with patch("shutil.which", return_value="/fake/cua-driver"), \
+         patch("subprocess.Popen", return_value=proc):
+        assert doctor.run_doctor(color=False) == 0
+
+    output = capsys.readouterr().out
+    assert "standalone" in output and "stdio_mcp" in output
+    assert f"configured permission mode: {configured}" in output
+    assert "bounded" in output and "unrestricted" in output
+    assert "private" in output and "not checked" in output

--- a/tools/computer_use/doctor.py
+++ b/tools/computer_use/doctor.py
@@ -287,10 +287,19 @@ def _wayland_environment_context(report: Report) -> Optional[Report]:
         return None
     return {"scope": "cli_process", "gateway_environment_checked": False}
 
+def _standalone_runtime_context() -> Report:
+    """Describe the connection we probe without starting or claiming to inspect an active session."""
+    from tools.computer_use.cua_backend import _cua_configured_permission_mode
+
+    return {"kind": "standalone", "connection": "stdio_mcp",
+            "configured_permission_mode": _cua_configured_permission_mode(), "session_runtime_checked": False,
+            "warning": "Active session runtime was not checked; bounded and unrestricted sessions use private "
+                       "daemons with separate permissions and sockets."}
+
 def _print_text_report(report: Report, color: bool, *, identity: Optional[Report] = None,
-                       environment: Optional[Report] = None) -> None:
+                       environment: Optional[Report] = None, runtime: Optional[Report] = None) -> None:
     """Render like `cua-driver call health_report`: header (CLI --version preferred over health_report's stale
-    ``driver_version``), identity block, environment note, one line per check + indented hint/``data`` rows
+    ``driver_version``), identity block, runtime/environment notes, one line per check + indented hint/``data`` rows
     (support staff need them)."""
     platform, report_v, overall = (report.get(k, "?") for k in ("platform", "driver_version", "overall"))
     identity = identity or {}
@@ -303,6 +312,10 @@ def _print_text_report(report: Report, color: bool, *, identity: Optional[Report
     lines = [f"{_OVERALL_GLYPH.get(overall, '•')} cua-driver {header_v} on {platform} — {col_for}{overall}{reset}"]
     if identity.get("resolved_binary"):
         lines.append(f"  {dim}binary: {identity['resolved_binary']}{reset}")
+    if runtime:
+        lines += [f"  {dim}runtime: {runtime['kind']} ({runtime['connection']}); "
+                  f"configured permission mode: {runtime['configured_permission_mode']}{reset}",
+                  f"  {yellow}⚠️ {runtime['warning']}{reset}"]
     if cli_v and report_v and str(report_v) not in str(cli_v) and str(cli_v) not in str(report_v):  # clearly differ
         lines += [f"  {dim}--version: {cli_v}{reset}", f"  {dim}health_report.driver_version: {report_v}{reset}"]
     if environment:
@@ -323,8 +336,8 @@ def _print_text_report(report: Report, color: bool, *, identity: Optional[Report
 
 def run_doctor(driver_cmd: Optional[str] = None, *, include: Sequence[str] = (), skip: Sequence[str] = (), json_output: bool = False,
                color: Optional[bool] = None) -> int:
-    """Resolve the binary via the shared runtime resolver (diagnose what `computer_use` actually invokes), call
-    `health_report`, render; on 0.10.x (denied) a report is synthesized from probes."""
+    """Resolve the driver binary and diagnose its standalone MCP connection, not an active session's private
+    daemon. On 0.10.x (denied), synthesize a report from probes of that same standalone runtime."""
     # Windows' locale codec (cp1252, cp936, ...) cannot encode the ✅ ❌ ⚠️ ⏭️ glyphs — force UTF-8.
     for stream in (sys.stdout, sys.stderr):
         with suppress(AttributeError, OSError):
@@ -345,15 +358,16 @@ def run_doctor(driver_cmd: Optional[str] = None, *, include: Sequence[str] = (),
     report = _apply_display_count_guard(report)
     identity = _build_identity(binary, report)
     environment = _wayland_environment_context(report)
+    runtime = _standalone_runtime_context()
     if json_output:
-        # Additive envelope: upstream keys preserved, identity under hermes_identity (and environment under
-        # hermes_environment when present) so overall/checks parsers keep working.
-        payload = {**report, "hermes_identity": identity}
+        # Additive envelope: upstream keys preserved; Hermes context cannot turn a standalone
+        # health result into a claim about a private session's health.
+        payload = {**report, "hermes_identity": identity, "hermes_runtime": runtime}
         if environment:
             payload["hermes_environment"] = environment
         json.dump(payload, sys.stdout, indent=2, sort_keys=True)
         sys.stdout.write("\n")
     else:
         _print_text_report(report, color=sys.stdout.isatty() if color is None else bool(color), identity=identity,
-                           environment=environment)
+                           environment=environment, runtime=runtime)
     return 0 if report.get("overall") == "ok" else 1  # unknown/missing overall must not look like success

--- a/website/docs/user-guide/features/computer-use.md
+++ b/website/docs/user-guide/features/computer-use.md
@@ -84,7 +84,7 @@ platform-appropriate prereqs:
 
 | Platform | Prereqs |
 |---|---|
-| **macOS** | System Settings → Privacy & Security → **Accessibility** + **Screen Recording**. Grant the identity named by `hermes computer-use doctor`. Standard mode uses CuaDriver.app; bounded and unrestricted modes use the Hermes host identity. |
+| **macOS** | System Settings → Privacy & Security → **Accessibility** + **Screen Recording**. Standard mode uses CuaDriver.app, the standalone identity checked by `hermes computer-use doctor`; bounded and unrestricted modes use the Hermes host identity. Grant permissions to the identity used by your session. |
 | **Windows** | None at install time. If you're driving over SSH (not RDP / console), you need the autostart pattern — see [cua.ai/docs/how-to-guides/driver/windows-ssh](https://cua.ai/docs/how-to-guides/driver/windows-ssh) for the Session 0 ↔ Session 1+ proxy. |
 | **Linux** | A reachable display server: `DISPLAY` set for X11, or `XDG_SESSION_TYPE=wayland`. Wayland sessions need an XWayland bridge for capture. AT-SPI must be on (default on GNOME/KDE/Xfce). |
 
@@ -171,12 +171,18 @@ compromise you accept.
 ## `hermes computer-use doctor` — your first triage stop
 
 `hermes computer-use doctor` runs cua-driver's structured
-`health_report` MCP tool and prints a per-check matrix. It's the single
-fastest way to find out *why* an action isn't working.
+`health_report` MCP tool over a standalone stdio connection and prints a
+per-check matrix. The output identifies this runtime and the configured
+permission mode. It does **not** check an active session's runtime: bounded
+and unrestricted sessions use private daemons with separate permissions and
+sockets, so a healthy standalone report does not establish their health.
+Doctor does not start a private daemon or enable unrestricted mode.
 
 ```
 $ hermes computer-use doctor
 ⚠️  cua-driver VERSION on darwin: degraded
+  runtime: standalone (stdio_mcp); configured permission mode: bounded
+  ⚠️ Active session runtime was not checked; bounded and unrestricted sessions use private daemons with separate permissions and sockets.
   ✅ binary_version: cua-driver VERSION
   ✅ platform_supported: macOS 26.4.1 (arm64)
   ✅ session_active: MCP session is active.
@@ -188,7 +194,7 @@ $ hermes computer-use doctor
   ✅ screen_capture_capability: ScreenCaptureKit reachable; 1 display(s) shareable.
 ```
 
-- **Exit code 0** when overall is `ok` — everything's wired up.
+- **Exit code 0** when the standalone report's overall is `ok`.
 - **Exit code 1** when `degraded` or `failed` — at least one check failed; the hint on each failure tells you what to fix.
 - **Exit code 2** when the cua-driver binary itself isn't reachable.
 
@@ -196,8 +202,10 @@ Useful flags:
 
 - `--include CHECK` — run only the listed checks (repeat for multiple)
 - `--skip CHECK` — skip a check (wins over `--include`)
-- `--json` — emit the raw structured payload, same shape as the
-  `tools/call health_report` MCP response
+- `--json` — preserve the structured health report and add Hermes context.
+  `hermes_runtime` identifies the diagnosed runtime, connection, configured
+  permission mode, and `session_runtime_checked: false`, with the same scope
+  warning shown in text output.
 
 The check matrix is platform-aware: `bundle_identity` / `tcc_*` are
 `skip` on Windows + Linux because those concepts don't apply.
@@ -536,7 +544,8 @@ HERMES_CUA_DRIVER_CMD=/path/to/cua/libs/cua-driver/rust/target/debug/cua-driver
 - `hermes computer-use status` prints the resolved binary path and
   version.
 - `hermes computer-use doctor` confirms the binary is reachable and
-  exercises the full MCP path end-to-end.
+  exercises the standalone MCP path end-to-end; it does not check a
+  bounded or unrestricted session's private connection.
 - In a session, `computer_use(action="capture")` exercises the spawned
   `cua-driver mcp` child process.
 


### PR DESCRIPTION
## What does this PR do?

With bounded or unrestricted Computer Use sessions, `hermes computer-use doctor` probes a standalone `cua-driver mcp` connection. Its green report previously gave no indication that the session uses a different private daemon, permissions and socket.

This implements the standalone-disclosure option requested in #90695: text and JSON identify the inspected runtime and configured permission mode, and explicitly say that the active session runtime was not checked. The CLI has no active backend connection to inspect; it does not start a private daemon or enable unrestricted mode for diagnostics.

## Related Issue

Fixes #90695 via the documented standalone-disclosure option.

## Type of Change

- [x] 🐛 Bug fix
- [x] ✅ Tests
- [x] 📝 Documentation update

## Changes Made

- Add `hermes_runtime` to JSON output: standalone runtime, stdio MCP connection, resolved configured permission mode, `session_runtime_checked: false`, and a scope warning.
- Render the same context in human-readable output, for both native health reports and the older-driver probe fallback.
- Reuse the backend's existing permission-mode resolver. Static `unrestricted` configuration still resolves to standard; unrestricted remains session-owned.
- Preserve the upstream health report and exit-code contract. Document that exit 0 describes the standalone report.
- Add two parameterized regression tests using real temporary profile configuration, covering five cases.

## How to Test

```bash
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/computer_use/test_doctor.py -q --tb=short
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/computer_use/ tests/hermes_cli/test_computer_use_cli.py -j 2 -q --tb=short
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/e2e -j 2 -q --tb=short
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh -j 8 -q --tb=short
ruff check .
git diff --check
```

Validated on macOS 26.6.2 arm64, Python 3.11.14, with dependencies installed from `uv.lock` using the CI extras.

- **Red/green:** all five new cases failed on unchanged production code at `ad03f20dd61919ca2135d6904e787a94284aacaf`; the complete doctor file then passed **20/20** with the fix.
- **Actual CLI and stdio:** 12 offline combinations passed, using a temporary executable that implements the driver protocol. These cover standard/bounded/static-unrestricted configuration, native/fallback reports, and JSON/text. Only `mcp`, `--version`, and `doctor` were invoked; no private daemon was launched and no real desktop/provider was accessed.
- **Computer Use directory + CLI:** **60 passed, 1 failed, 5 skipped**. The failure needs a CuaDriver.app fixture on macOS and reproduces on unchanged base: `test_serve_process_disables_overlay_when_policy_requires_it`.
- **Separate E2E job:** **63 passed, 0 failed, 7 skipped** (external Matrix service conditions).
- **Full default discovery:** completed all **4,049 files**, with **48,678 passed, 44 failed, 577 skipped, 3 xfailed, 1 xpassed, 0 errors**; exit 1, retries disabled. This is a completed full run, **not a passing full suite**. The default runner excludes the separate integration/e2e/docker directories; E2E is reported above.
- **Lint:** full `ruff check .` and `git diff --check` passed.

The full run used test-process overrides `NO_PROXY=*`, `no_proxy=*`, and `TMPDIR=/private/tmp`. Of the 44 failures, 42 match failure IDs already analyzed against the same base during #108351 validation. The other two were investigated separately:

1. `test_room_log_pages_are_bounded_by_serialized_event_bytes` passed when rerun alone on both base and this branch (45/45 in that file). Its budget assumes later events are no larger than the first despite variable-length timestamps. On unchanged base, explicit timestamps produce a 520-byte first page, a 526-byte second page, and a 521-byte test budget, deterministically raising the same error.
2. `test_create_openai_client_routes_via_proxy_when_env_set` also fails on base with wildcard `NO_PROXY`, which overrides the proxy it intentionally configures. With `NO_PROXY=localhost,127.0.0.1,::1`, all four proxy tests pass on base, and the proxy case plus a local-network isolation control pass on this branch. The full suite was not repeated under that adjusted environment.

Testing used the `ad03f20` baseline. Before submission, upstream was refreshed to `8226c2f6a283c48fb97c1750a0ec2907739146d0`; none of this PR's three files or applicable AGENTS instructions changed between those commits. Required CI still needs to validate the merge result. Keep this PR in draft pending that validation.

## Checklist

- [x] Read CONTRIBUTING.md and applicable AGENTS.md instructions.
- [x] Use a Conventional Commit and keep one logical fix in this PR.
- [x] Search open, closed and merged PRs, including issue references and affected-function keywords.
- [x] Add regression coverage and prove it fails before the fix.
- [x] Exercise the real CLI path on the stated platform.
- [ ] Full test suite passes.
- [x] Update relevant user documentation and docstrings.
- [x] Consider cross-platform impact: additive output only, existing mode resolution, no host-OS spoofing, explicit UTF-8 for new test files.
- [x] Config schema / architecture / tool schema updates: not applicable.

Prepared with AI assistance (Codex). No independent Linux or Windows execution is claimed.
