### PR TITLE
Add guarded Discord administration actions

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1445,6 +1445,8 @@ DEFAULT_CONFIG = {
         # list_channels, channel_info, list_roles, member_info, search_members, fetch_messages,
         # list_pins, pin_message, unpin_message, create_thread, add_role, remove_role.
         "server_actions": "",
+        # Destructive Discord guild leaves are fail-closed; configure numeric ID strings explicitly.
+        "leave_guild_ids": [],
         # DEPRECATED no-op (uploads are always cached; messaging auth is the gate). Kept so existing
         # configs don't error. Env: DISCORD_ALLOW_ANY_ATTACHMENT.
         "allow_any_attachment": False,

--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -3,7 +3,7 @@
 import json
 import urllib.error
 from io import BytesIO
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -17,6 +17,7 @@ from tools.discord_tool import (
     _detect_capabilities,
     _discord_request,
     _get_bot_token,
+    _load_leave_guild_ids,
     _load_allowed_actions_config,
     _reset_capability_cache,
     check_discord_tool_requirements,
@@ -146,7 +147,21 @@ class TestDiscordRequest:
         req = call_args[0][0]
         assert "https://discord.com/api/v10/test" in req.full_url
         assert req.get_header("Authorization") == "Bot token123"
+        assert req.get_header("Content-Type") is None
+        assert req.data is None
         assert req.get_method() == "GET"
+
+    @patch("tools.discord_tool.urllib.request.urlopen")
+    def test_json_body_sets_content_type(self, mock_urlopen_fn):
+        mock_urlopen_fn.return_value = _mock_urlopen({"ok": True})
+        result = _discord_request("POST", "/test", "token123", body={"name": "Beta Guild"})
+        assert result == {"ok": True}
+
+        req = mock_urlopen_fn.call_args.args[0]
+        assert req.data == b'{"name": "Beta Guild"}'
+        assert req.get_header("Content-type") == "application/json"
+        assert req.get_header("Authorization") == "Bot token123"
+        assert req.get_header("User-agent") == "Hermes-Agent (https://github.com/NousResearch/hermes-agent)"
 
 
     @patch("tools.discord_tool.urllib.request.urlopen")
@@ -305,6 +320,704 @@ class TestCreateThread:
             "POST", "/channels/11/messages/1001/threads", "test-token",
             body={"name": "Discussion", "auto_archive_duration": 1440},
         )
+
+
+class TestCreateGuildChannels:
+    @pytest.mark.parametrize(
+        "action, channel_type",
+        [("create_category", 4), ("create_text_channel", 0), ("create_forum", 15)],
+    )
+    @patch("tools.discord_tool._discord_request")
+    def test_creation_uses_the_action_channel_type(
+        self, mock_req, monkeypatch, action, channel_type,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = [[], {"id": "800", "name": "project"}]
+
+        result = json.loads(discord_admin_handler(
+            action=action, guild_id="111", name="project",
+        ))
+
+        assert result == {
+            "guild_id": "111", "channel_id": "800", "name": "project",
+            "type": _channel_type_name(channel_type), "created": True,
+        }
+        assert mock_req.call_args_list[0].args == (
+            "GET", "/guilds/111/channels", "test-token",
+        )
+        assert mock_req.call_args_list[1].args == (
+            "POST", "/guilds/111/channels", "test-token",
+        )
+        assert mock_req.call_args_list[1].kwargs["body"]["type"] == channel_type
+
+    @patch("tools.discord_tool._discord_request")
+    def test_exact_existing_channel_is_returned_without_post(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = [
+            {"id": "700", "name": "Projects", "type": 4, "parent_id": None},
+            {"id": "800", "name": "project", "type": 15, "parent_id": "700"},
+        ]
+
+        result = json.loads(discord_admin_handler(
+            action="create_forum", guild_id="111", name="project", category_id="700",
+        ))
+
+        assert result["channel_id"] == "800"
+        assert result["created"] is False
+        mock_req.assert_called_once_with("GET", "/guilds/111/channels", "test-token")
+
+    @pytest.mark.parametrize(
+        "channels",
+        [
+            [],
+            [{"id": "700", "name": "not-a-category", "type": 0, "parent_id": None}],
+        ],
+    )
+    @patch("tools.discord_tool._discord_request")
+    def test_creation_rejects_invalid_category_before_post(
+        self, mock_req, monkeypatch, channels,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = channels
+
+        result = json.loads(discord_admin_handler(
+            action="create_text_channel", guild_id="111", name="project", category_id="700",
+        ))
+
+        assert "error" in result
+        assert "category_id" in result["error"]
+        mock_req.assert_called_once_with("GET", "/guilds/111/channels", "test-token")
+
+    @patch("tools.discord_tool._discord_request")
+    def test_same_name_incompatible_channel_fails_without_post(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = [
+            {"id": "800", "name": "project", "type": 0, "parent_id": None},
+        ]
+        result = json.loads(discord_admin_handler(
+            action="create_forum", guild_id="111", name="project",
+        ))
+        assert "error" in result
+        assert "different type or category" in result["error"]
+        mock_req.assert_called_once_with("GET", "/guilds/111/channels", "test-token")
+
+    @patch("tools.discord_tool._discord_request")
+    def test_same_name_channel_with_requested_field_mismatch_is_not_compatible(
+        self, mock_req, monkeypatch,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = [
+            {
+                "id": "800", "name": "project", "type": 15, "parent_id": None,
+                "topic": "old",
+            },
+        ]
+        result = json.loads(discord_admin_handler(
+            action="create_forum", guild_id="111", name="project", topic="new",
+        ))
+        assert "error" in result
+        assert "requested settings" in result["error"]
+        mock_req.assert_called_once_with("GET", "/guilds/111/channels", "test-token")
+
+    @patch("tools.discord_tool._discord_request")
+    def test_optional_fields_and_zero_overwrite_values_are_preserved(
+        self, mock_req, monkeypatch,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = [
+            [{"id": "700", "name": "Projects", "type": 4, "parent_id": None}],
+            {"id": "800", "name": "project"},
+        ]
+        overwrites = [{"id": "222", "type": 0, "allow": 0, "deny": 0}]
+
+        result = json.loads(discord_admin_handler(
+            action="create_forum", guild_id="111", name="project", category_id="700",
+            topic="Work", position=0, nsfw=False, rate_limit_per_user=0,
+            permission_overwrites=overwrites,
+        ))
+
+        assert result["created"] is True
+        assert mock_req.call_args_list[1].kwargs["body"] == {
+            "name": "project", "type": 15, "parent_id": "700", "topic": "Work",
+            "position": 0, "nsfw": False, "rate_limit_per_user": 0,
+            "permission_overwrites": [{"id": "222", "type": 0, "allow": "0", "deny": "0"}],
+        }
+
+    @pytest.mark.parametrize(
+        "overwrites",
+        [
+            "not-an-array",
+            [{"id": "222", "type": 2, "allow": 0, "deny": 0}],
+            [{"id": "bad", "type": 0, "allow": 0, "deny": 0}],
+            [{"id": "222", "type": 0, "allow": -1, "deny": 0}],
+            [{"id": "222", "type": 0, "allow": None, "deny": 0}],
+            [
+                {"id": "222", "type": 0, "allow": 0, "deny": 0},
+                {"id": "222", "type": 0, "allow": 0, "deny": 0},
+            ],
+            [{"id": str(index + 1), "type": 0, "allow": 0, "deny": 0} for index in range(101)],
+        ],
+    )
+    @patch("tools.discord_tool._discord_request")
+    def test_malformed_overwrites_fail_before_http(
+        self, mock_req, monkeypatch, overwrites,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_admin_handler(
+            action="create_text_channel", guild_id="111", name="project",
+            permission_overwrites=overwrites,
+        ))
+        assert "error" in result
+        assert "permission_overwrites" in result["error"]
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_grant_main_user_adds_only_view_and_manage_overwrites(
+        self, mock_req, monkeypatch,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        monkeypatch.setenv("DISCORD_MAIN_USER_ID", "222")
+        mock_req.side_effect = [[], {"id": "333"}, {"id": "800", "name": "project"}]
+
+        result = json.loads(discord_admin_handler(
+            action="create_text_channel", guild_id="111", name="project",
+            grant_main_user_access=True,
+        ))
+
+        assert result["created"] is True
+        assert mock_req.call_args_list[1].args == ("GET", "/users/@me", "test-token")
+        assert mock_req.call_args_list[2].kwargs["body"]["permission_overwrites"] == [
+            {"id": "222", "type": 1, "allow": "1040", "deny": "0"},
+            {"id": "333", "type": 1, "allow": "1040", "deny": "0"},
+        ]
+
+    @pytest.mark.parametrize(
+        "main_id, allowed",
+        [(None, ""), (None, "*"), (None, "222,333"), ("not-numeric", "222")],
+    )
+    @patch("tools.discord_tool._discord_request")
+    def test_grant_main_user_fails_closed_before_http(
+        self, mock_req, monkeypatch, main_id, allowed,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        if main_id is None:
+            monkeypatch.delenv("DISCORD_MAIN_USER_ID", raising=False)
+        else:
+            monkeypatch.setenv("DISCORD_MAIN_USER_ID", main_id)
+        monkeypatch.setenv("DISCORD_ALLOWED_USERS", allowed)
+
+        result = json.loads(discord_admin_handler(
+            action="create_text_channel", guild_id="111", name="project",
+            grant_main_user_access=True,
+        ))
+
+        assert "error" in result
+        assert "DISCORD_MAIN_USER_ID" in result["error"]
+        mock_req.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "action, params",
+        [
+            ("create_text_channel", {"guild_id": "bad", "name": "x"}),
+            ("create_text_channel", {"guild_id": "111", "name": ""}),
+            ("create_text_channel", {"guild_id": "111", "name": "x", "topic": "x" * 4097}),
+            ("create_text_channel", {"guild_id": "111", "name": "x", "topic": "x" * 1025}),
+            ("create_text_channel", {"guild_id": "111", "name": "x", "position": -1}),
+            ("create_text_channel", {"guild_id": "111", "name": "x", "nsfw": 1}),
+            ("create_text_channel", {"guild_id": "111", "name": "x", "rate_limit_per_user": 21601}),
+            ("create_category", {"guild_id": "111", "name": "x", "topic": "unsupported"}),
+            ("create_category", {"guild_id": "111", "name": "x", "grant_main_user_access": True}),
+            ("create_role", {"guild_id": "111", "name": "x", "color": 0x1000000}),
+            ("create_role", {"guild_id": "111", "name": "x", "hoist": "false"}),
+        ],
+    )
+    @patch("tools.discord_tool._discord_request")
+    def test_creation_boundaries_fail_before_http(self, mock_req, monkeypatch, action, params):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_admin_handler(action=action, **params))
+        assert "error" in result
+        mock_req.assert_not_called()
+
+
+class TestEditGuildChannels:
+    @pytest.mark.parametrize(
+        "action, params, body",
+        [
+            ("rename_channel", {"name": "renamed"}, {"name": "renamed"}),
+            ("set_channel_topic", {"topic": "New topic"}, {"topic": "New topic"}),
+            (
+                "move_channel_to_category", {"category_id": "700", "position": 0},
+                {"parent_id": "700", "position": 0},
+            ),
+        ],
+    )
+    @patch("tools.discord_tool._discord_request")
+    def test_channel_edits_patch_only_requested_fields(
+        self, mock_req, monkeypatch, action, params, body,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        if action == "set_channel_topic":
+            mock_req.side_effect = [{"id": "800", "type": 0}, {"id": "800"}]
+        elif action == "move_channel_to_category":
+            mock_req.side_effect = [
+                {"id": "800", "type": 0, "guild_id": "111"},
+                {"id": "700", "type": 4, "guild_id": "111"},
+                {"id": "800"},
+            ]
+        else:
+            mock_req.return_value = {"id": "800"}
+
+        result = json.loads(discord_admin_handler(
+            action=action, channel_id="800", **params,
+        ))
+
+        assert result == {"channel_id": "800", "updated": True}
+        expected_calls = [call("PATCH", "/channels/800", "test-token", body=body)]
+        if action == "set_channel_topic":
+            expected_calls.insert(0, call("GET", "/channels/800", "test-token"))
+        elif action == "move_channel_to_category":
+            expected_calls[:0] = [
+                call("GET", "/channels/800", "test-token"),
+                call("GET", "/channels/700", "test-token"),
+            ]
+        assert mock_req.call_args_list == expected_calls
+
+    @pytest.mark.parametrize(
+        "destination",
+        [
+            {"id": "700", "type": 0, "guild_id": "111"},
+            {"id": "700", "type": 4, "guild_id": "999"},
+        ],
+    )
+    @patch("tools.discord_tool._discord_request")
+    def test_move_rejects_invalid_category_before_patch(
+        self, mock_req, monkeypatch, destination,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = [
+            {"id": "800", "type": 0, "guild_id": "111"},
+            destination,
+        ]
+
+        result = json.loads(discord_admin_handler(
+            action="move_channel_to_category", channel_id="800", category_id="700",
+        ))
+
+        assert "error" in result
+        assert "category_id" in result["error"]
+        assert mock_req.call_args_list == [
+            call("GET", "/channels/800", "test-token"),
+            call("GET", "/channels/700", "test-token"),
+        ]
+
+    @patch("tools.discord_tool._discord_request")
+    def test_move_rejects_unsupported_source_type_before_patch(
+        self, mock_req, monkeypatch,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "800", "type": 4, "guild_id": "111"}
+
+        result = json.loads(discord_admin_handler(
+            action="move_channel_to_category", channel_id="800", category_id="700",
+        ))
+
+        assert "error" in result
+        assert "channel_id" in result["error"]
+        mock_req.assert_called_once_with("GET", "/channels/800", "test-token")
+
+    @pytest.mark.parametrize(
+        "action, expected_allow, expected_deny, locked",
+        [("lock_channel", "16", "2049", True), ("unlock_channel", "2064", "1", False)],
+    )
+    @patch("tools.discord_tool._discord_request")
+    def test_locking_changes_only_everyone_send_messages_bit(
+        self, mock_req, monkeypatch, action, expected_allow, expected_deny, locked,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = [
+            {
+                "id": "800", "guild_id": "111", "type": 0,
+                "permission_overwrites": [
+                    {"id": "111", "type": 0, "allow": "2064", "deny": "1"},
+                    {"id": "222", "type": 1, "allow": "7", "deny": "8"},
+                ],
+            },
+            {"id": "800"},
+        ]
+
+        result = json.loads(discord_admin_handler(
+            action=action, channel_id="800", guild_id="111",
+        ))
+
+        assert result == {"channel_id": "800", "guild_id": "111", "locked": locked}
+        assert mock_req.call_args_list[1].args == (
+            "PUT", "/channels/800/permissions/111", "test-token",
+        )
+        assert mock_req.call_args_list[1].kwargs["body"] == {
+            "type": 0, "allow": expected_allow, "deny": expected_deny,
+        }
+
+    @patch("tools.discord_tool._discord_request")
+    def test_lock_refuses_channel_from_another_guild(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "800", "guild_id": "999", "permission_overwrites": []}
+
+        result = json.loads(discord_admin_handler(
+            action="lock_channel", channel_id="800", guild_id="111",
+        ))
+
+        assert "error" in result
+        assert "guild_id" in result["error"]
+        mock_req.assert_called_once_with("GET", "/channels/800", "test-token")
+
+    @pytest.mark.parametrize("channel_type", [2, 4, 13])
+    @patch("tools.discord_tool._discord_request")
+    def test_lock_rejects_unsupported_channel_type_before_put(
+        self, mock_req, monkeypatch, channel_type,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {
+            "id": "800", "guild_id": "111", "type": channel_type,
+            "permission_overwrites": [],
+        }
+
+        result = json.loads(discord_admin_handler(
+            action="lock_channel", channel_id="800", guild_id="111",
+        ))
+
+        assert "error" in result
+        assert "channel_id" in result["error"]
+        mock_req.assert_called_once_with("GET", "/channels/800", "test-token")
+
+    @patch("tools.discord_tool._discord_request")
+    def test_set_topic_rejects_non_forum_limit_before_http(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "800", "type": 0}
+        result = json.loads(discord_admin_handler(
+            action="set_channel_topic", channel_id="800", topic="x" * 1025,
+        ))
+        assert "error" in result
+        assert "1024" in result["error"]
+        mock_req.assert_called_once_with("GET", "/channels/800", "test-token")
+
+    @patch("tools.discord_tool._discord_request")
+    def test_set_topic_allows_forum_limit(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = [{"id": "800", "type": 15}, {"id": "800"}]
+        result = json.loads(discord_admin_handler(
+            action="set_channel_topic", channel_id="800", topic="x" * 4096,
+        ))
+        assert result == {"channel_id": "800", "updated": True}
+        assert mock_req.call_args_list == [
+            call("GET", "/channels/800", "test-token"),
+            call("PATCH", "/channels/800", "test-token", body={"topic": "x" * 4096}),
+        ]
+
+
+class TestManageRoles:
+    @patch("tools.discord_tool._discord_request")
+    def test_create_role_is_idempotent_and_preserves_zero_color(
+        self, mock_req, monkeypatch,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = [[], {"id": "900", "name": "Editors"}]
+
+        result = json.loads(discord_admin_handler(
+            action="create_role", guild_id="111", name="Editors", color=0,
+            hoist=False, mentionable=True,
+        ))
+
+        assert result == {
+            "guild_id": "111", "role_id": "900", "name": "Editors", "created": True,
+        }
+        assert mock_req.call_args_list[0].args == ("GET", "/guilds/111/roles", "test-token")
+        assert mock_req.call_args_list[1].args == ("POST", "/guilds/111/roles", "test-token")
+        assert mock_req.call_args_list[1].kwargs["body"] == {
+            "name": "Editors", "color": 0, "hoist": False, "mentionable": True,
+        }
+
+    @patch("tools.discord_tool._discord_request")
+    def test_existing_unmanaged_role_is_returned_without_post(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = [
+            {"id": "900", "name": "Editors", "managed": False, "permissions": "0"},
+        ]
+        result = json.loads(discord_admin_handler(
+            action="create_role", guild_id="111", name="Editors",
+        ))
+        assert result["created"] is False
+        assert result["role_id"] == "900"
+        mock_req.assert_called_once_with("GET", "/guilds/111/roles", "test-token")
+
+    @patch("tools.discord_tool._discord_request")
+    def test_existing_privileged_role_is_an_incompatible_collision(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = [
+            {"id": "900", "name": "Editors", "managed": False, "permissions": "8"},
+        ]
+        result = json.loads(discord_admin_handler(
+            action="create_role", guild_id="111", name="Editors",
+        ))
+        assert "error" in result
+        assert "permissions" in result["error"]
+        mock_req.assert_called_once_with("GET", "/guilds/111/roles", "test-token")
+
+    @patch("tools.discord_tool._discord_request")
+    def test_update_role_rejects_empty_payload_before_http(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_admin_handler(
+            action="update_role", guild_id="111", role_id="900",
+        ))
+        assert "error" in result
+        assert "at least one" in result["error"]
+        mock_req.assert_not_called()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_update_role_patches_only_supplied_fields(self, mock_req, monkeypatch):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = {"id": "900", "name": "Editors"}
+        result = json.loads(discord_admin_handler(
+            action="update_role", guild_id="111", role_id="900", color=0,
+        ))
+        assert result == {"guild_id": "111", "role_id": "900", "updated": True}
+        mock_req.assert_called_once_with(
+            "PATCH", "/guilds/111/roles/900", "test-token", body={"color": 0},
+        )
+
+    def test_role_schema_does_not_expose_permissions_or_administrator(self):
+        schema = get_dynamic_schema_admin
+        properties = __import__("tools.discord_tool", fromlist=["_SCHEMA_PROPERTIES"])._SCHEMA_PROPERTIES
+        assert "permissions" not in properties
+        assert "administrator" not in properties
+        assert callable(schema)
+
+
+class TestLeaveGuild:
+    @pytest.fixture(autouse=True)
+    def _leave_config(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"leave_guild_ids": ["900000000000000001", "900000000000000002"]}},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_leave_guild_requires_approved_target_and_exact_name(
+        self, mock_req, monkeypatch,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = [{"id": "900000000000000001", "name": "Alpha Guild"}]
+
+        result = json.loads(discord_admin_handler(
+            action="leave_guild", guild_id="900000000000000001",
+            expected_guild_name="Wrong",
+        ))
+
+        assert "error" in result
+        assert "Alpha Guild" not in result["error"]
+        assert "expected_guild_name" in result["error"]
+        mock_req.assert_called_once_with(
+            "GET", "/users/@me/guilds", "test-token", params={"limit": "200"},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_leave_guild_is_idempotent_when_approved_target_is_absent(
+        self, mock_req, monkeypatch,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.return_value = []
+        result = json.loads(discord_admin_handler(
+            action="leave_guild", guild_id="900000000000000002",
+            expected_guild_name="Beta Guild",
+        ))
+        assert result == {
+            "guild_id": "900000000000000002", "name": "Beta Guild", "left": False,
+        }
+        mock_req.assert_called_once_with(
+            "GET", "/users/@me/guilds", "test-token", params={"limit": "200"},
+        )
+
+    @patch("tools.discord_tool._discord_request")
+    def test_leave_guild_deletes_only_after_exact_identity_match(
+        self, mock_req, monkeypatch,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = [
+            [{"id": "900000000000000002", "name": "Beta Guild"}], None,
+        ]
+        result = json.loads(discord_admin_handler(
+            action="leave_guild", guild_id="900000000000000002",
+            expected_guild_name="Beta Guild",
+        ))
+        assert result == {
+            "guild_id": "900000000000000002", "name": "Beta Guild", "left": True,
+        }
+        assert mock_req.call_args_list[1].args == (
+            "DELETE", "/users/@me/guilds/900000000000000002", "test-token",
+        )
+
+    @patch("tools.discord_tool.time.sleep")
+    @patch("tools.discord_tool._discord_request")
+    def test_leave_guild_retries_delete_rate_limit_without_reinventory(
+        self, mock_req, mock_sleep, monkeypatch,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = [
+            [{"id": "900000000000000002", "name": "Beta Guild"}],
+            DiscordAPIError(429, '{"message":"You are being rate limited.","retry_after":0.5}'),
+            None,
+        ]
+
+        result = json.loads(discord_admin_handler(
+            action="leave_guild", guild_id="900000000000000002",
+            expected_guild_name="Beta Guild",
+        ))
+
+        assert result == {
+            "guild_id": "900000000000000002", "name": "Beta Guild", "left": True,
+        }
+        assert [item.args[0] for item in mock_req.call_args_list] == ["GET", "DELETE", "DELETE"]
+        mock_sleep.assert_called_once_with(0.5)
+
+    @pytest.mark.parametrize("body", ["not-json", '{"retry_after": "later"}', '{"retry_after": 5.1}'])
+    @patch("tools.discord_tool.time.sleep")
+    @patch("tools.discord_tool._discord_request")
+    def test_leave_guild_rejects_invalid_or_excessive_rate_limit_data(
+        self, mock_req, mock_sleep, monkeypatch, body,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        mock_req.side_effect = [
+            [{"id": "900000000000000002", "name": "Beta Guild"}],
+            DiscordAPIError(429, body),
+        ]
+
+        result = json.loads(discord_admin_handler(
+            action="leave_guild", guild_id="900000000000000002",
+            expected_guild_name="Beta Guild",
+        ))
+
+        assert "error" in result
+        assert "retry" in result["error"].lower()
+        assert body not in result["error"]
+        mock_sleep.assert_not_called()
+        assert mock_req.call_count == 2
+
+    @patch("tools.discord_tool.time.sleep")
+    @patch("tools.discord_tool._discord_request")
+    def test_leave_guild_stops_after_one_rate_limit_retry(
+        self, mock_req, mock_sleep, monkeypatch,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        rate_limit = DiscordAPIError(429, '{"retry_after":0}')
+        mock_req.side_effect = [
+            [{"id": "900000000000000002", "name": "Beta Guild"}], rate_limit, rate_limit,
+        ]
+
+        result = json.loads(discord_admin_handler(
+            action="leave_guild", guild_id="900000000000000002",
+            expected_guild_name="Beta Guild",
+        ))
+
+        assert "error" in result
+        assert "429" in result["error"]
+        assert mock_req.call_count == 3
+        mock_sleep.assert_called_once_with(0.0)
+
+    @pytest.mark.parametrize(
+        "guild_id,name",
+        [
+            ("900000000000000003", "Gamma Guild"),
+            ("999", "Other"),
+            ("*", "Beta Guild"),
+        ],
+    )
+    @patch("tools.discord_tool._discord_request")
+    def test_leave_guild_rejects_every_other_target_before_http(
+        self, mock_req, monkeypatch, guild_id, name,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+        result = json.loads(discord_admin_handler(
+            action="leave_guild", guild_id=guild_id, expected_guild_name=name,
+        ))
+        assert "error" in result
+        mock_req.assert_not_called()
+
+    def test_new_surface_has_no_other_destructive_administration(self):
+        import tools.discord_tool as discord_tool
+
+        assert discord_tool._NEW_DESTRUCTIVE_ACTIONS == frozenset({"leave_guild"})
+        assert not ({"delete_channel", "delete_role", "ban", "kick", "purge", "webhook"} & _ACTIONS.keys())
+
+
+class TestExpandedAdminContract:
+    def test_original_actions_and_new_actions_are_disjoint_and_complete(self):
+        import tools.discord_tool as discord_tool
+
+        original = {
+            "list_guilds", "server_info", "list_channels", "channel_info", "list_roles",
+            "member_info", "search_members", "fetch_messages", "list_pins", "pin_message",
+            "unpin_message", "delete_message", "create_thread", "add_role", "remove_role",
+        }
+        expected_new = {
+            "create_category", "create_text_channel", "create_forum", "rename_channel",
+            "set_channel_topic", "move_channel_to_category", "lock_channel", "unlock_channel",
+            "create_role", "update_role", "leave_guild",
+        }
+        assert expected_new <= discord_tool._NEW_ACTION_NAMES
+        assert original | expected_new <= set(_ACTIONS)
+        assert original.isdisjoint(expected_new)
+
+    def test_manifest_declares_required_parameters_and_schema_fields(self):
+        import tools.discord_tool as discord_tool
+
+        expected = {
+            "create_category": ["guild_id", "name"],
+            "create_text_channel": ["guild_id", "name"],
+            "create_forum": ["guild_id", "name"],
+            "rename_channel": ["channel_id", "name"],
+            "set_channel_topic": ["channel_id", "topic"],
+            "move_channel_to_category": ["channel_id", "category_id"],
+            "lock_channel": ["channel_id", "guild_id"],
+            "unlock_channel": ["channel_id", "guild_id"],
+            "create_role": ["guild_id", "name"],
+            "update_role": ["guild_id", "role_id"],
+            "leave_guild": ["guild_id", "expected_guild_name"],
+        }
+        assert {name: discord_tool._REQUIRED_PARAMS[name] for name in expected} == expected
+        schema = discord_tool._build_schema(list(discord_tool._ADMIN_ACTIONS), tool_name="discord_admin")
+        assert schema is not None
+        assert expected.keys() <= set(schema["parameters"]["properties"]["action"]["enum"])
+        for field in {field for fields in expected.values() for field in fields}:
+            assert field in schema["parameters"]["properties"]
+
+    def test_admin_only_parameters_do_not_expand_the_core_discord_schema(self):
+        import tools.discord_tool as discord_tool
+
+        core = discord_tool._build_schema(list(_CORE_ACTIONS), tool_name="discord")
+        admin = discord_tool._build_schema(list(_ADMIN_ACTIONS), tool_name="discord_admin")
+        assert core is not None and admin is not None
+        admin_only = {
+            "category_id", "topic", "position", "nsfw", "rate_limit_per_user",
+            "permission_overwrites", "grant_main_user_access", "color", "hoist",
+            "mentionable", "expected_guild_name",
+        }
+        assert not (admin_only & core["parameters"]["properties"].keys())
+        assert admin_only <= admin["parameters"]["properties"].keys()
+
+    @patch("tools.discord_tool._discord_request")
+    def test_new_action_api_error_is_actionable_and_redacts_token(
+        self, mock_req, monkeypatch, caplog,
+    ):
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "secret-token")
+        mock_req.side_effect = DiscordAPIError(500, "failed secret-token traceback")
+
+        result = json.loads(discord_admin_handler(
+            action="create_text_channel", guild_id="111", name="project",
+        ))
+
+        assert "error" in result
+        assert "retry" in result["error"].lower()
+        assert "secret-token" not in result["error"]
+        assert "secret-token" not in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -545,6 +1258,34 @@ class TestConfigAllowlist:
         )
         result = _load_allowed_actions_config()
         assert result == ["list_guilds", "list_channels", "fetch_messages"]
+
+    def test_leave_guild_ids_missing_defaults_to_empty(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"discord": {}})
+        assert _load_leave_guild_ids() == frozenset()
+
+    @pytest.mark.parametrize("raw", [None, "900000000000000001", ("900000000000000001",), [1]])
+    def test_leave_guild_ids_rejects_malformed_values(self, monkeypatch, raw):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"leave_guild_ids": raw}},
+        )
+        with pytest.raises(ValueError, match="discord.leave_guild_ids"):
+            _load_leave_guild_ids()
+
+    def test_leave_guild_ids_rejects_excessive_list(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"leave_guild_ids": [str(i + 1) for i in range(101)]}},
+        )
+        with pytest.raises(ValueError, match="at most"):
+            _load_leave_guild_ids()
+
+    def test_leave_guild_ids_accepts_numeric_string_list(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"discord": {"leave_guild_ids": ["900000000000000001"]}},
+        )
+        assert _load_leave_guild_ids() == frozenset({"900000000000000001"})
 
 
     def test_config_load_failure_is_permissive(self, monkeypatch):

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -10,6 +10,7 @@ import functools
 import hashlib
 import json
 import logging
+import math
 import threading
 import time
 import urllib.error
@@ -59,11 +60,14 @@ def _discord_request(
     url = f"{DISCORD_API_BASE}{path}"
     if params:
         url += "?" + urllib.parse.urlencode(params)
-    req = urllib.request.Request(
-        url, data=None if body is None else json.dumps(body).encode("utf-8"), method=method,
-        headers={
-            "Authorization": f"Bot {token}", "Content-Type": "application/json",
-            "User-Agent": "Hermes-Agent (https://github.com/NousResearch/hermes-agent)"})
+    request_body = None if body is None else json.dumps(body).encode("utf-8")
+    headers = {
+        "Authorization": f"Bot {token}",
+        "User-Agent": "Hermes-Agent (https://github.com/NousResearch/hermes-agent)",
+    }
+    if request_body is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=request_body, method=method, headers=headers)
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             if resp.status == 204:
@@ -369,6 +373,504 @@ def _create_thread(
     return json.dumps({"success": True, "thread_id": thread["id"], "name": thread.get("name")})
 
 
+def _require_snowflake(value: Any, field: str) -> str:
+    if (
+        not isinstance(value, str) or not value.isascii()
+        or not value.isdigit() or int(value) <= 0
+    ):
+        raise ValueError(f"{field} must be a positive numeric Discord ID; provide a valid {field}.")
+    return value
+
+
+def _require_name(value: Any, field: str = "name") -> str:
+    if not isinstance(value, str) or not value.strip() or not 1 <= len(value) <= 100:
+        raise ValueError(f"{field} must contain 1 to 100 characters; provide a valid {field}.")
+    return value
+
+
+def _optional_int(value: Any, field: str, minimum: int, maximum: int) -> Optional[int]:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or not minimum <= value <= maximum:
+        raise ValueError(
+            f"{field} must be an integer from {minimum} to {maximum}; provide a valid {field}."
+        )
+    return value
+
+
+def _optional_bool(value: Any, field: str) -> Optional[bool]:
+    if value is not None and not isinstance(value, bool):
+        raise ValueError(f"{field} must be a boolean; provide true or false.")
+    return value
+
+
+def _validate_overwrites(value: Any) -> Optional[List[Dict[str, Any]]]:
+    if value is None:
+        return None
+    if not isinstance(value, list):
+        raise ValueError("permission_overwrites must be an array of overwrite objects; correct the input.")
+    if len(value) > 100:
+        raise ValueError("permission_overwrites accepts at most 100 entries; reduce the input.")
+    result = []
+    seen = set()
+    for item in value:
+        if not isinstance(item, dict) or not {"id", "type", "allow", "deny"}.issubset(item):
+            raise ValueError(
+                "permission_overwrites entries require id, type, allow, and deny; correct the input."
+            )
+        if set(item) - {"id", "type", "allow", "deny"}:
+            raise ValueError("permission_overwrites entries contain unsupported fields; correct the input.")
+        target_id = _require_snowflake(item["id"], "permission_overwrites id")
+        target_type = item["type"]
+        if isinstance(target_type, bool) or target_type not in (0, 1):
+            raise ValueError("permission_overwrites type must be 0 (role) or 1 (member); correct the input.")
+        if (target_id, target_type) in seen:
+            raise ValueError("permission_overwrites contains a duplicate target; combine it into one entry.")
+        seen.add((target_id, target_type))
+        allow = _optional_int(item["allow"], "permission_overwrites allow", 0, (1 << 64) - 1)
+        deny = _optional_int(item["deny"], "permission_overwrites deny", 0, (1 << 64) - 1)
+        if allow is None or deny is None:
+            raise ValueError(
+                "permission_overwrites allow and deny must be non-negative integers; correct the input."
+            )
+        result.append({"id": target_id, "type": target_type, "allow": str(allow), "deny": str(deny)})
+    return result
+
+
+def _get_main_user_id() -> str:
+    configured = (get_secret("DISCORD_MAIN_USER_ID", "") or "").strip()
+    if configured:
+        try:
+            return _require_snowflake(configured, "DISCORD_MAIN_USER_ID")
+        except ValueError as exc:
+            raise ValueError(
+                "DISCORD_MAIN_USER_ID must be one numeric user ID; configure it before granting access."
+            ) from exc
+    allowed = (get_secret("DISCORD_ALLOWED_USERS", "") or "").strip()
+    entries = [entry.strip() for entry in allowed.split(",") if entry.strip()]
+    if len(entries) != 1 or entries[0] == "*" or not entries[0].isdigit():
+        raise ValueError(
+            "DISCORD_MAIN_USER_ID is not configured and DISCORD_ALLOWED_USERS is not exactly one "
+            "numeric user ID; configure DISCORD_MAIN_USER_ID before granting access."
+        )
+    return _require_snowflake(entries[0], "DISCORD_MAIN_USER_ID")
+
+
+def _grant_channel_access(
+    overwrites: Optional[List[Dict[str, Any]]], target_ids: List[str],
+) -> List[Dict[str, Any]]:
+    required = (1 << 4) | (1 << 10)  # MANAGE_CHANNELS | VIEW_CHANNEL
+    result = [dict(item) for item in (overwrites or [])]
+    for target_id in dict.fromkeys(target_ids):
+        existing = next(
+            (item for item in result if item["id"] == target_id and item["type"] == 1), None,
+        )
+        if existing is None:
+            result.append({"id": target_id, "type": 1, "allow": str(required), "deny": "0"})
+        else:
+            existing["allow"] = str(int(existing["allow"]) | required)
+            existing["deny"] = str(int(existing["deny"]) & ~required)
+    return result
+
+
+def _create_guild_channel(
+    token: str, guild_id: str, name: str, channel_type: int,
+    category_id: Optional[str] = None, topic: Optional[str] = None,
+    position: Optional[int] = None, nsfw: Optional[bool] = None,
+    rate_limit_per_user: Optional[int] = None,
+    permission_overwrites: Any = None, grant_main_user_access: bool = False,
+    **_kwargs: Any,
+) -> str:
+    guild_id = _require_snowflake(guild_id, "guild_id")
+    name = _require_name(name)
+    if channel_type == 4 and (
+        category_id or topic is not None or nsfw is not None
+        or rate_limit_per_user is not None or grant_main_user_access
+    ):
+        raise ValueError(
+            "create_category accepts only name, position, and permission_overwrites; remove unsupported fields."
+        )
+    if category_id:
+        category_id = _require_snowflake(category_id, "category_id")
+    else:
+        category_id = None
+    topic_limit = 4096 if channel_type == 15 else 1024
+    if topic is not None and (not isinstance(topic, str) or len(topic) > topic_limit):
+        raise ValueError(
+            f"topic must be a string of at most {topic_limit} characters for this channel type; "
+            "provide a valid topic."
+        )
+    position = _optional_int(position, "position", 0, (1 << 31) - 1)
+    nsfw = _optional_bool(nsfw, "nsfw")
+    rate_limit_per_user = _optional_int(
+        rate_limit_per_user, "rate_limit_per_user", 0, 21600,
+    )
+    overwrites = _validate_overwrites(permission_overwrites)
+    if not isinstance(grant_main_user_access, bool):
+        raise ValueError("grant_main_user_access must be a boolean; provide true or false.")
+    main_user_id = _get_main_user_id() if grant_main_user_access else None
+    expected_parent = category_id if channel_type != 4 else None
+    channels = _discord_request("GET", f"/guilds/{guild_id}/channels", token)
+    if expected_parent is not None and not any(
+        channel.get("id") == expected_parent and channel.get("type") == 4
+        for channel in channels
+    ):
+        raise ValueError(
+            "category_id must identify a category in this guild; use list_channels to choose "
+            "a category ID from the target guild."
+        )
+    same_name = [channel for channel in channels if channel.get("name") == name]
+    if grant_main_user_access:
+        assert main_user_id is not None
+        bot = _discord_request("GET", "/users/@me", token)
+        bot_id = _require_snowflake(bot.get("id"), "bot user ID")
+        overwrites = _grant_channel_access(overwrites, [main_user_id, bot_id])
+    requested: Dict[str, Any] = {
+        key: value for key, value in (
+            ("topic", topic), ("position", position), ("nsfw", nsfw),
+            ("rate_limit_per_user", rate_limit_per_user),
+        ) if value is not None
+    }
+    if overwrites is not None:
+        requested["permission_overwrites"] = overwrites
+
+    def _settings_match(channel: Dict[str, Any]) -> bool:
+        for key, expected in requested.items():
+            if key == "permission_overwrites":
+                try:
+                    actual = [{
+                        "id": _require_snowflake(row["id"], "permission overwrite ID"),
+                        "type": int(row["type"]), "allow": str(int(row.get("allow", 0))),
+                        "deny": str(int(row.get("deny", 0))),
+                    } for row in channel.get(key, [])]
+                    if any(
+                        row["type"] not in (0, 1) or int(row["allow"]) < 0 or int(row["deny"]) < 0
+                        for row in actual
+                    ):
+                        return False
+                except (KeyError, TypeError, ValueError):
+                    return False
+                if sorted(actual, key=lambda row: (row["type"], row["id"])) != sorted(
+                    expected, key=lambda row: (row["type"], row["id"]),
+                ):
+                    return False
+            elif channel.get(key) != expected:
+                return False
+        return True
+
+    compatible = [
+        channel for channel in same_name
+        if channel.get("type") == channel_type and channel.get("parent_id") == expected_parent
+        and _settings_match(channel)
+    ]
+    if len(compatible) == 1 and len(same_name) == 1:
+        channel = compatible[0]
+        created = False
+    elif same_name:
+        raise ValueError(
+            f"A Discord channel named '{name}' already exists with a different type or category "
+            "or requested settings; "
+            "choose another name or use the existing channel ID."
+        )
+    else:
+        body: Dict[str, Any] = {"name": name, "type": channel_type}
+        if expected_parent is not None:
+            body["parent_id"] = expected_parent
+        for key, value in (
+            ("topic", topic), ("position", position), ("nsfw", nsfw),
+            ("rate_limit_per_user", rate_limit_per_user),
+        ):
+            if value is not None:
+                body[key] = value
+        if overwrites is not None:
+            body["permission_overwrites"] = overwrites
+        channel = _discord_request("POST", f"/guilds/{guild_id}/channels", token, body=body)
+        created = True
+    return json.dumps({
+        "guild_id": guild_id, "channel_id": channel["id"], "name": channel.get("name", name),
+        "type": _channel_type_name(channel_type), "created": created,
+    })
+
+
+_create_category = functools.partial(_create_guild_channel, channel_type=4)
+_create_text_channel = functools.partial(_create_guild_channel, channel_type=0)
+_create_forum = functools.partial(_create_guild_channel, channel_type=15)
+
+
+def _edit_channel(token: str, channel_id: str, body: Dict[str, Any]) -> str:
+    channel_id = _require_snowflake(channel_id, "channel_id")
+    _discord_request("PATCH", f"/channels/{channel_id}", token, body=body)
+    return json.dumps({"channel_id": channel_id, "updated": True})
+
+
+def _rename_channel(token: str, channel_id: str, name: str, **_kwargs: Any) -> str:
+    return _edit_channel(token, channel_id, {"name": _require_name(name)})
+
+
+def _set_channel_topic(token: str, channel_id: str, topic: str, **_kwargs: Any) -> str:
+    channel_id = _require_snowflake(channel_id, "channel_id")
+    if not isinstance(topic, str) or len(topic) > 4096:
+        raise ValueError("topic must be a string of at most 4096 characters; provide a valid topic.")
+    channel = _discord_request("GET", f"/channels/{channel_id}", token)
+    channel_type = channel.get("type")
+    if channel_type not in (0, 5, 15):
+        raise ValueError(
+            "set_channel_topic supports text, announcement, and forum channels; "
+            "provide a supported channel_id."
+        )
+    topic_limit = 4096 if channel_type == 15 else 1024
+    if len(topic) > topic_limit:
+        raise ValueError(
+            f"topic must be at most {topic_limit} characters for this channel type; shorten it and retry."
+        )
+    return _edit_channel(token, channel_id, {"topic": topic})
+
+
+def _move_channel_to_category(
+    token: str, channel_id: str, category_id: str,
+    position: Optional[int] = None, **_kwargs: Any,
+) -> str:
+    channel_id = _require_snowflake(channel_id, "channel_id")
+    category_id = _require_snowflake(category_id, "category_id")
+    position = _optional_int(position, "position", 0, (1 << 31) - 1)
+    channel = _discord_request("GET", f"/channels/{channel_id}", token)
+    if channel.get("type") not in (0, 2, 5, 13, 15, 16) or not channel.get("guild_id"):
+        raise ValueError(
+            "channel_id must identify a movable guild channel; provide a text, voice, announcement, "
+            "stage, forum, or media channel ID."
+        )
+    category = _discord_request("GET", f"/channels/{category_id}", token)
+    if category.get("type") != 4 or category.get("guild_id") != channel.get("guild_id"):
+        raise ValueError(
+            "category_id must identify a category in the same guild as channel_id; "
+            "use list_channels to choose a category ID from that guild."
+        )
+    body: Dict[str, Any] = {"parent_id": category_id}
+    if position is not None:
+        body["position"] = position
+    return _edit_channel(token, channel_id, body)
+
+
+def _set_channel_lock(
+    token: str, channel_id: str, guild_id: str, locked: bool, **_kwargs: Any,
+) -> str:
+    channel_id = _require_snowflake(channel_id, "channel_id")
+    guild_id = _require_snowflake(guild_id, "guild_id")
+    channel = _discord_request("GET", f"/channels/{channel_id}", token)
+    if channel.get("guild_id") != guild_id:
+        raise ValueError(
+            "channel_id does not belong to guild_id; provide the channel's actual guild_id."
+        )
+    if channel.get("type") not in (0, 5, 15, 16):
+        raise ValueError(
+            "channel_id must identify a text, announcement, forum, or media channel for "
+            "SEND_MESSAGES locking; provide a supported channel ID."
+        )
+    overwrites = []
+    everyone = None
+    for raw in channel.get("permission_overwrites", []):
+        try:
+            item = {
+                "id": _require_snowflake(raw["id"], "permission overwrite ID"),
+                "type": int(raw["type"]), "allow": str(int(raw.get("allow", 0))),
+                "deny": str(int(raw.get("deny", 0))),
+            }
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(
+                "Discord returned malformed permission overwrites; inspect the channel before retrying."
+            ) from exc
+        if item["type"] not in (0, 1) or int(item["allow"]) < 0 or int(item["deny"]) < 0:
+            raise ValueError(
+                "Discord returned malformed permission overwrites; inspect the channel before retrying."
+            )
+        overwrites.append(item)
+        if item["id"] == guild_id and item["type"] == 0:
+            everyone = item
+    if everyone is None:
+        everyone = {"id": guild_id, "type": 0, "allow": "0", "deny": "0"}
+        overwrites.append(everyone)
+    send_messages = 1 << 11
+    if locked:
+        everyone["allow"] = str(int(everyone["allow"]) & ~send_messages)
+        everyone["deny"] = str(int(everyone["deny"]) | send_messages)
+    else:
+        everyone["deny"] = str(int(everyone["deny"]) & ~send_messages)
+    _discord_request(
+        "PUT", f"/channels/{channel_id}/permissions/{guild_id}", token,
+        body={
+            "type": 0, "allow": everyone["allow"], "deny": everyone["deny"],
+        },
+    )
+    return json.dumps({"channel_id": channel_id, "guild_id": guild_id, "locked": locked})
+
+
+_lock_channel = functools.partial(_set_channel_lock, locked=True)
+_unlock_channel = functools.partial(_set_channel_lock, locked=False)
+
+
+def _role_fields(
+    *, name: Any = None, color: Any = None, hoist: Any = None, mentionable: Any = None,
+) -> Dict[str, Any]:
+    body: Dict[str, Any] = {}
+    if name is not None:
+        body["name"] = _require_name(name)
+    color = _optional_int(color, "color", 0, 0xFFFFFF)
+    if color is not None:
+        body["color"] = color
+    for field, value in (("hoist", hoist), ("mentionable", mentionable)):
+        value = _optional_bool(value, field)
+        if value is not None:
+            body[field] = value
+    return body
+
+
+def _create_role(
+    token: str, guild_id: str, name: str, color: Optional[int] = None,
+    hoist: Optional[bool] = None, mentionable: Optional[bool] = None, **_kwargs: Any,
+) -> str:
+    guild_id = _require_snowflake(guild_id, "guild_id")
+    body = _role_fields(name=name, color=color, hoist=hoist, mentionable=mentionable)
+    roles = _discord_request("GET", f"/guilds/{guild_id}/roles", token)
+    same_name = [role for role in roles if role.get("name") == name]
+    requested = {key: value for key, value in body.items() if key != "name"}
+    compatible = [
+        role for role in same_name
+        if role.get("managed") is False and str(role.get("permissions")) == "0"
+        and all(role.get(key) == value for key, value in requested.items())
+    ]
+    if len(compatible) == 1 and len(same_name) == 1:
+        role = compatible[0]
+        created = False
+    elif same_name:
+        raise ValueError(
+            f"A managed, privileged, ambiguous, or differently configured Discord role named "
+            f"'{name}' already exists; permissions are never modified by create_role. "
+            "choose another name or use the existing role ID."
+        )
+    else:
+        role = _discord_request("POST", f"/guilds/{guild_id}/roles", token, body=body)
+        created = True
+    return json.dumps({
+        "guild_id": guild_id, "role_id": role["id"], "name": role.get("name", name),
+        "created": created,
+    })
+
+
+def _update_role(
+    token: str, guild_id: str, role_id: str, name: Optional[str] = None,
+    color: Optional[int] = None, hoist: Optional[bool] = None,
+    mentionable: Optional[bool] = None, **_kwargs: Any,
+) -> str:
+    guild_id = _require_snowflake(guild_id, "guild_id")
+    role_id = _require_snowflake(role_id, "role_id")
+    body = _role_fields(name=name, color=color, hoist=hoist, mentionable=mentionable)
+    if not body:
+        raise ValueError(
+            "update_role requires at least one of name, color, hoist, or mentionable; provide a field."
+        )
+    _discord_request("PATCH", f"/guilds/{guild_id}/roles/{role_id}", token, body=body)
+    return json.dumps({"guild_id": guild_id, "role_id": role_id, "updated": True})
+
+
+_MAX_LEAVE_GUILD_IDS = 100
+_NEW_DESTRUCTIVE_ACTIONS = frozenset({"leave_guild"})
+
+
+def _load_leave_guild_ids() -> frozenset[str]:
+    """Load the explicit, fail-closed guild leave allowlist from YAML config."""
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+    except Exception as exc:
+        raise ValueError(
+            "discord.leave_guild_ids could not be loaded; configure an explicit YAML list before leaving a guild."
+        ) from exc
+    discord_cfg = cfg.get("discord")
+    if not isinstance(discord_cfg, dict) or "leave_guild_ids" not in discord_cfg:
+        return frozenset()
+    raw = discord_cfg["leave_guild_ids"]
+    if not isinstance(raw, list):
+        raise ValueError(
+            "discord.leave_guild_ids must be an explicit YAML list of numeric Discord ID strings."
+        )
+    if len(raw) > _MAX_LEAVE_GUILD_IDS:
+        raise ValueError(
+            f"discord.leave_guild_ids accepts at most {_MAX_LEAVE_GUILD_IDS} entries; reduce the list."
+        )
+    ids = []
+    for index, value in enumerate(raw):
+        try:
+            ids.append(_require_snowflake(value, f"discord.leave_guild_ids[{index}]"))
+        except ValueError as exc:
+            raise ValueError(
+                f"discord.leave_guild_ids[{index}] must be a numeric Discord ID string; correct the list."
+            ) from exc
+    if len(set(ids)) != len(ids):
+        raise ValueError("discord.leave_guild_ids must not contain duplicate guild IDs; remove duplicates.")
+    return frozenset(ids)
+
+
+def _leave_guild(
+    token: str, guild_id: str, expected_guild_name: str, **_kwargs: Any,
+) -> str:
+    guild_id = _require_snowflake(guild_id, "guild_id")
+    if guild_id not in _load_leave_guild_ids():
+        raise ValueError(
+            "guild_id is not authorized by discord.leave_guild_ids; add it to the explicit YAML list if intended."
+        )
+    expected_guild_name = _require_name(expected_guild_name, "expected_guild_name")
+    guild = None
+    after = None
+    for _page in range(100):
+        params = {"limit": "200"}
+        if after is not None:
+            params["after"] = after
+        guilds = _discord_request("GET", "/users/@me/guilds", token, params=params)
+        guild = next((item for item in guilds if item.get("id") == guild_id), None)
+        if guild is not None or len(guilds) < 200:
+            break
+        next_after = guilds[-1].get("id")
+        if not isinstance(next_after, str) or next_after == after:
+            raise ValueError(
+                "Discord guild pagination did not advance; inspect guild membership and retry."
+            )
+        after = next_after
+    else:
+        raise ValueError("Discord guild inventory exceeded the safety bound; narrow membership and retry.")
+    if guild is None:
+        return json.dumps({
+            "guild_id": guild_id, "name": expected_guild_name, "left": False,
+        })
+    actual_name = guild.get("name")
+    if actual_name != expected_guild_name:
+        raise ValueError(
+            "Discord guild identity did not match expected_guild_name; "
+            "retry only with the exact current guild name."
+        )
+    delete_path = f"/users/@me/guilds/{guild_id}"
+    try:
+        _discord_request("DELETE", delete_path, token)
+    except DiscordAPIError as error:
+        if error.status != 429:
+            raise
+        try:
+            retry_after = json.loads(error.body).get("retry_after")
+            if not isinstance(retry_after, (int, float)) or isinstance(retry_after, bool):
+                raise ValueError
+            retry_after = float(retry_after)
+        except (TypeError, ValueError, json.JSONDecodeError, AttributeError):
+            raise ValueError(
+                "Discord rate limit response did not contain a valid retry_after; retry later."
+            ) from None
+        if not math.isfinite(retry_after) or retry_after < 0 or retry_after > 5:
+            raise ValueError(
+                "Discord rate limit retry_after exceeded the 5 second safety bound; retry later."
+            )
+        time.sleep(retry_after)
+        _discord_request("DELETE", delete_path, token)
+    return json.dumps({"guild_id": guild_id, "name": actual_name, "left": True})
+
+
 def _mutation(method: str, path: str, message: str):
     """Body-less write action: ``path``/``message`` are format templates over the action kwargs."""
     def _action(token: str, **kw: Any) -> str:
@@ -407,7 +909,23 @@ _ACTION_MANIFEST = [
     ("create_thread", _create_thread, "(channel_id, name)", "create a public thread; optional message_id anchor"),
     ("add_role", _add_role, "(guild_id, user_id, role_id)", "assign a role"),
     ("remove_role", _remove_role, "(guild_id, user_id, role_id)", "remove a role"),
+    ("create_category", _create_category, "(guild_id, name)", "create an idempotent category"),
+    ("create_text_channel", _create_text_channel, "(guild_id, name)", "create an idempotent text channel"),
+    ("create_forum", _create_forum, "(guild_id, name)", "create an idempotent forum channel"),
+    ("rename_channel", _rename_channel, "(channel_id, name)", "rename a channel"),
+    ("set_channel_topic", _set_channel_topic, "(channel_id, topic)", "set a channel topic"),
+    ("move_channel_to_category", _move_channel_to_category, "(channel_id, category_id)", "move a channel"),
+    ("lock_channel", _lock_channel, "(channel_id, guild_id)", "deny @everyone SEND_MESSAGES"),
+    ("unlock_channel", _unlock_channel, "(channel_id, guild_id)", "clear @everyone SEND_MESSAGES deny"),
+    ("create_role", _create_role, "(guild_id, name)", "create an idempotent role without permissions"),
+    ("update_role", _update_role, "(guild_id, role_id)", "update safe role display fields"),
+    ("leave_guild", _leave_guild, "(guild_id, expected_guild_name)", "leave one approved guild by exact identity"),
 ]
+_NEW_ACTION_NAMES = frozenset({
+    "create_category", "create_text_channel", "create_forum", "rename_channel",
+    "set_channel_topic", "move_channel_to_category", "lock_channel", "unlock_channel",
+    "create_role", "update_role", "leave_guild",
+})
 _ACTIONS = {name: fn for name, fn, _sig, _desc in _ACTION_MANIFEST}
 _REQUIRED_PARAMS: Dict[str, List[str]] = {
     name: [p.strip() for p in sig.strip("()").split(",") if p.strip()]
@@ -477,6 +995,7 @@ _SCHEMA_PROPERTIES: Dict[str, Any] = {
     "channel_id": {"type": "string", "description": "Discord channel ID."},
     "user_id": {"type": "string", "description": "Discord user ID."},
     "role_id": {"type": "string", "description": "Discord role ID."},
+    "category_id": {"type": "string", "description": "Optional parent category ID."},
     "message_id": {"type": "string", "description": "Discord message ID."},
     "query": {"type": "string", "description": "Member name prefix to search for (search_members)."},
     "name": {"type": "string", "description": "New thread name (create_thread)."},
@@ -493,7 +1012,42 @@ _SCHEMA_PROPERTIES: Dict[str, Any] = {
         "enum": [60, 1440, 4320, 10080],
         "description": "Thread archive duration in minutes (create_thread, default 1440).",
     },
+    "topic": {"type": "string", "maxLength": 4096, "description": "Channel topic."},
+    "position": {"type": "integer", "minimum": 0, "description": "Channel position."},
+    "nsfw": {"type": "boolean", "description": "Whether a channel is age-restricted."},
+    "rate_limit_per_user": {
+        "type": "integer", "minimum": 0, "maximum": 21600,
+        "description": "Slowmode in seconds.",
+    },
+    "permission_overwrites": {
+        "type": "array", "maxItems": 100,
+        "items": {
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"}, "type": {"type": "integer", "enum": [0, 1]},
+                "allow": {"type": "integer", "minimum": 0},
+                "deny": {"type": "integer", "minimum": 0},
+            },
+            "required": ["id", "type", "allow", "deny"], "additionalProperties": False,
+        },
+        "description": "Deterministic channel permission overwrites.",
+    },
+    "grant_main_user_access": {
+        "type": "boolean", "description": "Grant VIEW_CHANNEL and MANAGE_CHANNELS to the main user and bot.",
+    },
+    "color": {"type": "integer", "minimum": 0, "maximum": 16777215, "description": "Role RGB color."},
+    "hoist": {"type": "boolean", "description": "Display the role separately."},
+    "mentionable": {"type": "boolean", "description": "Allow role mentions."},
+    "expected_guild_name": {
+        "type": "string", "minLength": 1, "maxLength": 100,
+        "description": "Exact current guild name required by leave_guild.",
+    },
 }
+_ADMIN_ONLY_SCHEMA_PROPERTIES = frozenset({
+    "category_id", "topic", "position", "nsfw", "rate_limit_per_user",
+    "permission_overwrites", "grant_main_user_access", "color", "hoist",
+    "mentionable", "expected_guild_name",
+})
 
 _CONTENT_NOTE = (
     "\n\nNOTE: Bot does NOT have the MESSAGE_CONTENT privileged intent. "
@@ -518,12 +1072,16 @@ def _build_schema(
     if affected_actions and caps.get("detected") and caps.get("has_message_content") is False:
         content_note = _CONTENT_NOTE.format(names=" and ".join(sorted(affected_actions)))
     lead, guidance = _TOOL_DESCRIPTIONS.get(tool_name, _TOOL_DESCRIPTIONS["discord"])
+    properties = {
+        name: value for name, value in _SCHEMA_PROPERTIES.items()
+        if tool_name == "discord_admin" or name not in _ADMIN_ONLY_SCHEMA_PROPERTIES
+    }
     return {
         "name": tool_name,
         "description": f"{lead}\n\nAvailable actions:\n{manifest_block}\n\n{guidance}{content_note}",
         "parameters": {
             "type": "object",
-            "properties": {"action": {"type": "string", "enum": actions}, **_SCHEMA_PROPERTIES},
+            "properties": {"action": {"type": "string", "enum": actions}, **properties},
             "required": ["action"]}}
 
 
@@ -581,7 +1139,12 @@ def check_discord_tool_requirements() -> bool:
 # ── handlers ─────────────────────────────────────────────────────────────────
 _HANDLER_DEFAULTS = {
     "guild_id": "", "channel_id": "", "user_id": "", "role_id": "", "message_id": "", "query": "",
-    "name": "", "limit": 50, "before": "", "after": "", "auto_archive_duration": 1440}
+    "category_id": "", "name": None, "topic": None, "position": None, "nsfw": None,
+    "rate_limit_per_user": None, "permission_overwrites": None, "grant_main_user_access": False,
+    "color": None, "hoist": None, "mentionable": None,
+    "expected_guild_name": None,
+    "limit": 50, "before": "", "after": "",
+    "auto_archive_duration": 1440}
 
 
 def _run_discord_action(action: str, valid_actions: Dict[str, Any], tool_label: str, **params: Any) -> str:
@@ -605,10 +1168,26 @@ def _run_discord_action(action: str, valid_actions: Dict[str, Any], tool_label: 
         return tool_error(f"Missing required parameters for '{action}': {', '.join(missing)}")
     try:
         return action_fn(token=token, **kwargs)
+    except ValueError as e:
+        return tool_error(str(e))
     except DiscordAPIError as e:
+        if action in _NEW_ACTION_NAMES:
+            logger.warning(
+                "Discord API status %s in %s action '%s'", e.status, tool_label, action,
+            )
+            hint = _ACTION_403_HINT.get(action) if e.status == 403 else None
+            guidance = hint or "Verify Discord availability and the bot's permission for this action"
+            return tool_error(
+                f"Discord API {e.status} on '{action}'. {guidance}; correct the issue and retry."
+            )
         logger.warning("Discord API error in %s action '%s': %s", tool_label, action, e)
         return tool_error(_enrich_403(action, e.body) if e.status == 403 else str(e))
     except Exception as e:
+        if action in _NEW_ACTION_NAMES:
+            logger.warning("Unexpected failure in %s action '%s'", tool_label, action)
+            return tool_error(
+                f"Unexpected failure in '{action}'; verify the inputs and retry without exposing credentials."
+            )
         logger.exception("Unexpected error in %s action '%s'", tool_label, action)
         return tool_error(f"Unexpected error: {e}")
 


### PR DESCRIPTION
## Summary

- split Discord participation actions from administrative operations
- add schema-validated, idempotent category, channel, forum, and role management
- guard guild departure behind an explicit fail-closed configuration allowlist and exact-name confirmation
- handle the relevant rate-limit response with one bounded retry without repeating discovery
- omit JSON content headers from bodyless requests

## Safety

- destructive guild departure is disabled unless `discord.leave_guild_ids` is an explicit YAML list
- malformed, duplicate, null, oversized, or non-numeric allowlist entries fail with actionable errors
- Discord API error bodies are not exposed through the tool response

## Validation

- 160 focused Discord tool and registry tests passed
- 279 affected toolset, web-server, and webhook integration tests passed, with 6 skipped
- Ruff, Python bytecode compilation, whitespace validation, and independent edge-case checks passed
