### PR TITLE
fix(delegation): bound schema correction by the child timeout

### DIFF
--- a/tests/tools/test_delegate_output_schema.py
+++ b/tests/tools/test_delegate_output_schema.py
@@ -198,6 +198,69 @@ def _run(child):
 
 
 class TestRunSingleChildSchemaValidation:
+    def test_schema_retry_keeps_child_context(self):
+        from agent.delegation_context import is_delegated_child_context
+
+        child = _StubChild(["invalid", '{"city": "Oslo"}'])
+        child._delegate_output_schema = ADDRESS_SCHEMA
+        observed = []
+        original = child.run_conversation
+
+        def observe(**kwargs):
+            observed.append(is_delegated_child_context())
+            return original(**kwargs)
+
+        child.run_conversation = observe
+        entry = _run(child)
+        assert entry["schema_valid"] is True
+        assert observed == [True, True]
+        assert not is_delegated_child_context()
+
+    def test_schema_retry_timeout_defers_close_until_retry_unwinds(self, monkeypatch):
+        import threading
+        from tools import delegate_tool
+
+        child = _StubChild(["invalid", '{"city": "Oslo"}'])
+        child._delegate_output_schema = ADDRESS_SCHEMA
+        retry_started = threading.Event()
+        release_retry = threading.Event()
+        returned = threading.Event()
+        closed = threading.Event()
+        stopped = threading.Event()
+        entries = []
+        original = child.run_conversation
+
+        def blocking_retry(**kwargs):
+            if child.calls:
+                retry_started.set()
+                assert release_retry.wait(10)
+            return original(**kwargs)
+
+        child.run_conversation = blocking_retry
+        child.hard_interrupt = lambda *_: stopped.set()
+        child.close = closed.set
+        monkeypatch.setattr(delegate_tool, "_get_child_timeout", lambda: 0.5)
+        monkeypatch.setattr(delegate_tool, "_get_worktree_isolation", lambda: False)
+
+        def run():
+            try:
+                entries.append(_run(child))
+            finally:
+                returned.set()
+
+        caller = threading.Thread(target=run, daemon=True)
+        caller.start()
+        try:
+            assert retry_started.wait(5)
+            assert returned.wait(2), "schema retry escaped the configured child timeout"
+            assert entries[0]["status"] == "timeout"
+            assert stopped.is_set()
+            assert not closed.is_set(), "the retry still owns the child"
+        finally:
+            release_retry.set()
+            caller.join(5)
+            assert closed.wait(5)
+
     def test_valid_first_try_no_retry(self):
         child = _StubChild(['{"city": "Berlin"}'])
         child._delegate_output_schema = ADDRESS_SCHEMA

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 # ``tools.delegate_tool.<name>`` is re-imported here. Mutable flag globals live only in their owning module.
 from tools.delegate_tool_child_run import (  # noqa: F401
     _ChildRun, _attach_child, _build_result_entry, _dump_subagent_timeout_diagnostic, _fabricated_entry,
-    _lease_child_credential, _merge_late_steer, _register_child, _start_heartbeat, _validate_child_output_schema,
+    _lease_child_credential, _merge_late_steer, _register_child, _start_heartbeat,
 )
 from tools.delegate_tool_config import (  # noqa: F401
     _DEFAULT_MAX_CONCURRENT_CHILDREN, _get_child_timeout, _get_max_async_children, _get_max_concurrent_children,
@@ -331,7 +331,6 @@ def _run_single_child(
         if failure_entry is not None:
             return failure_entry
 
-        schema = _validate_child_output_schema(child, result, task_index, run.child_task_id, run.relay_text)
         _merge_late_steer(result, _subagent_id, child)
         # Flush any remaining batched progress to gateway
         if child_progress_cb and hasattr(child_progress_cb, "_flush"):
@@ -339,7 +338,7 @@ def _run_single_child(
                 child_progress_cb._flush()
 
         duration = run.elapsed()
-        entry = _build_result_entry(child, result, task_index, duration, schema)
+        entry = _build_result_entry(child, result, task_index, duration, run.schema)
         run.append_sibling_write_reminder(entry)
         run.account_background_processes(entry)
         run.emit_complete(result, entry, duration)

--- a/tools/delegate_tool_child_run.py
+++ b/tools/delegate_tool_child_run.py
@@ -562,6 +562,7 @@ class _ChildRun:
     parent_task_id: Optional[str] = None
     wall_start: float = 0.0
     parent_reads_snapshot: list = field(default_factory=list)
+    schema: _SchemaOutcome = field(default_factory=lambda: _SchemaOutcome(None, None, [], 0))
 
     def elapsed(self) -> float:
         return round(time.monotonic() - self.child_start, 2)
@@ -656,9 +657,15 @@ class _ChildRun:
             worker_thread_holder["t"] = threading.current_thread()
             from agent.delegation_context import delegated_child_context
             with delegated_child_context(str(getattr(child, "session_id", "") or "")):
-                return child.run_conversation(
+                result = child.run_conversation(
                     user_message=self.goal, task_id=self.child_task_id, stream_callback=self.relay_text,
                 )
+                # The correction is part of this child run: retain its approval/context bindings and
+                # charge both turns to the same timeout. A blocked retry also needs deferred close.
+                self.schema = _validate_child_output_schema(
+                    child, result, task_index, self.child_task_id, self.relay_text,
+                )
+                return result
 
         future = executor.submit(contextvars.copy_context().run, _run_with_thread_capture)
         try:


### PR DESCRIPTION
## What does this PR do?

An invalid delegated `output_schema` response triggers a corrective conversation. That call currently runs on the parent caller's thread after the timed worker has exited, so a hung correction bypasses `delegation.child_timeout_seconds` and loses the child's context/approval handling.

Run validation and its one correction inside the existing child worker. Both conversations now share one timeout, and the existing timeout path interrupts the child and delays closing it until its live worker finishes.

## Related Issue

Fixes #108473

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/delegate_tool_child_run.py`: retain the schema outcome on `_ChildRun`; validate before its future resolves.
- `tools/delegate_tool.py`: consume that outcome when building the result.
- Add two regression tests through the real `_run_single_child` executor/context/cleanup path, replacing only the conversation boundary with a deterministic child double.

## How to Test

`scripts/run_tests.sh tests/tools/test_delegate_output_schema.py tests/tools/test_delegate_timeout_cleanup.py tests/tools/test_delegate_kanban_isolation.py tests/tools/test_delegate.py --file-retries 0 -j 2 -q`

- Before: 2 failures / 27 passes in the schema test file. The retry exceeded a 0.5-second timeout, and context observations were `[True, False]`.
- After: 117 passed across the four focused files.
- Broader delegation, async delegation, daemon pool and live-log regression run: 25 files, **316 passed, 1 skipped**, no failures. The skip is a macOS-only test on Windows.
- Ruff on changed files, `git diff --check`, and `scripts/check_compat_pointers.py` passed.

## Compatibility and risks

No new configuration or model-tool schema. The existing one-correction policy and no-timeout default are preserved. The configured timeout now includes correction time, which is the intended behavioral change. Cancellation remains cooperative; a blocking operation can continue unwinding in the daemon worker, with close deferred rather than raced.

Related #104325 fixes a different session-key binding; #107124's schema retry remains a direct conversation call. Those PRs touch the same area and may need rebasing.

## Checklist

- [x] Read the Contributing Guide and scoped development instructions
- [x] Conventional commit; only related changes
- [x] Searched existing issues/PRs, source history and releases
- [x] Regression tests fail before and pass after
- [x] Tested on native Windows with Python 3.13 / Git Bash
- [x] Considered cross-platform impact: standard Python executor/context code
- [x] Documentation/config/tool-schema changes: N/A
- [ ] Full repository test suite (focused and related suites above were run)
