### PR TITLE
fix(gateway): anchor system service identity on the installed unit (#108674)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1097,11 +1097,8 @@ def _systemctl_show(properties: tuple[str, ...], *, system: bool) -> dict[str, s
     return _parse_kv_pairs(result.stdout.splitlines()) if result.returncode == 0 else {}
 
 
-def _hermes_home_from_systemd_unit_file(system: bool = False) -> str | None:
-    """``HERMES_HOME`` from the on-disk unit file — what refresh/compare already read, and reliable under ``sudo``."""
-    unit_path = get_systemd_unit_path(system=system)
-    if not unit_path.exists():
-        return None
+def _hermes_home_pinned_by_unit(unit_path: Path) -> str | None:
+    """``HERMES_HOME`` pinned by the unit file at *unit_path*, or None when absent/unreadable."""
     try:
         text = unit_path.read_text(encoding="utf-8")
     except OSError:
@@ -1113,6 +1110,11 @@ def _hermes_home_from_systemd_unit_file(system: bool = False) -> str | None:
             if body.startswith("HERMES_HOME="):
                 return body.split("=", 1)[1].strip().strip('"') or None
     return None
+
+
+def _hermes_home_from_systemd_unit_file(system: bool = False) -> str | None:
+    """``HERMES_HOME`` from the on-disk unit file - what refresh/compare already read, and reliable under ``sudo``."""
+    return _hermes_home_pinned_by_unit(get_systemd_unit_path(system=system))
 
 
 def _sync_hermes_home_from_systemd_unit(system: bool) -> None:
@@ -1937,6 +1939,8 @@ def _windows_gateway_breakaway_state() -> bool | None:
 _SERVICE_BASE = "hermes-gateway"
 SERVICE_DESCRIPTION = "Hermes Agent Gateway - Messaging Platform Integration"
 
+_SYSTEM_UNIT_DIR = Path("/etc/systemd/system")
+
 
 def _profile_name_from_home(home: Path, default: Path) -> str | None:
     """Profile name when ``home`` is ``<default>/profiles/<name>`` with a service-safe name, else None."""
@@ -1950,19 +1954,40 @@ def _profile_name_from_home(home: Path, default: Path) -> str | None:
     return None
 
 
-def _profile_suffix() -> str:
-    """Service-name suffix for HERMES_HOME: "" for the platform-native default home (``~/.hermes``), the
-    profile name for ``<root>/profiles/<name>``, else a short hash of the path.
+def _bare_unit_pinned_home() -> Path | None:
+    """Resolved ``HERMES_HOME`` pinned by an installed ``hermes-gateway.service``, or None.
 
-    The bare name is reserved for the NATIVE default, not ``get_default_hermes_root()``: that helper
-    treats any HERMES_HOME outside ``~/.hermes`` (Docker ``/opt/data``, a temp dir) as "the root itself",
-    which let a temp-home harness resolve to the default profile's ``hermes-gateway`` unit and uninstall
-    the production gateway. Service names are host-wide identities; only the real default home owns the
-    bare one."""
+    The installed unit is the authority on which home owns the BARE name: under ``sudo`` the naming
+    basis moves MID-COMMAND (sudo strips HERMES_HOME and sets HOME=/root, then
+    ``_sync_hermes_home_from_systemd_unit()`` adopts the unit's own HERMES_HOME into ``os.environ``),
+    so a basis derived from the process would name one unit before the adoption and another after it.
+    Reading it from the unit is stable for every elevated identity, including ``sudo -i`` and cron
+    where SUDO_USER is absent.
+    """
+    pinned = _hermes_home_pinned_by_unit(_SYSTEM_UNIT_DIR / f"{_SERVICE_BASE}.service")
+    if not pinned:
+        return None
+    try:
+        return Path(pinned).expanduser().resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def _profile_suffix() -> str:
+    """Service-name suffix for HERMES_HOME: "" for a home that owns the bare name, the profile name for
+    ``<root>/profiles/<name>``, else a short hash of the path.
+
+    Two homes own the bare name: this process's platform-native default (``~/.hermes``) and the home
+    pinned by an installed ``hermes-gateway.service``. The bare name is deliberately NOT tied to
+    ``get_default_hermes_root()``: that helper treats any HERMES_HOME outside ``~/.hermes`` (Docker
+    ``/opt/data``, a temp dir) as "the root itself", which let a temp-home harness resolve to the default
+    profile's ``hermes-gateway`` unit and uninstall the production gateway. Service names are host-wide
+    identities; a home with no installed bare unit and no native default keeps its own suffix.
+    """
     import hashlib
     from hermes_constants import _get_platform_default_hermes_home, get_default_hermes_root
     home = get_hermes_home().resolve()
-    if home == _get_platform_default_hermes_home().resolve():
+    if home == _get_platform_default_hermes_home().resolve() or home == _bare_unit_pinned_home():
         return ""
     name = _profile_name_from_home(home, get_default_hermes_root().resolve())
     return name or hashlib.sha256(str(home).encode()).hexdigest()[:8]
@@ -1998,7 +2023,7 @@ def get_service_name() -> str:
 def get_systemd_unit_path(system: bool = False) -> Path:
     name = get_service_name()
     if system:
-        return Path("/etc/systemd/system") / f"{name}.service"
+        return _SYSTEM_UNIT_DIR / f"{name}.service"
     return Path.home() / ".config" / "systemd" / "user" / f"{name}.service"
 
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1957,13 +1957,19 @@ def _profile_name_from_home(home: Path, default: Path) -> str | None:
 def _bare_unit_pinned_home() -> Path | None:
     """Resolved ``HERMES_HOME`` pinned by an installed ``hermes-gateway.service``, or None.
 
-    The installed unit is the authority on which home owns the BARE name: under ``sudo`` the naming
-    basis moves MID-COMMAND (sudo strips HERMES_HOME and sets HOME=/root, then
-    ``_sync_hermes_home_from_systemd_unit()`` adopts the unit's own HERMES_HOME into ``os.environ``),
-    so a basis derived from the process would name one unit before the adoption and another after it.
-    Reading it from the unit is stable for every elevated identity, including ``sudo -i`` and cron
-    where SUDO_USER is absent.
+    Under ``sudo`` the process-derived naming basis moves MID-COMMAND: sudo strips HERMES_HOME and
+    sets HOME=/root, then ``_sync_hermes_home_from_systemd_unit()`` adopts the unit's own HERMES_HOME
+    into ``os.environ``, so a process-derived basis names one unit before the adoption and another
+    after it. The installed unit is the only basis that holds still, and it holds for every elevated
+    identity — ``sudo -i`` and cron included, where SUDO_USER is absent.
+
+    Linux-gated because a systemd unit is not an identity authority for launchd labels, Windows
+    scheduled tasks, or s6 slots, which share ``_profile_suffix()``. ``is_linux()`` is a plain
+    ``sys.platform`` test; ``supports_systemd_services()`` would be wrong here, since it can shell out
+    to ``systemctl is-system-running`` on WSL/containers and this runs on every name resolution.
     """
+    if not is_linux():
+        return None
     pinned = _hermes_home_pinned_by_unit(_SYSTEM_UNIT_DIR / f"{_SERVICE_BASE}.service")
     if not pinned:
         return None
@@ -1978,11 +1984,16 @@ def _profile_suffix() -> str:
     ``<root>/profiles/<name>``, else a short hash of the path.
 
     Two homes own the bare name: this process's platform-native default (``~/.hermes``) and the home
-    pinned by an installed ``hermes-gateway.service``. The bare name is deliberately NOT tied to
-    ``get_default_hermes_root()``: that helper treats any HERMES_HOME outside ``~/.hermes`` (Docker
-    ``/opt/data``, a temp dir) as "the root itself", which let a temp-home harness resolve to the default
-    profile's ``hermes-gateway`` unit and uninstall the production gateway. Service names are host-wide
-    identities; a home with no installed bare unit and no native default keeps its own suffix.
+    pinned by an installed ``hermes-gateway.service``. The unit-pinned check must precede the profile
+    branch: ``sudo hermes gateway install --system`` resolves the BARE name from root's default, then
+    pins the invoking user's remapped home, so the bare unit legitimately carries a
+    ``<root>/profiles/<name>`` home and must keep answering with the bare name it was installed under.
+
+    The bare name is deliberately NOT tied to ``get_default_hermes_root()``: that helper treats any
+    HERMES_HOME outside ``~/.hermes`` (Docker ``/opt/data``, a temp dir) as "the root itself", which let a
+    temp-home harness resolve to the default profile's ``hermes-gateway`` unit and uninstall the
+    production gateway. Service names are host-wide identities; a home with no installed bare unit and
+    no native default keeps its own suffix.
     """
     import hashlib
     from hermes_constants import _get_platform_default_hermes_home, get_default_hermes_root

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+import hermes_constants
 
 pwd = pytest.importorskip("pwd")
 grp = pytest.importorskip("grp")
@@ -2736,3 +2737,72 @@ class TestTimeoutStopSecCoversCronFloor:
             env={"HERMES_CRON_DRAIN_TIMEOUT": "200"},
         )
         assert "TimeoutStopSec=240" in unit
+
+
+class TestUnitAnchoredServiceIdentity:
+    """The installed ``hermes-gateway.service`` owns the bare name: under ``sudo`` the naming basis moves
+    mid-command when ``_sync_hermes_home_from_systemd_unit()`` adopts the unit's HERMES_HOME (#108674)."""
+
+    def test_service_name_survives_hermes_home_adoption_from_unit(self, tmp_path, monkeypatch):
+        alice_home = tmp_path / "alice" / ".hermes"
+        alice_home.mkdir(parents=True)
+        root_home = tmp_path / "root" / ".hermes"
+        root_home.mkdir(parents=True)
+        unit_dir = tmp_path / "systemd"
+        unit_dir.mkdir()
+        unit_path = unit_dir / f"{gateway_cli._SERVICE_BASE}.service"
+        unit_path.write_text(f'[Service]\nEnvironment="HERMES_HOME={alice_home}"\n', encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
+        monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root_home)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        pre_name = gateway_cli.get_service_name()
+        monkeypatch.setenv("HERMES_HOME", str(alice_home))
+        assert gateway_cli.get_service_name() == pre_name
+
+    def test_unit_pinned_home_owns_the_bare_name(self, tmp_path, monkeypatch):
+        alice_home = tmp_path / "alice" / ".hermes"
+        alice_home.mkdir(parents=True)
+        root_home = tmp_path / "root" / ".hermes"
+        root_home.mkdir(parents=True)
+        unit_dir = tmp_path / "systemd"
+        unit_dir.mkdir()
+        unit_path = unit_dir / f"{gateway_cli._SERVICE_BASE}.service"
+        unit_path.write_text(f'[Service]\nEnvironment="HERMES_HOME={alice_home}"\n', encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
+        monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root_home)
+        monkeypatch.setenv("HERMES_HOME", str(alice_home))
+        assert gateway_cli.get_service_name() == gateway_cli._SERVICE_BASE
+        assert gateway_cli.get_systemd_unit_path(system=True) == unit_path
+
+    def test_foreign_home_without_installed_unit_keeps_its_suffix(self, tmp_path, monkeypatch):
+        unit_dir = tmp_path / "empty"
+        unit_dir.mkdir()
+        foreign = tmp_path / "elsewhere"
+        foreign.mkdir()
+        root_home = tmp_path / "root" / ".hermes"
+        root_home.mkdir(parents=True)
+        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
+        monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root_home)
+        monkeypatch.setenv("HERMES_HOME", str(foreign))
+        name = gateway_cli.get_service_name()
+        assert name != gateway_cli._SERVICE_BASE
+        assert name.startswith(gateway_cli._SERVICE_BASE + "-")
+
+    def test_home_not_pinned_by_unit_keeps_its_suffix(self, tmp_path, monkeypatch):
+        alice_home = tmp_path / "alice" / ".hermes"
+        alice_home.mkdir(parents=True)
+        bob_home = tmp_path / "bob" / ".hermes"
+        bob_home.mkdir(parents=True)
+        root_home = tmp_path / "root" / ".hermes"
+        root_home.mkdir(parents=True)
+        unit_dir = tmp_path / "systemd"
+        unit_dir.mkdir()
+        (unit_dir / f"{gateway_cli._SERVICE_BASE}.service").write_text(
+            f'[Service]\nEnvironment="HERMES_HOME={alice_home}"\n', encoding="utf-8"
+        )
+        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
+        monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root_home)
+        monkeypatch.setenv("HERMES_HOME", str(bob_home))
+        name = gateway_cli.get_service_name()
+        assert name != gateway_cli._SERVICE_BASE
+        assert name.startswith(gateway_cli._SERVICE_BASE + "-")

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2741,8 +2741,13 @@ class TestTimeoutStopSecCoversCronFloor:
 
 class TestUnitAnchoredServiceIdentity:
     """The installed ``hermes-gateway.service`` owns the bare name: under ``sudo`` the naming basis moves
-    mid-command when ``_sync_hermes_home_from_systemd_unit()`` adopts the unit's HERMES_HOME (#108674)."""
+    mid-command when ``_sync_hermes_home_from_systemd_unit()`` adopts the unit's HERMES_HOME (#108674).
 
+    ``linux_only`` because ``_bare_unit_pinned_home()`` is Linux-gated on purpose: a systemd unit is not
+    an identity authority for launchd labels, Windows tasks, or s6 slots, which share the same resolver.
+    """
+
+    @pytest.mark.linux_only
     def test_service_name_survives_hermes_home_adoption_from_unit(self, tmp_path, monkeypatch):
         alice_home = tmp_path / "alice" / ".hermes"
         alice_home.mkdir(parents=True)
@@ -2759,6 +2764,7 @@ class TestUnitAnchoredServiceIdentity:
         monkeypatch.setenv("HERMES_HOME", str(alice_home))
         assert gateway_cli.get_service_name() == pre_name
 
+    @pytest.mark.linux_only
     def test_unit_pinned_home_owns_the_bare_name(self, tmp_path, monkeypatch):
         alice_home = tmp_path / "alice" / ".hermes"
         alice_home.mkdir(parents=True)
@@ -2774,6 +2780,7 @@ class TestUnitAnchoredServiceIdentity:
         assert gateway_cli.get_service_name() == gateway_cli._SERVICE_BASE
         assert gateway_cli.get_systemd_unit_path(system=True) == unit_path
 
+    @pytest.mark.linux_only
     def test_foreign_home_without_installed_unit_keeps_its_suffix(self, tmp_path, monkeypatch):
         unit_dir = tmp_path / "empty"
         unit_dir.mkdir()
@@ -2788,6 +2795,7 @@ class TestUnitAnchoredServiceIdentity:
         assert name != gateway_cli._SERVICE_BASE
         assert name.startswith(gateway_cli._SERVICE_BASE + "-")
 
+    @pytest.mark.linux_only
     def test_home_not_pinned_by_unit_keeps_its_suffix(self, tmp_path, monkeypatch):
         alice_home = tmp_path / "alice" / ".hermes"
         alice_home.mkdir(parents=True)
@@ -2806,3 +2814,73 @@ class TestUnitAnchoredServiceIdentity:
         name = gateway_cli.get_service_name()
         assert name != gateway_cli._SERVICE_BASE
         assert name.startswith(gateway_cli._SERVICE_BASE + "-")
+
+    @pytest.mark.linux_only
+    def test_bare_unit_pinning_a_named_profile_home_keeps_the_bare_name(self, tmp_path, monkeypatch):
+        """``sudo ... install --system`` names the unit from root's default but pins the invoking user's
+        remapped home, so the BARE unit legitimately carries a ``profiles/<name>`` home. The unit-pinned
+        check therefore has to win over the profile branch, which would answer ``-kimi`` for a unit that
+        was installed bare."""
+        profile_home = tmp_path / "alice" / ".hermes" / "profiles" / "kimi"
+        profile_home.mkdir(parents=True)
+        root_home = tmp_path / "root" / ".hermes"
+        root_home.mkdir(parents=True)
+        unit_dir = tmp_path / "systemd"
+        unit_dir.mkdir()
+        unit_path = unit_dir / f"{gateway_cli._SERVICE_BASE}.service"
+        unit_path.write_text(f'[Service]\nEnvironment="HERMES_HOME={profile_home}"\n', encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
+        monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root_home)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        assert gateway_cli.get_service_name() == gateway_cli._SERVICE_BASE
+        # The profile branch, consulted against the home that owns the profile, would have answered
+        # with the readable suffix -- which is why the unit-pinned check has to be evaluated first.
+        assert gateway_cli._profile_name_from_home(profile_home, profile_home.parent.parent) == profile_home.name
+
+    @pytest.mark.linux_only
+    def test_real_unit_sync_keeps_the_name_it_validated(self, tmp_path, monkeypatch):
+        """Drive the production sync instead of simulating the adoption with setenv: the name resolved
+        before ``_sync_hermes_home_from_systemd_unit()`` must survive the mutation it performs."""
+        alice_home = tmp_path / "alice" / ".hermes"
+        alice_home.mkdir(parents=True)
+        root_home = tmp_path / "root" / ".hermes"
+        root_home.mkdir(parents=True)
+        unit_dir = tmp_path / "systemd"
+        unit_dir.mkdir()
+        (unit_dir / f"{gateway_cli._SERVICE_BASE}.service").write_text(
+            f'[Service]\nEnvironment="HERMES_HOME={alice_home}"\n', encoding="utf-8"
+        )
+        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
+        monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root_home)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+
+        pre_sync_name = gateway_cli.get_service_name()
+        gateway_cli._sync_hermes_home_from_systemd_unit(system=True)
+
+        assert os.environ["HERMES_HOME"] == str(alice_home)  # the sync really ran
+        assert gateway_cli.get_service_name() == pre_sync_name
+
+    @pytest.mark.linux_only
+    def test_unreadable_unit_does_not_grant_the_bare_name(self, tmp_path, monkeypatch):
+        """A unit we cannot read must not hand its bare name to an unrelated home: the parser returns
+        None on OSError, so resolution falls through to the suffix branches."""
+        foreign_home = tmp_path / "elsewhere"
+        foreign_home.mkdir()
+        root_home = tmp_path / "root" / ".hermes"
+        root_home.mkdir(parents=True)
+        unit_dir = tmp_path / "systemd"
+        unit_dir.mkdir()
+        unit_path = unit_dir / f"{gateway_cli._SERVICE_BASE}.service"
+        unit_path.write_text(f'[Service]\nEnvironment="HERMES_HOME={foreign_home}"\n', encoding="utf-8")
+        real_read_text = Path.read_text
+
+        def deny_unit(self, *args, **kwargs):
+            if self == unit_path:
+                raise PermissionError(13, "Permission denied")
+            return real_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
+        monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root_home)
+        monkeypatch.setattr(Path, "read_text", deny_unit)
+        monkeypatch.setenv("HERMES_HOME", str(foreign_home))
+        assert gateway_cli.get_service_name().startswith(gateway_cli._SERVICE_BASE + "-")


### PR DESCRIPTION
## What does this PR do?

`sudo hermes gateway start|stop|restart|status|uninstall|install --system` resolves the systemd unit as `hermes-gateway-<sha256[:8]>` although the installed unit is `hermes-gateway.service`, so `systemctl` is invoked on a unit that does not exist (`Unit ... not found`, exit 5).

This PR makes the **installed unit** the authority on which home owns the bare service name, instead of re-deriving that decision from mutable process state.

**This is a complementary follow-up to @huklaa's #108681, not a replacement.** #108681 fixes the reported scenario and its author owns that work. This PR targets the two residual paths #108674 itself declares out of scope for the minimal fix, and it does not touch #108681's `_native_service_homes()` design. See *Relationship to existing work* for how the two compose, and please treat #108681 as the canonical fix for the reported case.

Design credit: the SUDO_USER-based approach was designed by @Mintianzeyun in the #108674 report and implemented by @huklaa in #108681. This PR deliberately takes a different basis (the unit, not the caller identity) for the reasons below.

**Provenance — this is original work, not a cherry-pick.** The single commit `9a8588ece9` has one parent, `1021a032` (`origin/main`), i.e. the branch was cut from upstream `main` and not from any PR head; it carries no `cherry picked from`, `Co-authored-by`, or supersede trailer, because no other contributor's commit or code is included. `_native_service_homes()` does not appear anywhere in my diff, and the only occurrence of the string `SUDO_USER` in it is one docstring line explaining why this basis differs. `git patch-id --stable` over the three diffs gives three distinct ids (mine `e8e11921`, #108681 `8f37f826`, #93386 `52991a34`), so no patch here duplicates another. The only actions I took on other contributors' objects were comments: the GitHub timeline for #108681 records exactly `["commented", "cross-referenced"]` from my account — no close, no label, no force-push, no retarget, and both #108681 and #93386 remain `OPEN` on their original heads.

## Related Issue

Refs #108674

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Root cause

The service name is derived from the **current process's** `HERMES_HOME`, and under `sudo` that value changes **mid-command**. All line numbers are on `1021a032` (`origin/main` at the time of writing).

1. `_profile_suffix()` (`hermes_cli/gateway.py:1953-1968`) returns `""` only when `get_hermes_home().resolve() == _get_platform_default_hermes_home().resolve()`, else a profile name, else `hashlib.sha256(str(home).encode()).hexdigest()[:8]`.
2. `sudo` strips `HERMES_HOME` and sets `HOME=/root`, so both sides resolve to `/root/.hermes`: the suffix is `""`, and the `_require_service_installed()` pre-flight (`gateway.py:3259-3262`) validates the real `/etc/systemd/system/hermes-gateway.service` and **passes**.
3. `_sync_hermes_home_from_systemd_unit(system=True)` (`gateway.py:1118-1129`) then writes the unit's pinned `HERMES_HOME=/home/<user>/.hermes` into `os.environ`. This is deliberate and must stay: it was introduced by `1508dcb9c2` so runtime-status/PID reads find the unit's own profile (#22035), and centralised at the compare/regenerate chokepoint by `d54a8f7079`.
4. Every **later** `get_service_name()` in the same command re-derives with the adopted home, which is neither root's default nor a `<root>/profiles/` path, so the hash branch runs.

The regression came in with the #105525 fix (PR #106611, commit `4746e34448`, confirmed an ancestor of `main`), which changed the comparison basis from `get_default_hermes_root()` to `_get_platform_default_hermes_home()`. That change is **correct** for #105525's scenario (a temp-dir/Docker/custom root must never resolve to the operator's unit) but wrong for an elevated process, whose `~/.hermes` is not the home that owns the unit.

### Corrections and additions to the issue's blast-radius table

Verified by reading the code, not inferred:

| Claim in #108674 | Verdict | Evidence |
|---|---|---|
| `start --system` fails exit 5 | **Confirmed** | `refresh_systemd_unit_if_needed()` captures `unit_path` at `:2951` *before* the sync, so it rewrites the correct unit and prints `↻ Updated ...`; `systemd_start()` then re-derives at `:3269` → hashed name → `systemctl start` fails. Exactly the reporter's output. |
| `stop --system` fails the same way | **Confirmed** | `systemd_stop()` syncs at `:3275`, then resolves at `:3278`. |
| `status --system` permanently "outdated" | **Confirmed** | `systemd_unit_is_current()` syncs as its *first* action (`:2901`), then resolves `get_systemd_unit_path()` (`:2903`) → hashed path → `exists()` False → always `False` → the warning at `:3415-3418` always prints. |
| `uninstall --system` prints success without removing | **Confirmed** | `_systemd_unit_belongs_to_current_home()` syncs at `:3226`, then reads `_hermes_home_from_systemd_unit_file()`, which uses the **post-sync hashed** path → `None` → the ownership guard returns `True` silently. `stop`/`disable` use `check=False` (`:3241-3242`), `unlink` is skipped because the hashed path does not exist (`:3244`), and `✓ ... uninstalled` still prints (`:3250`). |
| "the unit file is rewritten on every sudo invocation, baking the caller's `PATH` into it" | **Partially correct** | The rewrite is real (`systemd_unit_is_current()` is always `False` in this state), but it overwrites the **correct** `hermes-gateway.service`, because `refresh_systemd_unit_if_needed()` captured `unit_path` at `:2951` before the sync — it does not create a hashed unit. And the baked `PATH` is a *constructed* sane path (`:2846`), not the caller's raw `PATH`. |
| *(not in the issue)* | **New symptom** | `install --system` with an existing unit reaches `systemctl enable <hashed name>` with `check=True` (`:3164`), so a repair run fails exit 5 too. `systemd_install()` also derives the name *before* its own sync at `:3158`. |

Scope checks: user scope is genuinely unaffected — `_sync_hermes_home_from_systemd_unit()` returns at `:1121-1122` when `system=False`. macOS launchd (`get_launchd_label()` `:3480`, `get_launchd_plist_path()` `:2559`) and the Windows Scheduled-Task path (`gateway_windows.py:223`) each resolve their name **once** and have no unit-env adoption, so they are not affected by this mid-command flip. s6 does not use `get_service_name()` at all.

## Changes Made

`hermes_cli/gateway.py` (+40/-15):

- **`_SYSTEM_UNIT_DIR`** — new module constant for `/etc/systemd/system`, so the system unit directory has one source of truth (and one monkeypatch seam). `get_systemd_unit_path()` now uses it instead of an inline literal. The unrelated literal in the scope-conflict scanner (`:2241`) is intentionally left alone.
- **`_hermes_home_pinned_by_unit(unit_path)`** — the existing `Environment=`/`HERMES_HOME=` parser, split out so a caller can read an **explicit** unit path. `_hermes_home_from_systemd_unit_file(system=...)` is now a one-line wrapper over it and keeps its exact previous behaviour and signature; its only existing caller (`:1126`, and `:3252` for the ownership guard) is untouched. The redundant `exists()` pre-check was dropped because a missing file raises `FileNotFoundError`, already caught by the `except OSError`.
- **`_bare_unit_pinned_home()`** — resolves the `HERMES_HOME` pinned by an installed `hermes-gateway.service`, or `None`.
- **`_profile_suffix()`** — returns `""` when the home is the platform-native default **or** the home pinned by that installed bare unit.

`tests/hermes_cli/test_gateway_service.py` (+70): one new class, `TestUnitAnchoredServiceIdentity`, with four tests.

### Why the unit, and not `SUDO_USER`

Reading the basis from the unit is stable for **every** elevated identity, because it does not ask "who invoked me?" — it asks "who owns the unit I am about to operate on?". That closes the residual case #108674 names as out of scope ("a root shell with no `SUDO_USER` (`sudo -i`, cron) operating another user's home still hashes; resolving the name from the installed unit's pinned `HERMES_HOME` would close that too") and additionally covers a custom `HERMES_HOME` pinned in the unit, which a `pwd.getpwnam(SUDO_USER).pw_dir / ".hermes"` lookup cannot express.

Correctness constraints respected in the implementation:

- `_bare_unit_pinned_home()` builds the bare path from the constants and **never** calls `get_service_name()` / `get_systemd_unit_path()`; doing so would recurse back into `_profile_suffix()`. Asserted structurally (`ast`) as part of verification.
- The native-default comparison stays **first** and short-circuits, so the common path does no file I/O.
- **Nothing is memoized.** `hermes_cli/profiles.py::_cleanup_gateway_service` (`profiles.py:1264-1294`) temporarily swaps `HERMES_HOME` and calls `get_service_name()` for per-profile cleanup, and `tests/hermes_cli/test_gateway_service.py:210-218` pins that re-derivation. A module- or process-level cache would break both.
- No new imports: `Path` and `os` were already imported.

## Relationship to existing work

- **#108681 (@huklaa, open) — complementary, and canonical for the reported case.** It adds `SUDO_USER`'s `~/.hermes` to the set of homes owning the bare name. Verified against its head (`a0008336`): with `SUDO_USER` present it stabilises the name across the adoption. #108681 remains the right fix to merge for the reported scenario; this PR adds the unit-anchored basis for the paths `SUDO_USER` cannot describe.

  **Correction to an earlier version of this description:** the two are logically independent disjuncts, but they are **not** textually conflict-free — both rewrite the `_profile_suffix()` docstring and insert a helper at the same point, so `git merge-tree` reports `changed in both` with 4 conflict markers. I resolved it locally to verify the combination is sound: keep **both** helpers and make the condition a three-way disjunct, native set first so the common path short-circuits before any file I/O.

  ```python
  if home in _native_service_homes() or home == _bare_unit_pinned_home():
      return ""
  ```

  Result under identical conditions (same POSIX stubs, same `-k` selection): #108681 alone → `4 failed, 4 passed`; the combined tree → `4 failed, 8 passed`. Same four failures (stub artefacts where `getpwnam` raises `KeyError`, reproducible on #108681 alone), plus exactly my four new passes — so the merge resolution costs nothing on either side. `ruff` and `py_compile` clean on the combined file. Whichever of the two lands first, the second is a small docstring-and-condition merge; I'm happy to rebase onto #108681 and carry the resolution, or to have mine rebased onto, whichever maintainers prefer.
- **#105525 (closed) / PR #106611 (merged, `4746e34448`) — guard preserved.** With no installed bare unit, a temp-dir, Docker `/opt/data`, or `/srv/hermes` home still keeps its own hashed suffix and can never resolve to (or uninstall) the operator's `hermes-gateway.service`. Pinned by two of the four new tests and by `#105525`'s own surviving tests (`TestServiceIdentityForForeignHome`).
- **#93386 (@chelsealong, open) — does not cover this case, and is not touched.** Verified: `mergeable: CONFLICTING`, `behind_by: 8931`. Its `_real_native_hermes_root()` anchors on `pwd.getpwuid(os.getuid())`, which is `/root` for the elevated process, so the unit's own home still compares as custom. Replicating its logic at euid 0 with `SUDO_USER=alice` reproduced `hermes-gateway-4b0659f69617` in the post-adoption state, matching the reporter's own finding.
- **Also closed by this basis:** the identity half of #93349 (bare-name collisions across independent `HERMES_HOME` roots) benefits from the same anchor. Adjacent but **not** addressed: #45830 (merged prior art), #30155, #6729, #92091.

## Alternatives considered and rejected

1. **Add `SUDO_USER`'s `~/.hermes` to the native set** (#108681's approach) — correct and already owned by another contributor; leaves `sudo -i`/cron and unit-pinned custom homes hashed. Not duplicated here.
2. **"Resolve once, pass down"**: thread the pre-flight-validated unit name through every `systemctl` call. Architecturally the cleanest, but it touches ~13 functions (`_require_service_installed`, `systemd_start/stop/restart/status/install/uninstall`, `refresh_*`, `_recover_pending_systemd_restart`, …) for an estimated 120-220 lines. Rejected as too large a blast radius for a P1 regression fix; it remains the right follow-up if maintainers want the plumbing.
3. **Memoize the service identity per process** — rejected outright: `profiles.py:1264` depends on re-derivation (proved above).
4. **Stop `_sync_hermes_home_from_systemd_unit()` from mutating `os.environ`** — rejected: the mutation is the documented fix for #22035 and is load-bearing for restart's PID/drain reads.
5. **Glob `hermes-gateway*.service` and pick the match** — rejected: needs an ambiguity policy for multiple units and changes install-time naming, well beyond this regression.

## How to Test

### 1. Deterministic reproduction against the real production functions

No real Linux/sudo host was available, so the harness injects only what `sudo` actually does to this process's *inputs* (platform default home, and `HERMES_HOME` absent → then set to the unit's pinned value, which is what the sync writes). It does **not** fake the OS: no `sys.platform` patch, no `os.geteuid` patch. It imports the real `hermes_cli.gateway` from each worktree and calls `get_service_name()`.

Base (`origin/main` `1021a032`) — 3 of 7 checks fail:

```
[FAIL] sudo, unit pins alice   pre='hermes-gateway' post='hermes-gateway-525becc1'
[FAIL] sudo -i, no SUDO_USER   pre='hermes-gateway' post='hermes-gateway-525becc1'
[FAIL] unit pins /srv-hermes   pre='hermes-gateway' post='hermes-gateway-ef2ca229'
[PASS] #105525 guard, no unit  name='hermes-gateway-7349f39c' (must be suffixed)
[PASS] unrelated home (bob)    name='hermes-gateway-52a2d6b6' (must be suffixed)
[PASS] named profile kimi      name='hermes-gateway-kimi'
[PASS] native default home     name='hermes-gateway'
RESULT: 3 FAILING CHECK(S)
```

This branch (`9a8588ece9`) — all 7 pass:

```
[PASS] sudo, unit pins alice   pre='hermes-gateway' post='hermes-gateway'
[PASS] sudo -i, no SUDO_USER   pre='hermes-gateway' post='hermes-gateway'
[PASS] unit pins /srv-hermes   pre='hermes-gateway' post='hermes-gateway'
[PASS] #105525 guard, no unit  name='hermes-gateway-7349f39c' (must be suffixed)
[PASS] unrelated home (bob)    name='hermes-gateway-52a2d6b6' (must be suffixed)
[PASS] named profile kimi      name='hermes-gateway-kimi'
[PASS] native default home     name='hermes-gateway'
RESULT: ALL PASS
```

**Honest scope note on the #108681 column:** running the same harness against #108681's head also shows 3 failures, but *only* because this harness sets no `SUDO_USER` and does not claim euid 0 — i.e. it exercises exactly the `sudo -i`/cron path #108674 lists as out of scope for that fix. With `SUDO_USER` present, #108681 stabilises the name correctly (separately verified). That column is evidence of an uncovered path, **not** of a defect in #108681.

### 2. Regression tests (proven RED on base)

With `hermes_cli/gateway.py` restored from `origin/main` and the new tests kept, the two behaviour-contract tests fail with the issue's exact symptom, while the two guard tests pass (they pin behaviour that must be preserved):

```
test_service_name_survives_hermes_home_adoption_from_unit FAILED
  AssertionError: assert 'hermes-gateway-834eb573' == 'hermes-gateway'
test_unit_pinned_home_owns_the_bare_name                  FAILED
  AssertionError: assert 'hermes-gateway-50d01eaa' == 'hermes-gateway'
test_foreign_home_without_installed_unit_keeps_its_suffix PASSED
test_home_not_pinned_by_unit_keeps_its_suffix             PASSED
2 failed, 2 passed, 111 deselected
```

On this branch: `4 passed, 111 deselected`.

The tests assert **relationships** (pre-name equals post-name; suffixed name differs from and is prefixed by `gateway_cli._SERVICE_BASE`), never a frozen hash literal, and never read source text. They carry `@pytest.mark.linux_only`: the second commit gates the unit anchor on `is_linux()`, so the behaviour is genuinely host-dependent and per AGENTS.md belongs on the host that has it — never behind a faked `sys.platform`. `_SYSTEM_UNIT_DIR` is redirected to a `tmp_path` dir with `raising=False`, so the tests exercise the contract on an unpatched tree instead of erroring on a missing attribute, and nothing reads the real `/etc/systemd/system` or writes to `~/.hermes`.

### 3. Real-Linux verification of the `linux_only` regressions

Run under WSL2 (`Linux 6.6.87.1-microsoft-standard-WSL2 x86_64`, Python 3.12.13) — the host the marker targets.

This branch, the new class:

```
test_service_name_survives_hermes_home_adoption_from_unit            PASSED
test_unit_pinned_home_owns_the_bare_name                             PASSED
test_foreign_home_without_installed_unit_keeps_its_suffix            PASSED
test_home_not_pinned_by_unit_keeps_its_suffix                        PASSED
test_bare_unit_pinning_a_named_profile_home_keeps_the_bare_name      PASSED
test_real_unit_sync_keeps_the_name_it_validated                      PASSED
test_unreadable_unit_does_not_grant_the_bare_name                    PASSED
7 passed, 111 deselected
```

RED proof on the same host, with `hermes_cli/gateway.py` restored from `origin/main` and the tests kept:

```
AssertionError: assert 'hermes-gateway-54de6eee' == 'hermes-gateway'   # adoption flips the name
AssertionError: assert 'hermes-gateway-f6a72c95' == 'hermes-gateway'   # unit-pinned home not recognised
AssertionError: assert 'hermes-gateway-kimi'     == 'hermes-gateway'   # profile branch wins -> wrong unit
os.environ["HERMES_HOME"] == str(alice_home)                           # real sync path
4 failed, 3 passed, 111 deselected
```

The three guard tests stay green on the unpatched tree, which is what they are for. The `-kimi` failure is the one that proves the disjunct order is load-bearing.

Whole file, identical command on both trees, on that Linux host:

| tree | result |
|---|---|
| `origin/main` `1021a032` | 4 failed, **106** passed, 1 skipped |
| this branch `5f9fe4cd95` | 4 failed, **113** passed, 1 skipped |

Same four pre-existing failures (`TestSystemUnitHermesHome`, `TestGeneratedUnitIncludesLocalBin`, `TestMigrateLegacyCommand`, `TestGatewayStatusParser` — all reproduce on unmodified `main`), plus exactly the seven new passes.

### 4. Suite comparison (base vs branch, identical commands)

| Scope | Base `1021a032` | This branch | Delta |
|---|---|---|---|
| `tests/hermes_cli/test_gateway_service.py` (POSIX stubs, see limitations) | 41 failed, 68 passed, 2 skipped | 41 failed, **72** passed, 2 skipped | **+4 passed**, same 41 failures |
| `tests/hermes_cli/test_gateway.py` | 35 passed, 5 skipped | 35 passed, 5 skipped | unchanged |
| `test_profiles.py` + `test_service_manager.py` + `test_gateway_s6_dispatch.py` + `test_gateway_service_paths.py` | 8 failed, 62 passed, 2 skipped | 8 failed, 62 passed, 2 skipped | unchanged |

Every failure above reproduces identically on the unmodified base and is a Windows/POSIX environment artefact (`No module named 'pwd'`, `os has no attribute getuid`, `os.mkfifo`, `WinError 1314` symlink privilege), not a regression from this change.

Also run: `python -m ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py` → **All checks passed!**; `python -m py_compile` on both files → OK; `scripts/check_compat_pointers.py` → "no in-tree dependency on the 2091 plugin-compat pointers"; `git diff --check` → no whitespace errors; committed blobs verified LF (no CRLF leakage from the Windows checkout).

## Review follow-ups (second commit `5f9fe4cd95`)

Found by auditing the first commit rather than by review feedback; recorded here so the reasoning is on the record.

- **The unit anchor is now Linux-gated.** `_profile_suffix()` is not systemd-only: it also feeds `get_launchd_plist_path()`, `get_launchd_label()`, `gateway_windows.py::get_task_name()` and the `_current_profile_name()` fallback. Reading a systemd unit to decide a launchd label or a Windows task name is wrong in principle, so `_bare_unit_pinned_home()` returns early off Linux. The gate is `is_linux()` deliberately: `supports_systemd_services()` can shell out to `systemctl is-system-running` on WSL/containers, which must never happen in a helper invoked on every name resolution.
- **Measured cost, since the helper made a pure function do I/O.** Isolating each component of `_profile_suffix()` on a non-default home (20k iterations): `_bare_unit_pinned_home()` ≈ **19 µs/call** on the miss path, against `get_hermes_home().resolve()` ≈ 355 µs and `get_default_hermes_root()` ≈ 117 µs — both pre-existing. The new read is ~3% of the call, and the native-default check short-circuits before it in the common case. No caching was added, because `hermes_cli/profiles.py::_cleanup_gateway_service` swaps `HERMES_HOME` mid-process and depends on re-derivation.
- **The disjunct order is load-bearing and is now pinned.** `install --system` resolves the bare name from root's default, then writes the invoking user's remapped home into the unit, so a bare unit can legitimately pin `<root>/profiles/<name>`. Profile-branch-first would answer `hermes-gateway-kimi` for a unit installed bare. Documented in the docstring and covered by a test that fails on `main` with exactly that string.
- **Three further regressions**: the named-profile-pinned bare unit; a test that drives the real `_sync_hermes_home_from_systemd_unit()` instead of simulating the adoption with `setenv`; and an unreadable unit (`PermissionError`), which must fall through to the suffix branches instead of granting its bare name to an unrelated home.
- **Checked and deliberately not changed:** `_current_profile_name()` is unaffected — `profile_name_for_home()` answers `default` before the `or _profile_suffix()` fallback is reached (verified by executing both). `_wait_for_systemd_service_restart()` resolves the name once *before* its poll loop, so a 150 s wait adds zero extra reads. The parser's known limits (multiple assignments on one `Environment=` line, `EnvironmentFile=`) are **pre-existing upstream behaviour**, unreachable from Hermes-generated units, and out of scope for this regression fix.
- **Known residual, proposed as a follow-up rather than scope creep:** when the only installed system unit is non-bare (e.g. `hermes-gateway-fbdca692.service` for a custom home), `sudo hermes gateway start --system` still exits 1 at `_require_service_installed()` with "Gateway service is not installed", because the preamble derives the bare path. That is unchanged by this PR — neither improved nor worsened — and closing it needs a unit-discovery policy (ambiguity handling for multiple units) that does not belong in a P1 regression fix.

## Limitations — what was NOT verified

- **Tests now run on a real Linux kernel; a live `sudo ... --system` receipt is still missing.** The suite below was executed under WSL2 (`Linux 6.6.87.1-microsoft-standard-WSL2 x86_64`, Python 3.12.13), so the `linux_only` class is verified on the host it targets rather than by simulation. What is still absent is an end-to-end run of `sudo hermes gateway start --system` against a live systemd PID 1 with an installed unit: that distro has no systemd (`/etc/systemd` absent) and Docker Desktop would not start here. The resolver is proven on Linux; the systemctl round trip is not, and I will not claim it.
- **`scripts/run_tests.sh` could not run here**: `error: no virtualenv with pytest found in <worktree>/.venv or <worktree>/venv, and HERMES_PYTHON is not a python with pytest`. All results above come from an explicit interpreter (Python 3.11.15) with `TZ=UTC`, `LANG=C.UTF-8` and a temp `HERMES_HOME`, which is **not** the canonical wrapper. CI's Linux lane is the authoritative run.
- `tests/hermes_cli/test_gateway_service.py` `importorskip("pwd")`s on Windows, so it reports `1 skipped` natively here. To avoid shipping never-executed tests, the four new tests were run locally with minimal `pwd`/`grp` stubs on `PYTHONPATH` (outside the repo). Those stubs are what produce the 41 pre-existing failures in the table above — they are a local workaround, not a repo change, and are the reason the base/branch comparison is presented side by side under identical conditions.
- macOS launchd and the Windows Scheduled-Task path were analysed from code and found unaffected by this mid-command flip; neither was exercised on its native host.
- `restart --system`'s graceful-PID fallback and the fleet-restart interaction in `update_cmd_fleet.py` were traced but not executed.

## Security considerations

Not a security fix, and **out of scope** under `SECURITY.md` §3.1 (no OS-isolation escape, no unauthorized external-surface access, no credential exfiltration, no documented trust-boundary violation).

Worth stating explicitly because the alternative design was identity-based: this PR deliberately does **not** derive a privileged identity from `SUDO_USER`, an inherited environment variable that proves propagation rather than lineage. The basis it reads is a root-owned file under `/etc/systemd/system`, which an unprivileged user cannot write. The name still feeds only the fixed `_SYSTEM_UNIT_DIR / f"{name}.service"` construction (`gateway.py:1998-2002`), so no attacker-chosen path reaches `unlink`/`write_text`; the pinned value is parsed with the existing parser and used solely as an equality comparand against the resolved home, never interpolated into a command. Pre-existing hardening is unchanged: the uninstall ownership guard (`:3223-3234`) and the temp-home write refusal (`:2936-2946`).

Independently noted while reading the issue's debug bundle, unrelated to this diff and **not** fixed here: the reporter observes that `agent/redact.py::_SENSITIVE_QUERY_PARAMS` has no entry for the Lark/Feishu `access_key=` / `ticket=` query params that appear in `gateway.log`. Those are short-lived per-connection session values rather than app credentials. Flagging it for triage as a separate item, not claiming it as a vulnerability.

## Commit / branch / CI readback

- Commits: `789d36467d2ab487c6b09f5fffe76d2b197700f2` — `fix(gateway): anchor system service identity on the installed unit`; `5f9fe4cd95eb540d25f1fec2be2d382bd4a2def1` — `fix(gateway): keep the unit anchor Linux-only and pin the order it depends on`
- Branch: `JoaoMarcos44:fix/108674-unit-anchored-service-identity`; base `NousResearch/hermes-agent@main`
- Base commit: `1021a0325696e9070e6659f95fcd84c3e7e114df` — `git rev-list --left-right --count origin/main...HEAD` → `0  1` (not stale at push time)
- Remote head readback: `5f9fe4cd95eb540d25f1fec2be2d382bd4a2def1` (matches local `HEAD`); both commits authored and committed by `JoaoMarcos44`, no `Co-authored-by`/cherry-pick trailers
- Diff: 2 files changed, 199 insertions(+), 15 deletions(-)
- CI: not yet reported at the time of writing — to be read back after the checks run. No check is claimed green here.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate — #108681 and #93386 reviewed in detail above; ownership of #108681 explicitly preserved
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run in full**; targeted suites were run and compared against the base, and the canonical wrapper was unavailable (see Limitations)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (Python 3.11.15), with the honest limitations recorded above

### Documentation & Housekeeping

- [x] Documentation changes are N/A — naming semantics for users are unchanged (`hermes-gateway` stays `hermes-gateway`); the rationale lives in the docstrings. The docs referencing `hermes-gateway` were checked and need no update.
- [x] `cli-config.yaml.example` changes are N/A — no config keys added or changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A
- [x] Cross-platform impact considered — launchd, Windows Scheduled Task and s6 analysed explicitly; the new helper is POSIX-path-only in effect and imports nothing platform-specific
- [x] Tool descriptions/schemas are N/A

Fixes https://github.com/NousResearch/hermes-agent/issues/108674