### PR TITLE
fix(tui): normalize empty fast status without mutating service tier

### DIFF
--- a/tests/tui_gateway/test_empty_fast_status.py
+++ b/tests/tui_gateway/test_empty_fast_status.py
@@ -1,0 +1,21 @@
+from types import SimpleNamespace
+import pytest
+from tui_gateway import methods_config_set as config
+
+
+@pytest.mark.parametrize('tier,expected', [('', 'normal'), (None, 'normal'), ('priority', 'fast'), ('normal', 'normal'), ('auto', 'auto'), ('cold', 'cold')])
+@pytest.mark.parametrize('built', [True, False])
+def test_fast_status_preserves_tier_semantics_without_mutation(monkeypatch, tier, expected, built):
+    session = {'agent': SimpleNamespace(service_tier=tier)} if built else {'create_service_tier_override': tier}
+    replies = []
+    monkeypatch.setattr(config, '_load_service_tier', lambda: tier, raising=False)
+    monkeypatch.setattr(config, '_kv', lambda rid, key, value: replies.append((rid, key, value)))
+    def forbidden(*args, **kwargs):
+        pytest.fail('Status query must not write configuration')
+    monkeypatch.setattr(config, '_write_config_key', forbidden, raising=False)
+    config._set_fast(1, {'session_id': 'test'}, 'fast', 'status', session)
+    assert replies == [(1, 'fast', expected)]
+    if built:
+        assert session['agent'].service_tier == tier
+    else:
+        assert session['create_service_tier_override'] == tier

--- a/tui_gateway/methods_config_set.py
+++ b/tui_gateway/methods_config_set.py
@@ -168,7 +168,7 @@ def _set_fast(rid, params, key, value, session):
     else:
         current_tier = _load_service_tier()
     if raw == "status":
-        return _kv(rid, key, {"priority": "fast", None: "normal"}.get(current_tier, current_tier))
+        return _kv(rid, key, {"priority": "fast", None: "normal", "": "normal"}.get(current_tier, current_tier))
     nv = _FAST_WORDS.get(raw, ("normal" if current_tier == "priority" else "fast") if raw in {"", "toggle"} else None)
     if nv is None:
         return _err(rid, 4002, f"unknown fast mode: {value}")


### PR DESCRIPTION
## Summary
Normalize only the explicit empty service tier to `normal` in the read-only `config.set fast=status` response. A built agent can hold `service_tier=''`; the pre-build override path already normalizes this sentinel, while the built-agent status path previously returned an empty value.

This leaves stored configuration and agent state untouched and preserves priority/auto/cold values. Clients can distinguish normal mode from an unknown response without changing their fail-closed behavior.

## Verification
`scripts/run_tests.sh tests/tui_gateway/test_empty_fast_status.py` passes against current main. Parameterized tests cover built and pre-build sessions, empty/None/normal/priority/auto/cold, response values and absence of configuration mutation. No live credentials or provider calls are used.
