### PR TITLE
fix(agent): screen vision fallbacks by capability; don't rotate pool on upstream-capacity 429

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3357,6 +3357,24 @@ def _recoverable_pool_provider(
     return None
 
 
+def _is_upstream_capacity_error(exc: Exception) -> bool:
+    """True when a 429 is the aggregator's UPSTREAM capacity signal, not this key's rate limit.
+
+    Nous Portal multiplexes upstream providers behind one key; when an upstream model is
+    temporarily out of capacity the 429 body says so explicitly ("temporarily at capacity
+    upstream ... not your API key's rate limit"). The credential is healthy — marking it
+    exhausted starves the only pool identity and rotates to nothing (or a sibling that will
+    hit the same upstream wall). Mirrors ``agent.nous_rate_guard.is_genuine_nous_rate_limit``
+    for the aux path, which only has the error text (no bucket headers parsed here).
+    See NousResearch/hermes-agent#108349.
+    """
+    if getattr(exc, "status_code", None) != 429 and type(exc).__name__ != "RateLimitError":
+        return False
+    err_lower = str(exc).lower()
+    return ("not your api key" in err_lower and "rate limit" in err_lower) \
+        or "capacity upstream" in err_lower or "upstream capacity" in err_lower
+
+
 def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str = "") -> bool:
     """Try same-provider credential-pool recovery for auxiliary calls.
 
@@ -3394,6 +3412,15 @@ def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str
     if _is_payment_error(exc):
         return _rotate(402)
     if _is_rate_limit_error(exc):
+        if _is_upstream_capacity_error(exc):
+            # The 429 is the upstream's capacity, not this credential's quota (the body says
+            # "not your API key's rate limit"). The key is healthy: rotating marks the only
+            # pool identity exhausted and starves every lane that shares it (#108349).
+            # Fall through to provider-level fallback instead (the caller treats rate limits
+            # as capacity errors and walks the chains), and let retry-backoff ride out the flap.
+            logger.info("Auxiliary client: 429 on %s is upstream capacity, not credential quota — "
+                        "skipping pool rotation (credential stays healthy)", normalized)
+            return False
         return _rotate(429)
     return False
 
@@ -3899,6 +3926,26 @@ def _failed_backend_skip(
     return _skip
 
 
+def _vision_fallback_incapable(provider: str, model: Optional[str], task: Optional[str], label: str) -> bool:
+    """True when a fallback candidate provably cannot accept image input on a vision task.
+
+    Vision calls that fall back (e.g. a transient Nous upstream-capacity 429) must never be
+    handed to a text-only model: the request is rejected with a hard 400/1210 instead of the
+    caller getting a retryable signal (NousResearch/hermes-agent#108349). Mirrors the
+    capability check the vision auto-route path already does (``_vision_main_provider_client``),
+    which the runtime fallback chains were skipping. Unknown capability passes (attempt the
+    call) so custom/unrecognised endpoints keep working; only a PROVEN text-only model is
+    screened out. Non-vision tasks are never affected.
+    """
+    if task != "vision":
+        return False
+    if _main_model_supports_vision(provider, model):
+        return False
+    logger.info("Auxiliary vision: skipping fallback %s (%s/%s reports no vision capability) — "
+                "will not route an image to a text-only model", label, provider, model or "default")
+    return True
+
+
 def _try_main_agent_model_fallback(
     failed_provider: str, task: str = None, reason: str = "error",
     failed_model: Optional[str] = None, failed_base_url: str = "", failure_scope: Any = None,
@@ -3931,6 +3978,8 @@ def _try_main_agent_model_fallback(
     if client is None:
         return None, None, ""
     label = f"main-agent({main_provider})"
+    if _vision_fallback_incapable(main_provider, resolved_model or main_model, task, label):
+        return None, None, ""
     logger.info("Auxiliary %s: %s on %s — falling back to main agent model %s (%s)",
                 task or "call", reason, failed_provider, label, resolved_model or main_model)
     return client, resolved_model or main_model, label
@@ -4031,6 +4080,9 @@ def _try_configured_fallback_chain(
             if too_small:
                 tried.append(too_small)
                 continue
+            if _vision_fallback_incapable(fb_provider, resolved_model or fb_model, task, label):
+                tried.append(f"{label} (no vision capability)")
+                continue
             logger.info("Auxiliary %s: %s on %s — configured fallback to %s (%s)",
                         task, reason, failed_provider, label, resolved_model or fb_model or "default")
             return fb_client, resolved_model or fb_model, label
@@ -4122,6 +4174,9 @@ def _try_main_fallback_chain(
             )
             if too_small:
                 tried.append(too_small)
+                continue
+            if _vision_fallback_incapable(fb_provider, resolved_model or fb_model, task, label):
+                tried.append(f"{label} (no vision capability)")
                 continue
             logger.info("Auxiliary %s: %s on %s — main fallback chain to %s (%s)",
                         task or "call", reason, failed_provider or "auto", label, resolved_model or fb_model)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1993,6 +1993,107 @@ class TestTryMainAgentModelFallback:
         assert model == "anthropic/claude-sonnet-4"
         assert label == "main-agent(openrouter)"
 
+    def test_vision_fallback_refuses_proven_text_only_main_model(self):
+        """#108349: a transient upstream 429 on the pinned vision lane must never route the
+        IMAGE to a main model that provably rejects image content (zai glm-5.3 answers the
+        call with 400/1210 instead). Known-text-only → refuse the fallback so the original
+        retryable error surfaces."""
+        from agent.auxiliary_client import _try_main_agent_model_fallback
+        fake_client = MagicMock()
+        with patch("agent.auxiliary_client._read_main_provider", return_value="zai"), \
+             patch("agent.auxiliary_client._read_main_model", return_value="glm-5.3"), \
+             patch("agent.auxiliary_client._is_provider_unhealthy", return_value=False), \
+             patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(fake_client, "glm-5.3")), \
+             patch("agent.auxiliary_client._main_model_supports_vision", return_value=False):
+            client, model, label = _try_main_agent_model_fallback("nous", task="vision", reason="rate limit")
+        assert client is None and model is None and label == ""
+
+    def test_vision_screen_does_not_affect_non_vision_tasks(self):
+        """Same text-only main model is a perfectly good compression/vision-free fallback."""
+        from agent.auxiliary_client import _try_main_agent_model_fallback
+        fake_client = MagicMock()
+        with patch("agent.auxiliary_client._read_main_provider", return_value="zai"), \
+             patch("agent.auxiliary_client._read_main_model", return_value="glm-5.3"), \
+             patch("agent.auxiliary_client._is_provider_unhealthy", return_value=False), \
+             patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(fake_client, "glm-5.3")), \
+             patch("agent.auxiliary_client._main_model_supports_vision", return_value=False):
+            client, model, label = _try_main_agent_model_fallback("nous", task="compression")
+        assert client is fake_client
+        assert label == "main-agent(zai)"
+
+    def test_vision_fallback_allows_unknown_capability(self):
+        """Fail-open on unknown: an unrecognised/custom model may accept images — attempt the
+        call rather than stranding vision when capability data is missing."""
+        from agent.auxiliary_client import _try_main_agent_model_fallback
+        fake_client = MagicMock()
+        with patch("agent.auxiliary_client._read_main_provider", return_value="custom"), \
+             patch("agent.auxiliary_client._read_main_model", return_value="mystery-model"), \
+             patch("agent.auxiliary_client._is_provider_unhealthy", return_value=False), \
+             patch("agent.auxiliary_client.resolve_provider_client",
+                   return_value=(fake_client, "mystery-model")), \
+             patch("agent.auxiliary_client._main_model_supports_vision", return_value=True):
+            client, model, label = _try_main_agent_model_fallback("nous", task="vision")
+        assert client is fake_client
+
+
+class TestUpstreamCapacityPoolGuard:
+    """#108349 part 2: a Nous upstream-capacity 429 must not mark the pool identity exhausted.
+
+    The error body explicitly says "not your API key's rate limit" — the credential is
+    healthy, and rotating starves every lane sharing the single-identity pool.
+    """
+
+    _UPSTREAM_MSG = ("Error code: 429 - {'status': 429, 'message': 'The requested model is "
+                     "temporarily at capacity upstream. This is not your API key's rate limit "
+                     "— please retry shortly.'}")
+
+    def _pool_double(self):
+        pool = MagicMock()
+        pool.has_credentials.return_value = True
+        pool.mark_exhausted_and_rotate.return_value = SimpleNamespace(id="cred-b")
+        return pool
+
+    def test_upstream_capacity_429_does_not_rotate(self):
+        from agent.auxiliary_client import _recover_provider_pool
+        exc = Exception(self._UPSTREAM_MSG)
+        exc.status_code = 429
+        pool = self._pool_double()
+        with patch("agent.auxiliary_client.load_pool", return_value=pool), \
+             patch("agent.auxiliary_client._normalize_aux_provider", return_value="nous"), \
+             patch("agent.auxiliary_client._evict_cached_clients"):
+            recovered = _recover_provider_pool("nous", exc)
+        assert recovered is False
+        pool.mark_exhausted_and_rotate.assert_not_called()
+
+    def test_genuine_rate_limit_429_still_rotates(self):
+        from agent.auxiliary_client import _recover_provider_pool
+        exc = Exception("Error code: 429 - rate limit exceeded, resets in 30s")
+        exc.status_code = 429
+        pool = self._pool_double()
+        with patch("agent.auxiliary_client.load_pool", return_value=pool), \
+             patch("agent.auxiliary_client._normalize_aux_provider", return_value="nous"), \
+             patch("agent.auxiliary_client._evict_cached_clients"):
+            recovered = _recover_provider_pool("nous", exc)
+        assert recovered is True
+        pool.mark_exhausted_and_rotate.assert_called_once()
+
+    def test_capacity_classifier_needs_429_shape(self):
+        from agent.auxiliary_client import _is_upstream_capacity_error
+        upstream = Exception(self._UPSTREAM_MSG)
+        upstream.status_code = 429
+        assert _is_upstream_capacity_error(upstream) is True
+        # Same body text but NOT a 429/RateLimitError → not a capacity signal
+        other = Exception(self._UPSTREAM_MSG)
+        other.status_code = 400
+        assert _is_upstream_capacity_error(other) is False
+        # RateLimitError class without status_code (OpenAI shape) still classifies
+        class RateLimitError(Exception):
+            pass
+        rle = RateLimitError(self._UPSTREAM_MSG)
+        assert _is_upstream_capacity_error(rle) is True
+
 
 
 


### PR DESCRIPTION
Fixes #108349.

## The two chained mis-handlings

When the pinned aux vision lane (`auxiliary.vision.provider: nous`) hits a **transient upstream-capacity 429**:

```
Error code: 429 - {'status': 429, 'message': 'The requested model is temporarily at capacity upstream. This is not your API key's rate limit — please retry shortly.'}
```

**1. The image gets routed to a text-only model → hard 400/1210.**
`_try_main_agent_model_fallback()`, `_try_configured_fallback_chain()`, and `_try_main_fallback_chain()` all resolved a client and returned it for `task="vision"` **without any vision-capability check** — unlike the vision auto-route path (`_vision_main_provider_client()`), which already consults `_main_model_supports_vision()` and skips text-only models. With a text-only main (e.g. `zai/glm-5.3`, which `_lookup_supports_vision` correctly reports as `False`), the vision call fails with:

```
400 - {'error': {'code': '1210', 'message': "messages.content.type is invalid, allowed values: ['text']"}}
```

The user loses a retryable 429 ("please retry shortly") and gets a permanent-looking 400 instead.

**2. The same 429 marks the credential-pool identity exhausted and rotates.**
`_recover_provider_pool()` treated it as a per-key rate limit, despite the body explicitly saying otherwise. With a single-identity pool this starves every lane sharing it:

```
credential pool: marking <email> exhausted (status=429), rotating
credential pool: no available entries (all exhausted or empty)
```

(Still firing in the reporter's `agent.log` as of today — 5 occurrences in the last hour of the log.)

## The fix

1. **`_vision_fallback_incapable()`** screens each fallback candidate on vision tasks, reusing the same `_main_model_supports_vision()` the auto-route path already trusts — the runtime chains were simply skipping a check the sibling path had. Wired into all three producers (whole bug class, not just the one function the issue named). **Fail-open on unknown capability** (custom/unrecognised endpoints still attempt the call); only a *proven* text-only model is skipped. Non-vision tasks are untouched, so a text-only main remains a perfectly good compression fallback.

2. **`_is_upstream_capacity_error()`** detects the aggregator's upstream-capacity phrasing on a 429/`RateLimitError`; `_recover_provider_pool()` skips rotation for it (the credential is healthy — the caller still walks the provider fallback chains, and retry-backoff rides out the flap). A genuine per-key 429 still rotates exactly as before.

## Verification

- 6 new tests: 3 for the vision screen (refuse proven-text-only / don't touch non-vision / fail-open on unknown), 3 for the pool guard (upstream-429 doesn't rotate / genuine-429 still rotates / classifier needs the 429 shape).
- The two core-contract tests are **red on base, green with the fix**.
- Tested against the **exact production 429 message** from the reporter's `agent.log`.
- Full `tests/agent/test_auxiliary_client*.py` + `test_credential_pool.py`: no new failures (the 7 failures in `test_auxiliary_client.py` are pre-existing on `main` — identical set with and without this patch; they're async-path flakes unrelated to fallback routing).
