### PR TITLE
fix(dashboard): give the shell chrome a background fallback

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -532,9 +532,11 @@ export default function App() {
           "bg-background-base",
         )}
         style={{
-          background: "var(--component-header-background)",
-          borderImage: "var(--component-header-border-image)",
-          clipPath: "var(--component-header-clip-path)",
+          // Same trap as the sidebar: this bar is `fixed`, so without a fallback the
+          // page content scrolling underneath showed straight through it.
+          background: "var(--component-header-background, var(--background-base))",
+          borderImage: "var(--component-header-border-image, none)",
+          clipPath: "var(--component-header-clip-path, none)",
         }}
       >
         <Button
@@ -591,9 +593,13 @@ export default function App() {
               collapsed && "lg:w-14",
             )}
             style={{
-              background: "var(--component-sidebar-background)",
-              clipPath: "var(--component-sidebar-clip-path)",
-              borderImage: "var(--component-sidebar-border-image)",
+              // A theme that defines no `sidebar` bucket leaves these vars unset, and a
+              // bare var() in a shorthand invalidates the whole declaration — which used
+              // to paint the sidebar transparent over whatever sat behind it. Fall back
+              // to the theme's background so the shell is always readable.
+              background: "var(--component-sidebar-background, var(--background-base))",
+              clipPath: "var(--component-sidebar-clip-path, none)",
+              borderImage: "var(--component-sidebar-border-image, none)",
             }}
           >
             <div

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1764,13 +1764,19 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             "border-l border-current/20 text-midground",
             "bg-background-base/95",
             "transition-transform duration-200 ease-out",
-            "[background:var(--component-sidebar-background)]",
-            "[clip-path:var(--component-sidebar-clip-path)]",
-            "[border-image:var(--component-sidebar-border-image)]",
             mobilePanelOpen
               ? "translate-x-0"
               : "pointer-events-none translate-x-full",
           )}
+          style={{
+            // Same trap as the desktop shell: with no `sidebar` bucket in the active
+            // theme the component vars are unset, a bare var() shorthand drops out, and
+            // the sheet painted transparent — vivid blue text on the dimmed terminal
+            // measured 1.05:1. Keep the theme value when present, else the theme bg.
+            background: "var(--component-sidebar-background, var(--background-base))",
+            clipPath: "var(--component-sidebar-clip-path, none)",
+            borderImage: "var(--component-sidebar-border-image, none)",
+          }}
         >
           <div
             className={cn(


### PR DESCRIPTION
### What this fixes

Three shell surfaces take their background from `--component-<bucket>-*` custom properties: the shell sidebar (`App.tsx`, inline style), the mobile header (`App.tsx`, a `fixed` bar visible below `lg`), and the tablet chat sheet (`ChatPage.tsx`, Tailwind arbitrary properties; it also lists sessions). Those properties are only emitted for themes that declare the matching `componentStyles` bucket — and no built-in preset (`web/src/themes/presets.ts`) declares any, so with the shipped `nous-blue` theme none of them exist.

CSS then does the rest: a bare `var()` in a shorthand is *invalid at computed-value time*, which invalidates the entire `background` declaration rather than the single value. `background` falls back to its initial `transparent`, and because that declaration still wins the cascade it also overrides the `bg-background-base` / `bg-background-base/95` utilities authored as the visible fallback.

Measured on a tablet viewport (820×1180, CDP + pixel analysis of the rendered page, theme `nous-blue`):

| | before | after |
|---|---|---|
| `#chat-side-panel` computed `background-color` | `rgba(0, 0, 0, 0)` | `rgb(232, 242, 253)` |
| `header` computed `background-color` | `rgba(0, 0, 0, 0)` | `rgb(232, 242, 253)` |
| desktop `<aside>` computed `background-color` | `rgba(0, 0, 0, 0)` | `rgb(232, 242, 253)` |
| dominant pixel colour in the sheet | `rgb(98, 99, 101)` — the dimmed terminal underneath | `#E8F2FD` (89.6% of the region) |
| foreground text pixel | `rgb(19, 86, 222)` | `rgb(0, 83, 253)` (the theme's `midground`) |
| **contrast ratio** | **1.02:1** | **5.07:1** (AA for body text) |

### The change

Every component var gets a fallback, so the theme extension point is preserved instead of removed:

```diff
-  background: "var(--component-sidebar-background)",
+  background: "var(--component-sidebar-background, var(--background-base))",
```

The same one-liner applies to `--component-header-background`. `clipPath` / `borderImage` get `none` fallbacks for the same reason — they happen to resolve to their initial values today, but any future consumer of those vars would hit the identical trap.

One deliberate trade-off: the inline declaration wins over `bg-background-base/95`, so the sheet renders fully opaque (5.07:1) rather than 95% translucent (4.76:1). If translucency over the transcript is preferred, the fallback can be `color-mix(in srgb, var(--background-base) 95%, transparent)` — still above AA.

### Verification

- `tsc -p web/tsconfig.json --noEmit` — clean
- `vitest run src/pages/ChatPage.test.tsx src/lib/xterm-touch-scroll.test.ts` — 19/19 pass
- rebuilt bundle carries both fallbacks (`sidebar`, `header`) and no bare `var(--component-*-background)` remains in any chunk
- re-measured in the browser after the rebuild: sheet, mobile header and desktop `<aside>` all `rgb(232, 242, 253)`; sheet contrast 5.07:1

### Notes

- Affects every theme without a `componentStyles` bucket, i.e. all eight built-in presets; a theme that sets e.g. `componentStyles.sidebar.background` keeps overriding it unchanged.
- An alternative fix is to emit defaults for the component buckets server-side. This PR stays minimal and client-side; happy to reshape it if you'd rather do it that way.
- Unrelated to the touch-scrolling PR (#108449) — different lines, separate branch.