### PR TITLE
fix(ci): exclude HEAD tag from updater E2E sources

### DIFF
--- a/scripts/sandbox/pick-release-tags.sh
+++ b/scripts/sandbox/pick-release-tags.sh
@@ -7,7 +7,9 @@
 # newest release the day after it ships, and pins the "oldest" forever even
 # after it stops being a version anyone still runs.
 #
-# Selection: the newest tag, the oldest tag, and evenly spaced tags in between.
+# Selection: the newest tag strictly older than HEAD, the oldest tag, and evenly
+# spaced tags in between. A tag resolving to HEAD cannot exercise an update and
+# is excluded — especially important for release-tag-triggered workflow runs.
 # Newest catches "did the last release break updating?", oldest is the longest
 # upgrade jump anyone can still make, and the spread samples the migrations in
 # between (config-schema bumps, venv layout changes, dependency floors).
@@ -65,10 +67,17 @@ if [ -z "$REPO" ]; then
 fi
 
 # sort -V orders v2026.4.8 before v2026.4.13 (numeric), which a plain
-# lexicographic sort gets wrong.
+# lexicographic sort gets wrong. Exclude a release tag resolving to HEAD:
+# installing HEAD and then "updating" to HEAD is not an updater E2E and the
+# drivers correctly reject that no-op.
+head_commit="$(git -C "$REPO" rev-parse --verify 'HEAD^{commit}')"
 mapfile -t tags < <(
   git -C "$REPO" tag --list 'v*' \
     | grep -E '^v[0-9]{4}\.[0-9]+\.[0-9]+(\.[0-9]+)?$' \
+    | while IFS= read -r tag; do
+        tag_commit="$(git -C "$REPO" rev-parse --verify "$tag^{commit}")"
+        [ "$tag_commit" = "$head_commit" ] || printf '%s\n' "$tag"
+      done \
     | sort -V
 )
 

--- a/tests/test_pick_release_tags.py
+++ b/tests/test_pick_release_tags.py
@@ -1,0 +1,74 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "sandbox" / "pick-release-tags.sh"
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+
+
+def _commit(repo: Path, message: str) -> None:
+    marker = repo / "marker.txt"
+    marker.write_text(message, encoding="utf-8")
+    _git(repo, "add", "marker.txt")
+    _git(
+        repo,
+        "-c", "user.name=E2E Test",
+        "-c", "user.email=e2e@example.invalid",
+        "commit", "-m", message,
+    )
+
+
+def test_picker_excludes_release_tag_pointing_at_update_destination(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+
+    _commit(repo, "old release")
+    _git(repo, "tag", "v2026.8.31")
+    _commit(repo, "new release")
+    _git(repo, "tag", "v2026.9.11")
+
+    command = [str(SCRIPT), "--count", "1", "--repo", str(repo)]
+    bash_major = int(
+        subprocess.run(
+            ["bash", "-c", "echo ${BASH_VERSINFO[0]}"],
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout
+    )
+    if bash_major < 4:
+        # The production picker runs on Ubuntu. macOS ships Bash 3.2, so
+        # provide only the Bash 4 `mapfile -t ARRAY` primitive it uses.
+        shim = r'''mapfile() {
+  [ "${1-}" = "-t" ] && shift
+  local array="${1:-MAPFILE}" line escaped i=0
+  eval "$array=()"
+  while IFS= read -r line; do
+    printf -v escaped '%q' "$line"
+    eval "$array[$i]=$escaped"
+    i=$((i + 1))
+  done
+}
+export -f mapfile
+exec "$@"'''
+        command = ["bash", "-c", shim, "bash", *command]
+
+    result = subprocess.run(
+        command,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    assert json.loads(result.stdout) == ["v2026.8.31"]


### PR DESCRIPTION
## Summary
- exclude any release tag resolving to the E2E destination `HEAD` from `pick-release-tags.sh`
- preserve the newest/oldest/spread selection over the remaining valid update sources
- add a regression test for release-tag-triggered runs

## Root cause
Release run [34638609883](https://github.com/NousResearch/hermes-agent/actions/runs/34638609883) selected newly-created `v2026.9.11` as the source while the workflow destination was the same commit. All three macOS `hermes-update` legs failed before installation with:

```
E2E ASSERTION FAILED: OLD (v2026.9.11) IS HEAD; no update would be available
```

A release tag at `HEAD` cannot exercise an update, so the source picker now excludes it.

## Test plan
- `python -m pytest tests/test_pick_release_tags.py -q -o addopts=`
- `ruff check tests/test_pick_release_tags.py`
- `bash -n scripts/sandbox/pick-release-tags.sh`
- `git diff --check`