### PR TITLE
fix(state): exclude empty ghost sessions from title uniqueness

### DIFF
--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -123,7 +123,8 @@ _SESSION_MODEL_USAGE_V20_SEED_SQL = """INSERT OR IGNORE INTO session_model_usage
                                  + COALESCE(cache_write_tokens, 0)
                                  + COALESCE(reasoning_tokens, 0) > 0"""
 _TITLE_UNIQUE_INDEX_SQL = (
-    "CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_title_unique ON sessions(title) WHERE title IS NOT NULL"
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_title_unique ON sessions(title) "
+    "WHERE title IS NOT NULL AND message_count > 0"
 )
 _STALE_KEY_UPSERT_SQL = (
     "INSERT INTO state_meta (key, value) VALUES (?, '1') ON CONFLICT(key) DO UPDATE SET value = excluded.value"
@@ -1055,7 +1056,14 @@ class SessionSchemaMixin:
 
     def _ensure_unique_title_index(self, cursor: sqlite3.Cursor) -> None:
         """Unique title index. Older DBs may hold duplicate aliases from before the constraint;
-        the newest keeps the alias. Must never abort opening the DB, so the repair is guarded."""
+        the newest keeps the alias. Must never abort opening the DB, so the repair is guarded.
+        Schema v31: dropped and rebuilt the index to exclude empty ghost sessions."""
+        # Drop the old index if it exists (may have old filter clause)
+        try:
+            cursor.execute("DROP INDEX IF EXISTS idx_sessions_title_unique")
+        except sqlite3.Error:
+            pass  # Doesn't exist yet, fine
+        
         try:
             cursor.execute(_TITLE_UNIQUE_INDEX_SQL)
         except sqlite3.IntegrityError:

--- a/hermes_state_titles.py
+++ b/hermes_state_titles.py
@@ -97,7 +97,7 @@ class SessionTitlesMixin:
                 return 0
             if title:
                 conflict = conn.execute(
-                    "SELECT id FROM sessions WHERE title = ? AND id != ?", (title, session_id),
+                    "SELECT id FROM sessions WHERE title = ? AND id != ? AND message_count > 0", (title, session_id),
                 ).fetchone()
                 if conflict:
                     conflict_id = conflict["id"]

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2312,6 +2312,31 @@ class TestTitleUniqueness:
         assert db.get_session("s1")["title"] is None
         assert db.get_session("s2")["title"] is None
 
+    def test_empty_ghost_session_does_not_block_title(self, db):
+        """Empty sessions (0 messages) should not block title reuse (#81888).
+        
+        Regression test: ghost sessions created by interrupted flows (e.g., desktop
+        session creation that never sent a message) would block rename attempts even
+        though they were invisible in the UI.
+        """
+        # Create a ghost session (0 messages) with a title
+        ghost_id = db.create_session("ghost", "desktop")
+        db.set_session_title(ghost_id, "Canada")
+        assert db.get_session(ghost_id)["message_count"] == 0
+        
+        # Create a real session with messages
+        real_id = db.create_session("real", "desktop")
+        db.append_message(real_id, "user", "Hello")
+        db.append_message(real_id, "assistant", "Hi there")
+        assert db.get_session(real_id)["message_count"] == 2
+        
+        # Should be able to rename the real session to "Canada" — ghost doesn't block
+        db.set_session_title(real_id, "Canada")
+        assert db.get_session(real_id)["title"] == "Canada"
+        
+        # Ghost session should still exist but be effectively invisible
+        assert db.get_session(ghost_id) is not None
+
 
 
 


### PR DESCRIPTION
## Summary

Empty sessions (message_count=0) created by interrupted flows (e.g., desktop session creation that never sent a message) would block session rename attempts even though they were invisible in the UI.

## What does this PR do?

Fixes a bug where empty "ghost" sessions would reserve titles and prevent users from renaming active sessions to those titles, despite the ghost sessions being invisible in the session list.

## Related Issue

Closes #81888 (partial - addresses the title blocking aspect of ghost sessions)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Updated `idx_sessions_title_unique` index to exclude sessions with `message_count = 0`
- Modified `_set_session_title` conflict check to skip empty sessions
- Added migration in `_ensure_unique_title_index` to drop and rebuild the index
- Added regression test `test_empty_ghost_session_does_not_block_title`

## How to Test

1. Create a ghost session with 0 messages and set a title
2. Create a real session with messages  
3. Try to rename the real session to the ghost's title - should succeed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (ARM64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A