### PR TITLE
WhatsApp: quoting an image (incl. the bot's own cron-sent one) now attaches it to the agent's turn (salvage #77660)

### DIFF
--- a/contributors/emails/ishangodawatta@gmail.com
+++ b/contributors/emails/ishangodawatta@gmail.com
@@ -1,0 +1,1 @@
+ishangodawatta

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -550,14 +550,22 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         filename: Optional[str] = None, reply_to: Optional[str] = None,
         mime_type: Optional[str] = None,
     ) -> SendResult:
-        """HTTPS URL → ``link`` send (one fewer round trip); local path → upload + ``id`` send."""
+        """HTTPS URL → ``link`` send (one fewer round trip); local path → upload + ``id`` send.
+        Local sends are indexed in ``rich_sent_store`` so a later quote of the attachment can be
+        resolved (Meta's inbound ``context`` carries only the quoted id)."""
         ref: Dict[str, Optional[str]] = {"media_link": source}
         if not source.startswith(_HTTP_PREFIXES):
             media_id, err = await self._upload_media(source, media_kind, mime_type)
             if err:
                 return SendResult(success=False, error=err)
             ref = {"media_id": media_id}
-        return await self._send_media(chat_id, media_kind, caption=caption, filename=filename, reply_to=reply_to, **ref)
+        result = await self._send_media(chat_id, media_kind, caption=caption, filename=filename, reply_to=reply_to, **ref)
+        if result.success and result.message_id and "media_id" in ref:
+            mime = mime_type or mimetypes.guess_type(source)[0] or _DEFAULT_MIME.get(media_kind, "application/octet-stream")
+            rich_sent_store.record_media(chat_id, result.message_id, [(source, mime)])
+            if caption:
+                rich_sent_store.record(chat_id, result.message_id, caption)
+        return result
 
     # ``**kwargs`` absorbs base-class args (e.g. ``metadata``) the Cloud API has no use for.
     async def send_image(self, chat_id: str, image_url: str, caption: Optional[str] = None, reply_to: Optional[str] = None, **kwargs) -> SendResult:
@@ -986,8 +994,9 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             media_urls, media_types, body = await self._collect_inbound_media(msg_type_str, raw_message, body)
             if msg_type_str == "document" and media_urls:
                 body = self._inject_document_text(media_urls, body)
-        # Meta's ``context`` gives only the quoted message's id (+ author), never its text;
-        # resolve from rich_sent_store so run.py can build "[Replying to: ...]".
+        # Meta's ``context`` gives only the quoted message's id (+ author), never its text or
+        # bytes; resolve both from rich_sent_store so run.py can build "[Replying to: ...]" and
+        # the quoted attachment reaches the vision/audio pipeline like a direct one.
         context = raw_message.get("context") or {}
         reply_to_id = str(context.get("id") or "").strip() or None
         reply_to_text = rich_sent_store.lookup(chat_id, reply_to_id) if reply_to_id else None
@@ -1001,6 +1010,13 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             self._bounded_put(self._last_inbound_wamid_by_chat, chat_id, wamid)
             if body:
                 rich_sent_store.record(chat_id, wamid, body)
+            if msg_type_str in _INBOUND_MEDIA_KINDS and media_urls:
+                rich_sent_store.record_media(chat_id, wamid, list(zip(media_urls, media_types)))
+        if reply_to_id:
+            for path, mime in rich_sent_store.lookup_media(chat_id, reply_to_id):
+                if path not in media_urls:
+                    media_urls.append(path)
+                    media_types.append(mime)
         return MessageEvent(
             text=body, message_type=_MESSAGE_TYPE_BY_KIND.get(msg_type_str, MessageType.TEXT),
             source=self.build_source(

--- a/gateway/rich_sent_store.py
+++ b/gateway/rich_sent_store.py
@@ -1,8 +1,12 @@
-"""Local index of text we've sent via ``sendRichMessage`` (Bot API 10.1). Telegram does NOT echo a rich
-message's content back in ``reply_to_message`` (``.text``/``.caption`` empty, ``.api_kwargs`` None), so
-replies to rich sends arrive with no quotable text; we remember ``message_id -> text`` at send time and
-look it up by ``reply_to_id`` on inbound. Best-effort and dependency-free: every operation swallows
-errors and degrades to a no-op / ``None`` so it can never break a send or an inbound message.
+"""Local index of what we've sent (and, for WhatsApp, received) keyed by ``(chat_id, message_id)``.
+
+Telegram does NOT echo a rich message's content back in ``reply_to_message`` (``.text``/``.caption``
+empty, ``.api_kwargs`` None), and WhatsApp quotes carry only the quoted message's id (Cloud API) or a
+thumbnail stub (Baileys) — never the original bytes. So a reply to something we sent arrives with no
+quotable text and no way to re-fetch a quoted attachment. We remember ``message_id -> text`` and
+``message_id -> [(local_path, mime)]`` at send/receive time and look them up by ``reply_to_id`` on
+inbound. Best-effort and dependency-free: every operation swallows errors and degrades to a no-op /
+``None`` / ``[]`` so it can never break a send or an inbound message.
 """
 
 from __future__ import annotations
@@ -30,15 +34,16 @@ def _load(path: str) -> dict:
     return data if isinstance(data, dict) else {}
 
 
-def record(chat_id, message_id, text: Optional[str]) -> None:
-    """Persist ``text`` for ``(chat_id, message_id)``. No-op on any failure."""
-    if not text or message_id is None or chat_id is None:
-        return
+def _update(chat_id, message_id, fields: dict) -> None:
+    """Merge ``fields`` into the ``(chat_id, message_id)`` entry. No-op on any failure."""
     path = _store_path()
     try:
         os.makedirs(os.path.dirname(path), exist_ok=True)
         data = _load(path)
-        data[f"{chat_id}:{message_id}"] = {"t": text[:_MAX_TEXT_CHARS], "ts": int(time.time())}
+        key = f"{chat_id}:{message_id}"
+        entry = data.get(key)
+        entry = entry if isinstance(entry, dict) else {}
+        data[key] = {**entry, **fields, "ts": int(time.time())}
         if len(data) > _MAX_ENTRIES:  # trim oldest by timestamp
             for k, _ in sorted(data.items(), key=lambda kv: kv[1].get("ts", 0))[: len(data) - _MAX_ENTRIES]:
                 data.pop(k, None)
@@ -50,9 +55,33 @@ def record(chat_id, message_id, text: Optional[str]) -> None:
         return
 
 
+def record(chat_id, message_id, text: Optional[str]) -> None:
+    """Persist ``text`` for ``(chat_id, message_id)``. No-op on any failure."""
+    if not text or message_id is None or chat_id is None:
+        return
+    _update(chat_id, message_id, {"t": text[:_MAX_TEXT_CHARS]})
+
+
+def record_media(chat_id, message_id, media: list[tuple[str, str]]) -> None:
+    """Persist local attachment ``(path, mime)`` pairs for ``(chat_id, message_id)``."""
+    if not media or message_id is None or chat_id is None:
+        return
+    _update(chat_id, message_id, {"m": [[str(p), str(mt or "")] for p, mt in media if p]})
+
+
+def _entry(chat_id, message_id) -> dict:
+    if message_id is None or chat_id is None:
+        return {}
+    entry = _load(_store_path()).get(f"{chat_id}:{message_id}")
+    return entry if isinstance(entry, dict) else {}
+
+
 def lookup(chat_id, message_id) -> Optional[str]:
     """Return stored text for ``(chat_id, message_id)`` or ``None``."""
-    if message_id is None or chat_id is None:
-        return None
-    entry = _load(_store_path()).get(f"{chat_id}:{message_id}")
-    return (entry.get("t") or None) if isinstance(entry, dict) else None
+    return _entry(chat_id, message_id).get("t") or None
+
+
+def lookup_media(chat_id, message_id) -> list[tuple[str, str]]:
+    """Return stored ``(path, mime)`` pairs whose file still exists (attachments may be temp files)."""
+    pairs = _entry(chat_id, message_id).get("m") or []
+    return [(p, mt) for p, mt in pairs if isinstance(p, str) and os.path.isfile(p)]

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -3,6 +3,7 @@ client; messages are polled over a local HTTP API and responses are posted back 
 
 import asyncio
 import logging
+import mimetypes
 import os
 import platform
 import re
@@ -233,6 +234,11 @@ _MEDIA_NEEDLES = (("image", MessageType.PHOTO), ("video", MessageType.VIDEO), ("
 _MEDIA_INFO = {
     MessageType.PHOTO: ("image", "image/jpeg"), MessageType.VOICE: ("audio", "audio/ogg"), MessageType.AUDIO: ("audio", "audio/mpeg"),
     MessageType.VIDEO: ("video", "video/mp4"), MessageType.DOCUMENT: ("document", ""),
+}
+_MEDIA_TYPE_BY_BRIDGE_KIND = {"image": MessageType.PHOTO, "video": MessageType.VIDEO, "audio": MessageType.VOICE, "document": MessageType.DOCUMENT}
+_QUOTED_MIME_BY_BRIDGE_KIND = {
+    "image": "image/jpeg", "video": "video/mp4", "gif": "video/mp4", "audio": "audio/ogg", "ptt": "audio/ogg",
+    "document": "application/octet-stream", "sticker": "image/webp",
 }
 
 
@@ -599,9 +605,17 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     async def _send_media_to_bridge(self, chat_id: str, file_path: str, media_type: str, caption: Optional[str] = None, file_name: Optional[str] = None) -> SendResult:
         if not os.path.exists(file_path):
             return SendResult(success=False, error=f"File not found: {file_path}")
-        payload: Dict[str, Any] = {"chatId": to_whatsapp_jid(chat_id), "filePath": file_path, "mediaType": media_type}
+        jid = to_whatsapp_jid(chat_id)
+        payload: Dict[str, Any] = {"chatId": jid, "filePath": file_path, "mediaType": media_type}
         payload.update({k: v for k, v in (("caption", caption), ("fileName", file_name)) if v})
-        return await self._post_bridge_message("send-media", payload, timeout=120)
+        result = await self._post_bridge_message("send-media", payload, timeout=120)
+        if result.success and result.message_id:
+            # A later quote of this attachment carries only a thumbnail stub; the bridge's cache
+            # knows inbound media only, so index our own sends (the cron-delivered image case).
+            from gateway import rich_sent_store
+            mime = mimetypes.guess_type(file_path)[0] or _MEDIA_INFO.get(_MEDIA_TYPE_BY_BRIDGE_KIND.get(media_type), ("", ""))[1]
+            rich_sent_store.record_media(jid, result.message_id, [(file_path, mime or "application/octet-stream")])
+        return result
 
     @_needs_bridge
     async def send_poll(self, chat_id: str, question: str, options: list[str], *, selectable_count: int = 1) -> SendResult:
@@ -785,6 +799,27 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 print(f"[{self.name}] Failed to read document text: {e}", flush=True)
         return body
 
+    def _quoted_media(self, data: Dict[str, Any], raw_reply_id: Any) -> list[tuple[str, str]]:
+        """``(path, mime)`` for the quoted message's attachment, folded into this event's own media so the
+        vision/audio pipeline sees it like a direct send. ``contextInfo.quotedMessage`` carries only a
+        thumbnail stub, so the bridge resolves INBOUND quotes from its download cache (``quotedMediaUrls``,
+        guarded like direct media: a rogue bridge could hand back /etc/passwd); quotes of OUR media (cron
+        chart, generated image — any path we chose) resolve from the outbound index written by
+        ``_send_media_to_bridge``."""
+        quoted_type = str(data.get("quotedMediaType") or "").strip()
+        accepted: list[tuple[str, str]] = []
+        for path in data.get("quotedMediaUrls") or []:
+            if not (isinstance(path, str) and os.path.isabs(path) and _is_allowed_bridge_path(path)):
+                print(f"[{self.name}] Rejected quoted-media path outside cache dir: {path}", flush=True)
+                continue
+            accepted.append((path, _QUOTED_MIME_BY_BRIDGE_KIND.get(quoted_type, "application/octet-stream")))
+        if not accepted and raw_reply_id is not None:
+            from gateway import rich_sent_store
+            accepted = rich_sent_store.lookup_media(data.get("chatId", ""), str(raw_reply_id))
+        for path, _ in accepted:
+            print(f"[{self.name}] Attached quoted-reply media: {path}", flush=True)
+        return accepted
+
     async def _build_message_event(self, data: Dict[str, Any]) -> Optional[MessageEvent]:
         """Build a MessageEvent from bridge message data, downloading images to cache."""
         try:
@@ -803,33 +838,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             quoted = bool(data.get("hasQuotedMessage"))
             raw_reply_id = data.get("quotedMessageId") if quoted else None
             if quoted:
-                # contextInfo.quotedMessage only ever carries a thumbnail-sized
-                # stub for media (or nothing for an uncaptioned attachment) —
-                # never a way to fetch the original file. The bridge resolves
-                # the quoted message's already-downloaded media via its own
-                # cache and hands back real local paths in quotedMediaUrls.
-                # Append them to this event's own media so the existing
-                # vision/audio pipeline (which reads media_urls/media_types)
-                # picks up the quoted attachment exactly like a direct one —
-                # no separate reply-media code path needed.
-                quoted_media_urls = data.get("quotedMediaUrls") or []
-                quoted_media_type = str(data.get("quotedMediaType") or "").strip()
-                _quoted_mime_map = {
-                    "image": "image/jpeg",
-                    "video": "video/mp4",
-                    "gif": "video/mp4",
-                    "audio": "audio/ogg",
-                    "ptt": "audio/ogg",
-                    "document": "application/octet-stream",
-                    "sticker": "image/webp",
-                }
-                for _qurl in quoted_media_urls:
-                    if not (isinstance(_qurl, str) and os.path.isabs(_qurl) and _is_allowed_bridge_path(_qurl)):
-                        print(f"[{self.name}] Rejected quoted-media path outside cache dir: {_qurl}", flush=True)
-                        continue
-                    cached_urls.append(_qurl)
-                    media_types.append(_quoted_mime_map.get(quoted_media_type, "application/octet-stream"))
-                    print(f"[{self.name}] Attached quoted-reply media: {_qurl}", flush=True)
+                for path, mime in self._quoted_media(data, raw_reply_id):
+                    cached_urls.append(path)
+                    media_types.append(mime)
             if msg_type == MessageType.DOCUMENT and cached_urls:
                 body = self._inject_document_text(cached_urls, body)
             native_metadata = data.get("nativeMetadata")

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -802,6 +802,34 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # Quoted message stays in structured fields only — GatewayRunner renders the "[Replying to: ...]" pointer.
             quoted = bool(data.get("hasQuotedMessage"))
             raw_reply_id = data.get("quotedMessageId") if quoted else None
+            if quoted:
+                # contextInfo.quotedMessage only ever carries a thumbnail-sized
+                # stub for media (or nothing for an uncaptioned attachment) —
+                # never a way to fetch the original file. The bridge resolves
+                # the quoted message's already-downloaded media via its own
+                # cache and hands back real local paths in quotedMediaUrls.
+                # Append them to this event's own media so the existing
+                # vision/audio pipeline (which reads media_urls/media_types)
+                # picks up the quoted attachment exactly like a direct one —
+                # no separate reply-media code path needed.
+                quoted_media_urls = data.get("quotedMediaUrls") or []
+                quoted_media_type = str(data.get("quotedMediaType") or "").strip()
+                _quoted_mime_map = {
+                    "image": "image/jpeg",
+                    "video": "video/mp4",
+                    "gif": "video/mp4",
+                    "audio": "audio/ogg",
+                    "ptt": "audio/ogg",
+                    "document": "application/octet-stream",
+                    "sticker": "image/webp",
+                }
+                for _qurl in quoted_media_urls:
+                    if not (isinstance(_qurl, str) and os.path.isabs(_qurl) and _is_allowed_bridge_path(_qurl)):
+                        print(f"[{self.name}] Rejected quoted-media path outside cache dir: {_qurl}", flush=True)
+                        continue
+                    cached_urls.append(_qurl)
+                    media_types.append(_quoted_mime_map.get(quoted_media_type, "application/octet-stream"))
+                    print(f"[{self.name}] Attached quoted-reply media: {_qurl}", flush=True)
             if msg_type == MessageType.DOCUMENT and cached_urls:
                 body = self._inject_document_text(cached_urls, body)
             native_metadata = data.get("nativeMetadata")

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -733,8 +733,9 @@ async function startSocket() {
         continue;
       }
 
-      // Skip empty messages
-      if (!event.body && !event.hasMedia) {
+      // Skip empty messages (but not a bare quote-reply whose own text/media
+      // is empty when the quoted message resolved to cached media).
+      if (!event.body && !event.hasMedia && !event.quotedMediaUrls.length) {
         emitDebugEvent({
           stage: 'ignored',
           reason: 'empty',

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -40,6 +40,7 @@ import {
   buildLocationPayload,
   buildTextSendPayload,
   createBoundedMessageStore,
+  createQuotedMediaCache,
   extractBridgeEvent,
   getMessageContent,
   inboundReadReceiptKeys,
@@ -260,6 +261,10 @@ const MAX_QUEUE_SIZE = 100;
 const recentlySentIds = createOutboundIdTracker(512);
 const recentlyProcessedPollUpdates = createOutboundIdTracker(512);
 const messageStore = createBoundedMessageStore(512);
+// Bounded cache of already-downloaded inbound media, so a later reply to an
+// uncaptioned photo/video/document/voice note can still surface the original
+// file — see createQuotedMediaCache's doc comment in bridge_helpers.js.
+const quotedMediaCache = createQuotedMediaCache(512);
 
 function normalizePollUpdateOptions(aggregation, pollUpdateMessage, meId) {
   const selected = [];
@@ -711,6 +716,7 @@ async function startSocket() {
           document: DOCUMENT_CACHE_DIR,
           audio: AUDIO_CACHE_DIR,
         },
+        lookupQuotedMedia: (quotedChatId, quotedMessageId) => quotedMediaCache.get(quotedChatId, quotedMessageId),
       });
       event.fromOwner = fromOwner;
 
@@ -739,6 +745,15 @@ async function startSocket() {
       }
 
       messageStore.remember(msg);
+      // Remember this message's already-downloaded media/text so a later
+      // reply to it (even uncaptioned media) can resolve the original
+      // content instead of seeing only a stripped-down quoted-message stub.
+      quotedMediaCache.remember(chatId, msg.key.id, {
+        body: event.body,
+        hasMedia: event.hasMedia,
+        mediaType: event.mediaType,
+        mediaUrls: event.mediaUrls,
+      });
       messageQueue.push(event);
       emitDebugEvent({
         stage: 'queued',

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -177,6 +177,48 @@ import {
   console.log('  ✓ reply to uncaptioned quoted image resolves cached original file');
 }
 
+// -- bare quote-reply (no own text/media) still resolves quoted media -----
+{
+  // A reply with no caption of its own (e.g. a bare quote of an uncaptioned
+  // image) has empty own body/media, so bridge.js's empty-message guard must
+  // consult quotedMediaUrls rather than only event.body/event.hasMedia, or
+  // the reply is dropped even though extractBridgeEvent resolved real content.
+  const event = await extractBridgeEvent({
+    msg: {
+      key: {
+        id: 'incoming-4',
+        remoteJid: '15551234567@s.whatsapp.net',
+        participant: '15550001111@s.whatsapp.net',
+        fromMe: false,
+      },
+      pushName: 'Tester',
+      messageTimestamp: 123,
+      message: {
+        extendedTextMessage: {
+          text: '',
+          contextInfo: {
+            stanzaId: 'original-image-2',
+            participant: '15550001111@s.whatsapp.net',
+            remoteJid: '15551234567@s.whatsapp.net',
+            quotedMessage: { imageMessage: {} },
+          },
+        },
+      },
+    },
+    chatId: '15551234567@s.whatsapp.net',
+    senderId: '15550001111@s.whatsapp.net',
+    senderNumber: '15550001111',
+    botIds: [],
+    downloadMedia: async () => Buffer.from(''),
+    lookupQuotedMedia: () => ({ hasMedia: true, mediaType: 'image', mediaUrls: ['/cache/image/img_original.jpg'] }),
+  });
+
+  assert.equal(event.body, '');
+  assert.equal(event.hasMedia, false);
+  assert.deepEqual(event.quotedMediaUrls, ['/cache/image/img_original.jpg']);
+  console.log('  ✓ bare quote-reply with no own content still carries resolved quoted media');
+}
+
 // -- quoted media lookup miss leaves quoted fields empty (no crash) -------
 {
   const event = await extractBridgeEvent({

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -16,7 +16,6 @@ import {
   buildPollPayload,
   buildTextSendPayload,
   createBoundedMessageStore,
-  createQuotedMediaCache,
   appendMediaFailureNote,
   extractBridgeEvent,
   inboundReadReceiptKeys,
@@ -631,27 +630,6 @@ import {
   assert.equal(event.hasQuotedMessage, true);
   assert.equal(event.quotedText, 'Example appointment at 11:40');
   console.log('  ✓ nested envelopes: quote text resolves through both layers');
-}
-
-// -- createQuotedMediaCache ------------------------------------------------
-{
-  const cache = createQuotedMediaCache(2);
-  cache.remember('chat-a', 'msg-1', { hasMedia: true, mediaType: 'image', mediaUrls: ['/cache/img1.jpg'] });
-
-  assert.deepEqual(cache.get('chat-a', 'msg-1'), { hasMedia: true, mediaType: 'image', mediaUrls: ['/cache/img1.jpg'] });
-  // Different chatId, same messageId — must not collide; message ids are
-  // only unique within their own chat/JID.
-  assert.equal(cache.get('chat-b', 'msg-1'), null);
-  assert.equal(cache.get('chat-a', 'unknown-msg'), null);
-
-  cache.remember('chat-a', 'msg-2', { hasMedia: false });
-  cache.remember('chat-a', 'msg-3', { hasMedia: false });
-  // Capacity is 2: the oldest entry (msg-1) must have been evicted.
-  assert.equal(cache.get('chat-a', 'msg-1'), null);
-  assert.notEqual(cache.get('chat-a', 'msg-2'), null);
-  assert.notEqual(cache.get('chat-a', 'msg-3'), null);
-
-  console.log('  ✓ createQuotedMediaCache resolves by chatId+messageId and evicts oldest past capacity');
 }
 
 console.log('\n✅ All WhatsApp native bridge helper tests passed.');

--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -16,6 +16,7 @@ import {
   buildPollPayload,
   buildTextSendPayload,
   createBoundedMessageStore,
+  createQuotedMediaCache,
   appendMediaFailureNote,
   extractBridgeEvent,
   inboundReadReceiptKeys,
@@ -127,6 +128,89 @@ import {
   assert.equal(event.hasQuotedMessage, true);
   assert.equal(event.body, 'approved');
   console.log('  ✓ inbound quoted metadata includes quoted text');
+}
+
+// -- reply to uncaptioned quoted media resolves the cached original file --
+{
+  // contextInfo.quotedMessage only ever carries a thumbnail-sized stub for
+  // media (or nothing for an uncaptioned attachment) — extractBridgeEvent
+  // must fall back to lookupQuotedMedia to find the original cached file.
+  const event = await extractBridgeEvent({
+    msg: {
+      key: {
+        id: 'incoming-2',
+        remoteJid: '15551234567@s.whatsapp.net',
+        participant: '15550001111@s.whatsapp.net',
+        fromMe: false,
+      },
+      pushName: 'Tester',
+      messageTimestamp: 123,
+      message: {
+        extendedTextMessage: {
+          text: 'did you save this?',
+          contextInfo: {
+            stanzaId: 'original-image-1',
+            participant: '15550001111@s.whatsapp.net',
+            remoteJid: '15551234567@s.whatsapp.net',
+            // Real WhatsApp traffic: an uncaptioned quoted image carries no
+            // usable text, just a thumbnail-only imageMessage stub.
+            quotedMessage: { imageMessage: {} },
+          },
+        },
+      },
+    },
+    chatId: '15551234567@s.whatsapp.net',
+    senderId: '15550001111@s.whatsapp.net',
+    senderNumber: '15550001111',
+    botIds: [],
+    downloadMedia: async () => Buffer.from(''),
+    lookupQuotedMedia: (chatId, messageId) => {
+      assert.equal(chatId, '15551234567@s.whatsapp.net');
+      assert.equal(messageId, 'original-image-1');
+      return { hasMedia: true, mediaType: 'image', mediaUrls: ['/cache/image/img_original.jpg'] };
+    },
+  });
+
+  assert.deepEqual(event.quotedMediaUrls, ['/cache/image/img_original.jpg']);
+  assert.equal(event.quotedMediaType, 'image');
+  assert.equal(event.quotedText, 'sent an image');
+  console.log('  ✓ reply to uncaptioned quoted image resolves cached original file');
+}
+
+// -- quoted media lookup miss leaves quoted fields empty (no crash) -------
+{
+  const event = await extractBridgeEvent({
+    msg: {
+      key: {
+        id: 'incoming-3',
+        remoteJid: '15551234567@s.whatsapp.net',
+        participant: '15550001111@s.whatsapp.net',
+        fromMe: false,
+      },
+      messageTimestamp: 123,
+      message: {
+        extendedTextMessage: {
+          text: 'thanks',
+          contextInfo: {
+            stanzaId: 'long-gone-message',
+            participant: '15550001111@s.whatsapp.net',
+            remoteJid: '15551234567@s.whatsapp.net',
+            quotedMessage: { imageMessage: {} },
+          },
+        },
+      },
+    },
+    chatId: '15551234567@s.whatsapp.net',
+    senderId: '15550001111@s.whatsapp.net',
+    senderNumber: '15550001111',
+    botIds: [],
+    downloadMedia: async () => Buffer.from(''),
+    lookupQuotedMedia: () => null,
+  });
+
+  assert.deepEqual(event.quotedMediaUrls, []);
+  assert.equal(event.quotedMediaType, '');
+  console.log('  ✓ quoted media cache miss leaves quoted media fields empty');
 }
 
 {
@@ -505,6 +589,27 @@ import {
   assert.equal(event.hasQuotedMessage, true);
   assert.equal(event.quotedText, 'Example appointment at 11:40');
   console.log('  ✓ nested envelopes: quote text resolves through both layers');
+}
+
+// -- createQuotedMediaCache ------------------------------------------------
+{
+  const cache = createQuotedMediaCache(2);
+  cache.remember('chat-a', 'msg-1', { hasMedia: true, mediaType: 'image', mediaUrls: ['/cache/img1.jpg'] });
+
+  assert.deepEqual(cache.get('chat-a', 'msg-1'), { hasMedia: true, mediaType: 'image', mediaUrls: ['/cache/img1.jpg'] });
+  // Different chatId, same messageId — must not collide; message ids are
+  // only unique within their own chat/JID.
+  assert.equal(cache.get('chat-b', 'msg-1'), null);
+  assert.equal(cache.get('chat-a', 'unknown-msg'), null);
+
+  cache.remember('chat-a', 'msg-2', { hasMedia: false });
+  cache.remember('chat-a', 'msg-3', { hasMedia: false });
+  // Capacity is 2: the oldest entry (msg-1) must have been evicted.
+  assert.equal(cache.get('chat-a', 'msg-1'), null);
+  assert.notEqual(cache.get('chat-a', 'msg-2'), null);
+  assert.notEqual(cache.get('chat-a', 'msg-3'), null);
+
+  console.log('  ✓ createQuotedMediaCache resolves by chatId+messageId and evicts oldest past capacity');
 }
 
 console.log('\n✅ All WhatsApp native bridge helper tests passed.');

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -81,6 +81,45 @@ export function createBoundedMessageStore(limit = 512) {
   return { remember, get };
 }
 
+/**
+ * Bounded cache of the already-downloaded media (and plain text) for
+ * recently seen inbound messages, keyed by "chatId:messageId".
+ *
+ * When a user replies to an earlier message, Baileys' contextInfo.quotedMessage
+ * only carries a thumbnail-sized stub for media (or nothing at all for an
+ * uncaptioned attachment) — never a way to re-fetch the full original file.
+ * Without this cache, replying to a photo/video/document/voice note with no
+ * caption gives the agent no text and no media reference: it looks like the
+ * message never had an attachment. Since extractBridgeEvent already downloads
+ * and caches the media for every inbound message as it arrives, remembering
+ * that outcome here lets a later reply resolve the original file path.
+ */
+export function createQuotedMediaCache(limit = 512) {
+  const byKey = new Map();
+
+  function key(chatId, messageId) {
+    return `${chatId || ''}:${messageId || ''}`;
+  }
+
+  function remember(chatId, messageId, payload) {
+    if (!messageId) return;
+    const k = key(chatId, messageId);
+    byKey.delete(k);
+    byKey.set(k, payload);
+    while (byKey.size > limit) {
+      const oldest = byKey.keys().next().value;
+      byKey.delete(oldest);
+    }
+  }
+
+  function get(chatId, messageId) {
+    if (!messageId) return null;
+    return byKey.get(key(chatId, messageId)) || null;
+  }
+
+  return { remember, get };
+}
+
 export function pollCreationMessageSecret(pollCreation) {
   return pollCreation?.message?.messageContextInfo?.messageSecret
     || pollCreation?.messageContextInfo?.messageSecret
@@ -323,6 +362,7 @@ export async function extractBridgeEvent({
   downloadMedia,
   writeMediaFile,
   cacheDirs = {},
+  lookupQuotedMedia,
 }) {
   const messageContent = getMessageContent(msg);
   const contextInfo = getContextInfo(messageContent);
@@ -331,7 +371,38 @@ export async function extractBridgeEvent({
   const quotedParticipant = normalizeWhatsAppId(contextInfo?.participant || '') || null;
   const quotedRemoteJid = normalizeWhatsAppId(contextInfo?.remoteJid || '') || null;
   const hasQuotedMessage = !!contextInfo?.quotedMessage;
-  const quotedText = textFromQuotedMessage(contextInfo?.quotedMessage);
+  let quotedText = textFromQuotedMessage(contextInfo?.quotedMessage);
+  let quotedMediaUrls = [];
+  let quotedMediaType = '';
+
+  // contextInfo.quotedMessage only ever carries a thumbnail-sized stub for
+  // media (or nothing for an uncaptioned attachment) — never a way to
+  // re-fetch the original file. Resolve the quoted message's already-cached
+  // media (downloaded when it first arrived) via lookupQuotedMedia so a
+  // reply to an uncaptioned photo/video/document/voice note still gives the
+  // agent the original file, not just silence.
+  if (quotedMessageId && typeof lookupQuotedMedia === 'function') {
+    const original = lookupQuotedMedia(quotedRemoteJid || chatId, quotedMessageId);
+    if (original) {
+      if (original.hasMedia && original.mediaUrls?.length) {
+        quotedMediaUrls = original.mediaUrls;
+        quotedMediaType = original.mediaType || '';
+        if (!quotedText) {
+          quotedText = {
+            image: 'sent an image',
+            video: 'sent a video',
+            gif: 'sent a GIF',
+            audio: 'sent an audio message',
+            ptt: 'sent a voice message',
+            document: 'sent a document',
+            sticker: 'sent a sticker',
+          }[original.mediaType] || 'sent media';
+        }
+      } else if (original.body && !quotedText) {
+        quotedText = original.body;
+      }
+    }
+  }
 
   let body = '';
   let hasMedia = false;
@@ -498,6 +569,8 @@ export async function extractBridgeEvent({
     quotedParticipant,
     quotedRemoteJid,
     quotedText,
+    quotedMediaUrls,
+    quotedMediaType,
     hasQuotedMessage,
     botIds,
     readReceiptKey: {

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1400,3 +1400,29 @@ class TestReplyContextResolution:
         assert event.reply_to_text is None
         assert event.reply_to_is_own_message is False
 
+    @pytest.mark.asyncio
+    async def test_reply_to_bot_sent_image_attaches_the_file(self, tmp_path):
+        """The bot sends an uncaptioned image (a cron job delivering a chart); the user quotes it
+        and asks "what is this?". Meta's ``context`` carries only the wamid, so the bytes must come
+        from the outbound index written at send time — otherwise the agent never sees the image."""
+        adapter = _make_adapter()
+        image = tmp_path / "chart.png"
+        image.write_bytes(b"\x89PNG fake")
+        adapter._upload_media = AsyncMock(return_value=("MEDIA-ID", None))
+        adapter._post_messages = AsyncMock(return_value=([{"id": "wamid.BOT_IMG"}], None))
+        adapter._http_client = MagicMock()
+
+        sent = await adapter.send_image_file("15551234567", str(image))
+        assert sent.success and sent.message_id == "wamid.BOT_IMG"
+
+        event = await adapter._build_message_event_from_cloud(
+            {"from": "15551234567", "id": "wamid.REPLY", "type": "text",
+             "text": {"body": "what is this?"},
+             "context": {"id": "wamid.BOT_IMG", "from": "15550000000"}},
+            {"15551234567": "Alice"}, {"display_phone_number": "15550000000"},
+        )
+        assert event is not None
+        assert event.reply_to_is_own_message is True
+        assert event.media_urls == [str(image)]
+        assert event.media_types == ["image/png"]
+

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -216,6 +216,92 @@ class TestBridgeEventMetadata:
         assert event.raw_message["quotedRemoteJid"] == "15551234567@s.whatsapp.net"
         assert event.raw_message["hasQuotedMessage"] is True
 
+    @pytest.mark.asyncio
+    async def test_reply_to_uncaptioned_image_attaches_quoted_media(self, tmp_path, monkeypatch):
+        # contextInfo.quotedMessage only ever carries a thumbnail-sized stub
+        # for media (or nothing for an uncaptioned attachment). The bridge
+        # resolves the quoted message's already-downloaded media via its own
+        # cache (createQuotedMediaCache) and hands back the real cached path
+        # in quotedMediaUrls. The adapter must fold that into this event's
+        # own media_urls/media_types so the existing vision pipeline picks it
+        # up — otherwise a reply like "save this" to an uncaptioned photo
+        # someone else sent looks to the agent like there is no image at all.
+        adapter = _make_adapter()
+
+        cache_dir = tmp_path / "cache" / "image"
+        cache_dir.mkdir(parents=True)
+        quoted_image_path = cache_dir / "img_original.jpg"
+        quoted_image_path.write_bytes(b"fake-jpeg-bytes")
+
+        from plugins.platforms.whatsapp import adapter as adapter_module
+        monkeypatch.setattr(
+            adapter_module, "_is_allowed_bridge_path", lambda url: True,
+        )
+
+        data = {
+            "messageId": "reply-msg",
+            "chatId": "15551234567@s.whatsapp.net",
+            "senderId": "15551234567@s.whatsapp.net",
+            "senderName": "Ananya",
+            "chatName": "Family",
+            "isGroup": True,
+            "body": "did you save this wedding invite?",
+            "hasMedia": False,
+            "mediaUrls": [],
+            "mediaType": "",
+            "quotedMessageId": "original-image-msg",
+            "quotedParticipant": "99999999999@s.whatsapp.net",
+            "quotedRemoteJid": "15551234567@s.whatsapp.net",
+            "hasQuotedMessage": True,
+            "quotedText": "",
+            "quotedMediaUrls": [str(quoted_image_path)],
+            "quotedMediaType": "image",
+        }
+
+        event = await adapter._build_message_event(data)
+
+        assert event is not None
+        assert str(quoted_image_path) in event.media_urls
+        idx = event.media_urls.index(str(quoted_image_path))
+        assert event.media_types[idx] == "image/jpeg"
+
+    @pytest.mark.asyncio
+    async def test_quoted_media_path_outside_cache_dir_is_rejected(self, monkeypatch):
+        # _is_allowed_bridge_path guards against a compromised/buggy bridge
+        # handing back an arbitrary absolute path; quoted-media handling must
+        # respect the same guard as direct media, not bypass it.
+        adapter = _make_adapter()
+
+        from plugins.platforms.whatsapp import adapter as adapter_module
+        monkeypatch.setattr(
+            adapter_module, "_is_allowed_bridge_path", lambda url: False,
+        )
+
+        data = {
+            "messageId": "reply-msg-2",
+            "chatId": "15551234567@s.whatsapp.net",
+            "senderId": "15551234567@s.whatsapp.net",
+            "senderName": "Ananya",
+            "chatName": "Family",
+            "isGroup": True,
+            "body": "did you save this?",
+            "hasMedia": False,
+            "mediaUrls": [],
+            "mediaType": "",
+            "quotedMessageId": "original-image-msg",
+            "quotedParticipant": "99999999999@s.whatsapp.net",
+            "quotedRemoteJid": "15551234567@s.whatsapp.net",
+            "hasQuotedMessage": True,
+            "quotedText": "",
+            "quotedMediaUrls": ["/etc/passwd"],
+            "quotedMediaType": "image",
+        }
+
+        event = await adapter._build_message_event(data)
+
+        assert event is not None
+        assert "/etc/passwd" not in event.media_urls
+
 
 # ---------------------------------------------------------------------------
 # display_config tier classification

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -302,6 +302,34 @@ class TestBridgeEventMetadata:
         assert event is not None
         assert "/etc/passwd" not in event.media_urls
 
+    @pytest.mark.asyncio
+    async def test_reply_to_bot_sent_image_resolves_from_outbound_index(self, tmp_path):
+        """The bridge's quoted-media cache knows inbound messages only. A quote of an image WE sent
+        (cron chart, generated plot) must resolve from the outbound index written at send time —
+        otherwise "what is this?" under the bot's own image reaches the agent with no image."""
+        adapter = _make_adapter()
+        image = tmp_path / "chart.png"  # a workspace path, deliberately NOT inside a cache dir
+        image.write_bytes(b"\x89PNG fake")
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "BOT_IMG"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        sent = await adapter.send_image_file("15551234567", str(image))
+        assert sent.success and sent.message_id == "BOT_IMG"
+
+        event = await adapter._build_message_event({
+            "messageId": "reply-1", "chatId": "15551234567@s.whatsapp.net",
+            "senderId": "15551234567@s.whatsapp.net", "senderName": "Alice", "isGroup": False,
+            "body": "what is this?", "hasMedia": False, "mediaUrls": [], "mediaType": "",
+            "quotedMessageId": "BOT_IMG", "quotedParticipant": "15550000000@s.whatsapp.net",
+            "hasQuotedMessage": True, "quotedText": "", "quotedMediaUrls": [], "quotedMediaType": "",
+            "botIds": ["15550000000@s.whatsapp.net"],
+        })
+        assert event is not None
+        assert event.reply_to_is_own_message is True
+        assert event.media_urls == [str(image)]
+        assert event.media_types == ["image/png"]
+
 
 # ---------------------------------------------------------------------------
 # display_config tier classification

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -244,7 +244,7 @@ You can have **both** the Baileys (`whatsapp`) and Cloud (`whatsapp_cloud`) adap
 - **Voice notes** — auto-downloaded as `.ogg`, transcribed via your configured STT provider (local faster-whisper, OpenAI/Nous, Groq, etc.), then handed to the agent as text.
 - **Documents** — auto-downloaded. Small text-readable files (`.txt`, `.md`, `.json`, `.py`, `.csv`, etc.) up to 100KB get inlined into the agent's input so it can read them without a tool call. Larger files are cached locally for the agent's other tools to access.
 - **Button taps** — when the user taps a button the bot sent earlier (clarify choice, command approval, slash-command confirm), the tap is routed directly to the right handler. Stale taps fall back to being treated as regular text input.
-- **Reply context** — when the user replies to a previous bot message, the agent sees the original message as context.
+- **Reply context** — when the user replies to a previous message, the agent sees the original text as context. Quoting an image, voice note, video or document (yours or one the bot sent, e.g. a cron-delivered chart) also attaches that file to the turn, so "what is this?" under a quoted image works. Meta's webhook carries only the quoted message id, so this resolves from a local index of recent sends/receives (last 1000 messages per gateway); older quotes arrive without the attachment.
 
 ### Outbound
 

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -238,6 +238,10 @@ gateway:
 
 Set `text_batch_delay_seconds: 0` to dispatch each message immediately (disables batching).
 
+### Quoted Replies
+
+Replying to (quoting) an earlier message gives the agent the quoted text as context. Quoting an image, voice note, video or document also attaches that file to the turn, so "what is this?" under a quoted image works — whether the attachment came from another person or from the bot itself (a cron-delivered chart, a generated image). WhatsApp only ships a thumbnail stub with a quote, so the file is resolved from the bridge's download cache (inbound media, in-memory for the bridge's lifetime) or from a local index of the bot's own sends (last 1000 messages); quotes of anything older arrive without the attachment.
+
 ---
 
 ## Troubleshooting


### PR DESCRIPTION
Quoting an image (or voice note, video, document) in WhatsApp now attaches that file to the agent's turn — including media the bot itself sent, such as a cron-delivered chart.

**Symptom** (community report, WhatsApp): a cron job delivers an image; the user replies quoting it and asks "what is this?"; the agent answers as if no image exists. The quote reaches the agent text-only.

**Root cause:** WhatsApp never ships the quoted bytes. Baileys' `contextInfo.quotedMessage` is a thumbnail stub; Meta's Cloud webhook `context` is `{id, from}` only. The Baileys adapter resolved quoted *text* but never media, and the Cloud adapter's `rich_sent_store` indexed text only — so neither could recover a quoted attachment, and nothing at all indexed the bot's own outbound media.

## Changes

- **Salvage of #77660** (@ishangodawatta, reimplementing #52875 by @dhruvkej9): bridge-side bounded cache of already-downloaded inbound media; `extractBridgeEvent` resolves `quotedMediaUrls` for a quote of an uncaptioned attachment; the bridge's empty-message guard no longer drops a bare quote-reply; the adapter folds resolved paths into the event's own `media_urls`/`media_types` behind the existing cache-dir guard. Cherry-picked with authorship; conflict was test-file-only (both sides appended tests). The salvaged `textFromQuotedMessage` rewrite was kept compatible with the envelope-unwrap fix from `5de769956f5e`.
- **Outbound + Cloud half (ours), the reported case:** `gateway/rich_sent_store` gains `record_media` / `lookup_media` (`(chat_id, message_id) → [(path, mime)]`, files that no longer exist are dropped). Both WhatsApp adapters index every local media send at send time and every inbound media receive; a quoted reply resolves the pair list and appends it to the event so the normal vision/audio pipeline handles it. Baileys uses this as the fallback when the bridge cache misses (the bridge cache is inbound-only); Cloud uses it for both directions. Cloud `link` sends (public URL, no local bytes) are not indexed.
- Baileys adapter: quoted-media folding extracted into `WhatsAppAdapter._quoted_media` with a module-level MIME table instead of growing `_build_message_event`.
- Docs: `whatsapp.md` new "Quoted Replies" section; `whatsapp-cloud.md` reply-context bullet widened (also addresses the media-quote caveat in #80067).

## Validation

| Check | Result |
|---|---|
| `tests/gateway/test_whatsapp_cloud.py::…::test_reply_to_bot_sent_image_attaches_the_file` | red on `origin/main` (source A/B swap), green here |
| `tests/gateway/test_whatsapp_formatting.py::…::test_reply_to_bot_sent_image_resolves_from_outbound_index` | red on `origin/main`, green here |
| `…::test_reply_to_uncaptioned_image_attaches_quoted_media` (salvaged) | red on `origin/main`, green here |
| `scripts/run_tests.sh` on `test_whatsapp_cloud.py test_whatsapp_formatting.py test_whatsapp_native_delivery.py test_whatsapp_from_owner.py test_telegram_rich_messages.py` | all green |
| `node --test scripts/whatsapp-bridge/bridge.native.test.mjs` (+ reconnect, sendqueue) | pass |
| E2E (real `rich_sent_store` on a temp `HERMES_HOME`, real adapters with fake transport) | Cloud: `send_image_file` → quote → `event.media_urls == [path]`, `media_types == ["image/png"]`, `reply_to_is_own_message=True`, `_event_media_is_image` → True. Negative: quote of unindexed id → `[]`; file deleted after send → `[]`. Baileys: outbound index resolves a non-cache-dir path (our own send); bridge-supplied `/etc/passwd` still rejected. |
| ruff / windows-footguns / compat pointers / `git diff --check` | clean |

**Live repro:** no WhatsApp number is paired on this machine; the before/after above is the real adapter code path against a fake transport plus the real on-disk index, not a mocked store. A paired-number live pass is listed as not done.

Not covered: quotes older than the index (1000 entries per gateway) or of media whose cached file was cleaned up arrive text-only as before; the bridge's inbound cache is in-memory and resets with the bridge process.

Closes #77660 (salvaged with credit). Related: #52875, #80067, #80055, #37717.

## Infographic

![WhatsApp quoted media reaches the agent](https://v3b.fal.media/files/b/0aaa1110/ywxgLPWRyzfqdOtb2I-4C_xavMGVe4.png)
