### PR TITLE
fix(cron): preserve live owners when process identity is unavailable

### DIFF
--- a/cron/executions.py
+++ b/cron/executions.py
@@ -121,9 +121,11 @@ def _owner_is_live(pid: int, started_at: Optional[int]) -> bool:
     except Exception:
         return True  # fail safe: inability to prove death must not rewrite state
     if started_at is None:
-        return pid == os.getpid()
+        return True  # A live PID without a recorded fingerprint is not proved abandoned.
     current = _process_start_time(pid)
-    return current is not None and current == started_at
+    # Metadata may be temporarily unavailable even though the process is alive. Only a known
+    # mismatch proves PID reuse; otherwise preserve the writer's right to finish its records.
+    return current is None or current == started_at
 
 
 def _prune_unlocked(conn: sqlite3.Connection) -> None:

--- a/tests/cron/test_owner_uncertainty.py
+++ b/tests/cron/test_owner_uncertainty.py
@@ -1,0 +1,69 @@
+"""A live ledger writer must survive an unavailable process-start fingerprint."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+_OWNER = """
+import json
+import sys
+from cron import executions, delivery_queue
+import gateway.status
+if sys.argv[1] == 'recorded':
+    gateway.status.get_process_start_time = lambda pid: None
+row = executions.create_execution('live-job', source='builtin')
+executions.mark_execution_running(row['id'])
+delivery_queue.enqueue(row['id'], {'id': 'live-job'}, 'result')
+delivery_queue.claim_next()
+print(json.dumps(row), flush=True)
+sys.stdin.read(1)
+finished = executions.finish_execution(row['id'], success=True)
+delivered = delivery_queue._finish(row['id'], error=None)
+print(json.dumps({'execution': finished, 'delivered': delivered}), flush=True)
+"""
+
+
+@pytest.mark.parametrize("missing", ["recorded", "current"])
+def test_live_owner_can_finish_both_ledgers_when_fingerprint_is_unavailable(tmp_path, monkeypatch, missing):
+    from cron import executions, delivery_queue
+    import gateway.status
+
+    home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(executions, "EXECUTIONS_FILE", None)
+    monkeypatch.setattr(delivery_queue, "DELIVERY_DB", None)
+    env = dict(os.environ, HERMES_HOME=str(home))
+    repo = Path(__file__).resolve().parents[2]
+    owner = subprocess.Popen(
+        [sys.executable, "-c", _OWNER, missing], cwd=repo, env=env,
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+    )
+    try:
+        row = json.loads(owner.stdout.readline())
+        assert owner.poll() is None
+        assert gateway.status._pid_exists(owner.pid)
+        if missing == "current":
+            assert row["process_started_at"] is not None
+            assert not executions._owner_is_live(owner.pid, row["process_started_at"] + 1)
+            assert executions.recover_interrupted_executions() == 0
+            assert delivery_queue.recover_abandoned() == 0
+            # Fault at the OS metadata boundary; real PID probing, processes and SQLite remain active.
+            monkeypatch.setattr(gateway.status, "get_process_start_time", lambda pid: None)
+        else:
+            assert row["process_started_at"] is None
+        recovered = (executions.recover_interrupted_executions(), delivery_queue.recover_abandoned())
+        output, error = owner.communicate("x", timeout=15)
+        assert owner.returncode == 0, error
+        outcome = json.loads(output)
+        assert recovered == (0, 0), outcome
+        assert outcome["execution"]["status"] == "completed"
+        assert outcome["delivered"] is True
+        assert delivery_queue.get_status(row["id"])["status"] == "delivered"
+    finally:
+        if owner.poll() is None:
+            owner.communicate("x", timeout=15)


### PR DESCRIPTION
## What does this PR do?

When process-start metadata is unavailable, cron recovery currently rewrites live execution and delivery rows to `unknown`, preventing the owner from recording its eventual result. Preserve those rows while the PID is alive; only a known fingerprint mismatch proves PID reuse.

## Related Issue

Fixes #108480

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `cron/executions.py`: make both missing-fingerprint paths conservative in the shared `_owner_is_live` helper. This covers execution recovery and delivery recovery together.
- `tests/cron/test_owner_uncertainty.py`: real subprocess / temporary-profile SQLite reproduction, parameterized over missing recorded versus missing current metadata. It also checks known identity mismatch remains rejected and lets the original writer finish both ledgers.

## How to Test

`scripts/run_tests.sh tests/cron/test_owner_uncertainty.py tests/cron/test_execution_ledger.py tests/cron/test_delivery_queue.py --file-retries 0 -j 3 -q`

Before: both new cases fail; recovery changes one row in each ledger and the original writer returns `{"execution": null, "delivered": false}`. After: **36 tests pass**, including dead-owner recovery, terminal immutability and delivery retention tests. Ruff, Windows-footgun checks on changed files and `git diff --check` pass.

## Compatibility and risks

No schema migration or configuration change. Dead PIDs and known fingerprint mismatches retain existing behavior. With missing identity metadata, recovery may wait for a live PID to exit instead of inventing an authoritative terminal outcome. This is consistent with the documented conservative recovery contract. Actual OS metadata failure is injected at its boundary; process existence, IPC and SQLite are real.

Related #106627 protects a different handoff-successor path and does not change this helper.

## Checklist

- [x] Read contribution/security/scoped development instructions
- [x] Conventional commit; only related changes
- [x] Existing issues/PRs, source history and releases checked
- [x] Regression fails before and passes after
- [x] Tested on Windows / Python 3.13; no platform spoofing
- [x] Documentation/config/tool schemas: N/A
- [ ] Full repository suite (three relevant files above were run)
