### PR TITLE
fix(kanban): let idle profile gateways stop notifier polling

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -68,6 +68,18 @@ class GatewayKanbanWatchersMixin:
         dispatcher respawned a crashed task). All SQLite work runs in a thread;
         one tick's failure never stops the next.
         """
+        try:
+            from hermes_cli.config import load_config as _load_config
+
+            cfg = _load_config()
+            kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+        except Exception as exc:
+            logger.warning("kanban notifier: cannot load config (%s); continuing enabled", exc)
+            kanban_cfg = {}
+        if not kanban_cfg.get("notify_in_gateway", True):
+            logger.info("kanban notifier: disabled via config kanban.notify_in_gateway=false")
+            return
+
         from gateway.config import Platform as _Platform
         try:
             from hermes_cli import kanban_db as _kb

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1700,6 +1700,9 @@ DEFAULT_CONFIG = {
         # kanban_create is called from a session with a persistent delivery channel. Disable for
         # profiles that prefer explicit kanban_notify-subscribe calls per task.
         "auto_subscribe_on_create": True,
+        # Poll and deliver Kanban subscriptions from this gateway. Disable on profiles that do
+        # not own notification subscriptions to avoid an idle five-second board probe.
+        "notify_in_gateway": True,
         # Run the dispatcher inside the gateway process (~300µs per idle tick). False only if you
         # run it as a separate unit or don't want the gateway spawning workers.
         "dispatch_in_gateway": True,

--- a/tests/gateway/test_kanban_notifier_watcher_dispatch_gate.py
+++ b/tests/gateway/test_kanban_notifier_watcher_dispatch_gate.py
@@ -1,4 +1,4 @@
-"""Notifier polling stays active when another gateway owns dispatching."""
+"""Notifier polling has an independent gateway config gate."""
 
 import asyncio
 from unittest.mock import MagicMock, patch
@@ -13,6 +13,19 @@ def _make_runner(with_adapter=False):
     runner.adapters = {Platform.TELEGRAM: MagicMock()} if with_adapter else {}
     runner._kanban_sub_fail_counts = {}
     return runner
+
+
+def test_notifier_watcher_skips_when_notifications_disabled():
+    runner = _make_runner(with_adapter=True)
+
+    with patch(
+        "hermes_cli.config.load_config",
+        return_value={"kanban": {"notify_in_gateway": False}},
+    ):
+        with patch("hermes_cli.kanban_db.list_boards") as list_boards:
+            asyncio.run(runner._kanban_notifier_watcher())
+
+    list_boards.assert_not_called()
 
 
 def test_notifier_watcher_polls_without_dispatch_ownership():
@@ -33,13 +46,22 @@ def test_notifier_watcher_polls_without_dispatch_ownership():
 
     import hermes_cli.kanban_db as _kb
 
-    with patch.object(
-        _kb, "list_boards",
-        side_effect=lambda *a, **kw: past_gate.append(True) or [],
+    with patch(
+        "hermes_cli.config.load_config",
+        return_value={
+            "kanban": {
+                "dispatch_in_gateway": False,
+                "notify_in_gateway": True,
+            }
+        },
     ):
-        with patch("asyncio.sleep", side_effect=fake_sleep):
-            with patch("asyncio.to_thread", side_effect=fake_to_thread):
-                asyncio.run(runner._kanban_notifier_watcher())
+        with patch.object(
+            _kb, "list_boards",
+            side_effect=lambda *a, **kw: past_gate.append(True) or [],
+        ):
+            with patch("asyncio.sleep", side_effect=fake_sleep):
+                with patch("asyncio.to_thread", side_effect=fake_to_thread):
+                    asyncio.run(runner._kanban_notifier_watcher())
 
     assert past_gate, (
         "gateways without the dispatch lock must still poll owned subscriptions"

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -677,6 +677,7 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 | `orchestrator_profile` | `""` | Profile assigned to the root/orchestration task after decomposition. Empty = fall back to active default profile. |
 | `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |
 | `auto_subscribe_on_create` | `true` | When `kanban_create` runs inside a persistent gateway/TUI session, terminal events resume that originating agent with a synthetic status turn. Set to `false` for passive completion or to require explicit `kanban_notify-subscribe` calls. Independent of `auto_decompose`. |
+| `notify_in_gateway` | `true` | Poll and deliver Kanban subscriptions from this gateway. Set to `false` on profiles that own no notification subscriptions to stop the idle five-second notifier poll. Independent of `dispatch_in_gateway`; non-dispatch gateways may still own profile-specific delivery adapters. |
 | `done_sub_retention_days` | `30` | Notify subscriptions survive `done` (reopen-safe) and are removed on `archived`. The notifier GC purges subscriptions whose task has been `done` or `blocked` with no new events for this many days, bounding sub-table growth on boards that never archive. `0` disables the sweep. |
 
 And the two auxiliary LLM slots:


### PR DESCRIPTION
## What does this PR do?

Profile gateways with no Kanban notification subscriptions currently keep polling every five seconds and emit a DEBUG line on every empty tick. In the reported second-profile setup, that produced about 17,000 lines per day and consumed roughly one sixth of the configured log retention. This adds an independent, default-on `kanban.notify_in_gateway` gate so operators can stop that idle work without disabling dispatch ownership or suppressing unrelated DEBUG diagnostics.

### Symptom

A gateway whose profile owns no `kanban_notify_subs` rows repeatedly logs `kanban notifier: board ... has no subscriptions ...; skipping open` every five seconds.

### Impact

The reported gateway produced 11.9 empty-poll lines per minute, or about 17,137 lines per day. Raising the home-wide log level hides other useful diagnostics, while `kanban.dispatch_in_gateway: false` cannot safely disable notification delivery for profile-specific adapters.

### Bug Cause

**Trigger:** `gateway/kanban_watchers.py:60` starts `_kanban_notifier_watcher`, which enters its five-second loop for every gateway.

**Causal chain:**
1. Gateway startup schedules the notifier watcher unconditionally.
2. Each tick enumerates boards and reaches the zero-subscription probe in `gateway/kanban_watchers_notifier.py`.
3. The probe correctly avoids a writable SQLite open, but emits the same DEBUG line on every tick indefinitely.

**Why it is wrong:** There is no notifier-specific configuration gate, so a profile that intentionally owns no notification subscriptions cannot disable the idle loop without changing global logging behavior.

**Working sibling / contrast:** The embedded dispatcher has its own `kanban.dispatch_in_gateway` startup gate. Notification ownership is intentionally independent because a non-dispatch gateway may still host adapters for profile-owned subscriptions.

**Ruled out:** Reusing `dispatch_in_gateway` is unsafe. The existing non-dispatch notifier contract and the history behind `fix(kanban): deliver notifications from non-dispatch gateways` show that dispatcher and delivery ownership can reside in different processes.

### Fix

- Add `kanban.notify_in_gateway`, defaulting to `true` for backward compatibility.
- Exit the notifier before board enumeration and the initial delay when the setting is `false`.
- Preserve notifier polling when `dispatch_in_gateway` is `false` but `notify_in_gateway` remains enabled.
- Document the independent ownership boundary and cover both branches behaviorally.

## Related Issue

Closes #108549

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/kanban_watchers.py` - gate notifier startup on `kanban.notify_in_gateway` while preserving fail-open delivery if config loading fails.
- `hermes_cli/config_defaults.py` - define the backward-compatible default.
- `tests/gateway/test_kanban_notifier_watcher_dispatch_gate.py` - cover disabled notification polling and independent dispatcher ownership.
- `website/docs/user-guide/features/kanban.md` - document the new setting and its ownership semantics.

## How to Test

1. Set `kanban.notify_in_gateway: false`, start a gateway, and confirm notifier board enumeration does not occur.
2. Set `kanban.dispatch_in_gateway: false` with `kanban.notify_in_gateway: true`, and confirm profile-owned notifier polling still runs.
3. Run:

```bash
scripts/run_tests.sh tests/gateway/test_kanban_notifier_watcher_dispatch_gate.py tests/gateway/test_kanban_notifier_zero_sub_gate.py tests/gateway/test_kanban_notifier.py tests/hermes_cli/test_config.py
```

Result: 140 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant suites and all 140 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` is N/A because this repository documents Kanban configuration in the user guide and merges defaults dynamically
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or contribution workflow changed
- [x] Cross-platform impact is N/A because this is platform-independent Python configuration and loop control
- [x] Tool descriptions and schemas are N/A because no model tool behavior changed

## Screenshots / Logs

N/A. This changes a background polling loop and its log volume; focused automated verification is listed above.
