### PR TITLE
fix(agent): stop native media turns from answering about stale attachments

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1236,6 +1236,25 @@ def _consume_ephemeral_max_output(agent):
     return ephemeral_out
 
 
+_MEDIA_CONTENT_TYPES = frozenset({"image_url", "input_image", "video_url", "input_video"})
+
+
+def _disable_cache_prompt_for_media(request_overrides: dict, api_messages: list) -> dict:
+    """Disable backend prompt reuse for a request carrying native media."""
+    extra_body = request_overrides.get("extra_body")
+    if not isinstance(extra_body, dict) or extra_body.get("cache_prompt") is not True:
+        return request_overrides
+    has_media = any(
+        isinstance(part, dict) and part.get("type") in _MEDIA_CONTENT_TYPES
+        for message in api_messages or ()
+        if isinstance(message, dict) and isinstance(message.get("content"), list)
+        for part in message["content"]
+    )
+    if not has_media:
+        return request_overrides
+    return {**request_overrides, "extra_body": {**extra_body, "cache_prompt": False}}
+
+
 def _build_anthropic_kwargs(agent, api_messages, tools_for_api, reasoning_config, request_overrides):
     ctx_len = getattr(agent, "context_compressor", None)
     ephemeral_out = _consume_ephemeral_max_output(agent)
@@ -1391,6 +1410,7 @@ def _build_api_kwargs_for_mode(agent, api_messages: list, tools_for_api: list | 
         return _build_anthropic_kwargs(agent, api_messages, tools_for_api, reasoning_config, request_overrides)
     if agent.api_mode == "bedrock_converse":
         return _build_bedrock_kwargs(agent, api_messages, tools_for_api)
+    request_overrides = _disable_cache_prompt_for_media(request_overrides, api_messages)
     # Rotation-stable logical cache scope shared by every OpenAI-wire branch
     # (memoized on the agent); anthropic/bedrock above don't use it.
     cache_scope_id = _prompt_cache_scope_for_agent(agent)

--- a/tests/agent/test_native_media_cache_prompt.py
+++ b/tests/agent/test_native_media_cache_prompt.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+
+import pytest
+
+from agent import chat_completion_helpers as helpers
+
+
+def _request_overrides_for(messages, monkeypatch):
+    captured = {}
+    overrides = {"extra_body": {"cache_prompt": True, "keep": "value"}}
+    agent = SimpleNamespace(api_mode="chat_completions", tools=[])
+
+    monkeypatch.setattr(helpers, "_reasoning_config_for_wire", lambda _agent: None)
+    monkeypatch.setattr(helpers, "effective_request_overrides", lambda _agent: overrides)
+    monkeypatch.setattr(helpers, "_prompt_cache_scope_for_agent", lambda _agent: "scope")
+    monkeypatch.setattr(
+        helpers,
+        "_build_chat_completions_kwargs",
+        lambda _agent, _messages, _tools, _reasoning, request_overrides, _scope: captured.update(
+            request_overrides=request_overrides
+        )
+        or captured,
+    )
+
+    result = helpers._build_api_kwargs_for_mode(agent, messages)
+    return overrides, result["request_overrides"]
+
+
+@pytest.mark.parametrize("part_type", ["image_url", "input_image", "video_url", "input_video"])
+def test_native_media_disables_configured_prompt_reuse_per_request(part_type, monkeypatch):
+    configured, effective = _request_overrides_for(
+        [{"role": "user", "content": [{"type": part_type, "url": "media"}]}], monkeypatch
+    )
+
+    assert effective == {"extra_body": {"cache_prompt": False, "keep": "value"}}
+    assert configured["extra_body"]["cache_prompt"] is True
+
+
+def test_text_request_preserves_configured_prompt_reuse(monkeypatch):
+    configured, effective = _request_overrides_for(
+        [{"role": "user", "content": [{"type": "text", "text": "hello"}]}], monkeypatch
+    )
+
+    assert effective is configured
+    assert effective["extra_body"]["cache_prompt"] is True


### PR DESCRIPTION
## What does this PR do?

Prevents native image and video turns from reusing a backend prompt cache entry that may contain media from an earlier request. The request builder now disables an explicitly enabled `extra_body.cache_prompt` only for OpenAI-wire requests that carry native media, while plain-text turns retain the configured cache benefit.

### Symptom

With a custom vision provider configured with `cache_prompt: true`, a second image or video turn can receive a plausible answer about the previous attachment.

### Impact

Affected custom OpenAI-compatible vision backends can silently return incorrect multimodal answers. The blast radius is limited to backends whose prompt reuse does not account for media bytes and users who explicitly enable that backend flag.

### Bug Cause

**Trigger:** `agent/chat_completion_helpers.py` / `_build_api_kwargs_for_mode` forwards `extra_body.cache_prompt: true` on a request containing a native media content part.

**Causal chain:**
1. A user sends consecutive native image or video turns through a custom provider with prompt reuse enabled.
2. Hermes forwards the static provider override unchanged for both requests, while the backend matches its reusable cache on the otherwise stable textual prefix.
3. The backend can reuse state containing the prior attachment and return an answer about stale media.

**Why it is wrong:** The request-level media payload changes, but the backend-specific reuse flag is not adjusted to force that request to consume the new media.

**Working sibling / contrast:** Plain-text turns do not carry media state outside the textual prompt, so they can retain the configured prompt reuse benefit.

**Ruled out:** Hermes' logical `cache_scope_id` is not the source of this failure; the reported raw API control request changes behavior solely by setting the backend `cache_prompt` flag to false.

### Fix

Detect native image and video content-part types at the OpenAI-wire request boundary and copy the request overrides with `cache_prompt: false`. The configured override remains unchanged so later plain-text requests still use prompt caching.

## Related Issue

N/A


## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py` - disable backend prompt reuse per request when native media is present.
- `tests/agent/test_native_media_cache_prompt.py` - cover image/video wire types, text preservation, and non-mutation of configured overrides.

## How to Test

1. Configure a custom OpenAI-compatible vision provider with `extra_body.cache_prompt: true`.
2. Send different native images or videos in consecutive turns and confirm each answer describes the current attachment.
3. Ran `scripts/run_tests.sh tests/agent/test_custom_provider_extra_body.py tests/agent/test_fast_mode_auto.py tests/agent/test_native_media_cache_prompt.py` (9 passed).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant tests through `scripts/run_tests.sh` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

N/A - request-assembly behavior is covered by focused automated tests.
