### PR TITLE
fix(gateway): bind session context for plugin slash command handlers

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4217,6 +4217,17 @@ class GatewayRunner(
         from gateway.session_context import clear_session_vars
         clear_session_vars(tokens)
 
+    @_contextmanager
+    def _session_env_scope(self, context: SessionContext):
+        """Bind session context variables for the duration of the block, e.g. a plugin command
+        handler invoked outside the normal agent-turn path (``_set_session_env`` is otherwise only
+        reached there). Always cleared on exit, including on exception."""
+        tokens = self._set_session_env(context)
+        try:
+            yield
+        finally:
+            self._clear_session_env(tokens)
+
     async def _run_in_executor_with_context(self, func, *args):
         """Run blocking work in the thread pool while preserving session contextvars."""
         loop = asyncio.get_running_loop()

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -22,7 +22,8 @@ from gateway.platforms.base import EphemeralReply
 from gateway.platforms.event import MessageEvent, MessageType
 from gateway.run_common import _UNSET
 from gateway.session import (
-    SessionSource, is_shared_multi_user_session, neutralize_untrusted_inline_text
+    SessionSource, build_session_context, is_shared_multi_user_session,
+    neutralize_untrusted_inline_text,
 )
 from gateway.turn_lease import TurnLeaseTimeoutError
 from typing import Any, Dict, List, Optional, Tuple
@@ -993,9 +994,17 @@ class GatewayInboundMixin:
                 from hermes_cli.plugins import get_plugin_command_handler
                 plugin_handler = get_plugin_command_handler(command.replace("_", "-"))
                 if plugin_handler:
-                    result = plugin_handler(event.get_command_args().strip())
-                    if asyncio.iscoroutine(result):
-                        result = await result
+                    # The agent-turn path binds HERMES_SESSION_* via _set_session_env before running;
+                    # this dispatch sits outside that path, so a handler reading get_session_env()
+                    # (directly, or through code it calls: message delivery, cron, kanban, approvals)
+                    # would otherwise see an empty/stale session (#108698). No session_entry exists
+                    # yet here, so session_key is resolved from source instead of a persisted one.
+                    _plugin_context = build_session_context(source, self.config)
+                    _plugin_context.session_key = self._session_key_for_source(source)
+                    with self._session_env_scope(_plugin_context):
+                        result = plugin_handler(event.get_command_args().strip())
+                        if asyncio.iscoroutine(result):
+                            result = await result
                     return True, str(result) if result else None, command
             except Exception as e:
                 logger.warning("Plugin command dispatch failed: %s", e)

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -273,3 +273,46 @@ def test_cron_session_set_clear_and_reset_tristate(monkeypatch):
     reset_session_vars()
     assert get_session_env("HERMES_CRON_SESSION") == "1"
 
+
+@pytest.mark.asyncio
+async def test_plugin_slash_command_sees_session_env(monkeypatch):
+    """A plugin-registered slash command handler must see the same HERMES_SESSION_*
+    contextvars an agent turn would for that event (#108698): the agent-turn path binds
+    them via _set_session_env before running, but plugin command dispatch is a separate,
+    earlier path that previously called the handler with nothing bound."""
+    from gateway.config import GatewayConfig, PlatformConfig
+    from gateway.platforms.event import MessageEvent
+
+    monkeypatch.delenv("HERMES_SESSION_KEY", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")})
+    runner._draining = False
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM, chat_id="c1", user_id="u1", user_name="tester", chat_type="dm",
+    )
+    event = MessageEvent(text="/gsd bind", source=source, message_id="m1")
+
+    seen = {}
+
+    def _handler(raw_args):
+        seen["session_key"] = get_session_env("HERMES_SESSION_KEY")
+        seen["chat_id"] = get_session_env("HERMES_SESSION_CHAT_ID")
+        return f"Bound: {raw_args}"
+
+    from hermes_cli import plugins as _plugins_mod
+    monkeypatch.setattr(_plugins_mod, "get_plugin_command_handler",
+                         lambda name: _handler if name == "gsd-bind" else None)
+
+    handled, result, command = await runner._hm_dispatch_quick_and_plugin_commands(event, source, "gsd_bind")
+
+    assert handled is True
+    assert result == "Bound: bind"
+    assert seen["session_key"] == runner._session_key_for_source(source)
+    assert seen["session_key"] != ""
+    assert seen["chat_id"] == "c1"
+    # Bound only for the handler call, not leaked past dispatch
+    assert get_session_env("HERMES_SESSION_KEY") == ""
+


### PR DESCRIPTION
## What does this PR do?

Plugin-registered slash commands (`PluginContext.register_command`) are dispatched from the gateway's inbound path **before** session contextvars are bound, so a plugin handler that calls `gateway.session_context.get_session_env("HERMES_SESSION_KEY")` (or any other `HERMES_SESSION_*` var) gets an empty value. The agent-turn path binds them (`gateway/run_turn.py::_hmwa_prepare_turn` via `_set_session_env`), but the plugin command path in `gateway/run_inbound.py::_hm_dispatch_quick_and_plugin_commands` never did.

This factors the existing `_set_session_env`/`_clear_session_env` pair into a small `_session_env_scope` context manager on `GatewayRunner` (`gateway/run.py`) and wraps the `plugin_handler(...)` call in `_hm_dispatch_quick_and_plugin_commands` with it, per the fix suggested in the issue. No persisted `session_entry` exists yet at this point in dispatch, so `session_key` is resolved from `source` via the existing `_session_key_for_source` helper (the same one the idle-command dispatch path already uses) instead of a stored one. The binding is cleared in a `finally`, including when the handler raises.

## Related Issue

Fixes #108698

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` — new `_session_env_scope()` context manager wrapping the existing `_set_session_env`/`_clear_session_env` pair
- `gateway/run_inbound.py` — `_hm_dispatch_quick_and_plugin_commands` builds a `SessionContext` from `source` (session_key resolved via `_session_key_for_source`) and runs the plugin handler (including awaiting an async result) inside `_session_env_scope`
- `tests/gateway/test_session_env.py` — new regression test `test_plugin_slash_command_sees_session_env` asserting a plugin handler dispatched through `_hm_dispatch_quick_and_plugin_commands` can read `HERMES_SESSION_KEY`/`HERMES_SESSION_CHAT_ID` via `get_session_env`, and that the binding is cleared again after dispatch returns

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_session_env.py -q` — 10 passed
2. Regression proof: `git stash push -- gateway/run.py gateway/run_inbound.py` (keeping only the new test), then re-run the same test — it fails:
   ```
   AssertionError: assert '' == 'agent:main:telegram:dm:c1'
   ```
   `git stash pop` restores the fix and the test passes again.
3. Also ran the broader plugin/command-dispatch suites to check for regressions: `scripts/run_tests.sh tests/gateway/test_session_env.py tests/gateway/test_unknown_command.py tests/hermes_cli/test_plugins.py tests/gateway/test_slash_access_dispatch.py -q` — 98 passed, 0 failed.
4. `ruff check gateway/run.py gateway/run_inbound.py tests/gateway/test_session_env.py` — all checks passed.

Manually: register a plugin command whose handler calls `gateway.session_context.get_session_env("HERMES_SESSION_KEY")`, invoke it from a messaging platform, and confirm it now returns the live session key instead of `""`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` on the affected test files and they pass
- [x] I've added a regression test for this fix
- [x] Tested on Linux (Ubuntu, CI container)

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed

---

This PR was authored with AI assistance (Claude Code) under human review and verification, including running the full test/lint suite and manually confirming the regression test fails on the pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
