### PR TITLE
fix(model): report applied implicit provider changes

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.ts
@@ -33,7 +33,25 @@ export function handleStatusEvent(ctx: GatewayEventContext): boolean {
   } = deps
 
   if (event.type === 'status.update') {
-    if (sessionId && payload?.kind === 'compacting') {
+    if (sessionId && payload?.kind === 'model-switch-warning') {
+      const text = coerceGatewayText(payload?.text)
+
+      if (text) {
+        flushQueuedDeltas(sessionId)
+        updateSessionState(sessionId, state => ({
+          ...state,
+          messages: [
+            ...state.messages,
+            {
+              id: `model-switch-warning-${Date.now()}`,
+              role: 'system',
+              parts: [textPart(`warning: ${text}`, occurredAt)],
+              timestamp: occurredAt
+            }
+          ]
+        }))
+      }
+    } else if (sessionId && payload?.kind === 'compacting') {
       setSessionCompacting(sessionId, true)
       compactedTurnRef.current.add(sessionId)
     } else if (sessionId && payload?.kind === 'compacted') {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/timeline-events.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/timeline-events.test.tsx
@@ -74,6 +74,45 @@ describe('live transcript timeline events', () => {
     expect(system?.parts[0].timestamp).toBe(401.625)
   })
 
+  it.each([SID, 'background-session'])('keeps a full model-switch warning in its owning session %s', sessionId => {
+    event('message.start', 450)
+    if (sessionId !== SID) {
+      act(() => stream.handleEvent({ session_id: sessionId, type: 'message.start', payload: { timestamp: 450 } }))
+    }
+    const focusedBefore = stream.state(SID)
+    const before = stream.state(sessionId)
+    const text = '  PROVIDER AUTOMATICALLY CHANGED: openai-codex -> openrouter. Additional costs may apply.\n\n' +
+      'Catalog validation notice. Keep <b>literal markup</b> and \u001b[31mcontrol text\u001b[0m.\n'
+    expect(before.busy).toBe(true)
+
+    act(() => stream.handleEvent({
+      session_id: sessionId,
+      type: 'status.update',
+      payload: { kind: 'model-switch-warning', text, timestamp: 451.625 }
+    }))
+
+    const after = stream.state(sessionId)
+    const system = after.messages.at(-1)
+    expect(after.messages).toHaveLength(before.messages.length + 1)
+    expect(system).toMatchObject({
+      role: 'system',
+      parts: [{ type: 'text', text: `warning: ${text}`, timestamp: 451.625 }],
+      timestamp: 451.625
+    })
+    expect({ ...after, messages: before.messages }).toEqual(before)
+    expect(after.messages.slice(0, -1)).toEqual(before.messages)
+    if (sessionId !== SID) {
+      expect(stream.state(SID)).toEqual(focusedBefore)
+    }
+
+    act(() => stream.handleEvent({
+      session_id: sessionId,
+      type: 'status.update',
+      payload: { kind: 'progress', text: 'Working...', timestamp: 452 }
+    }))
+    expect(stream.state(sessionId)).toEqual(after)
+  })
+
   it('uses session.info time when it is the only stop boundary', () => {
     event('message.start', 500)
     event('tool.start', 501, { args: {}, name: 'terminal', tool_id: 'call-3' })

--- a/gateway/slash_commands_model.py
+++ b/gateway/slash_commands_model.py
@@ -307,6 +307,8 @@ class GatewayModelCommandsMixin:
             t("gateway.model.switched", model=format_model_for_display(result.new_model)),
             t("gateway.model.provider_label", provider=result.provider_label or result.target_provider),
         ]
+        if result.provider_switch_warning:
+            lines.insert(0, f"🚨 **{result.provider_switch_warning}**\n")
         # Provider-aware chain: Codex OAuth, Copilot and Nous caps win over the raw models.dev entry.
         mi = result.model_info
         model_cfg: dict = {}

--- a/hermes_cli/cli_model_switch_mixin.py
+++ b/hermes_cli/cli_model_switch_mixin.py
@@ -99,6 +99,8 @@ def _print_switch_summary(cli, result, old_model, *, one_turn: bool, strict_cont
         f"via {result.provider_label or result.target_provider}. "
         f"{'This override applies to the next turn only. ' if one_turn else ''}"
         f"Adjust your self-identification accordingly.]")
+    if result.provider_switch_warning:
+        _cprint(f"\033[1;31m  🚨 {result.provider_switch_warning}\033[0m")
     _cprint(f"  ✓ Model switched: {_display_new}")
     _cprint(f"    Provider: {result.provider_label or result.target_provider}")
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -440,6 +440,7 @@ class ModelSwitchResult:
     runtime_capabilities: Optional[dict[str, bool]] = None
     model_info: Optional[ModelInfo] = None
     is_global: bool = False
+    provider_switch_warning: str = ""
 
 
 @dataclass(frozen=True)
@@ -1042,6 +1043,7 @@ class _Switch:
     explicit_provider: str
     user_providers: Optional[dict]
     custom_providers: Optional[list]
+    provider_was_explicit: bool = False  # caller intent, before config routing promotes explicit_provider
     new_model: str = ""
     target_provider: str = ""
     resolved_alias: str = ""
@@ -1452,6 +1454,19 @@ def _build_switch_result(st: _Switch) -> ModelSwitchResult:
 
     warnings = [w for w in (st.validation.get("message"), _check_hermes_model_warning(st.new_model)) if w]
 
+    provider_switch_warning = ""
+    if st.provider_changed and not st.provider_was_explicit:
+        previous_def = resolve_provider_full(st.current_provider, st.user_providers, st.custom_providers)
+        target_def = resolve_provider_full(st.target_provider, st.user_providers, st.custom_providers)
+        previous_id = previous_def.id if previous_def else st.current_provider
+        target_id = target_def.id if target_def else st.target_provider
+        if previous_id != target_id:
+            provider_switch_warning = (
+                f"PROVIDER AUTOMATICALLY CHANGED: {previous_id} -> {target_id}. "
+                "No --provider argument was supplied. This change may incur "
+                "additional costs. Specify --provider explicitly to choose your provider."
+            )
+
     # Carry the switched provider's request_overrides (custom_providers ``extra_body`` such as
     # chat_template_kwargs) so the gateway applies them like the default-provider path does.
     request_overrides = None
@@ -1465,6 +1480,7 @@ def _build_switch_result(st: _Switch) -> ModelSwitchResult:
         success=True, new_model=st.new_model, target_provider=st.target_provider,
         provider_changed=st.provider_changed, api_key=st.api_key, base_url=st.base_url, api_mode=st.api_mode,
         request_overrides=dict(request_overrides or {}), warning_message=" | ".join(warnings) if warnings else "",
+        provider_switch_warning=provider_switch_warning,
         provider_label=st.provider_label, resolved_via_alias=st.resolved_alias, capabilities=capabilities,
         runtime_capabilities={
             k: v for k, v in runtime_capabilities.items() if isinstance(k, str) and isinstance(v, bool)},
@@ -1485,6 +1501,7 @@ def switch_model(
         raw_input=raw_input, current_provider=current_provider, current_model=current_model,
         current_base_url=current_base_url, current_api_key=current_api_key, is_global=is_global,
         explicit_provider=explicit_provider, user_providers=user_providers, custom_providers=custom_providers,
+        provider_was_explicit=bool(explicit_provider),
         new_model=raw_input.strip(), target_provider=current_provider)
     route = _route_explicit_provider if explicit_provider else _route_from_model_input
     for step in (route, _resolve_switch_credentials, _validate_switch):

--- a/tests/gateway/test_model_command_expensive_confirm.py
+++ b/tests/gateway/test_model_command_expensive_confirm.py
@@ -14,6 +14,7 @@ These tests pin the typed path:
 """
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 import yaml
@@ -30,6 +31,11 @@ def _make_runner():
     runner._voice_mode = {}
     runner._session_model_overrides = {}
     runner._running_agents = {}
+    runner._session_db = None
+    runner.session_store = SimpleNamespace()
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store, set_model_override=AsyncMock()
+    )
     return runner
 
 
@@ -66,19 +72,27 @@ def _fake_warning():
     )
 
 
-def _setup_isolated_home(tmp_path, monkeypatch, *, warn):
+def _setup_isolated_home(tmp_path, monkeypatch, *, warn, current_provider="openrouter"):
     import gateway.run as gateway_run
 
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()
     cfg_path = hermes_home / "config.yaml"
     cfg_path.write_text(
-        yaml.safe_dump({"model": {"default": "old-model", "provider": "openrouter"}, "providers": {}}),
+        yaml.safe_dump({"model": {"default": "old-model", "provider": current_provider}, "providers": {}}),
         encoding="utf-8",
     )
 
     monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    config = {"model": {"default": "old-model", "provider": current_provider}, "providers": {}}
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda **k: config)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+    monkeypatch.setattr("hermes_cli.config.read_user_config_raw", lambda *a: config)
+    monkeypatch.setattr("hermes_cli.config.save_config", Mock())
+    monkeypatch.setattr("hermes_cli.model_switch.resolve_display_context_length_async", AsyncMock(return_value=None))
+    monkeypatch.setattr("hermes_cli.context_switch_guard.enrich_model_switch_warnings_for_gateway", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_data_policy_guard.data_training_warning", lambda *a, **k: None)
     monkeypatch.setattr(
         "hermes_cli.model_switch.switch_model",
         lambda **kw: _fake_switch_result(),
@@ -113,6 +127,7 @@ async def test_typed_model_expensive_confirm_once_applies_switch(tmp_path, monke
     reply = await captured["handler"]("once")
 
     assert "gpt-5.5-pro" in reply
+    assert "PROVIDER AUTOMATICALLY CHANGED" not in reply
     overrides = list(runner._session_model_overrides.values())
     assert len(overrides) == 1
     assert overrides[0]["model"] == "openai/gpt-5.5-pro"
@@ -166,3 +181,107 @@ async def test_failed_inplace_swap_aborts_commit(tmp_path, monkeypatch):
     assert evicted == []
     # The agent stayed on its old model (rolled back).
     assert agent.model == "old-model"
+
+
+_PROVIDER_WARNING = (
+    "PROVIDER AUTOMATICALLY CHANGED: openai-codex -> openrouter. "
+    "No --provider argument was supplied. This change may incur additional costs."
+)
+
+
+def _provider_change_setup(tmp_path, monkeypatch, *, warn):
+    _setup_isolated_home(tmp_path, monkeypatch, warn=warn, current_provider="openai-codex")
+    runner = _make_runner()
+    result = _fake_switch_result()
+    result.provider_changed = True
+    result.provider_switch_warning = _PROVIDER_WARNING
+    result.warning_message = "Ordinary validation warning."
+    result.runtime_capabilities = {"native_compaction": True}
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", lambda **k: result)
+    runner._session_model_overrides["unused"] = {}  # independent session is preserved
+    agent = SimpleNamespace(model="old-model", provider="openai-codex")
+
+    def swap(**kwargs):
+        agent.model, agent.provider = kwargs["new_model"], kwargs["new_provider"]
+
+    agent.switch_model = Mock(side_effect=swap)
+    runner._cached_agent_for = lambda key: agent
+    runner._evict_cached_agent = Mock()
+    return runner, agent, result
+
+
+@pytest.mark.asyncio
+async def test_provider_warning_waits_for_confirmation_then_applied_swap(tmp_path, monkeypatch):
+    runner, agent, result = _provider_change_setup(tmp_path, monkeypatch, warn=True)
+    captured = {}
+
+    async def request_confirm(**kwargs):
+        captured.update(kwargs)
+        return kwargs["message"]
+
+    runner._request_slash_confirm = request_confirm
+    pending = await runner._handle_model_command(_make_event("/model openai/gpt-5.5-pro --session"))
+    assert _PROVIDER_WARNING not in pending
+    assert "EXPENSIVE MODEL WARNING" in pending
+    agent.switch_model.assert_not_called()
+    reply = await captured["handler"]("once")
+
+    assert reply.startswith(f"🚨 **{_PROVIDER_WARNING}**\n")
+    assert reply.index(_PROVIDER_WARNING) < reply.index("Model switched")
+    assert result.warning_message in reply
+    assert agent.model == result.new_model
+    assert agent.switch_model.call_args.kwargs["capabilities"] == result.runtime_capabilities
+    runner.async_session_store.set_model_override.assert_awaited_once()
+    assert runner._session_model_overrides["unused"] == {}
+
+
+@pytest.mark.asyncio
+async def test_cancelled_confirmation_has_no_provider_warning(tmp_path, monkeypatch):
+    runner, agent, result = _provider_change_setup(tmp_path, monkeypatch, warn=True)
+    captured = {}
+
+    async def request_confirm(**kwargs):
+        captured.update(kwargs)
+        return kwargs["message"]
+
+    runner._request_slash_confirm = request_confirm
+    pending = await runner._handle_model_command(_make_event("/model openai/gpt-5.5-pro --session"))
+    reply = await captured["handler"]("cancel")
+    assert _PROVIDER_WARNING not in pending + reply
+    assert "cancelled" in reply
+    agent.switch_model.assert_not_called()
+    assert runner._session_model_overrides == {"unused": {}}
+    runner.async_session_store.set_model_override.assert_not_awaited()
+    runner._evict_cached_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_failed_cached_swap_has_no_provider_warning(tmp_path, monkeypatch):
+    runner, agent, result = _provider_change_setup(tmp_path, monkeypatch, warn=False)
+    agent.switch_model.side_effect = RuntimeError("offline swap failure")
+    reply = await runner._handle_model_command(_make_event("/model openai/gpt-5.5-pro --session"))
+    assert "failed" in reply
+    assert _PROVIDER_WARNING not in reply
+    assert "Model switched" not in reply
+    assert agent.model == "old-model"
+    assert runner._session_model_overrides == {"unused": {}}
+    runner.async_session_store.set_model_override.assert_not_awaited()
+    runner._evict_cached_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scope", ["--session", "--once", "--global"])
+async def test_immediate_applied_provider_warning_preserves_scope(tmp_path, monkeypatch, scope):
+    runner, agent, result = _provider_change_setup(tmp_path, monkeypatch, warn=False)
+    runner._request_slash_confirm = AsyncMock(side_effect=AssertionError("no new confirmation gate"))
+    reply = await runner._handle_model_command(_make_event(f"/model openai/gpt-5.5-pro {scope}"))
+    assert reply.startswith(f"🚨 **{_PROVIDER_WARNING}**\n")
+    assert agent.model == result.new_model
+    assert result.warning_message in reply
+    if scope == "--once":
+        runner.async_session_store.set_model_override.assert_not_awaited()
+        assert runner._pending_one_turn_model_restores
+    else:
+        runner.async_session_store.set_model_override.assert_awaited_once()
+    from hermes_cli.config import save_config
+    assert save_config.called == (scope == "--global")

--- a/tests/hermes_cli/test_model_switch_confirm_thread.py
+++ b/tests/hermes_cli/test_model_switch_confirm_thread.py
@@ -16,6 +16,9 @@ synchronous.
 
 import threading
 from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
 
 from hermes_cli.model_switch import ModelSwitchResult
 
@@ -60,8 +63,21 @@ class _StubCLI:
     ):
         import cli as cli_mod
 
-        return cli_mod.HermesCLI._confirm_and_apply_cli_model_switch(
+        outcome = cli_mod.HermesCLI._confirm_and_apply_cli_model_switch(
             self, result, persist_global, one_turn, custom_provs
+        )
+        if hasattr(self, "apply_done"):
+            self.apply_done.set()
+        return outcome
+
+    def _snapshot_model_runtime(self):
+        from cli import HermesCLI
+        return HermesCLI._snapshot_model_runtime(self)
+
+    def _apply_model_switch_result(self, result, persist_global, custom_providers=None):
+        from cli import HermesCLI
+        return HermesCLI._apply_model_switch_result(
+            self, result, persist_global, custom_providers=custom_providers
         )
 
 
@@ -100,6 +116,17 @@ def _patch_deps(monkeypatch, printed):
     return cli_mod
 
 
+@pytest.fixture(autouse=True)
+def _offline_storage(monkeypatch):
+    config = {"model": {"default": "old/model", "provider": "openrouter"}}
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+    monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: config)
+    monkeypatch.setattr("cli.save_config_value", Mock())
+    monkeypatch.setattr("cli.HermesCLI._persist_model_switch_to_session", Mock())
+    monkeypatch.setattr("hermes_cli.context_switch_guard.merge_preflight_compression_warning", lambda *a, **k: None)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+
+
 def test_confirm_runs_off_main_thread_when_tui_present(monkeypatch):
     """With ``_app`` set, the confirm modal must not block the caller's
     thread: the switch is dispatched on a worker thread and the command
@@ -109,6 +136,7 @@ def test_confirm_runs_off_main_thread_when_tui_present(monkeypatch):
     stub = _StubCLI()
     stub.agent = _FakeAgent()
     stub._app = SimpleNamespace(loop=None)
+    stub.apply_done = threading.Event()
     printed = []
     cli_mod = _patch_deps(monkeypatch, printed)
 
@@ -131,6 +159,7 @@ def test_confirm_runs_off_main_thread_when_tui_present(monkeypatch):
 
     # The worker thread performs the confirm and completes the apply.
     assert ready.wait(timeout=10)
+    assert stub.apply_done.wait(timeout=10)
     assert called_on["is_main"] is False
 
     # Apply still lands on CLI + agent state.
@@ -164,3 +193,78 @@ def test_confirm_stays_synchronous_without_app(monkeypatch):
     assert called_on.get("is_main") is True
     assert stub.model == "claude-sonnet-4.6"
     assert stub.provider == "anthropic"
+    assert not any("PROVIDER AUTOMATICALLY CHANGED" in line for line in printed)
+
+
+_PROVIDER_WARNING = (
+    "PROVIDER AUTOMATICALLY CHANGED: openrouter -> anthropic. "
+    "No --provider argument was supplied. This change may incur additional costs."
+)
+
+
+@pytest.mark.parametrize("scope", ["--session", "--global", "--once", "picker"])
+def test_provider_warning_is_bold_red_after_swap_before_success(monkeypatch, scope):
+    stub = _StubCLI()
+    stub.agent = _FakeAgent()
+    printed = []
+    cli_mod = _patch_deps(monkeypatch, printed)
+    result = _make_result()
+    result.provider_switch_warning = _PROVIDER_WARNING
+    result.warning_message = "Ordinary validation warning."
+    result.runtime_capabilities = {"native_compaction": True}
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", lambda **k: result)
+    rendered_after = []
+
+    def record(text, *args, **kwargs):
+        printed.append(text)
+        if _PROVIDER_WARNING in text:
+            rendered_after.append(stub.agent.model)
+
+    monkeypatch.setattr(cli_mod, "_cprint", record)
+    if scope == "picker":
+        cli_mod.HermesCLI._confirm_and_apply_model_switch_result(stub, result, False)
+    else:
+        cli_mod.HermesCLI._handle_model_switch(stub, f"/model claude-sonnet-4.6 {scope}")
+
+    warning_line = f"\033[1;31m  🚨 {_PROVIDER_WARNING}\033[0m"
+    assert warning_line in printed
+    success = next(line for line in printed if "✓ Model switched:" in line)
+    assert printed.index(warning_line) < printed.index(success)
+    assert rendered_after == [result.new_model]
+    assert any(result.warning_message in line for line in printed)
+    assert stub.agent.calls[-1]["capabilities"] == result.runtime_capabilities
+    if scope == "--once":
+        assert stub._pending_one_turn_model_restore["model"] == "old/model"
+        cli_mod.HermesCLI._persist_model_switch_to_session.assert_not_called()
+    else:
+        cli_mod.HermesCLI._persist_model_switch_to_session.assert_called_once()
+    assert cli_mod.save_config_value.called == (scope == "--global")
+
+
+@pytest.mark.parametrize("picker", [False, True])
+@pytest.mark.parametrize("failure", ["cancel", "swap"])
+def test_unapplied_cli_switch_has_no_provider_warning(monkeypatch, picker, failure):
+    stub = _StubCLI()
+    stub.agent = _FakeAgent()
+    printed = []
+    cli_mod = _patch_deps(monkeypatch, printed)
+    result = _make_result()
+    result.provider_switch_warning = _PROVIDER_WARNING
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", lambda **k: result)
+    if failure == "cancel":
+        stub._confirm_expensive_model_switch = lambda result: False
+    else:
+        stub.agent.switch_model = Mock(side_effect=RuntimeError("offline swap failure"))
+
+    if picker:
+        cli_mod.HermesCLI._confirm_and_apply_model_switch_result(stub, result, False)
+    else:
+        cli_mod.HermesCLI._handle_model_switch(stub, "/model claude-sonnet-4.6 --session")
+
+    assert any("cancelled" in line or "failed" in line for line in printed)
+    assert not any(_PROVIDER_WARNING in line or "✓ Model switched:" in line for line in printed)
+    assert stub.model == stub.agent.model == "old/model"
+    assert stub.provider == stub.agent.provider == "openrouter"
+    assert stub._pending_model_switch_note is None
+    cli_mod.save_config_value.assert_not_called()
+    cli_mod.HermesCLI._persist_model_switch_to_session.assert_not_called()

--- a/tests/hermes_cli/test_model_switch_provider_warning.py
+++ b/tests/hermes_cli/test_model_switch_provider_warning.py
@@ -1,0 +1,437 @@
+"""Provider-change warnings use caller intent without changing the routing ladder."""
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import ANY, Mock
+
+import pytest
+
+from hermes_cli import model_switch as ms
+
+
+@pytest.fixture
+def offline_switch(monkeypatch):
+    """Exercise the real pipeline; replace catalogs, metadata and external I/O."""
+    config = {"model": {"default": "old-model", "provider": "openai-codex"}}
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+    save = Mock(side_effect=AssertionError("switch resolution must not persist config"))
+    monkeypatch.setattr("hermes_cli.config.save_config", save)
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("agent.usage_pricing.get_pricing_entry", lambda *a, **k: None)
+    monkeypatch.setattr(ms, "list_provider_models", lambda *a, **k: [])
+    monkeypatch.setattr(ms, "DIRECT_ALIASES", {})
+    monkeypatch.setattr(ms, "_DIRECT_ALIAS_LOADED", None)
+    catalog = Mock(return_value=[])
+    monkeypatch.setattr("hermes_cli.models.cached_provider_model_ids", catalog)
+    monkeypatch.setattr("hermes_cli.models.model_ids", lambda: ["vendor/foreign-model"])
+    monkeypatch.setattr("hermes_cli.models_detect.provider_has_credentials", lambda p: p == "openrouter")
+    runtime = Mock(return_value={
+        "api_key": "test-key", "base_url": "https://example.invalid/v1",
+        "api_mode": "chat_completions",
+    })
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", runtime)
+    monkeypatch.setattr("hermes_cli.runtime_provider._get_named_custom_provider", lambda p: None)
+    validation = {"accepted": True, "recognized": True, "message": "Catalog validation notice."}
+    monkeypatch.setattr("hermes_cli.models_validate.validate_requested_model", lambda *a, **k: validation)
+    capabilities = SimpleNamespace(vision=True)
+    model_info = SimpleNamespace(context_window=12345)
+    monkeypatch.setattr(ms, "get_model_capabilities", lambda *a, **k: capabilities)
+    monkeypatch.setattr(ms, "get_model_info", lambda *a, **k: model_info)
+    monkeypatch.setattr("agent.native_compaction.resolve_native_compaction_capabilities", lambda **k: {"native_compaction": True})
+    return SimpleNamespace(
+        config=config, catalog=catalog, runtime=runtime, validation=validation,
+        capabilities=capabilities, model_info=model_info, save=save,
+    )
+
+
+def _switch(**kwargs):
+    args: dict = dict(raw_input="foreign-model", current_provider="openai-codex", current_model="old-model")
+    args.update(kwargs)
+    return ms.switch_model(**args)
+
+
+def _assert_warning(result, previous, target):
+    assert result.success, result.error_message
+    warning = getattr(result, "provider_switch_warning", "")
+    assert f"{previous} -> {target}" in warning
+    assert "No --provider argument was supplied" in warning
+    assert "additional costs" in warning
+    assert "Specify --provider explicitly" in warning
+    assert warning not in result.warning_message
+
+
+def test_implicit_unmatched_catalog_fallback_warns_without_losing_metadata(offline_switch):
+    result = _switch()
+
+    _assert_warning(result, "openai-codex", "openrouter")
+    assert result.new_model == "vendor/foreign-model"
+    assert result.target_provider == "openrouter"
+    assert result.provider_changed
+    offline_switch.catalog.assert_called_with("openai-codex")
+    assert result.warning_message == "Catalog validation notice."
+    assert result.capabilities is offline_switch.capabilities
+    assert result.model_info is offline_switch.model_info
+    assert result.runtime_capabilities == {"native_compaction": True}
+    offline_switch.save.assert_not_called()
+
+
+def test_explicit_provider_change_has_no_automatic_warning(offline_switch):
+    result = _switch(explicit_provider="openrouter")
+
+    assert result.success
+    assert result.provider_changed
+    assert result.target_provider == "openrouter"
+    assert getattr(result, "provider_switch_warning", "") == ""
+    assert result.warning_message == "Catalog validation notice."
+
+
+@pytest.mark.parametrize("current_provider", ["openrouter", "openai"])
+def test_same_canonical_provider_including_alias_has_no_warning(offline_switch, current_provider):
+    assert ms.resolve_provider_full(current_provider).id == "openrouter"
+    offline_switch.config["model_aliases"] = {
+        "chosen-model": {"model": "vendor/foreign-model", "provider": "openrouter"},
+    }
+    result = _switch(raw_input="chosen-model", current_provider=current_provider)
+
+    assert result.success
+    assert result.target_provider == "openrouter"
+    assert result.resolved_via_alias == "chosen-model"
+    assert getattr(result, "provider_switch_warning", "") == ""
+
+
+@pytest.mark.parametrize("current_provider", ["anthropic", "openai-codex"])
+def test_target_provider_alias_uses_canonical_warning_identity(offline_switch, current_provider):
+    provider = ms.resolve_provider_full("claude")
+    assert provider is not None
+    assert provider.id == "anthropic"
+    offline_switch.config["model_aliases"] = {
+        "chosen-model": {"model": "claude-sonnet-4.6", "provider": "claude"},
+    }
+    result = _switch(raw_input="chosen-model", current_provider=current_provider)
+
+    assert result.success
+    assert result.target_provider == "claude"
+    assert result.resolved_via_alias == "chosen-model"
+    if current_provider == "anthropic":
+        assert result.provider_switch_warning == ""
+    else:
+        _assert_warning(result, current_provider, "anthropic")
+    offline_switch.save.assert_not_called()
+
+
+def test_config_promoted_provider_still_warns_for_implicit_selection(offline_switch):
+    providers = {"lab": {"base_url": "https://lab.invalid/v1", "models": ["foreign-model"]}}
+    result = _switch(user_providers=providers)
+
+    _assert_warning(result, "openai-codex", "lab")
+    assert result.target_provider == "lab"
+    assert result.new_model == "foreign-model"
+    assert offline_switch.runtime.call_args.kwargs["explicit_base_url"] == "https://lab.invalid/v1"
+    assert result.warning_message == "Catalog validation notice."
+
+
+@pytest.mark.parametrize("failure", ["credentials", "validation"])
+def test_failed_resolution_has_no_provider_warning(offline_switch, failure):
+    if failure == "credentials":
+        offline_switch.runtime.side_effect = RuntimeError("offline credential failure")
+    else:
+        offline_switch.validation.update(accepted=False, message="offline validation failure")
+    result = _switch()
+
+    assert not result.success
+    assert "failure" in result.error_message
+    assert getattr(result, "provider_switch_warning", "") == ""
+
+
+def test_current_cached_catalog_match_does_not_switch_provider(offline_switch):
+    offline_switch.catalog.return_value = ["foreign-model"]
+    result = _switch()
+
+    assert result.success
+    assert result.target_provider == "openai-codex"
+    assert not result.provider_changed
+    assert result.new_model == "foreign-model"
+    assert getattr(result, "provider_switch_warning", "") == ""
+
+
+def test_first_party_new_model_stays_on_current_provider_without_catalog_match(offline_switch):
+    result = _switch(raw_input="gpt-6-astra")
+
+    assert result.success
+    assert result.target_provider == "openai-codex"
+    assert result.new_model == "gpt-6-astra"
+    assert getattr(result, "provider_switch_warning", "") == ""
+
+
+@pytest.fixture
+def tui_switch(offline_switch, monkeypatch, tmp_path):
+    """Keep resolution, confirmation, live application and config.set dispatch real."""
+    test_home = tmp_path / "tui-home"
+    test_hermes_home = test_home / ".hermes"
+    test_hermes_home.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(test_home))
+    monkeypatch.setenv("HERMES_HOME", str(test_hermes_home))
+    from tui_gateway import server
+
+    # Known synthetic prices exercise the real cost guard without a pricing lookup.
+    offline_switch.model_info.has_cost_data = lambda: True
+    offline_switch.model_info.cost_input = 1
+    offline_switch.model_info.cost_output = 1
+
+    class FakeLiveAgent:
+        model = "old-model"
+        provider = "openai-codex"
+        api_key = ""
+        base_url = ""
+        api_mode = "codex_responses"
+        compression_enabled = False
+        fail_swap = False
+
+        def switch_model(self, *, new_model, new_provider, api_key, base_url, api_mode, capabilities):
+            if self.fail_swap:
+                raise RuntimeError("offline swap failure")
+            self.model, self.provider = new_model, new_provider
+            self.api_key, self.base_url, self.api_mode = api_key, base_url, api_mode
+
+    agent = FakeLiveAgent()
+    session = {
+        "agent": agent, "session_key": "provider-warning-key", "history": [],
+        "history_lock": threading.Lock(), "history_version": 0, "running": False,
+        "attached_images": [], "image_counter": 0, "cols": 80, "slash_worker": None,
+        "show_reasoning": False, "tool_progress_mode": "all",
+    }
+    sid = "provider-warning-sid"
+    monkeypatch.setattr(server, "_sessions", {sid: session})
+    effects = {}
+    for name in (
+        "_restart_slash_worker", "_persist_live_session_runtime",
+        "_persist_live_session_system_prompt", "_append_model_switch_marker",
+        "_emit_session_info", "_persist_model_switch",
+    ):
+        effects[name] = Mock(return_value=None)
+        monkeypatch.setattr(server, name, effects[name])
+
+    def request_model(value, *, confirmed=False):
+        return server.handle_request({
+            "id": "provider-warning-request", "method": "config.set",
+            "params": {"session_id": sid, "key": "model", "value": value,
+                       "confirm_expensive_model": confirmed},
+        })
+
+    try:
+        yield SimpleNamespace(agent=agent, session=session, request=request_model, effects=effects)
+    finally:
+        server._sessions.pop(sid, None)
+
+
+@pytest.mark.parametrize("case", ["immediate", "confirmed-idle", "explicit-provider", "same-provider"])
+def test_tui_applied_response_preserves_resolver_warnings(offline_switch, tui_switch, case):
+    raw = "foreign-model --session"
+    expected_model, expected_provider = "vendor/foreign-model", "openrouter"
+    if case == "explicit-provider":
+        raw = "vendor/foreign-model --provider openrouter --session"
+    elif case == "same-provider":
+        offline_switch.catalog.return_value = ["foreign-model"]
+        expected_model, expected_provider = "foreign-model", "openai-codex"
+    elif case == "confirmed-idle":
+        offline_switch.model_info.cost_input = 30
+        pending = tui_switch.request(raw)
+        assert "error" not in pending, pending
+        pending_result = pending["result"]
+        assert pending_result["confirm_required"] is True
+        assert pending_result["warning"] == pending_result["confirm_message"]
+        assert "EXPENSIVE MODEL WARNING" in pending_result["confirm_message"]
+        assert pending_result["warning"].endswith("\n\nCatalog validation notice.")
+        assert "PROVIDER AUTOMATICALLY CHANGED" not in str(pending)
+        assert (tui_switch.agent.model, tui_switch.agent.provider) == ("old-model", "openai-codex")
+        assert "model_override" not in tui_switch.session
+        for effect in tui_switch.effects.values():
+            effect.assert_not_called()
+
+    response = tui_switch.request(raw, confirmed=case == "confirmed-idle")
+
+    assert "error" not in response, response
+    result = response["result"]
+    assert result["confirm_required"] is False
+    assert result["confirm_message"] == ""
+    assert result["scope"] == "session"
+    assert result["value"] == tui_switch.agent.model == expected_model
+    assert tui_switch.agent.provider == expected_provider
+    override = tui_switch.session["model_override"]
+    assert override["model"] == expected_model
+    assert override["provider"] == expected_provider
+    for key in ("api_key", "base_url", "api_mode"):
+        assert override[key] == getattr(tui_switch.agent, key)
+    tui_switch.effects["_persist_model_switch"].assert_not_called()
+    assert "provider_switch_warning" not in result
+    if case in ("immediate", "confirmed-idle"):
+        warning = result["warning"]
+        assert warning.startswith("PROVIDER AUTOMATICALLY CHANGED: openai-codex -> openrouter. ")
+        assert "No --provider argument was supplied" in warning
+        assert "additional costs" in warning
+        assert "Specify --provider explicitly" in warning
+        assert warning.endswith("\n\nCatalog validation notice.")
+    else:
+        assert result["warning"] == "Catalog validation notice."
+
+
+@pytest.mark.parametrize("case", ["implicit", "confirmed", "explicit-provider", "same-provider", "empty-warning"])
+def test_tui_deferred_application_emits_resolver_warning_once(offline_switch, tui_switch, monkeypatch, case):
+    from tui_gateway import server
+
+    sid = "provider-warning-sid"
+    raw = "foreign-model --session"
+    model, provider = "vendor/foreign-model", "openrouter"
+    explicit_provider = ""
+    if case in ("explicit-provider", "empty-warning"):
+        raw = "vendor/foreign-model --provider openrouter --session"
+        explicit_provider = "openrouter"
+        if case == "empty-warning":
+            offline_switch.validation["message"] = ""
+    elif case == "same-provider":
+        offline_switch.catalog.return_value = ["foreign-model"]
+        model, provider = "foreign-model", "openai-codex"
+    elif case == "confirmed":
+        offline_switch.model_info.cost_input = 30
+
+    resolved = _switch(raw_input=raw.split()[0], explicit_provider=explicit_provider)
+    assert resolved.success
+    warning = "\n\n".join(w for w in (resolved.provider_switch_warning, resolved.warning_message) if w)
+    if case in ("implicit", "confirmed"):
+        _assert_warning(resolved, "openai-codex", "openrouter")
+        assert warning.endswith("\n\nCatalog validation notice.")
+    else:
+        assert warning == ("" if case == "empty-warning" else "Catalog validation notice.")
+
+    emit = Mock()
+    monkeypatch.setattr(server, "_emit", emit)
+    tui_switch.session["running"] = True
+    response = tui_switch.request(raw, confirmed=case == "confirmed")
+
+    assert "error" not in response, response
+    assert response["result"]["deferred"] is True
+    assert response["result"]["confirm_required"] is False
+    assert response["result"]["warning"] == ""
+    assert (tui_switch.agent.model, tui_switch.agent.provider) == ("old-model", "openai-codex")
+    assert "model_override" not in tui_switch.session
+    assert tui_switch.session["pending_model_switch"]["raw"] == raw
+    assert tui_switch.session["pending_model_switch"]["confirm_expensive_model"] is (case == "confirmed")
+    emit.assert_not_called()
+    for effect in tui_switch.effects.values():
+        effect.assert_not_called()
+
+    # The next turn applies the actual queued request, with real resolution and guards.
+    tui_switch.session["running"] = False
+    server._apply_pending_model_switch(sid, tui_switch.session)
+
+    assert (tui_switch.agent.model, tui_switch.agent.provider) == (model, provider)
+    assert tui_switch.session["model_override"] == {
+        "model": model, "provider": provider,
+        **{key: getattr(tui_switch.agent, key) for key in ("api_key", "base_url", "api_mode")},
+    }
+    assert "pending_model_switch" not in tui_switch.session
+    if warning:
+        emit.assert_called_once_with("status.update", sid, {"kind": "model-switch-warning", "text": warning, "timestamp": ANY})
+    else:
+        emit.assert_not_called()
+    before = list(emit.call_args_list)
+    server._apply_pending_model_switch(sid, tui_switch.session)
+    assert emit.call_args_list == before
+    tui_switch.effects["_persist_model_switch"].assert_not_called()
+    offline_switch.save.assert_not_called()
+
+
+def test_tui_deferred_warning_replay_preserves_application_timestamp(tui_switch, monkeypatch):
+    from tui_gateway import event_replay, server
+
+    sid = "provider-warning-sid"
+    previous_seq = event_replay.latest_seq(sid)
+    transport = SimpleNamespace(write=Mock(return_value=True))
+    tui_switch.session["transport"] = transport
+    clock = SimpleNamespace(now=1_700_000_000.25)
+    monkeypatch.setattr(server.time, "time", lambda: clock.now)
+    tui_switch.session["running"] = True
+    queued = tui_switch.request("foreign-model --session")
+    assert queued["result"]["deferred"] is True
+    transport.write.assert_not_called()
+
+    tui_switch.session["running"] = False
+    server._apply_pending_model_switch(sid, tui_switch.session)
+    frame = transport.write.call_args.args[0]["params"]
+    assert frame["type"] == "status.update"
+    assert frame["session_id"] == sid
+    assert frame["payload"]["timestamp"] == clock.now
+
+    clock.now += 900
+    replayed = event_replay.events_since(sid, previous_seq)
+    assert len(replayed) == 1
+    assert replayed[0]["payload"]["timestamp"] == 1_700_000_000.25
+    assert replayed[0]["payload"]["text"] == frame["payload"]["text"]
+
+
+@pytest.mark.parametrize("deferred", [False, True])
+@pytest.mark.parametrize("case", ["declined-confirmation", "resolver-failure", "swap-failure"])
+def test_tui_unapplied_switch_has_no_successful_provider_announcement(
+    offline_switch, tui_switch, monkeypatch, case, deferred,
+):
+    from tui_gateway import server
+
+    emit = Mock()
+    monkeypatch.setattr(server, "_emit", emit)
+    if deferred:
+        tui_switch.session["running"] = True
+        queued = tui_switch.request("foreign-model --session")
+        assert queued["result"]["deferred"] is True
+        assert queued["result"]["warning"] == ""
+        emit.assert_not_called()
+        tui_switch.session["running"] = False
+
+    if case == "declined-confirmation":
+        offline_switch.model_info.cost_input = 30
+    elif case == "resolver-failure":
+        offline_switch.validation.update(accepted=False, message="offline validation failure")
+    else:
+        tui_switch.agent.fail_swap = True
+    runtime_keys = ("model", "provider", "api_key", "base_url", "api_mode")
+    before = {key: getattr(tui_switch.agent, key) for key in runtime_keys}
+
+    # Declining means the client never sends the confirmed request.
+    if deferred:
+        server._apply_pending_model_switch("provider-warning-sid", tui_switch.session)
+        assert "pending_model_switch" not in tui_switch.session
+        emit.assert_called_once()
+        event_type, sid, payload = emit.call_args.args
+        assert (event_type, sid) == ("error", "provider-warning-sid")
+        response = payload
+        before_events = list(emit.call_args_list)
+        server._apply_pending_model_switch(sid, tui_switch.session)
+        assert emit.call_args_list == before_events
+    else:
+        response = tui_switch.request("foreign-model --session")
+        emit.assert_not_called()
+
+    assert "PROVIDER AUTOMATICALLY CHANGED" not in str(response)
+    assert {key: getattr(tui_switch.agent, key) for key in runtime_keys} == before
+    assert "model_override" not in tui_switch.session
+    for effect in tui_switch.effects.values():
+        effect.assert_not_called()
+    if deferred:
+        if case == "declined-confirmation":
+            assert "EXPENSIVE MODEL WARNING" in response["message"]
+            assert response["message"].endswith("\n\nCatalog validation notice.")
+        else:
+            expected_error = "offline validation failure" if case == "resolver-failure" else "offline swap failure"
+            assert response["message"].startswith("Could not switch model: ")
+            assert expected_error in response["message"]
+    elif case == "declined-confirmation":
+        assert "error" not in response, response
+        result = response["result"]
+        assert result["confirm_required"] is True
+        assert "EXPENSIVE MODEL WARNING" in result["confirm_message"]
+        assert result["warning"] == result["confirm_message"]
+        assert result["warning"].endswith("\n\nCatalog validation notice.")
+    else:
+        assert "result" not in response
+        assert response["error"]["code"] == 5001
+        expected_error = "offline validation failure" if case == "resolver-failure" else "offline swap failure"
+        assert expected_error in response["error"]["message"]

--- a/tui_gateway/model_switch.py
+++ b/tui_gateway/model_switch.py
@@ -242,7 +242,10 @@ def _apply_model_switch(
     if persist_global:
         _persist_model_switch(result)
     return {
-        "value": result.new_model, "warning": result.warning_message or "",
+        "value": result.new_model,
+        "warning": "\n\n".join(w for w in (
+            getattr(result, "provider_switch_warning", ""), result.warning_message
+        ) if w),
         "confirm_required": False,
         "scope": "once" if one_turn else ("global" if persist_global else "session")}
 

--- a/tui_gateway/session_compression.py
+++ b/tui_gateway/session_compression.py
@@ -185,6 +185,8 @@ def _apply_pending_model_switch(sid: str, session: dict) -> None:
         # on a model the user never confirmed.
         if result.get("confirm_required"):
             _emit("error", sid, {"message": result.get("confirm_message") or result.get("warning") or ""})
+        elif result.get("warning"):
+            _emit("status.update", sid, {"kind": "model-switch-warning", "text": result["warning"], "timestamp": time.time()})
     except Exception as e:
         _emit("error", sid, {"message": f"Could not switch model: {e}"})
 

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -208,6 +208,41 @@ describe('createGatewayEventHandler', () => {
     expect(getTurnState().todos).toEqual(todos)
   })
 
+  it('appends the full model-switch warning immediately without changing the active turn', () => {
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    ctx.system.sys.mockImplementation((text: string) => appended.push({ role: 'system', text }))
+    patchUiState({ sid: 'focused' })
+    const onEvent = createGatewayEventHandler(ctx)
+    onEvent({ session_id: 'focused', payload: {}, type: 'message.start' } as any)
+    onEvent({
+      session_id: 'focused',
+      payload: { request_id: 'approval', command: 'test' },
+      type: 'approval.request'
+    } as any)
+    const busyState = getUiState()
+    const busyTurn = getTurnState()
+    const busyOverlay = getOverlayState()
+    const text = 'PROVIDER AUTOMATICALLY CHANGED: openai-codex -> openrouter. Additional costs may apply.\n\n' +
+      'Catalog validation notice. Keep <b>literal markup</b> and \u001b[31mcontrol text\u001b[0m.\n'
+    expect(busyState.busy).toBe(true)
+
+    onEvent({ session_id: 'other', payload: { kind: 'model-switch-warning', text }, type: 'status.update' })
+    expect(ctx.system.sys).not.toHaveBeenCalled()
+    onEvent({ session_id: 'focused', payload: { kind: 'model-switch-warning', text }, type: 'status.update' })
+
+    expect(ctx.system.sys).toHaveBeenCalledExactlyOnceWith(`warning: ${text}`)
+    expect(appended).toEqual([{ role: 'system', text: `warning: ${text}` }])
+    expect(getUiState()).toEqual(busyState)
+    expect(getTurnState()).toEqual(busyTurn)
+    expect(getOverlayState()).toEqual(busyOverlay)
+
+    onEvent({ session_id: 'focused', payload: { kind: 'progress', text: 'Working...' }, type: 'status.update' })
+    expect(getUiState().status).toBe('Working...')
+    expect(getUiState().busy).toBe(true)
+    expect(ctx.system.sys).toHaveBeenCalledTimes(1)
+  })
+
   it('prints compaction progress status into the transcript', () => {
     const appended: Msg[] = []
     const ctx = buildCtx(appended)

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -850,6 +850,12 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           return
         }
 
+        if (p.kind === 'model-switch-warning') {
+          sys(`warning: ${p.text}`)
+
+          return
+        }
+
         if (p.kind === 'goal') {
           sys(p.text)
 


### PR DESCRIPTION
Show a provider-change warning after an implicit model switch is actually applied in the classic CLI, messaging gateway and TUI RPC paths. Canonicalize provider identities for comparison and display while retaining the original routing values. Explicit-provider selections, same-provider aliases, failed applies and pending confirmations do not produce an applied-switch warning.

Preserve the existing CLI/gateway formatting and combine the provider warning with validation warnings in the RPC response. When a busy session applies its queued switch on a later turn, forward the complete warning through a session-scoped status event into the existing Ink and Desktop transcripts. Preserve the owning session, event timestamp and unrelated activity state.

Validation: 41 targeted Python tests passed on both the final candidate and the current upstream integration, including replay of the original warning timestamp. The unchanged frontend paths passed 108 Ink event-handler tests and 7 Desktop stream-hook tests. The original CLI/gateway/RPC implementation also passed its earlier 62-test selection. All twelve final source files match the tested integration.

Native immediate Desktop picker rendering, rendered-app behavior and durable backend warning history were not verified by this change.
