### PR TITLE
fix(cron): preserve retained delivery outcomes at timeout

### DIFF
--- a/cron/delivery_queue.py
+++ b/cron/delivery_queue.py
@@ -346,6 +346,14 @@ def _terminalize_wait_timeout(execution_id: str) -> str:
             "SELECT status, error FROM deliveries WHERE execution_id=?",
             (str(execution_id),),
         ).fetchone()
+        if row is None:
+            # Retention can move a completed send between the worker's last
+            # poll and its deadline. Its durable outcome still confirms it.
+            row = conn.execute(
+                "SELECT terminal_status AS status, NULL AS error "
+                "FROM delivery_tombstones WHERE execution_id=?",
+                (str(execution_id),),
+            ).fetchone()
         _prune_terminal_unlocked(conn)
     if row is None:
         return "timed out waiting for live gateway delivery"

--- a/tests/cron/test_delivery_timeout_retention.py
+++ b/tests/cron/test_delivery_timeout_retention.py
@@ -1,0 +1,33 @@
+"""Timeout confirmation must honor an outcome moved to retained metadata."""
+
+import pytest
+
+
+@pytest.mark.parametrize("error", [None, "transport unavailable"])
+def test_timeout_keeps_terminal_outcome_after_retention(tmp_path, monkeypatch, error):
+    from cron import delivery_queue as queue
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(queue, "MAX_TERMINAL_DELIVERIES", 0)
+    original_enqueue = queue.enqueue
+    sends = []
+
+    def enqueue_then_deliver(*args, **kwargs):
+        pending = original_enqueue(*args, **kwargs)
+
+        def send(*delivery_args):
+            sends.append(delivery_args)
+            return error
+
+        assert queue.drain(send) == 1
+        return pending
+
+    # The gateway completes delivery and retention after the worker enqueues,
+    # just as the worker reaches its wait deadline. Real queue APIs and SQL.
+    monkeypatch.setattr(queue, "enqueue", enqueue_then_deliver)
+    result = queue.enqueue_and_wait("execution", {"id": "job"}, "content", timeout=0)
+    status = queue.get_status("execution")
+    assert status["status"] == ("failed" if error else "delivered")
+    assert result == ("delivery failed" if error else None)
+    assert len(sends) == 1
+    assert queue.drain(lambda *args: sends.append(args)) == 0


### PR DESCRIPTION
## What does this PR do?

A worker that resumes at its deadline after gateway delivery and retention can currently report a timeout even though the retained outcome says `delivered`. Look up the tombstone when the final timeout check finds no verbose row, so its result agrees with normal polling.

## Related Issue

Fixes #108685

## Changes Made

- Add a retained-outcome lookup to `_terminalize_wait_timeout` after its conditional fencing update.
- Add one parameterized invariant test through `enqueue_and_wait`, real enqueue/drain/retention and SQLite, with a local send callback. Both successful and failed outcomes remain terminal and cannot be sent twice.

The test uses retention zero to reach the same pruning path with one execution and timeout zero to select the worker's deadline path deterministically. These are test controls; production defaults are unchanged. No SQL results or transport receipts are fabricated.

This differs from #104909: that fix serialized **repeated enqueue** against retention. This test never re-enqueues or sends twice; the defect is the **final confirmation lookup**.

## How to Test

```bash
scripts/run_tests.sh tests/cron/test_delivery_timeout_retention.py tests/cron/test_delivery_queue.py tests/cron/test_delivery_queue_retention_race.py --file-retries 0 -j 3 -q
scripts/run_tests.sh tests/cron/test_restart_safe_worker.py tests/cron/test_cron_live_bot_delivery.py tests/cron/test_upgrade_module_skew.py --file-retries 0 -j 3 -q
```

- Unmodified main + new regression: **2 failed** (delivered and failed tombstones misreported as a wait timeout).
- Fixed queue suites: **12 passed**.
- Worker/live-adapter/module-upgrade regressions: **20 passed, 2 Linux-only skipped** on this Windows host.
- Ruff, Windows footguns, compatibility pointers and `git diff --check`: passed.

## Compatibility and risks

No migration or change to pending deferral, retention limits, or at-most-once sending. Retained success returns success; retained failure/unknown retains its terminal classification. Tombstones intentionally lack the original error text, matching `get_status`. The added indexed query runs only when the verbose row is absent. Local SQLite 3.45.3 uses the repository's DELETE-journal fallback; no external messaging service was contacted.

## Type of Change

- [x] Bug fix
- [x] Regression tests

## Checklist

- [x] Read the contributing guide; conventional commit and isolated scope
- [x] Searched existing Issues/PRs, including closed/merged work
- [x] Added an invariant test and proved it fails on current main
- [x] Tested on Windows with Python 3.13
- [x] Considered cross-platform behavior; Ruff, Windows footguns and compatibility-pointer checks pass
- [x] Documentation/config/tool-schema changes: not needed for this internal contract correction
- [ ] Full repository suite run locally

