### PR TITLE
fix(compression): preserve and report provider refusals

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -642,7 +642,15 @@ def _stream_final_message(stream_fn, api_kwargs, log_prefix, on_stream_event, on
         # returns the accumulated snapshot. TimeoutError is the caller's deadline seam: the host
         # has given up, so abandon the stream (``with`` closes it) instead of streaming an answer
         # nobody reads.
-        for event in stream if callable(on_stream_event) else ():
+        # Some SDK versions drop optional message_delta metadata from the final snapshot.
+        stop_details = None
+        for event in stream:
+            if getattr(event, "type", None) == "message_delta":
+                details = getattr(getattr(event, "delta", None), "stop_details", None)
+                if details is not None:
+                    stop_details = details
+            if not callable(on_stream_event):
+                continue
             try:
                 on_stream_event(event)
             except TimeoutError:
@@ -652,7 +660,10 @@ def _stream_final_message(stream_fn, api_kwargs, log_prefix, on_stream_event, on
                 raise
             except Exception:
                 logger.debug("%son_stream_event callback failed", log_prefix, exc_info=True)
-        return stream.get_final_message()
+        message = stream.get_final_message()
+        if stop_details is not None:
+            message.stop_details = stop_details
+        return message
 
 
 def create_anthropic_message(

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1689,8 +1689,7 @@ class _AnthropicCompletionsAdapter:
             self._client,
             anthropic_kwargs,
             # Record provider-response timing every event, but tick forward progress only for
-            # substantive payloads so keepalives can't hold a stalled summary open. None keeps
-            # the fast get_final_message path.
+            # substantive payloads so keepalives can't hold a stalled summary open.
             on_stream_event=(_anthropic_aux_stream_event_hook() if _aux_progress_active() else None),
         )
         _nr = get_transport("anthropic_messages").normalize_response(response, strip_tool_prefix=self._is_oauth)
@@ -1708,7 +1707,7 @@ class _AnthropicCompletionsAdapter:
             message=SimpleNamespace(content=_nr.content, tool_calls=_nr.tool_calls, reasoning=_nr.reasoning),
             finish_reason=_nr.finish_reason,
         )
-        return SimpleNamespace(choices=[choice], model=model, usage=usage)
+        return SimpleNamespace(choices=[choice], model=model, usage=usage, provider_data=_nr.provider_data)
 
 
 class AnthropicAuxiliaryClient:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -140,6 +140,10 @@ def _response_finish_reason(response: Any) -> str:
 _TRUNCATED_SUMMARY_MARKER = "finish_reason=length"
 
 
+class _SummaryRefusalError(RuntimeError):
+    """A provider refusal, distinct from retryable empty summary output."""
+
+
 def _is_summary_access_or_quota_error(exc: Exception) -> bool:
     """Return True for non-retryable summary auth, permission, or quota errors."""
 
@@ -595,6 +599,12 @@ def _classify_summary_failure(e: Exception) -> _SummaryFailureKind:
 # Summary failures that abort compress() regardless of abort_on_summary_failure, in precedence
 # order: (flag attribute, telemetry failure_class, user-facing warning with %d preserved messages).
 _TERMINAL_SUMMARY_FAILURES = (
+    (
+        "_last_summary_refusal_failure",
+        "summary_refusal_failure",
+        "Context compression refused by the provider — aborting compression. %d message(s) "
+        "preserved unchanged; the session was NOT rotated. Review the provider refusal.",
+    ),
     (
         "_last_summary_auth_failure",
         "summary_auth_failure",
@@ -3263,9 +3273,20 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
             )
         if self._compression_cancelled():
             raise AuxiliaryExplicitCancellation()
+        where = f"(provider={_aux_route.get('provider') or self.provider or 'auto'} model={_aux_model})"
+        if _response_finish_reason(response) == "content_filter":
+            data = response.get("provider_data") if isinstance(response, dict) else getattr(response, "provider_data", None)
+            details = data.get("stop_details") if isinstance(data, dict) else None
+            # Never echo provider explanation text or arbitrary category values into notices.
+            category = details.get("category") if isinstance(details, dict) else None
+            category = "cyber" if category == "cyber" else "unspecified"
+            route = re.sub(r"[\x00-\x1f\x7f]", "", _redact_compaction_text(where))[:160]
+            raise _SummaryRefusalError(
+                f"Context compression refused {route}; category={category}. "
+                "Original context preserved; review the provider refusal."
+            )
         # Reasoning-field fallback (DeepSeek/Qwen/Kimi put the summary in reasoning_content); capped.
         content = extract_content_or_reasoning(response, max_reasoning_chars=8000)
-        where = f"(provider={self.provider or 'auto'} model={self.summary_model or self.model})"
         # Some OpenAI-compatible proxies (e.g. cmkey.cn, one-api channels) return a well-formed HTTP 200
         # with an empty or whitespace-only ``content`` instead of an error or empty ``choices``. That
         # payload passes ``_validate_llm_response`` (a ``message`` exists), so it reaches here and would
@@ -3486,6 +3507,12 @@ Write only the summary body. Do not include any preamble or prefix."""
         self, e: Exception, turns_to_summarize: List[Dict[str, Any]], focus_topic: Optional[str], memory_context: str,
     ) -> Optional[str]:
         """Classify a summary-call failure; retry once on the main model (returning its result) or arm a cooldown (None)."""
+        if isinstance(e, _SummaryRefusalError):
+            self._last_summary_error = str(e)
+            self._last_summary_refusal_failure = True
+            self._record_compression_failure_cooldown(60, str(e))
+            logger.warning("%s", e)
+            return None
         # Only a genuine no-provider RuntimeError gets the long cooldown; empty/invalid-response
         # RuntimeErrors are transient and must get the main-model retry below first.
         # ``call_llm`` raises ``RuntimeError`` for two very different cases: 1. 2. An empty/invalid response

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -91,6 +91,9 @@ class AnthropicTransport(ProviderTransport):
                     name = _unprefix_oauth_tool_name(name)
                 tool_calls.append(ToolCall(id=block.id, name=name, arguments=json.dumps(block.input)))
         provider_data = {"reasoning_details": reasoning_details} if reasoning_details else {}
+        stop_details = _to_plain_data(getattr(response, "stop_details", None))
+        if stop_details is not None:
+            provider_data["stop_details"] = stop_details
         # Ordered channel only for the shape the parallel lists reconstruct wrongly.
         signed = any(b.get("type") in _THINKING_TYPES and (b.get("signature") or b.get("data")) for b in ordered_blocks)
         if signed and any(b.get("type") == "tool_use" for b in ordered_blocks):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -56,6 +56,9 @@ class _FakeAnthropicStream:
     def __exit__(self, exc_type, exc, tb):
         return False
 
+    def __iter__(self):
+        return iter(())
+
     def get_final_message(self):
         return self._final_message
 

--- a/tests/agent/test_compression_refusal_observability.py
+++ b/tests/agent/test_compression_refusal_observability.py
@@ -1,0 +1,162 @@
+"""Replay a recorded provider refusal through the real SDK and compression path.
+
+The SSE fixture is a captured HTTP-200 response to a benign inventory summary;
+only its message identifier was replaced. No request, headers, or credentials
+are included. Control variants below deliberately mutate this recorded response.
+"""
+import copy
+from pathlib import Path
+from unittest.mock import patch
+
+import anthropic
+import httpx
+import pytest
+
+from agent.anthropic_adapter import create_anthropic_message
+from agent.auxiliary_client import _AnthropicCompletionsAdapter
+from agent.context_compressor import ContextCompressor
+
+
+FIXTURE = Path(__file__).parents[1] / "fixtures/anthropic_compression_refusal.sse"
+
+
+def client_for(body, calls):
+    def respond(request):
+        calls.append(request)
+        return httpx.Response(200, headers={"content-type": "text/event-stream"}, content=body)
+    return anthropic.Anthropic(api_key="fixture-only", max_retries=0,
+                               http_client=httpx.Client(transport=httpx.MockTransport(respond)))
+
+
+@pytest.mark.parametrize("with_callback", [False, True])
+def test_recorded_delta_details_survive_sdk_aggregation(with_callback):
+    calls = []
+    with client_for(FIXTURE.read_text(), calls) as client:
+        message = create_anthropic_message(client, {
+            "model": "claude-opus-5", "max_tokens": 100,
+            "messages": [{"role": "user", "content": "Summarize inventory."}],
+        }, on_stream_event=(lambda event: None) if with_callback else None)
+    details = message.stop_details
+    assert details is not None
+    assert (details if isinstance(details, dict) else details.model_dump())["category"] == "cyber"
+    assert len(calls) == 1
+
+
+def test_recorded_refusal_preserves_context_and_reports_resolved_route(caplog):
+    calls = []
+    with client_for(FIXTURE.read_text(), calls) as client:
+        adapter = _AnthropicCompletionsAdapter(client, "claude-opus-5")
+        def call(**kwargs):
+            kwargs["route_info"].update(provider="claude-apx-1", model="claude-opus-5")
+            return adapter.create(messages=kwargs["messages"], model="claude-opus-5", max_tokens=100)
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            compressor = ContextCompressor(model="main-model",
+                                           provider="claude-apr", protect_first_n=2,
+                                           protect_last_n=2, abort_on_summary_failure=False)
+            compressor.summary_model = "configured-summary"
+            messages = [{"role": "user" if i % 2 == 0 else "assistant",
+                         "content": "Observatory inventory item " + str(i)} for i in range(12)]
+            original = copy.deepcopy(messages)
+            with patch("agent.context_compressor.call_llm", side_effect=call):
+                result = compressor.compress(messages, current_tokens=999999, force=True)
+    assert result == original
+    assert messages == original
+    assert len(calls) == 1  # Refusals must not enter the empty-response retry path.
+    assert compressor._last_compress_aborted
+    assert not compressor._last_summary_fallback_used
+    assert compressor._last_summary_dropped_count == 0
+    error = compressor._last_summary_error
+    assert "refus" in error.lower()
+    assert "cyber" in error
+    assert "claude-apx-1" in error and "claude-opus-5" in error
+    assert "claude-apr" not in error
+    assert "empty content" not in error
+    assert "Usage Policy" not in error  # Never echo provider free text.
+    assert "refus" in caplog.text.lower()
+
+
+@pytest.mark.parametrize("kind", ["empty", "success", "missing_details"])
+def test_controls(kind):
+    body = FIXTURE.read_text()
+    import json
+    events = [json.loads(line[6:]) for line in body.splitlines() if line.startswith("data: ")]
+    if kind == "missing_details":
+        events[1]["delta"].pop("stop_details")
+    else:
+        events[1]["delta"]["stop_reason"] = "end_turn"
+        events[1]["delta"].pop("stop_details")
+        if kind == "success":
+            events[1:1] = [
+                {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+                {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "The inventory was checked; continue recording observations."}},
+                {"type": "content_block_stop", "index": 0},
+            ]
+    body = "".join("event: " + e["type"] + "\ndata: " + json.dumps(e) + "\n\n" for e in events)
+    calls = []
+    with client_for(body, calls) as client:
+        adapter = _AnthropicCompletionsAdapter(client, "claude-opus-5")
+        def call(**kwargs):
+            kwargs["route_info"].update(provider="resolved-provider", model="claude-opus-5")
+            return adapter.create(messages=kwargs["messages"], max_tokens=100)
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            compressor = ContextCompressor(model="claude-opus-5", quiet_mode=True)
+            with patch("agent.context_compressor.call_llm", side_effect=call):
+                result = compressor._generate_summary([{"role": "user", "content": "Inventory checked."}])
+    assert len(calls) == 1
+    if kind == "success":
+        assert "inventory was checked" in result
+        assert compressor._last_summary_error is None
+    elif kind == "empty":
+        assert result is None
+        assert "empty content" in compressor._last_summary_error
+        assert "resolved-provider" in compressor._last_summary_error
+    else:
+        assert result is None
+        assert "refus" in compressor._last_summary_error.lower()
+
+
+@pytest.mark.parametrize("category", ["untrusted-category", {"unexpected": "shape"}, None])
+@pytest.mark.parametrize("as_dict", [False, True])
+def test_refusal_metadata_is_bounded_and_success_clears_failure(category, as_dict, caplog):
+    from types import SimpleNamespace
+
+    response = {
+        "choices": [{"finish_reason": "content_filter", "message": {"content": "not a summary"}}],
+        "provider_data": {"stop_details": {"category": category, "explanation": "private explanation"}},
+    }
+    if not as_dict:
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(finish_reason="content_filter", message=SimpleNamespace(content="not a summary"))],
+            provider_data=response["provider_data"],
+        )
+    with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+        compressor = ContextCompressor(model="main-model", quiet_mode=True)
+        compressor.summary_model = "distinct-summary"
+        turns = [{"role": "user", "content": "Inventory checked."}]
+        with patch("agent.context_compressor.call_llm", return_value=response) as call:
+            assert compressor._generate_summary(turns) is None
+        assert call.call_count == 1
+        assert compressor._last_summary_refusal_failure
+        assert "category=unspecified" in compressor._last_summary_error
+        assert "untrusted-category" not in caplog.text
+        assert "private explanation" not in caplog.text
+        success = {"choices": [{"finish_reason": "stop", "message": {"content": "Inventory checked; continue observations."}}]}
+        with patch("agent.context_compressor.call_llm", return_value=success):
+            assert compressor._generate_summary(turns, bypass_cooldown=True)
+        assert not compressor._last_summary_refusal_failure
+        assert compressor._last_summary_error is None
+
+
+def test_stream_cancellation_is_not_refusal_or_create_fallback():
+    class Cancelled(BaseException):
+        pass
+    calls = []
+    with client_for(FIXTURE.read_text(), calls) as client:
+        def cancel(event):
+            raise Cancelled()
+        with pytest.raises(Cancelled):
+            create_anthropic_message(client, {
+                "model": "claude-opus-5", "max_tokens": 100,
+                "messages": [{"role": "user", "content": "Inventory."}],
+            }, on_stream_event=cancel)
+    assert len(calls) == 1

--- a/tests/fixtures/anthropic_compression_refusal.sse
+++ b/tests/fixtures/anthropic_compression_refusal.sse
@@ -1,0 +1,9 @@
+event: message_start
+data: {"type":"message_start","message":{"model":"claude-opus-5","id":"msg_recorded_refusal","type":"message","role":"assistant","content":[],"container":null,"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":20557,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":0,"service_tier":"standard","inference_geo":"not_available"},"context_management":null} }
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"refusal","stop_sequence":null,"stop_details":{"type":"refusal","category":"cyber","explanation":"This request triggered restrictions on violative cyber content and was blocked under Anthropic's Usage Policy. To learn more, see https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback."},"container":null},"usage":{"input_tokens":20557,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":0,"iterations":[{"input_tokens":20557,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"type":"message"}]},"context_management":{"applied_edits":[]}  }
+
+event: message_stop
+data: {"type":"message_stop"             }
+


### PR DESCRIPTION
## Summary

An Anthropic HTTP-200 streaming refusal can reach context compression as an ordinary empty summary. Some SDK versions retain `message_delta.stop_details` on the event but omit it from the final message snapshot; the auxiliary response shim also drops provider metadata. Compression then reports empty content and may retry on the main model rather than identify the refusal.

- Preserve optional streamed `stop_details`, including when no progress callback is installed, and carry it through transport normalization and the auxiliary shim.
- Classify `content_filter` before empty-content/reasoning handling. Abort compression with original context intact, no automatic refusal retry or static fallback, and a distinct failure class.
- Report the resolved provider/model. Notices redact the route and only expose the recognized `cyber` category or `unspecified`, never provider explanation text or arbitrary category values.
- Keep existing stream deadline/cancellation behavior.

## Verification

On upstream base `1021a0325696e9070e6659f95fcd84c3e7e114df`:

- Recorded SSE replay before production edits: **5 failed, 2 passed** (metadata loss, misleading empty classification, wrong route, and unwanted second request).
- Replay plus metadata-shape/notice/reset controls and neighboring suites: **294 passed**.
- Neighbor suites: Anthropic adapter, auxiliary custom Anthropic client, context compressor, truncated-summary guard, reasoning fallback, and compression progress timeout.
- Tests use the real Anthropic SDK with HTTP transport replay, not a synthetic final-message mock. The fixture is a captured response with its message identifier replaced; it contains no request or credentials. Additional variants are explicitly constructed controls.

No provider policy, prompt, model configuration, or runtime deployment changes. Full CI remains the matrix backstop.
