### PR TITLE
docs(memory): explain that persistent memory needs session boundaries on gateway chats

### DIFF
--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -56,6 +56,14 @@ The format includes:
 
 **Frozen snapshot pattern:** The system prompt injection is captured once at session start and never changes mid-session. This is intentional — it preserves the LLM's prefix cache for performance. When the agent adds/removes memory entries during a session, the changes are persisted to disk immediately but won't appear in the system prompt until the next session starts. Tool responses always show the live state.
 
+## Memory Needs Session Boundaries
+
+The whole memory system is built around the moment a session **ends**: `MEMORY.md` and `USER.md` carry the essentials into the next session, and `session_search` fills the gaps once the old context is gone. Inside a single session none of that machinery has a reason to run — everything important is still in the live context, so the agent rarely consults `session_search` and mostly compacts memory entries instead of curating them.
+
+This matters on messaging platforms (Telegram, Discord, etc.), where a chat is deliberately [one continuous session](/user-guide/sessions#session-continuity) that survives restarts, gateway crashes, and machine reboots. Shutting the machine down overnight does **not** end the session — the next message picks it up exactly where it left off. If you never reset, a chat can run for weeks as a single session: convenient, but it grows expensive (compaction runs repeatedly over an ever-longer history) and the learning loop of *forget → recall from memory → search past sessions* almost never gets to fire. Fresh memory entries also stay invisible to the running session because of the frozen snapshot above.
+
+**Practice:** run `/new` at natural boundaries — a finished task, a change of topic, the start of a day. Each boundary is when memory pays off: the agent re-reads the updated `MEMORY.md`/`USER.md` snapshot, starts from a cheap short context, and reaches for `session_search` when it actually needs history. On the CLI this mostly takes care of itself (every invocation is a new session); on gateways the boundary is yours to create.
+
 ## Memory Tool Actions
 
 The agent uses the `memory` tool with these actions:


### PR DESCRIPTION
A community blog post ("I think I used the Hermes Agent wrong", also on HN) described running Hermes on a Raspberry Pi via Telegram for ~3 weeks and being surprised that `session_search` fired only 9 times across ~2,000 messages and memory files were only ever compacted, never curated — until realizing the chat had been **one continuous session** the whole time. The insight ("memory assumes session boundaries; I never let it forget") is correct and nowhere in our docs.

## Changes
- New section **"Memory Needs Session Boundaries"** in `website/docs/user-guide/features/memory.md`, right after the frozen-snapshot explanation:
  - the recall loop (MEMORY.md/USER.md snapshot + `session_search`) only fires at session boundaries
  - gateway chats (Telegram/Discord/etc.) are intentionally one continuous session across restarts and reboots — cross-linked to the session-continuity docs
  - recommends `/new` at natural boundaries (finished task, topic change, new day); notes CLI gets boundaries for free
- Docs-only; 8 lines added, no code.

## Validation
Docs-only change; section renders as plain Docusaurus markdown with an existing internal link target (`/user-guide/sessions#session-continuity` — verified the anchor exists in sessions.md "Session continuity").

Source: https://heyjonny.dev/posts/i-think-i-used-the-hermes-agent-wrong/ (HN item 49628740)

## Infographic
![Memory needs session boundaries](https://v3b.fal.media/files/b/0aaa06ac/BjRCmZl4WD0DrPOxkO1Un_Re2wQIsb.png)
