### PR TITLE
feat(desktop): per-bot session browser from the Bots roster context menu

### DIFF
--- a/apps/desktop/src/AGENTS.md
+++ b/apps/desktop/src/AGENTS.md
@@ -70,9 +70,11 @@ Sessions sidebar, so the bot row is the ONLY door — "newest visible session wi
 relationship off behind a row that previews one session and opens another. Side-chats ("New chat
 with this agent") are not plumbing-titled, stay visible in the sidebar, and are never the row's target.
 
-Reviewer corollaries: no per-bot session browser (removed in #90732; don't add it back). Reject any
-stored session-id pointer as canonical identity — including "as a fallback tier" or "for
-verification". Reject anything consulting recency/visibility/"where the user left off" for the row's
+Reviewer corollaries: the per-bot **session pointer** design is gone (removed in #90732) and must not
+come back — reject any stored session-id as canonical identity, including "as a fallback tier" or
+"for verification". The read-only session **browser** (`bot-sessions.ts`, context menu → "Show
+sessions") is different in kind and allowed: it lists `session.list` rows for the bot's profile,
+persists nothing, and never decides the row's click target. Reject anything consulting recency/visibility/"where the user left off" for the row's
 target; such reports are about side-chats and the fix belongs in the Sessions sidebar hide-sweep.
 The gateway reports the registry row as `canonical_session` on `profiles.list` (resolved server-side
 by title); roster preview, activity signals, and the `/new`→`/compact` guard all read it, so preview

--- a/apps/desktop/src/plugins/hermes-bots/bot-row.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row.tsx
@@ -31,6 +31,8 @@ import {
 
 import { avatarColor, botAppearance, BotFace } from './avatar'
 import { isBackfilledFacePng } from './avatar-image'
+import { $botSessionsOpen, isBotSessionsOpen, toggleBotSessions } from './bot-sessions'
+import { BotSessionsPanel } from './bot-sessions-panel'
 import {
   $botChatFocused,
   $focusedBotOwner,
@@ -106,6 +108,7 @@ export function BotRow({ bot, onDelete, onEdit, onGroup, onNewSection, showHandl
   const botChatFocused = useValue($botChatFocused)
   const activeGroup = useValue($groupChatWorkspace)
   const allMeta = useValue($botMeta)
+  const sessionsOpen = isBotSessionsOpen(bot, useValue($botSessionsOpen))
   const meta = botRosterMeta(bot, allMeta)
   const hidden = isBotHidden(bot, allMeta)
   const pinned = isBotPinned(bot, allMeta)
@@ -305,143 +308,151 @@ export function BotRow({ bot, onDelete, onEdit, onGroup, onNewSection, showHandl
     </RowButton>
   )
 
+  // The session browser renders as a sibling BELOW the row (not inside the
+  // menu trigger) so a click in the list is never a click on the bot row.
   return (
-    <ContextMenu>
-      <ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
-      <ContextMenuContent>
-        <ContextMenuItem onSelect={() => void openRosterBot(bot)}>{b.bot.openBotChat}</ContextMenuItem>
-        <ContextMenuSeparator />
-        <ContextMenuItem
-          onSelect={() => {
-            void ensureBotMetadata(bot)
-              .then(current => {
-                const pinned = Boolean(current.pinned)
-                void saveBotMeta(bot, {
-                  pinned: !pinned
-                })
-                host.notify({
-                  kind: 'info',
-                  message: `${displayName(bot, current)} ${pinned ? 'unpinned' : 'pinned to top'}`
-                })
-              })
-              .catch(error => host.notifyError?.(error, 'Could not load bot metadata'))
-          }}
-        >
-          {pinned ? 'Unpin' : 'Pin to top'}
-        </ContextMenuItem>
-        <ContextMenuItem
-          onSelect={() => {
-            void ensureBotMetadata(bot)
-              .then(current => {
-                const hidden = Boolean(current.hidden)
-                void saveBotMeta(bot, {
-                  hidden: !hidden
-                })
-
-                if (!hidden) {
-                  fallbackSelectionAfterHide(botSelectionKey(bot))
-                }
-
-                host.notify({
-                  kind: 'info',
-                  message: hidden
-                    ? `${displayName(bot, current)} is back in the roster`
-                    : `${displayName(bot, current)} hidden — use the eye button in the Bots header to see hidden bots`
-                })
-              })
-              .catch(error => host.notifyError?.(error, 'Could not load bot metadata'))
-          }}
-        >
-          {hidden ? 'Unhide' : 'Hide'}
-        </ContextMenuItem>
-        <ContextMenuSeparator />
-        <ContextMenuItem
-          onSelect={() =>
-            void ensureBotMetadata(bot)
-              .then(() => onEdit(bot))
-              .catch(error => host.notifyError?.(error, 'Could not load bot'))
-          }
-        >
-          {b.bot.editMenu}
-        </ContextMenuItem>
-        <ContextMenuItem
-          onSelect={() =>
-            void ensureBotMetadata(bot)
-              .then(() => onGroup(bot))
-              .catch(error => host.notifyError?.(error, 'Could not load bot groups'))
-          }
-        >
-          {groups.length ? `Groups: ${groups.join(', ')}…` : 'Manage groups…'}
-        </ContextMenuItem>
-        <ContextMenuItem
-          onSelect={() => {
-            host.notify({
-              kind: 'info',
-              message: `Duplicating ${displayName(bot, meta)}…`
-            })
-            duplicateBot(bot, $lastRoster.get())
-              .then(name => {
-                queryClient.invalidateQueries({
-                  queryKey: ROSTER_KEY
-                })
-                host.notify({
-                  kind: 'success',
-                  message: `Created ${name} — full copy of ${bot.name}`
-                })
-              })
-              .catch(err => host.notifyError(err, b.bot.duplicateFailed))
-          }}
-        >
-          {b.bot.duplicate}
-        </ContextMenuItem>
-        <ContextMenuSeparator />
-        <ContextMenuItem
-          onSelect={() => {
-            saveSelectedRosterBot(bot)
-            setBotsWorkspaceOwner(botWorkspaceOwnerKey(bot), bot)
-            newBotChat(bot)
-          }}
-        >
-          {b.bot.newChatWith}
-        </ContextMenuItem>
-        <ContextMenuSeparator />
-        {/* Filing. Membership is one field on the bot's meta (`sectionId`), so
-            this is a one-field write and no list anywhere has to be kept in
-            sync with it. */}
-        <ContextMenuSub>
-          <ContextMenuSubTrigger>{b.sections.moveTo}</ContextMenuSubTrigger>
-          <ContextMenuSubContent>
-            {sections.map(section => (
-              <ContextMenuItem
-                disabled={section.id === currentSectionId}
-                key={section.id}
-                onSelect={() => void moveBotsToSection([bot], section.id)}
-              >
-                <Codicon className="mr-1.5" name="folder" />
-                {section.name}
-              </ContextMenuItem>
-            ))}
-            {sections.length ? <ContextMenuSeparator /> : null}
-            <ContextMenuItem onSelect={() => onNewSection(bot)}>
-              <Codicon className="mr-1.5" name="new-folder" />
-              {b.sections.newSectionEllipsis}
-            </ContextMenuItem>
-            {currentSectionId ? (
-              <ContextMenuItem onSelect={() => void moveBotsToSection([bot], null)}>
-                <Codicon className="mr-1.5" name="inbox" />
-                {b.sections.removeFromSection}
-              </ContextMenuItem>
-            ) : null}
-          </ContextMenuSubContent>
-        </ContextMenuSub>
-        {isDefaultBot(bot) ? null : <ContextMenuSeparator />}
-        {isDefaultBot(bot) ? null : (
-          <ContextMenuItem onSelect={() => onDelete(bot)} variant="destructive">
-            {t.common.delete}
+    <>
+      <ContextMenu>
+        <ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuItem onSelect={() => void openRosterBot(bot)}>{b.bot.openBotChat}</ContextMenuItem>
+          <ContextMenuItem onSelect={() => toggleBotSessions(bot)}>
+            {sessionsOpen ? b.sessions.hideMenu : b.sessions.showMenu}
           </ContextMenuItem>
-        )}
-      </ContextMenuContent>
-    </ContextMenu>
+          <ContextMenuSeparator />
+          <ContextMenuItem
+            onSelect={() => {
+              void ensureBotMetadata(bot)
+                .then(current => {
+                  const pinned = Boolean(current.pinned)
+                  void saveBotMeta(bot, {
+                    pinned: !pinned
+                  })
+                  host.notify({
+                    kind: 'info',
+                    message: `${displayName(bot, current)} ${pinned ? 'unpinned' : 'pinned to top'}`
+                  })
+                })
+                .catch(error => host.notifyError?.(error, 'Could not load bot metadata'))
+            }}
+          >
+            {pinned ? 'Unpin' : 'Pin to top'}
+          </ContextMenuItem>
+          <ContextMenuItem
+            onSelect={() => {
+              void ensureBotMetadata(bot)
+                .then(current => {
+                  const hidden = Boolean(current.hidden)
+                  void saveBotMeta(bot, {
+                    hidden: !hidden
+                  })
+
+                  if (!hidden) {
+                    fallbackSelectionAfterHide(botSelectionKey(bot))
+                  }
+
+                  host.notify({
+                    kind: 'info',
+                    message: hidden
+                      ? `${displayName(bot, current)} is back in the roster`
+                      : `${displayName(bot, current)} hidden — use the eye button in the Bots header to see hidden bots`
+                  })
+                })
+                .catch(error => host.notifyError?.(error, 'Could not load bot metadata'))
+            }}
+          >
+            {hidden ? 'Unhide' : 'Hide'}
+          </ContextMenuItem>
+          <ContextMenuSeparator />
+          <ContextMenuItem
+            onSelect={() =>
+              void ensureBotMetadata(bot)
+                .then(() => onEdit(bot))
+                .catch(error => host.notifyError?.(error, 'Could not load bot'))
+            }
+          >
+            {b.bot.editMenu}
+          </ContextMenuItem>
+          <ContextMenuItem
+            onSelect={() =>
+              void ensureBotMetadata(bot)
+                .then(() => onGroup(bot))
+                .catch(error => host.notifyError?.(error, 'Could not load bot groups'))
+            }
+          >
+            {groups.length ? `Groups: ${groups.join(', ')}…` : 'Manage groups…'}
+          </ContextMenuItem>
+          <ContextMenuItem
+            onSelect={() => {
+              host.notify({
+                kind: 'info',
+                message: `Duplicating ${displayName(bot, meta)}…`
+              })
+              duplicateBot(bot, $lastRoster.get())
+                .then(name => {
+                  queryClient.invalidateQueries({
+                    queryKey: ROSTER_KEY
+                  })
+                  host.notify({
+                    kind: 'success',
+                    message: `Created ${name} — full copy of ${bot.name}`
+                  })
+                })
+                .catch(err => host.notifyError(err, b.bot.duplicateFailed))
+            }}
+          >
+            {b.bot.duplicate}
+          </ContextMenuItem>
+          <ContextMenuSeparator />
+          <ContextMenuItem
+            onSelect={() => {
+              saveSelectedRosterBot(bot)
+              setBotsWorkspaceOwner(botWorkspaceOwnerKey(bot), bot)
+              newBotChat(bot)
+            }}
+          >
+            {b.bot.newChatWith}
+          </ContextMenuItem>
+          <ContextMenuSeparator />
+          {/* Filing. Membership is one field on the bot's meta (`sectionId`), so
+              this is a one-field write and no list anywhere has to be kept in
+              sync with it. */}
+          <ContextMenuSub>
+            <ContextMenuSubTrigger>{b.sections.moveTo}</ContextMenuSubTrigger>
+            <ContextMenuSubContent>
+              {sections.map(section => (
+                <ContextMenuItem
+                  disabled={section.id === currentSectionId}
+                  key={section.id}
+                  onSelect={() => void moveBotsToSection([bot], section.id)}
+                >
+                  <Codicon className="mr-1.5" name="folder" />
+                  {section.name}
+                </ContextMenuItem>
+              ))}
+              {sections.length ? <ContextMenuSeparator /> : null}
+              <ContextMenuItem onSelect={() => onNewSection(bot)}>
+                <Codicon className="mr-1.5" name="new-folder" />
+                {b.sections.newSectionEllipsis}
+              </ContextMenuItem>
+              {currentSectionId ? (
+                <ContextMenuItem onSelect={() => void moveBotsToSection([bot], null)}>
+                  <Codicon className="mr-1.5" name="inbox" />
+                  {b.sections.removeFromSection}
+                </ContextMenuItem>
+              ) : null}
+            </ContextMenuSubContent>
+          </ContextMenuSub>
+          {isDefaultBot(bot) ? null : <ContextMenuSeparator />}
+          {isDefaultBot(bot) ? null : (
+            <ContextMenuItem onSelect={() => onDelete(bot)} variant="destructive">
+              {t.common.delete}
+            </ContextMenuItem>
+          )}
+        </ContextMenuContent>
+      </ContextMenu>
+      <BotSessionsPanel bot={bot} />
+    </>
   )
 }
 

--- a/apps/desktop/src/plugins/hermes-bots/bot-sessions-panel.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-sessions-panel.tsx
@@ -1,0 +1,171 @@
+/**
+ * The per-bot session browser as it renders inside the Bots rail: a
+ * collapsible block directly under the bot's row listing every stored chat in
+ * that bot's profile. Opened from the row's context menu ("Show sessions"),
+ * one bot at a time.
+ *
+ * Read-only over `session.list`; opening a row goes through the same
+ * workspace-aware open the canonical chat uses. Nothing here is persisted.
+ */
+
+import {
+  cn,
+  coarseElapsed,
+  Codicon,
+  GlyphSpinner,
+  host,
+  RowButton,
+  SessionStatusDot,
+  SidebarRowLead,
+  Tip,
+  useI18n,
+  useQuery,
+  useValue
+} from '@hermes/plugin-sdk'
+
+import {
+  $botSessionsOpen,
+  closeBotSessions,
+  isBotSessionsOpen,
+  isCanonicalRow,
+  listBotSessions,
+  openBotSession,
+  sessionActivity
+} from './bot-sessions'
+import type { BotSessionRow } from './bot-sessions'
+import { $botMeta, botRosterKey } from './data'
+import { useBots } from './i18n'
+import { displayName } from './labels'
+import { botRosterMeta } from './routing'
+import type { RosterRow, SidebarRowLabels } from './types'
+
+function rowAge(seconds: number, r: SidebarRowLabels): string {
+  const { unit, value } = coarseElapsed(Date.now() - seconds * 1000)
+
+  return unit === 'second' ? r.ageNow : `${value}${unit === 'day' ? r.ageDay : unit === 'hour' ? r.ageHour : r.ageMin}`
+}
+
+export const BOT_SESSIONS_QUERY_KEY = 'hermes-bots.sessions'
+
+interface BotSessionsPanelProps {
+  bot: RosterRow
+}
+
+/** Renders nothing unless this bot is the one expanded. Mounted under every
+ *  row so the roster's virtualization/sections need no extra plumbing; the
+ *  cost of a closed panel is one atom read. */
+export function BotSessionsPanel({ bot }: BotSessionsPanelProps) {
+  const open = useValue($botSessionsOpen)
+
+  if (!isBotSessionsOpen(bot, open)) {
+    return null
+  }
+
+  return <BotSessionsList bot={bot} />
+}
+
+function BotSessionsList({ bot }: BotSessionsPanelProps) {
+  const { t } = useI18n()
+  const b = useBots()
+  const meta = botRosterMeta(bot, useValue($botMeta))
+  const focused = useValue(host.state.focusedStoredSessionId)
+
+  const { data, error, isLoading, refetch } = useQuery({
+    queryKey: [BOT_SESSIONS_QUERY_KEY, botRosterKey(bot)],
+    queryFn: () => listBotSessions(bot),
+    refetchInterval: 15_000
+  })
+
+  const rows = data ?? []
+
+  const openRow = (row: BotSessionRow) =>
+    void openBotSession(bot, row).catch(err => host.notifyError?.(err, b.sessions.openFailed))
+
+  return (
+    <div
+      aria-label={b.sessions.ariaLabel(displayName(bot, meta))}
+      className="mb-1 ml-3 grid gap-0.5 border-l border-(--ui-stroke-tertiary) pl-1.5"
+      data-slot="bot-sessions"
+      role="region"
+    >
+      <div className="flex items-center gap-1 px-2 py-1 text-[0.6875rem] font-semibold uppercase tracking-wider text-(--ui-text-quaternary)">
+        <Codicon className="shrink-0" name="history" />
+        <span className="min-w-0 flex-1 truncate">{b.sessions.heading}</span>
+        {rows.length ? <span className="shrink-0 font-normal tabular-nums">{rows.length}</span> : null}
+        <Tip label={b.sessions.close}>
+          <button
+            aria-label={b.sessions.close}
+            className="flex size-5 shrink-0 items-center justify-center rounded text-(--ui-text-quaternary) hover:bg-(--chrome-action-hover) hover:text-(--ui-text-secondary)"
+            onClick={closeBotSessions}
+            type="button"
+          >
+            <Codicon name="close" />
+          </button>
+        </Tip>
+      </div>
+      {isLoading && !rows.length ? (
+        <div className="flex justify-center py-2">
+          <GlyphSpinner className="text-(--ui-text-tertiary)" spinner="breathe" />
+        </div>
+      ) : error && !rows.length ? (
+        <div className="grid gap-1.5 px-2 py-1.5 text-xs text-(--ui-text-tertiary)">
+          <span>{b.sessions.loadFailed(error instanceof Error ? error.message : 'gateway error')}</span>
+          <button
+            className="justify-self-start text-(--ui-accent) hover:underline"
+            onClick={() => void refetch()}
+            type="button"
+          >
+            {b.roster.retryNow}
+          </button>
+        </div>
+      ) : rows.length === 0 ? (
+        <div className="px-2 py-1.5 text-xs text-(--ui-text-tertiary)">{b.sessions.empty}</div>
+      ) : (
+        rows.map(row => {
+          const canonical = isCanonicalRow(row)
+          const storedId = String(row.resolved_id || row.id)
+          const active = focused != null && String(focused) === storedId
+          const title = canonical ? displayName(bot, meta) : String(row.title || '').trim() || b.sessions.untitled
+          const age = sessionActivity(row)
+
+          return (
+            <RowButton
+              aria-current={active ? 'true' : undefined}
+              className={cn(
+                'flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-(--chrome-action-hover)',
+                active && 'bg-(--ui-row-active-background)'
+              )}
+              data-session-id={row.id}
+              key={row.id}
+              onClick={() => openRow(row)}
+            >
+              <SidebarRowLead>
+                <SessionStatusDot storedSessionId={row.id} />
+              </SidebarRowLead>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-baseline justify-between gap-2">
+                  <span className="flex min-w-0 items-center gap-1 text-[0.8125rem]">
+                    {canonical ? (
+                      <Tip label={b.sessions.canonicalTip}>
+                        <Codicon className="shrink-0 text-[0.6875rem] text-(--ui-accent)" name="comment-discussion" />
+                      </Tip>
+                    ) : null}
+                    <span className="min-w-0 truncate">{title}</span>
+                  </span>
+                  {age ? (
+                    <span className="shrink-0 text-[0.6875rem] text-(--ui-text-quaternary)">
+                      {rowAge(age, t.sidebar.row)}
+                    </span>
+                  ) : null}
+                </div>
+                {row.preview ? (
+                  <div className="min-w-0 truncate text-xs text-(--ui-text-tertiary)">{row.preview}</div>
+                ) : null}
+              </div>
+            </RowButton>
+          )
+        })
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/plugins/hermes-bots/bot-sessions.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-sessions.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * The per-bot session browser: opened from the bot row's context menu, lists
+ * that bot's stored chats under the row, and opens one into the bot's
+ * workspace — without ever becoming an identity for the canonical chat.
+ *
+ * Contract:
+ * - The row's context menu offers "Show sessions"; selecting it lists the
+ *   bot's profile sessions via `session.list` with include_hidden on the
+ *   bot's own profile.
+ * - Rows sort by last_active (newest first); the canonical "Bot Chat" row is
+ *   labelled with the bot's name, not the plumbing title.
+ * - Clicking a listed row opens THAT stored session in the `bots` workspace
+ *   under the bot's owner key. The canonical registry path (openRosterBot)
+ *   is never invoked by the browser.
+ * - Only one bot's browser is open at a time.
+ */
+
+import type * as HermesSdk from '@hermes/plugin-sdk'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BotRow } from './bot-row'
+import { $botSessionsOpen, toggleBotSessions } from './bot-sessions'
+import type * as CanonicalChat from './canonical-chat'
+import { translateBots } from './i18n-test-helper'
+import type { RosterRow } from './types'
+
+const { ensureBotMetadata, openRosterBot, openSession, request, requestProfile } = vi.hoisted(() => ({
+  ensureBotMetadata: vi.fn(),
+  openRosterBot: vi.fn(),
+  openSession: vi.fn(),
+  request: vi.fn(),
+  requestProfile: vi.fn()
+}))
+
+vi.mock('@hermes/plugin-sdk', async importOriginal => {
+  const sdk = await importOriginal<typeof HermesSdk>()
+
+  return {
+    ...sdk,
+    host: { ...sdk.host, openSession, request, requestProfile, warmProfile: vi.fn(), notifyError: vi.fn() },
+    usePluginI18n: () => translateBots
+  }
+})
+
+vi.mock('./canonical-chat', async importOriginal => {
+  const actual = await importOriginal<typeof CanonicalChat>()
+
+  return {
+    ...actual,
+    ensureBotMetadata,
+    notifyBotOpenFailure: vi.fn(),
+    openBotCanonicalChat: vi.fn(),
+    prepareBotSource: vi.fn()
+  }
+})
+
+vi.mock('./roster-actions', () => ({ openRosterBot }))
+
+const noop = () => undefined
+
+const SESSIONS = [
+  { id: 'side-old', title: 'Old side thread', started_at: 1000, last_active: 1000, message_count: 3, hidden: false },
+  { id: 'forever', title: 'Bot Chat', started_at: 500, last_active: 9000, message_count: 40, hidden: true },
+  { id: 'side-new', title: 'Newer side thread', started_at: 2000, last_active: 5000, message_count: 2, hidden: false }
+]
+
+function Providers({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      {children}
+    </QueryClientProvider>
+  )
+}
+
+function renderRow(bot: RosterRow) {
+  render(
+    <Providers>
+      <BotRow bot={bot} onDelete={noop} onEdit={noop} onGroup={noop} onNewSection={noop} />
+    </Providers>
+  )
+}
+
+const bot = { name: 'alpha', connectionId: 'local' } as RosterRow
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  $botSessionsOpen.set(null)
+  ensureBotMetadata.mockResolvedValue({})
+  openSession.mockResolvedValue(undefined)
+  request.mockImplementation(async (method: string) => (method === 'session.list' ? { sessions: SESSIONS } : {}))
+})
+
+describe('bot session browser', () => {
+  it('lists the bot profile sessions newest-first with the canonical row named after the bot', async () => {
+    renderRow(bot)
+    toggleBotSessions(bot)
+
+    const region = await screen.findByRole('region')
+    await waitFor(() => expect(region.querySelectorAll('[data-session-id]').length).toBe(3))
+
+    expect(request).toHaveBeenCalledWith(
+      'session.list',
+      expect.objectContaining({ profile: 'alpha', include_hidden: true })
+    )
+
+    const ids = [...region.querySelectorAll('[data-session-id]')].map(el => el.getAttribute('data-session-id'))
+    expect(ids).toEqual(['forever', 'side-new', 'side-old'])
+    // Plumbing title never shows; the forever-chat reads as the bot.
+    expect(region.textContent).not.toContain('Bot Chat')
+    expect(region.textContent).toContain('Alpha')
+  })
+
+  it('opens a listed session in the bot workspace, not through the canonical registry', async () => {
+    renderRow(bot)
+    toggleBotSessions(bot)
+    const region = await screen.findByRole('region')
+
+    const row = await waitFor(() => {
+      const el = region.querySelector('[data-session-id="side-new"]')
+      expect(el).toBeTruthy()
+
+      return el as HTMLElement
+    })
+
+    fireEvent.click(row)
+
+    await waitFor(() => expect(openSession).toHaveBeenCalledTimes(1))
+    expect(openSession).toHaveBeenCalledWith(
+      'side-new',
+      expect.objectContaining({
+        profile: 'alpha',
+        workspaceMode: 'bots',
+        workspaceOwnerKey: expect.stringMatching(/^bot:/)
+      })
+    )
+    expect(openRosterBot).not.toHaveBeenCalled()
+  })
+
+  it('renders nothing for a bot whose browser is not the open one', async () => {
+    renderRow(bot)
+    toggleBotSessions({ name: 'beta', connectionId: 'local' } as RosterRow)
+
+    await new Promise(resolve => setTimeout(resolve, 20))
+    expect(screen.queryByRole('region')).toBeNull()
+    expect(request).not.toHaveBeenCalledWith('session.list', expect.anything())
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/bot-sessions.ts
+++ b/apps/desktop/src/plugins/hermes-bots/bot-sessions.ts
@@ -1,0 +1,114 @@
+/**
+ * Per-bot session browser: every stored chat that lives in ONE bot's profile,
+ * listed inside the Bots rail on request.
+ *
+ * This is a READ surface over `session.list`, not an identity. The canonical
+ * Bot Chat is still resolved by NAME through the registry (see
+ * canonical-chat.ts) — this browser never stores a session pointer, never picks
+ * "the" bot chat for the row, and never decides where a row click lands. It
+ * only lets the user see and reopen the side-chats (`+` threads, CLI sessions,
+ * routine runs) a bot's profile accumulated, which the Sessions rail hides
+ * behind the active-profile scope.
+ */
+
+import { atom, host } from '@hermes/plugin-sdk'
+
+import { CANONICAL_CHAT_TITLE, PROFILE_SESSION_LIST_LIMIT } from './canonical-chat'
+import { botRosterKey } from './data'
+import {
+  backendTargetProfile,
+  botConnectionRoute,
+  botWorkspaceOwnerKey,
+  requestForBot,
+  setBotsWorkspaceOwner
+} from './routing'
+import type { RosterRow } from './types'
+
+/** One `session.list` row as the browser reads it. `hidden` / `last_active`
+ *  arrive from a gateway that publishes them; an older gateway omits both and
+ *  the browser degrades to started_at order with no canonical badge. */
+export interface BotSessionRow {
+  id: string
+  resolved_id?: string
+  title?: string
+  preview?: string
+  started_at?: number
+  last_active?: number
+  message_count?: number
+  hidden?: boolean
+  source?: string
+}
+
+/** Roster key of the bot whose sessions are expanded in the rail; one at a
+ *  time — the rail is narrow and two open browsers would push the roster off
+ *  screen. Window-local on purpose: this is where the user is looking, not a
+ *  preference. */
+export const $botSessionsOpen = atom<string | null>(null)
+
+export function toggleBotSessions(bot: RosterRow): void {
+  const key = botRosterKey(bot)
+  $botSessionsOpen.set($botSessionsOpen.get() === key ? null : key)
+}
+
+export function closeBotSessions(): void {
+  $botSessionsOpen.set(null)
+}
+
+export function isBotSessionsOpen(bot: RosterRow, open: string | null): boolean {
+  return open !== null && open === botRosterKey(bot)
+}
+
+/** The bot's own profile sessions, most recent first. Hidden rows are
+ *  included so the canonical Bot Chat shows up (badged) beside the side-chats;
+ *  the deny-listed sources (kanban/tool workers) never reach `session.list`. */
+export async function listBotSessions(bot: RosterRow): Promise<BotSessionRow[]> {
+  const route = botConnectionRoute(bot)
+  const fallback = String(bot?.name || '').trim() || 'default'
+
+  const res = await requestForBot<{ sessions?: BotSessionRow[] }>(bot, 'session.list', {
+    profile: backendTargetProfile(route, fallback),
+    limit: PROFILE_SESSION_LIST_LIMIT,
+    include_hidden: true
+  })
+
+  const rows = Array.isArray(res?.sessions) ? res.sessions.filter(row => row && row.id) : []
+
+  return rows.sort((a, b) => sessionActivity(b) - sessionActivity(a))
+}
+
+export function sessionActivity(row: BotSessionRow): number {
+  return Number(row.last_active) || Number(row.started_at) || 0
+}
+
+/** The registry row itself — surfaced so the browser can badge it, never so
+ *  it can be stored. Title equality is the same test the registry uses. */
+export function isCanonicalRow(row: BotSessionRow): boolean {
+  return String(row.title || '').trim() === CANONICAL_CHAT_TITLE
+}
+
+/** Open one listed session in the bot's workspace. Same open contract the
+ *  canonical path uses (owner key, `bots` workspace, in-place intent) so the
+ *  tab lands beside the Bot Chat instead of in the Sessions strip; the browser
+ *  hands over the stored id and nothing else. */
+export async function openBotSession(bot: RosterRow, row: BotSessionRow): Promise<void> {
+  if (typeof host.openSession !== 'function') {
+    throw new Error('This Hermes Desktop version cannot open stored sessions')
+  }
+
+  const route = botConnectionRoute(bot)
+  const ownerKey = botWorkspaceOwnerKey(bot)
+  setBotsWorkspaceOwner(ownerKey, bot)
+
+  await host.openSession(String(row.resolved_id || row.id), {
+    ...(route ? { route } : {}),
+    profile: String(bot?.name || '').trim() || 'default',
+    intent: 'in-place',
+    awaitHydration: true,
+    expectHistory: (row.message_count ?? 0) > 0,
+    forceResume: true,
+    keepAllProfilesScope: true,
+    workspaceMode: 'bots',
+    workspaceOwnerKey: ownerKey,
+    ...(isCanonicalRow(row) ? { tabTitle: CANONICAL_CHAT_TITLE } : {})
+  })
+}

--- a/apps/desktop/src/plugins/hermes-bots/i18n.ts
+++ b/apps/desktop/src/plugins/hermes-bots/i18n.ts
@@ -96,6 +96,20 @@ type BotsMessages = {
     deleted: (name: string, count: number) => string
     undo: string
   }
+  /** The per-bot session browser (context menu → "Show sessions"). */
+  sessions: {
+    showMenu: string
+    hideMenu: string
+    heading: string
+    close: string
+    empty: string
+    untitled: string
+    /** The canonical Bot Chat row, badged so it reads as the forever-chat. */
+    canonicalTip: string
+    openFailed: string
+    loadFailed: (reason: string) => string
+    ariaLabel: (bot: string) => string
+  }
   /** Creating, editing and removing a bot. */
   bot: {
     newTitle: string
@@ -329,6 +343,18 @@ const en: BotsMessages = {
         : `Deleted “${name}” — ${count} ${count === 1 ? 'bot' : 'bots'} moved to Unassigned`,
     undo: 'Undo'
   },
+  sessions: {
+    showMenu: 'Show sessions',
+    hideMenu: 'Hide sessions',
+    heading: 'Sessions',
+    close: 'Close session list',
+    empty: 'No stored chats in this bot’s profile yet.',
+    untitled: 'Untitled',
+    canonicalTip: 'The Bot Chat — this bot’s permanent conversation',
+    openFailed: 'Could not open that session',
+    loadFailed: (reason: string) => `Could not list sessions — ${reason}`,
+    ariaLabel: (bot: string) => `Sessions with ${bot}`
+  },
   bot: {
     newTitle: 'New bot',
     editTitle: 'Edit profile',
@@ -548,6 +574,18 @@ const ja: BotsMessages = {
         : `「${name}」を削除しました — ${count} 件のボットを未分類に移動しました`,
     undo: '元に戻す'
   },
+  sessions: {
+    showMenu: 'セッションを表示',
+    hideMenu: 'セッションを隠す',
+    heading: 'セッション',
+    close: 'セッション一覧を閉じる',
+    empty: 'このボットのプロファイルに保存されたチャットはまだありません。',
+    untitled: '無題',
+    canonicalTip: 'ボットチャット — このボットの常設の会話',
+    openFailed: 'そのセッションを開けませんでした',
+    loadFailed: (reason: string) => `セッションを一覧できませんでした — ${reason}`,
+    ariaLabel: (bot: string) => `${bot} とのセッション`
+  },
   bot: {
     newTitle: '新しいボット',
     editTitle: 'プロファイルを編集',
@@ -763,6 +801,18 @@ const zh: BotsMessages = {
     deleted: (name, count) => (count === 0 ? `已删除“${name}”` : `已删除“${name}” — ${count} 个机器人已移至未分类`),
     undo: '撤销'
   },
+  sessions: {
+    showMenu: '显示会话',
+    hideMenu: '隐藏会话',
+    heading: '会话',
+    close: '关闭会话列表',
+    empty: '此机器人的配置中还没有已保存的聊天。',
+    untitled: '无标题',
+    canonicalTip: '机器人聊天 — 此机器人的永久对话',
+    openFailed: '无法打开该会话',
+    loadFailed: (reason: string) => `无法列出会话 — ${reason}`,
+    ariaLabel: (bot: string) => `与 ${bot} 的会话`
+  },
   bot: {
     newTitle: '新建机器人',
     editTitle: '编辑配置档案',
@@ -976,6 +1026,18 @@ const zhHant: BotsMessages = {
     removeFromSection: '移出分區',
     deleted: (name, count) => (count === 0 ? `已刪除「${name}」` : `已刪除「${name}」— ${count} 個機器人已移至未分類`),
     undo: '復原'
+  },
+  sessions: {
+    showMenu: '顯示工作階段',
+    hideMenu: '隱藏工作階段',
+    heading: '工作階段',
+    close: '關閉工作階段清單',
+    empty: '此機器人的設定檔中尚無已儲存的聊天。',
+    untitled: '無標題',
+    canonicalTip: '機器人聊天 — 此機器人的永久對話',
+    openFailed: '無法開啟該工作階段',
+    loadFailed: (reason: string) => `無法列出工作階段 — ${reason}`,
+    ariaLabel: (bot: string) => `與 ${bot} 的工作階段`
   },
   bot: {
     newTitle: '新增機器人',

--- a/tests/tui_gateway/test_session_list_browser_fields.py
+++ b/tests/tui_gateway/test_session_list_browser_fields.py
@@ -1,0 +1,77 @@
+"""Tests: ``session.list`` rows carry what a per-bot session browser needs.
+
+Why: the desktop Bots pane lists ONE bot's stored chats on demand (context menu
+→ "Show sessions"). To order that list by recency and badge the hidden canonical
+Bot Chat beside the user's side-chats, every listing row must publish
+``last_active`` and ``hidden`` — otherwise the client needs a second round-trip
+per row, or falls back to ``started_at`` order, which puts a long-running
+Bot Chat at the bottom of its own list.
+
+Contract under test:
+- ``include_hidden`` listings return hidden rows flagged ``hidden: true`` and
+  visible rows ``hidden: false``.
+- ``last_active`` tracks the newest activity, so a row created earlier but
+  written to later sorts ahead — it is not a copy of ``started_at``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import tui_gateway.server as srv
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    h = tmp_path / ".hermes"
+    h.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(h))
+    return h
+
+
+def _db(profile_dir):
+    from hermes_state import SessionDB
+
+    return SessionDB(db_path=profile_dir / "state.db")
+
+
+def _add_session(db, sid, *, title, ts, text, hidden=False):
+    db.create_session(sid, "desktop")
+    db.append_message(sid, "user", text, timestamp=ts)
+    with db._lock:
+        db._conn.execute("UPDATE sessions SET title = ? WHERE id = ?", (title, sid))
+    if hidden:
+        db.set_session_hidden(sid, True)
+
+
+def _list(monkeypatch, db, **params):
+    monkeypatch.setattr(srv, "_get_db", lambda: db)
+    return srv._methods["session.list"](1, params)["result"]["sessions"]
+
+
+def test_listing_rows_flag_hidden_and_visible(home, monkeypatch):
+    db = _db(home)
+    _add_session(db, "forever", title="Bot Chat", ts=1000, text="canonical", hidden=True)
+    _add_session(db, "side", title="Side thread", ts=2000, text="scratch")
+
+    by_id = {row["id"]: row for row in _list(monkeypatch, db, include_hidden=True)}
+    assert by_id["forever"]["hidden"] is True
+    assert by_id["side"]["hidden"] is False
+
+    # Without include_hidden the canonical row stays out, unchanged contract.
+    assert {row["id"] for row in _list(monkeypatch, db)} == {"side"}
+    db.close()
+
+
+def test_last_active_follows_newest_activity_not_creation(home, monkeypatch):
+    db = _db(home)
+    _add_session(db, "old-but-busy", title="Bot Chat", ts=1000, text="first", hidden=True)
+    _add_session(db, "newer-idle", title="Side thread", ts=2000, text="only message")
+    # Later activity on the OLDER session.
+    db.append_message("old-but-busy", "assistant", "reply much later", timestamp=5000)
+
+    by_id = {row["id"]: row for row in _list(monkeypatch, db, include_hidden=True)}
+    assert by_id["old-but-busy"]["last_active"] > by_id["newer-idle"]["last_active"]
+    # And it is the message clock, not a heartbeat that never fired.
+    assert by_id["old-but-busy"]["last_active"] == 5000
+    db.close()

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -122,12 +122,17 @@ def _cwd_info(session: dict, cwd: str, branch=None) -> dict:
 
 
 def _session_row_summary(row: dict, *, tip_row: dict | None = None, resolved_id=None) -> dict:
-    """Compact session.list row; ``tip_row``/``resolved_id`` come from the compression tip."""
+    """Compact session.list row; ``tip_row``/``resolved_id`` come from the compression tip.
+
+    ``last_active`` / ``hidden`` let owning surfaces (the Bots pane's per-bot session browser) sort by
+    recency and tell a plumbing row (hidden canonical Bot Chat) from a user side-chat without a second
+    round-trip per row."""
     tip_row = tip_row or row
     return {"id": row["id"], **({} if resolved_id is None else {"resolved_id": resolved_id}),
             "title": row.get("title") or "", "preview": tip_row.get("preview") or "",
             "started_at": row.get("started_at") or 0, "message_count": tip_row.get("message_count") or 0,
-            "source": row.get("source") or ""}
+            "last_active": tip_row.get("last_active") or tip_row.get("last_activity_at") or tip_row.get("started_at") or 0,
+            "hidden": bool(row.get("hidden")), "source": row.get("source") or ""}
 
 
 # Hidden from human listings (sub-agent runs, kanban workers); a deny-list so new platforms surface automatically.


### PR DESCRIPTION
## What does this PR do?

Right-click a bot in the Bots roster → **Show sessions** lists every stored chat in that bot's profile directly under the row (newest first, canonical Bot Chat badged and named after the bot). Clicking a row opens that session in the bot's workspace; one bot's list is open at a time.

The browser is read-only over `session.list` (`include_hidden`, the bot's own profile). It never stores a session pointer and never decides the row's click target — the canonical Bot Chat is still resolved by name through the registry — so it does not reintroduce the per-bot session-pointer design removed in #90732.

Gateway side, `session.list` rows now carry `last_active` (message-clock recency, the same expression `list_sessions_rich` already computes) and `hidden`, so the browser can sort and badge without a second round-trip per row.

## Related Issue

N/A — follow-up to the design discussion in #90732.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/bot-sessions.ts` — fetch + sort/badge model for a bot's sessions over `session.list`
- `apps/desktop/src/plugins/hermes-bots/bot-sessions-panel.tsx` — inline session list rendered under the bot row
- `apps/desktop/src/plugins/hermes-bots/bot-row.tsx` — "Show sessions" context-menu entry, one-open-at-a-time toggle, row click → open session in the bot's workspace
- `apps/desktop/src/plugins/hermes-bots/i18n.ts` — strings for the menu entry, badges, empty/error states
- `apps/desktop/src/plugins/hermes-bots/bot-sessions.test.tsx` — tests for sorting, canonical badge, and click routing
- `tui_gateway/methods_session.py` — `session.list` rows include `last_active` and `hidden`
- `tests/tui_gateway/test_session_list_browser_fields.py` — tests for the new fields

## How to Test

1. `npm install && cd apps/desktop && npm run dev`
2. Open the **Bots** tab, right-click a bot, choose **Show sessions**.
3. Sessions appear under the row, newest first, with the canonical Bot Chat badged. Click one to open it in the bot's workspace; opening another bot's list closes the first.

Tests run locally (macOS 26, Apple Silicon):
- `npx vitest run src/plugins/hermes-bots/bot-sessions.test.tsx` — 3 passed
- `pytest tests/tui_gateway/test_session_list_browser_fields.py` — 2 passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (ran the new test file and `tests/tui_gateway/`; full suite not run locally)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (Apple Silicon), desktop dev build

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A