### PR TITLE
fix(agent): prevent replay of compressed tool arguments

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -25,6 +25,7 @@ from agent.context_engine import ContextEngine, sanitize_memory_context
 from agent.context_compressor_summary import SummaryDispatchMixin
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.micro_compaction import MicroCompactionMixin
+from agent.historical_tool_arguments import omit_historical_tool_arguments
 from agent.prompt_builder import STEER_DISPLAY_KIND
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH, get_model_context_length, estimate_messages_tokens_rough, estimate_tokens_rough,
@@ -1261,27 +1262,6 @@ def evict_stale_outbound_tool_images(
     persisted history — the rewrite is send-path only.
     """
     return _retire_stale_tool_result_images(api_messages, keep_newest=keep_newest)
-
-
-def _truncate_tool_call_args_json(args: str, head_chars: int = 200) -> str:
-    """Shrink long string leaves in a tool-call arguments JSON blob, keeping it valid (providers 400 on malformed args)."""
-    try:
-        parsed = json.loads(args)
-    except (ValueError, TypeError):
-        return args
-
-    def _shrink(obj: Any) -> Any:
-        if isinstance(obj, str):
-            return obj[:head_chars] + "...[truncated]" if len(obj) > head_chars else obj
-        if isinstance(obj, dict):
-            return {k: _shrink(v) for k, v in obj.items()}
-        if isinstance(obj, list):
-            return [_shrink(v) for v in obj]
-        return obj
-
-    shrunken = _shrink(parsed)
-    # ensure_ascii=False keeps CJK/emoji from bloating into \uXXXX
-    return json.dumps(shrunken, ensure_ascii=False)
 
 
 _IMAGE_PART_TYPES = frozenset({"image_url", "input_image", "image"})
@@ -2656,15 +2636,15 @@ class ContextCompressor(SummaryDispatchMixin, MicroCompactionMixin, ContextEngin
         return pruned
 
     @staticmethod
-    def _truncate_tool_call_args_at(result: List[Dict[str, Any]], idx: int) -> bool:
-        """Shrink large tool_call argument payloads at ``idx`` (inside the parsed JSON, so it stays valid)."""
+    def _omit_historical_tool_call_args_at(result: List[Dict[str, Any]], idx: int) -> bool:
+        """Omit large historical tool-call arguments at ``idx`` with valid JSON."""
         msg = result[idx]
         if msg.get("role") != "assistant" or not msg.get("tool_calls"):
             return False
         new_tcs = []
         for tc in msg["tool_calls"]:
             args = tc.get("function", {}).get("arguments", "") if isinstance(tc, dict) else ""
-            new_args = _truncate_tool_call_args_json(args) if len(args) > 500 else args
+            new_args = omit_historical_tool_arguments(args) if len(args) > 500 else args
             new_tcs.append(tc if new_args == args else {**tc, "function": {**tc["function"], "arguments": new_args}})
         modified = any(new is not old for new, old in zip(new_tcs, msg["tool_calls"]))
         if modified:
@@ -2724,7 +2704,7 @@ class ContextCompressor(SummaryDispatchMixin, MicroCompactionMixin, ContextEngin
             if self._demote_tool_result_at(result, i, call_id_to_tool, min_prune_chars):
                 demoted += 1
                 pressure_hits += 1
-            if self._truncate_tool_call_args_at(result, i):
+            if self._omit_historical_tool_call_args_at(result, i):
                 pressure_hits += 1
 
         if demote_end <= prune_boundary or _protected_region_tokens() <= soft_ceiling:
@@ -2775,7 +2755,7 @@ class ContextCompressor(SummaryDispatchMixin, MicroCompactionMixin, ContextEngin
             for i in range(max(0, prune_boundary))
         )
         for i in range(max(0, prune_boundary)):
-            self._truncate_tool_call_args_at(result, i)
+            self._omit_historical_tool_call_args_at(result, i)
         # Pass 3.5: retire image payloads inside the protected tail; re-sent embeds otherwise make
         # compression look ineffective and trip anti-thrash. Newest frames stay live.
         # Newest frames stay live for follow-up QA; older ones become placeholders. See #92699.

--- a/agent/historical_tool_arguments.py
+++ b/agent/historical_tool_arguments.py
@@ -1,0 +1,79 @@
+"""Provenance markers for historical tool arguments omitted by compression."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+_HISTORY_OMITTED_KEY = "_hermes_history_omitted"
+_HISTORY_OMITTED_REASON = "context_compression"
+_MAX_MARKER_SCAN_NODES = 10_000
+NON_REPLAYABLE_HISTORY_MESSAGE = (
+    "Historical tool arguments omitted during context compression cannot be replayed. "
+    "Read current state and construct fresh arguments before calling this tool."
+)
+TOOL_ARGUMENTS_TOO_COMPLEX_MESSAGE = (
+    "Tool arguments are too deeply nested to inspect safely; tool was not executed."
+)
+
+
+class ToolArgumentTraversalLimit(RuntimeError):
+    """Raised when marker inspection exceeds its bounded container budget."""
+
+
+def omit_historical_tool_arguments(raw_arguments: Any) -> str:
+    """Return bounded valid JSON that cannot be mistaken for executable arguments."""
+    original_chars = len(raw_arguments) if isinstance(raw_arguments, str) else 0
+    return json.dumps(
+        {
+            _HISTORY_OMITTED_KEY: {
+                "non_replayable": True,
+                "reason": _HISTORY_OMITTED_REASON,
+                "original_chars": original_chars,
+            }
+        },
+        separators=(",", ":"),
+    )
+
+
+def contains_non_replayable_history_args(value: Any) -> bool:
+    """Detect the exact reserved marker with bounded, lazy traversal."""
+    frames = [iter((value,))]
+    seen: set[int] = set()
+    visited_containers = 0
+    while frames:
+        try:
+            current = next(frames[-1])
+        except StopIteration:
+            frames.pop()
+            continue
+
+        if isinstance(current, dict):
+            marker = current.get(_HISTORY_OMITTED_KEY)
+            if (
+                isinstance(marker, dict)
+                and len(marker) == 3
+                and marker.get("non_replayable") is True
+                and marker.get("reason") == _HISTORY_OMITTED_REASON
+                and type(marker.get("original_chars")) is int
+                and marker["original_chars"] >= 0
+            ):
+                return True
+            identity = id(current)
+            if identity in seen:
+                continue
+            seen.add(identity)
+            visited_containers += 1
+            if visited_containers > _MAX_MARKER_SCAN_NODES:
+                raise ToolArgumentTraversalLimit
+            frames.append(iter(current.values()))
+        elif isinstance(current, (list, tuple)):
+            identity = id(current)
+            if identity in seen:
+                continue
+            seen.add(identity)
+            visited_containers += 1
+            if visited_containers > _MAX_MARKER_SCAN_NODES:
+                raise ToolArgumentTraversalLimit
+            frames.append(iter(current))
+    return False

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -30,6 +30,12 @@ from agent.display import (
     _detect_tool_failure,
 )
 from agent.message_sanitization import coalesce_tool_call_id
+from agent.historical_tool_arguments import (
+    NON_REPLAYABLE_HISTORY_MESSAGE,
+    TOOL_ARGUMENTS_TOO_COMPLEX_MESSAGE,
+    ToolArgumentTraversalLimit,
+    contains_non_replayable_history_args,
+)
 from agent.inline_tool_executors import (
     INLINE_TOOL_EXECUTORS,
     InlineToolContext,
@@ -144,18 +150,64 @@ class _BatchAbandoned(BaseException):
     so ``except Exception`` handlers in the middleware chain can't swallow it."""
 
 
+def _non_replayable_history_error() -> str:
+    from tools.registry import tool_error
+
+    return tool_error(NON_REPLAYABLE_HISTORY_MESSAGE, code="non_replayable_history_arguments")
+
+
+def _tool_arguments_too_complex_error() -> str:
+    from tools.registry import tool_error
+
+    return tool_error(TOOL_ARGUMENTS_TOO_COMPLEX_MESSAGE, code="tool_arguments_too_complex")
+
+
 def _parse_tool_arguments(raw_arguments: Any) -> tuple[dict, Optional[str]]:
     """Parse model-emitted arguments without repairing or coercing them."""
-    try:
-        arguments = json.loads(raw_arguments)
-    except (json.JSONDecodeError, TypeError):
-        arguments = None
+    if isinstance(raw_arguments, dict):
+        arguments = raw_arguments
+    else:
+        try:
+            arguments = json.loads(raw_arguments)
+        except (json.JSONDecodeError, TypeError, RecursionError):
+            arguments = None
     if isinstance(arguments, dict):
         return arguments, None
     return {}, json.dumps(
         {"error": "Invalid tool arguments", "message": "Tool arguments must be a valid JSON object; tool was not executed."},
         ensure_ascii=False,
     )
+
+
+def _direct_argument_error(args: dict) -> Optional[str]:
+    try:
+        if contains_non_replayable_history_args(args):
+            return _non_replayable_history_error()
+    except ToolArgumentTraversalLimit:
+        return _tool_arguments_too_complex_error()
+    return None
+
+
+def _deferred_argument_error(name: str, args: dict) -> Optional[str]:
+    """Validate decoded arguments nested inside the deferred tool wrapper."""
+    if name != "tool_call":
+        return None
+
+    from tools.registry import tool_error
+    from tools.tool_gateway.names import is_connector_name
+    from tools.tool_search_validation import normalize_tool_call_entries
+
+    entries, error = normalize_tool_call_entries(args)
+    if error:
+        return tool_error(error, code="invalid_tool_arguments")
+    if entries and all(is_connector_name(entry["name"]) for entry in entries):
+        return None
+    try:
+        if any(contains_non_replayable_history_args(entry["arguments"]) for entry in entries):
+            return _non_replayable_history_error()
+    except ToolArgumentTraversalLimit:
+        return _tool_arguments_too_complex_error()
+    return None
 
 
 def _resolve_concurrent_tool_timeout() -> float | None:
@@ -433,6 +485,12 @@ def _parse_tool_call(agent, tool_call, *, flatten_probe: bool = False) -> _Parse
     name = _canonical_tool_name(tool_call.function.name)
     args, parse_error = _parse_tool_arguments(tool_call.function.arguments)
     scope_block = None
+    if parse_error is None:
+        parse_error = (
+            _deferred_argument_error(name, args)
+            if name == "tool_call"
+            else _direct_argument_error(args)
+        )
     if parse_error is None:
         name, args, scope_block = _unwrap_tool_search_call(agent, name, args, flatten_probe=flatten_probe)
     return _ParsedCall(tool_call, name, args, [], parse_error, scope_block)

--- a/model_tools_connectors.py
+++ b/model_tools_connectors.py
@@ -3,6 +3,12 @@
 import json
 from dataclasses import asdict
 
+from agent.historical_tool_arguments import (
+    NON_REPLAYABLE_HISTORY_MESSAGE,
+    TOOL_ARGUMENTS_TOO_COMPLEX_MESSAGE,
+    ToolArgumentTraversalLimit,
+    contains_non_replayable_history_args,
+)
 from tools.registry import tool_error
 from tools.tool_gateway.config import MAX_CALLS_PER_DISPATCH
 from tools.tool_gateway.merge import assemble_results, fill_remote_failure, partition_calls
@@ -44,6 +50,22 @@ def dispatch_connector_batch(calls, ids, *, user_task, enabled_tools,
                 partition.remote[offset:], "Stopped by the user before this call was made.",
                 code="INTERRUPTED"))
             break
+        try:
+            marker_found = contains_non_replayable_history_args(plan.arguments)
+        except ToolArgumentTraversalLimit:
+            entries.append({
+                "index": plan.position,
+                "name": plan.name,
+                "error": {"code": "tool_arguments_too_complex", "message": TOOL_ARGUMENTS_TOO_COMPLEX_MESSAGE},
+            })
+            continue
+        if marker_found:
+            entries.append({
+                "index": plan.position,
+                "name": plan.name,
+                "error": {"code": "non_replayable_history_arguments", "message": NON_REPLAYABLE_HISTORY_MESSAGE},
+            })
+            continue
         # Wrapper-level skip flags describe only the wrapper, never its entries.
         payload = handle_function_call(
             plan.name, plan.arguments, **asdict(ids), user_task=user_task,

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -2292,92 +2292,75 @@ class TestThresholdTokensCap:
 
 
 
-class TestTruncateToolCallArgsJson:
-    """Regression tests for #11762.
+class TestHistoricalToolCallArgumentOmission:
+    """Oversized historical arguments stay valid for providers but cannot be
+    mistaken for complete inputs to a future tool call."""
 
-    The previous implementation produced invalid JSON by slicing
-    ``function.arguments`` mid-string, which caused non-retryable 400s from
-    strict providers (observed on MiniMax) and stuck long sessions in a
-    re-send loop. The helper here must always emit parseable JSON whose
-    shape matches the original — shrunken, not corrupted.
-    """
-
-    def _helper(self):
-        from agent.context_compressor import _truncate_tool_call_args_json
-        return _truncate_tool_call_args_json
-
-    def test_shrunken_args_remain_valid_json(self):
+    def test_oversized_args_become_bounded_non_replayable_json(self):
         import json as _json
-        shrink = self._helper()
+
+        from agent.historical_tool_arguments import omit_historical_tool_arguments
+
         original = _json.dumps({
-            "path": "~/.hermes/skills/shopping/browser-setup-notes.md",
-            "content": "# Shopping Browser Setup Notes\n\n" + "abc " * 400,
+            "path": "/tmp/synthetic-target.md",
+            "content": "SYNTHETIC-START-" + "abc " * 400,
         })
-        assert len(original) > 500
-        shrunk = shrink(original)
-        parsed = _json.loads(shrunk)  # must not raise
-        assert parsed["path"] == "~/.hermes/skills/shopping/browser-setup-notes.md"
-        assert parsed["content"].endswith("...[truncated]")
-        assert len(shrunk) < len(original)
+        omitted = omit_historical_tool_arguments(original)
+        parsed = _json.loads(omitted)
 
+        assert len(omitted) <= 200
+        assert parsed["_hermes_history_omitted"]["non_replayable"] is True
+        assert parsed["_hermes_history_omitted"]["reason"] == "context_compression"
+        assert parsed["_hermes_history_omitted"]["original_chars"] == len(original)
+        assert "/tmp/synthetic-target.md" not in omitted
+        assert "SYNTHETIC-START" not in omitted
 
+        malformed = "{\"path\":\"/tmp/incomplete" + "x" * 800
+        malformed_marker = _json.loads(omit_historical_tool_arguments(malformed))
+        assert malformed_marker["_hermes_history_omitted"]["original_chars"] == len(malformed)
 
-
-    def test_non_string_leaves_preserved(self):
+    def test_pass3_omits_only_historical_args_and_preserves_pairing(self):
         import json as _json
-        shrink = self._helper()
-        payload = _json.dumps({
-            "retries": 3,
-            "enabled": True,
-            "timeout": None,
-            "items": [1, 2, 3],
-            "note": "z" * 500,
-        })
-        parsed = _json.loads(shrink(payload))
-        assert parsed["retries"] == 3
-        assert parsed["enabled"] is True
-        assert parsed["timeout"] is None
-        assert parsed["items"] == [1, 2, 3]
-        assert parsed["note"].endswith("...[truncated]")
 
-
-
-    def test_pass3_emits_valid_json_for_downstream_provider(self):
-        """End-to-end: Pass 3 must never produce the exact failure payload
-        that caused the 400 loop (unterminated string, missing brace)."""
-        import json as _json
         with patch("agent.context_compressor.get_model_context_length", return_value=100000):
             c = ContextCompressor(
                 model="test/model",
                 threshold_percent=0.85,
                 protect_first_n=1,
-                protect_last_n=1,
+                protect_last_n=2,
                 quiet_mode=True,
             )
-        huge_content = "# Shopping Browser Setup Notes\n\n## Overview\n" + "x " * 400
-        args_payload = _json.dumps({
-            "path": "~/.hermes/skills/shopping/browser-setup-notes.md",
-            "content": huge_content,
+        historical_args = _json.dumps({
+            "path": "/tmp/historical.md",
+            "content": "historical-" + "x " * 400,
         })
-        assert len(args_payload) > 500  # triggers the Pass-3 shrink
+        current_args = _json.dumps({
+            "path": "/tmp/current.md",
+            "content": "current-" + "y " * 400,
+        })
         messages = [
-            {"role": "user", "content": "please write two files"},
-            {"role": "assistant", "content": None, "tool_calls": [
-                {"id": "call_1", "type": "function",
-                 "function": {"name": "write_file", "arguments": args_payload}},
-            ]},
-            {"role": "tool", "tool_call_id": "call_1",
-             "content": '{"bytes_written": 727}'},
-            {"role": "user", "content": "ok"},
-            {"role": "assistant", "content": "done"},
+            {"role": "user", "content": "write the historical file"},
+            {"role": "assistant", "content": None, "tool_calls": [{
+                "id": "call-old", "type": "function",
+                "function": {"name": "write_file", "arguments": historical_args},
+            }]},
+            {"role": "tool", "tool_call_id": "call-old", "content": '{"ok": true}'},
+            {"role": "assistant", "content": None, "tool_calls": [{
+                "id": "call-current", "type": "function",
+                "function": {"name": "write_file", "arguments": current_args},
+            }]},
+            {"role": "tool", "tool_call_id": "call-current", "content": '{"ok": true}'},
         ]
-        result, _ = c._prune_old_tool_results(messages, protect_tail_count=2)
-        shrunk = result[1]["tool_calls"][0]["function"]["arguments"]
-        # Must parse — otherwise downstream provider returns 400
-        parsed = _json.loads(shrunk)
-        assert parsed["path"] == "~/.hermes/skills/shopping/browser-setup-notes.md"
-        assert parsed["content"].endswith("...[truncated]")
 
+        result, _ = c._prune_old_tool_results(messages, protect_tail_count=2)
+
+        historical = result[1]["tool_calls"][0]
+        omitted = _json.loads(historical["function"]["arguments"])
+        assert historical["id"] == "call-old"
+        assert omitted["_hermes_history_omitted"]["non_replayable"] is True
+        assert result[2]["tool_call_id"] == "call-old"
+        assert result[3]["tool_calls"][0]["function"]["arguments"] == current_args
+        assert result[4]["tool_call_id"] == "call-current"
 
 class TestLazyContextResolution:
     """Verify that ContextCompressor defers get_model_context_length until

--- a/tests/agent/test_historical_tool_arguments.py
+++ b/tests/agent/test_historical_tool_arguments.py
@@ -1,0 +1,58 @@
+import pytest
+
+from agent.historical_tool_arguments import (
+    ToolArgumentTraversalLimit,
+    contains_non_replayable_history_args,
+    omit_historical_tool_arguments,
+)
+
+
+def test_marker_detection_requires_exact_typed_metadata():
+    marker = {
+        "non_replayable": True,
+        "reason": "context_compression",
+        "original_chars": 900,
+    }
+
+    assert contains_non_replayable_history_args({
+        "nested": {"_hermes_history_omitted": marker}
+    })
+    assert not contains_non_replayable_history_args({
+        "_hermes_history_omitted": {**marker, "unexpected": "field"}
+    })
+    assert not contains_non_replayable_history_args({
+        "_hermes_history_omitted": {**marker, "original_chars": True}
+    })
+    assert not contains_non_replayable_history_args({"content": "...[truncated]"})
+
+
+def test_marker_scan_is_lazy_and_fails_closed_at_its_node_budget(monkeypatch):
+    import agent.historical_tool_arguments as provenance
+
+    class WideDict(dict):
+        def values(self):  # type: ignore[override]
+            for index, value in enumerate(super().values()):
+                if index > 1:
+                    raise AssertionError(
+                        "values were eagerly materialized past the node budget"
+                    )
+                yield value
+
+    monkeypatch.setattr(provenance, "_MAX_MARKER_SCAN_NODES", 1)
+    value = WideDict({"nested": {}, **{str(i): i for i in range(20)}})
+    with pytest.raises(ToolArgumentTraversalLimit):
+        provenance.contains_non_replayable_history_args(value)
+
+
+def test_marker_scan_handles_deep_and_cyclic_arguments():
+    marker = omit_historical_tool_arguments("x" * 900)
+    import json
+
+    nested = json.loads(marker)
+    for _ in range(2_000):
+        nested = [nested]
+    assert contains_non_replayable_history_args(nested)
+
+    cyclic = []
+    cyclic.append(cyclic)
+    assert not contains_non_replayable_history_args(cyclic)

--- a/tests/run_agent/test_malformed_tool_arguments.py
+++ b/tests/run_agent/test_malformed_tool_arguments.py
@@ -1,7 +1,9 @@
 """Malformed model tool arguments are rejected at the dispatch boundary."""
 
 import json
+from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -38,11 +40,11 @@ def _make_agent() -> AIAgent:
     return agent
 
 
-def _tool_call(call_id: str, arguments: str):
+def _tool_call(call_id: str, arguments: Any, name: str = "web_search"):
     return SimpleNamespace(
         id=call_id,
         type="function",
-        function=SimpleNamespace(name="web_search", arguments=arguments),
+        function=SimpleNamespace(name=name, arguments=arguments),
     )
 
 
@@ -55,6 +57,7 @@ def _tool_call(call_id: str, arguments: str):
         pytest.param("[]", id="list"),
         pytest.param("", id="empty"),
         pytest.param('{"query": "cut off', id="truncated"),
+        pytest.param('{"query":' + "[" * 2_000 + "0" + "]" * 2_000 + "}", id="too-deep"),
     ],
 )
 def test_malformed_arguments_are_rejected_without_blocking_valid_sibling(
@@ -95,3 +98,244 @@ def test_malformed_arguments_are_rejected_without_blocking_valid_sibling(
     assert '"error": "Invalid tool arguments"' in messages[0]["content"]
     assert "JSON object" in messages[0]["content"]
     assert json.loads(messages[1]["content"]) == {"ok": "valid"}
+
+
+@pytest.mark.parametrize("dispatch_mode", ["sequential", "concurrent"])
+@pytest.mark.parametrize(
+    "argument_shape",
+    ["direct", "decoded-direct", "deferred-legacy", "deferred-batch", "decoded-deferred-batch"],
+)
+def test_non_replayable_history_arguments_are_blocked_while_fresh_arguments_run(
+    dispatch_mode: str, argument_shape: str,
+):
+    from agent.historical_tool_arguments import omit_historical_tool_arguments
+
+    agent = _make_agent()
+    fresh_query = "fresh-" + "x" * 800
+    omitted = omit_historical_tool_arguments("z" * 900)
+    blocked_call = _tool_call("call-history", omitted)
+    if argument_shape == "decoded-direct":
+        blocked_call = _tool_call("call-history", json.loads(omitted))
+    elif argument_shape == "deferred-legacy":
+        blocked_call = _tool_call(
+            "call-history",
+            json.dumps({"name": "web_search", "arguments": omitted}),
+            name="tool_call",
+        )
+    elif argument_shape == "deferred-batch":
+        blocked_call = _tool_call(
+            "call-history",
+            json.dumps({"calls": [{"name": "web_search", "arguments": omitted}]}),
+            name="tool_call",
+        )
+    elif argument_shape == "decoded-deferred-batch":
+        blocked_call = _tool_call(
+            "call-history",
+            {"calls": [{"name": "web_search", "arguments": json.loads(omitted)}]},
+            name="tool_call",
+        )
+    assistant_message = SimpleNamespace(
+        content="",
+        tool_calls=[
+            blocked_call,
+            _tool_call("call-fresh", json.dumps({"query": fresh_query})),
+        ],
+    )
+    messages = []
+    executed = []
+
+    def fake_dispatch(name, args, task_id, *positional, **kwargs):
+        call_id = kwargs.get("tool_call_id") or (positional[0] if positional else None)
+        executed.append((name, args, call_id))
+        return json.dumps({"ok": args["query"]})
+
+    with (
+        patch("model_tools.handle_function_call", side_effect=fake_dispatch),
+        patch.object(agent, "_invoke_tool", side_effect=fake_dispatch),
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+    ):
+        execute = getattr(agent, f"_execute_tool_calls_{dispatch_mode}")
+        execute(assistant_message, messages, "task-1")
+
+    assert executed == [("web_search", {"query": fresh_query}, "call-fresh")]
+    assert [message["tool_call_id"] for message in messages] == ["call-history", "call-fresh"]
+    assert "non_replayable_history_arguments" in messages[0]["content"]
+    assert fresh_query in messages[1]["content"]
+
+
+def test_non_replayable_arguments_never_reach_a_real_registry_handler(tmp_path):
+    from agent.historical_tool_arguments import omit_historical_tool_arguments
+    from tools.registry import registry
+
+    tool_name = "historical_argument_write_probe"
+    schema = {
+        "name": tool_name,
+        "description": "Synthetic write probe",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "content": {"type": "string"},
+            },
+            "required": ["path", "content"],
+        },
+    }
+    executed_paths = []
+
+    def write_probe(args, **_kwargs):
+        executed_paths.append(args["path"])
+        Path(args["path"]).write_text(args["content"], encoding="utf-8")
+        return json.dumps({"ok": True})
+
+    registry.register(name=tool_name, toolset="test", schema=schema, handler=write_probe)
+    with (
+        patch("model_tools.get_tool_definitions", return_value=[{"type": "function", "function": schema}]),
+        patch("model_tools.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("agent.process_bootstrap.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()  # type: ignore[assignment]
+    agent._flush_messages_to_session_db = MagicMock()
+    fresh_path = tmp_path / "fresh.txt"
+    fresh_content = "fresh-" + "x" * 800
+    assistant_message = SimpleNamespace(
+        content="",
+        tool_calls=[
+            _tool_call("call-history", omit_historical_tool_arguments("z" * 900), tool_name),
+            _tool_call(
+                "call-fresh",
+                json.dumps({"path": str(fresh_path), "content": fresh_content}),
+                tool_name,
+            ),
+        ],
+    )
+    messages = []
+
+    with patch(
+        "agent.tool_executor.maybe_persist_tool_result",
+        side_effect=lambda **kwargs: kwargs["content"],
+    ):
+        agent._execute_tool_calls_sequential(assistant_message, messages, "task-1")
+
+    assert executed_paths == [str(fresh_path)]
+    assert fresh_path.read_text(encoding="utf-8") == fresh_content
+    assert "non_replayable_history_arguments" in messages[0]["content"]
+
+
+@pytest.mark.parametrize("dispatch_mode", ["sequential", "concurrent"])
+def test_fresh_wide_decoded_arguments_are_not_mistaken_for_history(dispatch_mode: str):
+    agent = _make_agent()
+    fresh_args = {"query": "fresh", "items": list(range(10_001))}
+    assistant_message = SimpleNamespace(
+        content="",
+        tool_calls=[_tool_call("call-fresh-wide", fresh_args)],
+    )
+    messages = []
+    executed = []
+
+    def fake_dispatch(name, args, task_id, *positional, **kwargs):
+        call_id = kwargs.get("tool_call_id") or (positional[0] if positional else None)
+        executed.append((name, args, call_id))
+        return json.dumps({"ok": True})
+
+    with (
+        patch("model_tools.handle_function_call", side_effect=fake_dispatch),
+        patch.object(agent, "_invoke_tool", side_effect=fake_dispatch),
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+    ):
+        execute = getattr(agent, f"_execute_tool_calls_{dispatch_mode}")
+        execute(assistant_message, messages, "task-1")
+
+    assert executed == [("web_search", fresh_args, "call-fresh-wide")]
+
+
+@pytest.mark.parametrize("dispatch_mode", ["sequential", "concurrent"])
+def test_deep_deferred_arguments_fail_without_blocking_a_valid_sibling(dispatch_mode: str):
+    agent = _make_agent()
+    too_deep = '{"query":' + "[" * 2_000 + "0" + "]" * 2_000 + "}"
+    assistant_message = SimpleNamespace(
+        content="",
+        tool_calls=[
+            _tool_call(
+                "call-deep",
+                json.dumps({"name": "web_search", "arguments": too_deep}),
+                "tool_call",
+            ),
+            _tool_call("call-good", json.dumps({"query": "valid"})),
+        ],
+    )
+    messages = []
+    executed = []
+
+    def fake_dispatch(name, args, task_id, *positional, **kwargs):
+        call_id = kwargs.get("tool_call_id") or (positional[0] if positional else None)
+        executed.append((name, args, call_id))
+        return json.dumps({"ok": args["query"]})
+
+    with (
+        patch("model_tools.handle_function_call", side_effect=fake_dispatch),
+        patch.object(agent, "_invoke_tool", side_effect=fake_dispatch),
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+    ):
+        execute = getattr(agent, f"_execute_tool_calls_{dispatch_mode}")
+        execute(assistant_message, messages, "task-1")
+
+    assert executed == [("web_search", {"query": "valid"}, "call-good")]
+    assert [message["tool_call_id"] for message in messages] == ["call-deep", "call-good"]
+
+
+@pytest.mark.parametrize("dispatch_mode", ["sequential", "concurrent"])
+def test_decoded_connector_batch_reaches_per_entry_dispatch(dispatch_mode: str):
+    from agent.historical_tool_arguments import omit_historical_tool_arguments
+
+    agent = _make_agent()
+    calls = [
+        {
+            "name": "connectors__gmail__SEND_EMAIL",
+            "arguments": json.loads(omit_historical_tool_arguments("x" * 900)),
+        },
+        {
+            "name": "connectors__slack__POST_MESSAGE",
+            "arguments": {"body": "fresh"},
+        },
+    ]
+    assistant_message = SimpleNamespace(
+        content="",
+        tool_calls=[_tool_call("call-connectors", {"calls": calls}, "tool_call")],
+    )
+    messages = []
+    executed = []
+
+    def fake_dispatch(name, args, task_id, *positional, **kwargs):
+        call_id = kwargs.get("tool_call_id") or (positional[0] if positional else None)
+        executed.append((name, args, call_id))
+        return json.dumps({"ok": True})
+
+    with (
+        patch("model_tools.handle_function_call", side_effect=fake_dispatch),
+        patch.object(agent, "_invoke_tool", side_effect=fake_dispatch),
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+    ):
+        execute = getattr(agent, f"_execute_tool_calls_{dispatch_mode}")
+        execute(assistant_message, messages, "task-1")
+
+    assert executed == [("tool_call", {"calls": calls}, "call-connectors")]

--- a/tests/tools/test_connector_dispatch_policy.py
+++ b/tests/tools/test_connector_dispatch_policy.py
@@ -5,6 +5,49 @@ import json
 import pytest
 
 
+def test_non_replayable_connector_entry_does_not_block_fresh_batch_sibling(monkeypatch):
+    import model_tools
+    from agent.historical_tool_arguments import omit_historical_tool_arguments
+    from tools.registry import invalidate_check_fn_cache
+    from tools.tool_gateway import bridge, config
+
+    monkeypatch.setattr(config, "connectors_available", lambda: True)
+    monkeypatch.setattr(bridge, "connectors_available", lambda: True)
+    invalidate_check_fn_cache()
+    wire = []
+
+    class Client:
+        def execute(self, planned):
+            wire.extend(planned)
+            return [{"data": "remote-ok", "error": None} for _ in planned]
+
+    monkeypatch.setattr(bridge, "_default_client_factory", Client)
+    calls = [
+        {
+            "name": "connectors__gmail__SEND_EMAIL",
+            "arguments": json.loads(omit_historical_tool_arguments("x" * 900)),
+        },
+        {
+            "name": "connectors__slack__POST_MESSAGE",
+            "arguments": {"body": "fresh"},
+        },
+    ]
+
+    result = json.loads(model_tools.handle_function_call(
+        "tool_call",
+        {"calls": calls},
+        enabled_toolsets=["connections"],
+        session_id="integrity-session",
+        tool_call_id="integrity-call",
+    ))
+
+    assert result["results"][0]["error"]["code"] == "non_replayable_history_arguments"
+    assert result["results"][1]["response"] == "remote-ok"
+    assert [(plan.name, plan.arguments) for plan in wire] == [
+        ("connectors__slack__POST_MESSAGE", {"body": "fresh"})
+    ]
+
+
 @pytest.mark.parametrize("blocked_by", ["hook", "execution"])
 def test_remote_entries_run_request_hook_and_execution_policies(monkeypatch, blocked_by):
     import model_tools

--- a/tools/tool_search_validation.py
+++ b/tools/tool_search_validation.py
@@ -171,7 +171,7 @@ def normalize_tool_call_entries(args: Dict[str, Any]) -> Tuple[List[Dict[str, An
         if isinstance(raw_args, str):
             try:
                 raw_args = json.loads(raw_args)
-            except json.JSONDecodeError as e:
+            except (json.JSONDecodeError, RecursionError) as e:
                 return [], f"tool_call calls[{position}].arguments is not valid JSON: {e}"
         if not isinstance(raw_args, dict):
             return [], f"tool_call calls[{position}].arguments must be an object"


### PR DESCRIPTION
### What does this PR do?

Context compression currently shortens string leaves inside old tool-call argument JSON. The shortened JSON can remain syntactically valid and retain actionable fields such as a path or command, so a model may later copy it into a new tool call as though it were authoritative input.

This change replaces oversized historical argument payloads wholesale with a bounded, structured omission marker that is explicitly non-replayable. The executor recognizes that marker before operational dispatch and returns a paired error instructing the model to reconstruct fresh arguments from current state.

The guard covers direct, sequential, concurrent, deferred Tool Search, MCP/connector, string-encoded, and already-decoded provider argument forms. Connector batches preserve existing per-entry isolation: a marked entry is rejected while valid siblings continue in stable order.

Fresh/current long arguments are not rewritten. Literal text containing `...[truncated]` is not rejected.

### Related Issue

No matching issue or pull request was found in the pre-submission search.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

### Changes Made

- `agent/context_compressor.py`
  - Replace oversized historical tool arguments with bounded omission metadata in ordinary pruning and protected-tail pressure demotion.
  - Preserve current/protected arguments unchanged.
- `agent/historical_tool_arguments.py`
  - Add marker construction and iterative, cycle-aware, container-budgeted marker detection.
  - Distinguish traversal-complexity failures from actual marker detection.
- `agent/tool_executor.py`
  - Reject non-replayable arguments before middleware, hooks, approvals, checkpoints, handlers, MCP, or network effects.
  - Convert malformed and pathologically deep direct/deferred JSON into isolated paired errors.
  - Preserve sequential/concurrent sibling execution and connector per-entry isolation.
- `tools/tool_search_validation.py` and `model_tools_connectors.py`
  - Harden nested argument decoding and independently reject invalid connector entries without suppressing valid siblings.
- Regression tests cover compression bounds, pairing, direct/deferred/connector dispatch, decoded and encoded provider forms, cycles, recursion limits, wide fresh arguments, current long-argument fidelity, and sequential/concurrent isolation.

### How to Test

1. Create an old oversized synthetic tool call and run context pruning. Confirm its arguments become a bounded `_hermes_history_omitted` marker while a protected/current oversized call remains byte-for-byte unchanged.
2. Dispatch the marker through direct, sequential, concurrent, deferred, and connector paths. Confirm it produces a paired `non_replayable_history_arguments` result and no handler or connector side effect.
3. Dispatch fresh long/wide arguments and mixed connector batches. Confirm fresh arguments reach the handler unchanged and valid siblings execute in stable order.
4. Run:

```bash
HERMES_PYTHON=/home/hermes/.hermes/venvs/hermes-upstream-pr/bin/python \
  scripts/run_tests.sh \
  tests/agent/test_context_compressor.py \
  tests/agent/test_historical_tool_arguments.py \
  tests/agent/test_tool_executor_checkpoint_paths.py \
  tests/run_agent/test_malformed_tool_arguments.py \
  tests/run_agent/test_tool_executor_contextvar_propagation.py \
  tests/tools/test_connector_bridge_wiring.py \
  tests/tools/test_connector_dispatch_policy.py
```

Observed locally: **223 passed, 0 failed**.

A complete `scripts/run_tests.sh` attempt also ran all 3,987 test files. It finished with 96 failures across 27 files in the locally generated minimal environment; representative failures were missing optional provider/backend dependencies such as `anthropic`, `hindsight-client`, `fal-client`, and Daytona/browser/media dependencies. None of the failing files overlaps the nine files changed by this contribution. The focused affected-component suites above and independent review are the release gate for this draft.

Static verification:

```bash
python -m ruff check <modified Python files>
python -m compileall -q <modified runtime files>
git diff --check
```

Observed locally: all passed.

### Checklist

#### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing open and merged issues/PRs for duplicates
- [x] My PR contains only changes related to this fix
- [ ] I've run the complete `pytest tests/ -q` suite and all tests pass
- [x] I've added synthetic regression tests for the change
- [x] I've tested on Linux with Python 3.11

#### Documentation & Housekeeping

- [x] Relevant documentation update — N/A; no public API or configuration changes
- [x] `cli-config.yaml.example` update — N/A; no configuration keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` update — N/A; no contributor workflow changed
- [x] Cross-platform impact considered; implementation uses portable Python data structures and standard-library JSON behavior
- [x] Tool descriptions/schemas update — N/A; no public tool schema changed

### Disclosure

Developed with AI assistance and validated using synthetic regression tests; no private application data is included.
