### PR TITLE
feat(vision): cap repeat vision_analyze calls via config.yaml

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -806,6 +806,13 @@ prompt_caching:
 # uses "google/gemini-3-flash-preview" and Nous uses "gemini-3-flash".
 # Other providers pick a sensible default automatically.
 #
+# vision:
+#   # Cap repeat vision_analyze calls on the same image in one session.
+#   # 0 = unlimited (default; current behavior). 1 = refuse the second call
+#   # without hitting the vision backend — each native-path call re-embeds
+#   # the full image into conversation history.
+#   max_calls_per_image: 0
+#
 # auxiliary:
 #   # Image analysis: vision_analyze tool + browser screenshots
 #   vision:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -447,6 +447,12 @@ DEFAULT_CONFIG = {
         # browser_cdp / browser_evaluate capabilities.
         "extension_control": {"enabled": False, "developer_mode": False},
     },
+    # vision_analyze repeat cap. 0 = unlimited (historical default). A positive int
+    # refuses further vision_analyze calls on the same image in one session so each
+    # native-path call cannot re-embed the full image into context.
+    "vision": {
+        "max_calls_per_image": 0,
+    },
     # Filesystem checkpoints: snapshot the working directory once per turn (on the first
     # write_file/patch call); restore with /rollback. Opt-in via `hermes chat --checkpoints` or
     # enabled=True (most users never use /rollback). Single shared shadow store with real pruning.

--- a/tests/tools/test_vision_repeat_guard.py
+++ b/tests/tools/test_vision_repeat_guard.py
@@ -1,0 +1,38 @@
+"""vision.max_calls_per_image: default off; cap=1 refuses the second call."""
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tools.vision_tools import _handle_vision_analyze
+
+
+ARGS = {"image_url": "https://example.com/photo.png", "question": "what is this?"}
+
+
+async def _call(config, session_id="sess-1"):
+    backend = AsyncMock(return_value=json.dumps({"result": "ok"}))
+    with patch("tools.vision_tools.vision_analyze_tool", backend), patch(
+        "tools.vision_tools._should_use_native_vision_fast_path", return_value=False
+    ), patch("hermes_cli.config.load_config", return_value=config):
+        first = await _handle_vision_analyze(ARGS, session_id=session_id)
+        second = await _handle_vision_analyze(ARGS, session_id=session_id)
+    return backend, first, second
+
+
+@pytest.mark.asyncio
+async def test_default_off_allows_repeat_calls():
+    backend, first, second = await _call({})
+    assert backend.await_count == 2
+    assert json.loads(first)["result"] == "ok"
+    assert json.loads(second)["result"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_cap_one_refuses_second_call_without_backend():
+    backend, first, second = await _call({"vision": {"max_calls_per_image": 1}})
+    assert backend.await_count == 1
+    assert json.loads(first)["result"] == "ok"
+    payload = json.loads(second)
+    assert payload.get("success") is False
+    assert "BLOCKED" in (payload.get("error") or payload.get("message") or str(payload))

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -8,11 +8,13 @@ model (multimodal tool-result envelope) or are described by the auxiliary vision
 
 import base64
 import asyncio
+import hashlib
 import json
 from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
 import logging
 import os
+import time
 import uuid
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, NamedTuple, Optional
@@ -33,7 +35,7 @@ def _load_auxiliary_client() -> None:
         extract_content_or_reasoning = extract_content_or_reasoning or _aux.extract_content_or_reasoning
 
 
-from hermes_constants import get_hermes_dir
+from hermes_constants import get_hermes_dir, get_hermes_home
 from tools.debug_helpers import DebugSession
 from tools.website_policy import check_website_access
 from tools.vision_tools_image_prep import (
@@ -55,6 +57,15 @@ def _cfg_auxiliary(*keys: str, default=None):
     try:
         from hermes_cli.config import cfg_get, load_config
         return cfg_get(load_config(), "auxiliary", *keys, default=default)
+    except Exception:
+        return default
+
+
+def _cfg_vision(*keys: str, default=None):
+    """``vision.<keys...>`` from config.yaml; ``default`` when config is unavailable."""
+    try:
+        from hermes_cli.config import cfg_get, load_config
+        return cfg_get(load_config(), "vision", *keys, default=default)
     except Exception:
         return default
 
@@ -873,11 +884,93 @@ def _configured_aux_model(sections: tuple, env_vars: tuple) -> Optional[str]:
     return next((v for v in (os.getenv(e, "").strip() for e in env_vars) if v), None)
 
 
+def _vision_repeat_guard(image_url: str, question: str, *, session_id: Optional[str] = None) -> Optional[str]:
+    """Cap repeat vision_analyze calls on one image per session.
+
+    Gated by ``vision.max_calls_per_image`` in config.yaml (int, default 0 =
+    disabled, matching historical unlimited repeats). When the cap is a
+    positive integer, further calls on the same normalized source return a
+    refusal without touching the vision backend or embedding image bytes.
+
+    State lives under ``$HERMES_HOME/cache/vision-repeat/<session>/``. Scope
+    comes from the tool ``session_id`` (falling back to ``task_id``); if
+    neither is set, a process-id directory is used so concurrent processes
+    do not share counters.
+    """
+    try:
+        max_calls = int(_cfg_vision("max_calls_per_image", default=0) or 0)
+    except (TypeError, ValueError):
+        max_calls = 0
+    if max_calls <= 0:
+        return None
+
+    src = (image_url or "").strip()
+    norm = src
+    try:
+        if src.startswith("file://"):
+            norm = os.path.realpath(os.path.expanduser(urlparse(src).path))
+        elif src and "://" not in src and not src.startswith("data:"):
+            norm = os.path.realpath(os.path.expanduser(src))
+    except Exception:
+        norm = src
+
+    sid_raw = (session_id or "").strip()
+    sid = "".join(c if c.isalnum() or c in "-_" else "_" for c in sid_raw) or f"pid-{os.getpid()}"
+    key = hashlib.sha256(norm.encode("utf-8", "replace")).hexdigest()[:24]
+    try:
+        d = get_hermes_home() / "cache" / "vision-repeat" / sid
+        d.mkdir(parents=True, exist_ok=True)
+        rec_path = d / f"{key}.json"
+        rec: Dict[str, Any] = {"source": norm, "calls": []}
+        if rec_path.exists():
+            try:
+                rec = json.loads(rec_path.read_text())
+            except Exception:
+                pass
+        calls = rec.get("calls") or []
+        if len(calls) >= max_calls:
+            first = calls[0] if calls else {}
+            logger.info(
+                "vision_analyze: repeat-call blocked by per-session budget "
+                "(%s, %d prior call(s))", norm, len(calls),
+            )
+            return tool_error(
+                "BLOCKED — per-session attachment budget: this image was already "
+                f"analyzed {len(calls)} time(s) in this session "
+                f"(first at {first.get('at', '?')}, question: "
+                f"{(first.get('question') or '')[:200]!r}). "
+                "Re-analyzing the same file is mechanically disabled because each "
+                "call re-embeds the full image into context. The image and/or its "
+                "description from the earlier call are ALREADY in your "
+                "conversation history — scroll up and use that answer. If it is "
+                "genuinely insufficient, proceed with what you have or escalate; "
+                "do NOT retry this tool on this file (all retries will be blocked).",
+                success=False,
+            )
+        calls.append({
+            "at": time.strftime("%Y-%m-%d %H:%M:%S"),
+            "question": (question or "")[:500],
+        })
+        rec["source"] = norm
+        rec["calls"] = calls
+        tmp = rec_path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(rec))
+        tmp.replace(rec_path)
+    except Exception:
+        logger.warning("vision_analyze: repeat-call guard errored; allowing call", exc_info=True)
+    return None
+
+
 async def _handle_vision_analyze(args: Dict[str, Any], **kw: Any) -> str:
     image_url, question, region = args.get("image_url", ""), args.get("question", ""), args.get("region")
     task_id = kw.get("task_id")
     # No concurrency gate around the whole analysis — the CPU burst is bounded inside the
     # encode/resize step, so multi-image fan-out keeps full request concurrency.
+    blocked = _vision_repeat_guard(
+        image_url, question, session_id=kw.get("session_id") or task_id,
+    )
+    if blocked is not None:
+        return blocked
     if _should_use_native_vision_fast_path():
         logger.info("vision_analyze: native fast path")
         return await _vision_analyze_native(image_url, question, task_id=task_id, region=region)


### PR DESCRIPTION
## Problem

`vision_analyze` can be called repeatedly on the same attachment. Each native-path call re-embeds the full image into conversation history, so a reworded retry multiplies token cost for the rest of the session. Prompt-text "call this once" does not stop it.

#44359 is desktop session-lineage dedupe, not a per-image call cap.

## Fix

New `vision.max_calls_per_image` in config.yaml (int, default 0 = unlimited, so unset config is unchanged). A positive cap records calls under `$HERMES_HOME/cache/vision-repeat/<session>/` and returns a refusal on further calls without hitting the vision backend.

Session scope uses the `session_id` already passed to tools (`task_id` as fallback). If neither is set, a process-id directory is used so concurrent processes do not share counters.

No new `HERMES_*` env var.

## Test

`scripts/run_tests.sh tests/tools/test_vision_repeat_guard.py tests/tools/test_vision_tools.py tests/tools/test_vision_native_fast_path.py tests/tools/test_vision_region.py tests/tools/test_vision_scale_disclosure.py`

80 passed, 0 failed. Invariants: default off allows repeats; cap=1 returns BLOCKED on the second call and does not invoke the backend.
