### PR TITLE
fix(windows): dedupe PATH entries across spelling variants at every prepend site

### DIFF
--- a/apps/desktop/electron/backend-env.test.ts
+++ b/apps/desktop/electron/backend-env.test.ts
@@ -189,3 +189,35 @@ test('Windows PATH casing and delimiter are preserved without POSIX sane entries
 test('appendUniquePathEntries drops empty entries and keeps first occurrence', () => {
   assert.equal(appendUniquePathEntries([':/a::/b', ['/a', '/c']], { delimiter: ':' }), '/a:/b:/c')
 })
+
+test('appendUniquePathEntries dedupes Windows spelling variants case-insensitively', () => {
+  // C:\Foo\, c:/foo and C:\FOO name the same directory on Windows (issue #108508)
+  assert.equal(
+    appendUniquePathEntries(['C:\\Foo\\;c:/foo', 'C:\\FOO', 'C:\\Bar'], { delimiter: ';' }),
+    'C:\\Foo\\;C:\\Bar'
+  )
+})
+
+test('appendUniquePathEntries keeps POSIX entries case-sensitive', () => {
+  // On POSIX, /opt/Git and /opt/git are genuinely different directories
+  assert.equal(
+    appendUniquePathEntries(['/opt/Git:/opt/git', '/OPT/GIT'], { delimiter: ':' }),
+    '/opt/Git:/opt/git:/OPT/GIT'
+  )
+})
+
+test('buildDesktopBackendPath does not stack venv Scripts duplicates on Windows', () => {
+  const venvScripts = 'C:\\Users\\test\\AppData\\Local\\hermes\\hermes-agent\\venv\\Scripts'
+
+  const result = buildDesktopBackendPath({
+    hermesHome: 'C:\\Users\\test\\AppData\\Local\\hermes',
+    venvRoot: 'C:\\Users\\test\\AppData\\Local\\hermes\\hermes-agent\\venv',
+    currentPath: `${venvScripts}\\;c:/users/test/appdata/local/hermes/hermes-agent/venv/scripts`,
+    platform: 'win32',
+    pathModule: path.win32
+  })
+
+  const entries = result.split(';')
+  const scriptsCount = entries.filter(e => e.toLowerCase().replace(/\\/g, '/').endsWith('venv/scripts') || e.toLowerCase().replace(/\\/g, '/').endsWith('venv/scripts/')).length
+  assert.equal(scriptsCount, 1)
+})

--- a/apps/desktop/electron/backend-env.ts
+++ b/apps/desktop/electron/backend-env.ts
@@ -37,6 +37,19 @@ function currentPathValue(env = process.env, platform = process.platform) {
 }
 
 function appendUniquePathEntries(entries, { delimiter = path.delimiter } = {}) {
+  // Windows PATH/PYTHONPATH entries are case-insensitive and tolerate either
+  // separator, so `C:\Foo\`, `c:/foo` and `C:\FOO` name the same directory and
+  // must dedupe against each other — otherwise every backend launch stacks
+  // spelling-variant duplicates. POSIX entries stay case-sensitive as-is;
+  // trailing separators are ignored on both.
+  const caseInsensitive = delimiter === ';'
+
+  const normalize = value => {
+    const trimmed = String(value).replace(/[\\/]+$/, '').replace(/\\/g, '/')
+
+    return caseInsensitive ? trimmed.toLowerCase() : trimmed
+  }
+
   const seen = new Set()
   const ordered = []
 
@@ -48,11 +61,11 @@ function appendUniquePathEntries(entries, { delimiter = path.delimiter } = {}) {
     const parts = Array.isArray(entry) ? entry : String(entry).split(delimiter)
 
     for (const part of parts) {
-      if (!part || seen.has(part)) {
+      if (!part || seen.has(normalize(part))) {
         continue
       }
 
-      seen.add(part)
+      seen.add(normalize(part))
       ordered.push(part)
     }
   }

--- a/hermes_cli/stdio.py
+++ b/hermes_cli/stdio.py
@@ -7,6 +7,7 @@ subprocesses and child Python ``print()`` calls agree on encoding.
 
 from __future__ import annotations
 
+import ntpath
 import os
 import sys
 
@@ -90,6 +91,13 @@ def _default_windows_editor() -> str:
     return "notepad" if shutil.which("notepad") else ""
 
 
+def _windows_path_key(value: str) -> str:
+    r"""Windows path equality key: ``C:\Foo\``, ``c:/foo`` and ``c:\FOO`` are the same
+    directory. ``ntpath`` is used explicitly so the comparison behaves Windows-correct
+    even when this module is imported on another host (tests, WSL introspection)."""
+    return ntpath.normcase(ntpath.normpath(value)) if value else value
+
+
 def _augment_path_with_known_tools() -> None:
     r"""Prepend Hermes-managed tool directories to ``PATH`` (no-op on POSIX / missing dirs).
 
@@ -114,7 +122,11 @@ def _augment_path_with_known_tools() -> None:
         os.path.join(local_appdata, "hermes", "hermes-agent", "venv", "Scripts"),
         os.path.join(local_appdata, "Microsoft", "WinGet", "Links")]
     existing = os.environ.get("PATH", "")
-    existing_lower = {p.lower() for p in existing.split(os.pathsep) if p}
-    prepend = [d for d in candidate_dirs if os.path.isdir(d) and d.lower() not in existing_lower]
+    existing_keys = {_windows_path_key(p) for p in existing.split(os.pathsep) if p}
+    prepend = [
+        d
+        for d in candidate_dirs
+        if os.path.isdir(d) and _windows_path_key(d) not in existing_keys
+    ]
     if prepend:
         os.environ["PATH"] = os.pathsep.join([*prepend, existing])

--- a/tests/hermes_cli/test_stdio_path_dedup.py
+++ b/tests/hermes_cli/test_stdio_path_dedup.py
@@ -1,0 +1,90 @@
+"""PATH dedup in ``hermes_cli/stdio.py`` must treat spelling variants of the same
+Windows directory as equal.
+
+``_augment_path_with_known_tools`` runs at every Python startup and prepends the
+Hermes-managed tool dirs when they are missing from PATH. The old membership
+check compared entries via ``entry.lower()``, so ``C:\\hermes\\venv\\Scripts`` and
+``C:\\hermes\\venv\\Scripts\\`` (or an MSYS-translated ``c:/hermes/venv/Scripts``)
+counted as different directories: every startup prepended another copy, and the
+bash session snapshot accumulated dozens of consecutive duplicates
+(issue #108508).
+
+The fakes below are string-level on purpose: ``_augment_path_with_known_tools``
+is exercised with Windows-shaped values (``LOCALAPPDATA`` with backslashes, a
+PATH mixing separators and case) while ``os.path.isdir`` is stubbed, because the
+behavior under test is pure string membership, not filesystem semantics.
+"""
+
+import os
+
+import pytest
+
+from hermes_cli import stdio as stdio_mod
+from hermes_cli.stdio import _augment_path_with_known_tools, _windows_path_key
+
+_FAKE_APPDATA = "C:\\HermesTest"
+
+
+class TestWindowsPathKey:
+    def test_spelling_variants_share_one_key(self):
+        assert _windows_path_key("C:\\Foo\\") == _windows_path_key("c:/foo")
+        assert _windows_path_key("c:\\FOO") == _windows_path_key("C:/foo/")
+        assert _windows_path_key(r"C:\Foo\Bar") == _windows_path_key("C:\\FOO\\bar")
+
+    def test_distinct_directories_stay_distinct(self):
+        assert _windows_path_key("C:\\hermes\\git\\bin") != _windows_path_key(
+            "C:\\hermes\\git\\usr\\bin"
+        )
+
+    def test_empty_is_identity(self):
+        assert _windows_path_key("") == ""
+
+
+class TestAugmentPathDedup:
+    """Repeated startups must not stack spelling-variant duplicates."""
+
+    @pytest.fixture
+    def fake_windows(self, monkeypatch):
+        monkeypatch.setattr(stdio_mod, "is_windows", lambda: True)
+        # Windows-shaped PATH semantics while running on any host: ";" as the
+        # entry separator and case/backslash-insensitive comparison keys.
+        monkeypatch.setattr(os, "pathsep", ";")
+        monkeypatch.setenv("LOCALAPPDATA", _FAKE_APPDATA)
+        monkeypatch.setattr(
+            os.path,
+            "isdir",
+            lambda p: (
+                "venv\\scripts"
+                in str(p).lower().replace("venv/scripts", "venv\\scripts")
+            ),
+        )
+
+    def _venv_entries(self):
+        return [
+            e
+            for e in os.environ["PATH"].split(os.pathsep)
+            if "scripts" in e.lower() and "hermestest" in e.lower()
+        ]
+
+    def test_no_prepend_when_variants_already_present(self, fake_windows, monkeypatch):
+        variants = os.pathsep.join([
+            _FAKE_APPDATA + "\\hermes\\hermes-agent\\venv\\Scripts\\",
+            "c:/hermestest/hermes/hermes-agent/venv/Scripts",
+        ])
+        monkeypatch.setenv("PATH", variants)
+        _augment_path_with_known_tools()
+        assert len(self._venv_entries()) == 2  # исходные варианты, ничего не добавлено
+
+    def test_repeated_startups_do_not_accumulate(self, fake_windows, monkeypatch):
+        monkeypatch.setenv("PATH", "c:/HERMESTEST/hermes/hermes-agent/venv/Scripts")
+        for _ in range(5):
+            _augment_path_with_known_tools()
+        assert len(self._venv_entries()) == 1
+
+    def test_missing_dir_is_prepended_once(self, fake_windows, monkeypatch):
+        monkeypatch.setenv("PATH", "C:\\Windows\\System32")
+        _augment_path_with_known_tools()
+        _augment_path_with_known_tools()
+        entries = self._venv_entries()
+        assert len(entries) == 1
+        assert os.environ["PATH"].startswith(entries[0])

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -43,6 +43,7 @@ from tools.environments.local import (
     _make_run_env,
     _msys_to_windows_path,
     _prepend_git_bash_dirs,
+    _prepend_missing_path_entries,
     _quote_bash_path,
     _resolve_safe_cwd,
     _sanitize_subprocess_env,
@@ -332,3 +333,21 @@ class TestWrapCommandWindowsNativeCwd:
         script = captured["script"]
         assert "/c/Users/Alexander/AppData/Local/Temp/hermes-snap-deadbeef.sh" in script
         assert r"C:\Users\Alexander\AppData" not in script
+
+
+# ---------------------------------------------------------------------------
+# _prepend_missing_path_entries — Windows spelling-variant dedup (#108508)
+# ---------------------------------------------------------------------------
+
+class TestPrependMissingPathEntriesWindows:
+    @pytest.mark.windows_only
+    def test_spelling_variant_already_present_is_not_prepended(self):
+        existing = "C:\\Git\\bin;C:\\Windows\\System32"
+        result = _prepend_missing_path_entries(existing, ["c:/git/bin/"])
+        assert result == existing
+
+    @pytest.mark.linux_only
+    def test_posix_entries_stay_case_sensitive(self):
+        existing = "/opt/Git/bin:/bin"
+        result = _prepend_missing_path_entries(existing, ["/opt/git/bin"])
+        assert result == os.pathsep.join(["/opt/git/bin", existing])

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -417,10 +417,18 @@ def _compute_git_bash_bin_dirs() -> list[str]:
 
 
 def _prepend_missing_path_entries(existing_path: str, dirs: list[str]) -> str:
-    """Prepend *dirs* missing from *existing_path* (``os.pathsep``); an already-listed
-    dir keeps its position; unchanged input when nothing is missing."""
+    r"""Prepend *dirs* missing from *existing_path* (``os.pathsep``); an already-listed
+    dir keeps its position; unchanged input when nothing is missing.
+
+    On Windows the membership check compares case-insensitively with separators
+    normalized (``C:\Git\bin`` ≡ ``c:/git/bin\``), so repeated startup PATH prepends
+    cannot stack duplicates that differ only in spelling."""
     entries = [e for e in existing_path.split(os.pathsep) if e]
-    missing = [d for d in dirs if d not in entries]
+    if _IS_WINDOWS:
+        existing_keys = {_windows_path_key(e) for e in entries}
+        missing = [d for d in dirs if _windows_path_key(d) not in existing_keys]
+    else:
+        missing = [d for d in dirs if d not in entries]
     return os.pathsep.join([*missing, *entries]) if missing else existing_path
 
 
@@ -450,6 +458,10 @@ def _find_shell() -> str:
 
 
 # --- PATH completion for the terminal subshell ---
+
+# Windows path equality key used for PATH membership checks; imported from
+# hermes_cli.stdio so the normalization rule lives in exactly one place.
+from hermes_cli.stdio import _windows_path_key  # noqa: E402
 
 # Standard PATH entries for environments with minimal PATH.
 _SANE_PATH = ("/opt/homebrew/bin:/opt/homebrew/sbin:"


### PR DESCRIPTION
## What

Windows PATH dedup compared entries verbatim (`entry.lower()` / exact `Set` match), so spelling variants of the same directory — `C:\foo`, `c:/foo`, `C:\foo\`, MSYS-translated forms — counted as different entries. Every Python startup (`_augment_path_with_known_tools`) and every Desktop backend launch prepended the venv `Scripts` dir again, and the bash session snapshot (`export -p` re-dump per command) persisted the accumulation: 70+ consecutive duplicates reported in #108508.

## Changes

- **`hermes_cli/stdio.py`** — new `_windows_path_key()` (`ntpath.normcase(ntpath.normpath(p))`, explicit `ntpath` so the rule is host-independent) used as the membership key in `_augment_path_with_known_tools`. Matches the existing `_normalize_windows_path` pattern in `hermes_cli/_install_repair.py`.
- **`tools/environments/local.py`** — `_prepend_missing_path_entries` uses the same key on Windows (`_IS_WINDOWS` branch); POSIX entries stay case-sensitive (`/a` and `/A` are different directories there).
- **`apps/desktop/electron/backend-env.ts`** — `appendUniquePathEntries` dedupes Windows-delimiter (`;`) entries case-insensitively with back/forward slashes and trailing separators normalized, keeping the first-seen spelling. POSIX `:` dedup stays exact. This function feeds both the backend PATH/PYTHONPATH and `shell-path.ts` login-shell merging.

`realpath` is deliberately not used (per the discussion in #108508): it adds per-startup cost and diverges for subst/symlinked venv locations, while normcase+normpath covers every artifact observed in the snapshot. `_wrap_command_script` is also deliberately untouched: once prepend sites stop emitting duplicates, the snapshot cannot accumulate new ones, and rewriting PATH there would silently alter user-set entries.

## Tests

- `tests/hermes_cli/test_stdio_path_dedup.py` (new): key equivalence (`C:\Foo\` ≡ `c:/foo` ≡ `c:\FOO`), distinct dirs stay distinct; `_augment_path_with_known_tools` exercised with Windows-shaped PATH (`os.pathsep` patched to `;`): variants present → no prepend, 5 repeated startups → still 1 entry, missing dir → prepended exactly once.
- `tests/tools/test_local_env_windows_msys.py`: `windows_only` spelling-variant no-prepend + `linux_only` POSIX case-sensitivity guard (matches the file's established os-marker gating).
- `apps/desktop/electron/backend-env.test.ts`: Windows variant dedup, POSIX case-sensitivity, `buildDesktopBackendPath` does not stack venv `Scripts` duplicates on `win32`.

Fixes #108508