### PR TITLE
fix(multiplex): serve every profile, scope sessions.* + proxy readers, dashboard -p child env

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -42,37 +42,6 @@ def _coerce_bool(value: Any, default: bool = True) -> bool:
     return is_truthy_value(value, default=default)
 
 
-def _normalize_multiplex_profile_allowlist(value: Any) -> Optional[List[str]]:
-    """Normalize the optional named-profile allowlist: ``None`` = serve all; a malformed
-    outer value fails safe to ``[]`` (default profile only); bad entries are skipped."""
-    if value is None:
-        return None
-    if not isinstance(value, list):
-        logger.warning(
-            "Invalid gateway.multiplex_profile_allowlist (expected a list, got %s); "
-            "serving only the default profile",
-            type(value).__name__,
-        )
-        return []
-
-    from hermes_cli.profiles import normalize_profile_name, validate_profile_name
-
-    normalized: List[str] = []
-    for entry in value:
-        if not isinstance(entry, str):
-            logger.warning("Skipping invalid gateway.multiplex_profile_allowlist entry %r (expected a profile name)", entry)
-            continue
-        try:
-            name = normalize_profile_name(entry)
-            validate_profile_name(name)
-        except ValueError:
-            logger.warning("Skipping invalid gateway.multiplex_profile_allowlist entry %r", entry)
-            continue
-        if name != "default" and name not in normalized:
-            normalized.append(name)
-    return normalized
-
-
 def _env_multiplex_profiles_override() -> "bool | None":
     """GATEWAY_MULTIPLEX_PROFILES operator override: True/False for a recognized token.
 
@@ -557,9 +526,8 @@ class GatewayConfig:
     thread_sessions_per_user: bool = False  # False = threads shared across participants
     max_concurrent_sessions: Optional[int] = None  # Positive int caps simultaneous active sessions
     # Opt-in: the default profile's gateway serves every profile on the host (profiles stamped into
-    # session keys, per-profile adapters/credentials). Allowlist None = serve all; [] = default only.
+    # session keys, per-profile adapters/credentials).
     multiplex_profiles: bool = False
-    multiplex_profile_allowlist: Optional[List[str]] = None
     # Public HTTPS endpoint for scoped RoomLink calls (an API key alone must never advertise a
     # route); HERMES_ROOM_LINK_URL overrides.
     room_link_url: Optional[str] = None
@@ -588,14 +556,13 @@ class GatewayConfig:
     _SCALAR_DICT_FIELDS = (
         "write_sessions_json", "always_log_local", "filter_silence_narration", "stt_enabled",
         "stt_echo_transcripts", "group_sessions_per_user", "thread_sessions_per_user",
-        "max_concurrent_sessions", "multiplex_profiles", "multiplex_profile_allowlist",
+        "max_concurrent_sessions", "multiplex_profiles",
         "room_link_url", "systemd_watchdog_seconds", "loop_watchdog",
         "loop_watchdog_probe_interval_s", "loop_watchdog_probe_timeout_s",
         "loop_watchdog_max_strikes", "unauthorized_dm_behavior",
     )
 
     def __post_init__(self) -> None:
-        self.multiplex_profile_allowlist = _normalize_multiplex_profile_allowlist(self.multiplex_profile_allowlist)
         self.systemd_watchdog_seconds = coerce_systemd_watchdog_seconds(self.systemd_watchdog_seconds)
 
     def get_connected_platforms(self) -> List[Platform]:
@@ -731,7 +698,6 @@ class GatewayConfig:
             stt_enabled=_coerce_bool(stt_setting("stt_enabled", "enabled"), True),
             stt_echo_transcripts=_coerce_bool(stt_setting("stt_echo_transcripts", "echo_transcripts"), True),
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),
-            multiplex_profile_allowlist=pick("multiplex_profile_allowlist"),
             room_link_url=room_link_url if isinstance(room_link_url, str) else None,
             systemd_watchdog_seconds=systemd_watchdog_seconds,
             loop_watchdog=_coerce_bool(pick("loop_watchdog"), True),

--- a/gateway/config_loader.py
+++ b/gateway/config_loader.py
@@ -72,7 +72,7 @@ _TOPLEVEL_BRIDGE: tuple = (
     ("stt", "stt", "presence", lambda v: isinstance(v, dict), None),
     *_presence("stt_echo_transcripts", "group_sessions_per_user", "thread_sessions_per_user"),
     ("multiplex_profiles", "multiplex_profiles", "gwdata", None, None),
-    *_presence("multiplex_profile_allowlist", "room_link_url"),
+    *_presence("room_link_url"),
     ("profile_routes", "profile_routes", "none", lambda v: isinstance(v, list), None),
     *_presence("max_concurrent_sessions"),
     ("systemd_watchdog_seconds", "systemd_watchdog_seconds", "nested", None, None),

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1459,9 +1459,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             return None if _prefix_names_served_profile(profile) else _PROFILE_REJECTED
         try:
             from hermes_cli.profiles import profiles_to_serve
-            served = {
-                name for name, _ in profiles_to_serve(
-                    multiplex=True, profile_allowlist=getattr(cfg, "multiplex_profile_allowlist", None))}
+            served = {name for name, _ in profiles_to_serve(multiplex=True)}
         except Exception:
             return _PROFILE_REJECTED
         return profile if profile in served else _PROFILE_REJECTED

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -390,8 +390,7 @@ class WebhookAdapter(BasePlatformAdapter):
             return _PROFILE_REJECTED
         try:
             from hermes_cli.profiles import profiles_to_serve
-            allowlist = getattr(cfg, "multiplex_profile_allowlist", None)
-            served = {name for name, _ in profiles_to_serve(multiplex=True, profile_allowlist=allowlist)}
+            served = {name for name, _ in profiles_to_serve(multiplex=True)}
         except Exception:
             return _PROFILE_REJECTED
         return profile if profile in served else _PROFILE_REJECTED

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1605,7 +1605,12 @@ def _reload_runtime_env_preserving_config_authority() -> None:
 
 
 def _bridge_max_turns_from_config(home: "Path") -> None:
-    """Re-bridge agent.max_turns (+ sessions.*) per turn; managed overlay applies or it reverts."""
+    """Re-bridge agent.max_turns (+ sessions.*) per turn; managed overlay applies or it reverts.
+    Skipped inside a served secondary's scope: the env slots are the launch profile's and
+    hermes_state reads the routed profile's ``sessions.*`` from its own config under scope."""
+    from gateway.platforms._shared import profile_scoped
+    if profile_scoped():
+        return
     config_path = home / 'config.yaml'
     if not config_path.exists():
         return
@@ -1658,15 +1663,14 @@ class HygieneTurnHoldExceeded(Exception):
 def _multiplex_profile_homes(config: object) -> list[tuple[str, "Path"]]:
     """Return the authoritative profile set for one multiplex gateway config."""
     from hermes_cli.profiles import profiles_to_serve
-    return list(profiles_to_serve(
-        multiplex=True, profile_allowlist=getattr(config, "multiplex_profile_allowlist", None)))
+    return list(profiles_to_serve(multiplex=True))
 
 
 def _cron_tick_profile_homes(config: object) -> list[tuple[str, "Path"]]:
     """Profile homes the in-process ticker visits under multiplex: the served set PLUS the
-    process-active profile. ``profiles_to_serve`` starts at default + allowlist, so a
-    ``--profile <name>`` multiplexer was omitted unless allowlisted — and allowlisting it would
-    start a second adapter on its own bot token. Adapter startup already skips ``active``."""
+    process-active profile: ``profiles_to_serve`` lists default + every live named profile, but a
+    ``--profile <name>`` multiplexer's own profile may sit outside ``profiles/`` (custom
+    HERMES_HOME). Adapter startup already skips ``active``."""
     from hermes_cli.profiles import get_active_profile_name, get_profile_dir
 
     homes = _multiplex_profile_homes(config)

--- a/hermes_cli/AGENTS.md
+++ b/hermes_cli/AGENTS.md
@@ -129,7 +129,13 @@ matchers; parser-derived flag sets; never blanket-exclude gateway ancestors, #87
 `_apply_profile_override()` in `hermes_cli/main.py` sets `HERMES_HOME` before any module import, so
 every `get_hermes_home()` scopes to the active profile (rules in root). Profiles are independent
 islands by design — no live config inheritance; `--clone` copies at creation. Multiplex
-(`gateway.multiplex_profiles`) secret-scope rules: `gateway/AGENTS.md`.
+(`gateway.multiplex_profiles`) secret-scope rules: `gateway/AGENTS.md`. The served set is
+`profiles.py::profiles_to_serve(multiplex=True)` = default + every live (non-tombstoned) dir under
+`profiles/` — there is no allowlist (`gateway.multiplex_profile_allowlist` was retired in config v43).
+Enumeration is a pure read: never `mkdir` a profile home from a served path (`SessionDB`, logging,
+cron all go through `mkdir_under_hermes_home` / `_ensure_cron_dir`, which refuse a deleted or
+missing named profile, #94590). Process-global per-profile slots (MCP discovery in `mcp_startup.py`,
+tool registry overlays) key on `hermes_constants.hermes_home_key()`, never a single flag.
 
 ## Nous free tier (`hermes_cli/anon_auth.py`)
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1900,8 +1900,6 @@ DEFAULT_CONFIG = {
         "export": {"otlp": {"enabled": False, "endpoint": "", "headers_env": {}}},
     },
     "gateway": {  # Gateway settings (messaging platforms: Telegram, Discord, Slack, ...).
-        # Named-profile allowlist for multiplex mode. None = serve all; [] = default only.
-        "multiplex_profile_allowlist": None,
         # Seconds to let a SIGTERM-interrupted gateway agent unwind before adapter/database
         # teardown. Keep short so service-manager shutdowns don't exhaust their stop budget.
         "signal_interrupt_grace_timeout": 1,
@@ -2381,7 +2379,7 @@ DEFAULT_CONFIG = {
         # Extra ports detection probes for an external llama-server (besides 8080).
         "detect_ports": [],
     },
-    "_config_version": 42,  # Config schema version - bump this when adding new required fields
+    "_config_version": 43,  # Config schema version - bump this when adding new required fields
 }
 
 

--- a/hermes_cli/config_migrations.py
+++ b/hermes_cli/config_migrations.py
@@ -637,6 +637,16 @@ MIGRATIONS: Tuple[Tuple[int, Callable[[Dict[str, Any], bool], None]], ...] = (
             "  ✓ Removed cron.model_drift_guard — unpinned cron jobs now keep running on the "
             "model/provider they were created under when the global default changes, instead "
             "of being skipped. Pin a job or set cron.model to move it."))),
+    # 42 → 43: gateway.multiplex_profile_allowlist is gone. A multiplexing default gateway serves
+    # every live profile under profiles/; a profile that must not be served is archived or deleted.
+    (43, functools.partial(
+        _rewrite_key, section="gateway", key="multiplex_profile_allowlist", new=None,
+        match=lambda _cur: True,
+        added="removed gateway.multiplex_profile_allowlist",
+        message=(
+            "  ✓ Removed gateway.multiplex_profile_allowlist — the multiplexing gateway now serves "
+            "every profile under profiles/. Delete or archive a profile you do not want served."),
+        extra_guard=lambda raw: "multiplex_profile_allowlist" in raw)),
 )
 
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4361,14 +4361,7 @@ def named_profile_served_by_running_multiplexer(profile_name: str | None = None)
             if not (cfg.get("multiplex_profiles") or (cfg.get("gateway", {}) or {}).get("multiplex_profiles")):
                 return False
 
-        gateway_cfg = cfg.get("gateway", {}) or {}
-        if "multiplex_profile_allowlist" in cfg:
-            raw_allowlist = cfg.get("multiplex_profile_allowlist")
-        else:
-            raw_allowlist = gateway_cfg.get("multiplex_profile_allowlist")
-        from gateway.config import _normalize_multiplex_profile_allowlist
-        profile_allowlist = _normalize_multiplex_profile_allowlist(raw_allowlist)
-        return profile_allowlist is None or normalize_profile_name(suffix) in profile_allowlist
+        return True  # a multiplexing default gateway serves every named profile
     except Exception:
         logger.debug("Multiplexer-serving probe failed", exc_info=True)
         return False

--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -5,11 +5,17 @@ from __future__ import annotations
 import threading
 from contextlib import nullcontext
 from contextvars import copy_context
-from typing import Optional
+from typing import Dict, Optional, Set
+
+from hermes_constants import hermes_home_key
 
 _mcp_discovery_lock = threading.Lock()
-_mcp_discovery_started = False
-_mcp_discovery_thread: Optional[threading.Thread] = None
+# Discovery slot per profile home (``hermes_home_key()`` follows the context-local HERMES_HOME
+# override): a shared Desktop/dashboard backend serving several profiles runs one discovery per
+# profile instead of the first profile to build an agent claiming the slot for everybody (#67605).
+# A single-profile process has exactly one key, so behaviour is the old single-slot form.
+_mcp_discovery_started: Set[str] = set()
+_mcp_discovery_thread: Dict[str, threading.Thread] = {}
 _mcp_discovery_deferred: Optional[threading.Timer] = None
 # Process-wide MCP server-name allowlist derived from ``-t/--toolsets``.
 # ``None`` = no filter (spawn every configured server). Set once at CLI
@@ -66,16 +72,15 @@ def _any_mcp_connected() -> bool:
 
 
 def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
-    """Spawn one shared background MCP discovery thread for this process.
+    """Spawn one background MCP discovery thread per profile home.
 
     If the first run exits without connecting any server (e.g. startup cancellation / OOM restart),
-    later calls may retry instead of pinning the process in "already started" with zero MCP tools.
+    later calls may retry instead of pinning the profile in "already started" with zero MCP tools.
     """
-    global _mcp_discovery_started, _mcp_discovery_thread
-
+    home_key = hermes_home_key()
     with _mcp_discovery_lock:
-        if _mcp_discovery_started:
-            thread = _mcp_discovery_thread
+        if home_key in _mcp_discovery_started:
+            thread = _mcp_discovery_thread.get(home_key)
             if thread is not None and thread.is_alive():
                 return
             try:
@@ -87,10 +92,10 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
                 "Background MCP discovery previously exited with no connected "
                 "servers; retrying discovery thread"
             )
-            _mcp_discovery_started = False
-            _mcp_discovery_thread = None
+            _mcp_discovery_started.discard(home_key)
+            _mcp_discovery_thread.pop(home_key, None)
 
-        _mcp_discovery_started = True
+        _mcp_discovery_started.add(home_key)
         if not _has_configured_mcp_servers():
             return
 
@@ -112,11 +117,10 @@ def start_background_mcp_discovery(*, logger, thread_name: str) -> None:
                 logger.debug("Background MCP tool discovery failed", exc_info=True)
             finally:
                 with _mcp_discovery_lock:
-                    global _mcp_discovery_thread
-                    _mcp_discovery_thread = None
+                    _mcp_discovery_thread.pop(home_key, None)
 
         thread = threading.Thread(target=copy_context().run, args=(_discover,), name=thread_name, daemon=True)
-        _mcp_discovery_thread = thread
+        _mcp_discovery_thread[home_key] = thread
         thread.start()
 
 
@@ -171,7 +175,7 @@ def defer_background_mcp_discovery(*, logger, thread_name: str, delay: float) ->
     """
     global _mcp_discovery_deferred
     with _mcp_discovery_lock:
-        if _mcp_discovery_started or _mcp_discovery_deferred is not None:
+        if hermes_home_key() in _mcp_discovery_started or _mcp_discovery_deferred is not None:
             return
 
         def _fire() -> None:
@@ -205,14 +209,19 @@ def wait_for_mcp_discovery(timeout: "float | None" = None, *, single_query: bool
     (15s vs 1.5s) because one-shot sessions have no second turn to recover.
     """
     _start_deferred_mcp_discovery_now()
-    thread = _mcp_discovery_thread
+    thread = _current_home_thread()
     if thread is None or not thread.is_alive():
         return
     thread.join(timeout=_resolve_discovery_timeout(timeout, single_query=single_query))
 
 
+def _current_home_thread() -> Optional[threading.Thread]:
+    """Discovery thread for the profile home the caller is scoped to, if any."""
+    return _mcp_discovery_thread.get(hermes_home_key())
+
+
 def mcp_discovery_in_flight() -> bool:
-    """True if THIS module's discovery thread is still running.
+    """True if THIS module's discovery thread (for the current profile home) is still running.
 
     Mirrors ``tui_gateway.entry.mcp_discovery_in_flight``; surfaces that start discovery here
     (desktop, dashboard sidecar) populate this thread, so the late-refresh scheduler consults both.
@@ -221,14 +230,14 @@ def mcp_discovery_in_flight() -> bool:
     late-refresh scheduler must consult both to decide whether a slow server's tools are still pending (see
     #51587).
     """
-    thread = _mcp_discovery_thread
+    thread = _current_home_thread()
     return thread is not None and thread.is_alive()
 
 
 def join_mcp_discovery(timeout: "float | None" = None) -> bool:
     """Block up to ``timeout`` for THIS module's discovery; True once complete, False if still
     running. For the off-critical-path late-refresh waiter (accepts a long wait, reports outcome)."""
-    thread = _mcp_discovery_thread
+    thread = _current_home_thread()
     if thread is None:
         return True
     thread.join(timeout=timeout)

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -22,7 +22,6 @@ from hermes_constants import clear_named_profile_deleted, mark_named_profile_del
 logger = logging.getLogger(__name__)
 
 _PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
-_WARNED_MISSING_ALLOWLIST_ENTRIES: set[tuple[str, ...]] = set()
 
 # Directories bootstrapped inside every new profile. ``home`` is the back-compat/Docker
 # HOME for tool subprocesses (host subprocesses keep the real HOME so CLI credentials
@@ -704,38 +703,19 @@ def list_profiles() -> List[ProfileInfo]:
     return profiles
 
 
-def profiles_to_serve(multiplex: bool, profile_allowlist: Optional[List[str]] = None) -> List[Tuple[str, Path]]:
+def profiles_to_serve(multiplex: bool) -> List[Tuple[str, Path]]:
     """``(profile_name, hermes_home)`` pairs a gateway should serve — the single chokepoint
     for "which profiles does the inbound gateway handle".
 
     ``multiplex=False``: exactly one entry for the *active* profile (byte-for-byte the
     historical single-profile behavior; name is ``"default"`` or the named profile's id).
-    ``multiplex=True``: default plus every live named profile, optionally filtered by
-    *profile_allowlist* (invalid entries skipped, missing ones warned once)."""
+    ``multiplex=True``: default plus every live named profile under ``profiles/`` (tombstoned
+    profiles skipped). Pure directory read: never creates a profile dir (#94590)."""
     active = get_active_profile_name() or "default"
     if not multiplex:
         return [(active, get_profile_dir(active))]
     serve: List[Tuple[str, Path]] = [("default", _get_default_hermes_home())]
-    allowed: Optional[set[str]] = None
-    if profile_allowlist is not None:
-        allowed = set()
-        for entry in profile_allowlist:
-            if not isinstance(entry, str):
-                continue
-            try:
-                name = _canon_valid(entry)
-            except ValueError:
-                continue
-            if name != "default":
-                allowed.add(name)
-    for entry in _iter_named_profile_dirs():
-        if allowed is None or entry.name in allowed:
-            serve.append((entry.name, entry))
-    if allowed is not None:
-        missing = tuple(sorted(allowed - {name for name, _ in serve}))
-        if missing and missing not in _WARNED_MISSING_ALLOWLIST_ENTRIES:
-            _WARNED_MISSING_ALLOWLIST_ENTRIES.add(missing)
-            logger.warning("Skipping missing gateway.multiplex_profile_allowlist profile(s): %s", ", ".join(missing))
+    serve.extend((entry.name, entry) for entry in _iter_named_profile_dirs())
     return serve
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -99,12 +99,9 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
         try:
             from hermes_cli.profiles import (
                 _check_gateway_running, _served_by_running_multiplexer, profiles_to_serve)
-            from hermes_cli.web_server_cron import _default_multiplex_profile_allowlist
 
-            # Same served set as the multiplexer (allowlist honoured): a profile the default
-            # gateway deliberately does not serve must not be ticked from the Desktop either.
-            profile_homes = list(profiles_to_serve(
-                multiplex=True, profile_allowlist=_default_multiplex_profile_allowlist()))
+            # Same served set as the multiplexer: default + every live profile under profiles/.
+            profile_homes = list(profiles_to_serve(multiplex=True))
             if profile_homes:
                 # Even one profile needs the per-tick gateway gate; otherwise
                 # Desktop races its dedicated gateway for the same cron store.

--- a/hermes_cli/web_server_cron.py
+++ b/hermes_cli/web_server_cron.py
@@ -79,23 +79,6 @@ def _validate_dashboard_cron_context_from(refs: Optional[List[str]], profile_nam
                 detail=f"context_from job '{ref}' not found in profile '{profile_name}'")
 
 
-def _default_multiplex_profile_allowlist() -> "list[str] | None":
-    """``gateway.multiplex_profile_allowlist`` as the DEFAULT profile's config declares it (the
-    multiplexer's served set), so the Desktop ticker mirrors ``gateway/run.py::_multiplex_profile_homes``
-    instead of ticking every installed profile. ``None`` = serve all (historical behavior)."""
-    from gateway.config import _normalize_multiplex_profile_allowlist
-    from hermes_cli.config import read_user_config_raw
-    from hermes_constants import get_default_hermes_root
-
-    cfg_path = get_default_hermes_root() / "config.yaml"
-    if not cfg_path.exists():
-        return None
-    cfg = read_user_config_raw(cfg_path) or {}
-    raw = cfg.get("multiplex_profile_allowlist") if "multiplex_profile_allowlist" in cfg else (
-        cfg.get("gateway") or {}).get("multiplex_profile_allowlist")
-    return _normalize_multiplex_profile_allowlist(raw)
-
-
 def _cron_profile_dicts() -> List[Dict[str, Any]]:
     """Minimal profile records (callers only consume ``name``); avoids ``list_profiles()``,
     whose config parsing, gateway probes and skill counts are GIL pressure on large pools."""

--- a/hermes_cli/web_server_gateway.py
+++ b/hermes_cli/web_server_gateway.py
@@ -322,6 +322,78 @@ def _dashboard_spawn_executable() -> str:
     return sys.executable
 
 
+def _named_profile_from_action(subcommand: List[str]) -> Optional[str]:
+    """Return the named-profile selector that :func:`_profile_cli_args` puts in front of an action.
+
+    Deliberately inspects only the leading selector: values after the real subcommand may
+    legitimately contain ``-p`` / ``--profile`` for a nested process (``mcp add --args ...``).
+    """
+    if len(subcommand) >= 2 and subcommand[0] in {"-p", "--profile"}:
+        return str(subcommand[1]).strip() or None
+    if subcommand and str(subcommand[0]).startswith("--profile="):
+        return str(subcommand[0]).split("=", 1)[1].strip() or None
+    return None
+
+
+def _profile_action_environment(
+    subcommand: List[str], env_overrides: Optional[Dict[str, str]] = None,
+) -> Dict[str, str]:
+    """Environment for a detached ``hermes <subcommand>`` action.
+
+    The dashboard loads its own profile's ``.env`` into process-global ``os.environ``. Copying
+    that mapping verbatim into ``hermes -p <other> ...`` lets the named child see the dashboard
+    profile's platform credentials and ports *before* its own dotenv loads (``load_hermes_dotenv``
+    does not override keys already present): a supposedly A2A-only profile then claims the default
+    Discord token and binds the default API/BlueBubbles ports.
+
+    Named-profile actions therefore start from Hermes' standard scrubbed subprocess env, then drop
+    the profile-managed keys plus every key declared by the dashboard/default profile dotenv files
+    and their hydrated secret sources, and pin ``HERMES_HOME`` to the target profile. The child's
+    normal startup then loads that profile's own ``.env``. Actions without a profile selector keep
+    the historical environment exactly.
+    """
+    profile = _named_profile_from_action(subcommand)
+    if profile is None:
+        action_env = dict(os.environ)
+    else:
+        from hermes_cli.env_loader import (
+            _PROFILE_MANAGED_ENV_KEYS, _env_keys_defined_in_dotenv, get_secret_source_values,
+        )
+        from hermes_cli.web_server_profiles import _resolve_profile_dir
+        from hermes_constants import apply_subprocess_home_env, get_default_hermes_root
+        from tools.environments.local import build_subprocess_env
+
+        target_home = _resolve_profile_dir(profile)
+        action_env = build_subprocess_env(base=os.environ, scrub_secrets=True)
+
+        profile_keys = set(_PROFILE_MANAGED_ENV_KEYS)
+        try:
+            source_homes = {str(get_default_hermes_root()), str(get_hermes_home())}
+        except Exception:
+            source_homes = set()
+        for source_home in source_homes:
+            profile_keys.update(_env_keys_defined_in_dotenv(Path(source_home) / ".env"))
+            # Secret managers contribute locally named credentials that never appear in .env;
+            # the dashboard already hydrated its own sources, so their key names are a boundary too.
+            profile_keys.update(get_secret_source_values(source_home).keys())
+        for key in profile_keys:
+            action_env.pop(key, None)
+
+        # Pin the child before import-time startup runs; the explicit -p flag stays authoritative
+        # and resolves to the same validated directory.
+        action_env["HERMES_HOME"] = str(target_home)
+        apply_subprocess_home_env(action_env)
+
+    action_env["HERMES_NONINTERACTIVE"] = "1"
+    # The dashboard runs inside the gateway process, so os.environ carries _HERMES_GATEWAY=1;
+    # inheriting it trips the child's in-process restart-loop guard (exit 1). Drop it, like
+    # the gateway's own restart watcher does (gateway/run.py, #52470).
+    action_env.pop("_HERMES_GATEWAY", None)
+    if env_overrides:
+        action_env.update(env_overrides)
+    return action_env
+
+
 def _spawn_hermes_action(
     subcommand: List[str], name: str, *, env_overrides: Optional[Dict[str, str]] = None
 ) -> subprocess.Popen:
@@ -332,16 +404,13 @@ def _spawn_hermes_action(
     log_file.write(f"\n=== {name} started {time.strftime('%Y-%m-%d %H:%M:%S')} ===\n".encode())
 
     cmd = [_dashboard_spawn_executable(), "-m", "hermes_cli.main", *subcommand]
-    # The dashboard runs inside the gateway process, so os.environ carries _HERMES_GATEWAY=1;
-    # inheriting it trips the child's in-process restart-loop guard (exit 1). Drop it, like
-    # the gateway's own restart watcher does.
-    # The gateway's own restart watcher already drops it (gateway/run.py); mirror that here (#52470).
-    action_env = {**os.environ, "HERMES_NONINTERACTIVE": "1"}
-    action_env.pop("_HERMES_GATEWAY", None)
+    # Named-profile actions get a scrubbed, pinned environment so the child cannot inherit the
+    # dashboard profile's credentials; see _profile_action_environment (also drops _HERMES_GATEWAY).
+    action_env = _profile_action_environment(subcommand, env_overrides)
     detach = {"creationflags": windows_detach_flags()} if sys.platform == "win32" else {"start_new_session": True}
     proc = subprocess.Popen(
         cmd, cwd=str(PROJECT_ROOT), stdin=subprocess.DEVNULL, stdout=log_file, stderr=subprocess.STDOUT,
-        env={**action_env, **(env_overrides or {})}, **detach,
+        env=action_env, **detach,
     )
     log_file.close()  # child holds its own dup'd fd; keeping ours leaks one per action
     _ACTION_RESULTS.pop(name, None)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -24,7 +24,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 from agent.message_sanitization import _sanitize_surrogates
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, mkdir_under_hermes_home
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, TypeVar, cast
 
 from hermes_state_common import escape_like as _escape_like, stat_db_file_identity as _stat_db_file_identity
@@ -508,7 +508,9 @@ class SessionDB(
     def _open_writer(self) -> None:
         """Writable open: preflight, zero-byte quarantine, connect + schema (one in-place repair of a
         malformed sqlite_master), generation stamp."""
-        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        # Never materialize a deleted/archived named profile's home: a multiplexer or Desktop backend
+        # still holding the profile's route would otherwise re-scaffold it on the next turn (#94590).
+        mkdir_under_hermes_home(self.db_path.parent)
         # Read-only file/sidecar preflight BEFORE the first connection: an actionable message
         # instead of an opaque "attempt to write a readonly database" from inside _init_schema.
         preflight_db_writability(self.db_path, db_label="state.db")

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -23,6 +23,26 @@ _PREVIEW_SCAFFOLD_WINDOW = 400
 _PREVIEW_MAX_CHARS = 60
 
 
+def routed_sessions_setting(key: str, env_var: str) -> Any:
+    """``sessions.<key>`` for the profile whose state.db this process is touching.
+
+    ``gateway/run.py`` bridges the LAUNCH profile's ``sessions.*`` into ``env_var`` (the cross-process
+    carrier CLI/cron children read). Under a multiplexer a routed turn runs with a HERMES_HOME override
+    and that env slot holds the default profile's value, so a served profile with different
+    ``sessions.*`` settings must read its own config.yaml. Unscoped: the env bridge, as before.
+    Returns ``None`` when neither source sets the key.
+    """
+    from hermes_constants import get_hermes_home_override
+
+    if get_hermes_home_override():
+        try:
+            from hermes_cli.config import load_config_readonly
+            return (load_config_readonly().get("sessions") or {}).get(key)
+        except Exception:
+            return None
+    return os.environ.get(env_var)
+
+
 def escape_like(text: str) -> str:
     """Escape LIKE wildcards (``%``, ``_``) so derived text matches literally; pair with ``ESCAPE '\\'``.
     ``_`` is common in branch names/titles/paths and a substring match must not silently widen."""

--- a/hermes_state_fts.py
+++ b/hermes_state_fts.py
@@ -9,7 +9,8 @@ from pathlib import Path
 from typing import Sequence
 
 from hermes_constants import get_hermes_home
-from hermes_state_common import FTS_CJK_STALE_KEY, FTS_STALE_KEY, _FTS_CJK_TRIGGERS, _FTS_TRIGGERS
+from hermes_state_common import (FTS_CJK_STALE_KEY, FTS_STALE_KEY, _FTS_CJK_TRIGGERS, _FTS_TRIGGERS,
+    routed_sessions_setting)
 from hermes_state_errors import is_fts_scoped_corruption_error
 
 # caplog tests pin the "hermes_state" logger name.
@@ -102,8 +103,9 @@ def fts5_cjk_so_path() -> Path:
 
 
 def _cjk_fts_config_enabled() -> bool:
-    """config.yaml ``sessions.cjk_fts`` (default on), via its env bridge."""
-    return os.getenv("HERMES_CJK_FTS", "1").strip().lower() not in ("0", "false", "off", "no")
+    """config.yaml ``sessions.cjk_fts`` (default on) for the profile being served."""
+    value = routed_sessions_setting("cjk_fts", "HERMES_CJK_FTS")
+    return value is None or str(value).strip().lower() not in ("0", "false", "off", "no")
 
 
 def load_fts5_cjk_extension(conn: sqlite3.Connection) -> bool:

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -12,16 +12,24 @@ import time
 from typing import Any, Callable, Collection, Dict, List, Optional, Tuple
 
 from agent.skill_commands import describe_skill_invocation
-from utils import env_float
 from hermes_state_common import (
     FTS_CJK_STALE_KEY, FTS_SQL, FTS_STALE_KEY, FTS_STORAGE_VERSION, FTS_TOOL_CONTENT_PREFIX_CHARS,
     FTS_TOOL_FULL_CONTENT_HIGH_WATER_KEY, FTS_TRIGRAM_EXCLUDED_SOURCES, FTS_TRIGRAM_SQL,
     MAX_FTS5_QUERY_CHARS, SCHEMA_VERSION, _FTS_CJK_TRIGGERS,
-    escape_like as _escape_like, fts_rebuild_admission, fts_trigram_session_sql,
+    escape_like as _escape_like, fts_rebuild_admission, fts_trigram_session_sql, routed_sessions_setting,
 )
 
 # Pre-split logger identity so log filtering/capture is unchanged.
 logger = logging.getLogger("hermes_state")
+
+
+def _search_slow_ms() -> float:
+    """``sessions.search_slow_ms`` for the served profile (default 1000; 0 logs every call)."""
+    value = routed_sessions_setting("search_slow_ms", "HERMES_SEARCH_SLOW_MS")
+    try:
+        return 1000.0 if value is None or str(value).strip() == "" else float(value)
+    except (TypeError, ValueError):
+        return 1000.0
 
 # Characters FTS5's query grammar rejects outside a quoted phrase (anything missing
 # reaches MATCH raw and raises -> zero results). ``%`` is deliberately excluded: the
@@ -1015,7 +1023,7 @@ class SessionSearchMixin:
             return rows
         finally:
             elapsed_ms = (time.time() - started) * 1000.0
-            if elapsed_ms >= env_float("HERMES_SEARCH_SLOW_MS", 1000.0):
+            if elapsed_ms >= _search_slow_ms():
                 logger.info("slow session search: path=%s elapsed=%.0fms rows=%s query=%r",
                             self._describe_search_path(query), elapsed_ms, len(rows) if rows is not None else "err",
                             query[: 200])

--- a/tests/acp_adapter/test_acp_mcp_discovery.py
+++ b/tests/acp_adapter/test_acp_mcp_discovery.py
@@ -64,10 +64,10 @@ def _reset_mcp_startup_state():
     """Ensure each test starts with a clean discovery thread state."""
     saved_started = mcp_startup._mcp_discovery_started
     saved_thread = mcp_startup._mcp_discovery_thread
-    mcp_startup._mcp_discovery_started = False
-    mcp_startup._mcp_discovery_thread = None
+    mcp_startup._mcp_discovery_started = set()
+    mcp_startup._mcp_discovery_thread = {}
     yield
-    thread = mcp_startup._mcp_discovery_thread
+    thread = mcp_startup._current_home_thread()
     if thread is not None and thread.is_alive():
         thread.join(timeout=2.0)
     mcp_startup._mcp_discovery_started = saved_started
@@ -113,10 +113,11 @@ def test_acp_background_discovery_does_not_block_startup(monkeypatch):
     elapsed = time.monotonic() - start
 
     assert elapsed < 0.2, "start_background_mcp_discovery blocked for {:.3f}s".format(elapsed)
-    assert mcp_startup._mcp_discovery_thread is not None
-    assert mcp_startup._mcp_discovery_thread.is_alive()
+    thread = mcp_startup._current_home_thread()
+    assert thread is not None
+    assert thread.is_alive()
     block.set()
-    mcp_startup._mcp_discovery_thread.join(timeout=2.0)
+    thread.join(timeout=2.0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cron/test_cron_multiplex_desktop_ticker_scope.py
+++ b/tests/cron/test_cron_multiplex_desktop_ticker_scope.py
@@ -115,7 +115,7 @@ def test_desktop_ticker_gates_on_profile_gateway_running(tmp_path, monkeypatch, 
     homes = [("default", tmp_path / "default"), ("ops", tmp_path / "ops")][:profile_count]
     running = {homes[-1][1]}
     monkeypatch.setattr(
-        "hermes_cli.profiles.profiles_to_serve", lambda multiplex=False, profile_allowlist=None: list(homes)
+        "hermes_cli.profiles.profiles_to_serve", lambda multiplex=False: list(homes)
     )
     monkeypatch.setattr(
         "hermes_cli.profiles._check_gateway_running", lambda home: home in running

--- a/tests/gateway/test_api_server_multiplex_secret_scope.py
+++ b/tests/gateway/test_api_server_multiplex_secret_scope.py
@@ -110,7 +110,7 @@ async def test_profile_middleware_binds_auth_before_handler(
     )()
     monkeypatch.setattr(
         "hermes_cli.profiles.profiles_to_serve",
-        lambda multiplex, profile_allowlist=None: [
+        lambda multiplex: [
             ("default", tmp_path), ("worker", worker_home)
         ],
     )

--- a/tests/gateway/test_api_server_profile_prefix_misdelivery.py
+++ b/tests/gateway/test_api_server_profile_prefix_misdelivery.py
@@ -77,13 +77,11 @@ class TestResolverWithMultiplexOff:
 class TestMultiplexOnUnchanged:
     def test_served_profile_resolves(self, adapter, monkeypatch):
         adapter.gateway_runner = SimpleNamespace(
-            config=SimpleNamespace(
-                multiplex_profiles=True, multiplex_profile_allowlist=None
-            )
+            config=SimpleNamespace(multiplex_profiles=True)
         )
         monkeypatch.setattr(
             "hermes_cli.profiles.profiles_to_serve",
-            lambda multiplex, profile_allowlist: [("worker", object())],
+            lambda multiplex: [("worker", object())],
         )
         assert adapter._resolve_request_profile(_request("worker")) == "worker"
         assert adapter._resolve_request_profile(_request("ghost")) is _PROFILE_REJECTED

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -321,16 +321,16 @@ class TestLoadGatewayConfig:
 
         assert config.multiplex_profiles is True
 
-    def test_multiplex_allowlist_from_nested_gateway_section(self, tmp_path, monkeypatch):
+    def test_stale_multiplex_allowlist_key_is_ignored(self, tmp_path, monkeypatch):
+        # The removed ``multiplex_profile_allowlist`` key may linger in an un-migrated
+        # config.yaml; it must not break loading or the multiplex flag.
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
         (hermes_home / "config.yaml").write_text(
             "gateway:\n"
             "  multiplex_profiles: true\n"
             "  multiplex_profile_allowlist:\n"
-            "    - Worker\n"
-            "    - worker\n"
-            "    - guest\n",
+            "    - worker\n",
             encoding="utf-8",
         )
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
@@ -338,7 +338,7 @@ class TestLoadGatewayConfig:
         config = load_gateway_config()
 
         assert config.multiplex_profiles is True
-        assert config.multiplex_profile_allowlist == ["worker", "guest"]
+        assert not hasattr(config, "multiplex_profile_allowlist")
 
     def test_discord_websocket_health_settings_seed_platform_extra(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_handoff_watcher_multiprofile.py
+++ b/tests/gateway/test_handoff_watcher_multiprofile.py
@@ -25,9 +25,8 @@ from gateway import run
 
 
 class _FakeConfig:
-    def __init__(self, multiplex, allowlist=None):
+    def __init__(self, multiplex):
         self.multiplex_profiles = multiplex
-        self.multiplex_profile_allowlist = allowlist
 
 
 def test_scopes_single_profile_gateway_is_root_only():

--- a/tests/gateway/test_kanban_routed_transport.py
+++ b/tests/gateway/test_kanban_routed_transport.py
@@ -116,9 +116,12 @@ def test_route_denials_leave_events_retryable_at_claim_and_send(tmp_path, monkey
     runner._profile_adapters["yuki"] = {Platform.TELEGRAM: RecordingAdapter()}
     assert not collect(runner)
     runner._profile_adapters["yuki"] = {}
-    runner.config.multiplex_profile_allowlist = ["other"]
+    # A tombstoned (deleted) owner profile is no longer served by the multiplexer.
+    from hermes_constants import clear_named_profile_deleted, mark_named_profile_deleted
+    yuki_home = tmp_path / ".hermes" / "profiles" / "yuki"
+    mark_named_profile_deleted(yuki_home)
     assert not collect(runner)
-    runner.config.multiplex_profile_allowlist = ["yuki"]
+    clear_named_profile_deleted(yuki_home)
     rows = collect(runner)
     assert [row["task"].id for row in rows] == [good]
     # Reassignment after the claim must rewind, never send using stale authority.

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -808,10 +808,7 @@ class TestSecondaryProfileConfigHandling:
         from gateway.config import GatewayConfig
 
         runner = GatewayRunner.__new__(GatewayRunner)
-        runner.config = GatewayConfig(
-            multiplex_profiles=True,
-            multiplex_profile_allowlist=["bad", "good"],
-        )
+        runner.config = GatewayConfig(multiplex_profiles=True)
         runner.adapters = {}
         runner._profile_adapters = {}
         runner.pairing_stores = {
@@ -828,9 +825,8 @@ class TestSecondaryProfileConfigHandling:
             runner._profile_adapters[profile_name] = {}
             return 2
 
-        def fake_profiles_to_serve(multiplex, profile_allowlist=None):
+        def fake_profiles_to_serve(multiplex):
             assert multiplex is True
-            assert profile_allowlist == ["bad", "good"]
             return [
                 ("default", Path("/tmp/default")),
                 ("bad", Path("/tmp/bad")),
@@ -879,7 +875,7 @@ class TestSecondaryProfileConfigHandling:
 
         monkeypatch.setattr(
             "hermes_cli.profiles.profiles_to_serve",
-            lambda multiplex, profile_allowlist=None: [
+            lambda multiplex: [
                 ("default", Path("/tmp/default")),
                 ("unsafe", Path("/tmp/unsafe")),
             ],

--- a/tests/gateway/test_multiplex_api_server_routing.py
+++ b/tests/gateway/test_multiplex_api_server_routing.py
@@ -16,17 +16,12 @@ from gateway.platforms.api_server import (
 )
 
 
-def _make_adapter(
-    multiplex: bool = True, allowlist: list[str] | None = None
-) -> APIServerAdapter:
+def _make_adapter(multiplex: bool = True) -> APIServerAdapter:
     cfg = PlatformConfig(enabled=True, extra={"host": "127.0.0.1", "port": 8642, "key": "test-key"})
     adapter = APIServerAdapter(cfg)
 
     class _Runner:
-        config = GatewayConfig(
-            multiplex_profiles=multiplex,
-            multiplex_profile_allowlist=allowlist,
-        )
+        config = GatewayConfig(multiplex_profiles=multiplex)
 
     adapter.gateway_runner = _Runner()
     return adapter
@@ -43,10 +38,10 @@ class TestApiServerProfileResolution:
         assert adapter._resolve_request_profile(_FakeReq(None)) is None
 
     def test_unserved_prefix_is_rejected(self, monkeypatch):
-        adapter = _make_adapter(multiplex=True, allowlist=["worker"])
+        adapter = _make_adapter(multiplex=True)
         monkeypatch.setattr(
             "hermes_cli.profiles.profiles_to_serve",
-            lambda multiplex, profile_allowlist=None: [
+            lambda multiplex: [
                 ("default", "/profiles/default"),
                 ("worker", "/profiles/worker"),
             ],

--- a/tests/gateway/test_multiplex_http_routing.py
+++ b/tests/gateway/test_multiplex_http_routing.py
@@ -20,22 +20,14 @@ class TestSessionSourceProfileField:
 class TestWebhookProfileResolution:
     """_resolve_request_profile validates the /p/<profile>/ prefix."""
 
-    def _adapter(
-        self,
-        multiplex: bool,
-        served=("default", "coder"),
-        allowlist=None,
-    ):
+    def _adapter(self, multiplex: bool, served=("default", "coder")):
         from gateway.platforms.webhook import WebhookAdapter, _PROFILE_REJECTED
 
         class _FakeReq:
             def __init__(self, profile):
                 self.match_info = {"profile": profile} if profile is not None else {}
 
-        cfg = GatewayConfig(
-            multiplex_profiles=multiplex,
-            multiplex_profile_allowlist=allowlist,
-        )
+        cfg = GatewayConfig(multiplex_profiles=multiplex)
 
         class _Runner:
             config = cfg
@@ -51,15 +43,11 @@ class TestWebhookProfileResolution:
 
     def test_unserved_prefix_is_rejected(self, monkeypatch):
         adapter, Req, rejected, served = self._adapter(
-            multiplex=True,
-            served=("default", "worker"),
-            allowlist=["worker"],
+            multiplex=True, served=("default", "worker"),
         )
         monkeypatch.setattr(
             "hermes_cli.profiles.profiles_to_serve",
-            lambda multiplex, profile_allowlist=None: [
-                (name, f"/profiles/{name}") for name in served
-            ],
+            lambda multiplex: [(name, f"/profiles/{name}") for name in served],
         )
 
         assert adapter._resolve_request_profile(Req("worker")) == "worker"

--- a/tests/gateway/test_multiplex_lifecycle.py
+++ b/tests/gateway/test_multiplex_lifecycle.py
@@ -21,32 +21,27 @@ class TestServedProfilesStatus:
             importlib.reload(status)
 
 
-def test_cron_profile_homes_follow_allowlist(tmp_path, monkeypatch):
-    """The helper wired into in-process cron returns only selected profiles."""
+def test_cron_profile_homes_serve_every_live_profile(tmp_path, monkeypatch):
+    """The helper wired into in-process cron returns default + every live named profile;
+    a tombstoned profile dir is skipped."""
     monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
     default_home = tmp_path / ".hermes"
     monkeypatch.setenv("HERMES_HOME", str(default_home))
-    for name in ("worker", "guest"):
+    for name in ("worker", "guest", "gone"):
         (default_home / "profiles" / name).mkdir(parents=True)
+    from hermes_constants import mark_named_profile_deleted
+    mark_named_profile_deleted(default_home / "profiles" / "gone")
 
     import gateway.run as gateway_run
 
-    homes = gateway_run._multiplex_profile_homes(
-        GatewayConfig(
-            multiplex_profiles=True,
-            multiplex_profile_allowlist=["worker"],
-        )
-    )
+    homes = gateway_run._multiplex_profile_homes(GatewayConfig(multiplex_profiles=True))
 
-    assert [name for name, _home in homes] == ["default", "worker"]
+    assert [name for name, _home in homes] == ["default", "guest", "worker"]
 
 
 def test_cron_tick_homes_include_active_named_host(tmp_path, monkeypatch):
-    """Named-profile gateway + allowlist must still tick the host store.
-
-    Adapter homes stay allowlist-only so the host is not started a second
-    time as a secondary (same bot token). Cron unions the active profile.
-    """
+    """A named-profile host running the multiplexer ticks its own store exactly once:
+    it is part of the served set, and cron must not union it a second time."""
     monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
     default_home = tmp_path / ".hermes"
     for name in ("host", "worker"):
@@ -55,17 +50,14 @@ def test_cron_tick_homes_include_active_named_host(tmp_path, monkeypatch):
 
     import gateway.run as gateway_run
 
-    cfg = GatewayConfig(
-        multiplex_profiles=True,
-        multiplex_profile_allowlist=["worker"],
-    )
+    cfg = GatewayConfig(multiplex_profiles=True)
     adapter_names = [name for name, _home in gateway_run._multiplex_profile_homes(cfg)]
     cron_homes = gateway_run._cron_tick_profile_homes(cfg)
     cron_names = [name for name, _home in cron_homes]
     cron_by_name = dict(cron_homes)
 
-    assert adapter_names == ["default", "worker"]
-    assert cron_names == ["default", "worker", "host"]
+    assert adapter_names == ["default", "host", "worker"]
+    assert cron_names == ["default", "host", "worker"]
     assert cron_by_name["host"] == default_home / "profiles" / "host"
 
 
@@ -115,34 +107,29 @@ class TestNamedProfileMultiplexerGuard:
             gw._guard_named_profile_under_multiplexer(force=False)
         assert excinfo.value.code == GATEWAY_FATAL_CONFIG_EXIT_CODE
 
-    def test_served_profile_is_still_guarded(self, monkeypatch, tmp_path):
+    def test_recorded_served_profiles_win_over_config(self, monkeypatch, tmp_path):
+        """The live gateway's own ``served_profiles`` record is authoritative: a named profile
+        it does not list may run standalone even though the default config multiplexes."""
         self._fake_running_default_gateway(monkeypatch, tmp_path)
         (tmp_path / "config.yaml").write_text(
-            "gateway:\n"
-            "  multiplex_profiles: true\n"
-            "  multiplex_profile_allowlist:\n"
-            "    - Coder\n",
+            "gateway:\n  multiplex_profiles: true\n",
             encoding="utf-8",
+        )
+        import gateway.status as status
+        monkeypatch.setattr(
+            status, "read_runtime_status",
+            lambda path=None: {"gateway_state": "running", "served_profiles": ["default", "worker"]},
         )
 
         from hermes_cli import gateway as gw
 
-        with pytest.raises(SystemExit) as excinfo:
-            gw._guard_named_profile_under_multiplexer(force=False)
-        assert excinfo.value.code == GATEWAY_FATAL_CONFIG_EXIT_CODE
+        gw._guard_named_profile_under_multiplexer(force=False)
+        assert gw.named_profile_served_by_running_multiplexer("worker") is True
 
-    @pytest.mark.parametrize(
-        "allowlist_yaml",
-        ["[]", "[worker]", "coder"],
-    )
-    def test_unserved_profile_may_run_standalone(
-        self, monkeypatch, tmp_path, allowlist_yaml
-    ):
+    def test_non_multiplexing_default_gateway_lets_named_profile_run(self, monkeypatch, tmp_path):
         self._fake_running_default_gateway(monkeypatch, tmp_path)
         (tmp_path / "config.yaml").write_text(
-            "gateway:\n"
-            "  multiplex_profiles: true\n"
-            f"  multiplex_profile_allowlist: {allowlist_yaml}\n",
+            "gateway:\n  multiplex_profiles: false\n",
             encoding="utf-8",
         )
 

--- a/tests/gateway/test_multiplex_mcp_discovery.py
+++ b/tests/gateway/test_multiplex_mcp_discovery.py
@@ -33,7 +33,7 @@ async def test_gateway_boot_discovers_mcp_under_every_profile_home(
 
     monkeypatch.setattr(
         "hermes_cli.profiles.profiles_to_serve",
-        lambda multiplex, profile_allowlist=None: homes,
+        lambda multiplex: homes,
     )
     monkeypatch.setattr(_mcp_discovery, "discover_mcp_tools", fake_discover)
 

--- a/tests/gateway/test_multiplex_phase0.py
+++ b/tests/gateway/test_multiplex_phase0.py
@@ -105,39 +105,6 @@ class TestMultiplexConfigFlag:
         cfg = GatewayConfig.from_dict({"multiplex_profiles": True})
         assert cfg.multiplex_profiles is True
 
-    def test_profile_allowlist_defaults_to_serve_all(self):
-        assert GatewayConfig().multiplex_profile_allowlist is None
-
-    def test_profile_allowlist_normalizes_and_round_trips(self):
-        cfg = GatewayConfig.from_dict(
-            {
-                "gateway": {
-                    "multiplex_profiles": True,
-                    "multiplex_profile_allowlist": [
-                        " Worker ",
-                        "worker",
-                        "Guest",
-                        "default",
-                        "bad/name",
-                        7,
-                    ],
-                }
-            }
-        )
-
-        assert cfg.multiplex_profile_allowlist == ["worker", "guest"]
-        restored = GatewayConfig.from_dict(cfg.to_dict())
-        assert restored.multiplex_profile_allowlist == ["worker", "guest"]
-
-    def test_invalid_profile_allowlist_fails_safe_to_default_only(self, caplog):
-        with caplog.at_level("WARNING", logger="gateway.config"):
-            cfg = GatewayConfig.from_dict(
-                {"gateway": {"multiplex_profile_allowlist": "worker"}}
-            )
-
-        assert cfg.multiplex_profile_allowlist == []
-        assert "serving only the default profile" in caplog.text
-
 
 class TestSessionStoreProfileResolution:
     """SessionStore._generate_session_key honors the flag: legacy namespace

--- a/tests/gateway/test_multiplex_residue_parity.py
+++ b/tests/gateway/test_multiplex_residue_parity.py
@@ -1,0 +1,118 @@
+"""Multiplex parity: a served profile reads ITS ``sessions.*`` / proxy env, never the launch
+profile's; a stale served route never re-scaffolds an archived profile; MCP discovery runs once
+per served profile home."""
+
+import logging
+import threading
+
+import pytest
+
+from agent import secret_scope as ss
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+@pytest.fixture
+def two_homes(tmp_path, monkeypatch):
+    root = tmp_path / ".hermes"
+    alpha = root / "profiles" / "alpha"
+    for home in (root, alpha):
+        (home / "sessions").mkdir(parents=True)
+        (home / ".env").write_text("", encoding="utf-8")
+    (root / "config.yaml").write_text(
+        "sessions:\n  cjk_fts: true\n  search_slow_ms: 1000\n", encoding="utf-8")
+    (alpha / "config.yaml").write_text(
+        "sessions:\n  cjk_fts: false\n  search_slow_ms: 50\n", encoding="utf-8")
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    ss.set_multiplex_active(False)
+    yield root, alpha
+    ss.set_multiplex_active(False)
+
+
+def test_served_profile_reads_its_own_sessions_settings(two_homes, monkeypatch):
+    root, alpha = two_homes
+    from hermes_state_fts import _cjk_fts_config_enabled
+    from hermes_state_search import _search_slow_ms
+    # The multiplexer bridged the LAUNCH (default) profile's sessions.* into env at import.
+    monkeypatch.setenv("HERMES_CJK_FTS", "true")
+    monkeypatch.setenv("HERMES_SEARCH_SLOW_MS", "1000")
+    assert _cjk_fts_config_enabled() is True and _search_slow_ms() == 1000.0  # unscoped = env bridge
+    token = set_hermes_home_override(str(alpha))
+    try:
+        assert _cjk_fts_config_enabled() is False
+        assert _search_slow_ms() == 50.0
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_per_turn_sessions_bridge_skips_secondary_scope(two_homes, monkeypatch):
+    root, alpha = two_homes
+    from gateway import run as gw_run
+    monkeypatch.delenv("HERMES_CJK_FTS", raising=False)
+    ss.set_multiplex_active(True)
+    with gw_run._profile_runtime_scope(alpha):
+        gw_run._bridge_max_turns_from_config(alpha)
+    assert "HERMES_CJK_FTS" not in __import__("os").environ, "secondary scope must not write the process env"
+
+
+def test_resolve_proxy_url_reads_routed_profile_scope(two_homes, monkeypatch):
+    root, alpha = two_homes
+    from gateway.platforms.base import resolve_proxy_url
+    monkeypatch.setenv("TELEGRAM_PROXY", "socks5://default-proxy:1080")  # launch profile's .env
+    ss.set_multiplex_active(True)
+    token = ss.set_secret_scope({"TELEGRAM_PROXY": "socks5://alpha-proxy:1080"})
+    try:
+        assert resolve_proxy_url("TELEGRAM_PROXY") == "socks5://alpha-proxy:1080"
+    finally:
+        ss.reset_secret_scope(token)
+    token = ss.set_secret_scope({})  # a served profile with NO proxy must not borrow the default's
+    try:
+        monkeypatch.delenv("HTTPS_PROXY", raising=False)
+        assert resolve_proxy_url("TELEGRAM_PROXY") is None
+    finally:
+        ss.reset_secret_scope(token)
+    ss.set_multiplex_active(False)
+    assert resolve_proxy_url("TELEGRAM_PROXY") == "socks5://default-proxy:1080"  # standalone: env
+
+
+def test_stale_served_turn_never_recreates_archived_profile(two_homes):
+    """#94590: a multiplexer still holding an archived profile's route must not re-scaffold it."""
+    import shutil
+    root, alpha = two_homes
+    from gateway import run as gw_run
+    shutil.rmtree(alpha)
+    ss.set_multiplex_active(True)
+    with gw_run._profile_runtime_scope(alpha):
+        from hermes_state import SessionDB
+        with pytest.raises(FileNotFoundError):
+            SessionDB()
+    assert not alpha.exists()
+
+
+def test_mcp_discovery_slot_is_per_profile_home(two_homes, monkeypatch):
+    """#67605: alpha building an agent after default must still get ITS discovery run."""
+    root, alpha = two_homes
+    import hermes_cli.mcp_startup as ms
+    from hermes_constants import get_hermes_home
+    for home in (root, alpha):
+        (home / "config.yaml").write_text("mcp_servers:\n  demo:\n    command: /bin/true\n", encoding="utf-8")
+    monkeypatch.setattr(ms, "_mcp_discovery_started", set())
+    monkeypatch.setattr(ms, "_mcp_discovery_thread", {})
+    seen, done = [], threading.Event()
+
+    def fake_discover(**_kw):
+        seen.append(get_hermes_home().name)
+        done.set()
+
+    monkeypatch.setattr("tools.mcp_tool_discovery.discover_mcp_tools", fake_discover)
+    monkeypatch.setattr("tools.mcp_tool_discovery.get_mcp_status", lambda *a, **k: [{"connected": True}])
+    for home in (root, alpha):
+        token = set_hermes_home_override(str(home))
+        try:
+            done.clear()
+            ms.start_background_mcp_discovery(logger=logging.getLogger("t"), thread_name=f"mcp-{home.name}")
+            assert done.wait(5)
+            ms.wait_for_mcp_discovery(timeout=5)
+        finally:
+            reset_hermes_home_override(token)
+    assert seen == [root.name, "alpha"]

--- a/tests/gateway/test_profile_resolution.py
+++ b/tests/gateway/test_profile_resolution.py
@@ -175,8 +175,7 @@ class TestNonDiscordProfileRouting:
         ):
             assert mock_runner._profile_name_for_source(telegram_source) == "tg-profile"
 
-    def test_route_inside_allowlist_resolves(self, mock_runner, telegram_source):
-        mock_runner.config.multiplex_profile_allowlist = ["worker"]
+    def test_route_to_served_profile_resolves(self, mock_runner, telegram_source):
         mock_runner.config.profile_routes = [
             ProfileRoute(
                 name="worker-route",
@@ -194,12 +193,9 @@ class TestNonDiscordProfileRouting:
         ) as enumerate_profiles:
             assert mock_runner._profile_name_for_source(telegram_source) == "worker"
 
-        enumerate_profiles.assert_called_once_with(
-            multiplex=True, profile_allowlist=["worker"]
-        )
+        enumerate_profiles.assert_called_once_with(multiplex=True)
 
-    def test_route_outside_allowlist_rejects(self, mock_runner, telegram_source, caplog):
-        mock_runner.config.multiplex_profile_allowlist = ["worker"]
+    def test_route_to_unserved_profile_rejects(self, mock_runner, telegram_source, caplog):
         mock_runner.config.profile_routes = [
             ProfileRoute(
                 name="restricted-route",
@@ -221,7 +217,6 @@ class TestNonDiscordProfileRouting:
         assert "target profile 'restricted' is not served" in caplog.text
 
     def test_no_route_match_preserves_default_sentinel(self, mock_runner, telegram_source):
-        mock_runner.config.multiplex_profile_allowlist = ["worker"]
         mock_runner.config.profile_routes = [
             ProfileRoute(
                 name="other-chat",
@@ -376,7 +371,6 @@ class TestAdapterToSessionKeyIntegration:
 
     @pytest.mark.asyncio
     async def test_adapter_drops_rejected_route_before_dispatch(self, mock_runner):
-        mock_runner.config.multiplex_profile_allowlist = []
         mock_runner.config.profile_routes = [
             ProfileRoute(
                 name="restricted-route",
@@ -407,7 +401,6 @@ class TestAdapterToSessionKeyIntegration:
     @pytest.mark.asyncio
     async def test_direct_source_is_rejected_at_shared_ingress(self, mock_runner):
         mock_runner.config.multiplex_profiles = True
-        mock_runner.config.multiplex_profile_allowlist = []
         mock_runner.config.profile_routes = [
             ProfileRoute(
                 name="restricted-route",

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -974,7 +974,7 @@ class TestMultiplexProfileWebhookAuthentication:
         adapter.gateway_runner = runner
         monkeypatch.setattr(
             "hermes_cli.profiles.profiles_to_serve",
-            lambda multiplex, profile_allowlist=None: [
+            lambda multiplex: [
                 ("default", tmp_path),
                 ("worker", tmp_path / "profiles" / "worker"),
                 ("other", tmp_path / "profiles" / "other"),

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1006,6 +1006,25 @@ class TestConfigSupportFloor:
         assert (tmp_path / ".env").read_text(encoding="utf-8") == expected_env
 
 
+class TestRetiredMultiplexAllowlist:
+    def test_v43_drops_multiplex_profile_allowlist_from_user_config(self, tmp_path, monkeypatch):
+        """The multiplexer serves every profile; a stale allowlist must not linger in config.yaml."""
+        from hermes_cli.config import DEFAULT_CONFIG
+        from hermes_cli.config_migrations import run_migrations
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(yaml.safe_dump({
+            "_config_version": 42,
+            "gateway": {"multiplex_profiles": True, "multiplex_profile_allowlist": ["worker"]},
+        }), encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        run_migrations(42, {"env_added": [], "config_added": [], "warnings": []}, quiet=True)
+        raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert "multiplex_profile_allowlist" not in raw["gateway"]
+        assert raw["gateway"]["multiplex_profiles"] is True
+        assert "multiplex_profile_allowlist" not in DEFAULT_CONFIG["gateway"]
+
+
 class TestCustomProviderCompatibility:
     """Custom provider compatibility across legacy and v12+ config schemas.
 

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -1015,6 +1015,7 @@ def test_spawn_hermes_action_scrubs_gateway_loop_guard_env(monkeypatch, tmp_path
     import hermes_cli.web_server as ws
 
     monkeypatch.setenv("_HERMES_GATEWAY", "1")
+    monkeypatch.setenv("OPENAI_API_KEY", "default-action-provider-key")
     monkeypatch.setattr(_web_server_gateway, "_ACTION_LOG_DIR", tmp_path)
     # Isolate the module-global proc registry: _spawn_hermes_action stores
     # _FakeProc (no poll()) in _ACTION_PROCS, and later tests' lifespan
@@ -1036,6 +1037,135 @@ def test_spawn_hermes_action_scrubs_gateway_loop_guard_env(monkeypatch, tmp_path
 
     assert "_HERMES_GATEWAY" not in captured["env"]
     assert captured["env"]["HERMES_NONINTERACTIVE"] == "1"
+    # Default-profile actions preserve the historical process environment.
+    assert captured["env"]["OPENAI_API_KEY"] == "default-action-provider-key"
+
+
+def test_named_profile_action_isolates_parent_env_and_loads_target_env(monkeypatch, tmp_path):
+    """A dashboard action for a named profile must not borrow the dashboard profile's
+    platform/provider environment, while the target profile's own dotenv still loads in the child."""
+    import json
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    import hermes_cli.env_loader as env_loader
+    import hermes_cli.web_server as ws
+
+    user_home = tmp_path / "user"
+    default_home = user_home / ".hermes"
+    target_home = default_home / "profiles" / "verifier"
+    target_home.mkdir(parents=True)
+
+    (default_home / ".env").write_text(
+        "\n".join([
+            "DISCORD_BOT_TOKEN=default-discord",
+            "API_SERVER_ENABLED=true",
+            "API_SERVER_KEY=default-api-server",
+            "BLUEBUBBLES_SERVER_URL=http://127.0.0.1:1234",
+            "BLUEBUBBLES_PASSWORD=default-bluebubbles",
+            "NTFY_TOPIC=default-topic",
+            "NTFY_TOKEN=default-ntfy",
+            "OPENAI_API_KEY=default-openai",
+            "ZAI_API_KEY=default-zai",
+            # Locally named routing credentials must be isolated too, even without a secret suffix.
+            "A2A_AUTH_MINI=default-a2a-auth",
+        ]) + "\n",
+        encoding="utf-8",
+    )
+    (target_home / ".env").write_text(
+        "\n".join(["A2A_PORT=9917", "OPENAI_API_KEY=target-openai", "TARGET_ONLY_TOKEN=target-only"]) + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(Path, "home", lambda: user_home)
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    for key, value in {
+        "DISCORD_BOT_TOKEN": "default-discord",
+        "API_SERVER_ENABLED": "true",
+        "API_SERVER_KEY": "default-api-server",
+        "BLUEBUBBLES_SERVER_URL": "http://127.0.0.1:1234",
+        "BLUEBUBBLES_PASSWORD": "default-bluebubbles",
+        "NTFY_TOPIC": "default-topic",
+        "NTFY_TOKEN": "default-ntfy",
+        "OPENAI_API_KEY": "default-openai",
+        "ZAI_API_KEY": "default-zai",
+        "A2A_AUTH_MINI": "default-a2a-auth",
+        "EXTERNAL_PROFILE_AUTH": "default-secret-source-auth",
+        "HERMES_ACP_AUTH_METHOD": "default-acp",
+        "PROFILE_ENV_TEST_BENIGN": "keep-me",
+    }.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setattr(_web_server_gateway, "_ACTION_LOG_DIR", tmp_path / "logs")
+    monkeypatch.setattr(_web_server_gateway, "_ACTION_PROCS", {})
+    monkeypatch.setattr(
+        env_loader,
+        "get_secret_source_values",
+        lambda home: (
+            {"EXTERNAL_PROFILE_AUTH": "default-secret-source-auth"}
+            if Path(home).resolve() == default_home.resolve() else {}
+        ),
+    )
+
+    captured = {}
+    real_popen = subprocess.Popen
+
+    class _FakeProc:
+        pid = 4321
+
+    def _fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
+        return _FakeProc()
+
+    monkeypatch.setattr(ws.subprocess, "Popen", _fake_popen)
+    _web_server_gateway._spawn_hermes_action(["-p", "verifier", "gateway", "restart"], "gateway-restart")
+
+    child_env = captured["env"]
+    assert captured["cmd"][-4:] == ["-p", "verifier", "gateway", "restart"]
+    assert child_env["HERMES_HOME"] == str(target_home)
+    assert child_env["HERMES_NONINTERACTIVE"] == "1"
+    assert child_env["PROFILE_ENV_TEST_BENIGN"] == "keep-me"
+    for leaked_key in (
+        "DISCORD_BOT_TOKEN", "API_SERVER_ENABLED", "API_SERVER_KEY", "BLUEBUBBLES_SERVER_URL",
+        "BLUEBUBBLES_PASSWORD", "NTFY_TOPIC", "NTFY_TOKEN", "OPENAI_API_KEY", "ZAI_API_KEY",
+        "A2A_AUTH_MINI", "EXTERNAL_PROFILE_AUTH", "HERMES_ACP_AUTH_METHOD",
+    ):
+        assert leaked_key not in child_env, leaked_key
+
+    # Exercise the real dotenv loader in a fresh interpreter with precisely the environment handed
+    # to the named child: the target profile's own values must load without reviving any
+    # default-profile value.
+    monkeypatch.setattr(ws.subprocess, "Popen", real_popen)
+    probe = subprocess.run(
+        [
+            sys.executable, "-c",
+            "import json, os; "
+            "from hermes_cli.env_loader import load_hermes_dotenv; "
+            "load_hermes_dotenv(hermes_home=os.environ['HERMES_HOME']); "
+            "keys=['A2A_PORT','OPENAI_API_KEY','TARGET_ONLY_TOKEN','DISCORD_BOT_TOKEN',"
+            "'API_SERVER_ENABLED','API_SERVER_KEY','BLUEBUBBLES_SERVER_URL','BLUEBUBBLES_PASSWORD',"
+            "'NTFY_TOPIC','NTFY_TOKEN','ZAI_API_KEY','A2A_AUTH_MINI','EXTERNAL_PROFILE_AUTH']; "
+            "print(json.dumps({key: os.environ.get(key) for key in keys}))",
+        ],
+        cwd=Path(ws.PROJECT_ROOT), env=child_env, check=True, capture_output=True, text=True,
+    )
+    loaded = json.loads(probe.stdout.strip().splitlines()[-1])
+    assert loaded == {
+        "A2A_PORT": "9917",
+        "OPENAI_API_KEY": "target-openai",
+        "TARGET_ONLY_TOKEN": "target-only",
+        "DISCORD_BOT_TOKEN": None,
+        "API_SERVER_ENABLED": None,
+        "API_SERVER_KEY": None,
+        "BLUEBUBBLES_SERVER_URL": None,
+        "BLUEBUBBLES_PASSWORD": None,
+        "NTFY_TOPIC": None,
+        "NTFY_TOKEN": None,
+        "ZAI_API_KEY": None,
+        "A2A_AUTH_MINI": None,
+        "EXTERNAL_PROFILE_AUTH": None,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_desktop_cron_ticker_profiles.py
+++ b/tests/hermes_cli/test_desktop_cron_ticker_profiles.py
@@ -132,28 +132,33 @@ def test_external_provider_never_gets_profile_homes(monkeypatch, tmp_path):
     assert external.start_kwargs == {"interval": 13}
 
 
-def test_desktop_ticker_honours_allowlist_and_yields_to_default_multiplexer(monkeypatch, _providers, tmp_path):
-    """The Desktop ticker mirrors the multiplexer's served set (allowlist) and stands down for a
-    satellite the live default multiplexer already ticks — that profile has no gateway.pid of its
-    own, so the per-home liveness check alone lets both tickers race for its fires (#107485)."""
+def test_desktop_ticker_serves_every_profile_and_yields_to_owning_gateway(monkeypatch, _providers, tmp_path):
+    """The Desktop ticker mirrors the multiplexer's served set (default + every live profile dir)
+    and stands down, per tick, for a profile already owned by a gateway: its own running gateway,
+    or the live default multiplexer that already ticks it — such a satellite has no gateway.pid
+    of its own, so the per-home liveness check alone lets both tickers race for its fires
+    (#107485, #108428)."""
     import hermes_cli.profiles as profiles_mod
     import yaml
 
     _sp, builtin = _providers
     root = tmp_path / ".hermes"
-    for name in ("worker", "guest"):
+    for name in ("worker", "guest", "solo"):
         (root / "profiles" / name).mkdir(parents=True)
-    (root / "config.yaml").write_text(yaml.safe_dump(
-        {"gateway": {"multiplex_profiles": True, "multiplex_profile_allowlist": ["worker"]}}))
+    (root / "config.yaml").write_text(yaml.safe_dump({"gateway": {"multiplex_profiles": True}}))
     monkeypatch.setattr("hermes_constants.get_default_hermes_root", lambda: root)
     monkeypatch.setattr(profiles_mod, "_get_default_hermes_home", lambda: root)
     monkeypatch.setattr(profiles_mod, "_get_profiles_root", lambda: root / "profiles")
-    monkeypatch.setattr(profiles_mod, "_check_gateway_running", lambda home: False)
+    monkeypatch.setattr(
+        profiles_mod, "_check_gateway_running", lambda home: home == root / "profiles" / "solo")
     monkeypatch.setattr(profiles_mod, "_served_by_running_multiplexer", lambda name: name == "worker")
 
     ws._start_desktop_cron_ticker(threading.Event(), interval=0)
 
-    assert [name for name, _ in builtin.start_kwargs["profile_homes"]] == ["default", "worker"]
+    assert [name for name, _ in builtin.start_kwargs["profile_homes"]] == [
+        "default", "guest", "solo", "worker"]
     gate = builtin.start_kwargs["profile_gate"]
     assert gate("default", root) is True
+    assert gate("guest", root / "profiles" / "guest") is True
     assert gate("worker", root / "profiles" / "worker") is False
+    assert gate("solo", root / "profiles" / "solo") is False

--- a/tests/hermes_cli/test_mcp_discovery_timing.py
+++ b/tests/hermes_cli/test_mcp_discovery_timing.py
@@ -24,6 +24,7 @@ import types
 import pytest
 
 from hermes_cli import mcp_startup
+from hermes_constants import hermes_home_key
 
 
 @pytest.fixture(autouse=True)
@@ -31,11 +32,11 @@ def _reset_mcp_startup_state():
     saved_started = mcp_startup._mcp_discovery_started
     saved_thread = mcp_startup._mcp_discovery_thread
     try:
-        mcp_startup._mcp_discovery_started = False
-        mcp_startup._mcp_discovery_thread = None
+        mcp_startup._mcp_discovery_started = set()
+        mcp_startup._mcp_discovery_thread = {}
         yield
     finally:
-        thread = mcp_startup._mcp_discovery_thread
+        thread = mcp_startup._current_home_thread()
         if thread is not None and thread.is_alive():
             thread.join(timeout=1.0)
         mcp_startup._mcp_discovery_started = saved_started
@@ -135,7 +136,7 @@ def test_ensure_helper_starts_discovery_and_waits(monkeypatch):
     )
 
     # Discovery was started (thread created)
-    assert mcp_startup._mcp_discovery_thread is not None or waited
+    assert mcp_startup._current_home_thread() is not None or waited
     # Wait was called with single_query=True
     assert any(call[1] is True for call in waited)
 
@@ -146,12 +147,12 @@ def test_ensure_helper_is_idempotent(monkeypatch):
     logger = types.SimpleNamespace(debug=lambda *_a, **_k: None, warning=lambda *_a, **_k: None)
 
     mcp_startup.ensure_mcp_discovery_before_agent_build(logger=logger)
-    thread1 = mcp_startup._mcp_discovery_thread
+    thread1 = mcp_startup._current_home_thread()
     if thread1:
         thread1.join(timeout=2.0)
 
     mcp_startup.ensure_mcp_discovery_before_agent_build(logger=logger)
-    thread2 = mcp_startup._mcp_discovery_thread
+    thread2 = mcp_startup._current_home_thread()
     if thread2:
         thread2.join(timeout=2.0)
 
@@ -289,7 +290,7 @@ def test_wait_stays_bounded_when_discovery_is_slow(monkeypatch):
     stop = threading.Event()
     thread = threading.Thread(target=lambda: stop.wait(10), daemon=True)
     thread.start()
-    mcp_startup._mcp_discovery_thread = thread
+    mcp_startup._mcp_discovery_thread[hermes_home_key()] = thread
 
     try:
         start = time.monotonic()
@@ -306,7 +307,7 @@ def test_wait_stays_bounded_when_discovery_is_slow(monkeypatch):
 
 def test_wait_returns_instantly_when_discovery_done():
     """When discovery is already complete, the wait returns immediately."""
-    mcp_startup._mcp_discovery_thread = None
+    mcp_startup._mcp_discovery_thread.clear()
     t0 = time.time()
     mcp_startup.wait_for_mcp_discovery(single_query=True)
     assert time.time() - t0 < 0.2

--- a/tests/hermes_cli/test_mcp_startup.py
+++ b/tests/hermes_cli/test_mcp_startup.py
@@ -21,11 +21,11 @@ def _reset_mcp_startup_state():
     saved_started = mcp_startup._mcp_discovery_started
     saved_thread = mcp_startup._mcp_discovery_thread
     try:
-        mcp_startup._mcp_discovery_started = False
-        mcp_startup._mcp_discovery_thread = None
+        mcp_startup._mcp_discovery_started = set()
+        mcp_startup._mcp_discovery_thread = {}
         yield
     finally:
-        thread = mcp_startup._mcp_discovery_thread
+        thread = mcp_startup._current_home_thread()
         if thread is not None and thread.is_alive():
             thread.join(timeout=1.0)
         mcp_startup._mcp_discovery_started = saved_started
@@ -96,8 +96,9 @@ def test_prepare_agent_startup_backgrounds_blocking_mcp_for_chat(monkeypatch):
         while calls["mcp"] == 0 and time.monotonic() < deadline:
             time.sleep(0.01)
         assert calls["mcp"] == 1
-        assert mcp_startup._mcp_discovery_thread is not None
-        assert mcp_startup._mcp_discovery_thread.is_alive()
+        thread = mcp_startup._current_home_thread()
+        assert thread is not None
+        assert thread.is_alive()
     finally:
         stop.set()
 
@@ -149,7 +150,7 @@ def test_prepare_agent_startup_skips_discovery_when_chat_resolves_to_tui(
 
     assert calls["background"] == 0
     assert calls["inline"] == 0
-    assert mcp_startup._mcp_discovery_thread is None
+    assert mcp_startup._current_home_thread() is None
 
 
 def test_prepare_agent_startup_keeps_discovery_for_non_chat_commands(
@@ -229,8 +230,9 @@ def test_background_mcp_discovery_suppresses_interactive_oauth(monkeypatch):
         logger=types.SimpleNamespace(debug=lambda *_a, **_k: None),
         thread_name="test-mcp-discovery",
     )
-    assert mcp_startup._mcp_discovery_thread is not None
-    mcp_startup._mcp_discovery_thread.join(timeout=1.0)
+    thread = mcp_startup._current_home_thread()
+    assert thread is not None
+    thread.join(timeout=1.0)
 
     assert state["during_discover"] is True
     assert state["active"] is False
@@ -268,8 +270,9 @@ def test_background_mcp_discovery_propagates_profile_secret_scope(monkeypatch):
             logger=types.SimpleNamespace(debug=lambda *_a, **_k: None),
             thread_name="test-mcp-discovery",
         )
-        assert mcp_startup._mcp_discovery_thread is not None
-        mcp_startup._mcp_discovery_thread.join(timeout=1.0)
+        thread = mcp_startup._current_home_thread()
+        assert thread is not None
+        thread.join(timeout=1.0)
     finally:
         reset_secret_scope(token)
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -1115,32 +1115,6 @@ class TestProfilesToServe:
         assert serve["default"] == _get_default_hermes_home()
         assert serve["coder"] == get_profile_dir("coder")
 
-    def test_empty_allowlist_serves_only_default(self, profile_env):
-        create_profile("worker", no_alias=True)
-
-        serve = dict(profiles_to_serve(multiplex=True, profile_allowlist=[]))
-
-        assert serve == {"default": _get_default_hermes_home()}
-
-    def test_allowlist_normalizes_deduplicates_and_keeps_default(self, profile_env):
-        create_profile("worker", no_alias=True)
-        create_profile("guest", no_alias=True)
-
-        serve = dict(
-            profiles_to_serve(
-                multiplex=True,
-                profile_allowlist=[" Worker ", "worker", "default", "missing"],
-            )
-        )
-
-        assert set(serve) == {"default", "worker"}
-        assert serve["worker"] == get_profile_dir("worker")
-
-
-
-        assert set(serve) == {"default", "worker"}
-        assert serve["worker"] == get_profile_dir("worker")
-
 
 # ---------------------------------------------------------------------------
 # resolve_profile_env spelling preservation (#82581 junction follow-up)

--- a/tests/hermes_cli/test_serve_mcp_discovery_after_bind.py
+++ b/tests/hermes_cli/test_serve_mcp_discovery_after_bind.py
@@ -17,8 +17,8 @@ from tests.hermes_cli.test_dashboard_auth_gate import _stub_uvicorn_run
 
 
 def _reset_discovery_state(monkeypatch):
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_started", False)
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_started", set())
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", {})
     monkeypatch.setattr(mcp_startup, "_mcp_discovery_deferred", None)
 
 

--- a/tests/test_tui_entry_mcp_owner.py
+++ b/tests/test_tui_entry_mcp_owner.py
@@ -11,6 +11,7 @@ import threading
 import time
 
 from hermes_cli import mcp_startup
+from hermes_constants import hermes_home_key
 from tui_gateway import entry
 
 
@@ -31,7 +32,7 @@ def test_wait_falls_through_to_shared_owner(monkeypatch):
     )
     thread = threading.Thread(target=lambda: time.sleep(0.05), daemon=True)
     thread.start()
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", thread)
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", {hermes_home_key(): thread})
 
     start = time.monotonic()
     entry.wait_for_mcp_discovery(timeout=2.0)
@@ -43,7 +44,7 @@ def test_wait_falls_through_to_shared_owner(monkeypatch):
 
 def test_wait_noop_when_no_owner_has_a_thread(monkeypatch):
     monkeypatch.setattr(entry, "_mcp_discovery_thread", None)
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", {})
 
     start = time.monotonic()
     entry.wait_for_mcp_discovery(timeout=2.0)
@@ -78,7 +79,7 @@ def test_wait_reinvokes_shared_spawn_when_discovery_enabled(monkeypatch):
         calls.append(thread_name)
 
     monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", _fake_start)
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", {})
 
     entry.wait_for_mcp_discovery(timeout=0.1)
 
@@ -96,7 +97,7 @@ def test_wait_skips_spawn_when_discovery_not_enabled(monkeypatch):
         calls.append(thread_name)
 
     monkeypatch.setattr(mcp_startup, "start_background_mcp_discovery", _fake_start)
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", {})
 
     entry.wait_for_mcp_discovery(timeout=0.1)
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -841,8 +841,8 @@ def test_profile_scoped_mcp_discovery_uses_target_home(monkeypatch, tmp_path):
 
     seen = []
 
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_started", False)
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_started", set())
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", {})
     # ensure_mcp_discovery_started flips this module global; monkeypatch it so
     # the enablement doesn't leak into sibling tests in this file.
     monkeypatch.setattr(entry, "_mcp_discovery_enabled", False)
@@ -854,13 +854,11 @@ def test_profile_scoped_mcp_discovery_uses_target_home(monkeypatch, tmp_path):
 
     try:
         entry.ensure_mcp_discovery_started()
-        thread = mcp_startup._mcp_discovery_thread
+        thread = mcp_startup._current_home_thread()
         assert thread is not None
         thread.join(timeout=2)
     finally:
         reset_hermes_home_override(token)
-        mcp_startup._mcp_discovery_thread = None
-        mcp_startup._mcp_discovery_started = False
 
     assert seen == [str(profile_home)]
 

--- a/tests/tools/test_refresh_agent_mcp_tools.py
+++ b/tests/tools/test_refresh_agent_mcp_tools.py
@@ -221,7 +221,7 @@ def test_wait_returns_instantly_when_no_discovery_thread(monkeypatch):
     import time
     from hermes_cli import mcp_startup
 
-    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
+    monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", {})
     import hermes_cli.config as cfg
     monkeypatch.setattr(cfg, "load_config", lambda: {"mcp_discovery_timeout": 999.0})
 

--- a/tests/tui_gateway/test_mcp_late_refresh_thread_owner.py
+++ b/tests/tui_gateway/test_mcp_late_refresh_thread_owner.py
@@ -25,6 +25,7 @@ import threading
 import pytest
 
 import hermes_cli.mcp_startup as startup
+from hermes_constants import hermes_home_key
 import tui_gateway.entry as entry
 
 
@@ -34,7 +35,7 @@ def clean_discovery_globals():
     saved_entry = entry._mcp_discovery_thread
     saved_startup = startup._mcp_discovery_thread
     entry._mcp_discovery_thread = None
-    startup._mcp_discovery_thread = None
+    startup._mcp_discovery_thread = {}
     try:
         yield
     finally:
@@ -55,14 +56,14 @@ def test_entry_in_flight_sees_startup_thread(clean_discovery_globals):
     scheduler does not bail (the #51587 bug).
     """
     stop = threading.Event()
-    startup._mcp_discovery_thread = _alive_thread(stop)
+    startup._mcp_discovery_thread[hermes_home_key()] = _alive_thread(stop)
     try:
         # Entry's own thread is None, but the startup thread is alive.
         assert entry._mcp_discovery_thread is None
         assert entry.mcp_discovery_in_flight() is True
     finally:
         stop.set()
-        startup._mcp_discovery_thread.join(timeout=2.0)
+        startup._current_home_thread().join(timeout=2.0)
 
     # After the thread exits, neither owner is in flight.
     assert entry.mcp_discovery_in_flight() is False
@@ -81,7 +82,7 @@ def test_startup_module_exposes_in_flight_helpers(clean_discovery_globals):
 
     stop = threading.Event()
     t = _alive_thread(stop)
-    startup._mcp_discovery_thread = t
+    startup._mcp_discovery_thread[hermes_home_key()] = t
     try:
         assert startup.mcp_discovery_in_flight() is True
         assert startup.join_mcp_discovery(timeout=0.1) is False

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -212,18 +212,16 @@ def _has_configured_mcp_servers() -> bool:
 
 
 def ensure_mcp_discovery_started() -> None:
-    """Start background MCP discovery for the current profile context, once. ``main()`` calls
-    this for stdio; ``server._start_agent_build`` also calls it AFTER binding the session
-    profile's HERMES_HOME. MCP registration is process-global: the FIRST profile wins.
+    """Start background MCP discovery for the current profile context, once per profile home.
+    ``main()`` calls this for stdio; ``server._start_agent_build`` also calls it AFTER binding the
+    session profile's HERMES_HOME.
 
     WebSocket/Desktop entrypoints can accept sessions without running ``main()``, so the agent-build path
     (``server._start_agent_build``) also calls it AFTER binding the session profile's HERMES_HOME override —
     the shared owner in ``hermes_cli.mcp_startup`` captures the caller's context-local override and
     propagates it into the discovery thread, so discovery reads the SELECTED profile's ``mcp_servers``, not
-    the launch profile's (#67605).
-    Known limitation: MCP tool registration is process-global, so in a multi-profile process the FIRST
-    profile that builds an agent wins the discovery slot. Full per-profile MCP registries are tracked in
-    #67605.
+    the launch profile's. The discovery slot in ``hermes_cli.mcp_startup`` is keyed by profile home, so
+    every profile a shared backend serves discovers its own ``mcp_servers`` (#67605).
     """
     global _mcp_discovery_enabled
     if not _has_configured_mcp_servers():

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -136,7 +136,7 @@ spawning a `-p coder gateway restart` that could only fail.
 "Served" is read from the running gateway's own record (`served_profiles` in the
 default home's `gateway_state.json`), so it stays correct when the multiplexer was
 enabled only through `GATEWAY_MULTIPLEX_PROFILES` in the default profile's
-environment, or when the allowlist was edited after the gateway started.
+environment, or when profiles were added after the gateway started.
 
 The multiplexer is the single inbound process; a second profile gateway would
 double-bind that profile's platforms. Pass `--force` (accepted by `run`, `start`,
@@ -352,43 +352,36 @@ profile and never shares with the default or any sibling:
 | Working directory of a turn (unset `terminal.cwd`) | Same rule as a standalone gateway: `$HOME` for the local backend, sandbox default otherwise | Never the directory the multiplexer process was launched from |
 | Command approvals (`command_allowlist`, "always" choices) | The profile's own `config.yaml` | A default-profile "always" never pre-approves a secondary's command; a secondary's choice is saved to its own config |
 | Sandbox credential-file mounts (`terminal.credential_files`), `security.redact_secrets`, `browser.*` engine/headed flags, `lsp.*`, auxiliary-provider health marks, `logs/mcp-stderr.log` | The profile's own `config.yaml` / `.env` | Documented default — never the launch profile's cached value |
+| Session-search knobs (`sessions.cjk_fts`, `sessions.search_slow_ms`) | The profile's `config.yaml` | Documented default — never the default profile's bridged value |
+| Platform proxies (`TELEGRAM_PROXY`, `DISCORD_PROXY`, `HTTPS_PROXY`, …) | The profile's own `.env` | Direct connection — never the default profile's proxy |
+| MCP discovery in the Desktop/dashboard backend | Once per served profile home | A profile selected after another has already built an agent still discovers its own `mcp_servers` |
+| Dashboard actions (`hermes -p <name> …` spawned by the Desktop/dashboard) | A scrubbed child env pinned to that profile's `HERMES_HOME` | The child loads its own `.env`; the dashboard profile's tokens and ports are not inherited |
 
 What is **shared** by design: the process, its PID/lock and `gateway_state.json`
 (default home), the one HTTP listener, and the `profile_routes` table (declared
 on the default profile).
 
-### Serving selected profiles
+### Which profiles are served
 
-By default, `gateway.multiplex_profiles: true` serves every valid named profile
-on the host. To keep unrelated profiles installed without starting their
-adapters or cron jobs, set `gateway.multiplex_profile_allowlist`:
+`gateway.multiplex_profiles: true` serves the default profile plus **every**
+live named profile under `profiles/` — there is no per-profile opt-out list.
+(The former `gateway.multiplex_profile_allowlist` key is retired; a config
+migration removes it from `config.yaml`, and a profile you do not want served is
+archived or deleted instead — `hermes profile delete <name>`, or move the
+directory out of `profiles/`.) Deleted profiles leave a tombstone and are never
+enumerated; a profile whose directory is gone is never recreated by a served
+turn, the cron ticker or log routing.
 
-```yaml
-gateway:
-  multiplex_profiles: true
-  multiplex_profile_allowlist:
-    - worker
-    - guest
-```
+The served set controls `/p/<profile>/` API and webhook prefixes, runtime
+status, profile-route eligibility, and which profiles the in-process cron
+scheduler ticks (the Desktop backend's ticker enumerates the same set and stands
+down for any profile a running multiplexer or its own gateway already serves). A
+multiplexer started as `hermes -p <name> gateway run` always ticks its own
+profile's cron store as well.
 
-The default profile is always served and does not need to be listed. An unset
-allowlist preserves the historical serve-all behavior; an empty list serves
-only the default profile. Names are normalized and deduplicated. Invalid list
-entries or names that are not installed are skipped with a warning. A malformed
-non-list value fails safely to default-only.
-
-The resulting served set also controls `/p/<profile>/` API and webhook prefixes,
-runtime status, profile-route eligibility, and which profiles the in-process
-cron scheduler ticks (the Desktop backend's ticker follows the same allowlist and
-stands down for any profile a running multiplexer already serves). A multiplexer
-started as `hermes -p <name> gateway run` always ticks its own profile's cron store
-as well. A named profile outside the allowlist may still run its own standalone
-gateway.
-
-One caveat: the served set is a **start-time snapshot**. A profile created or
-added to the allowlist while the multiplexer is running is not picked up until
-`hermes gateway restart` (profiles deleted at runtime are dropped from cron
-ticking automatically).
+One caveat: the served set is a **start-time snapshot**. A profile created while
+the multiplexer is running is not picked up until `hermes gateway restart`
+(profiles deleted at runtime are dropped from cron ticking automatically).
 
 ### Routing shared-bot chats to profiles (`profile_routes`)
 
@@ -472,8 +465,7 @@ ids are unchanged.
 
 `profile_routes` requires `gateway.multiplex_profiles: true`; with
 multiplexing off the routes are ignored. If an explicit route matches but its
-target profile is not installed or is outside `multiplex_profile_allowlist`,
-the gateway rejects that ingress and logs the route and target. It does not run
+target profile is not installed (or was deleted), the gateway rejects that ingress and logs the route and target. It does not run
 the default profile. Traffic that matches no route keeps the historical
 default-profile behavior.
 


### PR DESCRIPTION
A profile served by the default multiplexer now behaves like its own standalone `hermes -p <name> gateway run` for six more surfaces — and the multiplexer serves **every** profile under `profiles/`; the `gateway.multiplex_profile_allowlist` knob is gone.

## ⚠️ Behaviour flip

Anyone who set `gateway.multiplex_profile_allowlist` now has their previously excluded profiles served (adapters started, cron ticked, `/p/<name>/` reachable). A profile that must not be served is archived or deleted (`hermes profile delete`, or move the dir out of `profiles/`). Config migration v43 deletes the key from `config.yaml`. Approved by Teknium for the parity campaign.

## Changes

| # | Symptom (served profile, before) | Change | Behaviour (after) |
|---|---|---|---|
| a | Dashboard `hermes -p <name> gateway restart` child inherited the dashboard profile's `.env` (`DISCORD_BOT_TOKEN`, API ports) and `HERMES_HOME` (#107434) | Salvage of #107434 by @BowmanStephen (cherry-picked, authorship kept): named-profile actions get a scrubbed env with dashboard-defined keys dropped and `HERMES_HOME` pinned to the target | Child sees only its own `.env`; default-profile actions unchanged |
| b | `sessions.cjk_fts` / `sessions.search_slow_ms` read `os.getenv` → always the default profile's bridged value | `hermes_state_common.routed_sessions_setting()` reads the routed profile's config under a HERMES_HOME override, the env bridge when unscoped; per-turn re-bridge skips secondary scope | Served alpha with `cjk_fts: false, search_slow_ms: 50` gets exactly that |
| c | `resolve_proxy_url` (`TELEGRAM_PROXY`/`DISCORD_PROXY`/`HTTPS_PROXY`…) read raw `os.environ` → every secondary routed through the default's proxy | Reads via `get_secret` (routed scope, misses fail closed); environ only on the unscoped path | Alpha uses its proxy; beta with none goes direct; default unchanged |
| d | `multiplex_profile_allowlist` existed | Dropped from `DEFAULT_CONFIG`, `GatewayConfig`, yaml bridge; `profiles_to_serve(multiplex=True)` = default + every live named dir; every reader (gateway served set, api_server/webhook `/p/` prefixes, named-profile standalone guard, Desktop ticker) follows; migration v43; docs + `hermes_cli/AGENTS.md` | Served set = all profiles; #108428 Desktop ticker standdown for a gateway-owned profile unchanged |
| e | A multiplexer/Desktop backend still holding an archived profile's route re-scaffolded `profiles/<name>` (`SOUL.md`, `cache/`, `cron/`, `logs/`) on its next turn (#94590) | `SessionDB._open_writer` goes through `mkdir_under_hermes_home` (refuses deleted/missing named homes); `profiles_to_serve` is a pure read of live dirs | Stale served turn raises `FileNotFoundError`; dir stays gone |
| f | `hermes_cli/mcp_startup.py` held one discovery slot per process → first profile to build an agent won, later profiles got zero MCP servers (#67605 residual) | Slot/thread table keyed by `hermes_home_key()` (follows the HERMES_HOME override); wait/in-flight/join read the current home's thread. Shape from #90027 (@100yenadmin) and #104534 (@Bergmann89), co-author credited | Each served profile discovers its own `mcp_servers`; single-profile processes identical to before |

## Live repro (temp HERMES_HOME: default + `alpha` + `beta`, distinct `.env`/`config.yaml`, real `_profile_runtime_scope`; before = `origin/main`, after = this branch)

| Observable | Before | After |
|---|---|---|
| (a) `DISCORD_BOT_TOKEN` in `-p alpha` child env / child `HERMES_HOME` | `tok-default` / default home | absent / `profiles/alpha` |
| (b) served alpha `cjk_fts` / `search_slow_ms` (config: false / 50) | `True` / `1000.0` | `False` / `50.0` |
| (c) served alpha `TELEGRAM_PROXY` (alpha `.env`: alpha-proxy; default: default-proxy) | `default-proxy` | `alpha-proxy` |
| (c) served beta (no proxy in `.env`) | `default-proxy` | `None` |
| (d) served set with `allowlist: [alpha]` in default config | `[default, alpha]` | `[default, alpha, beta]` |
| (d) allowlist key left in user `config.yaml` after migrate | yes | removed (v43) |
| (e) `profiles/beta` exists after archive + one stale served turn | recreated (`SOUL.md`, `cache/`, `cron/`, `logs/`…) | not recreated (`FileNotFoundError`) |
| (f) profiles whose MCP discovery ran (alpha builds, then beta) | `[alpha]` | `[alpha, beta]` |

Standalone (`hermes -p alpha`) values were identical before and after — parity, not a new default. Fresh-process canary: real `migrate_config()` on a v42 config with an allowlist → v43, key removed, `multiplex_profiles: true` kept, `load_gateway_config()` + `_multiplex_profile_homes` = all three profiles.

## Tests

- New `tests/gateway/test_multiplex_residue_parity.py` (5 invariants) + `TestRetiredMultiplexAllowlist` in `test_config.py` — all 6 **red on `origin/main`** (cp-swap of the touched sources), green here.
- Allowlist tests deleted (feature removed) or rewritten to "served set = all live profiles" with unserved cases via tombstone/missing dir; MCP discovery fixtures converted to the per-home slot.
- `scripts/run_tests.sh tests/gateway tests/state` → 8361 passed / 0 failed; `tests/hermes_cli tests/cron tests/tui_gateway tests/acp_adapter` + TUI/MCP files → 12518 passed / 1 failed. The 1 failure, `test_update_head_moved_gate.py::test_update_success_when_head_moves`, fails identically on a clean `origin/main` worktree (env-dependent fleet-version check) — not from this PR.

## Overlap with #106742

`gateway/run.py` (+10/−6: `_bridge_max_turns_from_config` early return, `_multiplex_profile_homes` drops the allowlist kwarg — #106742 adds a `_runtime_profile_homes` short-circuit above the same call), `hermes_cli/web_server.py` (−5/+2 in `_start_desktop_cron_ticker`, which #106742 moves), `gateway/platforms/base.py` (new `_proxy_env`, far from #106742's `_handle_message_while_active` hunk). All hunks kept minimal; no rewritten file touched beyond those lines.

## Credits

- #107434 @BowmanStephen — cherry-picked as-is (dashboard `-p` child env).
- #90027 @100yenadmin, #104534 @Bergmann89 — per-home MCP discovery slot shape (co-authored).

Fixes #107434. Fixes #94590. Fixes #67605.

## Not done

- #107485 (cron slot loss in a restart gap) — separate lane; shared with standalone.
- Other #67605 items already closed on main (#72219, #108352); `${VAR}` config interpolation and import-time globals listed there were not part of this lane's scope — reopen as their own issue if still reproducible.

## Infographic

![Multiplex parity](https://v3b.fal.media/files/b/0aaa0ee8/vrPaJSllEVR8wXRiXO1JE_eCipoLNP.png)
