### PR TITLE
fix(windows): retry detached spawns without CREATE_BREAKAWAY_FROM_JOB when denied

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -128,11 +128,11 @@ def _spawn_detached_update(hermes_cmd, output_path, exit_code_path) -> None:
     import shutil
     import subprocess
     if sys.platform == "win32":
-        from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
-        subprocess.Popen(
+        from hermes_cli._subprocess_compat import popen_detached_with_breakaway_fallback
+        popen_detached_with_breakaway_fallback(
             [sys.executable, "-c", _WINDOWS_UPDATE_HELPER, str(output_path), str(exit_code_path),
              sys.executable, "-m", "hermes_cli.main", "update", "--gateway"],
-            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, **windows_detach_popen_kwargs())
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         return
     hermes_cmd_str = " ".join(shlex.quote(part) for part in hermes_cmd)
     update_cmd = (

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -24,6 +24,7 @@ __all__ = [
     "windows_detach_flags_without_breakaway",
     "windows_hide_flags",
     "windows_detach_popen_kwargs",
+    "popen_detached_with_breakaway_fallback",
     "bounded_git_probe",
     "bounded_probe_run",
     "noninteractive_git_env",
@@ -209,6 +210,33 @@ def windows_detach_popen_kwargs() -> dict:
     if IS_WINDOWS:
         return {"creationflags": windows_detach_flags()}
     return {"start_new_session": True}
+
+
+def popen_detached_with_breakaway_fallback(argv, **kwargs):
+    """``subprocess.Popen`` detached, retrying without ``CREATE_BREAKAWAY_FROM_JOB`` when denied.
+
+    Some Windows hosts wrap every process they launch in a Job Object that does not set
+    ``JOB_OBJECT_LIMIT_BREAKAWAY_OK`` — **Task Scheduler does exactly this for every task it
+    starts**, which is the normal way a gateway comes back after a reboot.  When
+    ``CREATE_BREAKAWAY_FROM_JOB`` is requested from inside such a job, ``CreateProcess`` fails
+    outright with ``ERROR_ACCESS_DENIED`` (``PermissionError``, ``WinError 5``) instead of merely
+    ignoring the flag, so the detached child can *never* start on the auto-start path even though
+    the same spawn works fine from a plain shell.
+
+    Mirror ``gateway_windows._spawn_detached``: retry once with
+    :func:`windows_detach_flags_without_breakaway`, which drops only that bit.  On POSIX the
+    retry is meaningless (there is no breakaway concept), so the original error propagates.
+
+    ``kwargs`` must not contain ``creationflags`` — the detach flags own that slot.
+    """
+    try:
+        return subprocess.Popen(argv, **windows_detach_popen_kwargs(), **kwargs)
+    except OSError:
+        if not IS_WINDOWS:
+            raise
+        return subprocess.Popen(
+            argv, creationflags=windows_detach_flags_without_breakaway(), **kwargs
+        )
 
 
 # GIT_CONFIG_KEY_n/VALUE_n overrides for internal git children: no credential/askpass prompts, no

--- a/hermes_cli/web_server_gateway.py
+++ b/hermes_cli/web_server_gateway.py
@@ -13,7 +13,7 @@ import time
 import urllib.request
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-from hermes_cli._subprocess_compat import windows_detach_flags
+from hermes_cli._subprocess_compat import popen_detached_with_breakaway_fallback
 from hermes_cli.config import get_hermes_home
 
 # Same logger the code used before extraction (record parity).
@@ -338,10 +338,9 @@ def _spawn_hermes_action(
     # The gateway's own restart watcher already drops it (gateway/run.py); mirror that here (#52470).
     action_env = {**os.environ, "HERMES_NONINTERACTIVE": "1"}
     action_env.pop("_HERMES_GATEWAY", None)
-    detach = {"creationflags": windows_detach_flags()} if sys.platform == "win32" else {"start_new_session": True}
-    proc = subprocess.Popen(
+    proc = popen_detached_with_breakaway_fallback(
         cmd, cwd=str(PROJECT_ROOT), stdin=subprocess.DEVNULL, stdout=log_file, stderr=subprocess.STDOUT,
-        env={**action_env, **(env_overrides or {})}, **detach,
+        env={**action_env, **(env_overrides or {})},
     )
     log_file.close()  # child holds its own dup'd fd; keeping ours leaks one per action
     _ACTION_RESULTS.pop(name, None)

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Dict, Optional, Any
 
 from gateway.platforms._shared import get_scoped_secret, yaml_env_setter
-from hermes_cli._subprocess_compat import windows_detach_popen_kwargs
+from hermes_cli._subprocess_compat import popen_detached_with_breakaway_fallback
 from hermes_constants import (find_node_executable, get_hermes_dir, with_hermes_node_path)
 
 _IS_WINDOWS = platform.system() == "Windows"
@@ -472,9 +472,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # Bridge output goes to a log file so QR codes, errors, and reconnection messages survive for troubleshooting.
             self._bridge_log = self._session_path.parent / "bridge.log"
             self._bridge_log_fh = bridge_log_fh = open(self._bridge_log, "a", encoding="utf-8")
-            self._bridge_process = subprocess.Popen(
+            self._bridge_process = popen_detached_with_breakaway_fallback(
                 [find_node_executable("node") or "node", str(bridge_path), "--port", str(self._bridge_port), "--session", str(self._session_path),
-                 "--mode", _wenv("WHATSAPP_MODE", "self-chat")], stdout=bridge_log_fh, stderr=bridge_log_fh, env=self._bridge_env(), **windows_detach_popen_kwargs())
+                 "--mode", _wenv("WHATSAPP_MODE", "self-chat")], stdout=bridge_log_fh, stderr=bridge_log_fh, env=self._bridge_env())
             _write_bridge_pidfile(self._session_path, self._bridge_process.pid)
             if not await self._wait_for_bridge():
                 return False

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -425,6 +425,67 @@ class TestSubprocessCompatHelpers:
         # First element is either an absolute path (sh found) or the bare
         # name (fallback) — both are acceptable behaviours.
 
+    def test_popen_detached_retries_without_breakaway_when_denied(self, monkeypatch):
+        """A breakaway-denied CreateProcess must be retried without the bit.
+
+        Windows Task Scheduler wraps every task it starts in a Job Object that
+        does not set ``JOB_OBJECT_LIMIT_BREAKAWAY_OK``, so requesting
+        ``CREATE_BREAKAWAY_FROM_JOB`` from inside it makes ``CreateProcess``
+        fail outright with ``ERROR_ACCESS_DENIED`` (``WinError 5``) rather than
+        ignoring the flag.  The WhatsApp bridge, the dashboard action spawner
+        and the gateway-side ``/update`` spawner all route through this helper,
+        so the retry is the difference between "starts" and "can never start"
+        on the auto-start path a reboot depends on.
+
+        ``IS_WINDOWS`` is patched (not the flags) so both branches are exercised
+        on any host, including the Linux CI.
+        """
+        from hermes_cli import _subprocess_compat as sc
+
+        monkeypatch.setattr(sc, "IS_WINDOWS", True)
+        calls = []
+        sentinel = object()
+
+        def fake_popen(argv, **kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise PermissionError(5, "Access is denied")
+            return sentinel
+
+        monkeypatch.setattr(sc.subprocess, "Popen", fake_popen)
+
+        result = sc.popen_detached_with_breakaway_fallback(["node", "bridge.js"])
+
+        assert result is sentinel
+        assert len(calls) == 2, "the denied spawn must be retried exactly once"
+        assert calls[0]["creationflags"] & 0x01000000, (
+            "the first attempt must request CREATE_BREAKAWAY_FROM_JOB — dropping "
+            "it by default re-breaks the Electron job-teardown case (#40909)."
+        )
+        assert calls[1]["creationflags"] == sc.windows_detach_flags_without_breakaway(), (
+            "the retry must use windows_detach_flags_without_breakaway() so the "
+            "child still detaches, minus only the denied bit."
+        )
+        assert not calls[1]["creationflags"] & 0x01000000
+
+    def test_popen_detached_posix_surfaces_oserror_without_retry(self, monkeypatch):
+        """POSIX has no breakaway concept: the failure must propagate, not retry."""
+        from hermes_cli import _subprocess_compat as sc
+
+        monkeypatch.setattr(sc, "IS_WINDOWS", False)
+        calls = []
+
+        def fake_popen(argv, **kwargs):
+            calls.append(kwargs)
+            raise OSError("spawn failed")
+
+        monkeypatch.setattr(sc.subprocess, "Popen", fake_popen)
+
+        with pytest.raises(OSError):
+            sc.popen_detached_with_breakaway_fallback(["node", "bridge.js"])
+
+        assert len(calls) == 1
+        assert calls[0] == {"start_new_session": True}
 
     @pytest.mark.windows_only
     def test_windows_detach_flags_exclude_detached_process(self):


### PR DESCRIPTION
## Summary

Windows hosts that wrap each spawned process in a Job Object **without**
`JOB_OBJECT_LIMIT_BREAKAWAY_OK` make `CreateProcess` fail outright with
`ERROR_ACCESS_DENIED` (`WinError 5`) when `CREATE_BREAKAWAY_FROM_JOB` is
requested — the flag is not merely ignored.

**Windows Task Scheduler does exactly this for every task it starts**, and a
Task Scheduler task is how a gateway normally comes back after an unattended
reboot. So three detached spawns could never start on the auto-start path, even
though the identical spawn works fine from a plain shell or the Desktop app.

| Site | Failure |
| --- | --- |
| `plugins/platforms/whatsapp/adapter.py` — bridge | gateway starts and cron executes, but the bridge never connects; port 3000 never listens |
| `gateway/slash_commands.py` — `/update` | the gateway-side updater process dies |
| `hermes_cli/web_server_gateway.py` — dashboard actions | dashboard-spawned actions die |

The asymmetry is the tell: the same code path works when the gateway is started
by hand, and fails only when it is started by the mechanism that exists to keep
it running.

## Repro

Register a throwaway scheduled task with the same principal and have it attempt
both variants from inside a real Task Scheduler job:

```
WITH_BREAKAWAY    -> PermissionError: [WinError 5] Access is denied
WITHOUT_BREAKAWAY -> OK
```

Bridge symptom on a real install:

```
ERROR ... [Whatsapp] Failed to start bridge: [WinError 5] Access is denied
  File ".../plugins/platforms/whatsapp/adapter.py", line 477, in connect
    self._bridge_process = subprocess.Popen(
PermissionError: [WinError 5] Access is denied
```

retried every 60–300s, identical each time; `curl 127.0.0.1:3000/health` never
answers.

## Fix

Add `popen_detached_with_breakaway_fallback()` to `hermes_cli/_subprocess_compat.py`
and route all three sites through it, mirroring the fallback that already exists
in `gateway_windows._spawn_detached`: retry once with
`windows_detach_flags_without_breakaway()`, which drops only that bit.

POSIX is unaffected — there is no breakaway concept there, so the original error
propagates unmasked.

`hermes_cli/gateway.py::_spawn_detached_gateway` is deliberately left alone: it
is only reachable from the macOS-26 launchd fallback, where
`windows_detach_popen_kwargs()` returns `start_new_session` and the breakaway
bit is irrelevant. Fixing an unreachable-on-Windows path would be noise.

## Test Plan

- [x] `pytest` across `test_windows_native_support.py`, `test_gateway_windows.py`,
      `test_windows_gateway_job_teardown_48820.py`, `test_whatsapp_connect.py`,
      `test_75349_whatsapp_multiplex_secret_scope.py`, `test_whatsapp_bridge_pidfile.py`,
      `test_whatsapp_bridge_dir_resolution.py`, `test_whatsapp_from_owner.py`
      → **93 passed, 5 skipped, 1 pre-existing failure**
- [x] New tests fail against the unfixed helper and pass against the fixed one
      (RED → GREEN, verified by reverting the retry branch)
- [x] `ruff check` clean on all five changed files
- [x] Live verification on a Windows install: a gateway restarted *by its own
      scheduled task* now logs

      WARNING ... Bridge spawn failed ([WinError 5] Access is denied); retrying without CREATE_BREAKAWAY_FROM_JOB
      INFO    ... ✓ whatsapp connected
      INFO    ... Gateway running with 1 platform(s)

      and `curl 127.0.0.1:3000/health` returns `{"status":"connected"}`

The single failure (`TestWindowlessGatewayRestartSpec::test_noop_on_non_windows`)
is unrelated and pre-existing on Windows: it asserts a POSIX default
(`cwd == ""`) and receives a Windows temp directory. It fails identically with
these changes stashed, so it is not a regression from this PR.
