### PR TITLE
fix(goals): classify automatic continuation turns

### DIFF
--- a/tests/tui_gateway/test_goal_command.py
+++ b/tests/tui_gateway/test_goal_command.py
@@ -266,10 +266,14 @@ def test_active_goal_retries_once_without_judging_failed_turn(
     mgr.set("finish the current task")
     continuation = mgr.next_continuation_prompt()
     seen_prompts = []
+    seen_display_kinds = []
     results = iter([_compression_failure(), {"final_response": "recovered work"}])
 
-    def run_conversation(message, **_kwargs):
+    def run_conversation(
+        message, *, persist_user_display_kind=None, **kwargs
+    ):
         seen_prompts.append(message)
+        seen_display_kinds.append(persist_user_display_kind)
         return next(results)
 
     judged = []
@@ -289,6 +293,7 @@ def test_active_goal_retries_once_without_judging_failed_turn(
     server._run_prompt_submit("rid", "sid", session, "initial work")
 
     assert seen_prompts == ["initial work", continuation]
+    assert seen_display_kinds == [None, "auto_continue"]
     assert judged == ["recovered work"]
     assert GoalManager(session_key).state.turns_used == 0
     assert server._GOAL_COMPRESSION_RECOVERY_ATTEMPTS not in session

--- a/tui_gateway/prompt_turn.py
+++ b/tui_gateway/prompt_turn.py
@@ -353,12 +353,12 @@ def _after_complete_turn(sid: str, session: dict, st: _TurnRun, raw: Any) -> Non
 
 
 def _dispatch_followup_turn(rid, sid: str, session: dict, prompt: Any, what: str, *,
-                            on_done=None, on_error=None) -> None:
+                            display_kind: str | None = None, on_done=None, on_error=None) -> None:
     """Chain one follow-up turn (caller set ``running``); on failure run ``on_error``, log,
     release ``running``."""
     try:
         _emit("message.start", sid)
-        _run_prompt_submit(rid, sid, session, prompt)
+        _run_prompt_submit(rid, sid, session, prompt, display_kind=display_kind)
         if on_done is not None:
             on_done()
     except Exception as exc:
@@ -386,7 +386,9 @@ def _run_post_turn_followups(
             if session.get("running"):
                 return  # user already sent something — their turn wins
             session["running"] = True
-        _dispatch_followup_turn(rid, sid, session, goal_followup, "goal continuation dispatch")
+        _dispatch_followup_turn(
+            rid, sid, session, goal_followup, "goal continuation dispatch",
+            display_kind="auto_continue")
     # Safety net for completion events that arrived mid-turn.  Ownership is positive-proof
     # and compression-chain aware (same fail-closed gate as the poller): session B must
     # not consume session A's event.  Unclaimable events are requeued for the poller.


### PR DESCRIPTION
## Summary
- persist automatic standing-goal follow-ups with `display_kind: auto_continue`
- propagate display classification through the follow-up dispatch path
- add regression coverage for automatic goal retries

## Root cause
Standing-goal retries were synthetic turns but were persisted as ordinary user messages. Clients hydrating session history could not distinguish them from real user input.

## Validation
- `scripts/run_tests.sh tests/tui_gateway/test_goal_command.py`
- `scripts/run_tests.sh tests/tui_gateway/test_auto_continue.py tests/tui_gateway/test_session_history.py tests/tui_gateway/test_goal_command.py` (34 passed)

## Compatibility
Clients that understand `display_kind` render future continuations compactly. Legacy clients continue receiving the same content.