### PR TITLE
fix(cli): fire the first focus-regain repaint on a low monotonic clock

### DIFF
--- a/hermes_cli/cli_terminal_mixin.py
+++ b/hermes_cli/cli_terminal_mixin.py
@@ -138,7 +138,13 @@ class CLITerminalMixin:
         stacks on stale content (#60920, #25337); terminals without it never emit ``CSI I``.
         """
         now = time.monotonic()
-        if now - getattr(self, "_last_focus_regain_redraw", 0.0) < min_interval:
+        # None, not 0.0, is the "never fired" sentinel. time.monotonic() has an arbitrary
+        # origin -- on Linux it counts from boot -- so a 0.0 default reads as "repainted at
+        # monotonic zero" rather than "never repainted". On a host whose uptime is still
+        # below min_interval that suppresses the very first focus-in, which is the repaint
+        # that matters most: the one recovering the stale surface after a regain.
+        last = getattr(self, "_last_focus_regain_redraw", None)
+        if last is not None and now - last < min_interval:
             return
         self._last_focus_regain_redraw = now
         self._force_full_redraw()

--- a/tests/cli/test_cli_force_redraw.py
+++ b/tests/cli/test_cli_force_redraw.py
@@ -418,6 +418,30 @@ class TestFocusRegainRedraw:
 
         assert calls == ["redraw"]
 
+    def test_focus_regain_redraw_fires_on_freshly_booted_host(self, bare_cli, monkeypatch):
+        """The first repaint fires even when the clock reads below ``min_interval``.
+
+        ``time.monotonic()`` has an arbitrary origin -- on Linux it counts from boot --
+        so on a host with low uptime (a fresh CI runner, a just-restarted box) the first
+        focus-in was compared against a 0.0 default and suppressed. Invisible on a
+        long-lived dev machine, where the monotonic clock is always large enough.
+
+        This is also why ``test_focus_regain_redraw_is_rate_limited`` above is
+        intermittent in CI: it pins ``min_interval=60.0``, so it fails on any runner
+        whose uptime is under 60 seconds when the slice runs, and passes on rerun.
+        """
+        from hermes_cli import cli_terminal_mixin
+
+        calls = []
+        bare_cli._force_full_redraw = lambda: calls.append("redraw")
+        monkeypatch.setattr(cli_terminal_mixin.time, "monotonic", lambda: 32.5)
+
+        bare_cli._schedule_focus_regain_redraw(min_interval=60.0)
+        bare_cli._schedule_focus_regain_redraw(min_interval=60.0)
+
+        # First fires despite 32.5 < 60.0; the second is still rate-limited.
+        assert calls == ["redraw"]
+
     def test_focus_regain_redraw_fires_again_after_interval(self, bare_cli):
         calls = []
         bare_cli._force_full_redraw = lambda: calls.append("redraw")


### PR DESCRIPTION
## What does this PR do?

`_schedule_focus_regain_redraw()` uses `0.0` as its "never fired" sentinel:

```python
if now - getattr(self, "_last_focus_regain_redraw", 0.0) < min_interval:
    return
```

`time.monotonic()` has an arbitrary origin — on Linux it counts from boot — so `0.0` is not "long ago", it is "at monotonic zero". On a host whose uptime is still below `min_interval`, `now - 0.0 < min_interval` holds and the very first focus-in is suppressed. That is the repaint that matters most: the one recovering the stale surface after a focus regain, which is the whole point of tracking `CSI I`.

It is invisible on a long-lived dev machine, where `monotonic()` is always large enough that the comparison passes.

Using `None` as the sentinel makes "never fired" distinguishable from "fired at monotonic zero". The first call always fires; rate limiting is otherwise unchanged.

## Related Issue

No existing issue. I searched open and merged PRs and issues for `focus regain redraw`, `_last_focus_regain_redraw`, `focus_regain`, and `test_focus_regain_redraw_is_rate_limited` and found nothing, so this is not a duplicate.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/cli_terminal_mixin.py` — `None` sentinel instead of `0.0` in `_schedule_focus_regain_redraw()`, with a comment explaining why the default matters
- `tests/cli/test_cli_force_redraw.py` — adds `test_focus_regain_redraw_fires_on_freshly_booted_host`

## This also explains an intermittent test

`test_focus_regain_redraw_is_rate_limited` pins `min_interval=60.0` and asserts `calls == ["redraw"]`. Against the current source that assertion holds only once the machine has been up for a minute, so it fails on a fresh runner and passes on rerun.

Running the real method against a pinned clock, the boundary is exactly `min_interval`:

| uptime | current | with this PR | existing test |
|---|---|---|---|
| 5.0s | `[]` | `['redraw']` | fails |
| 32.5s | `[]` | `['redraw']` | fails |
| 59.9s | `[]` | `['redraw']` | fails |
| 60.1s | `['redraw']` | `['redraw']` | passes |
| 900000s | `['redraw']` | `['redraw']` | passes |

Not a flaky test; a real bug with a narrow trigger.

## How to Test

1. `pytest tests/cli/test_cli_force_redraw.py -q` — 20 pass on this branch (19 before, plus the new one).
2. Revert `hermes_cli/cli_terminal_mixin.py` and rerun — `test_focus_regain_redraw_fires_on_freshly_booted_host` fails, 19 pass. The new test pins `monotonic()` to 32.5 with `min_interval=60.0`, so it reproduces the low-uptime case deterministically on any machine.
3. For the intermittent one, pin `monotonic()` below 60.0 and run `test_focus_regain_redraw_is_rate_limited` against the unpatched source.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **ran `tests/cli/` in full, not the whole suite.** Leaving this unticked rather than overclaiming. Result: **1426 passed, 9 skipped, 1 failed**. The one failure is `test_resume_quiet_stderr.py::test_session_not_found_goes_to_stdout_in_full_mode`, which is order-dependent and unrelated: it passes in isolation both on this branch and on a clean detached checkout of `main` at the same base. I also did not run `tests/agent/`, which has pre-existing failures on this base that I have not investigated and do not want to imply I cleared.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.6), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, the explanation lives in the code comment and the test docstring
- [x] I've updated `cli-config.yaml.example` — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow change
- [x] I've considered cross-platform impact — the bug is most visible on Linux, where `monotonic()` counts from boot, and the fix is platform-independent
- [x] I've updated tool descriptions/schemas — N/A, no tool behavior change
