### PR TITLE
fix(backup): skip non-regular filesystem entries

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -226,9 +226,21 @@ def _iter_external_files(base: Path) -> List[Path]:
     for dirpath, dirnames, filenames in os.walk(base, followlinks=False):
         dirnames[:] = [d for d in dirnames if d not in _EXCLUDED_DIRS]
         files.extend(fp for fp in (Path(dirpath) / f for f in filenames)
-                     if not (fp.is_symlink() or fp.name in _EXCLUDED_NAMES
+                     if not (_is_non_regular_path(fp) or fp.name in _EXCLUDED_NAMES
                              or fp.name.endswith(_EXCLUDED_SUFFIXES)))
     return files
+
+
+def _is_non_regular_path(path: Path) -> bool:
+    """True for symlinks, sockets, devices, and other non-regular filesystem entries.
+
+    A failed ``lstat`` is not treated as an exclusion: the archive writer must see the path and
+    report the read failure instead of silently claiming a complete backup.
+    """
+    try:
+        return not stat.S_ISREG(path.lstat().st_mode)
+    except OSError:
+        return False
 
 
 def _should_exclude(rel_path: Path) -> bool:
@@ -265,7 +277,7 @@ def _iter_backup_files(hermes_root: Path, out_path: Path, skipped_dirs: Optional
             fpath = hermes_root / rel
             # zipfile.write() follows file symlinks, so skip links before any archive write can
             # copy data from outside HERMES_HOME; never archive the output zip into itself.
-            if _should_exclude(rel) or fpath.is_symlink():
+            if _should_exclude(rel) or _is_non_regular_path(fpath):
                 continue
             with suppress(OSError, ValueError):
                 if fpath.resolve() == out_path.resolve():

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import socket
 import sqlite3
 import stat
 import zipfile
@@ -245,6 +246,20 @@ class TestIterBackupFiles:
         list(_iter_backup_files(root, tmp_path / "out.zip", skipped))
         assert "models" in skipped
         assert "hermes-agent" in skipped
+
+    @pytest.mark.linux_only
+    def test_skips_unix_sockets(self, tmp_path):
+        from hermes_cli.backup import _iter_backup_files
+
+        root = tmp_path / ".hermes"
+        root.mkdir()
+        socket_path = root / "gateway.sock"
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as gateway_socket:
+            gateway_socket.bind(str(socket_path))
+
+            selected = {str(rel) for _, rel in _iter_backup_files(root, tmp_path / "out.zip")}
+
+        assert "gateway.sock" not in selected
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- skip Unix sockets and other non-regular filesystem entries during full backups
- preserve failure reporting when lstat itself fails
- apply the same rule to external memory-provider paths

## Validation
- `scripts/run_tests.sh tests/hermes_cli/test_backup.py` on Linux: 80 passed
- focused Windows run for `TestIterBackupFiles`: 2 passed, Linux-only socket test skipped as expected
- Ruff check passed