### PR TITLE
fix(agent): short-circuit empty-response ladder on proven output-cap starvation

### DIFF
--- a/agent/empty_response_guard.py
+++ b/agent/empty_response_guard.py
@@ -265,13 +265,14 @@ def is_output_starvation(
     response: Any,
     has_visible_content: bool,
     has_tool_calls: bool,
-    visible_content_preview: str = "",
 ) -> bool:
     """True when the response provably hit the endpoint's output cap with nothing
     usable delivered: truncating finish reason + usage-backed completion tokens,
-    no tool calls, no visible content. Fails OPEN on ambiguous evidence — any
-    content (or an inline unclosed think block standing in for content), tool
-    calls, missing usage, or a disabled guard keeps legacy ladder behaviour.
+    no tool calls, no visible content. Callers pass ``has_visible_content`` AFTER
+    stripping inline think blocks so a truncated-mid-thought response (content is
+    only an unclosed think tag) does not fail open. Fails OPEN on ambiguous
+    evidence — any surviving content, tool calls, missing usage, or a disabled
+    guard keeps legacy ladder behaviour.
     """
     if not guard_enabled(agent):
         return False
@@ -302,8 +303,9 @@ def starvation_retry_budget(agent: Any, finish_reason: str) -> int:
     """Retry budget when the current streak is a proven output-cap starvation:
     ONE retry for the first starved attempt, ZERO for every attempt after (a
     systematic cap truncates identically; a second retry is a pure re-bill), then
-    the ladder proceeds to fallback/terminal. Non-starvation streaks and a
-    disabled guard keep the default budget."""
+    the ladder proceeds to fallback/terminal. Any truncating finish reason across
+    the streak counts (gateways normalize length/max_tokens differently); mixed
+    non-truncating evidence keeps the default budget."""
     if not guard_enabled(agent):
         return DEFAULT_EMPTY_RETRY_BUDGET
     if str(finish_reason or "") not in _TRUNCATION_FINISH_REASONS:
@@ -311,7 +313,7 @@ def starvation_retry_budget(agent: Any, finish_reason: str) -> int:
     attempts = getattr(agent, _ATTEMPTS_ATTR, None) or []
     if not attempts:
         return DEFAULT_EMPTY_RETRY_BUDGET
-    if not all(a.finish_reason == str(finish_reason) for a in attempts):
+    if not all(a.finish_reason in _TRUNCATION_FINISH_REASONS for a in attempts):
         return DEFAULT_EMPTY_RETRY_BUDGET
     retries = getattr(agent, "_empty_content_retries", 0)
     if retries >= 1:

--- a/agent/empty_response_guard.py
+++ b/agent/empty_response_guard.py
@@ -241,3 +241,81 @@ def streak_cost_usd(agent: Any) -> Optional[Decimal]:
     """Accumulated estimated cost of the current empty streak, if known."""
     cost = getattr(agent, _STREAK_COST_ATTR, None)
     return cost if cost is not None and cost > 0 else None
+
+
+# ── Server-side truncation starvation ────────────────────────────────────────────
+# ``finish_reason`` length/max_tokens with zero visible output means the endpoint's
+# output cap consumed the response. When reasoning counts against that cap (typical
+# for thinking models behind OpenAI-compatible gateways that apply an internal cap
+# when the request omits ``max_tokens``), the ENTIRE allocation goes to reasoning
+# before any answer token: retrying is guaranteed to truncate identically, and the
+# ladder's nudge/prefill/retries each re-bill the full input for no possible gain.
+_TRUNCATION_FINISH_REASONS = frozenset({"length", "max_tokens"})
+
+
+def _completion_reasoning_tokens(canonical: Any) -> int:
+    """Best-effort reasoning-token count from canonical usage (0 when unreported)."""
+    return getattr(canonical, "reasoning_tokens", 0) or 0
+
+
+def is_output_starvation(
+    agent: Any,
+    *,
+    finish_reason: str,
+    response: Any,
+    has_visible_content: bool,
+    has_tool_calls: bool,
+    visible_content_preview: str = "",
+) -> bool:
+    """True when the response provably hit the endpoint's output cap with nothing
+    usable delivered: truncating finish reason + usage-backed completion tokens,
+    no tool calls, no visible content. Fails OPEN on ambiguous evidence — any
+    content (or an inline unclosed think block standing in for content), tool
+    calls, missing usage, or a disabled guard keeps legacy ladder behaviour.
+    """
+    if not guard_enabled(agent):
+        return False
+    if str(finish_reason or "") not in _TRUNCATION_FINISH_REASONS:
+        return False
+    if has_tool_calls or has_visible_content:
+        return False
+    canonical = _normalized_usage(agent, response, "starvation detection")
+    if canonical is None:
+        return False
+    completion = getattr(canonical, "output_tokens", 0) or 0
+    if completion <= 0:
+        # Zero output + length-finish is the deterministic-empty guard's case.
+        return False
+    reasoning = _completion_reasoning_tokens(canonical)
+    if reasoning <= 0:
+        # Gateways often omit reasoning breakdown; completion tokens with empty
+        # content on a truncating finish reason still proves the cap ate the
+        # output UNLESS the content was actually delivered (checked above).
+        # Treated as starvation: the retry would truncate identically.
+        return True
+    # Reasoning breakdown present: starvation when reasoning effectively consumed
+    # the completion budget (>=95%) with no content surviving.
+    return reasoning >= completion * 0.95
+
+
+def starvation_retry_budget(agent: Any, finish_reason: str) -> int:
+    """Retry budget when the current streak is a proven output-cap starvation:
+    ONE retry for the first starved attempt, ZERO for every attempt after (a
+    systematic cap truncates identically; a second retry is a pure re-bill), then
+    the ladder proceeds to fallback/terminal. Non-starvation streaks and a
+    disabled guard keep the default budget."""
+    if not guard_enabled(agent):
+        return DEFAULT_EMPTY_RETRY_BUDGET
+    if str(finish_reason or "") not in _TRUNCATION_FINISH_REASONS:
+        return DEFAULT_EMPTY_RETRY_BUDGET
+    attempts = getattr(agent, _ATTEMPTS_ATTR, None) or []
+    if not attempts:
+        return DEFAULT_EMPTY_RETRY_BUDGET
+    if not all(a.finish_reason == str(finish_reason) for a in attempts):
+        return DEFAULT_EMPTY_RETRY_BUDGET
+    retries = getattr(agent, "_empty_content_retries", 0)
+    if retries >= 1:
+        # Already burned the one controlled retry — further attempts on the same
+        # cap are guaranteed identical truncations.
+        return 0
+    return REDUCED_EMPTY_RETRY_BUDGET

--- a/agent/turn_empty_response.py
+++ b/agent/turn_empty_response.py
@@ -185,15 +185,18 @@ def recover_empty_response(
     # any usable output (reasoning consumed the cap). Nudging/prefilling would
     # mutate the prompt (breaking the cached prefix) and re-bill the full input for
     # a guaranteed-identical truncation — skip the nudge/prefill rounds below and
-    # run the budgeted retry path directly.
-    if _empty_guard.is_output_starvation(
+    # run the budgeted retry path directly. The flag is ASSIGNED (not one-way set)
+    # so every ladder entry reflects the CURRENT response and a stale True can
+    # never suppress a later benign streak's nudge.
+    _starved_now = _empty_guard.is_output_starvation(
         agent,
         finish_reason=finish_reason,
         response=response,
         has_visible_content=bool(agent._strip_think_blocks(final_response or "").strip()),
         has_tool_calls=bool(getattr(assistant_message, "tool_calls", None)),
-    ):
-        agent._output_starvation_detected = True
+    )
+    agent._output_starvation_detected = _starved_now
+    if _starved_now:
         logger.warning(
             "Output-cap starvation detected (finish_reason=%s, no content/tool calls) — "
             "skipping nudge/prefill, budgeted retry only (model=%s provider=%s)",

--- a/agent/turn_empty_response.py
+++ b/agent/turn_empty_response.py
@@ -59,6 +59,11 @@ def _retry_empty(
         _empty_guard.empty_retry_budget(agent, response)
         if empty_candidate else _empty_guard.DEFAULT_EMPTY_RETRY_BUDGET
     )
+    # Proven output-cap starvation: ONE retry, never the default budget. The cap is
+    # a server-side property — retries 2+ would truncate identically and re-bill.
+    _starved_budget = _empty_guard.starvation_retry_budget(agent, finish_reason)
+    if _starved_budget != _empty_guard.DEFAULT_EMPTY_RETRY_BUDGET:
+        budget = min(budget, _starved_budget)
     deterministic = empty_candidate and _empty_guard.deterministic_empty(agent)
     if not (empty_candidate and agent._empty_content_retries < budget and not deterministic):
         return None, None, deterministic
@@ -176,6 +181,28 @@ def recover_empty_response(
         agent._response_was_previewed = False
         return _verdict("break")
 
+    # Server-side output-cap starvation: the endpoint truncated the response before
+    # any usable output (reasoning consumed the cap). Nudging/prefilling would
+    # mutate the prompt (breaking the cached prefix) and re-bill the full input for
+    # a guaranteed-identical truncation — skip straight to budgeted retries.
+    if _empty_guard.is_output_starvation(
+        agent,
+        finish_reason=finish_reason,
+        response=response,
+        has_visible_content=bool((final_response or "").strip()),
+        has_tool_calls=bool(getattr(assistant_message, "tool_calls", None)),
+    ):
+        agent._output_starvation_detected = True
+        logger.warning(
+            "Output-cap starvation detected (finish_reason=%s, no content/tool calls) — "
+            "skipping nudge/prefill, budgeted retry only (model=%s provider=%s)",
+            finish_reason, agent.model, agent.provider,
+        )
+        agent._buffer_status(
+            "⚠️ Endpoint truncated the response at its output cap — a retry may help once, "
+            "but set providers.<name>.extra_body.max_tokens to raise the cap"
+        )
+
     # Prior turn had real content + ONLY housekeeping tools: model is done, reuse it.
     # With substantive tools it was mid-task narration and the empty reply is a choke;
     # let the post-tool nudge handle it.
@@ -245,6 +272,19 @@ def recover_empty_response(
     # prefill exhaustion.
     _truly_empty = not agent._strip_think_blocks(final_response).strip()
     _empty_candidate = _truly_empty and (not _has_structured or agent._thinking_prefill_retries >= 2)
+    # Proven output-cap starvation collapses the retry budget to one; the streak
+    # also skips further nudge/prefill rounds (each re-bills full input and the
+    # truncation is deterministic while the cap is in effect).
+    if getattr(agent, "_output_starvation_detected", False) and _empty_guard.is_output_starvation(
+        agent, finish_reason=finish_reason, response=response,
+        has_visible_content=bool((final_response or "").strip()),
+        has_tool_calls=bool(getattr(assistant_message, "tool_calls", None)),
+    ):
+        _empty_candidate = _truly_empty or _has_structured
+        if _has_structured:
+            # Suppress prefill continuation for starved streaks: the reasoning IS
+            # the truncated output, not a missing-answer state.
+            agent._thinking_prefill_retries = 2
     action, interrupt_result, _deterministic_empty = _retry_empty(
         agent, response, finish_reason, _empty_candidate, messages=messages,
         conversation_history=conversation_history, api_call_count=api_call_count,

--- a/agent/turn_empty_response.py
+++ b/agent/turn_empty_response.py
@@ -184,12 +184,13 @@ def recover_empty_response(
     # Server-side output-cap starvation: the endpoint truncated the response before
     # any usable output (reasoning consumed the cap). Nudging/prefilling would
     # mutate the prompt (breaking the cached prefix) and re-bill the full input for
-    # a guaranteed-identical truncation — skip straight to budgeted retries.
+    # a guaranteed-identical truncation — skip the nudge/prefill rounds below and
+    # run the budgeted retry path directly.
     if _empty_guard.is_output_starvation(
         agent,
         finish_reason=finish_reason,
         response=response,
-        has_visible_content=bool((final_response or "").strip()),
+        has_visible_content=bool(agent._strip_think_blocks(final_response or "").strip()),
         has_tool_calls=bool(getattr(assistant_message, "tool_calls", None)),
     ):
         agent._output_starvation_detected = True
@@ -197,10 +198,6 @@ def recover_empty_response(
             "Output-cap starvation detected (finish_reason=%s, no content/tool calls) — "
             "skipping nudge/prefill, budgeted retry only (model=%s provider=%s)",
             finish_reason, agent.model, agent.provider,
-        )
-        agent._buffer_status(
-            "⚠️ Endpoint truncated the response at its output cap — a retry may help once, "
-            "but set providers.<name>.extra_body.max_tokens to raise the cap"
         )
 
     # Prior turn had real content + ONLY housekeeping tools: model is done, reuse it.
@@ -214,18 +211,22 @@ def recover_empty_response(
         agent._last_content_with_tools = None
         agent._last_content_tools_all_housekeeping = False
         agent._empty_content_retries = 0
+        agent._output_starvation_detected = False
         # Do NOT modify the assistant message content (injected text poisoned history).
         final_response = agent._strip_think_blocks(fallback).strip()
         agent._response_was_previewed = True
         return _verdict("break")
 
     # Post-tool-call empty (no prior content, or only mid-task narration): nudge once.
+    # Proven output-cap starvation NEVER nudges: the synthetic rows would mutate the
+    # prompt (breaking the cached prefix) and the retry truncates identically anyway.
     _prior_was_tool = any(m.get("role") == "tool" for m in messages[-5:])
-    # Ollama puts <think> in content, not reasoning_content, so _has_structured misses
+    # Ollama puts inline <think> tags in content, not reasoning_content, so _has_structured misses
     # it; detect here to route to prefill.
     _has_inline_thinking = bool(_INLINE_THINK_RE.search(final_response or ""))
     if (
         _prior_was_tool
+        and not getattr(agent, "_output_starvation_detected", False)
         and not getattr(agent, "_post_tool_empty_retried", False)
         and not _has_inline_thinking  # thinking model still working — let prefill handle
     ):
@@ -277,7 +278,7 @@ def recover_empty_response(
     # truncation is deterministic while the cap is in effect).
     if getattr(agent, "_output_starvation_detected", False) and _empty_guard.is_output_starvation(
         agent, finish_reason=finish_reason, response=response,
-        has_visible_content=bool((final_response or "").strip()),
+        has_visible_content=bool(agent._strip_think_blocks(final_response or "").strip()),
         has_tool_calls=bool(getattr(assistant_message, "tool_calls", None)),
     ):
         _empty_candidate = _truly_empty or _has_structured
@@ -285,6 +286,14 @@ def recover_empty_response(
             # Suppress prefill continuation for starved streaks: the reasoning IS
             # the truncated output, not a missing-answer state.
             agent._thinking_prefill_retries = 2
+        # Surface the escape hatch only when actually entering the starved retry
+        # path (detection alone doesn't warn — prior-turn reuse may resolve the
+        # turn without any truncation-facing UX).
+        _provider_key = (getattr(agent, "provider", "") or "custom").split(":")[-1]
+        agent._buffer_status(
+            f"⚠️ Endpoint truncated the response at its output cap — set "
+            f"providers.{_provider_key}.extra_body.max_tokens to raise the cap"
+        )
     action, interrupt_result, _deterministic_empty = _retry_empty(
         agent, response, finish_reason, _empty_candidate, messages=messages,
         conversation_history=conversation_history, api_call_count=api_call_count,
@@ -314,6 +323,7 @@ def recover_empty_response(
         if agent._try_activate_fallback():
             active_system_prompt = _sync_failover_system_message(agent, api_messages, active_system_prompt)
             agent._empty_content_retries = 0
+            agent._output_starvation_detected = False
             agent._buffer_status(f"↻ Switched to fallback: {agent.model} " f"({agent.provider})")
             logger.info(
                 "Fallback activated after empty responses: now using %s on %s",

--- a/tests/agent/test_starvation_breaker.py
+++ b/tests/agent/test_starvation_breaker.py
@@ -1,0 +1,153 @@
+"""Server-side truncation starvation: ``finish_reason`` length/max_tokens with empty
+content must short-circuit the empty-response ladder.
+
+Failure shape (observed on a hosted OpenAI-compatible gateway): a reasoning model
+with thinking enabled gets its *entire* output allocation consumed by reasoning
+tokens against the endpoint's internal output cap (applied when the request omits
+``max_tokens``). The response ends ``finish_reason=length``/``max_tokens`` with zero
+visible content. The ladder previously treated this identically to a benign empty:
+nudge (mutates the prompt → breaks the cached prefix) → prefill ×2 → retries ×3 →
+fallback — re-billing the full input on every attempt with no chance of success,
+because the cap will truncate the retry identically.
+
+The starvation guard fails open: ambiguous evidence (any visible content, tool
+calls, unknown finish reason) keeps legacy ladder behaviour.
+"""
+
+from types import SimpleNamespace
+
+from agent import empty_response_guard as guard
+
+
+def _agent(**overrides):
+    base = dict(
+        model="gemini-3.8-flash",
+        provider="custom:gateway",
+        api_mode="chat_completions",
+        base_url="https://gateway.example/v1",
+        api_key=None,
+        _empty_content_retries=0,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _response(prompt_tokens=34_000, completion_tokens=1_000, reasoning_tokens=0, usage_present=True):
+    if not usage_present:
+        return SimpleNamespace(usage=None)
+    usage = SimpleNamespace(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+        completion_tokens_details=SimpleNamespace(reasoning_tokens=reasoning_tokens),
+    )
+    return SimpleNamespace(usage=usage)
+
+
+class TestStarvationDetection:
+    def test_length_finish_with_reasoning_only_output_is_starvation(self):
+        agent = _agent()
+        assert guard.is_output_starvation(
+            agent, finish_reason="max_tokens",
+            response=_response(reasoning_tokens=996),
+            has_visible_content=False, has_tool_calls=False,
+        ) is True
+
+    def test_openai_length_finish_is_starvation(self):
+        agent = _agent()
+        assert guard.is_output_starvation(
+            agent, finish_reason="length",
+            response=_response(reasoning_tokens=956),
+            has_visible_content=False, has_tool_calls=False,
+        ) is True
+
+    def test_stop_finish_is_never_starvation(self):
+        """finish_reason=stop + empty content is a model-behaviour problem (refusal,
+        decode blip) — the existing ladder owns it, not the truncation guard."""
+        agent = _agent()
+        assert guard.is_output_starvation(
+            agent, finish_reason="stop",
+            response=_response(reasoning_tokens=0),
+            has_visible_content=False, has_tool_calls=False,
+        ) is False
+
+    def test_tool_calls_present_fails_open(self):
+        """A truncated response that still produced tool calls is mid-task work;
+        the tool round must proceed, not the breaker."""
+        agent = _agent()
+        assert guard.is_output_starvation(
+            agent, finish_reason="max_tokens",
+            response=_response(reasoning_tokens=956),
+            has_visible_content=False, has_tool_calls=True,
+        ) is False
+
+    def test_visible_content_fails_open(self):
+        """Content present (think-block stripping leaves text) is not starvation."""
+        agent = _agent()
+        assert guard.is_output_starvation(
+            agent, finish_reason="max_tokens",
+            response=_response(reasoning_tokens=956),
+            has_visible_content=True, has_tool_calls=False,
+        ) is False
+
+    def test_missing_usage_fails_open(self):
+        """No usage object → no proof of truncation shape → legacy behaviour."""
+        agent = _agent()
+        assert guard.is_output_starvation(
+            agent, finish_reason="max_tokens",
+            response=_response(usage_present=False),
+            has_visible_content=False, has_tool_calls=False,
+        ) is False
+
+    def test_guard_disabled_fails_open(self):
+        agent = _agent(_empty_guard_enabled=False)
+        assert guard.is_output_starvation(
+            agent, finish_reason="max_tokens",
+            response=_response(reasoning_tokens=956),
+            has_visible_content=False, has_tool_calls=False,
+        ) is False
+
+    def test_unclosed_think_block_only_content_counts_as_empty(self):
+        """DeepSeek-style endpoints inline ``智`` in content; a response truncated
+        mid-thought yields 'content' that is only an unclosed think tag."""
+        agent = _agent()
+        assert guard.is_output_starvation(
+            agent, finish_reason="length",
+            response=_response(reasoning_tokens=0, completion_tokens=1_000),
+            has_visible_content=False, has_tool_calls=False,
+            visible_content_preview="<智>partial reasoning without a closing tag",
+        ) is True
+
+
+class TestStarvationBudget:
+    def test_starved_streak_gets_single_retry(self):
+        """Budget is queried with _empty_content_retries at its PRE-increment value
+        (the loop records the attempt, picks the budget, then increments)."""
+        agent = _agent()
+        _record(agent, finish_reason="max_tokens", response=_response(reasoning_tokens=956))
+        agent._empty_content_retries = 0  # first starved attempt: budget check time
+        assert guard.starvation_retry_budget(agent, finish_reason="max_tokens") == 1
+
+    def test_starvation_budget_zero_after_one_starvation_retry(self):
+        agent = _agent()
+        _record(agent, finish_reason="max_tokens", response=_response(reasoning_tokens=956))
+        agent._empty_content_retries = 1
+        assert guard.starvation_retry_budget(agent, finish_reason="max_tokens") == 0
+
+    def test_non_starvation_streak_keeps_default_budget(self):
+        agent = _agent()
+        _record(agent, finish_reason="stop", response=_response(usage_present=False))
+        assert guard.starvation_retry_budget(agent, finish_reason="stop") == guard.DEFAULT_EMPTY_RETRY_BUDGET
+
+    def test_guard_disabled_keeps_default_budget(self):
+        agent = _agent(_empty_guard_enabled=False)
+        _record(agent, finish_reason="max_tokens", response=_response(reasoning_tokens=956))
+        assert guard.starvation_retry_budget(agent, finish_reason="max_tokens") == guard.DEFAULT_EMPTY_RETRY_BUDGET
+
+
+def _record(agent, *, finish_reason, response, observed_generation=False):
+    guard.record_empty_attempt(
+        agent, finish_reason=finish_reason, response=response,
+        observed_generation=observed_generation,
+    )
+    agent._empty_content_retries += 1

--- a/tests/agent/test_starvation_breaker.py
+++ b/tests/agent/test_starvation_breaker.py
@@ -108,14 +108,27 @@ class TestStarvationDetection:
         ) is False
 
     def test_unclosed_think_block_only_content_counts_as_empty(self):
-        """DeepSeek-style endpoints inline ``智`` in content; a response truncated
-        mid-thought yields 'content' that is only an unclosed think tag."""
+        """DeepSeek-style endpoints inline <think> tags in content; a response truncated
+        mid-thought yields 'content' that is only an unclosed think tag. Callers
+        strip think blocks before the has_visible_content check, so this shape
+        classifies as starvation (Flash round-1 BLOCKER 2)."""
+        agent = _agent()
+        assert guard.is_output_starvation(
+            agent, finish_reason="length",
+            response=_response(reasoning_tokens=0, completion_tokens=1_000),
+            has_visible_content=False,  # after _strip_think_blocks("<think>...partial")
+            has_tool_calls=False,
+        ) is True
+
+    def test_truncating_finish_with_unreported_reasoning_is_starvation(self):
+        """Gateway omits the reasoning breakdown (reported 0) but completion>0 on a
+        truncating finish reason with no content: the cap consumed the output
+        (GPT-OSS round-1 requested documentation of this exact shape)."""
         agent = _agent()
         assert guard.is_output_starvation(
             agent, finish_reason="length",
             response=_response(reasoning_tokens=0, completion_tokens=1_000),
             has_visible_content=False, has_tool_calls=False,
-            visible_content_preview="<智>partial reasoning without a closing tag",
         ) is True
 
 

--- a/tests/agent/test_starvation_ladder_integration.py
+++ b/tests/agent/test_starvation_ladder_integration.py
@@ -90,13 +90,35 @@ def _run_ladder(agent, finish_reason="max_tokens"):
 
 
 class TestLadderShortCircuit:
-    def test_starved_response_sets_flag_and_skips_nothing_on_first_pass(self):
-        """First starved empty: flag set, nudge ladder still runs its normal order
-        (the nudge happens only for post-tool empties; our minimal history has no
-        tool rows, so the ladder proceeds to prefill/retry handling)."""
-        agent = _agent()
-        verdict = _run_ladder(agent)
+    def test_starved_post_tool_response_skips_nudge(self):
+        """The primary trigger shape: tool result immediately before the starved
+        empty. Legacy ladder would append the "(empty)" + synthetic-user nudge
+        rows (prompt mutation, cache break); starved streaks must skip it
+        (Flash round-1 BLOCKER 1)."""
+        agent = _agent(_post_tool_empty_retried=False)
+        messages = [
+            {"role": "user", "content": "run the thing"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "t1"}]},
+            {"role": "tool", "tool_call_id": "t1", "content": "ok"},
+        ]
+        verdict = recover_empty_response(
+            agent,
+            assistant_message=_assistant_message(),
+            response=_starved_response(),
+            finish_reason="max_tokens",
+            final_response="",
+            messages=messages,
+            api_messages=[],
+            conversation_history=[],
+            active_system_prompt=None,
+            api_call_count=2,
+            turn_exit_reason=None,
+            preflight_compression_blocked=False,
+        )
         assert getattr(agent, "_output_starvation_detected", False) is True
+        # No synthetic nudge rows appended: history length unchanged.
+        assert len(messages) == 3
+        assert not any(m.get("_empty_recovery_synthetic") for m in messages)
 
     def test_starved_streak_suppresses_thinking_prefill(self):
         agent = _agent()

--- a/tests/agent/test_starvation_ladder_integration.py
+++ b/tests/agent/test_starvation_ladder_integration.py
@@ -146,6 +146,36 @@ class TestLadderShortCircuit:
         assert guard.starvation_retry_budget(agent, finish_reason="max_tokens") == 0
 
 
+class TestStaleFlagReset:
+    def test_benign_empty_after_starved_entry_resets_flag(self):
+        """Flag reflects the CURRENT response (Flash R2 finding 1): a starved
+        response followed by a benign (finish_reason=stop) empty must reset the
+        flag so the later streak's nudge is not suppressed."""
+        agent = _agent(_output_starvation_detected=True)  # stale from a prior streak
+        _run_ladder(agent, finish_reason="stop")
+        assert getattr(agent, "_output_starvation_detected", False) is False
+
+    def test_non_starved_entry_clears_flag_even_with_truncating_reason_shape(self):
+        """A response with content present + truncating reason is NOT starvation:
+        the flag must flip False on that entry (prior-turn reuse then works)."""
+        agent = _agent(_output_starvation_detected=True)
+        verdict = recover_empty_response(
+            agent,
+            assistant_message=_assistant_message(),
+            response=_starved_response(),
+            finish_reason="length",
+            final_response="real content survived truncation",
+            messages=[{"role": "user", "content": "task"}],
+            api_messages=[],
+            conversation_history=[],
+            active_system_prompt=None,
+            api_call_count=1,
+            turn_exit_reason=None,
+            preflight_compression_blocked=False,
+        )
+        assert getattr(agent, "_output_starvation_detected", False) is False
+
+
 class TestNoRegressionOnBenignEmpties:
     def test_stop_finish_empty_never_sets_starvation_flag(self):
         agent = _agent()

--- a/tests/agent/test_starvation_ladder_integration.py
+++ b/tests/agent/test_starvation_ladder_integration.py
@@ -1,0 +1,150 @@
+"""Ladder integration: output-cap starvation short-circuits recovery steps.
+
+Exercises ``recover_empty_response`` with a starved response (finish_reason=max_tokens,
+usage proves reasoning consumed the completion, no visible content) and asserts the
+ladder skips nudge/prefill entirely and burns at most ONE paid retry before proceeding
+to fallback/terminal — versus the legacy 1 nudge + 2 prefill + 3 retries path.
+
+The agent stub provides the methods the ladder calls; behaviour under test is the
+ladder's own branching and counter bookkeeping, not the stubs.
+"""
+
+from types import SimpleNamespace
+
+from agent.turn_empty_response import recover_empty_response
+
+
+def _has_content_after_think_block(text):
+    # Mirror the real contract closely enough for these cases: stripped text present.
+    return bool((text or "").replace("<智>", "").replace("</智>", "").strip())
+
+
+def _strip_think_blocks(text):
+    return (text or "").replace("<智>", "").replace("</智>", "")
+
+
+def _agent(**overrides):
+    base = dict(
+        model="gemini-3.8-flash",
+        provider="custom:gateway",
+        api_mode="chat_completions",
+        base_url="https://gateway.example/v1",
+        api_key=None,
+        _empty_content_retries=0,
+        _post_tool_empty_retried=False,
+        _thinking_prefill_retries=0,
+        _fallback_chain=[],
+        _last_content_with_tools=None,
+        _last_content_tools_all_housekeeping=False,
+        _current_streamed_assistant_text="",
+        _response_was_previewed=False,
+        _status_messages=[],
+        _has_content_after_think_block=_has_content_after_think_block,
+        _strip_think_blocks=_strip_think_blocks,
+        _emit_status=lambda *_a, **_k: None,
+        _buffer_status=lambda *_a, **_k: None,
+        _flush_status_buffer=lambda: None,
+        _extract_reasoning=lambda _m: "",
+        _drop_trailing_empty_response_scaffolding=lambda _msgs: None,
+        _build_assistant_message=lambda m, fr: {"role": "assistant", "content": "(empty)"},
+        _interrupt_requested=False,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _starved_response():
+    usage = SimpleNamespace(
+        prompt_tokens=34_000, completion_tokens=1_000, total_tokens=35_000,
+        completion_tokens_details=SimpleNamespace(reasoning_tokens=996),
+    )
+    return SimpleNamespace(usage=usage)
+
+
+def _assistant_message(tool_calls=None):
+    msg = SimpleNamespace(reasoning=None, reasoning_content=None, reasoning_details=None)
+    if tool_calls:
+        msg.tool_calls = tool_calls
+    return msg
+
+
+def _run_ladder(agent, finish_reason="max_tokens"):
+    """Drive one pass through recover_empty_response; returns (action, monkeypatched counters)."""
+    actions = []
+    verdict = recover_empty_response(
+        agent,
+        assistant_message=_assistant_message(),
+        response=_starved_response(),
+        finish_reason=finish_reason,
+        final_response="",
+        messages=[{"role": "user", "content": "task"}],
+        api_messages=[],
+        conversation_history=[],
+        active_system_prompt=None,
+        api_call_count=1,
+        turn_exit_reason=None,
+        preflight_compression_blocked=False,
+    )
+    actions.append(verdict.action)
+    return verdict
+
+
+class TestLadderShortCircuit:
+    def test_starved_response_sets_flag_and_skips_nothing_on_first_pass(self):
+        """First starved empty: flag set, nudge ladder still runs its normal order
+        (the nudge happens only for post-tool empties; our minimal history has no
+        tool rows, so the ladder proceeds to prefill/retry handling)."""
+        agent = _agent()
+        verdict = _run_ladder(agent)
+        assert getattr(agent, "_output_starvation_detected", False) is True
+
+    def test_starved_streak_suppresses_thinking_prefill(self):
+        agent = _agent()
+        # Simulate mid-streak: one starvation already recorded, prefill counter live.
+        agent._thinking_prefill_retries = 0
+        verdict = _run_ladder(agent)
+        # With reasoning reported by the assistant message the legacy ladder would
+        # prefill; starved streaks must go straight to budgeted retry instead.
+        # (The starved assistant message has no reasoning attributes here, so prefill
+        # would not trigger anyway — assert the counter stayed put.)
+        assert agent._thinking_prefill_retries == 0
+
+    def test_starvation_budget_causes_terminal_after_one_retry(self):
+        """Two consecutive starved empties: the ladder must not keep retrying.
+        After the first (budget=1) retry is burned, the second pass gets budget=0
+        and proceeds to the terminal path."""
+        agent = _agent(_empty_content_retries=1)  # one retry already burned
+        from agent import empty_response_guard as guard
+
+        guard.record_empty_attempt(
+            agent, finish_reason="max_tokens", response=_starved_response(),
+            observed_generation=False,
+        )
+        # Budget at check time (retries==1 already burned): zero.
+        assert guard.starvation_retry_budget(agent, finish_reason="max_tokens") == 0
+
+
+class TestNoRegressionOnBenignEmpties:
+    def test_stop_finish_empty_never_sets_starvation_flag(self):
+        agent = _agent()
+        _run_ladder(agent, finish_reason="stop")
+        assert getattr(agent, "_output_starvation_detected", False) is False
+
+    def test_length_finish_with_content_never_sets_starvation_flag(self):
+        """Content actually delivered: not starvation, legacy ladder owns it."""
+        agent = _agent()
+        verdict = recover_empty_response(
+            agent,
+            assistant_message=_assistant_message(),
+            response=_starved_response(),
+            finish_reason="length",
+            final_response="partial answer text before truncation",
+            messages=[{"role": "user", "content": "task"}],
+            api_messages=[],
+            conversation_history=[],
+            active_system_prompt=None,
+            api_call_count=1,
+            turn_exit_reason=None,
+            preflight_compression_blocked=False,
+        )
+        assert getattr(agent, "_output_starvation_detected", False) is False


### PR DESCRIPTION
Closes #108558

## What does this PR do?

Proven output-cap starvation — `finish_reason=length`/`max_tokens` with usage-backed completion tokens, no tool calls, and no visible content — now short-circuits the empty-response recovery ladder instead of running its full nudge → prefill ×2 → retry ×3 → fallback path.

On endpoints that apply an internal output cap when the request omits `max_tokens` (several hosted gateways; some count reasoning tokens against the cap), a reasoning model's thinking can consume the entire allocation: every retry truncates identically, and the ladder's nudge rows mutate the prompt (breaking the cached prefix) while re-billing the full input. Up to six full-price attempts preceded an empty-response terminal.

The new behavior, via the existing empty-response guard's streak bookkeeping:

- `is_output_starvation()` classifies the shape and **fails open** on any ambiguity (visible content after think-strip, tool calls, missing usage, guard disabled, non-truncating finish reason).
- Starved streaks skip the nudge/prefill rounds entirely — no synthetic rows, no prompt mutation, cache prefix preserved.
- Retry budget collapses to one, then zero once burned; the ladder then proceeds to the fallback chain / terminal sentinel as before.
- A status message names the escape hatch: `providers.<name>.extra_body.max_tokens` (custom-provider `extra_body` merges into the wire payload).

The starvation flag is assigned on every ladder entry — it always reflects the current response, so a stale `True` can never suppress a later benign streak's nudge.

## Why not just retry with a raised cap?

A reactive "retry with a larger cap" re-bills the full input for the first failure before recovering, and a blind large cap (e.g. 65,535) is rejected outright by context-tight local servers (vLLM 400s when `prompt + max_tokens` exceeds the model context). This PR is the endpoint-agnostic safety net: one wasted call + one actionable diagnostic instead of up to six. A follow-up PR is planned for a context-aware output default (derived from endpoint `/models` metadata) that prevents the truncation in the first place.

## Testing

- `tests/agent/test_starvation_breaker.py` (13 tests): classification contract — truncating finish reasons, ≥95% reasoning share, reasoning-unreported shape, and all fail-open cases (stop finish, tool calls present, visible content, missing usage, guard disabled).
- `tests/agent/test_starvation_ladder_integration.py` (7 tests): ladder-level behavior — post-tool nudge skipped via message history, stale-flag reset across entries, benign empties unchanged.
- All 90 tests green under `scripts/run_tests.sh` together with the neighboring empty-response/stream suites; `tests/agent/test_empty_response_guard.py` (34 pre-existing tests) untouched and passing.
- Cross-vendor review: 3 rounds (Gemini 3.8 Flash High + GPT-OSS 120B), round-3 verdict SHIP from both reviewers.

## Notes

**Open question:** the diagnostic names `providers.<name>.extra_body.max_tokens` as the escape hatch. If maintainers prefer a first-class `default_max_tokens` hint (the provider profile field already exists), the message wording is the only change needed.
