### PR TITLE
fix(approvals): bound tr pipeline gaps to keep dangerous-command scan…

### DIFF
--- a/tests/tools/test_approval_detection_pattern_performance.py
+++ b/tests/tools/test_approval_detection_pattern_performance.py
@@ -1,0 +1,64 @@
+"""Hard-timeout guard against quadratic patterns in the dangerous-command rule set.
+
+The approval scan runs inline on the caller's thread, so a quadratic pattern
+holds the GIL and stalls every other thread with no watchdog (see #104781 and
+#108451). Time the individual rule this repo already had to bound — the
+echo|tr|shell pipeline rule — against the shape that made it quadratic: long,
+separator-rich, pipe-free input full of `echo` start tokens. The bounded rule
+finishes in milliseconds; an unbounded `[^|]*` gap takes seconds and grows
+quadratically with input size.
+"""
+
+import os
+import pathlib
+import subprocess
+import sys
+import time
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+TR_RULE_DESCRIPTION = "pipe tr-transformed output to shell (possible command obfuscation)"
+
+# 512k chars, separator-rich, echo-heavy, contains no `|`. The probe imports
+# tools.approval_detection (stdlib-only import chain) and grabs the compiled
+# rule from the module, so it cannot drift from what production runs.
+PROBE = (
+    "import sys, time\n"
+    "sys.path.insert(0, sys.argv[1])\n"
+    "from tools.approval_detection import DANGEROUS_PATTERNS_COMPILED\n"
+    "rule = next(p for p, d in DANGEROUS_PATTERNS_COMPILED if d == sys.argv[2])\n"
+    "s = ('echo hi; ' * 60000)[:512000]\n"
+    "assert rule.search(\"echo 'eq -pe v/' | tr 'eqv' 'rmf' | bash\")\n"
+    "t0 = time.monotonic()\n"
+    "rule.search(s)\n"
+    "print(f'{time.monotonic() - t0:.3f}')\n"
+)
+
+# The bounded rule scans once (~milliseconds at 512k). An unbounded gap
+# rescans from every `echo` token and needs many seconds here.
+MAX_RULE_SECONDS = 2.0
+
+HARD_KILL_SECONDS = 30.0
+
+
+def test_tr_pipeline_rule_stays_bounded_on_separator_rich_input():
+    start = time.monotonic()
+    proc = subprocess.run(
+        [sys.executable, "-c", PROBE, str(REPO_ROOT), TR_RULE_DESCRIPTION],
+        cwd=str(REPO_ROOT),
+        env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+        capture_output=True,
+        text=True,
+        timeout=HARD_KILL_SECONDS,
+    )
+    elapsed = time.monotonic() - start
+    assert proc.returncode == 0, (
+        f"rule probe failed rc={proc.returncode}: {proc.stderr[-2000:]}"
+    )
+    rule_seconds = float(proc.stdout.strip().splitlines()[-1])
+    assert rule_seconds < MAX_RULE_SECONDS, (
+        f"the echo|tr|shell rule took {rule_seconds:.2f}s to scan 512k "
+        f"separator-rich input; its pipeline gaps must stay bounded "
+        f"([^|;&\\n]*), otherwise the scan is quadratic and starves the GIL"
+    )
+    assert elapsed < HARD_KILL_SECONDS

--- a/tests/tools/test_shell_bypass_denylist.py
+++ b/tests/tools/test_shell_bypass_denylist.py
@@ -109,6 +109,22 @@ class TestDecodeAndExecutePipes:
         assert dangerous is True, f"decode-and-execute pipe was not caught: {cmd!r}"
         assert "obfuscation" in desc
 
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "echo x; tr a b | bash",
+            "echo x | tr a b; bash",
+            "echo x && tr a b | bash",
+        ],
+    )
+    def test_tr_pipe_does_not_span_command_separators(self, cmd):
+        # A pipeline gap cannot contain a separator: `echo x; tr a b | bash` is two
+        # commands, not an obfuscated pipe, and must not match the tr rule.
+        dangerous, _key, desc = detect_dangerous_command(cmd)
+        assert (dangerous, desc) == (False, None) or "obfuscation" not in (desc or ""), (
+            f"tr rule spanned a separator: {cmd!r}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Benign commands must stay unflagged across all three additions.

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -290,7 +290,9 @@ DANGEROUS_PATTERNS = [
     # xxd uses -r for decode, not -d.
     (r'\bxxd\s+-r\b.*\|\s*\b(bash|sh|zsh|ksh|dash)\b', "pipe xxd-decoded content to shell (possible command obfuscation)"),
     # `echo 'eq -pe v/' | tr 'eqv' 'rmf' | bash` decodes to `rm -rf /`.
-    (r'\becho\b[^|]*\|\s*\btr\b[^|]*\|\s*\b(bash|sh|zsh|ksh|dash)\b', "pipe tr-transformed output to shell (possible command obfuscation)"),
+    # Pipeline gaps exclude separators: an unbounded gap makes the scan quadratic
+    # on long, `echo`-heavy, pipe-free commands (GIL stalls the whole process).
+    (r'\becho\b[^|;&\n]*\|\s*\btr\b[^|;&\n]*\|\s*\b(bash|sh|zsh|ksh|dash)\b', "pipe tr-transformed output to shell (possible command obfuscation)"),
     (r'\bopenssl\b.*\b(?:base64|enc)\b[^|]*\s+-[dD]\b[^|]*\|\s*\b(bash|sh|zsh|ksh|dash)\b',
      "pipe openssl-decoded content to shell (possible command obfuscation)"),
     (rf'\btee\b.*["\']?{_SENSITIVE_WRITE_TARGET}', "overwrite system file via tee"),


### PR DESCRIPTION
Closes #108451 (Finding 1). I checked open PRs and the issue timeline before starting — no claimant; the reporter noted they're holding off while #104781 is open. My change is in the pattern table (line 293), #104781's is the launchctl lookahead — no overlap in the diff.

## What

Bounds the two pipeline gaps of the `echo|tr|shell` obfuscation rule: `[^|]*` → `[^|;&\n]*`. A pipeline gap can't contain a separator, so this keeps the rule's coverage while removing the quadratic rescan-from-every-`echo` behavior that holds the GIL for seconds on long, pipe-free commands.

## Behavior unchanged

Still matches `echo 'eq -pe v/' | tr 'eqv' 'rmf' | bash`; still does not match `echo x; tr a b | bash`, `echo x | tr a b; bash`, `echo x && tr a b | bash` (new parametrized cases in `tests/tools/test_shell_bypass_denylist.py::TestDecodeAndExecutePipes`).

## Proof of fix

New guard `tests/tools/test_approval_detection_pattern_performance.py` grabs the compiled rule from `DANGEROUS_PATTERNS_COMPILED` (so it can't drift from what production runs) and times it in a hard-killed subprocess against a 512k separator-rich, echo-heavy, pipe-free input:

- with this change: ~0.00s (well under the 2.0s ceiling; subprocess hard kill at 30s)
- with the gap reverted to `[^|]*`: the guard fails (measured 0.73s at 128k, ~12s extrapolated at 512k on my machine)

Local suite: `tests/tools/test_shell_bypass_denylist.py` + the new guard → **37 passed**.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Notes

- This is only Finding 1. The tokenizer/lex passes from Finding 2 and the wall-clock budget are bigger design calls, so I left them out of this PR.
- The guard covers just this rule for now; widening it to every compiled pattern is only meaningful once #104781 lands, since the launchctl rule dominates until then.