### PR TITLE
fix(hooks): reap the hook process tree when _spawn is interrupted

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -310,10 +310,14 @@ def _spawn(spec: ShellHookSpec, stdin_json: str) -> Dict[str, Any]:
         return failed(next((msg for cls, msg in _POPEN_ERRORS if isinstance(exc, cls)), str(exc)))
     try:
         stdout, stderr = proc.communicate(input=stdin_json, timeout=spec.timeout)
-    except Exception as exc:
+    except BaseException as exc:
+        # BaseException, not Exception: Ctrl+C raises KeyboardInterrupt here, and the hook leads its own
+        # process group (above), so the terminal's SIGINT never reaches it — it would keep running.
         kill_process_tree(proc)  # the whole tree — forked helpers holding the pipes would stall the drain
         with suppress(Exception):
             proc.communicate(timeout=1)
+        if not isinstance(exc, Exception):  # KeyboardInterrupt / SystemExit: reap the hook, then propagate
+            raise
         if not isinstance(exc, subprocess.TimeoutExpired):  # pragma: no cover — defensive
             return failed(str(exc))
         result.update(timed_out=True, elapsed_seconds=round(time.monotonic() - t0, 3))

--- a/tests/agent/test_shell_hooks_tree_kill.py
+++ b/tests/agent/test_shell_hooks_tree_kill.py
@@ -164,7 +164,7 @@ def test_interrupt_kills_hook_and_propagates(tmp_path):
     """
     marker = tmp_path / "hook.pid"
     script = tmp_path / "hook.sh"
-    script.write_text(f"#!/bin/bash\necho $$ > {marker}\nsleep 300\n")
+    script.write_text(f'#!/bin/bash\necho $$ > "{marker}"\nsleep 300\n')
     script.chmod(0o755)
 
     def interrupt_once_running():

--- a/tests/agent/test_shell_hooks_tree_kill.py
+++ b/tests/agent/test_shell_hooks_tree_kill.py
@@ -13,8 +13,10 @@ semantics cannot be mocked.
 """
 
 import os
+import signal
 import sys
 import textwrap
+import threading
 import time
 
 import pytest
@@ -152,6 +154,42 @@ def test_fast_path_contract_unchanged(tmp_path):
     assert "errline" in r["stderr"]
     assert r["error"] is None
     assert r["timed_out"] is False
+
+
+def test_interrupt_kills_hook_and_propagates(tmp_path):
+    """Ctrl+C during a hook must reap the hook, then let KeyboardInterrupt through.
+
+    The hook leads its own process group, so the terminal's SIGINT never
+    reaches it: only ``_spawn``'s own cleanup can stop it.
+    """
+    marker = tmp_path / "hook.pid"
+    script = tmp_path / "hook.sh"
+    script.write_text(f"#!/bin/bash\necho $$ > {marker}\nsleep 300\n")
+    script.chmod(0o755)
+
+    def interrupt_once_running():
+        """Interrupt only once the hook is up, so the signal lands inside _spawn."""
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if marker.exists() and marker.read_text().strip():
+                os.kill(os.getpid(), signal.SIGINT)
+                return
+            time.sleep(0.05)
+
+    interrupter = threading.Thread(target=interrupt_once_running, daemon=True)
+    interrupter.start()
+    with pytest.raises(KeyboardInterrupt):
+        _spawn(_spec(str(script), timeout=300), "{}")
+    interrupter.join(timeout=5)
+
+    hook_pid = _read_marker(marker)
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline and _pid_alive(hook_pid):
+        time.sleep(0.05)
+    alive = _pid_alive(hook_pid)
+    if alive:  # cleanup so a failure doesn't leak a 300s sleeper
+        os.kill(hook_pid, 9)
+    assert not alive, f"hook {hook_pid} survived the interrupt"
 
 
 def test_missing_command_still_fails_open():


### PR DESCRIPTION
## What does this PR do?

Makes `_spawn` reap the hook process tree when it is interrupted, instead of only when the hook times out or errors.

`agent/shell_hooks.py::_spawn` puts the hook child in its own process group on POSIX (`process_group=0`), so the terminal's SIGINT never reaches the hook — only `_spawn`'s own cleanup can stop it. That cleanup sat in `except Exception`, and `KeyboardInterrupt` is a `BaseException`: pressing Ctrl+C while a hook was running skipped `kill_process_tree` entirely and left the hook (and anything it forked) running.

This is the interrupt half of #84901, which added the same cleanup for the timeout path.

## Related Issue

Fixes #108624

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `agent/shell_hooks.py`: `_spawn` catches `BaseException`, runs the existing `kill_process_tree` + drain, then re-raises anything that is not an `Exception` subclass, so `KeyboardInterrupt` / `SystemExit` still reach the caller unchanged. Every other return path is untouched.
- `tests/agent/test_shell_hooks_tree_kill.py`: one real-subprocess regression test that interrupts the process once the hook is confirmed running, then asserts both that `KeyboardInterrupt` propagates and that the hook pid is gone.

## How to Test

```bash
scripts/run_tests.sh tests/agent/test_shell_hooks_tree_kill.py
```

All 6 tests pass. The new test is a genuine regression control: with the fix reverted and the test kept, `test_interrupt_kills_hook_and_propagates` is the only failure and the other five still pass.

`ruff check .` is clean. `scripts/run_tests.sh tests/agent/` fails on exactly the same 8 files / 9 tests as the unmodified base commit here (auxiliary-provider credential tests, unrelated to this change).

## Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have added tests that prove my fix is effective
- [x] I have tested on: Linux

Found while maintaining a downstream fork.
