### PR TITLE
fix(gateway): preserve system service name under sudo

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1950,19 +1950,41 @@ def _profile_name_from_home(home: Path, default: Path) -> str | None:
     return None
 
 
-def _profile_suffix() -> str:
-    """Service-name suffix for HERMES_HOME: "" for the platform-native default home (``~/.hermes``), the
-    profile name for ``<root>/profiles/<name>``, else a short hash of the path.
+def _native_service_homes() -> set[Path]:
+    """Homes that own the bare native gateway service name in this process."""
+    from hermes_constants import _get_platform_default_hermes_home
+    from pathlib import Path as _Path
 
-    The bare name is reserved for the NATIVE default, not ``get_default_hermes_root()``: that helper
-    treats any HERMES_HOME outside ``~/.hermes`` (Docker ``/opt/data``, a temp dir) as "the root itself",
-    which let a temp-home harness resolve to the default profile's ``hermes-gateway`` unit and uninstall
-    the production gateway. Service names are host-wide identities; only the real default home owns the
-    bare one."""
+    homes = {_get_platform_default_hermes_home().resolve()}
+    if getattr(os, "geteuid", lambda: -1)() != 0:
+        return homes
+
+    sudo_user = os.environ.get("SUDO_USER", "").strip()
+    if not sudo_user or sudo_user == "root":
+        return homes
+    try:
+        import pwd
+
+        homes.add((_Path(pwd.getpwnam(sudo_user).pw_dir) / ".hermes").resolve())
+    except (ImportError, KeyError, AttributeError, TypeError):
+        pass
+    return homes
+
+
+def _profile_suffix() -> str:
+    """Service-name suffix for HERMES_HOME: "" for a native default home (``~/.hermes``), the profile
+    name for ``<root>/profiles/<name>``, else a short hash of the path.
+
+    The bare name is reserved for the process user's native default and, under sudo, the invoking user's
+    native default. It deliberately does not use ``get_default_hermes_root()``: that helper treats any
+    HERMES_HOME outside ``~/.hermes`` (Docker ``/opt/data``, a temp dir) as "the root itself", which let a
+    temp-home harness resolve to the default profile's ``hermes-gateway`` unit and uninstall the
+    production gateway. Service names are host-wide identities; only real default homes own the bare
+    one."""
     import hashlib
-    from hermes_constants import _get_platform_default_hermes_home, get_default_hermes_root
+    from hermes_constants import get_default_hermes_root
     home = get_hermes_home().resolve()
-    if home == _get_platform_default_hermes_home().resolve():
+    if home in _native_service_homes():
         return ""
     name = _profile_name_from_home(home, get_default_hermes_root().resolve())
     return name or hashlib.sha256(str(home).encode()).hexdigest()[:8]

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -217,6 +217,40 @@ class TestServiceIdentityForForeignHome:
         monkeypatch.setenv("HERMES_HOME", str(default_home / "profiles" / "alpha"))
         assert gateway_cli.get_service_name() == "hermes-gateway-alpha"
 
+    def test_sudo_user_default_home_keeps_bare_service_name(self, machine_home, tmp_path, monkeypatch):
+        sudo_home = tmp_path / "alice"
+        sudo_default = sudo_home / ".hermes"
+        sudo_default.mkdir(parents=True)
+        monkeypatch.setattr(os, "geteuid", lambda: 0)
+        monkeypatch.setenv("SUDO_USER", "alice")
+        monkeypatch.setattr(pwd, "getpwnam", lambda user: SimpleNamespace(pw_dir=str(sudo_home)))
+
+        # Before unit sync, sudo resolves the root process's native home.
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        assert gateway_cli.get_service_name() == "hermes-gateway"
+
+        # After unit sync, HERMES_HOME points at the invoking user's native home.
+        monkeypatch.setenv("HERMES_HOME", str(sudo_default))
+        assert gateway_cli.get_service_name() == "hermes-gateway"
+
+    def test_sudo_user_named_and_custom_homes_remain_distinct(
+        self, machine_home, tmp_path, monkeypatch
+    ):
+        sudo_home = tmp_path / "alice"
+        named_home = sudo_home / ".hermes" / "profiles" / "alpha"
+        custom_home = tmp_path / "custom-hermes"
+        named_home.mkdir(parents=True)
+        custom_home.mkdir()
+        monkeypatch.setattr(os, "geteuid", lambda: 0)
+        monkeypatch.setenv("SUDO_USER", "alice")
+        monkeypatch.setattr(pwd, "getpwnam", lambda user: SimpleNamespace(pw_dir=str(sudo_home)))
+
+        monkeypatch.setenv("HERMES_HOME", str(named_home))
+        assert gateway_cli.get_service_name() == "hermes-gateway-alpha"
+
+        monkeypatch.setenv("HERMES_HOME", str(custom_home))
+        assert gateway_cli.get_service_name() not in {"hermes-gateway", "hermes-gateway-alpha"}
+
 
 class TestUninstallRefusesForeignUnit:
     """systemd_uninstall must not stop/disable/unlink a unit pinned to another HERMES_HOME."""


### PR DESCRIPTION
## What does this PR do?

Fixes the system-service name changing mid-command under `sudo`.

Before the systemd unit is read, the elevated process sees `/root/.hermes` and selects `hermes-gateway`. After `_sync_hermes_home_from_systemd_unit()` adopts the unit's `HERMES_HOME`, the same command could switch to a hashed service name and target a unit that does not exist.

The service identity now treats both the process user's native default home and, while running under sudo, the invoking user's native default home as owners of the bare service name. Custom and temporary homes remain hashed, preserving the isolation guard from #105525.

## Related Issue

Fixes #108674

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add SUDO_USER-aware native service-home resolution in `hermes_cli/gateway.py`.
- Preserve `hermes-gateway` before and after the system unit synchronizes `HERMES_HOME`.
- Add regression coverage for the sudo transition, named profiles, and custom homes.

## How to Test

1. Run the gateway service, lifecycle, linger, profile-isolation, multiplex, and profile-secrets test selections.
2. Verify the sudo user's default `~/.hermes` resolves to `hermes-gateway` before and after unit sync.
3. Verify named profiles retain their readable suffix and custom homes retain a hash suffix.

Result: **187 passed, 4 skipped**. Ruff and Python compilation checks pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Linux

### Documentation & Housekeeping

- [x] Documentation changes are N/A; behavior and rationale are documented in code
- [x] `cli-config.yaml.example` changes are N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A
- [x] Cross-platform impact was considered; `pwd` and `geteuid` are guarded
- [x] Tool descriptions/schemas are N/A
