### PR TITLE
fix(acp): route set_model for configured custom providers

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -672,6 +672,29 @@ _KNOWN_PROVIDER_NAMES: set[str] = set(_PROVIDER_LABELS) | set(_PROVIDER_ALIASES)
 _CONFIG_ERRORS = (ImportError, OSError, RuntimeError, TypeError, ValueError, AttributeError)
 
 
+def _routable_provider_names() -> set[str]:
+    """Bare names valid left of the ``provider:model`` colon in :func:`parse_model_input`.
+
+    ``_KNOWN_PROVIDER_NAMES`` plus the bare keys of configured custom providers
+    (``custom:relay`` → ``relay``), so a user-configured key routes without
+    its ``custom:`` prefix. Canonical names keep precedence: a user key colliding
+    with one (``providers: anthropic:``) still routes natively because
+    :func:`parse_model_input` only maps names outside ``_KNOWN_PROVIDER_NAMES``
+    — letting it hijack ``anthropic:claude-…`` would silently re-route native
+    input to the user's relay. Such a provider stays reachable via
+    ``custom:<key>:``. Keys with an inner colon (``local-127.0.0.1:11434``)
+    are skipped: they can never be typed bare because the split happens at
+    the FIRST colon."""
+    names = set(_KNOWN_PROVIDER_NAMES)
+    for pid in _configured_custom_provider_ids():
+        if not pid.startswith("custom:"):
+            continue
+        bare = pid[len("custom:"):]
+        if bare and ":" not in bare:
+            names.add(bare)
+    return names
+
+
 def _configured_custom_provider_ids() -> set[str]:
     """Return routable custom-provider IDs configured by the user."""
     ids = {"custom"}
@@ -724,13 +747,14 @@ def list_available_providers() -> list[dict[str, str]]:
 
 def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
     """Parse ``/model`` input into ``(provider, model)``. The colon is a provider delimiter only when
-    the left side is a known provider/alias, so ``anthropic/claude-3.5-sonnet:beta`` stays a model."""
+    the left side is a known provider/alias or the bare key of a configured custom provider,
+    so ``anthropic/claude-3.5-sonnet:beta`` stays a model."""
     stripped = raw.strip()
     colon = stripped.find(":")
     if colon > 0:
         provider_part = stripped[:colon].strip().lower()
         model_part = stripped[colon + 1:].strip()
-        if provider_part and model_part and provider_part in _KNOWN_PROVIDER_NAMES:
+        if provider_part and model_part and provider_part in _routable_provider_names():
             if provider_part == "custom":
                 # Longest configured ``custom:<name>`` id that prefixes the input wins.
                 lowered = stripped.lower()
@@ -745,6 +769,10 @@ def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
                         if f"custom:{custom_name.lower()}" in _configured_custom_provider_ids():
                             return (f"custom:{custom_name.lower()}", actual_model)
                         return ("custom", model_part)
+            if provider_part not in _KNOWN_PROVIDER_NAMES:
+                # A bare configured key (``relay:…``) selects that named provider —
+                # canonical names took the branch above, so user keys never hijack them.
+                return (f"custom:{provider_part}", model_part)
             return (normalize_provider(provider_part), model_part)
     return (current_provider, stripped)
 

--- a/tests/acp/test_acp_set_model_configured_custom_provider.py
+++ b/tests/acp/test_acp_set_model_configured_custom_provider.py
@@ -1,0 +1,115 @@
+"""Bare configured custom-provider keys in ACP ``session/set_model``.
+
+``parse_model_input`` gated the ``provider:model`` split on the hardcoded
+``_KNOWN_PROVIDER_NAMES``, so the bare key of a user-configured
+``providers:`` entry fell through to ``(current_provider, <full string>)``.
+``set_session_model`` then kept the old endpoint and inference hit the
+previous relay.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from acp_adapter.server import HermesACPAgent
+from acp_adapter.session import SessionManager
+
+
+def _cfg(providers=None, custom_providers=None):
+    cfg = {}
+    if providers is not None:
+        cfg["providers"] = providers
+    if custom_providers is not None:
+        cfg["custom_providers"] = custom_providers
+    return cfg
+
+
+RELAY_PROVIDERS = {
+    "relay": {
+        "name": "Relay",
+        "base_url": "https://relay.example/v1",
+    }
+}
+
+
+class TestBareConfiguredCustomProviderKey:
+
+    def test_routes_to_named_provider(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.models.detect_provider_for_model", lambda m, c: None)
+        with patch("hermes_cli.config.load_config", return_value=_cfg(providers=RELAY_PROVIDERS)):
+            assert HermesACPAgent._resolve_model_selection(
+                "relay:meta/llama-3.3-70b", "opencode"
+            ) == ("custom:relay", "meta/llama-3.3-70b")
+
+    def test_rebuilds_endpoint_across_switch(self, monkeypatch):
+        """``keep_endpoint`` must not carry the old relay over the switch."""
+        monkeypatch.setattr("hermes_cli.models.detect_provider_for_model", lambda m, c: None)
+        calls = []
+        real_make_agent = SessionManager._make_agent
+
+        def spy(self, **kwargs):
+            calls.append(kwargs)
+            return real_make_agent(self, **kwargs)
+
+        manager = SessionManager(
+            agent_factory=lambda: SimpleNamespace(provider=None, model=None)
+        )
+        acp_agent = HermesACPAgent(session_manager=manager)
+        state = manager.create_session(cwd="/tmp")
+        state.agent.provider = "opencode"
+        state.agent.base_url = "https://opencode.example/v1"
+        state.agent.api_mode = "responses"
+
+        with patch("hermes_cli.config.load_config", return_value=_cfg(providers=RELAY_PROVIDERS)), patch.object(
+            SessionManager, "_make_agent", spy
+        ):
+            old, new, model = acp_agent._switch_model(
+                state, "relay:meta/llama-3.3-70b", keep_endpoint=True
+            )
+
+        assert (old, new, model) == ("opencode", "custom:relay", "meta/llama-3.3-70b")
+        assert calls[-1]["requested_provider"] == "custom:relay"
+        assert calls[-1]["model"] == "meta/llama-3.3-70b"
+        assert "base_url" not in calls[-1]
+        assert "api_mode" not in calls[-1]
+
+    def test_canonical_provider_name_wins_over_same_named_user_key(self):
+        """A ``providers:`` key named like a canonical provider must not hijack it."""
+        from hermes_cli.models import parse_model_input
+
+        cfg = _cfg(
+            providers={
+                "anthropic": {"name": "anthropic", "base_url": "https://relay.example/v1"},
+            }
+        )
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            assert parse_model_input("anthropic:claude-3.5-sonnet", "opencode") == (
+                "anthropic",
+                "claude-3.5-sonnet",
+            )
+
+    def test_unknown_prefix_keeps_legacy_fall_through(self):
+        from hermes_cli.models import parse_model_input
+
+        with patch("hermes_cli.config.load_config", return_value=_cfg(providers=RELAY_PROVIDERS)):
+            assert parse_model_input("foo:bar", "opencode") == ("opencode", "foo:bar")
+
+    def test_colon_bearing_provider_key_only_routes_via_custom_prefix(self):
+        from hermes_cli.models import parse_model_input
+
+        cfg = _cfg(
+            providers={
+                "local-127.0.0.1:11434": {
+                    "name": "Local Ollama",
+                    "base_url": "http://127.0.0.1:11434/v1",
+                }
+            }
+        )
+        with patch("hermes_cli.config.load_config", return_value=cfg):
+            assert parse_model_input("local-127.0.0.1:11434:qwen3:1.7b", "opencode") == (
+                "opencode",
+                "local-127.0.0.1:11434:qwen3:1.7b",
+            )
+            assert parse_model_input("custom:local-127.0.0.1:11434:qwen3:1.7b", "opencode") == (
+                "custom:local-127.0.0.1:11434",
+                "qwen3:1.7b",
+            )


### PR DESCRIPTION
## What does this PR do?

Fixes ACP `session/set_model` silently keeping the session endpoint when the
model id names a user-configured custom provider (`tokenrouter:…`, `b-ai:…`, …).

`parse_model_input` only splits `provider:model` when the left side is in
the hardcoded `_KNOWN_PROVIDER_NAMES`. Configured `providers:` keys are
missing there, so `tokenrouter:z-ai/glm-5.3-free` resolves to
`(current_provider, <full string>)` and `_switch_model(keep_endpoint=True)`
carries the old `base_url`/`api_mode` over. Inference then hits the wrong
relay and fails with `401 Model … is not supported`, even though
`set_model` itself returns success.

With this change, a bare configured key maps to its canonical
`custom:<key>` form (`tokenrouter:…` → `("custom:tokenrouter", …)`), the
endpoint is rebuilt for the right provider, and `resolve_runtime_provider`
serves it. The existing `custom:` branch, slash-form ids (`a/b:c`), unknown
prefixes, and the bare-name detection fallback are untouched. Only inputs
that previously fell through to the broken keep-endpoint path change
behavior. Canonical provider names still win over same-named user keys.

## Related Issue

No dedicated issue filed. Related (same symptom family, different root
causes): #63222 (stale base_url on switch), #72439 (set_model accepts
anything, silent end_turn).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/models.py`
  - new `_routable_provider_names()`: `_KNOWN_PROVIDER_NAMES` plus the bare
    slugs of configured custom providers (`custom:tokenrouter` →
    `tokenrouter`); canonical names and colon-bearing keys excluded
  - `parse_model_input`: gate on the extended set; bare configured keys map
    to `custom:<key>` before the existing `custom:` branch runs
- `tests/acp/test_acp_set_model_configured_custom_provider.py` (new,
  5 tests): bare configured id switches provider + endpoint; canonical name
  wins over same-named user key; unknown prefix keeps legacy fall-through;
  colon-bearing keys route only via `custom:` form

## How to Test

1. Configure a custom provider (e.g. `tokenrouter` in `config.yaml`).
2. Over raw ACP: `session/new` → `session/set_model`
   `{"modelId": "tokenrouter:z-ai/glm-5.3-free"}` → `session/prompt`.
3. Before: prompt is served by the previous endpoint (`HTTP 401: Model …
   is not supported` or `No LLM provider configured` when the previous
   provider has no usable credentials).
   After: prompt is served by the tokenrouter endpoint (`end_turn`).
   Verified locally with two fake OpenAI-compatible relays: 10 inference
   POSTs on the target relay, 0 on the previous one (and the reverse
   without the fix).
4. Regression: focused suites green
   (`tests/acp/test_acp_set_model_configured_custom_provider.py`,
   `tests/acp/`, `tests/acp_adapter/`,
   `tests/hermes_cli/test_model_validation.py`);
   `opencode-go:glm-5.3`, `anthropic/claude-3.5-sonnet:beta`, and unknown
   `foo:bar` inputs resolve exactly as before.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits
      (`fix(acp): route set_model for configured custom providers`)
- [x] Searched existing PRs/issues, no duplicates found
- [x] PR contains only changes related to this fix (1 commit, 2 files)
- [x] Focused suites pass (212 passed, 0 failed across `tests/acp/`,
      `tests/acp_adapter/`, `tests/hermes_cli/test_model_validation.py`).
      Full `scripts/run_tests.sh`: no new failures vs base. The only red
      files fail identically on unmodified `origin/main` (verified via
      worktree): 15 daytona + 2 modal + 2 parallel-web tests need optional
      third-party packages that the hermetic env blocks
      (`security.allow_lazy_installs=false`), 1 browser test needs a real
      browser profile, 1 FTS5 search test and 1 anthropic test fail on base
      too (missing `anthropic` package in this venv).
- [x] Tests added for the fix
- [x] Tested on: Arch Linux (CachyOS), Python 3.11 venv, raw ACP stdio
      against `python -m acp_adapter.entry`

### Documentation & Housekeeping

- [x] N/A, docstrings updated in code. No config keys, no arch/workflow
      change, no tool behavior change. Pure string routing, no OS surface
      (Windows footguns checker clean). `ruff` clean. `ty` left to CI:
      the checker cannot execute in this sandbox (killed on every run),
      the change adds only plainly typed stdlib code.

## Screenshots / Logs

Raw ACP against branch (fake relays on 127.0.0.1):

    session/set_model {"modelId": "e2erelay:e2e-model"} → {}
    session/prompt → stopReason: end_turn
    INFERENCE_HITS_B=10 STALE_POSTS_A=0

Same flow without the fix:

    session/set_model → Internal error (fall-through keeps old provider)
    INFERENCE_HITS_B=0 STALE_POSTS_A=10
