### PR TITLE
fix(gateway): serialize concurrent runtime status updates

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import threading
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -34,7 +35,9 @@ _LOCKS_DIRNAME = "gateway-locks"
 _IS_WINDOWS = sys.platform == "win32"
 _UNSET = object()
 _GATEWAY_LOCK_FILENAME = "gateway.lock"
+_RUNTIME_STATUS_LOCK_FILENAME = "gateway_state.lock"
 _gateway_lock_handle = None
+_runtime_status_write_lock = threading.RLock()
 # Windows byte-range locks are mandatory for other readers: lock a byte well past
 # the JSON payload so status/PID readers can read while another process holds it.
 _WINDOWS_LOCK_OFFSET = 1024 * 1024
@@ -164,6 +167,33 @@ def _get_gateway_lock_path(pid_path: Optional[Path] = None) -> Path:
 
 def _get_runtime_status_path() -> Path:
     return _get_process_hermes_home() / _RUNTIME_STATUS_FILE
+
+
+def _get_runtime_status_lock_path() -> Path:
+    return _get_process_hermes_home() / _RUNTIME_STATUS_LOCK_FILENAME
+
+
+@contextmanager
+def _runtime_status_write_guard():
+    """Serialize the read/merge/write transaction within and across processes."""
+    with _runtime_status_write_lock:
+        path = _get_runtime_status_lock_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        handle = open(path, "a+", encoding="utf-8")
+        try:
+            if _IS_WINDOWS:
+                handle.seek(0, os.SEEK_END)
+                if handle.tell() == 0:
+                    handle.write("\n")
+                    handle.flush()
+                handle.seek(_WINDOWS_LOCK_OFFSET)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+            else:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            yield
+        finally:
+            _release_file_lock(handle)
+            handle.close()
 
 
 def _get_lock_dir() -> Path:
@@ -790,7 +820,7 @@ def _coerce_session_store(session_store: Any) -> dict[str, str]:
     return {"status": state if state in {"ok", "unavailable", "retrying"} else "unknown"}
 
 
-def write_runtime_status(
+def _write_runtime_status_unlocked(
     *, gateway_state: Any = _UNSET, exit_reason: Any = _UNSET, restart_requested: Any = _UNSET,
     active_agents: Any = _UNSET, platform: Any = _UNSET, platform_state: Any = _UNSET,
     error_code: Any = _UNSET, error_message: Any = _UNSET, needs_attention: Any = _UNSET,
@@ -843,6 +873,12 @@ def write_runtime_status(
     with contextlib.suppress(Exception):
         from agent.monitoring.gateway_health import emit_runtime_status_transition
         emit_runtime_status_transition(previous_payload, payload)
+
+
+def write_runtime_status(**kwargs) -> None:
+    """Persist runtime health using a serialized read/merge/write transaction."""
+    with _runtime_status_write_guard():
+        _write_runtime_status_unlocked(**kwargs)
 
 
 def read_runtime_status(path: Optional[Path] = None) -> Optional[dict[str, Any]]:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -218,6 +219,25 @@ class TestScopedGatewayPidQuery:
 
 
 class TestGatewayRuntimeStatus:
+    def test_concurrent_platform_writes_preserve_both_updates(self, tmp_path, monkeypatch):
+        """The read/merge/write transaction must not lose a concurrent platform update."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        barrier = threading.Barrier(2)
+
+        def write(platform):
+            barrier.wait()
+            status.write_runtime_status(platform=platform, platform_state="connected")
+
+        threads = [threading.Thread(target=write, args=(platform,)) for platform in ("telegram", "discord")]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        platforms = status.read_runtime_status()["platforms"]
+        assert platforms["telegram"]["state"] == "connected"
+        assert platforms["discord"]["state"] == "connected"
+
     def test_clear_profile_platforms_preserves_primary_entries(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         (tmp_path / "gateway_state.json").write_text(


### PR DESCRIPTION
Fixes #108496

## Problem
Concurrent gateway status updates used an unlocked read-modify-write cycle. Atomic file replacement prevented torn JSON but not logical lost updates.

## Root cause
Two writers could read the same `gateway_state.json`, update different platform entries, and replace the file in sequence. The last writer discarded the first writer's changes.

## Impact
Platform health and runtime status entries could silently disappear, producing incomplete diagnostics and incorrect recovery decisions.

## Fix
- Add an in-process reentrant lock.
- Add cross-process locking through `gateway_state.lock`.
- Serialize the complete read/merge/write transaction.
- Include Windows-compatible byte-range locking.

## Verification
Added deterministic concurrent update coverage proving simultaneous platform updates survive. The new regression passed. The full status file had 78 passed and 1 unrelated `/proc` fallback failure.

## Scope
Files: `gateway/status.py` and `tests/gateway/test_status.py`. This does not overlap the cron PRs or the existing gateway routing ownership PR.