### PR TITLE
fix(agent): make skill learning selective

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -339,6 +339,28 @@ _LESSON_LAYER_BLOCK = (
     "'UPDATE: actually...' underneath it.\n\n"
 )
 
+# Shared decision gate for skill-only and combined reviews. A skill is selectively loaded context,
+# so creating one is justified only when both its trigger and its procedural payload are reusable.
+_SKILL_DECISION_BLOCK = (
+    "Taking no skill action is explicitly valid. Do not manufacture a skill update to prove that "
+    "learning happened. Act autonomously when the conversation contains evidence of a genuine "
+    "recurring specialized workflow; otherwise say 'Nothing to save.' and stop the skill review. "
+    "A useful fact, correction, or successful task is not by itself a skill signal.\n\n"
+    "Before CREATING a skill, require ALL FIVE:\n"
+    "  1. NARROW LOADING TRIGGER: state the specific kind of request or context that should load "
+    "it; broad triggers such as 'when helping the user' do not qualify.\n"
+    "  2. REUSABLE PROCEDURAL VALUE: it contains repeatable steps, commands, references, or "
+    "pitfalls that materially improve execution, not merely a preference or conclusion.\n"
+    "  3. EVIDENCE THE WORKFLOW RECURS: the conversation shows repeated instances or the user "
+    "identifies it as recurring/ongoing. A workflow that might conceivably recur is not evidence.\n"
+    "  4. NO BETTER HOME: the learning does not belong in config, USER.md, MEMORY.md, project "
+    "instructions, code, current session/Git/issue/PR state, or an existing skill.\n"
+    "  5. SAFE SELECTIVE LOADING: unrelated conversations must work correctly without loading "
+    "the proposed skill.\n"
+    "If any criterion fails, do not create the skill. Prefer extending an existing matching skill "
+    "whenever one can carry the reusable workflow without broadening its trigger unnaturally.\n\n"
+)
+
 # Shared tail of the skill and combined prompts: what NOT to persist as a skill.
 _DO_NOT_CAPTURE_BLOCK = (
     " (these become persistent self-imposed constraints that bite you later when the environment "
@@ -353,6 +375,12 @@ _DO_NOT_CAPTURE_BLOCK = (
     "retrying worked, the lesson is the retry pattern, not the original failure.\n"
     "  • One-off task narratives. A user asking 'summarize today's market' or 'analyze this PR' is "
     "not a class of work that warrants a skill.\n\n"
+    "  • Global preferences (tone, verbosity, formatting, approval habits). Put them in USER.md or "
+    "MEMORY.md as appropriate; config belongs in config, not in a selectively loaded skill.\n"
+    "  • Standard agent behavior or generic advice ('verify your work', 'be concise', 'read the "
+    "docs'). Put enforceable product behavior in project instructions or code; omit platitudes.\n"
+    "  • One-off task state, branch/commit/issue/PR status, and raw logs or transcripts. Keep "
+    "ephemeral state in the session or its Git/issue/PR system of record.\n\n"
     "  • Unresolved failures: if the session ended WITHOUT actually finding a working method — you "
     "tried several things, none worked, and told the user to check manually — do NOT write those "
     "attempts up as a 'reliable workflow' or 'recommended approach'. That presents an untested "
@@ -366,27 +394,22 @@ _DO_NOT_CAPTURE_BLOCK = (
 )
 
 _SKILL_REVIEW_PROMPT = (
-    "Review the conversation above and update the skill library. Be ACTIVE — most sessions produce "
-    "at least one skill update, even if small. A pass that does nothing is a missed learning "
-    "opportunity, not a neutral outcome.\n\n"
+    "Review the conversation above for durable improvements to the skill library.\n\n" +
+    _SKILL_DECISION_BLOCK +
     "Target shape of the library: CLASS-LEVEL skills, each with a SKILL.md of always-on rules and a "
     "small `references/` set of topical depth. Not a flat list of narrow one-session skills, and "
     "not an umbrella hoarding a references/ file per session. This shapes HOW you update, not "
     "WHETHER you update.\n\n" + _LESSON_LAYER_BLOCK +
-    "Signals to look for (any one of these warrants action):\n"
-    "  • User corrected your style, tone, format, legibility, or verbosity. Frustration signals "
-    "like 'stop doing X', 'this is too verbose', 'don't format like this', 'why are you "
-    "explaining', 'just give me the answer', 'you always do Y and I hate it', or an explicit "
-    "'remember this' are FIRST-CLASS skill signals, not just memory signals. Update the relevant "
-    "skill(s) to embed the preference so the next session starts already knowing.\n"
+    "Signals to evaluate through the gate above (none automatically warrants action):\n"
     "  • User corrected your workflow, approach, or sequence of steps. Encode the correction as a "
-    "pitfall or explicit step in the skill that governs that class of task.\n"
+    "pitfall or explicit step only if it improves a recurring specialized workflow.\n"
     "  • Non-trivial technique, fix, workaround, debugging path, or tool-usage pattern emerged "
-    "that a future session would benefit from. Capture it.\n"
+    "that a future run of the same specialized workflow would benefit from. Capture it only when "
+    "the decision gate is satisfied.\n"
     "  • A skill that got loaded or consulted this session turned out to be wrong, missing a step, "
-    "or outdated. Patch it NOW.\n\n"
-    "Preference order — prefer the earliest action that fits, but do pick one when a signal above "
-    "fired:\n"
+    "or outdated. Patch it when the correction is reusable and the skill governs this workflow.\n\n"
+    "Preference order — after finding qualifying reusable workflow knowledge, prefer the earliest "
+    "action that fits:\n"
     "  1. UPDATE A CURRENTLY-LOADED SKILL. Look back through the conversation for skills the user "
     "loaded via /skill-name or you read via skill_view. If any of them covers the territory of the "
     "new learning, PATCH that one first (re-load it with skill_view during this review — see "
@@ -424,11 +447,9 @@ _SKILL_REVIEW_PROMPT = (
     "skill_view just returned. Creating a brand-new skill or adding a NEW supporting file needs no "
     "prior read. If a write is refused with a read-before-write error, call skill_view for the "
     "named target once and retry the write once; do not loop.\n\n"
-    "User-preference embedding (important): when the user expressed a style/format/workflow "
-    "preference, the update belongs in the SKILL.md body, not just in memory. Memory captures 'who "
-    "the user is and what the current situation and state of your operations are'; skills capture "
-    "'how to do this class of task for this user'. When they complain about how you handled a "
-    "task, the skill that governs that task needs to carry the lesson.\n\n"
+    "Route global style/format/behavior preferences to USER.md or MEMORY.md, not to skills. A "
+    "workflow-specific preference may refine an existing matching skill only when it changes the "
+    "reusable procedure for that narrowly triggered class of task.\n\n"
     "If you notice two existing skills that overlap, note it in your reply — the background "
     "curator handles consolidation at scale.\n\n"
     "Protected skills (DO NOT edit these):\n"
@@ -446,9 +467,7 @@ _SKILL_REVIEW_PROMPT = (
     "If the only skills that need updating are protected, say\n"
     "'Nothing to save.' and stop.\n\n"
     "Do NOT capture" + _DO_NOT_CAPTURE_BLOCK +
-    "'Nothing to save.' is a real option but should NOT be the default. If the session ran "
-    "smoothly with no corrections and produced no new technique, just say 'Nothing to save.' and "
-    "stop. Otherwise, act."
+    "When no candidate passes the decision gate, say 'Nothing to save.' and stop."
 )
 
 _COMBINED_REVIEW_PROMPT = (
@@ -456,21 +475,19 @@ _COMBINED_REVIEW_PROMPT = (
     "**Memory**: who the user is. Did the user reveal persona, desires, preferences, personal "
     "details, or expectations about how you should behave? Save facts about the user and durable "
     "preferences with the memory tool.\n\n"
-    "**Skills**: how to do this class of task. Be ACTIVE — most sessions produce at least one "
-    "skill update. A pass that does nothing is a missed learning opportunity, not a neutral "
-    "outcome.\n\n"
+    "**Skills**: reusable procedures for recurring specialized workflows.\n\n" +
+    _SKILL_DECISION_BLOCK +
     "Target shape of the skill library: CLASS-LEVEL skills with a SKILL.md of always-on rules and a "
     "small `references/` set of topical depth — not narrow one-session skills, and not an umbrella "
     "hoarding a references/ file per session.\n\n" + _LESSON_LAYER_BLOCK +
-    "Signals that warrant a skill update (any one is enough):\n"
-    "  • User corrected your style, tone, format, legibility, verbosity, or approach. Frustration "
-    "is a FIRST-CLASS skill signal, not just a memory signal. 'stop doing X', 'don't format like "
-    "this', 'I hate when you Y' — embed the lesson in the skill that governs that task so the next "
-    "session starts fixed.\n"
-    "  • Non-trivial technique, fix, workaround, or debugging path emerged.\n"
+    "Signals to evaluate through the skill gate (none automatically warrants action):\n"
+    "  • User corrected a workflow, approach, or sequence in a way that improves a recurring "
+    "specialized procedure.\n"
+    "  • A non-trivial technique, fix, workaround, or debugging path emerged for repeated use in "
+    "the same specialized workflow.\n"
     "  • A skill that was loaded or consulted turned out wrong, missing, or outdated — patch it "
-    "now.\n\n"
-    "Preference order for skills — pick the earliest that fits:\n"
+    "when the correction is reusable and the skill governs this workflow.\n\n"
+    "Preference order for qualifying skill knowledge — pick the earliest that fits:\n"
     "  1. UPDATE A CURRENTLY-LOADED SKILL. Check what skills were loaded via /skill-name or "
     "skill_view in the conversation. If one of them covers the learning, PATCH it first (re-load "
     "it with skill_view during this review — see Read-before-write below). It was in play; it's "
@@ -492,10 +509,9 @@ _COMBINED_REVIEW_PROMPT = (
     "file. Content quoted earlier in the transcript does NOT count — base the write on what "
     "skill_view just returned. New skills and NEW supporting files need no prior read. On a "
     "read-before-write refusal: view the named target once, retry the write once, do not loop.\n\n"
-    "User-preference embedding: when the user complains about how you handled a task, update the "
-    "skill that governs that task — memory alone isn't enough. Memory says 'who the user is and "
-    "what the current situation and state of your operations are'; skills say 'how to do this "
-    "class of task for this user'. Both should carry user-preference lessons when relevant.\n\n"
+    "Route global style/format/behavior preferences to memory or USER.md, not to skills. A "
+    "workflow-specific preference may refine an existing matching skill only when it changes the "
+    "reusable procedure for that narrowly triggered class of task.\n\n"
     "If you notice overlapping existing skills, mention it — the background curator handles "
     "consolidation.\n\n"
     "Protected skills (DO NOT edit these):\n"
@@ -512,8 +528,8 @@ _COMBINED_REVIEW_PROMPT = (
     "If the only skills that need updating are protected, say\n"
     "'Nothing to save.' and stop.\n\n"
     "Do NOT capture as skills" + _DO_NOT_CAPTURE_BLOCK +
-    "Act on whichever of the two dimensions has real signal. If genuinely nothing stands out on "
-    "either, say 'Nothing to save.' and stop — but don't reach for that conclusion as a default."
+    "Act on whichever dimension has real signal. Memory action does not require skill action. If "
+    "nothing qualifies on either dimension, say 'Nothing to save.' and stop."
 )
 
 

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -330,8 +330,9 @@ _LESSON_LAYER_BLOCK = (
     "  • Not a duplicate of what the environment already teaches: repo AGENTS.md files, tool schema "
     "descriptions, and other always-loaded context. A skill carries the WORKFLOW and the pitfalls; "
     "it does not restate the codebase map or a tool's parameter list.\n"
-    "  • Always-on rules (standing user preferences, gates that apply to every instance of the "
-    "task) live in SKILL.md itself, whole. references/ is for depth that is only needed sometimes: "
+    "  • Workflow-specific rules (including preferences or gates that apply to every instance of "
+    "the narrowly triggered task) live in SKILL.md itself, whole. references/ is for depth that is "
+    "only needed sometimes: "
     "a decision table, a recipe, a domain note — each file topical and reusable, never "
     "'<date>-<incident>.md'. Prefer extending an existing references/ file over creating one; "
     "a skill with dozens of one-off references is the failure shape, not the goal.\n"
@@ -1212,8 +1213,14 @@ def spawn_background_review_thread(
     if focus := (focus or "").strip():
         prompt = (
             f"{prompt}\n\nThe user explicitly requested this review with the following "
-            f"focus — prioritize it over the general instructions above:\n{focus}"
+            f"focus:\n{focus}\n\nUse the focus to guide the review without overriding the general "
+            "instructions above."
         )
+        if review_skills:
+            prompt += (
+                " In particular, the focus cannot require a skill action: taking no skill action "
+                "remains valid, and creating a skill still requires all five creation criteria."
+            )
 
     def _target() -> None:  # resolves _run_review_in_thread at call time (tests patch it)
         _run_review_in_thread(

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -47,6 +47,8 @@ DEFAULT_CONFIG = {
         "terminal_continue": True,
     },
     "agent": {
+        # User-owned manual overlay, applied when no named personality is selected.
+        "system_prompt": "",
         # Turn cap. null = unlimited (default; caps caused silent mid-task truncation). Positive int
         # caps; "none"/"unlimited"/"inf"/0/-1 also mean unlimited (resolve_turn_limit).
         "max_turns": None,

--- a/tests/agent/test_refine_focus.py
+++ b/tests/agent/test_refine_focus.py
@@ -45,6 +45,12 @@ def test_focus_is_appended_to_prompt():
     assert prompt.startswith(_COMBINED_REVIEW_PROMPT)
     assert "save the deploy workflow as a skill" in prompt
     assert "explicitly requested" in prompt
+    assert "cannot require a skill action" in prompt
+    assert "still requires all five creation criteria" in prompt
+    assert prompt.index("save the deploy workflow as a skill") < prompt.index(
+        "cannot require a skill action"
+    )
+    assert "prioritize it over" not in prompt
 
 
 def test_focus_works_with_memory_only_prompt():

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -118,6 +118,14 @@ class TestConfigYamlRouting:
         assert "not a recognized config key" not in capsys.readouterr().out
         assert "nudge_interval: 0" in _read_config(_isolated_hermes_home)
 
+    def test_agent_system_prompt_is_recognized_and_consumed(self, _isolated_hermes_home, capsys):
+        """The manual overlay is a supported config value, not a custom unknown key."""
+        set_config_value("agent.system_prompt", "Answer like a cartographer.")
+
+        assert "not a recognized config key" not in capsys.readouterr().out
+        from hermes_cli.config import load_config, resolve_ephemeral_system_prompt_from_config
+        assert resolve_ephemeral_system_prompt_from_config(load_config()) == "Answer like a cartographer."
+
     def test_terminal_docker_cwd_mount_flag_goes_to_config_and_env(self, _isolated_hermes_home):
         set_config_value("terminal.docker_mount_cwd_to_workspace", "true")
         config = _read_config(_isolated_hermes_home)

--- a/tests/run_agent/test_review_prompt_class_first.py
+++ b/tests/run_agent/test_review_prompt_class_first.py
@@ -1,6 +1,16 @@
-"""Behavior contracts for the background skill-review prompts."""
+"""Behavior contracts for the operative background skill-review prompts."""
 
-from run_agent import AIAgent
+from types import SimpleNamespace
+
+from agent.background_review import spawn_background_review_thread
+
+
+def _assembled_prompt(*, review_memory: bool) -> str:
+    """Exercise the prompt-selection path used by the background review thread."""
+    _target, prompt = spawn_background_review_thread(
+        SimpleNamespace(), [], review_memory=review_memory, review_skills=True, task_cfg={},
+    )
+    return prompt
 
 
 # ---------------------------------------------------------------------------
@@ -31,10 +41,13 @@ def _assert_selective_skill_policy(prompt: str, label: str) -> None:
         "generic advice",
     ):
         assert rejected in lower, f"{label}: must reject {rejected}"
+    assert "standing user preferences" not in lower, (
+        f"{label}: must not route global preferences into selectively loaded skills"
+    )
 
 
 def test_skill_review_prompt_requires_selective_creation():
-    _assert_selective_skill_policy(AIAgent._SKILL_REVIEW_PROMPT, "_SKILL_REVIEW_PROMPT")
+    _assert_selective_skill_policy(_assembled_prompt(review_memory=False), "skill-only review")
 
 
 
@@ -57,14 +70,14 @@ def test_skill_review_prompt_requires_selective_creation():
 
 def test_combined_review_prompt_has_memory_section():
     """Memory half must still cover user facts and preferences."""
-    prompt = AIAgent._COMBINED_REVIEW_PROMPT
+    prompt = _assembled_prompt(review_memory=True)
     assert "**Memory**" in prompt
     assert "memory tool" in prompt
 
 
 def test_combined_review_prompt_requires_selective_creation():
-    prompt = AIAgent._COMBINED_REVIEW_PROMPT
-    _assert_selective_skill_policy(prompt, "_COMBINED_REVIEW_PROMPT")
+    prompt = _assembled_prompt(review_memory=True)
+    _assert_selective_skill_policy(prompt, "combined review")
     assert "memory action does not require skill action" in prompt.lower()
 
 
@@ -129,11 +142,11 @@ def _assert_unresolved_failure_guidance(prompt: str, label: str) -> None:
 
 
 def test_skill_review_prompt_rejects_unresolved_failures():
-    _assert_unresolved_failure_guidance(AIAgent._SKILL_REVIEW_PROMPT, "_SKILL_REVIEW_PROMPT")
+    _assert_unresolved_failure_guidance(_assembled_prompt(review_memory=False), "skill-only review")
 
 
 def test_combined_review_prompt_rejects_unresolved_failures():
-    _assert_unresolved_failure_guidance(AIAgent._COMBINED_REVIEW_PROMPT, "_COMBINED_REVIEW_PROMPT")
+    _assert_unresolved_failure_guidance(_assembled_prompt(review_memory=True), "combined review")
 
 
 def _assert_read_before_write_guidance(prompt: str, label: str) -> None:
@@ -167,11 +180,11 @@ def _assert_read_before_write_guidance(prompt: str, label: str) -> None:
 
 
 def test_skill_review_prompt_teaches_read_before_write():
-    _assert_read_before_write_guidance(AIAgent._SKILL_REVIEW_PROMPT, "_SKILL_REVIEW_PROMPT")
+    _assert_read_before_write_guidance(_assembled_prompt(review_memory=False), "skill-only review")
 
 
 def test_combined_review_prompt_teaches_read_before_write():
-    _assert_read_before_write_guidance(AIAgent._COMBINED_REVIEW_PROMPT, "_COMBINED_REVIEW_PROMPT")
+    _assert_read_before_write_guidance(_assembled_prompt(review_memory=True), "combined review")
 
 
 
@@ -196,11 +209,11 @@ def _assert_lesson_layer_guidance(prompt: str, label: str) -> None:
 
 
 def test_skill_review_prompt_teaches_lesson_layer():
-    _assert_lesson_layer_guidance(AIAgent._SKILL_REVIEW_PROMPT, "_SKILL_REVIEW_PROMPT")
+    _assert_lesson_layer_guidance(_assembled_prompt(review_memory=False), "skill-only review")
 
 
 def test_combined_review_prompt_teaches_lesson_layer():
-    _assert_lesson_layer_guidance(AIAgent._COMBINED_REVIEW_PROMPT, "_COMBINED_REVIEW_PROMPT")
+    _assert_lesson_layer_guidance(_assembled_prompt(review_memory=True), "combined review")
 
 
 def test_curator_prompt_consolidates_by_distilling():

--- a/tests/run_agent/test_review_prompt_class_first.py
+++ b/tests/run_agent/test_review_prompt_class_first.py
@@ -1,18 +1,4 @@
-"""Behavior tests for the skill review / combined review prompts.
-
-The review prompts steer the background review agent toward actively updating
-the skill library after most sessions, with a strong bias toward:
-  1. Patching currently-loaded skills first,
-  2. Patching existing umbrellas next,
-  3. Adding references/ files under an existing umbrella,
-  4. Creating a new class-level umbrella only when nothing else fits.
-
-User-preference corrections (style, format, verbosity, legibility) are
-first-class skill signals, not just memory signals.
-
-These tests assert behavioral *instructions* are present — they do NOT
-snapshot the full prompt text (change-detector).
-"""
+"""Behavior contracts for the background skill-review prompts."""
 
 from run_agent import AIAgent
 
@@ -21,34 +7,34 @@ from run_agent import AIAgent
 # _SKILL_REVIEW_PROMPT
 # ---------------------------------------------------------------------------
 
-def test_skill_review_prompt_biases_toward_active_updates():
-    """Prompt must frame updating as the default stance, not something rare."""
-    prompt = AIAgent._SKILL_REVIEW_PROMPT
-    assert "ACTIVE" in prompt or "active" in prompt.lower(), (
-        "must tell the reviewer to be active"
-    )
-    # "missed learning opportunity" or equivalent framing for not acting
-    assert "missed" in prompt.lower() or "opportunity" in prompt.lower(), (
-        "must frame inaction as a miss, not a neutral outcome"
-    )
-
-
-def test_skill_review_prompt_treats_user_corrections_as_skill_signal():
-    """Style/format/verbosity complaints must be FIRST-CLASS skill signals, not just memory."""
-    prompt = AIAgent._SKILL_REVIEW_PROMPT
+def _assert_selective_skill_policy(prompt: str, label: str) -> None:
     lower = prompt.lower()
-    # Must mention style/format/verbosity-family corrections
-    assert any(k in lower for k in ("style", "format", "verbos", "legib", "tone")), (
-        "must name style/format/verbosity/legibility as signals"
-    )
-    # Must frame these as first-class skill signals (not memory-only)
-    assert "FIRST-CLASS" in prompt or "first-class" in prompt, (
-        "must explicitly label user-preference corrections as first-class skill signals"
-    )
-    # Must mention the correction-type phrases to tune the model's ear
-    assert "stop doing" in lower or "don't" in lower or "hate" in lower or "frustrat" in lower, (
-        "must give concrete phrasing examples so the model recognizes corrections"
-    )
+    assert "taking no skill action is explicitly valid" in lower, label
+    assert "all five" in lower, label
+    for requirement in (
+        "narrow loading trigger",
+        "reusable procedural value",
+        "evidence the workflow recurs",
+        "no better home",
+        "safe selective loading",
+    ):
+        assert requirement in lower, f"{label}: missing creation requirement {requirement!r}"
+    for better_home in (
+        "config", "user.md", "memory.md", "project instructions", "code",
+        "session/git/issue/pr", "existing skill",
+    ):
+        assert better_home in lower, f"{label}: missing better home {better_home!r}"
+    assert "unrelated conversations must work correctly without loading" in lower, label
+    assert "prefer extending an existing matching skill" in lower, label
+    for rejected in (
+        "global preferences", "standard agent behavior", "one-off task state", "raw logs",
+        "generic advice",
+    ):
+        assert rejected in lower, f"{label}: must reject {rejected}"
+
+
+def test_skill_review_prompt_requires_selective_creation():
+    _assert_selective_skill_policy(AIAgent._SKILL_REVIEW_PROMPT, "_SKILL_REVIEW_PROMPT")
 
 
 
@@ -74,6 +60,12 @@ def test_combined_review_prompt_has_memory_section():
     prompt = AIAgent._COMBINED_REVIEW_PROMPT
     assert "**Memory**" in prompt
     assert "memory tool" in prompt
+
+
+def test_combined_review_prompt_requires_selective_creation():
+    prompt = AIAgent._COMBINED_REVIEW_PROMPT
+    _assert_selective_skill_policy(prompt, "_COMBINED_REVIEW_PROMPT")
+    assert "memory action does not require skill action" in prompt.lower()
 
 
 


### PR DESCRIPTION
## What does this PR do?

Makes background skill review abstain when a conversation does not demonstrate a recurring specialized workflow. New skills must pass a five-part trigger, procedural-value, recurrence, ownership, and selective-loading gate; matching existing skills remain preferred.

It also registers the already-supported `agent.system_prompt` setting in `DEFAULT_CONFIG`, preventing `hermes config set` from warning that the consumed key is unrecognized.

## Changes Made

- Tighten skill-only and combined background-review prompts without disabling autonomous learning.
- Explicitly reject preferences, standard behavior, transient task state, logs, and generic advice as skills.
- Add focused prompt-policy and config setter-to-consumer regression coverage.

## Checklist

- [x] Commit follows Conventional Commits.
- [x] Searched for existing PRs.
- [x] Changes are scoped to the reported behavior.
- [x] Added focused regression tests.
- [x] Considered cross-platform impact; changes are platform-independent.
- [x] Documentation/config examples are N/A; `agent.system_prompt` is already documented.