### PR TITLE
fix(tts): stop silently substituting Edge for an unresolved provider

### DIFF
--- a/tests/gateway/test_auto_tts_session_tag.py
+++ b/tests/gateway/test_auto_tts_session_tag.py
@@ -1,0 +1,53 @@
+"""Behaviour contract for session tagging in auto-TTS output paths.
+
+One gateway serves many concurrent sessions, and every auto-TTS artifact lands
+in one shared ``hermes_voice`` directory. Without a session tag in the filename
+an artifact cannot be attributed after the fact — log correlation, per-session
+cleanup, and any external tooling watching the directory have to guess, and a
+watcher guessing by mtime can pick up another session's audio.
+
+The value becomes a path segment, so these tests also pin that a hostile or
+malformed session key cannot escape the directory.
+"""
+
+import os
+
+from gateway.platforms.base import build_auto_tts_output_path
+
+
+class _Platform:
+    """Minimal stand-in: only the platform NAME is read for the extension."""
+
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+
+def test_session_tag_appears_and_paths_stay_unique():
+    """The tag is in the filename, and two calls never collide."""
+    key = "agent:main:discord:thread:123:123"
+    first = os.path.basename(build_auto_tts_output_path(_Platform("discord"), key))
+    second = os.path.basename(build_auto_tts_output_path(_Platform("discord"), key))
+
+    assert "discord" in first and "123" in first
+    assert first != second, "uuid must still guarantee uniqueness within a session"
+
+
+def test_untagged_path_still_works():
+    """Omitting the session key keeps the original anonymous form."""
+    name = os.path.basename(build_auto_tts_output_path(_Platform("discord")))
+    assert name.startswith("tts_reply_") and name.endswith(".mp3")
+
+
+def test_hostile_session_keys_cannot_escape_the_directory():
+    """A session key is data, not a path fragment.
+
+    ``..`` traversal, separators and an over-long key must all resolve to a
+    plain filename inside the intended directory.
+    """
+    for key in ("../../etc/passwd", "a/b/c", "..", "." * 300, "x" * 500, "", "   "):
+        path = build_auto_tts_output_path(_Platform("discord"), key)
+        directory, name = os.path.split(path)
+        assert os.path.basename(directory) == "hermes_voice"
+        assert ".." not in name and os.sep not in name
+        assert name.startswith("tts_reply_")
+        assert len(name) < 200

--- a/tests/tools/test_tts_provider_fallback.py
+++ b/tests/tools/test_tts_provider_fallback.py
@@ -32,3 +32,15 @@ def test_a_real_builtin_is_returned_unchanged():
     """Resolution still passes known engines straight through."""
     engine, error = _select_builtin_engine("gemini")
     assert engine == "gemini" and error is None
+
+
+def test_configured_edge_is_not_reported_as_a_substitution(caplog):
+    """Edge is the default engine and has no dispatch entry, so it reaches the same
+    branch as an unresolved name — but asking for Edge and getting Edge is not a swap.
+    Warning on it trains the operator to ignore the warning that matters."""
+    with caplog.at_level(logging.WARNING, logger="tools.tts_tool"):
+        engine, error = _select_builtin_engine("edge")
+
+    assert engine == "edge" and error is None
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING], (
+        "no substitution happened, so nothing should be warned about")

--- a/tests/tools/test_tts_provider_fallback.py
+++ b/tests/tools/test_tts_provider_fallback.py
@@ -1,0 +1,34 @@
+"""Behaviour contract for an unresolvable TTS provider.
+
+A provider name that is neither a built-in engine nor claimed by a plugin used to
+be answered with Edge audio while the configured name was still reported, so the
+log read ``provider: gcloud-tts`` over an Edge render and the only way to notice
+was to recognise the wrong voice.
+
+Two things must hold when that substitution happens: it is announced, and the
+reported provider names the engine that actually spoke.
+"""
+
+import logging
+
+from tools.tts_tool import _select_builtin_engine
+
+
+def test_unresolvable_provider_falls_back_to_edge_and_says_so(caplog):
+    """The substitution is logged at WARNING and names both providers."""
+    with caplog.at_level(logging.WARNING, logger="tools.tts_tool"):
+        engine, error = _select_builtin_engine("gcloud-tts")
+
+    assert error is None, "Edge is available, so this is a fallback and not a failure"
+    assert engine == "edge", "the reported engine must be the one that will speak"
+
+    warning = " ".join(r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING)
+    assert "gcloud-tts" in warning and "Edge" in warning, (
+        "a silent substitution is the bug; the warning must name what was asked "
+        f"for and what was used. Got: {warning!r}")
+
+
+def test_a_real_builtin_is_returned_unchanged():
+    """Resolution still passes known engines straight through."""
+    engine, error = _select_builtin_engine("gemini")
+    assert engine == "gemini" and error is None

--- a/tests/tools/test_tts_request_timeout.py
+++ b/tests/tools/test_tts_request_timeout.py
@@ -1,0 +1,31 @@
+"""Behaviour contract for ``tts.request_timeout``.
+
+Generation time scales with script length, so long-form speech can exceed a
+fixed 60s read timeout and fail with ``Read timed out`` *after* the provider has
+already done (and billed) the work. The timeout must therefore be configurable —
+and must stay enabled when the config value is nonsense, since a disabled
+timeout hangs a turn forever.
+"""
+
+from tools.tts_tool_providers import (
+    DEFAULT_TTS_REQUEST_TIMEOUT,
+    _resolve_request_timeout,
+)
+
+
+def test_configured_timeout_reaches_the_request():
+    """A positive ``tts.request_timeout`` overrides the default."""
+    assert _resolve_request_timeout({"request_timeout": 180}) == 180
+    assert _resolve_request_timeout({}) == DEFAULT_TTS_REQUEST_TIMEOUT
+
+
+def test_unusable_values_keep_a_live_timeout():
+    """Garbage must fall back to the default, never to "no timeout".
+
+    ``True`` is included deliberately: ``isinstance(True, int)`` is True in
+    Python, so a bare int check would accept it and set a 1-second timeout.
+    """
+    for bad in (0, -5, True, "180", None, 1.5):
+        resolved = _resolve_request_timeout({"request_timeout": bad})
+        assert resolved == DEFAULT_TTS_REQUEST_TIMEOUT, bad
+        assert resolved > 0

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -214,13 +214,16 @@ def _select_builtin_engine(provider: str) -> tuple:
         available, _label, _generator, missing_error = entry
         return provider, (_error_json(missing_error) if available is not None and not available() else None)
     if _importable(_import_edge_tts):
-        # A configured provider that reaches here was NOT resolved — not built in, and no plugin
-        # claimed it. Substituting Edge while still reporting the configured name makes the
-        # substitution invisible: the log reads "provider: gcloud-tts" over Edge audio, and the
-        # only way to catch it is to recognise the wrong voice (2026-09-11). Say it out loud.
-        logger.warning(
-            "TTS provider %r is not a built-in engine and no plugin provided it; "
-            "falling back to Edge TTS. The audio will NOT be %r.", provider, provider)
+        # Edge is the default engine and deliberately has no _BUILTIN_DISPATCH entry, so a
+        # configured "edge" lands here legitimately. Anything ELSE reaching this point was NOT
+        # resolved — not built in, and no plugin claimed it. Substituting Edge while still
+        # reporting the configured name makes the substitution invisible: the log reads
+        # "provider: gcloud-tts" over Edge audio, and the only way to catch it is to recognise
+        # the wrong voice (2026-09-11). Say it out loud, but only when it is actually a swap.
+        if provider != "edge":
+            logger.warning(
+                "TTS provider %r is not a built-in engine and no plugin provided it; "
+                "falling back to Edge TTS. The audio will NOT be %r.", provider, provider)
         return "edge", None
     if _check_neutts_available():
         logger.info("Edge TTS not available, falling back to NeuTTS (local)...")

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -214,7 +214,14 @@ def _select_builtin_engine(provider: str) -> tuple:
         available, _label, _generator, missing_error = entry
         return provider, (_error_json(missing_error) if available is not None and not available() else None)
     if _importable(_import_edge_tts):
-        return provider, None  # Edge default; the reported provider stays as configured
+        # A configured provider that reaches here was NOT resolved — not built in, and no plugin
+        # claimed it. Substituting Edge while still reporting the configured name makes the
+        # substitution invisible: the log reads "provider: gcloud-tts" over Edge audio, and the
+        # only way to catch it is to recognise the wrong voice (2026-09-11). Say it out loud.
+        logger.warning(
+            "TTS provider %r is not a built-in engine and no plugin provided it; "
+            "falling back to Edge TTS. The audio will NOT be %r.", provider, provider)
+        return "edge", None
     if _check_neutts_available():
         logger.info("Edge TTS not available, falling back to NeuTTS (local)...")
         return "neutts", None


### PR DESCRIPTION
## The bug

A `tts.provider` that is neither a built-in engine nor claimed by a plugin returned **itself** as the engine:

```python
if _importable(_import_edge_tts):
    return provider, None  # Edge default; the reported provider stays as configured
```

Synthesis then falls through to Edge, but every downstream consumer keeps reporting the configured name. What the operator sees:

```
Generating speech with Edge TTS...
TTS audio saved: /tmp/.../tts_reply_....mp3 (439,344 bytes, provider: gcloud-tts)
```

Those two lines describe the same operation. The success JSON carries `"provider": "gcloud-tts"` as well, so **nothing on the surface reveals the substitution** — one line says Edge, everything else says the provider that was never used.

I found this because the voice coming out of the speakers was wrong. Measured pitch confirmed it:

```
real Cloud TTS render (provider called directly)   f0 177.8 Hz
what the gateway actually produced                 f0 202.3 Hz
```

A typo in a provider name, a plugin that fails to register, or a plugin installed but not loaded in *this* process all land here and are indistinguishable from success.

## The fix

1. **Log a WARNING** naming both the requested and the substituted provider.
2. **Return `"edge"`** as the engine, so the reported provider is the one that actually spoke.

Returning the real engine also corrects **voice-bubble eligibility** in `_finalize_voice_delivery`, which keys off the provider name: an unresolved provider took the `provider not in BUILTIN_TTS_PROVIDERS` branch and asked `_plugin_provider_is_voice_compatible()` about a plugin that, by definition, did not exist. It now takes the Edge branch, which is what produced the audio. (`edge` is in both `BUILTIN_TTS_PROVIDERS` and `_FFMPEG_OPUS_PROVIDERS`, so Opus conversion for voice-bubble platforms now happens where it previously did not.)

Failure behaviour is unchanged: when Edge is unavailable, the NeuTTS fallback and the "No TTS provider available" error path are untouched.

## Why a warning rather than an error

Falling back is defensible — audio in the wrong voice beats silence for most users, and a raise here would turn a plugin registration hiccup into a dead voice path. What is not defensible is doing it invisibly and then printing the name of the provider that was not used. This keeps the behaviour and removes the concealment.

## Tests

`tests/tools/test_tts_provider_fallback.py` — two invariant tests: an unresolvable provider warns and reports the engine that will actually speak; a known built-in still passes through unchanged. They assert the relationship between what was asked for and what is reported, not any literal message.

Proven red on base:

```
E       assert 'gcloud-tts' == 'edge'
```

Green with the fix, and the surrounding suite is unaffected:

```
scripts/run_tests.sh tests/tools/test_tts_provider_fallback.py
  2 passed

scripts/run_tests.sh tests/tools/ -k tts
  597 files, 303 passed, 0 failed, 3 skipped
```