### PR TITLE
feat(cli): audit one-shot invocation provenance

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2477,6 +2477,50 @@ def _should_seed_interactive(query, image, quiet: bool, oneshot: bool) -> bool:
         return False
 
 
+@contextmanager
+def _audit_single_query_run(prompt, input_mode: str, enabled: bool, state: dict[str, object]):
+    """Correlate a non-interactive CLI query without changing its exception behavior."""
+    if not enabled:
+        yield
+        return
+
+    def session_id():
+        try:
+            cli = state.get("cli")
+            return _oneshot_agent_and_session(cli)[1] if cli is not None else None
+        except Exception:
+            return None
+
+    try:
+        from hermes_cli.oneshot_audit import start_oneshot_audit
+
+        audit = start_oneshot_audit(prompt or "", input_mode)
+    except Exception:
+        yield
+        return
+    state["audit"] = audit
+    try:
+        yield
+    except KeyboardInterrupt:
+        audit.finish("interrupted", 130, session_id())
+        raise
+    except SystemExit as exc:
+        exit_code = exc.code if isinstance(exc.code, int) else (0 if exc.code is None else 1)
+        outcomes = {0: "success", 2: "validation_error", 130: "interrupted"}
+        audit.finish(outcomes.get(exit_code, "agent_error"), exit_code, session_id())
+        raise
+    except ValueError:
+        audit.finish("validation_error", 1, session_id())
+        raise
+    except BaseException:
+        audit.finish("agent_error", 1, session_id())
+        raise
+    else:
+        cli = state.get("cli")
+        outcome = getattr(cli, "_single_query_audit_outcome", "success") if cli is not None else "success"
+        audit.finish(outcome, 0, session_id())
+
+
 def _panel_box_width(title: str, content_lines: list[str], min_width: int = 46, max_width: int = 76) -> int:
     """Stable TUI panel width wide enough for the title and content (incl. borders)."""
     term_cols = shutil.get_terminal_size((100, 20)).columns
@@ -4226,6 +4270,10 @@ def _install_single_query_signal_handlers(cli):
                 # store here or the worker's turn (and its usage deltas) never become durable (#88583 /
                 # #50881 class). Best-effort under the SIGALRM deadman above.
                 _flush_one_shot_session_store(cli)
+            with suppress(Exception):
+                audit = getattr(cli, "_oneshot_audit", None)
+                if audit is not None:
+                    audit.finish("interrupted", 0, _oneshot_agent_and_session(cli)[1])
             _flush_logging_and_stdio()
             os._exit(0)
         raise KeyboardInterrupt()
@@ -4430,7 +4478,9 @@ def _run_single_query_mode(cli, query, image, quiet, oneshot):
         if _query_label:
             cli.console.print(f"[bold blue]Query:[/] {_query_label}")
         cli._show_security_advisories()
-        cli.chat(query, images=single_query_images or None)
+        response = cli.chat(query, images=single_query_images or None)
+        if response is None:
+            cli._single_query_audit_outcome = "agent_error"
         cli._print_exit_summary(clear_screen=False)
     finally:
         _finalize_single_query(cli)
@@ -4463,6 +4513,7 @@ def main(
     pass_session_id: bool = False,
     ignore_user_config: bool = False,
     ignore_rules: bool = False,
+    _input_mode: str = "programmatic",
 ):
     """
     Hermes Agent CLI - Interactive AI Assistant
@@ -4517,40 +4568,46 @@ def main(
         _run_legacy_gateway()
         return
 
-    _join_worktree = _start_worktree_setup(list_tools, list_toolsets, worktree, w)
     query = query or q
-    cli = _build_cli_from_args(model, toolsets, provider, reasoning, api_key, base_url, max_turns, run_budget,
-                               verbose, compact, resume, checkpoints, pass_session_id, ignore_rules, skills)
+    audit_enabled = bool(query or image) and not _should_seed_interactive(query, image, quiet, oneshot)
+    audit_state: dict[str, object] = {}
+    with _audit_single_query_run(query, _input_mode, audit_enabled, audit_state):
+        _join_worktree = _start_worktree_setup(list_tools, list_toolsets, worktree, w)
+        cli = _build_cli_from_args(model, toolsets, provider, reasoning, api_key, base_url, max_turns, run_budget,
+                                   verbose, compact, resume, checkpoints, pass_session_id, ignore_rules, skills)
+        audit_state["cli"] = cli
+        if audit_state.get("audit") is not None:
+            cli._oneshot_audit = audit_state["audit"]
 
-    # Join the background worktree creation before anything consumes TERMINAL_CWD.
-    # A requested worktree whose setup failed aborts: never silently run without isolation.
-    wt_info = _join_worktree() if _join_worktree is not None else None
-    if _join_worktree is not None and not wt_info:
-        return
+        # Join the background worktree creation before anything consumes TERMINAL_CWD.
+        # A requested worktree whose setup failed aborts: never silently run without isolation.
+        wt_info = _join_worktree() if _join_worktree is not None else None
+        if _join_worktree is not None and not wt_info:
+            return
 
-    # Inject worktree context into agent's system prompt
-    if wt_info:
-        wt_note = (
-            f"\n\n[System note: You are working in an isolated git worktree at "
-            f"{wt_info['path']}. Your branch is `{wt_info['branch']}`. "
-            f"Changes here do not affect the main working tree or other agents. "
-            f"Remember to commit and push your changes, and create a PR if appropriate. "
-            f"The original repo is at {wt_info['repo_root']}.]"
-        )
-        cli.system_prompt = (cli.system_prompt or "") + wt_note
+        # Inject worktree context into agent's system prompt
+        if wt_info:
+            wt_note = (
+                f"\n\n[System note: You are working in an isolated git worktree at "
+                f"{wt_info['path']}. Your branch is `{wt_info['branch']}`. "
+                f"Changes here do not affect the main working tree or other agents. "
+                f"Remember to commit and push your changes, and create a PR if appropriate. "
+                f"The original repo is at {wt_info['repo_root']}.]"
+            )
+            cli.system_prompt = (cli.system_prompt or "") + wt_note
 
-    if list_tools or list_toolsets:
-        cli.show_banner()
-        (cli.show_tools if list_tools else cli.show_toolsets)()
-        sys.exit(0)
+        if list_tools or list_toolsets:
+            cli.show_banner()
+            (cli.show_tools if list_tools else cli.show_toolsets)()
+            sys.exit(0)
 
-    atexit.register(_run_cleanup)  # interactive mode registers again in run() (idempotent)
-    _install_single_query_signal_handlers(cli)
+        atexit.register(_run_cleanup)  # interactive mode registers again in run() (idempotent)
+        _install_single_query_signal_handlers(cli)
 
-    if query or image:
-        _run_single_query_mode(cli, query, image, quiet, oneshot)
-        return
-    cli.run()
+        if query or image:
+            _run_single_query_mode(cli, query, image, quiet, oneshot)
+            return
+        cli.run()
 
 
 if __name__ == "__main__":

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -142,6 +142,7 @@ def _run_and_exit_oneshot(
     usage_file: object = None,
     resume: object = None,
     reasoning: object = None,
+    input_mode: str = "programmatic",
 ) -> None:
     try:
         from hermes_cli.oneshot import run_oneshot
@@ -155,6 +156,7 @@ def _run_and_exit_oneshot(
             usage_file=usage_file,
             resume=resume,
             reasoning=reasoning,
+            input_mode=input_mode,
         )
     except KeyboardInterrupt:
         rc = 130
@@ -1746,6 +1748,7 @@ def cmd_chat(args):
         "ignore_rules": getattr(args, "ignore_rules", False) or safe_mode,
         "ignore_user_config": getattr(args, "ignore_user_config", False) or safe_mode,
         "compact": getattr(args, "compact", False),
+        "_input_mode": "query-file" if getattr(args, "query_file", None) else "query",
         **{k: getattr(args, k, d) for k, d in _CHAT_PASSTHROUGH},
     }
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
@@ -2930,6 +2933,7 @@ def _run_oneshot_from_args(args) -> None:
         usage_file=getattr(args, "usage_file", None),
         resume=getattr(args, "resume", None),
         reasoning=getattr(args, "reasoning", None),
+        input_mode="prompt",
     )
 
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -169,6 +169,7 @@ def run_oneshot(
     usage_file: Optional[str] = None,
     resume: Optional[str] = None,
     reasoning: object = None,
+    input_mode: str = "programmatic",
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -177,6 +178,55 @@ def run_oneshot(
     the CLI layer: latest/title/--continue resolution) whose transcript is loaded and continued
     by this turn. Returns the exit code; the caller owns process termination.
     """
+    audit = None
+    try:
+        from hermes_cli.oneshot_audit import start_oneshot_audit
+
+        audit = start_oneshot_audit(prompt, input_mode)
+    except Exception:
+        pass
+    try:
+        exit_code, outcome, session_id = _run_oneshot_impl(
+            prompt,
+            model=model,
+            provider=provider,
+            toolsets=toolsets,
+            skills=skills,
+            usage_file=usage_file,
+            resume=resume,
+            reasoning=reasoning,
+        )
+    except KeyboardInterrupt:
+        if audit is not None:
+            audit.finish("interrupted", 130)
+        raise
+    except SystemExit as exc:
+        exit_code = exc.code if isinstance(exc.code, int) else (0 if exc.code is None else 1)
+        outcome = "interrupted" if exit_code == 130 else ("success" if exit_code == 0 else "agent_error")
+        if audit is not None:
+            audit.finish(outcome, exit_code)
+        raise
+    except BaseException:
+        if audit is not None:
+            audit.finish("agent_error", 1)
+        raise
+
+    if audit is not None:
+        audit.finish(outcome, exit_code, session_id=session_id)
+    return exit_code
+
+
+def _run_oneshot_impl(
+    prompt: str,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
+    toolsets: object = None,
+    skills: object = None,
+    usage_file: Optional[str] = None,
+    resume: Optional[str] = None,
+    reasoning: object = None,
+) -> tuple[int, str, object]:
+    """Execute the existing one-shot behavior and describe its terminal audit state."""
     # Silence every stdlib logger: AIAgent, tools and provider adapters log to stderr through the
     # root logger. File handlers from setup_logging() keep working (level-independent).
     logging.disable(logging.CRITICAL)
@@ -189,12 +239,12 @@ def run_oneshot(
             "hermes -z: --provider requires --model (or HERMES_INFERENCE_MODEL). "
             "Pass both explicitly, or neither to use your configured defaults.\n"
         )
-        return 2
+        return 2, "validation_error", None
 
     explicit_toolsets, toolsets_error = _validate_explicit_toolsets(toolsets)
     if toolsets_error:
         sys.stderr.write(toolsets_error)
-        return 2
+        return 2, "validation_error", None
     use_config_toolsets = _normalize_toolsets(toolsets) is None
 
     # Non-interactive by definition — an approval prompt would hang forever.
@@ -240,7 +290,7 @@ def run_oneshot(
         _write_usage_file(usage_file, result, failure=str(failure))
         real_stderr.write(f"hermes -z: agent failed: {failure}\n")
         real_stderr.flush()
-        return 1
+        return 1, "agent_error", result.get("session_id")
 
     _write_usage_file(usage_file, result)
 
@@ -258,11 +308,11 @@ def run_oneshot(
 
     if not (response or "").strip():
         if result.get("failed") or result.get("partial"):
-            return 2
+            return 2, "agent_error", result.get("session_id")
         real_stderr.write("hermes -z: no final response was produced; treating the run as failed.\n")
         real_stderr.flush()
-        return 1
-    return 0
+        return 1, "agent_error", result.get("session_id")
+    return 0, "success", result.get("session_id")
 
 
 def _create_session_db_for_oneshot():

--- a/hermes_cli/oneshot_audit.py
+++ b/hermes_cli/oneshot_audit.py
@@ -1,0 +1,136 @@
+"""Best-effort, profile-local provenance records for one-shot CLI runs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+import threading
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from hermes_constants import get_hermes_home
+
+_AUDIT_FILENAME = "oneshot-audit.jsonl"
+_INPUT_MODES = frozenset({"prompt", "query", "query-file", "programmatic"})
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _executable_basename(path: object) -> str | None:
+    value = str(path or "").strip()
+    return Path(value).name or None
+
+
+def _parent_executable() -> str | None:
+    """Return only the parent executable's basename; command arguments are private."""
+    try:
+        import psutil
+
+        parent = psutil.Process(os.getppid())
+        return _executable_basename(parent.exe() or parent.name())
+    except Exception:
+        return None
+
+
+def _safe_process_value(fn) -> object | None:
+    try:
+        return fn()
+    except Exception:
+        return None
+
+
+def _tty_name() -> str | None:
+    for stream in (sys.stdin, sys.stdout, sys.stderr):
+        try:
+            if stream is not None and stream.isatty():
+                return os.ttyname(stream.fileno())
+        except Exception:
+            continue
+    return None
+
+
+def _append_record(path: Path | None, record: dict[str, object]) -> None:
+    """Append one complete JSONL record with one write, without affecting the CLI run."""
+    if path is None:
+        return
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = (json.dumps(record, separators=(",", ":"), sort_keys=True) + "\n").encode("utf-8")
+        fd = os.open(path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o600)
+        try:
+            os.write(fd, payload)
+        finally:
+            os.close(fd)
+    except Exception:
+        pass
+
+
+class OneshotAudit:
+    """Correlates the started and finished records for one one-shot invocation."""
+
+    __slots__ = ("_common", "_finished", "_lock", "_path")
+
+    def __init__(self, path: Path | None, common: dict[str, object]) -> None:
+        self._path = path
+        self._common = common
+        self._finished = False
+        self._lock = threading.Lock()
+
+    def finish(self, outcome: str, exit_code: int, session_id: object = None) -> None:
+        """Write the terminal outcome at most once; audit failures never escape."""
+        try:
+            with self._lock:
+                if self._finished:
+                    return
+                self._finished = True
+            record = {
+                **self._common,
+                "event": "finished",
+                "timestamp": _utc_timestamp(),
+                "outcome": outcome,
+                "exit_code": int(exit_code),
+                "session_id": str(session_id) if session_id is not None else None,
+            }
+            _append_record(self._path, record)
+        except Exception:
+            pass
+
+
+class _NoopAudit(OneshotAudit):
+    def finish(self, outcome: str, exit_code: int, session_id: object = None) -> None:
+        return None
+
+
+def start_oneshot_audit(prompt: str, input_mode: str = "programmatic") -> OneshotAudit:
+    """Start a one-shot audit pair without retaining prompt text or process arguments."""
+    try:
+        prompt_bytes = (prompt or "").encode("utf-8", errors="surrogatepass")
+        normalized_mode = input_mode if input_mode in _INPUT_MODES else "programmatic"
+        common: dict[str, object] = {
+            "audit_id": uuid.uuid4().hex,
+            "input_mode": normalized_mode,
+            "prompt_chars": len(prompt or ""),
+            "prompt_sha256": hashlib.sha256(prompt_bytes).hexdigest(),
+            "pid": os.getpid(),
+            "ppid": os.getppid(),
+            "uid": _safe_process_value(os.getuid) if hasattr(os, "getuid") else None,
+            "cwd": _safe_process_value(os.getcwd),
+            "tty": _tty_name(),
+            "executable": _executable_basename(sys.executable),
+            "parent_executable": _parent_executable(),
+        }
+        path = get_hermes_home() / "logs" / _AUDIT_FILENAME
+    except Exception:
+        return _NoopAudit()
+
+    try:
+        audit = OneshotAudit(path, common)
+        _append_record(path, {**common, "event": "started", "timestamp": _utc_timestamp()})
+        return audit
+    except Exception:
+        return _NoopAudit()

--- a/tests/cli/test_oneshot_audit.py
+++ b/tests/cli/test_oneshot_audit.py
@@ -1,0 +1,163 @@
+"""Behavior contract for profile-local CLI one-shot audit provenance."""
+
+from __future__ import annotations
+
+import json
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import pytest
+
+
+def _records(home):
+    path = home / "logs" / "oneshot-audit.jsonl"
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_audit_append_is_concurrent_safe_and_excludes_prompt_and_argv(tmp_path, monkeypatch):
+    from hermes_cli import oneshot_audit
+
+    probe_home = tmp_path / "probe"
+    monkeypatch.setenv("HERMES_HOME", str(probe_home))
+    prompt_marker = "raw-prompt-must-not-appear"
+    argv_marker = "argv-marker-must-not-appear"
+    monkeypatch.setattr(sys, "argv", ["hermes", "-q", argv_marker])
+
+    open_flags = []
+    writes = []
+    real_open = oneshot_audit.os.open
+    real_write = oneshot_audit.os.write
+
+    def traced_open(path, flags, mode):
+        open_flags.append(flags)
+        return real_open(path, flags, mode)
+
+    def traced_write(fd, payload):
+        writes.append(payload)
+        return real_write(fd, payload)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(oneshot_audit.os, "open", traced_open)
+        patch.setattr(oneshot_audit.os, "write", traced_write)
+        audit = oneshot_audit.start_oneshot_audit("probe", "programmatic")
+        audit.finish("success", 0)
+
+    assert len(writes) == 2
+    assert all(flags & oneshot_audit.os.O_APPEND for flags in open_flags)
+    assert all(payload.endswith(b"\n") and payload.count(b"\n") == 1 for payload in writes)
+
+    concurrent_home = tmp_path / "concurrent"
+    monkeypatch.setenv("HERMES_HOME", str(concurrent_home))
+
+    def write_pair(index: int) -> None:
+        audit = oneshot_audit.start_oneshot_audit(f"{prompt_marker}-{index}", "programmatic")
+        audit.finish("success", 0, session_id=f"session-{index}")
+
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        list(pool.map(write_pair, range(64)))
+
+    path = concurrent_home / "logs" / "oneshot-audit.jsonl"
+    raw = path.read_text(encoding="utf-8")
+    records = _records(concurrent_home)
+    assert len(records) == 128
+    assert prompt_marker not in raw
+    assert argv_marker not in raw
+    assert "argv" not in raw.lower()
+
+    by_id = {}
+    for record in records:
+        by_id.setdefault(record["audit_id"], []).append(record)
+        assert record["prompt_chars"] > 0
+        assert len(record["prompt_sha256"]) == 64
+        assert record["input_mode"] == "programmatic"
+        assert record["pid"] > 0
+        assert record["ppid"] >= 0
+        assert "uid" in record
+        assert "cwd" in record
+        assert "tty" in record
+        if record["parent_executable"] is not None:
+            assert "/" not in record["parent_executable"]
+            assert "\\" not in record["parent_executable"]
+    assert len(by_id) == 64
+    assert all([entry["event"] for entry in pair] == ["started", "finished"] for pair in by_id.values())
+
+
+def test_both_cli_oneshot_seams_record_correlated_lifecycle_outcomes(tmp_path, monkeypatch):
+    import cli as cli_mod
+    from hermes_cli import oneshot, oneshot_audit
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(oneshot, "_validate_explicit_toolsets", lambda _value: (None, None))
+
+    cases = [
+        ("success", lambda *_a, **_k: ("ok", {"session_id": "session-ok"}), 0, "success", "session-ok"),
+        ("agent-error", lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("boom")), 1, "agent_error", None),
+        ("interrupted", lambda *_a, **_k: (_ for _ in ()).throw(KeyboardInterrupt()), 130, "interrupted", None),
+    ]
+    for label, run_agent, exit_code, outcome, session_id in cases:
+        monkeypatch.setattr(oneshot, "_run_agent", run_agent)
+        before = len(_records(tmp_path)) if (tmp_path / "logs" / "oneshot-audit.jsonl").exists() else 0
+        if outcome == "interrupted":
+            with pytest.raises(KeyboardInterrupt):
+                oneshot.run_oneshot(f"private-{label}", input_mode="prompt")
+        else:
+            assert oneshot.run_oneshot(f"private-{label}", input_mode="prompt") == exit_code
+        pair = _records(tmp_path)[before:]
+        assert [entry["event"] for entry in pair] == ["started", "finished"]
+        assert pair[0]["audit_id"] == pair[1]["audit_id"]
+        assert pair[1]["outcome"] == outcome
+        assert pair[1]["exit_code"] == exit_code
+        assert pair[1]["session_id"] == session_id
+        assert all(entry["input_mode"] == "prompt" for entry in pair)
+
+    before = len(_records(tmp_path))
+    assert oneshot.run_oneshot("private-validation", provider="custom", input_mode="prompt") == 2
+    validation_pair = _records(tmp_path)[before:]
+    assert validation_pair[1]["outcome"] == "validation_error"
+    assert validation_pair[1]["exit_code"] == 2
+
+    cli_prompt = "private-query-file"
+
+    def build_cli(*_args, **_kwargs):
+        # The start record must exist before any model/agent setup seam is entered.
+        assert _records(tmp_path)[-1]["event"] == "started"
+        return SimpleNamespace(session_id="cli-session", agent=None)
+
+    monkeypatch.setattr(cli_mod, "_build_cli_from_args", build_cli)
+    monkeypatch.setattr(cli_mod, "_install_single_query_signal_handlers", lambda _cli: None)
+    monkeypatch.setattr(cli_mod, "_start_worktree_setup", lambda *_args: None)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args: None)
+
+    cli_cases = [
+        ("query", None, "success", 0),
+        ("query-file", SystemExit(2), "validation_error", 2),
+        ("query-file", SystemExit(1), "agent_error", 1),
+        ("query-file", KeyboardInterrupt(), "interrupted", 130),
+    ]
+    for input_mode, raised, outcome, exit_code in cli_cases:
+        def run_single_query(fake_cli, *_args, raised=raised):
+            fake_cli.agent = SimpleNamespace(session_id="cli-agent-session")
+            if raised is not None:
+                raise raised
+
+        monkeypatch.setattr(cli_mod, "_run_single_query_mode", run_single_query)
+        before = len(_records(tmp_path))
+        if raised is None:
+            cli_mod.main(query=cli_prompt, quiet=True, _input_mode=input_mode)
+        else:
+            with pytest.raises(type(raised)) as exc:
+                cli_mod.main(query=cli_prompt, quiet=True, _input_mode=input_mode)
+            if isinstance(raised, SystemExit):
+                assert exc.value.code == exit_code
+        pair = _records(tmp_path)[before:]
+        assert [entry["event"] for entry in pair] == ["started", "finished"]
+        assert pair[0]["audit_id"] == pair[1]["audit_id"]
+        assert pair[1]["outcome"] == outcome
+        assert pair[1]["exit_code"] == exit_code
+        assert pair[1]["session_id"] == "cli-agent-session"
+        assert all(entry["input_mode"] == input_mode for entry in pair)
+
+    monkeypatch.setattr(oneshot_audit, "start_oneshot_audit", lambda *_a, **_k: (_ for _ in ()).throw(OSError("disk")))
+    monkeypatch.setattr(oneshot, "_run_agent", lambda *_a, **_k: ("still works", {}))
+    assert oneshot.run_oneshot("fail-open") == 0


### PR DESCRIPTION
## Summary

- add a profile-local `logs/oneshot-audit.jsonl` ledger for CLI one-shot invocations
- record correlated lifecycle events for `hermes -z` and finite `hermes chat` query paths
- retain safe process, TTY, input-mode, prompt-digest, outcome, exit-code, and session provenance without storing prompts or argv

## Implementation

Each invocation writes a `started` record before model setup and a correlated `finished` record on success, validation failure, agent failure, or interruption. Records use a generated audit ID and are appended with `O_APPEND` using one encoded `os.write` per JSON line. Audit setup and writes are best-effort so logging failures do not change CLI behavior.

The chat dispatcher distinguishes `query` and `query-file`; direct programmatic calls retain the `programmatic` mode. Finished records include the resulting session ID when one is available.

## Proof receipt

Before implementation, the focused test failed with two expected errors: the audit helper did not exist and the one-shot seam did not accept an input mode.

After implementation:

```text
scripts/run_tests.sh tests/cli/test_oneshot_audit.py
2 passed, 0 failed

scripts/run_tests.sh tests/hermes_cli/test_oneshot_resume.py tests/cli/test_single_query_session_finalize.py
18 passed, 0 failed

scripts/run_tests.sh tests/hermes_cli/test_actual_provider.py
27 passed, 0 failed
```

The focused coverage verifies lifecycle correlation, outcome classification, session propagation, concurrent append behavior, `O_APPEND` plus one-write records, and exclusion of raw prompts and argv.

## Review and risk

- P0 self-review: 0
- independent P0 review was triggered by diff size; one repair/re-review cycle completed with P0: 0
- UID and TTY remain `null` where the platform cannot provide them
- audit failures intentionally fail open to preserve existing invocation behavior

Fixes #108618
