### PR TITLE
fix(state): deliver unseen reactions from visible compacted history

### DIFF
--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -419,13 +419,15 @@ class SessionMessagesMixin:
 
     def take_unseen_reactions(self, session_id: str, *, author: str = "user") -> List[Dict[str, Any]]:
         """Return *author*'s not-yet-surfaced reactions and mark them seen. Reactions are announced on the
-        NEXT user turn (never by rewriting the reacted message: cache-safe); ``seen`` makes it exactly once."""
+        NEXT user turn (never by rewriting the reacted message: cache-safe); ``seen`` makes it exactly once.
+        Include compaction-archived history that remains visible, but exclude rewound/superseded rows."""
         if not session_id:
             return []
         def _do(conn):
             pending = []
             for row in conn.execute("SELECT id, role, content, display_metadata FROM messages "
-                    "WHERE session_id = ? AND active = 1 AND display_metadata IS NOT NULL ORDER BY id",
+                    "WHERE session_id = ? AND (active = 1 OR compacted = 1) "
+                    "AND display_metadata IS NOT NULL ORDER BY id",
                     (session_id,)).fetchall():
                 meta = self._decode_display_metadata(row["display_metadata"])
                 reactions = meta.get(self.REACTIONS_METADATA_KEY) if meta else None

--- a/tests/state/test_compacted_message_reactions.py
+++ b/tests/state/test_compacted_message_reactions.py
@@ -1,0 +1,53 @@
+"""Visible archived messages keep the same once-only reaction contract."""
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.mark.parametrize("react_before_compaction", [False, True])
+def test_compacted_reactions_are_delivered_once_without_reviving_rewound_rows(
+    tmp_path, monkeypatch, react_before_compaction,
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    try:
+        sid = db.create_session("compacted-reactions", "test")
+        db.append_message(sid, "user", "remember this answer")
+        target = db.append_message(sid, "assistant", "the original answer")
+        db.append_message(sid, "user", "continue")
+        tail = db.get_messages_as_conversation(sid)[-1]
+        if react_before_compaction:
+            db.set_message_reaction(sid, target, "👍")
+        db.archive_and_compact(
+            sid, [{"role": "user", "content": "summary"}, tail], tail_count=1,
+        )
+        visible = db.get_messages(sid, include_compacted=True)
+        assert target in {row["id"] for row in visible}
+        if not react_before_compaction:
+            assert db.set_message_reaction(sid, target, "👍")
+
+        rewind_target = db.append_message(sid, "user", "discard this turn")
+        discarded = db.append_message(sid, "assistant", "discarded answer")
+        db.set_message_reaction(sid, discarded, "👎")
+        db.rewind_to_message(sid, rewind_target)
+        before = db.get_messages_as_conversation(sid)
+
+        pending = db.take_unseen_reactions(sid)
+        assert [(item["row_id"], item["emoji"], item["text"]) for item in pending] == [
+            (target, "👍", "the original answer"),
+        ]
+        assert db.take_unseen_reactions(sid) == []
+        assert db.get_messages_as_conversation(sid) == before
+        archived = {row["id"]: row for row in db.get_messages(sid, include_compacted=True)}
+        assert archived[target]["content"] == "the original answer"
+        assert discarded not in archived
+    finally:
+        db.close()
+
+    reopened = SessionDB(db_path=db_path)
+    try:
+        assert reopened.take_unseen_reactions(sid) == []
+    finally:
+        reopened.close()


### PR DESCRIPTION
## What does this PR do?

After in-place compaction, older messages remain visible in history and `set_message_reaction()` successfully persists a user's reaction. However, `take_unseen_reactions()` never returns reactions on those archived rows. The next-turn reaction context therefore silently omits feedback the UI accepted. An unseen reaction saved just before compaction is lost from delivery in the same way.

Use the same active-or-compacted eligibility for unseen reactions, retaining the existing atomic seen update and author filter. Add a real SQLite regression covering reactions before/after compaction, exclusion of rewound rows, unchanged content, and once-only delivery across reopening the database.

## Related Issue

Fixes #108541

## Type of Change

- [x] Bug fix

## Changes Made

- `hermes_state_messages.py`
- `tests/state/test_compacted_message_reactions.py`

## How to Test

Base: `7469c0f2a52baf70c574b110af0772b81bf84227`.

```bash
bash scripts/run_tests.sh tests/state/test_compacted_message_reactions.py tests/test_message_reactions.py tests/agent/test_reactions.py --file-retries 0 -j 3 -q
python -m ruff check .
python scripts/check_compat_pointers.py
python scripts/check-windows-footguns.py hermes_state_messages.py tests/state/test_compacted_message_reactions.py
git diff --check
```

New regression: 2 failed on unmodified main, 2 passed with the fix. Final reaction suite: 43 passed. Expanded `test_in_place_compaction.py`: 1 passed, 10 failed; the same 10 fail without this change on the initial audit baseline, with Windows WinError 32 while cleaning up unclosed database handles.

Ruff, compatibility-pointer checks, changed-file Windows checks and whitespace checks passed. No effective test was removed or skipped to obtain a passing result.

## Compatibility and limitations

Validated with real temporary SessionDB files, compaction, rewind, persistence and reopen on Windows/Python 3.13. No desktop UI run was performed. Reaction gating and message content/prompt caching are unchanged. The full repository suite was not run; the baseline compaction cleanup failures are not presented as passing.

## Duplicate check

Searched all states for `take_unseen_reactions`, reactions/compaction, and reactions/archived. #80670 / #80675 / #95833 address message.react 4040 and session/row routing before a successful write. This reproduction successfully saves the reaction to a visible, valid row; the later unseen-reaction query drops it. #86298 adds message transform hooks and does not change this predicate.

## Checklist

- [x] Read the contributing guide; Conventional Commit; one focused fix.
- [x] Searched existing open/closed/merged work and current main.
- [x] Added regression tests and ran the related suite via `scripts/run_tests.sh`.
- [x] Tested on Windows with Python 3.13; considered platform impact.
- [ ] Full repository suite: not run.
- [x] Configuration/schema/architecture documentation changes: N/A; local comments/docstrings updated where needed.
