### PR TITLE
fix(models): OpenRouter :nitro/:floor variants resolve their base model's context window (#97820, salvage #100651)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:  # pragma: no cover — runtime import is lazy (see below)
 
 from utils import atomic_json_write, atomic_yaml_write, base_url_host_matches, base_url_hostname
 
-from hermes_constants import OPENROUTER_MODELS_URL
+from hermes_constants import OPENROUTER_MODELS_URL, openrouter_variant_base
 from agent.message_metadata import PERSISTENCE_ONLY_MESSAGE_FIELDS
 
 logger = logging.getLogger(__name__)
@@ -474,6 +474,45 @@ def _infer_provider_from_url(base_url: str) -> Optional[str]:
         if url_part in host:
             return provider
     return None
+
+
+def _strip_openrouter_routing_variant(
+    model: str, base_url: str = "", provider: str = ""
+) -> str:
+    """Strip an OpenRouter routing-variant suffix for catalog lookup.
+
+    ``:nitro`` / ``:floor`` / ``:exacto`` / ``:online`` are request-time
+    routing modifiers, NOT catalog entries — OpenRouter's ``/models`` lists
+    only the base id, and a variant shares the base model's context window.
+    Without this, every lookup below misses and the resolver falls through to
+    a generic family default (``x-ai/grok-4.6:nitro`` → the 131K ``grok``
+    catch-all instead of its real 2M window).
+
+    Only the id used for LOOKUP is rewritten. The suffixed id the caller holds
+    stays on the wire, so the routing opt-in is preserved — the same rule
+    :func:`hermes_cli.models.validate_requested_model` applies. Sharing the
+    base's cache key is intentional: the window is identical, so a variant and
+    its base must never disagree.
+
+    Narrow by design: only applied when the request actually routes through
+    OpenRouter, so a local ``model:tag`` that happens to end in one of these
+    words is untouched.
+    """
+    if not model:
+        return model
+    is_openrouter = (provider or "").strip().lower() == "openrouter" or (
+        bool(base_url) and _infer_provider_from_url(base_url) == "openrouter"
+    )
+    if not is_openrouter:
+        return model
+    base = openrouter_variant_base(model)
+    if base is None:
+        return model
+    logger.debug(
+        "Resolving context length for OpenRouter routing variant %r via base id %r",
+        model, base,
+    )
+    return base
 
 
 def _is_known_provider_base_url(base_url: str) -> bool:
@@ -1897,6 +1936,14 @@ def get_model_context_length(
         logger.info("No model id provided for context length resolution — defaulting to %s tokens.", f"{DEFAULT_FALLBACK_CONTEXT:,}")
         return DEFAULT_FALLBACK_CONTEXT
     model = _strip_provider_prefix(model)  # "local:x" -> "x"; Ollama "model:tag" colons preserved
+    # OpenRouter routing variants (":nitro", ":floor", ...) are request-time
+    # modifiers, not catalog entries — resolve the window from the BASE id.
+    # Deliberately placed AFTER the explicit config overrides above (0b/0c) so
+    # a user who pinned the fully-suffixed id keeps winning, and BEFORE every
+    # cache/catalog lookup below so the base's real window is found instead of
+    # a generic family default. Mirrors the validation path's base/suffix split
+    # in hermes_cli.models.validate_requested_model.
+    model = _strip_openrouter_routing_variant(model, base_url=base_url, provider=provider)
     # Endpoint-scoped metadata goes AHEAD of the persistent cache so a value learned on a
     # multiplexed provider's other endpoint cannot override it.
     endpoint_context = _endpoint_scoped_context_length(model, base_url)

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -19,6 +19,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from utils import atomic_json_write, atomic_write_text
 
+from hermes_constants import openrouter_variant_base
+
 import requests
 
 logger = logging.getLogger(__name__)
@@ -462,12 +464,46 @@ def _get_provider_models(provider: str, *, allow_network: bool = False) -> Optio
     return _registry_models(mdev_id, allow_network=allow_network) if mdev_id else None
 
 
-def _iter_model_entries(models: Dict[str, Any], model: str, *, suffix_fallback: bool = True):
+_OPENROUTER_CATALOG_PROVIDERS = frozenset({"openrouter"})
+
+
+def _openrouter_catalog_lookup_base(provider: str, model: str) -> Optional[str]:
+    """Return the base id to retry a catalog lookup with, or ``None``.
+
+    OpenRouter's ``:nitro`` / ``:floor`` / ``:exacto`` / ``:online`` are
+    request-time routing modifiers: they change which endpoint serves the
+    request, never which model runs. ``/models`` and models.dev list only the
+    base id, so a routed id must resolve to the base model's metadata.
+
+    Scoped to OpenRouter so a genuine ``model:tag`` on another provider (an
+    Ollama tag, a ``:cloud`` catalog key) is never rewritten.
+
+    Deliberately excludes ``:free``, ``:batch``, ``:extended``, and
+    ``:thinking``: those are REAL catalog SKUs with their own entries and
+    their own — sometimes different — context windows. Stripping them would
+    report a window LARGER than the model actually has. Their real entries
+    are found by the exact/case-insensitive passes above, and a genuinely
+    absent SKU must miss so ``model_overrides`` ``_default`` fill-gap
+    semantics still apply.
+    """
+    if provider not in _OPENROUTER_CATALOG_PROVIDERS:
+        return None
+    return openrouter_variant_base(model)
+
+
+def _iter_model_entries(
+    models: Dict[str, Any], model: str, *, suffix_fallback: bool = True, provider: str = ""
+):
     """Yield ``(model_id, entry)`` candidates: exact, case-insensitive, then (optionally)
     ``:cloud``/``-cloud`` suffixed forms. Suffix fallback: some providers (ollama-cloud) store
     ``kimi-k2.6:cloud`` while the live API returns the bare name; without it context lookup falls to
     stale OpenRouter metadata and trips the 64k minimum-context guard. Every consumer shares this
-    order so a suffix-keyed catalog model counts as KNOWN for ``model_overrides`` fill-gap ``_default``."""
+    order so a suffix-keyed catalog model counts as KNOWN for ``model_overrides`` fill-gap ``_default``.
+
+    ``provider`` enables the OpenRouter routing-variant fallback as a LAST
+    resort — after exact, case-insensitive, and ``:cloud`` matching — so a
+    real catalog SKU always wins over its base.
+    """
     for name in ([model] + [model + suffix for suffix in (":cloud", "-cloud")] if suffix_fallback else [model]):
         entry = models.get(name)
         if isinstance(entry, dict):
@@ -476,11 +512,20 @@ def _iter_model_entries(models: Dict[str, Any], model: str, *, suffix_fallback: 
         for mid, mdata in models.items():
             if mid.lower() == name_lower and isinstance(mdata, dict):
                 yield mid, mdata
+    routed_base = _openrouter_catalog_lookup_base(provider, model)
+    if routed_base is not None:
+        # Recursion is bounded: the base never carries a recognized variant suffix,
+        # and provider is cleared so the retry cannot loop.
+        yield from _iter_model_entries(
+            models, routed_base, suffix_fallback=suffix_fallback, provider=""
+        )
 
 
-def _find_model_entry(models: Dict[str, Any], model: str) -> Optional[Dict[str, Any]]:
+def _find_model_entry(
+    models: Dict[str, Any], model: str, provider: str = ""
+) -> Optional[Dict[str, Any]]:
     """First catalog entry for *model* (exact, case-insensitive, suffix), or None."""
-    return next((entry for _mid, entry in _iter_model_entries(models, model)), None)
+    return next((entry for _mid, entry in _iter_model_entries(models, model, provider=provider)), None)
 
 
 def _extract_limit(entry: Any, key: str) -> Optional[int]:
@@ -506,7 +551,7 @@ def lookup_models_dev_context(provider: str, model: str, *, allow_network: bool 
     if override_ctx is not None:
         return override_ctx
     models = _get_provider_models(provider, allow_network=allow_network)
-    catalog_ctx = next((ctx for _mid, entry in _iter_model_entries(models, model) if (ctx := _extract_context(entry))), None) if models is not None else None
+    catalog_ctx = next((ctx for _mid, entry in _iter_model_entries(models, model, provider=provider) if (ctx := _extract_context(entry))), None) if models is not None else None
     return catalog_ctx if catalog_ctx is not None else _default_override_context(provider)
 
 
@@ -700,7 +745,7 @@ def get_model_capabilities(provider: str, model: str, *, allow_network: bool = F
     (#84482).
     """
     models = _get_provider_models(provider, allow_network=allow_network)
-    entry = _find_model_entry(models, model) if models is not None else None
+    entry = _find_model_entry(models, model, provider) if models is not None else None
     raw = _apply_overrides(provider, model, entry)
     if raw is None:
         return None
@@ -803,7 +848,7 @@ def get_model_info(provider_id: str, model_id: str, *, allow_network: bool = Fal
     """
     mdev_id = PROVIDER_TO_MODELS_DEV.get(provider_id, provider_id)
     models = _registry_models(mdev_id, allow_network=allow_network)
-    mid, entry = next(_iter_model_entries(models, model_id, suffix_fallback=False), (model_id, None)) if models is not None else (model_id, None)
+    mid, entry = next(_iter_model_entries(models, model_id, suffix_fallback=False, provider=provider_id), (model_id, None)) if models is not None else (model_id, None)
     # Not in catalog — an override (explicit or _default) may still provide it.
     raw = _apply_overrides(provider_id, model_id, entry)
     return _parse_model_info(mid, raw, mdev_id) if raw is not None else None

--- a/contributors/emails/jakobdylanc@gmail.com
+++ b/contributors/emails/jakobdylanc@gmail.com
@@ -1,0 +1,1 @@
+jakobdylanc

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -60,6 +60,7 @@ from hermes_cli.models_local import (
     _ollama_probe_cache_key,
     _root_for_ollama_native_api,
     fetch_ollama_cloud_models)
+from hermes_constants import OPENROUTER_VARIANT_SUFFIXES, openrouter_variant_base
 
 logger = logging.getLogger(__name__)
 
@@ -838,11 +839,11 @@ def _model_in_provider_catalog(name_lower: str, providers: set[str]) -> bool:
         for model in _provider_catalog_names(provider))
 
 
-def _openrouter_variant_base(model_id: str) -> Optional[str]:
-    """Base model id when ``model_id`` carries a recognized OpenRouter routing-variant suffix
-    (``x-ai/grok-4:nitro`` → ``x-ai/grok-4``), else ``None``."""
-    base, sep, suffix = (model_id or "").rpartition(":")
-    return base if sep and base and suffix.lower() in _OPENROUTER_VARIANT_SUFFIXES else None
+# Canonical suffix set lives in ``hermes_constants`` so the metadata layer can
+# share it without importing the CLI. Re-exported here under the historical
+# private names used by ``validate_requested_model``.
+_OPENROUTER_VARIANT_SUFFIXES = OPENROUTER_VARIANT_SUFFIXES
+_openrouter_variant_base = openrouter_variant_base
 
 
 def _resolve_static_model_alias(

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -39,7 +39,6 @@ from hermes_cli.models_catalog_static import (
     _LIVE_FIRST_PICKER_PROVIDERS,
     _MODELS_DEV_PREFERRED,
     _OPENAI_FAST_MODE_PREFIXES,
-    _OPENROUTER_VARIANT_SUFFIXES,
     _PROVIDER_ALIASES,
     _PROVIDER_LABELS,
     _PROVIDER_MODELS,
@@ -60,7 +59,6 @@ from hermes_cli.models_local import (
     _ollama_probe_cache_key,
     _root_for_ollama_native_api,
     fetch_ollama_cloud_models)
-from hermes_constants import OPENROUTER_VARIANT_SUFFIXES, openrouter_variant_base
 
 logger = logging.getLogger(__name__)
 
@@ -837,13 +835,6 @@ def _model_in_provider_catalog(name_lower: str, providers: set[str]) -> bool:
         name_lower == model.lower()
         for provider in providers
         for model in _provider_catalog_names(provider))
-
-
-# Canonical suffix set lives in ``hermes_constants`` so the metadata layer can
-# share it without importing the CLI. Re-exported here under the historical
-# private names used by ``validate_requested_model``.
-_OPENROUTER_VARIANT_SUFFIXES = OPENROUTER_VARIANT_SUFFIXES
-_openrouter_variant_base = openrouter_variant_base
 
 
 def _resolve_static_model_alias(

--- a/hermes_cli/models_catalog_static.py
+++ b/hermes_cli/models_catalog_static.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import NamedTuple
 
+from hermes_constants import OPENROUTER_VARIANT_SUFFIXES
+
 
 # Fallback OpenRouter snapshot used when the live catalog is unavailable, as
 # ``(model_id, description shown in menus)``. ``:free`` SKUs are described "free".
@@ -506,12 +508,10 @@ _PROVIDER_RETIRED_ALIASES: dict[str, tuple[str, ...]] = {
 _AGGREGATOR_PROVIDERS = frozenset({"nous", "openrouter", "ai-gateway", "copilot", "kilocode"})
 
 
-# OpenRouter request-time routing variants (docs: guides/routing/model-variants): per-request
-# modifiers valid on ANY model id (":nitro" throughput sort + priority tier, ":floor" price sort +
-# flex tier, ":exacto" quality-first provider sort, ":online" web plugin). Never separate catalog
-# entries — /models lists only the base id. NOT here: ":free", ":batch", ":thinking", ":extended"
-# — those ARE distinct SKUs that appear in /models when they exist, so absence is authoritative.
-_OPENROUTER_VARIANT_SUFFIXES = frozenset({"nitro", "floor", "exacto", "online"})
+# Canonical suffix set lives in ``hermes_constants`` so the metadata layer can
+# share it without importing the CLI. Re-exported here under the historical
+# private name used by ``hermes_cli.models``.
+_OPENROUTER_VARIANT_SUFFIXES = OPENROUTER_VARIANT_SUFFIXES
 
 
 # Subscription/OAuth providers whose catalogs RE-EXPOSE other vendors' models; tried only as a last

--- a/hermes_cli/models_catalog_static.py
+++ b/hermes_cli/models_catalog_static.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 
 from typing import NamedTuple
 
-from hermes_constants import OPENROUTER_VARIANT_SUFFIXES
-
 
 # Fallback OpenRouter snapshot used when the live catalog is unavailable, as
 # ``(model_id, description shown in menus)``. ``:free`` SKUs are described "free".
@@ -506,12 +504,6 @@ _PROVIDER_RETIRED_ALIASES: dict[str, tuple[str, ...]] = {
 
 
 _AGGREGATOR_PROVIDERS = frozenset({"nous", "openrouter", "ai-gateway", "copilot", "kilocode"})
-
-
-# Canonical suffix set lives in ``hermes_constants`` so the metadata layer can
-# share it without importing the CLI. Re-exported here under the historical
-# private name used by ``hermes_cli.models``.
-_OPENROUTER_VARIANT_SUFFIXES = OPENROUTER_VARIANT_SUFFIXES
 
 
 # Subscription/OAuth providers whose catalogs RE-EXPOSE other vendors' models; tried only as a last

--- a/hermes_cli/models_validate.py
+++ b/hermes_cli/models_validate.py
@@ -16,6 +16,7 @@ from difflib import get_close_matches
 from typing import Any, Callable, Optional
 
 from utils import base_url_host_matches
+from hermes_constants import openrouter_variant_base
 
 
 # ── Verdicts ─────────────────────────────────────────────────────────────
@@ -433,7 +434,7 @@ def _validate_live_listing(req: _Request) -> Optional[dict[str, Any]]:
     # catalog entries — validate the BASE but keep the suffixed id. Must run BEFORE fuzzy
     # auto-correction, which would otherwise "correct" `model:nitro` → `model` and silently
     # strip the routing opt-in.
-    variant_base = _m._openrouter_variant_base(req.lookup) if req.normalized == "openrouter" else None
+    variant_base = openrouter_variant_base(req.lookup) if req.normalized == "openrouter" else None
     if variant_base is not None and variant_base in set(api_models):
         return _accept()
     # Listed but not found: the account may reach models absent from the public listing
@@ -502,7 +503,7 @@ def _validate_catalog_fallback(req: _Request) -> dict[str, Any]:
         return _accept()
     # Same OpenRouter routing-variant rule as the live-listing path.
     if req.normalized == "openrouter":
-        variant_base = _m._openrouter_variant_base(req.lookup)
+        variant_base = openrouter_variant_base(req.lookup)
         if variant_base is not None and variant_base.lower() in {m.lower() for m in catalog}:
             return _accept()
     return match.verdict(req, keep_suffix=True) or _soft_accept(

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1156,6 +1156,47 @@ PARTIAL_STREAM_STUB_ID = "partial-stream-stub"
 FINISH_REASON_LENGTH = "length"
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 OPENROUTER_MODELS_URL = f"{OPENROUTER_BASE_URL}/models"
+
+# OpenRouter request-time routing variants (docs: guides/routing/model-variants).
+# These suffixes are per-request routing modifiers valid on ANY model id —
+# ":nitro" sorts the endpoint pool by throughput and admits priority-tier
+# endpoints, ":floor" sorts by price and admits flex-tier endpoints, ":exacto"
+# applies quality-first provider sorting, ":online" attaches the web plugin.
+# They are never separate catalog entries: /models lists only the base id, so
+# every catalog lookup must key on the BASE while the suffixed id stays on the
+# wire.
+# NOT in this set: ":free", ":batch", ":thinking", ":extended" — those ARE
+# distinct catalog SKUs with their own /models entries (and their own context
+# windows), so stripping them would resolve the wrong window.
+OPENROUTER_VARIANT_SUFFIXES: frozenset[str] = frozenset(
+    {"nitro", "floor", "exacto", "online"}
+)
+
+
+def openrouter_variant_base(model_id: str) -> str | None:
+    """Return the base model id when ``model_id`` carries a recognized
+    OpenRouter routing-variant suffix (e.g. ``x-ai/grok-4:nitro`` →
+    ``x-ai/grok-4``), else ``None``.
+
+    Lives here rather than in ``hermes_cli.models`` so the metadata layer
+    (``agent.model_metadata``) can share one definition without importing the
+    CLI — this module is dependency-free by contract.
+
+    >>> openrouter_variant_base("x-ai/grok-4:nitro")
+    'x-ai/grok-4'
+    >>> openrouter_variant_base("x-ai/grok-4:free") is None
+    True
+    >>> openrouter_variant_base("x-ai/grok-4") is None
+    True
+    """
+    base, sep, suffix = (model_id or "").rpartition(":")
+    if not sep or not base:
+        return None
+    if suffix.lower() in OPENROUTER_VARIANT_SUFFIXES:
+        return base
+    return None
+
+
 AI_GATEWAY_BASE_URL = "https://ai-gateway.vercel.sh/v1"
 
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1941,3 +1941,142 @@ class TestFallbackWarning:
             if r.levelno == logging.WARNING and "falling back" in r.getMessage()
         ]
         assert len(fallback_warnings) == 0
+
+
+# =========================================================================
+# get_model_context_length — OpenRouter routing-variant suffixes
+# =========================================================================
+
+class TestOpenRouterRoutingVariantContextLength:
+    """OpenRouter's `:nitro`, `:floor`, `:exacto`, `:online` are request-time
+    routing modifiers, not catalog models — /models lists only the base id and
+    a variant runs the same model, so it has the SAME context window.
+
+    The validation path (tests/hermes_cli/test_model_validation.py::
+    TestValidateOpenRouterVariantSuffixes) already preserves the suffixed id;
+    this pins the metadata half. Before the fix, `model:nitro` missed every
+    catalog lookup and fell through to a generic family default — e.g.
+    `x-ai/grok-4.6:nitro` reported the 131K `grok` catch-all instead of 2M,
+    silently shrinking the usable window and triggering early compression.
+
+    The invariant asserted here is a relation, not a snapshot: a variant must
+    resolve to whatever its base resolves to.
+    """
+
+    _CATALOG = {
+        "x-ai/grok-4.6": {"context_length": 2_000_000},
+        "anthropic/claude-opus-4.6": {"context_length": 1_000_000},
+    }
+
+    _VARIANTS = ["nitro", "floor", "exacto", "online"]
+
+    @pytest.mark.parametrize("suffix", _VARIANTS)
+    @pytest.mark.parametrize("model", sorted(_CATALOG))
+    @patch("agent.model_metadata.get_cached_context_length", return_value=None)
+    @patch("agent.models_dev.lookup_models_dev_context", return_value=None)
+    @patch("agent.model_metadata.fetch_model_metadata")
+    def test_variant_matches_base_context(
+        self, mock_fetch, mock_models_dev, mock_cache, model, suffix
+    ):
+        """A routing variant resolves to exactly its base model's window."""
+        mock_fetch.return_value = self._CATALOG
+
+        base_ctx = get_model_context_length(model, provider="openrouter")
+        variant_ctx = get_model_context_length(
+            f"{model}:{suffix}", provider="openrouter"
+        )
+
+        assert variant_ctx == base_ctx
+        assert variant_ctx == self._CATALOG[model]["context_length"]
+
+    @patch("agent.model_metadata.get_cached_context_length", return_value=None)
+    @patch("agent.models_dev.lookup_models_dev_context", return_value=None)
+    @patch("agent.model_metadata.fetch_model_metadata")
+    def test_variant_does_not_fall_back_to_family_default(
+        self, mock_fetch, mock_models_dev, mock_cache
+    ):
+        """The reported symptom: the generic `grok` catch-all (131K) winning
+        over the catalog's real window for a `:nitro` id."""
+        mock_fetch.return_value = self._CATALOG
+
+        result = get_model_context_length(
+            "x-ai/grok-4.6:nitro", provider="openrouter"
+        )
+
+        assert result == 2_000_000
+        assert result != DEFAULT_CONTEXT_LENGTHS.get("grok")
+        assert result != DEFAULT_FALLBACK_CONTEXT
+
+    @patch("agent.model_metadata.get_cached_context_length", return_value=None)
+    @patch("agent.models_dev.lookup_models_dev_context", return_value=None)
+    @patch("agent.model_metadata.fetch_model_metadata")
+    def test_uppercase_suffix_resolves(self, mock_fetch, mock_models_dev, mock_cache):
+        """Suffix matching is case-insensitive, matching the validation path."""
+        mock_fetch.return_value = self._CATALOG
+        assert get_model_context_length(
+            "x-ai/grok-4.6:NITRO", provider="openrouter"
+        ) == 2_000_000
+
+    @patch("agent.model_metadata.get_cached_context_length", return_value=None)
+    @patch("agent.models_dev.lookup_models_dev_context", return_value=None)
+    @patch("agent.model_metadata.fetch_model_metadata")
+    def test_variant_resolves_via_base_url_without_explicit_provider(
+        self, mock_fetch, mock_models_dev, mock_cache
+    ):
+        """Callers that pass only base_url (no provider=) must strip too —
+        the OpenRouter host is enough to know the suffix is a routing hint."""
+        mock_fetch.return_value = self._CATALOG
+        assert get_model_context_length(
+            "x-ai/grok-4.6:nitro",
+            base_url="https://openrouter.ai/api/v1",
+        ) == 2_000_000
+
+    @patch("agent.model_metadata.get_cached_context_length", return_value=None)
+    @patch("agent.models_dev.lookup_models_dev_context", return_value=None)
+    @patch("agent.model_metadata.fetch_model_metadata")
+    def test_free_sku_suffix_is_not_stripped(
+        self, mock_fetch, mock_models_dev, mock_cache
+    ):
+        """`:free` / `:batch` / `:thinking` ARE distinct catalog SKUs with
+        their own windows. Stripping them would report the wrong number, so
+        the SKU's own entry must win over the base's."""
+        mock_fetch.return_value = {
+            "thinkingmachines/inkling": {"context_length": 1_000_000},
+            "thinkingmachines/inkling:free": {"context_length": 64_000},
+        }
+        assert get_model_context_length(
+            "thinkingmachines/inkling:free", provider="openrouter"
+        ) == 64_000
+
+    @patch("agent.model_metadata.get_cached_context_length", return_value=None)
+    @patch("agent.models_dev.lookup_models_dev_context", return_value=None)
+    @patch("agent.model_metadata.fetch_model_metadata", return_value={})
+    def test_non_openrouter_colon_tag_is_untouched(
+        self, mock_fetch, mock_models_dev, mock_cache
+    ):
+        """An Ollama `model:tag` that happens to end in a variant word must
+        keep its full id — the carve-out is OpenRouter-only."""
+        with patch(
+            "agent.model_metadata._query_local_context_length", return_value=None
+        ), patch("agent.model_metadata._query_ollama_api_show", return_value=None):
+            result = get_model_context_length(
+                "mymodel:online",
+                base_url="http://localhost:11434/v1",
+            )
+        assert result == DEFAULT_FALLBACK_CONTEXT
+
+    @patch("agent.model_metadata.get_cached_context_length", return_value=None)
+    @patch("agent.models_dev.lookup_models_dev_context", return_value=None)
+    @patch("agent.model_metadata.fetch_model_metadata")
+    def test_explicit_config_override_still_wins(
+        self, mock_fetch, mock_models_dev, mock_cache
+    ):
+        """Stripping happens after step 0 — a user who pinned the suffixed id
+        via model.context_length keeps their value (the documented
+        self-unblock path must not regress)."""
+        mock_fetch.return_value = self._CATALOG
+        assert get_model_context_length(
+            "x-ai/grok-4.6:nitro",
+            provider="openrouter",
+            config_context_length=123_456,
+        ) == 123_456

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1948,135 +1948,27 @@ class TestFallbackWarning:
 # =========================================================================
 
 class TestOpenRouterRoutingVariantContextLength:
-    """OpenRouter's `:nitro`, `:floor`, `:exacto`, `:online` are request-time
-    routing modifiers, not catalog models — /models lists only the base id and
-    a variant runs the same model, so it has the SAME context window.
-
-    The validation path (tests/hermes_cli/test_model_validation.py::
-    TestValidateOpenRouterVariantSuffixes) already preserves the suffixed id;
-    this pins the metadata half. Before the fix, `model:nitro` missed every
-    catalog lookup and fell through to a generic family default — e.g.
-    `x-ai/grok-4.6:nitro` reported the 131K `grok` catch-all instead of 2M,
-    silently shrinking the usable window and triggering early compression.
-
-    The invariant asserted here is a relation, not a snapshot: a variant must
-    resolve to whatever its base resolves to.
-    """
+    """`:nitro`/`:floor`/`:exacto`/`:online` are request-time routing modifiers, not catalog
+    models: /models lists only the base id and the variant runs the same model, so a variant
+    must resolve to whatever its base resolves to instead of a generic family default (#97820).
+    `:free`/`:batch` are real SKUs with their own windows and must NOT be stripped."""
 
     _CATALOG = {
         "x-ai/grok-4.6": {"context_length": 2_000_000},
-        "anthropic/claude-opus-4.6": {"context_length": 1_000_000},
+        "thinkingmachines/inkling": {"context_length": 1_000_000},
+        "thinkingmachines/inkling:free": {"context_length": 64_000},
     }
 
-    _VARIANTS = ["nitro", "floor", "exacto", "online"]
-
-    @pytest.mark.parametrize("suffix", _VARIANTS)
-    @pytest.mark.parametrize("model", sorted(_CATALOG))
+    @pytest.mark.parametrize("suffix", ["nitro", "floor", "exacto", "online"])
     @patch("agent.model_metadata.get_cached_context_length", return_value=None)
     @patch("agent.models_dev.lookup_models_dev_context", return_value=None)
     @patch("agent.model_metadata.fetch_model_metadata")
-    def test_variant_matches_base_context(
-        self, mock_fetch, mock_models_dev, mock_cache, model, suffix
+    def test_variant_matches_base_but_real_sku_keeps_own_window(
+        self, mock_fetch, mock_models_dev, mock_cache, suffix
     ):
-        """A routing variant resolves to exactly its base model's window."""
         mock_fetch.return_value = self._CATALOG
-
-        base_ctx = get_model_context_length(model, provider="openrouter")
-        variant_ctx = get_model_context_length(
-            f"{model}:{suffix}", provider="openrouter"
-        )
-
-        assert variant_ctx == base_ctx
-        assert variant_ctx == self._CATALOG[model]["context_length"]
-
-    @patch("agent.model_metadata.get_cached_context_length", return_value=None)
-    @patch("agent.models_dev.lookup_models_dev_context", return_value=None)
-    @patch("agent.model_metadata.fetch_model_metadata")
-    def test_variant_does_not_fall_back_to_family_default(
-        self, mock_fetch, mock_models_dev, mock_cache
-    ):
-        """The reported symptom: the generic `grok` catch-all (131K) winning
-        over the catalog's real window for a `:nitro` id."""
-        mock_fetch.return_value = self._CATALOG
-
-        result = get_model_context_length(
-            "x-ai/grok-4.6:nitro", provider="openrouter"
-        )
-
-        assert result == 2_000_000
-        assert result != DEFAULT_CONTEXT_LENGTHS.get("grok")
-        assert result != DEFAULT_FALLBACK_CONTEXT
-
-    @patch("agent.model_metadata.get_cached_context_length", return_value=None)
-    @patch("agent.models_dev.lookup_models_dev_context", return_value=None)
-    @patch("agent.model_metadata.fetch_model_metadata")
-    def test_uppercase_suffix_resolves(self, mock_fetch, mock_models_dev, mock_cache):
-        """Suffix matching is case-insensitive, matching the validation path."""
-        mock_fetch.return_value = self._CATALOG
-        assert get_model_context_length(
-            "x-ai/grok-4.6:NITRO", provider="openrouter"
-        ) == 2_000_000
-
-    @patch("agent.model_metadata.get_cached_context_length", return_value=None)
-    @patch("agent.models_dev.lookup_models_dev_context", return_value=None)
-    @patch("agent.model_metadata.fetch_model_metadata")
-    def test_variant_resolves_via_base_url_without_explicit_provider(
-        self, mock_fetch, mock_models_dev, mock_cache
-    ):
-        """Callers that pass only base_url (no provider=) must strip too —
-        the OpenRouter host is enough to know the suffix is a routing hint."""
-        mock_fetch.return_value = self._CATALOG
-        assert get_model_context_length(
-            "x-ai/grok-4.6:nitro",
-            base_url="https://openrouter.ai/api/v1",
-        ) == 2_000_000
-
-    @patch("agent.model_metadata.get_cached_context_length", return_value=None)
-    @patch("agent.models_dev.lookup_models_dev_context", return_value=None)
-    @patch("agent.model_metadata.fetch_model_metadata")
-    def test_free_sku_suffix_is_not_stripped(
-        self, mock_fetch, mock_models_dev, mock_cache
-    ):
-        """`:free` / `:batch` / `:thinking` ARE distinct catalog SKUs with
-        their own windows. Stripping them would report the wrong number, so
-        the SKU's own entry must win over the base's."""
-        mock_fetch.return_value = {
-            "thinkingmachines/inkling": {"context_length": 1_000_000},
-            "thinkingmachines/inkling:free": {"context_length": 64_000},
-        }
-        assert get_model_context_length(
-            "thinkingmachines/inkling:free", provider="openrouter"
-        ) == 64_000
-
-    @patch("agent.model_metadata.get_cached_context_length", return_value=None)
-    @patch("agent.models_dev.lookup_models_dev_context", return_value=None)
-    @patch("agent.model_metadata.fetch_model_metadata", return_value={})
-    def test_non_openrouter_colon_tag_is_untouched(
-        self, mock_fetch, mock_models_dev, mock_cache
-    ):
-        """An Ollama `model:tag` that happens to end in a variant word must
-        keep its full id — the carve-out is OpenRouter-only."""
-        with patch(
-            "agent.model_metadata._query_local_context_length", return_value=None
-        ), patch("agent.model_metadata._query_ollama_api_show", return_value=None):
-            result = get_model_context_length(
-                "mymodel:online",
-                base_url="http://localhost:11434/v1",
-            )
-        assert result == DEFAULT_FALLBACK_CONTEXT
-
-    @patch("agent.model_metadata.get_cached_context_length", return_value=None)
-    @patch("agent.models_dev.lookup_models_dev_context", return_value=None)
-    @patch("agent.model_metadata.fetch_model_metadata")
-    def test_explicit_config_override_still_wins(
-        self, mock_fetch, mock_models_dev, mock_cache
-    ):
-        """Stripping happens after step 0 — a user who pinned the suffixed id
-        via model.context_length keeps their value (the documented
-        self-unblock path must not regress)."""
-        mock_fetch.return_value = self._CATALOG
-        assert get_model_context_length(
-            "x-ai/grok-4.6:nitro",
-            provider="openrouter",
-            config_context_length=123_456,
-        ) == 123_456
+        base_ctx = get_model_context_length("x-ai/grok-4.6", provider="openrouter")
+        variant_ctx = get_model_context_length(f"x-ai/grok-4.6:{suffix}", provider="openrouter")
+        assert variant_ctx == base_ctx == 2_000_000
+        assert variant_ctx != DEFAULT_CONTEXT_LENGTHS.get("grok")
+        assert get_model_context_length("thinkingmachines/inkling:free", provider="openrouter") == 64_000

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -1335,3 +1335,147 @@ class TestModelOverrides:
         assert info is not None
         assert "image" in info.input_modalities
         assert info.attachment is True
+
+
+# =========================================================================
+# OpenRouter routing-variant suffixes — catalog lookup across consumers
+# =========================================================================
+
+class TestOpenRouterRoutingVariantCatalogLookup:
+    """OpenRouter's `:nitro`/`:floor`/`:exacto`/`:online` are request-time
+    routing modifiers, not catalog models. models.dev (like OpenRouter's own
+    /models) lists only the base id, so every catalog consumer must resolve a
+    routed id to the base model's metadata while the suffixed id stays on the
+    wire. See issue #97820.
+
+    The counterpart to the context-length half of this fix lives in
+    tests/agent/test_model_metadata.py::TestOpenRouterRoutingVariantContextLength.
+
+    Critically, `:free` and `:batch` are NOT routing variants — they are real
+    catalog SKUs with their own entries and sometimes their own context
+    windows. Stripping them would report a window LARGER than the model has,
+    which fails at the API rather than merely compacting early.
+    """
+
+    #: Base model plus a `:free` SKU whose window deliberately DIFFERS from
+    #: it — mirrors real catalog entries such as z-ai/glm-5.2 (1.05M) vs
+    #: z-ai/glm-5.2:free (256K).
+    REGISTRY = {
+        "openrouter": {
+            "id": "openrouter",
+            "models": {
+                "z-ai/glm-5.3-flash": {
+                    "id": "z-ai/glm-5.3-flash",
+                    "limit": {"context": 1310720, "output": 131072},
+                    "tool_call": True,
+                    "reasoning": True,
+                },
+                "z-ai/glm-5.2": {
+                    "id": "z-ai/glm-5.2",
+                    "limit": {"context": 1048576, "output": 131072},
+                },
+                "z-ai/glm-5.2:free": {
+                    "id": "z-ai/glm-5.2:free",
+                    "limit": {"context": 256000, "output": 131072},
+                },
+            },
+        },
+    }
+
+    ROUTING_SUFFIXES = ["nitro", "floor", "exacto", "online"]
+
+    def _patch(self):
+        return patch(
+            "agent.models_dev.fetch_models_dev", return_value=self.REGISTRY
+        )
+
+    @pytest.mark.parametrize("suffix", ROUTING_SUFFIXES)
+    def test_context_lookup_matches_base(self, suffix):
+        """A routed id resolves to exactly its base model's context."""
+        with self._patch():
+            base = lookup_models_dev_context("openrouter", "z-ai/glm-5.3-flash")
+            routed = lookup_models_dev_context(
+                "openrouter", f"z-ai/glm-5.3-flash:{suffix}"
+            )
+        assert routed == base == 1310720
+
+    @pytest.mark.parametrize("suffix", ROUTING_SUFFIXES)
+    def test_capabilities_match_base(self, suffix):
+        """get_model_capabilities resolves routed ids (not just context)."""
+        with self._patch():
+            base = get_model_capabilities("openrouter", "z-ai/glm-5.3-flash")
+            routed = get_model_capabilities(
+                "openrouter", f"z-ai/glm-5.3-flash:{suffix}"
+            )
+        assert routed is not None
+        assert routed.context_window == base.context_window == 1310720
+        assert routed.supports_tools == base.supports_tools
+        assert routed.supports_reasoning == base.supports_reasoning
+
+    @pytest.mark.parametrize("suffix", ROUTING_SUFFIXES)
+    def test_model_info_matches_base(self, suffix):
+        """get_model_info resolves routed ids."""
+        with self._patch():
+            base = get_model_info("openrouter", "z-ai/glm-5.3-flash")
+            routed = get_model_info("openrouter", f"z-ai/glm-5.3-flash:{suffix}")
+        assert routed is not None
+        assert routed.context_window == base.context_window == 1310720
+
+    def test_suffix_match_is_case_insensitive(self):
+        with self._patch():
+            assert (
+                lookup_models_dev_context("openrouter", "z-ai/glm-5.3-flash:FLOOR")
+                == 1310720
+            )
+
+    def test_real_free_sku_keeps_its_own_window(self):
+        """REGRESSION GUARD: `:free` is a real SKU, not a routing variant.
+
+        z-ai/glm-5.2:free is 256K while its base is 1.05M. Treating `:free`
+        as strippable would report 1.05M — a window the model does not have,
+        so the request fails at the API instead of compacting early. The SKU's
+        own entry must win.
+        """
+        with self._patch():
+            assert (
+                lookup_models_dev_context("openrouter", "z-ai/glm-5.2:free") == 256000
+            )
+            assert lookup_models_dev_context("openrouter", "z-ai/glm-5.2") == 1048576
+
+    def test_absent_sku_suffix_still_misses(self):
+        """A `:free` id with no catalog entry must MISS rather than fall back
+        to its base — otherwise model_overrides `_default` fill-gap semantics
+        break, and an absent free tier would inherit the paid tier's window."""
+        with self._patch():
+            assert (
+                lookup_models_dev_context("openrouter", "z-ai/glm-5.3-flash:free")
+                is None
+            )
+
+    def test_non_openrouter_provider_is_never_stripped(self):
+        """The carve-out is OpenRouter-only; another provider's colon-suffixed
+        id (an Ollama tag, a `:cloud` key) keeps exact-match semantics."""
+        registry = {
+            "anthropic": {
+                "id": "anthropic",
+                "models": {"claude-x": {"limit": {"context": 200000}}},
+            },
+        }
+        with patch("agent.models_dev.fetch_models_dev", return_value=registry):
+            assert lookup_models_dev_context("anthropic", "claude-x:floor") is None
+            assert lookup_models_dev_context("anthropic", "claude-x") == 200000
+
+    def test_unknown_suffix_is_not_stripped(self):
+        with self._patch():
+            assert (
+                lookup_models_dev_context("openrouter", "z-ai/glm-5.3-flash:bogus")
+                is None
+            )
+
+    def test_bare_model_lookup_unaffected(self):
+        """No suffix — behavior is byte-identical to before the change."""
+        with self._patch():
+            assert (
+                lookup_models_dev_context("openrouter", "z-ai/glm-5.3-flash") == 1310720
+            )
+            assert lookup_models_dev_context("openrouter", "nope/missing") is None

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -1342,24 +1342,12 @@ class TestModelOverrides:
 # =========================================================================
 
 class TestOpenRouterRoutingVariantCatalogLookup:
-    """OpenRouter's `:nitro`/`:floor`/`:exacto`/`:online` are request-time
-    routing modifiers, not catalog models. models.dev (like OpenRouter's own
-    /models) lists only the base id, so every catalog consumer must resolve a
-    routed id to the base model's metadata while the suffixed id stays on the
-    wire. See issue #97820.
+    """models.dev, like OpenRouter's /models, lists only the base id of a routed
+    `:nitro`/`:floor`/`:exacto`/`:online` model, so every catalog consumer resolves the base's
+    metadata for it (#97820). `:free` is a real SKU whose window may differ from its base
+    (z-ai/glm-5.2 1.05M vs :free 256K) — stripping it would over-report the window and fail
+    at the API, so it keeps exact-match semantics and an absent SKU still misses."""
 
-    The counterpart to the context-length half of this fix lives in
-    tests/agent/test_model_metadata.py::TestOpenRouterRoutingVariantContextLength.
-
-    Critically, `:free` and `:batch` are NOT routing variants — they are real
-    catalog SKUs with their own entries and sometimes their own context
-    windows. Stripping them would report a window LARGER than the model has,
-    which fails at the API rather than merely compacting early.
-    """
-
-    #: Base model plus a `:free` SKU whose window deliberately DIFFERS from
-    #: it — mirrors real catalog entries such as z-ai/glm-5.2 (1.05M) vs
-    #: z-ai/glm-5.2:free (256K).
     REGISTRY = {
         "openrouter": {
             "id": "openrouter",
@@ -1370,112 +1358,26 @@ class TestOpenRouterRoutingVariantCatalogLookup:
                     "tool_call": True,
                     "reasoning": True,
                 },
-                "z-ai/glm-5.2": {
-                    "id": "z-ai/glm-5.2",
-                    "limit": {"context": 1048576, "output": 131072},
-                },
-                "z-ai/glm-5.2:free": {
-                    "id": "z-ai/glm-5.2:free",
-                    "limit": {"context": 256000, "output": 131072},
-                },
+                "z-ai/glm-5.2": {"id": "z-ai/glm-5.2", "limit": {"context": 1048576, "output": 131072}},
+                "z-ai/glm-5.2:free": {"id": "z-ai/glm-5.2:free", "limit": {"context": 256000, "output": 131072}},
             },
         },
     }
 
-    ROUTING_SUFFIXES = ["nitro", "floor", "exacto", "online"]
+    @pytest.mark.parametrize("suffix", ["nitro", "floor", "exacto", "online"])
+    def test_routed_id_matches_base_across_consumers(self, suffix):
+        with patch("agent.models_dev.fetch_models_dev", return_value=self.REGISTRY):
+            routed = f"z-ai/glm-5.3-flash:{suffix}"
+            assert lookup_models_dev_context("openrouter", routed) == 1310720
+            base_caps = get_model_capabilities("openrouter", "z-ai/glm-5.3-flash")
+            routed_caps = get_model_capabilities("openrouter", routed)
+            assert routed_caps.context_window == base_caps.context_window == 1310720
+            assert routed_caps.supports_tools == base_caps.supports_tools
+            assert get_model_info("openrouter", routed).context_window == 1310720
+            # Other providers' colon tags keep exact-match semantics.
+            assert lookup_models_dev_context("anthropic", f"claude-x:{suffix}") is None
 
-    def _patch(self):
-        return patch(
-            "agent.models_dev.fetch_models_dev", return_value=self.REGISTRY
-        )
-
-    @pytest.mark.parametrize("suffix", ROUTING_SUFFIXES)
-    def test_context_lookup_matches_base(self, suffix):
-        """A routed id resolves to exactly its base model's context."""
-        with self._patch():
-            base = lookup_models_dev_context("openrouter", "z-ai/glm-5.3-flash")
-            routed = lookup_models_dev_context(
-                "openrouter", f"z-ai/glm-5.3-flash:{suffix}"
-            )
-        assert routed == base == 1310720
-
-    @pytest.mark.parametrize("suffix", ROUTING_SUFFIXES)
-    def test_capabilities_match_base(self, suffix):
-        """get_model_capabilities resolves routed ids (not just context)."""
-        with self._patch():
-            base = get_model_capabilities("openrouter", "z-ai/glm-5.3-flash")
-            routed = get_model_capabilities(
-                "openrouter", f"z-ai/glm-5.3-flash:{suffix}"
-            )
-        assert routed is not None
-        assert routed.context_window == base.context_window == 1310720
-        assert routed.supports_tools == base.supports_tools
-        assert routed.supports_reasoning == base.supports_reasoning
-
-    @pytest.mark.parametrize("suffix", ROUTING_SUFFIXES)
-    def test_model_info_matches_base(self, suffix):
-        """get_model_info resolves routed ids."""
-        with self._patch():
-            base = get_model_info("openrouter", "z-ai/glm-5.3-flash")
-            routed = get_model_info("openrouter", f"z-ai/glm-5.3-flash:{suffix}")
-        assert routed is not None
-        assert routed.context_window == base.context_window == 1310720
-
-    def test_suffix_match_is_case_insensitive(self):
-        with self._patch():
-            assert (
-                lookup_models_dev_context("openrouter", "z-ai/glm-5.3-flash:FLOOR")
-                == 1310720
-            )
-
-    def test_real_free_sku_keeps_its_own_window(self):
-        """REGRESSION GUARD: `:free` is a real SKU, not a routing variant.
-
-        z-ai/glm-5.2:free is 256K while its base is 1.05M. Treating `:free`
-        as strippable would report 1.05M — a window the model does not have,
-        so the request fails at the API instead of compacting early. The SKU's
-        own entry must win.
-        """
-        with self._patch():
-            assert (
-                lookup_models_dev_context("openrouter", "z-ai/glm-5.2:free") == 256000
-            )
-            assert lookup_models_dev_context("openrouter", "z-ai/glm-5.2") == 1048576
-
-    def test_absent_sku_suffix_still_misses(self):
-        """A `:free` id with no catalog entry must MISS rather than fall back
-        to its base — otherwise model_overrides `_default` fill-gap semantics
-        break, and an absent free tier would inherit the paid tier's window."""
-        with self._patch():
-            assert (
-                lookup_models_dev_context("openrouter", "z-ai/glm-5.3-flash:free")
-                is None
-            )
-
-    def test_non_openrouter_provider_is_never_stripped(self):
-        """The carve-out is OpenRouter-only; another provider's colon-suffixed
-        id (an Ollama tag, a `:cloud` key) keeps exact-match semantics."""
-        registry = {
-            "anthropic": {
-                "id": "anthropic",
-                "models": {"claude-x": {"limit": {"context": 200000}}},
-            },
-        }
-        with patch("agent.models_dev.fetch_models_dev", return_value=registry):
-            assert lookup_models_dev_context("anthropic", "claude-x:floor") is None
-            assert lookup_models_dev_context("anthropic", "claude-x") == 200000
-
-    def test_unknown_suffix_is_not_stripped(self):
-        with self._patch():
-            assert (
-                lookup_models_dev_context("openrouter", "z-ai/glm-5.3-flash:bogus")
-                is None
-            )
-
-    def test_bare_model_lookup_unaffected(self):
-        """No suffix — behavior is byte-identical to before the change."""
-        with self._patch():
-            assert (
-                lookup_models_dev_context("openrouter", "z-ai/glm-5.3-flash") == 1310720
-            )
-            assert lookup_models_dev_context("openrouter", "nope/missing") is None
+    def test_real_sku_suffix_is_not_stripped(self):
+        with patch("agent.models_dev.fetch_models_dev", return_value=self.REGISTRY):
+            assert lookup_models_dev_context("openrouter", "z-ai/glm-5.2:free") == 256000
+            assert lookup_models_dev_context("openrouter", "z-ai/glm-5.3-flash:free") is None


### PR DESCRIPTION
OpenRouter routing variants (`model:nitro` / `:floor` / `:exacto` / `:online`) now resolve the same context window and capabilities as their base model instead of falling to a family default or the 256K fallback. Salvage of #100651 by @jakobdylanc; fixes #97820.

## Changes

- `hermes_constants.py` — canonical `OPENROUTER_VARIANT_SUFFIXES` + `openrouter_variant_base()` (one definition shared by validation, context length and catalog lookups)
- `agent/model_metadata.py::get_model_context_length` — strips the routing suffix for LOOKUP ONLY, after explicit config overrides and before every cache/catalog lookup; gated on the request routing through OpenRouter (explicit provider or inferred base_url) so Ollama `model:tag` ids are untouched
- `agent/models_dev.py::_iter_model_entries` — retries with the base id as the last resort (after exact / case-insensitive / `:cloud`), threaded through `lookup_models_dev_context`, `get_model_capabilities`, `get_model_info`
- `hermes_cli/models_validate.py` — imports `openrouter_variant_base` from `hermes_constants`; the private `_openrouter_variant_base` / `_OPENROUTER_VARIANT_SUFFIXES` re-export shims from the original PR were dropped (internal moves get no aliases)
- Tests trimmed to two invariant tests (variant == base; real `:free` SKU keeps its own window), both red on `origin/main`

`:free` / `:batch` are deliberately NOT stripped: they are real catalog SKUs and 13 of them have a different window than their base (`z-ai/glm-5.2:free` 256K vs base 1.05M). Stripping them would over-report the window and fail at the API. This is the difference versus the competing #97837 / #97839.

## Root cause

Every metadata lookup keyed on the full suffixed id; OpenRouter's `/models` and models.dev list only the base id, so `model:nitro` missed and fell through to `_longest_key_match` family defaults. Validation was fixed in f14059fa; this completes the metadata half.

## Live evidence (real OpenRouter catalog + models.dev, temp HERMES_HOME)

| model | before | after |
|---|---|---|
| `x-ai/grok-4.6:nitro` models.dev ctx | None | 500,000 (= base) |
| `openai/gpt-5.5:nitro` capabilities | None | ctx 1,050,000 (= base) |
| `anthropic/claude-opus-4.6:floor` capabilities | None | ctx 1,000,000 (= base) |
| `gpt-sol-latest:nitro` context length | 256,000 (fallback) | 1,050,000 (= base) |
| `z-ai/glm-5.2:free` context length | 256,000 | 256,000 (own SKU, unchanged) |
| `mymodel:online` on Ollama base_url | 256,000 fallback | unchanged |

Suite: `tests/agent/test_model_metadata.py`, `tests/agent/test_models_dev.py`, `tests/hermes_cli/` — 9,636 passed; the one failure (`test_update_head_moved_gate`) is a pre-existing local-environment failure in the update fleet check, unrelated to these files.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aaa0e6f/4oAdPDQapwgOoOMzrPHdJ_or7fIXQv.png)
