### PR TITLE
fix(gateway): keep Mattermost voice replies playable on iOS

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -16,6 +16,9 @@ import logging
 import mimetypes
 import os
 import re
+import shutil
+import subprocess
+import tempfile
 from pathlib import Path
 from urllib.parse import unquote as _unquote
 from typing import Any, Dict, List, Optional, Tuple
@@ -122,6 +125,7 @@ class MattermostAdapter(BasePlatformAdapter):
         self._last_post_status: Optional[int] = None  # POST-only, read by the broken-thread-root fallback
         self._last_post_error: str = ""
         self._dedup = MessageDeduplicator()
+        self._warned_no_ffmpeg = False
 
     # --- HTTP helpers ---
 
@@ -312,9 +316,57 @@ class MattermostAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None, metadata: _Metadata = None) -> SendResult:
         return await self._send_local_file(chat_id, file_path, caption, reply_to, file_name, metadata)
 
-    async def send_voice(self, chat_id: str, audio_path: str, caption: Optional[str] = None,
-                         reply_to: Optional[str] = None, metadata: _Metadata = None) -> SendResult:
+    async def send_voice(
+        self, chat_id: str, audio_path: str, caption: Optional[str] = None,
+        reply_to: Optional[str] = None, metadata: _Metadata = None, **kwargs: Any,
+    ) -> SendResult:
+        """Upload Apple-incompatible OGG/Opus audio as an MP3 attachment when ffmpeg is available."""
+        source = Path(audio_path)
+        if source.suffix.lower() in {".ogg", ".opus"} and source.exists():
+            converted = await self._transcode_voice_to_mp3(source)
+            if converted is not None:
+                try:
+                    return await self._send_local_file(
+                        chat_id, str(converted), caption, reply_to, metadata=metadata)
+                finally:
+                    with contextlib.suppress(OSError):
+                        converted.unlink()
         return await self._send_local_file(chat_id, audio_path, caption, reply_to, metadata=metadata)
+
+    async def _transcode_voice_to_mp3(self, source: Path) -> Optional[Path]:
+        """Return a temporary MP3 for Mattermost's generic attachment clients, or None on failure."""
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg is None:
+            if not self._warned_no_ffmpeg:
+                self._warned_no_ffmpeg = True
+                logger.warning("Mattermost: ffmpeg not found; uploading OGG/Opus audio unchanged")
+            return None
+
+        with tempfile.NamedTemporaryFile(prefix="hermes-mattermost-", suffix=".mp3", delete=False) as tmp:
+            output = Path(tmp.name)
+        from hermes_cli._subprocess_compat import windows_hide_flags
+
+        def run_ffmpeg() -> subprocess.CompletedProcess:
+            return subprocess.run(
+                [ffmpeg, "-y", "-loglevel", "error", "-i", str(source), "-vn", "-codec:a", "libmp3lame",
+                 "-q:a", "4", str(output)],
+                stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+                timeout=60, check=False, creationflags=windows_hide_flags(),
+            )
+
+        try:
+            result = await asyncio.to_thread(run_ffmpeg)
+            if result.returncode == 0 and output.stat().st_size > 0:
+                return output
+            logger.warning(
+                "Mattermost: ffmpeg MP3 conversion failed (returncode=%s): %s",
+                result.returncode, result.stderr.decode("utf-8", errors="replace")[:300],
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            logger.warning("Mattermost: ffmpeg MP3 conversion failed: %s", exc)
+        with contextlib.suppress(OSError):
+            output.unlink()
+        return None
 
     async def send_video(self, chat_id: str, video_path: str, caption: Optional[str] = None,
                          reply_to: Optional[str] = None, metadata: _Metadata = None) -> SendResult:

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -453,6 +453,56 @@ class TestMattermostFileUpload:
         assert result.success is True
         assert result.message_id == "post_with_file"
 
+    @pytest.mark.asyncio
+    async def test_send_voice_transcodes_ogg_to_temporary_mp3(self, tmp_path):
+        source = tmp_path / "voice.ogg"
+        source.write_bytes(b"ogg audio")
+        converted = tmp_path / "converted.mp3"
+        converted.write_bytes(b"mp3 audio")
+        self.adapter._transcode_voice_to_mp3 = AsyncMock(return_value=converted)
+        self.adapter._upload_file = AsyncMock(return_value="file_audio")
+        self.adapter._post_with_file = AsyncMock(return_value=MagicMock(success=True))
+
+        result = await self.adapter.send_voice(
+            "channel_1", str(source), caption="Voice", reply_to="root", is_voice=True,
+        )
+
+        assert result.success is True
+        self.adapter._upload_file.assert_awaited_once_with(
+            "channel_1", b"mp3 audio", "converted.mp3", "audio/mpeg",
+        )
+        self.adapter._post_with_file.assert_awaited_once_with(
+            "channel_1", "file_audio", "Voice", "root", None,
+        )
+        assert not converted.exists()
+
+    @pytest.mark.asyncio
+    async def test_voice_transcoder_produces_mp3_with_ffmpeg(self, tmp_path, monkeypatch):
+        from plugins.platforms.mattermost import adapter as mattermost
+
+        source = tmp_path / "voice.opus"
+        source.write_bytes(b"opus audio")
+        commands = []
+
+        def fake_run(command, **kwargs):
+            commands.append((command, kwargs))
+            with open(command[-1], "wb") as output:
+                output.write(b"mp3 audio")
+            return mattermost.subprocess.CompletedProcess(command, 0, stderr=b"")
+
+        monkeypatch.setattr(mattermost.shutil, "which", lambda _name: "ffmpeg")
+        monkeypatch.setattr(mattermost.subprocess, "run", fake_run)
+
+        output = await self.adapter._transcode_voice_to_mp3(source)
+
+        assert output is not None and output.suffix == ".mp3"
+        command, kwargs = commands[0]
+        assert command[0] == "ffmpeg"
+        assert str(source) in command
+        assert command[command.index("-codec:a") + 1] == "libmp3lame"
+        assert kwargs["stdin"] is mattermost.subprocess.DEVNULL
+        output.unlink()
+
 
 # ---------------------------------------------------------------------------
 # Dedup cache


### PR DESCRIPTION
## What does this PR do?

Mattermost voice replies generated as OGG/Opus are uploaded as generic attachments that iPad and iOS clients cannot play inline. This change converts those local files to temporary MP3 attachments before upload, while preserving the original upload path when ffmpeg is unavailable or conversion fails.

### Symptom

A Mattermost voice or TTS reply uploads successfully and plays on Android, but the same OGG/Opus attachment is unplayable on iPad and iOS clients. Routed media delivery can also fail earlier because the adapter does not accept the `is_voice` keyword used by the gateway.

### Impact

Mattermost users on Apple mobile clients cannot listen to affected Hermes voice replies. Other gateway platforms and non-OGG Mattermost attachments are not affected by this patch.

### Bug Cause

**Trigger:** `plugins/platforms/mattermost/adapter.py` / `MattermostAdapter.send_voice`

**Causal chain:**
1. TTS or `MEDIA:` delivery routes a local OGG/Opus path to Mattermost as voice audio.
2. The adapter either rejects the routed `is_voice` keyword or passes the source file unchanged to `_send_local_file`.
3. Mattermost serves that OGG/Opus file as a generic attachment, which iPad and iOS clients cannot play inline.

**Why it is wrong:** Mattermost has no native voice-note delivery path here, so retaining the platform-specific OGG container assumes client support that generic Apple playback does not provide.

**Working sibling / contrast:** Telegram and other voice-note-aware platforms can retain Opus because their native message types provide compatible playback. Mattermost needs a broadly supported generic audio attachment instead.

**Ruled out:** The upload transport is not the failure. The file reaches Mattermost and Android plays the same attachment; the failure is the client/container compatibility of generic delivery.

### Fix

- Accept gateway media metadata keywords in `send_voice`.
- Convert local `.ogg` and `.opus` inputs to a temporary MP3 with an explicit codec, a bounded subprocess timeout, non-interactive stdin, and hidden Windows process flags.
- Upload the MP3 with the existing Mattermost file path and always remove the temporary output.
- Fall back to the original attachment if ffmpeg is missing or conversion fails.

## Related Issue

N/A
## Why this PR vs existing PR #108650

This implementation closes subprocess reliability gaps in `plugins/platforms/mattermost/adapter.py`: ffmpeg is resolved before launch, runs with a 60-second timeout and closed stdin so a media send cannot stall the gateway indefinitely, and uses the repository's Windows hidden-process flags to avoid a console flash. It also selects `libmp3lame` explicitly rather than relying on ffmpeg's output inference. The existing PR has no timeout, inherits stdin, and launches a visible default child process on Windows.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/mattermost/adapter.py` - transcode Mattermost OGG/Opus voice attachments to temporary MP3 files and accept routed voice metadata.
- `tests/gateway/test_mattermost.py` - cover the MP3 upload, metadata forwarding, temporary-file cleanup, and ffmpeg invocation contract.

## How to Test

1. Send a local `.ogg` or `.opus` voice attachment through Mattermost and verify the uploaded filename and MIME type are MP3.
2. Open the resulting attachment in the Mattermost iOS/iPadOS client and verify playback.
3. Run `scripts/run_tests.sh tests/gateway/test_mattermost.py` after PR creation.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs and statically compared this branch with PR #108650
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A
- [x] `cli-config.yaml.example` updates are N/A
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A
- [x] Cross-platform process behavior is handled through the existing Windows child-process helper
- [x] Tool description and schema updates are N/A
