### PR TITLE
fix(desktop): route Ctrl+R to the terminal instead of reloading the app

### DIFF
--- a/apps/desktop/src/app/context-menu/app-context-menu.test.tsx
+++ b/apps/desktop/src/app/context-menu/app-context-menu.test.tsx
@@ -432,6 +432,7 @@ describe('AppContextMenu', () => {
     const unregister = registerTerminalContextMenu(host.querySelector('[data-terminal]')!, {
       getSelection: () => 'picked text',
       paste,
+      reload: vi.fn(),
       selectAll: vi.fn()
     })
 
@@ -451,6 +452,7 @@ describe('AppContextMenu', () => {
     const unregister = registerTerminalContextMenu(host.querySelector('[data-terminal]')!, {
       getSelection: () => '',
       paste: null,
+      reload: vi.fn(),
       selectAll: vi.fn()
     })
 

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react'
 import { closeActiveTab } from '@/app/chat/close-tab'
 import { commandFocusedPreview } from '@/app/chat/right-rail/preview-nav'
 import { openSession } from '@/app/open-session'
+import { commandFocusedTerminal } from '@/app/right-sidebar/terminal/terminal-context-menu'
 import { resolveDeepLinkAction } from '@/lib/deeplink-routes'
 import { pathFromHermesDeepLink, resolveHermesOpenPath } from '@/lib/hermes-open-target'
 import { storedSessionIdForNotification } from '@/lib/session-ids'
@@ -356,6 +357,10 @@ export function useDesktopIntegrations({
   // app-level meaning to fall back to; an unfocused swipe is a no-op.
   useEffect(() => {
     const unsubscribe = window.hermesDesktop?.onPreviewNav?.(command => {
+      if (commandFocusedTerminal(command)) {
+        return
+      }
+
       if (!commandFocusedPreview(command) && command === 'reload') {
         window.location.reload()
       }

--- a/apps/desktop/src/app/right-sidebar/terminal/terminal-context-menu.test.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/terminal-context-menu.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { commandFocusedTerminal, registerTerminalContextMenu, terminalMenuHandleFor } from './terminal-context-menu'
+
+const handle = (overrides: Partial<Parameters<typeof registerTerminalContextMenu>[1]> = {}) => ({
+  getSelection: () => '',
+  paste: null,
+  reload: vi.fn(),
+  selectAll: vi.fn(),
+  ...overrides
+})
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+/** instance.tsx shape: outer div carries data-terminal, hostRef points at the
+ *  inner xterm host div, and a click lands on the canvas inside it. */
+function mountProductionShape(): { canvas: HTMLElement; host: HTMLElement; scope: HTMLElement } {
+  const scope = document.createElement('div')
+  scope.setAttribute('data-terminal', '')
+  const host = document.createElement('div')
+  const canvas = document.createElement('canvas')
+  host.appendChild(canvas)
+  scope.appendChild(host)
+  document.body.appendChild(scope)
+
+  return { canvas, host, scope }
+}
+
+describe('terminalMenuHandleFor (production DOM shape)', () => {
+  it('finds the handle registered on the xterm host, not the scope div', () => {
+    const { canvas, host } = mountProductionShape()
+
+    const registered = handle()
+    const unregister = registerTerminalContextMenu(host, registered)
+
+    expect(terminalMenuHandleFor(canvas)).toBe(registered)
+    unregister()
+  })
+
+  it('returns null outside any terminal scope', () => {
+    const outside = document.createElement('div')
+    document.body.appendChild(outside)
+
+    expect(terminalMenuHandleFor(outside)).toBeNull()
+  })
+})
+
+describe('commandFocusedTerminal', () => {
+  it('runs reload on the terminal holding DOM focus', () => {
+    const { host, scope } = mountProductionShape()
+    const textarea = document.createElement('textarea')
+    host.appendChild(textarea)
+    textarea.focus()
+
+    const reload = vi.fn()
+    const unregister = registerTerminalContextMenu(host, handle({ reload }))
+
+    expect(commandFocusedTerminal('reload')).toBe(true)
+    expect(reload).toHaveBeenCalledTimes(1)
+    unregister()
+    scope.remove()
+  })
+
+  it('answers false when focus is outside every terminal', () => {
+    const outside = document.createElement('div')
+    document.body.appendChild(outside)
+    outside.focus?.()
+
+    expect(commandFocusedTerminal('reload')).toBe(false)
+  })
+
+  it('answers false for back and forward — no terminal verb', () => {
+    const { host, scope } = mountProductionShape()
+    const textarea = document.createElement('textarea')
+    host.appendChild(textarea)
+    textarea.focus()
+
+    const reload = vi.fn()
+    const unregister = registerTerminalContextMenu(host, handle({ reload }))
+
+    expect(commandFocusedTerminal('back')).toBe(false)
+    expect(commandFocusedTerminal('forward')).toBe(false)
+    expect(reload).not.toHaveBeenCalled()
+    unregister()
+    scope.remove()
+  })
+
+  it('unregisters idempotently — a later handle for the same scope replaces, an old remove does not', () => {
+    const { host, scope } = mountProductionShape()
+    const textarea = document.createElement('textarea')
+    host.appendChild(textarea)
+    textarea.focus()
+
+    const first = handle()
+    const second = handle()
+    const removeFirst = registerTerminalContextMenu(host, first)
+    registerTerminalContextMenu(host, second)
+
+    removeFirst()
+
+    expect(commandFocusedTerminal('reload')).toBe(true)
+    expect(first.reload).not.toHaveBeenCalled()
+    expect(second.reload).toHaveBeenCalledTimes(1)
+    scope.remove()
+  })
+})

--- a/apps/desktop/src/app/right-sidebar/terminal/terminal-context-menu.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/terminal-context-menu.ts
@@ -1,29 +1,42 @@
 /**
- * Context-menu handles for the GUI terminals.
+ * Verb registry for the GUI terminals.
  *
  * xterm paints to a canvas: a right-click inside it crosses no link, image,
  * editable, or DOM selection, so the app context menu would see a bare
- * surface and offer the window verbs. Each terminal registers a handle for
- * its host instead, and the coordinator resolves a click back to it through
- * the `[data-terminal]` focus-scope marker both terminal flavours carry.
+ * surface and offer the window verbs. Focus-routed chords hit the same blind
+ * spot from the other side: main claims Ctrl/Cmd+R on every window
+ * (before-input-event + preventDefault) so Chromium's default host reload
+ * cannot fire, and that claim also stops the keystroke before xterm sees it.
+ * Both paths resolve through a handle registered for the terminal's
+ * `[data-terminal]` scope.
  */
 
 export interface TerminalMenuHandle {
   getSelection: () => string
   /** Null on the read-only agent mirror — it has no PTY to paste into. */
   paste: ((text: string) => void) | null
+  /** Re-deliver the Ctrl/Cmd+R chord main claimed (#96482). User terminals
+   *  write the ^R byte into their PTY (readline reverse-i-search). Read-only
+   *  agent mirrors have no PTY, so they swallow it — focus is still in a
+   *  terminal, and the app-level reload fallback must not fire there. */
+  reload: () => void
   selectAll: () => void
 }
 
 const handles = new WeakMap<Element, TerminalMenuHandle>()
 
-/** Register the handle for a terminal host. Returns an idempotent remove. */
+/** Register the handle for a terminal host. The registry keys by the
+ *  `[data-terminal]` scope above the host: both resolvers start from a click
+ *  target or the focused element and walk up to that scope, while the xterm
+ *  host is a nested div inside it (instance.tsx). Returns an idempotent
+ *  remove. */
 export function registerTerminalContextMenu(host: Element, handle: TerminalMenuHandle): () => void {
-  handles.set(host, handle)
+  const scope = host.closest('[data-terminal]') ?? host
+  handles.set(scope, handle)
 
   return () => {
-    if (handles.get(host) === handle) {
-      handles.delete(host)
+    if (handles.get(scope) === handle) {
+      handles.delete(scope)
     }
   }
 }
@@ -33,4 +46,22 @@ export function terminalMenuHandleFor(element: Element | null): TerminalMenuHand
   const host = element?.closest('[data-terminal]')
 
   return host ? (handles.get(host) ?? null) : null
+}
+
+/** Run a focus-routed chord on the terminal holding DOM focus — the terminal
+ *  rung of the preview-nav routing (see commandFocusedPreview in
+ *  chat/right-rail/preview-nav.ts). Only `reload` is a terminal verb; `back`
+ *  and `forward` mean nothing there. False = focus is elsewhere in the app,
+ *  so the caller falls back to the app-level meaning. */
+export function commandFocusedTerminal(command: 'back' | 'forward' | 'reload'): boolean {
+  if (command !== 'reload') {
+    return false
+  }
+
+  const host = document.activeElement?.closest('[data-terminal]')
+  const handle = host ? handles.get(host) : undefined
+
+  handle?.reload()
+
+  return Boolean(handle)
 }

--- a/apps/desktop/src/app/right-sidebar/terminal/use-agent-terminal.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-agent-terminal.ts
@@ -86,10 +86,13 @@ export function useAgentTerminal({ active, id, procId }: { active: boolean; id: 
 
     // Right-clicks resolve through the app context menu; the handle carries
     // the xterm selection the DOM resolver cannot see. paste stays null —
-    // there is nothing to paste into.
+    // there is nothing to paste into. reload swallows the chord for the same
+    // reason: no PTY, and focus being here must still stop the app-level
+    // Ctrl/Cmd+R reload fallback.
     const contextMenuDisposable = registerTerminalContextMenu(host, {
       getSelection: () => term.getSelection(),
       paste: null,
+      reload: () => {},
       selectAll: () => term.selectAll()
     })
 

--- a/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
@@ -796,7 +796,9 @@ export function useTerminalSession({
 
     // The app context menu resolves right-clicks on this host through the
     // registered handle: xterm's selection is not a DOM selection, so the
-    // DOM resolver would see nothing here.
+    // DOM resolver would see nothing here. The same handle answers the
+    // focus-routed Ctrl/Cmd+R: main claimed the keystroke, so re-deliver the
+    // ^R byte to the PTY ourselves (#96482).
     cleanup.push(
       registerTerminalContextMenu(host, {
         getSelection: () => term.getSelection(),
@@ -804,6 +806,14 @@ export function useTerminalSession({
           hasSessionActivityRef.current = true
           term.focus()
           term.paste(text)
+        },
+        reload: () => {
+          hasSessionActivityRef.current = true
+          const sessionId = sessionIdRef.current
+
+          if (sessionId) {
+            void terminalApi.write(sessionId, '\x12')
+          }
         },
         selectAll: () => term.selectAll()
       })


### PR DESCRIPTION
## What does this PR do?

Ctrl+R in the desktop terminal pane reloaded the whole app. The key never reached the shell, so readline reverse-i-search did not work.

Main claims Ctrl/Cmd+R on every window (`installPreviewShortcut` in `electron/main.ts`). The claim uses `before-input-event` plus `preventDefault`. This stops the Chromium default reload. Main then sends `preview-nav: reload` to the renderer. But the renderer routing knew only browser panes. With focus in a terminal, the routing fell through to `window.location.reload()`. The `preventDefault` also stopped the keystroke before xterm saw it.

This PR routes the chord the same way the app routes Cmd+W: main keeps the claim, and the renderer routes by focus. The renderer gains the missing terminal rung. The user terminal writes the ^R byte (`0x12`) into its PTY. The read-only agent mirror swallows the chord, because it has no PTY. Focus in a terminal must also stop the app-level reload fallback.

The terminal handle registry also had a key mismatch. It stored handles under the inner xterm host div. Both resolvers walk up to the `[data-terminal]` scope div. So no handle was ever found in production. Only the tests registered on the scope div itself, so the tests passed while production missed. This PR keys the registry by the scope div. A new test uses the production DOM shape and was red before the fix.

Related open PRs for the same issue:

- #96501 limits the main-process claim to webview guests. When main does not prevent the key, the Chromium default fires. On the host window, that default is a reload. So the app still reloads. The PR notes say that it had no packaged desktop run.
- #96586 routes in the renderer but removes the app-reload fallback. The issue checklist asks for the fallback: Ctrl+R elsewhere in the app still reloads the client.

This PR keeps both behaviors: the key reaches the shell in the terminal, and the app-reload escape hatch stays everywhere else. Main needs no change.

## Related Issue

Fixes #96482

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/right-sidebar/terminal/terminal-context-menu.ts`: handle interface gains `reload`. The registry now keys by the `[data-terminal]` scope. New `commandFocusedTerminal()` mirrors `commandFocusedPreview()`.
- `apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts`: the user terminal handle writes the ^R byte into its PTY.
- `apps/desktop/src/app/right-sidebar/terminal/use-agent-terminal.ts`: the read-only agent mirror swallows the chord.
- `apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts`: terminal rung added ahead of the browser-pane rung.
- `apps/desktop/src/app/right-sidebar/terminal/terminal-context-menu.test.ts`: new tests for the production DOM shape and `commandFocusedTerminal`.
- `apps/desktop/src/app/context-menu/app-context-menu.test.tsx`: test handles gain the new `reload` member.

## How to Test

1. Open the desktop app. Open the terminal pane.
2. Press Ctrl+R with the terminal focused. Reverse-i-search starts. The app does not reload.
3. Press Ctrl+R with a preview tab focused. The preview reloads.
4. Press Ctrl+R elsewhere in the app. The client reloads.
5. Ctrl+Shift+R (force reload) is unchanged.
6. Unit tests: from `apps/desktop`, run `npx vitest run src/app/right-sidebar/terminal/ src/app/context-menu/`. The production-shape test fails on the previous registry keying.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (NixOS)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
