### PR TITLE
fix(mcp): reuse zero-TTL schema snapshots for lazy startup

### DIFF
--- a/tests/tools/test_mcp_lazy_start.py
+++ b/tests/tools/test_mcp_lazy_start.py
@@ -334,3 +334,33 @@ class TestResolveServerLazy:
 
     def test_explicit_false(self):
         assert _mcp_discovery._resolve_server_lazy("s", {"command": "npx", "lazy": False}) is False
+
+
+class TestLazyStartupWithZeroTtlCache:
+    """A server whose ``tools/list`` reported ``ttlMs: 0`` must still register lazily from its
+    on-disk snapshot; expiry applies only to positive TTLs (tests/tools/test_mcp_schema_cache_ttl.py)."""
+
+    def test_zero_ttl_entry_registers_without_connect(self, tmp_path, monkeypatch):
+        from tools import mcp_schema_cache as sc
+
+        monkeypatch.setattr(sc, "_cache_path", lambda: tmp_path / "cache.json")
+        config = _lazy_config()
+        fp = sc.config_fingerprint(config["playwright"])
+        sc.write_cache_entry("playwright", fp, tools=_fake_cache_entry()["tools"], ttl_ms=0)
+
+        with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+             patch(
+                 "tools.mcp_tool_registration._register_from_cache_sync",
+                 return_value=["mcp_playwright_browser_navigate"],
+             ) as mock_register, \
+             patch("tools.mcp_tool_discovery._discover_and_register_server", new_callable=AsyncMock) as mock_discover, \
+             patch("tools.mcp_tool_loop._ensure_mcp_loop") as mock_loop, \
+             patch("tools.mcp_tool_loop._run_on_mcp_loop") as mock_run:
+
+            _mcp_discovery.register_mcp_servers(config)
+
+        mock_register.assert_called_once()
+        assert mock_register.call_args.args[2]["tools"] == _fake_cache_entry()["tools"]
+        mock_discover.assert_not_called()
+        mock_run.assert_not_called()
+        mock_loop.assert_not_called()

--- a/tests/tools/test_mcp_schema_cache_ttl.py
+++ b/tests/tools/test_mcp_schema_cache_ttl.py
@@ -49,3 +49,17 @@ def test_cache_scope_round_trips():
         "srv", "fp", tools=[{"name": "t"}], ttl_ms=60_000, cache_scope="private"
     )
     assert sc.get_cached_entry("srv", "fp")["cache_scope"] == "private"
+
+
+@pytest.mark.parametrize("ttl_ms", [0, -1])
+def test_non_positive_ttl_is_served_like_absent_ttl(ttl_ms, monkeypatch):
+    """A 0 or negative ttlMs entry stays eligible over time exactly like one written with no TTL."""
+    real_time = time.time
+    monkeypatch.setattr(sc.time, "time", lambda: real_time())
+    sc.write_cache_entry("with-ttl", "fp", tools=[{"name": "t"}], ttl_ms=ttl_ms)
+    sc.write_cache_entry("no-ttl", "fp", tools=[{"name": "t"}])
+    monkeypatch.setattr(sc.time, "time", lambda: real_time() + 3600.0)
+    with_ttl = sc.get_cached_entry("with-ttl", "fp")
+    no_ttl = sc.get_cached_entry("no-ttl", "fp")
+    assert (with_ttl is not None) == (no_ttl is not None)
+    assert with_ttl["tools"] == [{"name": "t"}]

--- a/tools/mcp_schema_cache.py
+++ b/tools/mcp_schema_cache.py
@@ -58,16 +58,21 @@ def _save_all(data: Dict[str, Any]) -> None:
 
 def get_cached_entry(server_name: str, fingerprint: str) -> Optional[dict]:
     """Return cached entry when fingerprint matches (and TTL holds), else None. ``tools/list``
-    results may carry ``ttlMs`` (SEP-2549); an entry older than a recorded TTL is a miss so the
-    next startup re-probes instead of serving a stale manifest forever. Entries without a TTL
-    never expire. ``cacheScope`` is irrelevant: this cache is per-user local disk."""
+    results may carry ``ttlMs`` (SEP-2549); an entry older than a recorded positive TTL is a miss
+    so the next startup re-probes instead of serving a stale manifest forever. The spec calls
+    ``0`` (and negative, treated as 0) "immediately stale", the same default it assigns an absent
+    value; this cache serves all three like an absent TTL. Its one consumer is lazy startup,
+    which deliberately registers a stale snapshot under a matching fingerprint and refreshes it
+    on the server's first use. ``cacheScope`` is irrelevant: this cache is per-user local disk."""
     with _cache_lock:
         entry = _load_all().get(server_name)
     if not isinstance(entry, dict) or entry.get("fingerprint") != fingerprint:
         return None
     ttl_ms = entry.get("ttl_ms")
     written_at = entry.get("written_at")
-    expired = (isinstance(ttl_ms, (int, float)) and isinstance(written_at, (int, float))
+    # Only a positive TTL expires on time; ``>= 0`` made every 0-TTL entry a miss at write time.
+    expired = (isinstance(ttl_ms, (int, float)) and ttl_ms > 0
+               and isinstance(written_at, (int, float))
                and (time.time() - written_at) * 1000.0 >= float(ttl_ms))
     return None if expired else entry
 


### PR DESCRIPTION
`get_cached_entry` expired an entry when `(now - written_at) * 1000 >= ttl_ms`.
With `ttl_ms == 0` that is `X >= 0`, true the moment the entry is written, so a
server reporting `ttlMs: 0` never produced a cache hit.

The only consumer of this cache is lazy startup (`_register_lazy_from_cache`):
no cached entry means the `lazy: true` server falls back to an eager connect
on every session start, and nothing in the logs says so. `lazy` exists to
register a snapshot without spawning the server; the snapshot is reconciled
against the live `tools/list` on the server's first use (phantom tools are
deregistered, the cache is rewritten), which is the freshness mechanism the
positive-TTL expiry is a shortcut around.

SEP-2549 calls `ttlMs: 0` "immediately stale" and gives an absent `ttlMs`
that same default; negative maps to 0. Hermes already serves absent-TTL
entries without time-based expiry (`test_entry_without_ttl_never_expires`).
This change applies that policy to 0 and negative as well, so a server's
conservative default no longer disables a feature the user asked for.
Positive TTLs expire exactly as before.

Observed on one host (1 vCPU, two `lazy: true` servers both reporting
`ttlMs: 0`): both servers spawned on every session open; with this change
neither does until first use. Not a controlled benchmark.

Tests: the cache-level contract (0 and -1 served like absent, after elapsed
time) and a lazy-discovery test (an on-disk 0-TTL entry registers without
connecting). All three fail on main, pass with the fix.