### PR TITLE
feat(cli): clarify notifications carry the question, with an OS fallback for terminals without OSC 9

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1782,6 +1782,10 @@ display:
   # Play terminal bell when a blocking prompt opens and waits on you:
   # clarify questions, dangerous-command approvals, sudo password, secret
   # capture. Same mechanism as bell_on_complete (\a) — works over SSH.
+  # Also raises a desktop notification: the clarify notification carries the
+  # question text; known OSC 9 terminals raise it natively; other terminals
+  # get an OS notification (macOS via osascript, attributed to Script Editor;
+  # Linux notify-send; Windows PowerShell toast), skipped over SSH.
   #   true:  Ring whenever the agent is waiting for your input
   #   false: Silent (default)
   bell_on_prompt: false

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1784,8 +1784,9 @@ display:
   # capture. Same mechanism as bell_on_complete (\a) — works over SSH.
   # Also raises a desktop notification: the clarify notification carries the
   # question text; known OSC 9 terminals raise it natively; other terminals
-  # get an OS notification (macOS via osascript, attributed to Script Editor;
-  # Linux notify-send; Windows PowerShell toast), skipped over SSH.
+  # (and sessions inside tmux/screen, which drop OSC sequences unless
+  # passthrough is configured) get an OS notification (macOS via osascript,
+  # attributed to Script Editor; Linux notify-send), skipped over SSH.
   #   true:  Ring whenever the agent is waiting for your input
   #   false: Silent (default)
   bell_on_prompt: false

--- a/hermes_cli/cli_modal_mixin.py
+++ b/hermes_cli/cli_modal_mixin.py
@@ -581,6 +581,7 @@ class CLIModalMixin:
         The single-question path below is unchanged. See #18450.
         """
         from cli import CLI_CONFIG, _DIM, _RST, _cprint
+        from hermes_cli.terminal_notify import prompt_body
         from tools.clarify_gateway import resolve_clarify_timeout
 
         if questions:
@@ -601,7 +602,7 @@ class CLIModalMixin:
         self._clarify_deadline = None if timeout <= 0 else _time.monotonic() + timeout
         self._clarify_freetext = is_open_ended  # open-ended → straight to freetext
         self._clarify_multi_base = None
-        self._ring_bell(prompt=True, context="clarify")
+        self._ring_bell(prompt=True, context=prompt_body("clarify", question))
         self._paint_now()
 
         result = self._poll_modal_queue(response_queue, "_clarify_deadline")
@@ -702,6 +703,7 @@ class CLIModalMixin:
         the deadline expires with partial answers; a cancel string passes through unchanged so the
         tool core resolves the batch empty."""
         from cli import CLI_CONFIG, _DIM, _RST, _cprint
+        from hermes_cli.terminal_notify import prompt_body
         from tools.clarify_gateway import resolve_clarify_timeout
 
         timeout = resolve_clarify_timeout(CLI_CONFIG)
@@ -721,7 +723,7 @@ class CLIModalMixin:
         self._clarify_state = state
         self._clarify_batch_set_active(state, 0)
         self._clarify_deadline = None if timeout <= 0 else _time.monotonic() + timeout
-        self._ring_bell(prompt=True, context="clarify")
+        self._ring_bell(prompt=True, context=prompt_body("clarify", state["question"]))
         self._paint_now()
 
         result = self._poll_modal_queue(response_queue, "_clarify_deadline")

--- a/hermes_cli/os_notify.py
+++ b/hermes_cli/os_notify.py
@@ -1,0 +1,187 @@
+"""OS-native desktop notification fallback.
+
+This module provides a fire-and-forget OS notification mechanism for terminals that
+ignore OSC 9 (the terminal-native notification protocol used by ``terminal_notify.py``).
+It is intended as a fallback only — the primary notification path remains OSC 9 because
+it integrates better with terminal emulators. On macOS the notifications are attributed
+to Script Editor rather than Hermes (Apple removed the sender override), which is why
+this module exists solely as a secondary path.
+
+The public API follows a frozen interface used elsewhere in the CLI:
+
+* ``notifier_argv(kind: str, title: str, body: str) -> list[str] | None`` — returns the
+  subprocess argv for the requested OS, or ``None`` for unsupported kinds. ``kind`` must
+  be one of ``"darwin"``, ``"linux"`` or ``"win32"``; the function never reads
+  ``sys.platform`` internally.
+
+* ``usable_kind(*, env=None, platform=None, which=None) -> str | None`` — determines
+  which notifier to use on the current host. Returns ``None`` when no notifier should
+  be used (e.g. under SSH, missing binaries, or unknown platforms). ``which`` is a
+  callable compatible with ``shutil.which`` and is injectable for tests.
+
+* ``notify(title: str, body: str) -> bool`` — spawns the notification process in a
+  detached child. Returns ``True`` when a notifier was launched, ``False`` otherwise.
+  All exceptions are caught so the clarify prompt is never delayed.
+
+The implementation is deliberately minimal and fail-graceful — any failure to launch
+a notification must not break the CLI flow.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+from typing import Callable, List, Optional
+
+# Export the public symbols for ``from hermes_cli.os_notify import *``
+__all__ = ["notifier_argv", "usable_kind", "notify"]
+
+# ``hermes_cli._subprocess_compat`` provides the correct detach flags for the
+# current Python version and platform.  It is part of the shipped CLI helpers.
+try:
+    from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
+except Exception:  # pragma: no cover — fallback if the compat module moves
+    # ``start_new_session`` works on POSIX; on Windows we try to detach the process.
+    def windows_detach_popen_kwargs() -> dict:
+        return {"start_new_session": True}
+
+
+def notifier_argv(kind: str, title: str, body: str) -> Optional[List[str]]:
+    """Return the subprocess argv for an OS notification.
+
+    Parameters
+    ----------
+    kind: str
+        One of ``"darwin"``, ``"linux"`` or ``"win32"``. The function never reads
+        ``sys.platform`` — the caller must provide the correct kind.
+    title: str
+        Notification title.
+    body: str
+        Notification body text.
+
+    Returns
+    -------
+    list[str] | None
+        The argv ready for ``subprocess.Popen``. ``None`` for unsupported ``kind``.
+    """
+    if kind == "darwin":
+        # AppleScript via osascript.  The title and body are passed as run arguments
+        # after ``--`` so they are not interpolated into the script source.  This avoids
+        # any quoting or injection surface and matches the verified working shape on
+        # macOS.
+        return [
+            "osascript",
+            "-e",
+            "on run {t, b}",
+            "-e",
+            "display notification b with title t",
+            "-e",
+            "end run",
+            "--",
+            title,
+            body,
+        ]
+    if kind == "linux":
+        # ``notify-send`` respects the freedesktop.org desktop notification spec.
+        return ["notify-send", "--app-name=Hermes", title, body]
+    if kind == "win32":
+        # Windows toast via WinRT (ToastNotificationManager) invoked through PowerShell.
+        # This path is best-effort and is NOT verified on a real Windows host by us.
+        # Per Microsoft Learn, desktop apps require a registered Application User Model ID
+        # (AUMID) on a Start-menu shortcut to display toast notifications from a desktop
+        # process. We use the well-known Windows PowerShell AUMID, so any toast the user
+        # sees is attributed to Windows PowerShell rather than Hermes.
+        # Title and body arrive as $args[0] and $args[1] (never interpolated into the script)
+        # and are assigned via XPath InnerText, which automatically handles XML escaping.
+        script = (
+            "$null = [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime]\n"
+            "$xml = [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType, Windows.UI.Notifications, ContentType = WindowsRuntime]::ToastText02)\n"
+            "$xml.SelectSingleNode('//text[@id=\"1\"]').InnerText = $args[0]\n"
+            "$xml.SelectSingleNode('//text[@id=\"2\"]').InnerText = $args[1]\n"
+            "$AppId = '{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\\WindowsPowerShell\\v1.0\\powershell.exe'\n"
+            "[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime]::CreateToastNotifier($AppId).Show($xml)"
+        )
+        return ["powershell", "-NoProfile", "-NonInteractive", "-Command", script, title, body]
+    return None
+
+
+def usable_kind(
+    *,
+    env: Optional[dict] = None,
+    platform: Optional[str] = None,
+    which: Optional[Callable[[str], Optional[str]]] = None,
+) -> Optional[str]:
+    """Determine which notifier to use on this host.
+
+    Parameters
+    ----------
+    env: dict, optional
+        Environment mapping (defaults to ``os.environ``).  ``SSH_CONNECTION``,
+        ``SSH_TTY`` or ``SSH_CLIENT`` in this mapping cause an immediate ``None``
+        return because notifications on a remote desktop are not intended for the
+        local user.
+    platform: str, optional
+        Value to treat as ``sys.platform`` (defaults to ``sys.platform``).
+    which: Callable[[str], Optional[str]], optional
+        A function compatible with ``shutil.which`` used to probe for binaries.
+        Injectable for tests; defaults to ``shutil.which``.
+
+    Returns
+    -------
+    str | None
+        The ``kind`` to use, or ``None`` when no notifier should be launched.
+    """
+    if env is None:
+        env = os.environ
+    # SSH check — notifications should never fire over SSH.
+    if any(var in env for var in ("SSH_CONNECTION", "SSH_TTY", "SSH_CLIENT")):
+        return None
+    if platform is None:
+        platform = sys.platform
+    if which is None:
+        which = shutil.which
+    # Probe for required binaries.
+    if platform == "darwin":
+        if not which("osascript"):
+            return None
+        return "darwin"
+    if platform == "linux":
+        if not which("notify-send"):
+            return None
+        return "linux"
+    if platform == "win32":
+        # ``powershell`` is the only viable route on Windows.  ``notify-send`` is not
+        # available and the WinRT APIs are accessed through PowerShell.
+        if not which("powershell"):
+            return None
+        return "win32"
+    return None
+
+
+def notify(title: str, body: str) -> bool:
+    """Fire a desktop notification in a detached child process.
+
+    All failures are caught so the clarify prompt is never delayed.  The function
+    returns ``True`` when a notifier was successfully launched, ``False`` otherwise.
+    """
+    try:
+        kind = usable_kind()
+        if kind is None:
+            return False
+        argv = notifier_argv(kind, title, body)
+        if argv is None:
+            return False
+        # ``windows_detach_popen_kwargs`` provides ``start_new_session=True`` on POSIX
+        # and the appropriate Win32 flags on Windows.
+        kwargs = windows_detach_popen_kwargs()
+        # ``DEVNULL`` suppresses all output from the notification process.
+        subprocess.Popen(
+            argv,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            **kwargs,
+        )
+        return True
+    except Exception:
+        return False

--- a/hermes_cli/os_notify.py
+++ b/hermes_cli/os_notify.py
@@ -173,8 +173,8 @@ def notify(title: str, body: str) -> bool:
         argv = notifier_argv(kind, title, body)
         if argv is None:
             return False
-        # ``windows_detach_popen_kwargs`` provides ``start_new_session=True`` on POSIX
-        # and the appropriate Win32 flags on Windows.
+        # ``windows_detach_popen_kwargs`` is the repo's cross-platform detach helper
+        # (``start_new_session=True`` on POSIX, Win32 creation flags on Windows).
         kwargs = windows_detach_popen_kwargs()
         # ``DEVNULL`` suppresses all output from the notification process.
         proc = subprocess.Popen(

--- a/hermes_cli/os_notify.py
+++ b/hermes_cli/os_notify.py
@@ -7,16 +7,25 @@ it integrates better with terminal emulators. On macOS the notifications are att
 to Script Editor rather than Hermes (Apple removed the sender override), which is why
 this module exists solely as a secondary path.
 
+Windows delivery is not implemented — deferred until someone with a Windows host can
+validate the mechanism end-to-end (documented follow-up). Previous iterations attempted
+PowerShell-driven WinRT toasts, but were removed because:
+1. PowerShell folds trailing arguments after ``-Command <script>`` into the parsed
+   command string, creating a command-substitution injection surface with model-generated text.
+2. The WinRT toast construction bypassed creating a ``Windows.UI.Notifications.ToastNotification``
+   object (passing ``XmlDocument`` directly to ``Show()``), which cannot be validated without
+   a Windows host.
+
 The public API follows a frozen interface used elsewhere in the CLI:
 
 * ``notifier_argv(kind: str, title: str, body: str) -> list[str] | None`` — returns the
   subprocess argv for the requested OS, or ``None`` for unsupported kinds. ``kind`` must
-  be one of ``"darwin"``, ``"linux"`` or ``"win32"``; the function never reads
+  be one of ``"darwin"`` or ``"linux"`` (``"win32"`` returns ``None``); the function never reads
   ``sys.platform`` internally.
 
 * ``usable_kind(*, env=None, platform=None, which=None) -> str | None`` — determines
   which notifier to use on the current host. Returns ``None`` when no notifier should
-  be used (e.g. under SSH, missing binaries, or unknown platforms). ``which`` is a
+  be used (e.g. under SSH, missing binaries, or unsupported platforms like win32). ``which`` is a
   callable compatible with ``shutil.which`` and is injectable for tests.
 
 * ``notify(title: str, body: str) -> bool`` — spawns the notification process in a
@@ -52,8 +61,9 @@ def notifier_argv(kind: str, title: str, body: str) -> Optional[List[str]]:
     Parameters
     ----------
     kind: str
-        One of ``"darwin"``, ``"linux"`` or ``"win32"``. The function never reads
+        One of ``"darwin"`` or ``"linux"``. The function never reads
         ``sys.platform`` — the caller must provide the correct kind.
+        ``"win32"`` is not implemented and returns ``None``.
     title: str
         Notification title.
     body: str
@@ -84,24 +94,6 @@ def notifier_argv(kind: str, title: str, body: str) -> Optional[List[str]]:
     if kind == "linux":
         # ``notify-send`` respects the freedesktop.org desktop notification spec.
         return ["notify-send", "--app-name=Hermes", title, body]
-    if kind == "win32":
-        # Windows toast via WinRT (ToastNotificationManager) invoked through PowerShell.
-        # This path is best-effort and is NOT verified on a real Windows host by us.
-        # Per Microsoft Learn, desktop apps require a registered Application User Model ID
-        # (AUMID) on a Start-menu shortcut to display toast notifications from a desktop
-        # process. We use the well-known Windows PowerShell AUMID, so any toast the user
-        # sees is attributed to Windows PowerShell rather than Hermes.
-        # Title and body arrive as $args[0] and $args[1] (never interpolated into the script)
-        # and are assigned via XPath InnerText, which automatically handles XML escaping.
-        script = (
-            "$null = [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime]\n"
-            "$xml = [Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType, Windows.UI.Notifications, ContentType = WindowsRuntime]::ToastText02)\n"
-            "$xml.SelectSingleNode('//text[@id=\"1\"]').InnerText = $args[0]\n"
-            "$xml.SelectSingleNode('//text[@id=\"2\"]').InnerText = $args[1]\n"
-            "$AppId = '{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\\WindowsPowerShell\\v1.0\\powershell.exe'\n"
-            "[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime]::CreateToastNotifier($AppId).Show($xml)"
-        )
-        return ["powershell", "-NoProfile", "-NonInteractive", "-Command", script, title, body]
     return None
 
 
@@ -149,13 +141,22 @@ def usable_kind(
         if not which("notify-send"):
             return None
         return "linux"
-    if platform == "win32":
-        # ``powershell`` is the only viable route on Windows.  ``notify-send`` is not
-        # available and the WinRT APIs are accessed through PowerShell.
-        if not which("powershell"):
-            return None
-        return "win32"
     return None
+
+
+_ACTIVE: list = []   # spawned notifier children, reaped on the next spawn
+
+
+def _reap() -> None:
+    """Drop notifier children that have already exited (Popen.poll() reaps them)."""
+    still_active = []
+    for proc in _ACTIVE:
+        try:
+            if proc.poll() is None:
+                still_active.append(proc)
+        except Exception:
+            pass
+    _ACTIVE[:] = still_active
 
 
 def notify(title: str, body: str) -> bool:
@@ -164,6 +165,7 @@ def notify(title: str, body: str) -> bool:
     All failures are caught so the clarify prompt is never delayed.  The function
     returns ``True`` when a notifier was successfully launched, ``False`` otherwise.
     """
+    _reap()
     try:
         kind = usable_kind()
         if kind is None:
@@ -175,13 +177,15 @@ def notify(title: str, body: str) -> bool:
         # and the appropriate Win32 flags on Windows.
         kwargs = windows_detach_popen_kwargs()
         # ``DEVNULL`` suppresses all output from the notification process.
-        subprocess.Popen(
+        proc = subprocess.Popen(
             argv,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             **kwargs,
         )
+        if proc is not None:
+            _ACTIVE.append(proc)
         return True
     except Exception:
         return False

--- a/hermes_cli/terminal_notify.py
+++ b/hermes_cli/terminal_notify.py
@@ -1,6 +1,6 @@
 """Terminal-native desktop notifications: OSC 9 and Warp's OSC 777 CLI-agent protocol.
 
-OSC 9 (``ESC ] 9 ; <body> BEL``): Ghostty, iTerm2, Kitty and WezTerm raise an OS notification;
+OSC 9 (``ESC ] 9 ; <body> BEL``): Foot, Ghostty, iTerm2, Kitty and WezTerm raise an OS notification;
 others drop it. OSC 777 (``ESC ] 777 ; notify ; warp://cli-agent ; <json> BEL``): Warp's
 structured CLI-agent protocol (tab status + notification mailbox).
 
@@ -79,20 +79,25 @@ def warp_osc777(event: str, detail: str, session_id: str = "") -> str:
     return f"\x1b]777;notify;warp://cli-agent;{json.dumps(payload, separators=(',', ':'))}\x07"
 
 
-# Terminals that raise an OS notification for OSC 9. Anything else — Apple Terminal, an unknown
-# TERM_PROGRAM, a multiplexer we cannot see through — gets the OS-notifier fallback instead.
-_OSC9_TERM_PROGRAMS = {"iterm.app", "ghostty", "wezterm", "warpterminal", "vscode", "cursor"}
+# Terminals that raise an OS notification for OSC 9. Verified against terminal-support
+# references: iTerm2, Ghostty, WezTerm, Warp (and kitty/foot, which leave TERM_PROGRAM unset and
+# are matched on TERM). xterm.js-based terminals (VS Code, Cursor) are deliberately absent —
+# xterm.js does not implement OSC 9 notifications.
+_OSC9_TERM_PROGRAMS = {"iterm.app", "ghostty", "wezterm", "warpterminal"}
+_OSC9_TERMS = ("kitty", "foot")
 
 
 def osc9_capable(env=None) -> bool:
     """True when the terminal described by `env` raises an OS notification for OSC 9."""
     env = os.environ if env is None else env
-    term_prog = (env.get("TERM_PROGRAM") or "").lower()
-    if term_prog in _OSC9_TERM_PROGRAMS:
+    if env.get("TMUX") or env.get("STY"):
+        # tmux/screen drop unknown OSC unless passthrough is configured, so the sequence never
+        # reaches the terminal — treat the session as incapable and let the OS notifier cover it.
+        return False
+    if (env.get("TERM_PROGRAM") or "").lower() in _OSC9_TERM_PROGRAMS:
         return True
-    if "kitty" in (env.get("TERM") or "").lower():
-        return True
-    return False
+    term = (env.get("TERM") or "").lower()
+    return any(name in term for name in _OSC9_TERMS)
 
 
 def notify(context: str, *, prompt: bool, session_id: str = "", detail: str = "") -> None:

--- a/hermes_cli/terminal_notify.py
+++ b/hermes_cli/terminal_notify.py
@@ -38,6 +38,20 @@ def _write_tty(seq: str) -> None:
         pass
 
 
+_BODY_LIMIT = 200  # matches the Warp payload's existing detail[:200] cap so both surfaces
+                   # carry the same text
+
+
+def prompt_body(kind: str, detail: str = "") -> str:
+    """Notification body for a blocking prompt: "<kind> — <detail>", detail collapsed to a
+    single line (whitespace runs, including newlines, become one space) and capped at
+    _BODY_LIMIT codepoints. Falls back to just <kind> when detail is empty/whitespace."""
+    collapsed = " ".join(detail.split())
+    if not collapsed:
+        return kind
+    return f"{kind} — {collapsed[:_BODY_LIMIT]}"
+
+
 def osc9(body: str) -> str:
     """OSC 9 sequence with C0 controls and DEL stripped from the body."""
     return f"\x1b]9;{_C0_AND_DEL.sub('', body)}\x07"

--- a/hermes_cli/terminal_notify.py
+++ b/hermes_cli/terminal_notify.py
@@ -79,6 +79,22 @@ def warp_osc777(event: str, detail: str, session_id: str = "") -> str:
     return f"\x1b]777;notify;warp://cli-agent;{json.dumps(payload, separators=(',', ':'))}\x07"
 
 
+# Terminals that raise an OS notification for OSC 9. Anything else — Apple Terminal, an unknown
+# TERM_PROGRAM, a multiplexer we cannot see through — gets the OS-notifier fallback instead.
+_OSC9_TERM_PROGRAMS = {"iterm.app", "ghostty", "wezterm", "warpterminal", "vscode", "cursor"}
+
+
+def osc9_capable(env=None) -> bool:
+    """True when the terminal described by `env` raises an OS notification for OSC 9."""
+    env = os.environ if env is None else env
+    term_prog = (env.get("TERM_PROGRAM") or "").lower()
+    if term_prog in _OSC9_TERM_PROGRAMS:
+        return True
+    if "kitty" in (env.get("TERM") or "").lower():
+        return True
+    return False
+
+
 def notify(context: str, *, prompt: bool, session_id: str = "", detail: str = "") -> None:
     """Emit OSC 9 (plus Warp OSC 777 when supported) for a blocking prompt or turn end."""
     seq = osc9(f"Hermes: {context}")
@@ -86,3 +102,10 @@ def notify(context: str, *, prompt: bool, session_id: str = "", detail: str = ""
         event = "permission_request" if prompt else "stop"
         seq += warp_osc777(event, detail or context, session_id)
     _write_tty(seq)
+    if not osc9_capable():
+        try:
+            from hermes_cli import os_notify
+
+            os_notify.notify("Hermes", context)
+        except Exception:
+            pass

--- a/tests/hermes_cli/test_os_notify.py
+++ b/tests/hermes_cli/test_os_notify.py
@@ -1,0 +1,356 @@
+"""Tests for hermes_cli/os_notify.py.
+
+The tests verify the frozen interface and behaviour without spawning real OS
+notifications (except for a host-native sanity check on macOS).  All process
+spawning is mocked; the real ``subprocess.Popen`` is patched to capture calls and
+verify the correct argv is built.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+from typing import List
+
+import pytest
+
+import hermes_cli.os_notify
+from hermes_cli.os_notify import notifier_argv, notify, usable_kind
+
+# ---------------------------------------------------------------------------
+# notifier_argv tests
+# ---------------------------------------------------------------------------
+
+def test_notifier_argv_darwin():
+    sentinel_title = "SENTINEL-TITLE-7f3a"
+    sentinel_body = "SENTINEL-BODY-9c1b"
+    argv = notifier_argv("darwin", sentinel_title, sentinel_body)
+    expected = [
+        "osascript",
+        "-e",
+        "on run {t, b}",
+        "-e",
+        "display notification b with title t",
+        "-e",
+        "end run",
+        "--",
+        sentinel_title,
+        sentinel_body,
+    ]
+    assert argv == expected
+
+    # Invariant: caller text is never part of the script source;
+    # it travels as separate argv items after '--'.
+    script_elements = argv[:8]  # flags, script lines, and '--'
+    assert not any(sentinel_title in arg for arg in script_elements)
+    assert not any(sentinel_body in arg for arg in script_elements)
+    assert argv[-2] == sentinel_title
+    assert argv[-1] == sentinel_body
+
+    # Verify that a body containing quotes/backslashes survives as a single argument.
+    test_body = 'say "hello" \'world\''
+    argv2 = notifier_argv("darwin", "t", test_body)
+    assert argv2[-1] == test_body
+    assert not any(test_body in arg for arg in argv2[:8])
+
+
+def test_notifier_argv_linux():
+    sentinel_title = "SENTINEL-TITLE-7f3a"
+    sentinel_body = "SENTINEL-BODY-9c1b"
+    argv = notifier_argv("linux", sentinel_title, sentinel_body)
+    expected = ["notify-send", "--app-name=Hermes", sentinel_title, sentinel_body]
+    assert argv == expected
+
+    # Invariant: caller text is never part of command tokens;
+    # it travels as separate trailing argv items.
+    command_elements = argv[:2]
+    assert not any(sentinel_title in arg for arg in command_elements)
+    assert not any(sentinel_body in arg for arg in command_elements)
+    assert argv[-2] == sentinel_title
+    assert argv[-1] == sentinel_body
+
+    # Body with special characters should be passed as a single argument.
+    test_body = "a'b'c"
+    argv2 = notifier_argv("linux", "t", test_body)
+    assert argv2[-1] == test_body
+    assert test_body not in argv2[0]
+    assert test_body not in argv2[1]
+
+
+def test_notifier_argv_win32():
+    sentinel_title = "SENTINEL-TITLE-7f3a"
+    sentinel_body = "SENTINEL-BODY-9c1b"
+    argv = notifier_argv("win32", sentinel_title, sentinel_body)
+    assert argv is not None
+    assert argv[:4] == ["powershell", "-NoProfile", "-NonInteractive", "-Command"]
+
+    script = argv[4]
+
+    # Invariant: caller text is never part of the script source;
+    # it travels as separate trailing argv items.
+    assert sentinel_title not in script
+    assert sentinel_body not in script
+    assert argv[-2] == sentinel_title
+    assert argv[-1] == sentinel_body
+
+    # Verify that the script uses the WinRT toast API and the well-known PowerShell AUMID
+    assert "Windows.UI.Notifications.ToastNotificationManager" in script
+    assert "ToastText02" in script
+    assert "$args[0]" in script
+    assert "$args[1]" in script
+    assert "InnerText" in script
+    assert "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\\WindowsPowerShell\\v1.0\\powershell.exe" in script
+
+    # Verify that XML-significant characters are not in the script
+    # and survive unescaped in trailing argv items.
+    test_body = '<tag>value</tag> & "'
+    argv2 = notifier_argv("win32", "t", test_body)
+    script2 = argv2[4]
+    assert "<tag>" not in script2
+    assert test_body not in script2
+    assert argv2[-2] == "t"
+    assert argv2[-1] == test_body
+
+
+def test_notifier_argv_unknown():
+    assert notifier_argv("unknown", "title", "body") is None
+    assert notifier_argv("freebsd", "title", "body") is None
+
+# ---------------------------------------------------------------------------
+# usable_kind tests
+# ---------------------------------------------------------------------------
+
+def test_usable_kind_darwin(monkeypatch):
+    # Mock shutil.which to return a path for osascript.
+    dummy_path = "/usr/bin/osascript"
+    monkeypatch.setattr(shutil, "which", lambda cmd: dummy_path if cmd == "osascript" else None)
+    kind = usable_kind(platform="darwin")
+    assert kind == "darwin"
+
+    # Missing binary should return None.
+    monkeypatch.setattr(shutil, "which", lambda cmd: None)
+    assert usable_kind(platform="darwin") is None
+
+
+def test_usable_kind_linux(monkeypatch):
+    dummy_path = "/usr/bin/notify-send"
+    monkeypatch.setattr(shutil, "which", lambda cmd: dummy_path if cmd == "notify-send" else None)
+    kind = usable_kind(platform="linux")
+    assert kind == "linux"
+
+    # Missing notify-send should return None.
+    monkeypatch.setattr(shutil, "which", lambda cmd: None)
+    assert usable_kind(platform="linux") is None
+
+
+def test_usable_kind_win32(monkeypatch):
+    dummy_path = "C:\\Windows\\System32\\powershell.exe"
+    monkeypatch.setattr(shutil, "which", lambda cmd: dummy_path if cmd == "powershell" else None)
+    kind = usable_kind(platform="win32")
+    assert kind == "win32"
+
+    # Missing PowerShell should return None.
+    monkeypatch.setattr(shutil, "which", lambda cmd: None)
+    assert usable_kind(platform="win32") is None
+
+
+def test_usable_kind_unknown_platform():
+    assert usable_kind(platform="freebsd") is None
+
+
+def test_usable_kind_ssh_env(monkeypatch):
+    # Simulate SSH environment variables.
+    env = {"SSH_CONNECTION": "192.168.1.1 22", "PATH": "/usr/bin"}
+    monkeypatch.setattr(os, "environ", env)
+    # Even if binaries exist, SSH should disable notifications.
+    dummy_path = "/usr/bin/osascript"
+    monkeypatch.setattr(shutil, "which", lambda cmd: dummy_path if cmd == "osascript" else None)
+    assert usable_kind(env=env, platform="darwin") is None
+
+
+def test_usable_kind_ssh_tty(monkeypatch):
+    env = {"SSH_TTY": "/dev/pts/0"}
+    monkeypatch.setattr(os, "environ", env)
+    dummy_path = "/usr/bin/osascript"
+    monkeypatch.setattr(shutil, "which", lambda cmd: dummy_path)
+    assert usable_kind(env=env, platform="darwin") is None
+
+# ---------------------------------------------------------------------------
+# notify tests (mocked subprocess)
+# ---------------------------------------------------------------------------
+
+def test_notify_success(monkeypatch):
+    # Patch subprocess.Popen to capture the call.
+    calls = []
+
+    def mock_popen(*args, **kwargs):
+        calls.append((args, kwargs))
+        return None
+
+    monkeypatch.setattr(subprocess, "Popen", mock_popen)
+
+    # Test each supported platform.
+    for kind in ["darwin", "linux", "win32"]:
+        # Force usable_kind to return the expected kind.
+        monkeypatch.setattr(
+            hermes_cli.os_notify,
+            "usable_kind",
+            lambda *a, **kw: kind,
+        )
+        # Ensure notifier_argv returns something.
+        monkeypatch.setattr(
+            hermes_cli.os_notify,
+            "notifier_argv",
+            lambda k, t, b: ["cmd", "arg1", t, b],
+        )
+        result = notify("title", "body")
+        assert result is True
+        # Verify Popen was called with the expected argv.
+        (args, kwargs) = calls[-1]
+        expected_argv = ["cmd", "arg1", "title", "body"]
+        assert args[0] == expected_argv
+        # Verify detach kwargs are applied (we only check that they were passed).
+        assert "start_new_session" in kwargs or "stdin" in kwargs
+
+    # Reset monkeypatches for the failure cases.
+    monkeypatch.undo()
+
+
+def test_notify_no_notifier(monkeypatch):
+    # When usable_kind returns None, notify should return False and not spawn.
+    calls = []
+
+    def mock_popen(*args, **kwargs):
+        calls.append((args, kwargs))
+        return None
+
+    monkeypatch.setattr(subprocess, "Popen", mock_popen)
+
+    monkeypatch.setattr(
+        hermes_cli.os_notify,
+        "usable_kind",
+        lambda *a, **kw: None,
+    )
+    result = notify("title", "body")
+    assert result is False
+    assert not calls
+    monkeypatch.undo()
+
+
+def test_notify_popen_failure(monkeypatch):
+    # If Popen raises an exception, notify should return False and not propagate.
+    def mock_popen(*args, **kwargs):
+        raise OSError("failed to spawn")
+
+    monkeypatch.setattr(subprocess, "Popen", mock_popen)
+
+    monkeypatch.setattr(
+        hermes_cli.os_notify,
+        "usable_kind",
+        lambda *a, **kw: "darwin",
+    )
+    monkeypatch.setattr(
+        hermes_cli.os_notify,
+        "notifier_argv",
+        lambda k, t, b: ["osascript", "-e", "..."],
+    )
+    result = notify("title", "body")
+    assert result is False
+    monkeypatch.undo()
+
+
+def test_notify_usable_kind_exception(monkeypatch):
+    # If usable_kind raises an unexpected error, notify must catch it and return False.
+    def failing_usable_kind(*args, **kwargs):
+        raise RuntimeError("unexpected probe failure")
+
+    monkeypatch.setattr(
+        hermes_cli.os_notify,
+        "usable_kind",
+        failing_usable_kind,
+    )
+    assert notify("title", "body") is False
+    monkeypatch.undo()
+
+
+def test_notify_notifier_argv_exception(monkeypatch):
+    # If notifier_argv raises an unexpected error, notify must catch it and return False.
+    monkeypatch.setattr(
+        hermes_cli.os_notify,
+        "usable_kind",
+        lambda *a, **kw: "darwin",
+    )
+
+    def failing_notifier_argv(*args, **kwargs):
+        raise RuntimeError("unexpected argv failure")
+
+    monkeypatch.setattr(
+        hermes_cli.os_notify,
+        "notifier_argv",
+        failing_notifier_argv,
+    )
+    assert notify("title", "body") is False
+    monkeypatch.undo()
+
+
+def test_notify_unsupported_argv(monkeypatch):
+    # If notifier_argv returns None, notify should return False without spawning.
+    calls = []
+
+    def mock_popen(*args, **kwargs):
+        calls.append((args, kwargs))
+        return None
+
+    monkeypatch.setattr(subprocess, "Popen", mock_popen)
+    monkeypatch.setattr(
+        hermes_cli.os_notify,
+        "usable_kind",
+        lambda *a, **kw: "freebsd",
+    )
+    monkeypatch.setattr(
+        hermes_cli.os_notify,
+        "notifier_argv",
+        lambda k, t, b: None,
+    )
+    assert notify("title", "body") is False
+    assert not calls
+    monkeypatch.undo()
+
+# ---------------------------------------------------------------------------
+# Host-native sanity check (macOS only)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.macos_only
+def test_real_notifier_usable():
+    # This test runs only on macOS and verifies that the real notifier is detected.
+    # It must not actually pop a notification; we only check the internal state.
+    # Ensure osascript is present (the test will fail on a machine without it).
+    assert shutil.which("osascript") is not None
+    # Verify that the returned kind is darwin and that notifier_argv returns the expected shape.
+    kind = usable_kind()
+    assert kind == "darwin"
+    argv = notifier_argv(kind, "title", "body")
+    expected = [
+        "osascript",
+        "-e",
+        "on run {t, b}",
+        "-e",
+        "display notification b with title t",
+        "-e",
+        "end run",
+        "--",
+        "title",
+        "body",
+    ]
+    assert argv == expected
+
+# ---------------------------------------------------------------------------
+# Import-time sanity: ensure the public symbols are exported.
+# ---------------------------------------------------------------------------
+
+def test_public_symbols():
+    # ``from hermes_cli.os_notify import *`` should expose the three functions.
+    import hermes_cli.os_notify as mod
+    assert hasattr(mod, "notifier_argv")
+    assert hasattr(mod, "usable_kind")
+    assert hasattr(mod, "notify")

--- a/tests/hermes_cli/test_os_notify.py
+++ b/tests/hermes_cli/test_os_notify.py
@@ -9,7 +9,6 @@ verify the correct argv is built.
 import os
 import shutil
 import subprocess
-import sys
 from typing import List
 
 import pytest
@@ -321,11 +320,9 @@ def test_real_notifier_usable():
 def test_notify_win32_does_not_spawn(monkeypatch):
     calls = []
     monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: calls.append((a, kw)))
-    monkeypatch.setattr(sys, "platform", "win32")
-    assert notify("title", "body") is False
-    assert not calls
-
-    # Even if usable_kind somehow returned "win32", notifier_argv is None so no spawn occurs
+    # No Windows notifier is implemented: `usable_kind()` cannot return "win32" on a real host, and
+    # even if it did, `notifier_argv` returns None — either way nothing may be spawned. (The host is
+    # never faked here; `usable_kind` is the seam.)
     monkeypatch.setattr(hermes_cli.os_notify, "usable_kind", lambda *a, **kw: "win32")
     assert notify("title", "body") is False
     assert not calls

--- a/tests/hermes_cli/test_os_notify.py
+++ b/tests/hermes_cli/test_os_notify.py
@@ -78,38 +78,8 @@ def test_notifier_argv_linux():
 
 
 def test_notifier_argv_win32():
-    sentinel_title = "SENTINEL-TITLE-7f3a"
-    sentinel_body = "SENTINEL-BODY-9c1b"
-    argv = notifier_argv("win32", sentinel_title, sentinel_body)
-    assert argv is not None
-    assert argv[:4] == ["powershell", "-NoProfile", "-NonInteractive", "-Command"]
-
-    script = argv[4]
-
-    # Invariant: caller text is never part of the script source;
-    # it travels as separate trailing argv items.
-    assert sentinel_title not in script
-    assert sentinel_body not in script
-    assert argv[-2] == sentinel_title
-    assert argv[-1] == sentinel_body
-
-    # Verify that the script uses the WinRT toast API and the well-known PowerShell AUMID
-    assert "Windows.UI.Notifications.ToastNotificationManager" in script
-    assert "ToastText02" in script
-    assert "$args[0]" in script
-    assert "$args[1]" in script
-    assert "InnerText" in script
-    assert "{1AC14E77-02E7-4E5D-B744-2EB1AE5198B7}\\WindowsPowerShell\\v1.0\\powershell.exe" in script
-
-    # Verify that XML-significant characters are not in the script
-    # and survive unescaped in trailing argv items.
-    test_body = '<tag>value</tag> & "'
-    argv2 = notifier_argv("win32", "t", test_body)
-    script2 = argv2[4]
-    assert "<tag>" not in script2
-    assert test_body not in script2
-    assert argv2[-2] == "t"
-    assert argv2[-1] == test_body
+    # Windows delivery is not implemented; notifier_argv returns None.
+    assert notifier_argv("win32", "title", "body") is None
 
 
 def test_notifier_argv_unknown():
@@ -144,14 +114,18 @@ def test_usable_kind_linux(monkeypatch):
 
 
 def test_usable_kind_win32(monkeypatch):
+    # Windows notifier is not implemented; usable_kind returns None even when powershell exists.
     dummy_path = "C:\\Windows\\System32\\powershell.exe"
-    monkeypatch.setattr(shutil, "which", lambda cmd: dummy_path if cmd == "powershell" else None)
-    kind = usable_kind(platform="win32")
-    assert kind == "win32"
+    which_calls = []
 
-    # Missing PowerShell should return None.
-    monkeypatch.setattr(shutil, "which", lambda cmd: None)
+    def fake_which(cmd):
+        which_calls.append(cmd)
+        return dummy_path if cmd == "powershell" else None
+
+    monkeypatch.setattr(shutil, "which", fake_which)
     assert usable_kind(platform="win32") is None
+    # No powershell probe should be executed for win32
+    assert "powershell" not in which_calls
 
 
 def test_usable_kind_unknown_platform():
@@ -190,7 +164,7 @@ def test_notify_success(monkeypatch):
     monkeypatch.setattr(subprocess, "Popen", mock_popen)
 
     # Test each supported platform.
-    for kind in ["darwin", "linux", "win32"]:
+    for kind in ["darwin", "linux"]:
         # Force usable_kind to return the expected kind.
         monkeypatch.setattr(
             hermes_cli.os_notify,
@@ -344,13 +318,86 @@ def test_real_notifier_usable():
     ]
     assert argv == expected
 
-# ---------------------------------------------------------------------------
-# Import-time sanity: ensure the public symbols are exported.
-# ---------------------------------------------------------------------------
+def test_notify_win32_does_not_spawn(monkeypatch):
+    calls = []
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: calls.append((a, kw)))
+    monkeypatch.setattr(sys, "platform", "win32")
+    assert notify("title", "body") is False
+    assert not calls
 
-def test_public_symbols():
-    # ``from hermes_cli.os_notify import *`` should expose the three functions.
-    import hermes_cli.os_notify as mod
-    assert hasattr(mod, "notifier_argv")
-    assert hasattr(mod, "usable_kind")
-    assert hasattr(mod, "notify")
+    # Even if usable_kind somehow returned "win32", notifier_argv is None so no spawn occurs
+    monkeypatch.setattr(hermes_cli.os_notify, "usable_kind", lambda *a, **kw: "win32")
+    assert notify("title", "body") is False
+    assert not calls
+
+
+def test_notify_real_argv_darwin_and_linux(monkeypatch):
+    calls = []
+
+    class DummyProc:
+        def poll(self):
+            return None
+
+    monkeypatch.setattr(
+        subprocess,
+        "Popen",
+        lambda *a, **kw: calls.append((a, kw)) or DummyProc(),
+    )
+
+    title = "Test Title"
+    body = "Test Body"
+
+    # Darwin: real notifier_argv is wired through to Popen
+    monkeypatch.setattr(hermes_cli.os_notify, "usable_kind", lambda *a, **kw: "darwin")
+    assert notify(title, body) is True
+    args, kwargs = calls[-1]
+    expected_darwin = [
+        "osascript",
+        "-e",
+        "on run {t, b}",
+        "-e",
+        "display notification b with title t",
+        "-e",
+        "end run",
+        "--",
+        title,
+        body,
+    ]
+    assert args[0] == expected_darwin
+    assert "start_new_session" in kwargs or "stdin" in kwargs
+
+    # Linux: real notifier_argv is wired through to Popen
+    monkeypatch.setattr(hermes_cli.os_notify, "usable_kind", lambda *a, **kw: "linux")
+    assert notify(title, body) is True
+    args, kwargs = calls[-1]
+    expected_linux = ["notify-send", "--app-name=Hermes", title, body]
+    assert args[0] == expected_linux
+    assert "start_new_session" in kwargs or "stdin" in kwargs
+
+
+def test_reap():
+    class FakeProc:
+        def __init__(self, exit_code):
+            self.exit_code = exit_code
+            self.polled = False
+
+        def poll(self):
+            self.polled = True
+            return self.exit_code
+
+    live1 = FakeProc(None)
+    exited1 = FakeProc(0)
+    live2 = FakeProc(None)
+    exited2 = FakeProc(1)
+
+    saved_active = hermes_cli.os_notify._ACTIVE[:]
+    try:
+        hermes_cli.os_notify._ACTIVE = [live1, exited1, live2, exited2]
+        hermes_cli.os_notify._reap()
+        assert live1.polled is True
+        assert exited1.polled is True
+        assert live2.polled is True
+        assert exited2.polled is True
+        assert hermes_cli.os_notify._ACTIVE == [live1, live2]
+    finally:
+        hermes_cli.os_notify._ACTIVE = saved_active

--- a/tests/hermes_cli/test_terminal_notify.py
+++ b/tests/hermes_cli/test_terminal_notify.py
@@ -48,3 +48,77 @@ def test_warp_osc777_only_under_supported_warp_build(monkeypatch):
     # Not Warp at all → OSC 9 only.
     not_warp = dict(_WARP_OK, TERM_PROGRAM="ghostty")
     assert prefix not in _ring(monkeypatch, flag_on=True, env=not_warp, context="approval")
+
+
+def test_clarify_callback_notification_carries_question(monkeypatch):
+    for key in _WARP_OK:
+        monkeypatch.delenv(key, raising=False)
+    written = []
+    monkeypatch.setattr(terminal_notify, "_write_tty", written.append)
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.bell_on_prompt = True
+    cli.session_id = "sess-1"
+    cli._paint_now = lambda: None
+    cli._poll_modal_queue = lambda queue, deadline_attr: "a.txt"
+    cli._persist_prompt_summary = lambda *args, **kwargs: None
+
+    cli._clarify_callback("Which output file should I write?", ["a.txt", "b.txt"])
+    out = "".join(written)
+    assert "Which output file should I write?" in out
+    assert out == "\x1b]9;Hermes: clarify — Which output file should I write?\x07"
+
+
+def test_clarify_callback_batch_notification_carries_first_question(monkeypatch):
+    for key in _WARP_OK:
+        monkeypatch.delenv(key, raising=False)
+    written = []
+    monkeypatch.setattr(terminal_notify, "_write_tty", written.append)
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.bell_on_prompt = True
+    cli.session_id = "sess-1"
+    cli._paint_now = lambda: None
+    cli._poll_modal_queue = lambda queue, deadline_attr: {"q0": "a.txt"}
+    cli._persist_prompt_summary = lambda *args, **kwargs: None
+
+    questions = [
+        {"qid": "q0", "question": "Which output file should I write?", "choices": ["a.txt", "b.txt"], "multi_select": False},
+        {"qid": "q1", "question": "Overwrite existing files?", "choices": ["yes", "no"], "multi_select": False},
+    ]
+    cli._clarify_callback("", None, questions=questions)
+    out = "".join(written)
+    assert "Which output file should I write?" in out
+    assert "Overwrite existing files?" not in out
+    assert out == "\x1b]9;Hermes: clarify — Which output file should I write?\x07"
+
+
+def test_prompt_body_multiline_collapses_to_one_line():
+    question = "Which output file\nshould I write?\n\n  Please pick   one."
+    assert terminal_notify.prompt_body("clarify", question) == (
+        "clarify — Which output file should I write? Please pick one."
+    )
+
+
+def test_prompt_body_empty_or_whitespace_detail_yields_kind():
+    assert terminal_notify.prompt_body("clarify", "") == "clarify"
+    assert terminal_notify.prompt_body("clarify", "   \t\n  ") == "clarify"
+    assert terminal_notify.prompt_body("clarify") == "clarify"
+
+
+def test_prompt_body_capped_to_limit():
+    long_question = "x" * 250
+    res = terminal_notify.prompt_body("clarify", long_question)
+    assert res == f"clarify — {'x' * terminal_notify._BODY_LIMIT}"
+    assert len(res) == len("clarify — ") + terminal_notify._BODY_LIMIT
+
+
+def test_prompt_body_control_characters_sanitized_in_emitted_bytes(monkeypatch):
+    for key in _WARP_OK:
+        monkeypatch.delenv(key, raising=False)
+    written = []
+    monkeypatch.setattr(terminal_notify, "_write_tty", written.append)
+    body = terminal_notify.prompt_body("clarify", "Which\x1b file\x07 to\x00 write\x7f?")
+    terminal_notify.notify(body, prompt=True)
+    out = "".join(written)
+    assert out == "\x1b]9;Hermes: clarify — Which file to write?\x07"
+
+

--- a/tests/hermes_cli/test_terminal_notify.py
+++ b/tests/hermes_cli/test_terminal_notify.py
@@ -2,8 +2,10 @@
 
 import json
 
+import pytest
+
 from cli import HermesCLI
-from hermes_cli import terminal_notify
+from hermes_cli import os_notify, terminal_notify
 
 _WARP_OK = {
     "TERM_PROGRAM": "WarpTerminal",
@@ -120,5 +122,111 @@ def test_prompt_body_control_characters_sanitized_in_emitted_bytes(monkeypatch):
     terminal_notify.notify(body, prompt=True)
     out = "".join(written)
     assert out == "\x1b]9;Hermes: clarify — Which file to write?\x07"
+
+
+def test_notify_fallback_when_terminal_not_osc9_capable(monkeypatch):
+    monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+    monkeypatch.delenv("TERM", raising=False)
+    for key in ("WARP_CLI_AGENT_PROTOCOL_VERSION", "WARP_CLIENT_VERSION"):
+        monkeypatch.delenv(key, raising=False)
+    written = []
+    monkeypatch.setattr(terminal_notify, "_write_tty", written.append)
+    spy = []
+    monkeypatch.setattr(os_notify, "notify", lambda title, body: spy.append((title, body)) or True)
+
+    prompt_text = "clarify — Which output file should I write?"
+    terminal_notify.notify(prompt_text, prompt=True)
+
+    assert len(spy) == 1
+    assert spy[0] == ("Hermes", prompt_text)
+    out = "".join(written)
+    assert out == f"\x1b]9;Hermes: {prompt_text}\x07"
+
+
+def test_notify_no_double_notification_when_terminal_osc9_capable(monkeypatch):
+    monkeypatch.setenv("TERM_PROGRAM", "iTerm.app")
+    monkeypatch.delenv("TERM", raising=False)
+    for key in ("WARP_CLI_AGENT_PROTOCOL_VERSION", "WARP_CLIENT_VERSION"):
+        monkeypatch.delenv(key, raising=False)
+    written = []
+    monkeypatch.setattr(terminal_notify, "_write_tty", written.append)
+    spy = []
+    monkeypatch.setattr(os_notify, "notify", lambda title, body: spy.append((title, body)) or True)
+
+    prompt_text = "clarify — Which output file should I write?"
+    terminal_notify.notify(prompt_text, prompt=True)
+
+    assert len(spy) == 0
+    out = "".join(written)
+    assert out == f"\x1b]9;Hermes: {prompt_text}\x07"
+
+
+def test_notify_fallback_failure_isolation(monkeypatch):
+    monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+    monkeypatch.delenv("TERM", raising=False)
+    for key in ("WARP_CLI_AGENT_PROTOCOL_VERSION", "WARP_CLIENT_VERSION"):
+        monkeypatch.delenv(key, raising=False)
+    written = []
+    monkeypatch.setattr(terminal_notify, "_write_tty", written.append)
+
+    def _broken_notify(title, body):
+        raise OSError("notification daemon unreachable")
+
+    monkeypatch.setattr(os_notify, "notify", _broken_notify)
+
+    prompt_text = "clarify — Which output file should I write?"
+    terminal_notify.notify(prompt_text, prompt=True)
+
+    out = "".join(written)
+    assert out == f"\x1b]9;Hermes: {prompt_text}\x07"
+
+
+@pytest.mark.parametrize(
+    "term_prog",
+    [
+        "iterm.app",
+        "iTerm.app",
+        "ITERM.APP",
+        "ghostty",
+        "Ghostty",
+        "GHOSTTY",
+        "wezterm",
+        "WezTerm",
+        "WEZTERM",
+        "warpterminal",
+        "WarpTerminal",
+        "WARPTERMINAL",
+        "vscode",
+        "VSCode",
+        "VSCODE",
+        "cursor",
+        "Cursor",
+        "CURSOR",
+    ],
+)
+def test_osc9_capable_set_members_case_insensitive(term_prog):
+    assert terminal_notify.osc9_capable({"TERM_PROGRAM": term_prog}) is True
+
+
+def test_osc9_capable_kitty():
+    assert terminal_notify.osc9_capable({"TERM": "xterm-kitty"}) is True
+    assert terminal_notify.osc9_capable({"TERM": "kitty"}) is True
+    assert terminal_notify.osc9_capable({"TERM": "xterm-kitty", "TERM_PROGRAM": ""}) is True
+
+
+def test_osc9_capable_incapable_and_empty():
+    assert terminal_notify.osc9_capable({"TERM_PROGRAM": "Apple_Terminal"}) is False
+    assert terminal_notify.osc9_capable({"TERM_PROGRAM": "alacritty"}) is False
+    assert terminal_notify.osc9_capable({"TERM_PROGRAM": "unknown_term"}) is False
+    assert terminal_notify.osc9_capable({}) is False
+    assert terminal_notify.osc9_capable({"TERM_PROGRAM": "", "TERM": ""}) is False
+
+
+def test_osc9_capable_defaults_to_environ(monkeypatch):
+    monkeypatch.setenv("TERM_PROGRAM", "iTerm.app")
+    assert terminal_notify.osc9_capable() is True
+    monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+    monkeypatch.delenv("TERM", raising=False)
+    assert terminal_notify.osc9_capable() is False
 
 

--- a/tests/hermes_cli/test_terminal_notify.py
+++ b/tests/hermes_cli/test_terminal_notify.py
@@ -1,6 +1,8 @@
 """display.bell_on_prompt / bell_on_complete also drive OSC 9 + Warp OSC 777 via _ring_bell."""
 
 import json
+import shutil
+import subprocess
 
 import pytest
 
@@ -196,30 +198,75 @@ def test_notify_fallback_failure_isolation(monkeypatch):
         "warpterminal",
         "WarpTerminal",
         "WARPTERMINAL",
-        "vscode",
-        "VSCode",
-        "VSCODE",
-        "cursor",
-        "Cursor",
-        "CURSOR",
     ],
 )
 def test_osc9_capable_set_members_case_insensitive(term_prog):
     assert terminal_notify.osc9_capable({"TERM_PROGRAM": term_prog}) is True
 
 
-def test_osc9_capable_kitty():
+def test_osc9_capable_terms_kitty_and_foot():
     assert terminal_notify.osc9_capable({"TERM": "xterm-kitty"}) is True
     assert terminal_notify.osc9_capable({"TERM": "kitty"}) is True
     assert terminal_notify.osc9_capable({"TERM": "xterm-kitty", "TERM_PROGRAM": ""}) is True
+    assert terminal_notify.osc9_capable({"TERM": "foot"}) is True
+    assert terminal_notify.osc9_capable({"TERM": "foot-extra"}) is True
+    assert terminal_notify.osc9_capable({"TERM": "foot", "TERM_PROGRAM": ""}) is True
 
 
-def test_osc9_capable_incapable_and_empty():
-    assert terminal_notify.osc9_capable({"TERM_PROGRAM": "Apple_Terminal"}) is False
-    assert terminal_notify.osc9_capable({"TERM_PROGRAM": "alacritty"}) is False
-    assert terminal_notify.osc9_capable({"TERM_PROGRAM": "unknown_term"}) is False
-    assert terminal_notify.osc9_capable({}) is False
-    assert terminal_notify.osc9_capable({"TERM_PROGRAM": "", "TERM": ""}) is False
+@pytest.mark.parametrize(
+    "env",
+    [
+        {"TERM_PROGRAM": "Apple_Terminal"},
+        {"TERM_PROGRAM": "vscode"},
+        {"TERM_PROGRAM": "VSCode"},
+        {"TERM_PROGRAM": "VSCODE"},
+        {"TERM_PROGRAM": "cursor"},
+        {"TERM_PROGRAM": "Cursor"},
+        {"TERM_PROGRAM": "CURSOR"},
+        {"TERM_PROGRAM": "alacritty"},
+        {"TERM_PROGRAM": "unknown_term"},
+        {},
+        {"TERM_PROGRAM": ""},
+        {"TERM_PROGRAM": "", "TERM": ""},
+    ],
+)
+def test_osc9_capable_incapable_and_empty(env):
+    assert terminal_notify.osc9_capable(env) is False
+
+
+def test_osc9_capable_tmux_and_screen():
+    # Multiplexers discard unknown OSC sequences; must be treated as incapable
+    # even when nested inside an otherwise capable terminal.
+    assert terminal_notify.osc9_capable({"TERM_PROGRAM": "iTerm.app", "TMUX": "/tmp/tmux-1000/default,1234,0"}) is False
+    assert terminal_notify.osc9_capable({"TERM_PROGRAM": "ghostty", "TMUX": "1"}) is False
+    assert terminal_notify.osc9_capable({"TERM_PROGRAM": "iTerm.app", "STY": "1234.pts-0.host"}) is False
+    assert terminal_notify.osc9_capable({"TERM": "xterm-kitty", "TMUX": "1"}) is False
+    assert terminal_notify.osc9_capable({"TERM": "foot", "STY": "1"}) is False
+
+
+def test_notify_fallback_fires_under_tmux_and_screen(monkeypatch):
+    monkeypatch.setenv("TERM_PROGRAM", "iTerm.app")
+    monkeypatch.delenv("TERM", raising=False)
+    for key in ("WARP_CLI_AGENT_PROTOCOL_VERSION", "WARP_CLIENT_VERSION"):
+        monkeypatch.delenv(key, raising=False)
+    written = []
+    monkeypatch.setattr(terminal_notify, "_write_tty", written.append)
+    spy = []
+    monkeypatch.setattr(os_notify, "notify", lambda title, body: spy.append((title, body)) or True)
+
+    # TMUX set -> fallback fires
+    monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,1234,0")
+    terminal_notify.notify("test context", prompt=True)
+    assert len(spy) == 1
+    assert spy[0] == ("Hermes", "test context")
+
+    # STY set -> fallback fires
+    spy.clear()
+    monkeypatch.delenv("TMUX")
+    monkeypatch.setenv("STY", "1234.pts-0.host")
+    terminal_notify.notify("test context 2", prompt=True)
+    assert len(spy) == 1
+    assert spy[0] == ("Hermes", "test context 2")
 
 
 def test_osc9_capable_defaults_to_environ(monkeypatch):
@@ -228,5 +275,50 @@ def test_osc9_capable_defaults_to_environ(monkeypatch):
     monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
     monkeypatch.delenv("TERM", raising=False)
     assert terminal_notify.osc9_capable() is False
+
+
+def test_notify_ssh_skip_integration(monkeypatch):
+    monkeypatch.setenv("TERM_PROGRAM", "Apple_Terminal")
+    monkeypatch.delenv("TERM", raising=False)
+    for key in ("WARP_CLI_AGENT_PROTOCOL_VERSION", "WARP_CLIENT_VERSION"):
+        monkeypatch.delenv(key, raising=False)
+
+    # Ensure os_notify probes find a binary on any platform
+    orig_which = shutil.which
+    monkeypatch.setattr(
+        shutil,
+        "which",
+        lambda cmd: orig_which(cmd) or f"/usr/bin/{cmd}",
+    )
+
+    popen_calls = []
+
+    class DummyProc:
+        def poll(self):
+            return None
+
+    monkeypatch.setattr(
+        subprocess,
+        "Popen",
+        lambda *args, **kwargs: popen_calls.append((args, kwargs)) or DummyProc(),
+    )
+
+    written = []
+    monkeypatch.setattr(terminal_notify, "_write_tty", written.append)
+
+    # 1. With SSH_CONNECTION set: OSC 9 is emitted to tty, but no OS notifier child is spawned
+    monkeypatch.setenv("SSH_CONNECTION", "10.0.0.1 50000 10.0.0.2 22")
+    terminal_notify.notify("clarify — question?", prompt=True)
+
+    assert written == ["\x1b]9;Hermes: clarify — question?\x07"]
+    assert len(popen_calls) == 0
+
+    # 2. Inverse without SSH_CONNECTION: OS notifier child is spawned
+    written.clear()
+    monkeypatch.delenv("SSH_CONNECTION")
+    terminal_notify.notify("clarify — question?", prompt=True)
+
+    assert written == ["\x1b]9;Hermes: clarify — question?\x07"]
+    assert len(popen_calls) == 1
 
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1986,13 +1986,13 @@ display:
   resume_display: full    # full (show previous messages on resume) | minimal (one-liner only)
   bell_on_complete: false # Play terminal bell when agent finishes (great for long tasks)
   bell_on_prompt: false   # Play terminal bell when a blocking prompt opens (clarify, approval, sudo password, secret capture) — works over SSH
-  # Both bell flags also emit an OSC 9 desktop notification (Ghostty, iTerm2, Kitty, WezTerm, VS Code, Cursor
+  # Both bell flags also emit an OSC 9 desktop notification (Ghostty, iTerm2, Kitty, Foot, WezTerm
   # raise an OS notification; a clarify notification carries the question being asked) and, inside Warp
   # (TERM_PROGRAM=WarpTerminal with the CLI-agent protocol advertised), a warp://cli-agent OSC 777 event
   # (`stop` on completion, `permission_request` on blocking prompts) so Warp's tab status and notification
-  # mailbox track Hermes. Terminals that cannot render OSC 9 fall back to an OS-level notification (macOS
-  # `osascript` — attributed to Script Editor; Linux `notify-send`; Windows PowerShell toast — attributed to
-  # Windows PowerShell), skipped over SSH. No extra keys needed.
+  # mailbox track Hermes. Terminals that cannot render OSC 9 (and sessions inside tmux/screen, which drop
+  # OSC sequences unless passthrough is configured) fall back to an OS-level notification (macOS `osascript`
+  # — attributed to Script Editor; Linux `notify-send`), skipped over SSH. No extra keys needed.
   show_reasoning: true    # Show model reasoning/thinking above each response (default: true; toggle with /reasoning show|hide)
   streaming: false        # Stream tokens to terminal as they arrive (real-time output)
   show_cost: false        # Show estimated $ cost in the CLI status bar

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1986,10 +1986,13 @@ display:
   resume_display: full    # full (show previous messages on resume) | minimal (one-liner only)
   bell_on_complete: false # Play terminal bell when agent finishes (great for long tasks)
   bell_on_prompt: false   # Play terminal bell when a blocking prompt opens (clarify, approval, sudo password, secret capture) — works over SSH
-  # Both bell flags also emit an OSC 9 desktop notification (Ghostty, iTerm2, Kitty, WezTerm raise an OS
-  # notification; other terminals ignore it) and, inside Warp (TERM_PROGRAM=WarpTerminal with the CLI-agent
-  # protocol advertised), a warp://cli-agent OSC 777 event (`stop` on completion, `permission_request` on
-  # blocking prompts) so Warp's tab status and notification mailbox track Hermes. No extra keys needed.
+  # Both bell flags also emit an OSC 9 desktop notification (Ghostty, iTerm2, Kitty, WezTerm, VS Code, Cursor
+  # raise an OS notification; a clarify notification carries the question being asked) and, inside Warp
+  # (TERM_PROGRAM=WarpTerminal with the CLI-agent protocol advertised), a warp://cli-agent OSC 777 event
+  # (`stop` on completion, `permission_request` on blocking prompts) so Warp's tab status and notification
+  # mailbox track Hermes. Terminals that cannot render OSC 9 fall back to an OS-level notification (macOS
+  # `osascript` — attributed to Script Editor; Linux `notify-send`; Windows PowerShell toast — attributed to
+  # Windows PowerShell), skipped over SSH. No extra keys needed.
   show_reasoning: true    # Show model reasoning/thinking above each response (default: true; toggle with /reasoning show|hide)
   streaming: false        # Stream tokens to terminal as they arrive (real-time output)
   show_cost: false        # Show estimated $ cost in the CLI status bar


### PR DESCRIPTION
## What does this PR do?

Closes the two remaining gaps from #47403: the clarify notification never carried the question, and
terminals that ignore OSC 9 still blocked silently.

Most of that request already landed on `main` in #101320: when `display.bell_on_prompt` /
`bell_on_complete` are on, `_ring_bell()` also raises an OSC 9 desktop notification (plus Warp's
`warp://cli-agent` OSC 777 payload), and the earlier attempts (#58957, #100805) were salvaged there.
What was still missing:

1. **The notification never carried the question.** The clarify body was the literal string
   `Hermes: clarify`, so the user still had to switch to the terminal to learn what was asked —
   which is the behaviour #47403 explicitly asks to fix ("the notification should surface the
   question being asked so the user can decide whether to switch to the terminal").
2. **Terminals that ignore OSC 9 got nothing at all.** OSC 9 is only rendered by some terminals;
   Apple Terminal, Alacritty, VTE (GNOME Terminal), Konsole, xfce4-terminal, tmux/screen and unknown
   `TERM_PROGRAM`s were still a silent block.

## Related Issue

Fixes #47403 — with one deliberate exception: the **Windows toast fallback** is not in this PR (see
Notes). Windows Terminal renders OSC 9, so it gets the question text from this change like any other
OSC 9-capable terminal; legacy Windows consoles without an OSC-9-capable terminal stay uncovered and
are tracked by the existing #65654. If you'd rather this PR only *reference* #47403 and leave the
issue open for the Windows half, say so and I'll switch the keyword.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- **`hermes_cli/os_notify.py` (new)** — OS-level notification fallback for **macOS (`osascript`) and
  Linux (`notify-send`)**. No new dependencies; `kind` is passed as data so each argv builder is a
  pure, unit-testable function. Fire-and-forget through the repo's shared detach helper
  (`windows_detach_popen_kwargs()`, which returns `start_new_session=True` here); any failure returns
  `False` instead of propagating to the CLI; spawned children are reaped on the next call; and the
  whole path is skipped when the CLI runs over SSH (a banner raised on a remote host would land on
  the *remote* desktop, not the user's).
- **`hermes_cli/terminal_notify.py`** — new `prompt_body(kind, detail)` collapses whitespace to one
  line and caps at 200 codepoints (the same cap the Warp payload applies, so both surfaces carry
  identical text); corrected `osc9_capable(env)`; `notify()` calls the OS notifier **only** when the
  terminal cannot render OSC 9, so capable terminals keep exactly today's behaviour and never get a
  second banner.
- **`hermes_cli/cli_modal_mixin.py`** — the two clarify call sites pass the question (single-question
  path; the batch panel passes the first question). Approval, sudo, secret, unlock and turn-complete
  notification text is unchanged.
- **`cli-config.yaml.example`**, **`website/docs/user-guide/configuration.md`** — document the
  behaviour. **No new config keys** — the notifications ride the existing bell flags, as #101320
  established.

### OSC 9 capability detection — two entries go against the obvious guess

| Environment | OSC 9 renders? | Fallback fires? |
|---|---|---|
| iTerm2, Ghostty, WezTerm, Warp | yes | no |
| kitty, foot (`TERM`-matched; they leave `TERM_PROGRAM` unset) | yes | no |
| VS Code / Cursor (xterm.js) | **no** — xterm.js does not implement OSC 9 notifications (VS Code is adding OSC *99* support in its own contribution) | yes |
| Apple Terminal, Alacritty, VTE, Konsole, xfce4, unknown | no | yes |
| anything under tmux / screen | no — multiplexers drop unrecognised OSC unless the sender DCS-wraps the sequence *and* the user has set `allow-passthrough on` (tmux 3.3+) | yes |

Both rows are the opposite of what an allow-list-by-vendor-name would suggest, so they are called out
here rather than buried: treating VS Code/Cursor as capable would leave those users with nothing, and
treating a tmux session as capable does the same because tmux drops the bare sequence.

## How to Test

1. Set `display.bell_on_prompt: true` and start `hermes`.
2. Ask for something that makes the agent call the `clarify` tool, then switch to another app.
3. In Ghostty / iTerm2 / Kitty / WezTerm / Warp: one OSC 9 banner reading
   `Hermes: clarify — <the question>`.
4. In Apple Terminal (or any terminal that ignores OSC 9, including a tmux session): an OS
   notification instead — `osascript` on macOS, `notify-send` on Linux.

Evidence from this machine (macOS 26.6.2), driving the real `_clarify_callback` call site with only
the tty write and `subprocess.Popen` intercepted:

| `TERM_PROGRAM` | emitted to `/dev/tty` | OS notifier |
|---|---|---|
| `iTerm.app` | `ESC]9;Hermes: clarify — Which output file should I write…?BEL` | not called |
| `ghostty` | same | not called |
| `Apple_Terminal` | same | `osascript` |
| unknown | same | `osascript` |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (no PR references #47403; `terminal_notify.py` was last touched by #101320)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the affected suites: `scripts/run_tests.sh tests/cli/ tests/hermes_cli/` — **10845 passed, 15 failed, 194 skipped across 1030 files; all 15 failures reproduce identically on clean `main`** (1 session-recovery sqlite3-CLI test, 4 launchd/fleet-restart update tests, 1 head-moved gate, 1 fleet-restart-pending, 9 update-autostash — all environment-specific to a machine running a live gateway fleet). Nothing else fails.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6.2 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/configuration.md`, plus the bell-flag comments in `cli-config.yaml.example`; no new keys added)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide

## Notes

- **Windows has no OS-level fallback in this PR.** An earlier revision drove a WinRT toast through
  PowerShell, but it passed the title/body as trailing argv after `-Command <script>`, which
  PowerShell folds into the command string it parses — a command-substitution surface fed by
  model-generated text — and it handed the `XmlDocument` straight to `ToastNotifier.Show()` instead of
  constructing a `ToastNotification`. Neither fix can be validated without a Windows host, so that
  path is removed rather than shipped unverified: `notifier_argv("win32", …)` returns `None` and
  Windows gets no OS fallback, while OSC 9-capable Windows terminals (Windows Terminal) still receive
  the notification with the question text. Legacy consoles are the remaining gap and are tracked by
  the existing #65654.
- **Attribution caveat, deliberately not papered over:** an `osascript`-raised macOS notification is
  attributed to **Script Editor** (Apple removed the sender override — which is why OSC 9 remains the
  primary path). Getting Hermes its own notification identity needs a signed/registered app.
- **tmux/screen:** inside a multiplexer the OS fallback is the *only* delivery path, not a duplicate of
  the OSC 9 one. tmux does not handle OSC 9 itself and forwards it only when the sender wraps the
  sequence in a DCS passthrough (```\ePtmux;…\e\\```) **and** the user has set `allow-passthrough on`
  (tmux 3.3+) — we deliberately send the plain sequence, so inside tmux nothing reaches the terminal
  and exactly one banner (the OS one) is raised. If maintainers would rather tmux users get the native
  banner, DCS-wrapping when `TMUX` is set is a small change — but it then requires user config, so the
  OS fallback would have to stay as the backstop.
- **Unknown terminals still get the fallback** — the large majority of emulators do not implement
  OSC 9, so silence is the likelier wrong guess. Inverting it is a one-line change in `osc9_capable()`.
- **The fallback commits are separable.** The OS-notifier commits can be dropped without touching the
  question-text change; happy to split them into their own PR if preferred.
