### PR TITLE
fix(agent): reconcile key-scoped credential endpoints at pool load

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from agent.credential_pool_admin import CredentialPoolAdminMixin
 
+import hashlib
 import logging
 import os
 import random
@@ -2595,6 +2596,51 @@ _ENV_BASE_URL_RESOLVERS = {
 }
 
 
+def _zai_key_hash(token: str) -> str:
+    """Key-hash form the Z.AI endpoint cache is stored under (``auth_zai_kimi``)."""
+    return hashlib.sha256(token.encode()).hexdigest()[:16]
+
+
+def _reconcile_key_scoped_base_url(provider: str, entry: PooledCredential) -> PooledCredential:
+    """Adopt the endpoint this credential's KEY resolves to (Z.AI / Kimi Coding).
+
+    These providers sell per-region endpoints behind one key shape: a Coding Plan key
+    authenticates only against ``/api/coding/paas/v4``. ``hermes auth add`` persists the
+    provider's standard URL on the row, and ``_swap_credential`` adopts the stored value
+    verbatim, so any rotation routes the key at the standard endpoint — which answers
+    ``429`` code ``1113`` ("Insufficient balance or no resource package."). That body
+    classifies as *verified billing*, benching the sole credential for an hour and
+    replaying the latched error without a request until ``hermes auth reset``.
+
+    Env-seeded rows already resolve this way (``_seed_from_env``); manual rows did not.
+    Reads the endpoint cached on the key hash only — probing here would put seconds of
+    network latency inside a pool load, and a probe already happens on first client build.
+    """
+    if provider not in _ENV_BASE_URL_RESOLVERS:
+        return entry
+    token = str(entry.access_token or "").strip()
+    if not token:
+        return entry
+    try:
+        cached = (_load_provider_state(_load_auth_store(), provider) or {}).get("detected_endpoint")
+    except Exception:
+        return entry
+    if not isinstance(cached, dict):
+        return entry
+    cached_hash = str(cached.get("key_hash") or "")
+    if cached_hash and cached_hash != _zai_key_hash(token):
+        return entry
+    resolved = str(cached.get("base_url") or "").strip().rstrip("/")
+    current = str(entry.base_url or "").strip().rstrip("/")
+    if not resolved or resolved == current:
+        return entry
+    logger.info(
+        "Pool entry %s: adopting key-resolved endpoint %s (stored %s)",
+        entry.id, resolved, current or "<none>",
+    )
+    return replace(entry, base_url=resolved)
+
+
 def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool, Set[str]]:
     seed = _Seeder(provider, entries)
     # Copilot's singleton branch exchanges the raw ghu_ OAuth token for the
@@ -2725,6 +2771,8 @@ def load_pool(provider: str) -> CredentialPool:
         for payload in raw_entries
     )
     entries = [PooledCredential.from_dict(provider, payload) for payload in raw_entries]
+    # A stored row's base_url is not authoritative for key-scoped endpoints.
+    entries = [_reconcile_key_scoped_base_url(provider, entry) for entry in entries]
     raw_needs_auth_normalization = any(
         isinstance(payload, dict)
         and _normalize_pool_auth_type(

--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -87,12 +87,18 @@ def _error_text(error: Any) -> str:
 
 def is_zai_coding_overload_error(*, base_url: str | None, model: str | None, error: Any) -> bool:
     """True only for the narrow Z.AI Coding Plan overload shape (429 + code
-    1305 / "temporarily overloaded"), so ordinary quota 429s still fail fast."""
+    1305 / "temporarily overloaded"), so ordinary quota 429s still fail fast.
+
+    Model match is the ``glm-5`` family, not a frozen version: the plan rotates
+    models (5.2 → 5.3 → 5.3-flash) under one endpoint, and a pinned version silently
+    drops every overload onto the generic fail-fast path — which benches the only
+    credential instead of riding out a transient overload.
+    """
     text = _error_text(error)
     return (
         getattr(error, "status_code", None) == 429
         and "api.z.ai/api/coding/paas/v4" in (base_url or "").lower()
-        and "glm-5.2" in (model or "").lower()
+        and "glm-5" in (model or "").lower()
         and ("1305" in text or "temporarily overloaded" in text)
     )
 

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2209,3 +2209,77 @@ def test_a_persist_without_declared_intent_still_cannot_erase_a_cooldown(
     entry = _disk_entry(tmp_path)
     assert entry["last_status"] == "exhausted"
     assert entry["last_error_code"] == 402
+
+
+def _zai_auth_store(token: str, stored_base_url: str, detected_base_url: str, detected_hash: str = "match") -> dict:
+    import hashlib
+
+    key_hash = hashlib.sha256(token.encode()).hexdigest()[:16] if detected_hash == "match" else "deadbeefdeadbeef"
+    return {
+        "version": 1,
+        "providers": {
+            "zai": {
+                "detected_endpoint": {
+                    "base_url": detected_base_url,
+                    "endpoint_id": "coding-global",
+                    "model": "glm-5.3",
+                    "key_hash": key_hash,
+                }
+            }
+        },
+        "credential_pool": {
+            "zai": [
+                {
+                    "id": "zai-1",
+                    "label": "hermes-api-key",
+                    "auth_type": "api_key",
+                    "priority": 0,
+                    "source": "manual",
+                    "access_token": token,
+                    "base_url": stored_base_url,
+                    "last_status": None,
+                }
+            ]
+        },
+    }
+
+
+def test_zai_manual_row_adopts_key_resolved_endpoint(tmp_path, monkeypatch):
+    """A Coding Plan key must not be routed at the standard endpoint.
+
+    `hermes auth add` stores the provider default on the row and `_swap_credential`
+    adopts it verbatim; the standard endpoint answers 429/1113 ("Insufficient
+    balance"), which classifies as billing and benches the sole credential for an
+    hour. The key's own cached endpoint wins over the stored row.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    from agent.credential_pool import load_pool
+
+    coding = "https://api.z.ai/api/coding/paas/v4"
+    _write_auth_store(tmp_path, _zai_auth_store("sk-coding-key", "https://api.z.ai/api/paas/v4", coding))
+
+    pool = load_pool("zai")
+    entry = next(e for e in pool.entries() if e.id == "zai-1")
+    assert entry.base_url == coding, "stored standard endpoint must be reconciled to the key's endpoint"
+    assert entry.runtime_base_url == coding, "the runtime route is what _swap_credential adopts"
+
+
+def test_zai_row_for_a_different_key_is_left_alone(tmp_path, monkeypatch):
+    """Only the credential's OWN cached endpoint is authoritative.
+
+    A stale `detected_endpoint` left by a previous key must not rewrite the row —
+    silently switching a rotated key to another key's endpoint would be worse than
+    the misrouting this fixes.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    from agent.credential_pool import load_pool
+
+    stored = "https://api.z.ai/api/paas/v4"
+    _write_auth_store(
+        tmp_path,
+        _zai_auth_store("sk-new-key", stored, "https://api.z.ai/api/coding/paas/v4", detected_hash="stale"),
+    )
+
+    pool = load_pool("zai")
+    entry = next(e for e in pool.entries() if e.id == "zai-1")
+    assert entry.base_url == stored

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -208,3 +208,30 @@ class TestParseRetryAfterSeconds:
                 raise RuntimeError("boom")
 
         assert parse_retry_after_seconds(Explosive()) is None
+
+
+def _zai_error(model: str, body_code: str, message: str, base_url: str = "https://api.z.ai/api/coding/paas/v4"):
+    return SimpleNamespace(status_code=429, body={"error": {"code": body_code, "message": message}}), base_url, model
+
+
+def test_zai_overload_detection_follows_the_model_family():
+    """The Coding Plan rotates models under one endpoint (5.2 → 5.3 → 5.3-flash).
+
+    A pinned version silently drops every overload onto the generic fail-fast path,
+    which benches the only credential instead of riding out a transient overload.
+    """
+    for model in ("glm-5.2", "glm-5.3", "glm-5.3-flash"):
+        err, base_url, model_name = _zai_error(model, "1305", "The service may be temporarily overloaded, please try again later")
+        assert is_zai_coding_overload_error(base_url=base_url, model=model_name, error=err), model
+
+
+def test_zai_overload_detection_stays_narrow():
+    """Ordinary quota 429s (1113 "Insufficient balance") and the standard endpoint
+    must keep failing fast — the long backoff is only for the overload shape."""
+    overload_text = "The service may be temporarily overloaded, please try again later"
+    err, base_url, model = _zai_error("glm-5.3-flash", "1113", "Insufficient balance or no resource package. Please recharge.")
+    assert not is_zai_coding_overload_error(base_url=base_url, model=model, error=err)
+    err, base_url, model = _zai_error("glm-5.3-flash", "1305", overload_text)
+    assert not is_zai_coding_overload_error(
+        base_url="https://api.z.ai/api/paas/v4", model=model, error=err
+    )


### PR DESCRIPTION
## What & why

Reconciles credential-pool rows for **key-scoped providers** (Z.AI, Kimi Coding) at load time.

A Z.AI Coding Plan key authenticates only against `https://api.z.ai/api/coding/paas/v4`.
`hermes auth add` persists the provider's default `base_url` (`…/api/paas/v4`) on the pool row, and
`_swap_credential` adopts the stored value verbatim — so **any rotation routed the key at the standard
endpoint**. That endpoint answers:

```
HTTP 429 {"error":{"code":"1113","message":"Insufficient balance or no resource package. Please recharge."}}
```

The body matches `_BILLING_PATTERNS` ("insufficient balance") → classified as *verified* billing →
`_exhausted_ttl` deliberately skips the sole-credential 60s cooldown → **3600s bench**. With one key in
the pool there is nothing to rotate to, and the exhaustion latch then replays the stored error **without
issuing a request**, so the provider looks permanently broken until `hermes auth reset <provider>`.

`_seed_from_env` already resolved the key's endpoint via `_ENV_BASE_URL_RESOLVERS`; manual rows never
did. `_reconcile_key_scoped_base_url()` closes that gap at `load_pool()`, reading only the endpoint
already cached on the key hash (no probing in a load path). A stale endpoint cached for a *different*
key is ignored — switching a rotated key onto another key's endpoint would be worse than the original
bug.

Also widens `is_zai_coding_overload_error` from a pinned `glm-5.2` to the `glm-5` family: the Coding
Plan rotates models under one endpoint (5.2 → 5.3 → 5.3-flash), and the pinned version silently dropped
every overload onto the generic fail-fast path, which benches the only credential instead of riding out
the transient overload.

## How to test

Repro (on `main`): a pool row with `base_url = https://api.z.ai/api/paas/v4` and a Coding-Plan key —
calls hit the standard endpoint, return `429`/`1113`, and the credential is benched for an hour. The
same key returns `HTTP 200` on `…/api/coding/paas/v4` (verified directly with curl).

After: `load_pool("zai")` adopts the key's endpoint.

```
scripts/run_tests.sh tests/agent/test_credential_pool.py tests/test_retry_utils.py
# → 2 files, 77 tests passed

# both new tests fail on the unfixed base:
#   test_zai_manual_row_adopts_key_resolved_endpoint
#       assert 'https://api.z.ai/api/paas/v4' == 'https://api.z.ai/api/coding/paas/v4'
#   test_zai_overload_detection_follows_the_model_family   (glm-5.3 / 5.3-flash)
```

Manual receipt from the machine this was found on: 122 of 290 live calls in one day went to the standard
endpoint and returned 1113, while the same key served normal traffic on the coding endpoint; three
benching events in one day, each cleared by `hermes auth reset zai`. After the fix, a fresh
`hermes chat --provider zai -m glm-5.3-flash` logs:

```
agent.credential_pool: Pool entry 42509b: adopting key-resolved endpoint
  https://api.z.ai/api/coding/paas/v4 (stored https://api.z.ai/api/paas/v4)
agent.conversation_loop: API call #1: model=glm-5.3-flash provider=zai … out=3
```

## Platforms tested

Linux (Ubuntu-kernel 7.0, Python 3.11 venv, RTX 4080s desktop). No platform-specific code touched —
the change is pure resolution logic plus a string match.

## Scope (one logical change)

Both edits fix the same failure mode: **a transient Z.AI Coding-Plan condition must not bench the
only credential.** The endpoint reconcile removes the misroute that produces a billing-shaped 429;
the `glm-5` family match keeps a genuine overload on the long-backoff path instead of the generic
fail-fast path that latches the pool. Splitting them would leave the overload path broken for the
models the plan currently serves (`glm-5.3`, `glm-5.3-flash`), which is the same user-visible symptom.

If you'd prefer the retry-utils widening as its own PR, say so and I'll split it — the endpoint
reconcile stands alone.
