### PR TITLE
feat(acp): negotiate commentary and correlate late review notifications

### DIFF
--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -9,10 +9,11 @@ thread-safely onto the loop.
 import asyncio
 import logging
 from collections import deque
-from typing import Any, Callable, Deque, Dict
+from typing import Any, Callable, Deque, Dict, Literal
+from uuid import uuid4
 
 import acp
-from acp.schema import AgentPlanUpdate, PlanEntry
+from acp.schema import AgentMessageChunk, AgentPlanUpdate, PlanEntry, TextContentBlock
 
 from .tools import _json_loads_maybe, build_tool_complete, build_tool_start, coerce_tool_args, make_tool_call_id
 
@@ -69,6 +70,25 @@ def _upgrade_queue(tool_call_ids: Dict[str, Deque[str]], name: str) -> Deque[str
     if isinstance(queue, str):
         queue = tool_call_ids[name] = deque([queue])
     return queue
+
+
+def make_commentary_cb(
+    conn: acp.Client, session_id: str, loop: asyncio.AbstractEventLoop,
+    turn_id: str, source: Literal["assistant", "background_review"],
+) -> Callable:
+    """Additional opt-in copies; never change the ordinary stream's delivery state."""
+    def _cb(text: str, *, already_streamed: bool = False) -> None:
+        if text:
+            _send_update(conn, session_id, loop, AgentMessageChunk(
+                session_update="agent_message_chunk",
+                message_id=f"hermes:{uuid4()}",
+                content=TextContentBlock(type="text", text=text),
+                field_meta={"hermes": {
+                    "messagePhases": 1, "phase": "commentary", "source": source, "turnId": turn_id,
+                }},
+            ))
+
+    return _cb
 
 
 def make_tool_progress_cb(

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -13,6 +13,7 @@ from collections import defaultdict, deque
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Any, Callable, Deque, Optional
+from uuid import UUID
 
 import acp
 from acp.schema import (
@@ -28,7 +29,8 @@ from acp_adapter.auth import TERMINAL_SETUP_AUTH_METHOD_ID, build_auth_methods, 
 from acp_adapter.commands import HERMES_VERSION, SlashCommandsMixin, _estimate_tokens
 from acp_adapter.content import PromptBlock, _content_blocks_to_openai_user_content, _extract_text
 from acp_adapter.events import (
-    _build_plan_update_from_todo_result, make_message_cb, make_step_cb, make_thinking_cb, make_tool_progress_cb,
+    _build_plan_update_from_todo_result, make_commentary_cb, make_message_cb, make_step_cb,
+    make_thinking_cb, make_tool_progress_cb,
 )
 from acp_adapter.model_catalog import build_model_state, encode_model_choice
 from acp_adapter.permissions import make_approval_callback
@@ -221,6 +223,8 @@ class _TurnCallbacks:
     approval_cb: Any = None
     edit_approval_requester: Any = None
     streamed: bool = False
+    interim_cb: Any = None
+    background_review_cb: Any = None
 
 
 class HermesACPAgent(SlashCommandsMixin, acp.Agent):
@@ -248,12 +252,14 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
         super().__init__()
         self.session_manager = session_manager or SessionManager()
         self._conn: Optional[acp.Client] = None
+        self._message_phases = False
 
     # ---- Connection lifecycle -----------------------------------------------
 
     def on_connect(self, conn: acp.Client) -> None:
         """Store the client connection for sending session updates."""
         self._conn = conn
+        self._message_phases = False
         logger.info("ACP client connected")
 
     async def _send(self, session_id: str, update: Any, *, fail_msg: str, level: int = logging.WARNING) -> bool:
@@ -501,6 +507,10 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
         self, protocol_version: int | None = None, client_capabilities: ClientCapabilities | None = None,
         client_info: Implementation | None = None, **kwargs: Any,
     ) -> InitializeResponse:
+        meta = client_capabilities.field_meta if client_capabilities else None
+        hermes = meta.get("hermes") if isinstance(meta, dict) else None
+        version = hermes.get("messagePhases") if isinstance(hermes, dict) else None
+        self._message_phases = type(version) is int and version == 1
         auth_methods = build_auth_methods()
         logger.info(
             "Initialize from %s (protocol v%s)", client_info.name if client_info else "unknown",
@@ -511,6 +521,7 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
             protocol_version=acp.PROTOCOL_VERSION,
             agent_info=Implementation(name="hermes-agent", version=HERMES_VERSION),
             agent_capabilities=AgentCapabilities(
+                field_meta={"hermes": {"messagePhases": 1}} if self._message_phases else None,
                 load_session=True,
                 prompt_capabilities=PromptCapabilities(image=True),
                 session_capabilities=SessionCapabilities(
@@ -810,7 +821,19 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
         conn, loop = self._conn, asyncio.get_running_loop()
         if state.cancel_event:
             state.cancel_event.clear()
-        cbs = self._wire_turn_callbacks(state, session_id, conn, loop)
+        # ACP's router expands top-level _meta into keyword arguments.
+        hermes = kwargs.get("hermes")
+        turn_id = hermes.get("turnId") if isinstance(hermes, dict) else None
+        if isinstance(turn_id, str):
+            try:
+                UUID(turn_id)
+            except ValueError:
+                turn_id = None
+        else:
+            turn_id = None
+        previous_interim = getattr(state.agent, "interim_assistant_callback", None)
+        previous_review = getattr(state.agent, "background_review_callback", None)
+        cbs = self._wire_turn_callbacks(state, session_id, conn, loop, turn_id)
 
         def _run_agent() -> dict:
             return self._run_agent_turn(
@@ -831,15 +854,24 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
                 state.is_running = False
                 state.current_prompt_text = ""
             return PromptResponse(stop_reason="end_turn")
+        finally:
+            # Restore before _finish_turn drains queued prompts. Reviews retain a
+            # snapshot taken when their worker was created, including a disabled None.
+            state.agent.interim_assistant_callback = previous_interim
+            state.agent.background_review_callback = previous_review
 
         return await self._finish_turn(state, session_id, conn, result, pre_turn_hermes_id, cbs.streamed)
 
     def _wire_turn_callbacks(
-        self, state: SessionState, session_id: str, conn: Any, loop: asyncio.AbstractEventLoop
+        self, state: SessionState, session_id: str, conn: Any, loop: asyncio.AbstractEventLoop,
+        turn_id: str | None = None,
     ) -> _TurnCallbacks:
         """Install the ACP streaming callbacks on the session agent for one turn."""
         cbs = _TurnCallbacks()
         if conn:
+            if self._message_phases and turn_id:
+                cbs.interim_cb = make_commentary_cb(conn, session_id, loop, turn_id, "assistant")
+                cbs.background_review_cb = make_commentary_cb(conn, session_id, loop, turn_id, "background_review")
             tool_call_ids: dict[str, Deque[str]] = defaultdict(deque)
             tool_call_meta: dict[str, dict[str, Any]] = {}
             policy_getter = lambda: self._edit_approval_policy_for_state(state)  # noqa: E731
@@ -871,6 +903,8 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
         agent.thinking_callback = None
         agent.reasoning_callback, agent.step_callback = cbs.reasoning_cb, cbs.step_cb
         agent.stream_delta_callback = cbs.stream_delta_cb
+        agent.interim_assistant_callback = cbs.interim_cb
+        agent.background_review_callback = cbs.background_review_cb
         return cbs
 
     async def _finish_turn(

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -20,6 +20,8 @@ from agent.thread_scoped_output import thread_scoped_silence
 
 logger = logging.getLogger(__name__)
 
+_CALLBACK_UNSET = object()
+
 _BACKGROUND_REVIEW_CANCEL_TIMEOUT_SECONDS = 2.0
 
 
@@ -1077,18 +1079,19 @@ def _run_review_fork(
     st.review_agent = None
 
 
-def _publish_review_summary(agent: Any, actions: List[str]) -> None:
+def _publish_review_summary(agent: Any, actions: List[str], callback: Any) -> None:
     summary = " · ".join(dict.fromkeys(actions))
     agent._safe_print(f"  💾 Self-improvement review: {summary}")
-    if agent.background_review_callback:
+    if callback:
         with suppress(Exception):
-            agent.background_review_callback(f"💾 Self-improvement review: {summary}")
+            callback(f"💾 Self-improvement review: {summary}")
 
 
 def _run_review_in_thread(
     agent: Any, messages_snapshot: List[Dict], prompt: str,
     task_cfg: Optional[Dict[str, Any]] = None, review_run: Optional[_BackgroundReviewRun] = None,
     review_memory: bool = False, explicit: bool = False,
+    background_review_callback: Any = _CALLBACK_UNSET,
 ) -> None:
     """Daemon-thread worker: build the fork, run the prompt, surface the action summary via
     ``agent._safe_print`` / ``background_review_callback``. ``review_run`` (from
@@ -1097,6 +1100,8 @@ def _run_review_in_thread(
 
     See #84423.
     """
+    if background_review_callback is _CALLBACK_UNSET:
+        background_review_callback = getattr(agent, "background_review_callback", None)
     if review_run is not None and review_run.cancel_requested.is_set():
         finish_background_review_run(agent, review_run)
         return
@@ -1150,7 +1155,7 @@ def _run_review_in_thread(
             actions = []
         _log_review_completion(st.review_usage, _classify_review_result(actions))
         if actions:
-            _publish_review_summary(agent, actions)
+            _publish_review_summary(agent, actions, background_review_callback)
     except Exception as e:
         logger.warning("Background memory/skill review failed: %s", e)
         if st.review_usage:
@@ -1199,10 +1204,14 @@ def spawn_background_review_thread(
             f"focus — prioritize it over the general instructions above:\n{focus}"
         )
 
+    # The parent can start a new turn or restore its callbacks before this worker
+    # publishes. Bind the initiating destination now; None also must stay None.
+    callback = getattr(agent, "background_review_callback", None)
+
     def _target() -> None:  # resolves _run_review_in_thread at call time (tests patch it)
         _run_review_in_thread(
             agent, messages_snapshot, prompt, task_cfg=task_cfg, review_run=review_run,
-            review_memory=review_memory, explicit=explicit)
+            review_memory=review_memory, explicit=explicit, background_review_callback=callback)
 
     return _target, prompt
 

--- a/tests/acp/test_commentary.py
+++ b/tests/acp/test_commentary.py
@@ -1,0 +1,197 @@
+"""Opt-in notifications preserve the ordinary response and their initiating turn."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import acp
+import pytest
+from acp.agent.router import build_agent_router
+
+from acp_adapter.server import HermesACPAgent
+from acp_adapter.session import SessionManager
+from agent import background_review
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("version", [None, 1, True, "1", 2])
+@pytest.mark.parametrize("streamed", [False, True])
+async def test_commentary_is_opt_in_additive_and_restores_callbacks(version, streamed, monkeypatch):
+    manager = SessionManager(agent_factory=lambda: MagicMock(name="Agent"))
+    adapter = HermesACPAgent(manager)
+    router = build_agent_router(adapter)
+    conn = MagicMock(spec=acp.Client)
+    conn.session_update = AsyncMock()
+    adapter._conn = conn
+    init = await router("initialize", {
+        "protocolVersion": acp.PROTOCOL_VERSION,
+        "clientCapabilities": {"_meta": {"hermes": {"messagePhases": version}}},
+    }, False)
+    init = init.model_dump(by_alias=True, exclude_none=True)
+    enabled = type(version) is int and version == 1
+    assert init["agentCapabilities"].get("_meta", {}).get("hermes") == (
+        {"messagePhases": 1} if enabled else None
+    )
+    session = await adapter.new_session(cwd=".")
+    state = manager.get_session(session.session_id)
+    state.agent.session_id = session.session_id
+    prior_interim, prior_review = lambda text, **kw: None, lambda text: None
+    state.agent.interim_assistant_callback = prior_interim
+    state.agent.background_review_callback = prior_review
+    conn.session_update.reset_mock()
+    token = str(uuid4())
+    captured = []
+
+    def run(**kwargs):
+        if streamed:
+            state.agent.stream_delta_callback("Working. Done.")
+        if state.agent.interim_assistant_callback:
+            state.agent.interim_assistant_callback("Working.", already_streamed=streamed)
+            state.agent.interim_assistant_callback("Working.", already_streamed=streamed)
+        captured.append(state.agent.background_review_callback)
+        return {"final_response": "Working. Done.", "messages": []}
+
+    monkeypatch.setattr(adapter, "_run_agent_turn", run)
+    monkeypatch.setattr(adapter, "_send_usage_update", AsyncMock())
+    await router("session/prompt", {
+        "sessionId": session.session_id,
+        "prompt": [{"type": "text", "text": "Do it"}],
+        "_meta": {"hermes": {"turnId": token}},
+    }, False)
+    assert state.agent.interim_assistant_callback is prior_interim
+    assert state.agent.background_review_callback is prior_review
+    # A finished turn's callback can report late without reading a later turn's callback.
+    if captured[0]:
+        await asyncio.to_thread(captured[0], "Self-improvement review: Skill 'example' patched")
+    updates = [call.args[1] if len(call.args) > 1 else call.kwargs["update"]
+               for call in conn.session_update.call_args_list]
+    chunks = [update.model_dump(by_alias=True, exclude_none=True)
+              for update in updates if update.session_update == "agent_message_chunk"]
+    raw = [chunk["content"]["text"] for chunk in chunks if "_meta" not in chunk]
+    assert raw == ["Working. Done."]
+    notices = [chunk for chunk in chunks if "_meta" in chunk]
+    assert len(notices) == (3 if enabled else 0)
+    if enabled:
+        assert len({chunk["messageId"] for chunk in notices}) == 3
+        assert [chunk["_meta"]["hermes"]["source"] for chunk in notices] == [
+            "assistant", "assistant", "background_review",
+        ]
+        assert all(chunk["_meta"]["hermes"]["turnId"] == token for chunk in notices)
+        assert all(chunk["_meta"]["hermes"]["phase"] == "commentary" for chunk in notices)
+
+
+@pytest.mark.parametrize("initially_enabled", [False, True])
+def test_background_review_uses_callback_captured_before_thread_start(initially_enabled, monkeypatch):
+    delivered, wrong_owner = [], []
+    parent = SimpleNamespace(
+        background_review_callback=delivered.append if initially_enabled else None,
+        _safe_print=lambda text: None, memory_notifications="on",
+    )
+    monkeypatch.setattr(background_review, "_parent_can_emit_tool_calls", lambda agent: True)
+    monkeypatch.setattr(background_review, "_set_thread_approval_callback", lambda cb: None)
+    monkeypatch.setattr(background_review, "_run_review_fork", lambda *args: None)
+    monkeypatch.setattr(background_review, "summarize_background_review_actions", lambda *a, **kw: ["Skill 'example' patched"])
+    monkeypatch.setattr(background_review, "_log_review_completion", lambda *a: None)
+    target, _ = background_review.spawn_background_review_thread(
+        parent, [], review_skills=True, task_cfg={},
+    )
+    parent.background_review_callback = wrong_owner.append
+    target()
+    assert wrong_owner == []
+    assert bool(delivered) is initially_enabled
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", ["error", "cancel", "queued", "reconnect"])
+async def test_turn_callbacks_do_not_escape_errors_cancellation_or_queued_prompts(outcome, monkeypatch):
+    manager = SessionManager(agent_factory=lambda: MagicMock(name="Agent"))
+    adapter = HermesACPAgent(manager)
+    router = build_agent_router(adapter)
+    adapter._conn = MagicMock(spec=acp.Client)
+    adapter._conn.session_update = AsyncMock()
+    await router("initialize", {
+        "protocolVersion": acp.PROTOCOL_VERSION,
+        "clientCapabilities": {"_meta": {"hermes": {"messagePhases": 1}}},
+    }, False)
+    session = await adapter.new_session(cwd=".")
+    state = manager.get_session(session.session_id)
+    prior = lambda text, **kwargs: None
+    state.agent.interim_assistant_callback = prior
+    state.agent.background_review_callback = prior
+    state.agent.session_id = session.session_id
+    callbacks = []
+
+    def run(**kwargs):
+        callbacks.append(state.agent.interim_assistant_callback)
+        if len(callbacks) == 1:
+            if outcome == "reconnect":
+                assert state.agent.interim_assistant_callback is None
+                assert state.agent.background_review_callback is None
+            else:
+                assert state.agent.interim_assistant_callback is not prior
+            if outcome == "error":
+                raise RuntimeError("provider failed")
+            if outcome == "cancel":
+                state.cancel_event.set()
+            if outcome == "queued":
+                state.queued_prompts.append("queued without a client token")
+        else:
+            # A queued admission with no original client token must not inherit
+            # the first owner's destination or generate correlated notices.
+            assert state.agent.interim_assistant_callback is None
+            assert state.agent.background_review_callback is None
+        return {"final_response": "done", "messages": []}
+
+    monkeypatch.setattr(adapter, "_run_agent_turn", run)
+    monkeypatch.setattr(adapter, "_send_usage_update", AsyncMock())
+    if outcome == "reconnect":
+        adapter.on_connect(adapter._conn)
+    response = await router("session/prompt", {
+        "sessionId": session.session_id,
+        "prompt": [{"type": "text", "text": "Do it"}],
+        "_meta": {"hermes": {"turnId": str(uuid4())}},
+    }, False)
+    assert state.agent.interim_assistant_callback is prior
+    assert state.agent.background_review_callback is prior
+    assert len(callbacks) == (2 if outcome == "queued" else 1)
+    if outcome == "queued":
+        assert callbacks[1] is None
+    assert not state.is_running
+    if outcome == "reconnect":
+        assert callbacks == [None]
+    if outcome == "cancel":
+        assert response.stop_reason == "cancelled"
+
+
+@pytest.mark.parametrize("commentary_enabled", [False, True])
+def test_codex_commentary_consumer_preserves_analysis_reasoning_and_final_text(commentary_enabled):
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    events = []
+    items = []
+    for phase, text in [("commentary", "Working."), ("analysis", "Private analysis."), ("final_answer", "Done.")]:
+        item = {"id": phase, "type": "message", "phase": phase,
+                "content": [{"type": "output_text", "text": text}]}
+        items.append(item)
+        events.extend([
+            {"type": "response.output_item.added", "item": item},
+            {"type": "response.output_text.delta", "delta": text},
+            {"type": "response.output_item.done", "item": item},
+        ])
+    events.extend([
+        {"type": "response.reasoning_text.delta", "delta": "Private reasoning."},
+        {"type": "response.completed", "response": {"status": "completed"}},
+    ])
+    commentary, reasoning, output = [], [], []
+    response = _consume_codex_event_stream(
+        events, model="fixture-model", on_text_delta=output.append,
+        on_reasoning_delta=reasoning.append,
+        on_commentary_message=commentary.append if commentary_enabled else None,
+    )
+    assert output == ["Done."]
+    assert response.output_text == "Done."
+    assert response.output == items
+    assert commentary == (["Working."] if commentary_enabled else [])
+    assert reasoning == (["Private analysis.", "Private reasoning."] if commentary_enabled
+                         else ["Working.", "Private analysis.", "Private reasoning."])

--- a/website/docs/developer-guide/acp-internals.md
+++ b/website/docs/developer-guide/acp-internals.md
@@ -76,14 +76,55 @@ The manager is thread-safe and supports:
 Bridged callbacks:
 
 - `tool_progress_callback`
-- `thinking_callback` (currently set to `None` in the ACP bridge — reasoning is forwarded through `step_callback` instead)
+- `reasoning_callback` (provider reasoning; `thinking_callback` stays `None`)
 - `step_callback`
+- `stream_delta_callback`
+- `interim_assistant_callback` and `background_review_callback` (negotiated extension below)
 
 Because `AIAgent` runs in a worker thread while ACP I/O lives on the main event loop, the bridge uses:
 
 ```python
 asyncio.run_coroutine_threadsafe(...)
 ```
+
+### Optional commentary extension
+
+Clients opt in with `clientCapabilities._meta.hermes.messagePhases: 1` in
+`initialize`. Hermes acknowledges the exact integer version in
+`agentCapabilities._meta.hermes.messagePhases: 1`. Other versions retain ordinary
+ACP behavior. For each `session/prompt`, the client supplies a UUID at
+`_meta.hermes.turnId`; it is an opaque correlation token, never owner identity or
+prompt content. Missing or invalid tokens disable additional notifications for
+that prompt.
+
+Hermes emits an additional `agent_message_chunk` for each interim callback and
+background review summary, with a unique `messageId` and:
+
+```json
+{"hermes":{"messagePhases":1,"phase":"commentary","source":"assistant","turnId":"<client prompt UUID>"}}
+```
+
+Background summaries use `source: "background_review"` and retain their
+Self-improvement review label. These copies leave raw response chunks and the
+ordinary final response unchanged, including when `already_streamed` is true.
+They contain no provider reasoning or raw tool output. For Codex-backed Hermes,
+installing the commentary consumer replaces the existing fallback that displayed
+commentary in thought events; real analysis/reasoning and final text are preserved.
+
+Callbacks capture the connection, session, and turn token. The background worker
+snapshots its callback before it starts, including a disabled `None`, so later
+turns cannot change its destination. Prompt callbacks restore their previous
+values before draining queued prompts. Queued prompts without a client token
+produce only ordinary ACP output.
+
+A background summary can arrive after its initiating prompt finishes or during
+another prompt. Clients must correlate using the captured token, exclude these
+additional copies from ordinary output, and avoid attributing them to the active
+turn. A relay should use bounded, connection-scoped token mappings, reject
+unknown/replayed tokens, honor its notification toggle at delivery time, and
+reauthorize the original recipient. Hermes does not persist or replay these
+notifications or supply recipient identities. Reconnect requires negotiation
+again; a late worker retains its old connection.
 
 ### Permission bridge
 

--- a/website/docs/user-guide/features/acp.md
+++ b/website/docs/user-guide/features/acp.md
@@ -21,6 +21,21 @@ Hermes. ACP is a good fit when you want Hermes to keep its existing identity,
 provider setup, memory, skills, and tools while another application owns the
 conversation transport.
 
+## Optional progress and review notifications
+
+Clients supporting Hermes' optional commentary extension can show intermediate
+assistant messages while a task runs and Self-improvement review summaries when
+background work finishes. These are additional notifications: the normal streamed
+response and final answer remain unchanged and may repeat intermediate text.
+Reasoning and tool output are separate ACP events. With a Codex-backed Hermes
+provider, enabling this extension moves commentary out of the legacy thought-event
+fallback; real reasoning and the final response remain unchanged.
+
+The client controls notification delivery and its own toggle. A review can finish
+after the answer, so supporting clients associate it with the original request.
+Older clients retain their existing behavior. Adapter authors can find the
+negotiation and correlation contract in [ACP Internals](../../developer-guide/acp-internals.md#optional-commentary-extension).
+
 ## What Hermes exposes in ACP mode
 
 Hermes runs with a curated `hermes-acp` toolset designed for editor workflows. It includes:


### PR DESCRIPTION
## What does this PR do?

Expose optional ACP commentary and self-improvement review notifications with original-turn correlation. Today ACP does not bind the interim assistant or background review callbacks. A review may finish after a later prompt starts, so looking up the current callback at publication time can misattribute it.

Clients explicitly negotiate `_meta.hermes.messagePhases = 1` and provide an opaque `_meta.hermes.turnId` UUID with each prompt. Additional commentary chunks carry a unique message ID, source and original turn ID. Existing raw text and final responses remain unchanged; clients that do not negotiate retain current behavior.

## Related Issue

No dedicated issue. Related open work: #12509 and #15839 also bridge interim assistant messages. This proposal adds explicit opt-in negotiation, per-message IDs, original-turn correlation and callback capture for late self-improvement reviews. #62558 handles process/delegation completion notifications, a different notification source. These proposals overlap at ACP callback wiring and should be coordinated before merge.

Client counterpart: https://github.com/adapt-toolkit/ours-fleet/pull/166.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `acp_adapter/events.py`: construct additional, source-labelled commentary updates without changing ordinary streaming state.
- `acp_adapter/server.py`: negotiate support, validate turn IDs, bind/restore prompt callbacks and reset negotiation on reconnect.
- `agent/background_review.py`: capture the review callback before spawning the worker, preserving the originating prompt even when delivery is late.
- `tests/acp/test_commentary.py`: cover negotiation, actual SDK routing, callback cleanup, reconnect, streaming preservation and late review attribution.
- ACP user/developer docs: document the optional extension and intentional duplicate text. For the Codex runtime, installing a first-class commentary consumer replaces its previous commentary-as-reasoning fallback; actual reasoning remains unchanged.

## How to Test

```sh
scripts/run_tests.sh tests/acp/test_commentary.py tests/acp/test_events.py tests/acp/test_server.py tests/run_agent/test_run_agent_codex_responses.py -j 2
```

Result: **118 passed, four files, zero failures** on Linux. `git diff --check` and the Windows-footgun scan over the changed files passed. Independent code review found no blocking issues.

A deterministic cross-repository probe also passed through the real Hermes ACP stdio server, Fleet ACP adapter and owner channel: interim commentary, review A arriving during turn B routed to A, ordinary/final text preserved, comments-off suppression and diagnostic redaction. Model/tool side effects and the owner transport were stubbed; this was not a live-provider delivery test.

## Checklist

- [x] Commit follows Conventional Commits.
- [x] Searched existing open/merged PRs and issues; overlaps are described above.
- [x] Only related changes are included.
- [ ] Full `pytest tests/ -q` suite (not run; focused canonical-runner results above).
- [x] Tests added and run on Linux.
- [x] Relevant ACP documentation updated.
- [x] Config keys, tool schemas and development workflows: N/A.
- [x] Cross-platform impact considered: no platform-specific APIs or dependencies added.
