### PR TITLE
fix(dashboard): scroll embedded TUI with Safari touch

### DIFF
--- a/web/src/lib/pty-touch-scroll.test.ts
+++ b/web/src/lib/pty-touch-scroll.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { touchScrollLines } from "./pty-touch-scroll";
+
+describe("touchScrollLines", () => {
+  it("turns an upward finger swipe into positive terminal scroll lines", () => {
+    expect(touchScrollLines(240, 180, 20)).toBe(3);
+  });
+
+  it("turns a downward finger swipe into negative terminal scroll lines", () => {
+    expect(touchScrollLines(180, 240, 20)).toBe(-3);
+  });
+
+  it("allows slow drags to accumulate against a retained anchor", () => {
+    expect(touchScrollLines(240, 231, 20)).toBe(0);
+    expect(touchScrollLines(240, 220, 20)).toBe(1);
+  });
+
+  it("ignores finger jitter smaller than one terminal row", () => {
+    expect(touchScrollLines(200, 211, 20)).toBe(0);
+  });
+});

--- a/web/src/lib/pty-touch-scroll.ts
+++ b/web/src/lib/pty-touch-scroll.ts
@@ -1,0 +1,18 @@
+/**
+ * Convert a vertical one-finger drag into xterm scrollback lines.
+ *
+ * A finger moving upward reveals newer terminal output, which is positive in
+ * xterm's `scrollLines` convention. Small moves below one row are ignored so
+ * a tap does not nudge the transcript.
+ */
+export function touchScrollLines(
+  startY: number,
+  currentY: number,
+  rowHeight: number,
+): number {
+  if (!Number.isFinite(startY) || !Number.isFinite(currentY) || rowHeight <= 0) {
+    return 0;
+  }
+  const rows = Math.trunc((startY - currentY) / rowHeight);
+  return rows || 0;
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -72,6 +72,7 @@ import {
   parseResumeControlMessage,
   shouldFollowPtyOutput,
 } from "@/lib/pty-scroll";
+import { touchScrollLines } from "@/lib/pty-touch-scroll";
 import {
   imageFilesFromTransfer,
   transferMayContainImage,
@@ -818,6 +819,55 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       return false;
     });
 
+    // xterm's custom wheel hook does not receive touch drags. On a phone this
+    // otherwise leaves the browser trying to scroll its fixed dashboard chrome
+    // while the terminal history remains stuck. Keep one active finger and
+    // translate each movement into whole terminal rows.
+    let touchId: number | null = null;
+    let touchY: number | null = null;
+    const activeTouch = (list: TouchList) => {
+      for (let i = 0; i < list.length; i += 1) {
+        if (list[i].identifier === touchId) return list[i];
+      }
+      return null;
+    };
+    const onTouchStart = (ev: TouchEvent) => {
+      if (ev.touches.length !== 1) {
+        touchId = null;
+        touchY = null;
+        return;
+      }
+      touchId = ev.touches[0].identifier;
+      touchY = ev.touches[0].clientY;
+    };
+    const onTouchMove = (ev: TouchEvent) => {
+      if (ev.touches.length !== 1 || touchId === null || touchY === null) return;
+      const touch = activeTouch(ev.touches);
+      if (!touch) return;
+      const rowHeight = Math.max(1, host.clientHeight / Math.max(1, term.rows));
+      const lines = touchScrollLines(touchY, touch.clientY, rowHeight);
+      // Keep the fractional movement in the anchor. Updating it to every move
+      // would discard sub-row deltas and make slow Safari drags appear inert.
+      if (lines) {
+        touchY += lines * rowHeight;
+        term.scrollLines(lines);
+      }
+      // Safari otherwise hands a slow drag to the document before it crosses a
+      // full terminal row, then rubber-bands the fixed dashboard instead.
+      ev.preventDefault();
+      ev.stopPropagation();
+    };
+    const onTouchEnd = (ev: TouchEvent) => {
+      if (!activeTouch(ev.touches)) {
+        touchId = null;
+        touchY = null;
+      }
+    };
+    host.addEventListener("touchstart", onTouchStart, { passive: true });
+    host.addEventListener("touchmove", onTouchMove, { passive: false });
+    host.addEventListener("touchend", onTouchEnd, { passive: true });
+    host.addEventListener("touchcancel", onTouchEnd, { passive: true });
+
     const unicode11 = new Unicode11Addon();
     term.loadAddon(unicode11);
     term.unicode.activeVersion = "11";
@@ -1522,6 +1572,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       host.removeEventListener("paste", handleBrowserPaste, true);
       host.removeEventListener("dragover", handleBrowserDragOver, true);
       host.removeEventListener("drop", handleBrowserDrop, true);
+      host.removeEventListener("touchstart", onTouchStart);
+      host.removeEventListener("touchmove", onTouchMove);
+      host.removeEventListener("touchend", onTouchEnd);
+      host.removeEventListener("touchcancel", onTouchEnd);
       if (metricsDebounce) clearTimeout(metricsDebounce);
       window.removeEventListener("resize", scheduleSyncTerminalMetrics);
       keyboardInsetSyncRef.current = null;


### PR DESCRIPTION
## Summary
- route one-finger touch drags on the xterm host into terminal scrollback
- prevent Safari from scrolling or rubber-banding the fixed dashboard chrome
- preserve sub-row motion so slow drags accumulate into terminal rows

Closes #108621

## Validation
- `npm test -- --run src/lib/pty-touch-scroll.test.ts` (4 passed)
- `npm run typecheck`