### PR TITLE
fix(cron): serialize notepad capacity checks across processes

### DIFF
--- a/cron/notepad.py
+++ b/cron/notepad.py
@@ -74,6 +74,9 @@ def set_note(job_id: str, key: str, value: str) -> Dict[str, Any]:
     _validate(job_id, key, value)
     now = _hermes_now().isoformat()
     with _transaction() as conn:
+        # The size check and write must serialize across CLI processes too;
+        # a SELECT alone does not start sqlite3's implicit transaction.
+        conn.execute("BEGIN IMMEDIATE")
         row = conn.execute(
             """SELECT COALESCE(SUM(LENGTH(CAST(key AS BLOB))
                  + LENGTH(CAST(value AS BLOB))), 0)

--- a/tests/cron/test_notepad_capacity_race.py
+++ b/tests/cron/test_notepad_capacity_race.py
@@ -1,0 +1,63 @@
+"""The per-job byte cap holds across independent notepad writers."""
+
+import sqlite3
+import subprocess
+import sys
+
+
+def test_concurrent_writes_cannot_exceed_job_capacity(tmp_path, monkeypatch):
+    from cron import notepad
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    value = "x" * (notepad.MAX_VALUE_BYTES - 1)
+    for key in "abc":
+        notepad.set_note("job", key, value)
+    attempts = []
+
+    def write_competitor():
+        result = subprocess.run(
+            [sys.executable, "-c", """
+import sqlite3
+import sys
+from cron import notepad
+try:
+    notepad.set_note('job', 'e', 'x' * (notepad.MAX_VALUE_BYTES - 1))
+except sqlite3.OperationalError as exc:
+    if 'locked' not in str(exc):
+        raise
+    sys.exit(75)
+except ValueError:
+    sys.exit(76)
+"""], capture_output=True, text=True, timeout=30,
+        )
+        assert result.returncode in (0, 75, 76), result.stderr
+        return result.returncode
+
+    class InterleavedCursor(sqlite3.Cursor):
+        def fetchone(self):
+            row = super().fetchone()
+            # Finish the aggregate SELECT so its read cursor alone does not
+            # block a writer in DELETE-journal mode. Keep its observed total.
+            super().fetchall()
+            attempts.append(write_competitor())
+            return row
+
+    class InterleavedConnection(sqlite3.Connection):
+        def execute(self, sql, parameters=()):
+            if "SELECT COALESCE(SUM" in sql:
+                return self.cursor(factory=InterleavedCursor).execute(sql, parameters)
+            return super().execute(sql, parameters)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(notepad, "_connect", lambda: sqlite3.connect(
+            notepad._current_notepad_file(), timeout=5, factory=InterleavedConnection))
+        notepad.set_note("job", "d", value)
+
+    assert attempts
+    if attempts == [75]:
+        assert write_competitor() == 76
+    rows = notepad.list_notes("job")
+    total = sum(len(row["key"].encode()) + len(row["value"].encode()) for row in rows)
+    assert total <= notepad.MAX_JOB_TOTAL_BYTES
+    assert notepad.get_note("job", "d") == value
+    assert notepad.get_note("job", "e") is None


### PR DESCRIPTION
## What does this PR do?

Keep the notepad capacity check and its write in one SQLite writer transaction. Two independent CLI writers can currently both approve the same remaining capacity and persist 80 KiB in a notepad capped at 64 KiB; later ordinary updates can then fail until entries are removed.

## Related Issue

Fixes #108684

## Changes Made

- Acquire `BEGIN IMMEDIATE` in `set_note` before reading the aggregate size. The shared ledger context already commits or rolls back and closes the connection.
- Add one invariant test using real profile-local SQLite and an independent Python process. It interleaves a competing write after the real aggregate read; blocked work is retried after the first write completes.

The RLock only protects threads in one process, and `with conn:` does not start a transaction for SELECT. Serializing this specific read/write sequence addresses the root without changing read-only operations or the shared ledger helper.

## How to Test

```bash
scripts/run_tests.sh tests/cron/test_notepad_capacity_race.py tests/cron/test_notepad.py --file-retries 0 -j 2 -q
```

- Unmodified main + new test: **1 failed**, persisted total `81920 > 65536`.
- Fixed branch: **28 passed**. Existing coverage includes overwrites, capacity rejection, profile isolation, CLI and deletion cleanup.
- SQL results and locks are real; the connection/cursor subclass only schedules the competing process.
- Ruff, Windows footguns, compatibility pointers and `git diff --check`: passed.

## Compatibility and risks

No schema, configuration, tool surface, or capacity changes. Contended writers now wait before the capacity read under the existing five-second busy timeout. A failed size check rolls the transaction back. Local SQLite 3.45.3 uses the project's normal DELETE-journal safety fallback; WAL and other operating systems await CI.

## Type of Change

- [x] Bug fix
- [x] Regression tests

## Checklist

- [x] Read the contributing guide; conventional commit and isolated scope
- [x] Searched existing Issues/PRs, including closed/merged work
- [x] Added an invariant test and proved it fails on current main
- [x] Tested on Windows with Python 3.13
- [x] Considered cross-platform behavior; Ruff, Windows footguns and compatibility-pointer checks pass
- [x] Documentation/config/tool-schema changes: not needed for this internal contract correction
- [ ] Full repository suite run locally

