### PR TITLE
fix(discord): keep clarify buttons ephemeral so clicks resolve

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -6437,16 +6437,19 @@ def _define_discord_view_classes() -> None:
             super().__init__(allowed_user_ids, allowed_role_ids, timeout=_read_discord_prompt_timeout())
             self.choices = list(choices)[:24]
             self.clarify_id = clarify_id
+            # Do not set custom_id. discord.py treats any custom_id as a persistent
+            # component and routes the click through ViewStore; without add_view()
+            # that path replies "Unknown button" (localized) and never reaches
+            # these callbacks. Timeout-bound views must stay ephemeral so the
+            # in-memory View that sent the message owns the interaction.
             for index, choice in enumerate(self.choices):
                 button = discord.ui.Button(
                     label=self._button_label(index, choice), style=discord.ButtonStyle.primary,
-                    custom_id=f"clarify:{clarify_id}:{index}",
                 )
                 button.callback = self._make_choice_callback(index, choice)
                 self.add_item(button)
             other_btn = discord.ui.Button(
                 label="✏️ Other (type answer)", style=discord.ButtonStyle.secondary,
-                custom_id=f"clarify:{clarify_id}:other",
             )
             other_btn.callback = self._on_other
             self.add_item(other_btn)

--- a/tests/gateway/test_discord_clarify_buttons.py
+++ b/tests/gateway/test_discord_clarify_buttons.py
@@ -126,6 +126,18 @@ class TestClarifyChoiceViewConstruction:
             f"Label cuts mid-word at {last_char!r}: {first_label!r}"
         )
 
+    def test_choice_and_other_buttons_are_ephemeral(self):
+        """custom_id would make discord.py persist the view; unregistered
+        persistent clicks become the localized "Unknown button" error (#108443)."""
+        view = ClarifyChoiceView(
+            choices=["yes", "no"],
+            clarify_id="cid-ephemeral",
+            allowed_user_ids=set(),
+        )
+        assert len(view.children) == 3
+        for child in view.children:
+            assert getattr(child, "custom_id", None) in (None, "")
+
 
 # ===========================================================================
 # Choice callback → resolve_gateway_clarify


### PR DESCRIPTION
## Summary

Discord native **Hermes needs your input** clarify buttons set a `custom_id` on every choice. discord.py treats any `custom_id` as a *persistent* component and routes the click through `ViewStore`. `ClarifyChoiceView` never called `add_view()`, so the click never reached the in-memory callbacks and Discord replied with the localized **Unknown button** error (`Tanınmayan düğme.`).

Timeout-bound clarify views must omit `custom_id` so the View that sent the message owns the interaction — same pattern as the decorator-built approval/slash/update views.

Fixes #108443

## Root cause

`ClarifyChoiceView` constructed buttons with `custom_id=f"clarify:{id}:{index}"`. Persistent routing + no `bot.add_view()` ⇒ unknown-button.

## Change

- Drop `custom_id` on choice and Other buttons.
- Regression: all clarify buttons must have empty/`None` custom_id.

## Testing

```
python3 -m pytest tests/gateway/test_discord_clarify_buttons.py tests/gateway/test_discord_view_base_parity.py tests/gateway/test_discord_prompt_content_siblings.py -q
```

28 passed.

## How to test

Send a Discord clarify with choices, click a button: answer should resolve instead of Unknown button.