### PR TITLE
fix(terminal): restore sudo in Linux Desktop sessions

### DIFF
--- a/tests/tools/test_local_no_new_privs.py
+++ b/tests/tools/test_local_no_new_privs.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+
+from tools.environments.local_no_new_privs import (
+    no_new_privs_enabled,
+    prepare_systemd_run_escape,
+)
+
+
+def _status(tmp_path: Path, value: int) -> Path:
+    status = tmp_path / "status"
+    status.write_text(f"Name:\tpython\nNoNewPrivs:\t{value}\n", encoding="utf-8")
+    return status
+
+
+def test_no_new_privs_reads_proc_status_value(tmp_path):
+    assert no_new_privs_enabled(_status(tmp_path, 1)) is True
+    assert no_new_privs_enabled(_status(tmp_path, 0)) is False
+    assert no_new_privs_enabled(tmp_path / "missing") is False
+
+
+def test_systemd_escape_transfers_sanitized_environment_over_stdin(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", "/home/alice")
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("API_TOKEN", "must-not-reach-systemd-client")
+    run_env = {
+        "EMPTY": "",
+        "PATH": "/opt/hermes/bin:/usr/bin",
+        "SUDO_PASSWORD": "terminal-secret",
+        "VALUE": "contains=equals\nand-newline",
+    }
+
+    escape = prepare_systemd_run_escape(
+        ["/bin/bash", "-c", "sudo -S id"],
+        run_env,
+        "/home/alice/project",
+        "terminal-secret\ncommand-input\n",
+        has_sudo=True,
+        platform="linux",
+        status_path=_status(tmp_path, 1),
+        which=lambda command: "/usr/bin/systemd-run" if command == "systemd-run" else None,
+        getuid=lambda: 1000,
+        path_exists=lambda path: path == "/run/user/1000/bus",
+    )
+
+    assert escape is not None
+    assert escape.args[:7] == [
+        "/usr/bin/systemd-run",
+        "--user",
+        "--pipe",
+        "--quiet",
+        "--collect",
+        "--wait",
+        "--working-directory=/home/alice/project",
+    ]
+    assert escape.args[-3:] == ["/bin/bash", "-c", "sudo -S id"]
+    assert "terminal-secret" not in "\0".join(escape.args)
+    assert escape.env == {
+        "DBUS_SESSION_BUS_ADDRESS": "unix:path=/run/user/1000/bus",
+        "HOME": "/home/alice",
+        "PATH": "/usr/bin",
+        "XDG_RUNTIME_DIR": "/run/user/1000",
+    }
+    assert escape.stdin_data == (
+        "EMPTY=\0"
+        "PATH=/opt/hermes/bin:/usr/bin\0"
+        "SUDO_PASSWORD=terminal-secret\0"
+        "VALUE=contains=equals\nand-newline\0"
+        "\0"
+        "terminal-secret\ncommand-input\n"
+    )
+
+
+def test_systemd_escape_leaves_unaffected_commands_on_direct_path(tmp_path):
+    common = {
+        "args": ["/bin/bash", "-c", "id"],
+        "run_env": {"PATH": "/usr/bin"},
+        "cwd": "/tmp",
+        "stdin_data": None,
+        "platform": "linux",
+        "status_path": _status(tmp_path, 1),
+        "which": lambda _command: "/usr/bin/systemd-run",
+        "getuid": lambda: 1000,
+        "path_exists": lambda _path: True,
+    }
+
+    assert prepare_systemd_run_escape(**common, has_sudo=False) is None
+    assert prepare_systemd_run_escape(**{**common, "platform": "darwin"}, has_sudo=True) is None
+    assert prepare_systemd_run_escape(
+        **{**common, "status_path": _status(tmp_path, 0)}, has_sudo=True
+    ) is None
+    assert prepare_systemd_run_escape(
+        **{**common, "path_exists": lambda _path: False}, has_sudo=True
+    ) is None

--- a/tests/tools/test_local_no_new_privs.py
+++ b/tests/tools/test_local_no_new_privs.py
@@ -54,12 +54,11 @@ def test_systemd_escape_transfers_sanitized_environment_over_stdin(tmp_path, mon
     ]
     assert escape.args[-3:] == ["/bin/bash", "-c", "sudo -S id"]
     assert "terminal-secret" not in "\0".join(escape.args)
-    assert escape.env == {
-        "DBUS_SESSION_BUS_ADDRESS": "unix:path=/run/user/1000/bus",
-        "HOME": "/home/alice",
-        "PATH": "/usr/bin",
-        "XDG_RUNTIME_DIR": "/run/user/1000",
-    }
+    assert escape.env["DBUS_SESSION_BUS_ADDRESS"] == "unix:path=/run/user/1000/bus"
+    assert escape.env["HOME"] == "/home/alice"
+    assert escape.env["PATH"] == "/usr/bin"
+    assert escape.env["XDG_RUNTIME_DIR"] == "/run/user/1000"
+    assert "API_TOKEN" not in escape.env
     assert escape.stdin_data == (
         "EMPTY=\0"
         "PATH=/opt/hermes/bin:/usr/bin\0"

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -27,8 +27,10 @@ from tools.environments.local_env_policy import (
 from tools.environments.local_gitbash_probe import (
     _bash_probe_details_cache, _bash_starts, _git_bash_aslr_help,
     _looks_like_msys_spawn_failure, _mandatory_aslr_enabled)
+from tools.environments.local_no_new_privs import prepare_systemd_run_escape
 from tools.environments.local_pythonpath import (
     _build_hermes_repo_root_aliases, _strip_hermes_owned_pythonpath_and_runtime_markers)
+from tools.terminal_tool_sudo import _count_real_sudo_invocations
 
 
 _IS_WINDOWS = platform.system() == "Windows"
@@ -780,8 +782,16 @@ class LocalEnvironment(BaseEnvironment):
             cmd_string = _prepend_shell_init(cmd_string, _resolve_shell_init_files())
         args = [bash, *(["-l"] if login else []), "-c", cmd_string]
         self._recover_cwd()
+        run_env = _make_run_env(self.env)
+        escape = prepare_systemd_run_escape(
+            args, run_env, self.cwd, stdin_data,
+            has_sudo=_count_real_sudo_invocations(cmd_string) > 0)
+        if escape is not None:
+            args = escape.args
+            run_env = escape.env
+            stdin_data = escape.stdin_data
         proc = subprocess.Popen(
-            args, text=True, env=_make_run_env(self.env), encoding="utf-8", errors="replace",
+            args, text=True, env=run_env, encoding="utf-8", errors="replace",
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
             stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
             start_new_session=True, cwd=self.cwd,

--- a/tools/environments/local_no_new_privs.py
+++ b/tools/environments/local_no_new_privs.py
@@ -1,0 +1,109 @@
+"""Linux ``no_new_privs`` escape for local sudo commands.
+
+Electron enables the one-way ``PR_SET_NO_NEW_PRIVS`` latch.  A Desktop-spawned
+backend inherits it, so the kernel ignores sudo's setuid bit.  A transient user
+service is created by the systemd user manager rather than by that process tree
+and therefore does not inherit the latch.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping, Sequence
+
+
+_STATUS_PATH = Path("/proc/self/status")
+_ENV_LOADER = """while IFS= read -r -d '' entry; do
+    [ -z "$entry" ] && break
+    export "$entry"
+done
+exec "$@"
+"""
+_SYSTEMD_CLIENT_ENV_KEYS = frozenset({"HOME", "LANG", "LOGNAME", "PATH", "TERM", "USER"})
+
+
+@dataclass(frozen=True)
+class SystemdRunEscape:
+    args: list[str]
+    env: dict[str, str]
+    stdin_data: str
+
+
+def no_new_privs_enabled(status_path: Path = _STATUS_PATH) -> bool:
+    """Read the current process's kernel latch from procfs."""
+    try:
+        for line in status_path.read_text(encoding="utf-8", errors="replace").splitlines():
+            if line.startswith("NoNewPrivs:"):
+                return line.split(maxsplit=1)[1].strip() == "1"
+    except (OSError, IndexError):
+        return False
+    return False
+
+
+def _systemd_client_env(source: Mapping[str, str], runtime_dir: str) -> dict[str, str]:
+    """Minimal non-secret environment needed by the systemd-run client."""
+    env = {
+        key: value
+        for key, value in source.items()
+        if key in _SYSTEMD_CLIENT_ENV_KEYS or key.startswith("LC_")
+    }
+    env["XDG_RUNTIME_DIR"] = runtime_dir
+    env["DBUS_SESSION_BUS_ADDRESS"] = f"unix:path={runtime_dir}/bus"
+    return env
+
+
+def prepare_systemd_run_escape(
+    args: Sequence[str],
+    run_env: Mapping[str, str],
+    cwd: str,
+    stdin_data: str | None,
+    *,
+    has_sudo: bool,
+    platform: str = os.sys.platform,
+    status_path: Path = _STATUS_PATH,
+    which: Callable[[str], str | None] = shutil.which,
+    getuid: Callable[[], int] | None = getattr(os, "getuid", None),
+    path_exists: Callable[[str], bool] = os.path.exists,
+) -> SystemdRunEscape | None:
+    """Return a systemd-manager launch when inherited NNP would break sudo.
+
+    The sanitized terminal environment is transferred over stdin as NUL-delimited
+    entries.  Unlike ``systemd-run --setenv``, this keeps credentials out of argv
+    and the journal.  A blank NUL entry terminates the prefix; the command then
+    inherits the still-open stdin at the exact byte where the caller's original
+    payload begins.
+    """
+    if platform != "linux" or not has_sudo or not no_new_privs_enabled(status_path):
+        return None
+    if getuid is None:
+        return None
+
+    systemd_run = which("systemd-run")
+    runtime_dir = f"/run/user/{getuid()}"
+    if not systemd_run or not path_exists(f"{runtime_dir}/bus"):
+        return None
+
+    env_prefix = "".join(f"{key}={value}\0" for key, value in sorted(run_env.items())) + "\0"
+    escaped_args = [
+        systemd_run,
+        "--user",
+        "--pipe",
+        "--quiet",
+        "--collect",
+        "--wait",
+        f"--working-directory={cwd}",
+        "--",
+        "/bin/bash",
+        "-c",
+        _ENV_LOADER,
+        "hermes-no-new-privs",
+        *args,
+    ]
+    return SystemdRunEscape(
+        args=escaped_args,
+        env=_systemd_client_env(os.environ, runtime_dir),
+        stdin_data=env_prefix + (stdin_data or ""),
+    )


### PR DESCRIPTION
## What does this PR do?

Linux Desktop users can run approved `sudo` commands from the local terminal tool again. Electron's inherited `no_new_privs` kernel latch prevents setuid from taking effect in every descendant; this change routes only real sudo-bearing local commands through a transient service created by the user's systemd manager, while leaving all other commands and platforms on the existing path.

### Symptom

A terminal-tool command containing `sudo` fails from the Linux Desktop backend even when `SUDO_PASSWORD` is configured or sudoers allows NOPASSWD. The same command works from a CLI- or gateway-started backend.

### Impact

Linux Desktop users cannot perform approved privileged terminal operations. Other platforms and remote terminal backends are unaffected.

### Bug Cause

**Trigger:** `tools/environments/local.py:LocalEnvironment._run_bash` when the backend inherited `NoNewPrivs: 1` and the shell command contains a real command-position `sudo` invocation.

**Causal chain:**
1. Electron starts the local Hermes backend after Chromium has enabled the one-way `PR_SET_NO_NEW_PRIVS` latch.
2. The backend's local terminal subprocesses inherit that latch, so the kernel refuses to honor sudo's setuid bit.
3. Password and NOPASSWD authentication both fail because sudo cannot gain privileges.

**Why it is wrong:** The terminal path assumes sudo can use its normal setuid transition, but that transition is prohibited for the entire Electron-descended process tree.

**Working sibling / contrast:** CLI and gateway launches are not descendants of Electron and retain `NoNewPrivs: 0`, so their existing direct local-terminal path works.

**Ruled out:** This is not a password-prompt or PTY issue because NOPASSWD commands fail under the Desktop process tree as well, and `/proc/self/status` distinguishes the failing backend with `NoNewPrivs: 1`.

### Fix

- Detect the kernel latch from `/proc/self/status` only for Linux local commands that contain a real sudo invocation.
- Run that command as a transient user service created by the systemd user manager, which is outside the Electron process tree.
- Transfer the already-sanitized terminal environment as a NUL-delimited stdin prefix so values do not appear in process arguments or the journal, then preserve the caller's original stdin for `sudo -S` and command input.
- Fall back to the unchanged direct execution path when the latch, systemd-run, or the user bus is unavailable.

## Related Issue


N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/local_no_new_privs.py` - detect inherited no-new-privileges and build the systemd user-manager escape invocation.
- `tools/environments/local.py` - apply the escape only to real sudo-bearing local shell commands.
- `tests/tools/test_local_no_new_privs.py` - cover latch detection, environment/stdin transfer, and unaffected-path fallbacks.

## How to Test

1. Launch Hermes Desktop on Linux with a systemd user session and confirm `/proc/self/status` reports `NoNewPrivs: 1` in the backend.
2. Run an approved `sudo -n true` or configured `sudo -S id` command through the terminal tool and confirm it succeeds.
3. Run the focused automated tests:

```bash
scripts/run_tests.sh tests/tools/test_terminal_tool.py tests/tools/test_local_no_new_privs.py
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the focused repository test entry and all 16 tests pass
- [x] I've added tests for my changes
- [ ] I've tested on Linux Desktop

### Documentation & Housekeeping

- [x] Relevant documentation - N/A; behavior is internal and documented in code
- [x] `cli-config.yaml.example` - N/A; no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` - N/A; no architecture or workflow contract changed
- [x] Cross-platform impact considered; non-Linux paths retain direct execution
- [x] Tool descriptions/schemas - N/A; the terminal schema is unchanged

## Screenshots / Logs

Focused automated tests: 16 passed. Linux Desktop verification is delegated to the review phase.