### PR TITLE
feat(gateway): localize the pairing DM and home-channel prompt, name the skin

### DIFF
--- a/gateway/branding.py
+++ b/gateway/branding.py
@@ -1,0 +1,43 @@
+"""Product name for gateway-authored, user-facing text.
+
+Messenger notices (pairing DM, home-channel prompt, ...) used to hardcode
+"Hermes".  A deployment that ships a custom skin with its own
+``branding.agent_name`` should see that name in chat too, so the catalog
+strings carry a ``{brand}`` placeholder and this helper fills it.
+"""
+
+from __future__ import annotations
+
+_STOCK_AGENT_NAME = "Hermes Agent"
+_STOCK_SHORT_NAME = "Hermes"
+
+
+def agent_display_name() -> str:
+    """Return the active skin's ``agent_name`` for chat messages.
+
+    The gateway never calls ``init_skin_from_config()`` -- that is a CLI
+    startup step -- so ``get_active_skin()`` alone would always report the
+    stock skin here.  Resolve ``display.skin`` from config.yaml directly.
+    The stock skin keeps the short "Hermes" the notices always used, so
+    default installs see no change; only a custom skin swaps the name.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+        from hermes_cli.skin_engine import get_active_skin, load_skin
+
+        skin = get_active_skin()
+        display = load_config_readonly().get("display") or {}
+        configured = (
+            str(display.get("skin") or "").strip() if isinstance(display, dict) else ""
+        )
+        if configured and configured != getattr(skin, "name", ""):
+            skin = load_skin(configured)
+        name = str(skin.get_branding("agent_name", _STOCK_AGENT_NAME) or "").strip()
+    except Exception:
+        name = ""
+    if not name or name == _STOCK_AGENT_NAME:
+        return _STOCK_SHORT_NAME
+    return name[:64]
+
+
+__all__ = ["agent_display_name"]

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -16,6 +16,7 @@ import json
 import os
 import re
 import time
+from agent.i18n import t
 from contextlib import suppress
 from gateway.config import Platform
 from gateway.platforms.base import EphemeralReply
@@ -95,14 +96,15 @@ class GatewayInboundMixin:
                 else ""
             )
             reply = (
-                f"Hi~ I don't recognize you yet!\n\n"
-                f"Here's your pairing code: `{code}`\n\n"
-                f"Ask the bot owner to run:\n"
-                f"`hermes {profile_arg}pairing approve "
-                f"{platform_name} {code}`"
+                t("gateway.pairing.greeting") + "\n\n"
+                + t("gateway.pairing.code", code=code) + "\n\n"
+                + t(
+                    "gateway.pairing.approve_hint",
+                    command=f"hermes {profile_arg}pairing approve {platform_name} {code}",
+                )
             )
         else:
-            reply = "Too many pairing requests right now~ Please try again later!"
+            reply = t("gateway.pairing.rate_limited")
         if adapter:
             await adapter.send(source.chat_id, reply)
         if not code:

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -19,6 +19,7 @@ from agent.i18n import t
 from agent.session_activity import format_iteration_progress
 from contextlib import nullcontext, suppress
 from contextvars import copy_context
+from gateway.branding import agent_display_name
 from gateway.config import Platform
 from gateway.media_repair import repair_explicit_computer_use_media_paths
 from gateway.platforms.base import BasePlatformAdapter
@@ -1315,10 +1316,13 @@ class GatewayTurnMixin:
             # Slack routes every command through the parent `/hermes`; bare `/sethome` would fail.
             sethome_cmd = "/hermes sethome" if source.platform == Platform.SLACK else "/sethome"
             await self._deliver_platform_notice(
-                source, f"📬 No home channel is set for {platform_name.title()}. "
-                f"A home channel is where Hermes delivers cron job results and cross-platform "
-                f"messages.\n\nType {sethome_cmd} to make this chat your home channel, or ignore "
-                f"to skip.",
+                source,
+                t(
+                    "gateway.home_channel.notice",
+                    platform=platform_name.title(),
+                    brand=agent_display_name(),
+                    cmd=sethome_cmd,
+                ),
             )
 
     def _hmwa_apply_message_timestamp(self, event, message_text):

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -20,6 +20,20 @@ approval:
   blocklist_message: "Hierdie opdrag is op die onvoorwaardelike blokkeerlys en kan nie goedgekeur word nie."
 
 gateway:
+  # Pairing DM sent to an unknown sender. `{command}` is the literal CLI
+  # invocation the owner runs; keep it verbatim in every language.
+  pairing:
+    greeting:     "Hallo~ Ek herken jou nog nie!"
+    code:         "Hier is jou koppelkode: `{code}`"
+    approve_hint: "Vra die bot-eienaar om dit uit te voer:\n`{command}`"
+    rate_limited: "Te veel koppelversoeke op die oomblik~ Probeer asseblief later weer!"
+
+  # One-time notice when a platform has no home channel. `{brand}` is the
+  # active skin's agent name ("Hermes" for the stock skin); `{cmd}` is the
+  # platform's sethome command.
+  home_channel:
+    notice: "📬 Geen tuiskanaal is vir {platform} gestel nie. 'n Tuiskanaal is waar {brand} cron-taakresultate en kruisplatform-boodskappe aflewer.\n\nTik {cmd} om hierdie gesprek jou tuiskanaal te maak, of ignoreer dit."
+
   approval_expired: "⚠️ Goedkeuring het verval (die agent wag nie meer nie). Vra die agent om weer te probeer."
   draining:         "⏳ Wag vir {count} aktiewe agent(e) voor herbegin..."
   goal_cleared:     "✓ Doelwit verwyder."

--- a/locales/ar.yaml
+++ b/locales/ar.yaml
@@ -25,6 +25,20 @@ approval:
   blocklist_message: "هذا الأمر مدرج في قائمة الحظر غير المشروطة ولا يمكن الموافقة عليه."
 
 gateway:
+  # Pairing DM sent to an unknown sender. `{command}` is the literal CLI
+  # invocation the owner runs; keep it verbatim in every language.
+  pairing:
+    greeting:     "مرحبًا~ لا أعرفك بعد!"
+    code:         "هذا هو رمز الاقتران الخاص بك: `{code}`"
+    approve_hint: "اطلب من مالك البوت تنفيذ الأمر التالي:\n`{command}`"
+    rate_limited: "هناك طلبات اقتران كثيرة جدًا الآن~ يُرجى المحاولة لاحقًا!"
+
+  # One-time notice when a platform has no home channel. `{brand}` is the
+  # active skin's agent name ("Hermes" for the stock skin); `{cmd}` is the
+  # platform's sethome command.
+  home_channel:
+    notice: "📬 لم يتم تعيين قناة رئيسية لـ {platform}. القناة الرئيسية هي المكان الذي يرسل إليه {brand} نتائج مهام cron والرسائل بين المنصات.\n\nاكتب {cmd} لجعل هذه المحادثة قناتك الرئيسية، أو تجاهل هذه الرسالة."
+
   context:
     header:                "🧠 **Context Window**"
     model:                 "Model: `{model}`"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -20,6 +20,20 @@ approval:
   blocklist_message: "Dieser Befehl steht auf der unbedingten Sperrliste und kann nicht genehmigt werden."
 
 gateway:
+  # Pairing DM sent to an unknown sender. `{command}` is the literal CLI
+  # invocation the owner runs; keep it verbatim in every language.
+  pairing:
+    greeting:     "Hallo~ Ich kenne dich noch nicht!"
+    code:         "Hier ist dein Kopplungscode: `{code}`"
+    approve_hint: "Bitte den Bot-Besitzer, Folgendes auszuführen:\n`{command}`"
+    rate_limited: "Gerade zu viele Kopplungsanfragen~ Bitte versuche es später noch einmal!"
+
+  # One-time notice when a platform has no home channel. `{brand}` is the
+  # active skin's agent name ("Hermes" for the stock skin); `{cmd}` is the
+  # platform's sethome command.
+  home_channel:
+    notice: "📬 Für {platform} ist kein Home-Kanal festgelegt. Im Home-Kanal liefert {brand} Cron-Job-Ergebnisse und plattformübergreifende Nachrichten.\n\nGib {cmd} ein, um diesen Chat zum Home-Kanal zu machen, oder ignoriere diese Nachricht."
+
   approval_expired: "⚠️ Genehmigung abgelaufen (Agent wartet nicht mehr). Bitten Sie den Agenten, es erneut zu versuchen."
   draining:         "⏳ Warte auf {count} aktive(n) Agent(en) vor dem Neustart..."
   goal_cleared:     "✓ Ziel gelöscht."

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -30,6 +30,20 @@ approval:
   blocklist_message: "This command is on the unconditional blocklist and cannot be approved."
 
 gateway:
+  # Pairing DM sent to an unknown sender. `{command}` is the literal CLI
+  # invocation the owner runs; keep it verbatim in every language.
+  pairing:
+    greeting:     "Hi~ I don't recognize you yet!"
+    code:         "Here's your pairing code: `{code}`"
+    approve_hint: "Ask the bot owner to run:\n`{command}`"
+    rate_limited: "Too many pairing requests right now~ Please try again later!"
+
+  # One-time notice when a platform has no home channel. `{brand}` is the
+  # active skin's agent name ("Hermes" for the stock skin); `{cmd}` is the
+  # platform's sethome command.
+  home_channel:
+    notice: "📬 No home channel is set for {platform}. A home channel is where {brand} delivers cron job results and cross-platform messages.\n\nType {cmd} to make this chat your home channel, or ignore to skip."
+
   # Messenger replies to slash commands and implicit state changes.
   approval_expired: "⚠️ Approval expired (agent is no longer waiting). Ask the agent to try again."
   draining:         "⏳ Draining {count} active agent(s) before restart..."

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -20,6 +20,20 @@ approval:
   blocklist_message: "Este comando está en la lista de bloqueo incondicional y no se puede aprobar."
 
 gateway:
+  # Pairing DM sent to an unknown sender. `{command}` is the literal CLI
+  # invocation the owner runs; keep it verbatim in every language.
+  pairing:
+    greeting:     "¡Hola~ Todavía no te reconozco!"
+    code:         "Este es tu código de emparejamiento: `{code}`"
+    approve_hint: "Pide al propietario del bot que ejecute:\n`{command}`"
+    rate_limited: "Demasiadas solicitudes de emparejamiento ahora mismo~ ¡Inténtalo de nuevo más tarde!"
+
+  # One-time notice when a platform has no home channel. `{brand}` is the
+  # active skin's agent name ("Hermes" for the stock skin); `{cmd}` is the
+  # platform's sethome command.
+  home_channel:
+    notice: "📬 No hay un canal principal configurado para {platform}. El canal principal es donde {brand} entrega los resultados de las tareas programadas y los mensajes entre plataformas.\n\nEscribe {cmd} para convertir este chat en tu canal principal, o ignora este mensaje."
+
   approval_expired: "⚠️ La aprobación ha caducado (el agente ya no está esperando). Pida al agente que lo intente de nuevo."
   draining:         "⏳ Esperando a que terminen {count} agente(s) activo(s) antes de reiniciar..."
   goal_cleared:     "✓ Objetivo eliminado."

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -20,6 +20,20 @@ approval:
   blocklist_message: "Cette commande est sur la liste de blocage inconditionnel et ne peut pas être approuvée."
 
 gateway:
+  # Pairing DM sent to an unknown sender. `{command}` is the literal CLI
+  # invocation the owner runs; keep it verbatim in every language.
+  pairing:
+    greeting:     "Salut~ Je ne te reconnais pas encore !"
+    code:         "Voici ton code d'appairage : `{code}`"
+    approve_hint: "Demande au propriétaire du bot d'exécuter :\n`{command}`"
+    rate_limited: "Trop de demandes d'appairage pour le moment~ Réessaie plus tard !"
+
+  # One-time notice when a platform has no home channel. `{brand}` is the
+  # active skin's agent name ("Hermes" for the stock skin); `{cmd}` is the
+  # platform's sethome command.
+  home_channel:
+    notice: "📬 Aucun canal principal n'est défini pour {platform}. Le canal principal est l'endroit où {brand} envoie les résultats des tâches planifiées et les messages inter-plateformes.\n\nTape {cmd} pour faire de cette conversation ton canal principal, ou ignore ce message."
+
   approval_expired: "⚠️ Approbation expirée (l'agent n'attend plus). Demandez à l'agent de réessayer."
   draining:         "⏳ Vidage de {count} agent(s) actif(s) avant redémarrage..."
   goal_cleared:     "✓ Objectif effacé."

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -24,6 +24,20 @@ approval:
   blocklist_message: "Tá an t-ordú seo ar an liosta cosc gan choinníoll agus ní féidir é a cheadú."
 
 gateway:
+  # Pairing DM sent to an unknown sender. `{command}` is the literal CLI
+  # invocation the owner runs; keep it verbatim in every language.
+  pairing:
+    greeting:     "Dia duit~ Ní aithním thú fós!"
+    code:         "Seo do chód péireála: `{code}`"
+    approve_hint: "Iarr ar úinéir an bhota é seo a rith:\n`{command}`"
+    rate_limited: "An iomarca iarratas péireála faoi láthair~ Bain triail eile as ar ball!"
+
+  # One-time notice when a platform has no home channel. `{brand}` is the
+  # active skin's agent name ("Hermes" for the stock skin); `{cmd}` is the
+  # platform's sethome command.
+  home_channel:
+    notice: "📬 Níl cainéal baile socraithe do {platform}. Is é an cainéal baile an áit a seachadann {brand} torthaí jabanna cron agus teachtaireachtaí trasardáin.\n\nClóscríobh {cmd} chun an comhrá seo a dhéanamh mar do chainéal baile, nó déan neamhaird de."
+
   approval_expired: "⚠️ Tá an cead imithe in éag (níl an gníomhaire ag fanacht níos mó). Iarr ar an ngníomhaire iarracht eile a dhéanamh."
   draining:         "⏳ Ag fanacht le {count} gníomhaire(í) gníomhach roimh atosú..."
   goal_cleared:     "✓ Sprioc glanta."

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -20,6 +20,20 @@ approval:
   blocklist_message: "Ez a parancs a feltétel nélküli tiltólistán van, és nem hagyható jóvá."
 
 gateway:
+  # Pairing DM sent to an unknown sender. `{command}` is the literal CLI
+  # invocation the owner runs; keep it verbatim in every language.
+  pairing:
+    greeting:     "Szia~ Még nem ismerlek!"
+    code:         "Itt a párosítási kódod: `{code}`"
+    approve_hint: "Kérd meg a bot tulajdonosát, hogy futtassa:\n`{command}`"
+    rate_limited: "Túl sok párosítási kérés érkezett most~ Kérlek, próbáld újra később!"
+
+  # One-time notice when a platform has no home channel. `{brand}` is the
+  # active skin's agent name ("Hermes" for the stock skin); `{cmd}` is the
+  # platform's sethome command.
+  home_channel:
+    notice: "📬 Nincs beállítva otthoni csatorna ehhez: {platform}. Az otthoni csatornába kézbesíti {brand} a cron feladatok eredményeit és a platformok közötti üzeneteket.\n\nÍrd be: {cmd}, hogy ez a beszélgetés legyen az otthoni csatornád, vagy hagyd figyelmen kívül."
+
   approval_expired: "⚠️ A jóváhagyás lejárt (az ügynök már nem vár). Kérd meg az ügynököt, hogy próbálja újra."
   draining:         "⏳ {count} aktív ügynök befejezésére várunk az újraindítás előtt..."
   goal_cleared:     "✓ A cél törölve."

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -20,6 +20,20 @@ approval:
   blocklist_message: "Questo comando è nella lista di blocco incondizionata e non può essere approvato."
 
 gateway:
+  # Pairing DM sent to an unknown sender. `{command}` is the literal CLI
+  # invocation the owner runs; keep it verbatim in every language.
+  pairing:
+    greeting:     "Ciao~ Non ti riconosco ancora!"
+    code:         "Ecco il tuo codice di abbinamento: `{code}`"
+    approve_hint: "Chiedi al proprietario del bot di eseguire:\n`{command}`"
+    rate_limited: "Troppe richieste di abbinamento in questo momento~ Riprova più tardi!"
+
+  # One-time notice when a platform has no home channel. `{brand}` is the
+  # active skin's agent name ("Hermes" for the stock skin); `{cmd}` is the
+  # platform's sethome command.
+  home_channel:
+    notice: "📬 Nessun canale principale impostato per {platform}. Il canale principale è dove {brand} consegna i risultati dei cron job e i messaggi tra piattaforme.\n\nDigita {cmd} per rendere questa chat il canale principale, oppure ignora questo messaggio."
+
   approval_expired: "⚠️ Approvazione scaduta (l'agente non è più in attesa). Chiedi all'agente di riprovare."
   draining:         "⏳ Attendo il completamento di {count} agente/i attivo/i prima di riavviare..."
   goal_cleared:     "✓ Obiettivo cancellato."

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -20,6 +20,20 @@ approval:
   blocklist_message: "このコマンドは無条件ブロックリストに含まれており、承認できません。"
 
 gateway:
+  # Pairing DM sent to an unknown sender. `{command}` is the literal CLI
+  # invocation the owner runs; keep it verbatim in every language.
+  pairing:
+    greeting:     "こんにちは〜 まだあなたのことを認識していません！"
+    code:         "ペアリングコードはこちらです: `{code}`"
+    approve_hint: "ボットの所有者に次のコマンドを実行してもらってください:\n`{command}`"
+    rate_limited: "現在ペアリングリクエストが多すぎます〜 しばらくしてからもう一度お試しください！"
+
+  # One-time notice when a platform has no home channel. `{brand}` is the
+  # active skin's agent name ("Hermes" for the stock skin); `{cmd}` is the
+  # platform's sethome command.
+  home_channel:
+    notice: "📬 {platform} にホームチャンネルが設定されていません。ホームチャンネルは {brand} が cron ジョブの結果やプラットフォーム間のメッセージを届ける場所です。\n\nこのチャットをホームチャンネルにするには {cmd} と入力してください。不要な場合は無視してかまいません。"
+
   approval_expired: "⚠️ 承認の有効期限が切れました（エージェントはもう待機していません）。エージェントに再試行を依頼してください。"
   draining:         "⏳ 再起動前に {count} 個のアクティブエージェントの終了を待っています..."
   goal_cleared:     "✓ 目標をクリアしました。"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -20,6 +20,20 @@ approval:
   blocklist_message: "이 명령은 무조건 차단 목록에 있으며 승인할 수 없습니다."
 
 gateway:
+  # Pairing DM sent to an unknown sender. `{command}` is the literal CLI
+  # invocation the owner runs; keep it verbatim in every language.
+  pairing:
+    greeting:     "안녕하세요~ 아직 당신을 알지 못해요!"
+    code:         "페어링 코드입니다: `{code}`"
+    approve_hint: "봇 소유자에게 다음 명령을 실행해 달라고 요청하세요:\n`{command}`"
+    rate_limited: "지금 페어링 요청이 너무 많아요~ 나중에 다시 시도해 주세요!"
+
+  # One-time notice when a platform has no home channel. `{brand}` is the
+  # active skin's agent name ("Hermes" for the stock skin); `{cmd}` is the
+  # platform's sethome command.
+  home_channel:
+    notice: "📬 {platform}에 홈 채널이 설정되어 있지 않습니다. 홈 채널은 {brand}이(가) 크론 작업 결과와 플랫폼 간 메시지를 전달하는 곳입니다.\n\n이 채팅을 홈 채널로 만들려면 {cmd}를 입력하세요. 원하지 않으면 무시해도 됩니다."
+
   approval_expired: "⚠️ 승인이 만료되었습니다 (에이전트가 더 이상 대기하지 않습니다). 에이전트에게 다시 시도하도록 요청하세요."
   draining:         "⏳ 재시작 전에 활성 에이전트 {count}명을 정리하는 중..."
   goal_cleared:     "✓ 목표가 삭제되었습니다."

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -20,6 +20,20 @@ approval:
   blocklist_message: "Este comando está na lista de bloqueio incondicional e não pode ser aprovado."
 
 gateway:
+  # Pairing DM sent to an unknown sender. `{command}` is the literal CLI
+  # invocation the owner runs; keep it verbatim in every language.
+  pairing:
+    greeting:     "Olá~ Ainda não reconheço você!"
+    code:         "Aqui está o seu código de pareamento: `{code}`"
+    approve_hint: "Peça ao responsável pelo bot para executar:\n`{command}`"
+    rate_limited: "Muitos pedidos de pareamento neste momento~ Tente novamente mais tarde!"
+
+  # One-time notice when a platform has no home channel. `{brand}` is the
+  # active skin's agent name ("Hermes" for the stock skin); `{cmd}` is the
+  # platform's sethome command.
+  home_channel:
+    notice: "📬 Nenhum canal principal está definido para {platform}. O canal principal é onde o {brand} entrega os resultados das tarefas agendadas e as mensagens de outras plataformas.\n\nDigite {cmd} para tornar esta conversa o canal principal, ou ignore esta mensagem."
+
   approval_expired: "⚠️ A aprovação expirou (o agente já não está à espera). Peça ao agente para tentar novamente."
   draining:         "⏳ A aguardar que {count} agente(s) ativo(s) terminem antes de reiniciar..."
   goal_cleared:     "✓ Objetivo removido."

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -20,6 +20,20 @@ approval:
   blocklist_message: "Эта команда находится в безусловном списке блокировки и не может быть одобрена."
 
 gateway:
+  # Pairing DM sent to an unknown sender. `{command}` is the literal CLI
+  # invocation the owner runs; keep it verbatim in every language.
+  pairing:
+    greeting:     "Привет~ Я тебя пока не знаю!"
+    code:         "Вот твой код сопряжения: `{code}`"
+    approve_hint: "Попроси владельца бота выполнить:\n`{command}`"
+    rate_limited: "Сейчас слишком много запросов на сопряжение~ Попробуй позже!"
+
+  # One-time notice when a platform has no home channel. `{brand}` is the
+  # active skin's agent name ("Hermes" for the stock skin); `{cmd}` is the
+  # platform's sethome command.
+  home_channel:
+    notice: "📬 Для {platform} не задан домашний канал. В домашний канал {brand} доставляет результаты cron-задач и сообщения с других платформ.\n\nВведи {cmd}, чтобы сделать этот чат домашним каналом, или просто проигнорируй это сообщение."
+
   approval_expired: "⚠️ Срок одобрения истёк (агент больше не ожидает). Попросите агента повторить попытку."
   draining:         "⏳ Ожидание завершения {count} активных агент(ов) перед перезапуском..."
   goal_cleared:     "✓ Цель очищена."

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -20,6 +20,20 @@ approval:
   blocklist_message: "Bu komut koşulsuz engelleme listesinde ve onaylanamaz."
 
 gateway:
+  # Pairing DM sent to an unknown sender. `{command}` is the literal CLI
+  # invocation the owner runs; keep it verbatim in every language.
+  pairing:
+    greeting:     "Merhaba~ Seni henüz tanımıyorum!"
+    code:         "İşte eşleştirme kodun: `{code}`"
+    approve_hint: "Bot sahibinden şunu çalıştırmasını iste:\n`{command}`"
+    rate_limited: "Şu anda çok fazla eşleştirme isteği var~ Lütfen daha sonra tekrar dene!"
+
+  # One-time notice when a platform has no home channel. `{brand}` is the
+  # active skin's agent name ("Hermes" for the stock skin); `{cmd}` is the
+  # platform's sethome command.
+  home_channel:
+    notice: "📬 {platform} için ana kanal ayarlanmamış. Ana kanal, {brand} tarafından cron görevi sonuçlarının ve platformlar arası mesajların iletildiği yerdir.\n\nBu sohbeti ana kanal yapmak için {cmd} yaz ya da bu mesajı yok say."
+
   approval_expired: "⚠️ Onay süresi doldu (ajan artık beklemiyor). Ajanın tekrar denemesini isteyin."
   draining:         "⏳ Yeniden başlatmadan önce {count} aktif ajan bekleniyor..."
   goal_cleared:     "✓ Hedef temizlendi."

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -20,6 +20,20 @@ approval:
   blocklist_message: "Ця команда є в безумовному списку блокування, її не можна схвалити."
 
 gateway:
+  # Pairing DM sent to an unknown sender. `{command}` is the literal CLI
+  # invocation the owner runs; keep it verbatim in every language.
+  pairing:
+    greeting:     "Привіт~ Я тебе ще не знаю!"
+    code:         "Ось твій код сполучення: `{code}`"
+    approve_hint: "Попроси власника бота виконати:\n`{command}`"
+    rate_limited: "Зараз забагато запитів на сполучення~ Спробуй пізніше!"
+
+  # One-time notice when a platform has no home channel. `{brand}` is the
+  # active skin's agent name ("Hermes" for the stock skin); `{cmd}` is the
+  # platform's sethome command.
+  home_channel:
+    notice: "📬 Для {platform} не задано домашній канал. У домашній канал {brand} доставляє результати cron-завдань і повідомлення з інших платформ.\n\nВведи {cmd}, щоб зробити цей чат домашнім каналом, або просто проігноруй це повідомлення."
+
   approval_expired: "⚠️ Час схвалення минув (агент більше не очікує). Попросіть агента спробувати ще раз."
   draining:         "⏳ Очікування завершення {count} активних агент(ів) перед перезапуском..."
   goal_cleared:     "✓ Ціль очищено."

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -20,6 +20,20 @@ approval:
   blocklist_message: "此指令位於無條件封鎖清單中，無法被批准。"
 
 gateway:
+  # Pairing DM sent to an unknown sender. `{command}` is the literal CLI
+  # invocation the owner runs; keep it verbatim in every language.
+  pairing:
+    greeting:     "你好~ 我還不認識你！"
+    code:         "這是你的配對碼：`{code}`"
+    approve_hint: "請讓機器人的擁有者執行：\n`{command}`"
+    rate_limited: "目前配對請求過多~ 請稍後再試！"
+
+  # One-time notice when a platform has no home channel. `{brand}` is the
+  # active skin's agent name ("Hermes" for the stock skin); `{cmd}` is the
+  # platform's sethome command.
+  home_channel:
+    notice: "📬 {platform} 尚未設定主頻道。主頻道是 {brand} 投遞排程任務結果和跨平台訊息的地方。\n\n輸入 {cmd} 將此聊天設為主頻道，或忽略此訊息。"
+
   approval_expired: "⚠️ 批准已逾期（代理不再等待）。請讓代理重試。"
   draining:         "⏳ 正在等待 {count} 個活躍代理結束後重新啟動..."
   goal_cleared:     "✓ 目標已清除。"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -20,6 +20,20 @@ approval:
   blocklist_message: "此命令位于无条件拦截列表中，无法被批准。"
 
 gateway:
+  # Pairing DM sent to an unknown sender. `{command}` is the literal CLI
+  # invocation the owner runs; keep it verbatim in every language.
+  pairing:
+    greeting:     "你好~ 我还不认识你！"
+    code:         "这是你的配对码：`{code}`"
+    approve_hint: "请让机器人的所有者运行：\n`{command}`"
+    rate_limited: "当前配对请求过多~ 请稍后再试！"
+
+  # One-time notice when a platform has no home channel. `{brand}` is the
+  # active skin's agent name ("Hermes" for the stock skin); `{cmd}` is the
+  # platform's sethome command.
+  home_channel:
+    notice: "📬 {platform} 尚未设置主频道。主频道是 {brand} 投递定时任务结果和跨平台消息的地方。\n\n输入 {cmd} 将此聊天设为主频道，或忽略此消息。"
+
   approval_expired: "⚠️ 批准已过期（代理不再等待）。请让代理重试。"
   draining:         "⏳ 正在等待 {count} 个活跃代理结束后重启..."
   goal_cleared:     "✓ 目标已清除。"

--- a/tests/gateway/test_notice_i18n.py
+++ b/tests/gateway/test_notice_i18n.py
@@ -1,0 +1,108 @@
+"""Pairing DM and home-channel prompt come from the i18n catalog and carry the skin's name.
+
+Both notices are the first thing a person sees from a fresh gateway, so they must
+follow ``display.language`` like every other messenger reply, and a custom skin
+must not leak the stock product name into chat.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent.i18n import SUPPORTED_LANGUAGES, t
+from gateway.branding import agent_display_name
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+PAIRING_KEYS = (
+    "gateway.pairing.greeting",
+    "gateway.pairing.code",
+    "gateway.pairing.approve_hint",
+    "gateway.pairing.rate_limited",
+)
+HOME_KEY = "gateway.home_channel.notice"
+
+
+def test_keys_exist_in_every_catalog():
+    for lang in SUPPORTED_LANGUAGES:
+        for key in (*PAIRING_KEYS, HOME_KEY):
+            assert t(key, lang=lang) != key, f"{key} missing in {lang}"
+
+
+def test_english_notice_text_is_unchanged_for_the_stock_skin():
+    rendered = t(HOME_KEY, lang="en", platform="Discord", brand="Hermes", cmd="/sethome")
+    assert rendered == (
+        "📬 No home channel is set for Discord. A home channel is where Hermes delivers "
+        "cron job results and cross-platform messages.\n\nType /sethome to make this chat "
+        "your home channel, or ignore to skip."
+    )
+
+
+def test_portuguese_notice_is_localized():
+    rendered = t(HOME_KEY, lang="pt", platform="Telegram", brand="Atlas", cmd="/sethome")
+    assert "canal principal" in rendered
+    assert "Atlas" in rendered
+    assert "/sethome" in rendered
+    assert "Hermes" not in rendered
+
+
+def test_stock_skin_keeps_the_short_name(monkeypatch):
+    from hermes_cli import config as cli_config
+
+    monkeypatch.setattr(cli_config, "load_config_readonly", lambda: {"display": {}})
+    assert agent_display_name() == "Hermes"
+
+
+def test_custom_skin_name_is_used(tmp_path, monkeypatch):
+    from hermes_cli import config as cli_config
+    from hermes_cli import skin_engine
+
+    (tmp_path / "atlas.yaml").write_text(
+        "name: atlas\nbranding:\n  agent_name: Atlas\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(skin_engine, "_skins_dir", lambda: tmp_path)
+    monkeypatch.setattr(cli_config, "load_config_readonly", lambda: {"display": {"skin": "atlas"}})
+    assert agent_display_name() == "Atlas"
+
+
+def _bare_runner(code):
+    runner = object.__new__(GatewayRunner)
+    store = MagicMock()
+    store._is_rate_limited.return_value = False
+    store.generate_code.return_value = code
+    store.profile = "default"
+    runner._pairing_store_for = lambda source: store
+    adapter = SimpleNamespace(send=AsyncMock())
+    runner._adapter_for_source = lambda source: adapter
+    return runner, adapter, store
+
+
+@pytest.mark.asyncio
+async def test_pairing_dm_is_rendered_from_the_catalog(monkeypatch):
+    monkeypatch.setattr("agent.i18n.get_language", lambda: "pt")
+    runner, adapter, _ = _bare_runner("XDQAAUY6")
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="42", chat_type="dm", user_id="7")
+
+    await runner._hm_offer_pairing_code(source)
+
+    adapter.send.assert_awaited_once()
+    chat_id, text = adapter.send.await_args.args
+    assert chat_id == "42"
+    assert "pareamento" in text
+    assert "`XDQAAUY6`" in text
+    assert "`hermes pairing approve telegram XDQAAUY6`" in text
+
+
+@pytest.mark.asyncio
+async def test_rate_limited_reply_is_rendered_from_the_catalog(monkeypatch):
+    monkeypatch.setattr("agent.i18n.get_language", lambda: "en")
+    runner, adapter, store = _bare_runner(None)
+    source = SessionSource(platform=Platform.DISCORD, chat_id="9", chat_type="dm", user_id="1")
+
+    await runner._hm_offer_pairing_code(source)
+
+    chat_id, text = adapter.send.await_args.args
+    assert text == t("gateway.pairing.rate_limited", lang="en")
+    store._record_rate_limit.assert_called_once_with("discord", "1")


### PR DESCRIPTION
## What does this PR do?

The pairing DM ("Hi~ I don't recognize you yet!") and the one-time "📬 No home channel is set for …" notice were the only messenger replies still hardcoded in English, and both wrote the product name as a literal. They are the first thing a person sees from a fresh gateway, so they now follow `display.language` like every other notice, and a custom skin's `branding.agent_name` shows up in chat instead of the stock name.

Default installs see **byte-identical English output**: the stock skin keeps the short "Hermes" the notices always used (there's a test pinning that).

Why a small `gateway/branding.py` instead of `get_active_skin()` directly: the gateway never calls `init_skin_from_config()` (that's a CLI startup step), so the cached active skin is always the stock one in the gateway process. The helper resolves `display.skin` from `config.yaml` and falls back to "Hermes" on any error.

## Related Issue

No issue filed — found while running a white-label deployment (custom skin, `display.language: pt`) where these two notices were the only English/"Hermes" text left in Teams/Telegram chats.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `locales/*.yaml` — new keys `gateway.pairing.{greeting,code,approve_hint,rate_limited}` and `gateway.home_channel.notice`, translated in all 17 catalogs. The CLI approval command travels through `{command}` so it stays verbatim in every language; `{brand}` carries the skin name; `{cmd}` the platform's sethome command (`/hermes sethome` on Slack).
- `gateway/branding.py` — `agent_display_name()` (new, 43 lines).
- `gateway/run_inbound.py` — `_hm_offer_pairing_code` renders via `t()`.
- `gateway/run_turn.py` — home-channel notice renders via `t()`.
- `tests/gateway/test_notice_i18n.py` — catalog coverage for every language, unchanged English text for the stock skin, custom skin name resolution, and the pairing reply / rate-limit reply driven through the real `_hm_offer_pairing_code` on a bare runner.

## How to Test

1. `pytest tests/agent/test_i18n.py tests/gateway/test_notice_i18n.py -q` — catalog parity (keys + placeholders) across the 17 locales and the new behaviour.
2. Set `display.language: pt` (or any supported language) in `~/.hermes/config.yaml`, restart the gateway, DM the bot from an unpaired account → pairing DM arrives localized, approval command untouched.
3. With a skin that sets `branding.agent_name`, remove the platform's home channel and send a message → the notice names the skin instead of "Hermes". Without a custom skin the text is exactly what it was before.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran `tests/agent/test_i18n.py`, `tests/gateway/test_notice_i18n.py`, `tests/gateway/test_internal_event_bypass_pairing.py`, `tests/gateway/test_multiplex_pairing_stores.py`, `tests/gateway/test_notice_delivery.py`, `tests/gateway/test_home_target_env_var.py`, `tests/gateway/test_unauthorized_dm_behavior.py`, `tests/gateway/test_pairing_allowlist_bypass.py`, `tests/gateway/test_config_driven_access_policy.py`, `tests/e2e/test_platform_commands.py`, `tests/cron/test_scheduler.py` (289 passed, 4 skipped); `ruff check` clean on the touched files
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Python 3.12); gateway behaviour verified on Ubuntu 24.04 containers running Teams + Telegram

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings; N/A otherwise
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure Python/YAML, no filesystem or shell assumptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
