### PR TITLE
fix(kanban): surface skipped_locked, respawn_guarded and rate_limited in dispatch output

### DIFF
--- a/hermes_cli/kanban_ops.py
+++ b/hermes_cli/kanban_ops.py
@@ -105,7 +105,17 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
                 for (tid, who, current) in res.skipped_per_profile_capped
             ],
             "auto_assigned_default": res.auto_assigned_default,
+            "skipped_locked": res.skipped_locked,
+            "respawn_guarded": [
+                {"task_id": tid, "reason": reason} for (tid, reason) in res.respawn_guarded
+            ],
+            "rate_limited": res.rate_limited,
         }, ascii=True)
+        return 0
+    # A lock-loss tick did no work and wrote nothing: every counter below would
+    # be a meaningless 0, indistinguishable from "board idle". Say so and stop.
+    if res.skipped_locked:
+        print("Skipped: another dispatcher held the board lock; no work attempted.")
         return 0
     print(f"Reclaimed:    {res.reclaimed}")
     for label, items in (
@@ -136,6 +146,10 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             f"Skipped (non-spawnable assignee — terminal lane, OK): "
             f"{', '.join(res.skipped_nonspawnable)}"
         )
+    for tid, reason in res.respawn_guarded:
+        print(f"Respawn-guarded ({reason}): {tid}")
+    if res.rate_limited:
+        print(f"Rate-limited (released to ready): {', '.join(res.rate_limited)}")
     return 0
 
 


### PR DESCRIPTION
Fixes #108512.

## Problem

`DispatchResult` carries `skipped_locked`, `respawn_guarded` and `rate_limited`, but `hermes kanban dispatch` dropped all three from **both** the human renderer and `--json`.

A tick that lost the non-blocking board lock in `_dispatch_tick_lock` therefore printed `Spawned: 0` with every counter at zero, wrote no event, and was byte-identical to "board idle, nothing to do".

This is easy to hit in the normal supported setup: the embedded gateway dispatcher ticks every 60s, so a manual `hermes kanban dispatch` loses the lock roughly at random. It gets actively misleading because `--dry-run` reports the same task as spawnable, since the dry-run path records the spawn *before* the claim while the real path returns early on lock loss. The two disagree with nothing explaining why.

## Change

Report the lock loss and return early. Every remaining counter is a meaningless zero for a tick that did no work and wrote nothing, so printing them is worse than not printing them.

Also emit `respawn_guarded` reasons and `rate_limited` ids, which were likewise collected and never surfaced. `respawn_guarded` at least appends an event and is recoverable from `tail`; `skipped_locked` left no trace anywhere.

14 lines, renderer only. No behaviour change to dispatch itself.

## Verification

Reproduced by holding an exclusive `flock` on `<root>/kanban.db.dispatch.lock` in a second process and running the CLI.

| | before | after |
|---|---|---|
| lock held, human | `Spawned: 0` plus six zero counters | `Skipped: another dispatcher held the board lock; no work attempted.` |
| lock held, `--json` | key absent | `"skipped_locked": true` |
| uncontended | `Spawned: 0` | `Deferred (<profile> at per-profile cap, 1 running)` |

The third row is the practical win: the uncontended path now shows a real reason where only a bare `Spawned: 0` appeared before.

`tests/hermes_cli/test_kanban_dispatch_lock.py` passes.

## Note on unrelated test failures

While verifying I hit three failures that are **pre-existing on unmodified `main`** and not caused by this change:

```
tests/hermes_cli/test_kanban_dispatch_tick_hook.py::test_active_tick_fires_hook_with_outcome_ok
tests/hermes_cli/test_kanban_dispatch_tick_hook.py::test_tick_hook_fires_after_dispatch_lock_released
tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py::test_dispatch_spawn_fires_worker_spawned
```

They fail only when run after `test_kanban_cli_dispatch_passthrough.py`, and pass in isolation. Confirmed by running the identical selections against clean `main` with this patch stashed. Reported separately rather than touched here.
