### PR TITLE
fix(providers): opt-in shared cookie jar for cookie-based LB sticky routing

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -893,10 +893,11 @@ def _apply_openai_header_policy(agent, client_kwargs: Dict[str, Any]) -> None:
     # model.default_headers override provider/SDK defaults (WAFs rejecting SDK headers).
     agent._apply_user_default_headers()
     try:
-        from hermes_cli.config import (
+        from hermes_cli.config import load_config
+        from hermes_cli.config_providers import (
+            apply_custom_provider_cookie_jar,
             apply_custom_provider_extra_headers_to_client_kwargs,
             apply_custom_provider_tls_to_client_kwargs, get_compatible_custom_providers,
-            load_config,
         )
         _cp_entries = get_compatible_custom_providers(load_config())
         _cp_base_url = str(client_kwargs.get("base_url") or agent.base_url or "")
@@ -904,6 +905,9 @@ def _apply_openai_header_policy(agent, client_kwargs: Dict[str, Any]) -> None:
         # Per-provider extra_headers applied last so the most specific config level wins.
         # SECURITY: values may carry credentials — never log them.
         apply_custom_provider_extra_headers_to_client_kwargs(client_kwargs, _cp_base_url, _cp_entries)
+        # Opt-in cookie sticky routing (providers.<name>.cookie_jar: true): persist the shared
+        # cookie jar on the agent so per-request client builds thread it into their transport.
+        apply_custom_provider_cookie_jar(agent, _cp_base_url, _cp_entries)
     except Exception:
         logger.debug("custom-provider TLS resolution skipped", exc_info=True)
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1664,7 +1664,8 @@ def _gemini_native_client(agent, client_kwargs: dict, httpx_verify, *, reason: s
         if k in {"api_key", "base_url", "default_headers", "timeout", "http_client"}
     }
     if "http_client" not in safe_kwargs:
-        keepalive_http = agent._build_keepalive_http_client(base_url, verify=httpx_verify)
+        keepalive_http = agent._build_keepalive_http_client(
+            base_url, verify=httpx_verify, cookie_jar=getattr(agent, "_shared_cookie_jar", None))
         if keepalive_http is not None:
             safe_kwargs["http_client"] = keepalive_http
     client = GeminiNativeClient(**safe_kwargs)
@@ -1758,7 +1759,10 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
             client_kwargs, timeout=timeout if isinstance(timeout, (int, float)) else None,
         )
     if "http_client" not in client_kwargs:
-        keepalive_http = agent._build_keepalive_http_client(client_kwargs.get("base_url", ""), verify=httpx_verify)
+        keepalive_http = agent._build_keepalive_http_client(
+            client_kwargs.get("base_url", ""), verify=httpx_verify,
+            cookie_jar=getattr(agent, "_shared_cookie_jar", None),
+        )
         if keepalive_http is not None:
             client_kwargs["http_client"] = keepalive_http
     # Retries belong to the outer conversation loop (honors Retry-After); SDK retries would

--- a/agent/client_lifecycle.py
+++ b/agent/client_lifecycle.py
@@ -172,10 +172,17 @@ class ClientLifecycleMixin:
         return False
 
     @staticmethod
-    def _build_keepalive_http_client(base_url: str = "", *, verify: Any = True) -> Any:
-        """Build the shared OpenAI httpx client used by main and aux paths."""
+    def _build_keepalive_http_client(
+        base_url: str = "", *, verify: Any = True, cookie_jar: Any = None,
+    ) -> Any:
+        """Build the shared OpenAI httpx client used by main and aux paths.
+
+        ``cookie_jar`` (optional ``http.cookiejar.CookieJar``) enables cookie-based LB sticky
+        routing: the shared-jar transport extracts ``Set-Cookie`` from responses and injects
+        the ``Cookie`` header on subsequent requests, surviving per-request client rebuilds.
+        """
         from agent.process_bootstrap import build_keepalive_http_client
-        return build_keepalive_http_client(base_url, verify=verify)
+        return build_keepalive_http_client(base_url, verify=verify, cookie_jar=cookie_jar)
 
     _create_openai_client = _forward("agent.agent_runtime_helpers", "create_openai_client")
     _force_close_tcp_sockets = _forward_static("agent.agent_runtime_helpers", "force_close_tcp_sockets")

--- a/agent/process_bootstrap.py
+++ b/agent/process_bootstrap.py
@@ -384,7 +384,10 @@ def close_shared_transports() -> int:
     return len(transports)
 
 
-def build_keepalive_http_client(base_url: str = "", *, async_mode: bool = False, verify: Any = True) -> Optional[Any]:
+def build_keepalive_http_client(
+    base_url: str = "", *, async_mode: bool = False, verify: Any = True,
+    cookie_jar: Any = None,
+) -> Optional[Any]:
     """httpx client for OpenAI SDK calls with env-only proxy policy (None on failure).
 
     Explicit no-proxy mounts disable httpx's ``trust_env`` path so macOS system
@@ -399,6 +402,11 @@ def build_keepalive_http_client(base_url: str = "", *, async_mode: bool = False,
     connection pool + SSL context. Async clients are never shared: an httpcore async pool is
     bound to the event loop that first used it. Proxy-backed clients keep httpx's own transport.
 
+    ``cookie_jar`` (optional ``http.cookiejar.CookieJar``) opts the client into cookie-based
+    LB sticky routing: a ``SharedCookieTransport`` extract/replays ``Set-Cookie``/``Cookie``
+    through the jar, which is shared across every client rebuild (unlike the pools). Bypasses
+    the shared-transport pool — a sticky route must ride THIS process's jar-coherent sockets.
+
     See #12952, #54049.
     See #10933.
     """
@@ -407,6 +415,11 @@ def build_keepalive_http_client(base_url: str = "", *, async_mode: bool = False,
         proxy = _get_proxy_for_base_url(base_url)
         limits = httpx.Limits(max_keepalive_connections=20, max_connections=100, keepalive_expiry=20.0)
         timeout = httpx.Timeout(connect=15.0, read=None, write=15.0, pool=10.0)  # read=None for SSE streaming
+        if cookie_jar is not None:
+            from agent.shared_cookie_transport import build_shared_cookie_http_client
+            return build_shared_cookie_http_client(
+                jar=cookie_jar, proxy=proxy, verify=verify, limits=limits, timeout=timeout,
+            )
         transport_cls = httpx.AsyncHTTPTransport if async_mode else httpx.HTTPTransport
         client_cls = httpx.AsyncClient if async_mode else httpx.Client
         mounts = None

--- a/agent/process_bootstrap.py
+++ b/agent/process_bootstrap.py
@@ -418,7 +418,8 @@ def build_keepalive_http_client(
         if cookie_jar is not None:
             from agent.shared_cookie_transport import build_shared_cookie_http_client
             return build_shared_cookie_http_client(
-                jar=cookie_jar, proxy=proxy, verify=verify, limits=limits, timeout=timeout,
+                jar=cookie_jar, async_mode=async_mode, proxy=proxy,
+                verify=verify, limits=limits, timeout=timeout,
             )
         transport_cls = httpx.AsyncHTTPTransport if async_mode else httpx.HTTPTransport
         client_cls = httpx.AsyncClient if async_mode else httpx.Client

--- a/agent/shared_cookie_transport.py
+++ b/agent/shared_cookie_transport.py
@@ -1,0 +1,120 @@
+"""Shared-cookie-jar transport for cookie-based LB sticky routing.
+
+Some OpenAI-compatible deployments sit behind nginx / Cloudflare with
+cookie-based sticky sessions (``Set-Cookie: route=...``).  Hermes builds a
+fresh ``httpx.Client`` per request (see ``AIAgent._create_request_openai_client``
+and the #10933 closed-transport invariants), so a default httpx cookie jar —
+which lives on the *client* — is discarded after every turn and the LB treats
+each request as a brand-new session, breaking prompt-cache locality.
+
+``SharedCookieTransport`` moves cookie persistence to the transport layer: it
+wraps the normal ``HTTPTransport`` machinery but reads the ``Cookie`` request
+header from, and writes ``Set-Cookie`` responses into, a single
+``http.cookiejar.CookieJar`` shared across every per-request client rebuild
+for the life of the agent.
+
+Opt-in per provider via ``providers.<name>.cookie_jar: true`` in config.yaml
+(resolved in ``hermes_cli.config_providers.get_custom_provider_cookie_jar``
+and threaded through ``create_openai_client``).
+"""
+
+from __future__ import annotations
+
+import httpx
+import threading
+from http.cookiejar import CookieJar
+from typing import Any, Optional
+
+
+class SharedCookieTransport(httpx.BaseTransport):
+    """Transport that persists cookies in a shared jar.
+
+    Subclasses ``httpx.BaseTransport`` so it can be mounted directly.  Uses
+    ``httpx.Cookies`` for the RFC 6265 header math (``set_cookie_header`` /
+    ``extract_cookies``) over the caller-supplied jar, guarded by a lock
+    because per-request clients are rebuilt concurrently from multiple
+    threads.
+    """
+
+    def __init__(
+        self,
+        jar: CookieJar,
+        *,
+        verify: Any = True,
+        limits: Any = None,
+    ) -> None:
+        self._jar = jar
+        self._cookies = httpx.Cookies()
+        # httpx.Cookies wraps its own jar; swap in the shared one so every
+        # transport instance (and therefore every rebuilt client) reads and
+        # writes the SAME underlying cookies.
+        self._cookies.jar = jar
+        self._lock = threading.Lock()
+        self._transport = httpx.HTTPTransport(
+            verify=verify,
+            limits=limits or httpx.Limits(max_connections=100),
+        )
+
+    def handle_request(self, request) -> Any:
+        with self._lock:
+            self._cookies.set_cookie_header(request)
+            response = self._transport.handle_request(request)
+            # httpx's extract_cookies needs ``response.request`` set (the raw
+            # transport does not do this — it happens later in Client.send).
+            response.request = request
+            self._cookies.extract_cookies(response)
+        return response
+
+
+class _SharedCookieTransportCompat(SharedCookieTransport):
+    """Back-compat alias shim: keep ``__getattr__`` forwarding so any SDK or
+    plugin code reaching through the mounted transport's attributes (close,
+    stream handling) resolves against the inner HTTPTransport."""
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._transport, name)
+
+
+# The public name used by build_shared_cookie_http_client / tests.
+SharedCookieTransport = _SharedCookieTransportCompat  # noqa: F811
+
+
+def build_shared_cookie_http_client(
+    *,
+    jar: CookieJar,
+    proxy: Optional[str] = None,
+    verify: Any = True,
+    limits: Any = None,
+    timeout: Any = None,
+) -> Any:
+    """Build a real ``httpx.Client`` whose transport persists cookies in *jar*.
+
+    The OpenAI SDK requires ``http_client`` to be an ``httpx.Client`` (it
+    checks attributes like ``.build_request``), so the shared-jar transport
+    is mounted here rather than handed to the SDK directly.  ``trust_env``
+    is disabled and the resolved proxy is passed explicitly — the same
+    env-only proxy policy as ``build_keepalive_http_client`` — because a
+    mounted transport owns the request pipeline and would otherwise ignore
+    client-level proxy settings.
+
+    Each client gets its OWN transport instance (fresh sockets, closed with
+    the client per the #10933 invariants) but the SAME cookie jar, which is
+    the whole point: connection pools are per-request, cookies are not.
+    """
+    limits = limits or httpx.Limits(max_connections=100)
+    mounts = {
+        "http://": _SharedCookieTransportCompat(
+            jar=jar, verify=verify, limits=limits,
+        ),
+        "https://": _SharedCookieTransportCompat(
+            jar=jar, verify=verify, limits=limits,
+        ),
+    }
+    return httpx.Client(
+        limits=limits,
+        timeout=timeout,
+        proxy=proxy,
+        mounts=mounts,
+        verify=verify,
+        trust_env=False,
+    )

--- a/agent/shared_cookie_transport.py
+++ b/agent/shared_cookie_transport.py
@@ -13,6 +13,12 @@ header from, and writes ``Set-Cookie`` responses into, a single
 ``http.cookiejar.CookieJar`` shared across every per-request client rebuild
 for the life of the agent.
 
+Concurrency: one lock must guard a jar across ALL clients that share it —
+per-transport locks are wrong because every rebuild mints fresh transports.
+The jar and its lock travel together in a :class:`SharedCookieJar`; callers
+that bypass the bundle (hand-rolled ``CookieJar``) get a per-call lock, which
+is only safe for single-client use.
+
 Opt-in per provider via ``providers.<name>.cookie_jar: true`` in config.yaml
 (resolved in ``hermes_cli.config_providers.get_custom_provider_cookie_jar``
 and threaded through ``create_openai_client``).
@@ -20,43 +26,64 @@ and threaded through ``create_openai_client``).
 
 from __future__ import annotations
 
-import httpx
+import asyncio
 import threading
 from http.cookiejar import CookieJar
 from typing import Any, Optional
 
+import httpx
 
-class SharedCookieTransport(httpx.BaseTransport):
-    """Transport that persists cookies in a shared jar.
 
-    Subclasses ``httpx.BaseTransport`` so it can be mounted directly.  Uses
-    ``httpx.Cookies`` for the RFC 6265 header math (``set_cookie_header`` /
-    ``extract_cookies``) over the caller-supplied jar, guarded by a lock
-    because per-request clients are rebuilt concurrently from multiple
-    threads.
+class SharedCookieJar:
+    """A ``CookieJar`` bundled with the lock that guards it process-wide.
+
+    The bundle is the concurrency unit: every client sharing a jar MUST share
+    its lock.  Created alongside the jar in the config registry so all
+    per-request client rebuilds lock against the same primitive.
     """
+
+    __slots__ = ("jar", "lock")
+
+    def __init__(self) -> None:
+        self.jar = CookieJar()
+        self.lock = threading.Lock()
+
+    @classmethod
+    def _from(cls, jar: CookieJar, lock: Optional[threading.Lock] = None) -> "SharedCookieJar":
+        """Wrap a caller-supplied jar (e.g. hand-rolled ``CookieJar`` in tests).
+
+        ``lock=None`` mints a fresh lock — correct only when a single client
+        uses the jar; production callers pass the registry's bundle.
+        """
+        bundle = cls.__new__(cls)
+        bundle.jar = jar
+        bundle.lock = lock if lock is not None else threading.Lock()
+        return bundle
+
+
+class _SyncCookieTransport(httpx.BaseTransport):
+    """Sync transport that persists cookies in a shared jar (with its lock)."""
 
     def __init__(
         self,
-        jar: CookieJar,
+        bundle: SharedCookieJar,
         *,
         verify: Any = True,
         limits: Any = None,
     ) -> None:
-        self._jar = jar
+        self._bundle = bundle
         self._cookies = httpx.Cookies()
         # httpx.Cookies wraps its own jar; swap in the shared one so every
         # transport instance (and therefore every rebuilt client) reads and
         # writes the SAME underlying cookies.
-        self._cookies.jar = jar
-        self._lock = threading.Lock()
+        self._cookies.jar = bundle.jar
         self._transport = httpx.HTTPTransport(
             verify=verify,
             limits=limits or httpx.Limits(max_connections=100),
         )
 
     def handle_request(self, request) -> Any:
-        with self._lock:
+        with self._bundle.lock:
             self._cookies.set_cookie_header(request)
             response = self._transport.handle_request(request)
             # httpx's extract_cookies needs ``response.request`` set (the raw
@@ -65,31 +92,62 @@ class SharedCookieTransport(httpx.BaseTransport):
             self._cookies.extract_cookies(response)
         return response
 
-
-class _SharedCookieTransportCompat(SharedCookieTransport):
-    """Back-compat alias shim: keep ``__getattr__`` forwarding so any SDK or
-    plugin code reaching through the mounted transport's attributes (close,
-    stream handling) resolves against the inner HTTPTransport."""
-
     def __getattr__(self, name: str) -> Any:
+        # close(), stream handling, and any other httpx.Client-level API the
+        # SDK expects from its http_client's transport chain.
         return getattr(self._transport, name)
 
 
-# The public name used by build_shared_cookie_http_client / tests.
-SharedCookieTransport = _SharedCookieTransportCompat  # noqa: F811
+class _AsyncCookieTransport(httpx.AsyncBaseTransport):
+    """Async twin of :class:`_SyncCookieTransport`.
+
+    Uses an ``asyncio.Lock`` bound to the running loop (async clients are
+    loop-bound per #2681, so per-client-loop locking is correct here); the
+    jar itself remains guarded against sync readers by ``bundle.lock``.
+    """
+
+    def __init__(
+        self,
+        bundle: "SharedCookieJar",
+        *,
+        verify: Any = True,
+        limits: Any = None,
+    ) -> None:
+        self._bundle = bundle
+        self._cookies = httpx.Cookies()
+        self._cookies.jar = bundle.jar
+        self._alock = asyncio.Lock()
+        self._transport = httpx.AsyncHTTPTransport(
+            verify=verify,
+            limits=limits or httpx.Limits(max_connections=100),
+        )
+
+    async def handle_async_request(self, request) -> Any:
+        async with self._alock:
+            self._cookies.set_cookie_header(request)
+            response = await self._transport.handle_async_request(request)
+            response.request = request
+            self._cookies.extract_cookies(response)
+        return response
+
+
+# Back-compat alias: the pre-review name pointed at the sync transport.
+SharedCookieTransport = _SyncCookieTransport
 
 
 def build_shared_cookie_http_client(
     *,
-    jar: CookieJar,
+    jar: Any,
+    lock: Optional[threading.Lock] = None,
+    async_mode: bool = False,
     proxy: Optional[str] = None,
     verify: Any = True,
     limits: Any = None,
     timeout: Any = None,
 ) -> Any:
-    """Build a real ``httpx.Client`` whose transport persists cookies in *jar*.
+    """Build an ``httpx.Client``/``AsyncClient`` persisting cookies in *jar*.
 
-    The OpenAI SDK requires ``http_client`` to be an ``httpx.Client`` (it
+    The OpenAI SDK requires ``http_client`` to be an ``httpx`` client (it
     checks attributes like ``.build_request``), so the shared-jar transport
     is mounted here rather than handed to the SDK directly.  ``trust_env``
     is disabled and the resolved proxy is passed explicitly — the same
@@ -97,18 +155,37 @@ def build_shared_cookie_http_client(
     mounted transport owns the request pipeline and would otherwise ignore
     client-level proxy settings.
 
+    ``jar`` may be a plain ``CookieJar`` (lock defaults to a per-call lock —
+    only safe for single-client use) or a :class:`SharedCookieJar` whose
+    lock is shared across every client rebuild.  ``async_mode=True`` returns
+    an ``httpx.AsyncClient`` with the async transport twin.
+
     Each client gets its OWN transport instance (fresh sockets, closed with
     the client per the #10933 invariants) but the SAME cookie jar, which is
     the whole point: connection pools are per-request, cookies are not.
     """
+    bundle = jar if isinstance(jar, SharedCookieJar) else SharedCookieJar._from(jar, lock)
     limits = limits or httpx.Limits(max_connections=100)
+    if async_mode:
+        mounts = {
+            f"{scheme}://": _AsyncCookieTransport(
+                bundle, verify=verify, limits=limits,
+            )
+            for scheme in ("http", "https")
+        }
+        return httpx.AsyncClient(
+            limits=limits,
+            timeout=timeout,
+            proxy=proxy,
+            mounts=mounts,
+            verify=verify,
+            trust_env=False,
+        )
     mounts = {
-        "http://": _SharedCookieTransportCompat(
-            jar=jar, verify=verify, limits=limits,
-        ),
-        "https://": _SharedCookieTransportCompat(
-            jar=jar, verify=verify, limits=limits,
-        ),
+        f"{scheme}://": _SyncCookieTransport(
+            bundle, verify=verify, limits=limits,
+        )
+        for scheme in ("http", "https")
     }
     return httpx.Client(
         limits=limits,

--- a/hermes_cli/config_providers.py
+++ b/hermes_cli/config_providers.py
@@ -8,6 +8,8 @@ so tests patching that module still intercept the call.
 
 import logging
 import re
+import threading
+from http.cookiejar import CookieJar
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 from urllib.parse import urlparse
 
@@ -117,7 +119,8 @@ _KNOWN_PROVIDER_KEYS = {
     "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env", "key_cmd",
     "api_mode", "transport", "model", "default_model", "models", "models_discovered",
     "context_length", "rate_limit_delay", "request_timeout_seconds", "stale_timeout_seconds",
-    "discover_models", "extra_body", "extra_headers", "capabilities", "ssl_ca_cert", "ssl_verify"}
+    "discover_models", "extra_body", "extra_headers", "capabilities", "ssl_ca_cert", "ssl_verify",
+    "cookie_jar"}
 
 
 def _pick_provider_base_url(entry: Dict[str, Any], provider_key: str) -> str:
@@ -271,6 +274,12 @@ def _normalize_custom_provider_entry(
     elif isinstance(ssl_verify, str) and ssl_verify.strip():
         normalized["ssl_verify"] = ssl_verify.strip()
 
+    # Opt-in cookie sticky routing: persists LB Set-Cookie (e.g. nginx
+    # ``route=``) in a shared jar across per-request client rebuilds.
+    cookie_jar = entry.get("cookie_jar")
+    if isinstance(cookie_jar, bool):
+        normalized["cookie_jar"] = cookie_jar
+
     return normalized
 
 
@@ -285,7 +294,7 @@ def _custom_provider_entry_to_provider_config(
     for field in (
         "name", "api_key", "key_env", "key_cmd", "models", "models_discovered", "context_length",
         "rate_limit_delay", "discover_models", "extra_body", "extra_headers",
-        "ssl_ca_cert", "ssl_verify"):
+        "ssl_ca_cert", "ssl_verify", "cookie_jar"):
         if field in normalized:
             provider_entry[field] = normalized[field]
     if "model" in normalized:
@@ -437,6 +446,53 @@ def apply_custom_provider_tls_to_client_kwargs(
         client_kwargs["ssl_ca_cert"] = tls["ssl_ca_cert"]
     if "ssl_verify" in tls:
         client_kwargs["ssl_verify"] = tls["ssl_verify"]
+
+
+# Process-wide shared cookie jars for providers with ``cookie_jar: true`` — keyed by normalized
+# route. One jar per endpoint, created lazily and reused across every client rebuild so LB
+# sticky cookies (nginx ``route=``, Cloudflare ``__cf_bm``) survive per-request client churn.
+_SHARED_COOKIE_JARS: Dict[str, "CookieJar"] = {}
+_SHARED_COOKIE_JARS_LOCK = threading.Lock()
+
+
+def get_custom_provider_cookie_jar(
+    base_url: str,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+    config: Optional[Dict[str, Any]] = None) -> Optional["CookieJar"]:
+    """Shared ``CookieJar`` for a route-matching entry with ``cookie_jar: true``.
+
+    The SAME jar instance is returned on every call for a given endpoint — that identity is
+    the whole mechanism: per-request clients are rebuilt constantly, the jar must not be.
+    Returns ``None`` when no matching entry opts in.
+    """
+    from http.cookiejar import CookieJar  # noqa: F401 — re-exported for typing
+
+    for entry in _entries_for_route(base_url, custom_providers, config):
+        if not entry.get("cookie_jar"):
+            return None
+        route = normalize_route_base_url(base_url)
+        with _SHARED_COOKIE_JARS_LOCK:
+            jar = _SHARED_COOKIE_JARS.get(route)
+            if jar is None:
+                jar = CookieJar()
+                _SHARED_COOKIE_JARS[route] = jar
+            return jar
+    return None
+
+
+def apply_custom_provider_cookie_jar(
+    agent: Any,
+    base_url: str,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+    config: Optional[Dict[str, Any]] = None) -> None:
+    """Set ``agent._shared_cookie_jar`` when the provider opts into cookie sticky.
+
+    Called from agent init so every subsequent ``_create_openai_client`` call threads the
+    same jar into its per-request ``httpx.Client`` via ``SharedCookieTransport``.  Clears
+    the attribute when the provider does not opt in (e.g. after a model/provider switch).
+    """
+    agent._shared_cookie_jar = get_custom_provider_cookie_jar(
+        base_url, custom_providers, config)
 
 
 def normalize_extra_headers(extra_headers: Any) -> Dict[str, str]:

--- a/hermes_cli/config_providers.py
+++ b/hermes_cli/config_providers.py
@@ -9,10 +9,10 @@ so tests patching that module still intercept the call.
 import logging
 import re
 import threading
-from http.cookiejar import CookieJar
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 from urllib.parse import urlparse
 
+from agent.shared_cookie_transport import SharedCookieJar
 from hermes_cli.route_identity import normalize_route_base_url
 
 # Log-record parity with the origin module.
@@ -448,35 +448,36 @@ def apply_custom_provider_tls_to_client_kwargs(
         client_kwargs["ssl_verify"] = tls["ssl_verify"]
 
 
-# Process-wide shared cookie jars for providers with ``cookie_jar: true`` — keyed by normalized
-# route. One jar per endpoint, created lazily and reused across every client rebuild so LB
-# sticky cookies (nginx ``route=``, Cloudflare ``__cf_bm``) survive per-request client churn.
-_SHARED_COOKIE_JARS: Dict[str, "CookieJar"] = {}
+# Process-wide shared cookie-jar bundles for providers with ``cookie_jar: true`` — keyed by
+# normalized route.  A bundle (jar + its lock) travels together: every client sharing a jar
+# must share its lock, since per-request client rebuilds are concurrent.  The jar survives
+# client churn; the lock is the one process-wide guard over it.
+_SHARED_COOKIE_JARS: Dict[str, "SharedCookieJar"] = {}
 _SHARED_COOKIE_JARS_LOCK = threading.Lock()
 
 
 def get_custom_provider_cookie_jar(
     base_url: str,
     custom_providers: Optional[List[Dict[str, Any]]] = None,
-    config: Optional[Dict[str, Any]] = None) -> Optional["CookieJar"]:
-    """Shared ``CookieJar`` for a route-matching entry with ``cookie_jar: true``.
+    config: Optional[Dict[str, Any]] = None) -> Optional["SharedCookieJar"]:
+    """Shared ``CookieJar`` bundle for a route-matching entry with ``cookie_jar: true``.
 
-    The SAME jar instance is returned on every call for a given endpoint — that identity is
-    the whole mechanism: per-request clients are rebuilt constantly, the jar must not be.
-    Returns ``None`` when no matching entry opts in.
+    The SAME bundle (jar + lock) instance is returned on every call for a given endpoint —
+    that identity is the whole mechanism: per-request clients are rebuilt constantly, the
+    jar and the lock guarding it must not be.  Returns ``None`` when no matching entry opts in.
     """
-    from http.cookiejar import CookieJar  # noqa: F401 — re-exported for typing
+    from agent.shared_cookie_transport import SharedCookieJar
 
     for entry in _entries_for_route(base_url, custom_providers, config):
         if not entry.get("cookie_jar"):
             return None
         route = normalize_route_base_url(base_url)
         with _SHARED_COOKIE_JARS_LOCK:
-            jar = _SHARED_COOKIE_JARS.get(route)
-            if jar is None:
-                jar = CookieJar()
-                _SHARED_COOKIE_JARS[route] = jar
-            return jar
+            bundle = _SHARED_COOKIE_JARS.get(route)
+            if bundle is None:
+                bundle = SharedCookieJar()
+                _SHARED_COOKIE_JARS[route] = bundle
+            return bundle
     return None
 
 

--- a/tests/run_agent/test_opencode_free_client_headers.py
+++ b/tests/run_agent/test_opencode_free_client_headers.py
@@ -28,7 +28,7 @@ class _FakeAgent:
     def _client_log_context(self):
         return {}
 
-    def _build_keepalive_http_client(self, base_url, verify=True):
+    def _build_keepalive_http_client(self, base_url, verify=True, cookie_jar=None):
         return None
 
 

--- a/tests/run_agent/test_shared_cookie_sticky.py
+++ b/tests/run_agent/test_shared_cookie_sticky.py
@@ -144,3 +144,76 @@ class TestSharedCookieTransportReplay:
 
         # Second request went through a jar that never saw the Set-Cookie.
         assert _StickyHandler.received_cookies[1] is None
+
+
+# ---------------------------------------------------------------------------
+# Concurrency (PR review feedback): one lock per JAR, not per transport
+# ---------------------------------------------------------------------------
+
+class TestSharedJarLocking:
+    def test_bundles_from_registry_share_one_lock(self):
+        from agent.shared_cookie_transport import SharedCookieJar
+        from hermes_cli.config_providers import _SHARED_COOKIE_JARS
+
+        url = "https://lockcheck.example.com/v1"
+        entries = [_normalize_custom_provider_entry(_entry(url, cookie_jar=True))]
+        b1 = get_custom_provider_cookie_jar(url, entries)
+        b2 = get_custom_provider_cookie_jar(url, entries)
+        assert isinstance(b1, SharedCookieJar)
+        assert b1 is b2 and b1.lock is b2.lock
+        # Cleanup so route registries stay isolated between tests.
+        route = url.rstrip("/").lower()
+        _SHARED_COOKIE_JARS.pop(route, None)
+
+    def test_plain_jar_wraps_into_bundle_with_lock(self):
+        from agent.shared_cookie_transport import SharedCookieJar
+
+        jar = CookieJar()
+        bundle1 = SharedCookieJar._from(jar)
+        bundle2 = SharedCookieJar._from(jar)
+        # Same jar object, independently minted locks (single-client case).
+        assert bundle1.jar is jar and bundle2.jar is jar
+        assert bundle1.lock is not bundle2.lock
+
+    def test_concurrent_transports_share_lock(self, sticky_server):
+        """Two clients built from the same registry bundle serialize on one lock."""
+        import httpx
+        import openai
+        from agent.shared_cookie_transport import SharedCookieJar
+
+        bundle = SharedCookieJar()
+        lock_checks = []
+
+        def make_client():
+            client = build_shared_cookie_http_client(
+                jar=bundle, limits=None, timeout=5.0)
+            return openai.OpenAI(
+                api_key="test", base_url=sticky_server, http_client=client,
+            ), client
+
+        oc1, raw1 = make_client()
+        oc2, raw2 = make_client()
+        # Both clients' https transports must share the bundle's lock.
+        for raw in (raw1, raw2):
+            request = raw.build_request("POST", sticky_server + "/chat/completions")
+            transport = raw._transport_for_url(request.url)
+            lock_checks.append(getattr(transport, "_bundle", None) is bundle)
+        oc1.post("/chat/completions", body={}, cast_to=object)
+        oc2.post("/chat/completions", body={}, cast_to=object)
+        oc1.close()
+        oc2.close()
+        assert all(lock_checks), f"transports not sharing the bundle lock: {lock_checks}"
+
+    def test_async_mode_returns_async_client(self):
+        import httpx
+
+        client = build_shared_cookie_http_client(
+            jar=CookieJar(), async_mode=True, limits=None, timeout=5.0)
+        assert isinstance(client, httpx.AsyncClient)
+
+    def test_sync_mode_returns_sync_client(self):
+        import httpx
+
+        client = build_shared_cookie_http_client(
+            jar=CookieJar(), limits=None, timeout=5.0)
+        assert isinstance(client, httpx.Client)

--- a/tests/run_agent/test_shared_cookie_sticky.py
+++ b/tests/run_agent/test_shared_cookie_sticky.py
@@ -1,0 +1,146 @@
+"""Unit + live-server tests for shared-cookie-jar sticky routing
+(``providers.<name>.cookie_jar: true``).
+
+Hermes builds a fresh httpx/OpenAI client per request (see
+``AIAgent._create_request_openai_client`` and the #10933 closed-transport
+invariants). Behind cookie-sticky load balancers (nginx ``sticky cookie``,
+Cloudflare in front) each rebuild therefore lands as a brand-new LB session —
+prompt-cache locality dies and ``cached_tokens`` collapses. These tests pin:
+
+  * config resolution — ``cookie_jar`` opt-in matches by route, jar identity
+    is stable across calls, no opt-in → no jar
+  * transport behavior — Set-Cookie extraction on request 1 and Cookie
+    replay on request 2 across SEPARATE client builds (the LB invariant),
+    plus jar isolation between independent agents
+"""
+import http.server
+import threading
+from http.cookiejar import CookieJar
+
+import pytest
+
+from agent.shared_cookie_transport import build_shared_cookie_http_client
+from hermes_cli.config_providers import (
+    _normalize_custom_provider_entry,
+    get_custom_provider_cookie_jar,
+)
+
+
+# ---------------------------------------------------------------------------
+# Config resolution
+# ---------------------------------------------------------------------------
+
+def _entry(base_url, **extra):
+    entry = {"name": "test", "base_url": base_url, "key_env": "X_TEST_KEY"}
+    entry.update(extra)
+    return entry
+
+
+class TestGetCustomProviderCookieJar:
+    def test_opt_in_returns_jar(self):
+        url = "https://example.com/v1"
+        entries = [_normalize_custom_provider_entry(_entry(url, cookie_jar=True))]
+        assert get_custom_provider_cookie_jar(url, entries) is not None
+
+    def test_no_opt_in_returns_none(self):
+        url = "https://example.com/v1"
+        entries = [_normalize_custom_provider_entry(_entry(url))]
+        assert get_custom_provider_cookie_jar(url, entries) is None
+
+    def test_jar_is_shared_across_calls(self):
+        url = "https://shared.example.com/v1"
+        entries = [_normalize_custom_provider_entry(_entry(url, cookie_jar=True))]
+        jar1 = get_custom_provider_cookie_jar(url, entries)
+        jar2 = get_custom_provider_cookie_jar(url, entries)
+        assert jar1 is not None and jar1 is jar2
+
+    def test_no_match_returns_none(self):
+        entries = [_normalize_custom_provider_entry(
+            _entry("https://other.com/v1", cookie_jar=True))]
+        assert get_custom_provider_cookie_jar("https://nowhere.com/v1", entries) is None
+
+    def test_trailing_slash_insensitive(self):
+        entries = [_normalize_custom_provider_entry(
+            _entry("https://slashy.com/v1/", cookie_jar=True))]
+        assert get_custom_provider_cookie_jar("https://slashy.com/v1", entries) is not None
+
+
+# ---------------------------------------------------------------------------
+# Transport behavior
+# ---------------------------------------------------------------------------
+
+class _StickyHandler(http.server.BaseHTTPRequestHandler):
+    """Issues ``route=sticky42`` on the first cookieless request; logs Cookie headers."""
+
+    received_cookies = []
+
+    def do_POST(self):
+        _StickyHandler.received_cookies.append(self.headers.get("Cookie"))
+        body = b'{"ok": true}'
+        self.send_response(200)
+        if not self.headers.get("Cookie"):
+            self.send_header("Set-Cookie", "route=sticky42; Path=/")
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *a):
+        pass
+
+
+@pytest.fixture()
+def sticky_server():
+    _StickyHandler.received_cookies = []
+    server = http.server.HTTPServer(("127.0.0.1", 0), _StickyHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{server.server_address[1]}/v1"
+    server.shutdown()
+
+
+class TestSharedCookieTransportReplay:
+    def test_cookie_replayed_across_client_rebuilds(self, sticky_server):
+        import openai
+
+        jar = CookieJar()
+
+        def make_client():
+            client = build_shared_cookie_http_client(jar=jar, limits=None, timeout=5.0)
+            return openai.OpenAI(
+                api_key="test", base_url=sticky_server, http_client=client,
+            )
+
+        oc1 = make_client()
+        oc1.post("/chat/completions", body={}, cast_to=object)
+        oc1.close()
+
+        # Rebuild: fresh httpx.Client (like _create_request_openai_client),
+        # same shared jar.
+        oc2 = make_client()
+        oc2.post("/chat/completions", body={}, cast_to=object)
+        oc2.close()
+
+        assert _StickyHandler.received_cookies[0] is None
+        assert "route=sticky42" in (_StickyHandler.received_cookies[1] or "")
+
+    def test_independent_jars_do_not_leak(self, sticky_server):
+        import openai
+
+        jar_a, jar_b = CookieJar(), CookieJar()
+
+        def make_client(jar):
+            client = build_shared_cookie_http_client(jar=jar, limits=None, timeout=5.0)
+            return openai.OpenAI(
+                api_key="test", base_url=sticky_server, http_client=client,
+            )
+
+        oc1 = make_client(jar_a)
+        oc1.post("/chat/completions", body={}, cast_to=object)
+        oc1.close()
+        oc2 = make_client(jar_b)
+        oc2.post("/chat/completions", body={}, cast_to=object)
+        oc2.close()
+
+        # Second request went through a jar that never saw the Set-Cookie.
+        assert _StickyHandler.received_cookies[1] is None


### PR DESCRIPTION
## Summary

Custom OpenAI-compatible providers behind cookie-sticky load balancers (nginx `sticky cookie`, or Cloudflare in front of one) get a **fresh route assignment on every Hermes request**. `_create_request_openai_client` builds a fresh httpx client per turn (per the #10933 closed-transport invariants), and httpx's cookie jar lives on the *client* — so the LB's `Set-Cookie: route=...` is discarded after every turn and the next request routes to a random upstream pod.

Consequence: provider-side prompt-cache locality collapses on multi-turn conversations (`cached_tokens` stays ~0, every turn pays full prefill). This is the custom-provider analog of #70820 / #71782, which fixed the same symptom for OpenRouter's API-level `session_id` sticky routing — but for transport-level cookie affinity, where a cookie jar is the only fix.

This PR adds `providers.<name>.cookie_jar: true`:

```yaml
providers:
  my-vllm:
    api: https://cluster.example.com/vllm/models/my-model/v1
    key_env: MY_TOKEN
    cookie_jar: true   # persist LB Set-Cookie across turns
```

## How it works

- `agent/shared_cookie_transport.py` (new): `SharedCookieTransport` wraps `httpx.HTTPTransport` and does cookie persistence at the **transport layer** using `httpx.Cookies.set_cookie_header` / `extract_cookies` over a single shared `http.cookiejar.CookieJar` (lock-guarded — clients rebuild concurrently).
- `build_keepalive_http_client` accepts the jar and mounts `SharedCookieTransport` for both `http://` and `https://`, bypassing the shared-transport pool for these clients (a sticky route must ride this process's jar-coherent sockets).
- `get_custom_provider_cookie_jar` / `apply_custom_provider_cookie_jar` in `hermes_cli/config_providers.py` resolve the jar per provider route (route identity reuses `normalize_route_base_url`, same matching as TLS settings) and stash it on `agent._shared_cookie_jar` at init.
- `create_openai_client` threads `agent._shared_cookie_jar` into every build (main OpenAI path + Gemini native path).

**Invariants preserved:** connection pools stay per-request and close with their client (the #10933 closed-transport tests still pass unchanged); only the cookie jar persists. Opt-in per provider — zero behavior change unless `cookie_jar: true` is set.

## Test plan

- New `tests/run_agent/test_shared_cookie_sticky.py` (7 tests): config opt-in / route matching (trailing-slash, no-match) / jar identity across calls; live-server tests asserting the `Cookie` header is captured on request 1 and **replayed on request 2 through a completely separate client build**; jar isolation between independent agents.
- Existing regression suites pass: `test_create_openai_client_reuse`, `test_create_openai_client_disables_sdk_retries`, `test_create_openai_client_ssl_verify`, custom-provider TLS/extra-headers/context-length (42 tests total green in the touched area).
- E2E against a live cookie-issuing endpoint (vLLM behind Cloudflare→nginx sticky): `cached_tokens` goes from ~0 to **99–100% on consecutive turns** after enabling `cookie_jar: true`.