### PR TITLE
fix(slack): notify requester for channel clarify prompts

### DIFF
--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1263,10 +1263,20 @@ class TurnRunner:
                 flush(timeout=3.0)
         except Exception:
             logger.debug("Stream-consumer flush before clarify prompt failed", exc_info=True)
+        clarify_metadata = dict(ctx._status_thread_metadata or {})
+        if ctx.source.platform == Platform.SLACK:
+            # Slack thread replies do not reliably trigger a push notification for the
+            # requester. Carry the turn owner so Slack's clarify card can explicitly
+            # mention them without guessing from thread history.
+            if ctx.source.user_id:
+                clarify_metadata.setdefault("recipient_user_id", str(ctx.source.user_id))
+            if ctx.source.scope_id:
+                clarify_metadata.setdefault("recipient_team_id", str(ctx.source.scope_id))
+                clarify_metadata.setdefault("slack_team_id", str(ctx.source.scope_id))
         fut = self._schedule(
             ctx._status_adapter.send_clarify(
                 chat_id=ctx._status_chat_id, question=question, choices=choices, clarify_id=clarify_id,
-                session_key=session_key, metadata=ctx._status_thread_metadata,
+                session_key=session_key, metadata=clarify_metadata,
             ),
             "Clarify send failed to schedule",
         )

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -5045,16 +5045,26 @@ class SlackAdapter(BasePlatformAdapter):
         """Clarify prompt as Block Kit buttons: one ``hermes_clarify_choice_<idx>`` per option
         (value ``clarify_id|idx``) plus "✏️ Other…" (``hermes_clarify_other``), which flips the
         entry into text-capture mode for the gateway's text-intercept. No choices → base impl."""
+        recipient_user_id = str((metadata or {}).get("recipient_user_id") or "").strip()
+        mention = (
+            f"<@{recipient_user_id}> "
+            if not str(chat_id).startswith("D")
+            and re.fullmatch(r"[UW][A-Z0-9]+", recipient_user_id)
+            else ""
+        )
         if not choices:
             return await super().send_clarify(
-                chat_id=chat_id, question=question, choices=choices, clarify_id=clarify_id,
+                chat_id=chat_id, question=f"{mention}{question}", choices=choices, clarify_id=clarify_id,
                 session_key=session_key, metadata=metadata)
 
         def _build() -> Tuple[str, list]:
             # Escape mrkdwn control chars so the question renders literally;
             # budget against the 3000-char section cap.
             q = (question or "").replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-            body = f"❓ {q}"
+            # The explicit requester mention is part of both the Block Kit body and
+            # Slack's notification/accessibility fallback. A silent thread card can
+            # otherwise sit unnoticed until Hermes reports that it timed out.
+            body = f"{mention}❓ {q}"
             budget = 3000 - len("...")
             if len(body) > budget:
                 body = body[:budget] + "..."

--- a/tests/gateway/test_slack_clarify_buttons.py
+++ b/tests/gateway/test_slack_clarify_buttons.py
@@ -133,6 +133,44 @@ class TestSlackSendClarify:
                 action_ids = [element["action_id"] for element in block["elements"]]
                 assert len(action_ids) == len(set(action_ids))
 
+    @pytest.mark.asyncio
+    async def test_channel_clarify_mentions_requester_for_push_notification(self):
+        adapter = _make_adapter()
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postMessage = AsyncMock(return_value={"ts": "2.2"})
+
+        await adapter.send_clarify(
+            chat_id="C1",
+            question="Which direction?",
+            choices=["one", "two"],
+            clarify_id="cid-notify",
+            session_key="sk-notify",
+            metadata={"recipient_user_id": "U123", "slack_team_id": "T1"},
+        )
+
+        kwargs = mock_client.chat_postMessage.call_args.kwargs
+        assert kwargs["text"].startswith("<@U123> ❓")
+        assert kwargs["blocks"][0]["text"]["text"].startswith("<@U123> ❓")
+
+    @pytest.mark.asyncio
+    async def test_dm_clarify_does_not_repeat_requester_mention(self):
+        adapter = _make_adapter()
+        adapter._team_clients["T1"].chat_postMessage = AsyncMock(return_value={"ts": "3.3"})
+        adapter._channel_team["D1"] = "T1"
+
+        await adapter.send_clarify(
+            chat_id="D1",
+            question="Which direction?",
+            choices=["one", "two"],
+            clarify_id="cid-dm",
+            session_key="sk-dm",
+            metadata={"recipient_user_id": "U123", "slack_team_id": "T1"},
+        )
+
+        kwargs = adapter._team_clients["T1"].chat_postMessage.call_args.kwargs
+        assert not kwargs["text"].startswith("<@U123>")
+        assert not kwargs["blocks"][0]["text"]["text"].startswith("<@U123>")
+
 
     @pytest.mark.asyncio
     async def test_mrkdwn_escapes_question(self):


### PR DESCRIPTION
## Summary
- carry the requesting Slack user through clarification delivery metadata
- explicitly mention that requester on channel/thread clarification cards so Slack emits a notification
- avoid a redundant mention for direct messages

## Validation
- `scripts/run_tests.sh tests/gateway/test_slack_clarify_buttons.py -q`

Fixes the case where a Block Kit clarification card posted as a channel-thread reply could remain unseen by the user who needs to answer it.