### PR TITLE
fix(skills): preserve instructional results through both budgets

### DIFF
--- a/tests/tools/test_instructional_result_budgets.py
+++ b/tests/tools/test_instructional_result_budgets.py
@@ -1,0 +1,43 @@
+"""Instruction loads survive result spilling even when the turn exceeds its budget."""
+
+from dataclasses import replace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.budget_config import budget_for_context_window
+from tools.tool_result_storage import enforce_turn_budget, maybe_persist_tool_result
+
+
+@pytest.mark.parametrize("tool_name", ["skill_view", "read_file"])
+@pytest.mark.parametrize("storage", ["missing", "fails", "works"])
+@pytest.mark.parametrize("context_length", [65_536, 256_000])
+def test_instructional_results_survive_both_budgets(tool_name, storage, context_length):
+    content = "intro\n" + "instruction\n" * 20_000 + "final instruction"
+    env = None if storage == "missing" else MagicMock()
+    if env is not None:
+        env.execute.return_value = {"returncode": int(storage == "fails")}
+    config = replace(budget_for_context_window(context_length), tool_overrides={tool_name: 1})
+    output = maybe_persist_tool_result(content, tool_name, "instructions", env, config)
+    messages = [{"name": tool_name, "tool_call_id": "instructions", "content": output}]
+    enforce_turn_budget(messages, env, config)
+    assert messages[0]["content"] == content
+    if env is not None:
+        env.execute.assert_not_called()
+
+
+@pytest.mark.parametrize("identity_key", ["name", "tool_name"])
+def test_turn_budget_spills_only_eligible_results(identity_key):
+    content = "read every instruction\n" * 10_000
+    messages = [
+        {identity_key: name, "tool_call_id": name, "content": content}
+        for name in ["skill_view", "read_file", "custom_instructions", "terminal", ""]
+    ]
+    # Existing registry escape hatches must be honored by aggregate enforcement too.
+    def threshold(name, default):
+        return float("inf") if name == "custom_instructions" else default
+
+    with patch("tools.registry.registry.get_max_result_size", side_effect=threshold):
+        enforce_turn_budget(messages, config=budget_for_context_window(65_536))
+    assert all(message["content"] == content for message in messages[:3])
+    assert all(message["content"] != content for message in messages[3:])

--- a/tools/budget_config.py
+++ b/tools/budget_config.py
@@ -5,7 +5,11 @@ from dataclasses import dataclass, field
 from typing import Dict
 
 # Never overridden; read_file=inf prevents infinite persist->read->persist loops.
-PINNED_THRESHOLDS: Dict[str, float] = {"read_file": float("inf")}
+# skill_view loads instructions (including references) the model must read fully.
+PINNED_THRESHOLDS: Dict[str, float] = {
+    "read_file": float("inf"),
+    "skill_view": float("inf"),
+}
 
 # Single source of truth for the defaults; tool_result_storage.py imports these.
 DEFAULT_RESULT_SIZE_CHARS: int = 100_000

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -233,11 +233,16 @@ def maybe_persist_tool_result(content: str, tool_name: str, tool_use_id: str, en
 def enforce_turn_budget(tool_messages: list[dict], env=None,
                         config: BudgetConfig = DEFAULT_BUDGET) -> list[dict]:
     """Layer 3: persist the largest non-persisted results first until the turn's aggregate is
-    under budget. Mutates the list in-place and returns it."""
+    under budget. Unlimited per-tool thresholds are protected: their content counts
+    toward the total, but only eligible results can spill. A protected-only remainder
+    may exceed the budget. Mutates the list in-place and returns it."""
     sizes = [len(msg.get("content", "")) for msg in tool_messages]
     total_size = sum(sizes)
     candidates = [(i, size) for i, size in enumerate(sizes)
-                  if PERSISTED_OUTPUT_TAG not in tool_messages[i].get("content", "")]
+                  if PERSISTED_OUTPUT_TAG not in tool_messages[i].get("content", "")
+                  and config.resolve_threshold(
+                      tool_messages[i].get("name") or tool_messages[i].get("tool_name") or ""
+                  ) != float("inf")]
     if total_size <= config.turn_budget:
         return tool_messages
     for idx, size in sorted(candidates, key=lambda x: x[1], reverse=True):


### PR DESCRIPTION
## Summary
- Keep complete `skill_view` results in model context, including linked reference reads. Large instructional results currently become a 1,500-character preview; requiring the model to page through the rest defeats the skill-loading contract.
- Honor unlimited per-tool thresholds during aggregate enforcement too. This also preserves the existing `read_file` exemption and registry-provided unlimited thresholds. Eligible results still spill; a protected-only remainder may exceed the tool-output budget.
- No schema changes, new configuration, or changes to conversation compression. Both sequential and parallel executors use the same budget functions.

## Test plan
- [x] `scripts/run_tests.sh tests/tools/test_instructional_result_budgets.py tests/tools/test_budget_config.py tests/tools/test_tool_result_storage.py` — 73 passed on current upstream.
- [x] Regression matrix covers small/default context windows, missing/failed/working sandbox storage, both tool identity fields, mixed batches, and registry exemptions.
- [x] Equivalent minimal backport: 93 focused tests passed; consumer replay verifies complete on-disk skills and references in the next serialized model request for single/parallel loads.
