### PR TITLE
fix(browser): allow local Chrome eval through loopback CDP

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -399,6 +399,9 @@ DEFAULT_CONFIG = {
         # With a cloud provider, auto-spawn local Chromium for LAN/localhost URLs instead
         "auto_local_for_private_urls": True,
         "cdp_url": "",  # persistent CDP endpoint for attaching to an existing Chromium/Chrome
+        # Loopback-only CDP endpoints are treated as local for browser SSRF guards. Disable when
+        # localhost is an SSH tunnel to a browser on another machine.
+        "trust_loopback_cdp": True,
         # Consent to browse with the user's REAL logins locally: runs on a Hermes-managed SNAPSHOT
         # of the ACTIVE default-Chromium profile (Local State -> profile.last_used; cookies, logins,
         # prefs copied and re-synced per fresh session) driven by Hermes' packaged Chromium. The

--- a/tests/tools/test_browser_cdp_override.py
+++ b/tests/tools/test_browser_cdp_override.py
@@ -1,4 +1,6 @@
 from unittest.mock import Mock, patch
+
+import pytest
 from tools import browser_tool_cloud as bt_cloud
 from tools import browser_tool_cdp as bt_cdp
 from tools import browser_tool_session as bt_session
@@ -157,6 +159,49 @@ class TestGetCdpOverride:
         monkeypatch.setenv("BROWSER_CDP_URL", HTTP_URL)
         with patch("hermes_cli.config.read_raw_config", return_value={}):
             assert bc.is_camofox_mode() is False
+
+
+class TestLoopbackCdpOverride:
+    @pytest.mark.parametrize(
+        ("url", "answers", "expected"),
+        [
+            ("http://localhost:9222", None, True),
+            ("ws://dev.localhost:9222/devtools/browser/x", None, True),
+            ("http://127.7.8.9:9222", None, True),
+            ("ws://[::1]:9222/devtools/browser/x", None, True),
+            ("http://chrome.test:9222", ["127.0.0.1", "::1"], True),
+            ("http://chrome.test:9222", ["127.0.0.1", "192.168.1.5"], False),
+            ("http://192.168.1.5:9222", None, False),
+        ],
+    )
+    def test_trusts_only_exclusively_loopback_hosts(self, monkeypatch, url, answers, expected):
+        if answers is not None:
+            monkeypatch.setattr(
+                bt_cdp.socket,
+                "getaddrinfo",
+                lambda host, port: [(None, None, None, None, (address, 0)) for address in answers],
+            )
+
+        assert bt_cdp._is_loopback_cdp_override(url) is expected
+
+    def test_dns_timeout_is_bounded_and_fails_closed(self, monkeypatch):
+        class TimedOutThread:
+            def __init__(self, *, target, name, daemon):
+                assert daemon is True
+
+            def start(self):
+                pass
+
+            def join(self, *, timeout):
+                assert timeout == bt_cdp.LOOPBACK_CDP_DNS_TIMEOUT_S
+
+            def is_alive(self):
+                return True
+
+        monkeypatch.setattr(bt_cdp.threading, "Thread", TimedOutThread)
+
+        assert bt_cdp._is_loopback_cdp_override("http://blackholed.test:9222") is False
+
 
 class TestCreateCdpSession:
     """_create_cdp_session() must sanitize the CDP URL before logging.

--- a/tests/tools/test_browser_ssrf_local.py
+++ b/tests/tools/test_browser_ssrf_local.py
@@ -185,6 +185,26 @@ class TestIsLocalBackend:
 
         assert bt_cloud._is_local_backend() is True
 
+    @pytest.mark.parametrize(
+        ("cdp_url", "config", "terminal", "expected"),
+        [
+            ("http://127.0.0.1:9222", {}, "local", True),
+            ("http://127.0.0.1:9222", {"trust_loopback_cdp": False}, "local", False),
+            ("http://127.0.0.1:9222", {}, "docker", False),
+            ("http://192.168.1.5:9222", {}, "local", False),
+        ],
+    )
+    def test_cdp_override_preserves_loopback_trust_boundaries(
+        self, monkeypatch, cdp_url, config, terminal, expected
+    ):
+        monkeypatch.setattr("tools.browser_tool_cdp._get_cdp_override_raw", lambda: cdp_url)
+        monkeypatch.setattr(
+            "hermes_cli.config.read_raw_config", lambda: {"browser": config}
+        )
+        monkeypatch.setenv("TERMINAL_ENV", terminal)
+
+        assert bt_cloud._is_local_backend() is expected
+
 
 # ---------------------------------------------------------------------------
 # Post-redirect SSRF check

--- a/tools/browser_tool_cdp.py
+++ b/tools/browser_tool_cdp.py
@@ -3,10 +3,52 @@
 Split out of ``tools/browser_tool.py``. Facade-owned state is read through ``_bt`` (``tools.browser_tool``, resolved per call) — no import cycle."""
 
 import contextlib
+import ipaddress
 import os
+import socket
+import threading
 from typing import Tuple
+from urllib.parse import urlsplit
 
 from tools.browser_tool_origin import origin_module as _origin
+
+
+LOOPBACK_CDP_DNS_TIMEOUT_S = 0.25
+
+
+def _is_loopback_cdp_override(cdp_url: str) -> bool:
+    """Return whether a configured CDP endpoint resolves only to loopback.
+
+    Hostname DNS is bounded because this check runs on eval/console paths and
+    ``getaddrinfo`` has no timeout. Resolution errors, timeouts, empty answers,
+    and mixed loopback/non-loopback answers all fail closed.
+    """
+    try:
+        host = (urlsplit(cdp_url).hostname or "").lower().rstrip(".")
+    except ValueError:
+        return False
+    if not host:
+        return False
+    if host == "localhost" or host.endswith(".localhost"):
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        pass
+
+    result: list[bool] = []
+
+    def resolve() -> None:
+        try:
+            addresses = {item[4][0] for item in socket.getaddrinfo(host, None)}
+            result.append(bool(addresses) and all(ipaddress.ip_address(address).is_loopback for address in addresses))
+        except (OSError, ValueError):
+            result.append(False)
+
+    worker = threading.Thread(target=resolve, name="hermes-cdp-loopback-dns", daemon=True)
+    worker.start()
+    worker.join(timeout=LOOPBACK_CDP_DNS_TIMEOUT_S)
+    return not worker.is_alive() and result == [True]
 
 
 def _resolve_cdp_override(cdp_url: str) -> str:

--- a/tools/browser_tool_cloud.py
+++ b/tools/browser_tool_cloud.py
@@ -158,16 +158,21 @@ def _is_local_backend() -> bool:
     """True when the browser runs locally AND the terminal is also local.
 
     SSRF protection only matters when the browser can reach networks the terminal cannot (cloud backends,
-    containerized terminals). A CDP override is never trusted as local (that Chrome may live off-host) and MUST
-    be checked before the Camofox short-circuit; ``_is_local_mode`` treats overrides the same way — keep the two
-    in agreement.
+    containerized terminals). A CDP override is local only when its endpoint resolves exclusively to loopback;
+    LAN/private overrides remain untrusted. ``browser.trust_loopback_cdp: false`` restores the conservative
+    behavior for loopback endpoints backed by an SSH tunnel.
     """
     _bt = _origin()
-    if _cdp._get_cdp_override_raw():
-        return False
+    cdp_override = _cdp._get_cdp_override_raw()
+    if cdp_override:
+        if not _bt._browser_cfg("trust_loopback_cdp", True, lambda value: is_truthy_value(value, default=True),
+                                "trust_loopback_cdp from config"):
+            return False
+        if not _cdp._is_loopback_cdp_override(cdp_override):
+            return False
     if _bt._is_camofox_mode():
         return True
-    if _get_cloud_provider() is not None:
+    if not cdp_override and _get_cloud_provider() is not None:
         return False
     # Scope-aware: under gateway multiplexing the routed profile's terminal backend lives in the per-turn scope.
     # When terminal runs in a container, browser on host can access internal networks the terminal can't →


### PR DESCRIPTION
## What does this PR do?

Allows `browser_console(expression=...)` and related browser operations to treat a user-configured CDP endpoint as local when its host resolves exclusively to loopback and the terminal is local. Local development Chrome sessions no longer hit the remote-browser SSRF guard, while LAN, mixed-DNS, timed-out DNS, container-terminal, and explicitly untrusted loopback endpoints remain guarded.

### Symptom

A Chrome instance attached through `browser.cdp_url` or `BROWSER_CDP_URL`, including `http://localhost:9222`, is classified as non-local. Eval and console calls that access local/private development targets are therefore blocked even though Chrome runs on the same machine.

### Impact

Developers attaching Hermes to a local Chrome debugging port cannot use the normal eval/console workflow against local applications without disabling private-address protection more broadly.

### Bug Cause

**Trigger:** `tools/browser_tool_cloud.py:157` / `_is_local_backend()` treats every configured CDP override as non-local.

**Causal chain:**
1. The user configures a local Chrome endpoint through `browser.cdp_url` or `BROWSER_CDP_URL`.
2. `_is_local_backend()` returns `False` solely because an override exists, without classifying its host.
3. The eval/console SSRF policy activates and rejects local/private development targets.

**Why it is wrong:** A loopback-only CDP endpoint has the same host reachability boundary as a locally launched browser when the terminal is also local. Treating all overrides as remote conflates loopback Chrome with LAN or cloud CDP endpoints.

**Working sibling / contrast:** Hermes-launched local Chromium and Camofox already skip this guard when they share the local terminal's network boundary.

**Ruled out:** This does not trust RFC1918 or other private CDP hosts. Those endpoints may be separate LAN machines and remain non-local.

### Fix

Classify literal `localhost`, `*.localhost`, IPv4 `127.0.0.0/8`, IPv6 `::1`, and hostnames whose DNS answers are exclusively loopback as local CDP endpoints. DNS lookup runs in a daemon thread with a 250 ms bound and fails closed for errors, timeouts, empty results, or mixed answers. `browser.trust_loopback_cdp: false` restores conservative behavior for users whose loopback endpoint is an SSH tunnel, and container terminals remain non-local.

## Related Issue

Fixes #108597

## Why this PR vs existing PR #108600

This PR covers two issue requirements that `tools/browser_tool_cloud.py` in PR #108600 intentionally omits: DNS names that resolve exclusively to loopback, with a bounded fail-closed resolver, and an explicit opt-out for SSH-forwarded loopback endpoints. It also accepts the specified `*.localhost` namespace while preserving the existing container-terminal boundary. The competing patch handles only syntactic `localhost` and loopback IP literals, so it leaves the reported DNS and tunnel-safety cases unresolved.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `tools/browser_tool_cdp.py` - classify loopback-only CDP hosts with bounded fail-closed DNS.
- `tools/browser_tool_cloud.py` - trust only qualifying loopback overrides from local terminals and honor the config opt-out.
- `hermes_cli/config_defaults.py` - add the loopback trust control.
- `tests/tools/test_browser_cdp_override.py` - cover literal, DNS, mixed-answer, and timeout classification.
- `tests/tools/test_browser_ssrf_local.py` - cover local, opt-out, container, and LAN backend boundaries.

## How to Test

Focused tests pass: 59 tests across the three related files.

```bash
scripts/run_tests.sh tests/tools/test_browser_cdp_override.py tests/tools/test_browser_ssrf_local.py tests/tools/test_browser_eval_ssrf.py
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and statically compared this implementation with PR #108600
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've considered the Windows, macOS, and Linux socket APIs used by this code

### Documentation & Housekeeping

- [x] Relevant behavior and configuration are documented in code and default config comments
- [x] No example config file requires an update
- [x] No architecture or workflow documentation changes are required
- [x] No tool schema changes are required
