### PR TITLE
fix(serve): shut down gracefully on parent death instead of os._exit

### DIFF
--- a/hermes_cli/web_server_lifecycle.py
+++ b/hermes_cli/web_server_lifecycle.py
@@ -6,6 +6,7 @@ import logging
 import ipaddress
 import json
 import os
+import signal
 import subprocess
 import sys
 import tempfile
@@ -309,6 +310,35 @@ def _is_serve_orphaned(
         return False
 
 
+#: Ceiling on the post-orphan graceful unwind before the hard exit takes over.
+#: The desktop is already gone, so nothing escalates for us and this is the
+#: whole budget: comfortably past the 5s exit-flush budget
+#: (``HERMES_TUI_EXIT_FLUSH_BUDGET_S``), still short enough to keep the reap prompt.
+_ORPHAN_EXIT_CEILING_S = 10.0
+
+
+def _request_orphan_shutdown() -> threading.Timer:
+    """Ask this backend to shut itself down, with a hard-exit backstop.
+
+    ``os._exit`` here skipped the flush-on-kill handlers this same process
+    installs before serving (#96095, ``install_exit_flush_signal_handlers``)
+    and every ``atexit`` hook, so an unclean desktop exit dropped the in-memory
+    transcripts that a SIGTERM from a live desktop persists to ``state.db``.
+    Raise SIGTERM instead, and keep the reap guaranteed the way ``cli.py``'s
+    ``_arm_exit_watchdog`` does: a daemon timer that ``os._exit``\\ s if the
+    unwind stalls (it survives ``Py_FinalizeEx``'s non-daemon thread joins).
+    ``raise_signal`` reaches Python's handler on Windows too, where
+    ``os.kill(pid, SIGTERM)`` would terminate the process without running it.
+
+    Returns the armed ceiling timer.
+    """
+    ceiling = threading.Timer(_ORPHAN_EXIT_CEILING_S, os._exit, args=(0,))
+    ceiling.daemon = True
+    ceiling.start()
+    signal.raise_signal(signal.SIGTERM)
+    return ceiling
+
+
 def _start_parent_death_watchdog() -> None:
     """Exit when the exact desktop parent that spawned this backend dies.
 
@@ -352,13 +382,13 @@ def _start_parent_death_watchdog() -> None:
             time.sleep(poll)
         try:
             _log.warning(
-                "Parent-death watchdog: desktop PID %s appears orphaned (expected_start_marker=%r); exiting.",
+                "Parent-death watchdog: desktop PID %s appears orphaned (expected_start_marker=%r); shutting down.",
                 desktop_pid,
                 start_marker,
             )
         except Exception:
             pass
-        os._exit(0)
+        _request_orphan_shutdown()
 
     threading.Thread(target=_loop, daemon=True, name="serve-parent-watchdog").start()
 

--- a/tests/hermes_cli/test_serve_parent_watchdog.py
+++ b/tests/hermes_cli/test_serve_parent_watchdog.py
@@ -219,3 +219,77 @@ def test_ps_marker_probe_classifies_missing_process_vs_other_ps_failures(monkeyp
     with pytest.raises(OSError) as excinfo:
         web_server_lifecycle._process_start_marker(4242)
     assert not isinstance(excinfo.value, ProcessLookupError)
+
+
+def test_parent_watchdog_shuts_down_through_the_signal_path_not_os_exit(monkeypatch):
+    """#96095's flush-on-kill handlers only persist transcripts if a signal is raised.
+
+    ``os._exit`` skips signal handlers and ``atexit``, so an unclean desktop exit used
+    to drop exactly the in-memory state a SIGTERM from a live desktop would have saved.
+    """
+    import signal
+    import threading
+
+    from hermes_cli import web_server_lifecycle
+
+    monkeypatch.setenv("HERMES_PARENT_PID", "4242")
+    monkeypatch.delenv("HERMES_PARENT_START_MARKER", raising=False)
+    monkeypatch.delenv("HERMES_PARENT_NONCE", raising=False)
+    monkeypatch.setattr(web_server_lifecycle, "_is_serve_orphaned", lambda *_args: True)
+
+    hard_exits = []
+    monkeypatch.setattr(web_server_lifecycle.os, "_exit", lambda code: hard_exits.append(code))
+
+    timers = []
+
+    class _FakeThreading:
+        """Run the watchdog loop inline and keep its ceiling timer cancellable."""
+
+        @staticmethod
+        def Thread(target, **_kw):
+            class _Inline:
+                def start(self):
+                    target()
+
+            return _Inline()
+
+        @staticmethod
+        def Timer(*args, **kwargs):
+            timer = threading.Timer(*args, **kwargs)
+            timers.append(timer)
+            return timer
+
+    monkeypatch.setattr(web_server_lifecycle, "threading", _FakeThreading)
+
+    handled = []
+    previous = signal.signal(signal.SIGTERM, lambda *_a: handled.append("sigterm"))
+    try:
+        web_server_lifecycle._start_parent_death_watchdog()
+    finally:
+        for timer in timers:
+            timer.cancel()
+        signal.signal(signal.SIGTERM, previous)
+
+    assert handled == ["sigterm"], "parent loss must run this process's shutdown handlers"
+    assert hard_exits == [], "the watchdog must not bypass those handlers with os._exit"
+
+
+def test_parent_watchdog_arms_a_daemon_hard_exit_ceiling(monkeypatch):
+    """A stalled unwind must still reap the orphan, and the timer must outlive teardown joins."""
+    import os
+    import signal
+
+    from hermes_cli import web_server_lifecycle
+
+    raised = []
+    monkeypatch.setattr(web_server_lifecycle.signal, "raise_signal", raised.append)
+
+    ceiling = web_server_lifecycle._request_orphan_shutdown()
+    try:
+        assert raised == [signal.SIGTERM]
+        assert ceiling.function is os._exit
+        assert ceiling.daemon is True
+        assert ceiling.is_alive()
+        assert 0 < ceiling.interval <= 30
+    finally:
+        ceiling.cancel()


### PR DESCRIPTION
## What does this PR do?

The `hermes serve` parent-death watchdog ends its loop with `os._exit(0)`
(`hermes_cli/web_server_lifecycle.py`, `_start_parent_death_watchdog._loop`).
`os._exit` skips signal handlers and `atexit` entirely.

The same serve process installs chaining SIGTERM/SIGINT handlers a few lines
before it starts serving (`hermes_cli/web_server.py`,
`install_exit_flush_signal_handlers` from #96095) whose entire job is to persist
in-memory transcripts to `state.db` before shutdown. So the one exit path that
fires when the Desktop dies uncleanly (a crash, a SIGKILL, an update handoff
that exits before reaping the backend) is the one path that bypasses the flush
those handlers exist for. A user who quits the app normally (SIGTERM) keeps the
tail of the conversation; a user whose app crashes loses it. The same hard exit
skips every `atexit` hook reachable in a serve process: `tools/code_kernel.py`
(`shutdown_all_kernels`), `tools/browser_tool.py`, `agent/lsp/__init__.py`,
`agent/relay_runtime.py`.

The watchdog's own intent is preserved. Its job, as stated where it landed
(a9a0648f49, #73066), is to reap an orphaned backend and cascade to its MCP
child subtree; the process still
exits promptly and unconditionally: SIGTERM is raised in-process, backed by a
daemon `threading.Timer` that `os._exit(0)`s after a ceiling if the unwind
stalls. That is the graceful-then-ceiling idiom `cli.py::_arm_exit_watchdog`
already uses, and the daemon timer survives `Py_FinalizeEx`'s non-daemon thread
joins, so a wedged cleanup cannot resurrect the orphan leak.

`signal.raise_signal` rather than `os.kill(os.getpid(), SIGTERM)`: on Windows
`os.kill` with SIGTERM terminates the process without running its registered
handler, so the flush would be skipped exactly as before; `raise_signal` reaches
Python's handler on every platform.

The ceiling is 10s, past the 5s exit-flush budget
(`HERMES_TUI_EXIT_FLUSH_BUDGET_S`), and far inside the old "leaks until
something kills it" behavior. No new config key and no new env var.

## Related Issue

No earlier issue reported this defect (searched open and closed issues and PRs
for `os._exit` + watchdog, "parent death watchdog", `_start_parent_death_watchdog`,
"flush on kill", `install_exit_flush_signal_handlers`, "transcript lost", "state.db").
Opened #108601 to track it.

Related, not duplicated:

- #96095 (merged) installed the flush-on-kill handlers this path was skipping.
- #105319 (open) bounds uvicorn's graceful shutdown for the SIGTERM the Desktop
  sends. Complementary: it shortens the unwind this change now goes through,
  and this change's ceiling is independent of it.
- #83583, #95693, #103172, #100760 touch the same watchdog's *arming* decision
  (when it fires), not what it does when it fires.

Fixes #108601

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server_lifecycle.py`: new `_request_orphan_shutdown()`:
  arms a daemon ceiling timer (`_ORPHAN_EXIT_CEILING_S`, 10s) that
  `os._exit(0)`s, then raises SIGTERM in-process. `_start_parent_death_watchdog`'s
  loop calls it instead of `os._exit(0)`; the docstring records what the hard
  exit was skipping. The orphan log line now says "shutting down" rather than
  "exiting". Adds `import signal`.
- `tests/hermes_cli/test_serve_parent_watchdog.py`: two tests next to the
  existing watchdog coverage:
  `test_parent_watchdog_shuts_down_through_the_signal_path_not_os_exit` drives
  the real watchdog with an orphaned parent and asserts this process's SIGTERM
  handler runs and no `os._exit` is taken;
  `test_parent_watchdog_arms_a_daemon_hard_exit_ceiling` asserts the backstop is
  a daemon timer whose function is `os._exit` and whose interval is bounded.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_serve_parent_watchdog.py -q`.
   Observed: `15 tests passed, 0 failed, 1 skipped` (the skip is the
   pre-existing `macos_only` test, on a Linux host).
2. Revert only the production hunk in `hermes_cli/web_server_lifecycle.py` and
   rerun. Observed: both new tests fail
   (`AssertionError: parent loss must run this process's shutdown handlers`),
   i.e. they pin the fix rather than restating it.
3. Neighbouring suites that import the changed module:
   `scripts/run_tests.sh tests/hermes_cli/test_serve_parent_watchdog.py tests/hermes_cli/test_web_server.py tests/hermes_cli/test_serve_port_in_use.py tests/hermes_cli/test_web_server_boot_handshake.py tests/hermes_cli/test_serve_mcp_discovery_after_bind.py tests/hermes_cli/test_web_server_executor_isolation.py tests/tui_gateway/test_cold_start_gil_stall.py tests/test_web_server.py -q`.
   Observed: `233 tests passed, 0 failed, 5 skipped`; plus
   `tests/hermes_cli/test_dashboard_auth_gate.py` separately, `33 passed`.
4. Manual end-to-end (not run, stated for a reviewer with a Desktop build):
   launch the Desktop app, send a message, `kill -9` the Electron parent, then
   reopen and confirm the last turn is present in `state.db` instead of lost.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux, Python 3.13.12

> On the full suite: I ran the canonical runner on the affected module and on
> every suite that imports the changed file (see How to Test), not
> `pytest tests/ -q` over the whole tree. Windows and macOS behavior is
> unverified on my side; the change is platform-independent apart from the
> `raise_signal` choice, which exists precisely for the Windows path.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings): the new helper's docstring records what the hard exit skipped
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `raise_signal` is used so the handler runs on Windows; the ceiling timer is stdlib and platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/hermes_cli/test_serve_parent_watchdog.py -q
=== Summary: 1 files, 15 tests passed, 0 failed, 1 skipped (100% complete) in 0.9s ===

# with the production hunk reverted:
FAILED tests/hermes_cli/test_serve_parent_watchdog.py::test_parent_watchdog_shuts_down_through_the_signal_path_not_os_exit
FAILED tests/hermes_cli/test_serve_parent_watchdog.py::test_parent_watchdog_arms_a_daemon_hard_exit_ceiling
2 failed, 13 passed, 1 skipped
```
