### PR TITLE
fix(review): preserve the originating profile through idle dispatch

### DIFF
--- a/agent/review_idle_queue.py
+++ b/agent/review_idle_queue.py
@@ -12,6 +12,7 @@ fork. Idle truth is the supervisor's /slots held for a settle window.
 
 from __future__ import annotations
 
+import contextvars
 import json
 import logging
 import threading
@@ -64,6 +65,7 @@ class _PendingReview:
     session_key: str
     kwargs: Dict[str, Any]
     enqueued_at: float
+    context: contextvars.Context
 
 
 class ReviewIdleQueue:
@@ -98,7 +100,8 @@ class ReviewIdleQueue:
         with self._lock:
             existing = self._pending.get(session_key)
             enqueued_at = existing.enqueued_at if existing is not None else self._now()
-            self._pending[session_key] = _PendingReview(agent, session_key, kwargs, enqueued_at)
+            self._pending[session_key] = _PendingReview(
+                agent, session_key, kwargs, enqueued_at, contextvars.copy_context())
         self._ensure_thread()
         self._wake.set()
         logger.info("Background review deferred (session=%s, queued=%d)", session_key[-12:], len(self._pending))
@@ -149,19 +152,24 @@ class ReviewIdleQueue:
             try:
                 item = self._pop_dispatchable()
                 if item is not None:
-                    if not self._still_enabled(item):
-                        logger.info(
-                            "Deferred background review dropped: reviews were disabled while it was queued (session=%s)",
-                            item.session_key[-12:])
-                        continue
-                    logger.info(
-                        "Dispatching deferred background review (session=%s, waited=%.0fs, queued=%d)",
-                        item.session_key[-12:], self._now() - item.enqueued_at, self.pending_count())
-                    item.agent._spawn_background_review_now(**item.kwargs)
+                    # The shared dispatcher has no caller profile. Enter the item's context
+                    # before reading config AND spawning the context-propagating review worker.
+                    item.context.run(self._dispatch, item)
             except Exception:  # noqa: BLE001 — dispatcher must survive anything
                 logger.warning("Deferred review dispatch failed", exc_info=True)
             if item is None:
                 time.sleep(_POLL_INTERVAL_S)
+
+    def _dispatch(self, item: _PendingReview) -> None:
+        if not self._still_enabled(item):
+            logger.info(
+                "Deferred background review dropped: reviews were disabled while it was queued (session=%s)",
+                item.session_key[-12:])
+            return
+        logger.info(
+            "Dispatching deferred background review (session=%s, waited=%.0fs, queued=%d)",
+            item.session_key[-12:], self._now() - item.enqueued_at, self.pending_count())
+        item.agent._spawn_background_review_now(**item.kwargs)
 
     @staticmethod
     def _still_enabled(item: _PendingReview) -> bool:

--- a/tests/agent/test_review_idle_profile_scope.py
+++ b/tests/agent/test_review_idle_profile_scope.py
@@ -1,0 +1,77 @@
+"""Deferred review dispatch must use the profile that admitted each item."""
+
+import threading
+
+import pytest
+
+from agent.review_idle_queue import ReviewIdleQueue
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from tools.memory_tool_store import MemoryStore
+
+
+@pytest.mark.parametrize("ambient_enabled", [True, False])
+def test_deferred_review_keeps_profile_config_and_memory(tmp_path, monkeypatch, ambient_enabled):
+    ambient = tmp_path / "ambient"
+    profiles = [tmp_path / "first", tmp_path / "second"]
+    enabled = not ambient_enabled
+    for home, gate in [(ambient, ambient_enabled), *[(p, enabled) for p in profiles]]:
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            f"auxiliary:\n  background_review:\n    enabled: {str(gate).lower()}\n",
+            encoding="utf-8",
+        )
+    monkeypatch.setenv("HERMES_HOME", str(ambient))
+    queue = ReviewIdleQueue()
+    monkeypatch.setattr(queue, "_ensure_thread", lambda: None)
+    clock = [0.0]
+    queue._now = lambda: clock[0]
+    writes = []
+
+    class Parent:
+        def _spawn_background_review_now(self, **kwargs):
+            # Real profile-aware memory I/O at the spawn boundary; no model call.
+            writes.append(MemoryStore().add("memory", kwargs["fact"]))
+
+    parent = Parent()
+    for index, home in enumerate(profiles):
+        token = set_hermes_home_override(home)
+        try:
+            queue.enqueue(parent, str(index), {"fact": f"Project {index} uses Python", "task_cfg": {}})
+        finally:
+            reset_hermes_home_override(token)
+    clock[0] = 4000.0  # age-out avoids contacting a model server
+
+    class StopWorker(BaseException):
+        pass
+
+    class DrainWake(threading.Event):
+        def wait(self, timeout=None):
+            if queue.pending_count() == 0:
+                raise StopWorker
+            return True
+
+    queue._wake = DrainWake()
+    failures = []
+
+    def drain():
+        try:
+            queue._run()
+        except StopWorker:
+            pass
+        except BaseException as exc:
+            failures.append(exc)
+
+    worker = threading.Thread(target=drain, daemon=True)
+    worker.start()
+    worker.join(timeout=10)
+    assert not worker.is_alive()
+    assert not failures
+    assert queue.pending_count() == 0
+    assert len(writes) == (2 if enabled else 0)
+    assert all(result["success"] for result in writes)
+    assert not (ambient / "memories" / "MEMORY.md").exists()
+    for index, home in enumerate(profiles):
+        path = home / "memories" / "MEMORY.md"
+        assert path.exists() == enabled
+        if enabled:
+            assert path.read_text(encoding="utf-8") == f"Project {index} uses Python"


### PR DESCRIPTION
## What does this PR do?

A review deferred on the managed local runtime is dispatched by a shared thread without the ContextVars of the session that queued it. With multiple profiles in one process, the dispatch-time enabled check reads the ambient profile, and the review worker inherits that same ambient context. This can drop an enabled profile's review, run a disabled profile's review, or resolve profile-aware memory paths to the ambient home.

Capture `contextvars.copy_context()` per pending item and enter it around both the dispatch-time gate and worker spawn. The existing worker propagation can then carry the correct context onward. Coalescing replaces the context together with the snapshot; the original age-out time is unchanged.

## Related Issue

Fixes #108537

## Type of Change

- [x] Bug fix

## Changes Made

- `agent/review_idle_queue.py`
- `tests/agent/test_review_idle_profile_scope.py`

## How to Test

Base: `7469c0f2a52baf70c574b110af0772b81bf84227`.

```bash
bash scripts/run_tests.sh tests/agent/test_review_idle_profile_scope.py tests/agent/test_review_idle_queue.py tests/run_agent/test_background_review.py tests/run_agent/test_background_review_cache_parity.py --file-retries 0 -j 3 -q
python -m ruff check .
python scripts/check_compat_pointers.py
python scripts/check-windows-footguns.py agent/review_idle_queue.py tests/agent/test_review_idle_profile_scope.py
git diff --check
```

New regression: 2 failed on unmodified main, 2 passed with the fix. Final related suite: 43 passed. Earlier expanded review/session/memory/toolset regression: 44 passed.

Ruff, compatibility-pointer checks, changed-file Windows checks and whitespace checks passed. No effective test was removed or skipped to obtain a passing result.

## Compatibility and limitations

Validated with real temporary profile files and a real dispatch thread; only the model-spawn boundary is substituted with real MemoryStore I/O. No live model/GPU run was performed. No profile inheritance, global environment mutation, configuration keys, or prompt/tool schemas are added.

## Duplicate check

Searched open/closed Issues and PRs for `ReviewIdleQueue`, deferred review/profile, and background review/ContextVars. #108234 / #108260 cover retained queue memory, not context propagation. #91509 changes provider alias/credential resolution after entering a scope. #24392 and #54937 concern earlier direct-worker/global-home paths; the extra idle-dispatch hop still loses scope on current main. Their fixes do not cover this queue boundary.

## Checklist

- [x] Read the contributing guide; Conventional Commit; one focused fix.
- [x] Searched existing open/closed/merged work and current main.
- [x] Added regression tests and ran the related suite via `scripts/run_tests.sh`.
- [x] Tested on Windows with Python 3.13; considered platform impact.
- [ ] Full repository suite: not run.
- [x] Configuration/schema/architecture documentation changes: N/A; local comments/docstrings updated where needed.
