### PR TITLE
fix(review): keep preempted retries from replacing newer queued snapshots

### DIFF
--- a/agent/review_idle_queue.py
+++ b/agent/review_idle_queue.py
@@ -95,8 +95,15 @@ class ReviewIdleQueue:
     def enqueue(self, agent: Any, session_key: str, kwargs: Dict[str, Any]) -> None:
         """Add (or replace — newest snapshot wins) a session's pending review, keeping the ORIGINAL
         enqueue time on coalesce so a busy session cannot push its age-out forever."""
+        kwargs = dict(kwargs)
+        kwargs.setdefault("_review_snapshot_created_at", self._now())
         with self._lock:
             existing = self._pending.get(session_key)
+            # A cancelled worker can unwind after the next turn queued a newer snapshot.
+            # Its retry keeps the original creation time; arrival order is not freshness.
+            if (existing is not None and kwargs["_review_snapshot_created_at"]
+                    < existing.kwargs["_review_snapshot_created_at"]):
+                return
             enqueued_at = existing.enqueued_at if existing is not None else self._now()
             self._pending[session_key] = _PendingReview(agent, session_key, kwargs, enqueued_at)
         self._ensure_thread()

--- a/run_agent.py
+++ b/run_agent.py
@@ -772,7 +772,8 @@ class AIAgent(
     def _spawn_background_review_now(self, messages_snapshot: List[Dict], review_memory: bool = False,
                                      review_skills: bool = False, focus: Optional[str] = None,
                                      task_cfg: Optional[Dict[str, Any]] = None, _requeue_attempts: int = 0,
-                                     explicit: bool = False) -> None:
+                                     explicit: bool = False,
+                                     _review_snapshot_created_at: Optional[float] = None) -> None:
         """Spawn the background memory/skill review thread.
 
         ``threading.Thread`` is constructed here so tests patching ``run_agent.threading.Thread`` keep working.
@@ -786,6 +787,8 @@ class AIAgent(
         )
         from tools.thread_context import propagate_context_to_thread
 
+        if _review_snapshot_created_at is None:
+            _review_snapshot_created_at = time.monotonic()
         review_run = prepare_background_review_run(self)
         if review_run is None:
             return
@@ -800,7 +803,7 @@ class AIAgent(
                 self._maybe_requeue_preempted_review(review_run, dict(
                     messages_snapshot=messages_snapshot, review_memory=review_memory, review_skills=review_skills,
                     focus=focus, task_cfg=task_cfg, _requeue_attempts=_requeue_attempts + 1,
-                    explicit=explicit))
+                    explicit=explicit, _review_snapshot_created_at=_review_snapshot_created_at))
 
             # Carry the active profile into the review thread so MEMORY.md / skill review writes land in the
             # right profile.

--- a/tests/agent/test_review_requeue_order.py
+++ b/tests/agent/test_review_requeue_order.py
@@ -1,0 +1,67 @@
+"""A preempted review retains its original position relative to newer snapshots."""
+
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from agent import review_idle_queue
+from run_agent import AIAgent
+
+
+@pytest.mark.parametrize("retry_first", [False, True])
+def test_preempted_retry_cannot_replace_a_newer_snapshot(monkeypatch, retry_first):
+    queue = review_idle_queue.ReviewIdleQueue()
+    monkeypatch.setattr(queue, "_ensure_thread", lambda: None)
+    monkeypatch.setattr(review_idle_queue, "QUEUE", queue)
+    monkeypatch.setattr(review_idle_queue, "review_targets_managed_local", lambda *_: True)
+    now = [10.0]
+    queue._now = lambda: now[0]
+    parent = SimpleNamespace(session_id="session", _REVIEW_REQUEUE_MAX_ATTEMPTS=3)
+    old = [{"role": "user", "content": "Original task"}]
+    new = old + [{"role": "user", "content": "The corrected requirement"}]
+    queue.enqueue(parent, "session", {"messages_snapshot": old, "task_cfg": {}})
+    now[0] += 2000
+    running = queue._pop_dispatchable()
+    assert running is not None
+    retry = dict(running.kwargs, _requeue_attempts=1)
+    cancelled = threading.Event()
+    cancelled.set()
+
+    def requeue():
+        AIAgent._maybe_requeue_preempted_review(
+            parent, SimpleNamespace(cancel_requested=cancelled), retry)
+
+    if retry_first:
+        requeue()
+    now[0] += 1
+    queue.enqueue(parent, "session", {"messages_snapshot": new, "task_cfg": {}})
+    admitted_at = queue._pending["session"].enqueued_at
+    if not retry_first:
+        requeue()
+    pending = queue._pending["session"]
+    assert pending.kwargs["messages_snapshot"] == new
+    assert pending.kwargs.get("_requeue_attempts", 0) == 0
+    assert pending.enqueued_at == admitted_at
+
+
+def test_spawn_preserves_snapshot_age_through_the_worker(monkeypatch):
+    from agent import background_review
+
+    done = threading.Event()
+    captured = []
+    run = SimpleNamespace()
+    monkeypatch.setattr(background_review, "prepare_background_review_run", lambda _: run)
+    monkeypatch.setattr(background_review, "spawn_background_review_thread", lambda *a, **k: (lambda: None, ""))
+
+    def capture(finished, kwargs):
+        captured.append((finished, kwargs))
+        done.set()
+
+    parent = SimpleNamespace(_maybe_requeue_preempted_review=capture)
+    AIAgent._spawn_background_review_now(
+        parent, [{"role": "user", "content": "Task"}], _review_snapshot_created_at=12.5)
+    assert done.wait(10)
+    assert captured[0][0] is run
+    assert captured[0][1]["_review_snapshot_created_at"] == 12.5
+    assert captured[0][1]["_requeue_attempts"] == 1


### PR DESCRIPTION
## What does this PR do?

When a foreground turn preempts a managed-local background review, the old worker may unwind after the foreground turn has queued its updated conversation. The old worker's retry then overwrites that newer pending review. The next reviewer receives the old conversation and misses the latest correction, contrary to the queue's documented newest-snapshot-wins contract.

Carry an internal monotonic snapshot creation timestamp through dispatch and requeue. Reject an incoming older snapshot when a newer item is already pending, while preserving the existing age-out timestamp and normal coalescing behavior.

## Related Issue

Fixes #108539

## Type of Change

- [x] Bug fix

## Changes Made

- `agent/review_idle_queue.py`
- `run_agent.py`
- `tests/agent/test_review_requeue_order.py`

## How to Test

Base: `7469c0f2a52baf70c574b110af0772b81bf84227`.

```bash
bash scripts/run_tests.sh tests/agent/test_review_requeue_order.py tests/agent/test_review_idle_queue.py tests/run_agent/test_background_review.py tests/run_agent/test_background_review_cache_parity.py --file-retries 0 -j 3 -q
python -m ruff check .
python scripts/check_compat_pointers.py
python scripts/check-windows-footguns.py agent/review_idle_queue.py run_agent.py tests/agent/test_review_requeue_order.py
git diff --check
```

New regression on unmodified main: 2 failed, 1 passed (the already-correct opposite arrival order). With the fix: all 3 passed. Final related suite: 44 passed; additional session/memory/toolset regression: 29 passed.

Ruff, compatibility-pointer checks, changed-file Windows checks and whitespace checks passed. No effective test was removed or skipped to obtain a passing result.

## Compatibility and limitations

The test drives the real queue and AIAgent requeue method in both arrival orders, plus an actual worker thread for timestamp propagation; the managed-endpoint classifier and model execution are substituted. This protects a newer pending item and does not claim to serialize every reviewer or cross-session memory write.

## Duplicate check

Searched all states for `_maybe_requeue_preempted_review`, background review/requeue, and review/snapshot/stale. #108260 addresses queue memory bounds. #101074 fixes shallow snapshot aliasing. #9055 / #39806 guard memory/skill writes against live-state changes; they do not prevent the queue from discarding the newer pending review. This change is confined to pending-item selection, not a global stale-write guard.

## Checklist

- [x] Read the contributing guide; Conventional Commit; one focused fix.
- [x] Searched existing open/closed/merged work and current main.
- [x] Added regression tests and ran the related suite via `scripts/run_tests.sh`.
- [x] Tested on Windows with Python 3.13; considered platform impact.
- [ ] Full repository suite: not run.
- [x] Configuration/schema/architecture documentation changes: N/A; local comments/docstrings updated where needed.
