### PR TITLE
fix(models): discover Copilot ACP session catalog

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -17,6 +17,7 @@ import subprocess
 import threading
 import time
 from collections import deque
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -134,10 +135,32 @@ def _jsonrpc_error(message_id: Any, code: int, message: str) -> dict[str, Any]:
     return {"jsonrpc": "2.0", "id": message_id, "error": {"code": code, "message": message}}
 
 
-def _enabled_ids(entries: Any, key: str) -> set[str]:
-    """Ids of ``entries`` (dicts) whose ``_meta.copilotEnablement`` is not ``disabled``."""
-    return {str(e.get(key) or "").strip() for e in (entries or []) if isinstance(e, dict)
-            and str((e.get("_meta") or {}).get("copilotEnablement") or "").strip().lower() != "disabled"}
+def _enabled_id_list(entries: Any, key: str) -> list[str]:
+    """Ordered ids whose ``_meta.copilotEnablement`` is not ``disabled``."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for entry in entries or []:
+        if not isinstance(entry, dict):
+            continue
+        value = str(entry.get(key) or "").strip()
+        if (not value or value in seen
+                or str((entry.get("_meta") or {}).get("copilotEnablement") or "").strip().lower() == "disabled"):
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _model_config_option(session: dict[str, Any]) -> dict[str, Any] | None:
+    return next((option for option in (session.get("configOptions") or []) if isinstance(option, dict)
+                 and "model" in (option.get("category"), option.get("id"))), None)
+
+
+def _session_model_ids(session: dict[str, Any]) -> list[str]:
+    """Account-authorized model ids advertised by ``session/new`` in ACP v1 or its legacy extension."""
+    if option := _model_config_option(session):
+        return _enabled_id_list(option.get("options"), "value")
+    return _enabled_id_list((session.get("models") or {}).get("availableModels"), "modelId")
 
 
 def _model_selection_request(session: dict[str, Any], requested_model: str) -> tuple[str, dict[str, str]] | None:
@@ -149,12 +172,12 @@ def _model_selection_request(session: dict[str, Any], requested_model: str) -> t
     requested_model = str(requested_model or "").strip()
     if not session_id or not requested_model or requested_model == "copilot-acp":
         return None
-    options = [o for o in (session.get("configOptions") or []) if isinstance(o, dict) and "model" in (o.get("category"), o.get("id"))]
-    if options:
-        if requested_model not in _enabled_ids(options[0].get("options"), "value"):
+    option = _model_config_option(session)
+    if option:
+        if requested_model not in _session_model_ids(session):
             return None
-        return "session/set_config_option", {"sessionId": session_id, "configId": str(options[0].get("id") or "model"), "value": requested_model}
-    available = _enabled_ids((session.get("models") or {}).get("availableModels"), "modelId")
+        return "session/set_config_option", {"sessionId": session_id, "configId": str(option.get("id") or "model"), "value": requested_model}
+    available = set(_session_model_ids(session))
     return None if available and requested_model not in available else ("session/set_model", {"sessionId": session_id, "modelId": requested_model})
 
 
@@ -322,10 +345,11 @@ class CopilotACPClient:
             self._active_process = proc
         return proc
 
-    def _run_prompt(self, prompt_text: str, *, timeout_seconds: float, model: str | None = None) -> tuple[str, str]:
-        # The CLI's `--model` spawn flag is deliberately NOT used: `copilot --acp` validates it (unknown id
-        # aborts the spawn) but ignores it for the session; the model is applied after session/new instead.
-        requested_model = str(model or "").strip()
+    @contextlib.contextmanager
+    def _session(
+        self, timeout_seconds: float, *, allow_file_requests: bool = True
+    ) -> Iterator[tuple[dict[str, Any], Callable[..., Any]]]:
+        """Start one ACP process and yield its ``session/new`` result plus request callable."""
         proc = self._spawn()
         inbox: queue.Queue[dict[str, Any]] = queue.Queue()
         stderr_tail: deque[str] = deque(maxlen=40)
@@ -344,7 +368,8 @@ class CopilotACPClient:
         threading.Thread(target=_pump, args=(proc.stderr, lambda line: stderr_tail.append(line.rstrip("\n"))), daemon=True).start()
         request_ids = iter(range(1, 1 << 62))
 
-        def _request(method: str, params: dict[str, Any], *, text_parts: list[str] | None = None, reasoning_parts: list[str] | None = None) -> Any:
+        def _request(method: str, params: dict[str, Any], *, text_parts: list[str] | None = None,
+                     reasoning_parts: list[str] | None = None) -> Any:
             request_id = next(request_ids)
             proc.stdin.write(json.dumps({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}) + "\n")
             proc.stdin.flush()
@@ -355,7 +380,8 @@ class CopilotACPClient:
                 except queue.Empty:
                     continue
                 if self._handle_server_message(
-                    msg, process=proc, cwd=self._acp_cwd, text_parts=text_parts, reasoning_parts=reasoning_parts
+                    msg, process=proc, cwd=self._acp_cwd, text_parts=text_parts,
+                    reasoning_parts=reasoning_parts, allow_file_requests=allow_file_requests,
                 ) or msg.get("id") != request_id:
                     continue
                 if "error" in msg:
@@ -372,9 +398,23 @@ class CopilotACPClient:
         try:
             _request("initialize", _INITIALIZE_PARAMS)
             session = _request("session/new", {"cwd": self._acp_cwd, "mcpServers": []}) or {}
-            session_id = str(session.get("sessionId") or "").strip()
-            if not session_id:
+            if not str(session.get("sessionId") or "").strip():
                 raise RuntimeError("Copilot ACP did not return a sessionId.")
+            yield session, _request
+        finally:
+            self.close()
+
+    def list_models(self, *, timeout_seconds: float = 15.0) -> list[str]:
+        """Return the enabled models advertised by a short-lived authenticated ACP session."""
+        with self._session(timeout_seconds, allow_file_requests=False) as (session, _request):
+            return _session_model_ids(session)
+
+    def _run_prompt(self, prompt_text: str, *, timeout_seconds: float, model: str | None = None) -> tuple[str, str]:
+        # The CLI's `--model` spawn flag is deliberately NOT used: `copilot --acp` validates it (unknown id
+        # aborts the spawn) but ignores it for the session; the model is applied after session/new instead.
+        requested_model = str(model or "").strip()
+        with self._session(timeout_seconds) as (session, _request):
+            session_id = str(session.get("sessionId") or "").strip()
             if requested_model and requested_model != "copilot-acp":
                 try:
                     if (selection := _model_selection_request(session, requested_model)) is not None:
@@ -388,11 +428,10 @@ class CopilotACPClient:
             prompt = {"sessionId": session_id, "prompt": [{"type": "text", "text": prompt_text}]}
             _request("session/prompt", prompt, text_parts=text_parts, reasoning_parts=reasoning_parts)
             return "".join(text_parts), "".join(reasoning_parts)
-        finally:
-            self.close()
 
     def _handle_server_message(
         self, msg: dict[str, Any], *, process: subprocess.Popen[str], cwd: str, text_parts: list[str] | None, reasoning_parts: list[str] | None,
+        allow_file_requests: bool = True,
     ) -> bool:
         """Consume a server->client message; True when handled (notification or request answered)."""
         method = msg.get("method")
@@ -412,10 +451,13 @@ class CopilotACPClient:
         if method == "session/request_permission":
             response = _jsonrpc_result(message_id, {"outcome": {"outcome": "cancelled"}})
         elif method in _FS_HANDLERS:
-            try:
-                response = _jsonrpc_result(message_id, _FS_HANDLERS[method](msg.get("params") or {}, cwd))
-            except Exception as exc:
-                response = _jsonrpc_error(message_id, -32602, str(exc))
+            if not allow_file_requests:
+                response = _jsonrpc_error(message_id, -32601, "File access is unavailable during model discovery.")
+            else:
+                try:
+                    response = _jsonrpc_result(message_id, _FS_HANDLERS[method](msg.get("params") or {}, cwd))
+                except Exception as exc:
+                    response = _jsonrpc_error(message_id, -32602, str(exc))
         else:
             response = _jsonrpc_error(message_id, -32601, f"ACP client method '{method}' is not supported by Hermes yet.")
         process.stdin.write(json.dumps(response) + "\n")

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1238,6 +1238,23 @@ def _codex_catalog(normalized: str, force_refresh: bool) -> list[str]:
 
 
 def _copilot_catalog(normalized: str, force_refresh: bool) -> Optional[list[str]]:
+    if normalized == "copilot-acp":
+        try:
+            from agent.copilot_acp_client import CopilotACPClient
+            from hermes_cli.auth import resolve_external_process_provider_credentials
+
+            credentials = resolve_external_process_provider_credentials("copilot-acp")
+            if str(credentials.get("base_url") or "").startswith("acp://"):
+                live = CopilotACPClient(
+                    api_key=credentials.get("api_key"),
+                    base_url=credentials.get("base_url"),
+                    command=credentials.get("command"),
+                    args=credentials.get("args"),
+                ).list_models()
+                if live:
+                    return live
+        except Exception:
+            pass
     try:
         live = _fetch_github_models(_resolve_copilot_catalog_api_key())
         if live:

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -421,3 +422,72 @@ def test_run_prompt_receives_picker_model():
             model="gpt-5.6-terra", messages=[{"role": "user", "content": "hi"}]
         )
     assert seen["model"] == "gpt-5.6-terra"
+
+
+def test_list_models_reads_enabled_session_config_options(tmp_path):
+    server = tmp_path / "fake_copilot_acp.py"
+    server.write_text(
+        """import json
+import sys
+
+for line in sys.stdin:
+    request = json.loads(line)
+    method = request.get("method")
+    if method == "initialize":
+        result = {"protocolVersion": 1}
+    elif method == "session/new":
+        result = {
+            "sessionId": "catalog-session",
+            "configOptions": [{
+                "id": "model",
+                "category": "model",
+                "options": [
+                    {"value": "auto"},
+                    {"value": "gpt-5.6-terra"},
+                    {"value": "gpt-5.6-terra"},
+                    {"value": "claude-fable-5", "_meta": {"copilotEnablement": "disabled"}},
+                ],
+            }],
+            "models": {"availableModels": [{"modelId": "stale-legacy-model"}]},
+        }
+    else:
+        result = {}
+    print(json.dumps({"jsonrpc": "2.0", "id": request["id"], "result": result}), flush=True)
+""",
+        encoding="utf-8",
+    )
+    client = CopilotACPClient(
+        command=sys.executable,
+        args=[str(server)],
+        acp_cwd=str(tmp_path),
+    )
+
+    assert client.list_models(timeout_seconds=2) == ["auto", "gpt-5.6-terra"]
+    assert client.is_closed is True
+
+
+def test_model_discovery_does_not_allow_file_requests(tmp_path):
+    target = tmp_path / "should-not-be-read.txt"
+    target.write_text("private", encoding="utf-8")
+    server = tmp_path / "fake_copilot_acp_fs_request.py"
+    server.write_text(
+        f"""import json
+import sys
+
+initialize = json.loads(sys.stdin.readline())
+print(json.dumps({{"jsonrpc": "2.0", "id": initialize["id"], "result": {{"protocolVersion": 1}}}}), flush=True)
+session = json.loads(sys.stdin.readline())
+print(json.dumps({{"jsonrpc": "2.0", "id": 99, "method": "fs/read_text_file", "params": {{"path": {str(target)!r}}}}}), flush=True)
+file_response = json.loads(sys.stdin.readline())
+assert file_response["error"]["code"] == -32601
+print(json.dumps({{"jsonrpc": "2.0", "id": session["id"], "result": {{"sessionId": "catalog-session", "configOptions": [{{"id": "model", "options": [{{"value": "gpt-5.6-sol"}}]}}]}}}}), flush=True)
+""",
+        encoding="utf-8",
+    )
+    client = CopilotACPClient(
+        command=sys.executable,
+        args=[str(server)],
+        acp_cwd=str(tmp_path),
+    )
+
+    assert client.list_models(timeout_seconds=2) == ["gpt-5.6-sol"]

--- a/tests/hermes_cli/test_copilot_in_model_list.py
+++ b/tests/hermes_cli/test_copilot_in_model_list.py
@@ -7,6 +7,7 @@ import pytest
 
 from hermes_cli.model_switch import list_authenticated_providers
 from hermes_cli import model_switch_providers
+from hermes_cli.models import provider_model_ids
 
 
 @patch.dict(os.environ, {"GH_TOKEN": "test-key"}, clear=False)
@@ -83,3 +84,55 @@ def test_copilot_acp_hidden_when_executable_missing(monkeypatch, _no_other_copil
 
     assert all(p["slug"] != "copilot-acp" for p in providers), \
         "copilot-acp must stay hidden when no executable resolves"
+
+
+def test_copilot_acp_catalog_comes_from_authenticated_session_without_token():
+    session_models = ["auto", "gpt-5.6-sol", "claude-sonnet-5"]
+    credentials = {
+        "api_key": "copilot-acp",
+        "base_url": "acp://copilot",
+        "command": "copilot",
+        "args": ["--acp", "--stdio"],
+    }
+
+    with patch(
+        "hermes_cli.auth.resolve_external_process_provider_credentials",
+        return_value=credentials,
+    ), patch(
+        "agent.copilot_acp_client.CopilotACPClient.list_models",
+        return_value=session_models,
+    ) as list_models, patch(
+        "hermes_cli.models._resolve_copilot_catalog_api_key",
+        return_value="",
+    ), patch(
+        "hermes_cli.models._fetch_github_models",
+        return_value=[],
+    ) as github_models:
+        assert provider_model_ids("copilot-acp", force_refresh=True) == session_models
+
+    list_models.assert_called_once_with()
+    github_models.assert_not_called()
+
+
+def test_copilot_acp_catalog_falls_back_when_session_probe_fails():
+    credentials = {
+        "api_key": "copilot-acp",
+        "base_url": "acp://copilot",
+        "command": "copilot",
+        "args": ["--acp", "--stdio"],
+    }
+
+    with patch(
+        "hermes_cli.auth.resolve_external_process_provider_credentials",
+        return_value=credentials,
+    ), patch(
+        "agent.copilot_acp_client.CopilotACPClient.list_models",
+        side_effect=TimeoutError("probe timeout"),
+    ), patch(
+        "hermes_cli.models._resolve_copilot_catalog_api_key",
+        return_value="catalog-token",
+    ), patch(
+        "hermes_cli.models._fetch_github_models",
+        return_value=["api-fallback-model"],
+    ):
+        assert provider_model_ids("copilot-acp", force_refresh=True) == ["api-fallback-model"]


### PR DESCRIPTION
## What does this PR do?

Use the authenticated Copilot ACP session as the first model-catalog source for the `copilot-acp` picker.

Copilot CLI can keep its login in an OS credential store without exposing a reusable token to Hermes. In that setup, token-based GitHub model discovery returns nothing and Hermes falls back to its static catalog, even though `session/new` from the signed-in ACP process advertises the models enabled for that account. The session model options are already the authority used when applying a selected model, so using the same response for discovery keeps the picker and runtime selection on one contract.

The probe is short-lived and closes the ACP process after `session/new`. It does not allow filesystem requests during discovery. If the ACP probe is unavailable or fails, the existing GitHub API discovery and static fallback behavior remain unchanged.

## Related Issue

No linked issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Add a reusable short-lived ACP session context and model-list discovery to `agent/copilot_acp_client.py`.
- Prefer authenticated ACP session models for the local `copilot-acp` picker in `hermes_cli/models.py`.
- Deny ACP file access while the picker is only discovering models.
- Preserve token-based GitHub discovery and the static model list as fallbacks.
- Add subprocess and picker-level regressions for enabled-model filtering, cleanup, file-request denial, tokenless discovery, and fallback behavior.

## How to Test

1. Sign in with Copilot CLI on a platform where the login is stored outside plaintext Copilot config.
2. Open the Hermes model picker and select `copilot-acp`.
3. Confirm the picker shows the enabled model options returned by the signed-in ACP session instead of the static fallback list.

Focused automated verification on Windows 11:

```text
python -m pytest tests/agent/test_copilot_acp_client.py tests/hermes_cli/test_copilot_in_model_list.py -q
25 passed in 11.99s

python -m ruff check agent/copilot_acp_client.py hermes_cli/models.py tests/agent/test_copilot_acp_client.py tests/hermes_cli/test_copilot_in_model_list.py
All checks passed!
```

The picker regression was also neutralized locally by bypassing ACP session discovery. It failed against the old static list and passed again after restoring the change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings), or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility), or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior, or N/A

## Screenshots / Logs

Not applicable.
