### PR TITLE
fix(desktop): honor configured voice recording limit

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -29,7 +29,7 @@ interface UseComposerVoiceArgs {
   disabled: boolean
   focusInput: () => void
   insertText: (text: string) => void
-  maxRecordingSeconds: number
+  maxRecordingSeconds?: number | null
   /** Interrupt the in-flight agent turn (Stop-button seam) — fired when the
    *  user speaks over the model while it is still generating. */
   onInterrupt?: () => Promise<void> | void

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { notify } from '@/store/notifications'
+
+import { useVoiceRecorder } from './use-voice-recorder'
+
+const recorder = {
+  start: vi.fn(),
+  stop: vi.fn()
+}
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      notifications: {
+        voice: {
+          unavailable: 'Voice input unavailable',
+          transcriptionUnavailable: 'Transcription unavailable',
+          recordingFailed: 'Recording failed',
+          noSpeechDetected: 'No speech detected',
+          tryRecordingAgain: 'Try recording again',
+          transcriptionFailed: 'Transcription failed'
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('@/store/notifications', () => ({ notify: vi.fn(), notifyError: vi.fn() }))
+
+vi.mock('./use-mic-recorder', () => ({
+  useMicRecorder: () => ({ handle: recorder, level: 0, recording: false })
+}))
+
+describe('useVoiceRecorder', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useRealTimers()
+    recorder.start.mockResolvedValue(undefined)
+    recorder.stop.mockResolvedValue(null)
+  })
+
+  it('does not start an accidental 120-second recording before config arrives', async () => {
+    const { result } = renderHook(() =>
+      useVoiceRecorder({ maxRecordingSeconds: undefined, focusInput: vi.fn(), onTranscript: vi.fn(), onTranscribeAudio: vi.fn() })
+    )
+
+    await act(async () => {
+      result.current.dictate()
+    })
+
+    expect(recorder.start).not.toHaveBeenCalled()
+    expect(notify).toHaveBeenCalledWith({
+      kind: 'warning',
+      title: 'Voice input unavailable',
+      message: 'Transcription unavailable'
+    })
+  })
+
+  it('uses the configured duration for the browser hard cap', async () => {
+    vi.useFakeTimers()
+    const { result } = renderHook(() =>
+      useVoiceRecorder({ maxRecordingSeconds: 240, focusInput: vi.fn(), onTranscript: vi.fn(), onTranscribeAudio: vi.fn() })
+    )
+
+    await act(async () => {
+      result.current.dictate()
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(239_999)
+    })
+    expect(recorder.stop).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    expect(recorder.stop).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.ts
@@ -8,7 +8,8 @@ import type { VoiceActivityState, VoiceStatus } from '../types'
 import { useMicRecorder } from './use-mic-recorder'
 
 interface VoiceRecorderOptions {
-  maxRecordingSeconds: number
+  /** `undefined` means the shared config has not loaded yet; `null` is uncapped. */
+  maxRecordingSeconds?: number | null
   onTranscribeAudio?: (audio: Blob) => Promise<string>
   focusInput: () => void
   onTranscript: (text: string) => void
@@ -78,6 +79,12 @@ export function useVoiceRecorder({
   }
 
   const start = async () => {
+    if (maxRecordingSeconds === undefined) {
+      notify({ kind: 'warning', title: voiceCopy.unavailable, message: voiceCopy.transcriptionUnavailable })
+
+      return
+    }
+
     if (!onTranscribeAudio) {
       notify({ kind: 'warning', title: voiceCopy.unavailable, message: voiceCopy.transcriptionUnavailable })
 
@@ -90,8 +97,10 @@ export function useVoiceRecorder({
       setElapsedSeconds(0)
       setVoiceStatus('recording')
       intervalRef.current = window.setInterval(() => setElapsedSeconds((Date.now() - startedAtRef.current) / 1000), 250)
-      const cap = Math.max(1, Math.min(Math.trunc(maxRecordingSeconds), 600))
-      timeoutRef.current = window.setTimeout(() => void stop(), cap * 1000)
+      if (maxRecordingSeconds !== null) {
+        const cap = Math.max(1, Math.min(Math.trunc(maxRecordingSeconds), 600))
+        timeoutRef.current = window.setTimeout(() => void stop(), cap * 1000)
+      }
     } catch (error) {
       setVoiceStatus('idle')
       notifyError(error, voiceCopy.recordingFailed)

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -95,7 +95,7 @@ export function ChatBar({
   disabled,
   focusKey,
   gateway,
-  maxRecordingSeconds = 120,
+  maxRecordingSeconds,
   queueSessionKey,
   sessionId,
   state,

--- a/apps/desktop/src/app/chat/composer/types.ts
+++ b/apps/desktop/src/app/chat/composer/types.ts
@@ -35,7 +35,8 @@ export interface ChatBarProps {
   busy: boolean
   disabled: boolean
   focusKey?: string | null
-  maxRecordingSeconds?: number
+  /** `undefined` while config is loading; `null` explicitly disables the cap. */
+  maxRecordingSeconds?: number | null
   state: ChatBarState
   gateway?: HermesGateway | null
   queueSessionKey?: string | null

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -92,7 +92,7 @@ interface ChatViewProps extends Omit<React.ComponentProps<'div'>, 'onSubmit'> {
   onAddContextRef: (refText: string, label?: string, detail?: string) => void
   onAddUrl: (url: string) => void
   onBranchInNewChat?: (messageId: string) => void
-  maxVoiceRecordingSeconds?: number
+  maxVoiceRecordingSeconds?: number | null
   onAttachImageBlob: (blob: Blob) => Promise<boolean | void> | boolean | void
   onAttachDroppedItems: (candidates: DroppedFile[]) => Promise<boolean | void> | boolean | void
   onAttachPrCommentUrl?: (url: string) => boolean

--- a/apps/desktop/src/app/contrib/surfaces.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.tsx
@@ -115,7 +115,7 @@ export const ChatRoutesSurface = memo(function ChatRoutesSurface({
   maxVoiceRecordingSeconds
 }: {
   actions: WiringActions
-  maxVoiceRecordingSeconds?: number
+  maxVoiceRecordingSeconds?: number | null
 }) {
   const activeConnectionId = useStore($activeConnectionId)
   const activeGatewayProfile = useStore($activeGatewayProfile)

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
@@ -34,6 +34,8 @@ const mockConfig = (config: Record<string, unknown>) =>
 
 describe('useHermesConfig refreshHermesConfig', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useRealTimers()
     // Reset atoms and localStorage between tests
     setCurrentCwd('')
     setCurrentFastMode(false)
@@ -42,6 +44,48 @@ describe('useHermesConfig refreshHermesConfig', () => {
     setDefaultReasoningEffort('')
     setTerminalFontFamilyFromConfig('')
     persistString(WORKSPACE_CWD_KEY, null)
+  })
+
+  it('does not expose the 120-second fallback while the voice config is still loading', async () => {
+    const config = deferred<Awaited<ReturnType<typeof getHermesConfig>>>()
+    vi.mocked(getHermesConfig).mockReturnValueOnce(config.promise)
+    const { result } = renderHook(() => useHermesConfig({ activeSessionIdRef: { current: null } }))
+
+    expect(result.current.voiceMaxRecordingSeconds).toBeUndefined()
+
+    let refresh!: Promise<void>
+    act(() => {
+      refresh = result.current.refreshHermesConfig()
+    })
+
+    expect(result.current.voiceMaxRecordingSeconds).toBeUndefined()
+    config.resolve({ voice: { max_recording_seconds: 240 } } as Awaited<ReturnType<typeof getHermesConfig>>)
+
+    await act(async () => {
+      await refresh
+    })
+
+    expect(result.current.voiceMaxRecordingSeconds).toBe(240)
+  })
+
+  it('retries a transient config failure instead of falling back to 120 seconds', async () => {
+    vi.useFakeTimers()
+    vi.mocked(getHermesConfig)
+      .mockRejectedValueOnce(new Error('backend is still starting'))
+      .mockResolvedValueOnce({ voice: { max_recording_seconds: 240 } } as Awaited<ReturnType<typeof getHermesConfig>>)
+    const { result } = renderHook(() => useHermesConfig({ activeSessionIdRef: { current: null } }))
+
+    await act(async () => {
+      await result.current.refreshHermesConfig()
+    })
+
+    expect(result.current.voiceMaxRecordingSeconds).toBeUndefined()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000)
+    })
+
+    expect(result.current.voiceMaxRecordingSeconds).toBe(240)
   })
 
   // Regression: the composer keeps a manual model pick sticky, which skips the

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -1,4 +1,4 @@
-import { type MutableRefObject, useCallback, useRef, useState } from 'react'
+import { type MutableRefObject, useCallback, useEffect, useRef, useState } from 'react'
 
 import { setTerminalFontFamilyFromConfig } from '@/app/right-sidebar/terminal/terminal-font'
 import { getHermesConfig, getHermesConfigDefaults } from '@/hermes'
@@ -22,11 +22,17 @@ import {
   applyVoiceStopPhraseFromConfig
 } from '@/store/voice-prefs'
 
-const DEFAULT_VOICE_SECONDS = 120
+const CONFIG_REFRESH_RETRY_MS = 2_000
 const FAST_TIERS = new Set(['fast', 'priority', 'on'])
 
 function recordingLimit(value: unknown) {
-  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : DEFAULT_VOICE_SECONDS
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined
+  }
+
+  // Match the backend's contract: an explicit non-positive value disables the
+  // automatic cap. `undefined` means the config is not available yet.
+  return value > 0 ? value : null
 }
 
 /** config.yaml hands back whatever the user wrote — `reasoning_effort: false`
@@ -51,9 +57,22 @@ interface HermesConfigOptions {
 }
 
 export function useHermesConfig({ activeSessionIdRef }: HermesConfigOptions) {
-  const [voiceMaxRecordingSeconds, setVoiceMaxRecordingSeconds] = useState(DEFAULT_VOICE_SECONDS)
+  const [voiceMaxRecordingSeconds, setVoiceMaxRecordingSeconds] = useState<number | null | undefined>(undefined)
   const [sttEnabled, setSttEnabled] = useState(true)
   const profileRefreshEpochRef = useRef(0)
+  const configRetryTimerRef = useRef<number | null>(null)
+  const refreshHermesConfigRef = useRef<(() => Promise<void>) | null>(null)
+
+  const scheduleConfigRetry = useCallback(() => {
+    if (configRetryTimerRef.current !== null) {
+      return
+    }
+
+    configRetryTimerRef.current = window.setTimeout(() => {
+      configRetryTimerRef.current = null
+      void refreshHermesConfigRef.current?.()
+    }, CONFIG_REFRESH_RETRY_MS)
+  }, [])
 
   const refreshHermesConfig = useCallback(
     async (force = false, shouldPublish: () => boolean = () => true) => {
@@ -66,6 +85,11 @@ export function useHermesConfig({ activeSessionIdRef }: HermesConfigOptions) {
 
       try {
         const [config, defaults] = await Promise.all([getHermesConfig(), getHermesConfigDefaults().catch(() => ({}))])
+
+        if (configRetryTimerRef.current !== null) {
+          window.clearTimeout(configRetryTimerRef.current)
+          configRetryTimerRef.current = null
+        }
 
         const canPublish = () => profileRefreshEpochRef.current === profileRefreshEpoch && shouldPublish()
 
@@ -148,11 +172,25 @@ export function useHermesConfig({ activeSessionIdRef }: HermesConfigOptions) {
         applyVoiceStopPhraseFromConfig(config)
         applyThinkingSoundFromConfig(config)
       } catch {
-        // Config is nice-to-have; chat still works without it.
+        // Chat remains usable, but voice must not silently record with an
+        // unrelated default limit. Retry after transient startup failures.
+        scheduleConfigRetry()
       }
     },
-    [activeSessionIdRef]
+    [activeSessionIdRef, scheduleConfigRetry]
   )
+
+  useEffect(() => {
+    refreshHermesConfigRef.current = refreshHermesConfig
+
+    return () => {
+      refreshHermesConfigRef.current = null
+      if (configRetryTimerRef.current !== null) {
+        window.clearTimeout(configRetryTimerRef.current)
+        configRetryTimerRef.current = null
+      }
+    }
+  }, [refreshHermesConfig])
 
   return { refreshHermesConfig, sttEnabled, voiceMaxRecordingSeconds }
 }


### PR DESCRIPTION
## Problem

The desktop composer silently capped every voice recording at **120 s**, no matter what
`voice.max_recording_seconds` was configured.

`DEFAULT_VOICE_SECONDS = 120` in `use-hermes-config.ts` served as **both** the initial state *and*
the value `recordingLimit()` returned for any missing/non-numeric config, and `ChatBar` defaulted
its `maxRecordingSeconds` prop to `120`. `getHermesConfig()` failures were swallowed by
`catch { /* Config is nice-to-have */ }` with **no retry**, so a single failed or slow config fetch
at startup left the recorder on the 120 s fallback for the rest of the session.

Repro: set `voice.max_recording_seconds: 240` (verified — `load_config()` returns `240`), then
record; the recording still stops at 120 s. There is no other 120 in the voice path: the Python
side (`hermes_cli/voice.py`, `tui_gateway/methods_voice.py`, `tools/voice_mode.py`) carries no such
cap and reads the configured value correctly.

## Fix

- `recordingLimit()` now distinguishes "config not loaded yet" (`undefined`) from an explicit
  non-positive value (`null` = uncapped), matching the backend contract where a non-positive cap
  disables the limit.
- The recorder refuses to start without a known limit instead of silently recording under an
  unrelated 120 s default, and only arms the stop timer when a cap exists (existing 600 s ceiling
  kept).
- A failed config fetch retries every 2 s instead of staying on the fallback forever.

## Tests

- `apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.test.tsx` (new): does not start an
  accidental 120 s recording before config arrives; honours a configured 240 s cap (still recording
  at 239 s, stops at 240 s).
- `apps/desktop/src/app/session/hooks/use-hermes-config.test.ts`.

```
npx vitest run src/app/chat/composer/hooks/use-voice-recorder.test.tsx \
  src/app/session/hooks/use-hermes-config.test.ts
→ Test Files 2 passed (2) · Tests 12 passed (12)
```
