### PR TITLE
fix(tests): arm GitSpawn security fixtures on Windows

### DIFF
--- a/tests/security/test_gitspawn_config_injection.py
+++ b/tests/security/test_gitspawn_config_injection.py
@@ -99,15 +99,21 @@ def _make_malicious_repo(tmp: Path) -> tuple[Path, Path]:
     subprocess.run(["git", "-C", str(repo), *ident, "commit", "-qm", "init"], check=True, env=clean)
 
     marker = tmp / "MARKER"
+    marker_value = marker.as_posix()
     hooks = repo / "evil-hooks"
     hooks.mkdir()
     hook = hooks / "post-checkout"
-    hook.write_text(f"#!/bin/sh\ntouch {marker}.hook\n")
+    hook.write_text(f"#!/bin/sh\ntouch '{marker_value}.hook'\n")
     hook.chmod(0o755)
     with (repo / ".git" / "config").open("a") as f:
-        f.write(f'[core]\n\tfsmonitor = "touch {marker}.fsmonitor"\n\thooksPath = {hooks}\n')
-        f.write(f'[diff "evil"]\n\tcommand = "touch {marker}.extdiff"\n')
-        f.write(f'\ttextconv = "sh -c \'touch {marker}.textconv; cat\'"\n')
+        f.write(
+            f'[core]\n\tfsmonitor = "touch \'{marker_value}.fsmonitor\'"\n'
+            f'\thooksPath = {hooks.as_posix()}\n'
+        )
+        f.write(f'[diff "evil"]\n\tcommand = "touch \'{marker_value}.extdiff\'"\n')
+        f.write(
+            f'\ttextconv = "sh -c \\"touch \'{marker_value}.textconv\'; cat\\""\n'
+        )
     (repo / ".gitattributes").write_text("* diff=evil\n")
     (repo / "README").write_text("changed\n")  # dirty working tree so diffs run
     return repo, marker

--- a/tests/security/test_gitspawn_config_injection.py
+++ b/tests/security/test_gitspawn_config_injection.py
@@ -16,6 +16,7 @@ context-gathering git path Hermes runs neutralizes every sink. They use a real
 from __future__ import annotations
 
 import os
+import shlex
 import shutil
 import subprocess
 from pathlib import Path
@@ -81,6 +82,12 @@ class TestHardenGitArgv:
 # ---------------------------------------------------------------------------
 
 
+def _git_config_value(value: str) -> str:
+    """Quote a value for a double-quoted Git config entry."""
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
 def _make_malicious_repo(tmp: Path) -> tuple[Path, Path]:
     """Build a repo whose .git/config arms fsmonitor, a checkout hook, and an
     attribute-scoped external-diff + textconv driver. Returns (repo, marker_stem):
@@ -99,21 +106,22 @@ def _make_malicious_repo(tmp: Path) -> tuple[Path, Path]:
     subprocess.run(["git", "-C", str(repo), *ident, "commit", "-qm", "init"], check=True, env=clean)
 
     marker = tmp / "MARKER"
-    marker_value = marker.as_posix()
     hooks = repo / "evil-hooks"
     hooks.mkdir()
     hook = hooks / "post-checkout"
-    hook.write_text(f"#!/bin/sh\ntouch '{marker_value}.hook'\n")
+    hook.write_text(f"#!/bin/sh\ntouch {shlex.quote(f'{marker.as_posix()}.hook')}\n")
     hook.chmod(0o755)
+    fsmonitor = f"touch {shlex.quote(f'{marker.as_posix()}.fsmonitor')}"
+    extdiff = f"touch {shlex.quote(f'{marker.as_posix()}.extdiff')}"
+    textconv_payload = f"touch {shlex.quote(f'{marker.as_posix()}.textconv')}; cat"
+    textconv = f"sh -c {shlex.quote(textconv_payload)}"
     with (repo / ".git" / "config").open("a") as f:
         f.write(
-            f'[core]\n\tfsmonitor = "touch \'{marker_value}.fsmonitor\'"\n'
-            f'\thooksPath = {hooks.as_posix()}\n'
+            f"[core]\n\tfsmonitor = {_git_config_value(fsmonitor)}\n"
+            f"\thooksPath = {_git_config_value(hooks.as_posix())}\n"
         )
-        f.write(f'[diff "evil"]\n\tcommand = "touch \'{marker_value}.extdiff\'"\n')
-        f.write(
-            f'\ttextconv = "sh -c \\"touch \'{marker_value}.textconv\'; cat\\""\n'
-        )
+        f.write(f'[diff "evil"]\n\tcommand = {_git_config_value(extdiff)}\n')
+        f.write(f"\ttextconv = {_git_config_value(textconv)}\n")
     (repo / ".gitattributes").write_text("* diff=evil\n")
     (repo / "README").write_text("changed\n")  # dirty working tree so diffs run
     return repo, marker
@@ -139,6 +147,15 @@ def test_baseline_unhardened_git_fires_sinks(malicious_repo):
     """Sanity: without hardening the payload actually fires — proves the repo
     is armed and the test can detect a regression."""
     repo, marker = malicious_repo
+    subprocess.run(["git", "-C", str(repo), "diff", "HEAD"], capture_output=True)
+    fired = _fired(marker)
+    assert "fsmonitor" in fired and "extdiff" in fired, fired
+
+
+def test_baseline_fires_sinks_with_apostrophe_in_path(tmp_path):
+    root = tmp_path / "user's temp"
+    root.mkdir()
+    repo, marker = _make_malicious_repo(root)
     subprocess.run(["git", "-C", str(repo), "diff", "HEAD"], capture_output=True)
     fired = _fired(marker)
     assert "fsmonitor" in fired and "extdiff" in fired, fired


### PR DESCRIPTION
## Summary

- normalize malicious fixture paths to POSIX separators before writing `.git/config`
- POSIX-shell-quote command marker paths and escape them for Git config parsing
- keep the hook path and hook payload valid on Windows

## Testing

- `scripts/run_tests.sh tests/security/test_gitspawn_config_injection.py` (17 passed)

## Related Issue

Closes #108515
