### PR TITLE
fix(security): redact trajectory data before persistence

### DIFF
--- a/agent/trajectory.py
+++ b/agent/trajectory.py
@@ -5,7 +5,20 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List
 
+from agent.redact import redact_sensitive_text
+
 logger = logging.getLogger(__name__)
+
+
+def _redact_trajectory_value(value: Any) -> Any:
+    """Redact string leaves without allowing redaction markers to change JSON syntax."""
+    if isinstance(value, str):
+        return redact_sensitive_text(value, force=True)
+    if isinstance(value, list):
+        return [_redact_trajectory_value(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _redact_trajectory_value(item) for key, item in value.items()}
+    return value
 
 
 def convert_scratchpad_to_think(content: str) -> str:
@@ -26,8 +39,11 @@ def save_trajectory(trajectory: List[Dict[str, Any]], model: str, completed: boo
         filename = "trajectory_samples.jsonl" if completed else "failed_trajectories.jsonl"
     entry = {"conversations": trajectory, "timestamp": datetime.now().isoformat(), "model": model, "completed": completed}
     try:
+        # Trajectories are durable files and may contain tool arguments or user text.  Apply the
+        # central redactor at this persistence boundary regardless of the display/config toggle.
+        safe_entry = _redact_trajectory_value(entry)
         with open(filename, "a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+            f.write(json.dumps(safe_entry, ensure_ascii=False) + "\n")
         logger.info("Trajectory saved to %s", filename)
     except Exception as e:
         logger.warning("Failed to save trajectory: %s", e)

--- a/tests/agent/test_trajectory_persistence_redaction.py
+++ b/tests/agent/test_trajectory_persistence_redaction.py
@@ -1,0 +1,40 @@
+import json
+
+from agent.trajectory import save_trajectory
+
+
+def test_save_trajectory_redacts_secrets_in_temp_file(tmp_path):
+    secret = "sk-proj-trajectory-secret-1234567890"
+    path = tmp_path / "trajectory.jsonl"
+
+    save_trajectory(
+        [{"from": "human", "value": f"use api_key={secret}"}],
+        "test-model",
+        True,
+        filename=str(path),
+    )
+
+    raw = path.read_text(encoding="utf-8")
+    assert secret not in raw
+    entry = json.loads(raw)
+    assert entry["conversations"][0]["from"] == "human"
+    assert secret not in entry["conversations"][0]["value"]
+    assert entry["conversations"][0]["value"] != f"use api_key={secret}"
+
+
+def test_save_trajectory_preserves_sharegpt_shape_while_redacting_tool_arguments(tmp_path):
+    secret = "sk-proj-trajectory-secret-1234567890"
+    path = tmp_path / "trajectory.jsonl"
+    trajectory = [
+        {"from": "human", "value": "Run the tool"},
+        {"from": "gpt", "value": '{"name":"terminal","arguments":"token=' + secret + '"}'},
+        {"from": "tool", "value": "command completed"},
+    ]
+
+    save_trajectory(trajectory, "test-model", False, filename=str(path))
+
+    entry = json.loads(path.read_text(encoding="utf-8"))
+    assert entry["model"] == "test-model"
+    assert entry["completed"] is False
+    assert [item["from"] for item in entry["conversations"]] == ["human", "gpt", "tool"]
+    assert secret not in json.dumps(entry)


### PR DESCRIPTION
Fixes #108495

## Problem
Trajectory persistence serialized conversation data directly without centralized redaction. Tool arguments, user content, and provider output could contain credentials or other sensitive values.

## Root cause
`agent/trajectory.py` received structured conversation data and passed it to JSON serialization without recursively applying the existing redaction policy.

## Impact
When trajectory saving was enabled, secrets could remain in `trajectory_samples.jsonl` or `failed_trajectories.jsonl`, then be consumed by later dataset or diagnostic tooling.

## Fix
- Recursively redact every string value before JSONL serialization.
- Preserve the original structured trajectory shape and JSON validity.
- Use forced centralized redaction rather than ad-hoc regexes.

## Verification
Added temporary-directory regression tests for user content and tool arguments containing sensitive values. Canonical test wrapper passed: 2 tests. `git diff --check` passed.

## Scope
Files: `agent/trajectory.py` and `tests/agent/test_trajectory_persistence_redaction.py`. No logging or cron PR is duplicated.