### PR TITLE
fix(gateway): explicit tool_progress off disables Slack task cards; no text fallback in un-threaded chats

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -84,20 +84,42 @@ def resolve_display_setting(user_config: dict, platform_key: str, setting: str, 
     ``platform_key`` is the platform config key (``"telegram"``; see ``_platform_config_key`` in
     gateway/run.py). Returns *fallback* when nothing is configured.
     """
-    display_cfg = user_config.get("display") or {}
-    plat_overrides = (display_cfg.get("platforms") or {}).get(platform_key)
-    if isinstance(plat_overrides, dict) and plat_overrides.get(setting) is not None:
-        return _normalise(setting, plat_overrides[setting])
-    if setting == "tool_progress":  # legacy display.tool_progress_overrides.<platform>
-        legacy = display_cfg.get("tool_progress_overrides")
-        if isinstance(legacy, dict) and legacy.get(platform_key) is not None:
-            return _normalise(setting, legacy[platform_key])
-    if setting != "streaming" and display_cfg.get(setting) is not None:  # display.streaming is CLI-only
-        return _normalise(setting, display_cfg[setting])
+    configured = _configured_display_value(user_config, platform_key, setting)
+    if configured is not None:
+        return _normalise(setting, configured)
     val = _PLATFORM_DEFAULTS.get(platform_key, {}).get(setting)
     if val is None:
         val = _GLOBAL_DEFAULTS.get(setting)
     return fallback if val is None else val
+
+
+def _configured_display_value(user_config: dict, platform_key: str, setting: str) -> Any:
+    """First non-None operator value, without introducing tier defaults."""
+    display_cfg = user_config.get("display") or {}
+    plat_overrides = (display_cfg.get("platforms") or {}).get(platform_key)
+    if isinstance(plat_overrides, dict) and plat_overrides.get(setting) is not None:
+        return plat_overrides[setting]
+    if setting == "tool_progress":
+        legacy = display_cfg.get("tool_progress_overrides")
+        if isinstance(legacy, dict) and legacy.get(platform_key) is not None:
+            return legacy[platform_key]
+    if setting != "streaming":  # display.streaming is CLI-only
+        return display_cfg.get(setting)
+    return None
+
+
+def resolve_tool_progress(user_config: dict, platform_key: str, env_mode: str | None = None) -> tuple[str, bool]:
+    """Return (mode, explicit intent) from the same winning source.
+
+    Non-None YAML wins over the legacy env bridge. Null inherits through to env,
+    then tier defaults. A tier's off is not an operator request to disable cards.
+    """
+    configured = _configured_display_value(user_config, platform_key, "tool_progress")
+    if configured is not None:
+        return _normalise("tool_progress", configured), True
+    if env_mode:
+        return _normalise("tool_progress", env_mode), True
+    return resolve_display_setting(user_config, platform_key, "tool_progress"), False
 
 
 # --- Normalisation of YAML quirks (bare ``off`` → False in YAML 1.1, etc.) ---

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -659,6 +659,30 @@ class RelayAdapter(BasePlatformAdapter):
         except Exception as e:
             return SendResult(success=False, error=f"{op} transport error: {e}")
 
+    @staticmethod
+    def _task_card_metadata(
+        reply_to: Optional[str], metadata: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        merged_meta = dict(metadata or {})
+        if reply_to and "thread_ts" not in merged_meta:
+            # Slack card streams are thread replies anchored on the trigger.
+            merged_meta["thread_ts"] = str(reply_to)
+        return merged_meta
+
+    def native_task_card_destination_supported(
+        self, chat_id: str, *, reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Check the actual card-frame placement, not its per-turn card identity."""
+        if self._chat_platform(chat_id) != _SLACK:
+            return True
+        md = self._task_card_metadata(reply_to, metadata)
+        # Connector threadTs(): thread_id ?? thread_ts, and only strings thread.
+        thread = md.get("thread_id")
+        if thread is None:
+            thread = md.get("thread_ts")
+        return isinstance(thread, str)
+
     async def send_native_task_card_progress(
         self,
         chat_id: str,
@@ -678,10 +702,7 @@ class RelayAdapter(BasePlatformAdapter):
 
         See #85476.
         """
-        merged_meta = dict(metadata or {})
-        if reply_to and "thread_ts" not in merged_meta:
-            # Slack card streams are thread replies anchored on the trigger.
-            merged_meta["thread_ts"] = str(reply_to)
+        merged_meta = self._task_card_metadata(reply_to, metadata)
         result = await self._card_frame(
             chat_id, "task_card", reply_to, merged_meta, chunks=[dict(t) for t in tasks]
         )

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2611,11 +2611,6 @@ class GatewayTurnMixin:
         platform_key = _platform_config_key(source.platform)
         enabled_toolsets, disabled_toolsets = self._resolve_turn_toolsets(user_config, source, platform_key)
         adapter = self._adapter_for_source(source)
-        # display.platforms.<platform>.<key> → display.<key> → built-in platform defaults.
-        _display_cfg = user_config.get("display", {})
-        if not isinstance(_display_cfg, dict):
-            _display_cfg = {}
-
         # Tool preview length (0 = no limit) and friendly tool labels (default on), per-platform.
         for _setter, _setting, _default, _cast in (
             ("set_tool_preview_max_len", "tool_preview_length", 0, lambda v: int(v) if v else 0),
@@ -2626,24 +2621,10 @@ class GatewayTurnMixin:
                 _val = resolve_display_setting(user_config, platform_key, _setting, _default)
                 getattr(_agent_display, _setter)(_cast(_val))
 
-        # Tool progress mode; HERMES_TOOL_PROGRESS_MODE wins only when the config never set it.
-        _resolved_tp = resolve_display_setting(user_config, platform_key, "tool_progress")
-        _env_tp = os.getenv("HERMES_TOOL_PROGRESS_MODE")
-        _platform_cfg = (_display_cfg.get("platforms") or {}).get(platform_key) or {}
-        _legacy_tp_overrides = _display_cfg.get("tool_progress_overrides") or {}
-        _tool_progress_configured = "tool_progress" in _display_cfg or any(
-            isinstance(cfg, dict) and key in cfg
-            for cfg, key in ((_platform_cfg, "tool_progress"), (_legacy_tp_overrides, platform_key))
-        )
-        progress_mode = _env_tp if _env_tp and not _tool_progress_configured else (_resolved_tp or _env_tp or "all")
-        # Operator intent vs tier default: True when a human WROTE a mode (config or env). A ``null``
-        # value is inheritance, not intent — the resolver skips None (display_config.py), so a bare
-        # key with no value must not read as "explicitly off".
-        _tool_progress_explicit = bool(_env_tp) or any(
-            isinstance(cfg, dict) and cfg.get(key) is not None
-            for cfg, key in (
-                (_display_cfg, "tool_progress"), (_platform_cfg, "tool_progress"), (_legacy_tp_overrides, platform_key),
-            )
+        # Resolve the mode and its provenance together: null inherits, tier off is not intent.
+        from gateway.display_config import resolve_tool_progress
+        progress_mode, _tool_progress_explicit = resolve_tool_progress(
+            user_config, platform_key, os.getenv("HERMES_TOOL_PROGRESS_MODE"),
         )
         # "accumulate" (edit one bubble) or "separate" (one msg per tool)
         progress_grouping = resolve_display_setting(user_config, platform_key, "tool_progress_grouping") or "accumulate"

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2636,8 +2636,15 @@ class GatewayTurnMixin:
             for cfg, key in ((_platform_cfg, "tool_progress"), (_legacy_tp_overrides, platform_key))
         )
         progress_mode = _env_tp if _env_tp and not _tool_progress_configured else (_resolved_tp or _env_tp or "all")
-        # Operator intent vs tier default: True when a human wrote the mode (config or env).
-        _tool_progress_explicit = _tool_progress_configured or bool(_env_tp)
+        # Operator intent vs tier default: True when a human WROTE a mode (config or env). A ``null``
+        # value is inheritance, not intent — the resolver skips None (display_config.py), so a bare
+        # key with no value must not read as "explicitly off".
+        _tool_progress_explicit = bool(_env_tp) or any(
+            isinstance(cfg, dict) and cfg.get(key) is not None
+            for cfg, key in (
+                (_display_cfg, "tool_progress"), (_platform_cfg, "tool_progress"), (_legacy_tp_overrides, platform_key),
+            )
+        )
         # "accumulate" (edit one bubble) or "separate" (one msg per tool)
         progress_grouping = resolve_display_setting(user_config, platform_key, "tool_progress_grouping") or "accumulate"
         _generic_status_recent: List[str] = []

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2636,6 +2636,8 @@ class GatewayTurnMixin:
             for cfg, key in ((_platform_cfg, "tool_progress"), (_legacy_tp_overrides, platform_key))
         )
         progress_mode = _env_tp if _env_tp and not _tool_progress_configured else (_resolved_tp or _env_tp or "all")
+        # Operator intent vs tier default: True when a human wrote the mode (config or env).
+        _tool_progress_explicit = _tool_progress_configured or bool(_env_tp)
         # "accumulate" (edit one bubble) or "separate" (one msg per tool)
         progress_grouping = resolve_display_setting(user_config, platform_key, "tool_progress_grouping") or "accumulate"
         _generic_status_recent: List[str] = []
@@ -2693,8 +2695,16 @@ class GatewayTurnMixin:
         # native plan/task cards via chat.startStream — the progress queue is needed even though Slack keeps
         # ordinary text tool_progress off by default (requiring both flags would silently leave the native
         # feature inactive).
+        # Cards are still tool progress. Slack's TIER default (``off``) only quiets the text lane so
+        # cards stay on for unconfigured installs, but an operator who WRITES ``tool_progress: off``
+        # (global, platform override, or legacy overrides) has asked for no tool progress at all and
+        # gets no cards either. Every other explicit mode keeps the card lane.
         _native_slack_task_cards = False
-        if source.platform == Platform.SLACK and hasattr(adapter, "native_task_cards_enabled"):
+        if (
+            source.platform == Platform.SLACK
+            and hasattr(adapter, "native_task_cards_enabled")
+            and not (_tool_progress_explicit and progress_mode == "off")
+        ):
             try:
                 _native_slack_task_cards = bool(adapter.native_task_cards_enabled())
             except Exception:

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -460,8 +460,8 @@ class TurnRunner:
         return changed
 
     async def _send_native_task_card_progress(self, adapter) -> None:
-        """Drain the progress queue into Slack-native plan/task cards; on any native failure, fall
-        back to an editable in-thread message so progress stays live.
+        """Drain progress into native cards; supported destinations retain editable fallback.
+        Unsupported destinations and egress refusals suppress publication, never finalization.
 
         See #29483.
         """

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -34,6 +34,17 @@ if TYPE_CHECKING:  # string annotations only; never imported at runtime (cycle)
 # Log-record parity with the origin module.
 logger = logging.getLogger("gateway.run")
 
+# Card-lane failures that describe the DESTINATION, not a transient outage. Native Slack
+# (`No Slack thread target`) and the relay connector (`slack task_card requires a thread anchor`)
+# both refuse cards for un-threaded chats; the refusal repeats on every event of the turn.
+_CARD_DESTINATION_UNSUPPORTED_MARKERS = ("thread anchor", "thread target")
+
+
+def _card_destination_unsupported(result: Any) -> bool:
+    """True when a failed task-card send means this chat cannot host a card at all."""
+    error = str(getattr(result, "error", "") or "").lower()
+    return any(marker in error for marker in _CARD_DESTINATION_UNSUPPORTED_MARKERS)
+
 
 class _ExecApprovalDeclined(RuntimeError):
     """The connector refused the approval card's destination.
@@ -408,6 +419,18 @@ class TurnRunner:
                 )
                 return
             st.native_failed = True
+            if _card_destination_unsupported(result):
+                # The destination itself cannot host a card (flat DM: no thread anchor). This is
+                # a property of the chat, not a transient outage, and it repeats on every event.
+                # Degrading to text would deliver tool progress the operator never enabled
+                # (Slack's default is off), so the lane goes silent for this turn.
+                st.egress_declined = True
+                logger.info(
+                    "Slack native task cards are unsupported for this destination "
+                    "(%s); tool progress stays off for this turn",
+                    getattr(result, "error", "unknown error"),
+                )
+                return
             logger.warning(
                 "Slack native task-card progress failed; falling back "
                 "to an editable text update: %s", getattr(result, "error", "unknown error"),

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -34,16 +34,13 @@ if TYPE_CHECKING:  # string annotations only; never imported at runtime (cycle)
 # Log-record parity with the origin module.
 logger = logging.getLogger("gateway.run")
 
-# Card-lane failures that describe the DESTINATION, not a transient outage. Native Slack
-# (`No Slack thread target`) and the relay connector (`slack task_card requires a thread anchor`)
-# both refuse cards for un-threaded chats; the refusal repeats on every event of the turn.
-_CARD_DESTINATION_UNSUPPORTED_MARKERS = ("thread anchor", "thread target")
-
-
-def _card_destination_unsupported(result: Any) -> bool:
-    """True when a failed task-card send means this chat cannot host a card at all."""
-    error = str(getattr(result, "error", "") or "").lower()
-    return any(marker in error for marker in _CARD_DESTINATION_UNSUPPORTED_MARKERS)
+# Exact refusals retained for older adapters/connectors without destination preflight.
+# Substring matching would also silence transient thread-resolution errors.
+_CARD_DESTINATION_REFUSALS = {
+    "No Slack thread target",
+    "slack task_card requires a thread anchor",
+    "slack task_card requires a thread anchor (Slack streams are thread replies)",
+}
 
 
 class _ExecApprovalDeclined(RuntimeError):
@@ -394,6 +391,15 @@ class TurnRunner:
             # that cannot host a card); every later publication would re-deliver the
             # same task text there.
             return
+        # Resolve eligibility in the owning adapter BEFORE transport I/O: a first
+        # timeout/disconnect must not turn an un-cardable chat into text fallback.
+        # Optional for older adapters; only an explicit False refuses publication.
+        destination_supported = getattr(st.adapter, "native_task_card_destination_supported", None)
+        if callable(destination_supported) and destination_supported(
+            ctx.source.chat_id, reply_to=ctx._progress_reply_to, metadata=ctx._progress_metadata,
+        ) is False:
+            st.publication_suppressed = True
+            return
         if not st.native_failed:
             result = await st.adapter.send_native_task_card_progress(
                 chat_id=ctx.source.chat_id, tasks=st.visible_tasks(), title="Hermes is working",
@@ -422,7 +428,7 @@ class TurnRunner:
                 )
                 return
             st.native_failed = True
-            if _card_destination_unsupported(result):
+            if getattr(result, "error", None) in _CARD_DESTINATION_REFUSALS:
                 # The destination itself cannot host a card (flat DM: no thread anchor). This is
                 # a property of the chat, not a transient outage, and it repeats on every event.
                 # The text fallback exists to keep a WORKING card lane live through a transient

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -309,11 +309,13 @@ class TurnRunner:
         task_order: List[str] = dataclasses.field(default_factory=list)
         fallback_msg_id: Optional[str] = None
         native_failed: bool = False
-        # TERMINAL authorization refusal, distinct from native_failed: the
-        # connector refused this destination, so no later publication in this
-        # turn may re-deliver the task text through the text fallback. Declared
-        # rather than set dynamically so the state is visible where it lives.
-        egress_declined: bool = False
+        # TERMINAL for the turn, distinct from native_failed: no later publication
+        # in this turn may deliver task text through the native lane OR the text
+        # fallback. Two causes, both properties of the destination rather than of
+        # one attempt: the connector's egress guard refused the chat, or the chat
+        # cannot host a card (no thread anchor). Declared rather than set
+        # dynamically so the state is visible where it lives.
+        publication_suppressed: bool = False
         anonymous_seq: int = 0
 
         @staticmethod
@@ -359,7 +361,7 @@ class TurnRunner:
         text = st.fallback_text()
         from gateway.relay.egress import declined_send
 
-        if getattr(st, "egress_declined", False):
+        if st.publication_suppressed:
             return
         if st.fallback_msg_id:
             result = await st.adapter.edit_message(
@@ -377,7 +379,7 @@ class TurnRunner:
                     "guard; suppressing progress delivery for the rest of this "
                     "turn (the destination is not approved)"
                 )
-                st.egress_declined = True
+                st.publication_suppressed = True
                 return
         result = await self._send_progress_text(st, text)
         if getattr(result, "success", False) and getattr(result, "message_id", None):
@@ -387,9 +389,10 @@ class TurnRunner:
         ctx = self._ctx
         if not st.tasks:
             return
-        if getattr(st, "egress_declined", False):
-            # The connector refused this destination earlier in the turn; every
-            # later publication would re-deliver the same task text there.
+        if st.publication_suppressed:
+            # Publication was suppressed earlier in the turn (egress refusal or a chat
+            # that cannot host a card); every later publication would re-deliver the
+            # same task text there.
             return
         if not st.native_failed:
             result = await st.adapter.send_native_task_card_progress(
@@ -410,7 +413,7 @@ class TurnRunner:
                 # event skipped this branch (the lane is already "failed") and
                 # went straight to the text fallback. A refusal does not expire
                 # after one tick.
-                st.egress_declined = True
+                st.publication_suppressed = True
                 st.native_failed = True
                 logger.warning(
                     "Slack native task-card progress DECLINED by the connector's "
@@ -422,9 +425,10 @@ class TurnRunner:
             if _card_destination_unsupported(result):
                 # The destination itself cannot host a card (flat DM: no thread anchor). This is
                 # a property of the chat, not a transient outage, and it repeats on every event.
-                # Degrading to text would deliver tool progress the operator never enabled
-                # (Slack's default is off), so the lane goes silent for this turn.
-                st.egress_declined = True
+                # The text fallback exists to keep a WORKING card lane live through a transient
+                # native failure, not to turn an un-cardable chat into text bubbles; the lane
+                # goes silent for this turn whatever the configured mode.
+                st.publication_suppressed = True
                 logger.info(
                     "Slack native task cards are unsupported for this destination "
                     "(%s); tool progress stays off for this turn",

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1894,6 +1894,13 @@ class SlackAdapter(BasePlatformAdapter):
         return self._workspace_thread_key(
             self._metadata_team_id(metadata), chat_id, str(thread_ts))
 
+    def native_task_card_destination_supported(
+        self, chat_id: str, *, reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Placement eligibility independent of connection/stream availability."""
+        return self._native_task_card_key(chat_id, reply_to, metadata) is not None
+
     async def send_native_task_card_progress(
         self, chat_id: str, tasks: List[Dict[str, str]], *, title: str = "Hermes is working",
         reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None,

--- a/tests/gateway/test_decline_fallback_suppression.py
+++ b/tests/gateway/test_decline_fallback_suppression.py
@@ -207,6 +207,7 @@ def _card_state(adapter: _CardAdapter):
     return SimpleNamespace(
         tasks=[{"text": "step"}],
         native_failed=False,
+        publication_suppressed=False,
         visible_tasks=lambda: [{"text": "step"}],
         fallback_text=lambda: "step",
         adapter=adapter,
@@ -355,11 +356,11 @@ def test_task_card_fallback_edit_decline_does_not_send_progress_text():
         fallback_msg_id="m0",
         fallback_text=lambda: "task text",
         adapter=adapter,
-        egress_declined=False,
+        publication_suppressed=False,
     )
 
     asyncio.run(runner._task_card_send_or_edit_fallback(st))
 
     assert adapter.ops == ["edit"]
     assert sent == []
-    assert st.egress_declined is True
+    assert st.publication_suppressed is True

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -5,6 +5,25 @@
 # Resolver: resolution order
 # ---------------------------------------------------------------------------
 
+class TestToolProgressProvenance:
+    def test_winning_source_controls_mode_and_intent(self):
+        from gateway.display_config import resolve_tool_progress
+
+        cases = [
+            ({}, None, ("off", False)),
+            ({}, "all", ("all", True)),
+            ({"tool_progress": None}, "all", ("all", True)),
+            ({"platforms": {"slack": {"tool_progress": None}}}, "off", ("off", True)),
+            ({"tool_progress_overrides": {"slack": None}}, "new", ("new", True)),
+            ({"tool_progress": False}, "all", ("off", True)),
+            ({"tool_progress": "all", "platforms": {"slack": {"tool_progress": None}}}, "off", ("all", True)),
+            ({"tool_progress": "off", "tool_progress_overrides": {"slack": "new"}}, "all", ("new", True)),
+            ({"tool_progress_overrides": {"slack": "off"}, "platforms": {"slack": {"tool_progress": "all"}}}, None, ("all", True)),
+        ]
+        for display, env, expected in cases:
+            assert resolve_tool_progress({"display": display}, "slack", env) == expected
+
+
 class TestResolveDisplaySetting:
     """resolve_display_setting() resolves with correct priority."""
 

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1187,8 +1187,12 @@ async def test_slack_operator_tool_progress_off_disables_task_cards(monkeypatch,
     ],
     ids=["platform-null", "global-null", "legacy-null", "platform-null-over-global-all"],
 )
-async def test_slack_null_tool_progress_is_inheritance_not_explicit_off(monkeypatch, tmp_path, display_cfg):
+@pytest.mark.parametrize("env_mode", [None, "all", "new"])
+async def test_slack_null_tool_progress_is_inheritance_not_explicit_off(monkeypatch, tmp_path, display_cfg, env_mode):
     # A bare key with ``null`` inherits (the resolver skips None); it is not an operator saying "off".
+    monkeypatch.delenv("HERMES_TOOL_PROGRESS_MODE", raising=False)
+    if env_mode is not None:
+        monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", env_mode)
     adapter, result = await _run_with_agent(
         monkeypatch,
         tmp_path,

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -292,19 +292,19 @@ class DuplicateNativeToolsAgent:
         self.tools = []
 
     def run_conversation(self, message, conversation_history=None, task_id=None, **kwargs):
-        self.tool_start_callback("call-a", "web_search", {"query": "alpha"})
+        # Production (agent/tool_executor.py) fires these through _safe_callback, which skips a
+        # None callback; the card lane leaves them unset when cards are disabled for the turn.
+        start = self.tool_start_callback or (lambda *a, **k: None)
+        complete = self.tool_complete_callback or (lambda *a, **k: None)
+        start("call-a", "web_search", {"query": "alpha"})
         time.sleep(0.15)
-        self.tool_start_callback("call-b", "web_search", {"query": "beta"})
+        start("call-b", "web_search", {"query": "beta"})
         time.sleep(0.15)
         # Complete the second same-name call first. Correlation by tool name
         # would incorrectly mark call-a as failed here.
-        self.tool_complete_callback(
-            "call-b", "web_search", {"query": "beta"}, '{"error": "boom"}'
-        )
+        complete("call-b", "web_search", {"query": "beta"}, '{"error": "boom"}')
         time.sleep(0.15)
-        self.tool_complete_callback(
-            "call-a", "web_search", {"query": "alpha"}, '{"success": true}'
-        )
+        complete("call-a", "web_search", {"query": "alpha"}, '{"success": true}')
         time.sleep(0.15)
         return {"final_response": "done", "messages": [], "api_calls": 1}
 
@@ -1062,14 +1062,13 @@ async def _run_with_agent(
 async def test_slack_native_progress_correlates_concurrent_duplicate_tools_by_id(
     monkeypatch, tmp_path
 ):
+    # No display config: Slack's tier default (tool_progress off) keeps the TEXT lane quiet while
+    # the card lane stays on. An operator-written ``off`` is a different thing (see below).
     adapter, result = await _run_with_agent(
         monkeypatch,
         tmp_path,
         DuplicateNativeToolsAgent,
         session_id="sess-native-ids",
-        config_data={
-            "display": {"platforms": {"slack": {"tool_progress": "off"}}}
-        },
         platform=Platform.SLACK,
         chat_id="C1",
         thread_id="thread-1",
@@ -1129,6 +1128,64 @@ async def test_slack_native_failure_keeps_editing_one_live_text_fallback(
     assert {edit["message_id"] for edit in adapter.edits} == {"progress-1"}
     assert adapter.edits[-1]["content"].endswith("web_search - beta - error")
     assert "web_search - alpha - complete" in adapter.edits[-1]["content"]
+    assert adapter.native_stops == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "display_cfg",
+    [
+        {"platforms": {"slack": {"tool_progress": "off"}}},
+        {"tool_progress": "off"},
+        {"tool_progress_overrides": {"slack": "off"}},
+    ],
+    ids=["platform-override", "global", "legacy-overrides"],
+)
+async def test_slack_operator_tool_progress_off_disables_task_cards(monkeypatch, tmp_path, display_cfg):
+    # Task cards ARE tool progress rendered natively. When the operator writes ``off`` (not the
+    # tier default), neither the card lane nor its text fallback may publish anything.
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        DuplicateNativeToolsAgent,
+        session_id="sess-native-operator-off",
+        config_data={"display": display_cfg},
+        platform=Platform.SLACK,
+        chat_id="D1",
+        chat_type="dm",
+        thread_id=None,
+        adapter_cls=NativeTaskCardAdapter,
+        user_id="U1",
+        scope_id="T1",
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.native_updates == []
+    assert adapter.native_stops == 0
+    assert adapter.sent == []
+    assert adapter.edits == []
+
+
+@pytest.mark.asyncio
+async def test_slack_operator_tool_progress_new_keeps_task_cards(monkeypatch, tmp_path):
+    # An explicit non-off mode keeps the native card lane engaged (text lane stays swallowed by it).
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        DuplicateNativeToolsAgent,
+        session_id="sess-native-operator-new",
+        config_data={"display": {"platforms": {"slack": {"tool_progress": "new"}}}},
+        platform=Platform.SLACK,
+        chat_id="C1",
+        thread_id="thread-1",
+        adapter_cls=NativeTaskCardAdapter,
+        user_id="U1",
+        scope_id="T1",
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.native_updates
+    assert adapter.sent == []
     assert adapter.native_stops == 1
 
 

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1176,6 +1176,39 @@ async def test_slack_operator_tool_progress_off_disables_task_cards(monkeypatch,
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "display_cfg",
+    [
+        {"platforms": {"slack": {"tool_progress": None}}},
+        {"tool_progress": None},
+        {"tool_progress_overrides": {"slack": None}},
+        # null at the platform level over a global "all": the platform inherits "all", cards stay.
+        {"tool_progress": "all", "platforms": {"slack": {"tool_progress": None}}},
+    ],
+    ids=["platform-null", "global-null", "legacy-null", "platform-null-over-global-all"],
+)
+async def test_slack_null_tool_progress_is_inheritance_not_explicit_off(monkeypatch, tmp_path, display_cfg):
+    # A bare key with ``null`` inherits (the resolver skips None); it is not an operator saying "off".
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        DuplicateNativeToolsAgent,
+        session_id="sess-native-null",
+        config_data={"display": display_cfg},
+        platform=Platform.SLACK,
+        chat_id="C1",
+        thread_id="thread-1",
+        adapter_cls=NativeTaskCardAdapter,
+        user_id="U1",
+        scope_id="T1",
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.native_updates
+    assert adapter.native_stops == 1
+
+
+@pytest.mark.asyncio
 async def test_slack_operator_tool_progress_new_keeps_task_cards(monkeypatch, tmp_path):
     # An explicit non-off mode keeps the native card lane engaged (text lane stays swallowed by it).
     adapter, result = await _run_with_agent(

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1131,6 +1131,15 @@ async def test_slack_native_failure_keeps_editing_one_live_text_fallback(
     assert adapter.native_stops == 1
 
 
+class UnsupportedDestinationTaskCardAdapter(NativeTaskCardAdapter):
+    """Relay connector shape for a flat Slack DM: cards need a thread anchor, so the
+    connector rejects every card frame with a deterministic unsupported-destination error."""
+
+    async def send_native_task_card_progress(self, *args, **kwargs) -> SendResult:
+        await super().send_native_task_card_progress(*args, **kwargs)
+        return SendResult(success=False, error="slack task_card requires a thread anchor")
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "display_cfg",
@@ -1187,6 +1196,34 @@ async def test_slack_operator_tool_progress_new_keeps_task_cards(monkeypatch, tm
     assert adapter.native_updates
     assert adapter.sent == []
     assert adapter.native_stops == 1
+
+
+@pytest.mark.asyncio
+async def test_slack_unsupported_card_destination_does_not_degrade_to_text_progress(
+    monkeypatch, tmp_path
+):
+    # Flat Slack DM, no operator config (tier default: tool_progress off). The connector cannot
+    # render a card without a thread anchor; that is a property of the destination, not a
+    # transient native failure, so the lane must NOT fall back to text tool progress the operator
+    # never asked for. Transient failures keep the fallback (see the test above).
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        DuplicateNativeToolsAgent,
+        session_id="sess-native-unsupported-dest",
+        platform=Platform.SLACK,
+        chat_id="D1",
+        chat_type="dm",
+        thread_id=None,
+        adapter_cls=UnsupportedDestinationTaskCardAdapter,
+        user_id="U1",
+        scope_id="T1",
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.native_updates) == 1
+    assert adapter.sent == []
+    assert adapter.edits == []
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_task_card_destination_preflight.py
+++ b/tests/gateway/test_task_card_destination_preflight.py
@@ -1,0 +1,141 @@
+"""Destination eligibility must precede transport failure and its text fallback."""
+
+import queue
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.relay.adapter import RelayAdapter
+from gateway.relay.descriptor import CONTRACT_VERSION, CapabilityDescriptor
+from gateway.run_turn_runner import TurnRunner
+from plugins.platforms.slack.adapter import SlackAdapter
+
+
+class CardTransport:
+    def __init__(self, error="relay outbound timed out"):
+        self.error = error
+        self.frames = []
+
+    async def send_outbound(self, payload, platform=None):
+        self.frames.append(payload)
+        if payload["op"] == "task_card":
+            return {"success": False, "error": self.error, "ambiguous": True}
+        return {"success": True, "message_id": "900.1"}
+
+
+def make_adapter(kind, monkeypatch, *, error="relay outbound timed out"):
+    if kind == "native":
+        adapter = SlackAdapter(PlatformConfig(extra={"reply_in_thread": False}))
+        client = SimpleNamespace(
+            api_call=AsyncMock(side_effect=lambda *a, **kw: {"ts": "900.1"}),
+            chat_postMessage=AsyncMock(return_value={"ts": "900.2"}),
+            chat_update=AsyncMock(return_value={"ts": "900.2"}),
+        )
+        monkeypatch.setattr(adapter, "_get_client", Mock(return_value=client))
+        adapter._app = None
+        return adapter, client
+    descriptor = CapabilityDescriptor(
+        contract_version=CONTRACT_VERSION, platform="slack", label="Slack",
+        max_message_length=39000, supports_draft_streaming=True, supports_edit=True,
+        supports_threads=True, markdown_dialect="slack", len_unit="chars",
+        emoji="", platform_hint="", pii_safe=False,
+        supported_ops=("send", "edit", "task_card", "task_card_stop"),
+    )
+    transport = CardTransport(error)
+    adapter = RelayAdapter(PlatformConfig(), descriptor, transport=transport)
+    adapter._platform_by_chat["D1"] = "slack"
+    adapter._chat_type_by_chat["D1"] = "dm"
+    return adapter, transport
+
+
+async def run_progress(adapter, metadata, reply_to, after_first=None):
+    class Events(queue.Queue):
+        def get_nowait(self):
+            event = super().get_nowait()
+            if event["type"] == "tool.completed" and after_first:
+                after_first()
+            return event
+
+    events = Events()
+    for event_type in ("tool.started", "tool.completed", "tool.completed"):
+        events.put({"type": event_type, "tool_call_id": "call-1", "tool_name": "terminal"})
+    ctx = SimpleNamespace(
+        source=SimpleNamespace(chat_id="D1"), _progress_reply_to=reply_to,
+        _progress_metadata=metadata, _cleanup_progress=False, progress_queue=events,
+        _run_still_current=lambda: not events.empty(), agent_holder=[None],
+    )
+    await TurnRunner(None, ctx)._send_native_task_card_progress(adapter)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind,metadata,reply_to,eligible", [
+    ("native", {}, None, False),
+    ("native", {"thread_id": "100.1"}, "100.1", False),
+    ("native", {"thread_id": "100.1"}, "100.2", True),
+    ("native", {"thread_ts": "100.1"}, None, True),
+    ("relay", {}, None, False),
+    ("relay", {"message_id": "100.2", "reply_to_message_id": "100.2"}, None, False),
+    ("relay", {"thread_id": "100.1"}, "100.2", True),
+    ("relay", {"thread_ts": "100.1"}, None, True),
+    ("relay", {}, "100.1", True),
+])
+async def test_destination_preflight_survives_transport_recovery(
+    monkeypatch, kind, metadata, reply_to, eligible,
+):
+    adapter, io = make_adapter(kind, monkeypatch)
+    original_metadata = dict(metadata)
+    stop = AsyncMock(wraps=adapter.stop_native_task_card_progress)
+    monkeypatch.setattr(adapter, "stop_native_task_card_progress", stop)
+
+    await run_progress(adapter, metadata, reply_to, lambda: setattr(adapter, "_app", object()))
+
+    stop.assert_awaited_once_with("D1", reply_to=reply_to, metadata=metadata)
+    assert metadata == original_metadata
+    if kind == "native":
+        assert bool(io.chat_postMessage.await_count) is eligible
+        assert bool(io.chat_update.await_count) is eligible
+        io.api_call.assert_not_awaited()  # Disconnected first attempt stays on fallback.
+    else:
+        ops = [frame["op"] for frame in io.frames]
+        assert ops == (["task_card", "send", "edit", "edit", "task_card_stop"]
+                       if eligible else ["task_card_stop"])
+        if eligible:
+            card = io.frames[0]
+            anchor = card["metadata"].get("thread_id") or card["metadata"].get("thread_ts")
+            assert anchor == (metadata.get("thread_id") or metadata.get("thread_ts") or reply_to)
+
+    # Suppression belongs to this turn, not the adapter: the same chat can host
+    # a later real thread, which still gets native publication and finalization.
+    if not eligible:
+        if kind == "relay":
+            io.frames.clear()
+        await run_progress(adapter, {"thread_id": "200.1"}, "200.2")
+        if kind == "native":
+            methods = [call.args[0] for call in io.api_call.await_args_list]
+            assert methods == ["chat.startStream", "chat.appendStream", "chat.appendStream",
+                               "chat.appendStream", "chat.stopStream"]
+            assert not adapter._native_task_card_streams
+        else:
+            assert [frame["op"] for frame in io.frames] == [
+                "task_card", "send", "edit", "edit", "task_card_stop",
+            ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error,suppressed", [
+    ("slack task_card requires a thread anchor", True),
+    ("slack task_card requires a thread anchor (Slack streams are thread replies)", True),
+    ("thread anchor lookup timed out", False),
+    ("thread target temporarily unavailable", False),
+])
+async def test_only_explicit_destination_refusals_suppress_threaded_fallback(
+    monkeypatch, error, suppressed,
+):
+    adapter, io = make_adapter("relay", monkeypatch, error=error)
+    await run_progress(adapter, {"thread_id": "100.1"}, "100.2")
+    assert [frame["op"] for frame in io.frames] == (
+        ["task_card", "task_card_stop"] if suppressed
+        else ["task_card", "send", "edit", "edit", "task_card_stop"]
+    )

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -578,15 +578,19 @@ platforms:
   built-in default `tool_progress: off`. Writing `tool_progress: off` yourself
   (globally, under `display.platforms.slack`, or by cycling `/verbose` to off)
   turns cards off as well; `new` or `all` keeps them. A `null` value inherits
-  and is not an "off".
+  and is not an "off". Null also allows the existing environment bridge to
+  supply the mode when no YAML layer sets a non-null value. Changes apply
+  when the next turn resolves its display settings.
 - Cards need a thread. With the card lane active, a chat that has no thread to
   anchor on (a top-level DM under `reply_in_thread: false`) shows no tool
   progress at all rather than text bubbles; replies inside an existing thread
   still get cards.
 - Concurrent calls to the same tool are correlated by real tool-call ID, so
   parallel `web_search` calls each get their own row with the right status.
-- If the native stream fails for a recoverable reason (API error, rate
-  limit), Hermes falls back to a single continuously edited text message so
+- Hermes checks thread eligibility before attempting publication, so a
+  disconnect or timeout cannot turn an unthreaded destination into text fallback.
+- On a supported threaded destination, if the native stream fails for a
+  recoverable reason (API error, rate limit), Hermes falls back to a single continuously edited text message so
   progress stays live for the turn. A relay egress refusal of the destination
   is not recoverable and suppresses progress for the turn.
 - The card stream is stopped exactly once when the turn finalizes, including

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -468,7 +468,7 @@ platforms:
 | `platforms.slack.extra.unfurl_media` | Slack default | Set to `false` to suppress automatic media previews while preserving clickable links. Same caption-ordering and streaming notes as `unfurl_links`. |
 | `platforms.slack.extra.rich_blocks` | `false` | When `true`, agent messages are rendered as [Block Kit](https://docs.slack.dev/block-kit/) blocks (headers, dividers, true nested lists, and native tables). A plain-text fallback is always sent. Tables over Slack's limits fall back to aligned monospace. No app reinstall required — it's a send-side change only. |
 | `platforms.slack.extra.feedback_buttons` | `false` | When `true` with `rich_blocks`, appends Slack-native feedback controls to final replies. |
-| `platforms.slack.extra.native_task_cards` | `false` | When `true`, renders live tool calls as Slack-native plan/task cards. This is an explicit progress opt-in independent of Slack's default `tool_progress: off`; native API failures fall back to one continuously edited text update. |
+| `platforms.slack.extra.native_task_cards` | `false` | When `true`, renders live tool calls as Slack-native plan/task cards. Cards work with Slack's built-in default `tool_progress: off`; an explicitly configured `display.tool_progress: off` (global or `display.platforms.slack`) disables cards too. Native API failures fall back to one continuously edited text update. |
 | `platforms.slack.extra.suggested_prompts` | `[]` | Up to four `{title, message}` prompts for Agent/Assistant DM entry points; accepts either a list or `{title, prompts}`. |
 | `platforms.slack.extra.assistant_thread_titles` | `true` | When `true`, names Agent/Assistant DM threads from the first user message. |
 | `platforms.slack.extra.allow_bots` | `"none"` | Controls messages from other Slack bots: `"none"` ignores them, `"mentions"` accepts a bot message only when **that message itself** @mentions Hermes, and `"all"` accepts all of them. Use `"mentions"` for the safest bot-to-bot collaboration mode. See [Accepting messages from other bots](#accepting-messages-from-other-bots-allow_bots). |
@@ -573,8 +573,11 @@ platforms:
       native_task_cards: true
 ```
 
-- This is an explicit progress opt-in — it works even though Slack's default
-  is `tool_progress: off` (text bubbles spam channels; native cards don't).
+- Cards are the Slack rendering of tool progress. They work with Slack's
+  built-in default `tool_progress: off` (text bubbles spam channels; native
+  cards don't). Writing `tool_progress: off` yourself, globally or under
+  `display.platforms.slack`, turns cards off as well; `new` or `all` keeps
+  them.
 - Concurrent calls to the same tool are correlated by real tool-call ID, so
   parallel `web_search` calls each get their own row with the right status.
 - If the native stream can't start or update, Hermes falls back to a single

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -468,7 +468,7 @@ platforms:
 | `platforms.slack.extra.unfurl_media` | Slack default | Set to `false` to suppress automatic media previews while preserving clickable links. Same caption-ordering and streaming notes as `unfurl_links`. |
 | `platforms.slack.extra.rich_blocks` | `false` | When `true`, agent messages are rendered as [Block Kit](https://docs.slack.dev/block-kit/) blocks (headers, dividers, true nested lists, and native tables). A plain-text fallback is always sent. Tables over Slack's limits fall back to aligned monospace. No app reinstall required — it's a send-side change only. |
 | `platforms.slack.extra.feedback_buttons` | `false` | When `true` with `rich_blocks`, appends Slack-native feedback controls to final replies. |
-| `platforms.slack.extra.native_task_cards` | `false` | When `true`, renders live tool calls as Slack-native plan/task cards. Cards work with Slack's built-in default `tool_progress: off`; an explicitly configured `display.tool_progress: off` (global or `display.platforms.slack`) disables cards too. Native API failures fall back to one continuously edited text update. |
+| `platforms.slack.extra.native_task_cards` | `false` | When `true`, renders live tool calls as Slack-native plan/task cards. Cards work with Slack's built-in default `tool_progress: off`; an explicitly configured `display.tool_progress: off` (global or `display.platforms.slack`) disables cards too. Native API failures fall back to one continuously edited text update; chats that cannot host a card (flat DMs with `reply_in_thread: false`) show no tool progress. |
 | `platforms.slack.extra.suggested_prompts` | `[]` | Up to four `{title, message}` prompts for Agent/Assistant DM entry points; accepts either a list or `{title, prompts}`. |
 | `platforms.slack.extra.assistant_thread_titles` | `true` | When `true`, names Agent/Assistant DM threads from the first user message. |
 | `platforms.slack.extra.allow_bots` | `"none"` | Controls messages from other Slack bots: `"none"` ignores them, `"mentions"` accepts a bot message only when **that message itself** @mentions Hermes, and `"all"` accepts all of them. Use `"mentions"` for the safest bot-to-bot collaboration mode. See [Accepting messages from other bots](#accepting-messages-from-other-bots-allow_bots). |
@@ -578,6 +578,9 @@ platforms:
   cards don't). Writing `tool_progress: off` yourself, globally or under
   `display.platforms.slack`, turns cards off as well; `new` or `all` keeps
   them.
+- Cards need a thread. In flat DMs (`reply_in_thread: false`) Slack cannot
+  render them, and Hermes shows no tool progress rather than degrading to text
+  bubbles you did not enable.
 - Concurrent calls to the same tool are correlated by real tool-call ID, so
   parallel `web_search` calls each get their own row with the right status.
 - If the native stream can't start or update, Hermes falls back to a single

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -429,10 +429,11 @@ platforms:
       # Requires rich_blocks: true. Default: false.
       feedback_buttons: false
 
-      # Render live tool calls as Slack-native plan/task cards. This explicit
-      # opt-in activates native progress even when text tool_progress is off.
-      # If Slack rejects the native stream, Hermes keeps one editable text
-      # fallback current for the rest of the turn.
+      # Render live tool calls as Slack-native plan/task cards. Works with
+      # Slack's built-in tool_progress: off default; a tool_progress: off you
+      # write yourself disables cards too. Cards need a thread: an un-threaded
+      # chat shows no tool progress. Recoverable native API failures keep one
+      # editable text fallback current for the rest of the turn.
       native_task_cards: false
 
       # Suggested prompts pinned at the top of Agent view's Messages tab.
@@ -468,7 +469,7 @@ platforms:
 | `platforms.slack.extra.unfurl_media` | Slack default | Set to `false` to suppress automatic media previews while preserving clickable links. Same caption-ordering and streaming notes as `unfurl_links`. |
 | `platforms.slack.extra.rich_blocks` | `false` | When `true`, agent messages are rendered as [Block Kit](https://docs.slack.dev/block-kit/) blocks (headers, dividers, true nested lists, and native tables). A plain-text fallback is always sent. Tables over Slack's limits fall back to aligned monospace. No app reinstall required — it's a send-side change only. |
 | `platforms.slack.extra.feedback_buttons` | `false` | When `true` with `rich_blocks`, appends Slack-native feedback controls to final replies. |
-| `platforms.slack.extra.native_task_cards` | `false` | When `true`, renders live tool calls as Slack-native plan/task cards. Cards work with Slack's built-in default `tool_progress: off`; an explicitly configured `display.tool_progress: off` (global or `display.platforms.slack`) disables cards too. Native API failures fall back to one continuously edited text update; chats that cannot host a card (flat DMs with `reply_in_thread: false`) show no tool progress. |
+| `platforms.slack.extra.native_task_cards` | `false` | When `true`, renders live tool calls as Slack-native plan/task cards. Cards work with Slack's built-in default `tool_progress: off`; an explicitly configured `display.tool_progress: off` (global or `display.platforms.slack`; `/verbose` writes the same key) disables cards too. Cards need a thread: when the card lane is active and the chat has no thread to anchor on (a top-level DM with `reply_in_thread: false`), Hermes shows no tool progress instead of text bubbles. Recoverable native API failures fall back to one continuously edited text update. |
 | `platforms.slack.extra.suggested_prompts` | `[]` | Up to four `{title, message}` prompts for Agent/Assistant DM entry points; accepts either a list or `{title, prompts}`. |
 | `platforms.slack.extra.assistant_thread_titles` | `true` | When `true`, names Agent/Assistant DM threads from the first user message. |
 | `platforms.slack.extra.allow_bots` | `"none"` | Controls messages from other Slack bots: `"none"` ignores them, `"mentions"` accepts a bot message only when **that message itself** @mentions Hermes, and `"all"` accepts all of them. Use `"mentions"` for the safest bot-to-bot collaboration mode. See [Accepting messages from other bots](#accepting-messages-from-other-bots-allow_bots). |
@@ -574,17 +575,20 @@ platforms:
 ```
 
 - Cards are the Slack rendering of tool progress. They work with Slack's
-  built-in default `tool_progress: off` (text bubbles spam channels; native
-  cards don't). Writing `tool_progress: off` yourself, globally or under
-  `display.platforms.slack`, turns cards off as well; `new` or `all` keeps
-  them.
-- Cards need a thread. In flat DMs (`reply_in_thread: false`) Slack cannot
-  render them, and Hermes shows no tool progress rather than degrading to text
-  bubbles you did not enable.
+  built-in default `tool_progress: off`. Writing `tool_progress: off` yourself
+  (globally, under `display.platforms.slack`, or by cycling `/verbose` to off)
+  turns cards off as well; `new` or `all` keeps them. A `null` value inherits
+  and is not an "off".
+- Cards need a thread. With the card lane active, a chat that has no thread to
+  anchor on (a top-level DM under `reply_in_thread: false`) shows no tool
+  progress at all rather than text bubbles; replies inside an existing thread
+  still get cards.
 - Concurrent calls to the same tool are correlated by real tool-call ID, so
   parallel `web_search` calls each get their own row with the right status.
-- If the native stream can't start or update, Hermes falls back to a single
-  continuously edited text message so progress stays live for the turn.
+- If the native stream fails for a recoverable reason (API error, rate
+  limit), Hermes falls back to a single continuously edited text message so
+  progress stays live for the turn. A relay egress refusal of the destination
+  is not recoverable and suppresses progress for the turn.
 - The card stream is stopped exactly once when the turn finalizes, including
   on interrupt/disconnect, so no dangling live indicator is left behind.
 


### PR DESCRIPTION
## Summary

Slack task cards are tool progress rendered natively, but the card lane did not follow the operator's `tool_progress` setting, and in un-threaded chats its fallback re-created the text bubbles the setting was meant to remove. This PR makes an operator-written `tool_progress: off` disable cards too, keeps cards on for the unconfigured tier default, and stops the card lane from degrading to text in chats that cannot host a card.

## Symptom

Relay-fronted Slack, flat DMs (`reply_in_thread: false`), `display.platforms.slack.tool_progress: off`. Every tool call still produced an edited text message:

```
Hermes is working
- web_search - running
```

## Cause

- The text progress lane honours `off`. The blob comes from the task-card lane (`run_turn_runner.py` `_TaskCardState.fallback_text`).
- The card lane is gated only on `adapter.native_task_cards_enabled()`. #29483 (eb137762ff) decoupled it from `tool_progress` on purpose: Slack's built-in display tier is `tool_progress: off`, so requiring both would have left cards inactive for everyone. That decoupling also meant an operator who wrote `off` could not turn cards off.
- On the relay adapter, `native_task_cards_enabled()` returns the connector capability (#85796, 3683e70043), and the connector always advertises `task_card`. No configuration disabled cards on relay.
- In a flat DM the connector rejects the card (`slack task_card requires a thread anchor`; native Slack: `No Slack thread target`). The lane treated that like a transient native failure and fell back to an editable text message on every event.

## Change

1. `0032e85` `gateway/run_turn.py`: the card lane is disabled when the operator wrote `tool_progress: off` (global, `display.platforms.<platform>`, legacy `display.tool_progress_overrides`, or the `HERMES_TOOL_PROGRESS_MODE` bridge). The unconfigured tier default keeps cards on. `new`/`all` keep cards. One gate, both adapters (native Slack and relay); no new config key.
2. `e2183f3` `gateway/run_turn_runner.py`: a card refusal that describes the destination (no thread anchor / no thread target) suppresses card publication and the text fallback for the rest of the turn, at info level. Recoverable native failures keep the editable text fallback.
3. `7339f52` review fixes: `tool_progress: null` inherits (the resolver skips None) and is not an "off"; `_TaskCardState.egress_declined` renamed `publication_suppressed` because it now covers both causes; docs corrected.

Docs: `website/docs/user-guide/messaging/slack.md` (yaml comment, table row, Native Task Cards section).

## Behaviour table

| config | before | after |
|---|---|---|
| unconfigured (tier default off) | cards on, text off | unchanged |
| `tool_progress: off` written | cards on | cards off, text off |
| `tool_progress: null` | cards on | unchanged (inherits) |
| `tool_progress: new` / `all` | cards on | unchanged |
| flat DM, card lane active | text bubbles on every event | no tool progress |
| threaded, transient native failure | editable text fallback | unchanged |

## Proof

- `tests/gateway/test_run_progress_topics.py`: explicit off (3 config shapes) asserts no native card send, no stop, no text send/edit; `new` keeps cards; unconfigured keeps cards (existing test, config removed); 4 null cases keep cards; unsupported destination: exactly one native attempt, no text send/edit. Tests assert what reaches the adapter, not helper internals. The duplicate-tools fixture now mirrors production's `_safe_callback` null guard.
- Mutation checks: stubbing the `run_turn.py` gate → 3 explicit-off tests red on `native_updates == []`; stubbing the destination check → unsupported-destination test red on `sent == []`; reverting the null fix to key presence → 3 null tests red on `native_updates`.
- Canonical gate on the original reviewed tree (`7339f52`): `scripts/run_tests.sh tests/gateway/` → 822 files, 8217 passed, 0 failed, 17 skipped.
- Adversarial review (second profile, two rounds): round 1 found the null-as-explicit defect (fixed in `7339f52`); round 2 approved at the reviewed head.

Not live-verified yet. Before merge, staging must exercise explicit-off flat DM, unconfigured flat DM, threaded positive control, and transient-first flat DM. The original turn tests fake the adapter and agent; the new destination tests use real native/relay adapters with fault-injected external I/O. No deployed Slack verification is claimed.

## Not in this PR

- The native Slack default `platforms.slack.extra.native_task_cards: false` is unchanged. Proposal to flip it to on lands separately.
- Null plus the existing environment bridge is addressed in this PR: null inherits, and the winning mode and explicit intent are resolved together.
- Connector-side support for cards in flat DMs (recipient pair instead of `thread_ts`) is a gateway-gateway change.


## Self-review follow-up

- `2e1bb56bf3` resolves the mode and explicit intent from the same winning source. The canonical display resolver and progress gate share non-null YAML selection, followed by the existing env bridge and tier defaults. Null plus env `all`/`new` keeps cards, while explicit YAML off still wins.
- `4d86193e9c` checks card destination eligibility in the native/relay adapter before transport I/O. Native Slack reuses its destination-key resolver. Relay checks the metadata actually used for card placement. A first timeout cannot send an unthreaded destination into text fallback. Suppression stays per turn, and finalization remains unconditional. Exact known refusals remain compatible with older adapters.
- `5c4e2c5774` corrects the fallback docstring and documents next-turn config resolution and destination preflight.

Verification of the follow-up:
- Canonical focused gate: 4 files, 93 passed, 0 failed.
- Config mutation: restoring the old reader makes the retained null/env tests fail on missing native updates; restoring the fix passes all 12 null cases.
- Destination tests: real native and relay adapters, disconnected/timeout first attempt, supported threaded fallback, a subsequent threaded turn, exact refusals versus transient error text, and finalization. Preflight removal makes the unsupported cases fail.
- Both original fault-injection probes rerun successfully: null/env now resolves to `all` with cards enabled, and flat-DM recovery produces no text sends/edits.
- Focused lint and diff checks pass. Full gateway-area gate result is recorded in the follow-up comment when complete. Live staging remains a pre-merge requirement.
