### PR TITLE
fix(approval): bound echo|tr|shell regex to prevent O(n²) on separator-rich input

### DIFF
--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -290,7 +290,9 @@ DANGEROUS_PATTERNS = [
     # xxd uses -r for decode, not -d.
     (r'\bxxd\s+-r\b.*\|\s*\b(bash|sh|zsh|ksh|dash)\b', "pipe xxd-decoded content to shell (possible command obfuscation)"),
     # `echo 'eq -pe v/' | tr 'eqv' 'rmf' | bash` decodes to `rm -rf /`.
-    (r'\becho\b[^|]*\|\s*\btr\b[^|]*\|\s*\b(bash|sh|zsh|ksh|dash)\b', "pipe tr-transformed output to shell (possible command obfuscation)"),
+    # Bounded to separator-free segments: a pipeline gap cannot contain ;/& or newline, so
+    # [^|] → [^|;&\n] keeps coverage while eliminating O(n²) on separator-rich input.  #108451
+    (r'\becho\b[^|;&\n]*\|\s*\btr\b[^|;&\n]*\|\s*\b(bash|sh|zsh|ksh|dash)\b', "pipe tr-transformed output to shell (possible command obfuscation)"),
     (r'\bopenssl\b.*\b(?:base64|enc)\b[^|]*\s+-[dD]\b[^|]*\|\s*\b(bash|sh|zsh|ksh|dash)\b',
      "pipe openssl-decoded content to shell (possible command obfuscation)"),
     (rf'\btee\b.*["\']?{_SENSITIVE_WRITE_TARGET}', "overwrite system file via tee"),


### PR DESCRIPTION
## Summary

Bounds the `[^|]*` character class in the `echo | tr | shell` dangerous-command pattern to `[^|;&\n]*`, eliminating O(n²) blowup on separator-rich input.

## Problem

`detect_dangerous_command()` runs every dangerous pattern over every command variant inline on the caller's thread. The `echo ... | tr ... | bash` pattern uses `[^|]*` without an upper bound, so on input without `|` each attempt rescans the rest of the string: the cost is O(number of `echo` tokens × length).

Measured on `("echo hi; " * (n // 9))[:n]`:

| Input length | Before | After |
|---|---|---|
| 10,000 chars | 3.2 ms | ~0.0 ms |
| 100,000 chars | 314.5 ms | ~2.0 ms |

Overall `detect_dangerous_command()` at 100k drops ~38% on separator-rich input.

## Solution

A pipeline gap cannot contain `;`, `&`, or newline, so `[^|]` → `[^|;&\n]` keeps full coverage while eliminating the quadratic blowup.

## Verification

- All 151 tests in `test_approval.py` and `test_shell_bypass_denylist.py` pass
- The pattern still matches `echo 'eq -pe v/' | tr 'eqv' 'rmf' | bash`
- The pattern still rejects `echo x; tr a b | bash` (semicolon separator)

## Ref

Closes #108451 (Finding 1 — the bounded tr gap). The remaining slowness is the launchctl pattern, addressed by #104781.