### PR TITLE
feat(cli): trace every one-shot invocation without storing prompts

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4232,7 +4232,7 @@ def _install_single_query_signal_handlers(cli):
             with suppress(Exception):
                 audit = getattr(cli, "_oneshot_invocation_audit", None)
                 if audit is not None:
-                    audit.bind_session(getattr(cli, "session_id", None))
+                    audit.bind_session(_oneshot_agent_and_session(cli)[1])
                     audit.finish(130, "interrupted")
             _flush_logging_and_stdio()
             os._exit(0)
@@ -4438,21 +4438,25 @@ def _run_single_query_mode(cli, query, image, quiet, oneshot):
         if _query_label:
             cli.console.print(f"[bold blue]Query:[/] {_query_label}")
         cli._show_security_advisories()
-        cli.chat(query, images=single_query_images or None)
+        response = cli.chat(query, images=single_query_images or None)
+        if response is None:
+            audit = getattr(cli, "_oneshot_invocation_audit", None)
+            if audit is not None:
+                audit.set_outcome_hint("agent_error")
         cli._print_exit_summary(clear_screen=False)
     except BaseException as exc:
         from hermes_cli.oneshot_audit import finish_from_exception
 
         audit = getattr(cli, "_oneshot_invocation_audit", None)
         if audit is not None:
-            audit.bind_session(getattr(cli, "session_id", None))
+            audit.bind_session(_oneshot_agent_and_session(cli)[1])
         finish_from_exception(audit, exc)
         raise
     finally:
         _finalize_single_query(cli)
         audit = getattr(cli, "_oneshot_invocation_audit", None)
         if audit is not None:
-            audit.bind_session(getattr(cli, "session_id", None))
+            audit.bind_session(_oneshot_agent_and_session(cli)[1])
             audit.finish(0)
 
 

--- a/cli.py
+++ b/cli.py
@@ -4114,6 +4114,9 @@ def _run_quiet_single_query(cli, effective_query):
                 _exit_code = _RL_CODE
             except Exception:
                 _exit_code = 1
+    audit = getattr(cli, "_oneshot_invocation_audit", None)
+    if audit is not None and _exit_code != 0:
+        audit.set_outcome_hint("agent_error")
     sys.exit(_exit_code)
 
 
@@ -4226,6 +4229,11 @@ def _install_single_query_signal_handlers(cli):
                 # store here or the worker's turn (and its usage deltas) never become durable (#88583 /
                 # #50881 class). Best-effort under the SIGALRM deadman above.
                 _flush_one_shot_session_store(cli)
+            with suppress(Exception):
+                audit = getattr(cli, "_oneshot_invocation_audit", None)
+                if audit is not None:
+                    audit.bind_session(getattr(cli, "session_id", None))
+                    audit.finish(130, "interrupted")
             _flush_logging_and_stdio()
             os._exit(0)
         raise KeyboardInterrupt()
@@ -4432,8 +4440,20 @@ def _run_single_query_mode(cli, query, image, quiet, oneshot):
         cli._show_security_advisories()
         cli.chat(query, images=single_query_images or None)
         cli._print_exit_summary(clear_screen=False)
+    except BaseException as exc:
+        from hermes_cli.oneshot_audit import finish_from_exception
+
+        audit = getattr(cli, "_oneshot_invocation_audit", None)
+        if audit is not None:
+            audit.bind_session(getattr(cli, "session_id", None))
+        finish_from_exception(audit, exc)
+        raise
     finally:
         _finalize_single_query(cli)
+        audit = getattr(cli, "_oneshot_invocation_audit", None)
+        if audit is not None:
+            audit.bind_session(getattr(cli, "session_id", None))
+            audit.finish(0)
 
 
 def main(
@@ -4463,6 +4483,7 @@ def main(
     pass_session_id: bool = False,
     ignore_user_config: bool = False,
     ignore_rules: bool = False,
+    invocation_audit=None,
 ):
     """
     Hermes Agent CLI - Interactive AI Assistant
@@ -4517,15 +4538,28 @@ def main(
         _run_legacy_gateway()
         return
 
-    _join_worktree = _start_worktree_setup(list_tools, list_toolsets, worktree, w)
     query = query or q
-    cli = _build_cli_from_args(model, toolsets, provider, reasoning, api_key, base_url, max_turns, run_budget,
-                               verbose, compact, resume, checkpoints, pass_session_id, ignore_rules, skills)
+    if invocation_audit is None and (query or image) and not _should_seed_interactive(query, image, quiet, oneshot):
+        from hermes_cli.oneshot_audit import OneShotAudit
+
+        invocation_audit = OneShotAudit.start(query or "", "programmatic")
+    _join_worktree = _start_worktree_setup(list_tools, list_toolsets, worktree, w)
+    try:
+        cli = _build_cli_from_args(model, toolsets, provider, reasoning, api_key, base_url, max_turns, run_budget,
+                                   verbose, compact, resume, checkpoints, pass_session_id, ignore_rules, skills)
+    except BaseException as exc:
+        from hermes_cli.oneshot_audit import finish_from_exception
+
+        finish_from_exception(invocation_audit, exc)
+        raise
+    cli._oneshot_invocation_audit = invocation_audit
 
     # Join the background worktree creation before anything consumes TERMINAL_CWD.
     # A requested worktree whose setup failed aborts: never silently run without isolation.
     wt_info = _join_worktree() if _join_worktree is not None else None
     if _join_worktree is not None and not wt_info:
+        if invocation_audit is not None:
+            invocation_audit.finish(1, "agent_error")
         return
 
     # Inject worktree context into agent's system prompt

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1710,7 +1710,11 @@ def _prepare_oneshot_audit(args):
             except BaseException as exc:
                 from hermes_cli.oneshot_audit import OneShotAudit, finish_from_exception
 
-                audit = OneShotAudit.start(None, "query-file")
+                audit = OneShotAudit.start(
+                    None,
+                    "query-file",
+                    session_source=getattr(args, "source", None),
+                )
                 setattr(args, "_oneshot_audit", audit)
                 finish_from_exception(audit, exc)
                 raise
@@ -1720,7 +1724,11 @@ def _prepare_oneshot_audit(args):
         prompt = getattr(args, "query", None) or ""
     from hermes_cli.oneshot_audit import OneShotAudit
 
-    audit = OneShotAudit.start(prompt, input_mode)
+    audit = OneShotAudit.start(
+        prompt,
+        input_mode,
+        session_source=getattr(args, "source", None),
+    )
     setattr(args, "_oneshot_audit", audit)
     return audit
 
@@ -1732,6 +1740,8 @@ def _prepare_agent_startup_audited(args) -> None:
     except BaseException as exc:
         from hermes_cli.oneshot_audit import finish_from_exception
 
+        if audit is not None and isinstance(exc, SystemExit):
+            audit.set_outcome_hint("validation_error")
         finish_from_exception(audit, exc)
         raise
 
@@ -3002,22 +3012,24 @@ def _run_oneshot_from_args(args) -> None:
         # oneshot exit path takes over, else the flags parse fine but silently do nothing
         # and the turn starts a fresh session (every wire request loses all history).
         _resolve_chat_session_args(args, use_tui=False)
-        _run_and_exit_oneshot(
-            args.oneshot,
-            model=getattr(args, "model", None),
-            provider=getattr(args, "provider", None),
-            toolsets=getattr(args, "toolsets", None),
-            skills=getattr(args, "skills", None),
-            usage_file=getattr(args, "usage_file", None),
-            resume=getattr(args, "resume", None),
-            reasoning=getattr(args, "reasoning", None),
-            invocation_audit=invocation_audit,
-        )
     except BaseException as exc:
         from hermes_cli.oneshot_audit import finish_from_exception
 
+        if invocation_audit is not None and isinstance(exc, SystemExit):
+            invocation_audit.set_outcome_hint("validation_error")
         finish_from_exception(invocation_audit, exc)
         raise
+    _run_and_exit_oneshot(
+        args.oneshot,
+        model=getattr(args, "model", None),
+        provider=getattr(args, "provider", None),
+        toolsets=getattr(args, "toolsets", None),
+        skills=getattr(args, "skills", None),
+        usage_file=getattr(args, "usage_file", None),
+        resume=getattr(args, "resume", None),
+        reasoning=getattr(args, "reasoning", None),
+        invocation_audit=invocation_audit,
+    )
 
 
 def _light_chat_parser():

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -142,6 +142,7 @@ def _run_and_exit_oneshot(
     usage_file: object = None,
     resume: object = None,
     reasoning: object = None,
+    invocation_audit: object = None,
 ) -> None:
     try:
         from hermes_cli.oneshot import run_oneshot
@@ -155,6 +156,7 @@ def _run_and_exit_oneshot(
             usage_file=usage_file,
             resume=resume,
             reasoning=reasoning,
+            invocation_audit=invocation_audit,
         )
     except KeyboardInterrupt:
         rc = 130
@@ -174,6 +176,8 @@ def _run_and_exit_oneshot(
         except Exception:
             pass
         rc = 1
+    if invocation_audit is not None:
+        invocation_audit.finish(rc)
     try:
         _cleanup_oneshot_runtime()
     finally:
@@ -1653,6 +1657,8 @@ def _read_query_file(args) -> None:
     double-quoted shell argument truncates on quotes and executes $(...)
     (see tools/bot_mode_probe.py).
     """
+    if getattr(args, "_query_file_loaded", False):
+        return
     _qfile = getattr(args, "query_file", None)
     if not _qfile:
         return
@@ -1673,6 +1679,61 @@ def _read_query_file(args) -> None:
     if not (args.query or "").strip():
         print(f"Error: --query-file {_qfile} is empty", file=sys.stderr)
         sys.exit(2)
+    setattr(args, "_query_file_loaded", True)
+
+
+def _chat_args_are_oneshot(args) -> bool:
+    if not (getattr(args, "query", None) or getattr(args, "query_file", None) or getattr(args, "image", None)):
+        return False
+    if getattr(args, "oneshot_exit", False) or getattr(args, "quiet", False):
+        return True
+    try:
+        return not (sys.stdin.isatty() and sys.stdout.isatty())
+    except Exception:
+        return True
+
+
+def _prepare_oneshot_audit(args):
+    """Start one-shot provenance before provider/plugin/model setup."""
+    existing = getattr(args, "_oneshot_audit", None)
+    if existing is not None:
+        return existing
+    top_level_prompt = getattr(args, "oneshot", None)
+    if top_level_prompt:
+        input_mode, prompt = "prompt", top_level_prompt
+    else:
+        if getattr(args, "command", None) not in {None, "chat"}:
+            return None
+        if getattr(args, "query_file", None):
+            try:
+                _read_query_file(args)
+            except BaseException as exc:
+                from hermes_cli.oneshot_audit import OneShotAudit, finish_from_exception
+
+                audit = OneShotAudit.start(None, "query-file")
+                setattr(args, "_oneshot_audit", audit)
+                finish_from_exception(audit, exc)
+                raise
+        if not _chat_args_are_oneshot(args):
+            return None
+        input_mode = "query-file" if getattr(args, "query_file", None) else "query"
+        prompt = getattr(args, "query", None) or ""
+    from hermes_cli.oneshot_audit import OneShotAudit
+
+    audit = OneShotAudit.start(prompt, input_mode)
+    setattr(args, "_oneshot_audit", audit)
+    return audit
+
+
+def _prepare_agent_startup_audited(args) -> None:
+    audit = _prepare_oneshot_audit(args)
+    try:
+        _prepare_agent_startup(args)
+    except BaseException as exc:
+        from hermes_cli.oneshot_audit import finish_from_exception
+
+        finish_from_exception(audit, exc)
+        raise
 
 
 # args attr -> (kwarg, default) passed through to _launch_tui / cli.main.
@@ -1684,7 +1745,7 @@ _CHAT_PASSTHROUGH = (
 )
 
 
-def cmd_chat(args):
+def _cmd_chat(args):
     """Run interactive chat CLI."""
     _apply_safe_mode(args)
     _apply_user_config_bypass(args)
@@ -1746,6 +1807,7 @@ def cmd_chat(args):
         "ignore_rules": getattr(args, "ignore_rules", False) or safe_mode,
         "ignore_user_config": getattr(args, "ignore_user_config", False) or safe_mode,
         "compact": getattr(args, "compact", False),
+        "invocation_audit": getattr(args, "_oneshot_audit", None),
         **{k: getattr(args, k, d) for k, d in _CHAT_PASSTHROUGH},
     }
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
@@ -1755,6 +1817,9 @@ def cmd_chat(args):
 
         cli_main(**kwargs)
     except ValueError as e:
+        audit = getattr(args, "_oneshot_audit", None)
+        if audit is not None:
+            audit.set_outcome_hint("validation_error")
         print(f"Error: {e}")
         sys.exit(1)
     except ImportError as e:
@@ -1768,6 +1833,20 @@ def cmd_chat(args):
         if emit_partial_update_hint(e):
             sys.exit(1)
         raise
+
+
+def cmd_chat(args):
+    audit = _prepare_oneshot_audit(args)
+    try:
+        return _cmd_chat(args)
+    except BaseException as exc:
+        from hermes_cli.oneshot_audit import finish_from_exception
+
+        finish_from_exception(audit, exc)
+        raise
+    finally:
+        if audit is not None:
+            audit.finish(0)
 
 
 def cmd_gateway(args):
@@ -2916,21 +2995,29 @@ def _run_oneshot_from_args(args) -> None:
 
     Bypasses cli.py entirely; _run_and_exit_oneshot never returns.
     """
-    _confirm_startup_expensive_model_override(args)
-    # -z honors --resume/-c/--in exactly like chat (#105892): normalize BEFORE the
-    # oneshot exit path takes over, else the flags parse fine but silently do nothing
-    # and the turn starts a fresh session (every wire request loses all history).
-    _resolve_chat_session_args(args, use_tui=False)
-    _run_and_exit_oneshot(
-        args.oneshot,
-        model=getattr(args, "model", None),
-        provider=getattr(args, "provider", None),
-        toolsets=getattr(args, "toolsets", None),
-        skills=getattr(args, "skills", None),
-        usage_file=getattr(args, "usage_file", None),
-        resume=getattr(args, "resume", None),
-        reasoning=getattr(args, "reasoning", None),
-    )
+    invocation_audit = _prepare_oneshot_audit(args)
+    try:
+        _confirm_startup_expensive_model_override(args)
+        # -z honors --resume/-c/--in exactly like chat (#105892): normalize BEFORE the
+        # oneshot exit path takes over, else the flags parse fine but silently do nothing
+        # and the turn starts a fresh session (every wire request loses all history).
+        _resolve_chat_session_args(args, use_tui=False)
+        _run_and_exit_oneshot(
+            args.oneshot,
+            model=getattr(args, "model", None),
+            provider=getattr(args, "provider", None),
+            toolsets=getattr(args, "toolsets", None),
+            skills=getattr(args, "skills", None),
+            usage_file=getattr(args, "usage_file", None),
+            resume=getattr(args, "resume", None),
+            reasoning=getattr(args, "reasoning", None),
+            invocation_audit=invocation_audit,
+        )
+    except BaseException as exc:
+        from hermes_cli.oneshot_audit import finish_from_exception
+
+        finish_from_exception(invocation_audit, exc)
+        raise
 
 
 def _light_chat_parser():
@@ -3028,7 +3115,7 @@ def _try_fast_chat_launch() -> bool:
 
     if getattr(args, "yolo", False):
         os.environ["HERMES_YOLO_MODE"] = "1"
-    _prepare_agent_startup(args)
+    _prepare_agent_startup_audited(args)
 
     if getattr(args, "oneshot", None):
         _run_oneshot_from_args(args)
@@ -3072,12 +3159,13 @@ def _try_termux_fast_cli_launch() -> bool:
         return True
 
     if getattr(args, "oneshot", None):
-        _prepare_agent_startup(args)
+        _prepare_agent_startup_audited(args)
         _run_oneshot_from_args(args)
 
     _promote_top_level_resume(args)
     if args.command in {None, "chat"}:
         _set_chat_arg_defaults(args)
+        _prepare_oneshot_audit(args)
         interactive_prompt = not getattr(args, "query", None) and not getattr(args, "image", None)
         if interactive_prompt:
             # Reach the prompt first; agent-only discovery on the first turn.
@@ -3087,7 +3175,7 @@ def _try_termux_fast_cli_launch() -> bool:
             if getattr(args, "accept_hooks", False):
                 os.environ["HERMES_ACCEPT_HOOKS"] = "1"
         else:
-            _prepare_agent_startup(args)
+            _prepare_agent_startup_audited(args)
         cmd_chat(args)
         return True
 
@@ -3429,7 +3517,7 @@ def main():
     # Plugin discovery + shell hooks once, gated so introspection commands
     # (hooks list, cron list, gateway status, ...) pay no discovery cost and
     # trigger no consent prompts for hooks the user is still inspecting.
-    _prepare_agent_startup(args)
+    _prepare_agent_startup_audited(args)
 
     if getattr(args, "oneshot", None):
         _run_oneshot_from_args(args)

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -169,6 +169,7 @@ def run_oneshot(
     usage_file: Optional[str] = None,
     resume: Optional[str] = None,
     reasoning: object = None,
+    invocation_audit: object = None,
 ) -> int:
     """Execute a single prompt and print only the final content block.
 
@@ -185,6 +186,8 @@ def run_oneshot(
     # picking its catalog default hides the mismatch). Validate BEFORE the stderr redirect.
     env_model_early = os.getenv("HERMES_INFERENCE_MODEL", "").strip()
     if provider and not ((model or "").strip() or env_model_early):
+        if invocation_audit is not None:
+            invocation_audit.set_outcome_hint("validation_error")
         sys.stderr.write(
             "hermes -z: --provider requires --model (or HERMES_INFERENCE_MODEL). "
             "Pass both explicitly, or neither to use your configured defaults.\n"
@@ -193,6 +196,8 @@ def run_oneshot(
 
     explicit_toolsets, toolsets_error = _validate_explicit_toolsets(toolsets)
     if toolsets_error:
+        if invocation_audit is not None:
+            invocation_audit.set_outcome_hint("validation_error")
         sys.stderr.write(toolsets_error)
         return 2
     use_config_toolsets = _normalize_toolsets(toolsets) is None
@@ -225,6 +230,7 @@ def run_oneshot(
                 skills=skills,
                 resume=resume,
                 reasoning=reasoning,
+                invocation_audit=invocation_audit,
             )
         except BaseException as exc:  # noqa: BLE001
             # Capture anything escaping the agent (OSError from prompt_toolkit on a non-TTY pipe,
@@ -238,6 +244,8 @@ def run_oneshot(
             _write_usage_file(usage_file, result, failure=repr(failure))
             raise failure
         _write_usage_file(usage_file, result, failure=str(failure))
+        if invocation_audit is not None:
+            invocation_audit.set_outcome_hint("agent_error")
         real_stderr.write(f"hermes -z: agent failed: {failure}\n")
         real_stderr.flush()
         return 1
@@ -257,6 +265,8 @@ def run_oneshot(
         real_stdout.flush()
 
     if not (response or "").strip():
+        if invocation_audit is not None:
+            invocation_audit.set_outcome_hint("agent_error")
         if result.get("failed") or result.get("partial"):
             return 2
         real_stderr.write("hermes -z: no final response was produced; treating the run as failed.\n")
@@ -416,6 +426,7 @@ def _run_agent(
     skills: object = None,
     resume: Optional[str] = None,
     reasoning: object = None,
+    invocation_audit: object = None,
 ) -> tuple[str, dict]:
     """Build an AIAgent exactly like a normal CLI chat turn, run one conversation, and return
     ``(final_response, run_result)``. Imports are local to keep CLI startup cheap."""
@@ -493,12 +504,16 @@ def _run_agent(
             # commands via HERMES_YOLO_MODE=1, skill secret capture degrades gracefully.
             clarify_callback=_oneshot_clarify_callback,
         )
+        if invocation_audit is not None:
+            invocation_audit.bind_session(getattr(agent, "session_id", None))
         # Belt-and-braces: no streaming display callbacks may bypass our stdout capture.
         agent.suppress_status_output = True
         agent.stream_delta_callback = None
         agent.tool_gen_callback = None
 
         result = agent.run_conversation(prompt, conversation_history=conversation_history or None)
+        if invocation_audit is not None:
+            invocation_audit.bind_session(result.get("session_id") or getattr(agent, "session_id", None))
         return (result.get("final_response") or "", result)
     finally:
         _close_agent(agent, session_db)

--- a/hermes_cli/oneshot_audit.py
+++ b/hermes_cli/oneshot_audit.py
@@ -54,9 +54,8 @@ def _lock_file(handle) -> None:
     if sys.platform == "win32":
         import msvcrt
 
-        handle.seek(0)
-        if not handle.read(1):
-            handle.seek(0)
+        handle.seek(0, os.SEEK_END)
+        if handle.tell() == 0:
             handle.write(b"\0")
             handle.flush()
         handle.seek(0)

--- a/hermes_cli/oneshot_audit.py
+++ b/hermes_cli/oneshot_audit.py
@@ -106,10 +106,22 @@ def _normalized_exit_code(code: object) -> int:
     return code if isinstance(code, int) else (0 if code is None else 1)
 
 
+def _invocation_provenance(session_source: str | None = None) -> dict[str, object]:
+    """Return the privacy-safe caller identity available at process startup."""
+    from agent.turn_author import turn_author_from_env
+
+    author = turn_author_from_env()
+    return {
+        "session_source": session_source or os.environ.get("HERMES_SESSION_SOURCE") or "cli",
+        "caller_id": author.get("id") if author is not None else None,
+        "caller_is_bot": author.get("is_bot") if author is not None else None,
+    }
+
+
 class OneShotAudit:
     """Idempotent start/finish writer for one CLI invocation."""
 
-    def __init__(self, prompt: str | None, input_mode: str):
+    def __init__(self, prompt: str | None, input_mode: str, session_source: str | None = None):
         prompt_text = prompt if isinstance(prompt, str) else None
         self.audit_id = uuid.uuid4().hex
         self._session_id: str | None = None
@@ -130,14 +142,17 @@ class OneShotAudit:
                 else None
             ),
             "prompt_chars": len(prompt_text) if prompt_text is not None else None,
+            **_invocation_provenance(session_source),
         }
         self._write("started", outcome=None, exit_code=None)
 
     @classmethod
-    def start(cls, prompt: str | None, input_mode: str) -> OneShotAudit | None:
+    def start(
+        cls, prompt: str | None, input_mode: str, session_source: str | None = None,
+    ) -> OneShotAudit | None:
         """Start an audit without making ledger I/O fatal to the invocation."""
         try:
-            return cls(prompt, input_mode)
+            return cls(prompt, input_mode, session_source)
         except Exception:
             return None
 
@@ -145,7 +160,7 @@ class OneShotAudit:
         if session_id:
             self._session_id = str(session_id)
 
-    def set_outcome_hint(self, outcome: str) -> None:
+    def set_outcome_hint(self, outcome: str | None) -> None:
         self._outcome_hint = outcome
 
     def finish(self, exit_code: object = 0, outcome: str | None = None) -> None:

--- a/hermes_cli/oneshot_audit.py
+++ b/hermes_cli/oneshot_audit.py
@@ -1,0 +1,193 @@
+"""Profile-local provenance ledger for CLI one-shot invocations."""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import sys
+import threading
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+
+_APPEND_LOCK = threading.Lock()
+_AUDIT_FILENAME = "oneshot-audit.jsonl"
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _uid() -> int | None:
+    with contextlib.suppress(AttributeError, OSError):
+        return os.getuid()
+    return None
+
+
+def _tty() -> str | None:
+    try:
+        if not sys.stdin.isatty():
+            return None
+        with contextlib.suppress(AttributeError, OSError, ValueError):
+            return os.ttyname(sys.stdin.fileno())
+        name = getattr(sys.stdin, "name", None)
+        return str(name) if name and not str(name).startswith("<") else None
+    except Exception:
+        return None
+
+
+def _parent_executable() -> str | None:
+    try:
+        import psutil
+
+        return psutil.Process(os.getppid()).name() or None
+    except Exception:
+        return None
+
+
+def _lock_file(handle) -> None:
+    if sys.platform == "win32":
+        import msvcrt
+
+        handle.seek(0)
+        if not handle.read(1):
+            handle.seek(0)
+            handle.write(b"\0")
+            handle.flush()
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+
+
+def _unlock_file(handle) -> None:
+    if sys.platform == "win32":
+        import msvcrt
+
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _append_record(record: dict[str, Any]) -> None:
+    """Append one complete JSONL record under a cross-process lock."""
+    logs_dir = get_hermes_home() / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    payload = (json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+    lock_path = logs_dir / f".{_AUDIT_FILENAME}.lock"
+    with _APPEND_LOCK, lock_path.open("a+b") as lock_handle:
+        _lock_file(lock_handle)
+        try:
+            fd = os.open(logs_dir / _AUDIT_FILENAME, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o600)
+            try:
+                remaining = memoryview(payload)
+                while remaining:
+                    written = os.write(fd, remaining)
+                    if written <= 0:
+                        raise OSError("short write to one-shot audit ledger")
+                    remaining = remaining[written:]
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+        finally:
+            _unlock_file(lock_handle)
+
+
+def _normalized_exit_code(code: object) -> int:
+    return code if isinstance(code, int) else (0 if code is None else 1)
+
+
+class OneShotAudit:
+    """Idempotent start/finish writer for one CLI invocation."""
+
+    def __init__(self, prompt: str | None, input_mode: str):
+        prompt_text = prompt if isinstance(prompt, str) else None
+        self.audit_id = uuid.uuid4().hex
+        self._session_id: str | None = None
+        self._outcome_hint: str | None = None
+        self._finished = False
+        self._base = {
+            "audit_id": self.audit_id,
+            "pid": os.getpid(),
+            "ppid": os.getppid(),
+            "uid": _uid(),
+            "cwd": os.getcwd(),
+            "tty": _tty(),
+            "parent_executable": _parent_executable(),
+            "input_mode": input_mode,
+            "prompt_sha256": (
+                hashlib.sha256(prompt_text.encode("utf-8", "surrogatepass")).hexdigest()
+                if prompt_text is not None
+                else None
+            ),
+            "prompt_chars": len(prompt_text) if prompt_text is not None else None,
+        }
+        self._write("started", outcome=None, exit_code=None)
+
+    @classmethod
+    def start(cls, prompt: str | None, input_mode: str) -> OneShotAudit | None:
+        """Start an audit without making ledger I/O fatal to the invocation."""
+        try:
+            return cls(prompt, input_mode)
+        except Exception:
+            return None
+
+    def bind_session(self, session_id: object) -> None:
+        if session_id:
+            self._session_id = str(session_id)
+
+    def set_outcome_hint(self, outcome: str) -> None:
+        self._outcome_hint = outcome
+
+    def finish(self, exit_code: object = 0, outcome: str | None = None) -> None:
+        if self._finished:
+            return
+        code = _normalized_exit_code(exit_code)
+        resolved_outcome = outcome or self._outcome_hint
+        if resolved_outcome is None:
+            if code == 0:
+                resolved_outcome = "normal"
+            elif code == 130:
+                resolved_outcome = "interrupted"
+            elif code == 2:
+                resolved_outcome = "validation_error"
+            else:
+                resolved_outcome = "agent_error"
+        try:
+            self._write("finished", outcome=resolved_outcome, exit_code=code)
+        except Exception:
+            return
+        self._finished = True
+
+    def _write(self, event: str, *, outcome: str | None, exit_code: int | None) -> None:
+        _append_record(
+            {
+                **self._base,
+                "event": event,
+                "timestamp": _timestamp(),
+                "outcome": outcome,
+                "exit_code": exit_code,
+                "session_id": self._session_id,
+            }
+        )
+
+
+def finish_from_exception(audit: OneShotAudit | None, exc: BaseException) -> None:
+    if audit is None:
+        return
+    if isinstance(exc, KeyboardInterrupt):
+        audit.finish(130, "interrupted")
+    elif isinstance(exc, SystemExit):
+        audit.finish(exc.code)
+    else:
+        audit.finish(1, "agent_error")

--- a/tests/hermes_cli/test_oneshot_audit.py
+++ b/tests/hermes_cli/test_oneshot_audit.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import json
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 
 def _write_audit(home: str, prompt: str, index: int) -> str:
@@ -58,3 +61,89 @@ def test_concurrent_invocations_append_complete_correlated_records(tmp_path):
         assert [row["event"] for row in lifecycle] == ["started", "finished"]
     raw = (tmp_path / "logs" / "oneshot-audit.jsonl").read_text(encoding="utf-8")
     assert not any(prompt in raw for prompt in prompts)
+
+
+def test_audit_records_normalized_caller_without_raw_author_payload(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv(
+        "HERMES_TURN_AUTHOR",
+        json.dumps({
+            "id": "bot:worker",
+            "name": "Private Operator Name",
+            "is_bot": True,
+            "origin": "peer-host",
+            "private": "must not be copied",
+        }),
+    )
+    from hermes_cli.oneshot_audit import OneShotAudit
+
+    audit = OneShotAudit("hello", "query", session_source="peer")
+    audit.finish()
+
+    raw = (tmp_path / "logs" / "oneshot-audit.jsonl").read_text(encoding="utf-8")
+    rows = _records(tmp_path)
+    assert rows[0]["caller_id"] == "bot:peer-host/worker"
+    assert rows[0]["caller_is_bot"] is True
+    assert rows[0]["session_source"] == "peer"
+    assert "Private Operator Name" not in raw
+    assert "must not be copied" not in raw
+    assert "name" not in rows[0]
+
+
+def test_nonquiet_agent_failure_uses_continuation_session(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import cli as cli_mod
+    from hermes_cli.oneshot_audit import OneShotAudit
+
+    audit = OneShotAudit("hello", "query")
+    runner = SimpleNamespace(
+        agent=SimpleNamespace(session_id="continuation-session"),
+        session_id="compression-parent",
+        _oneshot_invocation_audit=audit,
+        _claim_active_session=lambda *_args, **_kwargs: True,
+        console=SimpleNamespace(print=lambda *_args, **_kwargs: None),
+        _show_security_advisories=lambda: None,
+        chat=lambda *_args, **_kwargs: None,
+        _print_exit_summary=lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(cli_mod, "_should_seed_interactive", lambda *_args: False)
+    monkeypatch.setattr(cli_mod, "_collect_query_images", lambda query, _image: (query, []))
+    monkeypatch.setattr(cli_mod, "_collect_kanban_task_images", lambda _images: [])
+    monkeypatch.setattr(cli_mod, "_finalize_single_query", lambda _cli: None)
+
+    cli_mod._run_single_query_mode(runner, "hello", None, False, True)
+
+    finished = _records(tmp_path)[-1]
+    assert finished["outcome"] == "agent_error"
+    assert finished["exit_code"] == 0
+    assert finished["session_id"] == "continuation-session"
+
+
+@pytest.mark.parametrize("entrypoint", ["startup", "oneshot"])
+def test_pre_agent_exit_one_is_validation_error(tmp_path, monkeypatch, entrypoint):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli import main as main_mod
+    from hermes_cli.oneshot_audit import OneShotAudit
+
+    audit = OneShotAudit("hello", "prompt")
+    monkeypatch.setattr(main_mod, "_prepare_oneshot_audit", lambda _args: audit)
+    args = SimpleNamespace(oneshot="hello")
+
+    if entrypoint == "startup":
+        monkeypatch.setattr(main_mod, "_prepare_agent_startup", lambda _args: (_ for _ in ()).throw(SystemExit(1)))
+        invoke = main_mod._prepare_agent_startup_audited
+    else:
+        monkeypatch.setattr(
+            main_mod,
+            "_confirm_startup_expensive_model_override",
+            lambda _args: (_ for _ in ()).throw(SystemExit(1)),
+        )
+        invoke = main_mod._run_oneshot_from_args
+
+    with pytest.raises(SystemExit) as exc_info:
+        invoke(args)
+
+    assert exc_info.value.code == 1
+    finished = _records(tmp_path)[-1]
+    assert finished["outcome"] == "validation_error"
+    assert finished["exit_code"] == 1

--- a/tests/hermes_cli/test_oneshot_audit.py
+++ b/tests/hermes_cli/test_oneshot_audit.py
@@ -11,8 +11,7 @@ def _write_audit(home: str, prompt: str, index: int) -> str:
     os.environ["HERMES_HOME"] = home
     from hermes_cli.oneshot_audit import OneShotAudit
 
-    audit = OneShotAudit.start(prompt, "query")
-    assert audit is not None
+    audit = OneShotAudit(prompt, "query")
     audit.bind_session(f"session-{index}")
     audit.finish(0)
     return audit.audit_id

--- a/tests/hermes_cli/test_oneshot_audit.py
+++ b/tests/hermes_cli/test_oneshot_audit.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+
+
+def _write_audit(home: str, prompt: str, index: int) -> str:
+    import os
+
+    os.environ["HERMES_HOME"] = home
+    from hermes_cli.oneshot_audit import OneShotAudit
+
+    audit = OneShotAudit.start(prompt, "query")
+    assert audit is not None
+    audit.bind_session(f"session-{index}")
+    audit.finish(0)
+    return audit.audit_id
+
+
+def _records(home: Path) -> list[dict]:
+    path = home / "logs" / "oneshot-audit.jsonl"
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_audit_correlates_lifecycle_without_copying_prompt(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli.oneshot_audit import OneShotAudit
+
+    prompt = "private prompt token: swordfish"
+    audit = OneShotAudit.start(prompt, "query-file")
+    assert audit is not None
+    audit.bind_session("session-123")
+    audit.finish(2, "validation_error")
+
+    raw = (tmp_path / "logs" / "oneshot-audit.jsonl").read_text(encoding="utf-8")
+    rows = [json.loads(line) for line in raw.splitlines()]
+    assert prompt not in raw
+    assert [row["event"] for row in rows] == ["started", "finished"]
+    assert {row["audit_id"] for row in rows} == {audit.audit_id}
+    assert rows[0]["prompt_sha256"] == rows[1]["prompt_sha256"]
+    assert rows[0]["prompt_chars"] == len(prompt)
+    assert rows[1]["outcome"] == "validation_error"
+    assert rows[1]["exit_code"] == 2
+    assert rows[1]["session_id"] == "session-123"
+    assert "argv" not in rows[0]
+
+
+def test_concurrent_invocations_append_complete_correlated_records(tmp_path):
+    prompts = [f"secret-{index}" for index in range(12)]
+    with ProcessPoolExecutor(max_workers=4) as pool:
+        audit_ids = list(pool.map(_write_audit, [str(tmp_path)] * len(prompts), prompts, range(len(prompts))))
+
+    rows = _records(tmp_path)
+    assert len(rows) == len(prompts) * 2
+    assert {row["audit_id"] for row in rows} == set(audit_ids)
+    for audit_id in audit_ids:
+        lifecycle = [row for row in rows if row["audit_id"] == audit_id]
+        assert [row["event"] for row in lifecycle] == ["started", "finished"]
+    raw = (tmp_path / "logs" / "oneshot-audit.jsonl").read_text(encoding="utf-8")
+    assert not any(prompt in raw for prompt in prompts)


### PR DESCRIPTION
## What does this PR do?

Adds a profile-local JSONL provenance ledger for every CLI one-shot invocation. Operators can correlate a persisted session with its launcher, input mode, prompt hash, and completion outcome without copying raw prompts or command-line arguments into a second log.

### Motivation

One-shot sessions currently retain `source=cli`, but not enough provenance to distinguish a user-entered prompt from a script, CI job, cron-like runner, or agent harness during incident investigation.

### Behavior

- `hermes -z`, non-interactive or forced `hermes chat -q`, `--query-file`, and programmatic one-shots append correlated `started` and `finished` records under the active profile's `logs/oneshot-audit.jsonl`.
- Records include PID, PPID, UID when available, CWD, TTY, parent executable name, input mode, prompt SHA-256 and character count, outcome, exit code, and resulting session ID when available.
- Raw prompt text and process command-line arguments are never recorded.
- Interactive `-q` sessions that stay open are not treated as one-shots.

### Implementation

- `hermes_cli/oneshot_audit.py` owns privacy-safe record construction and cross-process append locking on Windows and POSIX.
- `hermes_cli/main.py`, `cli.py`, and `hermes_cli/oneshot.py` start auditing before provider/plugin/model setup and finish it across normal, validation, agent-error, interrupt, and hard-exit paths.
- `tests/hermes_cli/test_oneshot_audit.py` covers lifecycle correlation, prompt exclusion, session linkage, and concurrent append integrity.

## Related Issue

Closes #108618

## Why this PR vs existing PR #108622

PR #108622 instruments only `hermes -z` inside `hermes_cli/oneshot.py`. It does not cover the separate `hermes chat -q/--query-file --oneshot` path required by the issue. Its parent executable lookup is POSIX-only, and its unlocked append does not satisfy the concurrent-invocation requirement. This PR covers both production entry paths, uses the existing cross-platform `psutil` dependency for parent names, and serializes each append with a portable process lock.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/oneshot_audit.py` - add the profile-local, privacy-preserving, concurrent-safe ledger.
- `hermes_cli/main.py` - start and finish audits around top-level and chat one-shots before runtime setup.
- `cli.py` - correlate chat one-shots, session IDs, failures, and interrupts.
- `hermes_cli/oneshot.py` - correlate the dedicated `-z` runner and its session outcome.
- `tests/hermes_cli/test_oneshot_audit.py` - verify lifecycle privacy and concurrent appends.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_oneshot_audit.py tests/hermes_cli/test_chat_query_file.py tests/hermes_cli/test_seeded_interactive_query.py tests/hermes_cli/test_oneshot_usage_file.py tests/hermes_cli/test_oneshot_resume.py tests/cli/test_oneshot_resumed_session_persist.py`.
2. On Windows, run an isolated `-z` validation-error invocation and inspect `logs/oneshot-audit.jsonl`.
3. Confirm the ledger contains correlated `started` and `finished` records with `outcome=validation_error`, exit code 2, and a SHA-256 hash without the raw prompt or argv.

Validation completed on Windows 11: 41 related tests passed. The isolated CLI smoke test also produced the expected correlated validation-error lifecycle.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs and statically compared this implementation with PR #108622
- [x] My PR contains only changes related to this feature
- [x] Related tests pass
- [x] I've added tests for my changes
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Relevant behavior is documented in module and function docstrings
- [x] Config example update is N/A because no config key changed
- [x] CONTRIBUTING.md and AGENTS.md updates are N/A because no workflow changed
- [x] Cross-platform impact is covered by Windows and POSIX locking branches
- [x] Tool description/schema updates are N/A because no model tool changed
