### PR TITLE
fix(tools): exempt package-manager installs from long-lived foreground guidance

### DIFF
--- a/tests/tools/test_blocked_command_guidance.py
+++ b/tests/tools/test_blocked_command_guidance.py
@@ -82,3 +82,32 @@ class TestBackgroundGuidanceRecipes:
 
     def test_quoted_ampersand_not_flagged(self):
         assert _foreground_background_guidance('git commit -m "a & b"') is None
+
+
+class TestPackageManagerInstallExemption:
+    def test_package_manager_installs_not_flagged(self):
+        # Installing a dependency merely names the same binary — nothing is
+        # launched, so the long-lived-server guidance must stay silent.
+        for cmd in (
+            "npm install nodemon",
+            "pip install uvicorn",
+            "pip3 install gunicorn",
+            "npm add nodemon --save-dev",
+            "python3 -m pip install uvicorn",
+            "apt install gunicorn",
+        ):
+            assert _foreground_background_guidance(cmd) is None, cmd
+
+    def test_install_then_launch_still_warns(self):
+        # The exemption is per chained segment: an install earlier in the line
+        # must not suppress the warning for a real launch later in it.
+        for cmd in (
+            "npm install nodemon && npm start",
+            "pip install uvicorn; uvicorn app:app",
+            "npm install nodemon || nodemon app.js",
+        ):
+            assert _foreground_background_guidance(cmd) is not None, cmd
+
+    def test_bare_launches_still_warn(self):
+        for cmd in ("npm start", "uvicorn app:app", "nodemon app.js", "yarn dev"):
+            assert _foreground_background_guidance(cmd) is not None, cmd

--- a/tools/terminal_tool_guards.py
+++ b/tools/terminal_tool_guards.py
@@ -97,6 +97,32 @@ _LONG_LIVED_FOREGROUND_PATTERNS = tuple(re.compile(p, re.IGNORECASE) for p in (
     r"\bpython(?:3)?\s+-m\s+http\.server\b",
 ))
 
+# A package-manager install merely names the same binary as a dependency
+# (``npm install nodemon``, ``pip install uvicorn``): nothing is launched, so
+# it must not trip the long-lived-server guidance.
+_PACKAGE_MANAGER_INSTALL_RE = re.compile(
+    r"\b(?:pip3?|python3?\s+-m\s+pip|conda|apt(?:-get)?|apk|brew|npm|pnpm|yarn|bun)\s+"
+    r"(?:\S+\s+)*(?:install|add)\b",
+    re.IGNORECASE,
+)
+# Split on top-level shell separators only — the input is already quote-blanked
+# by _strip_quotes, so quoted separators can't survive to look top-level.
+_TOP_LEVEL_SEPARATOR_RE = re.compile(r"&&|\|\||;|\n|\|")
+
+
+def _has_long_lived_foreground_launch(unquoted_command: str) -> bool:
+    """Long-lived-launch check scoped per chained command segment.
+
+    The exemption is evaluated per segment, not on the whole line: matching it
+    anywhere in the string would let ``npm install nodemon && npm start``
+    silently suppress the warning for the real ``npm start`` launch too.
+    """
+    return any(
+        any(pattern.search(segment) for pattern in _LONG_LIVED_FOREGROUND_PATTERNS)
+        for segment in _TOP_LEVEL_SEPARATOR_RE.split(unquoted_command)
+        if not _PACKAGE_MANAGER_INSTALL_RE.search(segment)
+    )
+
 # Ordered (predicate on the unquoted command, guidance) — first hit wins.
 _FOREGROUND_GUIDANCE = (
     (
@@ -113,7 +139,7 @@ _FOREGROUND_GUIDANCE = (
         "for bounded jobs — then run health checks and tests in follow-up terminal calls.",
     ),
     (
-        lambda s: any(p.search(s) for p in _LONG_LIVED_FOREGROUND_PATTERNS),
+        _has_long_lived_foreground_launch,
         "This foreground command appears to start a long-lived server/watch process. "
         "Run it with background=true, verify readiness (health endpoint/log signal), "
         "then execute tests in a separate command.",


### PR DESCRIPTION
## What does this PR do?

Fixes a false positive in the terminal tool's foreground/background guidance: a plain package-manager install such as `npm install nodemon` or `pip install uvicorn` tripped the "this looks like a long-lived server" guidance (the guard's bare-word patterns match the dependency name), steering the model toward `background=true` for a command that simply finishes and exits.

The fix adds a package-manager-install exemption (`pip/pip3/python -m pip/conda/apt/apt-get/apk/brew/npm/pnpm/yarn/bun … install|add`) and scopes it **per chained command segment**: the already quote-blanked command is split on top-level separators (`&&`, `||`, `;`, `|`, newline), and each segment is evaluated independently. A whole-line exemption would let `npm install nodemon && npm start` silently suppress the warning for the real `npm start` launch; per-segment evaluation keeps that warning while silencing bare installs.

## Related Issue

Fixes #108593

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/terminal_tool_guards.py`: added `_PACKAGE_MANAGER_INSTALL_RE` and `_TOP_LEVEL_SEPARATOR_RE` plus `_has_long_lived_foreground_launch()`, which replaces the previous whole-line `any(pattern.search(s))` predicate in `_FOREGROUND_GUIDANCE`. The separator split is safe because the input is already quote-blanked by `_strip_quotes` (and heredoc bodies masked), so quoted separators cannot survive to look top-level.
- `tests/tools/test_blocked_command_guidance.py`: added `TestPackageManagerInstallExemption` covering bare installs (silenced), install-then-launch chains (still warn on the launch segment), and bare launches (unchanged behavior).

Note: complementary to #95481 (which exempts installed-package *paths* under site-packages); this PR exempts package-manager *install commands* — different false-positive sources, no overlap in mechanism.

## How to Test

1. On `main`: `python -c "from tools.terminal_tool_guards import _foreground_background_guidance as g; print(g('npm install nodemon'))"` — Observed result: returns the long-lived-server guidance (false positive).
2. With this PR: the same call returns `None`; `g('pip install uvicorn')` and `g('apt install gunicorn')` also return `None`.
3. `g('npm install nodemon && npm start')` still returns the guidance (warns on the `npm start` segment); `g('npm start')`, `g('uvicorn app:app')`, `g('nodemon app.js')`, `g('yarn dev')` unchanged (warn).
4. `pytest tests/tools/test_blocked_command_guidance.py tests/tools/test_terminal_heredoc_background_guard.py tests/tools/test_command_guards.py tests/tools/test_terminal_tool.py -q` — Observed result: 85 passed, should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] N/A (no config keys changed)
- [ ] N/A (no architecture/workflow changes)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the guard is platform-independent lexical matching over POSIX-style command lines, which is what this tool already receives on every platform
- [ ] N/A (no tool description/schema changes)
