### PR TITLE
fix(email): declare splits_long_messages so long cron output is delivered whole

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -328,6 +328,12 @@ def _attach_file(msg: MIMEMultipart, path: Path, filename: str) -> None:
 class EmailAdapter(BasePlatformAdapter):
     """Email gateway adapter using IMAP (receive) and SMTP (send)."""
 
+    # Email has no practical body-length cap, so declare native long-message handling:
+    # the gateway hands us the full payload and send() delivers it in one message, instead
+    # of truncating oversized cron output at MAX_PLATFORM_OUTPUT (4000 chars) before we ever
+    # see it. Matches the 50_000 max_message_length advertised in register().
+    splits_long_messages = True
+
     # Per-account seen-UID snapshot surviving adapter recreation: the reconnect watcher builds a FRESH
     # adapter per retry; without this connect(is_reconnect=True) would re-mark the mailbox seen and skip
     # mail that arrived during the outage. Keyed by address (multiplex runs several accounts); same-process only.

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -331,6 +331,29 @@ async def test_long_output_truncated_for_non_chunking_adapter(tmp_path, monkeypa
     assert saved_files[0].read_text() == long_content
 
 
+@pytest.mark.asyncio
+async def test_long_output_preserved_for_chunking_adapter(tmp_path, monkeypatch):
+    """Chunking adapters receive the full payload, never a truncated one.
+
+    Counterpart to the non-chunking case above: an adapter that advertises
+    ``splits_long_messages = True`` (email, Discord, Telegram, Slack, ...) handles
+    long bodies natively, so the gateway must pass the content through untouched.
+    Truncating here would silently drop the tail of a long cron report even though
+    the adapter could have delivered all of it.
+    """
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    adapter = ChunkingAdapter()
+    router = DeliveryRouter(GatewayConfig(), adapters={Platform.DISCORD: adapter})
+    target = DeliveryTarget.parse("discord:123")
+
+    long_content = "y" * 5000
+    await router._deliver_to_platform(target, long_content, metadata={"job_id": "job1"})
+
+    delivered = adapter.calls[0]["content"]
+    assert delivered == long_content  # passed through untouched
+    assert "truncated" not in delivered.lower()
+
+
 def _simulate_windows_codepage_write(monkeypatch):
     """Make ``Path.write_text`` behave like a non-UTF-8 Windows console.
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1123,5 +1123,21 @@ class TestSenderAuthentication(unittest.TestCase):
         self.assertFalse(ok, reason)
 
 
+class TestLongMessageHandling(unittest.TestCase):
+    """EmailAdapter must advertise native long-message handling."""
+
+    def test_declares_splits_long_messages(self):
+        """Email has no practical body-length cap, so the adapter must opt in to
+        receiving the full payload.
+
+        Without this flag gateway/delivery.py::_cap_oversized_output truncates cron
+        output at MAX_PLATFORM_OUTPUT (4000 chars) before send() is called — which
+        silently cut the tail off long reports even though email could carry them.
+        """
+        from plugins.platforms.email.adapter import EmailAdapter
+
+        self.assertIs(EmailAdapter.splits_long_messages, True)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What does this PR do?

`EmailAdapter` advertises `max_message_length=50_000` when it registers, but it never declared `splits_long_messages`. `gateway/delivery.py` uses that flag to decide whether an adapter can carry a long payload natively:

```python
MAX_PLATFORM_OUTPUT = 4000          # gateway/delivery.py:23
...
if getattr(adapter, "splits_long_messages", False):
    return content                  # full payload — the adapter handles it
return content[:MAX_PLATFORM_OUTPUT - len(footer)] + footer
```

With the flag unset, email fell into the truncating branch: cron/agent output longer than 4000 characters was cut off and given a `... [truncated, full output saved to ...]` footer, and the adapter's own declared 50 000-character ceiling was unreachable. Email has no practical body-length limit, so this quietly dropped the tail off long scheduled reports.

The fix is one line — declare `splits_long_messages = True` on `EmailAdapter`, exactly as Discord, Telegram, Slack, Matrix, WhatsApp, Feishu, Mattermost, Teams and Signal already do.

## Related Issue

Fixes #61990 ("No way to override email delivery truncation").

This is also the email half of the same defect that #62751 reports for SMS. Further cross-references are in "Related work" below.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/platforms/email/adapter.py` — declare `splits_long_messages = True` on `EmailAdapter` (one line plus an explanatory comment). No other code path changes.
- `tests/gateway/test_email.py` — adds `TestLongMessageHandling::test_declares_splits_long_messages`, which pins the adapter contract and fails without the fix.
- `tests/gateway/test_delivery.py` — adds `test_long_output_preserved_for_chunking_adapter`, the positive counterpart to the existing `test_long_output_truncated_for_non_chunking_adapter`. `ChunkingAdapter` already existed in that file but no test used it, so this closes that gap as well.

Three files, +45 lines, no unrelated commits.

## How to Test

1. `pytest tests/gateway/test_email.py tests/gateway/test_delivery.py -q` → **54 passed**.
2. Confirm the regression is genuinely covered: remove the `splits_long_messages` line from the email adapter and re-run `pytest tests/gateway/test_email.py -k splits_long -q` → fails with `AssertionError: False is not True`. Restore it → passes. (Verified both directions.)
3. End-to-end: schedule a cron job whose output exceeds 4000 characters and deliver it to email. Before this change the message ends with the truncation footer; after it, the full body arrives.
4. `ruff check` on all three files → clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(email): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #62000 proposes the same one-liner; I'm happy to defer to it or fold in review comments here, whichever is easier for you
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran both modules this change touches (**54 passed**) and `ruff check` is clean. The full suite can't finish in my dev container because optional extras (`httpx`, `fastapi`, `uvicorn`) aren't installed there; the resulting collection errors are byte-identical on unmodified `main`.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Debian 12 LXC, Python 3.11)

### Documentation & Housekeeping

- [x] Documentation — N/A (no user-facing docs change; the inline comment explains the flag)
- [x] `cli-config.yaml.example` — N/A (no config keys added or changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture or workflow change)
- [x] Cross-platform impact — considered and N/A: the flag is a class attribute consumed by one branch in `gateway/delivery.py`; no file I/O, process handling or terminal behaviour is touched
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Before the change, `gateway/delivery.py` logs the truncation path for email delivery:

```
Cron output truncated (12844 chars) — full output: /root/.hermes/cron/output/…/job1_….txt
```

and the recipient receives the body ending in:

```
... [truncated, full output saved to /root/.hermes/cron/output/…/job1_….txt]
```

After the change the same payload takes the chunking path and is delivered whole:

```
Cron output preserved for chunking adapter (12844 chars) — full output saved to /root/.hermes/cron/output/…/job1_….txt
```

## Related work

| Ref | Kind | What it is | Relationship |
|---|---|---|---|
| #61990 | issue | "No way to override email delivery truncation" | This PR is the email-side fix |
| #62000 | PR | The same one-line change, open since 10 Jul 2026 | Independently proposed; happy to defer, or to fold review feedback in here |
| #62751 | issue | SmsAdapter doesn't declare `splits_long_messages` | Same defect class, non-email |
| #62752 / #67734 | PR | `fix(gateway): declare splits_long_messages on SmsAdapter` | Same class; deliberately out of scope here to keep this a one-line, low-risk diff |
| #50126 | issue/PR | Original cron-output truncation work that introduced `MAX_PLATFORM_OUTPUT` and the `splits_long_messages` escape hatch | This PR completes the email case of that design |
| #103196 / #104625 | PR | Related email work (subject-scoped sessions; cron reports starting fresh conversations) | Separate, already open, no file overlap with this diff |

## A note on the approach

Deliberately minimal: one class attribute, no behavioural change for any adapter that already sets the flag, and non-chunking adapters are untouched. The only adapters affected are the ones that genuinely can carry a long body, which for email is all of them. If you'd prefer this arrive as a change to `register()` / the capability declaration instead of a class attribute, I'm glad to rework it — the class-attribute form is just what every other long-message-capable adapter uses today.
