### PR TITLE
fix(terminal): avoid rereading locally scanned scripts

### DIFF
--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -1837,6 +1837,84 @@ class TestRestartLoopGuard:
         for ts in (1000.0, 1150.0, 1300.0, 1450.0):
             assert rlg.check_and_record(0, 60, now=ts) is False
 
+class TestBoundedLocalFallback:
+    """Native local scan results must not trigger a second script read."""
+
+    @pytest.fixture
+    def local_guard(self, monkeypatch, tmp_path):
+        from functools import partial
+        from pathlib import Path
+        from types import SimpleNamespace
+        from unittest.mock import Mock
+
+        from tools import process_registry
+        from tools.terminal_tool_guards import gateway_lifecycle_block
+
+        execute = Mock(return_value={"output": "printf safe\n", "returncode": 0})
+        read_bytes = Mock(side_effect=AssertionError("unexpected host reopen"))
+        monkeypatch.setattr(Path, "read_bytes", read_bytes)
+        monkeypatch.setattr(process_registry, "_is_supervised_gateway_process", lambda: True)
+        guard = partial(
+            gateway_lifecycle_block,
+            env=SimpleNamespace(cwd=str(tmp_path), execute=execute),
+            env_type="local",
+            cwd=str(tmp_path),
+            workdir=None,
+            session_key="bounded-local-fallback",
+        )
+        return guard, read_bytes, execute
+
+    @pytest.mark.parametrize("kind", [
+        "binary",
+        "directory",
+        pytest.param("dangling", marks=pytest.mark.require_symlinks),
+    ])
+    def test_native_skips_do_not_reopen_locally(self, tmp_path, local_guard, kind):
+        import shlex
+
+        script = tmp_path / "candidate.sh"
+        if kind == "binary":
+            script.write_bytes(b"\x7fELF" + bytes(64))
+        elif kind == "directory":
+            script.mkdir()
+        else:
+            script.symlink_to(tmp_path / "missing.sh")
+        guard, read_bytes, execute = local_guard
+
+        assert guard(command=f"bash {shlex.quote(str(script))}") is None
+
+        read_bytes.assert_not_called()
+        execute.assert_not_called()
+
+    @pytest.mark.parametrize("scan", ["skipped", "race-changed"])
+    def test_local_callback_stays_empty_after_scan(self, monkeypatch, tmp_path, local_guard, scan):
+        import cron.lifecycle_guard as lifecycle_guard
+
+        script = tmp_path / "candidate.sh"
+        script.write_bytes(b"\x7fELF" + bytes(64))
+        replacement = tmp_path / "replacement.sh"
+        replacement.write_text("printf safe\n", encoding="utf-8")
+        callback_results = []
+
+        def simulated_scan(command, *, cwd, read_remote_script):
+            if scan == "race-changed":
+                replacement.replace(script)
+            callback_results.append(read_remote_script(str(script)))
+            return False
+
+        monkeypatch.setattr(
+            lifecycle_guard, "contains_gateway_lifecycle_command_or_referenced_script",
+            simulated_scan,
+        )
+        guard, read_bytes, execute = local_guard
+
+        assert guard(command="bash candidate.sh") is None
+
+        assert callback_results == [""]
+        read_bytes.assert_not_called()
+        execute.assert_not_called()
+
+
 class TestTerminalToolGatewayLifecycleGuardRemote:
     """Remote-backend and two-session cwd regression coverage."""
 
@@ -1873,6 +1951,10 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
         fake_env = _RemoteEnv()
         fake_env.cwd = "/remote/workspace"
         self._patch_env(monkeypatch, fake_env, inside_gateway=True)
+        monkeypatch.setattr(tt, "_get_env_config", lambda: {
+            "env_type": "ssh", "cwd": "/remote/workspace", "timeout": 60,
+            "lifetime_seconds": 3600,
+        })
 
         result = json.loads(tt.terminal_tool(command=f"/bin/bash {script}"))
 

--- a/tools/terminal_tool_guards.py
+++ b/tools/terminal_tool_guards.py
@@ -13,8 +13,6 @@ import json
 import logging
 import re
 import shlex
-import stat
-from pathlib import Path
 from typing import Any, Optional
 
 from tools.shell_heredoc import strip_inert_heredoc_bodies
@@ -141,25 +139,15 @@ def _foreground_background_guidance(command: str) -> str | None:
     return next((msg for hit, msg in _FOREGROUND_GUIDANCE if hit(unquoted)), None)
 
 
-def _read_script_for_guard(env: Any, guard_cwd: str, script_path: str, max_bytes: int) -> Optional[str]:
-    """Best-effort script read: host filesystem first, then a bounded
+def _read_script_for_guard(env: Any, env_type: str, script_path: str, max_bytes: int) -> Optional[str]:
+    """Leave local reads to the native scanner; use a bounded
     ``env.execute('head -c ... < path')`` for remote backends. Binary content
     (NUL byte) is not a script: feeding it to the guard tokenizes machine code
     into bogus paths and crashes the scanner, so it yields None."""
     if env is None:
         return None
-    try:
-        local_path = Path(script_path).expanduser()
-        if not local_path.is_absolute():
-            local_path = Path(guard_cwd) / local_path
-        if local_path.is_file():
-            metadata = local_path.stat()
-            if stat.S_ISREG(metadata.st_mode) and metadata.st_size <= max_bytes:
-                data = local_path.read_bytes()
-                if len(data) <= max_bytes:
-                    return None if b"\x00" in data else data.decode("utf-8", errors="replace")
-    except Exception:
-        pass
+    if env_type == "local":
+        return ""
     # Remote backend: bound the read at the source with `head -c` so an
     # oversized binary never crosses the wire (an unbounded `cat` once
     # pinned the gateway's tool thread for 30+ min on a shlex scan). One
@@ -230,7 +218,7 @@ def gateway_lifecycle_block(
     if contains_gateway_lifecycle_command_or_referenced_script(
         command,
         cwd=guard_cwd,
-        read_remote_script=lambda p: _read_script_for_guard(env, guard_cwd, p, _MAX_REFERENCED_SCRIPT_BYTES),
+        read_remote_script=lambda p: _read_script_for_guard(env, env_type, p, _MAX_REFERENCED_SCRIPT_BYTES),
     ):
         return _blocked_json(
             "Blocked: command or referenced script cannot restart, stop, or "


### PR DESCRIPTION
The terminal lifecycle guard could reopen a local script after the native scanner skipped it, through an unbounded host read or a backend command. Let the native scanner own local reads and retain the bounded callback for remote backends.

The regressions cover binary files, directories, dangling links and skipped or changed local paths, and explicitly exercise the SSH callback.

Validation: 305 tests passed across `tests/hermes_cli/test_gateway_restart_loop.py` and `tests/cron/test_lifecycle_guard_live_db.py`.