### PR TITLE
fix(gateway): propagate launchd stop failures and bound bootstrap retries

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3548,13 +3548,26 @@ def _launchctl_domain_unsupported(returncode: int) -> bool:
 _LAUNCHCTL_BOOTSTRAP_EIO = 5
 
 
-def _launchctl_bootstrap(domain: str, plist_path, label: str, *, timeout: int = 30) -> None:
+def _launchctl_remaining_timeout(deadline: float, timeout: float) -> float:
+    """Cap one launchctl operation by the shared monotonic deadline."""
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise subprocess.TimeoutExpired("launchctl", timeout)
+    return min(timeout, remaining)
+
+
+def _launchctl_bootstrap(
+    domain: str, plist_path, label: str, *, timeout: float = 30,
+    deadline: float | None = None,
+) -> None:
     """Bootstrap a launchd job, recovering from a stale still-registered label (EIO 5). Without the
     bootout + retry that case is misread as an unmanageable domain and degrades to detached, silently
     losing auto-start and crash-restart."""
+    if deadline is None:
+        deadline = time.monotonic() + timeout
     bootstrap = ["launchctl", "bootstrap", domain, str(plist_path)]
     try:
-        subprocess.run(bootstrap, check=True, timeout=timeout)
+        subprocess.run(bootstrap, check=True, timeout=_launchctl_remaining_timeout(deadline, timeout))
     except subprocess.CalledProcessError as exc:
         if exc.returncode != _LAUNCHCTL_BOOTSTRAP_EIO:
             raise
@@ -3563,8 +3576,8 @@ def _launchctl_bootstrap(domain: str, plist_path, label: str, *, timeout: int = 
         # unloaded), so its expected 3/113/125 stderr must not leak to the terminal.
         subprocess.run(
             ["launchctl", "bootout", f"{domain}/{label}"],
-            check=False, timeout=timeout, **_CAPTURE_TEXT)
-        subprocess.run(bootstrap, check=True, timeout=timeout)
+            check=False, timeout=_launchctl_remaining_timeout(deadline, timeout), **_CAPTURE_TEXT)
+        subprocess.run(bootstrap, check=True, timeout=_launchctl_remaining_timeout(deadline, timeout))
 
 
 def _launchd_reload_log_path() -> Path:
@@ -3591,11 +3604,11 @@ def _launchd_reload_budget() -> float:
     return max(30.0, _get_restart_drain_timeout())
 
 
-def _launchctl_label_supervising_process(label: str) -> bool:
+def _launchctl_label_supervising_process(label: str, *, timeout: float = 10) -> bool:
     """True when launchd knows ``label`` AND runs a process for it. ``launchctl list`` exits 0 for a
     mere registered definition (``state = not running`` on macOS 26+), so a positive PID is required."""
     try:
-        result = subprocess.run(["launchctl", "list", label], check=False, timeout=10, **_CAPTURE_TEXT)
+        result = subprocess.run(["launchctl", "list", label], check=False, timeout=timeout, **_CAPTURE_TEXT)
     except (subprocess.TimeoutExpired, OSError):
         return False
     return result.returncode == 0 and _parse_launchd_pid_from_list_output(result.stdout) is not None
@@ -3608,10 +3621,14 @@ def _retry_launchctl_bootstrap_until_registered(
     load bootstrap can fail even after bootout, during a drain (default 180s) — ~10s is too short."""
     attempt = 0
     while True:
+        if time.monotonic() >= deadline:
+            return False
         attempt += 1
         try:
-            _launchctl_bootstrap(domain, plist_path, label, timeout=30)
-            if _launchctl_label_supervising_process(label):
+            _launchctl_bootstrap(domain, plist_path, label, timeout=30, deadline=deadline)
+            if _launchctl_label_supervising_process(
+                label, timeout=_launchctl_remaining_timeout(deadline, 10),
+            ):
                 return True
             outcome = f"exited 0 but {domain}/{label} has no supervised process (launchctl list)"
         except subprocess.CalledProcessError as exc:
@@ -3619,9 +3636,10 @@ def _retry_launchctl_bootstrap_until_registered(
         except subprocess.TimeoutExpired:
             outcome = f"timed out for {domain}/{label}"
         _append_launchd_reload_log(f"bootstrap attempt {attempt} {outcome} — retrying")
-        if time.monotonic() >= deadline:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
             return False
-        time.sleep(2)
+        time.sleep(min(2, remaining))
 
 
 # launchd-unsupported marker: written when the domain can't be managed (exit 5/125, macOS 26+) so
@@ -4006,10 +4024,8 @@ def launchd_install(force: bool = False):
 
 def launchd_uninstall():
     plist_path = get_launchd_plist_path()
-    # Captured: uninstalling an already-unloaded job is fine — don't print Boot-out failed: 3.
-    subprocess.run(
-        ["launchctl", "bootout", f"{_launchd_domain()}/{get_launchd_label()}"],
-        check=False, timeout=90, **_CAPTURE_TEXT)
+    if launchd_stop() is False:
+        raise LaunchdStopError("Gateway did not stop; preserving the launchd plist")
     if plist_path.exists():
         plist_path.unlink()
         print(f"✓ Removed {plist_path}")
@@ -4066,7 +4082,11 @@ def _launchd_ok(message: str) -> None:
     _clear_launchd_unsupported_marker()
 
 
-def launchd_stop():
+class LaunchdStopError(RuntimeError):
+    """The launchd gateway could not be confirmed stopped."""
+
+
+def launchd_stop() -> bool:
     target = f"{_launchd_domain()}/{get_launchd_label()}"
     _mark_planned_stop()
     # bootout unloads the definition so KeepAlive doesn't respawn; `hermes gateway start` re-bootstraps.
@@ -4080,14 +4100,22 @@ def launchd_stop():
         # below.
         if not (_launchd_error_indicates_unloaded(e) or _launchctl_domain_unsupported(e.returncode)):
             raise
-    _wait_for_gateway_exit(timeout=10.0, force_after=5.0)
+    if not _wait_for_gateway_exit(timeout=10.0, force_after=5.0):
+        return False
     print("✓ Service stopped")
+    return True
 
 
 def _wait_for_gateway_exit(timeout: float = 10.0, force_after: float | None = 5.0) -> bool:
     """Wait up to ``timeout`` s for the gateway (by gateway.pid, not launchd labels, so multiple
     HERMES_HOMEs work) to exit; SIGKILL it after ``force_after`` s of graceful waiting."""
     from gateway.status import get_process_start_time, get_running_pid
+    original_pid = get_running_pid()
+    if original_pid is None:
+        return True
+    original_start = get_process_start_time(original_pid)
+    if original_start is None:
+        return get_running_pid() is None
     deadline = time.monotonic() + timeout
     force_deadline = (time.monotonic() + force_after) if force_after is not None else None
     force_sent = False
@@ -4097,13 +4125,16 @@ def _wait_for_gateway_exit(timeout: float = 10.0, force_after: float | None = 5.
         if pid is None:
             return True  # Process exited cleanly.
 
+        if pid != original_pid or get_process_start_time(pid) != original_start:
+            return False  # Never signal a replacement or an unverified identity.
+
         if force_after is not None and not force_sent and time.monotonic() >= force_deadline:
             # Grace period expired — force-kill the specific PID.
             try:
-                terminate_pid(pid, force=True, expected_start_time=get_process_start_time(pid))
+                terminate_pid(original_pid, force=True, expected_start_time=original_start)
                 print(f"⚠ Gateway PID {pid} did not exit gracefully; sent SIGKILL")
             except (ProcessLookupError, PermissionError, OSError):
-                return True  # Already gone or we can't touch it.
+                return get_running_pid() is None
             force_sent = True
 
         time.sleep(0.3)
@@ -5524,7 +5555,10 @@ def _service_call(backend: str, verb: str, system: bool | None = False) -> None:
     if backend == "windows":
         return getattr(_gw_windows(), verb)()
     if backend == "launchd":
-        return globals()[f"launchd_{verb}"]()
+        result = globals()[f"launchd_{verb}"]()
+        if verb == "stop" and result is False:
+            raise LaunchdStopError("Gateway did not stop")
+        return result
     fn = globals()[f"systemd_{verb}"]
     return fn() if system is None else fn(system=system)
 
@@ -5769,6 +5803,9 @@ def gateway_command(args):
     """Handle gateway subcommands."""
     try:
         return _gateway_command_inner(args)
+    except LaunchdStopError as e:
+        print_error(str(e))
+        sys.exit(1)
     except UserSystemdUnavailableError as e:
         # Actionable message, not a traceback, when the user D-Bus session is unreachable.
         print_error("User systemd not reachable:")

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -173,6 +173,11 @@ class LaunchdServiceManager(_HostServiceManager):
     _backend = "gateway"
     _fn_prefix = "launchd_"
 
+    def stop(self, name: str) -> None:
+        backend = self._backend_module()
+        if backend.launchd_stop() is False:
+            raise backend.LaunchdStopError("Gateway did not stop")
+
     def is_running(self, name: str) -> bool:
         return self._backend_module()._probe_launchd_service_running()
 

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -481,6 +481,7 @@ class TestWaitForGatewayExit:
         monkeypatch.setattr("time.monotonic", fake_monotonic)
         monkeypatch.setattr("time.sleep", lambda _: None)
         monkeypatch.setattr("gateway.status.get_running_pid", mock_get_running_pid)
+        monkeypatch.setattr("gateway.status.get_process_start_time", lambda pid: 1000.0)
         monkeypatch.setattr(gateway, "terminate_pid", mock_terminate)
 
         gateway._wait_for_gateway_exit(timeout=10.0, force_after=5.0)

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1365,6 +1365,7 @@ class TestSystemUnitHermesHome:
 
     def test_system_unit_uses_target_user_home_not_calling_user(self, monkeypatch):
         # Simulate sudo: Path.home() returns /root, target user is alice
+        monkeypatch.setattr(gateway_cli, "_append_node_dir_for_service", lambda *args: None)
         monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/root")))
         monkeypatch.delenv("HERMES_HOME", raising=False)
         monkeypatch.setattr(
@@ -1595,13 +1596,13 @@ class TestSystemServiceIdentityRootHandling:
         monkeypatch.delenv("SUDO_USER", raising=False)
         monkeypatch.setenv("USER", "nobody")
         monkeypatch.setenv("LOGNAME", "nobody")
+        monkeypatch.setattr(pwd, "getpwnam", lambda name: SimpleNamespace(
+            pw_uid=65534, pw_gid=65534, pw_dir="/nonexistent",
+        ))
+        monkeypatch.setattr(grp, "getgrgid", lambda gid: SimpleNamespace(gr_name="nogroup"))
 
-        try:
-            username, group, home, _uid = gateway_cli._system_service_identity(run_as_user=None)
-            assert username == "nobody"
-        except ValueError as e:
-            # "nobody" might not exist on all systems
-            assert "Unknown user" in str(e)
+        username, group, home, uid = gateway_cli._system_service_identity(run_as_user=None)
+        assert (username, group, home, uid) == ("nobody", "nogroup", "/nonexistent", 65534)
 
 
 class TestEnsureUserSystemdEnv:
@@ -1804,6 +1805,8 @@ class TestSystemUnitPathRemapping:
     """System units must remap ALL paths from the caller's home to the target user."""
 
     def test_system_unit_has_no_root_paths(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(gateway_cli, "_append_node_dir_for_service", lambda *args: None)
+        monkeypatch.setattr(gateway_cli, "_build_user_local_paths", lambda *args: [])
         root_home = tmp_path / "root"
         root_home.mkdir()
         project = root_home / ".hermes" / "hermes-agent"
@@ -2673,11 +2676,13 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
-        monkeypatch.setattr(gateway_cli.time, "sleep", lambda *_a, **_k: None)
+        now = [0.0]
+        monkeypatch.setattr(gateway_cli.time, "monotonic", lambda: now[0])
+        monkeypatch.setattr(gateway_cli.time, "sleep", lambda seconds: now.__setitem__(0, now[0] + seconds))
 
         ok = gateway_cli._retry_launchctl_bootstrap_until_registered(
             self.DOMAIN, self.PLIST, self.LABEL,
-            deadline=gateway_cli.time.monotonic() - 1,  # already expired
+            deadline=1.0,  # Allow a real probe before the fake clock expires.
         )
         assert ok is False
         assert list_calls["n"] >= 1

--- a/tests/hermes_cli/test_launchd_public_contracts.py
+++ b/tests/hermes_cli/test_launchd_public_contracts.py
@@ -1,0 +1,268 @@
+"""Launchd lifecycle contracts with fake time and no live process operations."""
+
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from gateway import status
+from hermes_cli import gateway as gateway_cli
+from hermes_cli.service_manager import LaunchdServiceManager, SystemdServiceManager
+
+
+@pytest.fixture(autouse=True)
+def isolated_launchd(monkeypatch, tmp_path):
+    """Trap unintended execution even when a regression is present."""
+    def forbidden(*args, **kwargs):
+        raise AssertionError("unexpected process operation")
+
+    monkeypatch.setattr(subprocess, "Popen", forbidden)
+    monkeypatch.setattr(subprocess, "run", forbidden)
+    monkeypatch.setattr(gateway_cli, "terminate_pid", forbidden)
+    monkeypatch.setattr(status, "get_running_pid", lambda: None)
+    monkeypatch.setattr(status, "get_process_start_time", forbidden)
+    monkeypatch.setattr(gateway_cli, "_mark_planned_stop", lambda: None)
+    monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+    monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+    monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: tmp_path / "gateway.plist")
+    monkeypatch.setattr(gateway_cli, "_append_launchd_reload_log", lambda message: None)
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    clock = SimpleNamespace(now=0.0, sleeps=[])
+
+    def sleep(seconds):
+        clock.sleeps.append(seconds)
+        clock.now += seconds
+
+    monkeypatch.setattr(gateway_cli.time, "monotonic", lambda: clock.now)
+    monkeypatch.setattr(gateway_cli.time, "sleep", sleep)
+    return clock
+
+
+@pytest.mark.parametrize("error", [PermissionError, OSError, ProcessLookupError])
+@pytest.mark.parametrize("exited", [False, True])
+def test_force_error_requires_fresh_absence(monkeypatch, clock, error, exited):
+    live: list[int | None] = [4242]
+    monkeypatch.setattr(status, "get_running_pid", lambda: live[0])
+    monkeypatch.setattr(status, "get_process_start_time", lambda pid: 100)
+
+    def terminate(pid, **kwargs):
+        assert (pid, kwargs) == (4242, {"force": True, "expected_start_time": 100})
+        if exited:
+            live[0] = None
+        raise error("cannot signal")
+
+    monkeypatch.setattr(gateway_cli, "terminate_pid", terminate)
+    assert gateway_cli._wait_for_gateway_exit(timeout=1, force_after=0) is exited
+
+
+@pytest.mark.parametrize("replacement_pid,replacement_start", [(5252, 100), (4242, 200), (4242, None)])
+def test_wait_refuses_replacement_identity(monkeypatch, clock, replacement_pid, replacement_start):
+    monkeypatch.setattr(status, "get_running_pid", lambda: 4242 if clock.now == 0 else replacement_pid)
+    monkeypatch.setattr(status, "get_process_start_time", lambda pid: 100 if clock.now == 0 else replacement_start)
+    terminate = Mock()
+    monkeypatch.setattr(gateway_cli, "terminate_pid", terminate)
+
+    assert gateway_cli._wait_for_gateway_exit(timeout=1, force_after=0.2) is False
+    terminate.assert_not_called()
+
+
+def test_wait_refuses_missing_initial_identity(monkeypatch, clock):
+    monkeypatch.setattr(status, "get_running_pid", lambda: 4242)
+    monkeypatch.setattr(status, "get_process_start_time", lambda pid: None)
+    terminate = Mock()
+    monkeypatch.setattr(gateway_cli, "terminate_pid", terminate)
+
+    assert gateway_cli._wait_for_gateway_exit(timeout=1, force_after=0) is False
+    terminate.assert_not_called()
+
+
+def test_wait_force_keeps_original_identity(monkeypatch, clock):
+    live: list[int | None] = [4242]
+    monkeypatch.setattr(status, "get_running_pid", lambda: live[0])
+    monkeypatch.setattr(status, "get_process_start_time", lambda pid: 100)
+
+    def terminate(pid, **kwargs):
+        assert (pid, kwargs) == (4242, {"force": True, "expected_start_time": 100})
+        live[0] = None
+
+    terminate_mock = Mock(side_effect=terminate)
+    monkeypatch.setattr(gateway_cli, "terminate_pid", terminate_mock)
+    assert gateway_cli._wait_for_gateway_exit(timeout=1, force_after=0.2) is True
+    terminate_mock.assert_called_once()
+
+
+def test_wait_already_absent(monkeypatch, clock):
+    assert gateway_cli._wait_for_gateway_exit(timeout=1) is True
+
+
+@pytest.mark.parametrize("stopped", [False, True])
+def test_stop_reports_observed_outcome(monkeypatch, capsys, stopped):
+    run = Mock(return_value=SimpleNamespace(returncode=0, stdout="", stderr=""))
+    monkeypatch.setattr(subprocess, "run", run)
+    wait = Mock(return_value=stopped)
+    monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", wait)
+
+    assert gateway_cli.launchd_stop() is stopped
+    assert ("✓ Service stopped" in capsys.readouterr().out) is stopped
+    wait.assert_called_once_with(timeout=10.0, force_after=5.0)
+    assert run.call_args.kwargs["capture_output"] is True
+
+
+def test_uninstall_preserves_plist_when_stop_fails(monkeypatch, tmp_path, capsys):
+    plist = tmp_path / "gateway.plist"
+    plist.write_text("existing definition", encoding="utf-8")
+    monkeypatch.setattr(subprocess, "run", Mock(return_value=SimpleNamespace(returncode=0)))
+    monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda **kwargs: False)
+
+    with pytest.raises(RuntimeError) as caught:
+        gateway_cli.launchd_uninstall()
+    assert type(caught.value).__name__ == "LaunchdStopError"
+    assert plist.read_text(encoding="utf-8") == "existing definition"
+    assert "✓ Service uninstalled" not in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("entry", ["facade", "installed", "manager", "cli"])
+def test_failed_stop_propagates_through_public_callers(monkeypatch, entry, capsys):
+    monkeypatch.setattr(subprocess, "run", Mock(return_value=SimpleNamespace(returncode=0)))
+    monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda **kwargs: False)
+    monkeypatch.setattr(gateway_cli, "_installed_service_kind", lambda: "launchd")
+
+    def invoke():
+        if entry == "facade":
+            return gateway_cli._service_call("launchd", "stop")
+        if entry == "installed":
+            return gateway_cli._stop_installed_service(False)
+        if entry == "manager":
+            return LaunchdServiceManager().stop("ignored")
+        monkeypatch.setattr(gateway_cli, "_gateway_command_inner", lambda args: gateway_cli._stop_installed_service(False))
+        return gateway_cli.gateway_command(SimpleNamespace(gateway_command="stop"))
+
+    with pytest.raises(SystemExit if entry == "cli" else RuntimeError) as caught:
+        invoke()
+    if entry == "cli":
+        assert isinstance(caught.value, SystemExit)
+        assert caught.value.code == 1
+    else:
+        assert type(caught.value).__name__ == "LaunchdStopError"
+    assert "✓ Service stopped" not in capsys.readouterr().out
+
+
+def test_stop_success_through_launchd_manager(monkeypatch):
+    monkeypatch.setattr(gateway_cli, "launchd_stop", lambda: True)
+    assert LaunchdServiceManager().stop("ignored") is None
+
+
+def test_systemd_false_return_keeps_native_semantics(monkeypatch):
+    monkeypatch.setattr(gateway_cli, "systemd_stop", lambda **kwargs: False)
+    assert gateway_cli._service_call("systemd", "stop") is False
+    assert SystemdServiceManager().stop("ignored") is None
+
+
+@pytest.mark.parametrize("deadline,spent,expected", [
+    (None, (27, 2), [30, 3, 1]),
+    (5, (4, 0.5), [5, 1, 0.5]),
+])
+def test_bootstrap_eio_recovery_shares_one_budget(monkeypatch, clock, deadline, spent, expected):
+    calls = []
+
+    def run(cmd, **kwargs):
+        calls.append((cmd[1], kwargs))
+        if len(calls) == 1:
+            clock.now += spent[0]
+            raise subprocess.CalledProcessError(5, cmd)
+        if cmd[1] == "bootout":
+            clock.now += spent[1]
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", run)
+    options = {} if deadline is None else {"deadline": deadline}
+    gateway_cli._launchctl_bootstrap("gui/501", "gateway.plist", "ai.hermes.gateway", **options)
+    assert [verb for verb, kwargs in calls] == ["bootstrap", "bootout", "bootstrap"]
+    assert [kwargs["timeout"] for verb, kwargs in calls] == expected
+    assert calls[1][1]["capture_output"] is True
+
+
+@pytest.mark.parametrize("entry", ["bootstrap", "retry"])
+def test_expired_deadline_does_no_work(monkeypatch, clock, entry):
+    run = Mock(return_value=SimpleNamespace(returncode=0, stdout='"PID" = 4242;', stderr=""))
+    monkeypatch.setattr(subprocess, "run", run)
+    if entry == "bootstrap":
+        with pytest.raises(subprocess.TimeoutExpired):
+            gateway_cli._launchctl_bootstrap("gui/501", "gateway.plist", "ai.hermes.gateway", deadline=0)
+    else:
+        assert gateway_cli._retry_launchctl_bootstrap_until_registered(
+            "gui/501", "gateway.plist", "ai.hermes.gateway", deadline=0,
+        ) is False
+    run.assert_not_called()
+    assert clock.sleeps == []
+
+
+@pytest.mark.parametrize("spent", [9, 10])
+def test_retry_bounds_supervision_probe_by_remaining_time(monkeypatch, clock, spent):
+    calls = []
+
+    def run(cmd, **kwargs):
+        calls.append((cmd[1], kwargs["timeout"]))
+        if cmd[1] == "bootstrap":
+            clock.now += spent
+        return SimpleNamespace(returncode=0, stdout='"PID" = 4242;', stderr="")
+
+    monkeypatch.setattr(subprocess, "run", run)
+    assert gateway_cli._retry_launchctl_bootstrap_until_registered(
+        "gui/501", "gateway.plist", "ai.hermes.gateway", deadline=10,
+    ) is (spent < 10)
+    assert calls == ([("bootstrap", 10), ("list", 1)] if spent == 9 else [("bootstrap", 10)])
+    assert clock.sleeps == []
+
+
+def test_retry_forwards_deadline_and_caps_final_sleep(monkeypatch, clock):
+    bootstrap = Mock(side_effect=subprocess.CalledProcessError(1, ["launchctl", "bootstrap"]))
+    monkeypatch.setattr(gateway_cli, "_launchctl_bootstrap", bootstrap)
+
+    assert gateway_cli._retry_launchctl_bootstrap_until_registered(
+        "gui/501", "gateway.plist", "ai.hermes.gateway", deadline=0.5,
+    ) is False
+    assert clock.sleeps == [0.5]
+    bootstrap.assert_called_once_with(
+        "gui/501", "gateway.plist", "ai.hermes.gateway", timeout=30, deadline=0.5,
+    )
+
+
+@pytest.mark.parametrize("code", [1, 5, 125])
+def test_bootstrap_preserves_terminal_error_for_native_callers(monkeypatch, clock, code):
+    calls = []
+    failure = subprocess.CalledProcessError(code, ["launchctl", "bootstrap"], stderr="diagnostic")
+
+    def run(cmd, **kwargs):
+        calls.append(cmd[1])
+        if cmd[1] == "bootstrap":
+            raise failure
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", run)
+    with pytest.raises(subprocess.CalledProcessError) as caught:
+        gateway_cli._launchctl_bootstrap("gui/501", "gateway.plist", "ai.hermes.gateway")
+    assert caught.value is failure
+    assert caught.value.stderr == "diagnostic"
+    assert calls == (["bootstrap", "bootout", "bootstrap"] if code == 5 else ["bootstrap"])
+
+
+def test_bootstrap_stops_recovery_when_bootout_uses_remaining_budget(monkeypatch, clock):
+    calls = []
+
+    def run(cmd, **kwargs):
+        calls.append((cmd[1], kwargs["timeout"]))
+        if cmd[1] == "bootstrap" and len(calls) == 1:
+            clock.now += 29
+            raise subprocess.CalledProcessError(5, cmd)
+        clock.now += 1
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", run)
+    with pytest.raises(subprocess.TimeoutExpired):
+        gateway_cli._launchctl_bootstrap("gui/501", "gateway.plist", "ai.hermes.gateway")
+    assert calls == [("bootstrap", 30), ("bootout", 1)]


### PR DESCRIPTION
A failed macOS gateway stop can report success or continue with service removal. Propagate a typed stop failure through the service manager and CLI, wait for the original process identity, and remove the service definition only after a successful stop.

Bootstrap, EIO recovery and registration retries now share one monotonic timeout budget. This preserves the existing restart, reload and profile ownership checks. Refresh-exhaustion reporting (#68493) and reload-publication changes (#5110) are separate from this patch.

Validation: the four complete launchd-contract, gateway-service, service-manager and legacy gateway test files produced 186 passed, 5 skipped and one baseline-identical PTY-allocation failure in an isolated macOS run against current upstream. The failed case cannot allocate a PTY before launching its child process; it is not counted as passing. Process/service boundaries were faked, with no live service interruption.