### PR TITLE
fix(kanban): make hook tests stable and exercise plugin gate

### DIFF
--- a/tests/hermes_cli/conftest.py
+++ b/tests/hermes_cli/conftest.py
@@ -6,6 +6,24 @@ import pytest
 
 
 @pytest.fixture
+def plugin_hook_gate(monkeypatch):
+    """Force lifecycle-hook checks through the plugin-subscriber gate."""
+    from hermes_cli import observability, plugins
+
+    checked: list[str] = []
+    real_has_hook = plugins.has_hook
+
+    monkeypatch.setattr(observability, "handles_hook", lambda _hook_name: False)
+
+    def _record_has_hook(hook_name: str) -> bool:
+        checked.append(hook_name)
+        return real_has_hook(hook_name)
+
+    monkeypatch.setattr(plugins, "has_hook", _record_has_hook)
+    return checked
+
+
+@pytest.fixture
 def all_assignees_spawnable(monkeypatch):
     """Pretend every assignee maps to a real Hermes profile.
 

--- a/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
+++ b/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import sys
 import tempfile
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -23,9 +22,6 @@ def isolated_kanban_home(monkeypatch):
     test_home = tempfile.mkdtemp(prefix="kanban_cli_passthrough_")
     os.makedirs(os.path.join(test_home, "profiles", "default"), exist_ok=True)
     monkeypatch.setenv("HERMES_HOME", test_home)
-    for mod in list(sys.modules.keys()):
-        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
-            del sys.modules[mod]
     yield test_home
 
 

--- a/tests/hermes_cli/test_kanban_default_assignee.py
+++ b/tests/hermes_cli/test_kanban_default_assignee.py
@@ -7,8 +7,6 @@ the task is skipped (existing behavior preserved).
 from __future__ import annotations
 
 import json
-import os
-import sys
 import tempfile
 
 import pytest
@@ -19,10 +17,6 @@ def isolated_kanban_home(monkeypatch):
     """Spin up a fresh HERMES_HOME with a clean kanban DB."""
     test_home = tempfile.mkdtemp(prefix="kanban_default_assignee_test_")
     monkeypatch.setenv("HERMES_HOME", test_home)
-    # Force-reimport so the fresh HERMES_HOME is picked up.
-    for mod in list(sys.modules.keys()):
-        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
-            del sys.modules[mod]
     from hermes_cli import kanban_db
     yield kanban_db, test_home
     # Cleanup is best-effort; tempfile dir survives but pytest isolation

--- a/tests/hermes_cli/test_kanban_dispatch_tick_hook.py
+++ b/tests/hermes_cli/test_kanban_dispatch_tick_hook.py
@@ -23,7 +23,7 @@ from hermes_cli.plugins import VALID_HOOKS, get_plugin_manager
 
 
 @pytest.fixture
-def kanban_home(tmp_path, monkeypatch):
+def kanban_home(tmp_path, monkeypatch, plugin_hook_gate):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
@@ -47,7 +47,7 @@ def captured_ticks(monkeypatch):
         mgr._hooks = saved
 
 def test_active_tick_fires_hook_with_outcome_ok(
-    kanban_home, all_assignees_spawnable, captured_ticks,
+    kanban_home, all_assignees_spawnable, captured_ticks, plugin_hook_gate,
 ):
     """A tick that spawns a worker fires the hook with outcome='ok'."""
     conn = kbc.connect()
@@ -62,6 +62,7 @@ def test_active_tick_fires_hook_with_outcome_ok(
     )
     result = ok_events[-1]["result"]
     assert any(row[0] == tid for row in result.spawned)
+    assert "on_kanban_dispatch_tick" in plugin_hook_gate
 
 def test_tick_hook_fires_after_dispatch_lock_released(kanban_home):
     """The #56066 sweeper finding, as a contract: subscribers run OUTSIDE

--- a/tests/hermes_cli/test_kanban_per_profile_cap.py
+++ b/tests/hermes_cli/test_kanban_per_profile_cap.py
@@ -8,7 +8,6 @@ model / API quota / browser pool from being overwhelmed by a fan-out.
 from __future__ import annotations
 
 import os
-import sys
 import tempfile
 
 import pytest
@@ -21,9 +20,6 @@ def isolated_kanban_home_with_profiles(monkeypatch):
     for prof in ("alpha", "beta", "default"):
         os.makedirs(os.path.join(test_home, "profiles", prof), exist_ok=True)
     monkeypatch.setenv("HERMES_HOME", test_home)
-    for mod in list(sys.modules.keys()):
-        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
-            del sys.modules[mod]
     from hermes_cli import kanban_db
     yield kanban_db
 

--- a/tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py
+++ b/tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py
@@ -31,7 +31,7 @@ WORKER_HOOKS = (
 
 
 @pytest.fixture
-def kanban_home(tmp_path, monkeypatch):
+def kanban_home(tmp_path, monkeypatch, plugin_hook_gate):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
@@ -58,7 +58,7 @@ def captured_hooks(monkeypatch):
         mgr._hooks = saved
 
 def test_dispatch_spawn_fires_worker_spawned(
-    kanban_home, all_assignees_spawnable, captured_hooks,
+    kanban_home, all_assignees_spawnable, captured_hooks, plugin_hook_gate,
 ):
     """A dispatched spawn fires the hook AFTER the PID is durably persisted."""
     pid_at_fire_time: list = []
@@ -97,6 +97,7 @@ def test_dispatch_spawn_fires_worker_spawned(
     assert "profile_name" in kw
     assert "board" in kw
     assert pid_at_fire_time == [4242]
+    assert "on_kanban_worker_spawned" in plugin_hook_gate
 
 def test_crash_reclaim_fires_worker_exited(kanban_home, captured_hooks, monkeypatch):
     """A dead-PID reclaim fires the exit observer with the exit facts."""


### PR DESCRIPTION
## What does this PR do?

Kanban hook tests can fail after another test removes loaded `hermes_cli` modules from `sys.modules`, while isolated runs can pass through the built-in observability gate without checking plugin subscribers. This change removes the unsafe module purges from sibling kanban fixtures and forces hook suites through the plugin gate so their results are stable and meaningful.

### Symptom

Running `test_kanban_cli_dispatch_passthrough.py` before the dispatch-tick hook suite leaves registered callbacks on stale module objects, producing empty captured event lists. In isolation, built-in observability can make `lifecycle.has_hook()` return early before `plugins.has_hook()` is called.

### Impact

The affected tests are order-dependent and can both report unrelated failures and hide regressions in plugin hook subscription gating.

### Bug Cause

**Trigger:** `tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py:26` and sibling kanban isolation fixtures removed every loaded `hermes_cli` module from `sys.modules`.

**Causal chain:**
1. Pytest collection retains references to the original kanban and plugin modules.
2. A fixture deletes those modules, and later runtime imports create a second module graph for the same `HERMES_HOME`.
3. Hook callbacks register on one `PluginManager`, while the gate resolves another, so no callback fires.

**Why it is wrong:** Deleting imported application modules in-process does not update references held by already-collected test modules. It creates duplicate singleton registries instead of isolating them.

**Working sibling / contrast:** The suite-level hermetic fixture already assigns a unique `HERMES_HOME` and resets plugin managers without replacing module identities.

**Ruled out:** `_delivery_manager()` and `get_plugin_manager()` resolve the same manager at fire time; plugin discovery does not unload hooks on its normal lazy path.

### Fix

Remove in-process `hermes_cli` module deletion from all three kanban fixtures that used it. Add a shared hook-gate fixture that disables the built-in observability branch, records `plugins.has_hook()` checks, and makes the dispatch-tick and worker-spawn contracts assert that the plugin gate was reached.

## Related Issue

Closes #108524

## Type of Change

- [x] Tests (adding or improving test coverage)

## Changes Made

- `tests/hermes_cli/conftest.py` - add an explicit plugin-only lifecycle gate fixture.
- `tests/hermes_cli/test_kanban_*` - preserve module identity across test isolation and assert plugin-gate coverage for dispatch and worker hooks.

## How to Test

1. Run the original order-dependent and sibling fixture suites through the repository test runner.
2. Confirm the dispatch-tick and worker-spawn tests record `plugins.has_hook()` checks with observability disabled.
3. Targeted result: 15 tests passed.

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py tests/hermes_cli/test_kanban_default_assignee.py tests/hermes_cli/test_kanban_per_profile_cap.py tests/hermes_cli/test_kanban_dispatch_tick_hook.py tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - module identity is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - the targeted repository test run passed all 15 tests.
