### PR TITLE
fix(process): transfer completion responsibility with handoff ownership

### DIFF
--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -1610,6 +1610,13 @@ class GatewayNotificationsMixin:
         from gateway.run import _redact_gateway_user_facing_secrets
         from agent.redact import redact_terminal_output
         from tools.ansi_strip import strip_ansi
+        handoff_note = getattr(session, "handoff_note", "")
+        if isinstance(handoff_note, str) and handoff_note:
+            # A watcher may already be running when ownership moves. Its spawn-time session id is stale.
+            watcher = {**watcher, "session_key": session.session_key,
+                       "parent_session_id": session.parent_session_id}
+        else:
+            handoff_note = ""
         _command = getattr(session, "command", "") or ""
         _raw = strip_ansi(session.output_buffer) if session.output_buffer else ""
         _raw = redact_terminal_output(_raw, _command)
@@ -1628,6 +1635,7 @@ class GatewayNotificationsMixin:
         return {
             "type": "completion",
             "session_id": session_id,
+            **({"handoff_note": handoff_note} if handoff_note else {}),
             **{k: watcher.get(k, "") for k in _WATCHER_ROUTE_FIELDS},
             "message_id": str(watcher.get("message_id") or "").strip() or None,
             "started_at": getattr(session, "started_at", None),

--- a/tests/tools/test_subagent_process_handoff.py
+++ b/tests/tools/test_subagent_process_handoff.py
@@ -49,7 +49,8 @@ def clean_queue():
         process_registry.completion_queue.get_nowait()
 
 
-def test_handed_off_process_completion_reaches_parent_and_leftover_is_reported(clean_queue):
+@pytest.mark.parametrize("notify_at_spawn", [False, True])
+def test_handed_off_process_completion_reaches_parent_and_leftover_is_reported(clean_queue, notify_at_spawn):
     """A real child-owned process handed off carries the parent's owner id (so the parent's drain accepts it, with the
     handoff purpose), while a sibling the child did not hand off is still owned by the child and is listed as orphaned
     on the child's result."""
@@ -59,7 +60,7 @@ def test_handed_off_process_completion_reaches_parent_and_leftover_is_reported(c
     _register(sid, child)
     try:
         handed = process_registry.spawn_local("sleep 0.4; echo ci-green", task_id=sid, owner_task_id=sid)
-        handed.notify_on_complete = True
+        handed.notify_on_complete = notify_at_spawn
         leftover = process_registry.spawn_local("sleep 30", task_id=sid, owner_task_id=sid)
 
         out = json.loads(_handle_process(
@@ -129,5 +130,62 @@ def test_handoff_refuses_exited_foreign_or_non_child_callers(clean_queue):
         assert format_process_notification({"type": "completion", "session_id": "p", "command": "c", "exit_code": 0,
                                             "output": "", "handoff_note": "why"}).count("Handed off to you") == 1
     finally:
+        process_registry.kill_all(source="test")
+        _unregister_subagent(sid)
+
+
+@pytest.mark.parametrize("notify_at_spawn,async_delivery", [(False, True), (True, True), (False, False)])
+def test_gateway_handoff_retargets_completion_and_persists_owner(
+    clean_queue, tmp_path, monkeypatch, notify_at_spawn, async_delivery,
+):
+    from types import SimpleNamespace
+    from agent.delegation_context import delegated_child_context
+    from gateway.run_notifications import GatewayNotificationsMixin
+    from gateway.session_context import set_session_vars, clear_session_vars
+    from tools.terminal_tool_background import spawn_background_process
+    import tools.process_registry as pr
+
+    checkpoint = tmp_path / "processes.json"
+    monkeypatch.setattr(pr, "CHECKPOINT_PATH", checkpoint)
+    monkeypatch.setattr(process_registry, "pending_watchers", [])
+    sid = "sa-0-handoff-gateway"
+    parent = _Parent()
+    child = _Child(parent)
+    _register(sid, child)
+    tokens = set_session_vars(platform="telegram", chat_id="chat", session_key="parent-route",
+                              session_id=parent.session_id, async_delivery=async_delivery)
+    try:
+        with delegated_child_context("child-session"):
+            spawned = json.loads(spawn_background_process(
+                command="sleep 2; echo gateway-result", env=SimpleNamespace(env={}), env_type="local",
+                effective_task_id=sid, task_id=sid, session_key="parent-route", workdir=None,
+                cwd=str(tmp_path), effective_pty=False, notify_on_complete=notify_at_spawn,
+                watch_patterns=None, approval_note=None, pty_disabled_reason=None,
+            ))
+            out = json.loads(_handle_process(
+                {"action": "handoff", "session_id": spawned["session_id"], "data": "forward result"}, task_id=sid))
+        assert out["status"] == "handed_off"
+        session = process_registry.get(spawned["session_id"])
+        watchers = [w for w in process_registry.pending_watchers if w["session_id"] == session.id]
+        if not async_delivery:
+            assert session.owner_task_id == parent._current_task_id
+            assert out["notify_on_complete"] is False
+            assert "must poll/log/wait" in out["note"]
+            notice = _process_accounting_lines({"handed_off_processes": child._handed_off_processes})[0]
+            assert "poll/log/wait" in notice
+            assert not watchers
+            return
+        assert len(watchers) == 1, "handoff must register exactly one gateway completion watcher"
+        event = GatewayNotificationsMixin._build_process_completion_event(watchers[0], session, session.id)
+        assert event["parent_session_id"] == parent.session_id, "handoff must stop targeting the child session"
+        assert event["session_key"] == "parent-route"
+        assert event["handoff_note"] == "forward result"
+        saved = next(row for row in json.loads(checkpoint.read_text()) if row["session_id"] == session.id)
+        assert saved["owner_task_id"] == session.owner_task_id == parent._current_task_id
+        assert saved["parent_session_id"] == parent.session_id
+        assert saved["notify_on_complete"] is True
+        assert saved["handoff_note"] == event["handoff_note"]
+    finally:
+        clear_session_vars(tokens)
         process_registry.kill_all(source="test")
         _unregister_subagent(sid)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -449,7 +449,7 @@ _CHECKPOINT_FIELDS = (
     "command", "pid", "pid_scope", "host_start_time", "systemd_unit", "cwd",
     "started_at", "task_id", "owner_task_id", "session_key",
     *(f"watcher_{k}" for k in _WATCHER_ROUTE_KEYS), "watcher_interval",
-    "parent_session_id", "notify_on_complete", "watch_patterns")
+    "parent_session_id", "notify_on_complete", "watch_patterns", "handoff_note")
 _CHECKPOINT_DEFAULTS = {
     f.name: ([] if f.name == "watch_patterns" else f.default)
     for f in ProcessSession.__dataclass_fields__.values()
@@ -1949,10 +1949,11 @@ class ProcessRegistry(ProcessCheckpointMixin):
                     and s.id not in self._completion_consumed and s.id not in self._poll_observed]
 
     def transfer_ownership(self, session_id: str, *, from_owner: str, to_owner: str, to_task_id: str,
-                           to_session_key: str, note: str = "") -> Optional[ProcessSession]:
+                           to_session_key: str, to_parent_session_id: str = "",
+                           notify_on_complete: bool = True, note: str = "") -> Optional[ProcessSession]:
         """Move a RUNNING process from one owner to another under the registry lock. Ownership is the ``owner_task_id``
-        field: completion notices are stamped from it at exit time and teardown kills by it, so flipping it here is the
-        whole transfer. Returns the session, or None when it is unknown, already exited, or not owned by ``from_owner``
+        field: completion notices and teardown follow it. Move completion eligibility and its durable session target
+        alongside it. Returns the session, or None when it is unknown, already exited, or not owned by ``from_owner``
         (the caller must not report a transfer that did not happen)."""
         session = self.get(session_id)
         with self._lock:
@@ -1961,6 +1962,8 @@ class ProcessRegistry(ProcessCheckpointMixin):
             session.owner_task_id = to_owner
             session.task_id = to_task_id
             session.session_key = to_session_key
+            session.parent_session_id = to_parent_session_id
+            session.notify_on_complete = notify_on_complete
             session.handoff_note = note
             return session
 
@@ -2140,6 +2143,7 @@ def _handoff_process(session_id: str, args: dict, task_id: Optional[str]) -> dic
     no-op, so a PID mentioned in prose can't masquerade as a transfer."""
     from tools.delegate_tool_registry import _active_subagents, _active_subagents_lock
     from tools.terminal_tool import _resolve_container_task_id
+    from gateway.session_context import async_delivery_supported, get_session_env, scoped_current_session_id
     with _active_subagents_lock:
         record = _active_subagents.get(str(task_id or ""))
     child = record.get("agent") if record else None
@@ -2158,17 +2162,31 @@ def _handoff_process(session_id: str, args: dict, task_id: Optional[str]) -> dic
     note = str(args.get("data") or "").strip()
     if not note:
         return {"error": "handoff requires `data`: one sentence saying what the process is for and what the parent should do with its result."}
+    notify = async_delivery_supported()
+    parent_session_id = str(getattr(parent, "session_id", "") or "")
     session = process_registry.transfer_ownership(
         session_id, from_owner=str(task_id or ""), to_owner=parent_owner,
         to_task_id=_resolve_container_task_id(parent_owner),
-        to_session_key=str(getattr(parent, "session_id", "") or ""), note=note)
+        to_session_key=get_session_env("HERMES_SESSION_KEY", "") or parent_session_id,
+        to_parent_session_id=parent_session_id, notify_on_complete=notify, note=note)
     if session is None:
         return {"error": f"cannot hand off {session_id}: not a running process you own (already exited? read its result "
                          "with poll/log and report it instead)."}
-    handed.append({"session_id": session.id, "command": session.command, "note": note})
+    if notify:
+        from tools.terminal_tool_background import _stamp_gateway_routing, _register_completion_watcher
+        with scoped_current_session_id(parent_session_id):
+            _stamp_gateway_routing(session, get_session_env)
+        if session.watcher_platform and not session.watcher_interval:
+            _register_completion_watcher(process_registry, session, session.session_key)
+    process_registry._write_checkpoint()
+    handed.append({"session_id": session.id, "command": session.command, "note": note,
+                   "notify_on_complete": notify})
     return {"status": "handed_off", "session_id": session.id, "command": session.command,
-            "note": "Your parent now owns this process and will receive its completion; you will not. Mention the handoff "
-                    "in your final answer."}
+            "notify_on_complete": notify,
+            "note": ("Your parent now owns this process and will receive its completion; you will not. "
+                     "Mention the handoff in your final answer." if notify else
+                     "Your parent now owns this process. This session cannot receive asynchronous completions; "
+                     "the parent must poll/log/wait for its result. Mention the handoff in your final answer.")}
 
 
 _MAX_HANDOFFS_PER_CHILD = 3

--- a/tools/process_registry_checkpoint.py
+++ b/tools/process_registry_checkpoint.py
@@ -33,6 +33,7 @@ class ProcessCheckpointMixin:
                     # PID, never re-runs it), so masking is lossless.
                     # See #77484.
                     entry["command"] = redact_sensitive_text(s.command, code_file=True)
+                    entry["handoff_note"] = redact_sensitive_text(s.handoff_note, code_file=True)
                     entry["owner_task_id"] = s.owner_task_id or s.task_id
                     entries.append(entry)
                 if extra_entries:

--- a/tools/process_registry_notifications.py
+++ b/tools/process_registry_notifications.py
@@ -221,8 +221,11 @@ def _process_accounting_lines(r: dict) -> list:
     completion lands here) and what it left running (terminated at teardown — never trust a child's "watcher running")."""
     lines = []
     for h in r.get("handed_off_processes") or []:
+        delivery = ("You own it now; poll/log/wait for its result (asynchronous delivery is unavailable)."
+                    if h.get("notify_on_complete") is False else
+                    "You own it now; its completion notice will arrive here.")
         lines.append(f"Handed off to you: {h.get('session_id')} ({h.get('command', '')[:120]}) — {h.get('note', '')}. "
-                     "You own it now; its completion notice will arrive here.")
+                     + delivery)
     orphans = r.get("orphaned_processes") or []
     if orphans:
         lines.append(f"Child left {len(orphans)} background process(es) running that were TERMINATED with it "


### PR DESCRIPTION
## What does this PR do?

An accepted subagent process handoff currently promises parent completion while retaining the spawning process's notification flag and gateway watcher target. Transfer completion responsibility with ownership so silent spawns can notify, existing watchers address the parent, and restart checkpoints retain the transfer.

## Related Issue

Fixes #108479

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- Transfer the completion flag and durable parent session with the process owner. Keep the gateway routing key distinct from the parent session DB ID.
- Stamp parent routing and register a watcher only if none exists. Existing watchers resolve handed-off completion against current process ownership.
- Persist the transferred checkpoint identity and redacted handoff purpose.
- Preserve finite-session async limitations; both the child result and parent accounting notice explicitly require polling there.
- Parameterize the real-process handoff test and add gateway producer/checkpoint coverage under real session context, with no network transport mocked into success.

## How to Test

Before: the real-process/gateway tests produce **3 failures, 2 passes** (no event for notify-off, no gateway watcher, or stale child target). After: **6 handoff tests pass**, including the finite-session case.

Related runs through `scripts/run_tests.sh`:

- Background notifications, notify-on-complete, process registry and handoff: 119 passed, 32 skipped, 6 failed.
- The same 6 process-registry failures reproduce on unchanged process-registry source at the main baseline: 71 passed, 32 skipped, 6 failed. They concern existing stdin/PTY/Windows-vs-POSIX process mocks; no tests are weakened or skipped by this PR.
- Gateway completion delivery/admission/session-boundary and one-shot/terminal-yield paths: **70 passed, 4 platform skips**.
- Ruff on all changed files, Windows-footgun full scan (1,544 files), compat-pointer full scan and `git diff --check` pass.
- The repository subprocess-stdin scanner flags five existing example strings in unchanged `plugins/security-guidance/patterns.py`; the baseline control reports the same five.

## Compatibility and risks

No new model tools, dependencies or config keys. An explicit handoff enables completion on sessions that support it; finite sessions retain ownership transfer and polling. Existing notify-enabled handoffs retain a single watcher. Old checkpoint entries remain loadable because the purpose field has an empty default. Routing updates apply only to actual handoffs; ordinary process completion uses its existing watcher contract.

## Checklist

- [x] Read contribution/security/scoped development instructions
- [x] Conventional commit; changes belong to handoff completion ownership
- [x] All-state duplicate searches and related PR bodies/source inspected
- [x] Real-process regression fails before and passes after
- [x] Tested on native Windows / Python 3.13 / Git Bash
- [x] Config keys and model-tool schemas unchanged
- [ ] Full repository suite (relevant suites and baseline failures detailed above)
