### PR TITLE
fix(cli): dedup PATH entries with Windows-equivalent path normalization

### DIFF
--- a/hermes_cli/stdio.py
+++ b/hermes_cli/stdio.py
@@ -7,6 +7,7 @@ subprocesses and child Python ``print()`` calls agree on encoding.
 
 from __future__ import annotations
 
+import ntpath
 import os
 import sys
 
@@ -90,6 +91,18 @@ def _default_windows_editor() -> str:
     return "notepad" if shutil.which("notepad") else ""
 
 
+def _path_key(path: str) -> str:
+    r"""Comparison key for PATH dedup under Windows semantics (works on any host OS).
+
+    ``ntpath`` treats ``/`` and ``\`` as equivalent separators and resolves ``.``/``..``
+    lexically, so ``C:\a\b``, ``c:/a/b/`` and ``C:\a\x\..\b`` all map to the same key. A bare
+    ``str.lower()`` comparison (what the dedup used before) misses these variants — MSYS
+    auto-translation and trailing-slash forms especially — which made every Python startup
+    prepend the same venv ``Scripts`` dir again, snowballing into 70+ duplicate PATH entries.
+    """
+    return ntpath.normpath(path.rstrip("\\/")).casefold()
+
+
 def _augment_path_with_known_tools() -> None:
     r"""Prepend Hermes-managed tool directories to ``PATH`` (no-op on POSIX / missing dirs).
 
@@ -114,7 +127,7 @@ def _augment_path_with_known_tools() -> None:
         os.path.join(local_appdata, "hermes", "hermes-agent", "venv", "Scripts"),
         os.path.join(local_appdata, "Microsoft", "WinGet", "Links")]
     existing = os.environ.get("PATH", "")
-    existing_lower = {p.lower() for p in existing.split(os.pathsep) if p}
-    prepend = [d for d in candidate_dirs if os.path.isdir(d) and d.lower() not in existing_lower]
+    existing_keys = {_path_key(p) for p in existing.split(os.pathsep) if p}
+    prepend = [d for d in candidate_dirs if os.path.isdir(d) and _path_key(d) not in existing_keys]
     if prepend:
         os.environ["PATH"] = os.pathsep.join([*prepend, existing])

--- a/tests/hermes_cli/test_stdio_path_dedup.py
+++ b/tests/hermes_cli/test_stdio_path_dedup.py
@@ -1,0 +1,86 @@
+"""Regression tests for PATH dedup normalization in ``hermes_cli.stdio``.
+
+On Windows the same directory can appear on PATH under several spellings — case
+variants, ``/`` vs ``\\`` separators, trailing separators (MSYS auto-translation
+artifacts). ``_augment_path_with_known_tools`` used to dedup with a bare
+``str.lower()`` comparison, which missed those spellings, so every Python
+startup prepended the venv ``Scripts`` dir again — issue #108508 observed 70+
+consecutive duplicates in one bash session snapshot. The dedup now compares
+``_path_key()`` keys (``ntpath`` semantics + ``casefold``), which equate all of
+those spellings. The key function is pure string math, so these tests run on
+any host.
+"""
+
+from __future__ import annotations
+
+import os
+
+import hermes_cli.stdio as stdio
+from hermes_cli.stdio import _path_key
+
+
+def test_path_key_case_insensitive():
+    assert _path_key("C:\\Hermes\\venv\\Scripts") == _path_key("c:\\hermes\\VENV\\scripts")
+
+
+def test_path_key_forward_and_back_slashes_equivalent():
+    assert _path_key("C:\\Hermes\\venv\\Scripts") == _path_key("C:/Hermes/venv/Scripts")
+
+
+def test_path_key_trailing_separator_ignored():
+    assert _path_key("C:\\Hermes\\venv\\Scripts\\") == _path_key("C:\\Hermes\\venv\\Scripts")
+
+
+def test_path_key_dot_segments_resolved():
+    assert _path_key("C:\\Hermes\\venv\\..\\venv\\Scripts") == _path_key("C:\\Hermes\\venv\\Scripts")
+
+
+def test_path_key_different_dirs_stay_different():
+    assert _path_key("C:\\a\\Scripts") != _path_key("C:\\a\\Scripts2")
+
+
+def test_augment_skips_dir_already_on_path_in_another_spelling(monkeypatch, tmp_path):
+    """The issue-#108508 snowball: PATH already holds the venv Scripts dir in a
+    trailing-separator / mixed-case variant, so the old ``str.lower()`` dedup
+    missed it and prepended a fresh duplicate on every startup."""
+    monkeypatch.setattr(stdio, "is_windows", lambda: True)
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+    scripts = tmp_path / "hermes" / "hermes-agent" / "venv" / "Scripts"
+    scripts.mkdir(parents=True)
+    variant = str(scripts).replace("Scripts", "SCRIPTS") + os.sep
+    monkeypatch.setenv("PATH", variant)
+
+    stdio._augment_path_with_known_tools()
+
+    # Nothing new to prepend: PATH must come back exactly as it went in.
+    assert os.environ["PATH"] == variant
+
+
+def test_augment_still_prepends_a_missing_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr(stdio, "is_windows", lambda: True)
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+    scripts = tmp_path / "hermes" / "hermes-agent" / "venv" / "Scripts"
+    scripts.mkdir(parents=True)
+    monkeypatch.setenv("PATH", "/baseline/bin")
+
+    stdio._augment_path_with_known_tools()
+
+    entries = os.environ["PATH"].split(os.pathsep)
+    assert str(scripts) in entries
+    # Prepend semantics: Hermes-managed dirs win collisions with the ambient PATH.
+    assert entries.index(str(scripts)) < entries.index("/baseline/bin")
+
+
+def test_augment_keeps_case_only_match_deduped(monkeypatch, tmp_path):
+    """A plain case variant was already caught by the old ``str.lower()`` dedup;
+    the normalized key must keep that behaviour."""
+    monkeypatch.setattr(stdio, "is_windows", lambda: True)
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+    scripts = tmp_path / "hermes" / "hermes-agent" / "venv" / "Scripts"
+    scripts.mkdir(parents=True)
+    variant = str(scripts).replace("Scripts", "scripts")
+    monkeypatch.setenv("PATH", variant)
+
+    stdio._augment_path_with_known_tools()
+
+    assert os.environ["PATH"] == variant

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -291,6 +291,33 @@ class TestGitBashCoreutilsOnPath:
 
 
 # ---------------------------------------------------------------------------
+# _prepend_missing_path_entries — Windows-equivalent spellings must dedup
+# ---------------------------------------------------------------------------
+
+class TestPrependMissingPathEntries:
+    """Issue #108508: a bare string-equality ``in`` check treated Windows-equivalent
+    spellings of the same dir (case, ``/`` vs ``\\``, trailing separator) as missing,
+    so each prepended a duplicate of itself. Keys come from ``_path_key``.
+
+    Drive-letter-free spellings keep these tests host-agnostic: on POSIX the
+    ``os.pathsep`` separator is ``:``, which would otherwise split at the ``C:``
+    colon. Drive-letter forms are covered by the ``_path_key`` unit tests in
+    ``tests/hermes_cli/test_stdio_path_dedup.py``."""
+
+    def test_windows_equivalent_spelling_counts_as_present(self):
+        existing = "\\Git\\usr\\BIN"
+        assert local_mod._prepend_missing_path_entries(existing, ["/git/usr/bin/"]) == existing
+
+    def test_prepends_only_truly_missing(self):
+        result = local_mod._prepend_missing_path_entries("\\other", ["\\Git\\usr\\bin"])
+        assert result == "\\Git\\usr\\bin" + os.pathsep + "\\other"
+
+    def test_unchanged_when_nothing_missing(self):
+        existing = "\\Git\\usr\\bin"
+        assert local_mod._prepend_missing_path_entries(existing, ["\\Git\\usr\\bin"]) == existing
+
+
+# ---------------------------------------------------------------------------
 # Command wrapping — native Windows cwd must be Git Bash-friendly for cd
 # ---------------------------------------------------------------------------
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -20,6 +20,7 @@ from hermes_constants import get_process_hermes_home
 from tools.environments.base import BaseEnvironment
 from tools.environments.base_output import _pipe_stdin
 from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_cli.stdio import _path_key
 from tools.environments.local_env_policy import (
     _ALWAYS_STRIP_KEYS, _HERMES_PROVIDER_ENV_BLOCKLIST, _HERMES_PROVIDER_ENV_FORCE_PREFIX,
     _is_hermes_internal_secret, _is_terminal_first_party_env,
@@ -417,10 +418,13 @@ def _compute_git_bash_bin_dirs() -> list[str]:
 
 
 def _prepend_missing_path_entries(existing_path: str, dirs: list[str]) -> str:
-    """Prepend *dirs* missing from *existing_path* (``os.pathsep``); an already-listed
-    dir keeps its position; unchanged input when nothing is missing."""
+    r"""Prepend *dirs* missing from *existing_path* (``os.pathsep``); an already-listed
+    dir keeps its position; unchanged input when nothing is missing. Comparison goes
+    through ``_path_key`` so Windows-equivalent spellings (case, ``/`` vs ``\``,
+    trailing separator) don't count as missing and duplicate themselves."""
     entries = [e for e in existing_path.split(os.pathsep) if e]
-    missing = [d for d in dirs if d not in entries]
+    existing_keys = {_path_key(e) for e in entries}
+    missing = [d for d in dirs if _path_key(d) not in existing_keys]
     return os.pathsep.join([*missing, *entries]) if missing else existing_path
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes the PATH snowball reported in #108508: on Windows, `_augment_path_with_known_tools()` deduplicated PATH entries with a bare `str.lower()` comparison, so the same directory spelled slightly differently (mixed case, `/` vs `\`, trailing separator — exactly what MSYS auto-translation produces) counted as missing and was prepended **again on every Python startup**. The reporter's live session accumulated 72 consecutive `venv\Scripts` entries (204 PATH entries, 27.8 KB snapshot) before manual cleanup.

The dedup now compares `_path_key()` keys: `ntpath.normpath()` (which treats both separators as equivalent and resolves `.`/`..` lexically, with real Windows semantics on any host) + `casefold()`. So `C:\a\b`, `c:/a/b/` and `C:\a\x\..\b` all map to the same key and no longer duplicate themselves.

The same latent bug existed in `tools/environments/local.py::_prepend_missing_path_entries`, which used exact string equality (weaker than even the `lower()` check) — it gets the same key-based comparison via the shared helper.

## Related Issue

Fixes #108508

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/stdio.py` — add `_path_key()` (pure string normalization, Windows semantics via `ntpath`); `_augment_path_with_known_tools()` dedups `existing` PATH entries against candidate dirs by key instead of bare `lower()`.
- `tools/environments/local.py` — `_prepend_missing_path_entries()` compares by `_path_key` (imported from `hermes_cli.stdio`; this module already imports from `hermes_cli._subprocess_compat`) so Windows-equivalent spellings no longer count as missing.
- `tests/hermes_cli/test_stdio_path_dedup.py` — new: `_path_key` equivalence unit tests (case, separators, trailing slash, `..`) plus `_augment_path_with_known_tools()` integration tests (no re-prepend for an existing variant spelling; missing dir still prepended; case-only match stays deduped).
- `tests/tools/test_local_env_windows_msys.py` — new `TestPrependMissingPathEntries` covering variant-spelling dedup, prepend-only-missing, and unchanged-input.

## How to Test

1. `python -m pytest tests/hermes_cli/test_stdio_path_dedup.py tests/tools/test_local_env_windows_msys.py -q`
   Observed result: `11 passed, 20 skipped` (skips are the pre-existing platform-marked tests).
2. `python -m pytest tests/tools/test_local_env_blocklist.py -q` (touches the same `local.py` PATH surface)
   Observed result: `88 passed, 2 skipped`.
3. The new tests are host-agnostic on purpose: `_path_key` is pure string math over `ntpath`, and the `_augment` tests monkeypatch `is_windows`, so the Windows semantics run on any host (verified on macOS arm64); the Windows CI job exercises them natively.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64); new tests are cross-platform by design

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior-preserving dedup fix; helper carries its own docstring)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) (the fix is Windows-path-semantics-only; POSIX callers see `:`-separated behavior unchanged)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable (no visual change).
