### PR TITLE
fix(tui): guard details-mode config persistence and unwedge gateway recovery (#108534)

### DIFF
--- a/tests/tui_gateway/test_config_set_display_toggles.py
+++ b/tests/tui_gateway/test_config_set_display_toggles.py
@@ -54,3 +54,19 @@ def test_every_key_the_renderer_mirrors_is_listed():
     gated = {"display.message_reactions", "display.in_app_tips", "display.in_app_tours"}
 
     assert gated <= server._DISPLAY_TOGGLE_KEYS
+
+
+def test_config_set_error_guarded_against_write_failures(monkeypatch):
+    """Write failures in details_mode, toggles, or word setters must return 5001 instead of crashing."""
+    def boom(*args, **kwargs):
+        raise OSError("Permission denied: read-only filesystem")
+
+    monkeypatch.setattr(server, "_save_cfg", boom)
+    ans = _set("details_mode", "expanded")
+    assert ans.get("error", {}).get("code") == 5001
+    assert "Permission denied" in ans["error"]["message"]
+
+    ans_sec = _set("details_mode.thinking", "expanded")
+    assert ans_sec.get("error", {}).get("code") == 5001
+    assert "Permission denied" in ans_sec["error"]["message"]
+

--- a/tui_gateway/methods_config_set.py
+++ b/tui_gateway/methods_config_set.py
@@ -158,6 +158,7 @@ _FAST_WORDS = {"fast": "fast", "on": "fast", "normal": "normal", "off": "normal"
                "auto": "auto", "cold": "cold"}
 
 
+@_cfgset_guarded
 def _set_fast(rid, params, key, value, session):
     raw = _word(value)
     agent = session.get("agent") if session else None
@@ -202,12 +203,14 @@ def _set_fast(rid, params, key, value, session):
     return _kv(rid, key, nv)
 
 
+@_cfgset_guarded
 def _set_busy(rid, params, key, value, session):
     if _word(value) in {"", "status"}:
         return _kv(rid, key, _load_busy_input_mode())
     return _set_word(rid, params, key, value, session)
 
 
+@_cfgset_guarded
 def _set_verbose(rid, params, key, value, session):
     cycle = ["off", "new", "all", "verbose"]
     if value and value != "cycle":
@@ -225,6 +228,7 @@ def _set_verbose(rid, params, key, value, session):
     return _kv(rid, key, nv)
 
 
+@_cfgset_guarded
 def _set_focus(rid, params, key, value, session):
     # /focus: enabling stashes the configured tool_progress mode and pins it "off"; disabling restores.
     from hermes_cli.focus_view import FOCUS_TOOL_PROGRESS_MODE, normalize_tool_progress_mode, resolve_focus_arg
@@ -252,6 +256,7 @@ def _set_focus(rid, params, key, value, session):
     return _kv(rid, key, "on" if target else "off", tool_progress=effective)
 
 
+@_cfgset_guarded
 def _set_approval_mode(rid, params, key, value, session):
     return _set_word(rid, params, "approvals.mode", value, session)  # legacy alias reports the real key
 
@@ -347,6 +352,7 @@ def _word_setters() -> dict:
                       lambda w: _write_config_key("display.tui_status_indicator", w))}
 
 
+@_cfgset_guarded
 def _set_word(rid, params, key, value, session):
     norm, allowed, err, apply = _word_setters()[key]
     raw = norm(value)
@@ -356,6 +362,7 @@ def _set_word(rid, params, key, value, session):
     return _kv(rid, key, raw)
 
 
+@_cfgset_guarded
 def _set_details_section(rid, params, key, value, session):
     # `details_mode.<section>` -> `display.sections.<section>`; empty clears the override (frontend
     # then applies built-in section defaults before the global details_mode).
@@ -390,6 +397,7 @@ def _toggle_setters() -> dict:
                   lambda: "all" if _display_mouse_tracking(_display_cfg()) == "off" else "off", lambda v: v)}
 
 
+@_cfgset_guarded
 def _set_toggle(rid, params, key, value, session):
     norm, cfg_key, aliases, flipped, report = _toggle_setters()[key]
     raw = norm(value)
@@ -400,6 +408,7 @@ def _set_toggle(rid, params, key, value, session):
     return _kv(rid, key, report(nv))
 
 
+@_cfgset_guarded
 def _set_cwd(rid, params, key, value, session):
     raw = str(value or "").strip()
     if not raw:
@@ -443,6 +452,7 @@ def _set_skin(rid, params, key, value, session):
     return _kv(rid, key, value)
 
 
+@_cfgset_guarded
 def _set_display_toggle(rid, params, key, value, session):
     on = _BOOL_WORDS.get(str(value).strip().lower())
     if on is None:

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -9,6 +9,7 @@ import asyncio
 import concurrent.futures
 import json
 import logging
+import os
 import socket
 import threading
 import time
@@ -403,3 +404,17 @@ async def handle_ws(ws: Any, *, auth_identity: dict | None = None, subprotocol: 
             "dispatch_crashes=%d send_failures=%d reaped_sessions=%d detached_sessions=%d",
             peer, disconnect_reason, messages, parse_errors, dispatch_crashes, send_failures, reaped_sessions, detached_sessions,
         )
+        if dispatch_crashes > 0 or send_failures > 0 or "failed" in disconnect_reason:
+            try:
+                crash_log = getattr(server, "_CRASH_LOG", None)
+                if crash_log:
+                    os.makedirs(os.path.dirname(crash_log), exist_ok=True)
+                    with open(crash_log, "a", encoding="utf-8") as f:
+                        f.write(
+                            f"\n=== ws abnormal disconnect · {time.strftime('%Y-%m-%d %H:%M:%S')} ===\n"
+                            f"peer={peer} reason={disconnect_reason} crashes={dispatch_crashes} "
+                            f"send_failures={send_failures} reaped={reaped_sessions} detached={detached_sessions}\n"
+                        )
+            except Exception:
+                pass
+

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -1136,6 +1136,35 @@ describe('createSlashHandler', () => {
       expect(ctx.transcript.sys).toHaveBeenCalledWith('title: demo title')
     })
   })
+
+  it('invokes recoverGateway on /recover', () => {
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/recover')).toBe(true)
+    expect(ctx.session.recoverGateway).toHaveBeenCalled()
+  })
+
+  it('notifies when recoverGateway is unavailable on /recover', () => {
+    const ctx = buildCtx()
+    delete (ctx.session as { recoverGateway?: unknown }).recoverGateway
+
+    expect(createSlashHandler(ctx)('/recover')).toBe(true)
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('session recovery is not supported in this context')
+  })
+
+  it('routes config.set error to guardedErr on /details failure', async () => {
+    const ctx = buildCtx({
+      gateway: {
+        ...buildGateway(),
+        rpc: vi.fn(() => Promise.reject(new Error('write failed: read-only filesystem')))
+      }
+    })
+
+    expect(createSlashHandler(ctx)('/details expanded')).toBe(true)
+    await vi.waitFor(() => {
+      expect(ctx.transcript.sys).toHaveBeenCalledWith(expect.stringContaining('write failed'))
+    })
+  })
 })
 
 const buildCtx = (overrides: Partial<Ctx> = {}): Ctx => ({
@@ -1183,6 +1212,7 @@ const buildSession = () => ({
   guardBusySessionSwitch: vi.fn(() => false),
   newLiveSession: vi.fn(),
   newSession: vi.fn(),
+  recoverGateway: vi.fn(),
   resetVisibleHistory: vi.fn(),
   resumeById: vi.fn(),
   setSessionStartedAt: vi.fn()

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -795,7 +795,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         patchUiState(state => ({
           ...state,
           info,
-          status: state.status === 'starting agent…' ? 'ready' : state.status,
+          status: state.status === 'starting agent…' || state.status === 'gateway exited' ? 'ready' : state.status,
           usage: info.usage ? mergeUsageStable(state.usage, info.usage) : state.usage
         }))
 

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -543,6 +543,7 @@ export interface SlashHandlerContext {
     guardBusySessionSwitch: (what?: string) => boolean
     newLiveSession: (msg?: string, title?: string) => void
     newSession: (msg?: string, title?: string) => void
+    recoverGateway?: () => void
     resetVisibleHistory: (info?: null | SessionInfo) => void
     resumeById: (id: string) => void
     setSessionStartedAt: StateSetter<number>

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -241,6 +241,18 @@ export const coreCommands: SlashCommand[] = [
   },
 
   {
+    help: 'recover a disconnected or exited gateway session',
+    name: 'recover',
+    run: (_arg, ctx) => {
+      if (!ctx.session.recoverGateway) {
+        return ctx.transcript.sys('session recovery is not supported in this context')
+      }
+
+      ctx.session.recoverGateway()
+    }
+  },
+
+  {
     help: 'set or show current session title',
     name: 'title',
     run: (arg, ctx) => {
@@ -343,7 +355,7 @@ export const coreCommands: SlashCommand[] = [
         patchUiState({ sections: mode ? { ...rest, [first]: mode } : rest })
         gateway
           .rpc<ConfigSetResponse>('config.set', { key: `details_mode.${first}`, value: mode ?? '' })
-          .catch(() => {})
+          .catch(ctx.guardedErr)
         transcript.sys(`details ${first}: ${mode ?? 'reset'}`)
 
         return
@@ -358,7 +370,9 @@ export const coreCommands: SlashCommand[] = [
       const sections = Object.fromEntries(SECTION_NAMES.map(section => [section, next]))
 
       patchUiState({ detailsMode: next, detailsModeCommandOverride: true, sections })
-      gateway.rpc<ConfigSetResponse>('config.set', { key: 'details_mode', value: next }).catch(() => {})
+      gateway
+        .rpc<ConfigSetResponse>('config.set', { key: 'details_mode', value: next })
+        .catch(ctx.guardedErr)
       transcript.sys(`details: ${next}`)
     }
   },

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -940,9 +940,9 @@ export function useMainApp(gw: GatewayClient) {
         return
       }
 
-      recoverSidRef.current = null
+      recoverSidRef.current = plan.sid ?? recoverSidRef.current
       turnController.pushActivity('gateway exited · /logs to inspect', 'error')
-      sys('error: gateway exited')
+      sys('error: gateway exited (recovery limit reached — use /recover to retry)')
     }
 
     gw.on('event', handler)
@@ -986,6 +986,12 @@ export function useMainApp(gw: GatewayClient) {
           guardBusySessionSwitch: session.guardBusySessionSwitch,
           newLiveSession: session.newLiveSession,
           newSession: session.newSession,
+          recoverGateway: () => {
+            recoveryAtRef.current = []
+            turnController.pushActivity('gateway recovery requested', 'warn')
+            patchUiState({ status: 'recovering session…' })
+            gw.start()
+          },
           resetVisibleHistory: session.resetVisibleHistory,
           resumeById: session.resumeById,
           setSessionStartedAt


### PR DESCRIPTION
## Summary
Closes #108534.

Fixes an issue where executing `/details expanded` or setting section detail modes causes the gateway to crash and wedging the hosted dashboard TUI without a path to recover the active session.

### Root Cause Analysis
1. **Unguarded config setters in JSON-RPC**: In `tui_gateway/methods_config_set.py`, methods including `_set_word` (handling `details_mode`, `thinking_mode`, `theme`), `_set_details_section` (`details_mode.<section>`), `_set_toggle`, `_set_cwd`, and `_set_display_toggle` lacked the `@_cfgset_guarded` decorator. If file I/O permissions or YAML formatting issues occurred during persistence, unhandled exceptions crashed JSON-RPC dispatch, dropping the WebSocket connection and triggering an unexpected gateway death.
2. **Session target discard on exhaustion**: In `ui-tui/src/app/useMainApp.ts`, when `planGatewayRecovery` exhausted its automated recovery window (3 attempts within 60s), `recoverSidRef.current` was set to `null`, permanently destroying the active session id and stranding user work even if reconnection succeeded.
3. **Missing recovery affordance**: Once automatic retries were exhausted, users in hosted environments had no user affordance to trigger a recovery, leaving the dashboard stuck.
4. **Sticky "gateway exited" status**: In `ui-tui/src/app/createGatewayEventHandler.ts`, `session.info` only cleared `starting agent…`, leaving `gateway exited` permanently displayed in the status bar even after reconnect.
5. **WebSocket diagnostic visibility**: In `tui_gateway/ws.py`, abnormal disconnects left no crash breadcrumbs in `tui_gateway_crash.log`.

### Changes
- **methods_config_set.py**: Wrapped `_set_word`, `_set_details_section`, `_set_toggle`, `_set_cwd`, `_set_display_toggle`, `_set_fast`, `_set_busy`, `_set_verbose`, `_set_focus`, and `_set_approval_mode` with `@_cfgset_guarded` to return error code `5001` rather than crashing JSON-RPC dispatch on unexpected write failures.
- **useMainApp.ts**: Retain `recoverSidRef.current = plan.sid ?? recoverSidRef.current` on recovery limit exhaustion. Added `recoverGateway` to the `session` context so users can trigger recovery.
- **slash/commands/core.ts**: Added `/recover` command to re-initialize recovery and reset budget. Updated `/details` command to forward RPC rejections to `ctx.guardedErr` rather than silently swallowing.
- **createGatewayEventHandler.ts**: Cleared sticky `gateway exited` status when `session.info` arrives.
- **ws.py**: Added crash breadcrumb logging to `tui_gateway_crash.log` on abnormal WebSocket disconnects.

### Verification
- Added test in `tests/tui_gateway/test_config_set_display_toggles.py` verifying that filesystem/write errors return code 5001 instead of crashing.
- Added tests in `ui-tui/src/__tests__/createSlashHandler.test.ts` verifying `/recover` invocation and `/details` error propagation.
- Ran test suites: `pytest tests/tui_gateway/test_config_set_display_toggles.py` (all 6 tests passed), `vitest run src/__tests__/gatewayRecovery.test.ts` (all 4 passed), and `vitest run src/__tests__/createSlashHandler.test.ts` (all 85 passed).