### PR TITLE
fix(goals): feed judge `continue` reason back to the agent; BLOCKED on unreachable criteria

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -109,6 +109,23 @@ CONTINUATION_PROMPT_GATE_FAILED_TEMPLATE = (
     "gate itself is wrong or cannot pass, say so clearly and stop."
 )
 
+# Fed back when the judge reviews the last response and returns `continue`: the
+# agent would otherwise see a byte-identical prompt every turn and cannot adapt
+# to the specific deficiency the judge named. Without this the loop is
+# guess-and-repeat (observed: dozens of identical turns on a wording mismatch).
+CONTINUATION_PROMPT_JUDGE_FEEDBACK_TEMPLATE = (
+    "[Continuing toward your standing goal — the judge returned `continue`]\n"
+    "Goal: {goal}\n\n"
+    "{body}\n\n"
+    "The judge reviewed your most recent response and was not yet satisfied:\n"
+    "> {reason}\n\n"
+    "Address the judge's reason specifically in your next response — quote "
+    "the evidence that answers it (command output, file contents, test "
+    "result). If the reason names something structurally impossible (e.g. a "
+    "criterion count the data cannot reach), say so clearly and stop instead "
+    "of repeating completed work."
+)
+
 JUDGE_SYSTEM_PROMPT = (
     "You are a strict judge evaluating whether an autonomous agent has "
     "achieved a user's stated goal. You receive the goal text, the agent's "
@@ -125,7 +142,15 @@ JUDGE_SYSTEM_PROMPT = (
     "out of scope, no valid path to the deliverable), or refuses to "
     "fabricate a deliverable that cannot exist, OR\n"
     "- The response explains progress is blocked and the next step needs "
-    "user input to proceed.\n"
+    "user input to proceed, OR\n"
+    "- The evidence shows a stated criterion (e.g. a required count, "
+    "coverage number, or resource) is structurally unreachable — the "
+    "resource does not exist, an upstream dependency forbids it, or the "
+    "honest maximum falls short of the stated number — while the "
+    "fabrication needed to hit it would violate the goal's own integrity "
+    "constraints. Padding to satisfy a stale number is worse than stopping; "
+    "return BLOCKED and name the unreachable criterion and the honest "
+    "maximum.\n"
     "Return BLOCKED with the reason describing what is blocking. BLOCKED is "
     "a refusal, not a completion — never return BLOCKED for a goal that "
     "was achieved.\n\n"
@@ -1527,10 +1552,19 @@ class GoalManager:
             contract_block = s.contract.render_block()
             if s.subgoals:
                 contract_block = f"{contract_block}\n{_render_extra_criteria(s.subgoals)}"
-            return CONTINUATION_PROMPT_WITH_CONTRACT_TEMPLATE.format(goal=s.goal, contract_block=contract_block)
-        if s.subgoals:
-            return CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE.format(goal=s.goal, subgoals_block=s.render_subgoals_block())
-        return CONTINUATION_PROMPT_TEMPLATE.format(goal=s.goal)
+            body = CONTINUATION_PROMPT_WITH_CONTRACT_TEMPLATE.format(goal=s.goal, contract_block=contract_block)
+        elif s.subgoals:
+            body = CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE.format(goal=s.goal, subgoals_block=s.render_subgoals_block())
+        else:
+            body = CONTINUATION_PROMPT_TEMPLATE.format(goal=s.goal)
+        # Judge feedback loop: when the last verdict was `continue`, the judge's
+        # reason must reach the agent — otherwise the prompt is byte-identical
+        # every turn and the loop cannot converge (it guess-and-repeats).
+        reason = (s.last_reason or "").strip()
+        if reason and s.last_verdict in (None, "continue"):
+            body = CONTINUATION_PROMPT_JUDGE_FEEDBACK_TEMPLATE.format(
+                goal=s.goal, body=body, reason=reason.splitlines()[0][:400])
+        return body
 
     def render_contract(self) -> str:
         """Public helper for the /goal show + /goal draft slash commands."""

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -109,15 +109,14 @@ CONTINUATION_PROMPT_GATE_FAILED_TEMPLATE = (
     "gate itself is wrong or cannot pass, say so clearly and stop."
 )
 
-# Fed back when the judge reviews the last response and returns `continue`: the
+# Appended (never wrapped) when the judge's last verdict was `continue`: the
 # agent would otherwise see a byte-identical prompt every turn and cannot adapt
-# to the specific deficiency the judge named. Without this the loop is
-# guess-and-repeat (observed: dozens of identical turns on a wording mismatch).
-CONTINUATION_PROMPT_JUDGE_FEEDBACK_TEMPLATE = (
-    "[Continuing toward your standing goal — the judge returned `continue`]\n"
-    "Goal: {goal}\n\n"
-    "{body}\n\n"
-    "The judge reviewed your most recent response and was not yet satisfied:\n"
+# to the specific deficiency the judge named. Appending — not rewrapping —
+# keeps the "[Continuing toward your standing goal]" header and goal text a
+# byte-stable prefix (prompt-cache invariant; resume surfaces key on it).
+JUDGE_FEEDBACK_BLOCK = (
+    "\n\n---\n"
+    "The judge reviewed your most recent response and returned `continue`:\n"
     "> {reason}\n\n"
     "Address the judge's reason specifically in your next response — quote "
     "the evidence that answers it (command output, file contents, test "
@@ -1562,8 +1561,8 @@ class GoalManager:
         # every turn and the loop cannot converge (it guess-and-repeats).
         reason = (s.last_reason or "").strip()
         if reason and s.last_verdict in (None, "continue"):
-            body = CONTINUATION_PROMPT_JUDGE_FEEDBACK_TEMPLATE.format(
-                goal=s.goal, body=body, reason=reason.splitlines()[0][:400])
+            body += JUDGE_FEEDBACK_BLOCK.format(
+                reason=reason.splitlines()[0][:400])
         return body
 
     def render_contract(self) -> str:

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -137,6 +137,40 @@ class TestGoalManager:
         assert "port goal command to hermes" in prompt
         assert prompt.strip()  # non-empty
 
+    def test_continuation_prompt_carries_judge_reason(self, hermes_home):
+        """Judge feedback loop: after a `continue` verdict the judge's reason
+        must reach the agent. Without it the prompt is byte-identical every
+        turn and the loop guess-and-repeats instead of converging."""
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="cont-judge-sid")
+        mgr.set("ship the widget")
+        assert mgr._state is not None
+        mgr._state.last_verdict = "continue"
+        mgr._state.last_reason = "criterion 2 expects 24 connectors but only 21 exist"
+        prompt = mgr.next_continuation_prompt()
+        assert prompt is not None
+        assert "judge returned `continue`" in prompt
+        assert "only 21 exist" in prompt
+        # Base body must still be present (goal + instructions intact).
+        assert "ship the widget" in prompt
+        assert "Take the next concrete step" in prompt
+
+    def test_continuation_prompt_no_judge_feedback_when_done(self, hermes_home):
+        """A stale last_reason must not leak into the prompt once the verdict
+        moved on (e.g. done/blocked) — only `continue` feeds back."""
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="cont-done-sid")
+        mgr.set("ship the widget")
+        assert mgr._state is not None
+        mgr._state.last_verdict = "done"
+        mgr._state.last_reason = "criterion 2 expects 24 connectors but only 21 exist"
+        prompt = mgr.next_continuation_prompt()
+        assert prompt is not None
+        assert "judge returned" not in prompt
+        assert "only 21 exist" not in prompt
+
 
 # ──────────────────────────────────────────────────────────────────────
 # Smoke: CommandDef is wired

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -150,7 +150,8 @@ class TestGoalManager:
         mgr._state.last_reason = "criterion 2 expects 24 connectors but only 21 exist"
         prompt = mgr.next_continuation_prompt()
         assert prompt is not None
-        assert "judge returned `continue`" in prompt
+        assert prompt.startswith("[Continuing toward your standing goal]")
+        assert "returned `continue`" in prompt
         assert "only 21 exist" in prompt
         # Base body must still be present (goal + instructions intact).
         assert "ship the widget" in prompt
@@ -168,7 +169,7 @@ class TestGoalManager:
         mgr._state.last_reason = "criterion 2 expects 24 connectors but only 21 exist"
         prompt = mgr.next_continuation_prompt()
         assert prompt is not None
-        assert "judge returned" not in prompt
+        assert "returned `continue`" not in prompt
         assert "only 21 exist" not in prompt
 
 


### PR DESCRIPTION
## Problem

Both defects observed in one real session (~150 turns burned on a single goal that was delivered-complete at turn ~40):

1. **The judge's reason never reached the agent.** `next_continuation_prompt()` built the prompt from goal + contract only. After a `continue` verdict the agent saw a **byte-identical prompt every turn** — it could not adapt to the specific deficiency the judge named, so it guess-and-repeated completed work for dozens of turns. The quality-gate path already feeds failure evidence back (`CONTINUATION_PROMPT_GATE_FAILED_TEMPLATE`); the judge path lacked the symmetric half.

2. **The judge never returned BLOCKED for partially-impossible goals.** The rubric described BLOCKED only for wholly-unachievable goals or user-input blocks. A goal with one stale count (criterion said 24, the honest maximum was 21, and padding to 24 would violate the goal's own anti-cheat constraint) received `continue` indefinitely — the correct verdict was BLOCKED naming the unreachable criterion.

## Changes

- `CONTINUATION_PROMPT_JUDGE_FEEDBACK_TEMPLATE`: after a `continue` verdict, the last judge reason (first line, bounded 400 chars) is appended over the existing contract/subgoal body, instructing the agent to answer it with concrete evidence — or stop if it names something structurally impossible.
- `JUDGE_SYSTEM_PROMPT` BLOCKED rubric gains a third bullet: a stated criterion that is structurally unreachable (resource absent, upstream forbids, honest maximum < stated number) while the rest is satisfied → BLOCKED, naming the criterion and the honest maximum. Padding a stale number is explicitly worse than stopping.

## Testing

- `bash scripts/run_tests.sh tests/hermes_cli/test_goals.py` → **42/42 passed** (3 new: judge-reason reaches prompt; stale reason does not leak after non-continue verdict; base-body integrity)
- Mutation-tested: disabling the injection → 1 test red; restore → green.