### PR TITLE
fix(kanban): gate the notifier watcher with kanban.notify_in_gateway

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -60,6 +60,12 @@ class GatewayKanbanWatchersMixin:
     async def _kanban_notifier_watcher(self, interval: float = 5.0) -> None:
         """Poll ``kanban_notify_subs`` and deliver terminal events to users.
 
+        Gated by ``kanban.notify_in_gateway`` (default True), with the
+        ``HERMES_KANBAN_NOTIFY_IN_GATEWAY`` env override — mirroring the
+        dispatcher's ``dispatch_in_gateway`` gate; when disabled the loop
+        exits before its first tick, so a subscription-less home (e.g. a
+        secondary profile's gateway) pays no per-tick log line.
+
         Per subscription, claims ``task_events`` newer than the stored cursor
         (kinds in TERMINAL_KINDS), sends one message per event, then advances
         the cursor. The subscription is removed only when the task is
@@ -68,6 +74,34 @@ class GatewayKanbanWatchersMixin:
         dispatcher respawned a crashed task). All SQLite work runs in a thread;
         one tick's failure never stops the next.
         """
+        try:
+            from hermes_cli.config import load_config as _load_config
+        except Exception:
+            logger.warning(
+                "kanban notifier: config loader unavailable; notifier disabled"
+            )
+            return
+        env_override = (
+            os.environ.get("HERMES_KANBAN_NOTIFY_IN_GATEWAY", "").strip().lower()
+        )
+        if env_override in {"0", "false", "no", "off"}:
+            logger.info(
+                "kanban notifier: disabled via HERMES_KANBAN_NOTIFY_IN_GATEWAY env"
+            )
+            return
+        try:
+            cfg = _load_config()
+        except Exception as exc:
+            logger.warning(
+                "kanban notifier: cannot load config (%s); notifier disabled", exc
+            )
+            return
+        kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+        if not kanban_cfg.get("notify_in_gateway", True):
+            logger.info(
+                "kanban notifier: disabled via config kanban.notify_in_gateway=false"
+            )
+            return
         from gateway.config import Platform as _Platform
         try:
             from hermes_cli import kanban_db as _kb

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1700,6 +1700,10 @@ DEFAULT_CONFIG = {
         # kanban_create is called from a session with a persistent delivery channel. Disable for
         # profiles that prefer explicit kanban_notify-subscribe calls per task.
         "auto_subscribe_on_create": True,
+        # Run the notifier loop inside the gateway process. False when nothing in this home uses
+        # gateway subscriptions (e.g. a secondary profile's gateway): without it the notifier
+        # polls every 5s forever and writes one DEBUG line per tick into every board it checks.
+        "notify_in_gateway": True,
         # Run the dispatcher inside the gateway process (~300µs per idle tick). False only if you
         # run it as a separate unit or don't want the gateway spawning workers.
         "dispatch_in_gateway": True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -316,6 +316,7 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "HERMES_KANBAN_RUN_ID",
     "HERMES_KANBAN_CLAIM_LOCK",
     "HERMES_KANBAN_DISPATCH_IN_GATEWAY",
+    "HERMES_KANBAN_NOTIFY_IN_GATEWAY",
     # Pytest is routinely launched from a delegated worker.  The worker
     # lineage marker must not make parent-state tests run as delegated
     # children; tests that exercise child behavior set it explicitly.

--- a/tests/gateway/test_kanban_notifier_config_gate.py
+++ b/tests/gateway/test_kanban_notifier_config_gate.py
@@ -1,0 +1,142 @@
+"""The notifier watcher honours the ``kanban.notify_in_gateway`` config gate.
+
+Sibling of the dispatcher's ``dispatch_in_gateway`` gate: both watchers are
+spawned from the same startup tuple, and a home that has no notify
+subscriptions (e.g. a secondary profile's gateway) previously paid a permanent
+one-DEBUG-line-per-5s-tick with no config key to stop it.
+"""
+
+import asyncio
+import logging
+from unittest.mock import MagicMock, patch
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+
+import hermes_cli.config as _cfg_mod
+
+LOGGER_NAME = "gateway.run"
+
+
+def _make_runner(with_adapter=False):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.TELEGRAM: MagicMock()} if with_adapter else {}
+    runner._kanban_sub_fail_counts = {}
+    return runner
+
+
+class _StopLoop(Exception):
+    """Raised from the first pre-tick sleep to unwind the watcher deterministically."""
+
+
+def _run_watcher(monkeypatch, runner, cfg=None, *, env=None, load_fn=None):
+    """Run the watcher to (and just past) its gates; returns (passed_gates).
+
+    ``passed_gates`` is non-empty when execution reached the pre-tick wiring
+    delay — i.e. every gate (env override, config load, config flag, imports)
+    let it through.
+    """
+    if env is not None:
+        monkeypatch.setenv("HERMES_KANBAN_NOTIFY_IN_GATEWAY", env)
+    else:
+        monkeypatch.delenv("HERMES_KANBAN_NOTIFY_IN_GATEWAY", raising=False)
+
+    if load_fn is None:
+
+        def _default_load():
+            return cfg if cfg is not None else {"kanban": {}}
+
+        load_fn = _default_load
+
+    monkeypatch.setattr(_cfg_mod, "load_config", load_fn)
+
+    passed_gates = []
+
+    async def fake_sleep(delay):
+        passed_gates.append(delay)
+        runner._running = False
+        raise _StopLoop
+
+    async def fake_to_thread(fn, *args, **kwargs):
+        return []
+
+    async def run():
+        with (
+            patch("asyncio.sleep", side_effect=fake_sleep),
+            patch("asyncio.to_thread", side_effect=fake_to_thread),
+        ):
+            try:
+                await runner._kanban_notifier_watcher()
+            except _StopLoop:
+                pass
+
+    asyncio.run(run())
+    return passed_gates
+
+
+def test_notifier_watcher_disabled_by_config(monkeypatch, caplog):
+    """``kanban.notify_in_gateway: false`` must stop the loop before tick 1."""
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        runner = _make_runner(with_adapter=True)
+        passed = _run_watcher(
+            monkeypatch, runner, cfg={"kanban": {"notify_in_gateway": False}}
+        )
+
+    assert not passed, "watcher must return before the first tick when gated off"
+    assert "kanban.notify_in_gateway=false" in caplog.text, (
+        "an explicit disable must be visible at INFO"
+    )
+
+
+def test_notifier_watcher_disabled_by_env(monkeypatch, caplog):
+    """``HERMES_KANBAN_NOTIFY_IN_GATEWAY=0`` must short-circuit before config load."""
+    loaded_config = []
+
+    def _track_load():
+        loaded_config.append(True)
+        return {"kanban": {}}
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        runner = _make_runner(with_adapter=True)
+        passed = _run_watcher(monkeypatch, runner, env="0", load_fn=_track_load)
+
+    assert not passed, "env override must stop the loop before the first tick"
+    assert not loaded_config, "env disable must win without reading config.yaml"
+    assert "HERMES_KANBAN_NOTIFY_IN_GATEWAY" in caplog.text, (
+        "env disable must be visible at INFO"
+    )
+
+
+def test_notifier_watcher_enabled_by_default(monkeypatch):
+    """With the flag unset the watcher must reach its polling loop as before."""
+    runner = _make_runner(with_adapter=True)
+
+    passed = _run_watcher(monkeypatch, runner, cfg={"kanban": {}})
+
+    assert passed, "default must keep notifier polling for this profile's subscriptions"
+
+
+def test_notifier_watcher_env_truthy_value_does_not_disable(monkeypatch):
+    """Only the documented falsy spellings disable; arbitrary values don't."""
+    runner = _make_runner(with_adapter=True)
+
+    passed = _run_watcher(monkeypatch, runner, cfg={"kanban": {}}, env="1")
+
+    assert passed, "env value '1' must not disable the notifier"
+
+
+def test_notifier_watcher_config_load_failure_disables(monkeypatch, caplog):
+    """A config that cannot be loaded must fail closed: no notifier loop."""
+
+    def _boom():
+        raise RuntimeError("config unreadable")
+
+    with caplog.at_level(logging.INFO, logger=LOGGER_NAME):
+        runner = _make_runner(with_adapter=True)
+        passed = _run_watcher(monkeypatch, runner, load_fn=_boom)
+
+    assert not passed, "config-load failure must disable the notifier, not run ungated"
+    assert "cannot load config" in caplog.text, (
+        "a config-load failure must say why the notifier is off"
+    )

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -118,6 +118,13 @@ class TestConfigYamlRouting:
         assert "not a recognized config key" not in capsys.readouterr().out
         assert "nudge_interval: 0" in _read_config(_isolated_hermes_home)
 
+    def test_kanban_notify_in_gateway_is_recognized(self, _isolated_hermes_home, capsys):
+        """The notifier's gateway gate must be accepted by config set."""
+        set_config_value("kanban.notify_in_gateway", "false")
+
+        assert "not a recognized config key" not in capsys.readouterr().out
+        assert "notify_in_gateway: false" in _read_config(_isolated_hermes_home)
+
     def test_terminal_docker_cwd_mount_flag_goes_to_config_and_env(self, _isolated_hermes_home):
         set_config_value("terminal.docker_mount_cwd_to_workspace", "true")
         config = _read_config(_isolated_hermes_home)

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -131,6 +131,7 @@ Hermes reads environment variables from the process environment and, for user-ma
 | `HERMES_KANBAN_DB` | Pin the kanban database file path directly (highest precedence; beats `HERMES_KANBAN_BOARD` and `HERMES_KANBAN_HOME`). The dispatcher injects this into worker subprocess env so profile workers converge on the dispatcher's board |
 | `HERMES_KANBAN_WORKSPACES_ROOT` | Pin the kanban workspaces root directly (highest precedence for workspaces; beats `HERMES_KANBAN_HOME`). The dispatcher injects this into worker subprocess env |
 | `HERMES_KANBAN_DISPATCH_IN_GATEWAY` | Runtime override for `kanban.dispatch_in_gateway`. Set to `0`, `false`, `no`, or `off` to keep the gateway from starting the embedded Kanban dispatcher; any other non-empty value enables it. Useful when a separate dispatcher process owns the board. |
+| `HERMES_KANBAN_NOTIFY_IN_GATEWAY` | Runtime override for `kanban.notify_in_gateway`. Set to `0`, `false`, `no`, or `off` to keep the gateway from starting the Kanban notifier loop; any other non-empty value enables it. Useful on gateways whose home has no notify subscriptions, where the 5s poll would otherwise emit one DEBUG line per tick. |
 
 ## Provider Auth (OAuth)
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -278,6 +278,9 @@ up on the next tick (60s by default).
 # config.yaml
 kanban:
   dispatch_in_gateway: true        # default
+  notify_in_gateway: true          # default; set false on gateways whose home
+                                   # has no notify subscriptions (e.g. a second
+                                   # profile's gateway) to stop the 5s poll
   dispatch_interval_seconds: 60    # default
   review_dispatch: true            # default: spawn the assigned profile with
                                    # the bundled sdlc-review skill. Set false
@@ -285,7 +288,7 @@ kanban:
 ```
 
 Override the config flag at runtime via `HERMES_KANBAN_DISPATCH_IN_GATEWAY=0`
-for debugging. Standard gateway supervision applies: run `hermes gateway
+for debugging (and `HERMES_KANBAN_NOTIFY_IN_GATEWAY=0` for the notifier). Standard gateway supervision applies: run `hermes gateway
 start` directly, or wire the gateway up as a systemd user unit (see the
 gateway docs). Without a running gateway, `ready` tasks stay where they are
 until one comes up — `hermes kanban create` warns about this at creation


### PR DESCRIPTION
## What does this PR do?

Adds the missing config gate for the kanban notifier watcher — `kanban.notify_in_gateway` (default `true`) — mirroring the dispatcher's existing `dispatch_in_gateway` gate that is declared right next to it in the same `_PRE_RECONNECT_WATCHERS` startup tuple (`gateway/run_startup.py:1281-1283`). Closes #108549.

Before: a home with no notify subscriptions (e.g. a secondary profile's gateway) paid a permanent one-DEBUG-line-per-5s-tick (~12 lines/min, ~17k lines/day, ~1/6 of a 5 MB × 3 retention) with **no config key able to stop it** — the body of #108549 verified the complete list of accepted `kanban` keys and none gates the notifier.

## Changes

- `gateway/kanban_watchers.py` — `_kanban_notifier_watcher` now:
  1. reads the `HERMES_KANBAN_NOTIFY_IN_GATEWAY` env override (same falsy spellings `0/false/no/off` as the dispatcher's env escape hatch), returning with an INFO line before touching config;
  2. loads config once at boot and exits when `kanban.notify_in_gateway: false` (INFO line, same shape as the dispatcher's disable message);
  3. fails **closed** on a config-load error (WARNING + exit) — an unreadable config.yaml must not silently turn the notifier into an ungated loop again.
- `hermes_cli/config_defaults.py` — `notify_in_gateway: True` registered in `DEFAULT_CONFIG["kanban"]` so `hermes set-config kanban.notify_in_gateway false` is a recognized key (regression-tested).
- `tests/gateway/test_kanban_notifier_config_gate.py` — 5 tests: config-disable, env-disable (verified to win *before* config.yaml is even read), default-enabled, truthy-env-doesn't-disable, config-load-failure-fails-closed. Mutation-verified: killing the config branch, the env branch, or flipping the default each reddens exactly its test.
- `tests/hermes_cli/test_set_config_value.py` — `test_kanban_notify_in_gateway_is_recognized` (same pattern as the `dispatch_in_gateway`-era recognized-key tests).
- `tests/conftest.py` — `HERMES_KANBAN_NOTIFY_IN_GATEWAY` added to the kanban env-scrub list, next to `HERMES_KANBAN_DISPATCH_IN_GATEWAY`, so a developer shell cannot flip notifier tests.
- Docs: `kanban.md` config block + row in `environment-variables.md` (both mirror the dispatcher's existing documentation).

## Relationship to #108555

A sibling PR (#108555) implementing the same config key was opened 7 minutes after my claim comment on the issue (#108549 timeline: claim 19:36:29Z, sibling 19:43:26Z). Both add `kanban.notify_in_gateway` default-on; the deltas:

| Axis | This PR | #108555 |
|---|---|---|
| Config-load failure | fail-**closed** (WARNING + exit) | fail-**open** (WARNING + continues enabled) |
| Env override | `HERMES_KANBAN_NOTIFY_IN_GATEWAY` documented escape hatch | none |
| `set-config` recognition | key in `DEFAULT_CONFIG` + regression test | key in `DEFAULT_CONFIG`, no test |
| Gate tests | 5 (incl. env-before-config ordering, fail-closed, default-on) | reuses dispatch-gate test file |
| Docs | kanban.md + environment-variables.md row | kanban.md line |

The fail-open/fail-closed split is the substantive difference and the two changes do **not** compose — a maintainer should pick one direction. For what it's worth, the dispatcher's own boot path (`_kanban_dispatcher_boot`) fails closed on every config problem (`cannot load config (%s); disabled`), so this PR keeps the two sibling watchers symmetric. Happy to defer to #108555 if the maintainer prefers their shape — posting this so the decision has both options on the table.
