### PR TITLE
fix(tools): resolve symlink targets in the binary document write guard

### DIFF
--- a/tests/tools/test_binary_document_write_guard.py
+++ b/tests/tools/test_binary_document_write_guard.py
@@ -183,3 +183,67 @@ class TestPatchToolGuard:
         )
         assert not result.get("error")
         assert target.read_text() == "hello there"
+
+
+class TestSymlinkAliasBypass:
+    """A text-suffixed symlink must not smuggle a text write into the binary
+    document it points at — the OS write follows the link, so the guard checks
+    the resolved target too (#108715)."""
+
+    def test_guard_resolves_text_symlink_to_docx(self, tmp_path: Path):
+        docx = tmp_path / "report.docx"
+        _make_minimal_docx(docx)
+        alias = tmp_path / "alias.txt"
+        alias.symlink_to(docx)
+
+        err = _check_binary_document_write(str(alias))
+
+        assert err is not None, "symlink alias must trip the opaque-document guard"
+        assert "report.docx" in err
+
+    def test_guard_resolves_text_symlink_to_existing_pdf(self, tmp_path: Path):
+        pdf = tmp_path / "doc.pdf"
+        pdf.write_bytes(b"%PDF-1.4\n1 0 obj\nendobj\n%%EOF\n")
+        alias = tmp_path / "notes.txt"
+        alias.symlink_to(pdf)
+
+        err = _check_binary_document_write(str(alias))
+
+        assert err is not None
+        assert "overwrite" in err.lower()
+
+    def test_text_symlink_to_text_file_allowed(self, tmp_path: Path):
+        target = tmp_path / "notes.txt"
+        target.write_text("hello")
+        alias = tmp_path / "alias.txt"
+        alias.symlink_to(target)
+
+        assert _check_binary_document_write(str(alias)) is None
+
+    def test_write_file_via_symlink_refused_and_target_intact(self, tmp_path: Path):
+        docx = tmp_path / "report.docx"
+        _make_minimal_docx(docx)
+        original = docx.read_bytes()
+        alias = tmp_path / "alias.txt"
+        alias.symlink_to(docx)
+
+        result = json.loads(write_file_tool(str(alias), "rewritten text"))
+
+        assert result.get("error"), "write via text-suffixed symlink must be refused"
+        assert docx.read_bytes() == original, "document bytes must be untouched"
+        assert zipfile.is_zipfile(docx), "document must remain a valid container"
+
+    def test_patch_replace_via_symlink_refused_and_target_intact(self, tmp_path: Path):
+        docx = tmp_path / "report.docx"
+        _make_minimal_docx(docx)
+        original = docx.read_bytes()
+        alias = tmp_path / "alias.txt"
+        alias.symlink_to(docx)
+
+        result = json.loads(
+            patch_tool(mode="replace", path=str(alias),
+                       old_string="good", new_string="great")
+        )
+
+        assert result.get("error"), "patch via text-suffixed symlink must be refused"
+        assert docx.read_bytes() == original, "document bytes must be untouched"

--- a/tools/file_tools_write_guards.py
+++ b/tools/file_tools_write_guards.py
@@ -106,6 +106,16 @@ def _resolved_or_raw(filepath: str, task_id: str) -> str:
         return filepath
 
 
+def _symlink_target_or_raw(filepath: str, task_id: str) -> str:
+    """Fully symlink-resolved write target; the raw input when resolution fails.
+    The OS-level write follows the link, so suffix guards must check the target
+    as well as the supplied path."""
+    try:
+        return os.path.realpath(str(_resolve_path_for_task(filepath, task_id)))
+    except Exception:
+        return filepath
+
+
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     candidates = (_resolved_or_raw(filepath, task_id), os.path.normpath(_expand_tilde(filepath)))
@@ -378,31 +388,38 @@ def _check_binary_document_write(filepath: str, task_id: str = "default") -> str
     plausibly believes it holds the file's contents and tries to write the edited text back with
     write_file/patch. A plain-text write can never produce a valid OOXML/OLE/ODF container, so that write
     silently destroys the document (port of nearai/ironclaw#7109).
+
+    The suffix check runs on the supplied path AND its symlink-resolved target (#108715):
+    the write follows the link, so a text-suffixed alias to a binary document corrupts
+    it just as directly (symlink lesson from #41351: always realpath before matching).
     """
-    if has_opaque_document_extension(filepath):
-        ext = filepath[filepath.rfind("."):].lower()
-        return (
-            f"Refusing to write plain text to binary document '{filepath}' ({ext}). "
-            "A text write cannot produce a valid document container and would "
-            "corrupt the file (read_file showed you EXTRACTED text, not the real "
-            "bytes). Use the docx/xlsx/powerpoint skills or a library like "
-            "python-docx/openpyxl/python-pptx via the terminal to create or edit "
-            "this document.")
-    if is_pdf_path(filepath):
-        try:
-            resolved = Path(_resolve_path_for_task(filepath, task_id))
-        except Exception:
-            resolved = Path(_expand_tilde(filepath))
-        try:
-            if resolved.is_file():
-                return (
-                    f"Refusing to overwrite existing PDF '{filepath}' with plain text. "
-                    "read_file showed you EXTRACTED text, not the real bytes — writing "
-                    "text back would destroy the document. Use the pdf skill or a PDF "
-                    "library via the terminal to modify it. (Creating a NEW .pdf file "
-                    "is allowed.)")
-        except OSError:
-            pass
+    real = _symlink_target_or_raw(filepath, task_id)
+    candidates = (filepath,) if real == filepath else (filepath, real)
+    for candidate in candidates:
+        if has_opaque_document_extension(candidate):
+            ext = candidate[candidate.rfind("."):].lower()
+            return (
+                f"Refusing to write plain text to binary document '{candidate}' ({ext}). "
+                "A text write cannot produce a valid document container and would "
+                "corrupt the file (read_file showed you EXTRACTED text, not the real "
+                "bytes). Use the docx/xlsx/powerpoint skills or a library like "
+                "python-docx/openpyxl/python-pptx via the terminal to create or edit "
+                "this document.")
+        if is_pdf_path(candidate):
+            try:
+                resolved = Path(_resolve_path_for_task(candidate, task_id))
+            except Exception:
+                resolved = Path(_expand_tilde(candidate))
+            try:
+                if resolved.is_file():
+                    return (
+                        f"Refusing to overwrite existing PDF '{candidate}' with plain text. "
+                        "read_file showed you EXTRACTED text, not the real bytes — writing "
+                        "text back would destroy the document. Use the pdf skill or a PDF "
+                        "library via the terminal to modify it. (Creating a NEW .pdf file "
+                        "is allowed.)")
+            except OSError:
+                pass
     return None
 
 


### PR DESCRIPTION
## What does this PR do?

`_check_binary_document_write` matched the opaque-document and existing-PDF-overwrite suffixes against the **supplied path string only**. Because the OS-level write follows symlinks, a text-suffixed alias (`alias.txt -> report.docx`) sailed through the guard and let `write_file`/replace-mode `patch` overwrite the binary document with plain text — silently corrupting it, exactly what the guard exists to prevent.

The guard now checks **both the supplied path and its fully-resolved symlink target** (`os.path.realpath` via the task path resolver), for the opaque-extension check and the existing-PDF-overwrite check alike. This applies the "always realpath before matching" lesson already documented on the protected-instruction guard (#41351) to this guard. A text symlink pointing at a normal text file is still writable (no false positives); the refusal message names the resolved binary target so the model can see what the alias actually pointed at.

## Related Issue

Fixes #108715

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_tools_write_guards.py` — added `_symlink_target_or_raw()` helper (fully-resolved write target, raw input on resolution failure); `_check_binary_document_write()` now evaluates its suffix checks over `(supplied path, resolved target)`.
- `tests/tools/test_binary_document_write_guard.py` — new `TestSymlinkAliasBypass` class: guard-level resolution for `.docx` and existing-PDF aliases, a text→text control (must stay allowed), and fail-closed end-to-end cases for `write_file_tool`/`patch_tool` through an alias (refused + target bytes untouched).

## How to Test

1. `python -m pytest tests/tools/test_binary_document_write_guard.py -v` → 22 passed (17 pre-existing + 5 new).
2. Regression sweep: `python -m pytest tests/tools/test_cross_profile_guard.py tests/tools/test_credential_files.py tests/tools/test_file_read_guards.py tests/tools/test_file_operations_edge_cases.py tests/tools/test_file_ops_single_roundtrip.py` → 172 passed, 2 skipped (pre-existing skips). `tests/tools/test_file_operations.py` → 67 passed, 2 skipped.
3. Reproduction from the issue (synthetic fixture, temporary HOME): before this change `alias.txt -> document.docx` reported success and the target's sha256 changed for both `write` and `patch`; after this change both are refused and the target hash is identical before/after. Observed result: `direct_refused: true`, `alias_reported_success: false`, `target_changed: false` for both operations.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon, Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable (filesystem guard behavior, covered by the test output above).
