### PR TITLE
fix(model-picker): active provider row keeps its models through aggregator dedup

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -167,6 +167,13 @@ def _strip_aggregator_overlaps(rows: list[dict]) -> None:
     for row in rows:
         if row.get("is_user_defined") or not is_routing_aggregator(row.get("slug", "")):
             continue
+        # The row that is currently active is not an "aggregator duplicate" of anything: the user is
+        # already running on it. Stripping its models because a user-defined provider happens to serve
+        # the same id makes the picker misreport the active backend — the configured model vanishes
+        # from the very row the session is using (e.g. openrouter's deepseek/deepseek-v4.1-flash while
+        # a custom provider also lists it), and the model cannot be re-selected from the picker.
+        if row.get("is_current"):
+            continue
         # Only strip overlaps from TRUE routing aggregators (OpenRouter, custom:* proxies). Flat-namespace
         # resellers (opencode-go / opencode-zen) serve every listed model as a first-party model, so their
         # rows must keep models that a user's proxy happens to share a name with — otherwise a subscription

--- a/tests/hermes_cli/test_aggregator_overlap_current_row.py
+++ b/tests/hermes_cli/test_aggregator_overlap_current_row.py
@@ -1,0 +1,71 @@
+"""The active provider's row survives aggregator-overlap dedup.
+
+``_strip_aggregator_overlaps`` exists so picking a model from a routing
+aggregator (OpenRouter, custom:* proxies) cannot silently swap the provider
+the user expected when a more specific provider serves the same id. Applied
+to the row that IS the active provider, the same rule backfires: the model
+the session is running vanishes from its own row (e.g. openrouter's
+``deepseek/deepseek-v4.1-flash`` while ``custom:novita`` also lists it), so
+the picker misreports the active backend and the model cannot be re-selected.
+
+Contract: a current row keeps its full model list; non-current aggregator
+rows still drop overlaps; user-defined rows stay untouched either way.
+"""
+
+from __future__ import annotations
+
+import hermes_cli.inventory as inv
+
+
+SHARED = "deepseek/deepseek-v4.1-flash"
+ONLY_ROUTER = "anthropic/claude-fable-5"
+
+
+def _rows(*, router_is_current: bool) -> list[dict]:
+    return [
+        {
+            "slug": "openrouter",
+            "name": "OpenRouter",
+            "is_current": router_is_current,
+            "is_user_defined": False,
+            "models": [SHARED, ONLY_ROUTER],
+            "total_models": 2,
+        },
+        {
+            "slug": "custom:novita",
+            "name": "novita",
+            "is_current": not router_is_current,
+            "is_user_defined": True,
+            "models": [SHARED],
+            "total_models": 1,
+        },
+    ]
+
+
+def test_current_aggregator_row_keeps_overlapping_models():
+    rows = _rows(router_is_current=True)
+
+    inv._strip_aggregator_overlaps(rows)
+
+    assert rows[0]["models"] == [SHARED, ONLY_ROUTER], (
+        "the active provider's row must keep every model it serves")
+    assert rows[0]["total_models"] == 2
+
+
+def test_non_current_aggregator_row_still_drops_overlaps():
+    rows = _rows(router_is_current=False)
+
+    inv._strip_aggregator_overlaps(rows)
+
+    assert rows[0]["models"] == [ONLY_ROUTER], (
+        "an inactive aggregator row must still hide ids a custom provider serves")
+    assert rows[0]["total_models"] == 1
+
+
+def test_user_defined_row_is_never_stripped():
+    rows = _rows(router_is_current=True)
+
+    inv._strip_aggregator_overlaps(rows)
+
+    assert rows[1]["models"] == [SHARED], (
+        "a user's own provider is not a duplicate of itself")


### PR DESCRIPTION
## What does this PR do?

Fixes the `/model` picker hiding models from the row of the provider that is **currently active**.

`_strip_aggregator_overlaps()` (in `hermes_cli/inventory.py`) removes ids from routing-aggregator rows (`openrouter`, `custom:*` proxies) when a user-defined provider also serves them. That rule is right for inactive rows — it stops picking a model from an aggregator row from silently swapping the provider the user expected (#45954) — but it is wrong for the row the session is actually running on. The active provider is not a duplicate of anything.

Symptom: with `openrouter` active and `deepseek/deepseek-v4.1-flash` set as the model, plus a custom provider that resells the same id (`custom:novita`, `custom:inco`), the model vanishes from the OpenRouter row. The picker then misreports the active backend, and the model cannot be re-selected from the picker at all.

## Related Issue

Fixes #108462

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/inventory.py` — `_strip_aggregator_overlaps()`: skip the dedup for the row whose provider is current (`row.get("is_current")`), with a comment explaining why. Inactive aggregator rows and user-defined rows keep the existing behavior.
- `tests/hermes_cli/test_aggregator_overlap_current_row.py` — new test file covering the three row shapes: current row keeps every model it serves, inactive aggregator row still drops overlaps, user-defined row is never stripped. The first test fails before the fix and passes after.

## How to Test

1. `pytest tests/hermes_cli/test_aggregator_overlap_current_row.py -q` → 3 passed.
2. Revert `hermes_cli/inventory.py` and rerun → `test_current_aggregator_row_keeps_overlapping_models` fails, the other two still pass (confirms the test covers the actual change and nothing else).
3. Manually, without credentials:
   ```python
   from hermes_cli import inventory
   rows = [
     {"slug": "openrouter", "is_current": True, "is_user_defined": False,
      "models": ["deepseek/deepseek-v4.1-flash", "anthropic/claude-fable-5"], "total_models": 2},
     {"slug": "custom:novita", "is_current": False, "is_user_defined": True,
      "models": ["deepseek/deepseek-v4.1-flash"], "total_models": 1},
   ]
   inventory._strip_aggregator_overlaps(rows)
   assert rows[0]["models"] == ["deepseek/deepseek-v4.1-flash", "anthropic/claude-fable-5"]
   ```
4. End-to-end on a live config: with `model.provider: openrouter` and a custom provider sharing an id, `build_models_payload(ctx)` now returns the full OpenRouter row (289 models, active model present) instead of 215 with the active model removed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — closest is #47211 (fixed the opposite shape: a user-defined row being emptied), this one is the active aggregator row
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **partial**: `tests/hermes_cli/test_aggregator_overlap_current_row.py` (3 passed) plus `tests/hermes_cli/test_local_picker_identity.py`, `test_inventory_pricing.py`, `test_model_switch_custom_providers.py` (85 passed) in a clean venv. A full `pytest tests/ -q` cannot run in my environment: 83 collection errors from optional deps (starlette et al.) that are unrelated to this change and reproduce before it
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6.1, Python 3.13.7

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior change is documented in the code comment and the test docstring)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys added)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A (pure in-memory list filtering, no OS-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Picker payload on a live config before/after (agent-side call through the same `build_models_payload` path the CLI picker uses):

```
# before
current provider: openrouter | model: deepseek/deepseek-v4.1-flash
openrouter len: 215   v41 present: False

# after
current provider: openrouter | model: deepseek/deepseek-v4.1-flash
openrouter len: 289   is_current: True
v41: ['deepseek/deepseek-v4.1-flash']
```

Test run:

```
tests/hermes_cli/test_aggregator_overlap_current_row.py::test_current_aggregator_row_keeps_overlapping_models PASSED
tests/hermes_cli/test_aggregator_overlap_current_row.py::test_non_current_aggregator_row_still_drops_overlaps PASSED
tests/hermes_cli/test_aggregator_overlap_current_row.py::test_user_defined_row_is_never_stripped PASSED
3 passed in 2.73s
```
