### PR TITLE
fix(inference): queue concurrent local model turns instead of stalling

### DIFF
--- a/agent/local_endpoint_lock.py
+++ b/agent/local_endpoint_lock.py
@@ -1,0 +1,73 @@
+"""Process-wide admission control for local inference endpoints."""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from typing import Optional
+
+from agent.model_metadata import is_local_endpoint
+from utils import base_url_origin
+
+_LOCAL_ENDPOINT_LOCKS: dict[str, threading.RLock] = {}
+_LOCAL_ENDPOINT_LOCKS_GUARD = threading.Lock()
+_WAIT_POLL_SECONDS = 0.1
+
+
+def local_endpoint_key(base_url: str) -> Optional[str]:
+    """Return a normalized ``host:port`` key for a local inference URL."""
+    if not base_url or not is_local_endpoint(base_url):
+        return None
+    _scheme, host, port = base_url_origin(base_url)
+    if not host:
+        return None
+    if host == "localhost":
+        host = "127.0.0.1"
+    rendered_host = f"[{host}]" if ":" in host else host
+    return f"{rendered_host}:{port}"
+
+
+@contextmanager
+def local_endpoint_lock(
+    base_url: str,
+    *,
+    on_wait: Optional[Callable[[str], None]] = None,
+    cancel_requested: Optional[Callable[[], bool]] = None,
+) -> Iterator[Optional[str]]:
+    """Serialize one local backend while preserving same-thread nested calls.
+
+    The non-blocking probe lets callers surface a wait notice immediately. Queued
+    callers poll so an agent interrupt can cancel admission before any request is
+    sent. Cloud endpoints bypass the registry entirely.
+    """
+    key = local_endpoint_key(base_url)
+    if key is None:
+        yield None
+        return
+
+    with _LOCAL_ENDPOINT_LOCKS_GUARD:
+        lock = _LOCAL_ENDPOINT_LOCKS.setdefault(key, threading.RLock())
+
+    acquired = lock.acquire(blocking=False)
+    if not acquired:
+        if on_wait is not None:
+            with contextlib.suppress(Exception):
+                on_wait(key)
+        while not acquired:
+            cancelled = False
+            if cancel_requested is not None:
+                try:
+                    cancelled = bool(cancel_requested())
+                except Exception:
+                    pass
+            if cancelled:
+                raise InterruptedError(
+                    f"Interrupted while waiting for local backend {key}"
+                )
+            acquired = lock.acquire(timeout=_WAIT_POLL_SECONDS)
+    try:
+        yield key
+    finally:
+        lock.release()

--- a/agent/turn_api_call.py
+++ b/agent/turn_api_call.py
@@ -14,6 +14,7 @@ import logging
 import time
 from typing import Any, Dict, Optional
 
+from agent.local_endpoint_lock import local_endpoint_lock
 from agent.message_metadata import append_message
 
 logger = logging.getLogger("agent.conversation_loop")
@@ -122,14 +123,24 @@ def perform_api_call(
     with _bracket:
         if _model_request_active is not None:
             _model_request_active.set()
+
+    def _local_wait_notice(endpoint: str) -> None:
+        emit_status = getattr(agent, "_emit_status", None)
+        if callable(emit_status):
+            emit_status(f"⏳ another request is using the local backend ({endpoint}); waiting…")
+
     try:
-        response = run_llm_execution_middleware(
-            api_kwargs, _perform_api_call, original_request=_original_api_kwargs,
-            task_id=effective_task_id, turn_id=turn_id, api_request_id=api_request_id,
-            session_id=agent.session_id or "", platform=agent.platform or "", model=agent.model,
-            provider=agent.provider, base_url=agent.base_url, api_mode=agent.api_mode,
-            api_call_count=api_call_count, middleware_trace=list(_llm_middleware_trace),
-        )
+        with local_endpoint_lock(
+            str(agent.base_url or ""), on_wait=_local_wait_notice,
+            cancel_requested=lambda: bool(getattr(agent, "_interrupt_requested", False)),
+        ):
+            response = run_llm_execution_middleware(
+                api_kwargs, _perform_api_call, original_request=_original_api_kwargs,
+                task_id=effective_task_id, turn_id=turn_id, api_request_id=api_request_id,
+                session_id=agent.session_id or "", platform=agent.platform or "", model=agent.model,
+                provider=agent.provider, base_url=agent.base_url, api_mode=agent.api_mode,
+                api_call_count=api_call_count, middleware_trace=list(_llm_middleware_trace),
+            )
     finally:
         with _bracket:
             if _model_request_active is not None:

--- a/tests/agent/test_local_endpoint_lock.py
+++ b/tests/agent/test_local_endpoint_lock.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+from agent.local_endpoint_lock import local_endpoint_lock
+from agent.turn_api_call import perform_api_call
+
+
+def test_local_endpoint_lock_is_reentrant_for_nested_same_thread_calls():
+    notices: list[str] = []
+
+    with local_endpoint_lock("http://localhost:11434/v1", on_wait=notices.append):
+        with local_endpoint_lock("http://127.0.0.1:11434", on_wait=notices.append):
+            pass
+
+    assert notices == []
+
+
+def test_turn_calls_to_same_local_backend_queue_across_threads(monkeypatch):
+    release_first = threading.Event()
+    first_entered = threading.Event()
+    second_entered = threading.Event()
+    second_waiting = threading.Event()
+    interrupted_waiting = threading.Event()
+    interrupt_observed = threading.Event()
+    results: list[str] = []
+    errors: list[BaseException] = []
+
+    def run_middleware(request, call, **_kwargs):
+        return call(request)
+
+    monkeypatch.setattr(
+        "hermes_cli.middleware.run_llm_execution_middleware", run_middleware
+    )
+
+    def make_agent(base_url: str, entered: threading.Event, wait=None):
+        def api_call(_kwargs):
+            entered.set()
+            release_first.wait(timeout=2)
+            return base_url
+
+        return SimpleNamespace(
+            api_mode="chat_completions",
+            base_url=base_url,
+            provider="custom",
+            model="local-model",
+            session_id=base_url,
+            platform="cli",
+            _disable_streaming=True,
+            _interrupt_requested=False,
+            _model_request_active=None,
+            _pending_redirect_lock=None,
+            _pending_redirect=None,
+            _has_pending_redirect=lambda: False,
+            _has_stream_consumers=lambda: False,
+            _interruptible_api_call=api_call,
+            _emit_status=(wait or (lambda _message: None)),
+        )
+
+    first = make_agent("http://localhost:11434/v1", first_entered)
+    second = make_agent(
+        "http://127.0.0.1:11434/api", second_entered,
+        lambda message: second_waiting.set(),
+    )
+    interrupted = make_agent(
+        "http://LOCALHOST:11434/v1", threading.Event(),
+        lambda message: interrupted_waiting.set(),
+    )
+
+    def invoke(agent):
+        try:
+            verdict = perform_api_call(
+                agent,
+                api_kwargs={"model": "local-model"},
+                _original_api_kwargs={},
+                _llm_middleware_trace=[],
+                _moa_prepared_request=None,
+                _retry=None,
+                thinking_spinner=None,
+                retry_count=0,
+                api_call_count=0,
+                api_request_id="request",
+                effective_task_id=None,
+                turn_id="turn",
+                interrupted=False,
+            )
+            results.append(verdict.response)
+        except BaseException as exc:
+            errors.append(exc)
+            interrupt_observed.set()
+
+    owner = threading.Thread(target=invoke, args=(first,))
+    waiter = threading.Thread(target=invoke, args=(second,))
+    cancelled_waiter = threading.Thread(target=invoke, args=(interrupted,))
+    owner.start()
+    assert first_entered.wait(timeout=1)
+    waiter.start()
+    assert second_waiting.wait(timeout=1)
+    assert not second_entered.is_set()
+    cancelled_waiter.start()
+    assert interrupted_waiting.wait(timeout=1)
+    interrupted._interrupt_requested = True
+    assert interrupt_observed.wait(timeout=1)
+
+    release_first.set()
+    owner.join(timeout=2)
+    waiter.join(timeout=2)
+    cancelled_waiter.join(timeout=2)
+
+    assert not owner.is_alive()
+    assert not waiter.is_alive()
+    assert not cancelled_waiter.is_alive()
+    assert second_entered.is_set()
+    assert sorted(results) == sorted([first.base_url, second.base_url])
+    assert len(errors) == 1
+    assert isinstance(errors[0], InterruptedError)


### PR DESCRIPTION
## What does this PR do?

Concurrent Hermes turns aimed at the same local or self-hosted model backend now queue instead of competing for one inference slot and stalling both requests. A process-wide lock is keyed by normalized host and port at the shared turn-call boundary, so streaming, non-streaming, cron, and delegated call variants follow the same admission rule while cloud endpoints remain unchanged.

### Symptom

A foreground turn and concurrent background turn can submit large requests to the same single-GPU backend at once. Both requests then contend for model and KV-cache capacity instead of one waiting for the other.

### Impact

Users of local and private-LAN model servers can see a foreground turn stall or time out while background work targets the same backend.

### Bug Cause

**Trigger:** `agent/turn_api_call.py` / `perform_api_call` dispatched each turn without endpoint-level admission control.

**Causal chain:**
1. Two Hermes threads resolve to the same local host and port.
2. Each independently enters the streaming or non-streaming provider path.
3. The backend receives both requests concurrently, so they contend for the same constrained inference resources and can stop making useful progress.

**Why it is wrong:** Request concurrency was controlled per turn, but there was no process-wide coordination for a shared local inference destination.

**Working sibling / contrast:** Cloud endpoints can scale or queue independently and therefore bypass the new local-only lock.

**Ruled out:** This is not caused by one specific SDK path. Streaming and non-streaming dispatch converge at `perform_api_call`, including the inline variants selected for cron and delegated children.

### Fix

Add a process-wide per-local-endpoint `RLock` keyed by normalized `host:port`, and acquire it around the shared provider-call boundary. A contending turn emits one immediate status notice and polls the agent interrupt flag while queued. Reentrant acquisition preserves same-thread nested calls, while different local endpoints and all cloud endpoints remain independent.

## Related Issue


N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/local_endpoint_lock.py` - add normalized local endpoint admission and interruptible waiting.
- `agent/turn_api_call.py` - guard the shared streaming/non-streaming turn-call boundary.
- `tests/agent/test_local_endpoint_lock.py` - cover nested re-entry, cross-thread queueing, endpoint alias normalization, wait notices, and cancellation.

## How to Test

1. Run the focused endpoint-lock and neighboring local/inline request tests after PR creation.
2. Confirm a second thread targeting the same local host and port remains queued until the first releases the backend.
3. Confirm a queued turn can be interrupted before dispatch.

```bash
scripts/run_tests.sh tests/agent/test_local_endpoint_lock.py tests/agent/test_cron_inline_api_call_62151.py tests/agent/test_local_stream_timeout.py
```

Result: 25 tests passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested the implementation design for cross-platform compatibility

### Documentation & Housekeeping

- [x] Relevant documentation is N/A; the behavior is internal and documented in code
- [x] `cli-config.yaml.example` is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no architecture or workflow contract changed
- [x] Cross-platform impact was considered; the implementation uses Python standard-library synchronization
- [x] Tool descriptions and schemas are N/A; no tool behavior changed

## Screenshots / Logs

N/A - automated concurrency tests exercise the behavior.
