### PR TITLE
fix(desktop): page older chat history at top edge

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -40,7 +40,7 @@ import { isSecondaryWindow } from '@/store/windows'
 
 import { MessageRenderBoundary } from '../message-render-boundary'
 
-import { resolveShowEarlierAction, useTranscriptWindow } from './transcript-window'
+import { resolveShowEarlierAction, shouldAutoShowEarlier, useTranscriptWindow } from './transcript-window'
 
 type ThreadMessageComponents = ComponentProps<typeof ThreadPrimitive.MessageByIndex>['components']
 
@@ -953,6 +953,54 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
       expandWindow()
     }
   }, [anchorBeforePrepend, expandWindow, hiddenCount, olderAvailable, paneBudget])
+
+  // A long transcript is paged by the existing `showEarlier` path when the
+  // reader reaches its top edge. Listen to `wheel` too: a wheel against a
+  // clamped scrollTop of zero does not produce a native scroll event.
+  useEffect(() => {
+    const el = scrollRef.current
+
+    if (!el) {
+      return
+    }
+
+    let previousScrollTop = el.scrollTop
+
+    const tryShowEarlier = (direction: 'up' | 'down') => {
+      if (
+        shouldAutoShowEarlier({
+          atBottom: isAtBottom,
+          direction,
+          hasOlderContent: resolveShowEarlierAction(hiddenCount, olderAvailable) !== null,
+          loadSettled: loadSettledRef.current,
+          restorePending: restoreFromBottomRef.current !== null,
+          scrollTop: el.scrollTop
+        })
+      ) {
+        showEarlier()
+      }
+    }
+
+    const onScroll = () => {
+      const direction = el.scrollTop < previousScrollTop ? 'up' : 'down'
+      previousScrollTop = el.scrollTop
+      tryShowEarlier(direction)
+    }
+
+    const onWheel = (event: WheelEvent) => {
+      if (event.deltaY < 0) {
+        tryShowEarlier('up')
+      }
+    }
+
+    el.addEventListener('scroll', onScroll, { passive: true })
+    el.addEventListener('wheel', onWheel, { passive: true })
+
+    return () => {
+      el.removeEventListener('scroll', onScroll)
+      el.removeEventListener('wheel', onWheel)
+    }
+  }, [hiddenCount, isAtBottom, olderAvailable, scrollRef, showEarlier])
 
   useLayoutEffect(() => {
     const el = scrollRef.current

--- a/apps/desktop/src/components/assistant-ui/thread/transcript-window.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/transcript-window.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolveShowEarlierAction } from './transcript-window'
+import { resolveShowEarlierAction, shouldAutoShowEarlier } from './transcript-window'
 
 describe('resolveShowEarlierAction', () => {
   it('spends the already-materialized DOM page first', () => {
@@ -14,5 +14,20 @@ describe('resolveShowEarlierAction', () => {
 
   it('is a no-op when neither DOM nor store has older content', () => {
     expect(resolveShowEarlierAction(0, false)).toBe(null)
+  })
+})
+
+describe('shouldAutoShowEarlier', () => {
+  it('pages older content after an upward wheel at the clamped top edge', () => {
+    expect(
+      shouldAutoShowEarlier({
+        atBottom: false,
+        direction: 'up',
+        hasOlderContent: true,
+        loadSettled: true,
+        restorePending: false,
+        scrollTop: 0
+      })
+    ).toBe(true)
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/transcript-window.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/transcript-window.tsx
@@ -32,3 +32,37 @@ export function resolveShowEarlierAction(hiddenCount: number, olderAvailable: bo
 
   return olderAvailable ? 'window' : null
 }
+
+export const THREAD_TOP_EDGE_PX = 48
+
+export type AutoShowEarlierInput = {
+  atBottom: boolean
+  direction: 'up' | 'down' | null
+  hasOlderContent: boolean
+  loadSettled: boolean
+  restorePending: boolean
+  scrollTop: number
+}
+
+/**
+ * Page backward only after the reader deliberately reaches the transcript's
+ * top edge. This is shared by scroll and wheel listeners: a wheel at a
+ * clamped `scrollTop === 0` does not emit a scroll event.
+ */
+export function shouldAutoShowEarlier({
+  atBottom,
+  direction,
+  hasOlderContent,
+  loadSettled,
+  restorePending,
+  scrollTop
+}: AutoShowEarlierInput): boolean {
+  return (
+    loadSettled &&
+    !restorePending &&
+    !atBottom &&
+    hasOlderContent &&
+    direction === 'up' &&
+    scrollTop <= THREAD_TOP_EDGE_PX
+  )
+}


### PR DESCRIPTION
## What and why

Long and branched Desktop conversations stop at the top of the currently materialized transcript. The existing **Show earlier** control is still available, but this change lets an upward scroll at the top edge page older turns automatically through that same anchored path. A clamped wheel event is handled explicitly because it does not emit a native scroll event.

The gate only activates for a settled, scrolled-up reader with older content; it does not page during downward scrolling, bottom-following, or an in-flight prepend restore.

## How to test

1. Open a long or branched Desktop chat with older history.
2. Scroll upward to the top of the displayed transcript and continue scrolling upward with a wheel/trackpad.
3. Earlier turns should be prepended while the turn being read remains in place.
4. Confirm that scrolling down or streaming at the bottom does not page history.

Automated:
- `npm run test:ui -- src/components/assistant-ui/thread/transcript-window.test.ts src/components/assistant-ui/thread/list-session-scroll.test.tsx`
- `tsc -p . --noEmit`
- `eslint src/components/assistant-ui/thread/list.tsx src/components/assistant-ui/thread/transcript-window.tsx src/components/assistant-ui/thread/transcript-window.test.ts`
- `npm run build`

## Platforms tested

Linux build and jsdom UI tests.

Related to #106350; this is a clean, focused implementation for the current source base.