### PR TITLE
fix(cron): avoid treating Python data as shell scripts

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -1063,6 +1063,13 @@ def _contains_unsafe_gateway_action(
             return any(recurse(payload, cwd) for payload in payloads)
         # Unparseable/polyglot source keeps the old conservative shell walk.
 
+    from cron.lifecycle_heredoc import split_python_heredocs
+
+    command, python_bodies = split_python_heredocs(command)
+    for body in python_bodies:
+        if recurse(body, cwd, "python"):
+            return True
+
     for payload in _iter_shell_command_payloads(command):
         if recurse(payload, cwd):
             return True

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -710,7 +710,7 @@ def _python_operand(arguments: list[str]) -> tuple[Optional[str], Optional[str]]
             return "python", arguments[index + 1] if index + 1 < len(arguments) else None
         if argument.startswith("-c"):
             return "python", argument[2:]
-        if argument in {"-W", "-X"}:
+        if argument in {"-W", "-X", "--check-hash-based-pycs"}:
             index += 2
             continue
         if not argument.startswith("-"):

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -9,6 +9,7 @@ anchored on concrete command identifiers — so they cannot fire on prose. Defen
 
 from __future__ import annotations
 
+import ast
 import logging
 import os
 import re
@@ -692,7 +693,129 @@ def _iter_option_values(segment: list[str], start: int, option: str) -> Iterator
             yield token[len(prefix):]
 
 
-def _references_at(segment: list[str], index: int, cwd: Optional[str]) -> Iterator[Path]:
+_PYTHON_EXECUTABLE = re.compile(r"python(?:[23](?:\.\d+)*)?")
+
+
+def _python_operand(arguments: list[str]) -> tuple[Optional[str], Optional[str]]:
+    """Python's source operand, not its option values or the script's own argv."""
+    index = 0
+    while index < len(arguments):
+        argument = arguments[index]
+        if argument == "--":
+            index += 1
+            break
+        if argument == "-" or argument == "-m" or argument.startswith("-m"):
+            return None, None  # stdin/modules are not filesystem script operands
+        if argument == "-c":
+            return "python", arguments[index + 1] if index + 1 < len(arguments) else None
+        if argument.startswith("-c"):
+            return "python", argument[2:]
+        if argument in {"-W", "-X"}:
+            index += 2
+            continue
+        if not argument.startswith("-"):
+            break
+        index += 1
+    if index < len(arguments) and arguments[index] != "-":
+        return "file", arguments[index]
+    return None, None
+
+
+def _script_language(path: Path, text: str, language: Optional[str]) -> str:
+    """An explicit interpreter wins; direct execution consults only the shebang."""
+    if language is not None:
+        return language
+    if text.startswith("#!"):
+        try:
+            tokens = shlex.split(text.split("\n", 1)[0][2:])
+        except ValueError:
+            return "shell"
+        # A shebang's env -S tail has already been split above, unlike a shell
+        # command's quoted -S operand (handled by the command-payload walk).
+        if tokens and _executable_name(tokens[0]) == "env":
+            tokens = [token for token in tokens if token not in {"-S", "--split-string"}]
+        index = _executed_command_index(tokens)
+        if index is not None and _PYTHON_EXECUTABLE.fullmatch(_executable_name(tokens[index])):
+            return "python"
+        return "shell"
+    # Bash's executable-format fallback treats shebangless text as shell, regardless of suffix.
+    return "shell"
+
+
+def _python_command_payloads(text: str) -> Optional[list[str]]:
+    """Literal process-call operands only, never arbitrary Path/open/data strings.
+
+    Resolve ordinary import aliases, not data flow or computed commands. Invalid Python
+    falls back to the existing shell walk (important for mixed/polyglot source). The
+    caller charges the full source before parsing, and each payload before recursion.
+    """
+    try:
+        tree = ast.parse(text)
+    except (SyntaxError, ValueError, RecursionError):
+        return None
+    aliases: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for item in node.names:
+                if item.name in {"os", "subprocess", "asyncio"}:
+                    aliases[item.asname or item.name] = item.name
+        elif isinstance(node, ast.ImportFrom) and node.module in {"os", "subprocess", "asyncio"}:
+            for item in node.names:
+                aliases[item.asname or item.name] = f"{node.module}.{item.name}"
+
+    shell_calls = {
+        "os.system", "os.popen", "subprocess.getoutput", "subprocess.getstatusoutput",
+        "asyncio.create_subprocess_shell",
+    }
+    calls = shell_calls | {
+        "subprocess.run", "subprocess.Popen", "subprocess.call",
+        "subprocess.check_call", "subprocess.check_output", "asyncio.create_subprocess_exec",
+    }
+    payloads: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        function = node.func
+        if isinstance(function, ast.Name):
+            name = aliases.get(function.id, function.id)
+        elif isinstance(function, ast.Attribute) and isinstance(function.value, ast.Name):
+            name = f"{aliases.get(function.value.id, function.value.id)}.{function.attr}"
+        else:
+            continue
+        if name not in calls:
+            continue
+        operand = node.args[0] if node.args else next(
+            (kw.value for kw in node.keywords if kw.arg in {"args", "command", "cmd", "program"}),
+            None,
+        )
+        shell = name in shell_calls or (
+            name.startswith("subprocess.") and any(
+                kw.arg == "shell" and isinstance(kw.value, ast.Constant) and kw.value.value is True
+                for kw in node.keywords
+            )
+        )
+        if name == "asyncio.create_subprocess_exec":
+            # Unlike subprocess's sequence operand, asyncio takes program, *args.
+            items = node.args if node.args else [operand]
+        elif isinstance(operand, (ast.List, ast.Tuple)):
+            items = operand.elts
+        else:
+            items = [operand]
+        literal_items = [
+            item.value for item in items
+            if isinstance(item, ast.Constant) and isinstance(item.value, str)
+        ]
+        if literal_items and len(literal_items) == len(items):
+            # POSIX shell=True sequences supply command, then shell positional arguments;
+            # only the first element is shell source. Without a shell even a string is
+            # ONE executable path: preserve spaces rather than splitting it as a command.
+            payloads.append(literal_items[0] if shell else shlex.join(literal_items))
+    return payloads
+
+
+def _references_at(
+    segment: list[str], index: int, cwd: Optional[str]
+) -> Iterator[tuple[Path, Optional[str]]]:
     """Yield the scripts the token at *index* executes, if any."""
     if index >= len(segment):
         return
@@ -701,7 +824,20 @@ def _references_at(segment: list[str], index: int, cwd: Optional[str]) -> Iterat
 
     if executable_name in {".", "source"}:
         if len(segment) > index + 1:
-            yield from _resolved_or_nothing(segment[index + 1], cwd)
+            for path in _resolved_or_nothing(segment[index + 1], cwd):
+                yield path, "shell"
+        return
+
+    if _PYTHON_EXECUTABLE.fullmatch(executable_name):
+        # Interpreter-name recognition is additive: ./python3 may itself be a
+        # shell script. Direct execution uses its own identity, not Python's.
+        if "/" in executable:
+            for path in _resolved_or_nothing(executable, cwd):
+                yield path, None
+        kind, operand = _python_operand(segment[index + 1 :])
+        if kind == "file" and operand is not None:
+            for path in _resolved_or_nothing(operand, cwd):
+                yield path, "python"
         return
 
     if executable_name in _SHELL_EXECUTABLES:
@@ -722,17 +858,23 @@ def _references_at(segment: list[str], index: int, cwd: Optional[str]) -> Iterat
                 continue
             break
         if arg_index < len(arguments) and arguments[arg_index] not in _SHELL_COMMAND_FLAGS:
-            yield from _resolved_or_nothing(arguments[arg_index], cwd)
+            for path in _resolved_or_nothing(arguments[arg_index], cwd):
+                yield path, "shell"
         return
 
     # A bare "/" is pathlib's division operator in Python sources, not an executable; resolving it
     # hits the filesystem root and fails the regular-file check, hard-blocking innocent .py scripts.
     if executable.strip("/") and ("/" in executable or executable.endswith((".sh", ".bash", ".zsh"))):
-        yield from _resolved_or_nothing(executable, cwd)
+        for path in _resolved_or_nothing(executable, cwd):
+            yield path, None
 
 
-def _iter_referenced_shell_scripts(command: str, *, cwd: Optional[str] = None) -> Iterator[Path]:
-    """Yield scripts executed directly or through a POSIX shell. Each segment is read at the
+def _iter_referenced_script_edges(
+    command: str, *, cwd: Optional[str] = None
+) -> Iterator[tuple[Path, Optional[str]]]:
+    """Yield script paths with execution language (None means direct execution).
+
+    Each segment is read at the
     original token AND at the peeled wrapper target — additive on purpose: peeling must never REMOVE
     a reference (a local ``./timeout`` is a script, not the coreutils wrapper)."""
     for segment in _iter_command_segments(command):
@@ -743,6 +885,15 @@ def _iter_referenced_shell_scripts(command: str, *, cwd: Optional[str] = None) -
         peeled = _peel_transparent_prefixes(segment, index)
         if peeled != index:
             yield from _references_at(segment, peeled, cwd)
+
+
+def _iter_python_inline_payloads(command: str) -> Iterator[str]:
+    for segment in _iter_command_segments(command):
+        index = _executed_command_index(segment)
+        if index is not None and _PYTHON_EXECUTABLE.fullmatch(_executable_name(segment[index])):
+            kind, operand = _python_operand(segment[index + 1 :])
+            if kind == "python" and operand is not None:
+                yield operand
 
 
 def _iter_shell_command_payloads(command: str) -> Iterator[str]:
@@ -882,37 +1033,58 @@ def _read_script_for_scanning(script_path: str) -> str:
 # --- recursive walk ---------------------------------------------------------------------------
 
 def _contains_unsafe_gateway_action(
-    command: str, *, cwd: Optional[str], depth: int, visited: set[Path], budget: _LifecycleScanBudget,
+    command: str, *, cwd: Optional[str], depth: int,
+    visited: dict[Path, set[Optional[str]]], budget: _LifecycleScanBudget,
     read_remote_script: Optional[_ReadRemoteScriptFn] = None,
+    language: Optional[str] = "shell", source_path: Optional[Path] = None,
 ) -> bool:
-    # Charge BEFORE _direct_lifecycle_scan: every scan in it tokenizes with shlex.
+    # Charge BEFORE all tokenization, including shebang recognition and Python parsing.
     if not budget.charge_text(command):
         return _budget_exhausted("text", depth)
     if _direct_lifecycle_scan(command):
         return True
     if depth >= _MAX_REFERENCED_SCRIPT_DEPTH:
         return True
+    if source_path is not None:
+        language = _script_language(source_path, command, language)
 
-    def recurse(text: str, cwd: Optional[str]) -> bool:
+    def recurse(
+        text: str, cwd: Optional[str], language: Optional[str] = "shell",
+        source_path: Optional[Path] = None,
+    ) -> bool:
         return _contains_unsafe_gateway_action(
             text, cwd=cwd, depth=depth + 1, visited=visited, budget=budget,
-            read_remote_script=read_remote_script,
+            read_remote_script=read_remote_script, language=language, source_path=source_path,
         )
+
+    if language == "python":
+        payloads = _python_command_payloads(command)
+        if payloads is not None:
+            return any(recurse(payload, cwd) for payload in payloads)
+        # Unparseable/polyglot source keeps the old conservative shell walk.
 
     for payload in _iter_shell_command_payloads(command):
         if recurse(payload, cwd):
             return True
+    for payload in _iter_python_inline_payloads(command):
+        if recurse(payload, cwd, "python"):
+            return True
 
-    for script_path in _iter_referenced_shell_scripts(command, cwd=cwd):
+    for script_path, script_language in _iter_referenced_script_edges(command, cwd=cwd):
         # Do not touch a FileProvider path even to discover whether the file is hydrated.
         if _on_cloud_path(script_path):
             return True
         resolved = _resolve_lenient(script_path)
-        if resolved in visited:
+        contexts = visited.get(resolved)
+        if contexts is not None and script_language in contexts:
             continue
-        if not budget.charge_path():
-            return _budget_exhausted("paths", depth)
-        visited.add(resolved)
+        if contexts is None:
+            if not budget.charge_path():
+                return _budget_exhausted("paths", depth)
+            contexts = visited[resolved] = set()
+        # Python first must not suppress a later explicit shell edge to the same file.
+        # A new context is re-read/re-scanned under the same byte/line/remote budget.
+        contexts.add(script_language)
         # Never read more than the walk can still afford to tokenize; a file larger than the
         # remainder fails closed exactly like an oversized one.
         script_text, unsafe = _read_referenced_script(script_path, max_bytes=budget.bytes_remaining)
@@ -931,7 +1103,10 @@ def _contains_unsafe_gateway_action(
         if not script_text:
             continue
         # Relative references inside a script resolve against that script's directory, not the cwd.
-        if recurse(script_text, _resolve_script_directory(str(resolved)) or cwd):
+        if recurse(
+            script_text, _resolve_script_directory(str(resolved)) or cwd,
+            script_language, resolved,
+        ):
             return True
     return False
 
@@ -953,7 +1128,7 @@ def contains_gateway_lifecycle_command_or_referenced_script(
     """
     try:
         return _contains_unsafe_gateway_action(
-            command, cwd=cwd, depth=0, visited=set(), budget=_LifecycleScanBudget(),
+            command, cwd=cwd, depth=0, visited={}, budget=_LifecycleScanBudget(),
             read_remote_script=read_remote_script,
         )
     except Exception:
@@ -999,16 +1174,23 @@ def check_gateway_lifecycle(prompt: Optional[str], script: Optional[str] = None)
             combined = f"{combined}\n{script_text}"
 
     if python_script:
-        # Python runs via the interpreter, never a POSIX shell, and the shell reference walk is a
-        # false-positive generator on Python sources (pathlib "/" resolves to the filesystem root).
-        # The regex still scans the full text; non-regular/oversized files fail closed (sentinel).
-        # The data-exemption masker tokenizes with shlex, so it is charged against the walk budget.
-        # The direct command regex below still scans the full text, so a literal `hermes gateway restart`
-        # embedded in a .py script is still blocked. See #77131, #78398.
+        # Keep the combined-text check (including commands split across prompt/source),
+        # then walk each execution context separately. The scheduler runs .py via Python;
+        # the prompt can still explicitly invoke that same file via a shell.
         if not _LifecycleScanBudget().charge_text(combined):
             unsafe = _budget_exhausted("text", 0)
         else:
-            unsafe = _lifecycle_command_scan_with_data_exemption(combined)
+            unsafe = _direct_lifecycle_scan(combined)
+            if not unsafe:
+                budget = _LifecycleScanBudget()
+                visited: dict[Path, set[Optional[str]]] = {}
+                cwd = _resolve_script_directory(script) if script else None
+                unsafe = _contains_unsafe_gateway_action(
+                    script_text, cwd=cwd, depth=0, visited=visited, budget=budget,
+                    language="python",
+                ) or _contains_unsafe_gateway_action(
+                    prompt or "", cwd=cwd, depth=0, visited=visited, budget=budget,
+                )
     else:
         unsafe = contains_gateway_lifecycle_command_or_referenced_script(
             combined, cwd=_resolve_script_directory(script) if script else None

--- a/cron/lifecycle_heredoc.py
+++ b/cron/lifecycle_heredoc.py
@@ -1,0 +1,78 @@
+"""Prove Python stdin boundaries without treating Python bodies as inert data."""
+
+from __future__ import annotations
+
+import re
+
+from tools.shell_heredoc import (
+    _find_heredoc_close,
+    _parse_heredoc_operator,
+    _scan_heredoc_command_unit,
+)
+
+# Deliberately only bare interpreters with an explicit stdin operand. Wrappers,
+# executable paths, other redirects/options, and compound openers keep the shell
+# walk: their spelling alone cannot prove who consumes stdin.
+_PYTHON_STDIN = re.compile(r"\s*python(?:[23](?:\.\d+)*)?\s+-\s+(?=<<)")
+
+
+def split_python_heredocs(command: str) -> tuple[str, list[str]]:
+    """Return shell source and Python bodies for proven quoted stdin heredocs.
+
+    The shared shell scanner owns quotes, command units and delimiter matching.
+    All heredocs (including non-Python ones) are traversed so a fake opener inside
+    another consumer's body cannot establish a language boundary. Any incomplete
+    delimiter proof leaves the entire input unchanged. Call only after charging
+    the original source against the lifecycle walk budget.
+    """
+    if "<<" not in command:
+        return command, []
+    last_opener = command.rfind("<<")
+    start = 0
+    ranges: list[tuple[int, int]] = []
+    bodies: list[str] = []
+    while start <= last_opener:
+        end, specs, unknown, compound = _scan_heredoc_command_unit(command, start)
+        if unknown:
+            return command, []
+        if not specs:
+            start = end + 1
+            continue
+        if end >= len(command):
+            return command, []
+        cursor = end + 1
+        body_start = cursor
+        for delimiter, strip_tabs, _quoted in specs:
+            # Empty delimiters have an ambiguous EOF boundary; keep the original walk.
+            if not delimiter:
+                return command, []
+            close = _find_heredoc_close(command, cursor, delimiter, strip_tabs)
+            if close is None:
+                return command, []
+            cursor = close
+
+        opener = command[start:end]
+        match = _PYTHON_STDIN.match(opener)
+        if match and len(specs) == 1 and specs[0][2] and not compound:
+            parsed = _parse_heredoc_operator(opener, match.end())
+            # No second redirect, substitution, wrapper tail or command can be
+            # hidden by this proof. A trailing shell comment is harmless.
+            if parsed is not None:
+                tail = opener[parsed[0]:].lstrip(" \t")
+                if not tail or tail.startswith("#"):
+                    # The shared close finder includes the delimiter line.
+                    close_start = command.rfind("\n", body_start, cursor - 1) + 1
+                    close_start = max(body_start, close_start)
+                    body = command[body_start:close_start]
+                    if specs[0][1]:
+                        body = "".join(line.lstrip("\t") for line in body.splitlines(keepends=True))
+                    bodies.append(body)
+                    ranges.append((body_start, cursor))
+        start = cursor
+
+    parts: list[str] = []
+    previous = 0
+    for start, end in ranges:
+        parts.extend((command[previous:start], "\n" * command.count("\n", start, end)))
+        previous = end
+    return "".join(parts) + command[previous:], bodies

--- a/tests/cron/test_lifecycle_guard_heredoc.py
+++ b/tests/cron/test_lifecycle_guard_heredoc.py
@@ -1,0 +1,122 @@
+"""Python stdin source is executable Python, not shell or a data-file edge."""
+
+import json
+import shlex
+
+import pytest
+
+import cron.lifecycle_guard as lifecycle_guard
+
+
+@pytest.mark.parametrize("opener, terminator, tabs, shell_wrapper", [
+    ("python3 - <<'PY'", "PY\n", False, False),
+    ('python3 - <<"PY"', "PY\n", False, False),
+    (r"python3 - <<\PY", "PY\n", False, False),
+    ("python3 - <<-'PY'", "\tPY\n", True, False),
+    ("python3.12 - <<'PY' # stdin source", "PY", False, False),
+    ("python - <<'PY'", "PY\n", False, False),
+    ("python3 - <<'PY'", "PY\n", False, True),
+])
+def test_python_heredoc_does_not_read_large_json(
+    tmp_path, monkeypatch, opener, terminator, tabs, shell_wrapper,
+):
+    from tools import process_registry
+    from tools.terminal_tool_guards import gateway_lifecycle_block
+
+    monkeypatch.setattr(process_registry, "_is_supervised_gateway_process", lambda: True)
+    data = tmp_path / "report.json"
+    data.write_text(json.dumps([{}] * 20000, indent=2), encoding="utf-8")
+    source = (
+        "from pathlib import Path\nimport json\n"
+        f"data = Path({str(data)!r})\n"
+        "print(len(json.loads(data.read_text())))\n"
+    )
+    reads = []
+    original = lifecycle_guard._read_referenced_script
+
+    def recording_read(path, *, max_bytes=None):
+        reads.append(path)
+        return original(path, max_bytes=max_bytes)
+
+    monkeypatch.setattr(lifecycle_guard, "_read_referenced_script", recording_read)
+    if tabs:
+        source = "".join("\t" + line for line in source.splitlines(keepends=True))
+    command = f"{opener}\n{source}{terminator}"
+    if shell_wrapper:
+        command = "sh -c " + shlex.quote(command)
+    assert gateway_lifecycle_block(
+        command=command, env=None, env_type="local", cwd=str(tmp_path),
+        workdir=str(tmp_path), session_key="heredoc-regression",
+    ) is None
+    lifecycle_guard.check_gateway_lifecycle(command)
+    assert data not in reads
+
+    # An enabled guard still refuses a real lifecycle action and oversized root
+    # source. Proving a body boundary must never discount the original input.
+    guard = lifecycle_guard.contains_gateway_lifecycle_command_or_referenced_script
+    assert guard("hermes gateway restart")
+    for padding in (
+        "\n" * lifecycle_guard._MAX_LIFECYCLE_SCAN_LINES,
+        "#" * (lifecycle_guard._MAX_LIFECYCLE_SCAN_LINE_BYTES + 1),
+        "# padded source\n" * (lifecycle_guard._MAX_LIFECYCLE_SCAN_BYTES // 10),
+    ):
+        assert guard(f"{opener}\n{source}{padding}\n{terminator}", cwd=str(tmp_path))
+
+
+@pytest.mark.parametrize("command", [
+    # Literal process operands need Python AST discovery, including quoted argv
+    # paths which are not shell source. No fixture commands are ever executed.
+    "python3 - <<'PY'\nimport subprocess\nsubprocess.run(['sh', './child helper.sh'])\nPY\n",
+    'python3 - <<"PY"\nfrom subprocess import run as launch\nlaunch(args=["./child helper.sh"])\nPY\n',
+    "python3 - <<\\PY\nimport os\nos.system(\"sh './child helper.sh'\")\nPY\n",
+    "python3 - <<-'PY'\n\timport asyncio\n\tasync def main():\n"
+    "\t    await asyncio.create_subprocess_exec('sh', './child helper.sh')\n\tasyncio.run(main())\n\tPY\n",
+    # Commands outside the body remain shell source.
+    "./child.sh\npython3 - <<'PY'\npass\nPY\n",
+    "python3 - <<'PY'\npass\nPY\n./child.sh\n",
+    "./child.sh; python3 - <<'PY'\npass\nPY\n",
+    "python3 - <<'PY'; ./child.sh\npass\nPY\n",
+    # Ambiguous, expanding, malformed and non-Python consumers keep the old walk.
+    "bash <<'PY'\n./child.sh\nPY\n",
+    "sh <<'PY'\npython3 - <<'INNER'\npass\nINNER\n./child.sh\nPY\n",
+    "python3 - <<PY\nx = '$(hermes gateway restart)'\nPY\n",
+    "python3 - <<PY\nx = '`hermes gateway restart`'\nPY\n",
+    "python3 - <<'PY'\n('./child.sh')\n",
+    "python3 - <<''\nimport os\nos.system('./child.sh')\n",
+    'python3 - <<""\nimport os\nos.system(\'./child.sh\')\n',
+    "python3 - <<'PY'\n('./child.sh')\n PY\n",
+    "python3 - <<'PY\n./child.sh\nPY\n",
+    "python3 - <<'PY'\n./child.sh\nPY\n",  # invalid Python: shell fallback
+    "sudo python3 - <<'PY'\n('./child.sh')\nPY\n",
+    "env python3 - <<'PY'\n('./child.sh')\nPY\n",
+    "python3 - <<'PY' >$(sh ./child.sh)\npass\nPY\n",
+    "python3 - <<'ONE' <<'TWO'\npass\nONE\n('./child.sh')\nTWO\n",
+    "./python3 - <<'PY'\npass\nPY\n",
+    "./env python3 - <<'PY'\npass\nPY\n",
+    "sh -c \"python3 - <<'PY'\nimport os\nos.system('./child.sh')\nPY\"",
+])
+def test_heredoc_executable_edges_stay_guarded(tmp_path, command):
+    guard = lifecycle_guard.contains_gateway_lifecycle_command_or_referenced_script
+    for name in ("python3", "env"):
+        (tmp_path / name).write_text("#!/bin/sh\n./child.sh\n", encoding="utf-8")
+    for unsafe in (False, True):
+        for child in ("child.sh", "child helper.sh"):
+            (tmp_path / child).write_text(
+                '#!/bin/sh\n' + ('hermes gate"way" re"start"\n' if unsafe else 'exit 0\n'),
+                encoding="utf-8",
+            )
+        # Direct substitutions block independently of the child fixture.
+        if unsafe or "hermes gateway restart" not in command:
+            assert guard(command, cwd=str(tmp_path)) is unsafe
+    # The cron caller uses the same walk with script-relative path resolution.
+    wrapper = tmp_path / "wrapper.sh"
+    wrapper.write_text(command, encoding="utf-8")
+    with pytest.raises(lifecycle_guard.GatewayLifecycleBlocked):
+        lifecycle_guard.check_gateway_lifecycle("inspect", str(wrapper))
+
+    for child in ("child.sh", "child helper.sh"):
+        (tmp_path / child).write_text(
+            "# bounded descendant\n" * lifecycle_guard._MAX_LIFECYCLE_SCAN_LINES,
+            encoding="utf-8",
+        )
+    assert guard(command, cwd=str(tmp_path))

--- a/tests/cron/test_lifecycle_guard_python.py
+++ b/tests/cron/test_lifecycle_guard_python.py
@@ -28,7 +28,13 @@ class SyntheticRemote:
 
 
 @pytest.mark.parametrize("backend", ["local", "remote"])
-@pytest.mark.parametrize("invocation", ["./report", "python3 report"])
+@pytest.mark.parametrize("invocation", [
+    "./report",
+    "python3 report",
+    "python3 --check-hash-based-pycs always report",
+    "python3 --check-hash-based-pycs never report",
+    "python3 --check-hash-based-pycs default report",
+])
 @pytest.mark.parametrize("data_size", [32, 2 * guard._MAX_REFERENCED_SCRIPT_BYTES])
 def test_python_data_does_not_consume_script_budget(
     tmp_path, monkeypatch, backend, invocation, data_size,
@@ -93,9 +99,15 @@ def test_python_data_does_not_consume_script_budget(
 
 
 @pytest.mark.parametrize("backend", ["local", "remote"])
+@pytest.mark.parametrize("invocation", [
+    "python3 wrapper.py",
+    "python3 --check-hash-based-pycs always wrapper.py",
+    "python3 --check-hash-based-pycs never wrapper.py",
+    "python3 --check-hash-based-pycs default wrapper.py",
+])
 @pytest.mark.parametrize("shell", [False, True])
 def test_python_literal_process_descendants_keep_interpretation(
-    tmp_path, monkeypatch, backend, shell,
+    tmp_path, monkeypatch, backend, invocation, shell,
 ):
     from tools import process_registry
     from tools.terminal_tool_guards import gateway_lifecycle_block
@@ -117,7 +129,7 @@ def test_python_literal_process_descendants_keep_interpretation(
             path.write_text(text, encoding="utf-8")
             path.chmod(0o755)
 
-    def verdict(command="python3 wrapper.py"):
+    def verdict(command=invocation):
         return gateway_lifecycle_block(
             command=command, env=remote, env_type="ssh" if remote else "local",
             cwd=str(cwd), workdir=str(cwd), session_key="python-descendant",

--- a/tests/cron/test_lifecycle_guard_python.py
+++ b/tests/cron/test_lifecycle_guard_python.py
@@ -1,0 +1,187 @@
+"""Python data is not executable source; literal process descendants still are."""
+
+import json
+import shlex
+from pathlib import Path
+
+import pytest
+
+import cron.lifecycle_guard as guard
+
+
+class SyntheticRemote:
+    """Serve only bounded reader requests; never execute the inspected commands."""
+
+    def __init__(self):
+        self.files = {}
+        self.reads = []
+
+    def execute(self, command):
+        words = shlex.split(command)
+        assert words[:2] == ["head", "-c"] and words[3] == "<"
+        limit = int(words[2])
+        assert 0 < limit <= guard._MAX_REFERENCED_SCRIPT_BYTES + 1
+        path = Path(words[4])
+        self.reads.append(path)
+        data = self.files.get(path, "").encode("utf-8")[:limit]
+        return {"returncode": 0, "output": data.decode("utf-8", errors="replace")}
+
+
+@pytest.mark.parametrize("backend", ["local", "remote"])
+@pytest.mark.parametrize("invocation", ["./report", "python3 report"])
+@pytest.mark.parametrize("data_size", [32, 2 * guard._MAX_REFERENCED_SCRIPT_BYTES])
+def test_python_data_does_not_consume_script_budget(
+    tmp_path, monkeypatch, backend, invocation, data_size,
+):
+    from tools import process_registry
+    from tools.terminal_tool_guards import gateway_lifecycle_block
+
+    home = tmp_path / "home"
+    scripts = home / "scripts"
+    scripts.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(process_registry, "_is_supervised_gateway_process", lambda: True)
+    data = scripts / "report.json"
+    data.write_text(json.dumps({"value": "x" * data_size}), encoding="utf-8")
+    source = (
+        "#!/usr/bin/env python3\nimport json\nfrom pathlib import Path\n"
+        f"report = json.loads(Path({str(data)!r}).read_text())\n"
+    )
+    remote = SyntheticRemote() if backend == "remote" else None
+    cwd = tmp_path / "remote" if remote else scripts
+    wrapper = cwd / "report"
+    if remote:
+        remote.files[wrapper] = source
+    else:
+        wrapper.write_text(source, encoding="utf-8")
+        wrapper.chmod(0o755)
+    reads = []
+    real_read = guard._read_referenced_script
+
+    def read(path, *, max_bytes=None):
+        reads.append(path)
+        return real_read(path, max_bytes=max_bytes)
+
+    def verdict(command):
+        return gateway_lifecycle_block(
+            command=command, env=remote, env_type="ssh" if remote else "local",
+            cwd=str(cwd), workdir=str(cwd), session_key="python-data",
+        )
+
+    monkeypatch.setattr(guard, "_read_referenced_script", read)
+    assert verdict("hermes gateway restart") is not None  # supervised guard is active
+    assert verdict(invocation) is None
+    assert wrapper in reads
+    if remote:
+        assert wrapper in remote.reads
+        assert data not in remote.reads
+    # Cron fixture uses its unambiguous Python extension, not shebang dispatch.
+    cron_script = scripts / "report.py"
+    cron_script.write_text(source, encoding="utf-8")
+    guard.check_gateway_lifecycle("Generate report", str(cron_script))
+    assert data not in reads
+
+    oversized = source + "#" * (guard._MAX_REFERENCED_SCRIPT_BYTES + 1)
+    if remote:
+        remote.files[wrapper] = oversized
+    else:
+        wrapper.write_text(oversized, encoding="utf-8")
+    assert verdict(invocation) is not None  # source size still consumes the budget
+    cron_script.write_text(oversized, encoding="utf-8")
+    with pytest.raises(guard.GatewayLifecycleBlocked):
+        guard.check_gateway_lifecycle("Generate report", str(cron_script))
+
+
+@pytest.mark.parametrize("backend", ["local", "remote"])
+@pytest.mark.parametrize("shell", [False, True])
+def test_python_literal_process_descendants_keep_interpretation(
+    tmp_path, monkeypatch, backend, shell,
+):
+    from tools import process_registry
+    from tools.terminal_tool_guards import gateway_lifecycle_block
+
+    home = tmp_path / "home"
+    scripts = home / "scripts"
+    scripts.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(process_registry, "_is_supervised_gateway_process", lambda: True)
+    remote = SyntheticRemote() if backend == "remote" else None
+    cwd = tmp_path / "remote" if remote else scripts
+    wrapper = cwd / "wrapper.py"
+
+    def put(name, text):
+        path = cwd / name
+        if remote:
+            remote.files[path] = text
+        else:
+            path.write_text(text, encoding="utf-8")
+            path.chmod(0o755)
+
+    def verdict(command="python3 wrapper.py"):
+        return gateway_lifecycle_block(
+            command=command, env=remote, env_type="ssh" if remote else "local",
+            cwd=str(cwd), workdir=str(cwd), session_key="python-descendant",
+        )
+
+    # With a shell the space separates argv; without it the whole path is executable.
+    args = repr("./child helper.sh") if shell else repr(["./child helper.sh"])
+    put("wrapper.py", f"import subprocess\nsubprocess.run({args}, shell={shell!r})\n")
+    actual, other = ("child", "child helper.sh") if shell else ("child helper.sh", "child")
+    put(actual, "#!/bin/sh\nexit 0\n")
+    put(other, "#!/bin/sh\nhermes gateway restart\n")
+    assert verdict() is None
+    put(actual, "#!/bin/sh\nhermes gateway restart\n")
+    put(other, "#!/bin/sh\nexit 0\n")
+    blocked = verdict()
+    assert blocked is not None
+    assert json.loads(blocked)["exit_code"] == 1
+    if remote:
+        assert cwd / actual in remote.reads
+        assert cwd / other not in remote.reads
+    else:
+        with pytest.raises(guard.GatewayLifecycleBlocked):
+            guard.check_gateway_lifecycle("Generate report", str(wrapper))
+    put(actual, "# descendant line limit\n" * guard._MAX_LIFECYCLE_SCAN_LINES)
+    assert verdict() is not None
+
+    # An inert Python expression is a real shell subshell: Python visits cannot hide it.
+    # These fixtures are only classified, never executed (including by the remote adapter).
+    put("child helper.sh", "#!/bin/sh\nhermes gateway restart\n")
+    mixed = "python3 wrapper.py; sh wrapper.py"
+    direct_commands = ("./wrapper.py", "python3 wrapper.py; ./wrapper.py")
+    for shebang in ("#!/usr/bin/env python3\n", ""):
+        put("wrapper.py", shebang + "('./child helper.sh')\n")
+        assert verdict() is None
+        assert verdict("sh wrapper.py") is not None
+        assert verdict(mixed) is not None
+        for command in direct_commands:
+            # Without a shebang, Bash falls back to shell even for a .py filename.
+            assert (verdict(command) is not None) == (not shebang)
+        if not remote:
+            # Cron selects Python by .py independently of direct terminal execution.
+            guard.check_gateway_lifecycle("Generate report", str(wrapper))
+            guard.check_gateway_lifecycle("python3 wrapper.py", str(wrapper))
+            with pytest.raises(guard.GatewayLifecycleBlocked):
+                guard.check_gateway_lifecycle(mixed, str(wrapper))
+            for command in direct_commands:
+                if shebang:
+                    guard.check_gateway_lifecycle(command, str(wrapper))
+                else:
+                    with pytest.raises(guard.GatewayLifecycleBlocked):
+                        guard.check_gateway_lifecycle(command, str(wrapper))
+
+    # Re-visits share one path allowance, but a new interpretation pays for source again.
+    source = "#!/usr/bin/env python3\n# " + "x" * 80 + "\n"
+    put("wrapper.py", source)
+    same = "python3 wrapper.py; python3 wrapper.py"
+    with monkeypatch.context() as limits:
+        limits.setattr(guard, "_MAX_LIFECYCLE_SCAN_PATHS", 1)
+        assert verdict(mixed) is None
+        limits.setattr(guard, "_MAX_LIFECYCLE_SCAN_BYTES", len(same) + len(source))
+        assert verdict(same) is None
+        assert verdict(mixed) is not None
+    if remote:
+        with monkeypatch.context() as limits:
+            limits.setattr(guard, "_MAX_LIFECYCLE_SCAN_REMOTE_READS", 1)
+            assert verdict(same) is None
+            assert verdict(mixed) is not None


### PR DESCRIPTION
## What does this PR do?

I hit this with a small Python wrapper that reads a JSON export. Nothing in the command stops or restarts the gateway, but Hermes blocks the job before the wrapper runs. I've been carrying a local fix for it, and having to restore that after an update is a pain.

The reference walker treats the Python source as shell input. That lets an ordinary data path become a script reference. A large JSON file then exhausts the executable-source budget even though Python only reads it as data.

This change separates those two things. It uses Python syntax to find literal process-call arguments rather than following arbitrary strings in Python source. It still inspects the executable source and its recognized command descendants. Explicit shell execution remains shell execution, even when a filename ends in `.py`.

The same bug also affected `python3 - <<'PY'`. The follow-up commit brings that invocation into the Python walk too: it extracts only proven quoted stdin bodies, reuses the existing heredoc parser, and scans the body as executable Python rather than shell text. Ambiguous or expanding forms keep the existing conservative walk.

## Related Issue

Related to #98869's data-file traversal case. This does **not** close that whole issue.

I checked the existing Python-wrapper PRs before preparing this. #83075 is the closest approach, but its current head still blocks my large-JSON reproducer. #81824 handles the benign shebang case. This patch keeps the current shared scan budgets and follows literal Python process calls while keeping data paths out of the shell walk. It also preserves explicit shell interpretation.

#106595 addresses a different interpreter-binary problem, which I've kept out of this PR. I'm happy to fold this into existing work if that's easier for the maintainers; I don't want another competing patch that adds nothing.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/lifecycle_guard.py`: recognize Python script operands and direct-execution shebangs, then inspect literal `os`, `subprocess` and `asyncio` process-call arguments instead of arbitrary data strings. Keep explicit shell interpretation, conservative fallback for unparseable Python, and bounded recursive reads. Track visits by path and interpretation so a Python visit cannot suppress a later shell inspection of the same file. Keep cron `.py` source and prompt traversal under a shared budget.
- `tests/cron/test_lifecycle_guard_python.py`: two parameterized behavior tests, covering 36 cases. These exercise the real terminal guard with local files and a synthetic remote reader, JSON below/above the source limit, Python launch forms, shell versus argv interpretation, and repeated visits under shared limits.

- `cron/lifecycle_heredoc.py`: a small adapter over the existing shell heredoc parser, with no shared-parser changes.
- `tests/cron/test_lifecycle_guard_heredoc.py`: two parameterized behavior tests (32 cases) covering JSON reads, literal executable descendants, outside-body commands, source budgets and conservative delimiter fallback.

No new dependency, configuration option, guard-disable switch, service action or database change. This remains a bounded static guard, not a Python sandbox or a complete solution for computed commands.

## How to Test

### Python hash-check option follow-up

Review comment [5643801053](https://github.com/NousResearch/hermes-agent/pull/108572#issuecomment-5643801053) identified a missed option value in `_python_operand`. Fixed in `479caae39`: `--check-hash-based-pycs` now consumes its separate value before selecting source. The existing two invariant tests cover `always`, `never` and `default`, locally and through the synthetic remote reader. No new test helper or parser refactor.

- Before this one-line production fix, the expanded regression file produced **24 behavioral failures, 12 passes** on `73bb0816d`.
- After the fix: **36 passed, 0 failed** in that file.
- The combined affected command below: **1,746 passed, 0 failed, 1 Windows-only skip** across 106 files, retries disabled.
- Ruff, ty, Windows footgun and diff checks passed. A targeted independent read-only review of the exact commit returned CLEAR.
- Real `terminal_tool()` smoke with a clean environment and temporary home: each of the three modes scanned the actual Python wrapper, left its 2 MiB JSON data out of the source walk, and returned `DATA_OK 2097152`, exit 0, with the supervised guard enabled. No lifecycle fixture was executed.

CPython 3.11.16 rejects `--check-hash-based-pycs=always`; this fix does not add support for that invalid spelling. The previous full-suite and current-main integration results below remain historical evidence for their named commits; neither was rerun for this narrow follow-up. Current PR head: `479caae39c90640af6ae06aba9e1a7622bfef7e7`.

## Quoted heredoc follow-up

Added in `73bb0816d` (`fix(cron): inspect quoted Python heredocs as Python source`). I had fixed this locally too, but missed it when preparing the first PR head.

I copied the new heredoc tests onto the previous head (`be84ebe43`) before applying the fix: **11 failed, 21 passed**, all behavioral assertions. With both fixes present:

```bash
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/cron/ tests/hermes_cli/test_gateway_restart_loop.py tests/tools/test_launchctl_guard_diagnostic.py tests/tools/test_approval.py tests/tools/test_terminal_heredoc_background_guard.py -j 4
```

**1,722 passed, 0 failed, 1 Windows-only skip** across 106 files. Ruff, ty, the Windows footgun check and `git diff --check` also pass for the combined change. The two new files are the same bytes tested in my local follow-up; the integration adds seven lines to the guard.

I also exercised `terminal_tool()` with a quoted Python heredoc reading a synthetic 2 MiB JSON value. The previous head blocked it; this head returned `DATA_OK 2097152`, exit 0. That check uses a temporary `HERMES_HOME` with ordinary execution approval disabled for the harmless fixture; the supervised lifecycle guard stays enabled. Tests assert lifecycle blocks without executing those commands.

The full-suite run below belongs to the earlier head. I have **not rerun the whole repository suite** for this follow-up; the new validation is the affected suite, real terminal smoke, and current-main integration check.

### Original Python file/inline validation

Use the repository's test environment and canonical runner. Keep retries off so the results do not hide flaky failures.

1. Copy the new regression test file onto the unchanged base and run:

   ```bash
   HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/cron/test_lifecycle_guard_python.py -j 1
   ```

   Observed on base: **12 failed, 0 passed**. These were behavioral assertion failures, not missing imports.

2. Run the affected suite on the candidate:

   ```bash
   HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/cron/ tests/hermes_cli/test_gateway_restart_loop.py tests/tools/test_launchctl_guard_diagnostic.py tests/tools/test_approval.py -j 4
   ```

   Observed: **1,660 passed, 0 failed, 1 skipped** across 104 files. The unchanged base, without the new regression file, passed 1,648 tests with the same single Windows-only skip.

3. Run static checks with the test virtual environment selected:

   ```bash
   ruff check cron/lifecycle_guard.py tests/cron/test_lifecycle_guard_python.py
   ty check --python /path/to/test-venv/bin/python cron/lifecycle_guard.py tests/cron/test_lifecycle_guard_python.py
   python scripts/check-windows-footguns.py cron/lifecycle_guard.py tests/cron/test_lifecycle_guard_python.py
   git diff --check
   ```

   All passed locally. ruff 0.15.10 and ty 0.0.21 were used.

A separate manual check called the actual `terminal_tool()` entrypoint with an extensionless Python-shebang wrapper reading a synthetic JSON file containing a 2 MiB string. It used an isolated `HERMES_HOME` and enabled the supervised-gateway guard branch. Upstream returned the lifecycle block; the candidate ran the harmless reader successfully. No restart command was executed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.) — `be84ebe43`: `fix(cron): avoid treating Python data as shell scripts`
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — the related work is compared above; the large-JSON reproducer and execution-context behavior are not covered by an equivalent existing patch
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the canonical full runner completed: 47,350 passed, 22 failed, 411 skipped across 3,963 files. The failures are accounted for below; this is not an all-green run.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux, Python 3.11.16. macOS and native Windows runtime behavior are untested.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings explain traversal and execution-context rules
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — static footgun check passes; this is not a Windows/macOS runtime test
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema change

## Full-suite result

The full run used `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh -j 4` on `be84ebe43` with the locked test dependencies. It finished with **47,350 passed, 22 failed, 411 skipped**; exit code 1.

I reran all eight failing files on the unchanged base (`8d79c2ff`). Eighteen of the same failures reproduced. Follow-up checks narrowed these down:

- Thirteen home-directory checks were caused by my test launch using `umask 077`: the fixtures requested group-readable directories but inherited stricter creation permissions. The entire file passes on the unchanged base with `umask 022`.
- Three banner checks used an obsolete mock target. Upstream has since fixed them in 5d2d5e906d62e326e600855277403b8595325b38 (#107835).
- The FTS query-count failure is the read-connection tracing problem already tracked by #92270.
- The real-binary `sort` probe runs against uutils coreutils 0.8.0 here, rather than GNU coreutils. The existing capability-gating work in #82931 covers this GNU-specific probe.

These are outside the lifecycle fix. I have not copied their fixes into this branch.

The other four failures (compression stall fallback, the skill-maintenance watermark, STT idle timeout and slash-worker MCP discovery) passed in targeted reruns on both base and candidate. The compression failure also appeared in an earlier base run. That points to intermittent behavior, but does not make the original full run green. No unrelated code was changed to silence these failures.

## Current-main integration check

I applied both PR commits without conflicts to `main` at `31d0a2428e9db346d6781da66f5b37ff3e12def2` in a separate checkout. The combined affected suite shown above passed there: **1,725 passed, 0 failed, 1 skipped** across 107 files, with retries disabled and `umask 022`. This preserves upstream's SQLite-safe file reader. That integration check used the combined candidate `73bb0816d14ebba41c833ea74014208ca9a0f9db`; the integration run is additional evidence, not a replacement for the historical full-suite result.

<!-- lifecycle-python-scope-ledger -->
## Scope boundaries

- Python hash-check option operand ([comment 5643801053](https://github.com/NousResearch/hermes-agent/pull/108572#issuecomment-5643801053)): related, fixed in `479caae39`. Reproduced on previous PR head `73bb0816d`; the pre-PR base has no `_python_operand`, so this is not claimed as a newly introduced base regression. No separate issue or unrelated hardening.
- Banner mock mismatch: reproduced on the original base; fixed upstream by #107835 / 5d2d5e9.
- FTS trace coverage: reproduced on the original base; tracked in #92270.
- GNU-only sort fixture: reproduced on the original base with uutils; covered by the capability-gating proposal in #82931.
- Home-directory modes: reproduced on base under `umask 077`, passes under `022`; test-environment setup, not a lifecycle regression.
- Four intermittent full-run failures: all pass in targeted base and candidate reruns; not presented as new confirmed bugs. The earlier compression-stall base failure remains recorded above.

## Screenshots / Logs

Actual manual terminal result on the candidate:

```json
{"output": "DATA_OK 2097152", "exit_code": 0, "error": null}
```

Original-head affected-suite summary (`be84ebe43`):

```text
=== Summary: 104 files, 1660 tests passed, 0 failed, 1 skipped (100% complete) in 97.6s (4 workers) ===
```

The remote test backend is synthetic and never executes commands. The lifecycle-block controls are classifier assertions. No production gateway or Home Assistant was changed for this candidate.
