### PR TITLE
fix(local-runtime): detect Intel Xe VRAM

### DIFF
--- a/hermes_cli/local_runtime/hardware.py
+++ b/hermes_cli/local_runtime/hardware.py
@@ -13,6 +13,7 @@ import logging
 import os
 import re
 import shutil
+import struct
 import subprocess
 import sys
 import time
@@ -159,6 +160,121 @@ def _nvidia_vram() -> tuple[int, int] | None:
     return None
 
 
+# Linux xe DRM device-query ABI. The reply size is discovered from the kernel; the
+# request layout and ioctl number are fixed by the public xe UAPI header.
+_XE_QUERY_MEM_REGIONS = 1
+_XE_MEM_REGION_CLASS_VRAM = 1
+_XE_QUERY_FMT = "<QIIQQQ"
+_XE_QUERY_SIZE = struct.calcsize(_XE_QUERY_FMT)
+_XE_REGION_FMT = "<HHIQQQQ6Q"
+_XE_REGION_SIZE = struct.calcsize(_XE_REGION_FMT)
+_XE_DEVICE_QUERY_IOCTL = (3 << 30) | (ord("d") << 8) | (0x40) | (_XE_QUERY_SIZE << 16)
+_XE_CAP_SYS_ADMIN = 21
+_XE_CAP_PERFMON = 38
+
+
+def _xe_memory_query_allowed() -> bool:
+    """Whether this process can receive reliable xe memory accounting."""
+    if not sys.platform.startswith("linux"):
+        return False
+    try:
+        status = Path("/proc/self/status").read_text(encoding="ascii")
+    except (OSError, UnicodeError, ValueError):
+        return False
+    for line in status.splitlines():
+        if line.startswith("CapEff:"):
+            try:
+                effective = int(line.split()[1], 16)
+            except (IndexError, ValueError):
+                return False
+            return bool(effective & (1 << _XE_CAP_SYS_ADMIN)
+                        or effective & (1 << _XE_CAP_PERFMON))
+    return False
+
+
+def _parse_xe_mem_regions(payload: bytes) -> tuple[int, int] | None:
+    """Return (total, free) for VRAM regions in an xe query reply."""
+    if len(payload) < 8:
+        return None
+    count = struct.unpack_from("<I", payload)[0]
+    if count <= 0 or len(payload) < 8 + count * _XE_REGION_SIZE:
+        return None
+
+    total = used = 0
+    for offset in range(8, 8 + count * _XE_REGION_SIZE, _XE_REGION_SIZE):
+        fields = struct.unpack_from(_XE_REGION_FMT, payload, offset)
+        if fields[0] != _XE_MEM_REGION_CLASS_VRAM:
+            continue
+        total += fields[3]
+        used += fields[4]
+    if total <= 0:
+        return None
+    return total, max(0, total - min(used, total))
+
+
+def _query_xe_mem_regions(fd: int) -> tuple[int, int] | None:
+    """Read one xe device's VRAM through the two-phase DRM query ABI."""
+    import ctypes
+
+    class _XeDeviceQuery(ctypes.Structure):
+        _fields_ = (
+            ("extensions", ctypes.c_uint64),
+            ("query", ctypes.c_uint32),
+            ("pad", ctypes.c_uint32),
+            ("size", ctypes.c_uint64),
+            ("data", ctypes.c_uint64),
+            ("reserved", ctypes.c_uint64),
+        )
+
+    if ctypes.sizeof(_XeDeviceQuery) != _XE_QUERY_SIZE:
+        return None
+    libc = ctypes.CDLL(None, use_errno=True)
+    ioctl = libc.ioctl
+    ioctl.argtypes = (ctypes.c_int, ctypes.c_ulong, ctypes.c_void_p)
+    ioctl.restype = ctypes.c_int
+
+    query = _XeDeviceQuery(query=_XE_QUERY_MEM_REGIONS)
+    if ioctl(fd, _XE_DEVICE_QUERY_IOCTL, ctypes.byref(query)) != 0:
+        return None
+    size = query.size
+    if size <= 0 or size > (1 << 20):
+        return None
+
+    payload = ctypes.create_string_buffer(size)
+    query.size = size
+    query.data = ctypes.addressof(payload)
+    if ioctl(fd, _XE_DEVICE_QUERY_IOCTL, ctypes.byref(query)) != 0:
+        return None
+    return _parse_xe_mem_regions(payload.raw)
+
+
+def _intel_vram() -> tuple[int, int] | None:
+    """Return (total, free) VRAM for the largest accessible Intel xe card.
+
+    xe's query is capability-gated on some kernels. A gated or unavailable query
+    deliberately returns None so probe_budget() keeps its conservative UMA path.
+    """
+    if not sys.platform.startswith("linux"):
+        return None
+    if not _xe_memory_query_allowed():
+        return None
+
+    candidates: list[tuple[int, int]] = []
+    for node in sorted(Path("/dev/dri").glob("renderD*")):
+        driver = Path("/sys/class/drm") / node.name / "device" / "driver"
+        with suppress(OSError, ValueError):
+            if driver.resolve().name != "xe":
+                continue
+            fd = os.open(node, os.O_RDONLY | os.O_CLOEXEC)
+            try:
+                memory = _query_xe_mem_regions(fd)
+            finally:
+                os.close(fd)
+            if memory is not None:
+                candidates.append(memory)
+    return max(candidates, key=lambda item: item[0], default=None)
+
+
 def _cuda_driver_pool() -> "tuple[int, bool | None] | None":
     """(allocator_total_bytes, integrated_or_None) from the CUDA driver API via ctypes against the
     driver's own DLL/SO — no toolkit, no subprocess, ~ms. INTEGRATED is the vendor's own
@@ -266,6 +382,8 @@ def probe_budget(*, planning: bool = False) -> HardwareBudget:
     """
     ram_total, ram_avail = _ram_bytes()
     vram = _nvidia_vram()
+    if vram is None:
+        vram = _intel_vram()
 
     # Unified-memory NVIDIA: the CUDA allocator pool is the real capacity. Classification comes
     # from the driver API/engine and must not require nvidia-smi (stripped-PATH sessions lose smi

--- a/tests/hermes_cli/test_hardware.py
+++ b/tests/hermes_cli/test_hardware.py
@@ -1,0 +1,53 @@
+"""Hardware budget contracts for discrete Intel Xe devices."""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+
+_GIB = 1 << 30
+_REGION_FMT = "<HHIQQQQ6Q"
+
+
+def _region(mem_class: int, total: int, used: int) -> bytes:
+    return struct.pack(
+        _REGION_FMT,
+        mem_class,
+        0,
+        4096,
+        total,
+        used,
+        total,
+        used,
+        *(0 for _ in range(6)),
+    )
+
+
+def test_xe_memory_query_parses_vram_and_clamps_used():
+    from hermes_cli.local_runtime.hardware import _parse_xe_mem_regions
+
+    payload = struct.pack("<II", 3, 0)
+    payload += _region(0, 128 * _GIB, 0)
+    payload += _region(1, 32 * _GIB, 4 * _GIB)
+    payload += _region(1, 8 * _GIB, 12 * _GIB)
+
+    assert _parse_xe_mem_regions(payload) == (40 * _GIB, 24 * _GIB)
+
+
+@pytest.mark.linux_only
+def test_probe_budget_uses_intel_vram_when_query_is_available(monkeypatch):
+    import hermes_cli.local_runtime.hardware as hardware
+
+    monkeypatch.setattr(hardware, "_nvidia_vram", lambda: None)
+    monkeypatch.setattr(hardware, "_intel_vram", lambda: (32 * _GIB, 24 * _GIB))
+    monkeypatch.setattr(hardware, "_ram_bytes", lambda: (128 * _GIB, 96 * _GIB))
+
+    budget = hardware.probe_budget()
+
+    margin = max(2 * _GIB, int(32 * _GIB * 0.09))
+    assert budget.total_device_bytes == 32 * _GIB
+    assert budget.usable_vram_bytes == 24 * _GIB - margin
+    assert budget.ram_available_bytes == 96 * _GIB
+    assert budget.uma is False


### PR DESCRIPTION
## What does this PR do?

Adds Intel Xe discrete-GPU VRAM detection to Hermes local-runtime hardware budgeting.

Before this change, Intel Xe systems fell through to the conservative RAM/UMA budget. This could substantially understate the usable capacity of discrete Intel GPUs.

The implementation uses the public xe DRM device-query API with the required two-phase kernel-reported size discovery. If the query is unavailable or capability-gated, Hermes preserves the existing conservative fallback instead of claiming unreliable free VRAM.

## Related Issue

No exact existing issue found.

I searched existing open and merged issues and PRs. Related Intel GPU work includes #102505, #104281, and #100749, but those address SYCL/Vulkan runtime selection rather than VRAM budgeting.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added Intel Xe VRAM detection in `hermes_cli/local_runtime/hardware.py`.
- Added two-phase xe DRM ioctl size discovery.
- Added parsing for multiple VRAM regions.
- Selects the largest accessible Intel Xe card.
- Preserves the existing conservative UMA/RAM fallback when reliable xe accounting is unavailable.
- Added `tests/hermes_cli/test_hardware.py` covering:
  - VRAM-region parsing and used-memory clamping.
  - Intel VRAM integration into `probe_budget()`.

## How to Test

Targeted tests:

```bash
scripts/run_tests.sh \
  tests/hermes_cli/test_hardware.py \
  tests/hermes_cli/test_budget_source.py \
  tests/hermes_cli/test_local_runtime.py -q
```

Result:

```text
57 passed
```

Additional checks:

```bash
.venv/bin/ruff check \
  hermes_cli/local_runtime/hardware.py \
  tests/hermes_cli/test_hardware.py

.venv/bin/python scripts/check-windows-footguns.py \
  hermes_cli/local_runtime/hardware.py \
  tests/hermes_cli/test_hardware.py

git diff --check
```

All passed.

The full suite was also run locally. It has unrelated environment-sensitive baseline failures involving the live Hermes gateway on port `9119`, unavailable browser/Chrome tooling, host-specific `sort` behavior, and existing state/session tests. The persistent failures reproduce on a clean `origin/main` worktree and do not involve the files changed in this PR.

The live development host lacks `CAP_PERFMON` and `CAP_SYS_ADMIN`, so the actual xe VRAM happy path could not be exercised with privileged accounting. The conservative fallback was exercised live, and the parser/integration behavior is covered by tests.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits: `fix(local-runtime): detect Intel Xe VRAM`.
- [x] I searched existing PRs and issues for duplicate work.
- [x] My PR contains only changes related to this feature.
- [ ] I've run `pytest tests/ -q` and all tests pass.  
      The targeted suite passes; unrelated baseline failures are documented above.
- [x] I've added tests for the change.
- [x] I've tested on Linux: Ubuntu 26.04, Python 3.11.15, Intel Arc B70 hardware.

### Documentation & Housekeeping

- [x] No README or standalone documentation update is needed.
- [x] No `cli-config.yaml.example` changes are needed.
- [x] No `CONTRIBUTING.md` or `AGENTS.md` changes are needed.
- [x] Cross-platform impact was considered. The Intel implementation is Linux-gated, and the test uses the repository's `linux_only` marker.
- [x] No tool descriptions or schemas were changed.

## Screenshots / Logs

Not applicable. This is a local hardware-budgeting change.
