### PR TITLE
fix(compression): inherit main fallback policy on watchdog expiry

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4089,6 +4089,17 @@ def _try_main_fallback_chain(
     task: Optional[str], failed_provider: str = "", reason: str = "error", *,
     failed_model: Optional[str] = None, failed_base_url: str = "", failure_scope: Any = None,
 ) -> Tuple[Optional[Any], Optional[str], str]:
+    client, model, provider, _entry = _select_main_fallback_entry(
+        task, failed_provider, reason, failed_model=failed_model,
+        failed_base_url=failed_base_url, failure_scope=failure_scope,
+    )
+    return client, model, provider
+
+
+def _select_main_fallback_entry(
+    task: Optional[str], failed_provider: str = "", reason: str = "error", *,
+    failed_model: Optional[str] = None, failed_base_url: str = "", failure_scope: Any = None,
+) -> Tuple[Optional[Any], Optional[str], str, Optional[Dict[str, Any]]]:
     """Top-level main-agent fallback chain for a ``provider: auto`` auxiliary call: auto tasks honour the
     user's main fallback policy before the built-in discovery chain; read via ``get_fallback_chain`` so
     ``fallback_providers`` and legacy ``fallback_model`` keep the main agent's order."""
@@ -4098,9 +4109,9 @@ def _try_main_fallback_chain(
         chain = get_fallback_chain(load_config_readonly())
     except Exception as exc:
         logger.debug("Auxiliary %s: could not load main fallback chain: %s", task or "call", exc)
-        return None, None, ""
+        return None, None, "", None
     if not chain:
-        return None, None, ""
+        return None, None, "", None
     skip = _failed_backend_skip(
         failed_provider, failed_model, failed_base_url=failed_base_url, failure_scope=failure_scope)
     tried: List[str] = []
@@ -4136,11 +4147,11 @@ def _try_main_fallback_chain(
                 continue
             logger.info("Auxiliary %s: %s on %s — main fallback chain to %s (%s)",
                         task or "call", reason, failed_provider or "auto", label, resolved_model or fb_model)
-            return fb_client, resolved_model or fb_model, fb_provider
+            return fb_client, resolved_model or fb_model, fb_provider, entry
         tried.append(label)
     if tried:
         logger.debug("Auxiliary %s: main fallback chain exhausted (tried: %s)", task or "call", ", ".join(tried))
-    return None, None, ""
+    return None, None, "", None
 
 
 def _warn_stale_openai_base_url(runtime_provider: str) -> None:

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -772,13 +772,47 @@ def _record_stall_interrupted_backoff(
 
 
 def resolve_compression_fallback_route() -> Optional[dict]:
-    """Return the first usable ``auxiliary.compression.fallback_chain`` entry.
+    """Return a task fallback route, or an eligible inherited main route for auto.
     The aux client applies the chain only from its exception handler, so a silent stall never reaches it; this
     pins the route onto one bounded retry instead. Only the first complete entry: if it errors, the aux
     client's own exception path walks the rest. ``None`` when none is usable (skip compression)."""
     try:
         from agent.auxiliary_client import _fallback_entry_api_key, _get_auxiliary_task_config
-        chain = _get_auxiliary_task_config("compression").get("fallback_chain")
+        task_config = _get_auxiliary_task_config("compression")
+        chain = task_config.get("fallback_chain")
+        # Explicit task routes retain precedence. Auto tasks without one use
+        # the same eligibility policy as the auxiliary client's error path.
+        has_task_route = isinstance(chain, list) and any(
+            isinstance(entry, dict)
+            and str(entry.get("provider") or "").strip()
+            and str(entry.get("model") or "").strip()
+            for entry in chain
+        )
+        inherited = False
+        if not has_task_route and str(task_config.get("provider") or "auto").strip().lower() == "auto":
+            from agent.auxiliary_client import (
+                _fallback_destination_from_entry,
+                _select_main_fallback_entry,
+                _read_main_provider,
+                _read_main_model,
+                _custom_health_base_url,
+            )
+
+            client, model, _provider, entry = _select_main_fallback_entry(
+                "compression", _read_main_provider(), reason="summary stalled",
+                failed_model=task_config.get("model") or _read_main_model(),
+                failed_base_url=_custom_health_base_url(
+                    _read_main_provider(), task_config.get("base_url")
+                ),
+            )
+            if entry is not None:
+                destination = _fallback_destination_from_entry(entry, client, model)
+                chain = [dict(
+                    entry, model=model, base_url=destination.base_url,
+                    api_mode=destination.api_mode,
+                    api_key=_fallback_entry_api_key(entry) or getattr(client, "api_key", None),
+                )]
+                inherited = True
     except Exception:
         logger.debug("compression fallback_chain lookup failed", exc_info=True)
         return None
@@ -801,7 +835,8 @@ def resolve_compression_fallback_route() -> Optional[dict]:
         from agent.auxiliary_client import _coerce_positive_timeout
         timeout = _coerce_positive_timeout(entry.get("timeout"))
         return {
-            "label": f"fallback_chain[{index}]({provider})",
+            "label": (f"main fallback ({provider})" if inherited
+                      else f"fallback_chain[{index}]({provider})"),
             "provider": provider,
             "model": model,
             "base_url": str(entry.get("base_url") or "").strip() or None,

--- a/tests/agent/test_compression_fallback_inheritance.py
+++ b/tests/agent/test_compression_fallback_inheritance.py
@@ -1,0 +1,170 @@
+"""Watchdog and auxiliary errors share the main fallback eligibility policy."""
+import threading
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent import auxiliary_client as aux
+from agent.context_compressor import take_pinned_summary_route
+from agent.conversation_compression import (
+    CompressionCommitFence,
+    resolve_compression_fallback_route,
+    run_compress_context_with_progress_timeout,
+)
+
+
+@pytest.fixture
+def routes(monkeypatch):
+    entry = {"provider": "custom:backup", "model": "backup-model",
+             "base_url": "https://backup.invalid/v1", "api_key": "fixture-key",
+             "api_mode": "chat_completions", "timeout": 19}
+    config = {"provider": "auto", "model": ""}
+    monkeypatch.setattr(aux, "_get_auxiliary_task_config", lambda task: config)
+    monkeypatch.setattr("hermes_cli.config.load_config_readonly",
+                        lambda: {"fallback_providers": [entry]})
+    monkeypatch.setattr(aux, "_read_main_provider", lambda: "primary")
+    monkeypatch.setattr(aux, "_read_main_model", lambda: "primary-model")
+    monkeypatch.setattr(aux, "_custom_health_base_url", lambda provider, base_url=None: base_url or "")
+    monkeypatch.setattr(aux, "_is_provider_unhealthy", lambda *a, **kw: False)
+    monkeypatch.setattr(aux, "_task_minimum_context_length", lambda task: 10000)
+    monkeypatch.setattr(aux, "_candidate_context_window", lambda *a, **kw: 20000)
+    monkeypatch.setattr(aux, "_resolve_fallback_entry",
+                        lambda candidate: (SimpleNamespace(), candidate["model"]))
+    return config, entry
+
+
+def test_auto_inherits_main_fallback(routes):
+    _, entry = routes
+    route = resolve_compression_fallback_route()
+    assert route is not None
+    for key, value in entry.items():
+        assert route[key] == value
+
+
+def test_inherited_route_pins_inferred_transport(routes, monkeypatch):
+    config, entry = routes
+    config["api_mode"] = "responses"
+    entry.pop("api_mode")
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kw: {"api_mode": "chat_completions"},
+    )
+    route = resolve_compression_fallback_route()
+    assert route is not None
+    assert route["api_mode"] == "chat_completions"
+
+
+def test_inherited_route_preserves_resolved_credentials(routes, monkeypatch):
+    config, entry = routes
+    config["api_key"] = "primary-only-key"
+    entry.pop("api_key")
+    monkeypatch.setattr(
+        aux, "_resolve_fallback_entry",
+        lambda candidate: (SimpleNamespace(api_key="resolved-backup-key"), candidate["model"]),
+    )
+    route = resolve_compression_fallback_route()
+    assert route is not None
+    assert route["api_key"] == "resolved-backup-key"
+
+
+@pytest.mark.parametrize("same_model", [True, False])
+def test_inherited_exclusions_use_primary_backend_identity(routes, monkeypatch, same_model):
+    _, entry = routes
+    monkeypatch.setattr(aux, "_read_main_provider", lambda: entry["provider"])
+    monkeypatch.setattr(aux, "_read_main_model", lambda: "primary-model")
+    monkeypatch.setattr(aux, "_custom_health_base_url", lambda *a, **kw: entry["base_url"])
+    if same_model:
+        entry["model"] = "primary-model"
+    route = resolve_compression_fallback_route()
+    assert (route is None) == same_model
+
+
+def test_explicit_chain_precedes_main(routes):
+    config, _ = routes
+    config["fallback_chain"] = [{"provider": "other", "model": "task-backup"}]
+    route = resolve_compression_fallback_route()
+    assert route is not None
+    assert route["model"] == "task-backup"
+
+
+def test_explicit_provider_does_not_inherit(routes):
+    config, _ = routes
+    config["provider"] = "explicit"
+    assert resolve_compression_fallback_route() is None
+
+
+@pytest.mark.parametrize("ineligible", ["context", "unhealthy", "unavailable", "excluded"])
+def test_no_eligible_inherited_route(routes, monkeypatch, ineligible):
+    _, entry = routes
+    if ineligible == "context":
+        monkeypatch.setattr(aux, "_candidate_context_window", lambda *a, **kw: 100)
+    elif ineligible == "unhealthy":
+        monkeypatch.setattr(aux, "_is_provider_unhealthy", lambda *a, **kw: True)
+    elif ineligible == "unavailable":
+        monkeypatch.setattr(aux, "_resolve_fallback_entry", lambda entry: (None, None))
+    else:
+        entry["provider"] = "auto"
+    assert resolve_compression_fallback_route() is None
+
+
+@pytest.mark.parametrize("stopped", [False, True])
+def test_real_watchdog_inherits_once_and_fences_late_primary(routes, stopped):
+    original = [{"role": "user", "content": "original"}]
+    compressed = [{"role": "user", "content": "summary"}]
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+    stop = threading.Event()
+    if stopped:
+        stop.set()
+    calls = []
+    committed = []
+    primary = CompressionCommitFence()
+
+    def worker(fence):
+        calls.append(take_pinned_summary_route())
+        if fence is primary:
+            started.set()
+            assert release.wait(5)
+            try:
+                if fence.begin_commit():
+                    committed.append("stale")
+                    fence.finish_commit()
+                return original, "stale"
+            finally:
+                finished.set()
+        assert fence.begin_commit()
+        committed.append("fallback")
+        fence.finish_commit()
+        return compressed, "compressed-prompt"
+
+    # Advance the primary's observed idle age only once its worker is blocked.
+    # No stopwatch thresholds or scheduling-dependent sleeps.
+    def expired():
+        assert started.wait(5)
+        return 1000.0
+
+    try:
+        with patch.object(primary, "seconds_since_progress", side_effect=expired):
+            result = run_compress_context_with_progress_timeout(
+                worker=worker, messages=original, system_prompt_fallback="original-prompt",
+                idle_timeout_seconds=1, total_ceiling_seconds=10, fence=primary,
+                telemetry_agent=SimpleNamespace(_hard_interrupt_requested=stop),
+                new_fence=CompressionCommitFence,
+            )
+    finally:
+        release.set()
+        assert finished.wait(5)
+    assert calls[0] is None
+    if stopped:
+        assert result == (original, "original-prompt")
+        assert len(calls) == 1
+        assert committed == []
+    else:
+        assert result == (compressed, "compressed-prompt")
+        assert len(calls) == 2
+        assert calls[1]["provider"] == "custom:backup"
+        assert calls[1]["model"] == "backup-model"
+        assert committed == ["fallback"]
+    assert primary.is_cancelled

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -34,6 +34,21 @@ Configure via `hermes plugins` → Provider Plugins → Context Engine, or edit 
 
 For building a context engine plugin, see [Context Engine Plugins](/developer-guide/context-engine-plugin).
 
+## Stalled summary fallback
+
+When the progress watchdog aborts a stalled summary, it retries compression once
+with a pinned fallback route. An explicit `auxiliary.compression.fallback_chain`
+takes precedence. With `provider: auto` (including the default) and no complete
+task-chain route, the watchdog inherits the main `fallback_providers` policy
+(or legacy `fallback_model`). It uses the auxiliary error path's same candidate
+selection, including provider exclusions, health, credentials, and minimum
+context length; no separate compression fallback configuration is required.
+Explicit compression providers do not inherit this main chain on watchdog expiry.
+
+If no eligible route exists or the bounded retry fails, compression is skipped
+without replacing the original context. `/stop` does not start a fallback, and
+the cancelled primary attempt cannot commit after the fallback succeeds.
+
 ## Dual Compression System
 
 Hermes has two separate compression layers that operate independently:


### PR DESCRIPTION
## Summary
When `auxiliary.compression` uses `provider: auto` without a complete task fallback route, ordinary auxiliary errors inherit the main fallback policy, but a silent summary aborted by the watchdog previously did not. Reuse the same candidate selector for the watchdog's existing one-shot pinned retry.

- Keep explicit task-chain precedence and explicit-provider behavior.
- Preserve backend-scoped exclusions, health/credential/context eligibility, inferred transport, and resolved credentials.
- Leave watchdog budgets, cancellation, and commit fencing unchanged.
- Document inherited fallback behavior; no new configuration required.

## Tests
- On original main: new regression suite returned **3 failed, 7 passed**, including the real watchdog returning original context instead of the fallback summary.
- Event-synchronized watchdog test verifies one pinned fallback, successful compressed result, `/stop` suppression, and rejection of late-primary commit.
- Controls cover explicit task precedence/provider behavior, ineligible routes, inherited transport/credentials, and same-backend model exclusions.
- Canonical per-file runner: **265 passed, 0 failed**, with one unchanged timing assertion in `test_auxiliary_client.py` failing its first attempt and passing on retry (reported rather than hidden).
- Combined randomized execution exposed vision-test shared-state ordering failures and a short watchdog timing failure; canonical per-file isolation passes. These broader isolation/timing issues are not changed here.
- All runs used temporary HOME/HERMES_HOME and the installed interpreter with verified worktree imports; no live compression or provider calls.

Reviewed nearby open timeout/deadline PRs; this change only addresses route-policy inheritance, not deadline-race or shared-budget behavior.
