### PR TITLE
Add invocation-scoped context and availability for plugin slash commands

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2375,11 +2375,31 @@ def get_skill_bundles() -> dict:
 build_bundle_invocation_message = _lazy_shim("agent.skill_bundles", "build_bundle_invocation_message")
 
 
-def _get_plugin_cmd_handler_names() -> set:
+def _cli_plugin_invocation(cli) -> "PluginInvocationContext":
+    """Build trusted plugin context from the active interactive CLI session."""
+    from hermes_cli.plugin_invocation import _new_plugin_invocation
+    from hermes_cli.profiles import get_active_profile_name
+
+    session_id = str(getattr(cli, "session_id", "") or "").strip() or None
+    profile = str(get_active_profile_name() or "").strip() or None
+    return _new_plugin_invocation(
+        profile=profile,
+        session_id=session_id,
+        platform="cli",
+        authenticated_actor=None,
+        target=session_id,
+        chat_id=None,
+        thread_id=None,
+        origin=None,
+        execution_kind="root",
+    )
+
+
+def _get_plugin_cmd_handler_names(invocation=None) -> set:
     """Return plugin command names (without slash prefix) for dispatch matching."""
     try:
         from hermes_cli.plugins import get_plugin_commands
-        return set(get_plugin_commands().keys())
+        return set(get_plugin_commands(invocation).keys())
     except Exception:
         return set()
 
@@ -3250,14 +3270,19 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
         user_args = cmd_original[len(base_cmd):].strip()
         if bare in quick_commands:
             return self._run_quick_command(base_cmd, quick_commands[bare], user_args)
-        if bare in _get_plugin_cmd_handler_names():
-            self._run_plugin_slash_command(base_cmd, user_args)
-        elif base_cmd in skill_bundles:
-            self._run_skill_bundle_command(base_cmd, skill_bundles[base_cmd], user_args)
-        elif base_cmd in skill_commands:
-            self._run_skill_slash_command(base_cmd, skill_commands[base_cmd], user_args)
-        else:
-            return self._expand_slash_prefix(cmd_original, cmd_lower, skill_commands, skill_bundles)
+        plugin_invocation = _cli_plugin_invocation(self)
+        try:
+            if bare in _get_plugin_cmd_handler_names(plugin_invocation):
+                self._run_plugin_slash_command(base_cmd, user_args, plugin_invocation)
+            elif base_cmd in skill_bundles:
+                self._run_skill_bundle_command(base_cmd, skill_bundles[base_cmd], user_args)
+            elif base_cmd in skill_commands:
+                self._run_skill_slash_command(base_cmd, skill_commands[base_cmd], user_args)
+            else:
+                return self._expand_slash_prefix(cmd_original, cmd_lower, skill_commands, skill_bundles)
+        finally:
+            from hermes_cli.plugin_invocation import _revoke_plugin_invocation
+            _revoke_plugin_invocation(plugin_invocation)
         return True
 
     def _run_quick_command(self, base_cmd: str, qcmd: dict, user_args: str) -> bool:
@@ -3301,14 +3326,16 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
             self._console_print(f"[bold red]Quick command error: {e}[/]")
         return True
 
-    def _run_plugin_slash_command(self, base_cmd: str, user_args: str) -> None:
+    def _run_plugin_slash_command(self, base_cmd: str, user_args: str, invocation) -> None:
         from hermes_cli.plugins import get_plugin_command_handler, resolve_plugin_command_result
+        from hermes_cli.plugin_invocation import _bind_plugin_invocation
 
-        plugin_handler = get_plugin_command_handler(base_cmd.lstrip("/"))
+        plugin_handler = get_plugin_command_handler(base_cmd.lstrip("/"), invocation)
         if not plugin_handler:
             return
         try:
-            result = resolve_plugin_command_result(plugin_handler(user_args))
+            with _bind_plugin_invocation(invocation):
+                result = resolve_plugin_command_result(plugin_handler(user_args))
             if result:
                 _cprint(str(result))
         except Exception as e:

--- a/cli.py
+++ b/cli.py
@@ -2377,21 +2377,12 @@ build_bundle_invocation_message = _lazy_shim("agent.skill_bundles", "build_bundl
 
 def _cli_plugin_invocation(cli) -> "PluginInvocationContext":
     """Build trusted plugin context from the active interactive CLI session."""
-    from hermes_cli.plugin_invocation import _new_plugin_invocation
-    from hermes_cli.profiles import get_active_profile_name
+    from hermes_cli.plugin_invocation import _new_local_plugin_invocation
 
     session_id = str(getattr(cli, "session_id", "") or "").strip() or None
-    profile = str(get_active_profile_name() or "").strip() or None
-    return _new_plugin_invocation(
-        profile=profile,
+    return _new_local_plugin_invocation(
         session_id=session_id,
         platform="cli",
-        authenticated_actor=None,
-        target=session_id,
-        chat_id=None,
-        thread_id=None,
-        origin=None,
-        execution_kind="root",
     )
 
 

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -986,15 +986,50 @@ class GatewayInboundMixin:
         if command:
             try:
                 from hermes_cli.plugins import get_plugin_command_handler
-                plugin_handler = get_plugin_command_handler(command.replace("_", "-"))
-                if plugin_handler:
-                    result = plugin_handler(event.get_command_args().strip())
-                    if asyncio.iscoroutine(result):
-                        result = await result
-                    return True, str(result) if result else None, command
+                from hermes_cli.plugin_invocation import (
+                    _bind_plugin_invocation,
+                    _revoke_plugin_invocation,
+                )
+                invocation = self._hm_plugin_invocation(event, source)
+                try:
+                    plugin_handler = get_plugin_command_handler(
+                        command.replace("_", "-"), invocation
+                    )
+                    if plugin_handler:
+                        with _bind_plugin_invocation(invocation):
+                            result = plugin_handler(event.get_command_args().strip())
+                            if asyncio.iscoroutine(result):
+                                result = await result
+                        return True, str(result) if result else None, command
+                finally:
+                    _revoke_plugin_invocation(invocation)
             except Exception as e:
                 logger.warning("Plugin command dispatch failed: %s", e)
         return False, None, command
+
+    def _hm_plugin_invocation(
+        self, event: "MessageEvent", source: SessionSource
+    ) -> "PluginInvocationContext":
+        """Build trusted plugin context after gateway admission and authorization."""
+        from hermes_cli.plugin_invocation import _new_plugin_invocation
+
+        platform = source.platform.value if source.platform else None
+        profile = self._adapter_profile_for_source(source) or source.profile or "default"
+        session_id = self._session_key_for_source(source) or None
+        target = source.thread_id or source.chat_id or None
+        origin = event.message_id or source.message_id or None
+        internal = bool(getattr(event, "internal", False))
+        return _new_plugin_invocation(
+            profile=profile,
+            session_id=session_id,
+            platform=platform,
+            authenticated_actor=None if internal else source.user_id,
+            target=str(target) if target is not None else None,
+            chat_id=str(source.chat_id) if source.chat_id is not None else None,
+            thread_id=str(source.thread_id) if source.thread_id is not None else None,
+            origin=str(origin) if origin is not None else None,
+            execution_kind="background" if internal else "root",
+        )
 
     def _hm_bundle_slash_rewrite(
         self, event: "MessageEvent", source: SessionSource, _quick_key: str, command: str

--- a/hermes_cli/cli_tui_mixin.py
+++ b/hermes_cli/cli_tui_mixin.py
@@ -2123,7 +2123,12 @@ class CLITuiMixin:
     def _tui_build_input_area(self):
         """Multi-line prompt TextArea with slash completion, paste-collapse tracking and
         placeholder/password processors."""
-        from cli import _estimate_tui_input_height, get_skill_bundles, get_skill_commands
+        from cli import (
+            _cli_plugin_invocation,
+            _estimate_tui_input_height,
+            get_skill_bundles,
+            get_skill_commands,
+        )
         from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
         from prompt_toolkit.completion import ThreadedCompleter
         cli_ref = self
@@ -2131,10 +2136,20 @@ class CLITuiMixin:
         def get_prompt():
             return cli_ref._get_tui_prompt_fragments()
 
+        def _available_plugin_commands(current_cli):
+            from hermes_cli.plugins import get_plugin_commands
+            from hermes_cli.plugin_invocation import _revoke_plugin_invocation
+            invocation = _cli_plugin_invocation(current_cli)
+            try:
+                return get_plugin_commands(invocation)
+            finally:
+                _revoke_plugin_invocation(invocation)
+
         _completer = SlashCommandCompleter(
             skill_commands_provider=lambda: get_skill_commands(),
             command_filter=cli_ref._command_available,
-            skill_bundles_provider=lambda: get_skill_bundles())
+            skill_bundles_provider=lambda: get_skill_bundles(),
+            plugin_commands_provider=lambda: _available_plugin_commands(cli_ref))
         input_area = TextArea(
             height=Dimension(min=1, max=8, preferred=1),
             prompt=get_prompt,

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -385,8 +385,13 @@ def is_gateway_known_command(name: str | None) -> bool:
     up lazily); decides whether the gateway emits ``command:<name>`` hooks."""
     if not name:
         return False
-    return name in GATEWAY_KNOWN_COMMANDS or any(
-        plugin_name == name for plugin_name, _d, _h in _iter_plugin_command_entries())
+    if name in GATEWAY_KNOWN_COMMANDS:
+        return True
+    try:
+        from hermes_cli.plugins import is_plugin_command_registered
+        return is_plugin_command_registered(name.replace("_", "-"))
+    except Exception:
+        return False
 
 
 # Commands with explicit mid-run handling (busy_policy != "reject"). Kept

--- a/hermes_cli/commands_completion.py
+++ b/hermes_cli/commands_completion.py
@@ -271,10 +271,13 @@ class SlashCommandCompleter(Completer):
         self,
         skill_commands_provider: Callable[[], Mapping[str, dict[str, Any]]] | None = None,
         command_filter: Callable[[str], bool] | None = None,
-        skill_bundles_provider: Callable[[], Mapping[str, dict[str, Any]]] | None = None) -> None:
+        skill_bundles_provider: Callable[[], Mapping[str, dict[str, Any]]] | None = None,
+        plugin_commands_provider: Callable[[], Mapping[str, dict[str, Any]]] | None = None,
+    ) -> None:
         self._skill_commands_provider = skill_commands_provider
         self._command_filter = command_filter
         self._skill_bundles_provider = skill_bundles_provider
+        self._plugin_commands_provider = plugin_commands_provider
         # Cached project file list for fuzzy @ completions
         self._file_cache: list[str] = []
         self._file_cache_time: float = 0.0
@@ -454,8 +457,12 @@ class SlashCommandCompleter(Completer):
             if cmd[1:].startswith(word):
                 yield _cmd_completion(cmd[1:], f"⚡ {info.get('description', 'Skill command')}")
         try:
-            from hermes_cli.plugins import get_plugin_commands
-            for cmd_name, cmd_info in get_plugin_commands().items():
+            if self._plugin_commands_provider is None:
+                from hermes_cli.plugins import get_plugin_commands
+                plugin_commands = get_plugin_commands()
+            else:
+                plugin_commands = self._call_provider(self._plugin_commands_provider)
+            for cmd_name, cmd_info in plugin_commands.items():
                 if cmd_name.startswith(word):
                     yield _cmd_completion(
                         cmd_name, f"🔌 {cmd_info.get('description', 'Plugin command')}")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3145,7 +3145,7 @@ def _advertise_agent_env() -> None:
     os.environ.setdefault("HERMES_AGENT", "true")
 
 
-def _attach_plugin_cli_command(subparsers, cmd_info) -> None:
+def _attach_plugin_cli_command(subparsers, cmd_info, *, trusted_context: bool = False) -> None:
     """Register one plugin-provided top-level command from its descriptor."""
     plugin_parser = subparsers.add_parser(
         cmd_info["name"],
@@ -3156,6 +3156,31 @@ def _attach_plugin_cli_command(subparsers, cmd_info) -> None:
     cmd_info["setup_fn"](plugin_parser)
     if cmd_info.get("handler_fn") is not None:
         plugin_parser.set_defaults(func=cmd_info["handler_fn"])
+    if trusted_context:
+        plugin_parser.set_defaults(_plugin_cli_command=cmd_info["name"])
+
+
+def _run_cli_handler(args, parser):
+    """Run the parsed handler, applying the trusted plugin CLI dispatch gate."""
+    command_name = getattr(args, "_plugin_cli_command", None)
+    if not command_name:
+        return args.func(args)
+
+    from hermes_cli.plugin_invocation import (
+        _bind_plugin_invocation,
+        _new_local_plugin_invocation,
+        _revoke_plugin_invocation,
+    )
+    from hermes_cli.plugins import get_plugin_cli_commands
+
+    invocation = _new_local_plugin_invocation(platform="cli")
+    try:
+        if command_name not in get_plugin_cli_commands(invocation):
+            parser.error(f"command {command_name!r} is unavailable")
+        with _bind_plugin_invocation(invocation):
+            return args.func(args)
+    finally:
+        _revoke_plugin_invocation(invocation)
 
 
 def _register_plugin_cli_commands(subparsers) -> None:
@@ -3168,7 +3193,11 @@ def _register_plugin_cli_commands(subparsers) -> None:
         return
     try:
         from plugins.memory import discover_plugin_cli_commands
-        from hermes_cli.plugins import discover_plugins, get_plugin_manager
+        from hermes_cli.plugin_invocation import (
+            _new_local_plugin_invocation,
+            _revoke_plugin_invocation,
+        )
+        from hermes_cli.plugins import discover_plugins, get_plugin_cli_commands
 
         seen_plugin_commands = set()
         for cmd_info in discover_plugin_cli_commands():
@@ -3180,9 +3209,15 @@ def _register_plugin_cli_commands(subparsers) -> None:
         # register_cli_command side effect runs before we read _cli_commands.
         # See #54678.
         _resolve_deferred_platform_cli_command(_first_positional_argv())
-        for cmd_info in get_plugin_manager()._cli_commands.values():
-            if cmd_info["name"] not in seen_plugin_commands:
-                _attach_plugin_cli_command(subparsers, cmd_info)
+        invocation = _new_local_plugin_invocation(platform="cli")
+        try:
+            for cmd_info in get_plugin_cli_commands(invocation).values():
+                if cmd_info["name"] not in seen_plugin_commands:
+                    _attach_plugin_cli_command(
+                        subparsers, cmd_info, trusted_context=True
+                    )
+        finally:
+            _revoke_plugin_invocation(invocation)
     except Exception as _exc:
         logging.getLogger(__name__).debug("Plugin CLI discovery failed: %s", _exc)
 
@@ -3441,7 +3476,7 @@ def main():
 
     # A handler's int return code becomes the exit code (None = success).
     if hasattr(args, "func"):
-        rc = args.func(args)
+        rc = _run_cli_handler(args, parser)
         if isinstance(rc, int) and rc != 0:
             sys.exit(rc)
     else:

--- a/hermes_cli/plugin_invocation.py
+++ b/hermes_cli/plugin_invocation.py
@@ -1,0 +1,134 @@
+"""Trusted, invocation-local context for plugin command handlers."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import Context, ContextVar, copy_context
+from dataclasses import dataclass, field
+from typing import Iterator, Literal
+
+PluginExecutionKind = Literal["root", "background", "subagent"]
+
+
+@dataclass(frozen=True, slots=True, repr=False)
+class PluginInvocationContext:
+    """Host-derived identity and routing facts for one plugin invocation."""
+
+    _profile: str | None
+    _session_id: str | None
+    _platform: str | None
+    _authenticated_actor: str | None
+    _target: str | None
+    _chat_id: str | None
+    _thread_id: str | None
+    _origin: str | None
+    _execution_kind: PluginExecutionKind
+    _lease: list[bool] = field(default_factory=lambda: [True], repr=False, compare=False)
+
+    def _read(self, value):
+        if not self._lease[0]:
+            raise PluginInvocationContextUnavailable("plugin invocation context has expired")
+        return value
+
+    @property
+    def profile(self) -> str | None:
+        return self._read(self._profile)
+
+    @property
+    def session_id(self) -> str | None:
+        return self._read(self._session_id)
+
+    @property
+    def platform(self) -> str | None:
+        return self._read(self._platform)
+
+    @property
+    def authenticated_actor(self) -> str | None:
+        return self._read(self._authenticated_actor)
+
+    @property
+    def target(self) -> str | None:
+        return self._read(self._target)
+
+    @property
+    def chat_id(self) -> str | None:
+        return self._read(self._chat_id)
+
+    @property
+    def thread_id(self) -> str | None:
+        return self._read(self._thread_id)
+
+    @property
+    def origin(self) -> str | None:
+        return self._read(self._origin)
+
+    @property
+    def execution_kind(self) -> PluginExecutionKind:
+        return self._read(self._execution_kind)
+
+
+class PluginInvocationContextUnavailable(RuntimeError):
+    """No trusted plugin invocation is bound to the current execution context."""
+
+
+_CURRENT_PLUGIN_INVOCATION: ContextVar[PluginInvocationContext | None] = ContextVar(
+    "hermes_current_plugin_invocation", default=None
+)
+
+
+def current_plugin_invocation() -> PluginInvocationContext:
+    """Return the current host-bound invocation or fail closed when none exists."""
+    invocation = _CURRENT_PLUGIN_INVOCATION.get()
+    if invocation is None:
+        raise PluginInvocationContextUnavailable("no trusted plugin invocation is active")
+    invocation._read(None)
+    return invocation
+
+
+def _new_plugin_invocation(
+    *,
+    profile: str | None,
+    session_id: str | None,
+    platform: str | None,
+    authenticated_actor: str | None,
+    target: str | None,
+    chat_id: str | None,
+    thread_id: str | None,
+    origin: str | None,
+    execution_kind: PluginExecutionKind,
+) -> PluginInvocationContext:
+    """Create a host-owned, revocable invocation value."""
+    return PluginInvocationContext(
+        profile,
+        session_id,
+        platform,
+        authenticated_actor,
+        target,
+        chat_id,
+        thread_id,
+        origin,
+        execution_kind,
+    )
+
+
+def _revoke_plugin_invocation(invocation: PluginInvocationContext) -> None:
+    invocation._lease[0] = False
+
+
+def _context_without_plugin_invocation() -> Context:
+    context = copy_context()
+    context.run(_CURRENT_PLUGIN_INVOCATION.set, None)
+    return context
+
+
+@contextmanager
+def _bind_plugin_invocation(invocation: PluginInvocationContext) -> Iterator[None]:
+    """Bind one invocation for host dispatch and restore the prior value afterwards."""
+    if not isinstance(invocation, PluginInvocationContext):
+        raise TypeError("invocation must be a PluginInvocationContext")
+    token = _CURRENT_PLUGIN_INVOCATION.set(invocation)
+    try:
+        yield
+    finally:
+        _CURRENT_PLUGIN_INVOCATION.reset(token)
+        _revoke_plugin_invocation(invocation)

--- a/hermes_cli/plugin_invocation.py
+++ b/hermes_cli/plugin_invocation.py
@@ -111,6 +111,64 @@ def _new_plugin_invocation(
     )
 
 
+def _local_authenticated_actor() -> str | None:
+    """Return a local actor hint from a usable Nous JWT, not remote auth authority."""
+    try:
+        from hermes_cli.auth import get_provider_auth_state
+        from hermes_cli.auth_nous import _decode_jwt_claims, _state_invoke_jwt_status
+        from hermes_cli.anon_auth import is_guest_state
+
+        state = get_provider_auth_state("nous") or {}
+        if is_guest_state(state):
+            return None
+        token = state.get("access_token")
+        if _state_invoke_jwt_status(state, token) is not None:
+            return None
+        actor = (_decode_jwt_claims(token) or {}).get("sub")
+        actor = actor.strip() if isinstance(actor, str) else ""
+        stored_actor = state.get("user_id")
+        stored_actor = stored_actor.strip() if isinstance(stored_actor, str) else ""
+        if stored_actor and stored_actor != actor:
+            return None
+        return actor or None
+    except Exception:
+        return None
+
+
+def _new_local_plugin_invocation(
+    *,
+    platform: str,
+    session_id: str | None = None,
+    profile: str | None = None,
+) -> PluginInvocationContext:
+    """Build trusted context for a local CLI/TUI invocation from public host state."""
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        active_profile = str(get_active_profile_name() or "").strip() or None
+    except Exception:
+        active_profile = None
+    requested_profile = str(profile or "").strip() or None
+    profile = requested_profile or active_profile
+    actor = (
+        _local_authenticated_actor()
+        if requested_profile is None or requested_profile == active_profile
+        else None
+    )
+    clean_session_id = str(session_id or "").strip() or None
+    return _new_plugin_invocation(
+        profile=profile,
+        session_id=clean_session_id,
+        platform=platform,
+        authenticated_actor=actor,
+        target=clean_session_id,
+        chat_id=None,
+        thread_id=None,
+        origin=None,
+        execution_kind="root",
+    )
+
+
 def _revoke_plugin_invocation(invocation: PluginInvocationContext) -> None:
     invocation._lease[0] = False
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -11,6 +11,7 @@ and an ``__init__.py`` exposing ``register(ctx)``. Plugins register callbacks fo
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import importlib.metadata
 import inspect
 import json
@@ -33,6 +34,11 @@ from utils import env_var_enabled
 from hermes_cli.config import load_config_readonly
 from hermes_cli.middleware import VALID_MIDDLEWARE
 from hermes_cli.plugin_capabilities import plugin_capability_granted
+from hermes_cli.plugin_invocation import (
+    PluginInvocationContext,
+    _context_without_plugin_invocation,
+    current_plugin_invocation,
+)
 from hermes_cli.relay_plugin_cutover import RELAY_PLUGINS_CONFIG_ENV, legacy_relay_plugin_keys
 # Sibling modules' names are re-exported here (origin) so plugins and tests keep one import path.
 from hermes_cli.plugins_manifest import (  # noqa: F401 — re-exported
@@ -399,6 +405,15 @@ class PluginContext:
         except Exception:
             return "default"
 
+    @property
+    def invocation(self) -> PluginInvocationContext:
+        """Immutable host-derived context for the command currently invoking this plugin.
+
+        Access outside a host-bound dispatch raises instead of synthesizing identity or routing
+        facts from process environment or plugin-controlled arguments.
+        """
+        return current_plugin_invocation()
+
     def on_unload(self, callback: Callable[[], None]) -> PluginRegistration:
         """Register a cleanup callback for unload: runs in reverse acquisition order interleaved
         with registration teardown; exceptions are logged, never propagated."""
@@ -409,12 +424,14 @@ class PluginContext:
         return handle
 
     def spawn_task(self, coro, *, name: Optional[str] = None) -> "asyncio.Task":
-        """Spawn a supervised asyncio task; unload/force reload cancels it. Needs a running loop."""
+        """Spawn a supervised task without command invocation authority; unload cancels it."""
         if not asyncio.iscoroutine(coro):
             raise TypeError("spawn_task expects a coroutine")
         loop = asyncio.get_running_loop()
         task_name = name or f"plugin:{self.plugin_id}:task"
-        task = loop.create_task(coro, name=task_name)
+        task = _context_without_plugin_invocation().run(
+            loop.create_task, coro, name=task_name
+        )
         handle = self._track("background_task", task_name, lambda: task.done() or task.cancel())
         task.add_done_callback(lambda _t: handle.dispose())
         logger.debug("Plugin %s spawned supervised task: %s", self.manifest.name, task_name)
@@ -651,11 +668,16 @@ class PluginContext:
     @_serialized_replacement
     def register_command(
         self, name: str, handler: Callable, description: str = "", args_hint: str = "",
-        argument_mode: str | None = None,
+        argument_mode: str | None = None, *,
+        availability: Callable[[PluginInvocationContext], bool] | None = None,
     ) -> Optional[PluginRegistration]:
         """Register an in-session slash command (``/name``); handler ``fn(raw_args: str) -> str | None``
         (sync or async). ``args_hint`` (e.g. ``"<file>"``) lets adapters like Discord surface an argument
-        field; without it the command registers parameterless there but still accepts trailing text."""
+        field; without it the command registers parameterless there but still accepts trailing text.
+        ``availability`` is a cheap synchronous predicate over trusted invocation context. It must
+        return literal ``True``; missing context, exceptions, and awaitables deny the command."""
+        if availability is not None and not callable(availability):
+            raise TypeError("command availability must be callable")
         clean = name.lower().strip().lstrip("/").replace(" ", "-")
         if not clean:
             logger.warning("Plugin '%s' tried to register a command with an empty name.", self.manifest.name)
@@ -672,6 +694,7 @@ class PluginContext:
             "plugin": self.manifest.name, "plugin_key": self.plugin_id, "args_hint": hint,
             "argument_mode": argument_mode if argument_mode in {"options", "text", "mixed"}
             else ("text" if hint else None),
+            "availability": availability,
         }
         return self._register_entry("command", clean, self._manager._plugin_commands, entry,
                                     "Plugin %s registered command: /%s", clean)
@@ -1976,10 +1999,47 @@ def get_plugin_context_engine():
     return _ensure_plugins_discovered()._context_engine
 
 
-def get_plugin_command_handler(name: str) -> Optional[Callable]:
-    """Return the handler for a plugin-registered slash command, or ``None``."""
+def _plugin_command_available(
+    entry: Mapping[str, Any], invocation: PluginInvocationContext | None,
+) -> bool:
+    """Evaluate a command's optional trusted-context predicate, failing closed."""
+    availability = entry.get("availability")
+    if availability is None:
+        return True
+    if invocation is None:
+        return False
+    try:
+        result = availability(invocation)
+    except Exception:
+        logger.warning(
+            "Plugin %s command availability failed; command hidden",
+            entry.get("plugin") or "<unknown>",
+            exc_info=True,
+        )
+        return False
+    if inspect.isawaitable(result):
+        close = getattr(result, "close", None)
+        if callable(close):
+            close()
+        logger.warning(
+            "Plugin %s command availability returned an awaitable; command hidden",
+            entry.get("plugin") or "<unknown>",
+        )
+        return False
+    return result is True
+
+
+def get_plugin_command_handler(
+    name: str, invocation: PluginInvocationContext | None = None,
+) -> Optional[Callable]:
+    """Return an available plugin slash-command handler, or ``None``."""
     entry = _ensure_plugins_discovered()._plugin_commands.get(name)
-    return entry["handler"] if entry else None
+    return entry["handler"] if entry and _plugin_command_available(entry, invocation) else None
+
+
+def is_plugin_command_registered(name: str) -> bool:
+    """Return whether discovery registered a command name, independent of availability."""
+    return name in _ensure_plugins_discovered()._plugin_commands
 
 
 _PLUGIN_COMMAND_AWAIT_TIMEOUT_SECS = 30.0
@@ -2007,7 +2067,13 @@ def resolve_plugin_command_result(result: Any) -> Any:
         finally:
             done.set()
 
-    threading.Thread(target=_runner, name="hermes-plugin-command-await", daemon=True).start()
+    callback_context = contextvars.copy_context()
+    threading.Thread(
+        target=callback_context.run,
+        args=(_runner,),
+        name="hermes-plugin-command-await",
+        daemon=True,
+    ).start()
     if not done.wait(timeout=_PLUGIN_COMMAND_AWAIT_TIMEOUT_SECS):
         raise TimeoutError("Plugin command async handler did not complete within "
                            f"{_PLUGIN_COMMAND_AWAIT_TIMEOUT_SECS:.0f}s")
@@ -2016,9 +2082,16 @@ def resolve_plugin_command_result(result: Any) -> Any:
     return outcome.get("value")
 
 
-def get_plugin_commands() -> Dict[str, dict]:
-    """Plugin commands dict (name -> {handler, description, plugin}) after idempotent discovery."""
-    return _ensure_plugins_discovered()._plugin_commands
+def get_plugin_commands(
+    invocation: PluginInvocationContext | None = None,
+) -> Dict[str, dict]:
+    """Available plugin commands after discovery; ungated legacy commands remain visible."""
+    commands = _ensure_plugins_discovered()._plugin_commands
+    return {
+        name: entry
+        for name, entry in commands.items()
+        if _plugin_command_available(entry, invocation)
+    }
 
 
 def get_plugin_auxiliary_tasks() -> List[Dict[str, Any]]:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -36,6 +36,7 @@ from hermes_cli.middleware import VALID_MIDDLEWARE
 from hermes_cli.plugin_capabilities import plugin_capability_granted
 from hermes_cli.plugin_invocation import (
     PluginInvocationContext,
+    PluginInvocationContextUnavailable,
     _context_without_plugin_invocation,
     current_plugin_invocation,
 )
@@ -2006,15 +2007,19 @@ def _plugin_command_available(
     availability = entry.get("availability")
     if availability is None:
         return True
-    if invocation is None:
+    if not isinstance(invocation, PluginInvocationContext):
+        return False
+    try:
+        invocation._read(None)
+    except PluginInvocationContextUnavailable:
         return False
     try:
         result = availability(invocation)
-    except Exception:
+    except Exception as exc:
         logger.warning(
-            "Plugin %s command availability failed; command hidden",
+            "Plugin %s command availability failed (%s); command hidden",
             entry.get("plugin") or "<unknown>",
-            exc_info=True,
+            type(exc).__name__,
         )
         return False
     if inspect.isawaitable(result):

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -655,13 +655,18 @@ class PluginContext:
     @_serialized_replacement
     def register_cli_command(
         self, name: str, help: str, setup_fn: Callable, handler_fn: Callable | None = None,
-        description: str = "",
+        description: str = "", *,
+        availability: Callable[[PluginInvocationContext], bool] | None = None,
     ) -> PluginRegistration:
         """Register a CLI subcommand (``hermes <name> ...``). *setup_fn* receives the argparse
-        subparser; *handler_fn* becomes ``set_defaults(func=...)``."""
+        subparser; *handler_fn* becomes ``set_defaults(func=...)``. ``availability`` is the same
+        fail-closed trusted-context predicate used by in-session plugin commands."""
+        if availability is not None and not callable(availability):
+            raise TypeError("CLI command availability must be callable")
         entry = {
             "name": name, "help": help, "description": description, "setup_fn": setup_fn,
             "handler_fn": handler_fn, "plugin": self.manifest.name, "plugin_key": self.plugin_id,
+            "availability": availability,
         }
         return self._register_entry("cli_command", name, self._manager._cli_commands, entry,
                                     "Plugin %s registered CLI command: %s", name)
@@ -2040,6 +2045,26 @@ def get_plugin_command_handler(
     """Return an available plugin slash-command handler, or ``None``."""
     entry = _ensure_plugins_discovered()._plugin_commands.get(name)
     return entry["handler"] if entry and _plugin_command_available(entry, invocation) else None
+
+
+def get_plugin_cli_commands(
+    invocation: PluginInvocationContext | None = None,
+) -> Dict[str, dict]:
+    """Return plugin top-level CLI commands available to the trusted invocation."""
+    commands = _ensure_plugins_discovered()._cli_commands
+    return {
+        name: entry
+        for name, entry in commands.items()
+        if _plugin_command_available(entry, invocation)
+    }
+
+
+def get_plugin_cli_command_handler(
+    name: str, invocation: PluginInvocationContext | None = None,
+) -> Optional[Callable]:
+    """Return an available plugin top-level CLI handler, or ``None``."""
+    entry = _ensure_plugins_discovered()._cli_commands.get(name)
+    return entry.get("handler_fn") if entry and _plugin_command_available(entry, invocation) else None
 
 
 def is_plugin_command_registered(name: str) -> bool:

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -279,7 +279,8 @@ async def test_underscored_alias_for_hyphenated_builtin_not_flagged(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_command_hook_rewrite_routes_to_plugin(monkeypatch):
+@pytest.mark.parametrize("available", [True, False])
+async def test_command_hook_rewrite_routes_to_plugin(monkeypatch, available):
     """A rewrite decision should re-resolve the command and route to the new one."""
     import gateway.run as gateway_run
 
@@ -309,20 +310,24 @@ async def test_command_hook_rewrite_routes_to_plugin(monkeypatch):
     )
     from hermes_cli import plugins as _plugins_mod
 
-    monkeypatch.setattr(
-        _plugins_mod,
-        "get_plugin_commands",
-        lambda: {"metricas": {"description": "Metrics", "args_hint": "dias:7"}},
+    manager = PluginManager(scope_key="/tmp/hermes-rewritten-command-test")
+    context = PluginContext(PluginManifest(name="neutral-rewrite", source="user"), manager)
+    handler = MagicMock(side_effect=lambda args: f"metrics {args}")
+    context.register_command(
+        "metricas", handler, description="Metrics", args_hint="dias:7",
+        availability=lambda invocation: available and invocation.execution_kind == "root",
     )
-    monkeypatch.setattr(
-        _plugins_mod,
-        "get_plugin_command_handler",
-        lambda name: (lambda args: f"metrics {args}") if name == "metricas" else None,
-    )
+    monkeypatch.setattr(_plugins_mod, "_ensure_plugins_discovered", lambda: manager)
 
     result = await runner._handle_message(_make_event("/status"))
 
-    assert result == "metrics dias:7"
+    if available:
+        assert result == "metrics dias:7"
+        handler.assert_called_once_with("dias:7")
+    else:
+        assert "Unknown command" in result
+        handler.assert_not_called()
+    runner._run_agent.assert_not_awaited()
     # First emit_collect fires on the original command; after rewrite the
     # dispatcher does NOT re-fire for the new command (one decision per turn).
     assert call_log == ["command:status"]

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -5,6 +5,7 @@ text, which often leads to silent failure (e.g. the model inventing a bogus
 delegate_task call instead of telling the user the command doesn't exist).
 """
 
+import asyncio
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -14,6 +15,8 @@ import pytest
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.event import MessageEvent, MessageType
 from gateway.session import SessionEntry, SessionSource, build_session_key
+from hermes_cli.plugin_invocation import PluginInvocationContextUnavailable
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
 
 
 def _make_source() -> SessionSource:
@@ -131,6 +134,104 @@ async def test_known_slash_command_not_flagged_as_unknown(monkeypatch):
 
     assert result is not None
     assert "Unknown command" not in result
+
+
+def test_plugin_command_receives_admitted_gateway_context(monkeypatch):
+    from hermes_cli import plugins
+
+    runner = _make_runner()
+    manager = PluginManager(scope_key="/tmp/hermes-gateway-plugin-context-test")
+    context = PluginContext(PluginManifest(name="neutral-consumer", source="user"), manager)
+    seen = []
+
+    def handler(raw_args):
+        invocation = context.invocation
+        seen.append(
+            (
+                raw_args,
+                invocation,
+                {
+                    "platform": invocation.platform,
+                    "session_id": invocation.session_id,
+                    "chat_id": invocation.chat_id,
+                    "thread_id": invocation.thread_id,
+                },
+            )
+        )
+        return "gateway handled"
+
+    context.register_command(
+        "context-probe",
+        handler,
+        availability=lambda invocation: (
+            invocation.platform == "telegram"
+            and invocation.authenticated_actor == "u1"
+            and invocation.target == "thread-2"
+            and invocation.chat_id == "c1"
+            and invocation.thread_id == "thread-2"
+            and invocation.origin == "m1"
+            and invocation.execution_kind == "root"
+        ),
+    )
+    monkeypatch.setattr(plugins, "_ensure_plugins_discovered", lambda: manager)
+
+    event = _make_event("/context-probe MiXeD")
+    event.source.thread_id = "thread-2"
+    result = asyncio.run(runner._handle_message(event))
+
+    assert result == "gateway handled"
+    raw_args, invocation, snapshot = seen.pop()
+    assert raw_args == "MiXeD"
+    assert snapshot == {
+        "platform": "telegram",
+        "session_id": build_session_key(event.source),
+        "chat_id": "c1",
+        "thread_id": "thread-2",
+    }
+    with pytest.raises(PluginInvocationContextUnavailable, match="expired"):
+        _ = invocation.platform
+    with pytest.raises(PluginInvocationContextUnavailable):
+        _ = context.invocation
+
+
+def test_unavailable_registered_plugin_command_never_reaches_model(monkeypatch):
+    from hermes_cli import plugins
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("unavailable plugin command reached the model")
+    )
+    manager = PluginManager(scope_key="/tmp/hermes-gateway-unavailable-command-test")
+    context = PluginContext(PluginManifest(name="neutral-consumer", source="user"), manager)
+    handler = MagicMock()
+    context.register_command(
+        "context-probe",
+        handler,
+        availability=lambda invocation: invocation.execution_kind == "subagent",
+    )
+    monkeypatch.setattr(plugins, "_ensure_plugins_discovered", lambda: manager)
+
+    result = asyncio.run(runner._handle_message(_make_event("/context-probe do it")))
+
+    assert "Unknown command" in result
+    handler.assert_not_called()
+    runner._run_agent.assert_not_awaited()
+
+
+def test_internal_gateway_context_is_background_and_anonymous():
+    from hermes_cli.plugin_invocation import _revoke_plugin_invocation
+
+    runner = _make_runner()
+    event = _make_event("background wakeup")
+    event.internal = True
+    invocation = runner._hm_plugin_invocation(event, event.source)
+    try:
+        assert invocation.execution_kind == "background"
+        assert invocation.authenticated_actor is None
+        assert invocation.chat_id == "c1"
+        assert invocation.thread_id is None
+    finally:
+        _revoke_plugin_invocation(invocation)
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_plugin_cli_registration.py
+++ b/tests/hermes_cli/test_plugin_cli_registration.py
@@ -8,10 +8,14 @@ Covers:
   - Honcho register_cli() builds correct argparse tree
 """
 
+import argparse
 import sys
 from unittest.mock import MagicMock
 
+import pytest
 
+from hermes_cli import plugins
+from hermes_cli.plugin_invocation import PluginInvocationContext
 from hermes_cli.plugins import (
     PluginContext,
     PluginManager,
@@ -46,12 +50,223 @@ class TestRegisterCliCommand:
         assert entry["setup_fn"] is setup
         assert entry["handler_fn"] is handler
         assert entry["plugin"] == "test-plugin"
+        assert entry["availability"] is None
 
     def test_overwrites_on_duplicate(self):
         ctx, mgr = self._make_ctx()
         ctx.register_cli_command("x", "first", MagicMock())
         ctx.register_cli_command("x", "second", MagicMock())
         assert mgr._cli_commands["x"]["help"] == "second"
+
+    def test_availability_filters_catalog_and_handler(self, monkeypatch):
+        ctx, mgr = self._make_ctx()
+        handler = MagicMock()
+        ctx.register_cli_command(
+            "guarded",
+            "Guarded command",
+            MagicMock(),
+            handler,
+            availability=lambda invocation: (
+                invocation.platform == "cli"
+                and invocation.authenticated_actor == "nas-user-7"
+            ),
+        )
+        monkeypatch.setattr(plugins, "_ensure_plugins_discovered", lambda: mgr)
+        allowed = PluginInvocationContext(
+            "default", None, "cli", "nas-user-7", None, None, None, None, "root"
+        )
+        denied = PluginInvocationContext(
+            "default", None, "cli", None, None, None, None, None, "root"
+        )
+
+        assert "guarded" in plugins.get_plugin_cli_commands(allowed)
+        assert plugins.get_plugin_cli_command_handler("guarded", allowed) is handler
+        assert plugins.get_plugin_cli_commands(denied) == {}
+        assert plugins.get_plugin_cli_command_handler("guarded", denied) is None
+
+    def test_non_callable_availability_is_rejected(self):
+        ctx, _mgr = self._make_ctx()
+
+        with pytest.raises(TypeError, match="CLI command availability must be callable"):
+            ctx.register_cli_command(
+                "guarded", "Guarded command", MagicMock(), availability=True
+            )
+
+    def test_parser_handler_binds_context_and_rechecks_availability(
+        self, monkeypatch
+    ):
+        from hermes_cli import main as main_mod
+        from hermes_cli import plugin_invocation as invocation_mod
+
+        ctx, mgr = self._make_ctx()
+        enabled = [True]
+        seen = []
+
+        def handler(_args):
+            invocation = ctx.invocation
+            seen.append((invocation.profile, invocation.authenticated_actor))
+            return 7
+
+        ctx.register_cli_command(
+            "guarded",
+            "Guarded command",
+            lambda parser: parser.add_argument("--flag", action="store_true"),
+            handler,
+            availability=lambda invocation: enabled[0]
+            and invocation.authenticated_actor == "nas-user-7",
+        )
+        monkeypatch.setattr(plugins, "_ensure_plugins_discovered", lambda: mgr)
+
+        def invocation():
+            return PluginInvocationContext(
+                "work", None, "cli", "nas-user-7", None, None, None, None, "root"
+            )
+
+        monkeypatch.setattr(invocation_mod, "_new_local_plugin_invocation", lambda **_kw: invocation())
+        parser = argparse.ArgumentParser(prog="hermes")
+        subparsers = parser.add_subparsers(dest="command")
+        main_mod._attach_plugin_cli_command(
+            subparsers, mgr._cli_commands["guarded"], trusted_context=True
+        )
+        args = parser.parse_args(["guarded", "--flag"])
+
+        assert main_mod._run_cli_handler(args, parser) == 7
+        assert seen == [("work", "nas-user-7")]
+
+        enabled[0] = False
+        with pytest.raises(SystemExit) as denied:
+            main_mod._run_cli_handler(args, parser)
+        assert denied.value.code == 2
+        assert seen == [("work", "nas-user-7")]
+
+    @pytest.mark.parametrize("root_handler", [False, True])
+    def test_setup_installed_nested_handler_is_gated_after_parse(
+        self, monkeypatch, root_handler
+    ):
+        from hermes_cli import main as main_mod
+        from hermes_cli import plugin_invocation as invocation_mod
+
+        ctx, mgr = self._make_ctx()
+        enabled = [True]
+        seen = []
+
+        def nested_handler(_args):
+            seen.append(ctx.invocation.platform)
+            return 9
+
+        def setup(parser):
+            if not root_handler:
+                parser.set_defaults(func=lambda _args: 3)
+            nested = parser.add_subparsers(dest="action").add_parser("nested")
+            nested.set_defaults(func=nested_handler)
+
+        ctx.register_cli_command(
+            "guarded",
+            "Guarded command",
+            setup,
+            (lambda _args: 4) if root_handler else None,
+            availability=lambda _invocation: enabled[0],
+        )
+        monkeypatch.setattr(plugins, "_ensure_plugins_discovered", lambda: mgr)
+        monkeypatch.setattr(
+            invocation_mod,
+            "_new_local_plugin_invocation",
+            lambda **_kw: PluginInvocationContext(
+                "work", None, "cli", None, None, None, None, None, "root"
+            ),
+        )
+        parser = argparse.ArgumentParser(prog="hermes")
+        subparsers = parser.add_subparsers(dest="command")
+        main_mod._attach_plugin_cli_command(
+            subparsers, mgr._cli_commands["guarded"], trusted_context=True
+        )
+        args = parser.parse_args(["guarded", "nested"])
+
+        assert main_mod._run_cli_handler(args, parser) == 9
+        assert seen == ["cli"]
+
+        enabled[0] = False
+        with pytest.raises(SystemExit) as denied:
+            main_mod._run_cli_handler(args, parser)
+        assert denied.value.code == 2
+        assert seen == ["cli"]
+
+    def test_setup_only_root_handler_is_gated_after_parse(self, monkeypatch):
+        from hermes_cli import main as main_mod
+        from hermes_cli import plugin_invocation as invocation_mod
+
+        ctx, mgr = self._make_ctx()
+        enabled = [True]
+        seen = []
+
+        def setup(parser):
+            parser.set_defaults(func=lambda _args: seen.append(ctx.invocation.platform))
+
+        ctx.register_cli_command(
+            "guarded",
+            "Guarded command",
+            setup,
+            availability=lambda _invocation: enabled[0],
+        )
+        monkeypatch.setattr(plugins, "_ensure_plugins_discovered", lambda: mgr)
+        monkeypatch.setattr(
+            invocation_mod,
+            "_new_local_plugin_invocation",
+            lambda **_kw: PluginInvocationContext(
+                "work", None, "cli", None, None, None, None, None, "root"
+            ),
+        )
+        parser = argparse.ArgumentParser(prog="hermes")
+        subparsers = parser.add_subparsers(dest="command")
+        main_mod._attach_plugin_cli_command(
+            subparsers, mgr._cli_commands["guarded"], trusted_context=True
+        )
+        args = parser.parse_args(["guarded"])
+
+        main_mod._run_cli_handler(args, parser)
+        assert seen == ["cli"]
+
+        enabled[0] = False
+        with pytest.raises(SystemExit) as denied:
+            main_mod._run_cli_handler(args, parser)
+        assert denied.value.code == 2
+        assert seen == ["cli"]
+
+    def test_unavailable_registered_command_is_not_attached(self, monkeypatch):
+        from hermes_cli import main as main_mod
+        from hermes_cli import plugin_invocation as invocation_mod
+        from plugins import memory
+
+        ctx, mgr = self._make_ctx()
+        handler = MagicMock()
+        ctx.register_cli_command(
+            "guarded",
+            "Guarded command",
+            lambda _parser: None,
+            handler,
+            availability=lambda _invocation: False,
+        )
+        monkeypatch.setattr(plugins, "_ensure_plugins_discovered", lambda: mgr)
+        monkeypatch.setattr(plugins, "discover_plugins", lambda: None)
+        monkeypatch.setattr(memory, "discover_plugin_cli_commands", lambda: [])
+        monkeypatch.setattr(main_mod, "_resolve_deferred_platform_cli_command", lambda _name: None)
+        monkeypatch.setattr(
+            invocation_mod,
+            "_new_local_plugin_invocation",
+            lambda **_kw: PluginInvocationContext(
+                "work", None, "cli", None, None, None, None, None, "root"
+            ),
+        )
+        parser = argparse.ArgumentParser(prog="hermes")
+        subparsers = parser.add_subparsers(dest="command")
+
+        main_mod._register_plugin_cli_commands(subparsers)
+
+        assert "guarded" not in subparsers.choices
+        with pytest.raises(SystemExit) as denied:
+            parser.parse_args(["guarded"])
+        assert denied.value.code == 2
+        handler.assert_not_called()
 
 
 # ── Memory plugin CLI discovery ───────────────────────────────────────────

--- a/tests/hermes_cli/test_plugin_invocation.py
+++ b/tests/hermes_cli/test_plugin_invocation.py
@@ -1,0 +1,250 @@
+"""Trusted plugin invocation context and command availability contracts."""
+
+from __future__ import annotations
+
+import asyncio
+import pytest
+
+from hermes_cli import plugins
+from hermes_cli.plugin_invocation import (
+    PluginInvocationContext,
+    PluginInvocationContextUnavailable,
+    _bind_plugin_invocation,
+)
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+
+def _invocation(**overrides) -> PluginInvocationContext:
+    values = {
+        "_profile": "default",
+        "_session_id": "session-1",
+        "_platform": "cli",
+        "_authenticated_actor": None,
+        "_target": "session-1",
+        "_chat_id": None,
+        "_thread_id": None,
+        "_origin": None,
+        "_execution_kind": "root",
+    }
+    values.update({f"_{key}": value for key, value in overrides.items()})
+    return PluginInvocationContext(**values)
+
+
+@pytest.fixture()
+def neutral_consumer(monkeypatch):
+    manager = PluginManager(scope_key="/tmp/hermes-plugin-invocation-test")
+    context = PluginContext(
+        PluginManifest(name="neutral-context-consumer", source="user"), manager
+    )
+    seen = []
+
+    def handler(raw_args):
+        invocation = context.invocation
+        seen.append(
+            (
+                raw_args,
+                invocation,
+                {
+                    "session_id": invocation.session_id,
+                    "platform": invocation.platform,
+                    "authenticated_actor": invocation.authenticated_actor,
+                    "execution_kind": invocation.execution_kind,
+                },
+            )
+        )
+        return "handled"
+
+    context.register_command(
+        "context-probe",
+        handler,
+        availability=lambda invocation: invocation.platform == "cli",
+    )
+    monkeypatch.setattr(plugins, "_ensure_plugins_discovered", lambda: manager)
+    return context, manager, seen
+
+
+def test_context_is_immutable_and_unavailable_outside_dispatch(neutral_consumer):
+    context, _manager, _seen = neutral_consumer
+
+    with pytest.raises(PluginInvocationContextUnavailable):
+        _ = context.invocation
+    with pytest.raises((AttributeError, TypeError)):
+        _invocation().platform = "gateway"
+
+
+def test_availability_filters_discovery_and_dispatch(neutral_consumer):
+    _context, _manager, _seen = neutral_consumer
+    allowed = _invocation()
+    denied = _invocation(platform="telegram")
+
+    assert "context-probe" not in plugins.get_plugin_commands()
+    assert "context-probe" not in plugins.get_plugin_commands(denied)
+    assert plugins.get_plugin_command_handler("context-probe", denied) is None
+    assert "context-probe" in plugins.get_plugin_commands(allowed)
+    assert plugins.get_plugin_command_handler("context-probe", allowed) is not None
+    assert plugins.is_plugin_command_registered("context-probe") is True
+
+
+def test_bound_handler_sees_exact_context_and_binding_resets(neutral_consumer):
+    context, _manager, seen = neutral_consumer
+    invocation = _invocation(authenticated_actor="user-7")
+    handler = plugins.get_plugin_command_handler("context-probe", invocation)
+
+    with _bind_plugin_invocation(invocation):
+        assert handler("raw ARG") == "handled"
+        assert context.invocation is invocation
+
+    assert seen == [
+        (
+            "raw ARG",
+            invocation,
+            {
+                "session_id": "session-1",
+                "platform": "cli",
+                "authenticated_actor": "user-7",
+                "execution_kind": "root",
+            },
+        )
+    ]
+    with pytest.raises(PluginInvocationContextUnavailable, match="expired"):
+        _ = invocation.session_id
+    with pytest.raises(PluginInvocationContextUnavailable):
+        _ = context.invocation
+
+
+def test_predicate_exception_and_awaitable_fail_closed(monkeypatch, caplog):
+    manager = PluginManager(scope_key="/tmp/hermes-plugin-predicate-test")
+    context = PluginContext(PluginManifest(name="neutral-consumer", source="user"), manager)
+    context.register_command(
+        "raises", lambda _raw: None, availability=lambda _invocation: 1 / 0
+    )
+
+    async def async_predicate(_invocation):
+        return True
+
+    context.register_command("async", lambda _raw: None, availability=async_predicate)
+    monkeypatch.setattr(plugins, "_ensure_plugins_discovered", lambda: manager)
+
+    assert plugins.get_plugin_commands(_invocation()) == {}
+    assert "command availability failed" in caplog.text
+    assert "returned an awaitable" in caplog.text
+
+
+def test_non_callable_predicate_is_rejected():
+    manager = PluginManager(scope_key="/tmp/hermes-plugin-predicate-type-test")
+    context = PluginContext(PluginManifest(name="neutral-consumer", source="user"), manager)
+
+    with pytest.raises(TypeError, match="availability must be callable"):
+        context.register_command("bad", lambda _raw: None, availability=True)
+
+
+def test_legacy_command_without_predicate_is_unchanged(monkeypatch):
+    manager = PluginManager(scope_key="/tmp/hermes-plugin-legacy-test")
+    context = PluginContext(PluginManifest(name="legacy-consumer", source="user"), manager)
+    handler = lambda raw: raw
+    context.register_command("legacy", handler)
+    monkeypatch.setattr(plugins, "_ensure_plugins_discovered", lambda: manager)
+
+    assert plugins.get_plugin_commands()["legacy"]["handler"] is handler
+    assert plugins.get_plugin_command_handler("legacy") is handler
+
+
+def test_binding_is_isolated_between_async_tasks(neutral_consumer):
+    context, _manager, _seen = neutral_consumer
+
+    async def observe(invocation):
+        with _bind_plugin_invocation(invocation):
+            await asyncio.sleep(0)
+            return context.invocation.session_id
+
+    async def run_observers():
+        return await asyncio.gather(
+            observe(_invocation(session_id="first")),
+            observe(_invocation(session_id="second")),
+        )
+
+    first, second = asyncio.run(run_observers())
+
+    assert first == "first"
+    assert second == "second"
+
+
+def test_spawn_task_does_not_inherit_command_authority(neutral_consumer):
+    context, _manager, _seen = neutral_consumer
+
+    async def observe_background():
+        await asyncio.sleep(0)
+        with pytest.raises(PluginInvocationContextUnavailable):
+            _ = context.invocation
+        return "background"
+
+    async def run_background():
+        with _bind_plugin_invocation(_invocation()):
+            task = context.spawn_task(observe_background(), name="neutral-background")
+        return await task
+
+    assert asyncio.run(run_background()) == "background"
+
+
+def test_async_result_helper_thread_preserves_context(neutral_consumer):
+    context, _manager, _seen = neutral_consumer
+    invocation = _invocation(session_id="threaded")
+
+    async def async_handler():
+        await asyncio.sleep(0)
+        return context.invocation
+
+    async def run_handler():
+        with _bind_plugin_invocation(invocation):
+            return plugins.resolve_plugin_command_result(async_handler())
+
+    observed = asyncio.run(run_handler())
+
+    assert observed is invocation
+
+
+def test_cli_command_dispatch_binds_trusted_context(neutral_consumer, monkeypatch):
+    import cli as cli_mod
+
+    context, _manager, seen = neutral_consumer
+    cli = object.__new__(cli_mod.HermesCLI)
+    cli.session_id = "cli-session"
+    cli.config = {"quick_commands": {}}
+    monkeypatch.setattr(cli_mod, "_ensure_skill_commands", lambda: {})
+    monkeypatch.setattr(cli_mod, "get_skill_bundles", lambda: {})
+    monkeypatch.setattr(cli_mod, "_cprint", lambda _text: None)
+
+    assert cli._process_unregistered_slash("/context-probe MiXeD", "/context-probe mixed")
+
+    raw_args, invocation, snapshot = seen.pop()
+    assert raw_args == "MiXeD"
+    assert snapshot == {
+        "session_id": "cli-session",
+        "platform": "cli",
+        "authenticated_actor": None,
+        "execution_kind": "root",
+    }
+    with pytest.raises(PluginInvocationContextUnavailable, match="expired"):
+        _ = invocation.session_id
+    with pytest.raises(PluginInvocationContextUnavailable):
+        _ = context.invocation
+
+
+def test_cli_unavailable_registered_command_stops_as_unknown(neutral_consumer, monkeypatch):
+    import cli as cli_mod
+
+    _context, _manager, seen = neutral_consumer
+    cli = object.__new__(cli_mod.HermesCLI)
+    cli.session_id = "cli-session"
+    cli.config = {"quick_commands": {}}
+    cli._expand_slash_prefix = lambda *_args: "unknown"
+    monkeypatch.setattr(cli_mod, "_ensure_skill_commands", lambda: {})
+    monkeypatch.setattr(cli_mod, "get_skill_bundles", lambda: {})
+    monkeypatch.setattr(
+        cli_mod,
+        "_cli_plugin_invocation",
+        lambda _cli: _invocation(platform="tui"),
+    )
+
+    assert cli._process_unregistered_slash("/context-probe", "/context-probe") == "unknown"
+    assert seen == []

--- a/tests/hermes_cli/test_plugin_invocation.py
+++ b/tests/hermes_cli/test_plugin_invocation.py
@@ -10,6 +10,7 @@ from hermes_cli.plugin_invocation import (
     PluginInvocationContext,
     PluginInvocationContextUnavailable,
     _bind_plugin_invocation,
+    _new_local_plugin_invocation,
     _revoke_plugin_invocation,
 )
 from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
@@ -71,6 +72,123 @@ def test_context_is_immutable_and_unavailable_outside_dispatch(neutral_consumer)
         _ = context.invocation
     with pytest.raises((AttributeError, TypeError)):
         _invocation().platform = "gateway"
+
+
+def test_local_context_uses_refresh_free_host_actor_and_active_profile(monkeypatch):
+    import hermes_cli.auth as auth
+    import hermes_cli.auth_nous as auth_nous
+    import hermes_cli.profiles as profiles
+
+    monkeypatch.setattr(
+        auth,
+        "get_provider_auth_state",
+        lambda provider: {"access_token": "local-jwt", "scope": "inference:invoke"}
+        if provider == "nous"
+        else None,
+    )
+    monkeypatch.setattr(auth_nous, "_state_invoke_jwt_status", lambda _state, _token: None)
+    monkeypatch.setattr(
+        auth_nous, "_decode_jwt_claims", lambda _token: {"sub": "  nas-user-7  "}
+    )
+    monkeypatch.setattr("hermes_cli.anon_auth.is_guest_state", lambda _state: False)
+    monkeypatch.setattr(
+        auth,
+        "resolve_nous_runtime_credentials",
+        lambda *_args, **_kwargs: pytest.fail("discovery must not refresh credentials"),
+    )
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "work")
+
+    invocation = _new_local_plugin_invocation(
+        platform="cli", session_id="local-session"
+    )
+
+    assert invocation.profile == "work"
+    assert invocation.authenticated_actor == "nas-user-7"
+    assert invocation.session_id == "local-session"
+    assert invocation.target == "local-session"
+
+
+def test_local_context_rejects_expired_access_even_with_refresh(monkeypatch):
+    import hermes_cli.auth as auth
+    import hermes_cli.auth_nous as auth_nous
+
+    state = {"access_token": "expired-jwt", "refresh_token": "still-present"}
+    monkeypatch.setattr(auth, "get_provider_auth_state", lambda _provider: state)
+    monkeypatch.setattr(
+        auth_nous, "_state_invoke_jwt_status", lambda _state, _token: "invoke_jwt_expiring"
+    )
+    monkeypatch.setattr("hermes_cli.anon_auth.is_guest_state", lambda _state: False)
+
+    invocation = _new_local_plugin_invocation(platform="tui")
+
+    assert invocation.authenticated_actor is None
+
+
+def test_local_context_rejects_wrong_scope_or_missing_jwt_subject(monkeypatch):
+    import hermes_cli.auth as auth
+    import hermes_cli.auth_nous as auth_nous
+
+    monkeypatch.setattr(
+        auth,
+        "get_provider_auth_state",
+        lambda _provider: {"access_token": "local-jwt", "scope": "wrong:scope"},
+    )
+    monkeypatch.setattr(
+        auth_nous,
+        "_state_invoke_jwt_status",
+        lambda _state, _token: "missing_inference_invoke_scope",
+    )
+    monkeypatch.setattr(auth_nous, "_decode_jwt_claims", lambda _token: {"sub": "nas-user-7"})
+    monkeypatch.setattr("hermes_cli.anon_auth.is_guest_state", lambda _state: False)
+
+    wrong_scope = _new_local_plugin_invocation(platform="cli")
+    assert wrong_scope.authenticated_actor is None
+
+    monkeypatch.setattr(auth_nous, "_state_invoke_jwt_status", lambda _state, _token: None)
+    monkeypatch.setattr(auth_nous, "_decode_jwt_claims", lambda _token: {})
+    missing_subject = _new_local_plugin_invocation(platform="cli")
+    assert missing_subject.authenticated_actor is None
+
+
+def test_local_context_rejects_guest_or_mismatched_subject(monkeypatch):
+    import hermes_cli.auth as auth
+    import hermes_cli.auth_nous as auth_nous
+
+    state = {"access_token": "local-jwt", "user_id": "different-user"}
+    monkeypatch.setattr(auth, "get_provider_auth_state", lambda _provider: state)
+    monkeypatch.setattr(auth_nous, "_state_invoke_jwt_status", lambda _state, _token: None)
+    monkeypatch.setattr(
+        auth_nous, "_decode_jwt_claims", lambda _token: {"sub": "nas-user-7"}
+    )
+    monkeypatch.setattr("hermes_cli.anon_auth.is_guest_state", lambda _state: True)
+    assert _new_local_plugin_invocation(platform="cli").authenticated_actor is None
+
+    monkeypatch.setattr("hermes_cli.anon_auth.is_guest_state", lambda _state: False)
+    assert _new_local_plugin_invocation(platform="cli").authenticated_actor is None
+
+
+def test_local_context_fails_closed_on_state_reader_error(monkeypatch):
+    import hermes_cli.auth as auth
+
+    def fail(_provider):
+        raise OSError("unreadable auth store")
+
+    monkeypatch.setattr(auth, "get_provider_auth_state", fail)
+
+    assert _new_local_plugin_invocation(platform="cli").authenticated_actor is None
+
+
+def test_local_context_does_not_cross_profile_scope(monkeypatch):
+    import hermes_cli.profiles as profiles
+    import hermes_cli.plugin_invocation as invocation_mod
+
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "work")
+    monkeypatch.setattr(invocation_mod, "_local_authenticated_actor", lambda: "nas-user-7")
+
+    invocation = _new_local_plugin_invocation(platform="tui", profile="personal")
+
+    assert invocation.profile == "personal"
+    assert invocation.authenticated_actor is None
 
 
 def test_availability_filters_discovery_and_dispatch(neutral_consumer):

--- a/tests/hermes_cli/test_plugin_invocation.py
+++ b/tests/hermes_cli/test_plugin_invocation.py
@@ -10,6 +10,7 @@ from hermes_cli.plugin_invocation import (
     PluginInvocationContext,
     PluginInvocationContextUnavailable,
     _bind_plugin_invocation,
+    _revoke_plugin_invocation,
 )
 from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
 
@@ -85,6 +86,25 @@ def test_availability_filters_discovery_and_dispatch(neutral_consumer):
     assert plugins.is_plugin_command_registered("context-probe") is True
 
 
+def test_expired_context_denies_before_always_true_predicate(monkeypatch):
+    manager = PluginManager(scope_key="/tmp/hermes-plugin-expired-test")
+    context = PluginContext(PluginManifest(name="neutral-consumer", source="user"), manager)
+    predicate_calls = []
+
+    def always_true(invocation):
+        predicate_calls.append(invocation)
+        return True
+
+    context.register_command("expired", lambda _raw: None, availability=always_true)
+    monkeypatch.setattr(plugins, "_ensure_plugins_discovered", lambda: manager)
+    invocation = _invocation()
+    _revoke_plugin_invocation(invocation)
+
+    assert plugins.get_plugin_commands(invocation) == {}
+    assert plugins.get_plugin_command_handler("expired", invocation) is None
+    assert predicate_calls == []
+
+
 def test_bound_handler_sees_exact_context_and_binding_resets(neutral_consumer):
     context, _manager, seen = neutral_consumer
     invocation = _invocation(authenticated_actor="user-7")
@@ -126,7 +146,9 @@ def test_predicate_exception_and_awaitable_fail_closed(monkeypatch, caplog):
     monkeypatch.setattr(plugins, "_ensure_plugins_discovered", lambda: manager)
 
     assert plugins.get_plugin_commands(_invocation()) == {}
-    assert "command availability failed" in caplog.text
+    assert "command availability failed (ZeroDivisionError)" in caplog.text
+    assert "division by zero" not in caplog.text
+    assert "Traceback" not in caplog.text
     assert "returned an awaitable" in caplog.text
 
 

--- a/tests/tui_gateway/test_plugin_command_context.py
+++ b/tests/tui_gateway/test_plugin_command_context.py
@@ -1,0 +1,115 @@
+"""Trusted context for plugin commands dispatched through TUI gateway RPCs."""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_cli import plugins
+from hermes_cli.plugin_invocation import PluginInvocationContextUnavailable
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+
+@pytest.fixture()
+def server(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+        },
+    ):
+        module = importlib.import_module("tui_gateway.server")
+
+    methods = dict(module._methods)
+    yield module
+    module._methods.clear()
+    module._methods.update(methods)
+    module._sessions.clear()
+
+
+def test_catalog_and_dispatch_use_live_session_context(server, monkeypatch):
+    manager = PluginManager(scope_key="/tmp/hermes-tui-plugin-context-test")
+    context = PluginContext(PluginManifest(name="neutral-consumer", source="user"), manager)
+    seen = []
+
+    def handler(raw_args):
+        invocation = context.invocation
+        seen.append(
+            (
+                raw_args,
+                invocation,
+                {
+                    "profile": invocation.profile,
+                    "actor": invocation.authenticated_actor,
+                    "target": invocation.target,
+                    "origin": invocation.origin,
+                },
+            )
+        )
+        return "tui handled"
+
+    context.register_command(
+        "context-probe",
+        handler,
+        availability=lambda invocation: (
+            invocation.platform == "tui"
+            and invocation.session_id == "tui-session"
+            and invocation.execution_kind == "root"
+        ),
+    )
+    monkeypatch.setattr(plugins, "_ensure_plugins_discovered", lambda: manager)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    monkeypatch.setattr(server, "_current_profile_name", lambda: "default")
+    server._sessions["rpc-session"] = {
+        "session_key": "tui-session",
+        "profile_home": None,
+    }
+
+    hidden = server._methods["commands.catalog"](1, {})
+    visible = server._methods["commands.catalog"](2, {"session_id": "rpc-session"})
+    dispatched = server._methods["command.dispatch"](
+        3,
+        {"session_id": "rpc-session", "name": "context-probe", "arg": "MiXeD"},
+    )
+
+    assert "/context-probe" not in dict(hidden["result"]["pairs"])
+    assert "/context-probe" in dict(visible["result"]["pairs"])
+    assert dispatched["result"] == {"type": "plugin", "output": "tui handled"}
+    raw_args, invocation, snapshot = seen.pop()
+    assert raw_args == "MiXeD"
+    assert snapshot == {
+        "profile": "default",
+        "actor": None,
+        "target": "tui-session",
+        "origin": None,
+    }
+    with pytest.raises(PluginInvocationContextUnavailable, match="expired"):
+        _ = invocation.profile
+    with pytest.raises(PluginInvocationContextUnavailable):
+        _ = context.invocation
+
+
+def test_unavailable_registered_command_does_not_dispatch(server, monkeypatch):
+    manager = PluginManager(scope_key="/tmp/hermes-tui-unavailable-command-test")
+    context = PluginContext(PluginManifest(name="neutral-consumer", source="user"), manager)
+    handler = MagicMock()
+    context.register_command(
+        "context-probe",
+        handler,
+        availability=lambda invocation: invocation.authenticated_actor is not None,
+    )
+    monkeypatch.setattr(plugins, "_ensure_plugins_discovered", lambda: manager)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {})
+    monkeypatch.setattr(server, "_current_profile_name", lambda: "default")
+    server._sessions["rpc-session"] = {"session_key": "tui-session", "profile_home": None}
+
+    response = server._methods["command.dispatch"](
+        1, {"session_id": "rpc-session", "name": "context-probe", "arg": "do it"}
+    )
+
+    assert response["error"]["code"] == 4018
+    handler.assert_not_called()

--- a/tests/tui_gateway/test_plugin_command_context.py
+++ b/tests/tui_gateway/test_plugin_command_context.py
@@ -35,6 +35,15 @@ def test_catalog_and_dispatch_use_live_session_context(server, monkeypatch):
     manager = PluginManager(scope_key="/tmp/hermes-tui-plugin-context-test")
     context = PluginContext(PluginManifest(name="neutral-consumer", source="user"), manager)
     seen = []
+    availability_contexts = []
+
+    def available(invocation):
+        availability_contexts.append(invocation)
+        return (
+            invocation.platform == "tui"
+            and invocation.session_id == "tui-session"
+            and invocation.execution_kind == "root"
+        )
 
     def handler(raw_args):
         invocation = context.invocation
@@ -55,11 +64,7 @@ def test_catalog_and_dispatch_use_live_session_context(server, monkeypatch):
     context.register_command(
         "context-probe",
         handler,
-        availability=lambda invocation: (
-            invocation.platform == "tui"
-            and invocation.session_id == "tui-session"
-            and invocation.execution_kind == "root"
-        ),
+        availability=available,
     )
     monkeypatch.setattr(plugins, "_ensure_plugins_discovered", lambda: manager)
     monkeypatch.setattr(server, "_load_cfg", lambda: {})
@@ -91,6 +96,9 @@ def test_catalog_and_dispatch_use_live_session_context(server, monkeypatch):
         _ = invocation.profile
     with pytest.raises(PluginInvocationContextUnavailable):
         _ = context.invocation
+    for discovered_context in availability_contexts:
+        with pytest.raises(PluginInvocationContextUnavailable, match="expired"):
+            _ = discovered_context.session_id
 
 
 def test_unavailable_registered_command_does_not_dispatch(server, monkeypatch):

--- a/tests/tui_gateway/test_plugin_command_context.py
+++ b/tests/tui_gateway/test_plugin_command_context.py
@@ -32,6 +32,8 @@ def server(tmp_path, monkeypatch):
 
 
 def test_catalog_and_dispatch_use_live_session_context(server, monkeypatch):
+    import hermes_cli.plugin_invocation as invocation_mod
+
     manager = PluginManager(scope_key="/tmp/hermes-tui-plugin-context-test")
     context = PluginContext(PluginManifest(name="neutral-consumer", source="user"), manager)
     seen = []
@@ -69,6 +71,9 @@ def test_catalog_and_dispatch_use_live_session_context(server, monkeypatch):
     monkeypatch.setattr(plugins, "_ensure_plugins_discovered", lambda: manager)
     monkeypatch.setattr(server, "_load_cfg", lambda: {})
     monkeypatch.setattr(server, "_current_profile_name", lambda: "default")
+    monkeypatch.setattr(
+        invocation_mod, "_local_authenticated_actor", lambda: "nas-user-7"
+    )
     server._sessions["rpc-session"] = {
         "session_key": "tui-session",
         "profile_home": None,
@@ -88,7 +93,7 @@ def test_catalog_and_dispatch_use_live_session_context(server, monkeypatch):
     assert raw_args == "MiXeD"
     assert snapshot == {
         "profile": "default",
-        "actor": None,
+        "actor": "nas-user-7",
         "target": "tui-session",
         "origin": None,
     }

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -384,17 +384,12 @@ def _plugin_invocation(session: dict | None):
     invocation_mod = _tools_mod("hermes_cli.plugin_invocation")
     session_id = str(session.get("session_key") or "").strip() or None
     profile = profile_name_for_home(session.get("profile_home")) or _current_profile_name()
-    return invocation_mod._new_plugin_invocation(
-        profile=profile,
-        session_id=session_id,
-        platform="tui",
-        authenticated_actor=None,
-        target=session_id,
-        chat_id=None,
-        thread_id=None,
-        origin=None,
-        execution_kind="root",
-    )
+    with _session_profile_runtime_scope(session):
+        return invocation_mod._new_local_plugin_invocation(
+            profile=profile,
+            session_id=session_id,
+            platform="tui",
+        )
 
 
 def _catalog_plugin_commands(cat: _Catalog, invocation=None) -> None:

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -5,6 +5,7 @@ bodies reference server globals bare (``_ok``, ``_err``, ``_sessions``, ...).
 Helper names must not collide with server.py's own (``_cmd_`` / ``_toolset_`` / ``_mcp_`` prefixes).
 """
 
+import contextlib
 import sys
 from pathlib import Path
 
@@ -376,8 +377,37 @@ def _catalog_quick_commands(cat: _Catalog) -> None:
         cat.add(f"/{qname}", desc, "User commands")
 
 
-def _catalog_plugin_commands(cat: _Catalog) -> None:
-    plugin_cmds = _tools_mod("hermes_cli.plugins").get_plugin_commands() or {}
+def _plugin_invocation(session: dict | None):
+    """Build trusted plugin context from a live TUI gateway session record."""
+    if not session:
+        return None
+    invocation_mod = _tools_mod("hermes_cli.plugin_invocation")
+    session_id = str(session.get("session_key") or "").strip() or None
+    profile = profile_name_for_home(session.get("profile_home")) or _current_profile_name()
+    return invocation_mod._new_plugin_invocation(
+        profile=profile,
+        session_id=session_id,
+        platform="tui",
+        authenticated_actor=None,
+        target=session_id,
+        chat_id=None,
+        thread_id=None,
+        origin=None,
+        execution_kind="root",
+    )
+
+
+def _catalog_plugin_commands(cat: _Catalog, invocation=None) -> None:
+    plugins = _tools_mod("hermes_cli.plugins")
+    try:
+        plugin_cmds = (
+            plugins.get_plugin_commands(invocation)
+            if invocation is not None
+            else plugins.get_plugin_commands()
+        ) or {}
+    finally:
+        if invocation is not None:
+            _tools_mod("hermes_cli.plugin_invocation")._revoke_plugin_invocation(invocation)
     if plugin_cmds:
         cat.cat_map.setdefault("Plugin commands", [])
     for pname, info in sorted(plugin_cmds.items()):
@@ -412,7 +442,8 @@ def _(rid, params: dict) -> dict:
     except Exception as e:
         warning = f"quick_commands discovery unavailable: {e}"
     try:
-        _catalog_plugin_commands(cat)
+        session = _sessions.get(params.get("session_id", ""))
+        _catalog_plugin_commands(cat, _plugin_invocation(session))
     except Exception as e:
         warning = warning or f"plugin command discovery unavailable: {e}"
     skills: dict[str, dict] = {}
@@ -475,15 +506,28 @@ def _dispatch_quick(rid, params, session, name, arg):
     return _ok(rid, {"type": "alias", "target": qc.get("target", "")}) if qc.get("type") == "alias" else None
 
 
-def _plugin_command_handler(name: str):
+def _plugin_command_handler(name: str, invocation=None):
     try:
-        return _tools_mod("hermes_cli.plugins").get_plugin_command_handler(name)
+        plugins = _tools_mod("hermes_cli.plugins")
+        return (
+            plugins.get_plugin_command_handler(name, invocation)
+            if invocation is not None
+            else plugins.get_plugin_command_handler(name)
+        )
     except Exception:
         return None
 
 
-def _run_plugin_command(handler, arg: str) -> str:
-    return str(_tools_mod("hermes_cli.plugins").resolve_plugin_command_result(handler(arg)) or "")
+def _run_plugin_command(handler, arg: str, invocation) -> str:
+    invocation_mod = _tools_mod("hermes_cli.plugin_invocation")
+    scope = (
+        invocation_mod._bind_plugin_invocation(invocation)
+        if invocation is not None
+        else contextlib.nullcontext()
+    )
+    with scope:
+        result = _tools_mod("hermes_cli.plugins").resolve_plugin_command_result(handler(arg))
+    return str(result or "")
 
 
 def _is_profile_skill_command(session: dict, base: str) -> bool:
@@ -503,9 +547,17 @@ def _is_profile_skill_command(session: dict, base: str) -> bool:
 
 
 def _dispatch_plugin(rid, params, session, name, arg):
-    if handler := _plugin_command_handler(name):
-        with contextlib.suppress(Exception):
-            return _ok(rid, {"type": "plugin", "output": _run_plugin_command(handler, arg)})
+    invocation = _plugin_invocation(session)
+    try:
+        if handler := _plugin_command_handler(name, invocation):
+            with contextlib.suppress(Exception):
+                return _ok(
+                    rid,
+                    {"type": "plugin", "output": _run_plugin_command(handler, arg, invocation)},
+                )
+    finally:
+        if invocation is not None:
+            _tools_mod("hermes_cli.plugin_invocation")._revoke_plugin_invocation(invocation)
     return None
 
 
@@ -834,11 +886,19 @@ def _(rid, params: dict) -> dict:
         return _methods["command.dispatch"](rid, {"name": target.lstrip("/"), "arg": arg, "session_id": sid})
     if _is_profile_skill_command(session, base):
         return _err(rid, 4018, f"skill command: use command.dispatch for /{base}")
-    if plugin_handler := _plugin_command_handler(base) if base else None:
-        try:
-            return _ok(rid, {"output": _run_plugin_command(plugin_handler, arg) or "(no output)"})
-        except Exception as e:
-            return _ok(rid, {"output": f"Plugin command error: {e}"})
+    invocation = _plugin_invocation(session)
+    try:
+        if plugin_handler := _plugin_command_handler(base, invocation) if base else None:
+            try:
+                return _ok(
+                    rid,
+                    {"output": _run_plugin_command(plugin_handler, arg, invocation) or "(no output)"},
+                )
+            except Exception as e:
+                return _ok(rid, {"output": f"Plugin command error: {e}"})
+    finally:
+        if invocation is not None:
+            _tools_mod("hermes_cli.plugin_invocation")._revoke_plugin_invocation(invocation)
     worker = session.get("slash_worker")
     if not worker:
         # slash.exec runs on the RPC pool: two concurrent commands could both see slash_worker=None


### PR DESCRIPTION
## Scope
Draft generic host command API slice for external plugins. No Wisdom business logic is added to Agent. This does not yet provide the full tool/lifecycle/account interface needed by the external plugin.

## Changes
- Host-created invocation-local command context with profile, session, platform, actor hint, chat/thread, origin and execution kind; revoked after dispatch/discovery.
- Fail-closed synchronous availability for slash commands and top-level CLI commands, including setup-only and nested argparse handlers. Discovery and actual dispatch are both checked.
- CLI/TUI local actor hints use one usable non-guest credential snapshot without refresh. Expiry, malformed state, subject mismatch, and profile mismatch deny the hint. Gateway remains the remote authorization authority.
- Admitted gateway command context preserves actor/chat/thread bindings. Background tasks lose command invocation authority; unknown/unavailable commands cannot fall through into model handling.

## Verification
At c4032ae225adc1bfa042c5a458ba38891baeddf9, the integrator reran 102 focused command/context tests successfully. Pinned Ruff and diff checks passed. Local tests use Python 3.12 with isolated test tooling and read-only runtime dependencies from a reference environment; this is not a clean locked host installation.

Earlier full Linux CI at 2ad6e319 passed 47,549 tests with one failure caused by an old-signature mock in the command rewrite test. That fixture now exercises real plugin registration with allowed and denied rewrites; its full file passes. New-head full CI is tracked by this PR and must be checked independently.

## Still pending
Plugin-facing account/entitlement/request facade; tool and subagent invocation bindings; actual delivery facts, idle lifecycle, fencing and typed continuation events; live native acceptance. Static platform command publication has no user context and therefore hides gated commands. This PR is deliberately draft while the host milestone is incomplete.