### PR TITLE
fix(bedrock): don't replay a toolUse that was dropped from tool_calls

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -15,7 +15,7 @@ import time
 import traceback
 from contextlib import suppress
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 from urllib.parse import urlparse
 
 import httpx
@@ -546,9 +546,12 @@ def _decode_redacted(encoded) -> Optional[bytes]:
         return None
 
 
-def _replay_ordered_blocks(ordered_blocks: List) -> List[Dict]:
+def _replay_ordered_blocks(ordered_blocks: List, tool_call_ids: Set[str]) -> List[Dict]:
     """Rebuild the exact Bedrock block sequence captured at normalization time; redacted reasoning is
-    stored base64 (JSON-safe sidecar) and undecodable entries are skipped."""
+    stored base64 (JSON-safe sidecar) and undecodable entries are skipped. A toolUse whose id is no
+    longer in ``tool_calls`` is skipped too: post-call guardrails (identical-call dedup, delegate cap)
+    drop calls after capture, and replaying one sends a toolUse with no toolResult (ValidationException
+    "Expected toolResult blocks")."""
     content_blocks: List[Dict] = []
     for block in ordered_blocks:
         if not isinstance(block, dict):
@@ -570,6 +573,8 @@ def _replay_ordered_blocks(ordered_blocks: List) -> List[Dict]:
                 content_blocks.append({"reasoningContent": replay})
         elif "toolUse" in block and isinstance(block["toolUse"], dict):
             tu = block["toolUse"]
+            if tu.get("toolUseId", "") not in tool_call_ids:
+                continue
             content_blocks.append(_tool_use_block(tu.get("toolUseId", ""), tu.get("name", ""), tu.get("input", {})))
     return content_blocks
 
@@ -583,10 +588,12 @@ def _parse_tool_args(args) -> Any:
 
 
 def _assistant_blocks(msg: Dict, content) -> List[Dict]:
-    """Assistant message → Converse blocks. An ordered ``bedrock_content_blocks`` sidecar is authoritative;
-    otherwise redacted thinking from ``reasoning_details`` (byte-for-byte), then text, then tool calls."""
+    """Assistant message → Converse blocks. An ordered ``bedrock_content_blocks`` sidecar is authoritative
+    for block order (``tool_calls`` still decides which toolUse blocks exist); otherwise redacted thinking
+    from ``reasoning_details`` (byte-for-byte), then text, then tool calls."""
     ordered_blocks = msg.get("bedrock_content_blocks")
-    if isinstance(ordered_blocks, list) and (content_blocks := _replay_ordered_blocks(ordered_blocks)):
+    tool_call_ids = {tc.get("id", "") for tc in (msg.get("tool_calls") or []) if isinstance(tc, dict)}
+    if isinstance(ordered_blocks, list) and (content_blocks := _replay_ordered_blocks(ordered_blocks, tool_call_ids)):
         return content_blocks
     redacted = [
         _decode_redacted(d.get("data") or d.get("redactedContentBase64"))

--- a/tests/agent/test_bedrock_transport_replay.py
+++ b/tests/agent/test_bedrock_transport_replay.py
@@ -111,3 +111,45 @@ def test_bedrock_transport_preserves_reasoning_and_order(streaming):
         "reasoningContent", "toolUse", "reasoningContent", "toolUse"
     ]
     assert [block["reasoningContent"]["redactedContent"] for block in blocks if "reasoningContent" in block] == [b"r1", b"r2"]
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+def test_tool_call_dropped_after_capture_is_not_replayed(streaming):
+    """The model emits the same call twice; the post-call dedup drops the second from
+    ``tool_calls``, but the ordered-block sidecar still holds its toolUse. Replaying it sends a
+    toolUse with no toolResult -> ValidationException "Expected toolResult blocks"."""
+    from agent.bedrock_adapter import normalize_converse_response, normalize_converse_stream_events, convert_messages_to_converse
+    from agent.transports.bedrock import BedrockTransport
+
+    sys.modules.setdefault("requests", ModuleType("requests"))
+    from agent.chat_completion_helpers import build_assistant_message
+    from run_agent import AIAgent
+
+    raw = _stream_response() if streaming else _raw_response()
+    # Make the second call identical to the first, as the model did.
+    if streaming:
+        for event in raw["stream"]:
+            start = event.get("contentBlockStart", {}).get("start", {}).get("toolUse")
+            if start and start["toolUseId"] == "t2":
+                start["name"] = "one"
+            delta = event.get("contentBlockDelta", {})
+            if delta.get("contentBlockIndex") == 3:
+                delta["delta"]["toolUse"]["input"] = '{"n":1}'
+    else:
+        raw["output"]["message"]["content"][3]["toolUse"].update(name="one", input={"n": 1})
+    adapter_response = normalize_converse_stream_events(raw) if streaming else normalize_converse_response(raw)
+    normalized = BedrockTransport().normalize_response(adapter_response)
+
+    normalized.tool_calls = AIAgent._deduplicate_tool_calls(normalized.tool_calls)
+    history = build_assistant_message(_FakeAgent(), normalized, "tool_calls")
+    assert [tc["id"] for tc in history["tool_calls"]] == ["t1"]
+    results = [{"role": "tool", "tool_call_id": "t1", "content": "ok"}]
+    _system, messages = convert_messages_to_converse(
+        AIAgent._sanitize_api_messages([{"role": "user", "content": "go"}, history, *results])
+    )
+
+    blocks = messages[1]["content"]
+    assert [next(iter(block)) for block in blocks] == ["reasoningContent", "toolUse", "reasoningContent"]
+    tool_uses = [b["toolUse"]["toolUseId"] for m in messages for b in m["content"] if "toolUse" in b]
+    tool_results = [b["toolResult"]["toolUseId"] for m in messages for b in m["content"] if "toolResult" in b]
+    assert tool_uses == tool_results == ["t1"]


### PR DESCRIPTION
## What does this PR do?

On Bedrock, a tool call dropped by the post-call dedup (or the delegate cap) was still replayed from `bedrock_content_blocks`, so the next request carried a `toolUse` with no `toolResult` and failed with `ValidationException: Expected toolResult blocks`. The sidecar replay now skips a `toolUse` whose id is no longer in `tool_calls`. Block order and reasoning are untouched.

Before: `tool_calls` = `[A]`, wire `toolUse` = `[A, B]`, `toolResult` = `[A]` → 400, turn lost.
After: wire `toolUse` = `[A]`, `toolResult` = `[A]`.

The second commit covers the inverse, reported in the thread by @bartekczerwinski on Nova Pro: the sidecar lacks a `toolUse` that `tool_calls` still holds, its `toolResult` goes out anyway, and Converse fails with `number of toolResult blocks exceeds the number of toolUse blocks`. Those calls are now appended after the replayed blocks, so `tool_calls` decides which `toolUse` blocks exist in both directions and the sidecar keeps deciding order.

The Anthropic converter already covers this case with `_strip_orphaned_tool_blocks`; the Converse path had nothing.

## Related Issue

Fixes #108584

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/bedrock_adapter.py`: `_replay_ordered_blocks` takes the row's `tool_call_ids` and skips a `toolUse` outside it; `_assistant_blocks` passes them in, then appends a `toolUse` for any `tool_calls` id the replay lost. Both paths now build tool blocks through one `_tool_call_blocks` helper.
- `tests/agent/test_bedrock_transport_replay.py`: regression test (sync + streaming) through normalize → dedup → `build_assistant_message` → `_sanitize_api_messages` → `convert_messages_to_converse`. Fails on `main`, passes here. A second test covers the inverse direction and fails without the second commit.

## How to Test

1. `scripts/run_tests.sh tests/agent/test_bedrock_transport_replay.py tests/agent/test_bedrock_adapter.py` (83 passed)
2. Revert `agent/bedrock_adapter.py` and both new tests fail: one with an extra `toolUse`, one with a missing one.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `tests/agent` + `tests/run_agent`: no new failures (one pre-existing `httpx`/`httpx2` failure in `test_fallback_dynamic_credential.py` fails the same way on `main`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26 (tests), Ubuntu 24.04 (hit the bug in production)

### Documentation & Housekeeping

- [x] Docs / config example / CONTRIBUTING / tool schemas: N/A
- [x] Cross-platform impact: N/A (pure message conversion)

