### PR TITLE
fix: preserve Bot Chat receipts and Desktop continuity

### DIFF
--- a/apps/desktop/electron/quit-guard.test.ts
+++ b/apps/desktop/electron/quit-guard.test.ts
@@ -31,7 +31,10 @@ test('quitPromptFor stays out of the way when nothing is running', () => {
 })
 
 test('quitPromptFor stays out of the way during an update handoff', () => {
-  assert.equal(quitPromptFor({ count: 2, titles: ['Fix login'] }, true), null)
+  const work = mergeActiveWork([normalizeActiveWork({ count: 2, titles: ['Fix login'] })])
+
+  assert.ok(quitPromptFor(work, false))
+  assert.equal(quitPromptFor(work, true), null)
 })
 
 test('quitPromptFor names the running chats', () => {
@@ -58,5 +61,18 @@ test('quitPromptFor speaks singular for one chat', () => {
 
   assert.ok(prompt)
   assert.equal(prompt.message, 'Hermes is still working on 1 chat.')
-  assert.ok(prompt.detail.includes('mid-turn'))
+})
+
+test('active-work reports with unknown lifecycle keep a scoped confirmation, not a work-loss claim', () => {
+  // The real IPC summary has no connection identity or Desktop-tool activity.
+  // Neither named nor untitled work proves it is independent of the client.
+  for (const titles of [[], ['Fix login']]) {
+    const work = mergeActiveWork([normalizeActiveWork({ count: 1, titles })])
+    const prompt = quitPromptFor(work, false)
+
+    assert.ok(prompt)
+    assert.match(prompt.detail, /[Rr]unning and queued work on a persistent gateway continues after Desktop quits/)
+    assert.match(prompt.detail, /[Aa]ctivity that depends on this app or an older connection may be interrupted/)
+    assert.doesNotMatch(prompt.detail, /work.*(?:lost|stops)|stops the agent|all work continues/i)
+  }
 })

--- a/apps/desktop/electron/quit-guard.ts
+++ b/apps/desktop/electron/quit-guard.ts
@@ -1,8 +1,7 @@
-// Quitting with a turn in flight kills the backend mid-tool-call: the work is
-// lost, and anything the agent had half-written to disk stays half-written.
-// Renderers publish what they're running; the main process asks before it lets
-// that go. The decision + copy live here (pure, testable) so main.ts only owns
-// the IPC and the dialog call.
+// Persistent gateways own their work independently of Desktop. Renderer reports
+// do not identify connections or client-dependent activity, so a busy report
+// still needs a scoped confirmation, not a claim that quitting loses all work.
+// The decision + copy live here so main.ts only owns the IPC and dialog call.
 
 const MAX_LISTED = 4
 
@@ -82,7 +81,8 @@ export function quitPromptFor(work: ActiveWork, quittingForHandoff: boolean): nu
     detail: [
       lines.join('\n'),
       lines.length > 0 ? '' : null,
-      'Quitting stops the agent mid-turn. Any work it has not finished writing is lost.'
+      'Running and queued work on a persistent gateway continues after Desktop quits. ' +
+        'Activity that depends on this app or an older connection may be interrupted.'
     ]
       .filter(line => line !== null)
       .join('\n')

--- a/apps/desktop/src/api/canonical-protocol.ts
+++ b/apps/desktop/src/api/canonical-protocol.ts
@@ -1,6 +1,8 @@
 // Canonical local authority wire adapter. Remote legacy transports keep their
 // existing protocol; unsupported explicit semantics fail before network admission.
 
+export const CANONICAL_GATEWAY_PROTOCOL = 'hermes-gateway-v1'
+
 // Mirrors hermes_cli/gateway_mutations.slash_mutation: the typed directives
 // that are canonical mutations, not gateway-executed slash commands. Model
 // flags (--global/--once/--refresh) have no canonical mutation and stay on the

--- a/apps/desktop/src/api/client.ts
+++ b/apps/desktop/src/api/client.ts
@@ -2,7 +2,7 @@ import { type GatewayEvent, type GatewayEventName, JsonRpcGatewayClient } from '
 
 import type { HermesApiRequest } from '@/global'
 
-import { CanonicalDesktopProtocol } from './canonical-protocol'
+import { CANONICAL_GATEWAY_PROTOCOL, CanonicalDesktopProtocol } from './canonical-protocol'
 
 // Desktop startup fires a burst of read-only data calls (config, profiles,
 // model info/options, cron) the moment the backend passes readiness. On a
@@ -77,7 +77,7 @@ export class HermesGateway extends JsonRpcGatewayClient {
         if (!ticket) {throw new Error('Native gateway requires a fresh private ticket')}
         parsed.searchParams.delete('ticket')
 
-        return new WebSocket(parsed.toString(), ['hermes-gateway-v1', `hermes-gateway-ticket.${ticket}`])
+        return new WebSocket(parsed.toString(), [CANONICAL_GATEWAY_PROTOCOL, `hermes-gateway-ticket.${ticket}`])
       }
     })
     this.onEvent(event => { if (this.canonical) { this.protocol.event(event) } })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/queued-first-input.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/queued-first-input.test.tsx
@@ -1,0 +1,161 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { useRef } from 'react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+
+import { PRIMARY_SESSION_VIEW } from '@/app/chat/session-view'
+import { en } from '@/i18n/en'
+import { chatMessageText, textPart } from '@/lib/chat-messages'
+import {
+  $connection,
+  $messages,
+  setActiveSessionId,
+  setAwaitingResponse,
+  setBusy,
+  setMessages,
+  setSelectedStoredSessionId,
+  setSessions
+} from '@/store/session'
+import { clearAllSessionStates } from '@/store/session-states'
+import { makeSessionInfo } from '@/test/session-info'
+
+import { useSessionStateCache } from '../use-session-state-cache'
+
+import { useSubmitPrompt } from './submit'
+
+const SID = 'local-first-input'
+const INPUT = 'Prepare the weekly report'
+
+function mount(startBeforeReceipt = false) {
+  let start = () => undefined
+
+  const request = vi.fn(async (_method: string, params: Record<string, unknown>) => {
+    if (startBeforeReceipt) {
+      start()
+    }
+
+    return { admission_id: 'admission-1', submission_id: params.submission_id, session_id: SID, status: 'queued' }
+  })
+
+  const hook = renderHook(() => {
+    const busyRef = useRef(false)
+
+    const cache = useSessionStateCache({
+      activeSessionId: SID,
+      selectedStoredSessionId: SID,
+      busyRef,
+      setMessages,
+      setBusy,
+      setAwaitingResponse
+    })
+
+    const submit = useSubmitPrompt({
+      ...cache,
+      busyRef,
+      copy: en.desktop,
+      createBackendSessionForSend: async () => null,
+      getRoutedStoredSessionId: () => SID,
+      getRouteToken: () => `/${SID}`,
+      requestGateway: request as Parameters<typeof useSubmitPrompt>[0]['requestGateway'],
+      resumeStoredSession: async () => undefined,
+      syncAttachmentsForSubmit: async (sessionId, attachments) => ({ sessionId, attachments })
+    })
+
+    return { cache, submit }
+  })
+
+  act(() => {
+    hook.result.current.cache.updateSessionState(SID, state => state, SID)
+  })
+
+  start = () => {
+    hook.result.current.cache.updateSessionState(
+      SID,
+      state => ({
+        ...state,
+        busy: true,
+        awaitingResponse: true,
+        turnLive: true,
+        turnStartedAt: 1234
+      }),
+      SID
+    )
+  }
+
+  return { hook, request }
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+  clearAllSessionStates()
+  setMessages([])
+  setBusy(false)
+  setAwaitingResponse(false)
+  setActiveSessionId(SID)
+  setSelectedStoredSessionId(SID)
+  setSessions([makeSessionInfo({ id: SID, source: 'gui', message_count: 0 })])
+  $connection.set({
+    mode: 'local',
+    connectionId: 'local',
+    profile: 'default',
+    baseUrl: 'http://127.0.0.1:1',
+    wsUrl: 'ws://127.0.0.1:1/api/ws?native_dial=1',
+    token: '',
+    logs: [],
+    isFullscreen: false,
+    nativeOverlayWidth: 0,
+    windowButtonPosition: null
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  clearAllSessionStates()
+  setMessages([])
+  setBusy(false)
+  setAwaitingResponse(false)
+  setActiveSessionId(null)
+  setSelectedStoredSessionId(null)
+  setSessions([])
+  $connection.set(null)
+  vi.restoreAllMocks()
+})
+
+it.each([false, true])('keeps first input visible when a queued receipt races start=%s', async startBeforeReceipt => {
+  const { hook, request } = mount(startBeforeReceipt)
+  await act(async () => {
+    expect(await hook.result.current.submit(INPUT)).toBe(true)
+  })
+  expect(request).toHaveBeenCalledTimes(1)
+  expect(PRIMARY_SESSION_VIEW.$messages.get().map(chatMessageText)).toEqual([INPUT])
+  expect(PRIMARY_SESSION_VIEW.$messagesEmpty.get()).toBe(false)
+  expect(PRIMARY_SESSION_VIEW.$busy.get()).toBe(true)
+
+  if (startBeforeReceipt) {
+    expect(hook.result.current.cache.sessionStateByRuntimeIdRef.current.get(SID)).toMatchObject({
+      turnLive: true,
+      turnStartedAt: 1234
+    })
+  }
+})
+
+it('does not graft explicitly queued input onto the active turn', async () => {
+  const { hook } = mount()
+  act(() => {
+    hook.result.current.cache.updateSessionState(
+      SID,
+      state => ({
+        ...state,
+        busy: true,
+        turnLive: true,
+        messages: [{ id: 'current-answer', role: 'assistant', parts: [textPart('Still working')] }]
+      }),
+      SID
+    )
+  })
+  await act(async () => {
+    expect(await hook.result.current.submit(INPUT, { fromQueue: true })).toBe(true)
+  })
+  expect(PRIMARY_SESSION_VIEW.$messages.get().map(chatMessageText)).toEqual(['Still working'])
+  expect(PRIMARY_SESSION_VIEW.$busy.get()).toBe(true)
+  expect($messages.get().some(message => chatMessageText(message) === INPUT)).toBe(false)
+})

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -953,9 +953,10 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
               status: result.status
             })
 
-            if (result.status === 'queued') {
-              dropOptimistic(sessionId)
-            } else if (result.status === 'terminal') {
+            // Queued is also the initial receipt for an idle session's first
+            // turn. Keep its input and any start event that raced this ACK;
+            // explicit queue-only sends never inserted an optimistic bubble.
+            if (result.status === 'terminal') {
               // Deduplication does not start a turn or promise another terminal
               // event. Remove our duplicate bubble, but preserve any live turn
               // that an owner event established while the receipt was in flight.

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1678,7 +1678,7 @@ export function applyRuntimeInfo(
 
   // App/profile-level reporting is session-independent — a tile's runtime
   // reports backend skew and credential warnings just as usefully.
-  reportBackendContract(info.desktop_contract)
+  reportBackendContract(info.desktop_contract, info.desktop_protocol)
 
   if (info.approval_mode !== undefined) {
     reconcileApprovalModeForProfile($activeGatewayProfile.get(), info.approval_mode)

--- a/apps/desktop/src/plugins/hermes-bots/canonical-attachment-download.ts
+++ b/apps/desktop/src/plugins/hermes-bots/canonical-attachment-download.ts
@@ -1,0 +1,20 @@
+/** Use the existing browser-download -> Electron Save File workflow, not composer staging.
+ * Mirrors downloadTextFile and #104199's attachment delivery without a new native IPC. */
+export function downloadCanonicalAttachment(bytes: Uint8Array<ArrayBuffer>, name: string, mime: string, signal?: AbortSignal) {
+  if (signal?.aborted) {return}
+  const url = URL.createObjectURL(new Blob([bytes], { type: mime }))
+  const link = document.createElement('a')
+  link.href = url
+  link.download = name
+  link.rel = 'noopener noreferrer'
+  link.style.display = 'none'
+  document.body.appendChild(link)
+
+  try {
+    if (!signal?.aborted) {link.click()}
+  } finally {
+    link.remove()
+    // Keep the object URL alive while Chromium hands the bytes to its download manager.
+    window.setTimeout(() => URL.revokeObjectURL(url), 30_000)
+  }
+}

--- a/apps/desktop/src/plugins/hermes-bots/canonical-download-test-utils.ts
+++ b/apps/desktop/src/plugins/hermes-bots/canonical-download-test-utils.ts
@@ -1,0 +1,47 @@
+import { expect, vi } from 'vitest'
+
+/** Observe a user-facing browser download, not a private cache-writing IPC. */
+export function observeDownloads() {
+  const blobs = new Map<string, Blob>()
+  const downloads: Array<{ blob: Blob; name: string; connected: boolean }> = []
+
+  const create = vi.fn((blob: Blob) => {
+    const url = `blob:http://localhost/file-${blobs.size}`
+    blobs.set(url, blob)
+
+    return url
+  })
+
+  const revoke = vi.fn()
+  vi.stubGlobal('URL', class extends URL {
+    static createObjectURL = create
+    static revokeObjectURL = revoke
+  })
+
+  const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (this: HTMLAnchorElement) {
+    const blob = blobs.get(this.href)
+
+    if (!blob) {throw new Error('Download did not use the provided bytes')}
+    downloads.push({ blob, name: this.download, connected: this.isConnected })
+  })
+
+  return { downloads, create, revoke, click }
+}
+
+export async function expectDownloaded(
+  observed: ReturnType<typeof observeDownloads>, bytes: Uint8Array, name: string, mime: string, index = 0
+) {
+  const entry = observed.downloads[index]
+  expect(entry.name).toBe(name)
+  expect(entry.connected).toBe(true)
+  expect(entry.blob.type).toBe(mime)
+
+  const buffer = await new Promise<ArrayBuffer>((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as ArrayBuffer)
+    reader.onerror = () => reject(reader.error)
+    reader.readAsArrayBuffer(entry.blob)
+  })
+
+  expect(new Uint8Array(buffer)).toEqual(bytes)
+}

--- a/apps/desktop/src/plugins/hermes-bots/canonical-group-attachments.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/canonical-group-attachments.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ComponentProps } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+
+const request = vi.hoisted(() => vi.fn())
+vi.mock('@hermes/plugin-sdk', () => ({
+  host: { requestProfile: request },
+  Button: (props: ComponentProps<'button'>) => <button {...props} />
+}))
+vi.mock('./canonical-group-labels', () => ({
+  useCanonicalGroupLabels: () => ({ attachFiles: 'Attach files', download: 'Download',
+    removeAttachment: 'Remove', uploadFailed: 'Attachment failed' })
+}))
+
+import { CanonicalGroupAttachments } from './canonical-group-attachments'
+
+const binding = { connectionId: 'remote-owner', profile: 'reviewer', roomId: 'room' }
+const originalDesktop = window.hermesDesktop
+afterEach(() => { cleanup(); request.mockReset(); window.hermesDesktop = originalDesktop })
+
+it.each([32, 1_048_576])('uploads all %i bytes using the canonical owner method', async size => {
+  const bytes = Uint8Array.from({ length: size }, (_, index) => index % 256)
+  const file = new File([bytes], 'report.bin', { type: 'application/octet-stream' })
+  // jsdom lacks Blob.arrayBuffer; preserve its real FileReader implementation.
+  Object.defineProperty(file, 'arrayBuffer', { value: async () => bytes.buffer })
+  const uploaded = { attachment_id: 'file-one', kind: 'file', name: file.name, mime: file.type, size }
+  request.mockImplementation(async (route, method, params) => {
+    expect(route).toMatchObject({ connectionId: binding.connectionId, targetProfile: binding.profile })
+    if (method !== 'groups.attachment.upload') {throw new Error('Unknown gateway method')}
+    expect(params).toMatchObject({ profile: binding.profile, room_id: binding.roomId, name: file.name })
+    const decoded = Uint8Array.from(atob(params.data_base64), value => value.charCodeAt(0))
+    expect(Buffer.from(decoded).equals(Buffer.from(bytes))).toBe(true)
+
+    return { ...uploaded, sha256: 'receipt-digest', state: 'uploaded', created_at: 123,
+      idempotent: false, room_id: binding.roomId, authority: { gateway_id: 'owner', epoch: 1 } }
+  })
+  const changed = vi.fn()
+  const submit = vi.fn(event => event.preventDefault())
+  const view = render(<form onSubmit={submit}><CanonicalGroupAttachments attachments={[]} binding={binding} disabled={false} onChange={changed} /></form>)
+  fireEvent.click(screen.getByRole('button', { name: 'Attach files' }))
+  fireEvent.change(view.container.querySelector('input')!, { target: { files: [file] } })
+  await waitFor(() => expect(changed).toHaveBeenCalledWith([uploaded]), { timeout: 2000 })
+  expect(request).toHaveBeenCalledTimes(1)
+  expect(submit).not.toHaveBeenCalled()
+})
+
+it('downloads only the selected committed attachment from its captured owner', async () => {
+  const attachment = { attachment_id: 'file-one', event_id: 'event-one', kind: 'file', name: 'report.bin', mime: 'application/octet-stream' }
+  const save = vi.fn().mockResolvedValue(undefined)
+  window.hermesDesktop = { saveImageBuffer: save } as unknown as typeof window.hermesDesktop
+  request.mockImplementation(async (route, method, params) => {
+    expect(route).toMatchObject({ connectionId: binding.connectionId, targetProfile: binding.profile })
+    if (method !== 'groups.attachment.download') {throw new Error('Unknown gateway method')}
+    expect(params).toEqual({ profile: binding.profile, room_id: binding.roomId,
+      event_id: attachment.event_id, attachment_id: attachment.attachment_id })
+
+    return { ...attachment, data_base64: 'AAEC/w==' }
+  })
+  const submit = vi.fn(event => event.preventDefault())
+  const changed = vi.fn()
+  render(<form onSubmit={submit}><CanonicalGroupAttachments attachments={[attachment]} binding={binding} disabled={false} onChange={changed} /></form>)
+  fireEvent.click(screen.getByRole('button', { name: 'Download' }))
+  await waitFor(() => expect(save).toHaveBeenCalledWith(new Uint8Array([0, 1, 2, 255]), '.bin', attachment.name))
+  expect(request).toHaveBeenCalledTimes(1)
+  await waitFor(() => expect((screen.getByRole('button', { name: 'Remove' }) as HTMLButtonElement).disabled).toBe(false))
+  fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
+  expect(changed).toHaveBeenCalledWith([])
+  expect(submit).not.toHaveBeenCalled()
+})

--- a/apps/desktop/src/plugins/hermes-bots/canonical-group-attachments.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/canonical-group-attachments.test.tsx
@@ -2,6 +2,8 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import type { ComponentProps } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 
+import { expectDownloaded, observeDownloads } from './canonical-download-test-utils'
+
 const request = vi.hoisted(() => vi.fn())
 vi.mock('@hermes/plugin-sdk', () => ({
   host: { requestProfile: request },
@@ -16,7 +18,7 @@ import { CanonicalGroupAttachments } from './canonical-group-attachments'
 
 const binding = { connectionId: 'remote-owner', profile: 'reviewer', roomId: 'room' }
 const originalDesktop = window.hermesDesktop
-afterEach(() => { cleanup(); request.mockReset(); window.hermesDesktop = originalDesktop })
+afterEach(() => { cleanup(); request.mockReset(); vi.restoreAllMocks(); vi.unstubAllGlobals(); window.hermesDesktop = originalDesktop })
 
 it.each([32, 1_048_576])('uploads all %i bytes using the canonical owner method', async size => {
   const bytes = Uint8Array.from({ length: size }, (_, index) => index % 256)
@@ -26,6 +28,7 @@ it.each([32, 1_048_576])('uploads all %i bytes using the canonical owner method'
   const uploaded = { attachment_id: 'file-one', kind: 'file', name: file.name, mime: file.type, size }
   request.mockImplementation(async (route, method, params) => {
     expect(route).toMatchObject({ connectionId: binding.connectionId, targetProfile: binding.profile })
+
     if (method !== 'groups.attachment.upload') {throw new Error('Unknown gateway method')}
     expect(params).toMatchObject({ profile: binding.profile, room_id: binding.roomId, name: file.name })
     const decoded = Uint8Array.from(atob(params.data_base64), value => value.charCodeAt(0))
@@ -47,9 +50,11 @@ it.each([32, 1_048_576])('uploads all %i bytes using the canonical owner method'
 it('downloads only the selected committed attachment from its captured owner', async () => {
   const attachment = { attachment_id: 'file-one', event_id: 'event-one', kind: 'file', name: 'report.bin', mime: 'application/octet-stream' }
   const save = vi.fn().mockResolvedValue(undefined)
+  const observed = observeDownloads()
   window.hermesDesktop = { saveImageBuffer: save } as unknown as typeof window.hermesDesktop
   request.mockImplementation(async (route, method, params) => {
     expect(route).toMatchObject({ connectionId: binding.connectionId, targetProfile: binding.profile })
+
     if (method !== 'groups.attachment.download') {throw new Error('Unknown gateway method')}
     expect(params).toEqual({ profile: binding.profile, room_id: binding.roomId,
       event_id: attachment.event_id, attachment_id: attachment.attachment_id })
@@ -60,7 +65,9 @@ it('downloads only the selected committed attachment from its captured owner', a
   const changed = vi.fn()
   render(<form onSubmit={submit}><CanonicalGroupAttachments attachments={[attachment]} binding={binding} disabled={false} onChange={changed} /></form>)
   fireEvent.click(screen.getByRole('button', { name: 'Download' }))
-  await waitFor(() => expect(save).toHaveBeenCalledWith(new Uint8Array([0, 1, 2, 255]), '.bin', attachment.name))
+  await waitFor(() => expect(observed.downloads).toHaveLength(1))
+  await expectDownloaded(observed, new Uint8Array([0, 1, 2, 255]), attachment.name, attachment.mime)
+  expect(save).not.toHaveBeenCalled()
   expect(request).toHaveBeenCalledTimes(1)
   await waitFor(() => expect((screen.getByRole('button', { name: 'Remove' }) as HTMLButtonElement).disabled).toBe(false))
   fireEvent.click(screen.getByRole('button', { name: 'Remove' }))

--- a/apps/desktop/src/plugins/hermes-bots/canonical-group-attachments.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/canonical-group-attachments.tsx
@@ -38,14 +38,21 @@ export function CanonicalGroupAttachments({ binding, attachments, onChange, disa
     setBusy(true); setError('')
 
     try {
-      const data = await file.arrayBuffer()
-
-      const result = await canonicalGroupRequest<Attachment>(binding, 'bot.group.attachment.upload', {
-        room_id: binding.roomId, upload_id: crypto.randomUUID(), kind: kindFor(file), name: file.name,
-        mime: file.type || 'application/octet-stream', data_base64: btoa(String.fromCharCode(...new Uint8Array(data)))
+      const data = await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader()
+        reader.onload = () => resolve(String(reader.result).split(',', 2)[1])
+        reader.onerror = () => reject(reader.error ?? new Error(labels.uploadFailed))
+        reader.readAsDataURL(file)
       })
 
-      onChange([...attachments, result])
+      const result = await canonicalGroupRequest<Attachment>(binding, 'groups.attachment.upload', {
+        room_id: binding.roomId, upload_id: crypto.randomUUID(), kind: kindFor(file), name: file.name,
+        mime: file.type || 'application/octet-stream', data_base64: data
+      })
+
+      // Upload receipts include storage metadata; Send accepts only the manifest.
+      const { attachment_id, kind, name, mime, size } = result
+      onChange([...attachments, { attachment_id, kind, name, mime, size }])
     } catch (e) { setError(e instanceof Error ? e.message : String(e)) }
     finally { setBusy(false) }
   }
@@ -55,7 +62,7 @@ export function CanonicalGroupAttachments({ binding, attachments, onChange, disa
     setBusy(true); setError('')
 
     try {
-      const result = await canonicalGroupRequest<DownloadedAttachment>(binding, 'bot.group.attachment.download', {
+      const result = await canonicalGroupRequest<DownloadedAttachment>(binding, 'groups.attachment.download', {
         room_id: binding.roomId, event_id: attachment.event_id, attachment_id: attachment.attachment_id
       })
 
@@ -69,10 +76,10 @@ export function CanonicalGroupAttachments({ binding, attachments, onChange, disa
     <input hidden onChange={e => { const file = e.target.files?.[0];
 
  if (file) {void upload(file);} e.currentTarget.value = '' }} ref={input} type="file" />
-    <Button disabled={disabled || busy} onClick={() => input.current?.click()}>{labels.attachFiles}</Button>
+    <Button disabled={disabled || busy} onClick={() => input.current?.click()} type="button">{labels.attachFiles}</Button>
     {attachments.map(a => <span className="flex items-center gap-1" key={a.attachment_id ?? a.name}>
-      <span>{a.name}</span><Button disabled={disabled || busy} onClick={() => void download(a)}>{labels.download}</Button>
-      <Button disabled={disabled || busy} onClick={() => onChange(attachments.filter(item => item !== a))}>{labels.removeAttachment}</Button>
+      <span>{a.name}</span><Button disabled={disabled || busy} onClick={() => void download(a)} type="button">{labels.download}</Button>
+      <Button disabled={disabled || busy} onClick={() => onChange(attachments.filter(item => item !== a))} type="button">{labels.removeAttachment}</Button>
     </span>)}
     {error && <span role="alert">{labels.uploadFailed}: {error}</span>}
   </div>

--- a/apps/desktop/src/plugins/hermes-bots/canonical-group-attachments.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/canonical-group-attachments.tsx
@@ -1,10 +1,12 @@
 import { Button } from '@hermes/plugin-sdk'
-import { useRef, useState } from 'react'
+import { useLayoutEffect, useRef, useState } from 'react'
 
+import { downloadCanonicalAttachment } from './canonical-attachment-download'
 import { useCanonicalGroupLabels } from './canonical-group-labels'
 import { type CanonicalGroupBinding, canonicalGroupRequest } from './canonical-groups'
 
-interface Attachment { attachment_id?: string; event_id?: string; kind: string; name: string; mime: string; size?: number }
+export interface CanonicalGroupAttachment { attachment_id?: string; event_id?: string; kind: string; name: string; mime: string; size?: number }
+type Attachment = CanonicalGroupAttachment
 interface DownloadedAttachment extends Attachment { data_base64: string }
 
 function kindFor(file: File): string {
@@ -15,26 +17,29 @@ function kindFor(file: File): string {
   return 'file'
 }
 
-function extension(mime: string, name: string): string {
-  const dot = name.lastIndexOf('.')
-
-  if (dot > 0) {return name.slice(dot)}
-
-  return mime === 'application/pdf' ? '.pdf' : mime.split('/')[1] ? `.${mime.split('/')[1]}` : '.bin'
-}
-
-export function CanonicalGroupAttachments({ binding, attachments, onChange, disabled }: {
+export function CanonicalGroupAttachments({ binding, attachments, onChange, disabled, readOnly = false }: {
   binding: CanonicalGroupBinding
   attachments: Attachment[]
-  onChange: (attachments: Attachment[]) => void
   disabled: boolean
-}) {
+} & ({ readOnly: true; onChange?: never } | { readOnly?: false; onChange: (attachments: Attachment[]) => void })) {
   const labels = useCanonicalGroupLabels()
   const input = useRef<HTMLInputElement>(null)
   const [error, setError] = useState('')
   const [busy, setBusy] = useState(false)
+  const lifetime = useRef<AbortController | null>(null)
+
+  useLayoutEffect(() => {
+    const controller = new AbortController()
+    lifetime.current = controller
+
+    if (disabled) {controller.abort()}
+    setBusy(false)
+
+    return () => controller.abort()
+  }, [binding.connectionId, binding.profile, binding.roomId, disabled, readOnly])
 
   async function upload(file: File) {
+    if (readOnly) {return}
     setBusy(true); setError('')
 
     try {
@@ -52,13 +57,15 @@ export function CanonicalGroupAttachments({ binding, attachments, onChange, disa
 
       // Upload receipts include storage metadata; Send accepts only the manifest.
       const { attachment_id, kind, name, mime, size } = result
-      onChange([...attachments, { attachment_id, kind, name, mime, size }])
+      onChange?.([...attachments, { attachment_id, kind, name, mime, size }])
     } catch (e) { setError(e instanceof Error ? e.message : String(e)) }
     finally { setBusy(false) }
   }
 
   async function download(attachment: Attachment) {
-    if (!attachment.attachment_id || !attachment.event_id || !window.hermesDesktop?.saveImageBuffer) {return}
+    const signal = lifetime.current?.signal
+
+    if (!signal || signal.aborted || !attachment.attachment_id || !attachment.event_id) {return}
     setBusy(true); setError('')
 
     try {
@@ -66,20 +73,21 @@ export function CanonicalGroupAttachments({ binding, attachments, onChange, disa
         room_id: binding.roomId, event_id: attachment.event_id, attachment_id: attachment.attachment_id
       })
 
+      if (signal.aborted) {return}
       const bytes = Uint8Array.from(atob(result.data_base64), char => char.charCodeAt(0))
-      await window.hermesDesktop.saveImageBuffer(bytes, extension(result.mime, result.name), result.name)
-    } catch (e) { setError(e instanceof Error ? e.message : String(e)) }
-    finally { setBusy(false) }
+      downloadCanonicalAttachment(bytes, result.name, result.mime, signal)
+    } catch (e) { if (!signal.aborted) {setError(e instanceof Error ? e.message : String(e))} }
+    finally { if (!signal.aborted) {setBusy(false)} }
   }
 
   return <div className="flex flex-wrap items-center gap-2">
-    <input hidden onChange={e => { const file = e.target.files?.[0];
+    {!readOnly && <><input hidden onChange={e => { const file = e.target.files?.[0];
 
  if (file) {void upload(file);} e.currentTarget.value = '' }} ref={input} type="file" />
-    <Button disabled={disabled || busy} onClick={() => input.current?.click()} type="button">{labels.attachFiles}</Button>
+    <Button disabled={disabled || busy} onClick={() => input.current?.click()} type="button">{labels.attachFiles}</Button></>}
     {attachments.map(a => <span className="flex items-center gap-1" key={a.attachment_id ?? a.name}>
       <span>{a.name}</span><Button disabled={disabled || busy} onClick={() => void download(a)} type="button">{labels.download}</Button>
-      <Button disabled={disabled || busy} onClick={() => onChange(attachments.filter(item => item !== a))} type="button">{labels.removeAttachment}</Button>
+      {!readOnly && <Button disabled={disabled || busy} onClick={() => onChange?.(attachments.filter(item => item !== a))} type="button">{labels.removeAttachment}</Button>}
     </span>)}
     {error && <span role="alert">{labels.uploadFailed}: {error}</span>}
   </div>

--- a/apps/desktop/src/plugins/hermes-bots/canonical-group-download-lifetime.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/canonical-group-download-lifetime.test.tsx
@@ -1,0 +1,78 @@
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import type { ComponentProps, ReactNode } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+
+import { expectDownloaded, observeDownloads } from './canonical-download-test-utils'
+
+const request = vi.hoisted(() => vi.fn())
+vi.mock('@hermes/plugin-sdk', async () => {
+  const { en } = await import('@/i18n/en')
+
+  return { host: { requestProfile: request }, useI18n: () => ({ locale: 'en', t: en }),
+    Button: (props: ComponentProps<'button'>) => <button {...props} />,
+    Codicon: () => <span />, Tip: ({ children }: { children: ReactNode }) => <>{children}</> }
+})
+vi.mock('./canonical-group-labels', async () => {
+  const { CANONICAL_GROUP_LOCALES } = await import('./canonical-group-locales')
+
+  return { useCanonicalGroupLabels: () => ({ ...CANONICAL_GROUP_LOCALES.en, refresh: 'Refresh', retry: 'Retry',
+    send: 'Send', stop: 'Stop', download: 'Download', discard: 'Discard', cancel: 'Cancel' }) }
+})
+import { CanonicalGroupWorkspace } from './canonical-group-workspace'
+
+const binding = { connectionId: 'owner-a', profile: 'reviewer', roomId: 'room-one' }
+const attachment = { attachment_id: 'att_00000000000000000000000000000001', kind: 'file', name: 'retained.txt', mime: 'text/plain', size: 1 }
+const originalDesktop = window.hermesDesktop
+afterEach(() => { cleanup(); request.mockReset(); vi.restoreAllMocks(); vi.unstubAllGlobals(); localStorage.clear(); window.hermesDesktop = originalDesktop })
+
+function setup() {
+  const observed = observeDownloads()
+  const cache = vi.fn().mockResolvedValue('/private/composer-images/not-a-user-download')
+  window.hermesDesktop = { saveImageBuffer: cache } as unknown as typeof window.hermesDesktop
+  let release!: (value: unknown) => void
+  const held = new Promise(resolve => { release = resolve })
+  request.mockImplementation(async (_route, method) => {
+    if (method === 'groups.state') {return { room: { name: 'Room' } }}
+
+    if (method === 'groups.log') {return { events: [{ seq: 1, room_id: binding.roomId, event_id: 'committed',
+      kind: 'message.member', payload: { attachments: [attachment] } }] }}
+
+    if (method === 'groups.attachment.download') {return held}
+    throw new Error(`Unexpected method ${method}`)
+  })
+
+  return { observed, cache, release: () => release({ ...attachment, event_id: 'committed', data_base64: 'QQ==' }) }
+}
+
+it('initiates the real user-facing download with exact bytes/name, never the composer cache', async () => {
+  const { observed, cache, release } = setup()
+  render(<CanonicalGroupWorkspace binding={binding} />)
+  const history = within(screen.getByRole('log'))
+  fireEvent.click(await history.findByRole('button', { name: 'Download' }))
+  await act(async () => release())
+  await waitFor(() => expect(observed.downloads).toHaveLength(1), { timeout: 2000 })
+  await expectDownloaded(observed, new Uint8Array([65]), attachment.name, attachment.mime)
+  expect(cache).not.toHaveBeenCalled()
+  expect(request.mock.calls.find(call => call[1] === 'groups.attachment.download')?.[2]).toEqual({
+    profile: binding.profile, room_id: binding.roomId, event_id: 'committed', attachment_id: attachment.attachment_id
+  })
+})
+
+it.each(['unmount', 'hidden', 'profile', 'connection', 'room'])('does not initiate a late download or cache write after %s', async change => {
+  const { observed, cache, release } = setup()
+  const view = render(<CanonicalGroupWorkspace binding={binding} />)
+  fireEvent.click(await within(screen.getByRole('log')).findByRole('button', { name: 'Download' }))
+  await waitFor(() => expect(request.mock.calls.some(call => call[1] === 'groups.attachment.download')).toBe(true))
+
+  if (change === 'unmount') {view.unmount()}
+  else if (change === 'hidden') {view.rerender(<CanonicalGroupWorkspace binding={binding} visible={false} />)}
+  else {
+    const key = change === 'connection' ? 'connectionId' : change === 'room' ? 'roomId' : 'profile'
+    view.rerender(<CanonicalGroupWorkspace binding={{ ...binding, [key]: 'other' }} />)
+  }
+
+  await act(async () => release())
+  expect(observed.create).not.toHaveBeenCalled()
+  expect(observed.downloads).toHaveLength(0)
+  expect(cache).not.toHaveBeenCalled()
+})

--- a/apps/desktop/src/plugins/hermes-bots/canonical-group-history.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/canonical-group-history.test.tsx
@@ -1,0 +1,106 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import type { ComponentProps, ReactNode } from 'react'
+import { afterEach, expect, it, vi } from 'vitest'
+
+import { expectDownloaded, observeDownloads } from './canonical-download-test-utils'
+
+const request = vi.hoisted(() => vi.fn())
+vi.mock('@hermes/plugin-sdk', async () => {
+  const { en } = await import('@/i18n/en')
+
+  return { host: { requestProfile: request }, useI18n: () => ({ locale: 'en', t: en }),
+    Button: (props: ComponentProps<'button'>) => <button {...props} />,
+    Codicon: () => <span />, Tip: ({ children }: { children: ReactNode }) => <>{children}</> }
+})
+vi.mock('./canonical-group-labels', async () => {
+  const { CANONICAL_GROUP_LOCALES } = await import('./canonical-group-locales')
+
+  return { useCanonicalGroupLabels: () => ({ ...CANONICAL_GROUP_LOCALES.en, back: 'Back', refresh: 'Refresh', retry: 'Retry',
+    send: 'Send', stop: 'Stop', download: 'Download', discard: 'Discard', cancel: 'Cancel' }) }
+})
+
+import { CanonicalGroupWorkspace } from './canonical-group-workspace'
+
+const binding = { connectionId: 'original-owner', profile: 'reviewer', roomId: 'room-one' }
+const manifest = { attachment_id: 'att_00000000000000000000000000000001', kind: 'file', name: 'notes.txt', mime: 'text/plain', size: 1 }
+const originalDesktop = window.hermesDesktop
+afterEach(() => { cleanup(); request.mockReset(); vi.restoreAllMocks(); vi.unstubAllGlobals(); localStorage.clear(); window.hermesDesktop = originalDesktop })
+
+it('keeps a committed file downloadable in history after Send clears the composer (F31)', async () => {
+  const observed = observeDownloads()
+  const save = vi.fn().mockResolvedValue(undefined)
+  window.hermesDesktop = { saveImageBuffer: save } as unknown as typeof window.hermesDesktop
+  let sent = false
+  request.mockImplementation(async (_route, method, params) => {
+    if (method === 'groups.state') {return { room: { name: 'Room' }, driver_status: {} }}
+
+    if (method === 'groups.log') {return { events: sent ? [{ seq: 1, room_id: binding.roomId, event_id: 'committed-user-event',
+      kind: 'message.user', payload: { text: 'Review these notes', attachments: [manifest] } }] : [] }}
+
+    if (method === 'groups.attachment.upload') {return { ...manifest, sha256: 'receipt-only' }}
+
+    if (method === 'groups.send') {expect(params.payload.attachments).toEqual([manifest]); sent = true;
+
+ return { accepted: true }}
+
+    if (method === 'groups.attachment.download') {return { ...manifest, event_id: params.event_id, data_base64: 'QQ==' }}
+    throw new Error(`Unexpected method ${method}`)
+  })
+  const view = render(<CanonicalGroupWorkspace binding={binding} />)
+  await waitFor(() => expect((screen.getByRole('textbox') as HTMLTextAreaElement).disabled).toBe(false))
+  fireEvent.change(view.container.querySelector('input[type=file]')!, { target: { files: [new File(['A'], manifest.name, { type: manifest.mime })] } })
+  await waitFor(() => expect(screen.getByText(manifest.name)).toBeTruthy())
+  fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Review these notes' } })
+  fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+  await waitFor(() => expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe(''))
+  const history = within(screen.getByRole('log'))
+  await waitFor(() => expect(history.getByText(manifest.name)).toBeTruthy(), { timeout: 2000 })
+  expect(history.queryByRole('button', { name: 'Attach files' })).toBeNull()
+  expect(history.queryByRole('button', { name: 'Remove attachment' })).toBeNull()
+  expect(view.container.querySelector('form')?.textContent).not.toContain(manifest.name)
+  fireEvent.click(history.getByRole('button', { name: 'Download' }))
+  await waitFor(() => expect(observed.downloads).toHaveLength(1))
+  await expectDownloaded(observed, new Uint8Array([65]), manifest.name, manifest.mime)
+  expect(save).not.toHaveBeenCalled()
+  const call = request.mock.calls.find(call => call[1] === 'groups.attachment.download')!
+  expect(call[0]).toMatchObject({ connectionId: binding.connectionId, targetProfile: binding.profile })
+  expect(call[2]).toEqual({ profile: binding.profile, room_id: binding.roomId,
+    event_id: 'committed-user-event', attachment_id: manifest.attachment_id })
+  expect(request.mock.calls.some(call => call[1] === 'groups.attachment.list')).toBe(false)
+})
+
+it('binds user/member history downloads to their real event and refuses missing or foreign room identity', async () => {
+  const observed = observeDownloads()
+  const save = vi.fn().mockResolvedValue(undefined)
+  window.hermesDesktop = { saveImageBuffer: save } as unknown as typeof window.hermesDesktop
+
+  const events = [
+    { seq: 1, room_id: binding.roomId, event_id: 'user-event', kind: 'message.user' },
+    { seq: 2, room_id: binding.roomId, event_id: 'member-event', kind: 'message.member', actor: { member_id: 'helper' } },
+    { seq: 3, room_id: binding.roomId, kind: 'message.user' },
+    { seq: 4, room_id: 'other-room', event_id: 'foreign-event', kind: 'message.member' }
+  ].map(event => ({ ...event, payload: { attachments: [{ ...manifest, event_id: 'not-the-event' }] } }))
+
+  request.mockImplementation(async (_route, method, params) => {
+    if (method === 'groups.state') {return { room: { name: 'Room' } }}
+
+    if (method === 'groups.log') {return { events }}
+
+    if (method === 'groups.attachment.download') {return { ...manifest, event_id: params.event_id, data_base64: 'QQ==' }}
+    throw new Error(`Unexpected method ${method}`)
+  })
+  render(<CanonicalGroupWorkspace binding={binding} />)
+  const history = within(screen.getByRole('log'))
+  await waitFor(() => expect(history.getAllByRole('button', { name: 'Download' })).toHaveLength(4))
+  const buttons = history.getAllByRole('button', { name: 'Download' }) as HTMLButtonElement[]
+  expect(buttons.map(button => button.disabled)).toEqual([false, false, true, true])
+  fireEvent.click(buttons[0])
+  await waitFor(() => expect(observed.downloads).toHaveLength(1))
+  fireEvent.click(buttons[1])
+  await waitFor(() => expect(observed.downloads).toHaveLength(2))
+  expect(save).not.toHaveBeenCalled()
+  const reads = request.mock.calls.filter(call => call[1] === 'groups.attachment.download')
+  expect(reads.map(call => call[2].event_id)).toEqual(['user-event', 'member-event'])
+  expect(reads.every(call => call[2].room_id === binding.roomId && call[2].profile === binding.profile)).toBe(true)
+  expect(history.queryByRole('button', { name: 'Remove attachment' })).toBeNull()
+})

--- a/apps/desktop/src/plugins/hermes-bots/canonical-group-history.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/canonical-group-history.tsx
@@ -1,0 +1,21 @@
+import { type CanonicalGroupAttachment, CanonicalGroupAttachments } from './canonical-group-attachments'
+import type { CanonicalGroupBinding } from './canonical-groups'
+
+export interface CanonicalGroupEvent {
+  seq: number
+  event_id?: string
+  room_id?: string
+  kind: string
+  payload: { text?: string; content?: string; attachments?: CanonicalGroupAttachment[] }
+  actor?: { member_id?: string }
+}
+
+export function CanonicalGroupHistory({ binding, events, disabled = false }: { binding: CanonicalGroupBinding; events: CanonicalGroupEvent[]; disabled?: boolean }) {
+  return <>{events.map(event => <div className="whitespace-pre-wrap py-2" key={event.seq}>
+    {event.actor?.member_id && <strong>{event.actor.member_id}: </strong>}
+    {event.payload.text || event.payload.content || event.kind}
+    {!!event.payload.attachments?.length && <CanonicalGroupAttachments
+      attachments={event.payload.attachments.map(attachment => ({ ...attachment, event_id: event.event_id }))}
+      binding={binding} disabled={disabled || !event.event_id || event.room_id !== binding.roomId} readOnly />}
+  </div>)}</>
+}

--- a/apps/desktop/src/plugins/hermes-bots/canonical-group-workspace.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/canonical-group-workspace.tsx
@@ -2,13 +2,14 @@ import { Button } from '@hermes/plugin-sdk'
 import { useEffect, useRef, useState } from 'react'
 
 import { CanonicalGroupAttachments } from './canonical-group-attachments'
+import { type CanonicalGroupEvent, CanonicalGroupHistory } from './canonical-group-history'
 import { useCanonicalGroupLabels } from './canonical-group-labels'
 import { prepareCanonicalGroupSend, readCanonicalGroupSend, retireCanonicalGroupSend } from './canonical-group-send'
 import type { PreparedCanonicalGroupSend } from './canonical-group-send'
 import { actCanonicalGroup, canonicalGroupRequest } from './canonical-groups'
 import type { CanonicalGroupBinding, CanonicalPendingAction } from './canonical-groups'
 
-interface RoomEvent { seq: number; kind: string; payload: { text?: string; content?: string }; actor?: { member_id?: string } }
+type RoomEvent = CanonicalGroupEvent
 interface Attachment { attachment_id?: string; event_id?: string; kind: string; name: string; mime: string; size?: number }
 interface RoomState { room: { name: string }; driver_status?: { pending_actions?: CanonicalPendingAction[] } }
 
@@ -145,7 +146,7 @@ function CanonicalRoomView({ binding: initialBinding, visible, onBack }: {
     {error && <div role="alert">{error}</div>}
     {state && !state.driver_status && <p>{labels.driverUnavailable}</p>}
     <div className="min-h-0 flex-1 overflow-auto" role="log">
-      {events.map(event => <div className="whitespace-pre-wrap py-2" key={event.seq}>{event.actor?.member_id && <strong>{event.actor.member_id}: </strong>}{event.payload.text || event.payload.content || event.kind}</div>)}
+      <CanonicalGroupHistory binding={binding} disabled={!visible} events={events} />
     </div>
     {(state?.driver_status?.pending_actions || []).map(action => <div className="flex items-center gap-2" key={`${action.kind}:${action.task_id}:${action.execution_generation}`}>
       <span>{action.member_id}</span>

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -103,6 +103,7 @@ const {
   BACKGROUND_UPDATE_CHECK_MS
 } = await import('./updates')
 
+const { CANONICAL_GATEWAY_PROTOCOL } = await import('@/api/canonical-protocol')
 const { setConnection } = await import('./session')
 
 const registryOf = (ids: string[]) => ({
@@ -197,6 +198,18 @@ describe('reportBackendContract', () => {
     reportBackendContract(6)
     expect(dismissSpy).toHaveBeenCalledWith('backend-contract-skew')
     expect(notifySpy).not.toHaveBeenCalled()
+  })
+
+  it('accepts only the matching canonical gateway protocol without claiming the legacy contract', () => {
+    reportBackendContract(undefined, CANONICAL_GATEWAY_PROTOCOL)
+    expect(dismissSpy).toHaveBeenCalledWith('backend-contract-skew')
+    expect(notifySpy).not.toHaveBeenCalled()
+
+    reportBackendContract(undefined, 'hermes-gateway-v0')
+    expect(notifySpy).toHaveBeenCalledTimes(1)
+
+    reportBackendContract(Number.MAX_SAFE_INTEGER, 'hermes-gateway-v0')
+    expect(notifySpy).toHaveBeenCalledTimes(2)
   })
 
   it('warns when the backend is behind (or reports no contract)', () => {

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -5,6 +5,7 @@
 
 import { atom } from 'nanostores'
 
+import { CANONICAL_GATEWAY_PROTOCOL } from '@/api/canonical-protocol'
 import type {
   DesktopUpdateApplyOptions,
   DesktopUpdateApplyResult,
@@ -94,8 +95,10 @@ function isUpdateToastSnoozed(): boolean {
 }
 
 // Must match tui_gateway's DESKTOP_BACKEND_CONTRACT that this build was written
-// against. The backend reports its own value in session runtime info; a lower
-// value (or none — a pre-GUI checkout) means GUI<->backend skew.
+// against. Legacy backends report their own value in session runtime info; a
+// lower value (or none — a pre-GUI checkout) means GUI<->backend skew.
+// Canonical gateways identify their distinct wire protocol instead. That value
+// does not claim the legacy API features listed below.
 // v2: requires the file.attach RPC (remote-gateway non-image file upload).
 // v3: requires approvals.mode config RPCs and session.info reconciliation.
 // v4: requires explicit Fast-off session creation and session-scoped Fast edits.
@@ -149,8 +152,13 @@ function isInstallMethodToastSnoozed(): boolean {
  * Runs on every session open; closing the toast snoozes it for a cooldown so it
  * doesn't nag on every thread switch.
  */
-export function reportBackendContract(contract: number | undefined): void {
-  if ((contract ?? 0) >= REQUIRED_BACKEND_CONTRACT) {
+export function reportBackendContract(contract: number | undefined, protocol?: string): void {
+  // An unknown explicit protocol must not fall back to a legacy version claim.
+  const compatible = protocol === undefined
+    ? (contract ?? 0) >= REQUIRED_BACKEND_CONTRACT
+    : protocol === CANONICAL_GATEWAY_PROTOCOL
+
+  if (compatible) {
     dismissNotification(SKEW_TOAST_ID)
     // Backend caught up — forget any prior snooze so a future regression warns
     // immediately rather than staying silent for the rest of the window.

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -798,6 +798,7 @@ export interface SessionRuntimeInfo {
   credential_warning?: string
   cwd?: string
   desktop_contract?: number
+  desktop_protocol?: string
   fast?: boolean
   install_warning?: string
   model?: string

--- a/gateway/run_api.py
+++ b/gateway/run_api.py
@@ -156,6 +156,7 @@ class GatewayRuntimeAPI:
             return
         # The ticket names the served profile; this connection binds to that home's authority.
         scope['hermes.session_authority'] = authority
+        from gateway.session_contract import CANONICAL_GATEWAY_PROTOCOL
         from tui_gateway.ws import handle_ws
         from gateway.session_authorities import owner_scope
         with owner_scope(authority):
@@ -163,4 +164,4 @@ class GatewayRuntimeAPI:
                                               'profile_id': grant['profile_id'],
                                               'instance_id': grant['instance_id'],
                                               'capabilities': grant['capabilities'], 'native_bootstrap': True},
-                            subprotocol='hermes-gateway-v1')
+                            subprotocol=CANONICAL_GATEWAY_PROTOCOL)

--- a/gateway/run_runtime.py
+++ b/gateway/run_runtime.py
@@ -116,6 +116,8 @@ def publish_gateway_runtime_ready(runner):
         raise RuntimeError('gateway stopped before session API readiness')
     descriptor.update(state='ready', capabilities=[
         'session-authority-v1', 'durable-admission-v1', 'event-replay-v1'])
+    from gateway.session_hosted_service import start_ready_hosted_services
+    start_ready_hosted_services(runner)
 
 
 async def wait_gateway_runtime(runner):

--- a/gateway/session_authority.py
+++ b/gateway/session_authority.py
@@ -10,7 +10,7 @@ from dataclasses import asdict, dataclass, field
 import uuid
 
 from gateway.session_contract import (
-    AdmissionReceipt, PendingAdmission, Principal, SessionHandle, SessionRef, Submission,
+    CANONICAL_GATEWAY_PROTOCOL, AdmissionReceipt, PendingAdmission, Principal, SessionHandle, SessionRef, Submission,
     SubscriptionSnapshot,
 )
 from gateway.session_events import SessionEvents
@@ -159,6 +159,7 @@ class SessionAuthority:
             # prepared mutation must present.
             live.event_stream.publish(ref.session_id, {
                 'stored_session_id': ref.session_id, 'pending': pending,
+                'desktop_protocol': CANONICAL_GATEWAY_PROTOCOL,
                 'running': handle.execution_state == 'running',
                 'execution_generation': handle.execution_generation,
                 'revision': handle.revision,

--- a/gateway/session_bot.py
+++ b/gateway/session_bot.py
@@ -60,7 +60,7 @@ def _result(authority, record):
         status = record['status']
     return {k: v for k, v in dict(status=status, delivery_id=record['delivery_id'],
         profile_home=record['profile_home'], session_id=record['session_id'],
-        admission_id=record['admission_id'], reply=reply).items()}
+        admission_id=record['admission_id'], message=record['message'], reply=reply).items()}
 
 
 async def _record_reply(authority, home, key, future):

--- a/gateway/session_contract.py
+++ b/gateway/session_contract.py
@@ -5,6 +5,9 @@ from typing import Literal, Mapping, Protocol
 
 JsonObject = Mapping[str, object]
 
+# Authenticated local WebSocket family, separate from the legacy Desktop API contract.
+CANONICAL_GATEWAY_PROTOCOL = 'hermes-gateway-v1'
+
 
 @dataclass(frozen=True)
 class Principal:

--- a/gateway/session_controls.py
+++ b/gateway/session_controls.py
@@ -3,7 +3,8 @@ from dataclasses import asdict
 import sqlite3
 import uuid
 
-from gateway.session_contract import Principal, SessionRef, Submission
+from gateway.config import Platform
+from gateway.session_contract import CANONICAL_GATEWAY_PROTOCOL, Principal, SessionRef, Submission
 from hermes_state_runtime import RuntimeStoreError
 
 
@@ -161,7 +162,7 @@ class AuthorityConnection:
         return await readiness(self.authority, self.actor, params, runtime=True)
 
     async def create(self, ref, params):
-        from gateway.session_local import create_local_session, local_session_info
+        from gateway.session_local import create_local_session
         from gateway.session_local_title import resolve_titled_session, title_new_session, validate_title
         # ``-c <title> --create-if-missing``: resolve-or-create is one owner step (no await
         # between lookup and creation), so concurrent programmatic callers converge.
@@ -171,9 +172,7 @@ class AuthorityConnection:
             ref = create_local_session(self.authority, self.actor, params)
             if title:
                 title_new_session(self.authority, ref, title)
-        result = await self.resume(ref, {})
-        result['info'] = local_session_info(self.authority, ref)
-        return result
+        return await self.resume(ref, {})
 
     async def ping(self, ref, params):
         if not self.actor.capabilities:
@@ -222,6 +221,7 @@ class AuthorityConnection:
         return {'sessions': sessions[:limit], 'scope': 'live'}
 
     async def resume(self, ref, params):
+        from gateway.session_local import local_session_info
         if 'title' in params:
             from gateway.session_local_title import resolve_titled_session
             ref = resolve_titled_session(self.authority, self.actor, params['title'])
@@ -237,6 +237,11 @@ class AuthorityConnection:
             resume_editor_mcp(self.authority, ref, params['editor'])
         snapshot = await self.authority.attach(self.actor, ref)
         self.subscriptions[ref.session_id] = snapshot.subscription_id
+        # Only local routes have a frozen local launch policy to project.
+        info = {'desktop_protocol': CANONICAL_GATEWAY_PROTOCOL}
+        source = self.authority.sessions[snapshot.handle.ref.session_id].source
+        if source is not None and source.platform == Platform.LOCAL:
+            info = local_session_info(self.authority, snapshot.handle.ref)
         return {'session_id': ref.session_id, 'stored_session_id': ref.session_id,
                 'messages': list(snapshot.history), 'message_count': len(snapshot.history),
                 'running': snapshot.handle.execution_state == 'running',
@@ -245,7 +250,7 @@ class AuthorityConnection:
                 'subscription_id': snapshot.subscription_id, 'revision': snapshot.handle.revision,
                 'execution_generation': snapshot.handle.execution_generation,
                 'pending': [asdict(r) for r in snapshot.pending],
-                'prompts': list(snapshot.prompts), 'info': {}}
+                'prompts': list(snapshot.prompts), 'info': info}
 
     async def events_since(self, ref, params):
         self.authority.authorize(self.actor, ref, 'session:read')

--- a/gateway/session_hosted_rpc.py
+++ b/gateway/session_hosted_rpc.py
@@ -42,6 +42,11 @@ class HostedRoomAuthorityRPC:
         return future.result(self.timeout)
 
     async def _dispatch(self, operation, params):
+        from gateway.session_authorities import owner_scope
+        with owner_scope(self.authority):
+            return await self._dispatch_owned(operation, params)
+
+    async def _dispatch_owned(self, operation, params):
         if (params.get('profile', self.profile) != self.profile
                 or self.principal.profile_id != self.authority.profile_id):
             raise RuntimeStoreError('profile_mismatch')

--- a/gateway/session_hosted_service.py
+++ b/gateway/session_hosted_service.py
@@ -4,6 +4,7 @@ from contextlib import nullcontext
 from pathlib import Path
 
 from gateway.session_contract import Principal
+from gateway.session_authorities import active_authority, all_authorities, owner_scope
 from gateway.session_hosted_controls import HostedControls
 from hermes_state_runtime import RuntimeStoreError, _epoch
 from tui_gateway.hosted_room_service import HostedRoomService
@@ -28,7 +29,9 @@ class CanonicalHostedRoomService(HostedControls, HostedRoomService):
         from gateway.session_authorities import served_profile_name
         home = Path(self.authority.profile_id)
         own = served_profile_name(home)
-        configured = _load_gateway_config().get('hosted_rooms', {}).get('profiles', {})
+        # The coordinator's own threads do not inherit the caller's ContextVars.
+        with owner_scope(self.authority):
+            configured = _load_gateway_config().get('hosted_rooms', {}).get('profiles', {})
         result = {own: home}
         if not isinstance(configured, dict):
             raise RuntimeStoreError('invalid_params')
@@ -201,21 +204,49 @@ class CanonicalHostedRoomService(HostedControls, HostedRoomService):
 
 
 async def ensure_hosted_service(runner):
-    authority = runner.session_authority
-    service = getattr(authority, 'hosted_room_service', None)
-    if service is None:
-        loop = asyncio.get_running_loop()
-        service = await asyncio.to_thread(CanonicalHostedRoomService, authority, loop)
-        authority.hosted_room_service = service
-    if not getattr(service, '_transport_installed', False):
-        from gateway.session_hosted_transport import install_hosted_transport
-        install_hosted_transport(runner.session_control_server, authority, asyncio.get_running_loop(),
-                                 attest=service.attest)
-        service._transport_installed = True
-    await asyncio.to_thread(service.start)
-    return service
+    """Prepare every transport before readiness can release any coordinator."""
+    active = active_authority(runner)
+    if active is None:
+        raise RuntimeStoreError('profile_mismatch')
+    for authority in all_authorities(runner):
+        await _ensure_hosted_service(runner, authority)
+    start_ready_hosted_services(runner)
+    return active.hosted_room_service
+
+
+async def _ensure_hosted_service(runner, authority):
+    with owner_scope(authority):
+        service = getattr(authority, 'hosted_room_service', None)
+        if service is None:
+            loop = asyncio.get_running_loop()
+            service = await asyncio.to_thread(CanonicalHostedRoomService, authority, loop)
+            authority.hosted_room_service = service
+        if not getattr(service, '_transport_installed', False):
+            from gateway.session_hosted_transport import install_hosted_transport
+            install_hosted_transport(runner.session_control_server, authority, asyncio.get_running_loop(),
+                                     attest=service.attest)
+            service._transport_installed = True
+
+
+def start_ready_hosted_services(runner):
+    """Start only a fully prepared served set behind the published ready gate."""
+    if (getattr(runner, 'session_runtime_descriptor', {}).get('state') != 'ready'
+            or getattr(runner, '_draining', False)):
+        return
+    services = [getattr(authority, 'hosted_room_service', None) for authority in all_authorities(runner)]
+    if any(service is None or not getattr(service, '_transport_installed', False) for service in services):
+        return
+    for service in services:
+        # start() only releases its thread; preparation and disk access happened above.
+        service.start()
 
 
 async def stop_hosted_service(runner, timeout=5):
-    service = getattr(runner.session_authority, 'hosted_room_service', None)
-    return True if service is None else await asyncio.to_thread(service.stop, timeout=timeout)
+    loop = asyncio.get_running_loop()
+    deadline, stopped = loop.time() + max(0, timeout), True
+    for authority in all_authorities(runner):
+        service = getattr(authority, 'hosted_room_service', None)
+        if service is not None:
+            result = await asyncio.to_thread(service.stop, timeout=max(0, deadline - loop.time()))
+            stopped = result and stopped
+    return stopped

--- a/gateway/session_hosted_transport.py
+++ b/gateway/session_hosted_transport.py
@@ -19,6 +19,7 @@ import time
 
 from gateway.hosted_room_driver import TaskIdentity
 from gateway.session_contract import Principal
+from gateway.session_authorities import owner_scope
 from gateway.session_hosted_rpc import HostedRoomAuthorityRPC
 from hermes_state_runtime import RuntimeStoreError, _epoch
 
@@ -35,6 +36,20 @@ def owner_request(home, verb, params, *, timeout=30):
     home = Path(home)
     if home != home.resolve():
         raise RuntimeStoreError('permission_denied')
+    from hermes_cli.gateway_runtime import discover_gateway_endpoint, control_home_for
+    deadline = time.monotonic() + timeout
+    discovered = discover_gateway_endpoint(home, timeout=timeout)
+    if discovered.state != 'ready' or discovered.endpoint is None:
+        raise RuntimeStoreError('runtime_draining')
+    from hermes_constants import hermes_home_key
+    if hermes_home_key(discovered.endpoint.profile_id) != hermes_home_key(home):
+        raise RuntimeStoreError('profile_mismatch')
+    # Socket identity and logical authority identity are distinct under multiplex.
+    params = {**params, 'profile_id': discovered.endpoint.profile_id}
+    home = control_home_for(home, discovered.endpoint)
+    timeout = deadline - time.monotonic()
+    if timeout <= 0:
+        raise RuntimeStoreError('runtime_draining')
     request = json.dumps({'protocol': 1, 'id': 1, 'verb': verb, 'params': params}).encode() + b'\n'
     if len(request) > 65536:
         raise RuntimeStoreError('invalid_params')
@@ -44,7 +59,6 @@ def owner_request(home, verb, params, *, timeout=30):
     else:
         from hermes_cli.gateway_runtime_discovery import _socket_path
         from gateway.control_socket import _read_response_line
-        deadline = time.monotonic() + timeout
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as peer:
             peer.settimeout(timeout)
             peer.connect(str(_socket_path(home)))
@@ -137,20 +151,49 @@ def _principal(authority, binding):
 
 
 def install_hosted_transport(server, authority, loop, *, attest):
-    """Install private routing. attest(selector, operation, params) reads OWN state.
+    """Install profile-selected private routing over the existing authority registry.
 
     The callback must validate current room authority/member and, for submit and
     execute, exact TaskIdentity, generation and prompt against durable task data.
     It returns {'owner': durable_room_owner_subject}, never a client actor.
+    Every wire envelope names the logical profile_id, not its control socket home.
+    Reinstallation for a secondary preserves routing to all other served owners.
     """
-    def source(params, peer):
+    def select(envelope):
+        from hermes_constants import assert_named_profile_home_live
+        params = dict(envelope)
+        profile_id = params.pop('profile_id', None)
+        if not isinstance(profile_id, str) or not Path(profile_id).is_absolute():
+            raise RuntimeStoreError('profile_mismatch')
+        home = Path(profile_id)
+        if home != home.resolve():
+            raise RuntimeStoreError('profile_mismatch')
+        registry = getattr(getattr(authority, 'runner', None), 'session_authorities', None)
+        selected = registry.for_home(home) if registry is not None else authority
+        if selected is None or selected.profile_id != profile_id:
+            raise RuntimeStoreError('profile_mismatch')
+        assert_named_profile_home_live(home)
+        return selected, params
+
+    def source(envelope, peer):
+        selected, params = select(envelope)
         if set(params) != {'selector', 'operation', 'params'}:
             raise RuntimeStoreError('invalid_params')
         if params['operation'] not in _OPERATIONS | {'execute', 'attachment'}:
             raise RuntimeStoreError('invalid_params')
-        return attest(params['selector'], params['operation'], params['params'])
+        callback = attest if selected is authority else getattr(
+            getattr(selected, 'hosted_room_service', None), 'attest', None)
+        if callback is None:
+            raise RuntimeStoreError('runtime_draining')
+        with owner_scope(selected):
+            return callback(params['selector'], params['operation'], params['params'])
 
     def target(envelope, peer):
+        selected, params = select(envelope)
+        with owner_scope(selected):
+            return produce(selected, params)
+
+    def produce(authority, envelope):
         if set(envelope) != {'source_home', 'selector', 'operation', 'params'}:
             raise RuntimeStoreError('invalid_params')
         operation, params = envelope['operation'], dict(envelope['params'])
@@ -195,6 +238,11 @@ def check_remote_hosted_admission(authority, ref, row):
     fails closed on missing source, revoked membership or altered task payload.
     Call off the owner's event loop (the reverse RPC is synchronous).
     """
+    with owner_scope(authority):
+        return _check_remote_hosted_admission(authority, ref, row)
+
+
+def _check_remote_hosted_admission(authority, ref, row):
     with authority.db._read_ctx() as conn:
         stored = conn.execute('SELECT value FROM state_meta WHERE key=?',
                               (_BINDING + ref.session_id,)).fetchone()

--- a/gateway/session_local.py
+++ b/gateway/session_local.py
@@ -9,6 +9,7 @@ import uuid
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, SendResult
 from gateway.session import SessionSource
+from gateway.session_contract import CANONICAL_GATEWAY_PROTOCOL
 from hermes_state_runtime import RuntimeStoreError
 
 
@@ -165,4 +166,5 @@ def local_session_info(authority, ref):
     policy = policy_for_source(authority.runner, live.source)
     return {'source': policy.source if policy else live.source.platform.value,
             'model': getattr(agent, 'model', policy.model if policy else None), 'lazy': agent is None,
-            'profile_id': authority.profile_id, **({'cwd': policy.cwd} if policy else {})}
+            'profile_id': authority.profile_id, 'desktop_protocol': CANONICAL_GATEWAY_PROTOCOL,
+            **({'cwd': policy.cwd} if policy else {})}

--- a/tests/gateway/test_authority_connection.py
+++ b/tests/gateway/test_authority_connection.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 import pytest
 
 from gateway.session_authority import LiveSession, SessionAuthority
+from gateway.session_contract import CANONICAL_GATEWAY_PROTOCOL
 from gateway.session_controls import AuthorityConnection
 from hermes_state import SessionDB
 from hermes_state_runtime import begin_runtime_epoch
@@ -22,7 +23,8 @@ async def test_repeated_resume_and_close_preserve_only_live_memberships(tmp_path
         peer = AuthorityConnection(authority, object(), {'user_id': 'human'})
         request = {'id': 1, 'method': 'session.resume', 'params': {'session_id': 's'}}
         for connection in (first, peer, first, first):
-            assert 'result' in await connection.dispatch(request)
+            result = (await connection.dispatch(request))['result']
+            assert result['info'] == {'desktop_protocol': CANONICAL_GATEWAY_PROTOCOL}
         members = authority.sessions['s'].subscribers
         assert len(members) == 2
         await first.close()

--- a/tests/gateway/test_bot_result_recovery.py
+++ b/tests/gateway/test_bot_result_recovery.py
@@ -26,13 +26,14 @@ def test_bot_reply_recovery_uses_exact_terminal_admission(tmp_path):
         if settle:
             retain_result(db, epoch=epoch, row=row, result={'result': {'final_response': reply}, 'usage': {}})
         records.append(dict(status='canonical', admission_id=admission['admission_id'],
-                            delivery_id=key, profile_home=str(tmp_path), session_id='bot'))
+                            delivery_id=key, profile_home=str(tmp_path), session_id='bot', message=key))
     db.close()
     db = SessionDB(path)
     try:
         epoch = begin_runtime_epoch(db, instance_id='restart')
         recover_session_inputs(db, epoch=epoch)
         authority = SimpleNamespace(db=db)
+        assert [_result(authority, record)['message'] for record in records] == ['one', 'two', 'three']
         assert _result(authority, records[0])['reply'] == 'exact first reply'
         assert _result(authority, records[0])['status'] == 'settled'
         assert _result(authority, records[1])['reply'] == 'later reply is not first'

--- a/tests/gateway/test_canonical_desktop_metadata.py
+++ b/tests/gateway/test_canonical_desktop_metadata.py
@@ -1,0 +1,60 @@
+"""Canonical GUI metadata follows the authenticated local-session route."""
+import asyncio
+import json
+
+import pytest
+
+from tests.gateway.fixtures.local_recovery_probe import rpc, websocket
+from tests.gateway.test_session_busy_controls import owner, settled
+
+
+@pytest.mark.linux_only
+def test_canonical_desktop_metadata_survives_create_info_and_reattach(tmp_path):
+    """The native protocol, not the legacy contract number, identifies this route."""
+    with owner(tmp_path) as (home, _peer, desc):
+        async def probe():
+            async with websocket(home, desc) as creator:
+                created = await rpc(creator, 'session.create', request_id='desktop-metadata',
+                                    source='gui', toolsets=[])
+                assert 'result' in created, created
+                sid = created['result']['session_id']
+                created_info = created['result']['info']
+                assert created_info['desktop_protocol'] == creator.subprotocol
+                assert 'desktop_contract' not in created_info
+                assert created_info['lazy'] is True
+
+                lazy_info = await rpc(creator, 'session.info', session_id=sid)
+                assert lazy_info['result']['desktop_protocol'] == creator.subprotocol
+                assert lazy_info['result']['lazy'] is True
+
+                # Read every frame: the RPC helper deliberately skips events,
+                # but Desktop reconciles their metadata throughout each turn.
+                await creator.send(json.dumps({'jsonrpc': '2.0', 'id': 'initialize',
+                    'method': 'prompt.submit', 'params': {'session_id': sid,
+                        'input_id': 'initialize', 'text': 'INITIALIZE'}}))
+                submitted = saw_pending = finished = False
+                async with asyncio.timeout(30):
+                    while not submitted or not finished:
+                        frame = json.loads(await creator.recv())
+                        if frame.get('id') == 'initialize':
+                            assert frame['result']['status'] == 'queued', frame
+                            submitted = True
+                        event = frame.get('params', {})
+                        if event.get('type') == 'session.info' and event.get('session_id') == sid:
+                            info = event['payload']
+                            assert info['desktop_protocol'] == creator.subprotocol
+                            assert 'desktop_contract' not in info
+                            saw_pending |= bool(info['pending'])
+                            finished = saw_pending and not info['pending'] and not info['running']
+                await settled(home)
+
+                initialized_info = await rpc(creator, 'session.info', session_id=sid)
+                assert initialized_info['result']['desktop_protocol'] == creator.subprotocol
+                assert initialized_info['result']['lazy'] is False
+
+            async with websocket(home, desc) as reattached:
+                resumed = await rpc(reattached, 'session.resume', session_id=sid)
+                assert resumed['result']['info']['desktop_protocol'] == reattached.subprotocol
+                assert resumed['result']['info']['lazy'] is False
+
+        asyncio.run(probe())

--- a/tests/gateway/test_cron_canonical_receipt_regression.py
+++ b/tests/gateway/test_cron_canonical_receipt_regression.py
@@ -1,0 +1,125 @@
+"""Cron consumes the real Bot Chat receipt over an owned daemon's WebSocket."""
+import asyncio
+from contextlib import closing
+from http.server import ThreadingHTTPServer
+import json
+from pathlib import Path
+import sqlite3
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from tests.gateway.fixtures.local_recovery_probe import Model, child_env, daemon, rpc, websocket
+
+
+def admissions(home):
+    with closing(sqlite3.connect(f'file:{home / "state.db"}?mode=ro', uri=True)) as db:
+        db.row_factory = sqlite3.Row
+        return [dict(row) for row in db.execute('SELECT * FROM session_admissions ORDER BY seq')]
+
+
+def wait_for(predicate):
+    deadline = time.monotonic() + 25
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(.05)
+    pytest.fail('Timed out waiting for the test-owned admission')
+
+
+@pytest.fixture
+def canonical_bot(tmp_path, monkeypatch):
+    root = Path(__file__).resolve().parents[2]
+    home, user = tmp_path / 'state', tmp_path / 'user'
+    home.mkdir(mode=0o700)
+    user.mkdir()
+    monkeypatch.setenv('HERMES_HOME', str(home))
+    monkeypatch.setenv('HOME', str(user))
+    monkeypatch.setenv('USERPROFILE', str(user))
+    model = ThreadingHTTPServer(('127.0.0.1', 0), Model)
+    model.requests = []
+    model.blocked, model.release = threading.Event(), threading.Event()
+    thread = threading.Thread(target=model.serve_forever, daemon=True)
+    thread.start()
+    base = f'http://127.0.0.1:{model.server_port}/v1'
+    (home / 'config.yaml').write_text(json.dumps({
+        'gateway': {'multiplex_profiles': False},
+        'model': {'provider': 'custom', 'default': 'local-wire-stub', 'base_url': base},
+        'auxiliary': {'title_generation': {'enabled': False}},
+        'platform_toolsets': {'gui': []}, 'terminal': {'cwd': str(home)},
+    }))
+    env = child_env() | dict(HOME=str(user), USERPROFILE=str(user), HERMES_HOME=str(home),
+        PYTHONPATH=str(root), OPENAI_API_KEY='loopback-only', OPENAI_BASE_URL=base,
+        PYTHONUNBUFFERED='1')
+
+    async def prepare(desc):
+        async with websocket(home, desc) as ws:
+            created = await rpc(ws, 'session.create', request_id='cron-target', source='gui',
+                                cwd=str(home), toolsets=[])
+            assert 'result' in created, created
+            sid = created['result']['session_id']
+            renamed = await rpc(ws, 'session.mutate', session_id=sid, request_id='bot-title',
+                expected_revision=created['result']['revision'], operation='rename',
+                payload={'title': 'Bot Chat'})
+            assert 'result' in renamed, renamed
+            warm = await rpc(ws, 'prompt.submit', session_id=sid, input_id='warm', text='WARM_HISTORY')
+            assert 'result' in warm, warm
+            await asyncio.to_thread(wait_for, lambda: admissions(home)[0]['status'] == 'terminal')
+            held = await rpc(ws, 'prompt.submit', session_id=sid, input_id='held', text='BLOCK_STARTED')
+            assert 'result' in held, held
+            assert await asyncio.to_thread(model.blocked.wait, 20)
+            return sid
+
+    try:
+        with daemon(root, home, env, barrier=False) as (proc, desc):
+            sid = asyncio.run(prepare(desc))
+            try:
+                yield SimpleNamespace(home=home, model=model, sid=sid, pid=proc.pid)
+            finally:
+                model.release.set()
+        assert proc.poll() is not None
+    finally:
+        model.release.set()
+        model.shutdown()
+        model.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.mark.parametrize('phase', ['queued', 'settled'])
+def test_cron_tracks_real_canonical_receipt(canonical_bot, phase):
+    from cron.scheduler_delivery import _deliver_to_bot_chat
+
+    bot = canonical_bot
+    job = {'id': 'owned-cron', 'name': 'Receipt check', 'execution_id': 'one-owned-execution'}
+    content = 'CRON_REAL_RECEIPT_PROBE'
+    initial = _deliver_to_bot_chat(job, content, '')
+
+    def owned_rows():
+        return [row for row in admissions(bot.home) if content in row['payload_json']]
+
+    before = owned_rows()
+    assert len(before) == 1 and before[0]['status'] == 'queued', (initial, before)
+    admission_id = before[0]['admission_id']
+    if phase == 'settled':
+        bot.model.release.set()
+        wait_for(lambda: owned_rows()[0]['status'] == 'terminal')
+        observed = _deliver_to_bot_chat(job, content, '')
+    else:
+        observed = initial
+    after = owned_rows()
+    print(json.dumps({'phase': phase, 'daemon_pid': bot.pid, 'cron_result': observed,
+                      'admission_id': admission_id, 'admission_status': after[0]['status'],
+                      'admission_count': len(after),
+                      'bookkeeping': job.get('_bot_chat_delivery_receipts')}))
+    assert len(after) == 1 and after[0]['admission_id'] == admission_id
+    if phase == 'queued':
+        assert observed and 'queued' in observed, observed
+        assert job['_bot_chat_delivery_receipts']['bot-chat:(own)']['status'] == 'queued'
+        assert _deliver_to_bot_chat(job, content, '') == observed
+    else:
+        assert observed is None, observed
+        assert job['_bot_chat_delivery_receipts']['bot-chat:(own)']['status'] == 'settled'
+        assert _deliver_to_bot_chat(job, content, '') is None
+    assert len(owned_rows()) == 1

--- a/tests/gateway/test_hosted_mux_runtime.py
+++ b/tests/gateway/test_hosted_mux_runtime.py
@@ -1,0 +1,287 @@
+"""Hosted multiplexing through real owners and private sockets, without inference."""
+import asyncio
+import base64
+import json
+from pathlib import Path
+import threading
+import time
+
+import pytest
+
+from tests.gateway.test_session_authorities_multiplex import _reserve_homes, _runner
+
+
+@pytest.fixture
+def mux(tmp_path, monkeypatch, request):
+    from gateway.control_socket import GatewayControlServer
+    from gateway.run_runtime import initialize_gateway_runtime
+    from gateway.runtime_ownership import process_ownership
+
+    root, homes = _reserve_homes(tmp_path, monkeypatch)
+    for name, home in homes:
+        config = {'model': {'default': 'fixture-' + name}, 'platform_toolsets': {'cli': []},
+                  'hosted_rooms': {'profiles': {n: str(h) for n, h in homes if h != home}}}
+        (home / 'config.yaml').write_text(json.dumps(config))
+    process_ownership.reserve([home for _, home in homes])
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever)
+    thread.start()
+    runner = _runner(root, homes)
+    def call(coroutine):
+        return asyncio.run_coroutine_threadsafe(coroutine, loop).result(15)
+    try:
+        call(initialize_gateway_runtime(runner))
+        for authority in runner.session_authorities:
+            # This suite checks creation/admission, not model execution.
+            monkeypatch.setattr(authority, '_schedule', lambda ref: None)
+        descriptor = runner.session_runtime_descriptor
+        descriptor.update(state=getattr(request, 'param', 'ready'),
+                          capabilities=['session-authority-v1'], api_origin='http://127.0.0.1:1',
+                          supervisor='none')
+        server = runner.session_control_server = GatewayControlServer(
+            root, verb_handlers={'identify': lambda: descriptor})
+        assert call(server.start())
+        yield runner, dict(homes), loop, call
+    finally:
+        for authority in getattr(runner, 'session_authorities', []):
+            service = getattr(authority, 'hosted_room_service', None)
+            if service is not None:
+                assert service.stop(timeout=5)
+            authority.db.close()
+        server = getattr(runner, 'session_control_server', None)
+        if server is not None:
+            call(server.stop())
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(5)
+        assert not thread.is_alive()
+        loop.close()
+        for _, home in homes:
+            process_ownership.release(home)
+
+
+def test_hosted_lifecycle_serves_and_stops_every_authority(mux):
+    from gateway.run_runtime import recover_gateway_native_sessions
+    from gateway.session_hosted_service import stop_hosted_service
+
+    runner, homes, _, call = mux
+    assert call(recover_gateway_native_sessions(runner)) == {}
+    services = {a.profile_id: getattr(a, 'hosted_room_service', None)
+                for a in runner.session_authorities}
+    assert all(services.values()), 'each served profile needs its own hosted service'
+    assert len({id(s) for s in services.values()}) == len(homes)
+    assert all(s.runtime.status()['running'] for s in services.values())
+    assert call(runner._ensure_hosted_room_worker()) is runner.session_authority.hosted_room_service
+    call(recover_gateway_native_sessions(runner))
+    assert all(a.hosted_room_service is services[a.profile_id] for a in runner.session_authorities)
+    assert call(stop_hosted_service(runner))
+    assert all(not s.runtime.status()['running'] for s in services.values())
+
+
+def test_secondary_owner_transport_routes_both_directions_through_mux(mux):
+    from gateway import hosted_rooms
+    from gateway.session_authorities import owner_scope
+    from gateway.session_hosted_service import CanonicalHostedRoomService
+    from gateway.session_hosted_transport import (
+        HostedRoomOwnerRPC, install_hosted_transport, check_remote_hosted_admission,
+    )
+    from gateway import hosted_room_driver as tasks
+    from gateway.hosted_room_attachments import HostedRoomAttachmentStore
+    from gateway.session_ingress_media import restore_native_media
+    from hermes_state_runtime import list_session_admissions, RuntimeStoreError
+
+    runner, homes, loop, _ = mux
+    # Isolate routing from startup: construct the real per-profile services directly.
+    for authority in runner.session_authorities:
+        with owner_scope(authority):
+            service = CanonicalHostedRoomService(authority, loop)
+            authority.hosted_room_service = service
+            install_hosted_transport(runner.session_control_server, authority, loop, attest=service.attest)
+    source = runner.session_authorities.require(homes['alpha'])
+    target = runner.session_authorities.require(homes['beta'])
+    service = source.hosted_room_service
+    with owner_scope(source):
+        service.authorize_room('alice', 'room', create=True)
+        hosted_rooms.create_room(source.db.db_path, room_id='room', name='Room',
+            authority_gateway_id=hosted_rooms.local_authority_gateway_id(),
+            members=[{'member_id': 'helper', 'profile': 'beta', 'handle': 'helper'}])
+    rpc = HostedRoomOwnerRPC(home=homes['beta'], source_home=homes['alpha'],
+                            room_id='room', member_id='helper', profile='beta')
+    sid = rpc.create(profile='beta', source='bot_room', title='Group: room')['session_id']
+    assert target.db.get_session(sid)['source'] == 'bot_room'
+    assert source.db.get_session(sid) is None
+    assert runner.session_authority.db.get_session(sid) is None
+    assert rpc.resume(profile='beta', source='bot_room', session_id=sid)['session_id'] == sid
+    assert rpc.ref.profile_id == str(homes['beta'])
+    with pytest.raises(RuntimeStoreError, match='profile_mismatch'):
+        HostedRoomOwnerRPC(home=homes['default'], source_home=homes['alpha'],
+            room_id='room', member_id='helper', profile='beta').create(
+                profile='beta', source='bot_room', title='Group: room')
+
+    data = base64.b64decode(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aZ1sAAAAASUVORK5CYII=')
+    store = HostedRoomAttachmentStore(source.db.db_path)
+    saved = store.put(room_id='room', upload_id='upload', kind='image', name='image.png',
+                      mime='image/png', data=data)
+    manifest = [{k: saved[k] for k in ('attachment_id', 'kind', 'name', 'size', 'mime')}]
+    store.commit_message(room_id='room', event_id='event', manifest=manifest,
+                         recipient_member_ids=['helper'])
+    manifest[0]['event_id'] = 'event'
+    identity = tasks.TaskIdentity('room', 'task', 'thread', 'turn')
+    payload = {'target_profile': 'beta', 'target_member_id': 'helper', 'source_event_seq': 1,
+               'prompt': 'input', 'attachments': manifest}
+    tasks.admit_task(source.db.db_path, identity, payload=payload, clock=time.time)
+    lease = tasks.acquire_lease(source.db.db_path, room_id='room',
+        gateway_id=hosted_rooms.local_authority_gateway_id(), authority_epoch=1,
+        process_generation='fixture', ttl_seconds=30, clock=time.time)
+    tasks.start_task(source.db.db_path, identity, lease, expected_cancel_generation=0, clock=time.time)
+    try:
+        receipt = rpc.submit(profile='beta', source='bot_room', session_id=sid, prompt='input',
+            task=identity, execution_generation=1, attachments=manifest, on_terminal=lambda row: None)
+        repeated = rpc.submit(profile='beta', source='bot_room', session_id=sid, prompt='input',
+            task=identity, execution_generation=1, attachments=manifest, on_terminal=lambda row: None)
+        assert repeated['admission_id'] == receipt['admission_id']
+        row, = list_session_admissions(target.db, session_id=sid, pending_only=False)
+        assert row['status'] == 'queued'
+        assert check_remote_hosted_admission(target, rpc.ref, row)
+        with owner_scope(target):
+            paths = restore_native_media(row['payload']['attachments_v1']['media'])
+        assert len(paths) == 1
+        assert Path(paths[0]).is_relative_to(homes['beta'])
+        assert Path(paths[0]).read_bytes() == data
+    finally:
+        with rpc._lock:
+            rpc.callbacks.clear()
+        if rpc._monitor is not None:
+            rpc._monitor.join(5)
+            assert not rpc._monitor.is_alive()
+        # The queued admission and its running room-attempt row stay as evidence
+        # in the disposable database; no executor ran or needs to be settled.
+
+
+def test_private_rpc_builds_policy_in_destination_scope(mux):
+    from gateway.session_contract import Principal
+    from gateway.session_hosted_rpc import HostedRoomAuthorityRPC
+    from gateway.session_policy import policy_for_source
+
+    runner, homes, loop, _ = mux
+    authority = runner.session_authorities.require(homes['beta'])
+    actor = Principal('alice', authority.profile_id,
+                      frozenset({'session:create', 'session:read'}), 'private-owner')
+    rpc = HostedRoomAuthorityRPC(authority, loop, room_id='room', member_id='helper',
+                                profile='beta', principal=actor, authorize=lambda *args: True)
+    sid = rpc.create(profile='beta', source='bot_room', title='Group: room')['session_id']
+    policy = policy_for_source(runner, authority.sessions[sid].source)
+    assert policy.model == 'fixture-beta'
+    assert policy.config()['model']['default'] == 'fixture-beta'
+
+
+def test_room_coordinator_submits_once_to_destination_authority(mux, monkeypatch):
+    from gateway import hosted_rooms, session_finite
+    from gateway.session_authorities import owner_scope
+    from gateway.session_authority import SessionAuthority
+    from gateway.session_hosted_service import ensure_hosted_service
+    from hermes_constants import get_hermes_home
+    from hermes_state_runtime import list_session_admissions
+
+    runner, homes, _, call = mux
+    executed = []
+    async def execute(authority, ref, row):
+        executed.append((authority.profile_id, ref.profile_id, str(get_hermes_home()), row['admission_id']))
+        return 'member reply'
+    monkeypatch.setattr(session_finite, 'execute_finite_admission', execute)
+    for authority in runner.session_authorities:
+        monkeypatch.setattr(authority, '_schedule', SessionAuthority._schedule.__get__(authority))
+    call(ensure_hosted_service(runner))
+    source = runner.session_authorities.require(homes['alpha'])
+    target = runner.session_authorities.require(homes['beta'])
+    with owner_scope(source):
+        service = source.hosted_room_service
+        service.authorize_room('alice', 'room', create=True)
+        service.create_room(room_id='room', name='Room', members=[
+            {'member_id': 'host', 'profile': 'alpha', 'handle': 'host'},
+            {'member_id': 'helper', 'profile': 'beta', 'handle': 'helper'}])
+        service.send(room_id='room', event_id='input',
+                     payload={'text': '@helper hello', 'thread_id': 'thread'})
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        events = hosted_rooms.read_events(source.db.db_path, room_id='room')['events']
+        if any(event['kind'] == 'room.activity' and event['payload'].get('status') == 'settled'
+               for event in events):
+            break
+        time.sleep(0.02)
+    else:
+        pytest.fail(f'no canonical member publication: {service.status("room")}')
+    assert len(executed) == 1
+    assert executed[0][:3] == (str(homes['beta']),) * 3
+    sid, = target.sessions
+    row, = list_session_admissions(target.db, session_id=sid, pending_only=False)
+    assert row['admission_id'] == executed[0][3]
+    assert row['status'] == 'terminal'
+    assert not source.sessions and not runner.session_authority.sessions
+    assert sum(event['kind'] == 'message.member' for event in events) == 1
+
+
+@pytest.mark.parametrize('mux', ['starting'], indirect=True)
+def test_startup_preserves_queued_work_until_ready(mux, monkeypatch):
+    from types import SimpleNamespace
+    from gateway import hosted_room_driver as tasks, session_finite
+    from gateway.run_runtime import publish_gateway_runtime_ready
+    from gateway.session_authorities import owner_scope
+    from gateway.session_authority import SessionAuthority
+    from gateway.session_hosted_service import CanonicalHostedRoomService, ensure_hosted_service
+    from hermes_state_runtime import list_session_admissions
+
+    runner, homes, loop, call = mux
+    source = runner.session_authorities.require(homes['alpha'])
+    target = runner.session_authorities.require(homes['beta'])
+    executed = []
+    async def execute(authority, ref, row):
+        executed.append(row['admission_id'])
+        return 'member reply'
+    monkeypatch.setattr(session_finite, 'execute_finite_admission', execute)
+    for authority in runner.session_authorities:
+        monkeypatch.setattr(authority, '_schedule', SessionAuthority._schedule.__get__(authority))
+    with owner_scope(source):
+        service = CanonicalHostedRoomService(source, loop)
+        source.hosted_room_service = service
+        service.authorize_room('alice', 'startup-room', create=True)
+        service.create_room(room_id='startup-room', name='Startup', members=[
+            {'member_id': 'host', 'profile': 'alpha', 'handle': 'host'},
+            {'member_id': 'helper', 'profile': 'beta', 'handle': 'helper'}])
+        service.send(room_id='startup-room', event_id='input',
+                     payload={'text': '@helper hello', 'thread_id': 'thread'})
+    queued, = tasks.list_tasks(source.db.db_path, room_id='startup-room')
+    assert queued['status'] == 'queued'
+    call(ensure_hosted_service(runner))
+    # If startup released a worker, let its real pre-submit path finish. No
+    # exception is injected: the live private descriptor still says starting.
+    deadline = time.monotonic() + 3
+    while service.runtime.status()['running'] and time.monotonic() < deadline:
+        current = tasks.get_task(source.db.db_path, queued['identity'])
+        if current['status'] in tasks.TERMINAL_STATUSES:
+            break
+        time.sleep(0.02)
+    current = tasks.get_task(source.db.db_path, queued['identity'])
+    assert current['status'] == 'queued', current
+    assert current['execution_generation'] == 0
+    assert not executed and not target.sessions
+    assert all(getattr(a, 'hosted_room_service', None) is not None for a in runner.session_authorities)
+    assert all(not a.hosted_room_service.runtime.status()['running'] for a in runner.session_authorities)
+
+    async def ready():
+        runner._running = True
+        # Only listener-liveness metadata is needed; the private socket is real.
+        runner.session_api = SimpleNamespace(task=loop.create_future())
+        publish_gateway_runtime_ready(runner)
+    call(ready())
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        current = tasks.get_task(source.db.db_path, queued['identity'])
+        if current['status'] == 'settled':
+            break
+        time.sleep(0.02)
+    assert current['status'] == 'settled', current
+    assert len(executed) == 1
+    sid, = target.sessions
+    admission, = list_session_admissions(target.db, session_id=sid, pending_only=False)
+    assert admission['admission_id'] == executed[0] and admission['status'] == 'terminal'

--- a/tests/gateway/test_session_a2a.py
+++ b/tests/gateway/test_session_a2a.py
@@ -20,7 +20,11 @@ async def test_forwarded_identity_survives_reconnect_without_policy_override(tmp
     monkeypatch.setattr(run, '_load_gateway_config', lambda: {'model': {'default': 'fixture'}, 'platform_toolsets': {'cli': []}})
     monkeypatch.setattr(run, '_resolve_gateway_model', lambda config: 'fixture')
     store = SessionStore(tmp_path / 'sessions', GatewayConfig())
-    runner = SimpleNamespace(adapters={}, session_store=store, _session_db=store._db, _draining=False)
+    runner = run.GatewayRunner.__new__(run.GatewayRunner)
+    runner.adapters = {}
+    runner.session_store = store
+    runner._session_db = store._db
+    runner._draining = False
     authority = await initialize_session_authority(runner, profile_id='target', instance_id='test')
     db = authority.db
     authority._schedule = lambda ref: None
@@ -46,6 +50,10 @@ async def test_forwarded_identity_survives_reconnect_without_policy_override(tmp
     assert second['result']['session_id'] == sid
     assert second['result']['admission_id'] != first['admission_id']
     assert runner.adapters[next(iter(runner.adapters))].policies[sid] == policy
+    info = await again.dispatch({'id': 4, 'method': 'session.info', 'params': {'session_id': sid}})
+    assert info['result']['source'] == 'a2a'
+    assert info['result']['model'] == 'fixture'
+    assert info['result']['lazy'] is True
     # Source spelling alone must never grant producer policy.
     with pytest.raises(RuntimeStoreError):
         build_policy({'source': 'a2a'}, {})
@@ -65,7 +73,11 @@ async def test_forwarding_does_not_merge_lossy_context_or_peer_identity(tmp_path
     monkeypatch.setattr(run, '_load_gateway_config', lambda: {'model': {'default': 'fixture'}, 'platform_toolsets': {'cli': []}})
     monkeypatch.setattr(run, '_resolve_gateway_model', lambda config: 'fixture')
     store = SessionStore(tmp_path / 'sessions', GatewayConfig())
-    runner = SimpleNamespace(adapters={}, session_store=store, _session_db=store._db, _draining=False)
+    runner = run.GatewayRunner.__new__(run.GatewayRunner)
+    runner.adapters = {}
+    runner.session_store = store
+    runner._session_db = store._db
+    runner._draining = False
     authority = await initialize_session_authority(runner, profile_id='target', instance_id='test')
     db = authority.db
     authority._schedule = lambda ref: None

--- a/tests/gateway/test_session_hosted_transport.py
+++ b/tests/gateway/test_session_hosted_transport.py
@@ -3,14 +3,23 @@ import asyncio
 import json
 import threading
 from dataclasses import asdict
+from types import SimpleNamespace
 
 import pytest
 
 from tests.gateway.test_session_hosted_rpc import owner  # noqa: F401
 
 
-def test_authenticated_owner_transport_rechecks_source_and_cold_binding(owner, tmp_path):
+def _server(home):
     from gateway.control_socket import GatewayControlServer
+    descriptor = {'runtime_protocol': 1, 'state': 'ready', 'instance_id': 'test',
+                  'authority_epoch': 1, 'served_profiles': [{'home': str(home), 'profile_id': str(home)}],
+                  'capabilities': ['session-authority-v1'], 'api_origin': 'http://127.0.0.1:1',
+                  'supervisor': 'none'}
+    return GatewayControlServer(home, verb_handlers={'identify': lambda: descriptor})
+
+
+def test_authenticated_owner_transport_rechecks_source_and_cold_binding(owner, tmp_path):
     from gateway.session_hosted_transport import (
         HostedRoomOwnerRPC, install_hosted_transport, check_remote_hosted_admission,
         owner_request,
@@ -21,6 +30,8 @@ def test_authenticated_owner_transport_rechecks_source_and_cold_binding(owner, t
     source, target = tmp_path / 'source', tmp_path / 'target'
     source.mkdir(mode=0o700)
     target.mkdir(mode=0o700)
+    authority.profile_id = str(target)
+    source_authority = SimpleNamespace(profile_id=str(source))
     allowed = [True]
     task = TaskIdentity('room', 'task', 'thread', 'turn')
     def attest(selector, operation, params):
@@ -32,8 +43,8 @@ def test_authenticated_owner_transport_rechecks_source_and_cold_binding(owner, t
             if operation == 'submit' and params['prompt'] != 'input':
                 raise RuntimeStoreError('permission_denied')
         return {'owner': 'room-owner', 'target_home': authority.profile_id, 'prompt': 'input', 'attachments': []}
-    servers = [GatewayControlServer(source), GatewayControlServer(target)]
-    install_hosted_transport(servers[0], authority, loop, attest=attest)
+    servers = [_server(source), _server(target)]
+    install_hosted_transport(servers[0], source_authority, loop, attest=attest)
     install_hosted_transport(servers[1], authority, loop, attest=lambda *a: None)
     for server in servers:
         assert asyncio.run_coroutine_threadsafe(server.start(), loop).result()
@@ -124,14 +135,13 @@ def test_source_attestation_binds_bytes_to_task_member_and_current_home(tmp_path
             result = service.attest(selector, 'attachment', {**params, 'index': 0, 'offset': offset})
             chunks.append(base64.b64decode(result['data_base64']))
         assert b''.join(chunks) == data
-        from gateway.control_socket import GatewayControlServer
         from gateway.session_hosted_transport import install_hosted_transport, _attachment_data
         # The same chunk protocol crosses a real private socket; the target never
         # receives a filesystem path or opens the source database.
         loop = asyncio.new_event_loop()
         thread = threading.Thread(target=loop.run_forever)
         thread.start()
-        server = GatewayControlServer(tmp_path)
+        server = _server(tmp_path)
         install_hosted_transport(server, authority, loop, attest=service.attest)
         assert asyncio.run_coroutine_threadsafe(server.start(), loop).result()
         try:


### PR DESCRIPTION
## What does this PR do?

Fix-up for #106742, targeting **`feat/unified-gateway-runtime`**, not `main`. Keeps accepted work visible and preserves the receipt and compatibility information its callers need.

- **Bot Chat receipts:** return the already-validated input message so cron can record queued and settled delivery without creating another admission.
- **Desktop metadata:** recognize the canonical protocol separately from the legacy numeric contract. Unknown explicit protocols still warn; non-local resumes do not read a local launch policy.
- **First-message visibility:** keep the user's message after the initial `queued` acknowledgement, including when a start event arrives before that acknowledgement. Explicit Queue sends stay separate from the active turn.
- **Quit copy:** explain that persistent gateway work continues after Desktop closes, while retaining the warning for app-dependent or older-connection activity.
- **Hosted profile routing:** reach Bots in served profiles through their own canonical authority and control endpoint; do not fail queued room work before gateway startup is ready.
- **Group attachments:** restore upload/download RPCs, support normal-sized files without an argument-limit error, and pass the correct attachment manifest to Send. Attachment actions no longer submit the draft.
- **Retained files:** keep shared files visible and downloadable after Send or reopening the group, using the normal Save workflow rather than composer staging. Closed or switched views cannot initiate late downloads.

The canonical protocol does not implement every legacy v2-v6 API; advertising contract 6 simply to hide a warning would be misleading. These fixes retain one canonical execution owner and the existing profile-authorization boundary; they do not add a parallel executor or broaden operator access.

## Related Issue

Reproductions and acceptance evidence: https://github.com/NousResearch/hermes-agent/pull/106742#issuecomment-5633364316

Related legacy metadata fixes: #36112 and #83060. #73312 addresses repeated Quit gestures; this change only corrects the existing dialog's lifecycle explanation.

## Type of Change

- [x] Bug fix
- [x] Regression tests

## How to Test

The September 12 follow-ups are separate, cherry-pickable commits: `1e604c3576f` (hosted profiles/startup), `ff08f87b532` (attachment controls and wire format), and `e518b42421f` (retained-history downloads). The first two apply independently to #106742 at `0203b4f`; pick the retained-history repair after the attachment fix. The attachment fix addresses [F12](https://github.com/NousResearch/hermes-agent/pull/106742#discussion_r3995117016) and [F30](https://github.com/NousResearch/hermes-agent/pull/106742#discussion_r3995117052) from BearHuddleston's review, plus the RPC-name and upload-receipt mismatch. The retained-history commit addresses [F31](https://github.com/NousResearch/hermes-agent/pull/106742#discussion_r3995117053), also reported by BearHuddleston.

**Current follow-up verification:** 16 focused Python tests and 17 UI tests passed on the current #108594 base, with no Python retries. The changed-file contents match their independently reviewed versions; scoped lint and whitespace checks pass. The download repair also exercised real Electron DownloadItem completion/cancellation with a fixture-selected temporary destination; that is not a manually observed Save dialog. These focused checks are not a fresh full-suite, full-application build or native release-acceptance run.

<details>
<summary>Earlier repair commands and historical acceptance evidence</summary>

```sh
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh -j 1 tests/gateway/test_cron_canonical_receipt_regression.py tests/gateway/test_canonical_desktop_metadata.py tests/gateway/test_session_a2a.py
npm --workspace apps/desktop run test -- electron/quit-guard.test.ts src/app/session/hooks/use-prompt-actions/queued-first-input.test.tsx
npm --workspace apps/desktop run typecheck
```

- **Earlier repair revisions:** 1,123 related Desktop tests passed, plus their Desktop typechecks, changed-file lint and production build. This result is historical, not a build claim for the current #106742 head.
- **Signed macOS acceptance passed:** first input remains visible during a held turn; the native Queue button accepts a follower; normal GUI Quit exits Desktop while the same gateway completes both original admissions. Reopening shows both replies. Exactly two model requests, using a loopback model.
- The first-input regressions fail before the repair, including the late-acknowledgement ordering. Separate adversarial review found **no P1/P2 issues in the repair**.
- The full Python run exposed two A2A fixture failures caused by the earlier metadata change. Those fixtures now use the real runner's accessors without starting services, and check that metadata preserves the frozen launch policy. Corrected checks: **8 passed on Linux**; both A2A tests also pass on macOS. This test-only correction was independently reviewed.

</details>

<details>
<summary>Full-suite results, exact revisions and acceptance limits</summary>

The broader branch is **not full-suite or release green**. Canonical Linux Python coverage at `035fdabb` attempted all **4,249 default-selection files** across two validated, disjoint pause/resume segments: **49,273 passed, 165 failed, 434 skipped**, plus two expected failures and two unexpected passes. The default runner excludes its Docker/e2e/integration directories. That earlier Desktop repair did not change Python runtime code; the September 12 hosted-profile follow-up is separately covered by the focused runtime checks above.

The two A2A fixture failures now pass targeted checks; they are not subtracted from that historical total. Other failures include Docker/root/optional-dependency environment mismatches and untriaged behavior. The original browser reconnect timeout did not reproduce in three whole-file reruns per head. These observations do not establish that every remaining failure is pre-existing.

The earlier full Desktop run at `035fdabb` reported **9,786 passed, 6 failed, 6 skipped**. Three failures cleared with a supported Python interpreter and canonical temporary path; the Linux-launcher-on-macOS and storage-fixture failures remain recorded. The 1,123-test repair selection is separate, not a replacement claim for an all-green full run.

Native testing used signed runtime `efcdc829`; the subsequent change only corrects the A2A tests. It was a local Apple Development-signed installation, not public notarization or Windows installer certification. The native run used ordinary gateway processes and real SQLite, with test-only loopback inference and isolated user data. Production gateways were not redeployed.

Existing cross-host receipts cover a scripted client over SSH to an ordinary gateway, not native remote-Desktop or cross-subject operator parity. Ambiguous successful-send crash receipts show **one model execution and two deliveries**, with an explicit duplicate warning on the recovered copy. This is warned at-least-once delivery, not exactly-once external delivery.

</details>
