### PR TITLE
feat(sessions): add exact-selection prune manifests

### DIFF
--- a/hermes_cli/session_prune_selection.py
+++ b/hermes_cli/session_prune_selection.py
@@ -1,0 +1,125 @@
+"""Validate the private helper's frozen plan for exact native Prune."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_PLAN_FORMAT = "hermes-session-plan/v2"
+_AUTHORITY_FIELDS = (
+    "format",
+    "source",
+    "selection",
+    "provenance",
+    "candidates",
+    "exclusions",
+    "exclusion_predicates",
+)
+
+
+@dataclass(frozen=True)
+class ExactPruneSelection:
+    """Validated physical IDs and identity from one frozen helper plan."""
+
+    session_ids: tuple[str, ...]
+    plan_identity: str
+
+
+def _plan_identity(plan: dict[str, Any]) -> str:
+    authority = {key: plan.get(key) for key in _AUTHORITY_FIELDS}
+    encoded = json.dumps(
+        authority,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _session_ids(plan: dict[str, Any]) -> tuple[str, ...]:
+    selection = plan.get("selection")
+    raw_ids = selection.get("physical_session_ids") if isinstance(selection, dict) else None
+    if (
+        not isinstance(raw_ids, list)
+        or not raw_ids
+        or any(not isinstance(session_id, str) or not session_id for session_id in raw_ids)
+    ):
+        raise ValueError("selection.physical_session_ids must be a non-empty string list")
+    ids = tuple(raw_ids)
+    if len(set(ids)) != len(ids):
+        raise ValueError("selection.physical_session_ids must not contain duplicates")
+
+    candidates = plan.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise ValueError("candidates must be a non-empty list")
+    flattened: list[str] = []
+    for candidate in candidates:
+        candidate_ids = (
+            candidate.get("physical_session_ids") if isinstance(candidate, dict) else None
+        )
+        if not isinstance(candidate_ids, list) or any(
+            not isinstance(session_id, str) or not session_id for session_id in candidate_ids
+        ):
+            raise ValueError("candidate physical_session_ids must be string lists")
+        flattened.extend(candidate_ids)
+    if tuple(flattened) != ids:
+        raise ValueError("candidate physical_session_ids do not match the frozen selection")
+    return ids
+
+
+def load_exact_prune_selection(
+    plan_file: Path,
+    *,
+    expected_database: Path,
+) -> ExactPruneSelection:
+    """Load and validate a helper v2 plan bound to the active session database."""
+    try:
+        plan = json.loads(Path(plan_file).expanduser().read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"could not read exact-selection plan: {exc}") from exc
+    if not isinstance(plan, dict) or plan.get("format") != _PLAN_FORMAT:
+        raise ValueError(f"exact-selection plan format must be {_PLAN_FORMAT!r}")
+
+    source = plan.get("source")
+    if not isinstance(source, dict):
+        raise ValueError("exact-selection plan source must be an object")
+    source_database = source.get("database")
+    if not isinstance(source_database, str) or not source_database:
+        raise ValueError("exact-selection plan source.database must be a non-empty path")
+    if source.get("changed_during_read") is not False:
+        raise ValueError("exact-selection plan reports source drift")
+    try:
+        same_database = Path(source_database).expanduser().samefile(expected_database)
+    except OSError as exc:
+        raise ValueError(f"could not verify exact-selection source database: {exc}") from exc
+    if not same_database:
+        raise ValueError("exact-selection plan names a different session database")
+
+    provenance = plan.get("provenance")
+    provenance_fields = (
+        "helper_revision",
+        "native_revision",
+        "installed_command_provenance",
+    )
+    if not isinstance(provenance, dict) or any(
+        not isinstance(provenance.get(field), str) or not provenance[field].strip()
+        for field in provenance_fields
+    ):
+        raise ValueError("exact-selection plan provenance fields must be non-empty strings")
+
+    supplied_identity = plan.get("plan_identity")
+    computed_identity = _plan_identity(plan)
+    if not isinstance(supplied_identity, str) or not hmac.compare_digest(
+        supplied_identity,
+        computed_identity,
+    ):
+        raise ValueError("exact-selection plan identity does not match its contents")
+
+    return ExactPruneSelection(
+        session_ids=_session_ids(plan),
+        plan_identity=supplied_identity,
+    )

--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -607,8 +607,57 @@ def _note_pinned_skipped(db, filters, action):
           f"(pin is a keep flag). {optin}")
 
 
+def _cmd_prune_exact_selection(db, args):
+    """Prune the physical IDs frozen in one verified private-helper plan."""
+    conflicting = _any_filter_args(args) or any(
+        getattr(args, name, False)
+        for name in ("include_archived", "include_pinned", "never_active")
+    )
+    if conflicting:
+        print("Error: --selection-file cannot be combined with prune filters or include flags.")
+        return 1
+    from hermes_cli.session_prune_selection import load_exact_prune_selection
+    try:
+        selection = load_exact_prune_selection(
+            args.selection_file,
+            expected_database=db.db_path,
+        )
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        return 1
+
+    print(
+        f"Exact selection plan {selection.plan_identity} names "
+        f"{len(selection.session_ids)} physical session(s):"
+    )
+    for session_id in selection.session_ids:
+        print(f"  {session_id}")
+    if args.dry_run:
+        print("Dry run — nothing deleted. The exact selection will be rechecked during Prune.")
+        return
+    if not args.yes and not _confirm_prompt(
+        f"Delete exactly these {len(selection.session_ids)} physical session(s)? [y/N] "
+    ):
+        print("Cancelled.")
+        return
+    try:
+        result = db.prune_exact_selection(
+            list(selection.session_ids),
+            sessions_dir=_sessions_dir(),
+        )
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        return 1
+    print(
+        f"Pruned {result['count']} session(s) from exact selection plan "
+        f"{selection.plan_identity}."
+    )
+
+
 def _cmd_prune_or_archive(db, args, action):
     prune = action == "prune"
+    if prune and getattr(args, "selection_file", None):
+        return _cmd_prune_exact_selection(db, args)
     if prune and getattr(args, "never_active", False):
         return _prune_never_active_keyed(db, args)
     from hermes_cli.session_filters import build_prune_filters, describe_filters, format_epoch

--- a/hermes_cli/subcommands/sessions.py
+++ b/hermes_cli/subcommands/sessions.py
@@ -111,6 +111,11 @@ def build_sessions_parser(subparsers, *, cmd_sessions: Callable) -> None:
         help="Also delete archived sessions (excluded by default)")
     _flag(sessions_prune, "--include-pinned",
         help="Also delete pinned sessions (excluded by default — pin is a keep flag)")
+    sessions_prune.add_argument(
+        "--selection-file",
+        type=Path,
+        help="Delete exactly the physical session IDs in a hermes-session-plan/v2 file",
+    )
     _flag(sessions_prune, "--never-active",
         help="Instead of ended sessions, delete keyed gateway rows that were "
             "opened and never used (no messages, tokens, tool calls or title) "

--- a/hermes_state_maintenance.py
+++ b/hermes_state_maintenance.py
@@ -21,6 +21,7 @@ _LAST_ACTIVE_SQL = """COALESCE(
                    )"""
 _TOKENS_SQL = "(COALESCE(s.input_tokens, 0) + COALESCE(s.output_tokens, 0))"
 _COST_SQL = "COALESCE(s.actual_cost_usd, s.estimated_cost_usd, 0)"
+_SESSION_STATE_META_NAMESPACES = ("goal", "loop", "heartbeat")
 
 
 def _like(value: str) -> str:
@@ -296,6 +297,139 @@ class SessionMaintenanceMixin:
         for sid in removed_ids:
             self._remove_session_files(sessions_dir, sid)
         return count
+
+    def prune_exact_selection(self, session_ids: List[str], *, sessions_dir: Optional[Path] = None,
+                              include_pinned: bool = False) -> Dict[str, Any]:
+        """Delete exactly the caller-supplied physical session IDs, atomically, or none of them.
+
+        Unlike :meth:`prune_sessions` (filter-driven -- re-evaluating the filter at delete time can
+        match a different set than a caller last reviewed), this takes an explicit frozen ID list so
+        an external reviewer (e.g. a Store/Verify pipeline) can hand back precisely the rows it
+        already inspected. Every ID must currently exist, be ended, and be archived; unlisted children
+        referencing any selected row fail the whole batch closed rather than silently orphaning something the
+        caller never reviewed. ``include_pinned`` opts a pinned row into deletion explicitly (pin is
+        otherwise a durable keep flag). Returns ``{"count": int, "deleted": list[str]}``; raises
+        ``ValueError`` and deletes nothing on any failed precondition."""
+        ids = list(session_ids)
+        if not ids:
+            raise ValueError("prune_exact_selection: session_ids must not be empty")
+        if any(not isinstance(session_id, str) or not session_id for session_id in ids):
+            raise ValueError("prune_exact_selection: session_ids must contain non-empty strings")
+        if len(set(ids)) != len(ids):
+            raise ValueError("prune_exact_selection: session_ids must not contain duplicates")
+        def _do(conn) -> Dict[str, Any]:
+            found = {}
+            for chunk in _id_chunks(ids):
+                placeholders = _placeholders(chunk)
+                rows = conn.execute(
+                    f"SELECT id, ended_at, archived, pinned FROM sessions WHERE id IN ({placeholders})",
+                    chunk,
+                ).fetchall()
+                found.update({row["id"]: row for row in rows})
+            missing = [sid for sid in ids if sid not in found]
+            if missing:
+                raise ValueError(f"prune_exact_selection: session does not exist: {missing[0]!r}")
+            not_ended = [sid for sid in ids if found[sid]["ended_at"] is None]
+            if not_ended:
+                raise ValueError("prune_exact_selection: session is not ended, refusing to delete: "
+                                 f"{not_ended[0]!r}")
+            not_archived = [sid for sid in ids if not found[sid]["archived"]]
+            if not_archived:
+                raise ValueError("prune_exact_selection: session is not archived, refusing to delete: "
+                                 f"{not_archived[0]!r}")
+            if not include_pinned:
+                pinned = [sid for sid in ids if found[sid]["pinned"]]
+                if pinned:
+                    raise ValueError("prune_exact_selection: session is pinned (pass "
+                                     f"include_pinned=True to delete anyway): {pinned[0]!r}")
+            covered = set(ids)
+            for chunk in _id_chunks(ids):
+                placeholders = _placeholders(chunk)
+                children = conn.execute(
+                    f"SELECT id FROM sessions WHERE parent_session_id IN ({placeholders})",
+                    chunk,
+                ).fetchall()
+                uncovered = [str(row["id"]) for row in children if str(row["id"]) not in covered]
+                if uncovered:
+                    raise ValueError("prune_exact_selection: refuses an uncovered child session "
+                                     f"referencing the selection: {uncovered[0]!r}")
+            unverifiable = conn.execute(
+                "SELECT scope, session_key FROM gateway_routing "
+                "WHERE json_valid(entry_json) = 0 "
+                "OR json_type(entry_json) IS NOT 'object' "
+                "OR json_type(entry_json, '$.session_id') IS NOT 'text'"
+            ).fetchone()
+            if unverifiable is not None:
+                raise ValueError(
+                    "prune_exact_selection: cannot verify gateway_routing row "
+                    f"{unverifiable['scope']!r}/{unverifiable['session_key']!r}"
+                )
+            for chunk in _id_chunks(ids):
+                placeholders = _placeholders(chunk)
+                route = conn.execute(
+                    "SELECT scope, session_key, "
+                    "json_extract(entry_json, '$.session_id') AS session_id "
+                    "FROM gateway_routing "
+                    f"WHERE json_extract(entry_json, '$.session_id') IN ({placeholders})",
+                    chunk,
+                ).fetchone()
+                if route is not None:
+                    raise ValueError(
+                        "prune_exact_selection: refuses gateway_routing reference "
+                        f"to selected session: {route['session_id']!r}"
+                    )
+            for namespace in _SESSION_STATE_META_NAMESPACES:
+                for chunk in _id_chunks(ids):
+                    state_keys = [f"{namespace}:{session_id}" for session_id in chunk]
+                    state_ref = conn.execute(
+                        f"SELECT key FROM state_meta WHERE key IN ({_placeholders(state_keys)})",
+                        state_keys,
+                    ).fetchone()
+                    if state_ref is not None:
+                        raise ValueError(
+                            "prune_exact_selection: refuses state_meta reference "
+                            f"to selected session: {state_ref['key']!r}"
+                        )
+            for chunk in _id_chunks(ids):
+                placeholders = _placeholders(chunk)
+                lock = conn.execute(
+                    f"SELECT session_id FROM compression_locks WHERE session_id IN ({placeholders})",
+                    chunk,
+                ).fetchone()
+                if lock is not None:
+                    raise ValueError("prune_exact_selection: refuses compression_locks reference "
+                                     f"to selected session: {lock['session_id']!r}")
+                lease = conn.execute(
+                    f"SELECT conversation_id FROM session_turn_leases WHERE conversation_id "
+                    f"IN ({placeholders})", chunk,
+                ).fetchone()
+                if lease is not None:
+                    raise ValueError("prune_exact_selection: refuses session_turn_leases reference "
+                                     f"to selected session: {lease['conversation_id']!r}")
+            for chunk in _id_chunks(ids, size=450):
+                placeholders = _placeholders(chunk)
+                delegation = conn.execute(
+                    f"SELECT delegation_id, origin_session FROM async_delegations "
+                    f"WHERE origin_session IN ({placeholders}) "
+                    f"OR parent_session_id IN ({placeholders})", chunk + chunk,
+                ).fetchone()
+                if delegation is not None:
+                    raise ValueError("prune_exact_selection: refuses async_delegations reference "
+                                     f"to selected session: delegation_id={delegation['delegation_id']!r}")
+            for chunk in _id_chunks(ids):
+                placeholders = _placeholders(chunk)
+                conn.execute(
+                    f"UPDATE sessions SET parent_session_id = NULL WHERE parent_session_id IN ({placeholders})",
+                    chunk,
+                )
+                conn.execute(f"DELETE FROM messages WHERE session_id IN ({placeholders})", chunk)
+                conn.execute(f"DELETE FROM sessions WHERE id IN ({placeholders})", chunk)
+            self._delete_unreferenced_system_prompts(conn)
+            return {"count": len(ids), "deleted": list(ids)}
+        result = self._execute_write(_do)
+        for sid in result["deleted"]:
+            self._remove_session_files(sessions_dir, sid)
+        return result
 
     def _page_pragmas(self, names: Tuple[str, ...], fail_msg: str) -> Optional[list]:
         """Integer PRAGMAs over the existing connection (never a byte probe); None + debug log on failure."""

--- a/tests/hermes_cli/test_sessions_exact_prune.py
+++ b/tests/hermes_cli/test_sessions_exact_prune.py
@@ -1,0 +1,443 @@
+"""CLI contracts for pruning a frozen helper selection exactly."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.session_prune_selection import load_exact_prune_selection
+from hermes_state import SessionDB
+
+
+def _stamp_plan_identity(plan: dict) -> None:
+    authority = {
+        key: plan[key]
+        for key in (
+            "format",
+            "source",
+            "selection",
+            "provenance",
+            "candidates",
+            "exclusions",
+            "exclusion_predicates",
+        )
+    }
+    encoded = json.dumps(
+        authority,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    plan["plan_identity"] = hashlib.sha256(encoded).hexdigest()
+
+
+def _write_plan(path: Path, database: Path, session_ids: list[str]) -> dict:
+    plan = {
+        "format": "hermes-session-plan/v2",
+        "source": {
+            "database": str(database.absolute()),
+            "changed_during_read": False,
+        },
+        "selection": {"physical_session_ids": list(session_ids)},
+        "provenance": {
+            "helper_revision": "helper-test-revision",
+            "native_revision": "native-test-revision",
+            "installed_command_provenance": "test-source-checkout",
+        },
+        "candidates": [
+            {
+                "id": session_ids[-1],
+                "physical_session_ids": session_ids,
+            }
+        ],
+        "exclusions": {},
+        "exclusion_predicates": {},
+    }
+    _stamp_plan_identity(plan)
+    path.write_text(json.dumps(plan), encoding="utf-8")
+    return plan
+
+
+def _run_cli(monkeypatch, capsys, argv: list[str]) -> tuple[int, str]:
+    import hermes_cli.main as main_mod
+
+    monkeypatch.setattr(sys, "argv", ["hermes", "sessions", "prune", *argv])
+    try:
+        result = main_mod.main()
+        code = int(result or 0)
+    except SystemExit as exc:
+        code = int(exc.code or 0)
+    return code, capsys.readouterr().out
+
+
+def test_exact_selection_plan_rejects_non_string_session_id(tmp_path: Path) -> None:
+    database = tmp_path / "state.db"
+    SessionDB(db_path=database).close()
+    plan_file = tmp_path / "plan.json"
+    plan = _write_plan(plan_file, database, ["selected"])
+    plan["selection"]["physical_session_ids"] = [123]
+    plan["candidates"] = [{"id": "selected", "physical_session_ids": [123]}]
+    _stamp_plan_identity(plan)
+    plan_file.write_text(json.dumps(plan), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="non-empty string list"):
+        load_exact_prune_selection(plan_file, expected_database=database)
+
+
+def test_selection_file_conflicts_with_each_normal_prune_filter(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    database = tmp_path / "state.db"
+    db = SessionDB(db_path=database)
+    db.create_session("selected", source="cron")
+    db.end_session("selected", end_reason="done")
+    db.set_session_archived("selected", True)
+    db.close()
+    plan_file = tmp_path / "plan.json"
+    _write_plan(plan_file, database, ["selected"])
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: SessionDB(db_path=database))
+    for filter_flag in (
+        ("--include-archived",),
+        ("--include-pinned",),
+        ("--never-active",),
+    ):
+        code, output = _run_cli(
+            monkeypatch,
+            capsys,
+            ["--selection-file", str(plan_file), *filter_flag, "--yes"],
+        )
+        assert code == 1, output
+        assert "cannot be combined" in output
+        check = SessionDB(db_path=database)
+        try:
+            assert check.get_session("selected") is not None
+        finally:
+            check.close()
+
+
+def test_selection_file_accepts_yes_interactive_confirmation(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    database = tmp_path / "state.db"
+    db = SessionDB(db_path=database)
+    db.create_session("selected", source="cron")
+    db.end_session("selected", end_reason="done")
+    db.set_session_archived("selected", True)
+    db.close()
+    plan_file = tmp_path / "plan.json"
+    _write_plan(plan_file, database, ["selected"])
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: SessionDB(db_path=database))
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "y")
+    code, output = _run_cli(monkeypatch, capsys, ["--selection-file", str(plan_file)])
+
+    check = SessionDB(db_path=database)
+    try:
+        assert code == 0, output
+        assert check.get_session("selected") is None
+    finally:
+        check.close()
+
+
+def test_selection_file_deletes_each_of_multiple_frozen_ids(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    database = tmp_path / "state.db"
+    db = SessionDB(db_path=database)
+    for session_id in ("one", "two"):
+        db.create_session(session_id, source="cron")
+        db.end_session(session_id, end_reason="done")
+        db.set_session_archived(session_id, True)
+    db.create_session("keeper", source="cron")
+    db.end_session("keeper", end_reason="done")
+    db.close()
+    plan_file = tmp_path / "plan.json"
+    _write_plan(plan_file, database, ["one", "two"])
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: SessionDB(db_path=database))
+    code, output = _run_cli(
+        monkeypatch,
+        capsys,
+        ["--selection-file", str(plan_file), "--yes"],
+    )
+
+    check = SessionDB(db_path=database)
+    try:
+        assert code == 0, output
+        assert check.get_session("one") is None
+        assert check.get_session("two") is None
+        assert check.get_session("keeper") is not None
+    finally:
+        check.close()
+
+
+def test_exact_selection_plan_dry_run_lists_ids_without_deleting(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    database = tmp_path / "state.db"
+    db = SessionDB(db_path=database)
+    db.create_session("selected", source="cron")
+    db.end_session("selected", end_reason="done")
+    db.set_session_archived("selected", True)
+    db.create_session("keeper", source="cron")
+    db.end_session("keeper", end_reason="done")
+    db.close()
+    plan_file = tmp_path / "plan.json"
+    _write_plan(plan_file, database, ["selected"])
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: SessionDB(db_path=database))
+
+    code, output = _run_cli(
+        monkeypatch,
+        capsys,
+        ["--selection-file", str(plan_file), "--dry-run"],
+    )
+
+    check = SessionDB(db_path=database)
+    try:
+        assert code == 0, output
+        assert "selected" in output
+        assert "Dry run" in output
+        assert check.get_session("selected") is not None
+        assert check.get_session("keeper") is not None
+    finally:
+        check.close()
+
+
+def test_exact_selection_plan_yes_deletes_only_frozen_ids(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    database = tmp_path / "state.db"
+    db = SessionDB(db_path=database)
+    db.create_session("selected", source="cron")
+    db.end_session("selected", end_reason="done")
+    db.set_session_archived("selected", True)
+    db.create_session("keeper", source="cron")
+    db.end_session("keeper", end_reason="done")
+    db.close()
+    plan_file = tmp_path / "plan.json"
+    _write_plan(plan_file, database, ["selected"])
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: SessionDB(db_path=database))
+
+    code, output = _run_cli(
+        monkeypatch,
+        capsys,
+        ["--selection-file", str(plan_file), "--yes"],
+    )
+
+    check = SessionDB(db_path=database)
+    try:
+        assert code == 0, output
+        assert "Pruned 1 session" in output
+        assert check.get_session("selected") is None
+        assert check.get_session("keeper") is not None
+    finally:
+        check.close()
+
+
+def test_exact_selection_plan_requires_nonempty_provenance(tmp_path: Path) -> None:
+    database = tmp_path / "state.db"
+    SessionDB(db_path=database).close()
+    plan_file = tmp_path / "plan.json"
+    plan = _write_plan(plan_file, database, ["selected"])
+    plan["provenance"]["native_revision"] = ""
+    _stamp_plan_identity(plan)
+    plan_file.write_text(json.dumps(plan), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="provenance"):
+        load_exact_prune_selection(plan_file, expected_database=database)
+
+
+def test_exact_selection_plan_rejects_tampered_authority(tmp_path: Path) -> None:
+    database = tmp_path / "state.db"
+    SessionDB(db_path=database).close()
+    plan_file = tmp_path / "plan.json"
+    plan = _write_plan(plan_file, database, ["selected"])
+    plan["selection"]["physical_session_ids"].append("not-reviewed")
+    plan_file.write_text(json.dumps(plan), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="identity"):
+        load_exact_prune_selection(plan_file, expected_database=database)
+
+
+def test_exact_selection_plan_rejects_candidate_selection_mismatch(tmp_path: Path) -> None:
+    database = tmp_path / "state.db"
+    SessionDB(db_path=database).close()
+    plan_file = tmp_path / "plan.json"
+    plan = _write_plan(plan_file, database, ["selected"])
+    plan["selection"]["physical_session_ids"].append("not-in-candidates")
+    _stamp_plan_identity(plan)
+    plan_file.write_text(json.dumps(plan), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="do not match"):
+        load_exact_prune_selection(plan_file, expected_database=database)
+
+
+def test_exact_selection_plan_rejects_malformed_candidate_entry(tmp_path: Path) -> None:
+    database = tmp_path / "state.db"
+    SessionDB(db_path=database).close()
+    plan_file = tmp_path / "plan.json"
+    plan = _write_plan(plan_file, database, ["selected"])
+    plan["candidates"] = [{}]
+    _stamp_plan_identity(plan)
+    plan_file.write_text(json.dumps(plan), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="candidate physical_session_ids"):
+        load_exact_prune_selection(plan_file, expected_database=database)
+
+
+def test_exact_selection_plan_rejects_a_different_database(tmp_path: Path) -> None:
+    database = tmp_path / "state.db"
+    other_database = tmp_path / "other.db"
+    SessionDB(db_path=database).close()
+    SessionDB(db_path=other_database).close()
+    plan_file = tmp_path / "plan.json"
+    _write_plan(plan_file, other_database, ["selected"])
+
+    with pytest.raises(ValueError, match="different session database"):
+        load_exact_prune_selection(plan_file, expected_database=database)
+
+
+def test_exact_selection_plan_rejects_source_drift_during_read(tmp_path: Path) -> None:
+    database = tmp_path / "state.db"
+    SessionDB(db_path=database).close()
+    plan_file = tmp_path / "plan.json"
+    plan = _write_plan(plan_file, database, ["selected"])
+    plan["source"]["changed_during_read"] = True
+    _stamp_plan_identity(plan)
+    plan_file.write_text(json.dumps(plan), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="source drift"):
+        load_exact_prune_selection(plan_file, expected_database=database)
+
+
+def test_selection_file_conflicting_with_prune_filters_is_refused(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    database = tmp_path / "state.db"
+    db = SessionDB(db_path=database)
+    db.create_session("selected", source="cron")
+    db.end_session("selected", end_reason="done")
+    db.set_session_archived("selected", True)
+    db.close()
+    plan_file = tmp_path / "plan.json"
+    _write_plan(plan_file, database, ["selected"])
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: SessionDB(db_path=database))
+
+    code, output = _run_cli(
+        monkeypatch,
+        capsys,
+        ["--selection-file", str(plan_file), "--include-pinned", "--yes"],
+    )
+
+    check = SessionDB(db_path=database)
+    try:
+        assert code == 1, output
+        assert "cannot be combined" in output
+        assert check.get_session("selected") is not None
+    finally:
+        check.close()
+
+
+def test_selection_file_declined_confirmation_deletes_nothing(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    database = tmp_path / "state.db"
+    db = SessionDB(db_path=database)
+    db.create_session("selected", source="cron")
+    db.end_session("selected", end_reason="done")
+    db.set_session_archived("selected", True)
+    db.close()
+    plan_file = tmp_path / "plan.json"
+    _write_plan(plan_file, database, ["selected"])
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: SessionDB(db_path=database))
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "n")
+
+    code, output = _run_cli(
+        monkeypatch,
+        capsys,
+        ["--selection-file", str(plan_file)],
+    )
+
+    check = SessionDB(db_path=database)
+    try:
+        assert "Cancelled" in output
+        assert check.get_session("selected") is not None
+    finally:
+        check.close()
+
+
+def test_selection_file_revalidates_archived_eligibility_at_prune_time(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    database = tmp_path / "state.db"
+    db = SessionDB(db_path=database)
+    db.create_session("selected", source="cron")
+    db.end_session("selected", end_reason="done")
+    db.set_session_archived("selected", True)
+    db.close()
+    plan_file = tmp_path / "plan.json"
+    _write_plan(plan_file, database, ["selected"])
+
+    # The helper-reviewed selection remains syntactically valid, but native
+    # Prune must check the mutable destructive preconditions in its transaction.
+    db = SessionDB(db_path=database)
+    try:
+        db.set_session_archived("selected", False)
+    finally:
+        db.close()
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: SessionDB(db_path=database))
+    code, output = _run_cli(
+        monkeypatch,
+        capsys,
+        ["--selection-file", str(plan_file), "--yes"],
+    )
+
+    check = SessionDB(db_path=database)
+    try:
+        assert code == 1, output
+        assert "not archived" in output
+        assert check.get_session("selected") is not None
+    finally:
+        check.close()

--- a/tests/test_prune_exact_selection.py
+++ b/tests/test_prune_exact_selection.py
@@ -1,0 +1,383 @@
+"""Tests for ``SessionDB.prune_exact_selection`` — the frozen-manifest Prune
+primitive backing a future ``hermes sessions prune --selection-file``.
+
+Unlike ``prune_sessions`` (filter-driven, may select a different set than a
+caller previously reviewed), this takes an explicit, caller-supplied list of
+physical session IDs and deletes exactly that set or none of it. It exists so
+an external Store/Verify pipeline (e.g. a private cold-archive helper) can
+review precisely which rows a Prune will touch, then hand back the same exact
+ID list for deletion — with no filter re-evaluation gap between review and
+delete.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+import hermes_state_maintenance
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    database = SessionDB(db_path=tmp_path / "state.db")
+    yield database
+    database.close()
+
+
+def _mk_ended(
+    db,
+    sid,
+    *,
+    source="cli",
+    pinned=False,
+    archived=True,
+    parent_session_id=None,
+):
+    db.create_session(
+        session_id=sid, source=source, parent_session_id=parent_session_id
+    )
+    db.end_session(sid, end_reason="done")
+    if archived:
+        db.set_session_archived(sid, True)
+    if pinned:
+        db.set_session_pinned(sid, True)
+
+
+class TestPruneExactSelectionHappyPath:
+    def test_deletes_exactly_the_listed_ended_sessions(self, db):
+        _mk_ended(db, "a")
+        _mk_ended(db, "b")
+        _mk_ended(db, "c")
+
+        result = db.prune_exact_selection(["a", "b"])
+
+        assert result["count"] == 2
+        assert set(result["deleted"]) == {"a", "b"}
+        assert db.get_session("a") is None
+        assert db.get_session("b") is None
+        assert db.get_session("c") is not None
+
+    def test_chunks_every_sql_id_probe_under_a_tight_parameter_budget(self, db, monkeypatch):
+        """Exact Prune must retain its all-or-nothing contract when a frozen
+        plan is larger than the SQLite parameter budget."""
+        ids = ["a", "b", "c"]
+        for session_id in ids:
+            _mk_ended(db, session_id)
+
+        original_placeholders = hermes_state_maintenance._placeholders
+
+        def bounded_placeholders(items):
+            count = items if isinstance(items, int) else len(items)
+            if count > 1:
+                raise AssertionError("exact Prune built an oversized SQL IN list")
+            return original_placeholders(items)
+
+        monkeypatch.setattr(
+            hermes_state_maintenance,
+            "_id_chunks",
+            lambda values, size=900: ([value] for value in values),
+        )
+        monkeypatch.setattr(
+            hermes_state_maintenance,
+            "_placeholders",
+            bounded_placeholders,
+        )
+
+        result = db.prune_exact_selection(ids)
+
+        assert result == {"count": 3, "deleted": ids}
+        assert all(db.get_session(session_id) is None for session_id in ids)
+
+    def test_removes_messages_and_usage_rows_for_deleted_sessions(self, db):
+        _mk_ended(db, "a")
+        db.append_message("a", role="user", content="hi")
+
+        db.prune_exact_selection(["a"])
+
+        assert (
+            db._conn.execute(
+                "SELECT COUNT(*) FROM messages WHERE session_id = ?", ("a",)
+            ).fetchone()[0]
+            == 0
+        )
+
+
+class TestPruneExactSelectionFailsClosed:
+    def test_missing_id_deletes_nothing(self, db):
+        _mk_ended(db, "a")
+
+        with pytest.raises(ValueError, match="does not exist"):
+            db.prune_exact_selection(["a", "does-not-exist"])
+
+        # Atomic: the existing, valid id must NOT have been deleted either.
+        assert db.get_session("a") is not None
+
+    def test_open_session_in_selection_is_refused(self, db):
+        db.create_session(session_id="open", source="cli")
+        _mk_ended(db, "a")
+
+        with pytest.raises(ValueError, match="not ended"):
+            db.prune_exact_selection(["a", "open"])
+
+        assert db.get_session("a") is not None
+        assert db.get_session("open") is not None
+
+    def test_pinned_session_is_refused_by_default(self, db):
+        _mk_ended(db, "a", pinned=True)
+
+        with pytest.raises(ValueError, match="pinned"):
+            db.prune_exact_selection(["a"])
+
+        assert db.get_session("a") is not None
+
+    def test_pinned_session_can_be_included_explicitly(self, db):
+        _mk_ended(db, "a", pinned=True)
+
+        result = db.prune_exact_selection(["a"], include_pinned=True)
+
+        assert result["count"] == 1
+        assert db.get_session("a") is None
+
+    def test_unarchived_session_is_refused(self, db):
+        _mk_ended(db, "a", archived=False)
+
+        with pytest.raises(ValueError, match="not archived"):
+            db.prune_exact_selection(["a"])
+
+        assert db.get_session("a") is not None
+
+    def test_empty_selection_is_rejected(self, db):
+        with pytest.raises(ValueError, match="empty"):
+            db.prune_exact_selection([])
+
+    def test_duplicate_id_is_rejected_instead_of_normalized(self, db):
+        _mk_ended(db, "a")
+
+        with pytest.raises(ValueError, match="duplicate"):
+            db.prune_exact_selection(["a", "a"])
+
+        assert db.get_session("a") is not None
+
+    def test_removes_transcript_files_only_for_pruned_ids(self, db, tmp_path):
+        _mk_ended(db, "a")
+        _mk_ended(db, "b")
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        pruned_transcript = sessions_dir / "a.jsonl"
+        pruned_transcript.write_text("{}")
+        kept_transcript = sessions_dir / "b.jsonl"
+        kept_transcript.write_text("{}")
+
+        db.prune_exact_selection(["a"], sessions_dir=sessions_dir)
+
+        assert not pruned_transcript.exists()
+        assert kept_transcript.exists()
+
+
+class TestPruneExactSelectionReferenceSafety:
+    def test_uncovered_child_session_blocks_the_whole_operation(self, db):
+        """A child outside the selection still points at a row we would delete —
+        deleting the parent would silently orphan a session the caller never
+        reviewed. Refuse the whole batch rather than orphan it implicitly."""
+        _mk_ended(db, "parent")
+        _mk_ended(db, "child", parent_session_id="parent")
+        _mk_ended(db, "other")
+
+        with pytest.raises(ValueError, match="uncovered"):
+            db.prune_exact_selection(["parent", "other"])
+
+        assert db.get_session("parent") is not None
+        assert db.get_session("other") is not None
+
+    def test_child_included_in_the_same_selection_is_allowed(self, db):
+        """Covering both parent and child in one selection is fine — nothing is
+        orphaned because both rows go together."""
+        _mk_ended(db, "parent")
+        _mk_ended(db, "child", parent_session_id="parent")
+
+        result = db.prune_exact_selection(["parent", "child"])
+
+        assert result["count"] == 2
+        assert db.get_session("parent") is None
+        assert db.get_session("child") is None
+
+    def test_active_compression_lock_blocks_deletion(self, db):
+        """A live compression lock is a durable in-flight reference to the
+        session; deleting the row out from under it would corrupt the
+        compression pipeline."""
+        _mk_ended(db, "locked")
+        db._conn.execute(
+            "INSERT INTO compression_locks (session_id, holder, acquired_at, expires_at) "
+            "VALUES (?, 'worker-1', ?, ?)",
+            ("locked", time.time(), time.time() + 60),
+        )
+        db._conn.commit()
+
+        with pytest.raises(ValueError, match="compression_locks"):
+            db.prune_exact_selection(["locked"])
+
+        assert db.get_session("locked") is not None
+
+    @pytest.mark.parametrize("namespace", ["goal", "loop", "heartbeat"])
+    def test_session_state_meta_reference_blocks_deletion(self, db, namespace):
+        _mk_ended(db, "stateful")
+        db.set_meta(f"{namespace}:stateful", "persisted state")
+
+        with pytest.raises(ValueError, match="state_meta"):
+            db.prune_exact_selection(["stateful"])
+
+        assert db.get_session("stateful") is not None
+
+    def test_active_turn_lease_blocks_deletion(self, db):
+        """A live turn lease means a conversation is mid-turn on this exact
+        session id; deleting it would race the in-flight write."""
+        _mk_ended(db, "leased")
+        db._conn.execute(
+            "INSERT INTO session_turn_leases (conversation_id, holder, acquired_at, expires_at) "
+            "VALUES (?, 'worker-1', ?, ?)",
+            ("leased", time.time(), time.time() + 60),
+        )
+        db._conn.commit()
+
+        with pytest.raises(ValueError, match="session_turn_leases"):
+            db.prune_exact_selection(["leased"])
+
+        assert db.get_session("leased") is not None
+
+    def test_async_delegation_origin_reference_blocks_deletion(self, db):
+        """A delegation row naming this session as its origin is a durable
+        cross-session reference the caller did not review."""
+        _mk_ended(db, "origin")
+        db._conn.execute(
+            "INSERT INTO async_delegations "
+            "(delegation_id, origin_session, state, dispatched_at, updated_at) "
+            "VALUES ('deleg-1', ?, 'pending', ?, ?)",
+            ("origin", time.time(), time.time()),
+        )
+        db._conn.commit()
+
+        with pytest.raises(ValueError, match="async_delegations"):
+            db.prune_exact_selection(["origin"])
+
+        assert db.get_session("origin") is not None
+
+    def test_async_delegation_parent_reference_blocks_deletion(self, db):
+        _mk_ended(db, "target")
+        db._conn.execute(
+            "INSERT INTO async_delegations "
+            "(delegation_id, origin_session, parent_session_id, state, dispatched_at, updated_at) "
+            "VALUES ('deleg-2', 'unrelated-origin', ?, 'pending', ?, ?)",
+            ("target", time.time(), time.time()),
+        )
+        db._conn.commit()
+
+        with pytest.raises(ValueError, match="async_delegations"):
+            db.prune_exact_selection(["target"])
+
+        assert db.get_session("target") is not None
+
+    def test_gateway_routing_reference_blocks_deletion(self, db):
+        """A persisted gateway route can resume its embedded session id after
+        restart, so exact Prune must refuse rather than leave a dangling route."""
+        _mk_ended(db, "routed")
+        db.save_gateway_routing_entry(
+            "agent:main:telegram:dm:chat-1",
+            json.dumps({"session_id": "routed"}),
+            scope="/tmp/sessions",
+        )
+
+        with pytest.raises(ValueError, match="gateway_routing"):
+            db.prune_exact_selection(["routed"])
+
+        assert db.get_session("routed") is not None
+
+    def test_unrelated_gateway_routing_entry_is_preserved(self, db):
+        _mk_ended(db, "selected")
+        db.save_gateway_routing_entry(
+            "agent:main:telegram:dm:chat-2",
+            json.dumps({"session_id": "unrelated"}),
+            scope="/tmp/sessions",
+        )
+
+        result = db.prune_exact_selection(["selected"])
+
+        assert result["count"] == 1
+        assert db.load_gateway_routing_entries(scope="/tmp/sessions") == {
+            "agent:main:telegram:dm:chat-2": json.dumps({"session_id": "unrelated"})
+        }
+
+    def test_gateway_routing_check_never_parses_json_in_python(self, db):
+        """The reference-safety scan must push matching into SQLite (json1)
+        rather than fetch every entry_json blob and json.loads() it in
+        Python -- that would be O(total routes) CPU/memory under an
+        exclusive write lock. The production module deliberately carries no
+        top-level ``json`` import for this mixin; a reviewer reintroducing
+        Python-side JSON parsing here should fail this test."""
+        assert not hasattr(hermes_state_maintenance, "json"), (
+            "hermes_state_maintenance must not import json: the "
+            "gateway_routing reference-safety scan is SQL-side (json1) only"
+        )
+
+        _mk_ended(db, "selected")
+        for n in range(50):
+            db.save_gateway_routing_entry(
+                f"agent:main:telegram:dm:chat-{n}",
+                json.dumps({"session_id": f"unrelated-{n}"}),
+                scope="/tmp/sessions",
+            )
+
+        result = db.prune_exact_selection(["selected"])
+
+        assert result["count"] == 1
+
+    def test_gateway_routing_check_still_blocks_amid_many_unrelated_rows(self, db):
+        """A malformed row must still fail closed even when surrounded by many
+        well-formed unrelated rows that the SQL-side scoped query would
+        otherwise skip entirely."""
+        _mk_ended(db, "selected")
+        for n in range(50):
+            db.save_gateway_routing_entry(
+                f"agent:main:telegram:dm:chat-{n}",
+                json.dumps({"session_id": f"unrelated-{n}"}),
+                scope="/tmp/sessions",
+            )
+        db.save_gateway_routing_entry(
+            "agent:main:telegram:dm:damaged",
+            "not-json",
+            scope="/tmp/sessions",
+        )
+
+        with pytest.raises(ValueError, match="cannot verify gateway_routing"):
+            db.prune_exact_selection(["selected"])
+
+        assert db.get_session("selected") is not None
+
+    def test_unverifiable_non_object_gateway_routing_entry_blocks_deletion(self, db):
+        _mk_ended(db, "selected")
+        db.save_gateway_routing_entry(
+            "agent:main:telegram:dm:wrong-shape",
+            json.dumps(["not", "a", "routing", "object"]),
+            scope="/tmp/sessions",
+        )
+
+        with pytest.raises(ValueError, match="cannot verify gateway_routing"):
+            db.prune_exact_selection(["selected"])
+
+        assert db.get_session("selected") is not None
+
+    def test_unverifiable_gateway_routing_entry_blocks_deletion(self, db):
+        _mk_ended(db, "selected")
+        db.save_gateway_routing_entry(
+            "agent:main:telegram:dm:damaged",
+            "not-json",
+            scope="/tmp/sessions",
+        )
+
+        with pytest.raises(ValueError, match="cannot verify gateway_routing"):
+            db.prune_exact_selection(["selected"])
+
+        assert db.get_session("selected") is not None


### PR DESCRIPTION
## What does this PR do?

Adds a narrow, native Hermes exact-selection Prune path for a separately verified session-archive workflow.

Bug / safety boundary: filter-based pruning re-evaluates mutable criteria at deletion time, so it cannot prove that the physical sessions deleted are the same ones an external Store/Verify workflow reviewed. `hermes sessions prune --selection-file <hermes-session-plan/v2>` instead consumes a frozen, authenticated manifest and deletes exactly its declared physical IDs, or deletes nothing.

The native consumer validates manifest format, source-database identity, `changed_during_read`, non-empty provenance, plan authority digest, and exact candidate-to-selection agreement. Inside one native write transaction it revalidates ended/archived/pin eligibility and refuses deletion when durable references exist (parent/child coverage, compression locks, turn leases, async delegations, `gateway_routing`, or session-scoped `state_meta`).

The exact-ID queries and deletions are chunked without weakening the atomic transaction. The `gateway_routing` reference check uses SQLite JSON1 predicates rather than loading and Python-parsing every routing entry while the transaction owns its write lock. The external Store/Verify planner remains outside this repository; this PR owns only the fail-closed native consumer and deletion transaction.

History is intentionally one thematic commit: the final source tree is unchanged, while the PR no longer exposes the incremental construction diary as its landed rebase-merge history.

## Related Issue

N/A — no matching open or closed GitHub issue/PR was found for `"selection-file" prune session` during this maintenance pass.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/session_prune_selection.py`
  - validates the frozen `hermes-session-plan/v2` manifest contract and authority digest.
- `hermes_cli/subcommands/sessions.py` and `hermes_cli/sessions_cmd.py`
  - expose `hermes sessions prune --selection-file` with dry-run and interactive confirmation.
- `hermes_state_maintenance.py`
  - adds atomic, exact-ID native deletion; revalidates safety preconditions and chunks SQLite ID operations.
  - checks routing references with SQLite JSON1 so the safety check does not materialize and `json.loads()` every route in Python under the write lock.
- `tests/test_prune_exact_selection.py` and `tests/hermes_cli/test_sessions_exact_prune.py`
  - cover exact-only deletion, invalid/tampered plans, selection/filter conflicts, reference safety, parameter-budget chunking, routing JSON failure modes, and CLI confirmation.

## How to Test

Current exact source: `1021a0325696e9070e6659f95fcd84c3e7e114df..232a2bfc5b4cebf821030ac26676d0c51ea46cab`.

1. Run the canonical focused suites:
   ```bash
   scripts/run_tests.sh tests/test_prune_exact_selection.py tests/hermes_cli/test_sessions_exact_prune.py -q
   ```
   Result: 41 passed.
2. Run static checks:
   ```bash
   uv run ruff check hermes_state_maintenance.py tests/test_prune_exact_selection.py
   uv run ty check tests/test_prune_exact_selection.py tests/hermes_cli/test_sessions_exact_prune.py hermes_cli/session_prune_selection.py
   uv run python -m compileall -q hermes_state_maintenance.py tests/test_prune_exact_selection.py tests/hermes_cli/test_sessions_exact_prune.py
   git diff --check 1021a0325696e9070e6659f95fcd84c3e7e114df...232a2bfc5b4cebf821030ac26676d0c51ea46cab
   ```
   Result: passed. `hermes_state_maintenance.py` has pre-existing mixin typing diagnostics and is not claimed Ty-clean.
3. Run the disposable end-to-end smoke:
   ```bash
   CANDIDATE_REPO="$PWD" CANDIDATE_HEAD="$(git rev-parse HEAD)" E2E_SCRATCH="$(mktemp -d)" \
     uv run --directory "$PWD" python /tmp/rebased_exact_prune_e2e.py
   ```
   Result: `E2E_OK`; the selected DB row and transcript were deleted while the unselected row and transcript remained.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux / aarch64 (disposable E2E above)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (N/A; user-facing CLI help and code docstrings cover the contract)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (N/A)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (N/A)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (uses existing SQLite/Python paths; no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (N/A; this is a CLI subcommand, not a tool schema)

## Review Evidence

- Gemini 3.8 Flash High via Agy 1.2.1 maintained immutable-bundle adapter: `READY`, 0 blockers, exact range above.
- Claude Opus 4.6 Thinking via the same isolated immutable-bundle route: `READY`, 0 blockers, exact range above.

## Screenshots / Logs

No screenshots. The focused canonical test output and disposable E2E result are included above.
