### PR TITLE
feat(title): enforce configurable max_words for derived and LLM titles

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -115,6 +115,32 @@ def _auto_title_enabled() -> bool:
         return True
 
 
+def _title_max_words() -> Optional[int]:
+    """Configured ``auxiliary.title_generation.max_words``, or None when unset.
+
+    A positive integer (>= 1) is enforced on both title paths; anything else (absent, <=0,
+    non-numeric) means "not set" and keeps the legacy behavior.
+    """
+    try:
+        raw = _title_config().get("max_words")
+        if raw is None or raw == "":
+            return None
+        if isinstance(raw, bool) or not isinstance(raw, (int, str)):
+            return None
+        value = int(raw)
+        return value if value >= 1 else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _truncate_to_word_limit(text: str, max_words: int) -> str:
+    """Truncate ``text`` at a word boundary to at most ``max_words`` words, or return it unchanged."""
+    words = text.split()
+    if len(words) <= max_words:
+        return text
+    return " ".join(words[:max_words]).rstrip(" ,.;:—-")
+
+
 def strip_control_wrappers(text: str) -> str:
     """Remove leading control wrappers (nested too) so a slash-command turn reduces to the prose the user typed."""
     current = (text or "").strip()
@@ -161,6 +187,9 @@ def is_titleable_user_message(user_message: str) -> bool:
 def derive_title(user_message: str) -> Optional[str]:
     """Instant title: first meaningful line trimmed to a word boundary. No model, never fails."""
     line = " ".join(_first_line(_summarize_user_message(user_message)).split())
+    max_words = _title_max_words()
+    if max_words is not None:
+        line = _truncate_to_word_limit(line, max_words)
     if len(line) > MAX_DERIVED_TITLE_CHARS:
         cut = line[:MAX_DERIVED_TITLE_CHARS]
         space = cut.rfind(" ")
@@ -269,6 +298,11 @@ def generate_title(
             extra_body={"response_format": _TITLE_RESPONSE_FORMAT},
         )
         title = _clean_title(_extract_title_text(response.choices[0].message.content or ""))
+        # Enforce the configured word cap verbatim (not a prompt ask): truncate at a word boundary
+        # so the persisted title can never exceed max_words, whatever the model returned.
+        max_words = _title_max_words()
+        if title is not None and max_words is not None and len(title.split()) > max_words:
+            title = _truncate_to_word_limit(title, max_words)
         # Answer-shaped output guard: titling is a 3-7 word task, so a title with many words is a model that
         # ignored the task and answered the user's message instead ("I don't have context on X — that's not
         # something I recognize..."). Truncating would store half an assistant blob as the session title,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -723,6 +723,12 @@ DEFAULT_CONFIG = {
             "extra_body": {},
             "reasoning_effort": "",
             "language": "",
+            # Optional hard cap on title length in words for BOTH the instant derived title and the
+            # LLM title. Positive integer (>= 1), enforced at word boundaries once the LLM returns.
+            # Unset (0 or absent) keeps legacy behavior: derived titles cap at MAX_DERIVED_TITLE_CHARS,
+            # LLM titles keep the answer-shaped-output guard only. Invalid values (<=0, non-numeric)
+            # fall back to unset.
+            "max_words": 0,
         },
         "memory_query_rewrite": _aux(8, reasoning_effort=False),
         "tts_audio_tags": _aux(30),

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -8,6 +8,7 @@ from agent.title_generator import (
     generate_title,
     auto_title_session,
     maybe_auto_title,
+    derive_title,
     _title_language,
 )
 from hermes_state import SessionDB
@@ -598,3 +599,101 @@ class TestModelSwitchMarkerNotTitleable:
         assert apply_instant_title(db, "sess-1", "南京市秦淮区 小时级天气预报") == (
             "南京市秦淮区 小时级天气预报"
         )
+
+
+class TestMaxWordsConfig:
+    """auxiliary.title_generation.max_words parsing: positive int → enforced, else legacy."""
+
+    def _cfg(self, max_words):
+        return {"auxiliary": {"title_generation": {"max_words": max_words}}}
+
+    def test_absent_means_unset(self):
+        from agent.title_generator import _title_max_words
+        with patch("hermes_cli.config.load_config_readonly", return_value={}):
+            assert _title_max_words() is None
+
+    def test_positive_integer_is_enforced(self):
+        from agent.title_generator import _title_max_words
+        with patch("hermes_cli.config.load_config_readonly", return_value=self._cfg(5)):
+            assert _title_max_words() == 5
+
+    def test_disabled_default_zero_is_unset(self):
+        from agent.title_generator import _title_max_words
+        with patch("hermes_cli.config.load_config_readonly", return_value=self._cfg(0)):
+            assert _title_max_words() is None
+
+    @pytest.mark.parametrize("bad", [-3, -1, "four", 2.5, True, [3]])
+    def test_implausible_values_fall_back_to_unset(self, bad):
+        from agent.title_generator import _title_max_words
+        with patch("hermes_cli.config.load_config_readonly", return_value=self._cfg(bad)):
+            assert _title_max_words() is None
+
+
+class TestDerivedTitleMaxWords:
+    """The derived title is truncated at a word boundary when max_words is set."""
+
+    def test_truncates_at_word_boundary(self):
+        with patch("hermes_cli.config.load_config_readonly",
+                   return_value={"auxiliary": {"title_generation": {"max_words": 3}}}):
+            assert derive_title("Debugging Python import errors in the test suite") == (
+                "Debugging Python import"
+            )
+
+    def test_short_title_unchanged(self):
+        with patch("hermes_cli.config.load_config_readonly",
+                   return_value={"auxiliary": {"title_generation": {"max_words": 6}}}):
+            assert derive_title("Fix the flaky auth test") == "Fix the flaky auth test"
+
+    def test_unset_keeps_legacy_behavior(self):
+        with patch("hermes_cli.config.load_config_readonly", return_value={}):
+            assert derive_title("Debugging Python import errors in the test suite") == (
+                "Debugging Python import errors in the test suite"
+            )
+
+
+class TestLlmTitleMaxWords:
+    """The LLM title is truncated to the configured cap, verbatim (not a prompt ask)."""
+
+    def test_truncates_oversized_model_title(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = (
+            "one two three four five six seven eight nine ten"
+        )
+        with patch("hermes_cli.config.load_config_readonly",
+                   return_value={"auxiliary": {"title_generation": {"max_words": 4}}}):
+            with patch("agent.title_generator.call_llm", return_value=mock_response):
+                assert generate_title("question", "answer") == "one two three four"
+
+    def test_guaranteed_enforcement_under_answer_guard(self):
+        """A wordy answer is truncated to max_words and then passes the (larger) answer guard."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = (
+            "one two three four five six seven eight nine ten eleven twelve thirteen fourteen"
+        )
+        with patch("hermes_cli.config.load_config_readonly",
+                   return_value={"auxiliary": {"title_generation": {"max_words": 6}}}):
+            with patch("agent.title_generator.call_llm", return_value=mock_response):
+                title = generate_title("question", "answer")
+                assert title == "one two three four five six"
+                assert len(title.split()) <= 6
+
+    def test_unset_keeps_legacy_answer_guard(self):
+        """Without max_words an oversized answer is still rejected, not truncated."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = (
+            "one two three four five six seven eight nine ten eleven twelve thirteen fourteen"
+        )
+        with patch("hermes_cli.config.load_config_readonly", return_value={}):
+            with patch("agent.title_generator.call_llm", return_value=mock_response):
+                assert generate_title("question", "answer") is None
+
+    def test_unset_keeps_normal_title(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Investigate the title resolver bug"
+        with patch("hermes_cli.config.load_config_readonly", return_value={}):
+            with patch("agent.title_generator.call_llm", return_value=mock_response):
+                assert generate_title("question", "answer") == "Investigate the title resolver bug"

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1457,6 +1457,7 @@ auxiliary:
     api_key: ""
     timeout: 30
     language: ""
+    # max_words: 8                # Optional hard word cap for derived AND LLM titles; unset/0 = legacy
 
   # Skills hub — skill matching and search
   skills_hub:


### PR DESCRIPTION
# feat(title): enforce configurable `max_words` for derived and LLM titles

## Summary

Adds an optional `auxiliary.title_generation.max_words` setting and enforces it **deterministically on both title paths**:

- **Instant derived title:** truncated at a word boundary, on top of the existing `MAX_DERIVED_TITLE_CHARS` (48) character cap, which is unchanged.
- **LLM-generated title:** truncated to the word limit *after* the model returns — enforced in code, not as a prompt suggestion — so a persisted title can never exceed `max_words`.
- **Legacy behavior preserved:** when `max_words` is unset (`0`, absent, or invalid), behavior is byte-for-byte unchanged.

This is the focused "title-only" first step agreed with @oscarhenrycollins on #66353 — the larger PR stays open, and the Telegram semantic-icon/alias work can build on this once it lands.

## Changes

- `agent/title_generator.py` — `_title_max_words()` (config parsing: positive int ≥ 1, anything else means unset) and `_truncate_to_word_limit()` (uniform `split()`-based word counting, consistent with the existing answer-shaped-output guard); both title paths now enforce the limit.
- `hermes_cli/config_defaults.py` — new `max_words: 0` entry in `auxiliary.title_generation` with an explanatory comment.
- `tests/agent/test_title_generator.py` — three new test classes covering config parsing, the derived path, and the LLM path (99 lines).
- `website/docs/user-guide/configuration.md` — documented `max_words` in the existing config reference.

## Commit

`eb795438f4a7fd972e1176c5a4817f852accf028` — `feat(title): enforce configurable max_words for derived and LLM titles` (based on current upstream `main` at `31d0a2428e…`)

## Compatibility with the current title lifecycle

- The existing pipeline is untouched: instant derived title → optional LLM upgrade → provenance ordering (`derived < llm < user`), with user-set titles never overwritten. `max_words` only adds a hard upper bound inside both generation paths.
- Without `max_words` set, output is identical to `31d0a2428e…` — no behavior change for existing installs.
- Existing lifecycle and provenance tests in `tests/agent/test_title_generator.py` pass unchanged — no lifecycle regression.

## Tests

```
pytest tests/agent/test_title_generator.py                   → 52 passed
pytest tests/hermes_cli/test_aux_config.py                   → 7 passed
pytest tests/agent/test_auxiliary_client.py                  → 204 passed
pytest tests/agent/test_structured_output_rejection_retry.py → 24 passed
pytest tests/agent/test_auxiliary_main_first.py              → 17 passed
```

Note: running several files in a single process surfaces two unrelated failures in `test_auxiliary_main_first.py` (cross-file pollution); the existing per-file isolation of the test setup avoids this — all green in isolation. Independently re-verified.

## Out of scope

No changes to Telegram topic/icon logic, alias/canonical-name handling, or `enabled`/provider behavior — that stays in #66353.

---

*Will link this PR back in #66353 once opened (as requested: "open the smaller title-only PR referencing #66353 and link it here").*