### PR TITLE
fix(state): track repair/probe connections so byte-level probes cannot cancel their locks

### DIFF
--- a/hermes_state_repair.py
+++ b/hermes_state_repair.py
@@ -579,8 +579,28 @@ def _connect_repair_durable(db_path: Path, *, timeout: float = 5.0) -> sqlite3.C
     no ``checkpoint_fullfsync`` — on Darwin an interrupted ``REINDEX``/``VACUUM``/``writable_schema`` rewrite leaves
     half-written b-tree pages. Autocommit (``isolation_level=None``): DDL and ``VACUUM`` are illegal inside an
     implicit transaction. Barriers are best-effort: on a malformed schema even ``PRAGMA synchronous=FULL`` raises,
-    so whole-file rewrites call :func:`_reapply_durability_barriers` once the schema parses again."""
-    conn = sqlite3.connect(str(db_path), timeout=timeout, isolation_level=None)
+    so whole-file rewrites call :func:`_reapply_durability_barriers` once the schema parses again.
+
+    Opened through :func:`hermes_cli.sqlite_safe_read.connect_tracked` so the fd is registered for its whole
+    lifetime: the repair paths hold the strongest locks in the process (``_open_exclusive`` keeps
+    ``locking_mode=EXCLUSIVE`` across the snapshot → strategies → promotion window, and the write-health probe
+    opens a ``BEGIN IMMEDIATE`` reservation). While untracked, every byte-level probe of a *live* state.db — the
+    zeroed-file detector, header verification, kanban's post-commit page check — was allowed to ``open()``/
+    ``close()`` the file, which cancels every POSIX advisory lock this process holds on it
+    (https://sqlite.org/howtocorrupt.html#_posix_advisory_locks_canceled_by_a_separate_thread_doing_close_)
+    and lets an external writer commit into a database the repair still believes it owns (#63386).
+    """
+    try:
+        from hermes_cli.sqlite_safe_read import connect_tracked
+    except ImportError:
+        # Scaffold/embed installs without hermes_cli: the durable connection stays, only the guard is off.
+        logger.debug("hermes_cli.sqlite_safe_read unavailable; opening %s untracked "
+                     "(byte-probe guard inactive in this install)", db_path)
+        conn = sqlite3.connect(str(db_path), timeout=timeout, isolation_level=None)
+    else:
+        # Open through THIS module's sqlite3.connect so tests patching it keep control of the fd.
+        conn = connect_tracked(db_path, tracking_path=db_path, connect_fn=sqlite3.connect,
+                               timeout=timeout, isolation_level=None)
     _reapply_durability_barriers(conn)
     return conn
 

--- a/tests/test_sqlite_lock_safe_inspection.py
+++ b/tests/test_sqlite_lock_safe_inspection.py
@@ -285,6 +285,68 @@ def test_session_db_read_only_is_tracked(tmp_path, clean_registry, monkeypatch):
     assert read_header_bytes_preopen(db_path, length=16) is not None
 
 
+def test_repair_connections_are_tracked_for_byte_probe_safety(tmp_path, clean_registry, monkeypatch):
+    """End-to-end: live repair/probe connections block byte-level reads (#63386).
+
+    The repair paths never go through ``SessionDB`` and they hold the strongest
+    locks in the process: ``_open_exclusive`` keeps ``locking_mode=EXCLUSIVE``
+    across the whole snapshot -> strategies -> promotion window, and the
+    write-health probe opens a ``BEGIN IMMEDIATE`` reservation. They used to
+    connect outside the registry, so the byte-probe guard could not see them and
+    every inspection ``open()``/``close()`` cancelled those POSIX advisory locks
+    (``howtocorrupt`` §2.2), letting an external writer commit into the database
+    the repair still believed it owned.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_state import SessionDB
+    from hermes_state_repair import _connect_repair_durable, _repair_conn
+
+    db_path = tmp_path / "state.db"
+    seed = SessionDB(db_path=db_path)
+    seed.create_session("s1", source="cli")
+    seed.close()
+    assert not has_live_connection(db_path)
+
+    conn = _connect_repair_durable(db_path)
+    try:
+        assert has_live_connection(db_path)
+        assert read_header_bytes_preopen(db_path, length=16) is None
+    finally:
+        conn.close()
+    assert not has_live_connection(db_path)
+
+    with _repair_conn(db_path):
+        assert has_live_connection(db_path)
+        assert read_header_bytes_preopen(db_path, length=16) is None
+    assert not has_live_connection(db_path)
+    # The guard is released with the connection, not for good.
+    assert read_header_bytes_preopen(db_path, length=16) is not None
+
+
+def test_byte_probe_never_cancels_the_repair_exclusion(tmp_path, clean_registry):
+    """A live repair's EXCLUSIVE lock must survive Hermes' own inspection (#63386).
+
+    With the connection tracked the probe is refused, so nothing closes an fd and
+    the exclusion keeps holding; if the probe were allowed through, its ``close()``
+    would cancel the lock and the intruder would commit into the file mid-repair.
+    """
+    import hermes_state_repair as repair
+
+    db_path = tmp_path / "state.db"
+    _make_db(db_path, "DELETE")
+
+    guard = repair._open_exclusive(db_path, "BEGIN EXCLUSIVE")
+    try:
+        assert _external_writer_can_break_in(db_path) is False
+        assert read_header_bytes_preopen(db_path, length=16) is None
+        assert _external_writer_can_break_in(db_path) is False, (
+            "the repair's EXCLUSIVE lock was cancelled by a byte-level probe "
+            "on the database it holds"
+        )
+    finally:
+        guard.close()
+
+
 
 
 


### PR DESCRIPTION
## Problem

`_connect_repair_durable()` is the single entry point for every repair/probe connection to
`state.db` — the doctor's write-health probe (`_db_opens_cleanly`), the schema-repair ladder
(`repair_state_db_schema`), the exclusive repair guard (`_open_exclusive`), the live-writer guard
and the WAL checkpoint paths. It opened the database with a bare `sqlite3.connect(...)`, i.e.
**outside** the live-connection registry in `hermes_cli/sqlite_safe_read.py`, so
`has_live_connection()` reported `false` while a repair connection was open.

These paths hold the strongest locks in the process: `_open_exclusive()` keeps
`locking_mode=EXCLUSIVE` across the whole snapshot → strategies → promotion window, and the
write-health probe opens a `BEGIN IMMEDIATE` reservation. While the connection is invisible to the
registry, **any** byte-level probe running in the same process — the zeroed-file detector
(`is_zeroed_state_db`), header verification (`has_invalid_sqlite_header_preopen`), kanban's
post-commit page check — is allowed to `open()`/`close()` the file. Per
[howtocorrupt §2.2](https://sqlite.org/howtocorrupt.html#_posix_advisory_locks_canceled_by_a_separate_thread_doing_close_),
that `close()` cancels **every** POSIX advisory lock the process holds on that file, so an
external writer can commit into a database the repair still believes it owns — the corruption
mechanism behind #63386.

## Evidence (real database, no mocks)

Repair connection held with `BEGIN EXCLUSIVE`; an external writer (separate process, `timeout=0`)
tries to `BEGIN IMMEDIATE` → `INSERT` → `COMMIT` before and after Hermes' own inspection runs:

| step | before | after |
| --- | --- | --- |
| external writer while the repair holds the lock | `BLOCKED` | `BLOCKED` |
| `read_header_bytes_preopen()` (Hermes' own byte probe) | returns the header ⇒ `open()`+`close()` | `None` (refused) |
| external writer **after** the probe | `ACQUIRED` ← lock cancelled, writer got in | `BLOCKED` ← exclusion survived |
| registry released once the repair closes | — | `has_live_connection == False` |

End-to-end repair on a database with the exact #63386 damage (stale B-tree index produced with
`writable_schema` + `REINDEX`, no mocking):

```
integrity before : ['wrong # of entries in index idx_messages_session', 'row 1 missing from index ...']
check-only       : exit 1
repair           : ✓ Repaired — 1 sessions recovered.   →  integrity after: ['ok']
in-process repair: {'repaired': True, 'strategy': 'reindex_btree', ...}
after repair     : has_live_connection False (no registry leak), byte probe allowed again
```

## Change

`_connect_repair_durable()` opens through `connect_tracked(...)`, keeping the connection
registered for the lifetime of the fd (released on `close()`; a failed close keeps the entry, see
#75629). The `sqlite3.connect(str(db_path), ...)` call stays in this module so tests patching it
keep control of the fd, and scaffold/embed installs without `hermes_cli` keep the durable
connection (untracked) exactly as before.

No change to the repair lock, the strategy ladder, or the doctor's decision logic — this is only
the "the repair must be able to see its own locks" half.

## Tests

- `tests/test_sqlite_lock_safe_inspection.py::test_repair_connections_are_tracked_for_byte_probe_safety`
- `tests/test_sqlite_lock_safe_inspection.py::test_byte_probe_never_cancels_the_repair_exclusion`
- Both fail on `main` (probe returns the header ⇒ fd opened; intruder acquires the lock mid-repair).

Neighbours all green: `test_state_db_malformed_repair`, `test_state_db_repair_non_destructive`,
`test_state_db_repair_live_writer_guard`, `test_state_db_repair_loop_{cap,mtime}`,
`test_state_db_write_durability`, `test_zeroed_state_db`, `test_state_db_fts_segment_collision_probe`,
`tests/state/test_state_db_{lock_fail_closed,wal_unlink_race}`,
`tests/hermes_cli/test_doctor_{structural_corruption,wal_holder_guard,journal_modes}`, `ruff check` clean.

## Context

Direction previously proposed in #103321 (`jangomango76`, tracked repair/probe connections) and
deliberately left out of the #108130 salvage as *unverified against the current repair lock* — this
PR carries only that half plus the verification. Refs #63386, #75629.
