### PR TITLE
fix(agent): stop image models from failing every chat turn

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1120,11 +1120,14 @@ def restore_primary_runtime(agent) -> bool:
     rt = agent._primary_runtime
     primary_provider = str((rt or {}).get("provider") or "").strip().lower()
     primary_model = str((rt or {}).get("model") or "").strip()
-    from agent.fallback_cooldown import _is_entitlement_rejected
-    if primary_model and _is_entitlement_rejected(agent, primary_provider, primary_model):
-        # The primary slug was rejected as unentitled for this account (#106475): restoring
-        # here would announce a recovery that was never verified and re-fail every turn.
-        # Stay on the fallback; the user sees the terminal entitlement error instead.
+    from agent.fallback_cooldown import _is_entitlement_rejected, _is_non_chat_rejected
+    if primary_model and (
+        _is_entitlement_rejected(agent, primary_provider, primary_model)
+        or _is_non_chat_rejected(agent, primary_provider, primary_model)
+    ):
+        # The primary slug was rejected as unavailable for this session: restoring here would
+        # announce a recovery that was never verified and re-fail every turn.
+        # Stay on the fallback; the user sees the rejection/fallback status instead.
         return False
     primary_runtime_base_url = str((rt or {}).get("base_url") or "")
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1731,9 +1731,9 @@ def _should_skip_fallback_candidate(agent, fb: dict, fb_key: tuple, fb_provider:
         return True
     if not fb_provider or not fb_model:
         return True
-    from agent.fallback_cooldown import _is_entitlement_rejected
-    if _is_entitlement_rejected(agent, fb_provider, fb_model):
-        logger.info("Fallback skip: %s/%s was rejected as unentitled for this account", fb_provider, fb_model)
+    from agent.fallback_cooldown import _is_entitlement_rejected, _is_non_chat_rejected
+    if _is_entitlement_rejected(agent, fb_provider, fb_model) or _is_non_chat_rejected(agent, fb_provider, fb_model):
+        logger.info("Fallback skip: %s/%s was rejected as unavailable for this session", fb_provider, fb_model)
         return True
     local_skip_reason = _fallback_entry_unavailable_without_network(agent, fb)
     if local_skip_reason:

--- a/agent/fallback_cooldown.py
+++ b/agent/fallback_cooldown.py
@@ -82,3 +82,33 @@ def _is_entitlement_rejected(agent, provider: str, model: str) -> bool:
         return True
     from hermes_cli.model_normalize import normalize_model_for_provider
     return (provider, normalize_model_for_provider(model, provider)) in rejected
+
+
+def _mark_non_chat_model_rejected(agent, api_error) -> bool:
+    """Pin a fallback after a clearly non-chat model rejects a chat request with HTTP 400."""
+    if getattr(api_error, "status_code", None) != 400:
+        return False
+    provider = str(getattr(agent, "provider", "") or "").strip().lower()
+    model = str(getattr(agent, "model", "") or "").strip()
+    from hermes_cli.models import model_id_is_obviously_non_chat
+    if not provider or not model or not model_id_is_obviously_non_chat(model):
+        return False
+    rejected = getattr(agent, "_non_chat_rejected_models", None)
+    if rejected is None:
+        rejected = agent._non_chat_rejected_models = set()
+    rejected.add((provider, model))
+    logger.warning(
+        "Non-chat model rejection: %s via %s returned HTTP 400 to a chat request; "
+        "keeping the working fallback active for this session",
+        model, provider,
+    )
+    agent._buffer_status(
+        f"🚫 {model} via {provider} cannot handle chat requests; keeping the fallback model active "
+        "for this session. Use the image_gen toolset for generation models."
+    )
+    return True
+
+
+def _is_non_chat_rejected(agent, provider: str, model: str) -> bool:
+    rejected = getattr(agent, "_non_chat_rejected_models", None) or ()
+    return (provider, model) in rejected

--- a/agent/turn_api_error.py
+++ b/agent/turn_api_error.py
@@ -284,8 +284,11 @@ def settle_unrecovered_error(
     if is_client_error:
         # A Codex ChatGPT-account entitlement 400 names the model: with nothing to rotate the
         # slug is dead for this account, so record it before the fallback walk runs (#106475).
-        from agent.fallback_cooldown import _mark_entitlement_rejected_model
+        from agent.fallback_cooldown import (
+            _mark_entitlement_rejected_model, _mark_non_chat_model_rejected,
+        )
         _mark_entitlement_rejected_model(agent, api_error)
+        _mark_non_chat_model_rejected(agent, api_error)
         # Copilot self-heal BEFORE fallback: a stale credential yields a 400
         # ``model_not_available_for_integrator`` / ``model_not_supported``, not a 401.
         # Fresh token + client rebuild, one retry, SAME provider.

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1368,6 +1368,15 @@ def _validate_switch(st: _Switch) -> Optional[ModelSwitchResult]:
     st.new_model = _resolve_named_custom_model_id(st.new_model, st.target_provider, st.custom_providers)
     st.new_model = normalize_model_for_provider(st.new_model, st.target_provider)
 
+    from hermes_cli.models import model_id_is_obviously_non_chat
+    if model_id_is_obviously_non_chat(st.new_model):
+        return st.fail(
+            f"`{st.new_model}` is an image/video generation model and cannot be used for chat. "
+            "Use the image_gen toolset for generation models.",
+            new_model=st.new_model, target_provider=st.target_provider,
+            provider_label=st.provider_label,
+        )
+
     if st.target_provider.strip().lower() == "ollama":
         headers = {} if st.suppress_ollama_headers else (st.validation_headers or _get_ollama_request_headers())
     else:

--- a/hermes_cli/model_switch_providers.py
+++ b/hermes_cli/model_switch_providers.py
@@ -374,13 +374,16 @@ def _is_aws_sdk(pconfig) -> bool:
 def _live_or_curated_ids(slug: str, curated: dict, *fallback_keys: str, merge_models_dev: bool = True) -> list:
     """``cached_provider_model_ids`` (the SAME disk-cached list ``hermes model`` builds), falling
     back to the curated list (merged with models.dev for preferred providers) when live is empty."""
-    from hermes_cli.models import _MODELS_DEV_PREFERRED, _merge_with_models_dev, cached_provider_model_ids
+    from hermes_cli.models import (
+        _MODELS_DEV_PREFERRED, _merge_with_models_dev, cached_provider_model_ids,
+        model_id_is_obviously_non_chat,
+    )
     model_ids = cached_provider_model_ids(slug)
     if not model_ids:
         model_ids = _first_curated(curated, fallback_keys or (slug,))
         if merge_models_dev and slug in _MODELS_DEV_PREFERRED:
             model_ids = _merge_with_models_dev(slug, model_ids)
-    return model_ids
+    return [model_id for model_id in model_ids if not model_id_is_obviously_non_chat(model_id)]
 
 
 def _first_curated(curated: dict, keys) -> list:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -820,6 +820,21 @@ def curated_models_for_provider(
     return [(m, "") for m in models]
 
 
+# Generic OpenAI-compatible ``/models`` endpoints often mix chat with generation surfaces but
+# expose no modality metadata. Keep this deliberately narrow: these separator-qualified tokens
+# identify a generation API, while names such as ``vision`` / ``vl`` remain valid chat models.
+_NON_CHAT_MODEL_ID_RE = re.compile(
+    r"(?:^|[/_.-])(?:image(?:[/_.-]gen(?:eration)?)?|text[/_.-]to[/_.-]image|"
+    r"video(?:[/_.-]gen(?:eration)?)?|text[/_.-]to[/_.-]video)(?=$|[/_.-])",
+    re.IGNORECASE,
+)
+
+
+def model_id_is_obviously_non_chat(model_id: str) -> bool:
+    """Whether an untyped catalog ID clearly names an image/video generation model."""
+    return bool(_NON_CHAT_MODEL_ID_RE.search(str(model_id or "").strip()))
+
+
 def _provider_keys(provider: str) -> set[str]:
     key = (provider or "").strip().lower()
     normalized = normalize_provider(provider)

--- a/providers/base.py
+++ b/providers/base.py
@@ -35,6 +35,18 @@ def _profile_user_agent() -> str:
         return "hermes-cli"
 
 
+_IMAGE_ONLY_CATALOG_TYPES = frozenset({"image", "image_generation", "image-generation"})
+
+
+def _catalog_item_is_chat_candidate(item: dict[str, Any]) -> bool:
+    """Fail open unless structured catalog metadata proves the model is image-only."""
+    capabilities = item.get("capabilities")
+    if not isinstance(capabilities, dict):
+        return True
+    model_type = str(capabilities.get("type") or "").strip().lower()
+    return model_type not in _IMAGE_ONLY_CATALOG_TYPES
+
+
 @dataclass
 class ProviderProfile:
     """Base provider profile — subclass or instantiate with overrides."""
@@ -334,7 +346,10 @@ class ProviderProfile:
             with open_credentialed_url(req, timeout=timeout) as resp:
                 data = json.loads(resp.read().decode())
             items = data if isinstance(data, list) else data.get("data", [])
-            return [m["id"] for m in items if isinstance(m, dict) and "id" in m]
+            return [
+                m["id"] for m in items
+                if isinstance(m, dict) and "id" in m and _catalog_item_is_chat_candidate(m)
+            ]
         except Exception as exc:
             logger.debug("fetch_models(%s): %s", self.name, exc)
             return None

--- a/tests/hermes_cli/test_non_chat_model_selection.py
+++ b/tests/hermes_cli/test_non_chat_model_selection.py
@@ -1,0 +1,24 @@
+from unittest.mock import patch
+
+from hermes_cli.model_switch import _Switch, _validate_switch
+from hermes_cli.model_switch_providers import _live_or_curated_ids
+
+
+def test_generation_models_are_filtered_from_chat_catalogs_and_rejected_on_direct_switch():
+    with patch(
+        "hermes_cli.models.cached_provider_model_ids",
+        return_value=["qwen3.8-max", "wan2.7-image-pro", "wan2.7-video-pro"],
+    ):
+        assert _live_or_curated_ids("alibaba-token-plan", {}) == ["qwen3.8-max"]
+
+    state = _Switch(
+        raw_input="wan2.7-image-pro", current_provider="alibaba-token-plan",
+        current_model="qwen3.8-max", current_base_url="https://example.com/v1",
+        current_api_key="", is_global=False, explicit_provider="",
+        user_providers=None, custom_providers=None, new_model="wan2.7-image-pro",
+        target_provider="alibaba-token-plan", provider_label="Alibaba Cloud (Token Plan)",
+    )
+    result = _validate_switch(state)
+
+    assert result is not None and result.success is False
+    assert "cannot be used for chat" in result.error_message

--- a/tests/providers/test_fetch_models_base_url.py
+++ b/tests/providers/test_fetch_models_base_url.py
@@ -97,6 +97,52 @@ class TestFetchModelsBaseUrlOverride:
         finally:
             server.shutdown()
 
+    def test_catalog_excludes_explicit_image_only_models(self):
+        """Shared picker discovery must not offer a non-chat Token Plan model."""
+        response = MagicMock()
+        response.__enter__.return_value.read.return_value = json.dumps({"data": [
+            {"id": "wan2.7-image-pro", "capabilities": {"type": "image"}},
+            {"id": "qwen3.7-plus", "capabilities": {"type": "chat"}},
+        ]}).encode()
+        profile = ProviderProfile(
+            name="alibaba-token-plan",
+            base_url="https://token-plan.example.test/v1",
+        )
+
+        with (
+            patch("hermes_cli.urllib_security.open_credentialed_url", return_value=response),
+            patch("providers.get_provider_profile", return_value=profile),
+            patch("hermes_cli.auth.resolve_api_key_provider_credentials", return_value={
+                "api_key": "test-key", "base_url": profile.base_url,
+            }),
+            patch("hermes_cli.models._load_provider_models_cache", return_value={}),
+            patch("hermes_cli.models._store_cache_entry"),
+            patch.dict("hermes_cli.models._PROVIDER_MODELS", {}, clear=True),
+        ):
+            from hermes_cli.models import cached_provider_model_ids
+
+            assert cached_provider_model_ids("alibaba-token-plan") == ["qwen3.7-plus"]
+
+    def test_catalog_keeps_models_with_ambiguous_capabilities(self):
+        """Missing, malformed, or unknown metadata cannot prove a model is image-only."""
+        response = MagicMock()
+        response.__enter__.return_value.read.return_value = json.dumps({"data": [
+            {"id": "missing-capabilities"},
+            {"id": "malformed-capabilities", "capabilities": "image"},
+            {"id": "unknown-capability-type", "capabilities": {"type": "future-kind"}},
+        ]}).encode()
+        profile = ProviderProfile(
+            name="alibaba-token-plan",
+            base_url="https://token-plan.example.test/v1",
+        )
+
+        with patch("hermes_cli.urllib_security.open_credentialed_url", return_value=response):
+            assert profile.fetch_models(api_key="test-key") == [
+                "missing-capabilities",
+                "malformed-capabilities",
+                "unknown-capability-type",
+            ]
+
 
 
 

--- a/tests/run_agent/test_entitlement_fail_closed.py
+++ b/tests/run_agent/test_entitlement_fail_closed.py
@@ -6,7 +6,9 @@ and announce an unverified "Primary model restored" that would oscillate forever
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from agent.fallback_cooldown import _mark_entitlement_rejected_model
+from agent.fallback_cooldown import (
+    _mark_entitlement_rejected_model, _mark_non_chat_model_rejected,
+)
 
 from run_agent import AIAgent
 
@@ -87,3 +89,23 @@ def test_restore_primary_runtime_is_gated_on_rejected_primary_slug():
     _, restored, emitted = _run("some-other-slug")
     assert restored is True
     assert any("Primary model restored" in n for n in emitted)
+
+
+def test_image_generation_400_keeps_working_fallback_active_for_session():
+    agent = _make_agent(fallback_model={"provider": "zai", "model": "glm-5.2"})
+    agent.provider, agent.model = "alibaba-token-plan", "wan2.7-image-pro"
+    agent._primary_runtime["provider"], agent._primary_runtime["model"] = agent.provider, agent.model
+
+    assert _mark_non_chat_model_rejected(
+        agent, SimpleNamespace(status_code=400, message="input.messages is invalid")) is True
+    assert any(
+        "cannot handle chat requests" in notice
+        for kind, notice in agent._retry_status_buffer if kind == "status"
+    )
+
+    fb_client = MagicMock()
+    fb_client.api_key, fb_client.base_url = "fallback-" + "key-1234", "https://fallback.example.com/v1"
+    with patch("agent.auxiliary_client.resolve_provider_client", return_value=(fb_client, None)):
+        assert agent._try_activate_fallback() is True
+    assert agent._restore_primary_runtime() is False
+    assert (agent.provider, agent.model, agent._fallback_activated) == ("zai", "glm-5.2", True)


### PR DESCRIPTION
## What does this PR do?

Stops image/video generation models from being selected as chat models and prevents an already-selected generation model from failing again at the start of every turn. Mixed `/models` catalogs are filtered using explicit capability metadata first, while a narrow generation-model ID guard covers catalogs that omit metadata; if an existing session still reaches the provider and receives HTTP 400, Hermes keeps the working fallback active for that session.

### Symptom

Selecting `wan2.7-image-pro` in the Desktop chat model picker sends chat-completions requests to an image-generation endpoint. The endpoint returns HTTP 400, fallback answers the turn, and the next turn restores the same broken primary model.

### Impact

Affected sessions make one predictably failing provider request per turn and answer with a different model than the user selected. The repeated request can waste quota and the restore loop continues until the user changes models or restarts with a different configuration.

### Bug Cause

**Trigger:** `providers/base.py:ProviderProfile.fetch_models` and `agent/agent_runtime_helpers.py:restore_primary_runtime`

**Causal chain:**
1. A generic OpenAI-compatible `/models` response includes both chat and image-generation entries.
2. The shared picker accepted every ID, and model switching validated catalog membership rather than chat capability.
3. A non-retryable HTTP 400 activated fallback, but the next turn restored the generation model because only rate-limit and entitlement failures blocked primary restoration.

**Why it is wrong:** A model catalog advertises endpoint availability, not that every entry accepts chat-completions payloads. Restoring a model already proven incompatible repeats a deterministic failure and reports an unverified recovery.

**Working sibling / contrast:** Rate-limited and account-entitlement-rejected primary models already remain on fallback until they are eligible again; generation-model rejection lacked the same session gate.

**Ruled out:** This is not a malformed-history retry problem. The reported model is an image-generation route, and the same HTTP 400 followed by primary restoration repeats across otherwise independent turns.

### Fix

- Filter catalog items whose structured capability metadata identifies an image-only surface.
- Filter and reject separator-qualified image/video generation IDs when an untyped catalog omits modality metadata, without excluding chat-capable `vision` or `vl` models.
- Mark an image/video generation primary unavailable for the session after HTTP 400, skip it in fallback candidates, and prevent `restore_primary_runtime` from switching back.
- Surface a direct model-switch error that points users to the `image_gen` toolset.

## Related Issue
N/A
## Why this PR vs existing PR #108571

This branch preserves PR #108571's structured `capabilities.type` filter and its contributor-authored tests. It additionally closes two runtime paths left open there: `hermes_cli/model_switch.py` rejects direct selection when an endpoint omits capability metadata, and `agent/agent_runtime_helpers.py` keeps a successful fallback active when an existing or persisted session has already selected the generation model. Those paths prevent the reported per-turn HTTP 400 loop rather than only preventing new picker selections.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `providers/base.py` - filter explicitly image-only live catalog entries.
- `hermes_cli/models.py` and `hermes_cli/model_switch_providers.py` - keep clearly named generation models out of untyped chat catalogs.
- `hermes_cli/model_switch.py` - reject direct image/video generation model selection for chat.
- `agent/fallback_cooldown.py`, `agent/turn_api_error.py`, `agent/agent_runtime_helpers.py`, and `agent/chat_completion_helpers.py` - retain a working fallback after a generation model rejects chat.
- `tests/providers/test_fetch_models_base_url.py`, `tests/hermes_cli/test_non_chat_model_selection.py`, and `tests/run_agent/test_entitlement_fail_closed.py` - cover catalog filtering, direct rejection, and session fallback retention.

## How to Test

1. Return `wan2.7-image-pro` with `capabilities.type: image` beside a chat model from a provider `/models` endpoint and confirm only the chat model is selectable.
2. Attempt a direct switch to `wan2.7-image-pro` and confirm the switch is rejected with `image_gen` guidance.
3. Automated verification passed: 13 tests in 3 files.

```bash
scripts/run_tests.sh tests/providers/test_fetch_models_base_url.py tests/hermes_cli/test_non_chat_model_selection.py tests/run_agent/test_entitlement_fail_closed.py
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and statically compared this branch with PR #108571
- [x] My PR contains only changes related to this fix
- [x] I've added tests for the changed behavior
- [x] I've tested on my platform: Windows 11 (automated tests run after PR creation per the development pipeline)

### Documentation & Housekeeping

- [x] Documentation updates are not required
- [x] No config keys changed
- [x] No architecture or workflow documentation changed
- [x] Cross-platform impact was considered; the implementation is platform-independent
- [x] Tool descriptions and schemas are unchanged
