### PR TITLE
fix(state): paginate the combined results during deferred FTS rebuilds

### DIFF
--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1051,7 +1051,12 @@ class SessionSearchMixin:
             return []
 
         order_by_sql = _FTS_ORDER_BY.get(sort.strip().lower() if isinstance(sort, str) else None, "ORDER BY rank")
-        route = dict(order_by_sql=order_by_sql, limit=limit, offset=offset, **filters)
+        # During backfill the result is indexed hits followed by the unindexed gap.
+        # Applying OFFSET to only the first source repeats the gap's first page forever.
+        paginate_rebuild = offset > 0 and limit > 0 and self.fts_rebuild_status() is not None
+        route_limit = limit + offset if paginate_rebuild else limit
+        route = dict(order_by_sql=order_by_sql, limit=route_limit,
+                     offset=0 if paginate_rebuild else offset, **filters)
         # Tool rows and FTS_TRIGRAM_EXCLUDED_SOURCES sessions are excluded from the trigram/cjk
         # indexes (see FTS_TRIGRAM_SQL); an explicit filter for them must scan the base table.
         wants_unindexed_rows = (bool(role_filter) and "tool" in role_filter) or (
@@ -1075,13 +1080,14 @@ class SessionSearchMixin:
                 if not self._enter_fts_fail_open(exc):
                     raise
                 matches = self._search_messages_like_fallback(query, limit=limit, offset=offset, sort=sort, **filters)
+                return self._finalize_search_matches(matches, result_fields=result_fields)
 
         # Deferred-rebuild supplement: while the backfill is pending the FTS indexes miss
         # the (progress, high_water] gap; top up with a bounded LIKE scan so old messages
         # never vanish mid-rebuild. Cost decays to zero as the backfill advances.
-        if self.fts_rebuild_status() is not None and len(matches) < limit:
+        if self.fts_rebuild_status() is not None and len(matches) < route_limit:
             try:
-                gap_matches = self._search_unindexed_gap(query, limit - len(matches), **filters)
+                gap_matches = self._search_unindexed_gap(query, route_limit - len(matches), **filters)
                 seen_ids = {m["id"] for m in matches}
                 matches.extend(m for m in gap_matches if m["id"] not in seen_ids)
             except sqlite3.OperationalError as exc:
@@ -1105,6 +1111,8 @@ class SessionSearchMixin:
                 matches = self._match_rows("messages_fts_cjk", fb_query, **route) or matches
             if not matches and self._trigram_available and self._trigram_eligible_tokens(query):
                 matches = self._match_rows("messages_fts_trigram", fb_query, **route) or matches
+        if paginate_rebuild:
+            matches = matches[offset:offset + limit]
         return self._finalize_search_matches(matches, result_fields=result_fields)
 
     def _search_cjk(self, query: str, wants_unindexed_rows: bool, route: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/tests/state/test_search_rebuild_pagination.py
+++ b/tests/state/test_search_rebuild_pagination.py
@@ -1,0 +1,44 @@
+"""Pagination applies to the combined indexed and pending-backfill result set."""
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.mark.parametrize("indexed_rows", [0, 2])
+def test_rebuild_search_pages_partition_the_available_hits(tmp_path, monkeypatch, indexed_rows):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("search", "cli")
+        expected = {
+            db.append_message("search", "user", f"paginationneedle entry {i}")
+            for i in range(6)
+        }
+        # Pause a real deferred rebuild before any chunk, or after one partial chunk.
+        with db._lock:
+            db._reset_fts_index_to_empty(db._conn)
+            db._seed_fts_rebuild_markers(db._conn, force=True)
+            db._conn.commit()
+        if indexed_rows:
+            monkeypatch.setattr(db, "_FTS_REBUILD_CHUNK_ROWS", indexed_rows)
+            assert db.fts_rebuild_step()
+        assert db.fts_rebuild_status() is not None
+
+        def hits(limit, offset=0):
+            return [row["id"] for row in db.search_messages(
+                "paginationneedle", limit=limit, offset=offset, fields=("id",))]
+
+        whole = hits(20)
+        pages = [hits(2, offset) for offset in range(0, 8, 2)]
+        assert set(whole) == expected
+        assert [row for page in pages for row in page] == whole
+        assert pages[-1] == []
+        assert len(whole) == len(set(whole))
+
+        while db.fts_rebuild_step():
+            pass
+        assert set(hits(20)) == expected
+        assert [row for offset in range(0, 8, 2) for row in hits(2, offset)] == hits(20)
+    finally:
+        db.close()


### PR DESCRIPTION
## What does this PR do?

During deferred FTS backfill, the public `SessionDB.search_messages(limit=..., offset=...)` API repeatedly returns the first unindexed hits on later pages. Even an offset beyond all matches can return data. Consumers paging search results can duplicate hits and fail to reach the rest of the pending index gap.

For positive-offset searches during a pending rebuild, fetch a prefix large enough for offset+limit across indexed and gap results, then slice once after combining. Keep the fully indexed path and page-zero behavior intact. Corruption fallback already applies the requested offset and returns directly to avoid double slicing.

## Related Issue

Fixes #108543

## Type of Change

- [x] Bug fix

## Changes Made

- `hermes_state_search.py`
- `tests/state/test_search_rebuild_pagination.py`

## How to Test

Base: `7469c0f2a52baf70c574b110af0772b81bf84227`.

```bash
bash scripts/run_tests.sh tests/state/test_search_rebuild_pagination.py tests/tools/test_session_search.py tests/hermes_cli/test_web_server_session_search.py --file-retries 0 -j 3 -q
python -m ruff check .
python scripts/check_compat_pointers.py
python scripts/check-windows-footguns.py hermes_state_search.py tests/state/test_search_rebuild_pagination.py
git diff --check
```

New regression: 2 failed on unmodified main, 2 passed with the fix. Final search/caller suite: 56 passed. Earlier search caller/context/log suite: 61 passed. Expanded FTS/filter suite: 58 passed, 4 failed, 5 skipped; the same four FTS corruption/recovery cases fail without the fix (41 passed, 4 failed, 5 skipped in that baseline file).

Ruff, compatibility-pointer checks, changed-file Windows checks and whitespace checks passed. No effective test was removed or skipped to obtain a passing result.

## Compatibility and limitations

Real SQLite rebuild tests cover empty/partial indexes and completed backfill. The local Python links SQLite 3.45.3, so Hermes selects DELETE journaling; four baseline FTS corruption/recovery failures remain. The affected public API supports offset; current default UI/tool callers generally request page zero, so this PR does not claim that the default UI is stuck. Pagination across a concurrently changing index is outside this contract. Work grows with the requested prefix while backfill is pending.

## Duplicate check

Searched all states for `_search_unindexed_gap`, rebuild/pagination, and search_messages/offset. #78376 / #35308 / #32564 concern clamping invalid pagination arguments. #90619 paginates session listings; #14208 deduplicates search sessions. The existing FTS rebuild work does not apply pagination to the combined indexed/gap sequence. No equivalent current-main change was found.

## Checklist

- [x] Read the contributing guide; Conventional Commit; one focused fix.
- [x] Searched existing open/closed/merged work and current main.
- [x] Added regression tests and ran the related suite via `scripts/run_tests.sh`.
- [x] Tested on Windows with Python 3.13; considered platform impact.
- [ ] Full repository suite: not run.
- [x] Configuration/schema/architecture documentation changes: N/A; local comments/docstrings updated where needed.
