### PR TITLE
fix(cron): recognize additional systemctl lifecycle variants

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -107,6 +107,18 @@ _LAUNCHCTL_LIFECYCLE_VERBS_RE = re.compile(
 )
 _HERMES_GATEWAY_LABEL_RE = re.compile(r"(?i)\bhermes[.\-]?gateway\b")
 
+# systemctl accepts global options on either side of its lifecycle verb.
+_SYSTEMCTL_ALWAYS_BLOCKED_ACTIONS = frozenset({
+    "start", "stop", "restart", "kill", "try-restart", "reload-or-restart",
+    "reload-or-try-restart", "condrestart",
+})
+_SYSTEMCTL_NOW_BLOCKED_ACTIONS = frozenset({"disable", "mask"})
+_SYSTEMCTL_GATEWAY_UNIT_RE = re.compile(
+    r"^(?:ai[.\-])?hermes[.\-]?gateway"
+    r"(?:[-@][a-z0-9_.@\-]+)?(?:\.service)?$",
+    re.IGNORECASE,
+)
+
 _SHELL_EXECUTABLES = frozenset({"sh", "bash", "dash", "ksh", "zsh"})
 _SHELL_OPTIONS_WITH_VALUES = frozenset({"-O", "+O", "-o", "+o"})
 _SHELL_COMMAND_FLAGS = {"-c", "--command"}
@@ -237,13 +249,60 @@ def _contains_launchctl_gateway_lifecycle(normalized_text: str) -> bool:
     )
 
 
+def _systemctl_tokens_target_gateway_lifecycle(segment: list[str]) -> bool:
+    """Match the systemctl action and unit operands, excluding option values."""
+    options_with_values = {
+        "--host", "-H", "--machine", "-M", "--root", "--image",
+        "--image-policy", "--signal", "-s", "--kill-whom", "--kill-who",
+        "--type", "-t", "--state", "--property", "-p", "--job-mode",
+        "--lines", "-n", "--output", "-o", "--timestamp", "--what",
+        "--preset-mode", "--boot-loader-menu", "--boot-loader-entry",
+        "--reboot-argument", "--when",
+    }
+    for index, token in enumerate(segment):
+        if token.rsplit("/", 1)[-1].casefold() != "systemctl":
+            continue
+        arguments = segment[index + 1 :]
+        positional = []
+        now = False
+        parse_options = True
+        cursor = 0
+        while cursor < len(arguments):
+            argument = arguments[cursor]
+            cursor += 1
+            if parse_options and argument == "--":
+                parse_options = False
+                continue
+            if parse_options and argument in options_with_values:
+                cursor += 1
+                continue
+            if parse_options and argument.startswith("-"):
+                now = now or argument == "--now"
+                continue
+            positional.append(argument)
+        if not positional:
+            continue
+        action = positional[0].casefold()
+        if action not in _SYSTEMCTL_ALWAYS_BLOCKED_ACTIONS and not (
+            action in _SYSTEMCTL_NOW_BLOCKED_ACTIONS and now
+        ):
+            continue
+        if any(
+            _SYSTEMCTL_GATEWAY_UNIT_RE.fullmatch(argument.strip("'\"`$,:").rsplit("/", 1)[-1])
+            for argument in positional[1:]
+        ):
+            return True
+    return False
+
+
 def contains_gateway_lifecycle_command(text: str) -> bool:
     """Return True if *text* contains a gateway lifecycle command pattern.
 
     Passes, in order: raw-text regex (the only pass that fires on inputs shlex cannot tokenize, e.g.
     Python source); profile-flag form; the same regex on each shell-tokenized segment with quotes/
     escapes resolved (closes splice bypasses like ``kick"start"`` / ``kick\\start``);
-    order-independent launchctl pass. Single choke point for every recursion level of
+    systemctl verb/unit normalization; order-independent launchctl pass.
+    Single choke point for every recursion level of
     ``_contains_unsafe_gateway_action``.
 
     That second pass exists because a real shell resolves quote-splicing (``kick"start"``) and
@@ -291,9 +350,20 @@ def contains_gateway_lifecycle_command(text: str) -> bool:
         joined = " ".join(segment)
         if joined and _GATEWAY_LIFECYCLE_PATTERN.search(joined):
             return True
+        if _systemctl_tokens_target_gateway_lifecycle(segment):
+            return True
         stripped = _ARGV_LIST_PUNCTUATION.sub(" ", joined)
         if stripped != joined and _GATEWAY_LIFECYCLE_PATTERN.search(stripped):
             return True
+        if stripped != joined and _systemctl_tokens_target_gateway_lifecycle(stripped.split()):
+            return True
+        # Quoted command strings retain inner quotes until this additional pass.
+        # Reuse upstream segmentation so separate commands cannot share --now or units.
+        for token in segment:
+            if "systemctl" in token.casefold() and any(char.isspace() for char in token):
+                for nested in _iter_command_segments(token):
+                    if _systemctl_tokens_target_gateway_lifecycle(nested):
+                        return True
     # The label may be built in an earlier `;`-segment, so no pass above sees verb + label together.
     # Order-independent launchctl pass (#77083): a shell loop can build the gateway label from a variable
     # defined in an earlier `;`-separated segment (`label=${item%%:*}; launchctl bootout

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -131,6 +131,76 @@ class TestGatewayLifecyclePattern:
         assert contains_gateway_lifecycle_command_or_referenced_script(command)
 
     @pytest.mark.parametrize("text", [
+        "systemctl kill hermes-gateway",
+        "systemctl try-restart hermes-gateway",
+        "systemctl reload-or-restart hermes-gateway",
+        "systemctl reload-or-try-restart hermes-gateway",
+        "systemctl condrestart hermes-gateway",
+        "systemctl --now disable hermes-gateway",
+        "systemctl --now mask hermes-gateway",
+        "systemctl --user --no-block try-restart hermes-gateway.service",
+        "systemctl reload-or-restart --user hermes-gateway.service",
+        "systemctl reload-or-try-restart hermes-gateway.service --no-block",
+        "systemctl disable --user --now hermes-gateway.service",
+        "systemctl mask hermes-gateway.service --now",
+        "systemctl --signal SIGTERM kill hermes-gateway.service",
+        "systemctl --host example.invalid condrestart hermes-gateway.service",
+        "/usr/bin/systemctl --user try-restart hermes-gateway.service",
+        "sudo /bin/systemctl mask --now hermes-gateway.service",
+        '"systemctl" "try-restart" "hermes-gateway.service"',
+        'system"ctl" re"load"-or-restart hermes-"gateway".service',
+        "systemctl cond\\restart hermes-gateway.service",
+        "systemctl try-restart hermes.gateway.service",
+        "systemctl try-restart ai.hermes.gateway.service",
+        "systemctl try-restart hermes-gateway-work.service",
+        "systemctl try-restart hermes-gateway@work.service",
+        "systemctl disable --now /etc/systemd/system/hermes-gateway.service",
+        "systemctl try-restart nginx.service hermes-gateway.service",
+        "systemctl --user \\\n  reload-or-restart \\\n  hermes-gateway.service",
+        "true && (systemctl --now mask hermes-gateway.service)",
+        "sh -c 'systemctl re\"load\"-or-restart hermes-gateway.service'",
+        "sh -c 'systemctl \\\ntry-restart \\\nhermes-gateway.service'",
+        'subprocess.run(["systemctl", "--user", "try-restart", "hermes-gateway.service"])',
+    ])
+    def test_systemctl_disruptive_variants_target_gateway(self, text):
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script
+
+        assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
+        assert contains_gateway_lifecycle_command_or_referenced_script(text)
+
+    @pytest.mark.parametrize("text", [
+        "systemctl kill nginx.service",
+        "systemctl try-restart hermes-meta.service",
+        "systemctl reload-or-restart hermes-cron-helper.service",
+        "systemctl reload-or-try-restart payment-gateway.service",
+        "systemctl condrestart other.service",
+        "systemctl disable --now nginx.service",
+        "systemctl mask nginx.service --now",
+        "systemctl status hermes-gateway.service",
+        "systemctl --now status hermes-gateway.service",
+        "systemctl status hermes-gateway.service restart",
+        "systemctl --host hermes-gateway try-restart nginx.service",
+        "systemctl try-restart --host hermes-gateway nginx.service",
+        "systemctl status hermes-gateway.service disable --now",
+        "systemctl --user disable hermes-gateway.service",
+        "systemctl mask hermes-gateway.service --user",
+        "systemctl disable hermes-gateway.service; echo --now",
+        "systemctl --now disable nginx.service; echo hermes-gateway.service",
+        "systemctl try-restart nginx.service\necho hermes-gateway.service",
+        "systemctl try-restart not-hermes-gateway.service",
+        "systemctl try-restart hermes-gatewayish.service",
+        "systemctl-notes try-restart hermes-gateway.service",
+        "rg 'systemctl try-restart hermes-gateway.service' /tmp/service.log",
+        "journalctl --grep='systemctl mask --now hermes-gateway.service'",
+        "cat > /tmp/runbook.md <<'EOF'\nsystemctl mask --now hermes-gateway.service\nEOF",
+        "sh -c 'systemctl disable hermes-gateway.service'",
+    ])
+    def test_systemctl_non_disruptive_or_inert_variants_allowed(self, text):
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command_or_referenced_script
+
+        assert not contains_gateway_lifecycle_command_or_referenced_script(text), text
+
+    @pytest.mark.parametrize("text", [
         # The tokenizing pass must not widen the blast radius: prose and
         # non-gateway services stay allowed even though tokenization now
         # strips their quotes too.


### PR DESCRIPTION
Extend the supervised-gateway lifecycle guard to recognize `kill`, `try-restart`, `reload-or-restart`, `reload-or-try-restart`, `condrestart`, and `disable`/`mask` with `--now` when they target a Hermes gateway unit. These command forms can otherwise escape the existing systemctl check.

Parse the action and unit operands separately from option values, including options before and after the action. Status queries, unrelated services, and disable/mask without `--now` retain their existing behavior. The existing literal-unit matching and data-exemption policies remain in place.

Validation: all 352 tests in `tests/hermes_cli/test_gateway_restart_loop.py` pass on the review base and after integration with upstream `939e45c91d75`. The added cases cover quoted/spliced and nested commands, executable paths, option operands, and gateway unit suffixes.
