### PR TITLE
fix(bot-mode): pin the message_agent transport to the venv-beside hermes entrypoint

### DIFF
--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-from tools import bot_mode_dm, bot_mode_probe
+from tools import bot_mode_dm, bot_mode_probe, bot_relay
 
 
 @pytest.fixture(autouse=True)
@@ -234,6 +234,9 @@ def _runner_author(command):
 
 def test_local_delivery_command_and_ack(tmp_path, monkeypatch):
     calls = _capture_spawn(monkeypatch)
+    # These assertions target the -p/turn-args shape; pin the entrypoint resolution
+    # so the test stays hermetic across venvs that do/don't expose a sibling script.
+    monkeypatch.setattr(bot_relay, "_hermes_cli", lambda: "hermes")
     home = _managed_home(tmp_path, teammates=("researcher",))
     agent = _FakeAgent(home, title="Bot Chat")
 
@@ -295,6 +298,7 @@ def test_peer_delivery_command_pins_registry_profile_for_secondary_bots(
     tool-side roster (read from the machine-root config) validated the
     target."""
     calls = _capture_spawn(monkeypatch)
+    monkeypatch.setattr(bot_relay, "_hermes_cli", lambda: "hermes")
     home = _managed_home(tmp_path, peers=("spark",))
     # A reviewer-profile gateway context: the agent's session db lives under
     # that profile's home, so _agent_home() resolves there while the
@@ -316,6 +320,7 @@ def test_peer_delivery_command_pins_registry_profile_for_secondary_bots(
 
 def test_peer_delivery_command(tmp_path, monkeypatch):
     calls = _capture_spawn(monkeypatch)
+    monkeypatch.setattr(bot_relay, "_hermes_cli", lambda: "hermes")
     monkeypatch.setattr("socket.gethostname", lambda: "eri-mac.local")
     home = _managed_home(tmp_path, peers=("spark",))
     agent = _FakeAgent(home, title="Bot Chat")
@@ -339,6 +344,40 @@ def test_peer_delivery_command(tmp_path, monkeypatch):
     mode, _dm_file, transport_argv = _runner_parts(calls[1]["command"])
     assert mode == "stdin"
     assert transport_argv == ["hermes", "-p", "default", "peer", "dm", "spark"]
+
+
+def test_delivery_pins_the_hermes_entrypoint_beside_this_interpreter(tmp_path, monkeypatch):
+    """A background delivery must not rely on PATH: the runner's service context
+    lacks the gateway's venv bin dir, so a bare ``hermes`` resolves to a system
+    install whose shebang picks the wrong interpreter and dies on import (#108628).
+    Both transports must invoke the entrypoint beside this interpreter instead."""
+    venv_bin = tmp_path / "venv" / ("Scripts" if sys.platform == "win32" else "bin")
+    venv_bin.mkdir(parents=True)
+    hermes_entry = venv_bin / ("hermes.exe" if sys.platform == "win32" else "hermes")
+    hermes_entry.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setattr(sys, "executable", str(venv_bin / "python3"))
+
+    calls = _capture_spawn(monkeypatch)
+    home = _managed_home(tmp_path, teammates=("researcher",), peers=("spark",))
+    agent = _FakeAgent(home, title="Bot Chat")
+
+    result = json.loads(
+        bot_mode_dm.message_agent_tool(target="researcher", message="ping", agent=agent)
+    )
+    assert result["status"] == "sent"
+    mode, _dm_file, transport_argv = _runner_parts(calls[0]["command"])
+    assert mode == "query-file"
+    assert transport_argv[0] == str(hermes_entry)
+    assert transport_argv[1:] == ["-p", "researcher", "chat", "--in", "~", "-c", "Bot Chat",
+                                  "--create-if-missing", "-Q"]
+
+    result2 = json.loads(
+        bot_mode_dm.message_agent_tool(target="spark", message="ping", agent=agent)
+    )
+    assert result2["status"] == "sent"
+    mode, _dm_file, transport_argv = _runner_parts(calls[1]["command"])
+    assert mode == "stdin"
+    assert transport_argv == [str(hermes_entry), "-p", "default", "peer", "dm", "spark"]
 
 
 def test_peer_delivery_author_carries_the_sender_hostname_and_local_stays_bare(tmp_path, monkeypatch):

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -182,7 +182,7 @@ def message_agent_tool(target: str = "", message: str = "", task_id: Optional[st
             BOT_CHAT_TITLE, _handle, _hermes_root, _peers, _profile_name as _self_profile_name, _roster,
             is_bot_mode_managed,
         )
-        from tools.bot_relay import BOT_CHAT_TURN_ARGS
+        from tools.bot_relay import BOT_CHAT_TURN_ARGS, _hermes_cli
 
         if _session_title(agent) != BOT_CHAT_TITLE:
             return _err("message_agent is only available in a Bot Mode 'Bot Chat' session. "
@@ -230,7 +230,12 @@ def message_agent_tool(target: str = "", message: str = "", task_id: Optional[st
         # Pin the registry-owning profile: `hermes peer` resolves bot_peers via the profile-scoped
         # load_config(), while the roster above reads the machine-root config — the CLI must run
         # in that same profile or a secondary-profile bot sees an empty registry.
-        return _start_delivery(["hermes", "-p", _self_profile_name(root), "peer", "dm", dm_target], content,
+        # The delivery runs in a background service context whose PATH lacks the gateway's
+        # venv bin dir, so a bare "hermes" resolves to a system install and dies on import
+        # under the wrong interpreter (#108628). _hermes_cli pins the entrypoint beside
+        # this interpreter; _delivery_lock/_local_delivery_home match argv[0] by basename,
+        # so the absolute path stays compatible.
+        return _start_delivery([_hermes_cli(), "-p", _self_profile_name(root), "peer", "dm", dm_target], content,
                                f"@{peer_profile or peer_name} on peer '{peer_name}'", stdin_file=True,
                                author=peer_author, **delivery)
 
@@ -251,7 +256,7 @@ def message_agent_tool(target: str = "", message: str = "", task_id: Optional[st
         return _roster_err(f"No teammate named '{raw_target}' on this install, on a connected "
                            "machine, or on a registered peer. Pick a name from the roster "
                            "(roles are listed in your system prompt).")
-    return _start_delivery(["hermes", "-p", resolved, *BOT_CHAT_TURN_ARGS], content, f"@{_handle(resolved)}",
+    return _start_delivery([_hermes_cli(), "-p", resolved, *BOT_CHAT_TURN_ARGS], content, f"@{_handle(resolved)}",
                            stdin_file=False, profile_home=roster_homes[resolved], author=author, **delivery)
 
 


### PR DESCRIPTION
## What does this PR do?

A Bot Mode agent's `message_agent` background delivery invoked the CLI as a bare `"hermes"` and relied on PATH resolution inside the background service context. That context does not inherit the gateway's venv-rich PATH, so the resolved script's `#!/usr/bin/env python3` shebang picked the system interpreter and the delivery died on import (`ModuleNotFoundError: No module named 'dotenv'`) — the tool still reported `{"status": "sent"}` and the reply was never delivered (#108628).

Both transports (local teammate and peer DM) now resolve the entrypoint through `bot_relay._hermes_cli()` — the interpreter-pinned resolution the relay deliver path already adopted for #93590 ("service contexts lack PATH, so a bare hermes died with ENOENT"). `_delivery_lock` and `_local_delivery_home` already match `argv[0]` by basename, so absolute paths stay compatible; the `--run-delivery` runner itself already launches via `sys.executable`.

## Related Issue

Fixes #108628

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/bot_mode_dm.py`: import `_hermes_cli` from `tools.bot_relay` alongside `BOT_CHAT_TURN_ARGS`; replace the bare `"hermes"` in both `_start_delivery` call sites (peer DM and local teammate) with `_hermes_cli()`, with a comment documenting why PATH resolution is unsafe in the background runner context
- `tests/tools/test_bot_mode_dm.py`: pin `_hermes_cli` to `"hermes"` in the three existing full-path tests whose assertions target the `-p`/turn-args shape; add a regression test that fakes a venv (sibling `hermes` entrypoint beside a patched `sys.executable`) and asserts both transports carry the absolute entrypoint path

## How to Test

1. `pytest tests/tools/test_bot_mode_dm.py tests/tools/test_bot_relay.py -q` — Observed result: 80 passed, 1 skipped
2. Verified the new regression test fails on the pre-fix code (bare `"hermes"` in the transport argv) and passes with the fix
3. `ruff check tools/bot_mode_dm.py tests/tools/test_bot_mode_dm.py` — Observed result: All checks passed

Manual repro from the issue: run the gateway from its venv, call `message_agent(target=..., message=...)` from a Bot Chat session, and inspect the background process result log — the delivery process should now run under the gateway's venv interpreter instead of dying with `ModuleNotFoundError`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `_hermes_cli()` already handles the `hermes.exe` sibling shape on Windows, and the new test asserts the platform-appropriate entrypoint name
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A