### PR TITLE
fix(photon): preserve native iMessage poll votes

### DIFF
--- a/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
+++ b/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
@@ -127,9 +127,6 @@ function patchEmptyPollTitles(source) {
   // internal metadata on this inbound path; Hermes only consumes the selected
   // option title. Supply a non-empty placeholder and preserve the option map.
   const anchor = `\tconst poll = asPoll({\n\t\ttitle: input.title,`;
-  if (!source.includes("const toCachedPoll =") || !source.includes(anchor)) {
-    return source;
-  }
   return replaceOnce(
     source,
     anchor,
@@ -153,6 +150,9 @@ export function patchSpectrumTs(root = scriptDir()) {
     .filter((name) => name.endsWith(".js"))
     .map((name) => path.join(dist, name));
 
+  const writes = [];
+  let firstCandidate;
+  let alreadyPatched = false;
   for (const file of files) {
     const raw = fs.readFileSync(file, "utf8");
     // Normalize to LF for matching so the patch works regardless of the
@@ -171,8 +171,9 @@ export function patchSpectrumTs(root = scriptDir()) {
     if (!hasMixedMapper && !hasPollMapper) {
       continue;
     }
+    firstCandidate ??= file;
 
-    let patched = patchEmptyPollTitles(original);
+    let patched = hasPollMapper ? patchEmptyPollTitles(original) : original;
     // spectrum-ts 12.x replaced the attachment-only branches with
     // `buildUnwrappedContentMessage` + `toOrderedParts`, which already emits a
     // group containing both text and attachments. There is nothing left for
@@ -187,18 +188,28 @@ export function patchSpectrumTs(root = scriptDir()) {
       patched = `// ${MARKER}\n${patched}`;
     }
     if (patched === original) {
-      const reason = original.includes(POLL_MARKER) || original.includes(MARKER)
-        ? "already patched"
-        : "upstream preserves mixed payloads";
-      return { patched: false, file, reason };
+      alreadyPatched ||= original.includes(POLL_MARKER) || original.includes(MARKER);
+      continue;
     }
     if (usedCRLF) {
       patched = patched.split("\n").join(CRLF);
     }
-    fs.writeFileSync(file, patched, "utf8");
-    return { patched: true, file };
+    writes.push({ file, patched });
   }
-  throw new Error("could not find @spectrum-ts/imessage iMessage inbound chunk to patch");
+  if (!firstCandidate) {
+    throw new Error("could not find @spectrum-ts/imessage iMessage inbound chunk to patch");
+  }
+  for (const { file, patched } of writes) {
+    fs.writeFileSync(file, patched, "utf8");
+  }
+  if (writes.length > 0) {
+    return { patched: true, file: writes[0].file };
+  }
+  return {
+    patched: false,
+    file: firstCandidate,
+    reason: alreadyPatched ? "already patched" : "upstream preserves mixed payloads"
+  };
 }
 
 const _invokedDirectly =

--- a/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
+++ b/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-// Patch spectrum-ts' iMessage inbound mapper until upstream preserves mixed
-// text + attachment Apple events. The mapper returns only
+// Apply narrow compatibility fixes to spectrum-ts' bundled iMessage mapper.
+// Older releases return only
 // buildAttachmentMessage(...) whenever attachments are present, which drops
 // `message.content.text` before Hermes can see it. We rewrite the two inbound
 // mappers — `rebuildFromAppleMessage` (used by `space.getMessage`) and
@@ -13,13 +13,14 @@
 // lives in `@spectrum-ts/imessage/dist/index.js` (it used to be a chunk under
 // `spectrum-ts/dist`). The published output is tab-indented and uses
 // `const ... = async` declarations; the anchors below match that exactly and
-// fail loudly if a future spectrum-ts reshapes the mapper.
+// fail loudly if a future spectrum-ts reshapes a path that still needs repair.
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const MARKER = "Hermes patch: Preserve mixed text + attachment iMessage payloads";
-const POLL_MARKER = "Hermes patch: Accept empty inbound iMessage poll titles";
+const POLL_TITLE_MARKER = "Hermes patch: Accept empty inbound iMessage poll titles";
+const POLL_CACHE_MARKER = "Hermes patch: Preserve outbound iMessage poll metadata";
 
 function scriptDir() {
   return path.dirname(fileURLToPath(import.meta.url));
@@ -117,7 +118,7 @@ function patchChildIndices(source) {
 }
 
 function patchEmptyPollTitles(source) {
-  if (source.includes(POLL_MARKER)) {
+  if (source.includes(POLL_TITLE_MARKER)) {
     return source;
   }
   // Photon currently returns an empty poll title in both the live `created`
@@ -130,8 +131,53 @@ function patchEmptyPollTitles(source) {
   return replaceOnce(
     source,
     anchor,
-    `\t// ${POLL_MARKER}\n\tconst poll = asPoll({\n\t\ttitle: input.title || "Poll",`,
+    `\t// ${POLL_TITLE_MARKER}\n\tconst poll = asPoll({\n\t\ttitle: input.title || "Poll",`,
     "empty inbound poll title"
+  );
+}
+
+function patchPollMetadataCache(source) {
+  if (source.includes(POLL_CACHE_MARKER)) {
+    return source;
+  }
+  if (!source.includes("const toCachedPoll =")) {
+    return source;
+  }
+
+  // Spectrum 12.7 only populates its poll cache from inbound events and
+  // polls.get(). Photon can omit option identifiers from both, while the
+  // polls.create() response still has the identifiers needed to turn a later
+  // vote id into its choice title. Seed the same per-client cache on send and
+  // do not let a less-complete created/refresh payload overwrite it.
+  source = replaceOnce(
+    source,
+    `const cachePollInfo = (cache, info) => {\n\tconst cached = toCachedPoll(info);\n\tcache.set(info.pollMessageGuid, cached);\n\treturn cached;\n};`,
+    `// ${POLL_CACHE_MARKER}\nconst cachePoll = (cache, id, info) => {\n\tconst cached = toCachedPoll(info);\n\tconst existing = cache.get(id);\n\tif (existing && existing.optionsByIdentifier.size > cached.optionsByIdentifier.size) return existing;\n\tcache.set(id, cached);\n\treturn cached;\n};\nconst cachePollInfo = (cache, info) => cachePoll(cache, info.pollMessageGuid, info);`,
+    "poll metadata cache helper"
+  );
+  source = replaceOnce(
+    source,
+    `\t\tconst cached = toCachedPoll({\n\t\t\ttitle: event.delta.title,\n\t\t\toptions: event.delta.options\n\t\t});\n\t\tcache.set(event.pollMessageGuid, cached);\n\t\treturn cached;`,
+    `\t\treturn cachePoll(cache, event.pollMessageGuid, {\n\t\t\ttitle: event.delta.title,\n\t\t\toptions: event.delta.options\n\t\t});`,
+    "inbound poll metadata cache"
+  );
+  source = replaceOnce(
+    source,
+    `\t\tcase "poll":\n\t\t\tif (replyTo) throw unsupportedRemoteContent("poll", "polls cannot be sent as replies");\n\t\t\treturn outboundPoll(spaceId, await remote.polls.create(chat, content.title, content.options.map((option) => option.title)), content);`,
+    `\t\tcase "poll": {\n\t\t\tif (replyTo) throw unsupportedRemoteContent("poll", "polls cannot be sent as replies");\n\t\t\tconst created = await remote.polls.create(chat, content.title, content.options.map((option) => option.title));\n\t\t\tcachePollInfo(getPollCache(remote), { ...created, title: created.title || content.title });\n\t\t\treturn outboundPoll(spaceId, created, content);\n\t\t}`,
+    "outbound poll metadata cache"
+  );
+  source = replaceOnce(
+    source,
+    `\tconst pollCache = getPollCache(clients);`,
+    `\t// ${POLL_CACHE_MARKER}: share outbound metadata with this line's stream.`,
+    "shared poll cache declaration"
+  );
+  return replaceOnce(
+    source,
+    `\t\treturn clientStream(entry.client, pollCache, entry.phone, includeGroupEvents, tracker ? contactShareHandler(tracker, profileSyncGate) : void 0, recover);`,
+    `\t\treturn clientStream(entry.client, getPollCache(entry.client), entry.phone, includeGroupEvents, tracker ? contactShareHandler(tracker, profileSyncGate) : void 0, recover);`,
+    "per-client poll stream cache"
   );
 }
 
@@ -148,6 +194,7 @@ export function patchSpectrumTs(root = scriptDir()) {
   }
   const files = fs.readdirSync(dist)
     .filter((name) => name.endsWith(".js"))
+    .sort()
     .map((name) => path.join(dist, name));
 
   const writes = [];
@@ -174,6 +221,7 @@ export function patchSpectrumTs(root = scriptDir()) {
     firstCandidate ??= file;
 
     let patched = hasPollMapper ? patchEmptyPollTitles(original) : original;
+    patched = hasPollMapper ? patchPollMetadataCache(patched) : patched;
     // spectrum-ts 12.x replaced the attachment-only branches with
     // `buildUnwrappedContentMessage` + `toOrderedParts`, which already emits a
     // group containing both text and attachments. There is nothing left for
@@ -188,7 +236,8 @@ export function patchSpectrumTs(root = scriptDir()) {
       patched = `// ${MARKER}\n${patched}`;
     }
     if (patched === original) {
-      alreadyPatched ||= original.includes(POLL_MARKER) || original.includes(MARKER);
+      alreadyPatched ||= original.includes(POLL_TITLE_MARKER) ||
+        original.includes(POLL_CACHE_MARKER) || original.includes(MARKER);
       continue;
     }
     if (usedCRLF) {
@@ -208,7 +257,7 @@ export function patchSpectrumTs(root = scriptDir()) {
   return {
     patched: false,
     file: firstCandidate,
-    reason: alreadyPatched ? "already patched" : "upstream preserves mixed payloads"
+    reason: alreadyPatched ? "already patched" : "upstream preserves mixed payloads",
   };
 }
 

--- a/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
+++ b/plugins/platforms/photon/sidecar/patch-spectrum-mixed-attachments.mjs
@@ -19,6 +19,7 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const MARKER = "Hermes patch: Preserve mixed text + attachment iMessage payloads";
+const POLL_MARKER = "Hermes patch: Accept empty inbound iMessage poll titles";
 
 function scriptDir() {
   return path.dirname(fileURLToPath(import.meta.url));
@@ -115,6 +116,28 @@ function patchChildIndices(source) {
   );
 }
 
+function patchEmptyPollTitles(source) {
+  if (source.includes(POLL_MARKER)) {
+    return source;
+  }
+  // Photon currently returns an empty poll title in both the live `created`
+  // delta and `client.polls.get()`, even when the outbound poll had a title.
+  // spectrum-ts validates the reconstructed Poll before it can map a vote's
+  // option identifier, so the empty title drops every selection. The title is
+  // internal metadata on this inbound path; Hermes only consumes the selected
+  // option title. Supply a non-empty placeholder and preserve the option map.
+  const anchor = `\tconst poll = asPoll({\n\t\ttitle: input.title,`;
+  if (!source.includes("const toCachedPoll =") || !source.includes(anchor)) {
+    return source;
+  }
+  return replaceOnce(
+    source,
+    anchor,
+    `\t// ${POLL_MARKER}\n\tconst poll = asPoll({\n\t\ttitle: input.title || "Poll",`,
+    "empty inbound poll title"
+  );
+}
+
 export function patchSpectrumTs(root = scriptDir()) {
   const dist = path.join(
     root,
@@ -132,9 +155,6 @@ export function patchSpectrumTs(root = scriptDir()) {
 
   for (const file of files) {
     const raw = fs.readFileSync(file, "utf8");
-    if (raw.includes(MARKER)) {
-      return { patched: false, file, reason: "already patched" };
-    }
     // Normalize to LF for matching so the patch works regardless of the
     // checkout's line-ending style (Windows git autocrlf produces CRLF,
     // which would otherwise defeat the \n-based search strings). The
@@ -144,25 +164,34 @@ export function patchSpectrumTs(root = scriptDir()) {
     const CRLF = CR + "\n";
     const usedCRLF = raw.includes(CRLF);
     const original = usedCRLF ? raw.split(CRLF).join("\n") : raw;
-    if (!original.includes("const toInboundMessages = async") ||
-        !original.includes("const rebuildFromAppleMessage = async")) {
+    const hasMixedMapper =
+      original.includes("const toInboundMessages = async") &&
+      original.includes("const rebuildFromAppleMessage = async");
+    const hasPollMapper = original.includes("const toCachedPoll =");
+    if (!hasMixedMapper && !hasPollMapper) {
       continue;
     }
+
+    let patched = patchEmptyPollTitles(original);
     // spectrum-ts 12.x replaced the attachment-only branches with
     // `buildUnwrappedContentMessage` + `toOrderedParts`, which already emits a
     // group containing both text and attachments. There is nothing left for
     // Hermes to patch; keep the legacy v8 path below for older pinned installs.
-    if (
+    const upstreamPreservesMixed =
       original.includes("const buildUnwrappedContentMessage = async") &&
-      original.includes("const parts = toOrderedParts(message.content.text, attachments);")
-    ) {
-      return { patched: false, file, reason: "upstream preserves mixed payloads" };
+      original.includes("const parts = toOrderedParts(message.content.text, attachments);");
+    if (hasMixedMapper && !original.includes(MARKER) && !upstreamPreservesMixed) {
+      patched = patchRebuild(patched);
+      patched = patchInbound(patched);
+      patched = patchChildIndices(patched);
+      patched = `// ${MARKER}\n${patched}`;
     }
-    let patched = original;
-    patched = patchRebuild(patched);
-    patched = patchInbound(patched);
-    patched = patchChildIndices(patched);
-    patched = `// ${MARKER}\n${patched}`;
+    if (patched === original) {
+      const reason = original.includes(POLL_MARKER) || original.includes(MARKER)
+        ? "already patched"
+        : "upstream preserves mixed payloads";
+      return { patched: false, file, reason };
+    }
     if (usedCRLF) {
       patched = patched.split("\n").join(CRLF);
     }

--- a/tests/plugins/platforms/photon/test_poll_clarify.py
+++ b/tests/plugins/platforms/photon/test_poll_clarify.py
@@ -84,6 +84,27 @@ async def test_poll_vote_dispatched_as_choice_text(
     assert ev.source.chat_id == "+155****4567"
 
 
+@pytest.mark.asyncio
+async def test_poll_vote_and_later_text_remain_distinct(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    captured = _capture(adapter, monkeypatch)
+
+    await adapter._dispatch_inbound(_poll_option_event(title="Route"))
+    await adapter._dispatch_inbound(
+        _poll_option_event(title="Route", selected=False, msg_id="spc-msg-unvote")
+    )
+    later = _poll_option_event(title="", msg_id="spc-msg-text")
+    later["content"] = {"type": "text", "text": "Did you get my choice?"}
+    await adapter._dispatch_inbound(later)
+
+    assert [(event.message_id, event.text) for event in captured] == [
+        ("spc-msg-vote", "Route"),
+        ("spc-msg-text", "Did you get my choice?"),
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Outbound: send_clarify renders a native poll for choices.
 
@@ -146,5 +167,4 @@ async def test_send_clarify_with_choices_sends_native_poll(
     assert options == ["A", "B", "C"]
     # The vote returns as text, so text-capture must be enabled.
     assert marked == ["clar-1"]
-
 

--- a/tests/plugins/platforms/photon/test_spectrum_patch.py
+++ b/tests/plugins/platforms/photon/test_spectrum_patch.py
@@ -141,17 +141,41 @@ def _tabify(src: str) -> str:
     return "\n".join(out)
 
 
-# A faithful, *executable* slice of spectrum-ts 8.x's iMessage inbound mapper:
-# the two functions the patch rewrites (`rebuildFromAppleMessage` for
-# `space.getMessage`, `toInboundMessages` for the live stream), plus stubs of
-# the helpers they close over. Mirrors the published shape — tab-indented (via
-# `_tabify`), `const ... = async` declarations, single-line builder calls — so
-# the anchors exercise the real code path, and exporting the functions lets
-# the test assert runtime behavior rather than only string shape.
+# An executable slice combining spectrum-ts 8.x's attachment mappers with
+# 12.7's poll send/cache/resolve path, plus stubs of their closed-over helpers.
+# It mirrors each published shape (including tab indentation) so the anchors
+# exercise the dependency patch and exports the functions needed to assert the
+# resulting behavior.
 _SPECTRUM_IMESSAGE_FIXTURE = """
 const asPoll = (input) => {
   if (!input.title) throw new Error("poll title must not be empty");
   return { type: "poll", ...input };
+};
+const asPollOption = (input) => ({ type: "poll_option", ...input });
+class PollCache {
+  map = new Map();
+  get(id) { return this.map.get(id); }
+  set(id, poll) { this.map.set(id, poll); }
+}
+const pollCaches = new WeakMap();
+const getPollCache = (owner) => {
+  let cache = pollCaches.get(owner);
+  if (!cache) {
+    cache = new PollCache();
+    pollCaches.set(owner, cache);
+  }
+  return cache;
+};
+const outboundPoll = (spaceId, poll, content) => ({ id: poll.pollMessageGuid, content, space: { id: spaceId } });
+const unsupportedRemoteContent = () => new Error("unsupported");
+const send = async (remote, spaceId, content, replyTo) => {
+  const chat = spaceId;
+  switch (content.type) {
+    case "poll":
+      if (replyTo) throw unsupportedRemoteContent("poll", "polls cannot be sent as replies");
+      return outboundPoll(spaceId, await remote.polls.create(chat, content.title, content.options.map((option) => option.title)), content);
+    default: throw unsupportedRemoteContent(content.type);
+  }
 };
 const toCachedPoll = (input) => {
   const poll = asPoll({
@@ -164,6 +188,78 @@ const toCachedPoll = (input) => {
     if (option && optionInfo.optionIdentifier) optionsByIdentifier.set(optionInfo.optionIdentifier, option);
   }
   return { poll, optionsByIdentifier };
+};
+const cachePollInfo = (cache, info) => {
+  const cached = toCachedPoll(info);
+  cache.set(info.pollMessageGuid, cached);
+  return cached;
+};
+const cachePollEvent = (cache, event) => {
+  if (event.delta.type === "created" || event.delta.type === "optionAdded") try {
+    const cached = toCachedPoll({
+      title: event.delta.title,
+      options: event.delta.options
+    });
+    cache.set(event.pollMessageGuid, cached);
+    return cached;
+  } catch (e) {}
+};
+const resolvePoll = async (client, cache, event) => {
+  const cached = cache.get(event.pollMessageGuid);
+  if (cached) return cached;
+  return cachePollInfo(cache, await client.polls.get(event.pollMessageGuid));
+};
+const buildPollOptionMessage = (input) => {
+  const option = input.cached.optionsByIdentifier.get(input.optionId);
+  if (!option) return;
+  return {
+    id: `${input.event.pollMessageGuid}:${input.optionId}`,
+    content: asPollOption({ option, poll: input.cached.poll, selected: input.selected })
+  };
+};
+const refreshPollMetadata = async (client, pollCache, event) => {
+  const info = await client.polls.get(event.pollMessageGuid);
+  if (!info) return;
+  cachePollInfo(pollCache, info);
+  return pollCache.get(info.pollMessageGuid);
+};
+const toPollOptionMessage = async (client, pollCache, event) => {
+  const optionId = event.delta.optionIdentifier;
+  if (!optionId) return [];
+  let cached = await resolvePoll(client, pollCache, event);
+  if (!cached) return [];
+  if (!cached.optionsByIdentifier.has(optionId)) {
+    const refreshed = await refreshPollMetadata(client, pollCache, event);
+    if (refreshed) cached = refreshed;
+  }
+  const message = buildPollOptionMessage({
+    cached, event, optionId, selected: event.delta.type === "voted"
+  });
+  return message ? [message] : [];
+};
+const clientStream = (client, pollCache) => ({ client, pollCache });
+const contactShareHandler = () => undefined;
+const createStreamGroup = () => ({
+  builds: [],
+  add(key, build) { this.builds.push(build); }
+});
+const lineKey = () => "line";
+const getCloudRecover = () => undefined;
+const isSharedMode = () => false;
+const getContactShareTracker = () => undefined;
+const messages$1 = (clients, projectConfig, profileSyncGate) => {
+  const pollCache = getPollCache(clients);
+  const staticShareEnabled = projectConfig?.profile?.imessageSynced === true;
+  const recover = getCloudRecover(clients);
+  const shared = isSharedMode(clients);
+  const includeGroupEvents = !shared;
+  const build = (entry) => () => {
+    const tracker = staticShareEnabled || profileSyncGate ? getContactShareTracker(entry.client) : void 0;
+    return clientStream(entry.client, pollCache, entry.phone, includeGroupEvents, tracker ? contactShareHandler(tracker, profileSyncGate) : void 0, recover);
+  };
+  const group = createStreamGroup({ label: "imessage.messages" });
+  for (const entry of clients) group.add(lineKey(entry), build(entry));
+  return group;
 };
 const formatChildId = (partIndex, parentGuid) => `p:${partIndex}/${parentGuid}`;
 const asText = (text) => ({ type: "text", text });
@@ -241,7 +337,7 @@ const toInboundMessages = async (client, cache, event, phone) => {
   cacheMessage(cache, msg);
   return [msg];
 };
-export { rebuildFromAppleMessage, toCachedPoll, toInboundMessages };
+export { cachePollEvent, getPollCache, messages$1, rebuildFromAppleMessage, send, toCachedPoll, toInboundMessages, toPollOptionMessage };
 """
 
 
@@ -288,16 +384,27 @@ def test_spectrum_patch_rewrites_the_imessage_mapper(tmp_path: Path) -> None:
             "--input-type=module",
             "-e",
             (
-                f"import {{toCachedPoll}} from {json.dumps(chunk.as_uri())};"
+                f"import {{cachePollEvent,messages$1,send,toCachedPoll,toPollOptionMessage}} from {json.dumps(chunk.as_uri())};"
                 "const options=["
                 "{text:'Route',optionIdentifier:'choice-1'},"
                 "{text:'Calendar',optionIdentifier:'choice-2'}];"
                 "const empty=toCachedPoll({title:'',options});"
                 "const missing=toCachedPoll({options});"
                 "const named=toCachedPoll({title:'Question?',options});"
+                "const remote={polls:{"
+                "create:async()=>({pollMessageGuid:'poll-1',title:'',options}),"
+                "get:async()=>({pollMessageGuid:'poll-1',title:'',options:options.map(o=>({text:o.text,optionIdentifier:''}))})}};"
+                "await send(remote,'space-1',{type:'poll',title:'Question?',options:named.poll.options});"
+                "const streams=messages$1([{client:remote,phone:'line-1'}],{});"
+                "const cache=streams.builds[0]().pollCache;"
+                "cachePollEvent(cache,{pollMessageGuid:'poll-1',delta:{type:'created',title:'',"
+                "options:options.map(o=>({text:o.text,optionIdentifier:''}))}});"
+                "const [vote]=await toPollOptionMessage(remote,cache,{pollMessageGuid:'poll-1',"
+                "delta:{type:'voted',optionIdentifier:'choice-1'}});"
                 "console.log(JSON.stringify({emptyTitle:empty.poll.title,"
                 "missingTitle:missing.poll.title,namedTitle:named.poll.title,"
-                "choice:empty.optionsByIdentifier.get('choice-1').title}));"
+                "choice:empty.optionsByIdentifier.get('choice-1').title,"
+                "voteTitle:vote.content.option.title,votePollTitle:vote.content.poll.title}));"
             ),
         ],
         text=True,
@@ -310,6 +417,8 @@ def test_spectrum_patch_rewrites_the_imessage_mapper(tmp_path: Path) -> None:
         "missingTitle": "Poll",
         "namedTitle": "Question?",
         "choice": "Route",
+        "voteTitle": "Route",
+        "votePollTitle": "Question?",
     }
 
     # Re-running is a no-op (idempotent self-heal on every sidecar start).
@@ -324,25 +433,17 @@ def test_spectrum_patch_rewrites_the_imessage_mapper(tmp_path: Path) -> None:
     assert chunk.read_text(encoding="utf-8") == patched
 
 
-def test_spectrum_patch_rejects_unknown_poll_mapper_in_later_chunk(
+def test_spectrum_patch_rejects_unknown_poll_mapper_without_partial_writes(
     tmp_path: Path,
 ) -> None:
-    """An unchanged mixed mapper must not hide an unpatchable poll mapper."""
+    """A valid earlier chunk must not hide or be written before an unknown poll shape."""
     dist = tmp_path / "node_modules" / "@spectrum-ts" / "imessage" / "dist"
     dist.mkdir(parents=True)
-    (dist / "a-messages.js").write_text(
-        "\n".join(
-            (
-                "const buildUnwrappedContentMessage = async () => {};",
-                "const rebuildFromAppleMessage = async () => {};",
-                "const toInboundMessages = async () => {};",
-                "const parts = toOrderedParts(message.content.text, attachments);",
-            )
-        ),
-        encoding="utf-8",
-    )
-    poll = dist / "b-polls.js"
-    unknown_shape = _tabify(
+    valid = dist / "a-valid.js"
+    valid_source = _tabify(_SPECTRUM_IMESSAGE_FIXTURE)
+    valid.write_text(valid_source, encoding="utf-8")
+    poll = dist / "b-unknown-poll.js"
+    unknown_source = _tabify(
         """
 const toCachedPoll = (input) => {
   const poll = asPoll({
@@ -353,7 +454,7 @@ const toCachedPoll = (input) => {
 };
 """
     )
-    poll.write_text(unknown_shape, encoding="utf-8")
+    poll.write_text(unknown_source, encoding="utf-8")
 
     result = subprocess.run(
         ["node", str(_PATCHER), str(tmp_path)],
@@ -365,5 +466,5 @@ const toCachedPoll = (input) => {
 
     assert result.returncode == 1
     assert "expected exactly one empty inbound poll title match, found 0" in result.stderr
-    assert poll.read_text(encoding="utf-8") == unknown_shape
-
+    assert valid.read_text(encoding="utf-8") == valid_source
+    assert poll.read_text(encoding="utf-8") == unknown_source

--- a/tests/plugins/platforms/photon/test_spectrum_patch.py
+++ b/tests/plugins/platforms/photon/test_spectrum_patch.py
@@ -324,3 +324,46 @@ def test_spectrum_patch_rewrites_the_imessage_mapper(tmp_path: Path) -> None:
     assert chunk.read_text(encoding="utf-8") == patched
 
 
+def test_spectrum_patch_rejects_unknown_poll_mapper_in_later_chunk(
+    tmp_path: Path,
+) -> None:
+    """An unchanged mixed mapper must not hide an unpatchable poll mapper."""
+    dist = tmp_path / "node_modules" / "@spectrum-ts" / "imessage" / "dist"
+    dist.mkdir(parents=True)
+    (dist / "a-messages.js").write_text(
+        "\n".join(
+            (
+                "const buildUnwrappedContentMessage = async () => {};",
+                "const rebuildFromAppleMessage = async () => {};",
+                "const toInboundMessages = async () => {};",
+                "const parts = toOrderedParts(message.content.text, attachments);",
+            )
+        ),
+        encoding="utf-8",
+    )
+    poll = dist / "b-polls.js"
+    unknown_shape = _tabify(
+        """
+const toCachedPoll = (input) => {
+  const poll = asPoll({
+    title: normalizeTitle(input.title),
+    options: input.options.map((optionInfo) => ({ title: optionInfo.text }))
+  });
+  return { poll };
+};
+"""
+    )
+    poll.write_text(unknown_shape, encoding="utf-8")
+
+    result = subprocess.run(
+        ["node", str(_PATCHER), str(tmp_path)],
+        cwd=Path.cwd(),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "expected exactly one empty inbound poll title match, found 0" in result.stderr
+    assert poll.read_text(encoding="utf-8") == unknown_shape
+

--- a/tests/plugins/platforms/photon/test_spectrum_patch.py
+++ b/tests/plugins/platforms/photon/test_spectrum_patch.py
@@ -146,9 +146,25 @@ def _tabify(src: str) -> str:
 # `space.getMessage`, `toInboundMessages` for the live stream), plus stubs of
 # the helpers they close over. Mirrors the published shape — tab-indented (via
 # `_tabify`), `const ... = async` declarations, single-line builder calls — so
-# the anchors exercise the real code path, and exporting the two functions lets
+# the anchors exercise the real code path, and exporting the functions lets
 # the test assert runtime behavior rather than only string shape.
 _SPECTRUM_IMESSAGE_FIXTURE = """
+const asPoll = (input) => {
+  if (!input.title) throw new Error("poll title must not be empty");
+  return { type: "poll", ...input };
+};
+const toCachedPoll = (input) => {
+  const poll = asPoll({
+    title: input.title,
+    options: input.options.map((optionInfo) => ({ title: optionInfo.text }))
+  });
+  const optionsByIdentifier = new Map();
+  for (const [index, optionInfo] of input.options.entries()) {
+    const option = poll.options[index];
+    if (option && optionInfo.optionIdentifier) optionsByIdentifier.set(optionInfo.optionIdentifier, option);
+  }
+  return { poll, optionsByIdentifier };
+};
 const formatChildId = (partIndex, parentGuid) => `p:${partIndex}/${parentGuid}`;
 const asText = (text) => ({ type: "text", text });
 const asCustom = (message) => ({ type: "custom" });
@@ -225,7 +241,7 @@ const toInboundMessages = async (client, cache, event, phone) => {
   cacheMessage(cache, msg);
   return [msg];
 };
-export { rebuildFromAppleMessage, toInboundMessages };
+export { rebuildFromAppleMessage, toCachedPoll, toInboundMessages };
 """
 
 
@@ -262,6 +278,39 @@ def test_spectrum_patch_rewrites_the_imessage_mapper(tmp_path: Path) -> None:
     # The text is captured in both mappers before the attachment branches run.
     assert "const text2 = message.content.text;" in patched
     assert "const text2 = event.message.content.text;" in patched
+
+    # Photon can return an empty title for a poll that was sent with one. The
+    # patched mapper must still reconstruct its option-id map so a vote reaches
+    # the clarify response path.
+    probe = subprocess.run(
+        [
+            "node",
+            "--input-type=module",
+            "-e",
+            (
+                f"import {{toCachedPoll}} from {json.dumps(chunk.as_uri())};"
+                "const options=["
+                "{text:'Route',optionIdentifier:'choice-1'},"
+                "{text:'Calendar',optionIdentifier:'choice-2'}];"
+                "const empty=toCachedPoll({title:'',options});"
+                "const missing=toCachedPoll({options});"
+                "const named=toCachedPoll({title:'Question?',options});"
+                "console.log(JSON.stringify({emptyTitle:empty.poll.title,"
+                "missingTitle:missing.poll.title,namedTitle:named.poll.title,"
+                "choice:empty.optionsByIdentifier.get('choice-1').title}));"
+            ),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert probe.returncode == 0, probe.stderr
+    assert json.loads(probe.stdout) == {
+        "emptyTitle": "Poll",
+        "missingTitle": "Poll",
+        "namedTitle": "Question?",
+        "choice": "Route",
+    }
 
     # Re-running is a no-op (idempotent self-heal on every sidecar start).
     again = subprocess.run(


### PR DESCRIPTION
## Summary

- accept empty or missing poll titles in Spectrum's inbound iMessage cache mapper
- seed the per-client poll cache from `polls.create()`, where Photon still returns option identifiers
- keep richer outbound metadata when later created/refresh payloads omit those identifiers
- share the per-client cache between sends and that line's inbound stream
- scan generated SDK candidates deterministically and fail without partial writes when Spectrum changes shape
- cover the patched send/cache/vote path and keep later text messages distinct from poll selections

Photon can return empty poll titles and omit option identifiers from inbound or refreshed metadata. The title fallback alone avoids the schema error, but without an identifier map Spectrum still cannot turn a vote ID into the selected option text. Caching the complete `polls.create()` response preserves the mapping until the vote arrives.

A live Photon/iMessage test sent a native poll and received the selected option as `poll_option` with both the option title and original poll title intact. The full Photon suite passes at this head.

Fixes #76175.
Closes #80824.
Addresses #100068.

This supersedes #76176, which diagnosed and fixed the original bug against the earlier Spectrum 8 integration. Thanks to @FlorianVal for the original diagnosis, live reproduction, and implementation that established the direction for this fix.

## Verification

- `npm ci` with Spectrum 12.7.0 applied the compatibility patch successfully
- `scripts/run_tests.sh tests/plugins/platforms/photon/` passed all 135 tests at the current PR head
- `git diff --check`


