### PR TITLE
fix(plugins): skip foreign-harness dot-dir manifests during discovery

### DIFF
--- a/hermes_cli/plugins_discovery.py
+++ b/hermes_cli/plugins_discovery.py
@@ -118,6 +118,11 @@ def scan_directory(
             manifest = parse_manifest_file(manifest_file, child, source, prefix)
             if manifest is not None:
                 manifests.append(manifest)
+        elif child.name.startswith(".") and depth >= 1:
+            # Multi-harness repos carry sibling manifests for other tools (.claude-plugin/,
+            # .cursor-plugin/, ...) beside their .hermes-plugin/plugin.yaml; those plugin.json
+            # files are not Agent Plugins packages and would warn on every boot.
+            logger.debug("Skipping %s (dot-dir without plugin.yaml)", child)
         elif portable_file.exists() or portable_file.is_symlink():
             try:
                 manifests.append(portable_plugin_manifest(child, source, prefix))

--- a/tests/hermes_cli/test_plugin_scanner_recursion.py
+++ b/tests/hermes_cli/test_plugin_scanner_recursion.py
@@ -112,6 +112,30 @@ class TestCategoryNamespaceRecursion:
         ]
         assert non_bundled == []
 
+    def test_foreign_harness_manifests_in_dot_dirs_are_not_parsed(self, tmp_path, monkeypatch, caplog):
+        """A multi-harness plugin repo (obra/superpowers) ships ``.claude-plugin/plugin.json``,
+        ``.cursor-plugin/plugin.json`` etc. beside its ``.hermes-plugin/plugin.yaml``. Those
+        dot-dirs are other tools' manifests, not portable Agent Plugins packages; the recursion
+        into the repo must skip them instead of warning on every boot."""
+        import os
+        hermes_home = Path(os.environ["HERMES_HOME"])  # set by hermetic conftest fixture
+        repo = hermes_home / "plugins" / "multi-harness"
+        _write_plugin(hermes_home / "plugins", ["multi-harness", ".hermes-plugin"])
+        for foreign in (".claude-plugin", ".cursor-plugin", ".kimi-plugin"):
+            (repo / foreign).mkdir()
+            (repo / foreign / "plugin.json").write_text('{"name": "multi-harness", "version": "1.0.0"}')
+
+        with caplog.at_level("WARNING"):
+            mgr = PluginManager()
+            mgr.discover_and_load()
+
+        assert "multi-harness/.hermes-plugin" in mgr._plugins
+        foreign_warnings = [
+            rec.getMessage() for rec in caplog.records
+            if "Failed to parse" in rec.getMessage() and "-plugin/plugin.json" in rec.getMessage()
+        ]
+        assert foreign_warnings == []
+
 
 
 # ── Kind parsing ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Multi-harness plugin repos such as [obra/superpowers](https://github.com/obra/superpowers) (installed per its README via `hermes plugins install obra/superpowers`) ship `.claude-plugin/plugin.json`, `.cursor-plugin/`, `.devin-plugin/`, `.kimi-plugin/` and `.codex-plugin/` beside their `.hermes-plugin/plugin.yaml`.

`scan_directory` recurses one level into the repo, finds those `plugin.json` files, tries them as portable Agent Plugins packages, and logs on every session boot:

```
WARNING hermes_cli.plugins: Failed to parse .../superpowers/.claude-plugin/plugin.json: plugin.json declares an unsupported or missing Agent Plugins schema
```

Five lines per profile per start. On a four-profile kanban host that is ~1,300 lines/day in `errors.log`, all noise.

## Fix

Skip dot-dir children that lack a `plugin.yaml` on the recursed level (`depth >= 1`). `.hermes-plugin/` carries `plugin.yaml`, hits the YAML branch first, and is unaffected. Top-level dot-dirs are untouched.

## Verification

- New test builds `multi-harness/{.hermes-plugin/plugin.yaml, .claude-plugin/plugin.json, .cursor-plugin/plugin.json, .kimi-plugin/plugin.json}`, asserts the Hermes manifest is discovered and no `Failed to parse` warning fires. Red before the change, green after.
- `tests/hermes_cli/test_plugin_scanner_recursion.py`: 13 passed.
- All tests referencing `scan_directory` / `portable_plugin_manifest` / `plugins_discovery`: 89 passed.
- Real `~/.hermes/plugins/` with superpowers 6.3.0 checked out: zero warnings, `superpowers/.hermes-plugin` still discovered.