### PR TITLE
feat(desktop): connect remote gateways from links

### DIFF
--- a/apps/desktop/docs/gateway-links.md
+++ b/apps/desktop/docs/gateway-links.md
@@ -1,0 +1,40 @@
+# Open a remote gateway in Hermes Desktop
+
+A website or terminal can open this link in Hermes Desktop:
+
+```text
+hermes://gateway/connect?url=https%3A%2F%2Fgateway.example.com%2Fteam%2Falice&name=Work
+```
+
+Build the query with `URLSearchParams`, encoding the complete HTTPS gateway
+base URL as `url` and an optional display name as `name`. Desktop preserves the
+gateway's path prefix. Links containing credentials, a query or fragment in
+the gateway URL, other schemes, or unexpected parameters are rejected.
+
+Desktop opens Gateway settings and displays the target address. The user
+confirms before Desktop contacts the gateway or saves anything. The existing
+gateway sign-in window handles authentication; credentials are never accepted
+through a deep link. Canceled sign-in leaves the registry unchanged. A failed
+connection leaves the saved entry available for retry and reports the error.
+
+The connection is added to the existing registry. Opening the same URL again
+reuses its entry, and other connections and the primary startup choice remain
+intact. Switching uses the ordinary authenticated WebSocket connection flow.
+The existing Electron URL handler queues cold-start links and also delivers
+links to an already-running app.
+
+The calling website should say that it is opening Desktop, provide an install
+or update link if no connection prompt appears, and offer the gateway URL for
+manual setup. Launching a URI does not confirm that the app is installed or
+that the remote connection succeeded. Older Desktop versions do not support
+this handoff.
+
+Validation from `apps/desktop`:
+
+```sh
+bunx vitest run src/lib/gateway-connect-link.test.ts src/lib/connect-linked-gateway.test.ts src/lib/deeplink-routes.test.ts
+```
+
+Before release, exercise both cold-start and already-open handoff, canceled
+sign-in, two repeated opens of the same gateway, a failed WebSocket handshake,
+and a restart with the saved connection.

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -6,6 +6,7 @@ import { openSession } from '@/app/open-session'
 import { resolveDeepLinkAction } from '@/lib/deeplink-routes'
 import { pathFromHermesDeepLink, resolveHermesOpenPath } from '@/lib/hermes-open-target'
 import { storedSessionIdForNotification } from '@/lib/session-ids'
+import { requestGatewayConnect } from '@/store/gateway-connect-request'
 import { requestMcpInstallFromDeepLink } from '@/store/mcp-deeplink-install'
 import { startMcpHealthChecker, stopMcpHealthChecker } from '@/store/mcp-health'
 import {
@@ -295,6 +296,17 @@ export function useDesktopIntegrations({
       }
 
       const action = resolveDeepLinkAction(payload)
+
+      if (action.type === 'gateway-connect') {
+        requestGatewayConnect(action.request)
+        navigate('/settings?tab=gateway')
+
+        return
+      }
+
+      if (payload.kind === 'gateway') {
+        return
+      }
 
       if (action.type === 'composer-blueprint') {
         const slots = Object.entries(action.params || {})

--- a/apps/desktop/src/app/settings/gateway-connect-dialog.tsx
+++ b/apps/desktop/src/app/settings/gateway-connect-dialog.tsx
@@ -1,0 +1,52 @@
+import { useStore } from '@nanostores/react'
+
+import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { useI18n } from '@/i18n'
+import { connectLinkedGateway } from '@/lib/connect-linked-gateway'
+import { $activeConnectionId, selectConnection, setConnectionsRegistry } from '@/store/connections'
+import { $gatewayConnectRequest, closeGatewayConnect } from '@/store/gateway-connect-request'
+
+export function GatewayConnectDialog() {
+  const request = useStore($gatewayConnectRequest)
+  const { t } = useI18n()
+
+  if (!request) {
+    return null
+  }
+
+  return (
+    <ConfirmDialog
+      busyLabel={t.common.connecting}
+      confirmLabel={t.common.connect}
+      description={
+        <>
+          <span className="block">{request.name}</span>
+          <span className="break-all">{request.url}</span>
+        </>
+      }
+      doneLabel={t.connectors.connected}
+      onClose={closeGatewayConnect}
+      onConfirm={async () => {
+        if (!window.hermesDesktop?.connections || !window.hermesDesktop.oauthLoginConnectionConfig) {
+          throw new Error(t.boot.errors.ipcBridgeUnavailable)
+        }
+
+        await connectLinkedGateway(
+          request,
+          window.hermesDesktop,
+          async (registry, id) => {
+            setConnectionsRegistry(registry)
+            await selectConnection(id)
+
+            if ($activeConnectionId.get() !== id) {
+              throw new Error(t.connectors.failed)
+            }
+          },
+          t.boot.failure.signInIncompleteMessage
+        )
+      }}
+      open
+      title={t.settings.gateway.remoteTitle}
+    />
+  )
+}

--- a/apps/desktop/src/app/settings/gateway-settings.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.tsx
@@ -35,6 +35,7 @@ import { notify, notifyError, readableError } from '@/store/notifications'
 
 import { ConnectionsRegistrySection } from './connections-registry'
 import { CONTROL_TEXT } from './constants'
+import { GatewayConnectDialog } from './gateway-connect-dialog'
 import { ManagedUpdatesSection } from './managed-updates-section'
 import { EmptyState, ListRow, Pill, SettingsContent, SettingsSkeleton, ToggleRow } from './primitives'
 import { enrichSelectedSshHost, selectSshHost } from './ssh-host-selection'
@@ -1111,6 +1112,7 @@ export function GatewaySettings({ embedded = false }: { embedded?: boolean } = {
 
   return (
     <SettingsContent bare={embedded}>
+      <GatewayConnectDialog />
       {embedded ? null : (
         <div className="mb-5">
           <div className="flex items-center gap-2 text-[length:var(--conversation-text-font-size)] font-medium">

--- a/apps/desktop/src/lib/connect-linked-gateway.test.ts
+++ b/apps/desktop/src/lib/connect-linked-gateway.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { DesktopConnectionsRegistry, DesktopRegistryConnection } from '@/global'
+
+import { connectLinkedGateway } from './connect-linked-gateway'
+
+const request = { url: 'https://actual.inc/api/hermes/clusters/c-1', name: 'Studio' }
+const local: DesktopRegistryConnection = {
+  id: 'local',
+  kind: 'local',
+  label: 'Studio',
+  tokenSet: false,
+  tokenPreview: null
+}
+const remote: DesktopRegistryConnection = {
+  id: 'remote',
+  kind: 'remote',
+  label: 'Studio (2)',
+  url: request.url,
+  authMode: 'oauth',
+  tokenSet: false,
+  tokenPreview: null
+}
+
+function fixture(connected = true) {
+  let registry: DesktopConnectionsRegistry = {
+    version: 2,
+    primary: 'local',
+    secureTokenStorage: true,
+    connections: [local]
+  }
+
+  const save = vi.fn(async () => {
+    registry = { ...registry, connections: [...registry.connections, remote] }
+
+    return { ok: true, connection: remote, registry }
+  })
+
+  const bridge = {
+    connections: {
+      list: vi.fn(async () => registry),
+      save,
+      remove: vi.fn(),
+      setPrimary: vi.fn(),
+      test: vi.fn()
+    },
+    oauthLoginConnectionConfig: vi.fn(async () => ({ connected, ok: true, baseUrl: request.url }))
+  }
+
+  return { bridge, registry: () => registry }
+}
+
+describe('connect a linked gateway', () => {
+  it('signs in, preserves other connections, and reuses the saved target on repeated handoffs', async () => {
+    const { bridge, registry } = fixture()
+    const activate = vi.fn(async () => {})
+
+    await connectLinkedGateway(request, bridge, activate, 'Sign-in incomplete')
+    await connectLinkedGateway(request, bridge, activate, 'Sign-in incomplete')
+    expect(bridge.connections.save).toHaveBeenCalledTimes(1)
+    expect(bridge.connections.save).toHaveBeenCalledWith({
+      kind: 'remote',
+      label: 'Studio (2)',
+      url: request.url,
+      authMode: 'oauth'
+    })
+    expect(activate).toHaveBeenLastCalledWith(registry(), 'remote')
+    expect(registry().connections[0]).toEqual(local)
+    expect(bridge.connections.setPrimary).not.toHaveBeenCalled()
+  })
+
+  it('does not save or switch after canceled sign-in', async () => {
+    const { bridge } = fixture(false)
+    const activate = vi.fn()
+
+    await expect(connectLinkedGateway(request, bridge, activate, 'Sign-in incomplete')).rejects.toThrow(
+      'Sign-in incomplete'
+    )
+    expect(bridge.connections.save).not.toHaveBeenCalled()
+    expect(activate).not.toHaveBeenCalled()
+  })
+
+  it('surfaces an authenticated WebSocket switch failure and keeps the connection for retry', async () => {
+    const { bridge } = fixture()
+    const activate = vi.fn(async () => {
+      throw new Error('WebSocket rejected')
+    })
+
+    await expect(connectLinkedGateway(request, bridge, activate, 'Sign-in incomplete')).rejects.toThrow(
+      'WebSocket rejected'
+    )
+    expect(bridge.connections.remove).not.toHaveBeenCalled()
+    expect(bridge.connections.setPrimary).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/lib/connect-linked-gateway.ts
+++ b/apps/desktop/src/lib/connect-linked-gateway.ts
@@ -1,0 +1,50 @@
+import type { DesktopConnectionsRegistry, DesktopRegistryConnection } from '@/global'
+import type { GatewayConnectRequest } from '@/lib/gateway-connect-link'
+
+type DesktopBridge = Window['hermesDesktop']
+
+function existingConnection(registry: DesktopConnectionsRegistry, url: string): DesktopRegistryConnection | undefined {
+  return registry.connections.find(
+    connection =>
+      (connection.kind === 'remote' || connection.kind === 'cloud') && connection.url?.replace(/\/+$/, '') === url
+  )
+}
+
+export async function connectLinkedGateway(
+  request: GatewayConnectRequest,
+  bridge: Pick<DesktopBridge, 'connections' | 'oauthLoginConnectionConfig'>,
+  activate: (registry: DesktopConnectionsRegistry, id: string) => Promise<void>,
+  signInIncomplete: string
+): Promise<void> {
+  let registry = await bridge.connections.list()
+  let connection = existingConnection(registry, request.url)
+
+  if (!connection || connection.authMode === 'oauth') {
+    const signedIn = await bridge.oauthLoginConnectionConfig(request.url)
+
+    if (!signedIn.connected) {
+      throw new Error(signInIncomplete)
+    }
+  }
+
+  // Sign-in can outlive a registry edit in another window. Re-read before saving.
+  registry = await bridge.connections.list()
+  connection = existingConnection(registry, request.url)
+
+  if (!connection) {
+    const names = new Set(registry.connections.map(item => item.label.toLowerCase()))
+    let label = request.name
+    let suffix = 2
+
+    while (names.has(label.toLowerCase())) {
+      label = `${request.name} (${suffix++})`
+    }
+
+    const saved = await bridge.connections.save({ kind: 'remote', label, url: request.url, authMode: 'oauth' })
+
+    registry = saved.registry
+    connection = saved.connection
+  }
+
+  await activate(registry, connection.id)
+}

--- a/apps/desktop/src/lib/deeplink-routes.ts
+++ b/apps/desktop/src/lib/deeplink-routes.ts
@@ -1,5 +1,7 @@
 import type { PluginInstallLegacyHint } from '@/store/plugin-install-request'
 
+import { type GatewayConnectRequest, parseGatewayConnectRequest } from './gateway-connect-link'
+
 export interface DeepLinkPayload {
   kind: string
   name: string
@@ -7,6 +9,7 @@ export interface DeepLinkPayload {
 }
 
 export type DeepLinkAction =
+  | { type: 'gateway-connect'; request: GatewayConnectRequest }
   | { type: 'plugin-install'; repo: string; enable: boolean; force: boolean; legacyHint: PluginInstallLegacyHint }
   | { type: 'composer-blueprint'; name: string; params: Record<string, string> }
   | { type: 'ignore' }
@@ -24,6 +27,12 @@ function truthyParam(value: string | undefined, defaultValue = false): boolean {
 export function resolveDeepLinkAction(payload: DeepLinkPayload | null | undefined): DeepLinkAction {
   if (!payload?.kind) {
     return { type: 'ignore' }
+  }
+
+  if (payload.kind === 'gateway' && payload.name === 'connect') {
+    const request = parseGatewayConnectRequest(payload.params || {})
+
+    return request ? { type: 'gateway-connect', request } : { type: 'ignore' }
   }
 
   if (payload.kind === 'blueprint' && payload.name) {

--- a/apps/desktop/src/lib/gateway-connect-link.test.ts
+++ b/apps/desktop/src/lib/gateway-connect-link.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveDeepLinkAction } from './deeplink-routes'
+import { parseGatewayConnectRequest } from './gateway-connect-link'
+
+describe('gateway connection handoff', () => {
+  it('normalizes a gateway address without changing its cluster path', () => {
+    expect(
+      resolveDeepLinkAction({
+        kind: 'gateway',
+        name: 'connect',
+        params: { url: 'https://ACTUAL.inc/api/hermes/clusters/cluster-1/', name: 'Studio' }
+      })
+    ).toEqual({
+      type: 'gateway-connect',
+      request: { url: 'https://actual.inc/api/hermes/clusters/cluster-1', name: 'Studio' }
+    })
+  })
+
+  it.each([
+    'file:///etc/passwd',
+    'javascript:alert(1)',
+    'http://example.com',
+    'https://user:secret@example.com',
+    'https://example.com?token=secret',
+    'https://example.com#secret'
+  ])('rejects unsafe addresses: %s', url => {
+    expect(parseGatewayConnectRequest({ url })).toBeNull()
+  })
+
+  it('does not accept credentials or commands in the handoff', () => {
+    expect(parseGatewayConnectRequest({ url: 'https://example.com', token: 'secret' })).toBeNull()
+    expect(parseGatewayConnectRequest({ url: 'https://example.com', name: 'bad\nname' })).toBeNull()
+  })
+})

--- a/apps/desktop/src/lib/gateway-connect-link.ts
+++ b/apps/desktop/src/lib/gateway-connect-link.ts
@@ -1,0 +1,30 @@
+export interface GatewayConnectRequest {
+  url: string
+  name: string
+}
+
+export function parseGatewayConnectRequest(params: Record<string, string>): GatewayConnectRequest | null {
+  if (Object.keys(params).some(key => key !== 'url' && key !== 'name')) {
+    return null
+  }
+
+  try {
+    const url = new URL(params.url || '')
+
+    if (url.protocol !== 'https:' || url.username || url.password || url.search || url.hash) {
+      return null
+    }
+
+    const name = (params.name || url.hostname).trim()
+
+    if (!name || name.length > 128 || [...name].some(char => char.charCodeAt(0) < 32 || char.charCodeAt(0) === 127)) {
+      return null
+    }
+
+    url.pathname = url.pathname.replace(/\/+$/, '') || '/'
+
+    return { url: url.toString().replace(/\/$/, ''), name }
+  } catch {
+    return null
+  }
+}

--- a/apps/desktop/src/lib/incremental-external-store-runtime.ts
+++ b/apps/desktop/src/lib/incremental-external-store-runtime.ts
@@ -36,6 +36,50 @@ const shallowEqual = (a: object, b: object): boolean => {
 const getThreadListAdapter = (store: ExternalStoreAdapter) => store.adapters?.threadList ?? {}
 
 /**
+ * @assistant-ui/core 0.2.23 constructs thread-list state through a
+ * LazyMemoizeSubject, but ThreadListRuntimeImpl.subscribe() bypasses that
+ * subject and subscribes to the core directly. The subject therefore never
+ * becomes connected and getState() allocates a structurally identical object
+ * on every read. React 19's useSyncExternalStore tearing check correctly
+ * rejects that unstable snapshot and can take the whole chat surface down.
+ *
+ * Cache at the public runtime seam until the real thread-list subscription
+ * fires. This mirrors the upstream fix, where subscribe() now goes through the
+ * memoizing state binding, without pulling a broad assistant-ui minor upgrade
+ * into Desktop.
+ */
+function stabilizeThreadListSnapshot(runtime: AssistantRuntime): AssistantRuntime {
+  const threads = runtime.threads
+  const readSnapshot = threads.getState.bind(threads)
+  let dirty = false
+
+  // Runtime-lifetime subscription: `runtime` owns `threads`, and both become
+  // unreachable together when this hook unmounts. Register before the provider
+  // subscribes so a core publication marks the cache dirty first, and take the
+  // initial read only after registration so nothing published in between is
+  // ever missed.
+  threads.subscribe(() => {
+    dirty = true
+  })
+
+  let snapshot = readSnapshot()
+
+  Object.defineProperty(threads, 'getState', {
+    configurable: true,
+    value: () => {
+      if (dirty) {
+        snapshot = readSnapshot()
+        dirty = false
+      }
+
+      return snapshot
+    }
+  })
+
+  return runtime
+}
+
+/**
  * Write only the items whose (message, parentId) pair actually moved.
  *
  * `useRuntimeMessageRepository` caches normalized ThreadMessages by source
@@ -280,5 +324,5 @@ export function useIncrementalExternalStoreRuntime<T extends ThreadMessage>(
     return runtime.registerModelContextProvider(modelContext)
   }, [modelContext, runtime])
 
-  return useMemo(() => new AssistantRuntimeImpl(runtime), [runtime])
+  return useMemo(() => stabilizeThreadListSnapshot(new AssistantRuntimeImpl(runtime)), [runtime])
 }

--- a/apps/desktop/src/lib/incremental-runtime-thread-list-snapshot.test.tsx
+++ b/apps/desktop/src/lib/incremental-runtime-thread-list-snapshot.test.tsx
@@ -1,0 +1,59 @@
+import type { ExportedMessageRepository, ExternalStoreAdapter } from '@assistant-ui/react'
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { useIncrementalExternalStoreRuntime } from './incremental-external-store-runtime'
+
+const EMPTY_REPOSITORY: ExportedMessageRepository = {
+  headId: null,
+  messages: []
+}
+
+function adapter(threadId = 'DEFAULT_THREAD_ID'): ExternalStoreAdapter {
+  return {
+    messageRepository: EMPTY_REPOSITORY,
+    isRunning: false,
+    setMessages: () => {},
+    onNew: async () => {},
+    onCancel: async () => {},
+    adapters: {
+      threadList: { threadId }
+    }
+  }
+}
+
+describe('incremental runtime thread-list snapshots', () => {
+  it('caches the snapshot until the thread-list runtime publishes a change', () => {
+    const { result, rerender } = renderHook(
+      ({ threadId }: { threadId: string }) => useIncrementalExternalStoreRuntime(adapter(threadId)),
+      { initialProps: { threadId: 'thread-one' } }
+    )
+
+    const first = result.current.threads.getState()
+    const second = result.current.threads.getState()
+
+    expect(second).toBe(first)
+
+    rerender({ threadId: 'thread-two' })
+
+    const changed = result.current.threads.getState()
+
+    expect(changed).not.toBe(first)
+    expect(changed.mainThreadId).toBe('thread-two')
+    expect(result.current.threads.getState()).toBe(changed)
+  })
+
+  it('reflects a publication that fires before the first read', () => {
+    const { result, rerender } = renderHook(
+      ({ threadId }: { threadId: string }) => useIncrementalExternalStoreRuntime(adapter(threadId)),
+      { initialProps: { threadId: 'thread-one' } }
+    )
+
+    rerender({ threadId: 'thread-two' })
+
+    const first = result.current.threads.getState()
+
+    expect(first.mainThreadId).toBe('thread-two')
+    expect(result.current.threads.getState()).toBe(first)
+  })
+})

--- a/apps/desktop/src/store/gateway-connect-request.ts
+++ b/apps/desktop/src/store/gateway-connect-request.ts
@@ -1,0 +1,15 @@
+import { atom } from 'nanostores'
+
+import type { GatewayConnectRequest } from '@/lib/gateway-connect-link'
+
+export const $gatewayConnectRequest = atom<GatewayConnectRequest | null>(null)
+
+export function requestGatewayConnect(request: GatewayConnectRequest): void {
+  if (!$gatewayConnectRequest.get()) {
+    $gatewayConnectRequest.set(request)
+  }
+}
+
+export function closeGatewayConnect(): void {
+  $gatewayConnectRequest.set(null)
+}


### PR DESCRIPTION
## Summary
Open a remote gateway from a credential-free `hermes://gateway/connect` link. Desktop asks the user to confirm the displayed address, signs in through the existing gateway flow, saves or reuses the connection, and switches through the existing authenticated WebSocket path.

## Motivation
Remote gateway setup currently requires copying the address into Desktop. A website or terminal should be able to hand off the intended gateway to an already-running or newly opened app while preserving existing connections.

## Links
- [E-1090](https://linear.app/actualcomputer/issue/E-1090/connect-hermes-desktop-to-actual-with-automatic-setup).
- Prerequisite: [#94969](https://github.com/NousResearch/hermes-agent/pull/94969). Its thread-list snapshot fix is carried as a separate credited commit because the native restart regression otherwise crashes the workspace on current main. That commit can drop after the prerequisite merges.
- [Gateway link contract](apps/desktop/docs/gateway-links.md).

## Approach
Resolve the gateway link through the existing deep-link dispatcher, display the shared confirmation dialog, and reuse Electron's account sign-in and connection registry. HTTPS addresses retain their path prefix; credentials and unsupported parameters are rejected. Matching saved URLs are reused, and the primary startup choice is preserved.

## Reviewer Focus
Check address validation, cancellation, registry identity, and the existing authenticated source-switch boundary. The handoff does not save credentials in a URL or introduce a new authentication protocol.

Validation: 21 focused runtime/deep-link tests passed; renderer typecheck and full Desktop lint passed (existing warnings); production build passed. A real Hermes serve + native Electron run passed chat, generated title, compaction, window reconnect, app restart, cold and already-open handoff, and cancellation preserving saved connections. Actual inference recorded 19 Chat Completions calls and zero Responses calls. The native handoff checks exercise the confirmation/cancel path; the save/sign-in orchestration has focused bridge tests.

Upstream GitHub Actions currently require maintainer approval (`action_required`); those checks have not run. This PR remains draft until that gate is resolved. A real hosted browser sign-in over TLS is an explicit release smoke check.

## Failure Modes
Canceled sign-in does not create a connection. Failed source switches report the error and keep the saved entry for retry. Repeated links reuse an existing URL. Malformed or credential-bearing links are rejected. Existing app versions require manual gateway entry.

## Breaking Changes
None.

## Post-Merge Behavior
Requires a Hermes Desktop build/release containing this change. There is no backend provider change, gateway deployment, or new environment flag. The caller must offer install/update and manual URL fallback because launching a URI does not acknowledge connection success.

## Diagrams
```mermaid
sequenceDiagram
  participant C as Caller
  participant D as Desktop renderer
  participant E as Electron
  participant G as Remote gateway
  C->>E: hermes://gateway/connect (URL and name)
  E->>D: Existing queued deep-link event
  D->>D: Show address and ask user to connect
  D->>E: Existing gateway sign-in
  E->>G: Authenticate
  E-->>D: Sign-in result
  D->>E: Save or reuse registry connection
  D->>G: Existing authenticated WebSocket source switch
```
