### PR TITLE
fix(buzz): probe relay liveness before reconnecting on WS read idle

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -271,6 +271,11 @@ _WS_AUTH_TIMEOUT = 20.0
 # close the transport never surfaces (observed as a CLOSE_WAIT socket with the loop parked on recv, #98097)
 # leaves the gateway "connected" while inbound stops; this timeout forces the normal reconnect path instead.
 _WS_READ_IDLE_TIMEOUT = 300.0
+# Idle reads on a healthy-but-quiet relay are normal (no chat traffic ⇒ no app frames), so before the read
+# watchdog declares the connection silent it probes liveness with an explicit control ping and waits for the
+# pong (herc flap, 2026-09-10: relay answers pings fine — killing healthy connections every 300s opened a
+# message-loss window every cycle). The probe must stay well inside the transport's ping_timeout (20s).
+_WS_IDLE_PROBE_TIMEOUT = 10.0
 _WS_MAX_MESSAGE_BYTES = 2_000_000
 _WS_MEMBERSHIP_KIND = 44100  # Buzz channel-membership event — live DM discovery
 _WS_MEMBERSHIP_SUB_ID = "hermes-buzz-membership"
@@ -1263,7 +1268,7 @@ class BuzzAdapter(BasePlatformAdapter):
                 backoff = min(backoff * 2, 30.0)
 
     async def _ws_read_loop(self, websocket, subscriptions: Dict[str, Optional[str]]) -> None:
-        """Read frames until the relay closes; an idle read raises ConnectionError to reconnect."""
+        """Read frames until the relay closes; a read that stays idle past the liveness probe reconnects."""
         frame_iter = websocket.__aiter__()
         while True:
             try:
@@ -1271,7 +1276,18 @@ class BuzzAdapter(BasePlatformAdapter):
             except StopAsyncIteration:
                 return
             except asyncio.TimeoutError:
-                raise ConnectionError(f"no WebSocket frame for {_WS_READ_IDLE_TIMEOUT:.0f}s; assuming the connection went silent") from None
+                # 300s without an app frame is normal for a quiet relay; distinguish "quiet" from
+                # "dead" before reconnecting — a failed probe (or a closed transport raising here)
+                # still takes the reconnect path, so the #98097 CLOSE_WAIT cover holds.
+                try:
+                    pong = await websocket.ping()
+                    await asyncio.wait_for(pong, timeout=_WS_IDLE_PROBE_TIMEOUT)
+                    continue
+                except Exception:
+                    raise ConnectionError(
+                        f"no WebSocket frame for {_WS_READ_IDLE_TIMEOUT:.0f}s and idle liveness ping "
+                        f"got no pong within {_WS_IDLE_PROBE_TIMEOUT:.0f}s; assuming the connection went silent"
+                    ) from None
             try:
                 message = json.loads(raw)
             except (ValueError, TypeError):

--- a/tests/gateway/test_buzz_websocket.py
+++ b/tests/gateway/test_buzz_websocket.py
@@ -116,9 +116,10 @@ class _ScriptedWebSocket(_FakeWebSocket):
     a clean close.
     """
 
-    def __init__(self, anext_behavior):
+    def __init__(self, anext_behavior, pong_ok=False):
         super().__init__()
         self._anext_behavior = anext_behavior
+        self.pong_ok = pong_ok
         self.exited = False
 
     async def __aenter__(self):
@@ -133,6 +134,19 @@ class _ScriptedWebSocket(_FakeWebSocket):
     async def __anext__(self):
         return await self._anext_behavior()
 
+    async def ping(self, data=None):
+        """NIP-42 relays answer RFC 6455 control pings via the transport; script both outcomes.
+
+        Mirrors the real Connection.ping() contract: returns promptly with an
+        awaitable; the awaitable resolves with the latency on pong, or never
+        when the relay is dead.
+        """
+        if self.pong_ok:
+            fut = asyncio.get_running_loop().create_future()
+            fut.set_result(0.0)
+            return fut
+        return asyncio.get_running_loop().create_future()  # never resolves: the pong never comes
+
 
 @pytest.mark.asyncio
 async def test_websocket_loop_reconnects_when_read_goes_silent(monkeypatch, caplog):
@@ -146,6 +160,7 @@ async def test_websocket_loop_reconnects_when_read_goes_silent(monkeypatch, capl
 
     adapter = _make_adapter()
     monkeypatch.setattr(_buzz_mod, "_WS_READ_IDLE_TIMEOUT", 0.05)
+    monkeypatch.setattr(_buzz_mod, "_WS_IDLE_PROBE_TIMEOUT", 0.05)  # dead relay: probe must fail fast too
     caplog.set_level(logging.WARNING)
 
     sockets = []
@@ -177,6 +192,100 @@ async def test_websocket_loop_reconnects_when_read_goes_silent(monkeypatch, capl
     assert len(sockets) >= 2, "idle read watchdog did not force a reconnect"
     assert sockets[0].exited, "the silent connection was not closed before reconnecting"
     assert any("went silent" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_websocket_loop_reconnects_when_idle_ping_gets_no_pong(monkeypatch, caplog):
+    """Idle read + failed liveness probe must reconnect (the repaired #98097 cover).
+
+    A truly dead relay yields no app frames AND no pong, so the watchdog must
+    still take the reconnect path after probing — the probe narrows the
+    #98097 cover, it does not remove it.
+    """
+    import logging
+
+    adapter = _make_adapter()
+    monkeypatch.setattr(_buzz_mod, "_WS_READ_IDLE_TIMEOUT", 0.05)
+    monkeypatch.setattr(_buzz_mod, "_WS_IDLE_PROBE_TIMEOUT", 0.05)
+    caplog.set_level(logging.WARNING)
+
+    sockets = []
+
+    async def dead_anext():
+        await asyncio.Event().wait()  # never yields, never raises
+
+    def fake_connect(*args, **kwargs):
+        ws = _ScriptedWebSocket(dead_anext, pong_ok=False)
+        sockets.append(ws)
+        return ws
+
+    import websockets as _ws_mod
+
+    monkeypatch.setattr(_ws_mod, "connect", fake_connect)
+
+    task = asyncio.create_task(adapter._websocket_loop())
+    try:
+        deadline = time.monotonic() + 5.0
+        while len(sockets) < 2 and time.monotonic() < deadline:
+            await asyncio.sleep(0.02)
+    finally:
+        task.cancel()
+        try:
+            await asyncio.wait_for(task, 5.0)
+        except (asyncio.CancelledError, asyncio.TimeoutError):
+            pass
+
+    assert len(sockets) >= 2, "idle watchdog with a dead relay (no pong) did not force a reconnect"
+    assert sockets[0].exited, "the dead connection was not closed before reconnecting"
+    assert any("went silent" in record.message for record in caplog.records)
+    assert any("no pong" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_websocket_loop_survives_idle_when_relay_answers_ping(monkeypatch):
+    """A healthy-but-quiet relay (no app frames, pongs fine) must NOT be reconnected.
+
+    The herc flap (2026-09-10): the relay answered transport pings the whole
+    time, yet the 300s idle guard killed the healthy connection every 5
+    minutes. The liveness probe must distinguish this case and keep reading.
+    """
+    adapter = _make_adapter()
+    monkeypatch.setattr(_buzz_mod, "_WS_READ_IDLE_TIMEOUT", 0.05)
+
+    sockets = []
+    probes = []
+
+    async def quiet_anext():
+        await asyncio.Event().wait()  # relay is healthy but sends nothing
+
+    def fake_connect(*args, **kwargs):
+        ws = _ScriptedWebSocket(quiet_anext, pong_ok=True)
+        sockets.append(ws)
+        return ws
+
+    import websockets as _ws_mod
+
+    orig_ping = _ScriptedWebSocket.ping
+
+    async def counting_ping(self, data=None):
+        probes.append(time.monotonic())
+        return await orig_ping(self, data)
+
+    monkeypatch.setattr(_ScriptedWebSocket, "ping", counting_ping)
+    monkeypatch.setattr(_ws_mod, "connect", fake_connect)
+
+    task = asyncio.create_task(adapter._websocket_loop())
+    try:
+        await asyncio.sleep(0.4)  # several idle cycles' worth of time
+    finally:
+        task.cancel()
+        try:
+            await asyncio.wait_for(task, 5.0)
+        except (asyncio.CancelledError, asyncio.TimeoutError):
+            pass
+
+    assert len(sockets) == 1, "healthy-but-quiet relay was reconnected"
+    assert len(probes) >= 2, "liveness probe was not repeated on successive idle reads"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Symptom

Buzz platform gateway connections enter a reconnect loop when the WebSocket goes idle: the adapter's read-idle watchdog fires every ~300s of no traffic, the adapter tears down and reconnects **without first checking whether the relay is actually still reachable**, and the cycle repeats. On long-lived gateways this produces a flap every ~5 minutes indefinitely (observed: herc 23 flaps/night, neo 52/night pre-fix; 31 flaps in 3h post-update on an unfixed process).

## Root cause

`plugins/platforms/buzz/adapter.py`: on WS read idle, the reconnect path assumed the relay was dead and reconnected blindly. If the relay was merely quiet (no traffic, connection still healthy), the teardown killed a good connection and the reconnect cycle re-established it — then idle fired again. Classic NACHOS-style watchdog without liveness probe.

## Fix

Probe relay liveness **before** tearing down on WS read idle:

- If the relay answers the probe → the connection is healthy; reset the idle timer instead of reconnecting.
- Only reconnect when the probe confirms the relay is unreachable.

## Test evidence

`tests/gateway/test_buzz_websocket.py` — 20 tests covering idle-probe, reconnect, and flap-cycle behavior:

```
=== Summary: 1 files, 20 tests passed, 0 failed (100% complete) in 15.0s (16 workers) ===
```

Run via `scripts/run_tests.sh tests/gateway/test_buzz_websocket.py`.

## Reproduction

1. Run a gateway with the Buzz platform against a quiet relay
2. Observe `WARN hermes_plugins.buzz_platform.adapter: ... no WebSocket frame for 300s` + teardown every ~300s
3. With the fix: healthy quiet connections are probed and kept; only dead relays trigger reconnect

## Notes

- Fleet-observed and patched 2026-09-10; deployed on two hosts since with 0 old-format flaps in ~87 min windows post-reload (previously 23–52 flaps/night per gateway).
- No core changes — platform adapter + its test file only.