### PR TITLE
fix(tools): keep the default profile roster entry pointing at the root home

### DIFF
--- a/tests/tools/test_bot_mode_probe.py
+++ b/tests/tools/test_bot_mode_probe.py
@@ -273,3 +273,20 @@ def test_fingerprint_changes_when_a_peer_is_registered(tmp_path):
     )
     after = bot_mode_probe.capability_fingerprint(home)
     assert before != after
+
+
+def test_roster_resolves_default_to_root_home_over_stray_directory(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    _make_bot_profile(home, "researcher", managed=True)
+    # A stray profiles/default/ directory must not shadow the reserved root home.
+    stray = home / "profiles" / "default"
+    stray.mkdir()
+    (stray / "state.db").write_bytes(b"")
+
+    roster = bot_mode_probe._roster(home)
+    homes = dict(roster)
+    assert homes["default"] == home
+    assert homes["researcher"] == home / "profiles" / "researcher"
+    names = [name for name, _ in roster]
+    assert names.count("default") == 1

--- a/tools/bot_mode_probe.py
+++ b/tools/bot_mode_probe.py
@@ -71,7 +71,14 @@ def _handle(name: str) -> str:
 def _roster(root: Path) -> list[tuple[str, Path]]:
     """(name, dir) for the default profile + every named profile, sorted."""
     profiles = root / "profiles"
-    named = _swallow(lambda: [(c.name, c) for c in sorted(profiles.iterdir()) if c.is_dir()] if profiles.is_dir() else [], [])
+    named = _swallow(
+        lambda: [
+            (c.name, c)
+            for c in sorted(profiles.iterdir())
+            if c.is_dir() and c.name != "default"
+        ],
+        [],
+    )
     return [("default", root), *named]
 
 


### PR DESCRIPTION
## Summary

`tools/bot_mode_probe.py::_roster` returned `[("default", root), *named]` and `tools/bot_mode_dm.py:197` collapsed it with `dict(...)`. Dict is last-key-wins, so a stray `profiles/default/` directory replaced the reserved root-home entry; live DM admission then opened `profiles/default/state.db`, and an empty file passes `is_file()`, producing `no such table: sessions` → `status: ambiguous`, message silently lost.

Fix: the named-profile scan now skips the reserved `default` name — a `profiles/default/` directory is not a real profile home. This matches the existing precedent in `hermes_cli/container_boot.py:109` (skips a `profiles/default/` directory) and `hermes_cli/service_manager.py:408` (no `-p` flag for `default` — root sentinel).

## Testing

- Mutation RED confirmed: without the `c.name != "default"` guard the new regression test fails.
- `pytest tests/tools/test_bot_mode_probe.py -q` → 15 passed (with new `test_roster_resolves_default_to_root_home_over_stray_directory`).
- `pytest tests/tools/test_bot_mode_dm.py -q` → 47 passed, 1 skipped.
- `ruff check` on both files — clean.

Fixes #108564