### PR TITLE
feat(egress): inject custom credentials into sandbox requests

### DIFF
--- a/agent/proxy_sources/iron_proxy.py
+++ b/agent/proxy_sources/iron_proxy.py
@@ -239,7 +239,12 @@ def parse_extra_secret_specs(raw: object) -> List[CredentialMappingSpec]:
         for provider in _HEADER_AUTH_PROVIDERS.values()
         for alias in provider.get("aliases", ())
     }
-    reserved_env_names = builtins | builtin_aliases | set(_EGRESS_CONTROL_ENV_NAMES)
+    reserved_env_names = (
+        builtins
+        | builtin_aliases
+        | set(_EGRESS_CONTROL_ENV_NAMES)
+        | set(_PROXY_SUBPROCESS_ENV_ALLOWLIST)
+    )
     claimed_hosts = [
         (env_name, host)
         for env_name, hosts in _BEARER_PROVIDERS.items()

--- a/agent/proxy_sources/iron_proxy.py
+++ b/agent/proxy_sources/iron_proxy.py
@@ -140,6 +140,26 @@ _EGRESS_CONTROL_ENV_NAMES = frozenset({
     _HERMES_IRON_PROXY_NONCE_ENV,
 })
 
+# Names that can change host subprocess loading, executable resolution, invoked programs, or
+# Hermes policy. Custom credentials are copied into iron-proxy's own env, so accepting these
+# would turn credential configuration into subprocess control.
+_SUBPROCESS_EXECUTION_ENV_NAMES = frozenset({
+    "LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT", "LD_DEBUG",
+    "DYLD_INSERT_LIBRARIES", "DYLD_LIBRARY_PATH", "DYLD_FRAMEWORK_PATH",
+    "DYLD_FALLBACK_LIBRARY_PATH", "DYLD_FALLBACK_FRAMEWORK_PATH",
+    "PYTHONPATH", "PYTHONHOME", "PYTHONSTARTUP", "PYTHONUSERBASE",
+    "PYTHONEXECUTABLE", "PYTHONNOUSERSITE", "NODE_OPTIONS", "NODE_PATH",
+    "PATH", "SHELL", "BROWSER", "EDITOR", "VISUAL", "PAGER",
+    "GIT_SSH_COMMAND", "GIT_EXEC_PATH", "GIT_SHELL",
+    "HERMES_HOME", "HERMES_PROFILE", "HERMES_CONFIG", "HERMES_ENV",
+    "HERMES_CONFIG_PATH", "HERMES_ENV_PATH", "HERMES_OPTIONAL_MCPS",
+    "HERMES_COPILOT_ACP_COMMAND", "HERMES_COPILOT_ACP_ARGS",
+    "HERMES_YOLO_MODE", "HERMES_ACCEPT_HOOKS", "HERMES_REDACT_SECRETS",
+    "HERMES_INTERACTIVE", "HERMES_EXEC_ASK", "HERMES_GATEWAY_SESSION",
+    "HERMES_CRON_SESSION", "HERMES_SINGLE_QUERY_SESSION", "HERMES_SESSION_KEY",
+    "HERMES_SESSION_PLATFORM",
+})
+
 
 @dataclass
 class ProxyStatus:
@@ -242,7 +262,9 @@ def parse_extra_secret_specs(raw: object) -> List[CredentialMappingSpec]:
     reserved_env_names = (
         builtins
         | builtin_aliases
+        | set(_NON_BEARER_PROVIDERS)
         | set(_EGRESS_CONTROL_ENV_NAMES)
+        | set(_SUBPROCESS_EXECUTION_ENV_NAMES)
         | set(_PROXY_SUBPROCESS_ENV_ALLOWLIST)
     )
     claimed_hosts = [

--- a/agent/proxy_sources/iron_proxy.py
+++ b/agent/proxy_sources/iron_proxy.py
@@ -805,17 +805,40 @@ def discover_provider_mappings(
     ]
 
 
+def known_credential_env_names(*, extra_env_names: Sequence[str] = ()) -> set[str]:
+    """Return every configured credential name recognized by egress discovery."""
+    names = set(_BEARER_PROVIDERS) | set(_NON_BEARER_PROVIDERS) | set(extra_env_names)
+    for env_name, spec in _HEADER_AUTH_PROVIDERS.items():
+        names.add(env_name)
+        names.update(spec.get("aliases") or ())
+    return names
+
+
 def discover_uncovered_providers(*, available_env_names: Optional[List[str]] = None) -> List[str]:
     """Env names of recognized providers the proxy can't swap (SigV4 / SDK-minted OAuth)."""
     names = set(available_env_names) if available_env_names is not None else {k for k, v in os.environ.items() if v}
     return [n for n in _NON_BEARER_PROVIDERS if n in names]
 
 
+def _mapping_authority(mapping: TokenMapping) -> Tuple:
+    """Normalized authority granted to one sandbox-visible capability token."""
+    return (
+        mapping.real_env_name,
+        tuple(sorted(mapping.upstream_hosts)),
+        tuple(sorted(header.lower() for header in mapping.match_headers)),
+        tuple(sorted(mapping.alias_env_names)),
+        mapping.match_query,
+    )
+
+
 def merge_mappings(*, existing: List[TokenMapping], discovered: List[TokenMapping], rotate: bool = False) -> List[TokenMapping]:
-    """Existing tokens are preserved (containers baked with them keep working), hosts/headers/aliases refresh
-    from ``discovered``; ``rotate=True`` re-mints; undiscovered providers drop."""
-    by_name = {} if rotate else {m.real_env_name: m for m in existing}
-    return [replace(d, proxy_token=by_name[d.real_env_name].proxy_token) if d.real_env_name in by_name else d for d in discovered]
+    """Preserve tokens only while their complete authority remains unchanged."""
+    by_authority = {} if rotate else {_mapping_authority(m): m for m in existing}
+    return [
+        replace(d, proxy_token=by_authority[authority].proxy_token)
+        if (authority := _mapping_authority(d)) in by_authority else d
+        for d in discovered
+    ]
 
 
 def _pidfile() -> Path:
@@ -1202,8 +1225,8 @@ def _reset_for_tests() -> None:
 __all__ = [
     "CredentialMappingSpec", "ProxyStatus", "TokenMapping", "build_proxy_config", "discover_provider_mappings",
     "discover_uncovered_providers", "ensure_audit_log", "ensure_ca_cert", "ensure_management_token",
-    "find_iron_proxy", "get_status", "install_iron_proxy", "iron_proxy_version", "load_mappings",
-    "merge_mappings", "mint_proxy_token", "parse_extra_secret_specs", "reload_proxy", "start_proxy", "stop_proxy",
+    "find_iron_proxy", "get_status", "install_iron_proxy", "iron_proxy_version", "known_credential_env_names",
+    "load_mappings", "merge_mappings", "mint_proxy_token", "parse_extra_secret_specs", "reload_proxy", "start_proxy", "stop_proxy",
     "write_mappings", "write_proxy_config",
 ]
 

--- a/agent/proxy_sources/iron_proxy.py
+++ b/agent/proxy_sources/iron_proxy.py
@@ -130,6 +130,16 @@ _VERSION_CACHE: Dict[str, str] = {}
 _HERMES_IRON_PROXY_NONCE_ENV = "HERMES_IRON_PROXY_NONCE"
 _proxy_nonce: Optional[str] = None
 
+# Names owned by the proxy process or Docker egress plumbing. A custom mapping under one of
+# these names could replace routing/trust configuration with an opaque credential token.
+_EGRESS_CONTROL_ENV_NAMES = frozenset({
+    "HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "NO_PROXY",
+    "REQUESTS_CA_BUNDLE", "SSL_CERT_FILE", "CURL_CA_BUNDLE",
+    "NODE_EXTRA_CA_CERTS", "NODE_OPTIONS", "HERMES_EGRESS_PROXY",
+    "_HERMES_EGRESS_NODE_OPTIONS_APPEND", _MGMT_API_KEY_ENV,
+    _HERMES_IRON_PROXY_NONCE_ENV,
+})
+
 
 @dataclass
 class ProxyStatus:
@@ -161,6 +171,7 @@ class TokenMapping:
     upstream_hosts: Tuple[str, ...]
     match_headers: Tuple[str, ...] = ("Authorization",)
     alias_env_names: Tuple[str, ...] = ()
+    match_query: bool = True
 
 
 @dataclass(frozen=True)
@@ -170,6 +181,25 @@ class CredentialMappingSpec:
     env_var: str
     hosts: Tuple[str, ...]
     match_headers: Tuple[str, ...]
+
+
+def _host_scopes_overlap(left: str, right: str) -> bool:
+    """Return whether two validated exact/wildcard DNS scopes intersect."""
+    left_wildcard, right_wildcard = left.startswith("*."), right.startswith("*.")
+    left_suffix = left[2:] if left_wildcard else left
+    right_suffix = right[2:] if right_wildcard else right
+    if not left_wildcard and not right_wildcard:
+        return left_suffix == right_suffix
+    if left_wildcard and right_wildcard:
+        return (
+            left_suffix == right_suffix
+            or left_suffix.endswith(f".{right_suffix}")
+            or right_suffix.endswith(f".{left_suffix}")
+        )
+    exact, wildcard_suffix = (
+        (right_suffix, left_suffix) if left_wildcard else (left_suffix, right_suffix)
+    )
+    return exact.endswith(f".{wildcard_suffix}")
 
 
 def _validate_extra_secret_host(value: object, *, path: str) -> str:
@@ -204,6 +234,21 @@ def parse_extra_secret_specs(raw: object) -> List[CredentialMappingSpec]:
         raise ValueError("proxy.extra_secrets must be a list")
 
     builtins = set(_BEARER_PROVIDERS) | set(_HEADER_AUTH_PROVIDERS)
+    builtin_aliases = {
+        alias
+        for provider in _HEADER_AUTH_PROVIDERS.values()
+        for alias in provider.get("aliases", ())
+    }
+    reserved_env_names = builtins | builtin_aliases | set(_EGRESS_CONTROL_ENV_NAMES)
+    claimed_hosts = [
+        (env_name, host)
+        for env_name, hosts in _BEARER_PROVIDERS.items()
+        for host in hosts
+    ] + [
+        (env_name, host)
+        for env_name, provider in _HEADER_AUTH_PROVIDERS.items()
+        for host in provider["hosts"]
+    ]
     seen_env_names = set()
     specs: List[CredentialMappingSpec] = []
     for index, item in enumerate(raw):
@@ -217,8 +262,8 @@ def parse_extra_secret_specs(raw: object) -> List[CredentialMappingSpec]:
         env_var = item.get("env_var")
         if not isinstance(env_var, str) or not _ENV_NAME_RE.fullmatch(env_var):
             raise ValueError(f"{path}.env_var must be an uppercase environment variable name")
-        if env_var in builtins:
-            raise ValueError(f"{path}.env_var duplicates built-in mapping {env_var}")
+        if env_var in reserved_env_names or env_var.startswith("HERMES_PROXY_TOKEN_"):
+            raise ValueError(f"{path}.env_var uses reserved egress credential name {env_var}")
         if env_var in seen_env_names:
             raise ValueError(f"{path}.env_var duplicates an earlier custom mapping")
 
@@ -229,6 +274,16 @@ def parse_extra_secret_specs(raw: object) -> List[CredentialMappingSpec]:
             _validate_extra_secret_host(host, path=f"{path}.hosts[{host_index}]")
             for host_index, host in enumerate(raw_hosts)
         ))
+        for host in hosts:
+            if conflict := next(
+                ((owner, claimed) for owner, claimed in claimed_hosts
+                 if _host_scopes_overlap(host, claimed)),
+                None,
+            ):
+                owner, claimed = conflict
+                raise ValueError(
+                    f"{path}.hosts scope {host} overlaps mapping {owner} scope {claimed}"
+                )
 
         raw_headers = item.get("match_headers", ["Authorization"])
         if not isinstance(raw_headers, list) or not raw_headers:
@@ -248,6 +303,7 @@ def parse_extra_secret_specs(raw: object) -> List[CredentialMappingSpec]:
 
         seen_env_names.add(env_var)
         specs.append(CredentialMappingSpec(env_var, hosts, tuple(headers)))
+        claimed_hosts.extend((env_var, host) for host in hosts)
     return specs
 
 
@@ -622,7 +678,7 @@ def build_proxy_config(
         "source": {"type": "env", "var": m.real_env_name},
         "replace": {
             "proxy_value": m.proxy_token, "match_headers": list(m.match_headers or ("Authorization",)),
-            "match_query": True, "match_body": False, "require": True,
+            "match_query": m.match_query, "match_body": False, "require": True,
         },
         "rules": [{"host": h} for h in m.upstream_hosts],
     } for m in mappings]
@@ -696,6 +752,7 @@ def write_mappings(mappings: List[TokenMapping]) -> Path:
     payload = {"version": 1, "tokens": [{
         "proxy_token": m.proxy_token, "env_name": m.real_env_name, "upstream_hosts": list(m.upstream_hosts),
         "match_headers": list(m.match_headers), "alias_env_names": list(m.alias_env_names),
+        "match_query": m.match_query,
     } for m in mappings]}
     return _write_state_file_atomic(_proxy_state_dir(), "mappings.json", lambda f: json.dump(payload, f, indent=2))
 
@@ -712,8 +769,11 @@ def load_mappings() -> List[TokenMapping]:
     out: List[TokenMapping] = []
     for item in payload.get("tokens", []):
         with suppress(KeyError, TypeError):  # pre-header-auth files load with the bearer defaults they were written under
-            out.append(TokenMapping(item["proxy_token"], item["env_name"], tuple(item.get("upstream_hosts") or ()),
-                                    tuple(item.get("match_headers") or ("Authorization",)), tuple(item.get("alias_env_names") or ())))
+            out.append(TokenMapping(
+                item["proxy_token"], item["env_name"], tuple(item.get("upstream_hosts") or ()),
+                tuple(item.get("match_headers") or ("Authorization",)),
+                tuple(item.get("alias_env_names") or ()), bool(item.get("match_query", True)),
+            ))
     return out
 
 
@@ -726,12 +786,16 @@ def discover_provider_mappings(
     present -> ONE mapping on the canonical name (the subprocess-env builder mirrors aliases).
     ``available_env_names`` (Bitwarden adapter) overrides the non-empty names in the host env."""
     names = set(available_env_names) if available_env_names is not None else {k for k, v in os.environ.items() if v}
-    specs = [(n, h, ("Authorization",), ()) for n, h in _BEARER_PROVIDERS.items()] + [
-        (n, tuple(s["hosts"]), tuple(s["match_headers"]), tuple(s.get("aliases") or ())) for n, s in _HEADER_AUTH_PROVIDERS.items()
-    ] + [(s.env_var, s.hosts, s.match_headers, ()) for s in extra_specs]
+    specs = [(n, h, ("Authorization",), (), True) for n, h in _BEARER_PROVIDERS.items()] + [
+        (n, tuple(s["hosts"]), tuple(s["match_headers"]), tuple(s.get("aliases") or ()), True)
+        for n, s in _HEADER_AUTH_PROVIDERS.items()
+    ] + [(s.env_var, s.hosts, s.match_headers, (), False) for s in extra_specs]
     return [
-        TokenMapping(mint_proxy_token(prefix=env_name.lower().replace("_api_key", "")), env_name, hosts, headers, aliases)
-        for env_name, hosts, headers, aliases in specs
+        TokenMapping(
+            mint_proxy_token(prefix=env_name.lower().replace("_api_key", "")),
+            env_name, hosts, headers, aliases, match_query,
+        )
+        for env_name, hosts, headers, aliases, match_query in specs
         if env_name in names or any(a in names for a in aliases)
     ]
 

--- a/agent/proxy_sources/iron_proxy.py
+++ b/agent/proxy_sources/iron_proxy.py
@@ -225,10 +225,11 @@ def _host_scopes_overlap(left: str, right: str) -> bool:
 def _validate_extra_secret_host(value: object, *, path: str) -> str:
     if not isinstance(value, str) or not (host := value.strip()):
         raise ValueError(f"{path} must be a non-empty hostname")
+    if host.startswith("*."):
+        raise ValueError(f"{path} must be an exact DNS hostname; wildcard credential scopes are not allowed")
     if host != host.rstrip(".") or "://" in host or any(c in host for c in "/:@?#"):
         raise ValueError(f"{path} must be a hostname without a scheme, port, path, or trailing dot")
-    wildcard = host.startswith("*.")
-    hostname = host[2:] if wildcard else host
+    hostname = host
     try:
         ipaddress.ip_address(hostname)
     except ValueError:
@@ -238,13 +239,13 @@ def _validate_extra_secret_host(value: object, *, path: str) -> str:
     labels = hostname.split(".")
     if len(labels) < 2 or len(hostname) > 253 or any(not _DNS_LABEL_RE.fullmatch(label) for label in labels):
         raise ValueError(f"{path} must be a valid fully-qualified DNS hostname")
-    return ("*." if wildcard else "") + hostname.lower()
+    return hostname.lower()
 
 
 def parse_extra_secret_specs(raw: object) -> List[CredentialMappingSpec]:
     """Validate ``proxy.extra_secrets`` without ever reading secret values.
 
-    Hosts are deliberately limited to DNS names (with an optional left-most wildcard), and
+    Hosts are deliberately limited to exact DNS names, and
     hop-by-hop/routing headers are rejected so a typo cannot turn token replacement into request
     routing or framing mutation.
     """
@@ -282,6 +283,8 @@ def parse_extra_secret_specs(raw: object) -> List[CredentialMappingSpec]:
         path = f"proxy.extra_secrets[{index}]"
         if not isinstance(item, dict):
             raise ValueError(f"{path} must be a mapping")
+        if any(not isinstance(key, str) for key in item):
+            raise ValueError(f"{path} keys must be strings")
         unknown = set(item) - {"env_var", "hosts", "match_headers"}
         if unknown:
             raise ValueError(f"{path} has unsupported field(s): {', '.join(sorted(unknown))}")

--- a/agent/proxy_sources/iron_proxy.py
+++ b/agent/proxy_sources/iron_proxy.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import platform
+import re
 import shutil
 import signal
 import subprocess
@@ -27,7 +28,7 @@ import urllib.request
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +88,14 @@ _HEADER_AUTH_PROVIDERS: Dict[str, Dict[str, Tuple[str, ...]]] = {
 
 # Creds that static header replacement can't swap (SigV4, SDK-minted OAuth): warning only.
 _NON_BEARER_PROVIDERS: Tuple[str, ...] = ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "GOOGLE_APPLICATION_CREDENTIALS")
+
+_ENV_NAME_RE = re.compile(r"^[A-Z_][A-Z0-9_]*$")
+_DNS_LABEL_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$")
+_HEADER_NAME_RE = re.compile(r"^[!#$%&'*+.^_`|~0-9A-Za-z-]+$")
+_FORBIDDEN_MATCH_HEADERS = frozenset({
+    "connection", "content-length", "host", "keep-alive", "proxy-authenticate",
+    "proxy-authorization", "te", "trailer", "transfer-encoding", "upgrade",
+})
 
 # Default SSRF deny list (docs promise: cloud metadata IPs refused regardless of allowlist);
 # callers pass [] to disable (hermetic tests only).
@@ -152,6 +161,94 @@ class TokenMapping:
     upstream_hosts: Tuple[str, ...]
     match_headers: Tuple[str, ...] = ("Authorization",)
     alias_env_names: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class CredentialMappingSpec:
+    """Validated operator-defined static-header credential mapping."""
+
+    env_var: str
+    hosts: Tuple[str, ...]
+    match_headers: Tuple[str, ...]
+
+
+def _validate_extra_secret_host(value: object, *, path: str) -> str:
+    if not isinstance(value, str) or not (host := value.strip()):
+        raise ValueError(f"{path} must be a non-empty hostname")
+    if host != host.rstrip(".") or "://" in host or any(c in host for c in "/:@?#"):
+        raise ValueError(f"{path} must be a hostname without a scheme, port, path, or trailing dot")
+    wildcard = host.startswith("*.")
+    hostname = host[2:] if wildcard else host
+    try:
+        ipaddress.ip_address(hostname)
+    except ValueError:
+        pass
+    else:
+        raise ValueError(f"{path} must be a DNS hostname, not an IP address")
+    labels = hostname.split(".")
+    if len(labels) < 2 or len(hostname) > 253 or any(not _DNS_LABEL_RE.fullmatch(label) for label in labels):
+        raise ValueError(f"{path} must be a valid fully-qualified DNS hostname")
+    return ("*." if wildcard else "") + hostname.lower()
+
+
+def parse_extra_secret_specs(raw: object) -> List[CredentialMappingSpec]:
+    """Validate ``proxy.extra_secrets`` without ever reading secret values.
+
+    Hosts are deliberately limited to DNS names (with an optional left-most wildcard), and
+    hop-by-hop/routing headers are rejected so a typo cannot turn token replacement into request
+    routing or framing mutation.
+    """
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise ValueError("proxy.extra_secrets must be a list")
+
+    builtins = set(_BEARER_PROVIDERS) | set(_HEADER_AUTH_PROVIDERS)
+    seen_env_names = set()
+    specs: List[CredentialMappingSpec] = []
+    for index, item in enumerate(raw):
+        path = f"proxy.extra_secrets[{index}]"
+        if not isinstance(item, dict):
+            raise ValueError(f"{path} must be a mapping")
+        unknown = set(item) - {"env_var", "hosts", "match_headers"}
+        if unknown:
+            raise ValueError(f"{path} has unsupported field(s): {', '.join(sorted(unknown))}")
+
+        env_var = item.get("env_var")
+        if not isinstance(env_var, str) or not _ENV_NAME_RE.fullmatch(env_var):
+            raise ValueError(f"{path}.env_var must be an uppercase environment variable name")
+        if env_var in builtins:
+            raise ValueError(f"{path}.env_var duplicates built-in mapping {env_var}")
+        if env_var in seen_env_names:
+            raise ValueError(f"{path}.env_var duplicates an earlier custom mapping")
+
+        raw_hosts = item.get("hosts")
+        if not isinstance(raw_hosts, list) or not raw_hosts:
+            raise ValueError(f"{path}.hosts must be a non-empty list")
+        hosts = tuple(dict.fromkeys(
+            _validate_extra_secret_host(host, path=f"{path}.hosts[{host_index}]")
+            for host_index, host in enumerate(raw_hosts)
+        ))
+
+        raw_headers = item.get("match_headers", ["Authorization"])
+        if not isinstance(raw_headers, list) or not raw_headers:
+            raise ValueError(f"{path}.match_headers must be a non-empty list")
+        headers: List[str] = []
+        seen_headers = set()
+        for header_index, header in enumerate(raw_headers):
+            header_path = f"{path}.match_headers[{header_index}]"
+            if not isinstance(header, str) or not _HEADER_NAME_RE.fullmatch(header):
+                raise ValueError(f"{header_path} must be a valid HTTP header name")
+            normalized = header.lower()
+            if normalized in _FORBIDDEN_MATCH_HEADERS:
+                raise ValueError(f"{header_path} cannot target routing, framing, or hop-by-hop header {header}")
+            if normalized not in seen_headers:
+                headers.append(header)
+                seen_headers.add(normalized)
+
+        seen_env_names.add(env_var)
+        specs.append(CredentialMappingSpec(env_var, hosts, tuple(headers)))
+    return specs
 
 
 def _hermes_bin_dir() -> Path:
@@ -620,14 +717,18 @@ def load_mappings() -> List[TokenMapping]:
     return out
 
 
-def discover_provider_mappings(*, available_env_names: Optional[List[str]] = None) -> List[TokenMapping]:
-    """One TokenMapping per known provider whose env var is set (bearer providers first).  Canonical OR any alias
+def discover_provider_mappings(
+    *,
+    available_env_names: Optional[List[str]] = None,
+    extra_specs: Sequence[CredentialMappingSpec] = (),
+) -> List[TokenMapping]:
+    """One TokenMapping per configured credential whose env var is set (built-ins first). Canonical OR any alias
     present -> ONE mapping on the canonical name (the subprocess-env builder mirrors aliases).
     ``available_env_names`` (Bitwarden adapter) overrides the non-empty names in the host env."""
     names = set(available_env_names) if available_env_names is not None else {k for k, v in os.environ.items() if v}
     specs = [(n, h, ("Authorization",), ()) for n, h in _BEARER_PROVIDERS.items()] + [
         (n, tuple(s["hosts"]), tuple(s["match_headers"]), tuple(s.get("aliases") or ())) for n, s in _HEADER_AUTH_PROVIDERS.items()
-    ]
+    ] + [(s.env_var, s.hosts, s.match_headers, ()) for s in extra_specs]
     return [
         TokenMapping(mint_proxy_token(prefix=env_name.lower().replace("_api_key", "")), env_name, hosts, headers, aliases)
         for env_name, hosts, headers, aliases in specs
@@ -1030,10 +1131,10 @@ def _reset_for_tests() -> None:
 
 
 __all__ = [
-    "ProxyStatus", "TokenMapping", "build_proxy_config", "discover_provider_mappings",
+    "CredentialMappingSpec", "ProxyStatus", "TokenMapping", "build_proxy_config", "discover_provider_mappings",
     "discover_uncovered_providers", "ensure_audit_log", "ensure_ca_cert", "ensure_management_token",
     "find_iron_proxy", "get_status", "install_iron_proxy", "iron_proxy_version", "load_mappings",
-    "merge_mappings", "mint_proxy_token", "reload_proxy", "start_proxy", "stop_proxy",
+    "merge_mappings", "mint_proxy_token", "parse_extra_secret_specs", "reload_proxy", "start_proxy", "stop_proxy",
     "write_mappings", "write_proxy_config",
 ]
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2282,6 +2282,9 @@ DEFAULT_CONFIG = {
         # Extra allowed upstream hosts beyond the bundled major-provider defaults; wildcards
         # (`*.foo.com`) supported.
         "extra_allowed_hosts": [],
+        # Additional static-header credentials to replace at egress. Each entry names one host-side
+        # env var, bounded DNS hosts, and HTTP headers (default: Authorization).
+        "extra_secrets": [],
     },
     "desktop": {  # Hermes Desktop (Electron) launch options; only affect `hermes desktop`.
         # Git repo discovery for the Projects sidebar; empty roots = bounded scan of $HOME.

--- a/hermes_cli/proxy_cli.py
+++ b/hermes_cli/proxy_cli.py
@@ -147,6 +147,12 @@ def _setup_ca_cert(console: Console):
 def _setup_mint_tokens(console: Console, args: argparse.Namespace):
     """Discover providers, merge with existing tokens (rotating on request), print the table."""
     _step(console, 3, "Mint proxy tokens for known providers")
+    proxy_cfg = (load_config().get("proxy") or {})
+    try:
+        extra_specs = ip.parse_extra_secret_specs(proxy_cfg.get("extra_secrets"))
+    except ValueError as exc:
+        console.print(f"  [red]✗ Invalid custom credential mapping: {exc}[/red]")
+        return None
     available_env_names: List[str] = []
     if args.from_bitwarden:
         available_env_names = _bitwarden_env_names(console)
@@ -155,10 +161,13 @@ def _setup_mint_tokens(console: Console, args: argparse.Namespace):
     else:
         # Operators commonly keep provider keys only in ~/.hermes/.env (loaded when the agent
         # runs, NOT exported into an interactive shell); backfill so discovery sees them.
-        loaded = _load_env_file_into_environ()
+        loaded = _load_env_file_into_environ(extra_env_names=[spec.env_var for spec in extra_specs])
         if loaded:
             console.print(f"  [dim]Loaded {loaded} provider key name(s) from ~/.hermes/.env for discovery.[/dim]")
-    discovered = ip.discover_provider_mappings(available_env_names=available_env_names or None)
+    discovered = ip.discover_provider_mappings(
+        available_env_names=available_env_names or None,
+        extra_specs=extra_specs,
+    )
     # Preserve existing tokens unless rotation was requested — re-running setup must not
     # invalidate tokens baked into already-running sandboxes.
     existing = ip.load_mappings()
@@ -191,9 +200,11 @@ def _setup_mint_tokens(console: Console, args: argparse.Namespace):
         )
     mappings = ip.merge_mappings(existing=existing, discovered=discovered, rotate=rotate)
     if not mappings:
-        console.print("  [yellow]No known provider API keys found in env/Bitwarden.[/yellow]")
+        console.print("  [yellow]No configured credential env vars found in env/Bitwarden.[/yellow]")
         console.print("  Set at least one of these and rerun setup:")
-        for env_name in sorted(ip._BEARER_PROVIDERS):
+        known_env_names = set(ip._BEARER_PROVIDERS) | set(ip._HEADER_AUTH_PROVIDERS)
+        known_env_names.update(spec.env_var for spec in extra_specs)
+        for env_name in sorted(known_env_names):
             console.print(f"    - {env_name}")
         return None
     # Providers we recognise but can't proxy (SigV4, service-account OAuth) still work — they
@@ -569,15 +580,15 @@ def _bitwarden_env_names(console: Console) -> Optional[List[str]]:
         return None
 
 
-def _load_env_file_into_environ() -> int:
-    """Backfill known provider keys from ``~/.hermes/.env`` into ``os.environ``; returns the count.
-    Never overrides an exported value; only known provider names, so unrelated secrets stay out."""
+def _load_env_file_into_environ(*, extra_env_names: Optional[List[str]] = None) -> int:
+    """Backfill configured credential keys from ``~/.hermes/.env`` into ``os.environ``."""
     try:
         file_env = load_env()
     except Exception:  # noqa: BLE001 — best-effort convenience, never fatal
         return 0
     added = 0
-    known = set(ip._BEARER_PROVIDERS) | set(ip._NON_BEARER_PROVIDERS)
+    known = set(ip._BEARER_PROVIDERS) | set(ip._HEADER_AUTH_PROVIDERS) | set(ip._NON_BEARER_PROVIDERS)
+    known.update(extra_env_names or ())
     for name in known:
         if name in os.environ and os.environ[name].strip():
             continue

--- a/hermes_cli/proxy_cli.py
+++ b/hermes_cli/proxy_cli.py
@@ -144,6 +144,15 @@ def _setup_ca_cert(console: Console):
     return ca_crt, ca_key
 
 
+def _effective_credential_source(proxy_cfg: dict, args: argparse.Namespace) -> str:
+    """Resolve setup flags against the persisted source without a silent downgrade."""
+    if args.from_bitwarden:
+        return "bitwarden"
+    if getattr(args, "no_bitwarden", False):
+        return "env"
+    return "bitwarden" if proxy_cfg.get("credential_source") == "bitwarden" else "env"
+
+
 def _setup_mint_tokens(console: Console, args: argparse.Namespace):
     """Discover providers, merge with existing tokens (rotating on request), print the table."""
     _step(console, 3, "Mint proxy tokens for known providers")
@@ -154,7 +163,7 @@ def _setup_mint_tokens(console: Console, args: argparse.Namespace):
         console.print(f"  [red]✗ Invalid custom credential mapping: {exc}[/red]")
         return None
     available_env_names: List[str] = []
-    if args.from_bitwarden:
+    if _effective_credential_source(proxy_cfg, args) == "bitwarden":
         available_env_names = _bitwarden_env_names(console)
         if available_env_names is None:
             return None
@@ -283,19 +292,15 @@ def _setup_write_config(console: Console, args: argparse.Namespace, mappings, ca
     # ``--from-bitwarden`` setup keeps bitwarden mode (the documented rotation guarantee)
     # unless the operator passes an explicit --no-bitwarden.
     existing_source = proxy_cfg.get("credential_source")
-    if args.from_bitwarden:
-        proxy_cfg["credential_source"] = "bitwarden"
-    elif getattr(args, "no_bitwarden", False):
-        proxy_cfg["credential_source"] = "env"
-        if existing_source == "bitwarden":
-            console.print("[yellow]Switched credential_source from bitwarden to env.[/yellow]")
-    elif existing_source == "bitwarden":
+    effective_source = _effective_credential_source(proxy_cfg, args)
+    proxy_cfg["credential_source"] = effective_source
+    if effective_source == "env" and existing_source == "bitwarden":
+        console.print("[yellow]Switched credential_source from bitwarden to env.[/yellow]")
+    elif effective_source == "bitwarden" and not args.from_bitwarden:
         console.print(
             "[dim]Keeping credential_source=bitwarden from existing config. "
             "Pass --no-bitwarden to switch to env-based credentials.[/dim]"
         )
-    else:
-        proxy_cfg["credential_source"] = "env"
     save_config(cfg)
     return proxy_cfg
 

--- a/hermes_cli/proxy_cli.py
+++ b/hermes_cli/proxy_cli.py
@@ -592,9 +592,7 @@ def _load_env_file_into_environ(*, extra_env_names: Optional[List[str]] = None) 
     except Exception:  # noqa: BLE001 — best-effort convenience, never fatal
         return 0
     added = 0
-    known = set(ip._BEARER_PROVIDERS) | set(ip._HEADER_AUTH_PROVIDERS) | set(ip._NON_BEARER_PROVIDERS)
-    known.update(extra_env_names or ())
-    for name in known:
+    for name in ip.known_credential_env_names(extra_env_names=extra_env_names or ()):
         if name in os.environ and os.environ[name].strip():
             continue
         val = (file_env.get(name) or "").strip()

--- a/tests/test_iron_proxy.py
+++ b/tests/test_iron_proxy.py
@@ -66,6 +66,34 @@ def test_extra_secret_specs_reject_unbounded_or_unsafe_targets(extra_secrets, er
         ip.parse_extra_secret_specs(extra_secrets)
 
 
+@pytest.mark.parametrize("env_var", [
+    "GOOGLE_API_KEY", "HTTPS_PROXY", "HERMES_IRON_PROXY_MGMT_KEY",
+])
+def test_extra_secret_specs_reject_builtin_aliases_and_egress_control_names(env_var):
+    with pytest.raises(ValueError, match="reserved egress credential name"):
+        ip.parse_extra_secret_specs([{"env_var": env_var, "hosts": ["api.example.com"]}])
+
+
+@pytest.mark.parametrize("extra_secrets", [
+    [
+        {"env_var": "FIRST_SECRET", "hosts": ["api.example.com"]},
+        {"env_var": "SECOND_SECRET", "hosts": ["api.example.com"]},
+    ],
+    [
+        {"env_var": "FIRST_SECRET", "hosts": ["*.example.com"]},
+        {"env_var": "SECOND_SECRET", "hosts": ["api.example.com"]},
+    ],
+    [{"env_var": "SERVICE_SECRET", "hosts": ["api.openai.com"]}],
+    [
+        {"env_var": "FIRST_SECRET", "hosts": ["*.example.com"]},
+        {"env_var": "SECOND_SECRET", "hosts": ["*.api.example.com"]},
+    ],
+])
+def test_extra_secret_specs_reject_overlapping_host_scopes(extra_secrets):
+    with pytest.raises(ValueError, match="overlaps mapping"):
+        ip.parse_extra_secret_specs(extra_secrets)
+
+
 
 
 
@@ -102,6 +130,32 @@ def test_build_proxy_config_custom_allowed_hosts(tmp_path):
     # Custom allowed_hosts wins as the base; mapping's hosts get appended.
     assert "custom-host.test" in domains
     assert "openrouter.ai" in domains  # comes from the mapping
+
+
+def test_custom_static_headers_disable_query_replacement_but_gemini_keeps_it(
+    hermes_home, tmp_path,
+):
+    custom = ip.discover_provider_mappings(
+        available_env_names=["SERVICE_SECRET"],
+        extra_specs=ip.parse_extra_secret_specs([{
+            "env_var": "SERVICE_SECRET",
+            "hosts": ["api.example.com"],
+            "match_headers": ["x-service-secret"],
+        }]),
+    )[0]
+    gemini = ip.discover_provider_mappings(available_env_names=["GEMINI_API_KEY"])[0]
+    ip.write_mappings([custom, gemini])
+    cfg = ip.build_proxy_config(
+        mappings=ip.load_mappings(),
+        ca_cert=tmp_path / "ca.crt",
+        ca_key=tmp_path / "ca.key",
+    )
+    rules = cfg["transforms"][1]["config"]["secrets"]
+
+    assert {rule["source"]["var"]: rule["replace"]["match_query"] for rule in rules} == {
+        "SERVICE_SECRET": False,
+        "GEMINI_API_KEY": True,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -481,6 +535,17 @@ def test_mappings_roundtrip_preserves_headers_and_aliases(hermes_home):
     loaded = ip.load_mappings()
     assert loaded[0].match_headers == ("x-goog-api-key",)
     assert loaded[0].alias_env_names == ("GOOGLE_API_KEY",)
+
+
+def test_custom_credential_name_is_critical_for_docker_forwarding():
+    from tools.environments.docker_egress import (
+        _critical_egress_env_names,
+        check_forward_env_collisions,
+    )
+
+    critical = _critical_egress_env_names({"SERVICE_SECRET": "opaque-token"})
+    with pytest.raises(RuntimeError, match="SERVICE_SECRET"):
+        check_forward_env_collisions(["SERVICE_SECRET"], critical, enforce=True)
 
 
 

--- a/tests/test_iron_proxy.py
+++ b/tests/test_iron_proxy.py
@@ -67,7 +67,7 @@ def test_extra_secret_specs_reject_unbounded_or_unsafe_targets(extra_secrets, er
 
 
 @pytest.mark.parametrize("env_var", [
-    "GOOGLE_API_KEY", "HTTPS_PROXY", "HERMES_IRON_PROXY_MGMT_KEY",
+    "GOOGLE_API_KEY", "HTTPS_PROXY", "HERMES_IRON_PROXY_MGMT_KEY", "PATH",
 ])
 def test_extra_secret_specs_reject_builtin_aliases_and_egress_control_names(env_var):
     with pytest.raises(ValueError, match="reserved egress credential name"):

--- a/tests/test_iron_proxy.py
+++ b/tests/test_iron_proxy.py
@@ -55,6 +55,17 @@ def test_mint_proxy_token_has_prefix_and_length():
     assert len(t) >= len("alpha-") + 32
 
 
+@pytest.mark.parametrize("extra_secrets, error", [
+    ([{"env_var": "github-token", "hosts": ["api.github.com"]}], "uppercase environment"),
+    ([{"env_var": "GITHUB_TOKEN", "hosts": ["https://api.github.com"]}], "without a scheme"),
+    ([{"env_var": "GITHUB_TOKEN", "hosts": ["*"]}], "fully-qualified"),
+    ([{"env_var": "GITHUB_TOKEN", "hosts": ["api.github.com"], "match_headers": ["Host"]}], "routing, framing"),
+])
+def test_extra_secret_specs_reject_unbounded_or_unsafe_targets(extra_secrets, error):
+    with pytest.raises(ValueError, match=error):
+        ip.parse_extra_secret_specs(extra_secrets)
+
+
 
 
 

--- a/tests/test_iron_proxy.py
+++ b/tests/test_iron_proxy.py
@@ -68,6 +68,8 @@ def test_extra_secret_specs_reject_unbounded_or_unsafe_targets(extra_secrets, er
 
 @pytest.mark.parametrize("env_var", [
     "GOOGLE_API_KEY", "HTTPS_PROXY", "HERMES_IRON_PROXY_MGMT_KEY", "PATH",
+    "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "GOOGLE_APPLICATION_CREDENTIALS",
+    "LD_PRELOAD", "HERMES_HOME",
 ])
 def test_extra_secret_specs_reject_builtin_aliases_and_egress_control_names(env_var):
     with pytest.raises(ValueError, match="reserved egress credential name"):

--- a/tests/test_iron_proxy.py
+++ b/tests/test_iron_proxy.py
@@ -82,15 +82,7 @@ def test_extra_secret_specs_reject_builtin_aliases_and_egress_control_names(env_
         {"env_var": "FIRST_SECRET", "hosts": ["api.example.com"]},
         {"env_var": "SECOND_SECRET", "hosts": ["api.example.com"]},
     ],
-    [
-        {"env_var": "FIRST_SECRET", "hosts": ["*.example.com"]},
-        {"env_var": "SECOND_SECRET", "hosts": ["api.example.com"]},
-    ],
     [{"env_var": "SERVICE_SECRET", "hosts": ["api.openai.com"]}],
-    [
-        {"env_var": "FIRST_SECRET", "hosts": ["*.example.com"]},
-        {"env_var": "SECOND_SECRET", "hosts": ["*.api.example.com"]},
-    ],
 ])
 def test_extra_secret_specs_reject_overlapping_host_scopes(extra_secrets):
     with pytest.raises(ValueError, match="overlaps mapping"):

--- a/tests/test_iron_proxy.py
+++ b/tests/test_iron_proxy.py
@@ -158,6 +158,37 @@ def test_custom_static_headers_disable_query_replacement_but_gemini_keeps_it(
     }
 
 
+def test_merge_mappings_rotates_token_when_custom_authority_changes():
+    existing = ip.TokenMapping(
+        "old-token", "SERVICE_SECRET", ("api.example.com",),
+        ("x-service-secret",), (), False,
+    )
+    expanded = ip.TokenMapping(
+        "new-token", "SERVICE_SECRET", ("api.example.com", "upload.example.com"),
+        ("x-service-secret",), (), False,
+    )
+
+    merged = ip.merge_mappings(existing=[existing], discovered=[expanded])
+
+    assert merged[0].proxy_token == "new-token"
+    assert merged[0].upstream_hosts == ("api.example.com", "upload.example.com")
+
+
+def test_merge_mappings_preserves_token_for_normalized_unchanged_authority():
+    existing = ip.TokenMapping(
+        "old-token", "SERVICE_SECRET", ("upload.example.com", "api.example.com"),
+        ("X-Service-Secret", "Authorization"), (), False,
+    )
+    unchanged = ip.TokenMapping(
+        "new-token", "SERVICE_SECRET", ("api.example.com", "upload.example.com"),
+        ("authorization", "x-service-secret"), (), False,
+    )
+
+    merged = ip.merge_mappings(existing=[existing], discovered=[unchanged])
+
+    assert merged[0].proxy_token == "old-token"
+
+
 # ---------------------------------------------------------------------------
 # Default SSRF deny list (regression: docs promise cloud metadata is denied)
 # ---------------------------------------------------------------------------

--- a/tests/test_iron_proxy.py
+++ b/tests/test_iron_proxy.py
@@ -59,6 +59,7 @@ def test_mint_proxy_token_has_prefix_and_length():
     ([{"env_var": "github-token", "hosts": ["api.github.com"]}], "uppercase environment"),
     ([{"env_var": "GITHUB_TOKEN", "hosts": ["https://api.github.com"]}], "without a scheme"),
     ([{"env_var": "GITHUB_TOKEN", "hosts": ["*"]}], "fully-qualified"),
+    ([{"env_var": "GITHUB_TOKEN", "hosts": ["*.github.io"]}], "exact DNS hostname"),
     ([{"env_var": "GITHUB_TOKEN", "hosts": ["api.github.com"], "match_headers": ["Host"]}], "routing, framing"),
 ])
 def test_extra_secret_specs_reject_unbounded_or_unsafe_targets(extra_secrets, error):

--- a/tests/test_iron_proxy_cli.py
+++ b/tests/test_iron_proxy_cli.py
@@ -223,6 +223,15 @@ def test_setup_discovers_validated_custom_secret_from_hermes_env(hermes_home, mo
     assert os.environ["EBIRD_API_KEY"] == "real-ebird-secret"
 
 
+def test_load_env_file_backfills_header_auth_alias(hermes_home, monkeypatch):
+    (hermes_home / ".env").write_text("GOOGLE_API_KEY=google-secret\n", encoding="utf-8")
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
+    assert proxy_cli._load_env_file_into_environ() == 1
+    mappings = ip.discover_provider_mappings()
+    assert [mapping.real_env_name for mapping in mappings] == ["GEMINI_API_KEY"]
+
+
 def test_flagless_setup_reuses_persisted_bitwarden_source_and_custom_token(
     hermes_home, monkeypatch,
 ):

--- a/tests/test_iron_proxy_cli.py
+++ b/tests/test_iron_proxy_cli.py
@@ -223,6 +223,18 @@ def test_setup_discovers_validated_custom_secret_from_hermes_env(hermes_home, mo
     assert os.environ["EBIRD_API_KEY"] == "real-ebird-secret"
 
 
+def test_setup_rejects_non_string_custom_mapping_keys(monkeypatch):
+    monkeypatch.setattr(proxy_cli, "load_config", lambda: {
+        "proxy": {"extra_secrets": [{
+            "env_var": "SERVICE_SECRET",
+            "hosts": ["api.example.com"],
+            1: "unsupported",
+        }]},
+    })
+
+    assert proxy_cli._setup_mint_tokens(proxy_cli.Console(file=MagicMock()), _args()) is None
+
+
 def test_load_env_file_backfills_header_auth_alias(hermes_home, monkeypatch):
     (hermes_home / ".env").write_text("GOOGLE_API_KEY=google-secret\n", encoding="utf-8")
     monkeypatch.delenv("GOOGLE_API_KEY", raising=False)

--- a/tests/test_iron_proxy_cli.py
+++ b/tests/test_iron_proxy_cli.py
@@ -200,6 +200,27 @@ def test_cmd_restart_propagates_start_failure(hermes_home, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+def test_setup_discovers_validated_custom_secret_from_hermes_env(hermes_home, monkeypatch):
+    from hermes_cli.config import load_config, save_config
+
+    cfg = load_config()
+    cfg["proxy"]["extra_secrets"] = [{
+        "env_var": "EBIRD_API_KEY",
+        "hosts": ["API.EBIRD.ORG", "api.ebird.org"],
+        "match_headers": ["x-ebirdapitoken"],
+    }]
+    save_config(cfg)
+    (hermes_home / ".env").write_text("EBIRD_API_KEY=real-ebird-secret\n", encoding="utf-8")
+    monkeypatch.delenv("EBIRD_API_KEY", raising=False)
+    monkeypatch.setattr(ip, "load_mappings", lambda: [])
+
+    mappings = proxy_cli._setup_mint_tokens(proxy_cli.Console(file=MagicMock()), _args())
+
+    assert len(mappings) == 1
+    assert mappings[0].real_env_name == "EBIRD_API_KEY"
+    assert mappings[0].upstream_hosts == ("api.ebird.org",)
+    assert mappings[0].match_headers == ("x-ebirdapitoken",)
+    assert os.environ["EBIRD_API_KEY"] == "real-ebird-secret"
 
 
 

--- a/tests/test_iron_proxy_cli.py
+++ b/tests/test_iron_proxy_cli.py
@@ -223,6 +223,41 @@ def test_setup_discovers_validated_custom_secret_from_hermes_env(hermes_home, mo
     assert os.environ["EBIRD_API_KEY"] == "real-ebird-secret"
 
 
+def test_flagless_setup_reuses_persisted_bitwarden_source_and_custom_token(
+    hermes_home, monkeypatch,
+):
+    from hermes_cli.config import load_config, save_config
+
+    cfg = load_config()
+    cfg["proxy"]["credential_source"] = "bitwarden"
+    cfg["proxy"]["extra_secrets"] = [{
+        "env_var": "SERVICE_SECRET",
+        "hosts": ["api.example.com"],
+        "match_headers": ["x-service-secret"],
+    }]
+    save_config(cfg)
+    existing = ip.TokenMapping(
+        "service-existing-token", "SERVICE_SECRET", ("api.example.com",),
+        ("x-service-secret",), (), False,
+    )
+    monkeypatch.setattr(ip, "load_mappings", lambda: [existing])
+    calls = []
+
+    def fake_bitwarden_env_names(console):
+        calls.append(True)
+        return ["SERVICE_SECRET"]
+
+    monkeypatch.setattr(proxy_cli, "_bitwarden_env_names", fake_bitwarden_env_names)
+
+    mappings = proxy_cli._setup_mint_tokens(proxy_cli.Console(file=MagicMock()), _args())
+
+    assert calls == [True]
+    assert len(mappings) == 1
+    assert mappings[0].real_env_name == "SERVICE_SECRET"
+    assert mappings[0].proxy_token == "service-existing-token"
+    assert mappings[0].match_query is False
+
+
 
 
 def test_cmd_status_returns_0(hermes_home, monkeypatch):

--- a/tools/environments/docker_egress.py
+++ b/tools/environments/docker_egress.py
@@ -139,7 +139,9 @@ def _egress_enforce_on_docker(default: bool = True) -> bool:
 def _critical_egress_env_names(env_overrides: dict[str, str]) -> set[str]:
     """Env names that would weaken or bypass enforced egress if overridden."""
     critical = set(_PROXY_CONTROL_ENV) | {"NODE_OPTIONS"}
-    critical.update(k for k in env_overrides if k.endswith("_API_KEY") or k.endswith("_TOKEN"))
+    # Every override is proxy-owned, including arbitrary custom credential names such as
+    # SERVICE_SECRET. Suffix heuristics let docker_forward_env leak those real values.
+    critical.update(env_overrides)
     return critical
 
 

--- a/website/docs/developer-guide/egress-internals.md
+++ b/website/docs/developer-guide/egress-internals.md
@@ -85,7 +85,8 @@ hermes egress setup [--from-bitwarden | --no-bitwarden] [--rotate-tokens]
                  Write CA key via os.open(O_WRONLY|O_CREAT|O_TRUNC|O_NOFOLLOW, 0o600)
                    + os.replace.  Never exists on disk under default umask.
                  Write CA cert with 0o644 (public).
-       Step 3. discover_provider_mappings() or pull names from BWS via
+       Step 3. validate proxy.extra_secrets via parse_extra_secret_specs(), then
+                 discover_provider_mappings() or pull names from BWS via
                  fetch_bitwarden_secrets() when --from-bitwarden.
                  merge_mappings(existing=load_mappings(), discovered,
                                 rotate=args.rotate_tokens) preserves prior
@@ -167,6 +168,8 @@ All write paths use `os.open(O_WRONLY | O_CREAT | O_NOFOLLOW, 0o600)` + `os.fsta
 
 Regression: `test_subprocess_env_strips_unrelated_secrets`, `test_subprocess_env_strips_proxy_recursion_vars`, `test_subprocess_env_keeps_infrastructure_vars`.
 
+Operator-defined `proxy.extra_secrets` entries pass through `parse_extra_secret_specs()` before discovery. The parser accepts only uppercase env-var names, fully-qualified DNS hosts (optionally `*.`), and RFC-token header names; it rejects IP literals, global wildcards, URL components, built-in/duplicate env names, and routing/framing/hop-by-hop headers. This validation is the security boundary that prevents a broad or malformed mapping from sending one credential to unintended requests.
+
 ### Bind policy
 
 `_default_http_listen` returns a single-element list: on Linux the docker bridge gateway IP (containers reach the proxy via `host.docker.internal:host-gateway`, which resolves to the bridge gateway — a loopback bind is unreachable from inside containers there); on macOS/Windows Docker Desktop, loopback (VPNkit routes `host.docker.internal` to the host).  Linux without a detectable docker0 bridge falls back to loopback with a warning.  Never `0.0.0.0`, never `:PORT` (INADDR_ANY).
@@ -235,6 +238,10 @@ Regression: `test_merge_mappings_preserves_existing_tokens`, `test_merge_mapping
 Tested via the `cmd_setup` flow in CLI tests (the bitwarden-preservation path is exercised when `--from-bitwarden` is followed by a plain `setup` re-run).
 
 ## Extension points
+
+### Adding an operator-defined credential
+
+For services that authenticate with a static request header but do not belong in Hermes' bundled provider table, use `proxy.extra_secrets` in `config.yaml`. Setup validates each entry, discovers its env var from the host/`.env`/Bitwarden, mints a proxy token, and includes its hosts in the rendered allowlist through the mapping. Do not add user-specific services to the built-in tables.
 
 ### Adding a new bearer-token provider
 

--- a/website/docs/developer-guide/egress-internals.md
+++ b/website/docs/developer-guide/egress-internals.md
@@ -168,7 +168,7 @@ All write paths use `os.open(O_WRONLY | O_CREAT | O_NOFOLLOW, 0o600)` + `os.fsta
 
 Regression: `test_subprocess_env_strips_unrelated_secrets`, `test_subprocess_env_strips_proxy_recursion_vars`, `test_subprocess_env_keeps_infrastructure_vars`.
 
-Operator-defined `proxy.extra_secrets` entries pass through `parse_extra_secret_specs()` before discovery. The parser accepts only uppercase env-var names, fully-qualified DNS hosts (optionally `*.`), and RFC-token header names; it rejects IP literals, global wildcards, URL components, built-in/duplicate env names, and routing/framing/hop-by-hop headers. This validation is the security boundary that prevents a broad or malformed mapping from sending one credential to unintended requests.
+Operator-defined `proxy.extra_secrets` entries pass through `parse_extra_secret_specs()` before discovery. The parser accepts only uppercase env-var names, exact fully-qualified DNS hosts, and RFC-token header names; it rejects IP literals, wildcard scopes, URL components, built-in/duplicate env names, and routing/framing/hop-by-hop headers. Exact hosts are required because wildcard scopes can include attacker-controlled tenants under public or private suffixes. This validation is the security boundary that prevents a broad or malformed mapping from sending one credential to unintended requests.
 
 ### Bind policy
 

--- a/website/docs/user-guide/egress/iron-proxy.md
+++ b/website/docs/user-guide/egress/iron-proxy.md
@@ -101,6 +101,17 @@ proxy:
   # OpenAI, Anthropic, Google, xAI, Mistral, Groq, Together, DeepSeek,
   # and Nous Research.
   extra_allowed_hosts: []
+
+  # Additional static-header credentials. The real value stays on the host;
+  # the sandbox receives an opaque token under env_var. Hosts must be fully
+  # qualified DNS names (an optional left-most `*.` wildcard is allowed).
+  extra_secrets:
+    - env_var: GITHUB_TOKEN
+      hosts: [github.com, api.github.com]
+      match_headers: [Authorization]  # default when omitted
+    - env_var: EBIRD_API_KEY
+      hosts: [api.ebird.org]
+      match_headers: [x-ebirdapitoken]
 ```
 
 ### Default allowed upstream hosts
@@ -115,6 +126,8 @@ api.deepseek.com        inference.nousresearch.com
 ```
 
 If your agent needs an upstream that isn't on the list — a self-hosted inference endpoint, an extra cloud LLM, an MCP server — add it to `proxy.extra_allowed_hosts`. Wildcards are matched against the full hostname (`*.example.com` matches `api.example.com` and `staging.example.com` but not `example.com` itself).
+
+`extra_allowed_hosts` grants reachability only. To inject a non-provider credential without exposing its real value to the sandbox, add a `proxy.extra_secrets` entry and rerun `hermes egress setup`. Each mapping automatically allows its own `hosts`, so those hosts do not also need to appear in `extra_allowed_hosts`. Hermes rejects schemes, ports, paths, IP literals, bare or global wildcards, malformed env/header names, built-in env-var collisions, and routing/framing/hop-by-hop headers. Custom secret values may live in the process environment, `~/.hermes/.env`, or the configured Bitwarden project just like built-in provider keys.
 
 ### Default SSRF deny CIDRs
 

--- a/website/docs/user-guide/egress/iron-proxy.md
+++ b/website/docs/user-guide/egress/iron-proxy.md
@@ -104,7 +104,7 @@ proxy:
 
   # Additional static-header credentials. The real value stays on the host;
   # the sandbox receives an opaque token under env_var. Hosts must be fully
-  # qualified DNS names (an optional left-most `*.` wildcard is allowed).
+  # qualified, exact DNS names; wildcard credential scopes are rejected.
   extra_secrets:
     - env_var: GITHUB_TOKEN
       hosts: [github.com, api.github.com]
@@ -127,7 +127,7 @@ api.deepseek.com        inference.nousresearch.com
 
 If your agent needs an upstream that isn't on the list — a self-hosted inference endpoint, an extra cloud LLM, an MCP server — add it to `proxy.extra_allowed_hosts`. Wildcards are matched against the full hostname (`*.example.com` matches `api.example.com` and `staging.example.com` but not `example.com` itself).
 
-`extra_allowed_hosts` grants reachability only. To inject a non-provider credential without exposing its real value to the sandbox, add a `proxy.extra_secrets` entry and rerun `hermes egress setup`. Each mapping automatically allows its own `hosts`, so those hosts do not also need to appear in `extra_allowed_hosts`. Hermes rejects schemes, ports, paths, IP literals, bare or global wildcards, malformed env/header names, built-in env-var collisions, and routing/framing/hop-by-hop headers. Custom secret values may live in the process environment, `~/.hermes/.env`, or the configured Bitwarden project just like built-in provider keys.
+`extra_allowed_hosts` grants reachability only. To inject a non-provider credential without exposing its real value to the sandbox, add a `proxy.extra_secrets` entry and rerun `hermes egress setup`. Each mapping automatically allows its own `hosts`, so those hosts do not also need to appear in `extra_allowed_hosts`. Credential mappings require exact hosts because a wildcard could include attacker-controlled tenants under a shared suffix. Hermes rejects schemes, ports, paths, IP literals, wildcard scopes, malformed env/header names, built-in env-var collisions, and routing/framing/hop-by-hop headers. Custom secret values may live in the process environment, `~/.hermes/.env`, or the configured Bitwarden project just like built-in provider keys.
 
 ### Default SSRF deny CIDRs
 


### PR DESCRIPTION
## What does this PR do?

Adds a validated `proxy.extra_secrets` configuration surface so operators can give Docker sandboxes opaque proxy tokens for non-LLM services such as GitHub or eBird. The real credential remains in the host environment or Bitwarden and is swapped only for explicitly bounded DNS hosts and HTTP headers.

### Motivation

`proxy.extra_allowed_hosts` currently grants network reachability but cannot create token-swap mappings. Operators therefore have to forward real non-provider credentials into the sandbox or forgo those authenticated APIs.

### Behavior

- `proxy.extra_secrets` accepts an environment variable, one or more upstream DNS hosts, and optional matching headers.
- Setup discovers configured secrets from the process environment, `~/.hermes/.env`, or Bitwarden and persists normal proxy mappings.
- Mapping hosts are included in the rendered egress allowlist automatically.
- Invalid environment names, URL-like or unbounded hosts, IP literals, duplicate mappings, and routing/framing/hop-by-hop headers fail closed.
- Static header replacement is in scope; request signing, OAuth minting, arbitrary query parameters, and non-Docker backends are unchanged.

### Implementation

`iron_proxy.py` owns the pure validation and mapping-spec conversion. The setup CLI loads and validates the config before secret discovery, while existing mapping persistence, token preservation, minimal daemon environment, and Docker injection paths remain shared with built-in providers.

## Related Issue

Closes #108598

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/proxy_sources/iron_proxy.py` - validate custom env/host/header specs and include them in mapping discovery.
- `hermes_cli/proxy_cli.py` - load custom specs and discover their values from env, `.env`, or Bitwarden.
- `hermes_cli/config_defaults.py` - add the default `proxy.extra_secrets` list.
- `tests/test_iron_proxy.py`, `tests/test_iron_proxy_cli.py` - cover fail-closed validation and the real config-to-`.env` discovery path.
- `website/docs/` - document configuration, boundaries, and security invariants.

## How to Test

1. Add an `EBIRD_API_KEY` mapping under `proxy.extra_secrets` and put the value in `~/.hermes/.env`.
2. Run `hermes egress setup` and confirm `mappings.json` contains the custom env name, host, and header with an opaque proxy token.
3. Automated feature checks (5 passed):

```bash
scripts/run_tests.sh tests/test_iron_proxy.py tests/test_iron_proxy_cli.py -k "extra_secret_specs or setup_discovers_validated_custom_secret"
```

The unfiltered two-file run passed 34 tests and exposed 6 pre-existing Windows-only permission failures in `test_iron_proxy.py` (`os.fchmod` is unavailable and POSIX mode assertions do not hold on Windows). The feature-specific checks above are green; this PR does not change those unrelated filesystem paths.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.).
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this feature.
- [x] I've run the focused repository test entry and all feature-specific tests pass.
- [x] I've added tests for my changes.
- [x] I've tested on Windows 11 and considered cross-platform impact; validation and discovery are platform-independent, while the existing runtime remains Docker-only.

### Documentation & Housekeeping

- [x] I've updated relevant user and developer documentation.
- [x] `cli-config.yaml.example` is N/A because it does not enumerate the existing `proxy` section.
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because architecture and contributor workflows are unchanged.
- [x] Tool descriptions and schemas are N/A because no model tool changed.

## Screenshots / Logs

N/A - this is a configuration and backend behavior change.