### PR TITLE
fix(tools): stop disabled tools from triggering retry loops

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -711,15 +711,16 @@ def _dispatch_bridge_tool(function_name: str, function_args: Dict[str, Any],
         return ts.dispatch_tool_search(args, current_tool_defs=current_defs), None
     if function_name == ts.TOOL_DESCRIBE_NAME:
         return ts.dispatch_tool_describe(args, current_tool_defs=current_defs), None
-    underlying_name, underlying_args, err = ts.resolve_underlying_call(args)
+    underlying_name, underlying_args, err = ts.resolve_underlying_call(
+        args, current_tool_defs=current_defs,
+    )
     if err or not underlying_name:
         return tool_error(err or "tool_call could not be resolved"), None
     if underlying_name == ts.CONNECTOR_BATCH_SENTINEL:
         if not ts.connections_in_scope(current_defs):
             return tool_error("Connectors are not available in this session."), None
         return None, (underlying_name, underlying_args)
-    # Defense in depth: resolve_underlying_call only checks the global
-    # registry; also require membership in the session-scoped catalog.
+    # Deferrable tools must also belong to the session-scoped catalog.
     if underlying_name not in ts.scoped_deferrable_names(current_defs):
         return tool_error(f"'{underlying_name}' is not available in this session. "
                           "Use tool_search to find tools you can call."), None

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -552,14 +552,25 @@ class TestBridgeDispatch:
             result = json.loads(handle_function_call("tool_call", {}))
         assert "requires 'calls'" in result["error"]
 
-    def test_tool_call_reports_registered_tool_disabled_for_session(self):
-        with patch("model_tools.get_tool_definitions", return_value=[]):
-            result = json.loads(handle_function_call(
-                "tool_call", {"name": "terminal", "arguments": {"command": "true"}},
-            ))
+    def test_tool_call_distinguishes_disabled_direct_and_unknown_tools(self):
+        terminal_call = {
+            "name": "terminal", "arguments": {"command": "true"},
+        }
 
-        assert "not enabled for this session/platform" in result["error"]
-        assert "call it directly" not in result["error"]
+        disabled = json.loads(handle_function_call(
+            "tool_call", terminal_call, enabled_toolsets=["file"],
+        ))
+        direct = json.loads(handle_function_call(
+            "tool_call", terminal_call, enabled_toolsets=["terminal"],
+        ))
+        unknown = json.loads(handle_function_call(
+            "tool_call", {"name": "totally_fake_tool_xyz"}, enabled_toolsets=["file"],
+        ))
+
+        assert "not enabled for this session/platform" in disabled["error"]
+        assert "call it directly" not in disabled["error"]
+        assert "call it directly" in direct["error"]
+        assert "not available in this session" in unknown["error"]
 
     def test_tool_call_rejects_out_of_scope_and_unwraps_in_scope(self):
         import tools.tool_search as ts

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -552,6 +552,15 @@ class TestBridgeDispatch:
             result = json.loads(handle_function_call("tool_call", {}))
         assert "requires 'calls'" in result["error"]
 
+    def test_tool_call_reports_registered_tool_disabled_for_session(self):
+        with patch("model_tools.get_tool_definitions", return_value=[]):
+            result = json.loads(handle_function_call(
+                "tool_call", {"name": "terminal", "arguments": {"command": "true"}},
+            ))
+
+        assert "not enabled for this session/platform" in result["error"]
+        assert "call it directly" not in result["error"]
+
     def test_tool_call_rejects_out_of_scope_and_unwraps_in_scope(self):
         import tools.tool_search as ts
         with patch("model_tools.get_tool_definitions", return_value=[]), \

--- a/tests/tools/test_tool_search_multiquery.py
+++ b/tests/tools/test_tool_search_multiquery.py
@@ -475,6 +475,14 @@ class TestBatchedDescribe:
         )
         assert name not in result.get("not_found", [])
 
+        disabled = json.loads(dispatch_tool_describe(
+            {"names": [name]},
+            current_tool_defs=[],
+            config=ToolSearchConfig.from_raw({}),
+        ))
+        assert "not enabled for this session/platform" in disabled["errors"][name]
+        assert "call it directly" not in disabled["errors"][name]
+
     def test_registry_lookup_failure_is_not_found(self, monkeypatch):
         from tools.registry import registry
         from tools.tool_search import ToolSearchConfig, dispatch_tool_describe

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -479,7 +479,7 @@ def dispatch_tool_describe(args: Dict[str, Any], *, current_tool_defs: List[Dict
                            connector_describe: Optional[Any] = None) -> str:
     """Execute the ``tool_describe`` bridge tool -> JSON ``{tools: {name: {description,
     parameters}}, not_found: [...]  (unknown / not in this assembly; never fails the call),
-    errors: {name: msg}  (registered but non-deferrable)}``. Duplicates dedupe silently."""
+    errors: {name: msg}  (registered direct or session-disabled)}``. Duplicates dedupe silently."""
     config = config or load_config_readonly()
     names, err = _string_list_arg(
         args, "names", dedupe=True, max_items=_MAX_DESCRIBE_NAMES_PER_CALL,
@@ -488,6 +488,7 @@ def dispatch_tool_describe(args: Dict[str, Any], *, current_tool_defs: List[Dict
         return err
     deferrable = _deferrable_in(current_tool_defs)
     by_name = {name: _fn(td) for td, name in zip(deferrable, _tool_def_names(deferrable)) if name}
+    current_names = frozenset(_tool_def_names(current_tool_defs))
     remote_schemas = remote_schemas_for(names, current_tool_defs, connector_describe)
 
     tools: Dict[str, Dict[str, Any]] = {}
@@ -506,10 +507,14 @@ def dispatch_tool_describe(args: Dict[str, Any], *, current_tool_defs: List[Dict
             not_found.append(name)
         elif _registry_entry(name) is not None and not is_deferrable_tool_name(
             name, load_config_readonly().effective_defer_tools):
-            # Registered but bridge/core/GUI-surface: a real name, wrong door.
-            errors[name] = (
-                f"'{name}' is not a deferrable tool. If you see it in the tools list "
-                "already, call it directly; otherwise check the spelling against tool_search.")
+            if name in current_names:
+                errors[name] = (
+                    f"'{name}' is not a deferrable tool. If you see it in the tools list "
+                    "already, call it directly; otherwise check the spelling against tool_search.")
+            else:
+                errors[name] = (
+                    f"'{name}' is a known tool, but it is not enabled for this session/platform "
+                    "and is not callable this turn.")
         else:
             not_found.append(name)
     result: Dict[str, Any] = {"tools": tools}
@@ -530,7 +535,9 @@ def scoped_deferrable_names(tool_defs: List[Dict[str, Any]]) -> frozenset[str]:
                      if n and is_deferrable_tool_name(n, defer_tools))
 
 
-def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[str, Any], Optional[str]]:
+def resolve_underlying_call(
+    args: Dict[str, Any], *, current_tool_defs: Optional[List[Dict[str, Any]]] = None,
+) -> Tuple[Optional[str], Dict[str, Any], Optional[str]]:
     """Parse a ``tool_call`` invocation into (underlying_name, args, error_msg).
 
     Used by:
@@ -560,6 +567,16 @@ def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[s
     name = entries[0]["name"]
     raw_args = entries[0]["arguments"]
     if not is_deferrable_tool_name(name, load_config_readonly().effective_defer_tools):
+        if current_tool_defs is not None and name not in frozenset(_tool_def_names(current_tool_defs)):
+            if _registry_entry(name) is not None:
+                return None, {}, (
+                    f"'{name}' is a known tool, but it is not enabled for this session/platform "
+                    "and is not callable this turn."
+                )
+            return None, {}, (
+                f"'{name}' is not available in this session. "
+                "Use tool_search to find tools you can call."
+            )
         return None, {}, (
             f"'{name}' is not a deferrable tool. If it appears in the model-facing tools "
             "list already, call it directly instead of via tool_call."


### PR DESCRIPTION
## What does this PR do?

A CLI or one-shot session can ask for a globally registered tool that is disabled for its current platform. The tool-search bridge previously told the model to call that absent tool directly, causing repeated guaranteed failures. This change checks the session's assembled tool definitions before giving direct-call guidance and returns a terminal unavailable message for disabled tools.

### Symptom

`tool_describe` and `tool_call` tell the model to call a registered non-deferrable tool directly even when that tool is absent from the current session's function list.

### Impact

Models can repeatedly attempt an impossible call until the same-tool failure guard halts an otherwise valid CLI or one-shot task.

### Bug Cause

**Trigger:** `tools/tool_search.py:dispatch_tool_describe` and `tools/tool_search.py:resolve_underlying_call` when a requested non-deferrable tool is globally registered but missing from `current_tool_defs`.

**Causal chain:**
1. Platform toolset selection omits a registered direct tool from a session.
2. Both bridge paths classify the name from the process-global registry without checking session membership.
3. The model receives direct-call guidance for a function that cannot appear in the turn and retries the failed call.

**Why it is wrong:** Global registration proves that Hermes knows a tool, but it does not prove that the current session exposes it.

**Working sibling / contrast:** Deferred tools already pass through a session-scoped catalog gate before dispatch. The broken branch returned earlier for non-deferrable tools.

**Ruled out:** The retry guard is not the cause. It correctly halts repeated failures after the bridge has supplied misleading recovery guidance.

### Fix

`tool_describe` now reserves direct-call guidance for names present in the session definitions and explicitly reports globally known, session-disabled tools as not callable. `tool_call` receives the same session definitions and applies the same distinction before resolving a direct tool.

## Related Issue

Closes #108663

## Why this PR vs existing PR #108670

In `tools/tool_search.py`, PR #108670 puts a globally registered but session-disabled `tool_describe` target into `not_found`, making it indistinguishable from a genuinely unknown name. This PR preserves the issue's required three-way distinction: in-scope direct tools retain direct-call guidance, globally known session-disabled tools get an explicit terminal unavailable message, and unknown names remain lookup misses. It also prevents an unknown `tool_call` target from falling through to direct-call guidance when session definitions are available.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/tool_search.py` - classify direct, session-disabled, and unknown names using the current session definitions.
- `model_tools.py` - pass the session-scoped definitions into `tool_call` resolution.
- `tests/tools/test_tool_search_multiquery.py` - cover direct versus session-disabled describe guidance.
- `tests/test_model_tools.py` - cover session-disabled tool-call guidance through the real dispatcher.

## How to Test

1. Run the focused tool-search and dispatcher suites.
2. Confirm all 106 tests pass and disabled registered tools never receive `call it directly` guidance.

```bash
scripts/run_tests.sh -j 1 tests/test_model_tools.py tests/tools/test_tool_search.py tests/tools/test_tool_search_multiquery.py tests/tools/test_tool_search_context_provider.py -q
```

Result: 106 passed, 0 failed.

## Checklist

### Code

- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs and statically compared the linked competing implementation.
- [x] My PR contains only changes related to this fix.
- [x] The relevant test suites pass.
- [x] I've added tests for my changes.
- [x] I've tested on my platform: Windows 11.

### Documentation & Housekeeping

- [x] Relevant documentation changes are N/A.
- [x] Config example changes are N/A because no config key changed.
- [x] Architecture and workflow documentation changes are N/A.
- [x] Cross-platform impact was considered; the change is platform-neutral session classification.
- [x] Tool schema changes are N/A because the bridge schema is unchanged.
