### PR TITLE
fix(a2a): surface every reply artifact, not just the first

### DIFF
--- a/plugins/platforms/a2a/tools.py
+++ b/plugins/platforms/a2a/tools.py
@@ -135,11 +135,26 @@ def _reply_text_from_result(result: Any) -> str:
     result = protocol.unwrap_send_message_response(result)
     if not isinstance(result, dict):
         return str(result)
-    # Artifacts first (final output), then status message (interim/clarify), else bare Message.
+    # Collect text from EVERY artifact, not just the first: peers that run several
+    # commands emit stdout-1, stdout-2, ... plus a polished `response` artifact, and
+    # returning the first one silently drops later output. Thinking/reasoning
+    # artifacts are internal noise — skipped. When a polished `response`/`final`
+    # artifact exists it supersedes the raw stdout dumps.
+    skipped = ("thinking", "reasoning", "plan")
+    polished_names = ("response", "final", "answer")
+    texts: list[tuple[str, str]] = []
     for artifact in result.get("artifacts", []) or []:
+        name = str(artifact.get("name", "")).strip().lower()
+        if name in skipped:
+            continue
         txt = protocol.extract_text(artifact)
         if txt:
-            return txt
+            texts.append((name, txt))
+    polished = [t for name, t in texts if name in polished_names]
+    if polished:
+        return "\n\n".join(polished)
+    if texts:
+        return "\n\n".join(f"[{name}]\n{t}" if name else t for name, t in texts)
     return protocol.extract_text((result.get("status", {}) or {}).get("message") or result)
 
 

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -492,6 +492,52 @@ class TestClientTools:
         assert "input-required" in out
         assert "ctx-q" in out
 
+    def test_call_returns_all_artifacts_not_just_the_first(self, monkeypatch):
+        """Peers that run several commands emit stdout-1/stdout-2 artifacts; the
+        client must surface every artifact's text, never silently drop later ones."""
+        monkeypatch.setattr(tools, "_load_config",
+                            lambda: {"a2a_agents": {"r": {"url": "http://localhost:9999"}}})
+        monkeypatch.setattr(tools, "_http_get_json", lambda url, h, t: None)
+
+        def art(name, text):
+            return {"name": name, "parts": [protocol.text_part(text)]}
+
+        task = protocol.build_task("t", "c1", protocol.STATE_COMPLETED, "ignored")
+        task["artifacts"] = [
+            art("stdout-1", "week-one events"),
+            art("thinking", "internal monologue"),
+            art("stdout-2", "week-two events"),
+        ]
+
+        monkeypatch.setattr(tools, "_http_post_json",
+                            lambda url, body, headers, timeout: protocol.jsonrpc_result(body["id"], task))
+        out = tools.a2a_call({"agent": "r", "message": "what happened both weeks?"})
+        assert "week-one events" in out
+        assert "week-two events" in out  # was silently dropped (first-artifact return)
+        assert "internal monologue" not in out  # thinking artifacts stay invisible
+
+    def test_call_prefers_polished_response_artifact(self, monkeypatch):
+        """A `response` artifact supersedes raw stdout dumps (it is the agent's
+        formatted answer), but must not hide stdout text when absent."""
+        monkeypatch.setattr(tools, "_load_config",
+                            lambda: {"a2a_agents": {"r": {"url": "http://localhost:9999"}}})
+        monkeypatch.setattr(tools, "_http_get_json", lambda url, h, t: None)
+
+        def art(name, text):
+            return {"name": name, "parts": [protocol.text_part(text)]}
+
+        task = protocol.build_task("t", "c1", protocol.STATE_COMPLETED, "ignored")
+        task["artifacts"] = [
+            art("stdout-1", "raw dump"),
+            art("response", "formatted answer"),
+        ]
+
+        monkeypatch.setattr(tools, "_http_post_json",
+                            lambda url, body, headers, timeout: protocol.jsonrpc_result(body["id"], task))
+        out = tools.a2a_call({"agent": "r", "message": "summarize"})
+        assert "formatted answer" in out
+        assert "raw dump" not in out
+
     def test_rpc_url_prefers_supported_interfaces(self):
         card = {
             "url": "http://legacy:1/",


### PR DESCRIPTION
## Problem

`_reply_text_from_result()` in `plugins/platforms/a2a/tools.py` returns on the **first non-empty artifact** and silently drops every artifact after it:

```python
for artifact in result.get("artifacts", []) or []:
    txt = protocol.extract_text(artifact)
    if txt:
        return txt   # <-- everything after this artifact is lost
```

Peers that run several shell commands (a very normal A2A Task shape) emit multiple artifacts — `stdout-1`, `stdout-2`, … plus a polished `response` artifact. The caller only ever sees the first command's output, with no error or indication anything is missing.

**Live reproduction:** a peer agent answering *"what was on my calendar for sep 1 and sep 8?"* returns a task whose raw HTTP body contains `stdout-1` (week 1 JSON), `stdout-2` (week 2 JSON), `thinking`, and `response` (both weeks, formatted). `a2a_call` surfaced only `stdout-1` — the user saw half the answer and (reasonably) kept blaming the peer agent. The data was in the response the whole time; the plugin dropped it.

I confirmed this is not intentional: `git log -L` shows the early-return has been there since the plugin's first landing (`95f62ca3bf`, the a2a consolidation), no test pins the first-wins behavior, and the design docs describe artifacts as *the* final output with no single-artifact assumption.

## Fix

Collect text from **all** artifacts:
- skip internal `thinking` / `reasoning` / `plan` artifacts (agent-internal noise, per observed peer behavior)
- prefer a polished `response` / `final` / `answer` artifact when present (it is the agent's formatted answer and already incorporates the raw output)
- otherwise join all artifacts with `[name]` labels
- status.message fallback for artifact-free replies is unchanged; single-artifact replies (the common case today) are unchanged

## Tests

2 invariant tests in `TestClientTools` (mocked HTTP, real tool path):
- multi-artifact task surfaces stdout-1 **and** stdout-2, hides thinking
- polished `response` artifact supersedes raw stdout dumps

Both mutation-checked: **red on base, green with the fix**. Rest of the file passes (`106 passed`; the one pre-existing failure in `test_forward_to_profile_first_contact` also fails on pristine main and is unrelated).