### PR TITLE
fix(approval): route detached delegate_task child approvals through owner-bound leases with exact /approve and /deny selectors

### DIFF
--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -1292,6 +1292,37 @@ class TurnRunner:
                 logger.debug("resume_typing_for_chat after clarify answer failed", exc_info=True)
         return response
 
+    def _background_approval_notifier(self):
+        """Capture delivery independent of parent-turn status/streams.
+
+        Legacy adapter buttons resolve FIFO, not actor + request-id. Use the
+        authorized text lane with an exact token until buttons are equally bound.
+        A refusal never falls back to another destination or counts as delivery.
+        """
+        from copy import deepcopy
+        from gateway.run import _interim_metadata, _redact_approval_command
+        ctx = self._ctx
+        adapter, chat_id = ctx._status_adapter, ctx._status_chat_id
+        metadata = deepcopy(ctx._status_thread_metadata or {})
+        metadata["is_approval_prompt"] = True
+        loop = getattr(ctx, "_loop_for_step", None)
+        prefix = getattr(adapter, "typed_command_prefix", "/")
+
+        def notify(data):
+            rid = data["request_id"]
+            command = _redact_approval_command(data.get("command", ""))
+            text = (f"Background child approval — one execution only\n{data.get('description', '')}\n\n"
+                    f"{command}\n\nApprove: {prefix}approve {rid}\nDeny: {prefix}deny {rid}\n"
+                    "Only the requesting user can answer. This request expires with the child or approval timeout.")
+            future = self._schedule(adapter.send(chat_id, text, metadata=_interim_metadata(metadata)),
+                                    "Background approval scheduling error", loop=loop)
+            if future is None:
+                raise RuntimeError("background approval loop unavailable")
+            result = future.result(timeout=15)
+            if getattr(result, "success", None) is not True:
+                raise _ExecApprovalDeclined("background approval delivery refused or unconfirmed")
+        return notify
+
     def _approval_notify_sync(self, approval_data: dict) -> None:
         """Send the approval request from the agent thread: the adapter's interactive button
         approvals (``send_exec_approval``) when available, else plain text with ``/approve`` steps."""
@@ -1537,7 +1568,10 @@ class TurnRunner:
             # turn so a restart-interrupted turn is recorded WITH its id for drain-window dedup.
             if ctx.inbound_message_id is not None:
                 kwargs["persist_user_platform_id"] = str(ctx.inbound_message_id)
-            return agent.run_conversation(api_message, **kwargs)
+            from tools.approval_delegation import gateway_approval_origin, owner_for_source
+            owner = owner_for_source(ctx.source, session_key)
+            with gateway_approval_origin(owner, self._background_approval_notifier()):
+                return agent.run_conversation(api_message, **kwargs)
         finally:
             unregister_gateway_notify(session_key)
             # Cancel pending clarify entries so blocked agent threads don't hang past the end of the

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -64,7 +64,8 @@ _FOOTER_STATE_BY_ARG = {**dict.fromkeys(("on", "enable", "true", "1"), True),
                         **dict.fromkeys(("off", "disable", "false", "0"), False)}
 
 # /approve modifier tokens -> approval choice (default "once").
-_APPROVE_CHOICE_BY_ARG = {**dict.fromkeys(("always", "permanent", "permanently"), "always"),
+_APPROVE_CHOICE_BY_ARG = {"once": "once",
+                          **dict.fromkeys(("always", "permanent", "permanently"), "always"),
                           **dict.fromkeys(("session", "ses"), "session")}
 
 _PLATFORM_USAGE = ("Usage: /platform <list|pause|resume> [name]\n"
@@ -1139,8 +1140,24 @@ class GatewaySlashCommandsMixin(
                                                               "gateway.approve.no_pending")
         if stale:
             return stale
+        from tools.approval_delegation import owner_for_source
+        raw_args = event.get_command_args().strip()
+        import re
+        # A UUID selector never falls through to FIFO or a broader scope.
+        if raw_args and re.fullmatch(r"[0-9a-f]{32}", raw_args.split()[0]):
+            if len(raw_args.split()) != 1:
+                return "Use /approve <request-id> only; background approvals are one-shot."
+            count = resolve_gateway_approval(session_key, "once", request_id=raw_args,
+                                             owner=owner_for_source(event.source, session_key))
+            if not count:
+                return t("gateway.approve.no_pending")
+            return await self._deliver_approval_confirmation(event, t("gateway.approve.once_singular", count=1), "approve")
         # Args: "all", "all session", "all always", "session", "always" ("always" beats "session").
         args = event.get_command_args().strip().lower().split()
+        # Only explicit legacy scope words may enter FIFO. Unknown tokens are
+        # never discarded: a mistyped child selector is not consent to another job.
+        if any(a not in _APPROVE_CHOICE_BY_ARG and a != "all" for a in args):
+            return "Use /approve [all] [session|always] or /approve <request-id>."
         choices = {_APPROVE_CHOICE_BY_ARG[a] for a in args if a in _APPROVE_CHOICE_BY_ARG}
         choice = "always" if "always" in choices else "session" if "session" in choices else "once"
         count = resolve_gateway_approval(session_key, choice, resolve_all="all" in args)
@@ -1151,24 +1168,51 @@ class GatewaySlashCommandsMixin(
         return await self._deliver_approval_confirmation(event, confirmation_text, "approve")
 
     async def _handle_deny_command(self, event: MessageEvent) -> str:
-        """Handle /deny — reject pending dangerous command(s) with a definitive BLOCKED result, as in
-        the CLI. ``/deny`` denies the oldest; ``/deny all`` denies everything.
+        """Deny [all|exact-request-id] [--reason text].
 
-        ``/deny <reason>`` (or ``/deny all <reason>``) attaches a one-line reason that is relayed back to
-        the agent so it can adapt instead of only hearing "denied". Ported from qwibitai/nanoclaw#2832.
+        Bare/all target only eligible foreground entries. Background requests
+        require an exact ID and matching owner. Reasons must be explicitly
+        delimited so a mistyped selector can never become a foreground denial.
         """
         from tools.approval import resolve_gateway_approval
+        import re
+
+        tokens = event.get_command_args().split()
+        request_id = None
+        resolve_all = False
+        reason = None
+        usage = "Usage: /deny [all|exact-request-id] [--reason text]"
+        if tokens and tokens[0] != "--reason":
+            selector = tokens.pop(0)
+            if selector.lower() == "all":
+                resolve_all = True
+            elif re.fullmatch(r"[0-9a-f]{32}", selector):
+                request_id = selector
+            else:
+                return usage
+        if tokens:
+            if tokens[0] != "--reason" or len(tokens) < 2:
+                return usage
+            # The marker terminates option parsing; all remaining words are
+            # literal reason text, normalized to one line and capped as before.
+            reason = " ".join(tokens[1:])[:280].strip()
+
+        if request_id is not None:
+            # Exact selectors must not perform unrelated stale UI housekeeping.
+            session_key = self._session_key_for_source(event.source)
+            from tools.approval_delegation import owner_for_source
+            count = resolve_gateway_approval(session_key, "deny", request_id=request_id,
+                                             reason=reason,
+                                             owner=owner_for_source(event.source, session_key))
+            if not count:
+                return t("gateway.deny.no_pending")
+            key = "gateway.deny.denied" + ("_reason" if reason else "") + "_singular"
+            return await self._deliver_approval_confirmation(event, t(key, count=1, reason=reason), "deny")
         session_key, stale = self._blocking_approval_or_stale(event, "gateway.deny.stale",
                                                               "gateway.deny.no_pending")
         if stale:
             return stale
-        # A leading "all" denies every pending command; the rest (or the whole arg string without
-        # "all") is the optional deny reason relayed to the agent, capped to a sane one-liner.
-        raw_args = event.get_command_args().strip()
-        tokens = raw_args.split()
-        resolve_all = bool(tokens) and tokens[0].lower() == "all"
-        reason = (raw_args[len(tokens[0]):].strip() if resolve_all else raw_args)[:280].strip()
-        count = resolve_gateway_approval(session_key, "deny", resolve_all=resolve_all, reason=reason or None)
+        count = resolve_gateway_approval(session_key, "deny", resolve_all=resolve_all, reason=reason)
         if not count:
             return t("gateway.deny.no_pending")
         logger.info("User denied %d dangerous command(s) via /deny%s", count,

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -95,7 +95,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True, args_hint="[session|always]", busy_policy="dispatch",
                desktop="messaging"),
     CommandDef("deny", "Deny a pending dangerous command (optionally with a reason)", "Session",
-               gateway_only=True, args_hint="[all] [reason]", busy_policy="dispatch",
+               gateway_only=True, args_hint="[all|exact-request-id] [--reason text]", busy_policy="dispatch",
                desktop="messaging"),
     CommandDef("bg", "Run a prompt in a separate background session", "Session",
                args_hint="<prompt>", busy_policy="dispatch"),

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -215,7 +215,7 @@ class TestDenyCommand:
 
     @pytest.mark.asyncio
     async def test_deny_with_reason_attaches_reason(self):
-        """/deny <reason> attaches the reason to the resolved entry."""
+        """/deny --reason <reason> attaches the reason to the resolved entry."""
         from tools.approval import _gateway_queues
         from tools.approval_gateway_wait import _ApprovalEntry
 
@@ -227,7 +227,7 @@ class TestDenyCommand:
         _gateway_queues[session_key] = [entry]
 
         result = await runner._handle_deny_command(
-            _make_event("/deny that path is still in use")
+            _make_event("/deny --reason that path is still in use")
         )
         assert entry.result == "deny"
         assert entry.reason == "that path is still in use"
@@ -235,7 +235,7 @@ class TestDenyCommand:
 
     @pytest.mark.asyncio
     async def test_deny_all_with_reason(self):
-        """/deny all <reason> denies everything and relays one reason."""
+        """/deny all --reason <reason> denies everything and relays one reason."""
         from tools.approval import _gateway_queues
         from tools.approval_gateway_wait import _ApprovalEntry
 
@@ -248,7 +248,7 @@ class TestDenyCommand:
         _gateway_queues[session_key] = [e1, e2]
 
         result = await runner._handle_deny_command(
-            _make_event("/deny all wrong directory")
+            _make_event("/deny all --reason wrong directory")
         )
         assert "2 commands" in result
         assert all(e.result == "deny" for e in [e1, e2])

--- a/tests/gateway/test_deny_grammar_help.py
+++ b/tests/gateway/test_deny_grammar_help.py
@@ -1,0 +1,9 @@
+"""Generated messaging help must teach the unambiguous denial grammar."""
+from hermes_cli.commands import resolve_command, gateway_help_lines
+
+
+def test_generated_deny_help_requires_explicit_reason_marker():
+    command = resolve_command('deny')
+    assert command.args_hint == '[all|exact-request-id] [--reason text]'
+    line = next(line for line in gateway_help_lines() if '/deny' in line)
+    assert '--reason text' in line and 'exact-request-id' in line

--- a/tests/gateway/test_deny_stale_ui_compatibility.py
+++ b/tests/gateway/test_deny_stale_ui_compatibility.py
@@ -1,0 +1,59 @@
+"""Stale-only denial bookkeeping contracts; no consumers or payloads."""
+import asyncio
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform
+from gateway.session import SessionSource
+from gateway.slash_commands import GatewaySlashCommandsMixin
+from agent.i18n import t
+from tools import approval
+
+
+@pytest.mark.parametrize("args,preserve", [
+    ("0" * 32, True),
+    ("0" * 32 + " --reason not authorized", True),
+    ("unknown-id", True),
+    ("unknown-id --reason not authorized", True),
+    ("", False),
+    ("--reason not authorized", False),
+    ("all", False),
+    ("ALL --reason not authorized", False),
+])
+def test_stale_ui_selector_scope(tmp_path, monkeypatch, args, preserve):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(approval, "_gateway_queues", {})
+
+    class Slash(GatewaySlashCommandsMixin):
+        def _session_key_for_source(self, source):
+            return "fixture-stale-only"
+
+        async def _deliver_approval_confirmation(self, *args):
+            raise AssertionError("no confirmation for an absent request")
+
+    slash = Slash()
+    record = {"command": "inert obsolete prompt", "metadata": {"keep": [1, 2]}}
+    other = {"command": "other session prompt"}
+    registry = {"fixture-stale-only": record, "other-session": other}
+    before = deepcopy(registry)
+    slash._pending_approvals = registry
+    event = SimpleNamespace(
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="fixture", user_id="fixture"),
+        get_command_args=lambda: args,
+    )
+    reply = asyncio.run(slash._handle_deny_command(event))
+    assert slash._pending_approvals is registry
+    assert registry["other-session"] is other
+    assert not approval._gateway_queues
+    if preserve:
+        assert registry == before
+        assert registry["fixture-stale-only"] is record
+        if args.startswith("0" * 32):
+            assert reply == t("gateway.deny.no_pending")
+        else:
+            assert reply == "Usage: /deny [all|exact-request-id] [--reason text]"
+    else:
+        assert registry == {"other-session": other}
+        assert reply == t("gateway.deny.stale")

--- a/tests/tools/test_approval_followup.py
+++ b/tests/tools/test_approval_followup.py
@@ -1,0 +1,148 @@
+"""Offline real waiting-consumer regressions; no script is executed."""
+import asyncio
+from contextlib import contextmanager
+from types import SimpleNamespace as NS
+import threading
+
+import pytest
+from tests.tools.test_background_approval_routing import rig, wait_until
+from tools import approval as ap, approval_context as ac
+from tools.approval_delegation import owner_for_source
+from tools.approval_gateway_wait import _ApprovalEntry
+from gateway.config import Platform
+from gateway.session import SessionSource
+from gateway.slash_commands import GatewaySlashCommandsMixin
+
+
+@contextmanager
+def foreground_wait(rig):
+    sent = threading.Event()
+    results = []
+    ap.register_gateway_notify(rig.key, lambda data: sent.set())
+    def foreground():
+        token = ac.set_current_session_key(rig.key)
+        try:
+            results.append(ap.check_execute_code_guard('print("UNRELATED inert foreground")', 'local'))
+        finally:
+            ac.reset_current_session_key(token)
+    worker = threading.Thread(target=foreground)
+    worker.start()
+    try:
+        assert sent.wait(2)
+        with ap._lock:
+            entry = next(e for e in ap._gateway_queues[rig.key] if e.lease is None)
+        yield entry, results
+    finally:
+        ap.unregister_gateway_notify(rig.key)
+        worker.join(5)
+        assert not worker.is_alive()
+
+
+def malformed(rid):
+    return [rid[:-1], rid.upper(), rid[:8] + '-' + rid[8:], 'z' + rid[1:],
+            '<' + rid + '>', 'request:' + rid, 'id=' + rid, 'request ' + rid,
+            'unknown-id', '0' * 32, rid + ' extra', 'all ' + rid,
+            'session ' + rid, 'always ' + rid, 'sessionalways', 'once extra']
+
+
+@pytest.mark.parametrize('suffix', ['', ' session', ' always'])
+def test_malformed_approval_never_resolves_either_real_wait(rig, suffix):
+    rig.spawn(); rig.start(); assert rig.notified.wait(2)
+    rid = ap.list_gateway_approvals(rig.key)[0]['request_id']
+    with foreground_wait(rig) as (entry, results):
+        for arg in malformed(rid):
+            rig.answer('once', arg + suffix)
+            assert entry.result is None, arg + suffix
+            assert not entry.event.is_set(), arg + suffix
+            assert not rig.results and not results
+        rig.answer('deny', rid)
+        wait_until(lambda: bool(rig.results))
+        assert not rig.results[0]['approved']
+        assert entry.result is None
+    assert results and not results[0]['approved']
+
+
+@pytest.mark.parametrize('args,choice,all_', [
+    ('', 'once', False), ('once', 'once', False), ('all once', 'once', True),
+    ('all', 'once', True), ('session', 'session', False),
+    ('ses', 'session', False), ('always', 'always', False),
+    ('permanent', 'always', False), ('permanently', 'always', False),
+    ('ALL SESSION', 'session', True), ('all always', 'always', True),
+    ('session all', 'session', True), ('session always', 'always', False),
+])
+def test_explicit_legacy_approval_forms_remain_compatible(rig, args, choice, all_):
+    entries = [_ApprovalEntry({'command': 'inert first'}), _ApprovalEntry({'command': 'inert second'})]
+    ap._gateway_queues[rig.key] = entries.copy()
+    rig.answer('once', args)
+    assert entries[0].result == choice
+    assert entries[1].result == (choice if all_ else None)
+
+
+class StringTrap:
+    def __str__(self):
+        raise AssertionError('identity coercion executed')
+
+
+@pytest.mark.parametrize('field', ['user_id', 'chat_id', 'thread_id', 'session_key'])
+@pytest.mark.parametrize('value', [True, False, 123, ['owner'], {'id': 'owner'}, ' ', '\t', ' owner ', StringTrap()])
+def test_malformed_owner_values_rejected_without_coercion(rig, field, value):
+    key = rig.key
+    if field == 'session_key':
+        key = value
+    else:
+        setattr(rig.source, field, value)
+    assert owner_for_source(rig.source, key) is None
+
+
+@pytest.mark.parametrize('value', [True, 123, ' ', NS(value='telegram'), StringTrap()])
+def test_platform_is_not_an_arbitrary_value_wrapper(rig, value):
+    rig.source.platform = value
+    assert owner_for_source(rig.source, rig.key) is None
+
+
+@pytest.mark.parametrize('source', [None, True, 123, {}, NS(), NS(platform=Platform.TELEGRAM)])
+def test_malformed_source_is_refused(rig, source):
+    assert owner_for_source(source, rig.key) is None
+
+
+@pytest.mark.parametrize('value', [None, 0, 1, '', 'false', [], {}])
+def test_bot_flag_must_be_explicit_false(rig, value):
+    rig.source.is_bot = value
+    assert owner_for_source(rig.source, rig.key) is None
+
+
+@pytest.mark.parametrize('thread', [None, '', '123'])
+def test_canonical_source_strings_preserved(rig, thread):
+    rig.source.thread_id = thread
+    owner = owner_for_source(rig.source, rig.key)
+    assert owner.actor == rig.source.user_id
+    assert owner.chat == rig.source.chat_id
+    assert owner.thread == (thread if thread is not None else '')
+    assert owner.platform == 'telegram'
+
+
+@pytest.mark.parametrize('request_id', ['', False, 0, [], {}, ' ', StringTrap()])
+def test_explicit_invalid_core_selector_cannot_become_fifo(rig, request_id):
+    entry = _ApprovalEntry({'command': 'inert'})
+    ap._gateway_queues[rig.key] = [entry]
+    assert ap.resolve_gateway_approval(rig.key, 'once', request_id=request_id) == 0
+    assert entry.result is None and not entry.event.is_set()
+
+
+@pytest.mark.parametrize('dimension', ['actor', 'chat', 'thread', 'session', 'profile', 'platform'])
+def test_mixed_wait_exact_owner_mismatch_cannot_fall_back(rig, monkeypatch, dimension):
+    rig.spawn(); rig.start(); assert rig.notified.wait(2)
+    rid = ap.list_gateway_approvals(rig.key)[0]['request_id']
+    with foreground_wait(rig) as (entry, results):
+        source = SessionSource(platform=Platform.TELEGRAM, chat_id=rig.source.chat_id, user_id=rig.source.user_id)
+        key = rig.key
+        if dimension == 'session': key = 'wrong-session'
+        elif dimension == 'profile': monkeypatch.setenv('HERMES_HOME', str(rig.home / 'wrong-profile'))
+        else: setattr(source, {'actor': 'user_id', 'chat': 'chat_id', 'thread': 'thread_id', 'platform': 'platform'}[dimension],
+                      Platform.DISCORD if dimension == 'platform' else 'wrong')
+        assert ap.resolve_gateway_approval(rig.key, 'once', request_id=rid, owner=owner_for_source(source, key)) == 0
+        assert entry.result is None and not entry.event.is_set()
+        assert not results and not rig.results
+        monkeypatch.setenv('HERMES_HOME', str(rig.home))
+        rig.answer('deny', rid)
+    assert results and not results[0]['approved']

--- a/tests/tools/test_background_approval_routing.py
+++ b/tests/tools/test_background_approval_routing.py
@@ -1,0 +1,329 @@
+"""Offline lifecycle contract: real gateway turn -> dispatch -> child -> guard.
+
+Only transport delivery, async scheduler admission and model conversation bodies
+are fixtures. No actual script, producer, broker, gateway or message is executed.
+"""
+import asyncio
+import contextvars
+from concurrent.futures import Future
+from types import SimpleNamespace as NS
+import threading
+import socket
+
+import pytest
+
+# Installed before runtime imports; fixture transport below never opens a socket.
+def _no_network(*args, **kwargs):
+    raise AssertionError('offline approval test attempted network access')
+socket.socket.connect = _no_network
+socket.socket.connect_ex = _no_network
+
+from tools import approval as ap
+from tools import approval_context as ac
+from tools import delegate_tool_dispatch as dispatch
+from tools.delegate_tool_child_run import _ChildRun, _signal_child_stop
+from gateway.run_turn_runner import TurnRunner
+from gateway.slash_commands import GatewaySlashCommandsMixin
+from gateway.session import SessionSource
+from gateway.config import Platform
+import hermes_cli.config as hc
+
+
+@pytest.fixture
+def rig(tmp_path, monkeypatch):
+    home = tmp_path / 'profile'
+    home.mkdir()
+    (home / 'config.yaml').write_text('approvals:\n  mode: manual\n  timeout: 3\nsecurity:\n  tirith_enabled: false\n')
+    monkeypatch.setenv('HERMES_HOME', str(home))
+    monkeypatch.setenv('HERMES_SESSION_PLATFORM', 'telegram')
+    hc._LOAD_CONFIG_CACHE.clear()
+    ap._gateway_queues.clear()
+    ap._gateway_notify_cbs.clear()
+    ap._pending.clear()
+    ap._session_approved.clear()
+    ap._permanent_approved.clear()
+    monkeypatch.setattr(ac, '_fire_approval_hook', lambda *a, **kw: None)
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id='fixture-chat', user_id='fixture-owner')
+    key = 'fixture-conversation'
+    messages = []
+    notified = threading.Event()
+    class Adapter:
+        typed_command_prefix = '/'
+        async def send(self, chat_id, text, **kw):
+            messages.append((chat_id, text, kw))
+            notified.set()
+            return NS(success=True)
+    ctx = NS(session_key=key, session_id='parent-model-session', source=source,
+             _status_adapter=Adapter(), _status_chat_id=source.chat_id,
+             _status_thread_metadata={}, message='fixture', persist_user_display_kind=None,
+             persist_user_display_metadata=None, moa_config=None, inbound_message_id=None)
+    turn = TurnRunner(NS(), ctx)
+    monkeypatch.setattr(turn, '_native_image_run_message', lambda: 'fixture')
+    def schedule(coro, *args, **kw):
+        fut = Future()
+        try:
+            fut.set_result(asyncio.run(coro))
+        except Exception as exc:
+            fut.set_exception(exc)
+        return fut
+    monkeypatch.setattr(turn, '_schedule', schedule)
+    jobs = []
+    def enqueue(**kwargs):
+        jobs.append((contextvars.copy_context(), kwargs))
+        return {'status': 'dispatched', 'delegation_id': 'fixture-job'}
+    monkeypatch.setattr('tools.async_delegation.dispatch_async_delegation_batch', enqueue)
+    children = []
+    results = []
+    def aggregate(unit, **kwargs):
+        from concurrent.futures import ThreadPoolExecutor
+        def run(child):
+            cr = _ChildRun(child, NS(), 0, 'fixture', None, None)
+            results.append(cr.await_child()[0])
+        with ThreadPoolExecutor(max_workers=len(unit.children)) as pool:
+            futures = [pool.submit(contextvars.copy_context().run, run, child) for _, _, child in unit.children]
+            for future in futures:
+                future.result()
+        return {}
+    monkeypatch.setattr(dispatch, '_execute_and_aggregate', aggregate)
+    def spawn(count=1, mismatch=False, live=False):
+        for i in range(count):
+            def conversation(**kwargs):
+                token = ac.set_current_session_key('wrong-child-key') if mismatch else None
+                try:
+                    return ap.check_execute_code_guard('print("fixture only; never run")', 'local')
+                finally:
+                    if token is not None:
+                        ac.reset_current_session_key(token)
+            children.append(NS(session_id=f'child-{i}', run_conversation=conversation))
+        unit = NS(children=[(i, {'goal': 'fixture'}, c) for i, c in enumerate(children)],
+                  task_list=[{'goal': 'fixture'}] * len(children), context='', top_role='leaf', creds={'model': 'fixture'})
+        def parent_conversation(*a, **kw):
+            result = dispatch._dispatch_unit(unit, 'fixture-job', None, {})
+            if live:
+                start()
+                assert notified.wait(2)
+            return result
+        agent = NS(run_conversation=parent_conversation)
+        turn._run_conversation_with_approval(agent, [], None, None, None)
+    threads = []
+    def start():
+        for context, job in jobs:
+            thread = threading.Thread(target=context.run, args=(job['runner'],), daemon=True)
+            threads.append(thread)
+            thread.start()
+    class Slash(GatewaySlashCommandsMixin):
+        def _session_key_for_source(self, src):
+            return key if src.chat_id == source.chat_id else 'different-conversation'
+        async def _deliver_approval_confirmation(self, event, text, kind):
+            return text
+    slash = Slash()
+    slash._pending_approvals = {}
+    def answer(choice, request_id, actor='fixture-owner', platform=Platform.TELEGRAM):
+        event = NS(source=SessionSource(platform=platform, chat_id=source.chat_id, user_id=actor),
+                   get_command_args=lambda: request_id)
+        handler = slash._handle_approve_command if choice == 'once' else slash._handle_deny_command
+        return asyncio.run(handler(event))
+    state = NS(home=home, key=key, turn=turn, spawn=spawn, start=start, messages=messages,
+               notified=notified, jobs=jobs, results=results, children=children, answer=answer, source=source)
+    yield state
+    for child in children:
+        _signal_child_stop(child, 'fixture cleanup')
+    ap.unregister_gateway_notify(key)
+    for thread in threads:
+        thread.join(5)
+        assert not thread.is_alive(), 'fixture worker did not terminate'
+    hc._LOAD_CONFIG_CACHE.clear()
+
+
+@pytest.mark.parametrize('mismatch', [False, True], ids=['notifier-teardown', 'child-key-mismatch'])
+def test_background_approval_lifecycle(rig, mismatch):
+    rig.spawn(mismatch=mismatch)
+    assert ap._gateway_notify_cb(rig.key) is None, 'parent turn notifier must be removed'
+    rig.start()
+    if mismatch:
+        # Explicit identity mismatch must fail closed, not claim delivery or borrow a route.
+        for _ in range(100):
+            if rig.results:
+                break
+            threading.Event().wait(.02)
+        assert rig.results and not rig.results[0]['approved']
+        assert rig.results[0].get('outcome') == 'route_unavailable'
+        assert not rig.messages
+        assert not ap._pending
+    else:
+        assert rig.notified.wait(2), 'live child lost its owner notifier after parent teardown'
+        entries = ap.list_gateway_approvals(rig.key)
+        assert len(entries) == 1
+        rid = entries[0]['request_id']
+        assert rid in rig.messages[0][1]
+        rig.answer('once', rid)
+        for _ in range(100):
+            if rig.results:
+                break
+            threading.Event().wait(.02)
+        assert rig.results and rig.results[0]['approved']
+        assert not ap.has_blocking_approval(rig.key)
+        assert ap.resolve_gateway_approval(rig.key, 'once', request_id=rid) == 0
+        assert not ap._session_approved and not ap._permanent_approved
+
+
+def wait_until(predicate):
+    for _ in range(250):
+        if predicate():
+            return
+        threading.Event().wait(.02)
+    assert predicate(), 'fixture lifecycle did not reach expected state'
+
+
+@pytest.mark.parametrize('end', ['deny', 'timeout', 'cancel', 'termination', 'session-clear',
+                                 'notify-refused', 'loop-missing', 'cancel-before-start'])
+def test_background_request_fails_closed(rig, monkeypatch, end):
+    if end == 'notify-refused':
+        async def refused(*a, **kw):
+            return NS(success=False, error='fixture destination refused')
+        monkeypatch.setattr(rig.turn._ctx._status_adapter, 'send', refused)
+    if end == 'loop-missing':
+        def missing(coro, *a, **kw):
+            coro.close()
+            return None
+        monkeypatch.setattr(rig.turn, '_schedule', missing)
+    rig.spawn()
+    if end == 'cancel-before-start':
+        rig.jobs[0][1]['interrupt_fn']()
+    rig.start()
+    no_prompt = {'notify-refused', 'loop-missing', 'cancel-before-start'}
+    rid = None
+    if end not in no_prompt:
+        assert rig.notified.wait(2)
+        entry = ap.list_gateway_approvals(rig.key)[0]
+        rid = entry['request_id']
+        if end == 'deny':
+            rig.answer('deny', rid)
+        if end == 'cancel':
+            rig.jobs[0][1]['interrupt_fn']()
+        if end == 'termination':
+            _signal_child_stop(rig.children[0], 'fixture child termination')
+        if end == 'session-clear':
+            ap.clear_session(rig.key)
+    wait_until(lambda: bool(rig.results))
+    assert not rig.results[0]['approved']
+    assert not ap.has_blocking_approval(rig.key)
+    assert not ap._pending
+    if rid:
+        assert ap.resolve_gateway_approval(rig.key, 'once', request_id=rid) == 0
+
+
+@pytest.mark.parametrize('wrong', ['actor', 'platform', 'profile', 'request', 'unqualified', 'always', 'all'])
+def test_bound_concurrent_requests_do_not_cross_authority(rig, monkeypatch, wrong):
+    rig.spawn(count=2)
+    rig.start()
+    wait_until(lambda: len(ap.list_gateway_approvals(rig.key)) == 2)
+    entries = ap.list_gateway_approvals(rig.key)
+    first, second = [e['request_id'] for e in entries]
+    assert first != second
+    if wrong == 'actor':
+        rig.answer('once', first, actor='unrelated-authorized-user')
+    elif wrong == 'platform':
+        rig.answer('once', first, platform=Platform.DISCORD)
+    elif wrong == 'profile':
+        with monkeypatch.context() as m:
+            m.setenv('HERMES_HOME', str(rig.home / 'other-profile'))
+            rig.answer('once', first)
+    elif wrong == 'request':
+        rig.answer('once', '0' * 32)
+    elif wrong == 'unqualified':
+        assert ap.resolve_gateway_approval(rig.key, 'once') == 0
+    else:
+        rig.answer('once', f'{first} {wrong}')
+    assert len(ap.list_gateway_approvals(rig.key)) == 2
+    rig.answer('once', second)
+    wait_until(lambda: len(rig.results) == 1)
+    assert rig.results[0]['approved']
+    assert [e['request_id'] for e in ap.list_gateway_approvals(rig.key)] == [first]
+    rig.answer('deny', first)
+    wait_until(lambda: len(rig.results) == 2)
+    assert sum(bool(r['approved']) for r in rig.results) == 1
+    assert not ap._session_approved and not ap._permanent_approved
+
+
+def test_other_profile_cannot_clear_child_request(rig, monkeypatch):
+    rig.spawn()
+    rig.start()
+    assert rig.notified.wait(2)
+    rid = ap.list_gateway_approvals(rig.key)[0]['request_id']
+    with monkeypatch.context() as m:
+        m.setenv('HERMES_HOME', str(rig.home / 'other-profile'))
+        assert not ap.list_gateway_approvals(rig.key)
+        assert not ap.has_blocking_approval(rig.key)
+        assert ap.get_pending_gateway_approval(rig.key) is None
+        assert not ap.ack_gateway_approval(rig.key, rid)
+        ap.clear_session(rig.key)
+    assert [e['request_id'] for e in ap.list_gateway_approvals(rig.key)] == [rid]
+    rig.answer('deny', rid)
+    wait_until(lambda: bool(rig.results))
+
+
+@pytest.mark.parametrize('second', ['same-script', 'per-call-tool'])
+def test_one_shot_does_not_authorize_next_operation(rig, second):
+    rig.spawn()
+    first_results = []
+    def conversation(**kwargs):
+        first_results.append(ap.check_execute_code_guard('print("fixture")', 'local'))
+        if second == 'same-script':
+            return ap.check_execute_code_guard('print("fixture")', 'local')
+        return ap.request_tool_approval('fixture-broker-call', 'fixture per-call consent; no broker invoked')
+    rig.children[0].run_conversation = conversation
+    rig.start()
+    assert rig.notified.wait(2)
+    rid = ap.list_gateway_approvals(rig.key)[0]['request_id']
+    rig.answer('once', rid)
+    wait_until(lambda: bool(first_results) and bool(ap.list_gateway_approvals(rig.key)))
+    next_id = ap.list_gateway_approvals(rig.key)[0]['request_id']
+    assert next_id != rid
+    rig.answer('once', rid)
+    assert ap.has_blocking_approval(rig.key)
+    rig.answer('deny', next_id)
+    wait_until(lambda: bool(rig.results))
+    assert first_results[0]['approved'] and not rig.results[0]['approved']
+
+
+def test_parent_teardown_leaves_only_live_child_wait(rig):
+    from tools.approval_gateway_wait import _ApprovalEntry
+    parent_entry = _ApprovalEntry({'command': 'fixture parent wait'})
+    ap._gateway_queues[rig.key] = [parent_entry]
+    rig.spawn(live=True)
+    assert parent_entry.event.is_set()
+    pending = ap.list_gateway_approvals(rig.key)
+    assert len(pending) == 1 and pending[0]['background_approval']
+    rig.answer('once', pending[0]['request_id'])
+    wait_until(lambda: bool(rig.results))
+    assert rig.results[0]['approved']
+
+
+@pytest.mark.parametrize('missing', ['actor', 'notifier'])
+def test_missing_route_never_borrows_parent_callback(rig, monkeypatch, missing):
+    if missing == 'actor':
+        rig.source.user_id = None
+    else:
+        monkeypatch.setattr(rig.turn, '_background_approval_notifier', lambda: None)
+    rig.spawn()
+    rig.start()
+    wait_until(lambda: bool(rig.results))
+    assert rig.results[0]['outcome'] == 'route_unavailable'
+    assert not rig.messages and not ap._pending and not ap.has_blocking_approval(rig.key)
+
+
+def test_synchronous_grandchild_keeps_live_owner_route(rig):
+    rig.spawn()
+    grandchild = NS(session_id='fixture-grandchild', run_conversation=lambda **kw:
+                    ap.check_execute_code_guard('print("grandchild fixture")', 'local'))
+    def conversation(**kwargs):
+        return _ChildRun(grandchild, rig.children[0], 0, 'fixture', None, None).await_child()[0]
+    rig.children[0].run_conversation = conversation
+    rig.start()
+    assert rig.notified.wait(2), 'synchronous grandchild lost background owner route'
+    entry = ap.list_gateway_approvals(rig.key)[0]
+    assert entry['child_id'] == grandchild.session_id
+    rig.answer('once', entry['request_id'])
+    wait_until(lambda: bool(rig.results))
+    assert rig.results[0]['approved']

--- a/tests/tools/test_denial_no_effect_contract.py
+++ b/tests/tools/test_denial_no_effect_contract.py
@@ -1,0 +1,25 @@
+"""Literal unknown-selector no-effects contract, including stale UI bookkeeping.
+
+No waiting consumer exists in this boundary case; failure is not an approval bypass.
+"""
+import asyncio
+from types import SimpleNamespace as NS
+import pytest
+from gateway.slash_commands import GatewaySlashCommandsMixin
+from gateway.session import SessionSource
+from gateway.config import Platform
+from tools import approval as ap
+
+@pytest.mark.parametrize('args',['0'*32,'unknown-id'],ids=['unknown-exact-id','malformed-id'])
+def test_unrecognized_deny_selector_preserves_stale_ui_state(tmp_path,monkeypatch,args):
+    monkeypatch.setenv('HERMES_HOME',str(tmp_path))
+    ap._gateway_queues.clear()
+    class Slash(GatewaySlashCommandsMixin):
+        def _session_key_for_source(self,source):return 'fixture-stale-only'
+        async def _deliver_approval_confirmation(self,*args):raise AssertionError('no confirmation expected')
+    slash=Slash();record={'command':'inert obsolete UI prompt'}
+    slash._pending_approvals={'fixture-stale-only':record}
+    event=NS(source=SessionSource(platform=Platform.TELEGRAM,chat_id='fixture',user_id='fixture'),get_command_args=lambda:args)
+    asyncio.run(slash._handle_deny_command(event))
+    assert not ap._gateway_queues
+    assert slash._pending_approvals=={'fixture-stale-only':record}, 'unknown selector removed a different stale UI record'

--- a/tests/tools/test_deny_selector_ambiguity.py
+++ b/tests/tools/test_deny_selector_ambiguity.py
@@ -1,0 +1,12 @@
+"""Unresolved preservation conflict: RED only, no actual payload execution."""
+from tests.tools.test_background_approval_routing import rig
+from tests.tools.test_approval_followup import foreground_wait
+from tools import approval as ap
+
+
+def test_malformed_bound_deny_selector_must_not_resolve_unrelated_foreground(rig):
+    rig.spawn(); rig.start(); assert rig.notified.wait(2)
+    rid = ap.list_gateway_approvals(rig.key)[0]['request_id']
+    with foreground_wait(rig) as (entry, results):
+        rig.answer('deny', rid[:-1])
+        assert entry.result is None, 'legacy /deny <reason> fallback denied unrelated wait'

--- a/tests/tools/test_strict_deny_grammar.py
+++ b/tests/tools/test_strict_deny_grammar.py
@@ -1,0 +1,93 @@
+"""Owner-approved disjoint grammar, real waiting consumers, inert payloads."""
+import pytest
+from tests.tools.test_background_approval_routing import rig, wait_until
+from tests.tools.test_approval_followup import foreground_wait, malformed
+from tools import approval as ap
+from tools.approval_gateway_wait import _ApprovalEntry
+
+
+@pytest.mark.parametrize('mixed', [False, True])
+def test_invalid_deny_syntax_never_resolves_any_request(rig, mixed):
+    if mixed:
+        rig.spawn(); rig.start(); assert rig.notified.wait(2)
+        with ap._lock:
+            child = ap._gateway_queues[rig.key][0]
+        rid = child.data['request_id']
+    else:
+        child = None
+        rid = 'abcdef0123456789abcdef0123456789ab'
+    with foreground_wait(rig) as (entry, results):
+        invalid = malformed(rid) + [arg + ' --reason explicit text' for arg in malformed(rid)] + [
+            '--reason', 'all --reason', rid + ' --reason', '--reason   ',
+            '--unknown', '--Reason why', '--reason=why', 'all --unknown why',
+            rid + ' --unknown why', rid + ' all', rid + ' reason without marker',
+            'all all', 'all wrong directory', 'that path is still in use',
+            'extra --reason text', rid + ' extra --reason text',
+        ]
+        for args in invalid:
+            rig.answer('deny', args)
+            assert entry.result is None and not entry.event.is_set(), args
+            assert not results and not rig.results, args
+            if child:
+                assert child.result is None and not child.event.is_set(), args
+                with ap._lock:
+                    assert child in ap._gateway_queues[rig.key] and entry in ap._gateway_queues[rig.key]
+        if child:
+            rig.answer('deny', rid)
+            wait_until(lambda: bool(rig.results))
+            assert not rig.results[0]['approved']
+            assert entry.result is None
+
+
+@pytest.mark.parametrize('target', ['', 'all', 'child'])
+@pytest.mark.parametrize('reason', [None, 'path is still in use', '--unknown is literal reason text'])
+def test_valid_deny_selects_only_intended_real_wait(rig, target, reason):
+    rig.spawn(); rig.start(); assert rig.notified.wait(2)
+    with ap._lock:
+        child = ap._gateway_queues[rig.key][0]
+    rid = child.data['request_id']
+    with foreground_wait(rig) as (entry, results):
+        selector = rid if target == 'child' else target
+        args = selector + ((' --reason ' + reason) if reason is not None else '')
+        rig.answer('deny', args)
+        selected, untouched = (child, entry) if target == 'child' else (entry, child)
+        assert selected.result == 'deny' and selected.event.is_set()
+        assert selected.reason == reason
+        assert untouched.result is None and not untouched.event.is_set()
+        if target != 'child':
+            rig.answer('deny', rid)
+        wait_until(lambda: bool(rig.results))
+        assert not rig.results[0]['approved']
+        if target == 'child':
+            if reason is not None:
+                assert reason in rig.results[0]['message']
+            rig.answer('deny', args)  # stale exact ID cannot deny the foreground
+            assert entry.result is None and not entry.event.is_set()
+    assert results and not results[0]['approved']
+
+
+@pytest.mark.parametrize('dimension', ['actor', 'profile'])
+@pytest.mark.parametrize('suffix', ['', ' --reason explicit reason'])
+def test_bound_deny_owner_mismatch_has_no_foreground_fallback(rig, monkeypatch, dimension, suffix):
+    rig.spawn(); rig.start(); assert rig.notified.wait(2)
+    with ap._lock:
+        child = ap._gateway_queues[rig.key][0]
+    with foreground_wait(rig) as (entry, results):
+        if dimension == 'profile':
+            monkeypatch.setenv('HERMES_HOME', str(rig.home / 'wrong-profile'))
+        rig.answer('deny', child.data['request_id'] + suffix,
+                   actor='wrong-actor' if dimension == 'actor' else 'fixture-owner')
+        for pending in (entry, child):
+            assert pending.result is None and not pending.event.is_set()
+        assert not results and not rig.results
+        monkeypatch.setenv('HERMES_HOME', str(rig.home))
+        rig.answer('deny', child.data['request_id'])
+
+
+def test_reason_is_explicit_single_line_capped_and_all_remains_foreground_only(rig):
+    entries = [_ApprovalEntry({'command': 'inert first'}), _ApprovalEntry({'command': 'inert second'})]
+    ap._gateway_queues[rig.key] = entries.copy()
+    reason = 'word\n' + 'x' * 300
+    rig.answer('deny', 'ALL --reason ' + reason)
+    assert all(e.result == 'deny' and e.event.is_set() for e in entries)
+    assert all(e.reason == ('word ' + 'x' * 300)[:280] for e in entries)

--- a/tests/tools/test_telegram_owner_boundary.py
+++ b/tests/tools/test_telegram_owner_boundary.py
@@ -1,0 +1,26 @@
+"""SDK integers are already converted by the real adapter, not owner coercion."""
+from datetime import datetime, timezone
+import pytest
+from telegram import Chat, Message, User
+from gateway.config import PlatformConfig
+from gateway.platforms.event import MessageType
+from plugins.platforms.telegram.adapter import TelegramAdapter
+from tools.approval_delegation import owner_for_source
+from tests.tools.test_background_approval_routing import rig
+
+
+@pytest.mark.parametrize('chat_id,user_id', [(101, 202), (-100123456789, 202)])
+def test_sdk_integer_identity_converts_at_adapter_boundary(rig, chat_id, user_id):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token='fixture'))
+    message = Message(message_id=1, date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                      chat=Chat(id=chat_id, type='private'),
+                      from_user=User(id=user_id, first_name='Fixture', is_bot=False), text='/approve')
+    event = adapter._build_message_event(message, MessageType.TEXT)
+    assert type(event.source.user_id) is str
+    assert type(event.source.chat_id) is str
+    owner = owner_for_source(event.source, rig.key)
+    assert owner.actor == str(user_id)
+    assert owner.chat == str(chat_id)
+    # Raw integers/booleans do not have permission to bypass that boundary.
+    event.source.user_id = user_id
+    assert owner_for_source(event.source, rig.key) is None

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -111,7 +111,7 @@ def _denial_breaker_addendum(session_key: str) -> str:
 # --- Gateway approval queue (the blocking wait loop lives in approval_gateway_wait) ---------------------------------
 
 
-# Optional free-text reason supplied with an explicit deny (``/deny <reason>``) so the agent can adapt
+# Optional free-text reason supplied with an explicit deny (``/deny --reason <reason>``) so the agent can adapt
 # instead of only hearing "denied". Ported from qwibitai/nanoclaw#2832.
 _gateway_queues: dict[str, list] = {}        # session_key → [_ApprovalEntry, …]
 _gateway_notify_cbs: dict[str, object] = {}  # session_key → callable(approval_data)
@@ -129,7 +129,12 @@ def unregister_gateway_notify(session_key: str) -> None:
     they don't hang forever (agent run finished or interrupted)."""
     with _lock:
         _gateway_notify_cbs.pop(session_key, None)
-        entries = _gateway_queues.pop(session_key, [])
+        queue = _gateway_queues.get(session_key, [])
+        # Detached children are revoked by their own lifecycle, not this turn.
+        entries = [entry for entry in queue if entry.lease is None]
+        queue[:] = [entry for entry in queue if entry.lease is not None]
+        if not queue:
+            _gateway_queues.pop(session_key, None)
     for entry in entries:
         entry.event.set()
 
@@ -137,48 +142,61 @@ def unregister_gateway_notify(session_key: str) -> None:
 def resolve_gateway_approval(session_key: str, choice: str,
                              resolve_all: bool = False,
                              reason: Optional[str] = None,
-                             request_id: Optional[str] = None) -> int:
+                             request_id: Optional[str] = None, *, owner=None) -> int:
     """Unblock waiting agent thread(s) from the gateway's /approve or /deny handler.
 
     *resolve_all* resolves every pending approval (``/approve all``); otherwise the oldest
-    (FIFO) or the one matching *request_id*. *reason* is the ``/deny <reason>`` free text,
+    (FIFO) or the one matching *request_id*. *reason* is the ``/deny --reason <reason>`` free text,
     relayed to the agent in the BLOCKED message. Returns the number resolved.
     """
+    # None alone selects legacy FIFO. Explicit empty/malformed selectors must
+    # not become omitted selectors through truthiness (including False/0/[]).
+    if request_id is not None and (type(request_id) is not str or not request_id
+                                   or request_id != request_id.strip()):
+        return 0
     with _lock:
         queue = _gateway_queues.get(session_key)
         if not queue:
             return 0
+        from tools.approval_delegation import response_matches
+        eligible = [entry for entry in queue if entry.lease is None or
+                    response_matches(entry, owner, request_id, choice, resolve_all)]
         if request_id:
-            targets = [entry for entry in queue if entry.data.get("request_id") == request_id]
-            if not targets:
-                return 0
-            queue[:] = [entry for entry in queue if entry not in targets]
-        elif resolve_all:
-            targets = list(queue)
-            queue.clear()
+            targets = [entry for entry in eligible if entry.data.get("request_id") == request_id]
         else:
-            targets = [queue.pop(0)]
+            targets = eligible if resolve_all else eligible[:1]
+        if not targets:
+            return 0
+        queue[:] = [entry for entry in queue if entry not in targets]
         if not queue:
             _gateway_queues.pop(session_key, None)
-
-    for entry in targets:
-        entry.result = choice
-        if reason:
-            entry.reason = reason
-        entry.event.set()
+        # Resolution and removal are atomic against cancellation.
+        for entry in targets:
+            entry.result = choice
+            if reason:
+                entry.reason = reason
+            entry.event.set()
     return len(targets)
+
+
+def _profile_gateway_entries(session_key: str):
+    """Caller holds _lock. Bound child requests never cross profile snapshots."""
+    from hermes_constants import get_hermes_home
+    profile = str(get_hermes_home().resolve())
+    return [entry for entry in _gateway_queues.get(session_key, [])
+            if entry.lease is None or entry.lease.owner.profile == profile]
 
 
 def list_gateway_approvals(session_key: str) -> list[dict]:
     """Return replay-safe snapshots of unresolved approvals for one session."""
     with _lock:
-        return [dict(entry.data) for entry in _gateway_queues.get(session_key, [])]
+        return [dict(entry.data) for entry in _profile_gateway_entries(session_key)]
 
 
 def ack_gateway_approval(session_key: str, request_id: str) -> bool:
     """Record that a client received a particular pending approval request."""
     with _lock:
-        for entry in _gateway_queues.get(session_key, []):
+        for entry in _profile_gateway_entries(session_key):
             if entry.data.get("request_id") == request_id:
                 entry.acknowledged = True
                 return True
@@ -188,7 +206,7 @@ def ack_gateway_approval(session_key: str, request_id: str) -> bool:
 def has_blocking_approval(session_key: str) -> bool:
     """Check if a session has one or more blocking gateway approvals waiting."""
     with _lock:
-        return bool(_gateway_queues.get(session_key))
+        return bool(_profile_gateway_entries(session_key))
 
 
 def get_pending_gateway_approval(session_key: str) -> dict | None:
@@ -197,7 +215,7 @@ def get_pending_gateway_approval(session_key: str) -> dict | None:
     if not session_key:
         return None
     with _lock:
-        queue = _gateway_queues.get(session_key)
+        queue = _profile_gateway_entries(session_key)
         if not queue:
             return None
         return dict(queue[0].data)
@@ -249,11 +267,19 @@ def clear_session(session_key: str) -> None:
     """Remove all approval and yolo state for a given session."""
     if not session_key:
         return
+    from tools.approval_delegation import clear_child_approvals
+    clear_child_approvals(session_key)
     with _lock:
         _session_approved.pop(session_key, None)
         _session_yolo.discard(session_key)
         _pending.pop(session_key, None)
-        entries = _gateway_queues.pop(session_key, [])
+        # Owned leases were revoked above. Leave another profile's child
+        # entries alone even when a legacy conversation key collides.
+        queue = _gateway_queues.get(session_key, [])
+        entries = [entry for entry in queue if entry.lease is None]
+        queue[:] = [entry for entry in queue if entry.lease is not None]
+        if not queue:
+            _gateway_queues.pop(session_key, None)
     for entry in entries:
         # Cancel blocked waits now so the old run unwinds instead of idling until timeout.
         entry.result = "deny"
@@ -405,6 +431,9 @@ def _user_approved(session_key: str, description: str) -> dict:
 
 
 def _gateway_notify_cb(session_key: str):
+    from tools.approval_delegation import current_child_approval, child_notify
+    if current_child_approval() is not None:
+        return child_notify(session_key)
     with _lock:
         return _gateway_notify_cbs.get(session_key)
 
@@ -738,7 +767,7 @@ def _human_decision(spec: _GateSpec, *, command: str, description: str,
                 return _denied(spec.notify_failed, pattern_key=pattern_key,
                                description=description, outcome="notify_failed")
             # Consent contract: silence is NOT consent, and an explicit deny is a hard
-            # halt — both produce a BLOCKED outcome. ``/deny <reason>`` free text is
+            # halt — both produce a BLOCKED outcome. ``/deny --reason <reason>`` free text is
             # relayed verbatim so the agent can adapt rather than only hearing "denied".
             choice, deny_reason = decision["choice"], decision.get("reason")
             if not decision["resolved"]:
@@ -757,6 +786,13 @@ def _human_decision(spec: _GateSpec, *, command: str, description: str,
         if not _should_fall_through_to_cli_approval(
             is_cli=is_cli, approval_callback=approval_callback, notify_cb=notify_cb,
         ):
+            from tools.approval_delegation import current_child_approval
+            if current_child_approval() is not None:
+                return _denied(
+                    "BLOCKED: background approval route unavailable or expired. No approval request was delivered. "
+                    "Stop; do not retry or replay this operation.",
+                    pattern_key=pattern_key, description=description, outcome="route_unavailable",
+                )
             if not spec.pending_keys:
                 display_command, display_description = command, description
             return _pending_result(

--- a/tools/approval_delegation.py
+++ b/tools/approval_delegation.py
@@ -1,0 +1,166 @@
+"""Process-local approval delivery leases for detached delegate_task children.
+
+A copied ContextVar is not a notifier lifetime. Acquire before dispatch returns,
+revoke on child completion/cancel, and bind only inside that child's worker.
+Queue decisions remain tools.approval's responsibility. Nothing here approves a
+tool, persists a rule, replays an operation, or grants broker consent.
+"""
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Callable
+
+from hermes_constants import get_hermes_home
+from tools.approval_context import get_current_session_key, _get_session_platform
+
+
+@dataclass(frozen=True)
+class ApprovalOwner:
+    profile: str
+    session: str
+    platform: str
+    actor: str
+    chat: str
+    thread: str
+
+
+def owner_for_source(source, session_key):
+    """Bind an already-authenticated SessionSource, not arbitrary truthy values.
+
+    SessionSource uses Platform and string IDs. SDK numeric IDs are converted by
+    adapters before this boundary (e.g. Telegram._build_message_event). Do not
+    coerce raw integers, bools, containers or value-wrapper objects into authority.
+    Only an absent/empty optional thread is represented by the empty string.
+    """
+    from gateway.config import Platform
+    from gateway.session import SessionSource
+    if not isinstance(source, SessionSource):
+        return None
+    if not isinstance(source.platform, Platform) or source.is_bot is not False:
+        return None
+    platform = source.platform.value
+    required = (session_key, platform, source.user_id, source.chat_id)
+    if any(type(value) is not str or not value or value != value.strip()
+           or not value.isprintable() for value in required):
+        return None
+    thread = source.thread_id
+    if thread is None:
+        thread = ''
+    elif type(thread) is not str or thread != thread.strip() or (thread and not thread.isprintable()):
+        return None
+    return ApprovalOwner(str(get_hermes_home().resolve()), session_key, platform,
+                         source.user_id, source.chat_id, thread)
+
+
+@dataclass(eq=False)
+class _Route:
+    owner: ApprovalOwner | None
+    notify: Callable | None
+    active: bool = True
+
+
+@dataclass(eq=False)
+class ChildApprovalLease(_Route):
+    child_id: str = ''
+
+
+_origin = ContextVar('background_approval_origin', default=None)
+_child = ContextVar('background_approval_child', default=None)
+_leases: set[ChildApprovalLease] = set()  # protected by approval._lock
+
+
+@contextmanager
+def gateway_approval_origin(owner, notify):
+    route = _Route(owner, notify)
+    token = _origin.set(route)
+    try:
+        yield
+    finally:
+        from tools import approval
+        with approval._lock:
+            route.active = False
+        _origin.reset(token)
+
+
+def _matches(route, session_key):
+    owner = route.owner
+    return bool(route.active and owner and route.notify and owner.session == session_key
+                and owner.profile == str(get_hermes_home().resolve())
+                and owner.platform == _get_session_platform())
+
+
+def acquire_child_approval(child_id):
+    from tools import approval
+    with approval._lock:
+        # Nested children may derive a new lease from their still-live owner,
+        # not from a stale parent-turn registration in a copied context.
+        route = _child.get() or _origin.get()
+        valid = bool(child_id and route and _matches(route, get_current_session_key()))
+        lease = ChildApprovalLease(route.owner if valid else None,
+                                   route.notify if valid else None, valid, str(child_id or ''))
+        if valid:
+            _leases.add(lease)
+        return lease
+
+
+def current_child_approval():
+    return _child.get()
+
+
+def child_notify(session_key):
+    from tools import approval
+    with approval._lock:
+        lease = _child.get()
+        return lease.notify if lease and _matches(lease, session_key) else None
+
+
+@contextmanager
+def child_approval_scope(lease):
+    token = _child.set(lease)
+    try:
+        yield
+    finally:
+        release_child_approval(lease)
+        _child.reset(token)
+
+
+def _release_locked(lease, approval):
+    lease.active = False
+    _leases.discard(lease)
+    for key, queue in list(approval._gateway_queues.items()):
+        for entry in list(queue):
+            if entry.lease is lease:
+                queue.remove(entry)
+                entry.result = 'deny'
+                entry.event.set()
+        if not queue:
+            approval._gateway_queues.pop(key, None)
+
+
+def release_child_approval(lease):
+    if lease is None:
+        return
+    from tools import approval
+    with approval._lock:
+        _release_locked(lease, approval)
+
+
+def clear_child_approvals(session_key):
+    from tools import approval
+    profile = str(get_hermes_home().resolve())
+    with approval._lock:
+        for lease in list(_leases):
+            if lease.owner.profile == profile and lease.owner.session == session_key:
+                _release_locked(lease, approval)
+
+
+def lease_matches(lease, session_key):
+    """Caller holds approval._lock when admitting/resolving a queue entry."""
+    return _matches(lease, session_key)
+
+
+def response_matches(entry, owner, request_id, choice, resolve_all):
+    lease = entry.lease
+    return bool(lease and lease.active and owner is not None and lease.owner == owner
+                and request_id == entry.data['request_id'] and not resolve_all
+                and choice in {'once', 'deny'})

--- a/tools/approval_gateway_wait.py
+++ b/tools/approval_gateway_wait.py
@@ -24,15 +24,16 @@ logger = logging.getLogger("tools.approval")
 
 class _ApprovalEntry:
     """One pending dangerous-command approval inside a gateway session."""
-    __slots__ = ("event", "data", "result", "reason", "acknowledged")
+    __slots__ = ("event", "data", "result", "reason", "acknowledged", "lease")
 
     def __init__(self, data: dict):
         self.event = threading.Event()
         self.data = dict(data)
         self.data.setdefault("request_id", uuid.uuid4().hex)
         self.acknowledged = False
+        self.lease = None
         self.result: str | None = None  # "once"|"session"|"always"|"deny"
-        # Free-text reason from ``/deny <reason>`` so the agent can adapt, not just hear "denied".
+        # Free-text reason from ``/deny --reason <reason>`` so the agent can adapt, not just hear "denied".
         self.reason: str | None = None
 
 
@@ -116,6 +117,8 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict, *,
     the leader's ``session``/``always``/``deny``/timeout; a ``once`` covers only
     the leader, so the follower falls through to a fresh prompt."""
     from tools import approval as _approval
+    from tools.approval_delegation import current_child_approval, lease_matches
+    lease = current_child_approval()
 
     primary_key = approval_data.get("pattern_key", "")
     payload = {
@@ -128,7 +131,8 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict, *,
     keys = list(approval_data.get("pattern_keys") or [])
     with _approval._lock:
         leader = next((e for e in _approval._gateway_queues.get(session_key, [])
-                       if e.data.get("command") == approval_data.get("command")
+                       if lease is None and e.lease is None
+                       and e.data.get("command") == approval_data.get("command")
                        and list(e.data.get("pattern_keys") or []) == keys), None)
     if leader is not None:
         adopted = _await_coalesced_leader(session_key, leader, payload)
@@ -136,7 +140,13 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict, *,
             return adopted
 
     entry = _ApprovalEntry(approval_data)
+    entry.lease = lease
     with _approval._lock:
+        if lease is not None:
+            if not lease_matches(lease, session_key):
+                return {"resolved": True, "choice": "deny", "reason": "approval route expired"}
+            entry.data.update(allow_session=False, allow_permanent=False, background_approval=True,
+                              child_id=lease.child_id)
         _approval._gateway_queues.setdefault(session_key, []).append(entry)
 
     def _drop_entry() -> None:
@@ -164,4 +174,8 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict, *,
         entry.result = "deny"
         entry.event.set()
     _drop_entry()
+    if lease is not None:
+        with _approval._lock:
+            if not lease_matches(lease, session_key):
+                entry.result = "deny"
     return _finish(payload, state != "timeout", entry.result, entry.reason)

--- a/tools/delegate_tool_child_run.py
+++ b/tools/delegate_tool_child_run.py
@@ -75,6 +75,8 @@ def _detach_child(parent_agent: Any, child: Any) -> None:
 
 def _signal_child_stop(child: Any, *reason: str) -> None:
     """Cooperative interrupt so the child's worker thread can exit cleanly."""
+    from tools.approval_delegation import release_child_approval
+    release_child_approval(getattr(child, "_background_approval_lease", None))
     with _quiet(None):
         if child is not None and not request_hard_interrupt(child, *reason) and hasattr(child, "_interrupt_requested"):
             child._interrupt_requested = True
@@ -645,6 +647,11 @@ class _ChildRun:
         from tools.delegate_tool import (_get_child_timeout, _get_subagent_approval_callback, _set_subagent_approval_cb)
         from tools.daemon_pool import DaemonThreadPoolExecutor
         child, task_index = self.child, self.task_index
+        from tools.approval_delegation import acquire_child_approval, current_child_approval
+        # Synchronous grandchildren of a detached orchestrator also need their
+        # own lease; resetting its inherited scope to None would orphan them.
+        if current_child_approval() is not None and not hasattr(child, "_background_approval_lease"):
+            child._background_approval_lease = acquire_child_approval(getattr(child, "session_id", ""))
         child_timeout = _get_child_timeout()
         executor = DaemonThreadPoolExecutor(
             max_workers=1, initializer=_set_subagent_approval_cb, initargs=(_get_subagent_approval_callback(),),
@@ -655,7 +662,9 @@ class _ChildRun:
         def _run_with_thread_capture():
             worker_thread_holder["t"] = threading.current_thread()
             from agent.delegation_context import delegated_child_context
-            with delegated_child_context(str(getattr(child, "session_id", "") or "")):
+            from tools.approval_delegation import child_approval_scope
+            with delegated_child_context(str(getattr(child, "session_id", "") or "")), \
+                    child_approval_scope(getattr(child, "_background_approval_lease", None)):
                 return child.run_conversation(
                     user_message=self.goal, task_id=self.child_task_id, stream_callback=self.relay_text,
                 )

--- a/tools/delegate_tool_dispatch.py
+++ b/tools/delegate_tool_dispatch.py
@@ -358,21 +358,44 @@ def _dispatch_unit(unit: _Batch, unit_id: Optional[str], slot_key: Optional[str]
     """Hand ONE unit to the async registry; the runner joins on that unit's children only."""
     from tools.async_delegation import dispatch_async_delegation_batch
     child_agents = [c for (_, _, c) in unit.children]
+    from tools.approval_delegation import acquire_child_approval, release_child_approval
+    from tools.approval_context import _is_gateway_approval_context
+    # Acquire before dispatch returns, not when a queued worker eventually starts.
+    if _is_gateway_approval_context():
+        for child in child_agents:
+            child._background_approval_lease = acquire_child_approval(getattr(child, "session_id", ""))
+
+    def _release():
+        for child in child_agents:
+            release_child_approval(getattr(child, "_background_approval_lease", None))
+
+    def _run():
+        try:
+            return _execute_and_aggregate(unit, honor_parent_interrupt=False)
+        finally:
+            _release()
 
     def _interrupt():
         for c in child_agents:
             _signal_child_stop(c, "Async delegation cancelled")
 
-    return dispatch_async_delegation_batch(
-        # Call-wide goals: completion formatting indexes them by task_index.
-        goals=[t["goal"] for t in unit.task_list], context=unit.context,
-        toolsets=None,  # metadata for the completion block only; subagents inherit the parent's toolsets
-        role=unit.top_role, model=unit.creds["model"],
-        runner=lambda: _execute_and_aggregate(unit, honor_parent_interrupt=False),
-        interrupt_fn=_interrupt, delegation_id=unit_id, slot_key=slot_key,
-        task_indexes=[i for (i, _, _) in unit.children] if len(unit.children) < len(unit.task_list) else None,
-        progress_fn=lambda: _batch_progress_token(child_agents), **routing,
-    )
+    try:
+        result = dispatch_async_delegation_batch(
+            goals=[t["goal"] for t in unit.task_list], context=unit.context,
+            toolsets=None, role=unit.top_role, model=unit.creds["model"],
+            runner=_run, interrupt_fn=_interrupt, delegation_id=unit_id, slot_key=slot_key,
+            task_indexes=[i for (i, _, _) in unit.children] if len(unit.children) < len(unit.task_list) else None,
+            progress_fn=lambda: _batch_progress_token(child_agents), **routing,
+        )
+    except BaseException:
+        _release()
+        raise
+    if result.get("status") != "dispatched":
+        _release()
+        for child in child_agents:
+            if hasattr(child, "_background_approval_lease"):
+                del child._background_approval_lease
+    return result
 
 def _dispatch_background(batch: _Batch) -> str:
     """Dispatch the call as independent async units (see ``_units_of``) and return the tool result JSON. Every unit

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -298,12 +298,36 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | `/yolo` | Toggle YOLO mode — skip all dangerous command approval prompts. |
 | `/commands [page]` | Browse all commands and skills (paginated). |
 | `/approve [session\|always]` | Approve and execute a pending dangerous command. `session` approves for this session only; `always` adds to permanent allowlist. |
-| `/deny` | Reject a pending dangerous command. |
+| `/deny [all\|exact-request-id] [--reason text]` | Reject the oldest eligible foreground command, all eligible foreground commands, or exactly the identified request. Background requests require their exact ID. Reasons require `--reason`. |
 | `/update` | Update Hermes Agent to the latest version. |
 | `/restart` | Gracefully restart the gateway after draining active runs. When the gateway comes back online, it sends a confirmation to the requester's chat/thread. |
 | `/debug` | Upload debug report (system info + logs) and get shareable links. |
 | `/help` | Show messaging help. |
 | `/<skill-name>` | Invoke any installed skill by name. |
+
+### Denial grammar and migration
+
+Use `/deny` for the oldest eligible foreground request or `/deny all` for all
+eligible foreground requests. Neither form resolves a bound background request.
+To deny a background request, copy its full, case-sensitive, lowercase 32-hex ID:
+`/deny <exact-request-id>`. This resolves only that request and requires its
+original actor, conversation, and profile ownership; an expired or unknown ID
+never falls back to a foreground request. IDs are not repaired or normalized.
+
+Reasons require the explicit, case-sensitive `--reason` marker:
+
+- `/deny --reason that path is still in use`
+- `/deny all --reason wrong directory`
+- `/deny <exact-request-id> --reason do not run this operation`
+
+This intentionally replaces `/deny <free-text reason>`, `/deny all <reason>`,
+and `/deny <exact-request-id> <reason>`. Update saved responses and instructions
+by inserting `--reason`; unmarked text is rejected without resolving a request.
+`all` remains case-insensitive. Unknown options, extra arguments before the
+marker, malformed selectors, and `--reason` without non-whitespace text are
+rejected. After the marker, the entire remainder is literal reason text (even
+words that look like options or IDs), with whitespace collapsed to a single
+line and a 280-character cap. There is no shell quoting or escaping layer.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Detached (async) `delegate_task` children could not get a human approval decision through the gateway: the parent turn's approval notifier was removed at parent teardown, so the child's `check_execute_code_guard` prompt fell through to the native `_pending` fallback and claimed it was "asking for approval" while nothing was ever delivered. `/approve` and `/deny` resolve `_gateway_queues`, not `_pending`, so the request could never be resumed. This PR:

- **Routes child approvals through an explicit, process-local lease** (`tools/approval_delegation.py`): origin/child scopes with an immutable owner identity (profile home + gateway conversation key + platform + actor + chat + thread + child lease + random request ID). Acquired before async admission, revoked on scheduler refusal, cancellation, timeout, worker completion and session clear.
- **Delivers the prompt on an independent, fixed destination** captured from the authenticated event source (`gateway/run_turn_runner.py`), via the existing authorized text-send lane. Refused/unconfirmed send or unavailable loop raises into the guard's failure path — no "card sent" claim without delivery.
- **Adds exact-selector slash grammar** (`gateway/slash_commands.py`): `/approve <32-char-request-id>` and `/deny <request-id> [reason]`. Exact selectors never fall through to FIFO; only `once` / `deny` with the exact owner and ID can resolve a bound request. Legacy FIFO, `all`, session and permanent choices cannot approve it. Unknown IDs have **no effect** — including on stale UI records.
- **Preserves live child waits across parent notifier removal** and isolates bound snapshots/ack/session-clear by profile (`tools/approval.py`, `tools/approval_gateway_wait.py`).

Nothing is widened: no approval mode, allowlist, hardline floor, dangerous-command classifier, deny rule, smart-policy, subagent auto-approval callback or MCP consent hook changes. A whole-script consent is still not a per-call tool grant (covered by fixture).

Related: #82009 addresses the *parent-key leak* symptom in `agent/delegation_context.py`; this PR fixes the detached-child delivery/resolution path and the FIFO misresolution risk, and is complementary.

## Why text commands instead of adapter buttons

Existing adapter buttons call `resolve_gateway_approval(session_key, choice)` without a request ID or originating-actor binding. Reusing them for detached children would restore delivery but permit FIFO misresolution across concurrent children. Bound requests therefore advertise exact-token slash commands; legacy foreground buttons are unchanged.

## Test plan

- [x] New offline regression fixtures: `tests/tools/test_background_approval_routing.py` (24), `test_approval_followup.py` (86), `test_denial_no_effect_contract.py`, `test_strict_deny_grammar.py`, `test_deny_selector_ambiguity.py`, `test_telegram_owner_boundary.py`, `tests/gateway/test_approve_deny_commands.py`, `test_deny_grammar_help.py`, `test_deny_stale_ui_compatibility.py`.
- [x] Preserved 23-file approval/delegation selection run via `scripts/run_tests.sh` on a pristine `git archive` of `1021a03` with and without this patch: baseline 295 passed / 1 failed, candidate 407 passed / 1 failed — **no new failures**. The one failure is pre-existing on both trees (`test_approval.py::TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`, macOS `/tmp` → `/private/tmp` canonicalization).
- [x] Same result on the previous two HEADs (`fb5715c`, `6c3d4a4`); independently reviewed in isolation before submission.
- [ ] Live gateway delivery on Telegram (attended canary) — not yet exercised; requesting maintainer eyes on the send-lane choice in `run_turn_runner.py`.

Docs: `website/docs/reference/slash-commands.md` updated for the exact-selector forms.
