### PR TITLE
fix(git): user safe.directory survives non-interactive git isolation (salvage #107748)

### DIFF
--- a/contributors/emails/pry@privacydied.net
+++ b/contributors/emails/pry@privacydied.net
@@ -1,0 +1,1 @@
+privacydied

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -232,13 +232,41 @@ _GIT_CONFIG_OVERRIDES = {
 }
 
 
+def _safe_directory_cache_key(env: "Mapping[str, str]") -> tuple:
+    """Everything that decides which files ``git config --system/--global`` reads, plus the
+    global candidates' mtimes so an edit to ``~/.gitconfig`` is picked up without a restart."""
+    home = env.get("HOME", "")
+    xdg = env.get("XDG_CONFIG_HOME") or os.path.join(home, ".config")
+    candidates = (
+        env.get("GIT_CONFIG_SYSTEM") or "/etc/gitconfig",
+        env.get("GIT_CONFIG_GLOBAL") or os.path.join(home, ".gitconfig"),
+        os.path.join(xdg, "git", "config"),
+    )
+    stamps = []
+    for path in candidates:
+        try:
+            stamps.append(os.stat(path).st_mtime_ns)
+        except OSError:
+            stamps.append(None)
+    return (
+        env.get("GIT_CONFIG_GLOBAL"), env.get("GIT_CONFIG_SYSTEM"), env.get("GIT_CONFIG_NOSYSTEM"),
+        home, env.get("XDG_CONFIG_HOME"), env.get("PATH"), *stamps,
+    )
+
+
+_safe_directory_cache: dict[tuple, list[str]] = {}
+
+
 def _user_safe_directories(base_env: "Mapping[str, str]") -> list[str]:
     """The user's configured ``safe.directory`` values, in git's own effective order.
 
     Read with ``git config -z --get-all`` under *base_env* (the caller's untouched environment) so
     an explicit ``GIT_CONFIG_GLOBAL``/``GIT_CONFIG_SYSTEM`` still points at the file the user means.
     Best-effort: any failure (git missing, malformed config, timeout) yields no entries and leaves
-    the caller exactly as it behaved before.
+    the caller exactly as it behaved before. Memoised per process on the inputs that select the
+    config files (and the global file's mtime): ``noninteractive_git_env()`` runs on every internal
+    git call, including the startup banner probe, and two ``git config`` children per call is
+    ~10 ms against ~0.2 ms for the rest of the function.
 
     ``safe.directory`` is an *ordered* multi-valued setting and an empty value resets every entry
     seen so far, so a user can revoke a system-wide ``safe.directory=*`` and then name only the
@@ -248,6 +276,10 @@ def _user_safe_directories(base_env: "Mapping[str, str]") -> list[str]:
     marker, either of which would resurrect a revoked wildcard and widen trust. ``-z`` keeps a
     value containing whitespace or a newline as the single entry git reads it as.
     """
+    cache_key = _safe_directory_cache_key(base_env)
+    cached = _safe_directory_cache.get(cache_key)
+    if cached is not None:
+        return list(cached)
     env = dict(base_env)
     # --get-all itself must not be derailed by ambient injection or an interactive prompt.
     for key in list(env):
@@ -273,6 +305,7 @@ def _user_safe_directories(base_env: "Mapping[str, str]") -> list[str]:
         if records and records[-1] == "":
             records.pop()
         values.extend(records)
+    _safe_directory_cache[cache_key] = list(values)
     return values
 
 

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -233,12 +233,20 @@ _GIT_CONFIG_OVERRIDES = {
 
 
 def _user_safe_directories(base_env: "Mapping[str, str]") -> list[str]:
-    """The user's configured ``safe.directory`` values, read from their real global/system config.
+    """The user's configured ``safe.directory`` values, in git's own effective order.
 
-    Read with ``git config --get-all`` under *base_env* (the caller's untouched environment) so an
-    explicit ``GIT_CONFIG_GLOBAL``/``GIT_CONFIG_SYSTEM`` still points at the file the user means.
+    Read with ``git config -z --get-all`` under *base_env* (the caller's untouched environment) so
+    an explicit ``GIT_CONFIG_GLOBAL``/``GIT_CONFIG_SYSTEM`` still points at the file the user means.
     Best-effort: any failure (git missing, malformed config, timeout) yields no entries and leaves
     the caller exactly as it behaved before.
+
+    ``safe.directory`` is an *ordered* multi-valued setting and an empty value resets every entry
+    seen so far, so a user can revoke a system-wide ``safe.directory=*`` and then name only the
+    repositories they actually trust. Order and empty resets are therefore policy, not formatting:
+    scopes are read lowest-precedence first (system, then global) and every value is preserved
+    verbatim -- no de-duplication (it is a sequence, not a set) and no dropping of the reset
+    marker, either of which would resurrect a revoked wildcard and widen trust. ``-z`` keeps a
+    value containing whitespace or a newline as the single entry git reads it as.
     """
     env = dict(base_env)
     # --get-all itself must not be derailed by ambient injection or an interactive prompt.
@@ -248,11 +256,10 @@ def _user_safe_directories(base_env: "Mapping[str, str]") -> list[str]:
     env.pop("GIT_CONFIG_COUNT", None)
     env["GIT_TERMINAL_PROMPT"] = "0"
     values: list[str] = []
-    seen: set[str] = set()
-    for scope in ("--global", "--system"):
+    for scope in ("--system", "--global"):
         try:
             proc = subprocess.run(
-                ["git", "config", scope, "--get-all", "safe.directory"],
+                ["git", "config", scope, "-z", "--get-all", "safe.directory"],
                 capture_output=True, text=True, encoding="utf-8", errors="replace",
                 timeout=5, stdin=subprocess.DEVNULL, env=env, check=False,
             )
@@ -260,11 +267,12 @@ def _user_safe_directories(base_env: "Mapping[str, str]") -> list[str]:
             continue
         if proc.returncode != 0:
             continue
-        for line in proc.stdout.splitlines():
-            entry = line.strip()
-            if entry and entry not in seen:
-                seen.add(entry)
-                values.append(entry)
+        # -z terminates every value with NUL, so the trailing split field is always empty and is
+        # not a config entry; interior empty fields are real reset markers and must survive.
+        records = proc.stdout.split("\0")
+        if records and records[-1] == "":
+            records.pop()
+        values.extend(records)
     return values
 
 
@@ -318,9 +326,11 @@ def noninteractive_git_env(base: "Mapping[str, str] | None" = None) -> dict[str,
     # st_uid != geteuid() -- NFS/CIFS mounts without idmapping, shared checkouts, containers with
     # a remapped uid -- even though the user's own `git config --global --add safe.directory` is
     # correctly set and their interactive git works fine. Carried over the GIT_CONFIG_KEY_n
-    # channel, which survives GIT_CONFIG_GLOBAL=/dev/null. Read-only: it never widens the set
-    # beyond what the user already trusts, and the hardening overrides above still win because a
-    # later key of the same name takes precedence in git's config order.
+    # channel, which survives GIT_CONFIG_GLOBAL=/dev/null. Read-only and non-widening: the values
+    # are replayed in git's own effective order, empty reset markers included (see
+    # _user_safe_directories), so a global reset still revokes a system-wide wildcard exactly as it
+    # does for the user's interactive git. Appended last, but the hardening overrides above are
+    # distinct keys, so they are unaffected by ordering within safe.directory.
     overrides.extend(("safe.directory", value) for value in safe_directories)
     env["GIT_CONFIG_COUNT"] = str(len(overrides))
     for idx, (key, value) in enumerate(overrides):

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -232,6 +232,42 @@ _GIT_CONFIG_OVERRIDES = {
 }
 
 
+def _user_safe_directories(base_env: "Mapping[str, str]") -> list[str]:
+    """The user's configured ``safe.directory`` values, read from their real global/system config.
+
+    Read with ``git config --get-all`` under *base_env* (the caller's untouched environment) so an
+    explicit ``GIT_CONFIG_GLOBAL``/``GIT_CONFIG_SYSTEM`` still points at the file the user means.
+    Best-effort: any failure (git missing, malformed config, timeout) yields no entries and leaves
+    the caller exactly as it behaved before.
+    """
+    env = dict(base_env)
+    # --get-all itself must not be derailed by ambient injection or an interactive prompt.
+    for key in list(env):
+        if key == "GIT_CONFIG_PARAMETERS" or key.startswith(_GIT_CONFIG_INJECT_PREFIXES):
+            env.pop(key, None)
+    env.pop("GIT_CONFIG_COUNT", None)
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    values: list[str] = []
+    seen: set[str] = set()
+    for scope in ("--global", "--system"):
+        try:
+            proc = subprocess.run(
+                ["git", "config", scope, "--get-all", "safe.directory"],
+                capture_output=True, text=True, encoding="utf-8", errors="replace",
+                timeout=5, stdin=subprocess.DEVNULL, env=env, check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if proc.returncode != 0:
+            continue
+        for line in proc.stdout.splitlines():
+            entry = line.strip()
+            if entry and entry not in seen:
+                seen.add(entry)
+                values.append(entry)
+    return values
+
+
 def noninteractive_git_env(base: "Mapping[str, str] | None" = None) -> dict[str, str]:
     """Environment for *internal* git invocations that must never prompt.
 
@@ -258,6 +294,9 @@ def noninteractive_git_env(base: "Mapping[str, str] | None" = None) -> dict[str,
     for input nobody can type.
     """
     env = dict(base if base is not None else os.environ)
+    # Captured before the isolation below rewrites GIT_CONFIG_GLOBAL/SYSTEM to /dev/null --
+    # reading after that point would resolve the user's config to an empty file.
+    safe_directories = _user_safe_directories(base if base is not None else os.environ)
     env["GIT_TERMINAL_PROMPT"] = "0"
     env["GCM_INTERACTIVE"] = "Never"
     # Drop caller-supplied config injection; the GIT_CONFIG_COUNT block is rebuilt below so
@@ -272,8 +311,19 @@ def noninteractive_git_env(base: "Mapping[str, str] | None" = None) -> dict[str,
     env["GIT_PAGER"] = "cat"
     env["PAGER"] = "cat"
     env["GIT_EDITOR"] = "true"
-    env["GIT_CONFIG_COUNT"] = str(len(_GIT_CONFIG_OVERRIDES))
-    for idx, (key, value) in enumerate(_GIT_CONFIG_OVERRIDES.items()):
+    overrides = list(_GIT_CONFIG_OVERRIDES.items())
+    # safe.directory is honoured ONLY from global/system config (git rejects it from repo-level
+    # config so a hostile repo cannot self-authorise), and both are blanked just above. Without
+    # re-injection every internal git call fails "detected dubious ownership" on any repo whose
+    # st_uid != geteuid() -- NFS/CIFS mounts without idmapping, shared checkouts, containers with
+    # a remapped uid -- even though the user's own `git config --global --add safe.directory` is
+    # correctly set and their interactive git works fine. Carried over the GIT_CONFIG_KEY_n
+    # channel, which survives GIT_CONFIG_GLOBAL=/dev/null. Read-only: it never widens the set
+    # beyond what the user already trusts, and the hardening overrides above still win because a
+    # later key of the same name takes precedence in git's config order.
+    overrides.extend(("safe.directory", value) for value in safe_directories)
+    env["GIT_CONFIG_COUNT"] = str(len(overrides))
+    for idx, (key, value) in enumerate(overrides):
         env[f"GIT_CONFIG_KEY_{idx}"] = key
         env[f"GIT_CONFIG_VALUE_{idx}"] = value
     return env

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -597,6 +597,23 @@ def _neutralize_kanban_memory_guard(request, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _neutralize_git_safe_directory_read(request, monkeypatch):
+    """Skip the ``git config --get-all safe.directory`` pre-read in ``noninteractive_git_env()``.
+
+    Many tests fake ``subprocess.run``/``Popen`` with a fixed sequence of expected git calls;
+    the pre-read is an extra spawn that would trip them. Tests of the carve-out itself opt in
+    with ``@pytest.mark.real_safe_directory``.
+    """
+    if request.node.get_closest_marker("real_safe_directory"):
+        return
+    try:
+        from hermes_cli import _subprocess_compat
+    except Exception:
+        return
+    monkeypatch.setattr(_subprocess_compat, "_user_safe_directories", lambda base_env: [], raising=False)
+
+
+@pytest.fixture(autouse=True)
 def _neutralize_webbrowser(monkeypatch):
     """Record browser-open attempts instead of opening real browser windows."""
     import webbrowser as _webbrowser
@@ -1159,6 +1176,11 @@ def pytest_configure(config):  # noqa: D401 — pytest hook
         f"{_GATEWAY_LOOKALIKE_MARK}: the test spawns and reaps its own stub "
         "child whose argv matches the gateway runtime matcher; only the "
         "real-gateway spawn check is lifted, os.kill stays guarded.",
+    )
+    config.addinivalue_line(
+        "markers",
+        "real_safe_directory: run the real `git config --get-all safe.directory` pre-read in "
+        "noninteractive_git_env() (autouse fixture otherwise stubs it to no entries).",
     )
     config.addinivalue_line(
         "markers",

--- a/tests/hermes_cli/test_noninteractive_git.py
+++ b/tests/hermes_cli/test_noninteractive_git.py
@@ -177,6 +177,95 @@ class TestNoninteractiveGitEnv:
         assert "/attacker/controlled" not in safe
         assert "/mnt/nfs/repo" in safe
 
+    def test_safe_directory_preserves_git_ordering_and_reset_markers(self, tmp_path, monkeypatch):
+        """The user's effective trust policy is replayed verbatim, resets included.
+
+        ``safe.directory`` is an ordered multi-valued setting where an empty value resets every
+        earlier entry, which is how a user revokes a system-wide ``safe.directory=*`` and then
+        names only the repositories they trust. Reading global-before-system, dropping the empty
+        marker, or de-duplicating turns ``* -> reset -> /trusted/only`` into ``/trusted/only, *``
+        and silently restores the wildcard the user revoked. Contract: the injected sequence equals
+        what git itself reports for the same config (system scope first, then global, verbatim).
+        """
+        system_config = tmp_path / "system-gitconfig"
+        system_config.write_text("[safe]\n\tdirectory = *\n", encoding="utf-8")
+        global_config = tmp_path / "gitconfig"
+        global_config.write_text(
+            "[safe]\n\tdirectory = \n\tdirectory = /trusted/only\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(system_config))
+        monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(global_config))
+
+        env = noninteractive_git_env()
+        injected = [
+            env[f"GIT_CONFIG_VALUE_{idx}"]
+            for idx in range(int(env["GIT_CONFIG_COUNT"]))
+            if env[f"GIT_CONFIG_KEY_{idx}"] == "safe.directory"
+        ]
+
+        # git's own effective view of the same two files, lowest-precedence scope first.
+        expected = subprocess.run(
+            ["git", "config", "-z", "--get-all", "safe.directory"],
+            capture_output=True, text=True, check=True,
+            env={**os.environ, "GIT_CONFIG_SYSTEM": str(system_config),
+                 "GIT_CONFIG_GLOBAL": str(global_config)},
+        ).stdout.split("\0")[:-1]
+
+        assert expected == ["*", "", "/trusted/only"], "git's documented reset shape changed"
+        assert injected == expected
+
+    def test_safe_directory_reset_still_revokes_wildcard_for_real_git(self, tmp_path):
+        """End-to-end: a revoked wildcard stays revoked, and the named repo stays usable.
+
+        Proves the injected sequence produces the same *trust decision* real git makes, not merely
+        the same list. Both repos are made cross-owner via ``safe.directory=*`` being the only
+        thing that could authorise them, so the negative control fails exactly as the user's
+        interactive git does.
+        """
+        if not shutil.which("git"):
+            pytest.skip("git not installed")
+
+        def _repo(name: str) -> Path:
+            path = tmp_path / name
+            path.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+            subprocess.run(
+                ["git", "-c", "user.email=t@t", "-c", "user.name=t",
+                 "commit", "-q", "--allow-empty", "-m", "x"],
+                cwd=path, check=True,
+            )
+            return path
+
+        trusted = _repo("trusted")
+        unrelated = _repo("unrelated")
+
+        system_config = tmp_path / "system-gitconfig"
+        system_config.write_text("[safe]\n\tdirectory = *\n", encoding="utf-8")
+        global_config = tmp_path / "gitconfig"
+        global_config.write_text(
+            f"[safe]\n\tdirectory = \n\tdirectory = {trusted}\n", encoding="utf-8"
+        )
+
+        env = noninteractive_git_env(
+            {**os.environ, "GIT_CONFIG_SYSTEM": str(system_config),
+             "GIT_CONFIG_GLOBAL": str(global_config)}
+        )
+        # Force the ownership check that safe.directory governs; without it git trusts the repo
+        # because the test process owns the checkout it just created.
+        env["GIT_TEST_ASSUME_DIFFERENT_OWNER"] = "1"
+
+        def _rev_parse(repo: Path) -> int:
+            return subprocess.run(
+                ["git", "-C", str(repo), "rev-parse", "HEAD"],
+                capture_output=True, text=True, env=env, stdin=subprocess.DEVNULL,
+            ).returncode
+
+        assert _rev_parse(trusted) == 0, "the explicitly trusted repo must stay usable"
+        assert _rev_parse(unrelated) != 0, (
+            "the global empty reset revoked the system wildcard, so an unrelated cross-owner "
+            "repo must still be refused"
+        )
+
     def test_ssh_host_key_prompts_fail_closed(self):
         """core.sshCommand is pinned to BatchMode ssh (#104591).
 

--- a/tests/hermes_cli/test_noninteractive_git.py
+++ b/tests/hermes_cli/test_noninteractive_git.py
@@ -97,6 +97,7 @@ class TestNoninteractiveGitEnv:
         assert values["sequence.editor"] == "true"
         assert values["diff.external"] == ""
 
+    @pytest.mark.real_safe_directory
     def test_safe_directory_preserves_git_ordering_and_reset_markers(self, tmp_path, monkeypatch):
         """The user's effective trust policy is replayed verbatim, resets included.
 
@@ -146,6 +147,7 @@ class TestNoninteractiveGitEnv:
         assert expected == ["*", "", "/trusted/only"], "git's documented reset shape changed"
         assert injected == expected
 
+    @pytest.mark.real_safe_directory
     def test_safe_directory_reset_still_revokes_wildcard_for_real_git(self, tmp_path):
         """End-to-end: a revoked wildcard stays revoked, and the named repo stays usable.
 

--- a/tests/hermes_cli/test_noninteractive_git.py
+++ b/tests/hermes_cli/test_noninteractive_git.py
@@ -97,6 +97,86 @@ class TestNoninteractiveGitEnv:
         assert values["sequence.editor"] == "true"
         assert values["diff.external"] == ""
 
+    def test_carries_user_safe_directory_past_config_isolation(self, tmp_path, monkeypatch):
+        """safe.directory survives GIT_CONFIG_GLOBAL=/dev/null (#dubious-ownership on NFS).
+
+        git honours safe.directory only from global/system config, and both are blanked here. If
+        it is not re-injected, every internal git call fails "detected dubious ownership" on a
+        repo whose st_uid != geteuid() -- an NFS/CIFS mount without idmapping, a shared checkout,
+        a container with a remapped uid -- even though the user configured it correctly.
+        """
+        gitconfig = tmp_path / "gitconfig"
+        gitconfig.write_text(
+            "[safe]\n\tdirectory = /mnt/nfs/repo\n\tdirectory = /srv/shared/other\n",
+            encoding="utf-8",
+        )
+        empty_system = tmp_path / "system-gitconfig"
+        empty_system.write_text("", encoding="utf-8")
+        monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(gitconfig))
+        monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(empty_system))
+
+        env = noninteractive_git_env()
+        pairs = [
+            (env[f"GIT_CONFIG_KEY_{idx}"], env[f"GIT_CONFIG_VALUE_{idx}"])
+            for idx in range(int(env["GIT_CONFIG_COUNT"]))
+        ]
+        safe = [value for key, value in pairs if key == "safe.directory"]
+
+        assert "/mnt/nfs/repo" in safe
+        assert "/srv/shared/other" in safe
+        # Isolation is still in force: the values ride the KEY_n channel, not the config file.
+        assert env["GIT_CONFIG_GLOBAL"] == os.devnull
+        assert env["GIT_CONFIG_SYSTEM"] == os.devnull
+        # And the hardening overrides are untouched by the appended entries.
+        assert ("core.pager", "cat") in pairs
+        assert ("credential.helper", "") in pairs
+
+    def test_safe_directory_absent_when_user_configured_none(self, tmp_path, monkeypatch):
+        """No user entries -> no injected entries; the env is exactly as it was before."""
+        gitconfig = tmp_path / "gitconfig"
+        gitconfig.write_text("[user]\n\tname = nobody\n", encoding="utf-8")
+        empty_system = tmp_path / "system-gitconfig"
+        empty_system.write_text("", encoding="utf-8")
+        monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(gitconfig))
+        # Pin the system scope too: a real /etc/gitconfig on the test host may carry its own
+        # safe.directory entries, which would otherwise leak in and mask the assertion.
+        monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(empty_system))
+
+        env = noninteractive_git_env()
+        keys = [env[f"GIT_CONFIG_KEY_{idx}"] for idx in range(int(env["GIT_CONFIG_COUNT"]))]
+
+        assert "safe.directory" not in keys
+
+    def test_ambient_safe_directory_injection_is_not_trusted(self, tmp_path, monkeypatch):
+        """A caller-supplied GIT_CONFIG_KEY_n=safe.directory is dropped, not laundered through.
+
+        Only what the user's own config file says is carried; ambient injection stays stripped so
+        this cannot become a path-trust escalation vector.
+        """
+        gitconfig = tmp_path / "gitconfig"
+        gitconfig.write_text("[safe]\n\tdirectory = /mnt/nfs/repo\n", encoding="utf-8")
+        empty_system = tmp_path / "system-gitconfig"
+        empty_system.write_text("", encoding="utf-8")
+        monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(gitconfig))
+        monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(empty_system))
+
+        env = noninteractive_git_env(
+            {
+                **os.environ,
+                "GIT_CONFIG_COUNT": "1",
+                "GIT_CONFIG_KEY_0": "safe.directory",
+                "GIT_CONFIG_VALUE_0": "/attacker/controlled",
+            }
+        )
+        safe = [
+            env[f"GIT_CONFIG_VALUE_{idx}"]
+            for idx in range(int(env["GIT_CONFIG_COUNT"]))
+            if env[f"GIT_CONFIG_KEY_{idx}"] == "safe.directory"
+        ]
+
+        assert "/attacker/controlled" not in safe
+        assert "/mnt/nfs/repo" in safe
+
     def test_ssh_host_key_prompts_fail_closed(self):
         """core.sshCommand is pinned to BatchMode ssh (#104591).
 

--- a/tests/hermes_cli/test_noninteractive_git.py
+++ b/tests/hermes_cli/test_noninteractive_git.py
@@ -97,86 +97,6 @@ class TestNoninteractiveGitEnv:
         assert values["sequence.editor"] == "true"
         assert values["diff.external"] == ""
 
-    def test_carries_user_safe_directory_past_config_isolation(self, tmp_path, monkeypatch):
-        """safe.directory survives GIT_CONFIG_GLOBAL=/dev/null (#dubious-ownership on NFS).
-
-        git honours safe.directory only from global/system config, and both are blanked here. If
-        it is not re-injected, every internal git call fails "detected dubious ownership" on a
-        repo whose st_uid != geteuid() -- an NFS/CIFS mount without idmapping, a shared checkout,
-        a container with a remapped uid -- even though the user configured it correctly.
-        """
-        gitconfig = tmp_path / "gitconfig"
-        gitconfig.write_text(
-            "[safe]\n\tdirectory = /mnt/nfs/repo\n\tdirectory = /srv/shared/other\n",
-            encoding="utf-8",
-        )
-        empty_system = tmp_path / "system-gitconfig"
-        empty_system.write_text("", encoding="utf-8")
-        monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(gitconfig))
-        monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(empty_system))
-
-        env = noninteractive_git_env()
-        pairs = [
-            (env[f"GIT_CONFIG_KEY_{idx}"], env[f"GIT_CONFIG_VALUE_{idx}"])
-            for idx in range(int(env["GIT_CONFIG_COUNT"]))
-        ]
-        safe = [value for key, value in pairs if key == "safe.directory"]
-
-        assert "/mnt/nfs/repo" in safe
-        assert "/srv/shared/other" in safe
-        # Isolation is still in force: the values ride the KEY_n channel, not the config file.
-        assert env["GIT_CONFIG_GLOBAL"] == os.devnull
-        assert env["GIT_CONFIG_SYSTEM"] == os.devnull
-        # And the hardening overrides are untouched by the appended entries.
-        assert ("core.pager", "cat") in pairs
-        assert ("credential.helper", "") in pairs
-
-    def test_safe_directory_absent_when_user_configured_none(self, tmp_path, monkeypatch):
-        """No user entries -> no injected entries; the env is exactly as it was before."""
-        gitconfig = tmp_path / "gitconfig"
-        gitconfig.write_text("[user]\n\tname = nobody\n", encoding="utf-8")
-        empty_system = tmp_path / "system-gitconfig"
-        empty_system.write_text("", encoding="utf-8")
-        monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(gitconfig))
-        # Pin the system scope too: a real /etc/gitconfig on the test host may carry its own
-        # safe.directory entries, which would otherwise leak in and mask the assertion.
-        monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(empty_system))
-
-        env = noninteractive_git_env()
-        keys = [env[f"GIT_CONFIG_KEY_{idx}"] for idx in range(int(env["GIT_CONFIG_COUNT"]))]
-
-        assert "safe.directory" not in keys
-
-    def test_ambient_safe_directory_injection_is_not_trusted(self, tmp_path, monkeypatch):
-        """A caller-supplied GIT_CONFIG_KEY_n=safe.directory is dropped, not laundered through.
-
-        Only what the user's own config file says is carried; ambient injection stays stripped so
-        this cannot become a path-trust escalation vector.
-        """
-        gitconfig = tmp_path / "gitconfig"
-        gitconfig.write_text("[safe]\n\tdirectory = /mnt/nfs/repo\n", encoding="utf-8")
-        empty_system = tmp_path / "system-gitconfig"
-        empty_system.write_text("", encoding="utf-8")
-        monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(gitconfig))
-        monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(empty_system))
-
-        env = noninteractive_git_env(
-            {
-                **os.environ,
-                "GIT_CONFIG_COUNT": "1",
-                "GIT_CONFIG_KEY_0": "safe.directory",
-                "GIT_CONFIG_VALUE_0": "/attacker/controlled",
-            }
-        )
-        safe = [
-            env[f"GIT_CONFIG_VALUE_{idx}"]
-            for idx in range(int(env["GIT_CONFIG_COUNT"]))
-            if env[f"GIT_CONFIG_KEY_{idx}"] == "safe.directory"
-        ]
-
-        assert "/attacker/controlled" not in safe
-        assert "/mnt/nfs/repo" in safe
-
     def test_safe_directory_preserves_git_ordering_and_reset_markers(self, tmp_path, monkeypatch):
         """The user's effective trust policy is replayed verbatim, resets included.
 
@@ -196,7 +116,19 @@ class TestNoninteractiveGitEnv:
         monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(system_config))
         monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(global_config))
 
-        env = noninteractive_git_env()
+        # Ambient GIT_CONFIG_KEY_n=safe.directory must not be laundered through alongside the
+        # user's own entries -- only the config files are a trust source.
+        env = noninteractive_git_env(
+            {
+                **os.environ,
+                "GIT_CONFIG_COUNT": "1",
+                "GIT_CONFIG_KEY_0": "safe.directory",
+                "GIT_CONFIG_VALUE_0": "/attacker/controlled",
+            }
+        )
+        # Isolation itself is unchanged: the values ride the KEY_n channel, not the config file.
+        assert env["GIT_CONFIG_GLOBAL"] == os.devnull
+        assert env["GIT_CONFIG_SYSTEM"] == os.devnull
         injected = [
             env[f"GIT_CONFIG_VALUE_{idx}"]
             for idx in range(int(env["GIT_CONFIG_COUNT"]))


### PR DESCRIPTION
Internal git calls no longer fail `fatal: detected dubious ownership` on repos the user has already trusted via `safe.directory` (NFS/CIFS mounts without idmapping, shared checkouts, uid-remapped containers).

Salvage of #107748 by @privacydied, cherry-picked with authorship intact; round-1 review by @andrexibiza caught and the author closed a real trust-widening bug before this landed.

## Root cause

`noninteractive_git_env()` (`hermes_cli/_subprocess_compat.py`, the env for all ~35 internal git call sites) points `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` at `/dev/null` as GitSpawn hardening (#101483). Git honours `safe.directory` **only** from those two scopes, so the user's trust list was discarded before git read it and the error's own remedy (`git config --global --add safe.directory …`) could never work.

## Changes

- `_user_safe_directories()`: reads the user's `safe.directory` values with `git config -z --get-all`, system scope then global, under the caller's untouched env, and replays them verbatim over the `GIT_CONFIG_KEY_n` channel (which survives `/dev/null` config). Global/system isolation and every hardening override are unchanged.
- Ordering and empty reset markers are preserved, no de-duplication: `safe.directory` is an ordered multi-valued key where an empty value revokes earlier entries. The first version reordered/dropped them and resurrected a revoked system `*`; fixed by the author in round 2.
- Ambient `GIT_CONFIG_KEY_n=safe.directory` is still stripped first, so nothing outside the user's own config files is a trust source.
- Salvage additions (ours): tests trimmed 5 → 2 invariants; the config read is memoised per process on the file-selecting inputs plus config-file mtimes (10 ms/call → 0.04 ms cached; an edit to `~/.gitconfig` is picked up within the same process).

## Validation

| Probe | Before (origin/main) | After |
|---|---|---|
| `git rev-parse` on a cross-owner repo (`GIT_TEST_ASSUME_DIFFERENT_OWNER=1`) named in user gitconfig, under `noninteractive_git_env()` | `rc=128 dubious ownership` | `rc=0` |
| system `*` → global empty reset → global `/trusted/only`; unrelated cross-owner repo | rc=128 (real git) | rc=128 (matches) |
| Same process: user appends `safe.directory` to gitconfig after first call | n/a | rc 128 → 0, cache invalidated |
| `tests/hermes_cli/test_noninteractive_git.py` + `tests/security/test_gitspawn_config_injection.py` + `tests/tools/test_checkpoint_manager.py` | | 79 passed |
| ruff / windows-footguns / compat-pointers / subprocess-stdin | | clean |

Tests kept: injected sequence equals `git config -z --get-all` for the same files (with the ambient-injection negative folded in); end-to-end trust decision (named repo usable, unrelated cross-owner repo refused).

Composes cleanly with #105008 (filter-sink hardening in the same helper); no conflict today.

Closes #107748

## Infographic

![safe.directory carried past non-interactive git isolation](https://v3b.fal.media/files/b/0aaa1151/dGbdVuwCATj9-uKH1slD__f7eCv8HL.png)
