### PR TITLE
fix(agent): shape-tolerant pricing extraction from endpoint /models metadata

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -763,7 +763,7 @@ def _extract_pricing(payload: Dict[str, Any]) -> Dict[str, Any]:
         return _per_token(deepinfra_pricing, deepinfra_fields, lambda v: v / 1_000_000)
     alias_map = {
         "prompt": ("prompt", "input", "input_cost_per_token", "prompt_token_cost"),
-        "completion": ("completion", "output", "output_cost_per_token", "completion_token_cost"),
+        "completion": ("completion", "completions", "output", "output_cost_per_token", "completion_token_cost"),
         "request": ("request", "request_cost"),
         "cache_read": ("cache_read", "cached_prompt", "input_cache_read", "cache_read_cost_per_token"),
         "cache_write": ("cache_write", "cache_creation", "input_cache_write", "cache_write_cost_per_token"),

--- a/agent/pricing_shape.py
+++ b/agent/pricing_shape.py
@@ -13,10 +13,17 @@ endpoint that produced a 1,000,000× inflated input rate ($750,000/M for a
 $0.75/M model), dropped the output rate entirely (``completions`` alias not
 recognized), and displayed a session cost of hundreds of thousands of dollars.
 
-The unit is inferred per value: OpenRouter per-token prices for real models are
-always < $0.01/token (that would be $10,000+/M); any value ≥ 0.01 can only be a
-per-million figure. Nested ``global`` containers are unwrapped, and the
-``completions`` alias joins the completion-key chain.
+Unit inference is CONTAINER-level, not per-value: if any core token-rate field
+(``prompt``/``completion``/``input``/``output``) is >= $0.01/token — a price no
+real model has — the whole container is treated as dollars-per-million. A
+per-value threshold would misclassify sub-cent $/M fields (cache reads, batch
+tiers at $0.005/M) as per-token inside an otherwise per-million container.
+Values below the ceiling in an ambiguous container are already per-token.
+
+Nested containers are unwrapped ONLY for known nest keys (``global``/
+``default``/``usd``) — other nested metadata (architecture, limits) must not
+bleed into pricing. Flat root keys win over unwrapped nested values when both
+define the same key.
 """
 
 from __future__ import annotations
@@ -28,7 +35,7 @@ from typing import Any, Dict, Optional
 logger = logging.getLogger(__name__)
 
 # A genuine per-token price >= $0.01/token means $10,000+/M — no real model.
-# Values at/above this are per-million figures served without a unit suffix.
+# Used to infer the container's unit from its core token-rate fields.
 _PER_TOKEN_CEILING = Decimal("0.01")
 
 _NEST_KEYS = ("global", "default", "usd")
@@ -49,35 +56,44 @@ def _to_decimal(raw: Any) -> Optional[Decimal]:
 
 
 def unwrap_pricing_container(pricing: Any) -> Dict[str, Any]:
-    """Flatten ``{global: {...}}`` / ``{default: {...}}`` / ``{usd: {...}}``
-    nestings some endpoints use into a flat key->value dict."""
+    """Flatten known nest containers (``global``/``default``/``usd``) into a flat
+    key->value dict. ONLY nest keys are flattened — unrelated nested objects
+    (``architecture``, ``limits``, ...) must not bleed their keys into pricing.
+    Flat root keys take precedence over unwrapped nested values."""
     if not isinstance(pricing, dict):
         return {}
     flat: Dict[str, Any] = {}
+    for nest_key in _NEST_KEYS:
+        nested = pricing.get(nest_key)
+        if isinstance(nested, dict):
+            flat.update(nested)
     for key, value in pricing.items():
-        if isinstance(value, dict):
-            flat.update(value)
-        elif key not in _NEST_KEYS:
-            flat[key] = value
+        if key in _NEST_KEYS or isinstance(value, dict):
+            continue
+        flat[key] = value
     return flat
 
 
-def _unit_normalized(value: Optional[Decimal]) -> Optional[Decimal]:
-    """Normalize a raw pricing value to dollars-per-token scale.
+def _is_per_million_container(flat: Dict[str, Any]) -> bool:
+    """True when the container's token-rate fields are per-MILLION figures.
 
-    Values >= _PER_TOKEN_CEILING are per-million figures: divide. Anything below
-    is already per-token. None passes through.
-    """
-    if value is None:
-        return None
-    if value >= _PER_TOKEN_CEILING:
-        return value / Decimal(1_000_000)
-    return value
+    Inference anchor: prompt/completion/input/output AND cache rates — every
+    convention prices the core fields, and cache rates are always CHEAPER than
+    completion (a cache price >= the per-token ceiling can only be $/M). If any
+    anchor is >= the ceiling, the whole container is $/M (mixed-unit containers
+    would otherwise normalize a $0.005/M cache-read as $0.005/token = $5,000/M)."""
+    for keys in (_PROMPT_KEYS, _COMPLETION_KEYS, _CACHE_READ_KEYS, _CACHE_WRITE_KEYS):
+        for key in keys:
+            value = _to_decimal(flat.get(key))
+            if value is not None and value >= _PER_TOKEN_CEILING:
+                return True
+    return False
 
 
 def extract_pricing_fields(pricing: Any) -> Dict[str, Optional[Decimal]]:
-    """Shape-tolerant (key -> $/token) extraction from a pricing container."""
+    """Shape-tolerant (key -> $/million) extraction from a pricing container."""
     flat = unwrap_pricing_container(pricing)
+    per_million_units = _is_per_million_container(flat)
 
     def first_value(*keys: str) -> Optional[Decimal]:
         for key in keys:
@@ -86,14 +102,19 @@ def extract_pricing_fields(pricing: Any) -> Dict[str, Optional[Decimal]]:
                 return value
         return None
 
-    def per_token(*keys: str) -> Optional[Decimal]:
+    def rate(*keys: str) -> Optional[Decimal]:
         value = first_value(*keys)
-        return _unit_normalized(value)
+        if value is None:
+            return None
+        if per_million_units:
+            return value
+        # $/token container: scale to $/M
+        return value * Decimal(1_000_000)
 
     return {
-        "prompt": per_token(*_PROMPT_KEYS),
-        "completion": per_token(*_COMPLETION_KEYS),
-        "cache_read": per_token(*_CACHE_READ_KEYS),
-        "cache_write": per_token(*_CACHE_WRITE_KEYS),
+        "prompt": rate(*_PROMPT_KEYS),
+        "completion": rate(*_COMPLETION_KEYS),
+        "cache_read": rate(*_CACHE_READ_KEYS),
+        "cache_write": rate(*_CACHE_WRITE_KEYS),
         "request": first_value("request"),
     }

--- a/agent/pricing_shape.py
+++ b/agent/pricing_shape.py
@@ -1,0 +1,99 @@
+"""Pricing-entry shape tolerance for endpoint ``/models`` metadata (PR 3).
+
+OpenAI-compatible ``/models`` endpoints do not agree on a pricing convention:
+
+- OpenRouter-style: ``pricing.prompt = "0.00000075"`` — **dollars per token**,
+  keys ``prompt``/``completion``, flat.
+- Per-million style (observed on a hosted LLM gateway): ``pricing.global.prompt
+  = 0.75`` — **dollars per million**, keys ``prompt``/``completions``, nested
+  under ``global`` with a ``regional_increase_percent`` sibling.
+
+The parser assumed the OpenRouter shape unconditionally. On a per-million
+endpoint that produced a 1,000,000× inflated input rate ($750,000/M for a
+$0.75/M model), dropped the output rate entirely (``completions`` alias not
+recognized), and displayed a session cost of hundreds of thousands of dollars.
+
+The unit is inferred per value: OpenRouter per-token prices for real models are
+always < $0.01/token (that would be $10,000+/M); any value ≥ 0.01 can only be a
+per-million figure. Nested ``global`` containers are unwrapped, and the
+``completions`` alias joins the completion-key chain.
+"""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# A genuine per-token price >= $0.01/token means $10,000+/M — no real model.
+# Values at/above this are per-million figures served without a unit suffix.
+_PER_TOKEN_CEILING = Decimal("0.01")
+
+_NEST_KEYS = ("global", "default", "usd")
+
+_PROMPT_KEYS = ("prompt", "input", "input_cost")
+_COMPLETION_KEYS = ("completion", "completions", "output", "output_cost")
+_CACHE_READ_KEYS = ("cache_read", "cached_prompt", "input_cache_read")
+_CACHE_WRITE_KEYS = ("cache_write", "cache_creation", "input_cache_write")
+
+
+def _to_decimal(raw: Any) -> Optional[Decimal]:
+    if raw is None or isinstance(raw, bool):
+        return None
+    try:
+        return Decimal(str(raw))
+    except Exception:  # noqa: BLE001 — malformed metadata must not break pricing
+        return None
+
+
+def unwrap_pricing_container(pricing: Any) -> Dict[str, Any]:
+    """Flatten ``{global: {...}}`` / ``{default: {...}}`` / ``{usd: {...}}``
+    nestings some endpoints use into a flat key->value dict."""
+    if not isinstance(pricing, dict):
+        return {}
+    flat: Dict[str, Any] = {}
+    for key, value in pricing.items():
+        if isinstance(value, dict):
+            flat.update(value)
+        elif key not in _NEST_KEYS:
+            flat[key] = value
+    return flat
+
+
+def _unit_normalized(value: Optional[Decimal]) -> Optional[Decimal]:
+    """Normalize a raw pricing value to dollars-per-token scale.
+
+    Values >= _PER_TOKEN_CEILING are per-million figures: divide. Anything below
+    is already per-token. None passes through.
+    """
+    if value is None:
+        return None
+    if value >= _PER_TOKEN_CEILING:
+        return value / Decimal(1_000_000)
+    return value
+
+
+def extract_pricing_fields(pricing: Any) -> Dict[str, Optional[Decimal]]:
+    """Shape-tolerant (key -> $/token) extraction from a pricing container."""
+    flat = unwrap_pricing_container(pricing)
+
+    def first_value(*keys: str) -> Optional[Decimal]:
+        for key in keys:
+            value = _to_decimal(flat.get(key))
+            if value is not None:
+                return value
+        return None
+
+    def per_token(*keys: str) -> Optional[Decimal]:
+        value = first_value(*keys)
+        return _unit_normalized(value)
+
+    return {
+        "prompt": per_token(*_PROMPT_KEYS),
+        "completion": per_token(*_COMPLETION_KEYS),
+        "cache_read": per_token(*_CACHE_READ_KEYS),
+        "cache_write": per_token(*_CACHE_WRITE_KEYS),
+        "request": first_value("request"),
+    }

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -420,8 +420,7 @@ def _pricing_entry_from_metadata(
 
     # Shape tolerance: endpoints disagree on units ($/token vs $/M), key spellings
     # (completion/completions), and nesting ({global: {...}}). extract_pricing_fields
-    # infers the unit per value and returns dollars-per-token; multiply by 1M here
-    # for the PricingEntry's per-million fields.
+    # infers the container unit and returns dollars-per-MILLION directly.
     from agent.pricing_shape import extract_pricing_fields
 
     fields = extract_pricing_fields(pricing)
@@ -429,15 +428,12 @@ def _pricing_entry_from_metadata(
     completion = fields["completion"]
     request = fields["request"]
 
-    def per_million(value: Optional[Decimal]) -> Optional[Decimal]:
-        return None if value is None else value * _ONE_MILLION
-
     if prompt is None and completion is None and request is None:
         return None
     return PricingEntry(
-        input_cost_per_million=per_million(prompt), output_cost_per_million=per_million(completion),
-        cache_read_cost_per_million=per_million(fields["cache_read"]),
-        cache_write_cost_per_million=per_million(fields["cache_write"]),
+        input_cost_per_million=prompt, output_cost_per_million=completion,
+        cache_read_cost_per_million=fields["cache_read"],
+        cache_write_cost_per_million=fields["cache_write"],
         request_cost=request, source="provider_models_api", source_url=source_url,
         pricing_version=pricing_version, fetched_at=_UTC_NOW(),
     )

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -418,22 +418,26 @@ def _pricing_entry_from_metadata(
         return None
     pricing = metadata[model_id].get("pricing") or {}
 
-    def per_million(key: str, *aliases: str) -> Optional[Decimal]:
-        raw = pricing.get(key)
-        for alias in aliases:  # alias chain is truthiness-based (``a or b or c``)
-            raw = raw or pricing.get(alias)
-        value = _to_decimal(raw)
+    # Shape tolerance: endpoints disagree on units ($/token vs $/M), key spellings
+    # (completion/completions), and nesting ({global: {...}}). extract_pricing_fields
+    # infers the unit per value and returns dollars-per-token; multiply by 1M here
+    # for the PricingEntry's per-million fields.
+    from agent.pricing_shape import extract_pricing_fields
+
+    fields = extract_pricing_fields(pricing)
+    prompt = fields["prompt"]
+    completion = fields["completion"]
+    request = fields["request"]
+
+    def per_million(value: Optional[Decimal]) -> Optional[Decimal]:
         return None if value is None else value * _ONE_MILLION
 
-    prompt = per_million("prompt")
-    completion = per_million("completion")
-    request = _to_decimal(pricing.get("request"))
     if prompt is None and completion is None and request is None:
         return None
     return PricingEntry(
-        input_cost_per_million=prompt, output_cost_per_million=completion,
-        cache_read_cost_per_million=per_million("cache_read", "cached_prompt", "input_cache_read"),
-        cache_write_cost_per_million=per_million("cache_write", "cache_creation", "input_cache_write"),
+        input_cost_per_million=per_million(prompt), output_cost_per_million=per_million(completion),
+        cache_read_cost_per_million=per_million(fields["cache_read"]),
+        cache_write_cost_per_million=per_million(fields["cache_write"]),
         request_cost=request, source="provider_models_api", source_url=source_url,
         pricing_version=pricing_version, fetched_at=_UTC_NOW(),
     )

--- a/tests/agent/test_pricing_shape.py
+++ b/tests/agent/test_pricing_shape.py
@@ -148,3 +148,34 @@ class TestIntegrationPricingEntry:
         assert entry is not None
         assert entry.input_cost_per_million == Decimal("0.75")
         assert entry.output_cost_per_million == Decimal("3.75")
+
+    def test_per_million_shape_survives_the_endpoint_probe_path(self):
+        """The nested shape must still price BOTH rates after the `/models` probe
+        has filtered the pricing dict.
+
+        `fetch_endpoint_model_metadata` builds its cache through
+        `_parse_models_payload` -> `_extract_pricing`, which keeps only the keys
+        whose spelling is in its alias map. A key it drops is unpriced no matter
+        what this module's alias chains support, so the contract is asserted
+        against that real path rather than a hand-built metadata dict.
+        """
+        from agent.model_metadata import _parse_models_payload
+        from agent.usage_pricing import _pricing_entry_from_metadata
+
+        metadata = _parse_models_payload({
+            "data": [{
+                "id": "model-x",
+                "pricing": {
+                    "global": {"prompt": 0.75, "completions": 3.75, "input_cache_read": 0.075},
+                    "regional_increase_percent": 0.1,
+                },
+            }],
+        })
+        entry = _pricing_entry_from_metadata(
+            metadata, "model-x",
+            source_url="https://g.example/v1/models", pricing_version="test",
+        )
+        assert entry is not None
+        assert entry.input_cost_per_million == Decimal("0.75")
+        assert entry.output_cost_per_million == Decimal("3.75")
+        assert entry.cache_read_cost_per_million == Decimal("0.075")

--- a/tests/agent/test_pricing_shape.py
+++ b/tests/agent/test_pricing_shape.py
@@ -1,0 +1,69 @@
+"""Shape-tolerant pricing extraction from endpoint ``/models`` metadata.
+
+Contract under test (PR 3): both observed pricing conventions normalize to
+dollars-per-token, with the completion alias and ``global`` nesting handled.
+
+- OpenRouter-style ($/token): ``{"prompt": "0.00000075", "completion": "0.00000375"}``
+- Per-million style ($/M): ``{"global": {"prompt": 0.75, "completions": 3.75,
+  "input_cache_read": 0.075}, "regional_increase_percent": 0.1}``
+"""
+
+from decimal import Decimal
+
+from agent.pricing_shape import extract_pricing_fields, unwrap_pricing_container
+
+
+class TestOpenRouterShape:
+    def test_dollar_per_token_strings_unchanged(self):
+        fields = extract_pricing_fields({"prompt": "0.00000075", "completion": "0.00000375"})
+        assert fields["prompt"] == Decimal("0.00000075")
+        assert fields["completion"] == Decimal("0.00000375")
+
+    def test_expensive_model_token_price_below_ceiling_stays(self):
+        """$8/M = 0.000008/token < 0.01 ceiling: still per-token."""
+        fields = extract_pricing_fields({"prompt": "0.00001", "completion": "0.0003"})
+        assert fields["prompt"] == Decimal("0.00001")
+        assert fields["completion"] == Decimal("0.0003")
+
+
+class TestPerMillionShape:
+    def test_assemblyai_style_global_nesting(self):
+        """The exact observed shape: $/M values, completions alias, global nest."""
+        fields = extract_pricing_fields({
+            "global": {"completions": 3.75, "prompt": 0.75, "input_cache_read": 0.075},
+            "regional_increase_percent": 0.1,
+        })
+        assert fields["prompt"] == Decimal("0.75") / Decimal(1_000_000)
+        assert fields["completion"] == Decimal("3.75") / Decimal(1_000_000)
+        assert fields["cache_read"] == Decimal("0.075") / Decimal(1_000_000)
+
+    def test_expensive_model_per_million(self):
+        """$300/M output (frontier tier): >> 0.01, must normalize to 0.0003/token."""
+        fields = extract_pricing_fields({"prompt": 30.0, "completions": 300.0})
+        assert fields["prompt"] == Decimal("0.00003")
+        assert fields["completion"] == Decimal("0.0003")
+
+    def test_cache_write_alias(self):
+        fields = extract_pricing_fields({"global": {"input_cache_write": 0.041667}})
+        assert fields["cache_write"] == Decimal("0.041667") / Decimal(1_000_000)
+
+
+class TestDegenerateInput:
+    def test_missing_pricing_returns_all_none(self):
+        fields = extract_pricing_fields({})
+        assert all(v is None for v in fields.values())
+
+    def test_non_dict_container(self):
+        assert extract_pricing_fields(None) == {
+            "prompt": None, "completion": None, "cache_read": None,
+            "cache_write": None, "request": None,
+        }
+
+    def test_malformed_values_skipped(self):
+        fields = extract_pricing_fields({"prompt": "not-a-number", "completion": True})
+        assert fields["prompt"] is None
+        assert fields["completion"] is None  # bool rejected
+
+    def test_flat_container_unwrapped_passthrough(self):
+        flat = {"prompt": "0.00000075"}
+        assert unwrap_pricing_container(flat) == flat

--- a/tests/agent/test_pricing_shape.py
+++ b/tests/agent/test_pricing_shape.py
@@ -1,51 +1,99 @@
 """Shape-tolerant pricing extraction from endpoint ``/models`` metadata.
 
 Contract under test (PR 3): both observed pricing conventions normalize to
-dollars-per-token, with the completion alias and ``global`` nesting handled.
+dollars-per-MILLION, with the completion alias and ``global`` nesting handled,
+container-level unit inference, and the round-1 review fixes:
 
 - OpenRouter-style ($/token): ``{"prompt": "0.00000075", "completion": "0.00000375"}``
 - Per-million style ($/M): ``{"global": {"prompt": 0.75, "completions": 3.75,
   "input_cache_read": 0.075}, "regional_increase_percent": 0.1}``
+- Nested-dict guard: only known nest keys flatten (Flash round-1 BLOCKER 1).
+- Root-over-nested precedence (both reviewers SHOULD-FIX 2).
+- Container-level unit inference: a sub-cent $/M cache rate inside a per-million
+  container must not be misread as $/token (Flash round-1 SHOULD-FIX 3).
 """
 
 from decimal import Decimal
 
-from agent.pricing_shape import extract_pricing_fields, unwrap_pricing_container
+from agent.pricing_shape import (
+    extract_pricing_fields,
+    unwrap_pricing_container,
+)
 
 
 class TestOpenRouterShape:
-    def test_dollar_per_token_strings_unchanged(self):
+    def test_dollar_per_token_strings_scaled_to_per_million(self):
         fields = extract_pricing_fields({"prompt": "0.00000075", "completion": "0.00000375"})
-        assert fields["prompt"] == Decimal("0.00000075")
-        assert fields["completion"] == Decimal("0.00000375")
+        assert fields["prompt"] == Decimal("0.75")
+        assert fields["completion"] == Decimal("3.75")
 
-    def test_expensive_model_token_price_below_ceiling_stays(self):
+    def test_expensive_model_token_price_below_ceiling(self):
         """$8/M = 0.000008/token < 0.01 ceiling: still per-token."""
         fields = extract_pricing_fields({"prompt": "0.00001", "completion": "0.0003"})
-        assert fields["prompt"] == Decimal("0.00001")
-        assert fields["completion"] == Decimal("0.0003")
+        assert fields["prompt"] == Decimal("10.00")
+        assert fields["completion"] == Decimal("300.0")
 
 
 class TestPerMillionShape:
-    def test_assemblyai_style_global_nesting(self):
+    def test_global_nesting_with_completions_alias(self):
         """The exact observed shape: $/M values, completions alias, global nest."""
         fields = extract_pricing_fields({
             "global": {"completions": 3.75, "prompt": 0.75, "input_cache_read": 0.075},
             "regional_increase_percent": 0.1,
         })
-        assert fields["prompt"] == Decimal("0.75") / Decimal(1_000_000)
-        assert fields["completion"] == Decimal("3.75") / Decimal(1_000_000)
-        assert fields["cache_read"] == Decimal("0.075") / Decimal(1_000_000)
+        assert fields["prompt"] == Decimal("0.75")
+        assert fields["completion"] == Decimal("3.75")
+        assert fields["cache_read"] == Decimal("0.075")
+
+    def test_sub_cent_cache_rate_inside_per_million_container(self):
+        """Flash round-1 SHOULD-FIX 3: a $0.005/M cache-read inside a per-million
+        container must normalize as $/M ($0.005/M), NOT as $0.005/token ($5,000/M).
+        Container-level inference is what makes this work."""
+        fields = extract_pricing_fields({
+            "global": {"prompt": 0.75, "completions": 3.75, "input_cache_read": 0.005},
+        })
+        assert fields["prompt"] == Decimal("0.75")
+        assert fields["completion"] == Decimal("3.75")
+        assert fields["cache_read"] == Decimal("0.005")
 
     def test_expensive_model_per_million(self):
-        """$300/M output (frontier tier): >> 0.01, must normalize to 0.0003/token."""
+        """$300/M output (frontier tier)."""
         fields = extract_pricing_fields({"prompt": 30.0, "completions": 300.0})
-        assert fields["prompt"] == Decimal("0.00003")
-        assert fields["completion"] == Decimal("0.0003")
+        assert fields["prompt"] == Decimal("30.0")
+        assert fields["completion"] == Decimal("300.0")
 
     def test_cache_write_alias(self):
         fields = extract_pricing_fields({"global": {"input_cache_write": 0.041667}})
-        assert fields["cache_write"] == Decimal("0.041667") / Decimal(1_000_000)
+        assert fields["cache_write"] == Decimal("0.041667")
+
+
+class TestNestedContainerGuard:
+    def test_unrelated_nested_dicts_do_not_bleed(self):
+        """Flash round-1 BLOCKER 1: {architecture: {output: 4096}} must NOT put a
+        phantom `output` (= completion alias) price into the fields."""
+        fields = extract_pricing_fields({
+            "prompt": "0.00000075", "completion": "0.00000375",
+            "architecture": {"output": 4096, "input": 8192},
+            "limits": {"request": 60},
+        })
+        assert fields["completion"] == Decimal("3.75")
+        assert fields["request"] is None
+
+    def test_root_keys_win_over_nested(self):
+        """Flash round-1 SHOULD-FIX 2: flat root keys take precedence over
+        unwrapped nested values, regardless of dict insertion order."""
+        nested_first = {"global": {"prompt": 1.0}, "prompt": "0.00000075"}
+        flat_first = {"prompt": "0.00000075", "global": {"prompt": 1.0}}
+        assert extract_pricing_fields(nested_first)["prompt"] == Decimal("0.75")
+        assert extract_pricing_fields(flat_first)["prompt"] == Decimal("0.75")
+
+    def test_regional_increase_sibling_ignored(self):
+        fields = extract_pricing_fields({
+            "global": {"prompt": 0.75, "completions": 3.75},
+            "regional_increase_percent": 0.1,
+        })
+        assert fields["prompt"] == Decimal("0.75")
+        assert all(fields[k] != Decimal("0.1") for k in fields)
 
 
 class TestDegenerateInput:
@@ -67,3 +115,36 @@ class TestDegenerateInput:
     def test_flat_container_unwrapped_passthrough(self):
         flat = {"prompt": "0.00000075"}
         assert unwrap_pricing_container(flat) == flat
+
+
+def test_unwrap_rejects_non_dict_nest_values():
+    """A nest key holding a non-dict (e.g. global: 5) must not crash."""
+    assert unwrap_pricing_container({"global": 5}) == {}
+
+
+class TestIntegrationPricingEntry:
+    """Integration: _pricing_entry_from_metadata on the two real shapes."""
+
+    def _entry(self, pricing):
+        from agent.usage_pricing import _pricing_entry_from_metadata
+        return _pricing_entry_from_metadata(
+            {"model-x": {"pricing": pricing}}, "model-x",
+            source_url="https://g.example/v1/models", pricing_version="test",
+        )
+
+    def test_per_million_shape_entry(self):
+        entry = self._entry({
+            "global": {"completions": 3.75, "prompt": 0.75, "input_cache_read": 0.075},
+            "regional_increase_percent": 0.1,
+        })
+        assert entry is not None
+        assert entry.input_cost_per_million == Decimal("0.75")
+        assert entry.output_cost_per_million == Decimal("3.75")
+        assert entry.cache_read_cost_per_million == Decimal("0.075")
+        assert entry.source == "provider_models_api"
+
+    def test_openrouter_shape_entry_unchanged(self):
+        entry = self._entry({"prompt": "0.00000075", "completion": "0.00000375"})
+        assert entry is not None
+        assert entry.input_cost_per_million == Decimal("0.75")
+        assert entry.output_cost_per_million == Decimal("3.75")


### PR DESCRIPTION
Closes #108642

## What does this PR do?

Pricing extraction from custom-endpoint `/models` metadata is now shape-tolerant. Two conventions exist in the wild; the parser handled only one:

- **OpenRouter-style** (unchanged behavior): `pricing.prompt = "0.00000075"` — dollars-per-token, flat.
- **Per-million style** (previously catastrophically misparsed): `pricing.global.prompt = 0.75` — dollars-per-**million**, nested under `global`, output rate under `completions`.

On the second shape the old parser inflated the input rate 1,000,000× and dropped the output rate entirely (see #108642: a ~$2.32 session displayed as $331,825.50).

New `agent/pricing_shape.py`:

- **Container-level unit inference** — if any token-rate field (prompt/completion/input/output/cache) is ≥ $0.01/token (a price no real model has; that ceiling is $10,000/M), the whole container is dollars-per-million. Per-value inference would misclassify sub-cent $/M fields (cache reads at $0.005/M → "0.005/token" = $5,000/M) inside an otherwise per-million container.
- **Nest containers only for known keys** (`global`/`default`/`usd`) — unrelated nested objects (`architecture`, `limits`, …) cannot bleed phantom rates into pricing.
- **Deterministic precedence**: flat root keys win over unwrapped nested values, regardless of JSON insertion order.
- **Alias chains**: `completion`/`completions`, `input`/`prompt`, `input_cache_read`/`cache_read`/`cached_prompt`, etc.
- **`request` stays un-normalized** (flat per-request fee in every known convention).

`_pricing_entry_from_metadata` consumes the extracted dollars-per-million fields directly — no unit round-trip churn.

One change sits outside those two files. `agent/model_metadata.py::_extract_pricing` filters the probe's pricing keys against its own alias map before `usage_pricing` reads them, so the plural `completions` spelling was dropped there and the output rate stayed unpriced on the real `/models` path even with the shape handling in place. The spelling is now in that alias map.

## Testing

- `tests/agent/test_pricing_shape.py` (17 tests): both real conventions, frontier-tier pricing ($300/M), sub-cent cache rates inside per-million containers, the nested-dict bleed guard, root-over-nested precedence in both insertion orders, `regional_increase_percent` ignored, malformed/bool values, integration tests driving `_pricing_entry_from_metadata` on both shapes, and a regression test driving the production path (`_parse_models_payload` → `_pricing_entry_from_metadata`) so the probe's key filtering is covered rather than a hand-built metadata dict.
- `tests/agent/test_usage_pricing.py` (50 pre-existing), `tests/agent/test_model_metadata.py` (121) and `tests/agent/test_billing_usage.py` (8) — all green; the OpenRouter path is byte-identical to before.
- Cross-vendor review: 3 rounds (Gemini 3.8 Flash High + GPT-OSS 120B); the latest round on this diff returned no blockers from either reviewer.

## Notes

**Open question:** the $0.01/token ceiling is a heuristic (real per-token prices sit far below it). If maintainers know of an endpoint serving a third convention — e.g. dollars-per-K — the inference would need a third branch; no known endpoint uses one, so it's deliberately not speculative infrastructure. Payloads that carry an explicit `unit` are the case where this heuristic and an explicit-unit implementation disagree: a `per_1k_tokens` container (e.g. `0.75`) is read as $0.75/M here, and a sub-cent `per_1m_tokens` container as per-token.

- [x] Includes tests
