### PR TITLE
fix(kanban): warn at dispatch time when an assignee's max_turns is too low

### DIFF
--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -2160,6 +2160,42 @@ def _restart_safe_worker_argv(task: Task, command: list[str]) -> list[str]:
     )
 
 
+# A kanban worker burns several turns on startup alone (memory prefetch, MCP
+# handshakes, skill scans) before it can act on the task itself — a budget
+# below this cannot complete meaningful work. Matches the goal-mode dispatcher's
+# own GoalManager(default_max_turns=20) baseline elsewhere in this codebase.
+_IMPLAUSIBLY_LOW_MAX_TURNS = 20
+
+
+def _warn_if_max_turns_implausibly_low(task: Task, profile_home: str) -> None:
+    """Best-effort diagnostic for issue #108575: an assignee profile whose
+    effective agent.max_turns is too low for autonomous work fails with a bare
+    "Iteration budget exhausted (N/N)" that gives no hint the root cause is a
+    profile-level config value rather than the task itself. Warns only (never
+    blocks the spawn — a deliberately low budget is a legitimate choice) and
+    never lets a diagnostics read fail dispatch.
+    """
+    try:
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from hermes_cli.config import load_config
+
+        token = set_hermes_home_override(profile_home)
+        try:
+            max_turns = load_config().get("agent", {}).get("max_turns")
+        finally:
+            reset_hermes_home_override(token)
+        if isinstance(max_turns, int) and 0 < max_turns < _IMPLAUSIBLY_LOW_MAX_TURNS:
+            sys.stderr.write(
+                f"⚠ kanban: assignee '{task.assignee}' has agent.max_turns={max_turns}, "
+                f"below the {_IMPLAUSIBLY_LOW_MAX_TURNS}-turn floor a kanban worker needs for "
+                f"startup alone — task {task.id} will likely fail with "
+                f"'Iteration budget exhausted' before doing any task work. "
+                f"Raise agent.max_turns in {profile_home}/config.yaml.\n"
+            )
+    except Exception:
+        pass  # diagnostics only — never block or fail a spawn over this
+
+
 def _default_spawn(task: Task, workspace: str, *, board: Optional[str] = None) -> Optional[int]:
     """Fire-and-forget ``hermes -p <profile> chat -q ...`` subprocess.
 
@@ -2199,6 +2235,8 @@ def _default_spawn(task: Task, workspace: str, *, board: Optional[str] = None) -
         # No profile dir (isolated test fixtures) — the CLI resolves it from
         # HERMES_PROFILE (set below) instead.
         pass
+    else:
+        _warn_if_max_turns_implausibly_low(task, env["HERMES_HOME"])
     if task.tenant:
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -866,6 +866,99 @@ class TestSharedBoardPaths:
             assert key not in env
 
 
+class TestLowMaxTurnsWarning:
+    """Regression for issue #108575: a kanban worker cannot complete
+    meaningful work with a very low agent.max_turns budget (startup alone
+    -- memory prefetch, MCP handshakes, skill scans -- burns several
+    turns), and the resulting "Iteration budget exhausted" failure gives
+    no hint the cause is a profile-level config value, not the task
+    itself. Independently confirmed by @liuhao1024: no create/clone path
+    synthesizes a low value and no runtime default resolves to 4, so
+    however the value got there, a dispatch-time diagnostic is the
+    actionable fix regardless of root cause."""
+
+    def _profile_home(self, tmp_path, name, max_turns=None):
+        home = tmp_path / ".hermes" / "profiles" / name
+        home.mkdir(parents=True)
+        if max_turns is not None:
+            (home / "config.yaml").write_text(f"agent:\n  max_turns: {max_turns}\n")
+        return home
+
+    def _task(self, tmp_path, assignee):
+        return kb.Task(
+            id="t_low_budget", title="x", body=None, assignee=assignee, status="ready",
+            priority=0, created_by=None, created_at=0, started_at=None, completed_at=None,
+            workspace_kind="worktree", workspace_path=str(tmp_path / "ws"), claim_lock=None,
+            claim_expires=None, tenant=None, branch_name="wt/t_low_budget",
+        )
+
+    def test_warns_on_stderr_when_assignee_max_turns_is_implausibly_low(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        default_home = tmp_path / ".hermes"
+        default_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(default_home))
+        self._profile_home(tmp_path, "lowbudget", max_turns=4)
+        monkeypatch.setattr(
+            "hermes_cli.profiles.resolve_profile_env",
+            lambda profile: str(tmp_path / ".hermes" / "profiles" / profile),
+        )
+        monkeypatch.setattr("subprocess.Popen", lambda cmd, **kw: types.SimpleNamespace(pid=1))
+
+        kbd._default_spawn(self._task(tmp_path, "lowbudget"), str(tmp_path / "ws"))
+
+        err = capsys.readouterr().err
+        assert "lowbudget" in err
+        assert "max_turns=4" in err
+        assert "t_low_budget" in err
+
+    def test_does_not_warn_for_a_normal_max_turns_budget(self, tmp_path, monkeypatch, capsys):
+        default_home = tmp_path / ".hermes"
+        default_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(default_home))
+        self._profile_home(tmp_path, "normalbudget", max_turns=150)
+        monkeypatch.setattr(
+            "hermes_cli.profiles.resolve_profile_env",
+            lambda profile: str(tmp_path / ".hermes" / "profiles" / profile),
+        )
+        monkeypatch.setattr("subprocess.Popen", lambda cmd, **kw: types.SimpleNamespace(pid=1))
+
+        kbd._default_spawn(self._task(tmp_path, "normalbudget"), str(tmp_path / "ws"))
+
+        assert "max_turns" not in capsys.readouterr().err
+
+    def test_never_blocks_the_spawn_even_when_the_diagnostic_read_fails(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """A profile dir that exists but has no readable config.yaml (or any
+        other diagnostics-read failure) must never prevent the spawn
+        itself -- this is a warning, not a gate."""
+        default_home = tmp_path / ".hermes"
+        default_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(default_home))
+        self._profile_home(tmp_path, "noconfig")  # no config.yaml at all
+        monkeypatch.setattr(
+            "hermes_cli.profiles.resolve_profile_env",
+            lambda profile: str(tmp_path / ".hermes" / "profiles" / profile),
+        )
+        spawned = {}
+
+        def fake_popen(cmd, **kw):
+            spawned["called"] = True
+            return types.SimpleNamespace(pid=1)
+
+        monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+        pid = kbd._default_spawn(self._task(tmp_path, "noconfig"), str(tmp_path / "ws"))
+
+        assert spawned.get("called") is True
+        assert pid == 1
+        assert "max_turns" not in capsys.readouterr().err
+
+
 # ---------------------------------------------------------------------------
 # latest_summary / latest_summaries — surface task_runs.summary handoffs
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Addresses the remaining actionable part of #108575 (Proposed Fix #2), per @liuhao1024's independent follow-up investigation in that issue's thread: no create/clone code path synthesizes a low `max_turns` value and no runtime default resolves to 4, so the specific root cause of the reported `4` remains unconfirmed -- but the dispatch-time diagnostic is a genuinely actionable, root-cause-agnostic fix regardless of how a low value ends up in a profile's config.

(Proposed Fix #3 -- surfacing the budget value in the toast -- turned out to already be implemented: `agent/turn_finalizer.py` already formats the message as `"Iteration budget exhausted (N/N)"`.)

## Fix

Added `_warn_if_max_turns_implausibly_low()`, called from `_default_spawn()` right after the assignee's `HERMES_HOME` is resolved. Reads the assignee profile's effective `agent.max_turns` and writes a one-line warning to stderr when it's below 20 -- the same floor the goal-mode dispatcher's own `GoalManager(default_max_turns=20)` already uses elsewhere in this codebase. Warn-only: never blocks the spawn, and never lets a diagnostics-read failure prevent dispatch.

## Verification

Verified directly against a temp profile with `max_turns: 4`, confirming the exact warning text. Verified boundary cases (20 doesn't warn, 19 does; missing config.yaml and missing `max_turns` key are both silent).

Added 3 regression tests following the existing file's established `_set_home()`/`kb.Task(...)` setup pattern. Verified as a genuine regression by removing the call site and confirming the primary warning test fails while the negative-case tests still pass.

34/34 pass in the modified test file (1 pre-existing, unrelated skip); 6/6 across two additional related test files (no regression).