### PR TITLE
feat(agent): context-aware output-token default for custom providers

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1331,7 +1331,13 @@ def _build_chat_completions_kwargs(agent, api_messages, tools_for_api, reasoning
         cache_scope_id=cache_scope_id, ollama_num_ctx=agent._ollama_num_ctx,
         provider_preferences=_prefs or None, openrouter_min_coding_score=agent.openrouter_min_coding_score,
         supports_reasoning=agent._supports_reasoning_extra_body(),
-        qwen_session_metadata=_qwen_meta)
+        qwen_session_metadata=_qwen_meta,
+        # Context-aware output default inputs (custom-provider path only).
+        # config context_length is resolved inside get_model_context_length from
+        # custom_providers / model_overrides, so no separate plumbing is needed.
+        provider=agent.provider, api_key=agent.api_key,
+        custom_providers=getattr(agent, "_custom_providers", None),
+        config_context_length=None)
     if _profile:
         # Profiles handle per-provider quirks via hooks fed the context above.
         return transport.build_kwargs(provider_profile=_profile, **_common)

--- a/agent/output_token_default.py
+++ b/agent/output_token_default.py
@@ -1,0 +1,139 @@
+"""Context-aware output-token default for custom providers (PR 1 of the starvation fix set).
+
+When a custom provider omits ``max_tokens`` and no ephemeral boost applies, the
+request goes out with NO output cap. Two failure classes follow:
+
+- Hosted gateways with large contexts may apply their own small internal cap
+  (observed: ~1,000 tokens, thinking-inclusive) — reasoning starves the answer
+  (see the output-cap starvation breaker for the reactive half of this fix).
+- Context-tight local servers (vLLM/llama.cpp/MLX) fill to end-of-context or
+  400 when ``prompt + max_tokens`` exceeds it, so a blind large default is wrong.
+
+The consensus design (3-reviewer design review): compute an explicit default from
+the endpoint's own metadata when the cap is omitted::
+
+    effective = min(TARGET_CAP, max(FLOOR, context_length - prompt_estimate - BUFFER))
+
+- Hosted gateway, 270K context, 50K prompt → clamped to TARGET_CAP (65,535):
+  thinking never starves the answer.
+- Local 16K model, 12K prompt → headroom ≈ 3.5K: vLLM accepts the request.
+
+The computed value is quantized down to a 4,096 boundary: generation parameters
+do not affect KV prefix caching, but some proxy cache buckets key on the raw
+request body, and a cap that changes by a few tokens every turn would churn
+those. Only applies when the endpoint's context length is actually known
+(``get_model_context_length`` resolution; 0/unknown → no default, legacy
+behavior preserved). Native OpenAI/Anthropic/Google providers and any explicit
+``max_tokens``/ephemeral boost are never touched.
+
+Compression-threshold interaction (reviewed): the compressor's
+``_compute_threshold_tokens`` derives from ``agent.max_tokens`` (user config) —
+NOT from the wire default computed here — and its degenerate-window guards
+(``effective_window <= 0`` fallback, 85% trigger cap) already handle small
+windows, so no compressor change is needed.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Published Gemini ceiling: matches the native-Gemini auto-raise default.
+OUTPUT_DEFAULT_TARGET_CAP = 65_535
+# Never send a cap below this — too small to complete any real turn.
+OUTPUT_DEFAULT_FLOOR = 1_024
+# Headroom reserved for the response side of the context split.
+OUTPUT_DEFAULT_HEADROOM_BUFFER = 512
+# Quantization bucket: stable wire values across small prompt drift.
+OUTPUT_DEFAULT_QUANTUM = 4_096
+
+
+def estimate_prompt_tokens(messages: Any) -> int:
+    """JSON-serialized size estimate for headroom math (per review: no vendored
+    tokenizers for arbitrary custom models). Serializing the WHOLE payload counts
+    everything that will ride the wire — tool-call JSON arguments, base64 image
+    parts, tool results — so the estimate errs high. Over-estimation is safe
+    (only shrinks the output default); under-estimation risks endpoint 400s."""
+    if not messages:
+        return 0
+    try:
+        import json
+
+        return len(json.dumps(messages, default=str)) // 4
+    except Exception:  # noqa: BLE001 — estimate only; never break the request
+        return 0
+
+
+def context_aware_output_default(
+    *,
+    model: str,
+    base_url: str,
+    provider: str,
+    api_key: str | None,
+    custom_providers: list | None,
+    config_context_length: int | None,
+    prompt_token_estimate: int,
+) -> int | None:
+    """Output-cap default from endpoint metadata, or None (send no cap / legacy).
+
+    Returns None when the context length is unknown — a guessed default on an
+    unknown endpoint risks the exact 400s this default exists to avoid.
+    """
+    from agent.model_metadata import get_model_context_length
+
+    try:
+        context_length = get_model_context_length(
+            model, base_url=base_url or "", api_key=api_key or "",
+            config_context_length=config_context_length, provider=provider or "",
+            custom_providers=custom_providers,
+        )
+    except Exception:  # noqa: BLE001 — a metadata failure must never break the request
+        logger.debug("output default: context length lookup failed", exc_info=True)
+        return None
+    if not isinstance(context_length, int) or context_length <= 0:
+        return None
+    headroom = context_length - int(prompt_token_estimate or 0) - OUTPUT_DEFAULT_HEADROOM_BUFFER
+    if headroom < OUTPUT_DEFAULT_FLOOR:
+        # Prompt already fills the window: no safe output default exists; sending
+        # one would guarantee truncation or a 400. Legacy behavior (no cap) is the
+        # fail-open choice — the starvation breaker handles the aftermath.
+        return None
+    effective = min(OUTPUT_DEFAULT_TARGET_CAP, headroom)
+    # Quantize down so consecutive turns with slowly-growing prompts share one
+    # wire value (proxy request-body cache buckets).
+    quantized = max(
+        OUTPUT_DEFAULT_FLOOR,
+        (effective // OUTPUT_DEFAULT_QUANTUM) * OUTPUT_DEFAULT_QUANTUM,
+    )
+    return quantized
+
+
+_MANAGED_CAP_HOSTS = (
+    # Routes that manage their own caps (or reject max_tokens outright); the
+    # omission there is honored and must stay untouched.
+    "api.openai.com", "openai.azure.com", "api.anthropic.com", "anthropic.com",
+    "generativelanguage.googleapis.com", "openrouter.ai", "api.nous.ai",
+    "bedrock",
+)
+
+
+def context_aware_output_default_for_params(model: str, params: dict[str, Any]) -> int | None:
+    """Param-dict form of ``context_aware_output_default``; None when the route
+    manages its own caps (native bases), has no base URL, or the cap is unset."""
+    base_url = str(params.get("base_url") or "")
+    if not base_url:
+        return None
+    lowered = base_url.lower()
+    if any(host in lowered for host in _MANAGED_CAP_HOSTS):
+        return None
+    return context_aware_output_default(
+        model=model,
+        base_url=base_url,
+        provider=str(params.get("provider") or ""),
+        api_key=params.get("api_key"),
+        custom_providers=params.get("custom_providers"),
+        config_context_length=params.get("config_context_length"),
+        prompt_token_estimate=estimate_prompt_tokens(params.get("messages")),
+    )

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -258,6 +258,17 @@ def _apply_max_tokens(api_kwargs: dict, model: str, reasoning_config: Any, param
             return
     if profile_max and max_tokens_fn:
         api_kwargs.update(max_tokens_fn(_raise_gemini_thinking_max_tokens(model, reasoning_config, profile_max)))
+        return
+    # Every explicit source unset: custom endpoints on OpenAI-compatible bases
+    # get a metadata-derived default (hosted gateways with hidden caps starve
+    # reasoning models otherwise; context-tight local servers need the headroom
+    # clamp). Unknown-context endpoints and native routes keep legacy behavior.
+    if max_tokens_fn:
+        from agent.output_token_default import context_aware_output_default_for_params
+
+        default_cap = context_aware_output_default_for_params(model, params)
+        if default_cap is not None:
+            api_kwargs.update(max_tokens_fn(default_cap))
 
 
 

--- a/tests/agent/test_output_token_default.py
+++ b/tests/agent/test_output_token_default.py
@@ -1,0 +1,160 @@
+"""Context-aware output default: metadata-derived max_tokens for custom providers.
+
+Contract under test (PR 1 of the starvation fix set):
+- No explicit max_tokens/ephemeral/profile cap + known context length → explicit
+  ``max_tokens`` on the wire: min(65535, headroom), quantized to a 4,096 bucket.
+- Unknown context (metadata lookup fails / 0) → None: legacy no-cap behavior.
+- Prompt nearly fills the window → None (no safe default; starvation breaker owns
+  the aftermath).
+- Explicit max_tokens / ephemeral boost / profile cap → default never consulted.
+- Native provider bases (openai/anthropic/google/openrouter) → untouched.
+"""
+
+from unittest.mock import patch
+
+from agent.output_token_default import (
+    OUTPUT_DEFAULT_FLOOR,
+    OUTPUT_DEFAULT_QUANTUM,
+    OUTPUT_DEFAULT_TARGET_CAP,
+    context_aware_output_default,
+    context_aware_output_default_for_params,
+    estimate_prompt_tokens,
+)
+
+
+def _params(**overrides):
+    base = dict(
+        base_url="https://gateway.example/v1",
+        provider="custom:gateway",
+        api_key="k",
+        custom_providers=[],
+        config_context_length=None,
+        messages=[{"role": "user", "content": "x" * 4_000}],  # ~1,000 tokens
+        max_tokens=None,
+        ephemeral_max_output_tokens=None,
+    )
+    base.update(overrides)
+    return base
+
+
+def _ctx(value):
+    return patch(
+        "agent.model_metadata.get_model_context_length", return_value=value
+    )
+
+
+class TestContextAwareDefault:
+    def test_large_context_hosted_gateway_gets_target_cap(self):
+        """270K-context model, 1K prompt → quantized target cap (65,535 quantizes
+        down to the 61,440 bucket — within one bucket of the target)."""
+        with _ctx(270_000):
+            got = context_aware_output_default(
+                model="m", base_url="https://gateway.example/v1", provider="custom:gateway",
+                api_key="k", custom_providers=[], config_context_length=None,
+                prompt_token_estimate=1_000,
+            )
+        assert got == 61_440
+        assert got >= OUTPUT_DEFAULT_TARGET_CAP - OUTPUT_DEFAULT_QUANTUM
+
+    def test_tight_local_context_clamps_to_headroom(self):
+        """16K model, 12K prompt → headroom 3,872 → quantizes to the floor
+        (1,024): never 65,535, never a 400 from vLLM."""
+        with _ctx(16_384):
+            got = context_aware_output_default(
+                model="m", base_url="http://127.0.0.1:8080/v1", provider="custom:local",
+                api_key=None, custom_providers=[], config_context_length=None,
+                prompt_token_estimate=12_000,
+            )
+        assert got == OUTPUT_DEFAULT_FLOOR
+        assert got < OUTPUT_DEFAULT_TARGET_CAP
+
+    def test_unknown_context_returns_none(self):
+        with _ctx(0):
+            got = context_aware_output_default(
+                model="m", base_url="https://gateway.example/v1", provider="custom",
+                api_key=None, custom_providers=None, config_context_length=None,
+                prompt_token_estimate=1_000,
+            )
+        assert got is None
+
+    def test_metadata_failure_returns_none(self):
+        with patch(
+            "agent.model_metadata.get_model_context_length", side_effect=RuntimeError("boom")
+        ):
+            got = context_aware_output_default(
+                model="m", base_url="https://gateway.example/v1", provider="custom",
+                api_key=None, custom_providers=None, config_context_length=None,
+                prompt_token_estimate=1_000,
+            )
+        assert got is None
+
+    def test_prompt_filling_window_returns_none(self):
+        with _ctx(16_384):
+            got = context_aware_output_default(
+                model="m", base_url="http://127.0.0.1:8080/v1", provider="custom",
+                api_key=None, custom_providers=None, config_context_length=None,
+                prompt_token_estimate=16_300,
+            )
+        assert got is None
+
+    def test_quantization_buckets_stable(self):
+        """Headroom drift within one 4,096 bucket produces the same wire value.
+        20K context keeps headroom BELOW the target cap so quantization (not the
+        target clamp) is what makes the two estimates agree."""
+        with _ctx(20_000):
+            a = context_aware_output_default(
+                model="m", base_url="https://g.example/v1", provider="custom",
+                api_key=None, custom_providers=None, config_context_length=None,
+                prompt_token_estimate=10_000,
+            )
+        with _ctx(20_000):
+            b = context_aware_output_default(
+                model="m", base_url="https://g.example/v1", provider="custom",
+                api_key=None, custom_providers=None, config_context_length=None,
+                prompt_token_estimate=10_500,
+            )
+        assert a == b == 8_192
+
+
+class TestApplyGate:
+    def test_apply_populates_when_unset(self):
+        with _ctx(270_000):
+            got = context_aware_output_default_for_params("m", _params())
+        assert got == 61_440
+
+    def test_native_base_urls_untouched(self):
+        for host in (
+            "https://api.openai.com/v1", "https://api.openai.azure.com/v1",
+            "https://api.anthropic.com/v1",
+            "https://generativelanguage.googleapis.com/openai",
+            "https://openrouter.ai/api/v1", "https://api.nous.ai/v1",
+        ):
+            with _ctx(270_000):
+                got = context_aware_output_default_for_params("m", _params(base_url=host))
+            assert got is None, host
+
+    def test_no_base_url_untouched(self):
+        """Legacy/unknown transports without a base URL keep legacy behavior."""
+        assert context_aware_output_default_for_params("m", _params(base_url="")) is None
+
+
+def test_estimate_prompt_tokens_counts_tool_call_args():
+    """JSON-serialization estimate includes tool_calls arguments and image parts
+    (Pro round-1: the old text-only walker missed them -> under-estimate)."""
+    msgs = [
+        {"role": "assistant", "tool_calls": [{"function": {"arguments": "{\"x\": \"" + "a" * 4_000 + "\"}"}}]},
+        {"role": "user", "content": [{"type": "image_url", "image_url": {"url": "data:image/png;base64," + "A" * 4_000}}]},
+    ]
+    est = estimate_prompt_tokens(msgs)
+    # args(~4,010 chars) + image blob(~4,024 chars) serialized: well over 1,000 tokens
+    assert est > 1_500
+
+
+def test_estimate_prompt_tokens_multimodal_parts():
+    """JSON serialization counts BOTH shapes (string and multipart text); the
+    exact value includes JSON scaffolding, so assert a lower bound."""
+    msgs = [
+        {"role": "user", "content": [{"type": "text", "text": "x" * 400}]},
+        {"role": "assistant", "content": "y" * 400},
+    ]
+    assert estimate_prompt_tokens(msgs) >= 200


### PR DESCRIPTION
Closes #108558 (companion to the starvation breaker PR)

## What does this PR do?

Custom OpenAI-compatible endpoints that omit `max_tokens` now get an explicit, metadata-derived output cap instead of sending nothing:

```
max_tokens = quantize_down(min(65,535, context_length − prompt_estimate − 512), 4096)
```

Two failure classes this prevents:

- **Hosted gateways with hidden internal caps** (observed in the wild: ~1,000 tokens, counted inclusively of reasoning tokens). A reasoning model's thinking consumes the entire allocation before any answer token; the response ends `finish_reason=max_tokens` with zero visible content. With an explicit cap sized from the endpoint's own `/models` metadata, the gateway's hidden default never applies.
- **Context-tight local servers** (vLLM, llama.cpp, MLX): a blind large default would 400 (`prompt + max_tokens` over context). The headroom clamp shrinks the cap to what actually fits.

Scope guards:

- **Fail open**: unknown context length (metadata lookup failure, 0, absent) → no default, legacy behavior. The starvation breaker covers those endpoints reactively.
- **Explicit config always wins**: `agent.max_tokens`, ephemeral boosts, and provider-profile caps are checked first; the default fires only when every source is unset.
- **Native routes untouched**: OpenAI (incl. Azure), Anthropic, Google, OpenRouter, Nous, Bedrock manage their own caps; the omission there is honored.
- **Prompt estimate errs high**: JSON-serializes the whole payload (tool-call arguments, base64 image parts, tool results all counted) — under-estimation risks 400s, over-estimation only shrinks the cap.
- **Quantized to 4,096-token buckets**: consecutive turns share one wire value despite prompt drift (proxy request-body cache buckets).
- **Compression unaffected**: the compressor's threshold derives from `agent.max_tokens` (user config), not this wire default; its degenerate-window guards already handle small contexts.

## Testing

- `tests/agent/test_output_token_default.py` (11 tests): target-cap path, headroom clamping on 16K local models, unknown-context fallback, quantization stability below the target cap, native-host exclusion (6 hosts), estimator coverage of tool-call arguments + image parts.
- `scripts/run_tests.sh tests/agent/transports/` — 365 passed, 0 failed; neighboring max-tokens suites green.
- Cross-vendor review: 2 rounds (Gemini 3.1 Pro High + GPT-OSS 120B); round-2 verdict SHIP from both.

## Notes

**Open question:** should the target cap (65,535) and floor (1,024) be configurable? Left hardcoded to keep the diff narrow — the values mirror the existing native-Gemini auto-raise constant, and a config surface can follow if maintainers want one.

Related: the reactive half of this fix (empty-response ladder short-circuit on proven output-cap starvation) is in a separate PR.

- [x] Includes tests
