### PR TITLE
fix: preserve quota scope and retry timing across recovery paths

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -850,8 +850,8 @@ def recover_with_credential_pool(
         )
         return agent._swap_credential(next_entry) is not False
     if effective_reason == FailoverReason.upstream_rate_limit:
-        # Upstream (e.g. DeepSeek behind OpenRouter) is throttling the aggregator; the credential is
-        # healthy. Do not rotate/exhaust; let fallback switch models.
+        # The failure is scoped to a model (Gemini QuotaFailure or an aggregator's
+        # upstream), not this credential. Do not persist global key exhaustion.
         upstream = (error_context or {}).get("upstream_provider") if error_context else None
         if upstream:
             _ra().logger.info(
@@ -860,7 +860,7 @@ def recover_with_credential_pool(
             )
         else:
             _ra().logger.info(
-                "Upstream aggregator 429 (provider unknown) — skipping "
+                "Model-scoped upstream 429 — skipping "
                 "credential rotation, deferring to fallback chain"
             )
         return False, has_retried_429
@@ -3111,7 +3111,7 @@ _RESETS_IN_RE = re.compile(
     r"(?:(\d+(?:\.\d+)?)\s*(?:m|min|mins|minute|minutes)\b\s*)?"
     r"(?:(\d+(?:\.\d+)?)\s*(?:s|sec|secs|second|seconds)\b)?", re.IGNORECASE,
 )
-_RETRY_AFTER_SECONDS_RE = re.compile(r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)", re.IGNORECASE)
+_RETRY_AFTER_SECONDS_RE = re.compile(r"retry\s+(?:(?:after|in)\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)", re.IGNORECASE)
 
 
 def _reset_delay_from_message(message: str) -> Optional[float]:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -107,6 +107,7 @@ def aux_probe_mode():
 
 
 from agent.credential_pool import load_pool
+from agent.error_classifier import FailoverReason, classify_api_error
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH, get_model_context_length,
     strip_codex_context_variant_suffix as _strip_codex_ctx_variant,
@@ -3012,9 +3013,8 @@ def _contains_any(text: str, needles: Tuple[str, ...]) -> bool:
     return any(kw in text for kw in needles)
 
 
-# Billing-body markers (credit exhaustion wrapped in 402/403/404/429 bodies), plus daily/weekly quota
-# exhaustion (functionally credit exhaustion; "resource exhausted" is the Vertex/gRPC quota phrasing —
-# also serialized by SDK wrappers and NIM as RESOURCE_EXHAUSTED / ResourceExhausted / resource-exhausted).
+# Legacy access/plan messages. The shared classifier's rate/capacity verdict
+# takes precedence: generic quota wording must never arm a payment health ban.
 _PAYMENT_KEYWORDS = (
     "credits", "insufficient funds", "can only afford", "billing", "payment required",
     "out of funds", "run out of funds", "balance_depleted", "no usable credits",
@@ -3028,9 +3028,15 @@ _PAYMENT_KEYWORDS = (
 
 
 def _is_payment_error(exc: Exception) -> bool:
-    """Payment/credit/quota exhaustion: HTTP 402, or a billing/quota body on 403/404/429/no-status."""
-    status = getattr(exc, "status_code", None)
-    return status == 402 or (
+    """Shared billing/throttle verdicts, with legacy plan-access wording as a fallback."""
+    classified = classify_api_error(exc)
+    # Google includes "billing details" even in temporary quota responses; rendered
+    # guidance and RESOURCE_EXHAUSTED are not proof of a payment failure.
+    if classified.reason in {FailoverReason.rate_limit, FailoverReason.upstream_rate_limit,
+                              FailoverReason.overloaded}:
+        return False
+    status = classified.status_code
+    return classified.reason == FailoverReason.billing or status == 402 or (
         status in {403, 404, 429, None} and _contains_any(str(exc).lower(), _PAYMENT_KEYWORDS)
     )
 
@@ -3045,29 +3051,14 @@ def _nous_portal_account_has_fresh_paid_access() -> bool:
         return False
 
 
-_RATE_LIMIT_KEYWORDS = (
-    "rate limit", "rate_limit", "too many requests", "try again", "retry after", "resets in"
-)
-_RATE_LIMIT_BILLING_KEYWORDS = (
-    "credits", "insufficient funds", "billing", "payment required", "can only afford",
-    "out of funds", "run out of funds", "balance_depleted", "no usable credits",
-    "model_not_supported_on_free_tier", "not available on the free tier", "isn't available on the free tier",
-)
 
 
 def _is_rate_limit_error(exc: Exception) -> bool:
-    """429 rate limit (not billing/quota, which _is_payment_error owns).
-
-    OpenAI's RateLimitError may omit .status_code — matched by class name. A generic 429 without
-    billing keywords counts as a rate limit.
-    """
-    # (PR #8023 pattern)
-    if type(exc).__name__ == "RateLimitError":
-        return True
-    if getattr(exc, "status_code", None) != 429:
-        return False
-    err_lower = str(exc).lower()
-    return _contains_any(err_lower, _RATE_LIMIT_KEYWORDS) or not _contains_any(err_lower, _RATE_LIMIT_BILLING_KEYWORDS)
+    """Shared quota/capacity verdict, never inferred from payment-looking guidance."""
+    classified = classify_api_error(exc)
+    return classified.reason in {FailoverReason.rate_limit, FailoverReason.upstream_rate_limit} or (
+        classified.reason == FailoverReason.overloaded and classified.status_code in {None, 429}
+    )
 
 
 def _is_timeout_error(exc: Exception) -> bool:
@@ -3375,6 +3366,10 @@ def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str
     another process already rotated (current() would be None).
     """
     normalized = _normalize_aux_provider(provider)
+    classified = classify_api_error(exc, provider=normalized)
+    if classified.reason in {FailoverReason.upstream_rate_limit, FailoverReason.overloaded}:
+        # Match the main agent: a model/worker failure cannot exhaust the API key.
+        return False
     try:
         pool = load_pool(normalized)
     except Exception as load_exc:
@@ -3385,12 +3380,14 @@ def _recover_provider_pool(provider: str, exc: Exception, *, failed_api_key: str
     status_code = getattr(exc, "status_code", None)
 
     def _rotate(fallback_status: int) -> bool:
-        error_context: Dict[str, Any] = {"message": str(exc)}
+        from agent.agent_runtime_helpers import extract_api_error_context
+        error_context = extract_api_error_context(exc)
         if status_code is not None:
             error_context["status_code"] = status_code
         next_entry = pool.mark_exhausted_and_rotate(
             status_code=status_code if status_code is not None else fallback_status,
             error_context=error_context, api_key_hint=failed_api_key or None,
+            failure_reason=("billing_unverified" if classified.billing_unverified else classified.reason.value),
         )
         if next_entry is None:
             return False
@@ -6982,10 +6979,15 @@ def _ladder_credential_rungs(
     # process rotated the pool meanwhile (current() would be None).
     _client_api_key = str(getattr(client, "api_key", "") or "")
     if pool_provider and _credential_rung_accepts(first_err):
+        classified = classify_api_error(first_err, provider=pool_provider, model=route.final_model or "")
+        if classified.reason in {FailoverReason.upstream_rate_limit, FailoverReason.overloaded}:
+            return None, first_err
+        from agent.agent_runtime_helpers import extract_api_error_context
+        reset_at = extract_api_error_context(first_err).get("reset_at")
         recovery_err = first_err
-        # Skip the extra retry for clear payment/quota errors — the endpoint won't accept
-        # another request with the same exhausted key.
-        if _is_rate_limit_error(first_err) and not _is_payment_error(first_err):
+        # A provider minimum forbids this immediate same-key retry. Rotate eligible
+        # credentials or fall back instead; auxiliary tasks must not block on long waits.
+        if _is_rate_limit_error(first_err) and not _is_payment_error(first_err) and reset_at is None:
             resp, recovery_err = yield from _rung(
                 _LadderStep("call", (client, kwargs)), _credential_rung_accepts)
             if recovery_err is None:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6836,8 +6836,11 @@ def _rung(step: "_LadderStep", accept: Callable[[Exception], bool]):
 def _param_rung_accepts(exc: Exception) -> bool:
     """After a parameter-strip retry: fall through to the max_tokens/payment/auth
     chains with the stripped kwargs; re-raise anything those chains won't handle."""
-    return (_is_payment_error(exc) or _is_connection_error(exc) or _is_auth_error(exc)
-            or "max_tokens" in str(exc) or "unsupported_parameter" in str(exc))
+    return (
+        _is_payment_error(exc) or _is_connection_error(exc) or _is_auth_error(exc)
+        or _is_rate_limit_error(exc)
+        or "max_tokens" in str(exc) or "unsupported_parameter" in str(exc)
+    )
 
 
 def _credential_rung_accepts(exc: Exception) -> bool:
@@ -7051,11 +7054,20 @@ def _ladder_provider_fallback(first_err: Exception, route: _LadderRoute):
     if reason is None or not (is_auto or is_capacity_error):
         return None
     if reason == "payment error":
-        # Mark the concrete backend (not the "auto" label) unhealthy so later aux calls skip
-        # it instead of paying another doomed RTT.
-        _mark_provider_unhealthy(
-            _recoverable_pool_provider(resolved_provider, route.client, main_runtime=route.main_runtime)
-            or resolved_provider, base_url=route.base_info)
+        payment = classify_api_error(
+            first_err, provider=_normalize_aux_provider(resolved_provider),
+            model=route.final_model or "",
+        )
+        # Ambiguous billing bodies still justify fallback for this request, but are
+        # not evidence that later requests should skip the endpoint for the full
+        # 600s payment-health TTL.
+        if not payment.billing_unverified:
+            _mark_provider_unhealthy(
+                _recoverable_pool_provider(
+                    resolved_provider, route.client, main_runtime=route.main_runtime
+                ) or resolved_provider,
+                base_url=route.base_info,
+            )
     logger.info("Auxiliary %s%s: %s on %s (%s), trying fallback",
                 task or "call", tag, reason, resolved_provider, first_err)
     # Skip only the failed model for model-specific failures; 401/402 are provider-wide, so

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -374,7 +374,7 @@ _RETRY_DELAY_PATTERNS: Tuple[Tuple[re.Pattern, Callable[[re.Match], float]], ...
         lambda m: float(m.group(1)) / 1000.0 if m.group(2).lower() == "ms" else float(m.group(1)),
     ),
     (
-        re.compile(r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)", re.IGNORECASE),
+        re.compile(r"retry\s+(?:(?:after|in)\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)", re.IGNORECASE),
         lambda m: float(m.group(1)),
     ),
     # "Resets in 4hr 5min" format used by OpenCode Go weekly usage limits

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -550,6 +550,10 @@ def _nous_welcome_tier(c: _Ctx) -> Optional[Verdict]:
 def _provider_special_cases(c: _Ctx) -> Optional[Verdict]:
     """Highest-priority provider-specific shapes that a status code would misroute."""
     msg, status = c.msg, c.status_code
+    # NIM's worker-local admission counter is shared capacity, not key credit.
+    # A generic 429 carries no such scope evidence and keeps the normal policy.
+    if status in {None, 429} and "worker local total request limit reached" in msg:
+        return _v(_R.overloaded, should_fallback=True)
     welcome = _nous_welcome_tier(c)
     if welcome is not None:
         return welcome

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -29,7 +29,7 @@ class FailoverReason(enum.Enum):
     auth_permanent = "auth_permanent"    # Auth failed after refresh — abort
     billing = "billing"                  # 402 or confirmed credit exhaustion — rotate immediately
     rate_limit = "rate_limit"            # 429 or quota-based throttling — backoff then rotate
-    upstream_rate_limit = "upstream_rate_limit"  # Aggregator's upstream model 429 — fallback model, key is healthy
+    upstream_rate_limit = "upstream_rate_limit"  # Model-scoped upstream 429 — fallback model, key is healthy
     overloaded = "overloaded"            # 503/529 — provider overloaded, backoff
     server_error = "server_error"        # 500/502 — internal server error, retry
     timeout = "timeout"                  # Connection/read timeout — rebuild client + retry
@@ -710,6 +710,18 @@ def _status_404(c: _Ctx) -> Verdict:
 
 
 def _status_429(c: _Ctx) -> Verdict:
+    if c.provider_slug in {"gemini", "google"} or c.error_type == "GeminiAPIError":
+        from agent.gemini_quota import gemini_quota_context, gemini_retry_after_seconds
+
+        quota = gemini_quota_context(c.body)
+        if quota:
+            retry_after = gemini_retry_after_seconds(c.body, c.headers)
+            if retry_after is not None:
+                quota["retry_after"] = retry_after
+            return _v(
+                _R.upstream_rate_limit, retryable=not quota["quota_zero"],
+                should_fallback=True, error_context=quota,
+            )
     # Z.AI/Zhipu reuse 429 for server-wide overload: back off on the same
     # key instead of burning the pool (#14038).
     if any(p in c.msg for p in _OVERLOADED_PATTERNS):

--- a/agent/fallback_cooldown.py
+++ b/agent/fallback_cooldown.py
@@ -32,6 +32,13 @@ def _arm_rate_limit_cooldown(agent, reason: "FailoverReason | None") -> float | 
     primary_provider = ((agent._primary_runtime or {}).get("provider") or "").strip().lower()
     if getattr(agent, "_fallback_activated", False) and not (primary_provider and current_provider == primary_provider):
         return None
+    if (
+        getattr(agent, "_fallback_activated", False) and reason == FailoverReason.upstream_rate_limit
+        and getattr(agent, "model", None) != (agent._primary_runtime or {}).get("model")
+    ):
+        # Model-scoped failure of a same-provider fallback says nothing about the
+        # primary's bucket. Account-wide rate/billing failures retain their policy.
+        return None
     deadline = getattr(agent, "_model_quota_retry_deadline", None)
     if (
         deadline is not None and reason == FailoverReason.upstream_rate_limit

--- a/agent/fallback_cooldown.py
+++ b/agent/fallback_cooldown.py
@@ -10,7 +10,18 @@ logger = logging.getLogger(__name__)
 _RATE_LIMIT_FAILOVER_REASONS = frozenset({FailoverReason.rate_limit, FailoverReason.billing, FailoverReason.upstream_rate_limit})
 
 
-def _arm_rate_limit_cooldown(agent, reason: "FailoverReason | None") -> int | None:
+def _record_model_quota_retry_deadline(agent, classified) -> None:
+    """Carry only this failed route's minimum into fallback; never a global pool status."""
+    agent._model_quota_retry_deadline = None
+    quota = classified.error_context
+    delay = quota.get("retry_after")
+    if quota.get("quota_scope") == "model" and not quota.get("quota_zero") and delay is not None and delay > 0:
+        agent._model_quota_retry_deadline = (
+            agent.provider, agent.model, time.monotonic() + delay,
+        )
+
+
+def _arm_rate_limit_cooldown(agent, reason: "FailoverReason | None") -> float | None:
     """Arm the primary's exponential cooldown (60s → 2m → ... → 4h cap) on CONSECUTIVE rate-limits;
     restore_primary_runtime resets the counter. Only when leaving the primary: chain-switching from
     an active fallback means the primary was not the 429 source, so its cooldown is left alone.
@@ -21,6 +32,17 @@ def _arm_rate_limit_cooldown(agent, reason: "FailoverReason | None") -> int | No
     primary_provider = ((agent._primary_runtime or {}).get("provider") or "").strip().lower()
     if getattr(agent, "_fallback_activated", False) and not (primary_provider and current_provider == primary_provider):
         return None
+    deadline = getattr(agent, "_model_quota_retry_deadline", None)
+    if (
+        deadline is not None and reason == FailoverReason.upstream_rate_limit
+        and deadline[:2] == (agent.provider, agent.model)
+        and agent.model == (agent._primary_runtime or {}).get("model")
+    ):
+        agent._rate_limited_until = deadline[2]
+        agent._rate_limit_backoff_count = 0
+        remaining = max(0.0, deadline[2] - time.monotonic())
+        logger.info("Model quota retry deadline: cooldown %.3f s for %s", remaining, agent.model)
+        return remaining
     backoff_count = getattr(agent, "_rate_limit_backoff_count", 0)
     agent._rate_limit_backoff_count = backoff_count + 1
     backoff_seconds = min(60 * (2 ** backoff_count), 14400)

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -21,6 +21,7 @@ import httpx
 
 from agent.bounded_response import read_streaming_error_body
 from agent.gemini_schema import sanitize_gemini_tool_parameters
+from agent.gemini_quota import gemini_quota_context, gemini_retry_after_seconds
 
 logger = logging.getLogger(__name__)
 
@@ -39,10 +40,9 @@ DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
 GEMINI_DEFAULT_MAX_OUTPUT_TOKENS = 65535
 
 _FREE_TIER_GUIDANCE = (
-    "\n\nYour Google API key is on the free tier (a few hundred requests/day for Gemini Flash models). "
-    "Hermes typically makes 3-10 API calls per user turn, so the free tier is exhausted in a handful of "
-    "messages and cannot sustain an agent session. Enable billing on your Google Cloud project and "
-    "regenerate the key in a billing-enabled project: https://aistudio.google.com/apikey"
+    "\n\nGoogle reported a free tier quota limit for this request. Limits differ by model and "
+    "quota window; this does not by itself establish that the daily allowance or API key is exhausted. "
+    "Check the project's model quotas and billing: https://aistudio.google.com/apikey"
 )
 _STANDARD_KEY_GUIDANCE = (
     "\n\nGoogle Gemini rejected this API key's type — you do NOT need OAuth. Google began rejecting legacy "
@@ -137,7 +137,7 @@ def _response_text(response: Any) -> str:
 
 
 def is_free_tier_quota_error(error_message: str) -> bool:
-    """True when a Gemini 429 message indicates free-tier exhaustion."""
+    """True when a Gemini 429 message identifies a free-tier quota (not its reset window)."""
     return bool(error_message) and "free_tier" in error_message.lower()
 
 
@@ -152,10 +152,11 @@ class GeminiAPIError(Exception):
     """Error shape compatible with Hermes retry/error classification."""
 
     def __init__(self, message: str, *, code: str = "gemini_api_error", status_code: Optional[int] = None,
-                 response: Optional[httpx.Response] = None, retry_after: Optional[float] = None, details: Optional[Dict[str, Any]] = None):
+                 response: Optional[httpx.Response] = None, retry_after: Optional[float] = None, details: Optional[Dict[str, Any]] = None, body: Optional[Dict[str, Any]] = None):
         super().__init__(message)
         self.code, self.status_code, self.response = code, status_code, response
         self.retry_after, self.details = retry_after, details or {}
+        self.body = body
 
 
 # ── OpenAI → Gemini request translation ──────────────────────────────────────
@@ -591,23 +592,23 @@ def gemini_http_error(response: httpx.Response, *, body_text: Optional[str] = No
     err_obj = _error_object(body_text)
     err_status, err_message = (str(err_obj.get(k) or "").strip() for k in ("status", "message"))
     reason, metadata = _error_info(err_obj)
-    try:
-        retry_after: Optional[float] = float(response.headers.get("Retry-After") or response.headers.get("retry-after"))
-    except (TypeError, ValueError):
-        retry_after = None
+    retry_after = gemini_retry_after_seconds(err_obj, response.headers)
+    quota_context = gemini_quota_context(err_obj) if status == 429 else {}
     message = (
         f"Gemini HTTP {status} ({err_status or 'error'}): {err_message}" if err_message
         else f"Gemini returned HTTP {status}: {body_text[:500]}"
     )
-    # Users who bypassed the setup wizard (raw GOOGLE_API_KEY in .env) still need to learn the free
-    # tier cannot sustain an agent session; a legacy "Standard" key gets the real fix (Google's raw 401 asks for OAuth).
+    # Quota scope/window is not a statement about the whole key or daily allowance.
+    if quota_context.get("quota_zero"):
+        message += "\n\nThis model has zero quota allowance for the project; a retry delay does not guarantee access. Choose an available model or check the project's quota tier."
     if status == 429 and is_free_tier_quota_error(err_message or body_text):
         message += _FREE_TIER_GUIDANCE
     if is_standard_key_auth_error(status, err_message or body_text, reason):
         message += _STANDARD_KEY_GUIDANCE
     return GeminiAPIError(
         message, code=_HTTP_ERROR_CODES.get(status, f"gemini_http_{status}"), status_code=status, response=response,
-        retry_after=retry_after, details={"status": err_status, "reason": reason, "metadata": metadata, "message": err_message},
+        retry_after=retry_after, details={"status": err_status, "reason": reason, "metadata": metadata, "message": err_message, **quota_context},
+        body={**err_obj, "retry_after": retry_after},
     )
 
 

--- a/agent/gemini_quota.py
+++ b/agent/gemini_quota.py
@@ -1,0 +1,91 @@
+"""Google quota scope and retry hints, shared by native errors and classification."""
+from __future__ import annotations
+
+import math
+import re
+from typing import Any
+
+from agent.retry_utils import parse_retry_after_seconds
+
+_RETRY_IN = re.compile(r"\bretry\s+(?:in|after)\s+(\d+(?:\.\d+)?)\s*s(?:ec(?:ond)?s?)?\b", re.IGNORECASE)
+_DURATION = re.compile(r"(\d+(?:\.\d+)?)s")
+_QUOTA_LINE = re.compile(
+    r"Quota exceeded for metric:\s*[^,\n]+,\s*limit:\s*(\d+(?:\.\d+)?),\s*model:\s*([^\s,;]+)",
+    re.IGNORECASE,
+)
+
+
+def _nonnegative_number(value: Any) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (str, int, float)):
+        return None
+    try:
+        number = float(value)
+    except (ValueError, OverflowError):
+        return None
+    return number if math.isfinite(number) and number >= 0 else None
+
+
+def _duration_seconds(value: Any) -> float | None:
+    if isinstance(value, str):
+        match = _DURATION.fullmatch(value.strip())
+        return _nonnegative_number(match.group(1)) if match else None
+    if isinstance(value, dict):
+        seconds = _nonnegative_number(value.get("seconds", 0))
+        nanos = _nonnegative_number(value.get("nanos", 0))
+        if seconds is not None and nanos is not None and seconds.is_integer() and nanos.is_integer() and nanos < 1_000_000_000:
+            return seconds + nanos / 1_000_000_000
+    return None
+
+
+def gemini_error_payload(body: dict) -> dict:
+    nested = body.get("error")
+    return nested if isinstance(nested, dict) else body
+
+
+def gemini_retry_after_seconds(body: dict, headers: Any = None) -> float | None:
+    """Keep the largest valid minimum: Google's prose may be more precise than RetryInfo."""
+    payload = gemini_error_payload(body)
+    delays = [parse_retry_after_seconds(headers)]
+    details = payload.get("details")
+    for detail in details if isinstance(details, list) else []:
+        if isinstance(detail, dict) and detail.get("@type") == "type.googleapis.com/google.rpc.RetryInfo":
+            delays.append(_duration_seconds(detail.get("retryDelay")))
+    message = payload.get("message")
+    if isinstance(message, str):
+        delays.extend(float(match.group(1)) for match in _RETRY_IN.finditer(message))
+    valid = [delay for delay in delays if delay is not None and math.isfinite(delay) and delay > 0]
+    return max(valid) if valid else None
+
+
+def gemini_quota_context(body: dict) -> dict:
+    """Only exempt the credential when EVERY reported quota violation names a model.
+
+    Missing/malformed/mixed dimensions stay on the existing account-level path.
+    A retry hint is not proof that zero allowance will reopen after that delay.
+    """
+    payload = gemini_error_payload(body)
+    message = payload.get("message")
+    text_rows = list(_QUOTA_LINE.finditer(message)) if isinstance(message, str) else []
+    details = payload.get("details")
+    quota_details = [detail for detail in details if isinstance(detail, dict) and detail.get("@type") == "type.googleapis.com/google.rpc.QuotaFailure"] if isinstance(details, list) else []
+    models, zero = set(), False
+    if quota_details:
+        for detail in quota_details:
+            violations = detail.get("violations")
+            if not isinstance(violations, list) or not violations:
+                return {}
+            for violation in violations:
+                if not isinstance(violation, dict):
+                    return {}
+                dimensions = violation.get("quotaDimensions")
+                model = dimensions.get("model") if isinstance(dimensions, dict) else None
+                if not isinstance(model, str) or not model.strip():
+                    return {}
+                models.add(model.strip())
+                zero |= _nonnegative_number(violation.get("quotaValue")) == 0
+    elif text_rows and len(text_rows) == len(re.findall(r"Quota exceeded for metric:", message, re.IGNORECASE)):
+        models.update(match.group(2) for match in text_rows)
+    else:
+        return {}
+    zero |= any(float(match.group(1)) == 0 for match in text_rows)
+    return {"quota_scope": "model", "quota_models": sorted(models), "quota_zero": zero}

--- a/agent/turn_api_error.py
+++ b/agent/turn_api_error.py
@@ -355,7 +355,7 @@ def settle_unrecovered_error(
     wait_time = compute_error_backoff(
         agent, api_error, retry_count=retry_count, max_retries=max_retries,
         is_rate_limited=is_rate_limited, is_zai_coding_overload=_is_zai_coding_overload,
-        base_url=_base, model=_model,
+        base_url=_base, model=_model, error_context=classified.error_context,
     )
     # Same preserve-redirect rule as the invalid-response wait: a steering correction
     # must survive backoff, not die as "Operation interrupted".

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 import math
+import math
 import re
 import time
 from dataclasses import dataclass
@@ -490,6 +491,9 @@ def recover_after_classification(
             _vlines(agent, "🔐 Nous paid access verified — refreshed runtime credentials and retrying request...")
             return True, False
 
+    from agent.fallback_cooldown import _record_model_quota_retry_deadline
+
+    _record_model_quota_retry_deadline(agent, classified)
     recovered_with_pool, _retry.has_retried_429 = agent._recover_with_credential_pool(
         status_code=status_code, has_retried_429=_retry.has_retried_429,
         classified_reason=classified.reason, error_context=error_context,
@@ -1021,7 +1025,8 @@ def compute_error_backoff(
     is_zai_coding_overload: bool, base_url: Any, model: Any,
 ) -> float:
     """Pick the wait before the next API retry and announce it. Retry-After wins for
-    rate limits and any other retryable error (capped at 600s: Anthropic Tier 1 buckets
+    rate limits and any other retryable error (generic headers capped at 600s; a
+    normalized adapter minimum is never shortened). Anthropic Tier 1 buckets
     reset in ~171s, so a 120s cap re-tripped the limit); otherwise jittered backoff,
     replaced by the adaptive policy for 429s / Z.AI overloads. Normal retries are
     buffered; long Z.AI Coding waits surface immediately."""
@@ -1054,6 +1059,11 @@ def compute_error_backoff(
             # past, which the parser clamps to 0.0) carries no usable wait —
             # treat it as absent so we never hot-loop the provider.
             _retry_after = None
+    # Native adapters normalize structured provider hints onto the exception. Do not
+    # shorten that minimum (or discard its fractional part) with the generic header cap.
+    _adapter_retry_after = parse_retry_after_seconds(getattr(api_error, "retry_after", None))
+    if _adapter_retry_after is not None and math.isfinite(_adapter_retry_after) and _adapter_retry_after > 0:
+        _retry_after = max(_retry_after or 0.0, _adapter_retry_after)
     wait_time = _retry_after if _retry_after is not None else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
     _backoff_policy = None
     _adaptive = is_rate_limited or is_zai_coding_overload
@@ -1432,6 +1442,14 @@ def route_classified_error(
         (is_rate_limited and _wrapped_output_cap_budget is None)
         or (_is_transport_failure and retry_count >= 2)
     )
+    # A short model-local quota window gets the bounded normal retry budget first.
+    # Zero allowance is deliberately excluded: RetryInfo does not make that route usable.
+    _quota = classified.error_context
+    if (
+        _quota.get("quota_scope") == "model" and not _quota.get("quota_zero")
+        and 0 < (_quota.get("retry_after") or 0) <= 60 and retry_count < max_retries
+    ):
+        _should_fallback = False
     if _should_fallback and agent._fallback_index < len(agent._fallback_chain):
         # No eager fallback while credential pool rotation may recover. Exception: an
         # upstream-aggregator 429 — the pool can't help, always fall back.

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import logging
 import math
-import math
 import re
 import time
 from dataclasses import dataclass
@@ -1023,6 +1022,7 @@ _ZAI_POLICY_NOTES = {
 def compute_error_backoff(
     agent: Any, api_error: Exception, *, retry_count: int, max_retries: int, is_rate_limited: bool,
     is_zai_coding_overload: bool, base_url: Any, model: Any,
+    error_context: Optional[Dict[str, Any]] = None,
 ) -> float:
     """Pick the wait before the next API retry and announce it. Retry-After wins for
     rate limits and any other retryable error (generic headers capped at 600s; a
@@ -1059,11 +1059,21 @@ def compute_error_backoff(
             # past, which the parser clamps to 0.0) carries no usable wait —
             # treat it as absent so we never hot-loop the provider.
             _retry_after = None
-    # Native adapters normalize structured provider hints onto the exception. Do not
-    # shorten that minimum (or discard its fractional part) with the generic header cap.
-    _adapter_retry_after = parse_retry_after_seconds(getattr(api_error, "retry_after", None))
-    if _adapter_retry_after is not None and math.isfinite(_adapter_retry_after) and _adapter_retry_after > 0:
-        _retry_after = max(_retry_after or 0.0, _adapter_retry_after)
+    # Native adapters and the shared classifier normalize structured provider hints.
+    # Neither minimum may be shortened by the generic header/body cap. The classifier
+    # path is load-bearing for OpenAI-SDK-compatible Gemini routes, whose exception has
+    # no adapter-specific ``retry_after`` attribute even when RetryInfo is present.
+    for _normalized_retry_after in (
+        getattr(api_error, "retry_after", None),
+        (error_context or {}).get("retry_after"),
+    ):
+        _normalized_retry_after = parse_retry_after_seconds(_normalized_retry_after)
+        if (
+            _normalized_retry_after is not None
+            and math.isfinite(_normalized_retry_after)
+            and _normalized_retry_after > 0
+        ):
+            _retry_after = max(_retry_after or 0.0, _normalized_retry_after)
     wait_time = _retry_after if _retry_after is not None else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
     _backoff_policy = None
     _adaptive = is_rate_limited or is_zai_coding_overload

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -1397,13 +1397,13 @@ class TestIsPaymentError:
 
     @pytest.mark.parametrize("spelling", ["RESOURCE_EXHAUSTED", "ResourceExhausted", "resource-exhausted"])
     @pytest.mark.parametrize("status", [None, 429])
-    def test_resource_exhausted_separator_variants_are_payment(self, spelling, status):
-        """NIM / gRPC wrappers serialize the quota signal without the space; the fallback gate
-        must read every spelling like the literal ``resource exhausted`` (#85649)."""
+    def test_worker_capacity_separator_variants_are_not_payment(self, spelling, status):
+        """Worker saturation must reach fallback without a provider-wide payment ban."""
         exc = Exception(f"{spelling}: Worker local total request limit reached (32/32)")
         if status is not None:
             exc.status_code = status
-        assert _is_payment_error(exc) is True
+        assert _is_payment_error(exc) is False
+        assert _is_rate_limit_error(exc) is True
 
     def test_403_subscription_required_is_payment(self):
         exc = Exception(
@@ -2828,7 +2828,7 @@ class TestAuxiliaryAuthRefreshRetry:
 
 class TestAuxiliaryPoolRotationRetry:
     def test_call_llm_rotates_explicit_codex_pool_on_429(self):
-        rate_err = Exception("usage limit reached")
+        rate_err = Exception("Rate limit exceeded")
         rate_err.status_code = 429
 
         stale_client = MagicMock()

--- a/tests/agent/test_auxiliary_quota_recovery.py
+++ b/tests/agent/test_auxiliary_quota_recovery.py
@@ -4,6 +4,7 @@ from concurrent.futures import ThreadPoolExecutor
 import json
 import threading
 import time
+from types import SimpleNamespace
 
 import httpx
 import pytest
@@ -217,7 +218,6 @@ def test_auxiliary_pool_persists_retry_deadlines_without_losing_real_quota_walls
 @pytest.mark.parametrize('provider,model', [('gemini', HEALTHY), ('nvidia', NIM_HEALTHY)])
 @pytest.mark.parametrize('reason', [FailoverReason.upstream_rate_limit, FailoverReason.rate_limit, FailoverReason.billing])
 def test_fallback_model_failure_does_not_extend_primary_quota_deadline(provider, model, reason):
-    from types import SimpleNamespace
     from agent.fallback_cooldown import _arm_rate_limit_cooldown
     deadline = time.monotonic() + 48.100581664
     agent = SimpleNamespace(
@@ -235,3 +235,106 @@ def test_fallback_model_failure_does_not_extend_primary_quota_deadline(provider,
         assert armed is None
         assert agent._rate_limited_until == deadline
         assert agent._rate_limit_backoff_count == 2
+
+
+class _ReviewError(Exception):
+    def __init__(self, message, status_code=None, body=None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.body = body
+
+
+def _drive_review_ladder(mode, ladder, perform):
+    if mode == "sync":
+        return aux._drive_ladder(ladder, perform)
+
+    async def async_perform(step):
+        return perform(step)
+
+    return asyncio.run(aux._drive_ladder_async(ladder, async_perform))
+
+
+@pytest.mark.parametrize("mode", ["sync", "async"])
+def test_capacity_after_parameter_strip_reaches_fallback(monkeypatch, mode):
+    client = SimpleNamespace(api_key="offline-key", base_url=NVIDIA)
+    param_error = _ReviewError("Unsupported parameter: temperature", 400)
+    worker_error = _ReviewError(
+        "ResourceExhausted: Worker local total request limit reached (32/32)", 429
+    )
+    assert classify_api_error(worker_error).reason == FailoverReason.overloaded
+    healthy_response = object()
+    fallback_client = object()
+    monkeypatch.setattr(aux, "_recoverable_pool_provider", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        aux, "_try_configured_fallback_chain",
+        lambda *args, **kwargs: (
+            fallback_client, NIM_HEALTHY, "fallback_chain[0](nvidia)"
+        ),
+    )
+    seen = []
+
+    def perform(step):
+        seen.append(step.kind)
+        if step.kind == "call":
+            _, kwargs = step.args
+            assert "temperature" not in kwargs
+            raise worker_error
+        if step.kind == "fallback":
+            return healthy_response
+        raise AssertionError(step)
+
+    ladder = aux._aux_recovery_ladder(
+        param_error, client=client,
+        kwargs={"model": NIM_LIMITED, "messages": [], "temperature": 0.2},
+        task="moa_reference", async_mode=(mode == "async"), base_info=NVIDIA,
+        resolved_provider="nvidia", resolved_model=NIM_LIMITED,
+        resolved_base_url=NVIDIA, resolved_api_key="offline-key",
+        resolved_api_mode="chat_completions", final_model=NIM_LIMITED,
+        max_tokens=None, main_runtime=None, route_info={},
+    )
+    assert _drive_review_ladder(mode, ladder, perform) is healthy_response
+    assert seen == ["call", "fallback"]
+
+
+@pytest.mark.parametrize("mode", ["sync", "async"])
+@pytest.mark.parametrize(
+    "message,status_code,should_quarantine",
+    [("You're out of extra usage", 400, False),
+     ("Payment required: insufficient credits", 402, True)],
+)
+def test_unverified_billing_falls_back_without_health_quarantine(
+    monkeypatch, mode, message, status_code, should_quarantine,
+):
+    base_url = "https://claude-proxy.invalid/v1"
+    client = SimpleNamespace(api_key="offline-key", base_url=base_url)
+    error = _ReviewError(message, status_code)
+    classified = classify_api_error(error, provider="anthropic", model="claude-test")
+    assert classified.reason == FailoverReason.billing
+    assert classified.billing_unverified is (not should_quarantine)
+    fallback_client = object()
+    healthy_response = object()
+    quarantined = []
+    monkeypatch.setattr(aux, "_recoverable_pool_provider", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        aux, "_mark_provider_unhealthy",
+        lambda *args, **kwargs: quarantined.append((args, kwargs)),
+    )
+    monkeypatch.setattr(
+        aux, "_try_configured_fallback_chain",
+        lambda *args, **kwargs: (fallback_client, "healthy-model", "fallback_chain[0](healthy)"),
+    )
+
+    def perform(step):
+        assert step.kind == "fallback"
+        return healthy_response
+
+    ladder = aux._aux_recovery_ladder(
+        error, client=client, kwargs={"model": "claude-test", "messages": []},
+        task="title", async_mode=(mode == "async"), base_info=base_url,
+        resolved_provider="anthropic", resolved_model="claude-test",
+        resolved_base_url=base_url, resolved_api_key="offline-key",
+        resolved_api_mode="chat_completions", final_model="claude-test",
+        max_tokens=None, main_runtime=None, route_info={},
+    )
+    assert _drive_review_ladder(mode, ladder, perform) is healthy_response
+    assert bool(quarantined) is should_quarantine

--- a/tests/agent/test_auxiliary_quota_recovery.py
+++ b/tests/agent/test_auxiliary_quota_recovery.py
@@ -1,0 +1,237 @@
+"""Log-shaped quota failures through real auxiliary routing and persisted pools."""
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+import json
+import threading
+import time
+
+import httpx
+import pytest
+import yaml
+
+from agent import auxiliary_client as aux
+from agent.credential_pool import CredentialPool, PooledCredential, STATUS_EXHAUSTED, load_pool
+from agent.error_classifier import FailoverReason, classify_api_error
+from agent.gemini_native_adapter import GeminiNativeClient, GeminiAPIError, gemini_http_error
+
+GEMINI = 'https://generativelanguage.googleapis.com/v1beta'
+NVIDIA = 'https://integrate.api.nvidia.com/v1'
+LIMITED = 'gemini-test-limited'
+HEALTHY = 'gemini-test-healthy'
+NIM_LIMITED = 'nvidia/test-limited'
+NIM_HEALTHY = 'nvidia/test-healthy'
+
+
+def quota_body(kind='tokens', *, delay=48.100581664, scoped=True):
+    metric = ('generate_content_free_tier_requests' if kind == 'requests'
+              else 'generate_content_free_tier_input_token_count')
+    limit = 0 if kind == 'zero' else 20 if kind == 'requests' else 250000
+    message = ('You exceeded your current quota, please check your plan and billing details.\n'
+               f'* Quota exceeded for metric: generativelanguage.googleapis.com/{metric}, '
+               f'limit: {limit}, model: {LIMITED}\nPlease retry in {delay}s.')
+    violations = [{'quotaMetric': metric, 'quotaDimensions': {'model': LIMITED}, 'quotaValue': str(limit)}]
+    if kind == 'mixed':
+        violations.append({'quotaMetric': 'project_requests', 'quotaDimensions': {'project': 'offline'}})
+    details = [{'@type': 'type.googleapis.com/google.rpc.RetryInfo', 'retryDelay': f'{delay}s'}]
+    if kind != 'text':
+        details.insert(0, {'@type': 'type.googleapis.com/google.rpc.QuotaFailure', 'violations': violations})
+    if not scoped:
+        # RetryInfo-only responses have no model-scope evidence and no prose delay.
+        message = 'You exceeded your current quota, please check your plan and billing details.'
+        details = details[-1:]
+    return {'error': {'code': 429, 'status': 'RESOURCE_EXHAUSTED', 'message': message, 'details': details}}
+
+
+def persist_keys(provider, count=4):
+    entries = [PooledCredential(provider=provider, id=f'{provider}-{i}', label=f'offline-{i}',
+               auth_type='api_key', priority=i, source='manual', access_token=f'offline-{provider}-{i}')
+               for i in range(count)]
+    pool = CredentialPool(provider, entries)
+    pool._persist()
+    return entries
+
+
+@pytest.fixture
+def routed_wire(tmp_path, monkeypatch):
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    (tmp_path / 'config.yaml').write_text(yaml.safe_dump({
+        'model': {'provider': 'gemini', 'default': HEALTHY},
+        'auxiliary': {'transient_retries': 0, 'moa_reference': {
+            'provider': 'gemini', 'model': LIMITED,
+            'fallback_chain': [{'provider': 'gemini', 'model': HEALTHY}],
+        }},
+    }))
+    persist_keys('gemini')
+    persist_keys('nvidia')
+    state = {'kind': 'tokens', 'requests': []}
+    lock = threading.Lock()
+    clients = []
+    aux._reset_aux_unhealthy_cache()
+
+    def upstream(request):
+        body = json.loads(request.content)
+        is_google = request.url.host == 'generativelanguage.googleapis.com'
+        model = request.url.path.split('/models/', 1)[1].split(':', 1)[0] if is_google else body['model']
+        key = request.headers.get('x-goog-api-key') or request.headers.get('authorization')
+        with lock:
+            state['requests'].append((model, key))
+        if model == LIMITED:
+            return httpx.Response(429, json=quota_body(state['kind']))
+        if model == NIM_LIMITED:
+            return httpx.Response(429, json={'message': 'ResourceExhausted: Worker local total request limit reached (32/32)'})
+        if is_google:
+            data = {'candidates': [{'content': {'role': 'model', 'parts': [{'text': 'healthy route response'}]},
+                                    'finishReason': 'STOP'}],
+                    'usageMetadata': {'promptTokenCount': 84665, 'candidatesTokenCount': 3, 'totalTokenCount': 84668}}
+            if ':streamGenerateContent' in request.url.path:
+                return httpx.Response(200, text='data: ' + json.dumps(data) + '\n\n', headers={'content-type': 'text/event-stream'})
+            return httpx.Response(200, json=data)
+        data = {'id': 'offline', 'object': 'chat.completion', 'model': model,
+                'choices': [{'index': 0, 'message': {'role': 'assistant', 'content': 'healthy route response'}, 'finish_reason': 'stop'}]}
+        if body.get('stream'):
+            chunk = {'id': 'offline', 'object': 'chat.completion.chunk', 'model': model,
+                     'choices': [{'index': 0, 'delta': {'role': 'assistant', 'content': 'healthy route response'}, 'finish_reason': 'stop'}]}
+            return httpx.Response(200, text='data: ' + json.dumps(chunk) + '\n\ndata: [DONE]\n\n', headers={'content-type': 'text/event-stream'})
+        return httpx.Response(200, json=data)
+
+    transport = httpx.MockTransport(upstream)
+    original_init = GeminiNativeClient.__init__
+
+    def native_init(self, *args, **kwargs):
+        client = httpx.Client(transport=transport)
+        clients.append(client)
+        kwargs['http_client'] = client
+        original_init(self, *args, **kwargs)
+
+    def http_client_kwargs(base_url, *, async_mode=False):
+        client = httpx.AsyncClient(transport=transport) if async_mode else httpx.Client(transport=transport)
+        clients.append(client)
+        return {'http_client': client}
+
+    monkeypatch.setattr(GeminiNativeClient, '__init__', native_init)
+    monkeypatch.setattr(aux, '_openai_http_client_kwargs', http_client_kwargs)
+    yield state, tmp_path
+    aux._reset_aux_unhealthy_cache()
+    aux._evict_cached_clients('gemini')
+    aux._evict_cached_clients('nvidia')
+    for client in clients:
+        if isinstance(client, httpx.AsyncClient):
+            asyncio.run(client.aclose())
+        else:
+            client.close()
+
+
+@pytest.mark.parametrize('mode', ['sync', 'async', 'parallel'])
+@pytest.mark.parametrize('kind', ['tokens', 'requests', 'zero', 'text', 'worker', 'cross-provider'])
+def test_auxiliary_quota_keeps_other_routes_and_credentials_usable(routed_wire, mode, kind):
+    state, home = routed_wire
+    state['kind'] = kind if kind in {'tokens', 'requests', 'zero', 'text'} else 'tokens'
+    provider, model = ('nvidia', NIM_LIMITED) if kind in {'worker', 'cross-provider'} else ('gemini', LIMITED)
+    if kind in {'worker', 'cross-provider'}:
+        config = yaml.safe_load((home / 'config.yaml').read_text())
+        config['auxiliary']['moa_reference']['fallback_chain'] = (
+            [{'provider': 'gemini', 'model': LIMITED}, {'provider': 'nvidia', 'model': NIM_HEALTHY}]
+            if kind == 'cross-provider' else [{'provider': 'nvidia', 'model': NIM_HEALTHY}])
+        (home / 'config.yaml').write_text(yaml.safe_dump(config))
+
+    def invoke(p=provider, m=model):
+        kwargs = dict(task='moa_reference', provider=p, model=m,
+                      messages=[{'role': 'user', 'content': 'offline recovery check'}], max_tokens=64)
+        return asyncio.run(aux.async_call_llm(**kwargs)) if mode == 'async' else aux.call_llm(**kwargs)
+
+    if kind == 'cross-provider':
+        # The existing auxiliary candidate policy raises non-auth fallback failures.
+        # Both failed routes must remain available on the next call, not get payment bans.
+        with pytest.raises(GeminiAPIError):
+            invoke()
+        assert not aux._is_provider_unhealthy('gemini')
+        assert not aux._is_provider_unhealthy('nvidia')
+        result = invoke('gemini', LIMITED)
+        results, calls = [result], 2
+    elif mode == 'parallel':
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            results = list(executor.map(lambda _: invoke(), range(4)))
+        calls = 4
+    else:
+        results, calls = [invoke()], 1
+    assert all(result.choices[0].message.content == 'healthy route response' for result in results)
+    assert not aux._is_provider_unhealthy('gemini')
+    assert not aux._is_provider_unhealthy('nvidia')
+    # A model quota must not produce even an immediate duplicate call before fallback.
+    failed_calls = sum(m == model for m, _ in state['requests'])
+    assert failed_calls == (1 if kind == 'cross-provider' else calls)
+    for p in ('gemini', 'nvidia'):
+        reloaded = load_pool(p)
+        assert reloaded.has_available()
+        assert all(entry.last_status != STATUS_EXHAUSTED for entry in reloaded.entries())
+
+
+@pytest.mark.parametrize('count', [1, 4])
+@pytest.mark.parametrize('kind', ['google-retryinfo', 'google-mixed', 'nvidia-retryafter', 'billing', 'daily', 'auth'])
+def test_auxiliary_pool_persists_retry_deadlines_without_losing_real_quota_walls(tmp_path, monkeypatch, kind, count):
+    monkeypatch.setenv('HERMES_HOME', str(tmp_path))
+    now = [time.time()]
+    monkeypatch.setattr(time, 'time', lambda: now[0])
+    provider = 'nvidia' if kind == 'nvidia-retryafter' else 'gemini'
+    entries = persist_keys(provider, count)
+    delay = 48.100581664
+    if kind.startswith('google'):
+        error = gemini_http_error(httpx.Response(429, json=quota_body('mixed' if kind == 'google-mixed' else 'tokens',
+                                                                scoped=kind == 'google-mixed')))
+    elif kind == 'nvidia-retryafter':
+        from openai import RateLimitError
+        response = httpx.Response(429, json={'status': 429, 'title': 'Too Many Requests'},
+                                  headers={'retry-after': str(delay)}, request=httpx.Request('POST', NVIDIA))
+        error = RateLimitError('Too Many Requests', response=response, body={'status': 429, 'title': 'Too Many Requests'})
+    else:
+        error = Exception({'billing': 'Payment required: insufficient credits', 'daily': 'Daily quota exceeded', 'auth': 'Invalid API key'}[kind])
+        error.status_code = {'billing': 402, 'daily': 429, 'auth': 401}[kind]
+    temporary = kind in {'google-retryinfo', 'google-mixed', 'nvidia-retryafter'}
+    if temporary:
+        assert not aux._is_payment_error(error)
+        assert aux._is_rate_limit_error(error)
+        assert classify_api_error(error, provider=provider).reason == FailoverReason.rate_limit
+    else:
+        assert aux._is_payment_error(error) is (kind != 'auth')
+    first_reset = None
+    for entry in entries:
+        aux._recover_provider_pool(provider, error, failed_api_key=entry.runtime_api_key)
+        persisted = next(row for row in load_pool(provider).entries() if row.id == entry.id)
+        assert persisted.last_status == STATUS_EXHAUSTED
+        if temporary:
+            assert persisted.last_error_reset_at == pytest.approx(now[0] + delay, rel=0, abs=0.001)
+            first_reset = first_reset or persisted.last_error_reset_at
+        now[0] += 1
+    assert not load_pool(provider).has_available()
+    if temporary:
+        now[0] = first_reset + 0.01
+        recovered = load_pool(provider)
+        assert recovered.has_available()
+        assert recovered.select().id == entries[0].id
+        assert sum(row.last_status == STATUS_EXHAUSTED for row in recovered.entries()) == count - 1
+    elif kind in {'billing', 'daily'}:
+        now[0] += 61
+        assert not load_pool(provider).has_available()
+
+
+@pytest.mark.parametrize('provider,model', [('gemini', HEALTHY), ('nvidia', NIM_HEALTHY)])
+@pytest.mark.parametrize('reason', [FailoverReason.upstream_rate_limit, FailoverReason.rate_limit, FailoverReason.billing])
+def test_fallback_model_failure_does_not_extend_primary_quota_deadline(provider, model, reason):
+    from types import SimpleNamespace
+    from agent.fallback_cooldown import _arm_rate_limit_cooldown
+    deadline = time.monotonic() + 48.100581664
+    agent = SimpleNamespace(
+        provider=provider, model=model, _fallback_activated=True,
+        _primary_runtime={'provider': 'gemini', 'model': LIMITED},
+        _model_quota_retry_deadline=(provider, model, time.monotonic() + 300),
+        _rate_limited_until=deadline, _rate_limit_backoff_count=2,
+    )
+    armed = _arm_rate_limit_cooldown(agent, reason)
+    if provider == 'gemini' and reason != FailoverReason.upstream_rate_limit:
+        # Ordinary account/credential-wide failures retain the existing policy.
+        assert armed is not None
+        assert agent._rate_limit_backoff_count == 3
+    else:
+        assert armed is None
+        assert agent._rate_limited_until == deadline
+        assert agent._rate_limit_backoff_count == 2

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -284,15 +284,15 @@ class TestClassifyApiError:
         "ResourceExhausted",
         "resource-exhausted",
     ])
-    def test_resource_exhausted_separator_variants_without_status(self, spelling):
+    def test_worker_capacity_variants_do_not_rotate_credentials(self, spelling):
         result = classify_api_error(
             Exception(f"{spelling}: Worker local total request limit reached (32/32)"),
             provider="nvidia",
             model="nvidia/nemotron-3-ultra-550b-a55b",
         )
-        assert result.reason == FailoverReason.rate_limit
+        assert result.reason == FailoverReason.overloaded
         assert result.retryable is True
-        assert result.should_rotate_credential is True
+        assert result.should_rotate_credential is False
         assert result.should_fallback is True
 
     def test_anthropic_429_usage_limit_without_reset_is_billing(self):

--- a/tests/agent/test_gemini_quota_recovery.py
+++ b/tests/agent/test_gemini_quota_recovery.py
@@ -1,0 +1,198 @@
+"""Native Gemini quota scope and retry timing across the real recovery boundaries."""
+from functools import partial
+from types import SimpleNamespace
+import time
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+
+from agent.agent_runtime_helpers import extract_api_error_context, recover_with_credential_pool
+from agent.credential_pool import CredentialPool, PooledCredential, STATUS_EXHAUSTED, load_pool, _normalize_error_context
+from agent.error_classifier import FailoverReason, classify_api_error
+from agent.fallback_cooldown import _arm_rate_limit_cooldown
+from agent.gemini_native_adapter import GeminiAPIError, GeminiNativeClient, gemini_http_error
+from agent.turn_recovery import compute_error_backoff, recover_after_classification, route_classified_error
+from agent.turn_retry_state import TurnRetryState
+
+BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+MODEL = "gemini-test-pro"
+
+
+def quota_body(*, limit=0, scope="model", delay="3.6787s"):
+    violation = {
+        "quotaMetric": "generativelanguage.googleapis.com/generate_content_free_tier_input_token_count",
+        "quotaId": "GenerateContentInputTokensPerModelPerMinute-FreeTier",
+        "quotaDimensions": {"model": MODEL, "location": "global"},
+        "quotaValue": str(limit),
+    }
+    violations = [violation]
+    if scope == "mixed":
+        violations.append({"quotaMetric": "project_requests", "quotaDimensions": {"project": "offline"}})
+    if scope == "unknown":
+        violation.pop("quotaDimensions")
+    return {"error": {
+        "code": 429, "status": "RESOURCE_EXHAUSTED",
+        "message": f"Quota exceeded for metric: generate_content_free_tier_input_token_count, limit: {limit}, model: {MODEL}. Please retry in 3.6787s.",
+        "details": [
+            {"@type": "type.googleapis.com/google.rpc.QuotaFailure", "violations": violations},
+            {"@type": "type.googleapis.com/google.rpc.RetryInfo", "retryDelay": delay},
+        ],
+    }}
+
+
+def recovery_agent(pool=None):
+    agent = SimpleNamespace(
+        provider="gemini", model=MODEL, api_mode="chat_completions", base_url=BASE_URL, _credential_pool=pool,
+        _credential_pool_entry_id=None, api_key="offline-key", _fallback_activated=False,
+        _primary_runtime={"provider": "gemini", "model": MODEL}, _rate_limit_backoff_count=3,
+        _buffer_status=lambda message: None, _emit_status=lambda message: None,
+        _client_log_context=lambda: "offline Gemini regression",
+    )
+    agent._recover_with_credential_pool = partial(recover_with_credential_pool, agent)
+    return agent
+
+
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("scope,limit", [("model", 0), ("model", 250000), ("text", 0), ("text", 250000), ("mixed", 0), ("unknown", 0), ("malformed", 0), ("auth", 0), ("billing", 0)])
+def test_quota_scope_survives_native_error_and_pool_recovery(tmp_path, monkeypatch, stream, scope, limit):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    entries = [PooledCredential(
+        provider="gemini", id=f"key-{i}", label=f"offline {i}", auth_type="api_key",
+        priority=i, source="manual", access_token=f"offline-key-{i}",
+    ) for i in range(7)]
+    pool = CredentialPool("gemini", entries)
+    pool._persist()
+    agent = recovery_agent(pool)
+    sent_keys = []
+
+    def upstream(request):
+        sent_keys.append(request.headers["x-goog-api-key"])
+        if f"/models/{MODEL}:" in request.url.path:
+            body = quota_body(limit=limit, scope=scope)
+            status = 429
+            if scope == "text":
+                body["error"]["details"].pop(0)
+            elif scope == "malformed":
+                body["error"]["details"][0]["violations"] = ["invalid violation"]
+            elif scope in {"auth", "billing"}:
+                status = 401 if scope == "auth" else 402
+                body["error"]["message"] = "Invalid API key" if status == 401 else "Insufficient credits"
+            return httpx.Response(status, json=body)
+        return httpx.Response(200, json={
+            "candidates": [{"content": {"role": "model", "parts": [{"text": "Flash still works"}]}, "finishReason": "STOP"}],
+            "usageMetadata": {"promptTokenCount": 154803, "candidatesTokenCount": 3, "totalTokenCount": 154806},
+        })
+
+    for entry in entries:
+        agent.api_key, agent._credential_pool_entry_id = entry.runtime_api_key, entry.id
+        with GeminiNativeClient(api_key=entry.runtime_api_key, http_client=httpx.Client(transport=httpx.MockTransport(upstream))) as client:
+            with pytest.raises(GeminiAPIError) as raised:
+                result = client.chat.completions.create(model=MODEL, messages=[{"role": "user", "content": "hello"}], stream=stream)
+                if stream:
+                    list(result)
+            error = raised.value
+            classified = classify_api_error(error, provider=agent.provider, model=MODEL)
+            if scope not in {"model", "text"}:
+                assert classified.reason != FailoverReason.upstream_rate_limit
+                assert classified.should_rotate_credential
+                if scope not in {"auth", "billing"}:
+                    agent._swap_credential = lambda credential: True
+                    agent._recover_with_credential_pool(
+                        status_code=429, has_retried_429=True, classified_reason=classified.reason,
+                        error_context=extract_api_error_context(error),
+                    )
+                    assert any(row.last_status == STATUS_EXHAUSTED for row in pool.entries())
+                return
+            assert classified.reason == FailoverReason.upstream_rate_limit
+            assert not classified.should_rotate_credential
+            assert classified.retryable is (limit != 0)
+            recovered, _ = agent._recover_with_credential_pool(
+                status_code=429, has_retried_429=True, classified_reason=classified.reason,
+                error_context=extract_api_error_context(error),
+            )
+            assert not recovered
+            # Exercise the actual eager-fallback decision, not a copied policy predicate.
+            agent._fallback_index, agent._fallback_chain = 0, [{"provider": "gemini", "model": "gemini-test-flash"}]
+            attempts = []
+            agent._try_activate_fallback = lambda **kwargs: attempts.append(kwargs) or False
+            for retry_count in (1, 3):
+                attempts.clear()
+                route_classified_error(
+                    agent, error, classified, TurnRetryState(), error_msg=str(error),
+                    error_context=extract_api_error_context(error), recovered_with_pool=False,
+                    base_url=BASE_URL, model=MODEL, messages=[], api_messages=[], system_message=None,
+                    active_system_prompt="", conversation_history=[], retry_count=retry_count,
+                    max_retries=3, compression_attempts=0, max_compression_attempts=1,
+                    api_call_count=retry_count, effective_task_id=None,
+                )
+                assert bool(attempts) is (limit == 0 or retry_count == 3)
+            result = client.chat.completions.create(model="gemini-test-flash", messages=[{"role": "user", "content": "hello"}])
+            assert result.choices[0].message.content == "Flash still works"
+            assert result.usage.prompt_tokens == 154803
+            assert sent_keys[-2:] == [entry.runtime_api_key, entry.runtime_api_key]
+    # In-memory and persisted pool state stay usable for other models, including after reload.
+    assert all(entry.last_status != STATUS_EXHAUSTED for entry in pool.entries())
+    reloaded = load_pool("gemini")
+    assert reloaded.has_available()
+    assert {entry.id for entry in reloaded.entries()} >= {entry.id for entry in entries}
+    assert all(entry.last_status != STATUS_EXHAUSTED for entry in reloaded.entries())
+
+
+@pytest.mark.parametrize("retry_info,message_delay,header,expected", [
+    (None, "3.6787", None, 3.6787),
+    ("3s", "3.6787", None, 3.6787),
+    ("28.91s", "28.91", "2", 28.91),
+    ("3s", "3", "30", 30.0),
+    ({"seconds": "3", "nanos": 678700000}, "3", None, 3.6787),
+    ("NaNs", "25.57", None, 25.57),
+    ("-5s", "27.86", "NaN", 27.86),
+    ("750s", "750", None, 750.0),
+    ("3s", "3", "Sat, 12 Sep 2026 00:00:30 GMT", 30.0),
+])
+def test_body_retry_floor_reaches_backoff_reset_and_fallback(monkeypatch, retry_info, message_delay, header, expected):
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2026, 9, 12, tzinfo=timezone.utc)
+    monkeypatch.setattr("agent.retry_utils.datetime", FixedDateTime)
+    body = quota_body(limit=250000, delay=retry_info)
+    body["error"]["message"] = f"A free_tier quota limited this request. Please retry in {message_delay}s."
+    if retry_info is None:
+        body["error"]["details"].pop()
+    response = httpx.Response(429, json=body, headers={} if header is None else {"Retry-After": header})
+    error = gemini_http_error(response)
+    assert error.retry_after == pytest.approx(expected)
+    assert "cannot sustain an agent session" not in str(error)
+    assert "free tier is exhausted" not in str(error)
+    agent = recovery_agent()
+    wait = compute_error_backoff(
+        agent, error, retry_count=1, max_retries=3, is_rate_limited=True,
+        is_zai_coding_overload=False, base_url=BASE_URL, model=MODEL,
+    )
+    assert wait >= expected
+    before = time.time()
+    context = extract_api_error_context(error)
+    after = time.time()
+    assert before + expected <= context["reset_at"] <= after + expected
+    # Both legacy text consumers must also understand Google's fractional 'retry in' wording.
+    for parse in (extract_api_error_context, _normalize_error_context):
+        raw = RuntimeError(f"Please retry in {message_delay}s") if parse is extract_api_error_context else {"message": f"Please retry in {message_delay}s"}
+        before = time.time()
+        context = parse(raw)
+        after = time.time()
+        assert before + float(message_delay) <= context["reset_at"] <= after + float(message_delay)
+    classified = classify_api_error(error, provider="gemini", model=MODEL)
+    # Native transport semantics also survive a custom/unresolved provider label.
+    assert classify_api_error(error, provider="custom-gemini-relay", model=MODEL).reason == classified.reason
+    recover_after_classification(
+        agent, error, classified, TurnRetryState(), status_code=429,
+        error_context=extract_api_error_context(error), messages=[], api_messages=[],
+    )
+    # Falling back after retries must not convert a provider delay into level-3 / 480s cooldown.
+    cooldown = _arm_rate_limit_cooldown(agent, classified.reason)
+    assert cooldown is not None and 0 < cooldown <= expected
+    # The recorded deadline belongs to the failed model, not another same-provider fallback.
+    agent.model = "gemini-test-flash"
+    agent._rate_limit_backoff_count = 0
+    assert _arm_rate_limit_cooldown(agent, classified.reason) != cooldown

--- a/tests/agent/test_gemini_quota_recovery.py
+++ b/tests/agent/test_gemini_quota_recovery.py
@@ -191,7 +191,9 @@ def test_body_retry_floor_reaches_backoff_reset_and_fallback(monkeypatch, retry_
     )
     # Falling back after retries must not convert a provider delay into level-3 / 480s cooldown.
     cooldown = _arm_rate_limit_cooldown(agent, classified.reason)
-    assert cooldown is not None and 0 < cooldown <= expected
+    assert cooldown is not None and cooldown > 0
+    # Absolute monotonic deadline arithmetic can overshoot the source delay by a few ULPs.
+    assert cooldown <= expected + 1e-6
     # The recorded deadline belongs to the failed model, not another same-provider fallback.
     agent.model = "gemini-test-flash"
     agent._rate_limit_backoff_count = 0

--- a/tests/agent/test_gemini_quota_recovery.py
+++ b/tests/agent/test_gemini_quota_recovery.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 
 import httpx
 import pytest
+from openai import RateLimitError
 
 from agent.agent_runtime_helpers import extract_api_error_context, recover_with_credential_pool
 from agent.credential_pool import CredentialPool, PooledCredential, STATUS_EXHAUSTED, load_pool, _normalize_error_context
@@ -198,3 +199,22 @@ def test_body_retry_floor_reaches_backoff_reset_and_fallback(monkeypatch, retry_
     agent.model = "gemini-test-flash"
     agent._rate_limit_backoff_count = 0
     assert _arm_rate_limit_cooldown(agent, classified.reason) != cooldown
+
+
+def test_sdk_gemini_retryinfo_reaches_actual_backoff():
+    body = quota_body(limit=250000, delay="30s")
+    response = httpx.Response(
+        429, json=body, headers={"Retry-After": "2"},
+        request=httpx.Request("POST", BASE_URL + "/openai/chat/completions"),
+    )
+    error = RateLimitError("Gemini quota", response=response, body=body)
+    classified = classify_api_error(error, provider="gemini", model=MODEL)
+    assert classified.reason == FailoverReason.upstream_rate_limit
+    assert classified.error_context["retry_after"] == pytest.approx(30.0)
+    wait = compute_error_backoff(
+        recovery_agent(), error, retry_count=1, max_retries=3,
+        is_rate_limited=True, is_zai_coding_overload=False,
+        base_url=BASE_URL + "/openai", model=MODEL,
+        error_context=classified.error_context,
+    )
+    assert wait == pytest.approx(30.0)


### PR DESCRIPTION
## Summary

Fixes #108656.

Preserve **failure scope and retry timing together** across the main agent and auxiliary recovery. A model-local Gemini quota must not exhaust an otherwise usable API key, become a provider-wide payment ban, or turn a short upstream retry window into a much longer local cooldown.

## Review follow-up

Thanks @BearHuddleston for digging into this and for the concrete fixes — I've incorporated the review findings into the PR.

Follow-up commit `d302a5ef9ac521bbda04e4116ffa737785a718ef` addresses all three recovery regressions found during review:

- **SDK Gemini / OpenAI-compatible retry floors:** the classifier-normalized `RetryInfo` minimum now reaches `compute_error_backoff`, so a structured 30s Gemini minimum cannot be shortened to a smaller generic `Retry-After` header.
- **Parameter-strip recovery:** a retry that first removes an unsupported parameter can still flow into rate-limit / worker-capacity recovery and configured fallback instead of re-raising the second error.
- **Unverified billing health scope:** ambiguous billing bodies such as Anthropic `out of extra usage` still fall back for the current request, but no longer arm the provider/endpoint 600s payment-health quarantine. Verified billing failures retain the existing quarantine behavior.

[Focused review-fix verification](https://github.com/Xipong/hermes-agent/actions/runs/34666544147): **427 passed, 0 failed** across the focused Gemini/auxiliary/classifier suites; Python compilation, targeted Ruff fatal-error checks, and `git diff --check` also passed.

### Additional evidence from the affected installation

The supplied September 10 logs show this concrete auxiliary/MoA sequence:

- Gemini returns HTTP 429 `RESOURCE_EXHAUSTED`, `generate_content_free_tier_requests`, limit 20, a named model, and `Please retry in 40.767825073s`.
- Hermes immediately marks the credential exhausted and logs `marking gemini unhealthy for 600s (payment / credit error)`.
- A subsequent auxiliary call logs `skipping gemini (recently returned payment error, retry in 420s)`.

The auxiliary predicates matched `billing`, `quota exceeded`, and `RESOURCE_EXHAUSTED` in rendered exception text. Google's generic billing-details sentence and Hermes's appended guidance could therefore influence routing, not just diagnostics. The initial version of this PR fixed the main path but left that auxiliary path unchanged.

Other supplied sequences show Google's `48.100581664s` minimum followed by a local retry after approximately 2.67s, and several working credentials successively marked exhausted after token-quota responses. These observations motivate the regression fixtures; they do **not** establish that every short retry hint represents a minute rather than daily quota.

## Changes

- Recognize `google.rpc.QuotaFailure` as model-scoped only when **every violation supplies a model dimension**. Support complete rendered quota lines when structured violations are absent. Reuse `upstream_rate_limit` / healthy-credential recovery instead of persisting global key exhaustion. Unknown, malformed, or mixed-scope violations keep the existing credential-recovery path. Native Gemini errors are also recognized behind custom provider labels.
- Treat confirmed **zero model allowance** as non-retryable on that route, allowing configured fallback without burning through the key pool. A accompanying `RetryInfo` does not establish that waiting will grant access.
- Preserve native error bodies and normalize `google.rpc.RetryInfo.retryDelay` (duration string or seconds/nanos), fractional `Please retry in ...s` text, and numeric / HTTP-date `Retry-After`. The largest valid minimum wins; invalid, negative, and non-finite hints are ignored. Update both legacy free-text reset parsers to recognize `retry in`.
- Make the main retry calculation consume normalized retry minima from both native adapters and classifier context. Keep the existing bounded retry budget for short nonzero model quotas and carry the primary's model deadline into fallback cooldown rather than escalating to generic backoff.
- Make auxiliary payment/rate predicates defer to the shared classifier. Temporary/model quota and worker-capacity verdicts cannot arm the 600s payment-health cache. Both sync and async auxiliary recovery use this path, including MoA references.
- Stop auxiliary credential recovery from exhausting keys for model/worker failures. Preserve structured reset information and the classified failure reason when credential recovery is appropriate. This also prevents a genuine billing/quota wall on a **single-key pool** from being treated as a short unverified throttle.
- Skip the auxiliary ladder's immediate same-key retry for model/worker failures and errors with explicit reset information. Use eligible credential rotation or configured fallback instead of retrying before the minimum or blocking an auxiliary task on a long wait.
- Keep rate-limit/overload failures inside the auxiliary parameter-retry ladder after stripping unsupported request parameters, so the next failure still reaches credential/provider fallback.
- Classify the specific `Worker local total request limit reached` signature as retryable **overload**, with fallback enabled and credential rotation disabled. Update the old tests that explicitly expected payment classification / key rotation for this shared-worker signal. A bare NVIDIA 429 is **not** automatically declared worker overload.
- Preserve `billing_unverified` when auxiliary routing decides whether to quarantine a provider: ambiguous billing bodies fall back without a 600s health ban, while verified billing still quarantines.
- Prevent an active fallback model's **model-scoped** error from extending the primary model's cooldown merely because both use the same provider. Ordinary account-wide rate/billing cooldown behavior is preserved and tested separately.
- Replace categorical free-tier-exhaustion guidance with model/window-aware wording.

## Scope and policy choices

This uses the existing bounded recovery paths; it does **not** add a persistent per-model/per-project credential-pool schema. Confirmed model-scoped failures retry/fall back at the model route rather than testing every project in the pool. Authentication and real billing/quota walls retain their recovery behavior; unknown-scope responses do not acquire invented model scope.

The existing **600s cap for generic header/body handling remains**. A finite adapter/classifier-normalized minimum is applied after that cap and is not shortened; the original matrix includes 750s. Normal interruptible main-agent waiting remains available. A retry hint is a minimum, **not a guarantee that every violated quota has reset**.

The existing auxiliary candidate policy can still end an individual call on a non-auth fallback failure. The cross-provider test covers NIM worker failure -> Gemini quota failure, followed by a subsequent Gemini -> healthy NIM call, and verifies that neither provider nor its credentials were poisoned. This is not an unbounded or newly recursive fallback-chain implementation.

No configuration, dependency, auth-store schema, or upstream workflow changes. Original private logs, usernames, sessions, and credentials are not included; test credentials and model names are synthetic.

## Reproduction and verification

### Original main-path fix

Baseline: `bf51fee548ceaa28d2c299a41c0f65066c04c061`.
Initial fix: `706054b207d0331639d9371ed8f36f642aa38125`.

[Original successful red/green run](https://github.com/Xipong/hermes-agent/actions/runs/34657922338): **17 failed / 10 passed** on the baseline, **27 passed** after the fix, and **396 passed across 17 focused files**.

### Log-driven auxiliary/fallback follow-up

Before follow-up: `706054b207d0331639d9371ed8f36f642aa38125`.
Verified follow-up: `28fa2b5f985e27904bbfbd331d14c65997ba0d4d`.

**[Successful follow-up red/green run](https://github.com/Xipong/hermes-agent/actions/runs/34660021131)** — runs the new matrix against the existing PR head, applies the patch, verifies the expanded neighboring suites, then publishes the clean commit recorded in the log. Workbench files remain confined to a separate fork branch and are **not part of this PR**.

| Check | Result |
| --- | --- |
| New follow-up matrix on the prior PR head | **26 failed, 10 passed**; behavioral assertions, not import errors |
| Same follow-up matrix after the patch | **36 passed** |
| Follow-up + original matrix + neighboring suites | **790 passed, 0 failed across 38 files** |
| BearHuddleston review follow-up | **427 passed, 0 failed** + compile/Ruff/diff checks |
| Python compilation, targeted Ruff fatal-error checks, `git diff --check` | Passed |

The new matrix exercises actual `call_llm` / `async_call_llm` routing, concurrent reference calls, real native error construction, persisted one- and four-key pools, reload and re-entry at the supplied reset deadline, model-vs-credential scope, zero allowance, text-only quota responses, mixed/unknown scope, NIM worker failures, cross-provider next-call recovery, independent billing/auth/cooldown controls, SDK-compatible Gemini retry floors, parameter-strip-to-capacity fallback, and verified-vs-unverified billing health scope.

Tests use `bash scripts/run_tests.sh ... -q --tb=short` with file retries disabled. The complete 38-file invocation is in the linked log. Only the HTTP boundary is replaced with `httpx.MockTransport`; this is **offline behavioral/integration coverage**, not a live Google/NVIDIA quota test, a Windows installation validation, or a full repository test run.

## Related work

#39809 already proposes parsed retry-after handling and native `RetryInfo` support. This PR overlaps that portion and also addresses model-vs-credential scope, conflicting fractional minima, zero allowance, auxiliary payment-health poisoning, and model-specific fallback cooldown. Related earlier report: #38804 (Code Assist transport).