### PR TITLE
fix(shell_hooks): fail_closed must also block when the hook crashes silently

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -365,6 +365,10 @@ def _evaluate_result(spec: ShellHookSpec, r: Dict[str, Any]) -> Optional[Dict[st
         logger.warning("shell hook exited %d (event=%s command=%s); stderr=%s",
                        r["returncode"], spec.event, spec.command, stderr[:_STDERR_MESSAGE_LIMIT])
     stdout = (r["stdout"] or "").strip()
+    if fail_closed and r["returncode"] != 0 and not stdout:
+        # The hook crashed (traceback on stderr, nothing on stdout) — a fail-closed gate
+        # must not silently allow just because the gate itself broke.
+        return _fail_closed_block(spec, f"exited {r['returncode']} with no output")
     parsed = _parse_response(spec.event, stdout)
     if parsed is None and fail_closed and stdout and not _is_json_object(stdout):
         # A fail-closed gate must not silently allow on garbage stdout (e.g. a stack trace).

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -664,6 +664,23 @@ class TestEvaluateResult:
         )
         assert r is None
 
+    def test_crash_empty_stdout_fail_closed_blocks(self):
+        """A hook that crashes (traceback on stderr, exit!=0, empty stdout) must
+        block under fail_closed — the worst failure mode is failing open when the
+        gate itself breaks."""
+        r = shell_hooks._evaluate_result(
+            self._spec(fail_closed=True),
+            _spawn_result(returncode=1, stdout="", stderr="Traceback (most recent call last): ...\nZeroDivisionError"),
+        )
+        assert r == {"action": "block", "message": "hook /tmp/h.sh failed closed: exited 1 with no output"}
+
+    def test_crash_empty_stdout_fails_open_by_default(self):
+        r = shell_hooks._evaluate_result(
+            self._spec(),
+            _spawn_result(returncode=1, stdout="", stderr="Traceback (most recent call last): ...\nZeroDivisionError"),
+        )
+        assert r is None
+
     def test_fail_closed_on_non_blocking_event_still_fails_open(self):
         """Defense in depth: even if a spec sneaks past parsing with
         fail_closed on a non-blocking event, runtime fails open."""


### PR DESCRIPTION
## What does this PR do?

A `fail_closed` shell hook is a gate: if it can't render a verdict, it must block. Today it fails **open** in the one case that matters most — when the gate itself crashes.

`_evaluate_result` already refuses to allow on *garbage* stdout (a stack trace printed to stdout is treated as a block). But a hook that dies before printing anything — traceback on **stderr**, non-zero exit, **empty stdout** — falls through to `_parse_response`, which returns `None`, and `None` means "allow". So a `fail_closed` gate with a syntax error, a missing import, or a bad interpreter path silently permits every action it was installed to guard.

This is the failure mode a fail-closed gate exists to prevent, and it's silent: nothing distinguishes "hook approved" from "hook never ran".

## Related Issue

No existing issue — found when a `fail_closed` pre-tool hook of mine crashed on an import error and every subsequent tool call was allowed through with no signal.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix (a gate that fails open is an authorization bypass)

## Changes Made

- `agent/shell_hooks.py` (+4 lines) — in `_evaluate_result`, when `fail_closed` is set and the hook exited non-zero with empty stdout, return `_fail_closed_block(...)` with the reason `exited <rc> with no output`, instead of falling through to the parser. Reuses the existing `_fail_closed_block` helper and message shape, so the surfaced text matches the garbage-stdout case.
- `tests/agent/test_shell_hooks.py` (+17 lines) — two tests pinning both halves of the contract:
  - `fail_closed=True` + crash + empty stdout → **blocks**;
  - default (not fail-closed) + same crash → still **fails open** (`None`), so this does not change behaviour for ordinary hooks.

Scope is deliberately narrow: only `fail_closed` hooks change behaviour, and only on the crash-with-no-output path.

## How to Test

1. Install a `fail_closed` pre-tool hook that crashes immediately (e.g. a Python file whose first line is `import nonexistent_module`).
2. Run any tool call that the hook matches.
3. Before this change the call is **allowed** (hook fails open, no signal). After, it is blocked with `hook <path> failed closed: exited 1 with no output`.

Automated:

```
pytest tests/agent/test_shell_hooks.py -q
```

`40 passed` on this branch vs `38 passed` on unpatched `main` (the 2 new tests). The 9 failures in that file are pre-existing on this platform and reproduce identically on unpatched `main` — they are Windows-only (`.sh` hook fixtures are not directly executable), not introduced here.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and compared against an unpatched `main` baseline
- [x] I've added tests for my changes (both the block and the fail-open-by-default side)
- [x] I've tested on my platform: Windows 11 (native install)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (`fail_closed` is already documented as "block when the hook cannot approve"; this makes the implementation match that promise)
- [x] I've updated `cli-config.yaml.example` — N/A (no new config key)
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — pure return-code/stdout logic, no platform-specific calls; `scripts/check-windows-footguns.py --diff upstream/main` is clean on this branch
- [x] I've updated tool descriptions/schemas — N/A
