### PR TITLE
test: guard live Hermes state and macOS service commands

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ import asyncio
 import atexit
 import importlib
 import os
+import re
 import shutil
 import sqlite3
 import sys
@@ -113,6 +114,59 @@ os.environ["HERMES_TEST_ISOLATION"] = os.environ.get("HERMES_HOME", "") or "1"
 #: `_isolate_env` fixture has sandboxed it by then, so the check would pass
 #: even with this block removed.
 HERMES_HOME_AT_CONFTEST_IMPORT = os.environ.get("HERMES_HOME", "")
+
+
+_LAUNCHCTL_EXECUTABLE_RE = re.compile(
+    r"(?<![A-Za-z0-9_.-])launchctl(?=$|[^A-Za-z0-9_.-])",
+    re.IGNORECASE,
+)
+
+
+def _iter_command_text(value):
+    """Yield decoded command fragments without stringifying arbitrary objects."""
+    if isinstance(value, os.PathLike):
+        value = os.fspath(value)
+    if isinstance(value, bytes):
+        yield os.fsdecode(value)
+        return
+    if isinstance(value, str):
+        yield value
+        return
+    if isinstance(value, (list, tuple, set, frozenset)):
+        for item in value:
+            yield from _iter_command_text(item)
+
+
+def _command_mentions_launchctl(*values) -> bool:
+    """Detect launchctl in argv, shell fragments, bytes, or executable overrides."""
+    return any(
+        _LAUNCHCTL_EXECUTABLE_RE.search(fragment)
+        for value in values
+        for fragment in _iter_command_text(value)
+    )
+
+
+def _pytest_launchctl_audit_guard(event, args):
+    """Block Python process primitives before collection or fixture setup."""
+    guarded_events = {
+        "subprocess.Popen",
+        "os.system",
+        "os.exec",
+        "os.spawn",
+        "os.posix_spawn",
+    }
+    if event in guarded_events and _command_mentions_launchctl(args):
+        raise RuntimeError(
+            "tests/conftest.py live-system guard: blocked launchctl before "
+            "process creation; unit tests must use fakes and temporary paths"
+        )
+
+
+# Process-global: markers and imports of run/Popen before fixture setup cannot
+# bypass this hook. Install once during root conftest import, before collection.
+if not getattr(sys, "_hermes_pytest_launchctl_audit_guard", False):
+    sys.addaudithook(_pytest_launchctl_audit_guard)
+    setattr(sys, "_hermes_pytest_launchctl_audit_guard", True)
 
 
 # ── Per-file process isolation ──────────────────────────────────────────────
@@ -453,11 +507,11 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
 
 
 @pytest.fixture(autouse=True)
-def _hermetic_environment(tmp_path, monkeypatch):
+def _hermetic_environment(tmp_path, tmp_path_factory, monkeypatch):
     """Blank out all credential/behavioral env vars so local and CI match.
 
-    Also redirects HOME and HERMES_HOME to per-test tempdirs so code that
-    reads ``~/.hermes/*`` can't touch the real one, and pins TZ/LANG so
+    Redirects HERMES_HOME to a per-test tempdir while keeping HOME stable,
+    installs a POSIX launchctl PATH stub, and pins TZ/LANG so
     datetime/locale-sensitive tests are deterministic.
     """
     # 1. Blank every credential-shaped env var that's currently set.
@@ -514,6 +568,23 @@ def _hermetic_environment(tmp_path, monkeypatch):
     if hermes_state_mod is not None and hasattr(hermes_state_mod, "DEFAULT_DB_PATH"):
         monkeypatch.setattr(
             hermes_state_mod, "DEFAULT_DB_PATH", fake_hermes_home / "state.db"
+        )
+
+    if os.name == "posix":
+        # Opaque child scripts cannot be inspected by the Python guards. Bare
+        # launchctl resolves to this stub; absolute commands inside external
+        # scripts still require a separate disposable service sandbox.
+        guard_bin = tmp_path_factory.mktemp("live-system-guard-bin")
+        launchctl_stub = guard_bin / "launchctl"
+        launchctl_stub.write_text(
+            "#!/bin/sh\n"
+            "echo 'pytest live-system guard: launchctl blocked' >&2\n"
+            "exit 126\n",
+            encoding="utf-8",
+        )
+        launchctl_stub.chmod(0o700)
+        monkeypatch.setenv(
+            "PATH", f"{guard_bin}{os.pathsep}{os.environ.get('PATH', '')}"
         )
 
     # 4. Deterministic locale / timezone / hashseed. CI runs in UTC with
@@ -1150,9 +1221,10 @@ def pytest_configure(config):  # noqa: D401 — pytest hook
     """Register markers used by hermetic conftest."""
     config.addinivalue_line(
         "markers",
-        f"{_LIVE_SYSTEM_GUARD_BYPASS_MARK}: bypass the live-system guard "
+        f"{_LIVE_SYSTEM_GUARD_BYPASS_MARK}: bypass signal/process guards "
         "(only for tests that genuinely need real os.kill / subprocess "
-        "behaviour — e.g. PTY tests that signal their own child).",
+        "behaviour — e.g. PTY tests that signal their own child); "
+        "launchctl remains blocked and must be faked.",
     )
     config.addinivalue_line(
         "markers",
@@ -1297,11 +1369,12 @@ def pytest_collection_modifyitems(config, items):  # noqa: D401 — pytest hook
 
 @pytest.fixture(autouse=True)
 def _live_system_guard(request, monkeypatch):
-    """Block real os.kill / systemctl / gateway-pid scans during tests.
+    """Block real signals, launchctl, and mutating gateway service commands.
 
     See block comment above for the why. Tests that genuinely need
     real signal delivery (e.g. PTY tests that SIGINT their own child)
-    can opt out with ``@pytest.mark.live_system_guard_bypass``.
+    can opt out of signal/process guards with
+    ``@pytest.mark.live_system_guard_bypass``. launchctl is never bypassable.
 
     Coverage (every primitive that can deliver a signal to or otherwise
     terminate a foreign process):
@@ -1317,9 +1390,9 @@ def _live_system_guard(request, monkeypatch):
     are all caught. ``pkill``/``killall``/``taskkill`` invocations
     targeting hermes/python patterns are also blocked.
     """
-    if request.node.get_closest_marker(_LIVE_SYSTEM_GUARD_BYPASS_MARK):
-        yield
-        return
+    bypass_signal_and_process_guards = bool(
+        request.node.get_closest_marker(_LIVE_SYSTEM_GUARD_BYPASS_MARK)
+    )
 
     import os as _os
     import shlex as _shlex
@@ -1388,14 +1461,15 @@ def _live_system_guard(request, monkeypatch):
             "delivery is genuinely required."
         )
 
-    monkeypatch.setattr(_os, "kill", _guarded_kill)
+    if not bypass_signal_and_process_guards:
+        monkeypatch.setattr(_os, "kill", _guarded_kill)
 
     # ``os.killpg`` is the same risk class — sends a signal to every
     # process in a group. The gateway is a session leader (its own
     # PGID == its PID), so killpg(gateway_pid, SIGTERM) is a one-shot
     # kill of the live process. Allow it only when the target PGID is
     # the test process's own group.
-    if hasattr(_os, "killpg"):
+    if hasattr(_os, "killpg") and not bypass_signal_and_process_guards:
         real_killpg = _os.killpg
         own_pgid = _os.getpgrp()
 
@@ -1509,7 +1583,16 @@ def _live_system_guard(request, monkeypatch):
                     return True
         return False
 
-    def _check_subprocess_cmd(name, cmd):
+    def _check_subprocess_cmd(name, cmd, *, executable=None):
+        if _command_mentions_launchctl(cmd, executable):
+            raise RuntimeError(
+                f"tests/conftest.py live-system guard: blocked launchctl via "
+                f"subprocess.{name}({cmd!r}) - unit tests must use fakes and "
+                "temporary launchd paths. This block cannot be bypassed with "
+                "@pytest.mark.live_system_guard_bypass."
+            )
+        if bypass_signal_and_process_guards:
+            return
         if _is_blocked_systemctl(cmd):
             raise RuntimeError(
                 f"tests/conftest.py live-system guard: blocked "
@@ -1593,7 +1676,7 @@ def _live_system_guard(request, monkeypatch):
 
     def _wrap_subprocess(name, real):
         def _guarded(cmd, *args, **kwargs):
-            _check_subprocess_cmd(name, cmd)
+            _check_subprocess_cmd(name, cmd, executable=kwargs.get("executable"))
             return real(cmd, *args, **kwargs)
         _guarded.__name__ = f"_guarded_{name}"
         # Make the wrapper subscriptable like the wrapped callable when
@@ -1611,7 +1694,7 @@ def _live_system_guard(request, monkeypatch):
 
         class _GuardedPopen(real):  # type: ignore[misc, valid-type]
             def __init__(self, cmd, *args, **kwargs):
-                _check_subprocess_cmd("Popen", cmd)
+                _check_subprocess_cmd("Popen", cmd, executable=kwargs.get("executable"))
                 super().__init__(cmd, *args, **kwargs)
 
         _GuardedPopen.__name__ = "Popen"

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2517,7 +2517,7 @@ class TestLaunchctlBootstrapEioRetry:
 class TestLaunchdUnloadedJobStderrStaysOffTerminal:
     """#106273: against an UNLOADED job, ``launchctl bootout`` / ``kickstart -k`` exit 3 and print
     ``Could not find service ...`` / ``Boot-out failed: 3`` on fd 2. Those exits are the *handled*
-    case, so a real launchctl child (fake binary on PATH, real fd inheritance) must leave the
+    case, so a real fixture child (explicit fake executable, real fd inheritance) must leave the
     terminal's stderr empty while the CLI's own status lines print. ``capfd`` reads fd 2, so an
     inherited-stderr regression fires even though ``subprocess.run`` never touches ``sys.stderr``."""
 
@@ -2525,7 +2525,7 @@ class TestLaunchdUnloadedJobStderrStaysOffTerminal:
     def fake_launchctl(self, tmp_path, monkeypatch):
         bin_dir = tmp_path / "bin"
         bin_dir.mkdir()
-        script = bin_dir / "launchctl"
+        script = bin_dir / "service-probe.sh"
         # bootout exits $FAKE_BOOTOUT_RC (default 3 = unloaded); `kickstart -k` is the unloaded 3;
         # bootstrap / plain kickstart / print succeed. Every invocation is logged for the caller.
         script.write_text(
@@ -2540,7 +2540,14 @@ class TestLaunchdUnloadedJobStderrStaysOffTerminal:
         )
         script.chmod(0o755)
         log = tmp_path / "calls.log"
-        monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+        guarded_run = gateway_cli.subprocess.run
+
+        def run_fixture(cmd, *args, **kwargs):
+            if isinstance(cmd, (list, tuple)) and cmd and cmd[0] == "launchctl":
+                cmd = [str(script), *cmd[1:]]
+            return guarded_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", run_fixture)
         monkeypatch.setenv("FAKE_LAUNCHCTL_LOG", str(log))
         monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
         monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")

--- a/tests/test_live_system_guard_self_test.py
+++ b/tests/test_live_system_guard_self_test.py
@@ -22,8 +22,23 @@ import signal
 import subprocess
 import sys
 import types
+from pathlib import Path
 
 import pytest
+
+
+# Synthetic audit only: collection must be protected before autouse fixtures.
+# Absence of the hook records a failing assertion later, never starts a process.
+try:
+    sys.audit("subprocess.Popen", "/bin/launchctl", ["launchctl", "print"], None, None)
+except RuntimeError as exc:
+    _COLLECTION_LAUNCHCTL_ERROR = str(exc)
+else:
+    _COLLECTION_LAUNCHCTL_ERROR = ""
+
+_HOME_AT_COLLECTION = os.environ.get("HOME")
+_USERPROFILE_AT_COLLECTION = os.environ.get("USERPROFILE")
+_PATH_HOME_AT_COLLECTION = Path.home()
 
 # A guaranteed-foreign PID: PID 1 (init).  Owned by root, not us, and
 # always exists. A sane guard refuses to signal it.
@@ -203,6 +218,93 @@ def test_subprocess_getstatusoutput_systemctl_blocked():
         subprocess.getstatusoutput("systemctl --user restart hermes-gateway")
 
 
+def test_launchctl_is_blocked_during_collection():
+    assert "blocked launchctl" in _COLLECTION_LAUNCHCTL_ERROR
+
+
+@pytest.mark.parametrize(
+    ("command", "kwargs"),
+    [
+        (["launchctl", "print", "gui/501/ai.hermes.gateway"], {}),
+        (["/bin/launchctl", "bootout", "gui/501/ai.hermes.gateway"], {}),
+        (["sudo", "launchctl", "print"], {}),
+        (["env", "launchctl", "print"], {}),
+        (["setsid", "launchctl", "print"], {}),
+        (["bash", "-c", "launchctl print"], {}),
+        ("bash -c 'echo $(launchctl print)'", {"shell": True}),
+        ("launchctl>/dev/null", {"shell": True}),
+        (("launchctl", "print"), {}),
+        ([b"launchctl", b"print"], {}),
+        (b"launchctl print", {"shell": True}),
+        (Path("/bin/launchctl"), {}),
+        ([Path("/bin/launchctl"), "print"], {}),
+        (["env", (b"launchctl", "print")], {}),
+        (["ignored-argv-zero"], {"executable": "/bin/launchctl"}),
+        (["ignored-argv-zero"], {"executable": b"/bin/launchctl"}),
+        (["ignored-argv-zero"], {"executable": Path("/bin/launchctl")}),
+    ],
+)
+def test_subprocess_run_launchctl_shapes_are_blocked_before_exec(
+    command, kwargs, monkeypatch
+):
+    escaped = []
+
+    def final_popen_trap(*args, **popen_kwargs):
+        escaped.append((args, popen_kwargs))
+        raise AssertionError("launchctl escaped the live-system guard")
+
+    # Safe RED: the final executor cannot reach launchctl even without a guard.
+    monkeypatch.setattr(subprocess, "Popen", final_popen_trap)
+    with pytest.raises(RuntimeError, match="blocked.*launchctl"):
+        subprocess.run(command, check=False, **kwargs)
+    assert escaped == []
+
+
+@pytest.mark.parametrize(
+    ("event", "args"),
+    [
+        ("subprocess.Popen", ("/bin/launchctl", ["ignored-argv-zero"], None, None)),
+        ("os.system", (b"launchctl print",)),
+        ("os.exec", (Path("/bin/launchctl"), ["ignored-argv-zero"], None)),
+        ("os.spawn", (0, b"/bin/launchctl", ["ignored-argv-zero"], None)),
+        ("os.posix_spawn", ("/bin/launchctl", ["ignored-argv-zero"], {})),
+    ],
+)
+@pytest.mark.live_system_guard_bypass
+def test_process_global_audit_guard_blocks_launchctl_events(event, args):
+    # Exercise the installed hook, not its helper. sys.audit never executes args.
+    with pytest.raises(RuntimeError, match="blocked launchctl"):
+        sys.audit(event, *args)
+
+
+@pytest.mark.parametrize("command", ["launchctl-helper", "mylaunchctl", "launchctl.py"])
+def test_launchctl_audit_guard_allows_unrelated_command_names(command):
+    sys.audit("subprocess.Popen", command, [command], None, None)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX executable PATH stub")
+def test_launchctl_path_resolves_only_to_per_test_stub(tmp_path, tmp_path_factory):
+    import shutil
+
+    resolved = Path(shutil.which("launchctl") or "")
+    # Check ownership before reading, so RED cannot even read the system binary.
+    assert resolved.is_relative_to(tmp_path_factory.getbasetemp())
+    assert not resolved.is_relative_to(tmp_path)
+    assert resolved.name == "launchctl"
+    assert os.access(resolved, os.X_OK)
+    assert resolved.read_text(encoding="utf-8") == (
+        "#!/bin/sh\n"
+        "echo 'pytest live-system guard: launchctl blocked' >&2\n"
+        "exit 126\n"
+    )
+
+
+def test_launchctl_protection_keeps_native_home_stable():
+    assert os.environ.get("HOME") == _HOME_AT_COLLECTION
+    assert os.environ.get("USERPROFILE") == _USERPROFILE_AT_COLLECTION
+    assert Path.home() == _PATH_HOME_AT_COLLECTION
+
+
 # ──────────────────── os.system / os.popen ────────────────────
 
 
@@ -327,10 +429,31 @@ def test_bypass_marker_disables_guard():
     """The bypass marker exists for tests that genuinely need real signal delivery
     (e.g. PTY tests SIGINTing their own child). Verify it works.
 
-    We use it harmlessly here by signaling our own PID 0 (own group) so we
-    don't actually kill anything — but the call goes through real os.kill.
+    We use it harmlessly here by probing our own PID with signal 0, so we
+    don't actually kill anything - but the call goes through real os.kill.
     """
-    # With bypass, the guard yields without installing the monkeypatch,
-    # so we get the real os.kill. Calling os.kill(os.getpid(), 0) just
-    # checks that the PID exists — harmless.
-    os.kill(os.getpid(), 0)  # No exception — guard is OFF.
+    # With bypass, os.kill remains real. Calling os.kill(os.getpid(), 0)
+    # only checks that our PID exists; launchctl protection stays active.
+    os.kill(os.getpid(), 0)  # No exception - signal guard is OFF.
+
+
+@pytest.mark.live_system_guard_bypass
+@pytest.mark.parametrize("kwargs", [{}, {"executable": Path("/bin/launchctl")}])
+def test_bypass_marker_never_allows_launchctl(monkeypatch, kwargs):
+    escaped = []
+
+    def final_popen_trap(*args, **popen_kwargs):
+        escaped.append((args, popen_kwargs))
+        raise AssertionError("launchctl escaped through the bypass marker")
+
+    monkeypatch.setattr(subprocess, "Popen", final_popen_trap)
+    command = ["ignored-argv-zero"] if kwargs else ["launchctl", "print"]
+    with pytest.raises(RuntimeError, match="blocked.*launchctl"):
+        subprocess.run(command, check=False, **kwargs)
+    assert escaped == []
+
+
+@pytest.mark.live_system_guard_bypass
+def test_bypass_marker_preserves_native_signal_primitive():
+    assert isinstance(os.kill, types.BuiltinFunctionType)
+    os.kill(os.getpid(), 0)


### PR DESCRIPTION
Tests that change HOME can lose track of the original Hermes state directory, and service tests can reach real macOS launchctl commands. This extends the existing test guards to retain the original protected state path and intercept recognized launchctl commands through the subprocess wrappers, audit hook, and PATH stubs. The launchd stderr tests use a harmless subprocess fixture while retaining their assertions.

The guard remains a test-isolation aid with lexical command matching, not a general shell sandbox. Shell-computed executable names remain outside its coverage.

Validation: the complete live-system guard, gateway-service, and live-database guard test files produced 181 passed, 3 failed, and 1 skipped in an isolated macOS run, including integration with current main. The three failures match the baseline: two synthetic Linux Node-path permission failures and one unavailable synthetic group. No new failure was observed; the combined run is not fully green.