### PR TITLE
fix(gateway): arm a post-teardown exit backstop for wedged shutdowns

### DIFF
--- a/gateway/run_shutdown.py
+++ b/gateway/run_shutdown.py
@@ -25,7 +25,9 @@ from gateway.restart import (
     DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT, GATEWAY_SERVICE_RESTART_EXIT_CODE, resolve_cron_drain_budget
 )
 from gateway.run_common import _UNSET
-from gateway.shutdown_watchdog import arm_shutdown_watchdog, resolve_shutdown_watchdog_delay
+from gateway.shutdown_watchdog import (
+    DEFAULT_POST_TEARDOWN_EXIT_GRACE_S, arm_shutdown_watchdog, resolve_shutdown_watchdog_delay,
+)
 
 # Log-record parity with the origin module.
 logger = logging.getLogger("gateway.run")
@@ -1856,6 +1858,26 @@ class GatewayShutdownMixin:
             self._update_runtime_status("stopped", self._exit_reason)
         _shutdown_gateway_health_export(self)
         logger.info("Gateway stopped (total teardown %.2fs)", ctx.elapsed())
+        # The watchdog armed at the top of _stop_impl disarms the instant this method returns, but a
+        # non-cancellable blocking call an adapter left behind (e.g. a platform SDK thread stuck in an
+        # untimed socket read) can wedge asyncio.run()'s own task-cancellation sweep afterwards, so the
+        # loop never returns and the post-asyncio.run() os._exit backstop in
+        # _exit_after_graceful_shutdown is never reached. Arm an independent backstop, with no
+        # done_event to disarm it, so a process that is somehow still alive this long after teardown
+        # itself finished gets force-exited instead of lingering for the caller's full drain budget (a
+        # `hermes update` can wait up to 1875s). Skipped under pytest like the drain-scoped watchdog
+        # above. See #108729.
+        if not os.environ.get("PYTEST_CURRENT_TEST"):
+            from gateway.run import _CRON_SHUTDOWN_DRAIN_TIMEOUT, _HOUSEKEEPING_SHUTDOWN_DRAIN_TIMEOUT
+            # start_gateway()'s own coroutine can still be running _start_gateway_shutdown_tail's
+            # cron-ticker and housekeeping thread joins concurrently with (not after) this method —
+            # that chain isn't sequenced behind _stop_impl. Fold their full timeouts in so a
+            # slow-but-healthy drain there is never mistaken for the wedge this backstop targets.
+            arm_shutdown_watchdog(
+                _CRON_SHUTDOWN_DRAIN_TIMEOUT + _HOUSEKEEPING_SHUTDOWN_DRAIN_TIMEOUT
+                + DEFAULT_POST_TEARDOWN_EXIT_GRACE_S,
+                exit_code=1, name="gateway-post-teardown-exit-backstop",
+            )
 
     def _shutdown_watchdog_snapshot(self, ctx: "GatewayShutdownMixin._StopContext") -> dict:
         """State dumped by the thread-based shutdown watchdog when teardown hangs."""

--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -31,6 +31,12 @@ logger = logging.getLogger(__name__)
 # Extra leash beyond ``agent.restart_drain_timeout`` so a slow-but-progressing drain survives.
 # Matches the issue #66892 suggested hardening.
 DEFAULT_SHUTDOWN_WATCHDOG_GRACE_S = 60.0
+# Extra grace layered on top of the known bounded work that can still be running concurrently once
+# ``_stop_impl`` logs "Gateway stopped" — the cron ticker join, the housekeeping join, MCP shutdown
+# and the planned-stop-watcher join all happen in a separate coroutine chain
+# (``_start_gateway_shutdown_tail``) that isn't sequenced after ``_stop_impl``, so this alone must
+# not double as that budget. See #108729.
+DEFAULT_POST_TEARDOWN_EXIT_GRACE_S = 20.0
 DEFAULT_HEARTBEAT_INTERVAL_S = 30.0
 DEFAULT_LOOP_FLOOR_TIMER_INTERVAL_S = 5.0
 DEFAULT_LOOP_WATCHDOG_INTERVAL_S = 30.0

--- a/tests/gateway/test_post_teardown_exit_backstop.py
+++ b/tests/gateway/test_post_teardown_exit_backstop.py
@@ -1,0 +1,73 @@
+"""Regression coverage for #108729: `hermes update` can burn its whole drain budget when
+teardown itself finishes (logs "Gateway stopped") but a non-cancellable blocking call an adapter
+left behind — e.g. a platform SDK thread stuck in an untimed socket read — wedges
+``asyncio.run()``'s own task-cancellation sweep afterwards. The drain-scoped shutdown watchdog is
+already disarmed by that point, and the process never reaches the post-``asyncio.run()``
+``os._exit`` backstop because the loop never returns, so nothing is left to force the exit.
+
+``_stop_persist_exit_state`` must arm an independent, never-disarmed backstop right where it logs
+"Gateway stopped" (skipped under pytest, matching the drain-scoped watchdog it complements).
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+from gateway.run import (
+    _CRON_SHUTDOWN_DRAIN_TIMEOUT, _HOUSEKEEPING_SHUTDOWN_DRAIN_TIMEOUT, GatewayRunner,
+)
+from gateway.run_shutdown import GatewayShutdownMixin
+from gateway.shutdown_watchdog import DEFAULT_POST_TEARDOWN_EXIT_GRACE_S
+
+
+def _make_bare_runner():
+    runner = object.__new__(GatewayRunner)
+    runner._exit_reason = None
+    return runner
+
+
+def _make_ctx():
+    return GatewayShutdownMixin._StopContext(deferred_count=lambda: 0, started_at=time.monotonic())
+
+
+def test_stop_persist_exit_state_arms_post_teardown_backstop(monkeypatch):
+    """Outside pytest, finishing teardown must arm the post-teardown exit backstop."""
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    runner = _make_bare_runner()
+    ctx = _make_ctx()
+
+    with patch("gateway.status.remove_pid_file"), \
+         patch("gateway.status.release_gateway_runtime_lock"), \
+         patch("gateway.run.GatewayRunner._update_runtime_status"), \
+         patch("gateway.run_shutdown.arm_shutdown_watchdog") as arm_mock:
+        GatewayRunner._stop_persist_exit_state(runner, ctx)
+
+    assert arm_mock.call_count == 1
+    (delay,), kwargs = arm_mock.call_args
+    # Must fold in the concurrent _start_gateway_shutdown_tail budgets (cron + housekeeping joins),
+    # not just the extra grace, or a slow-but-healthy drain there reads as the wedge we're guarding.
+    expected_delay = (
+        _CRON_SHUTDOWN_DRAIN_TIMEOUT + _HOUSEKEEPING_SHUTDOWN_DRAIN_TIMEOUT
+        + DEFAULT_POST_TEARDOWN_EXIT_GRACE_S
+    )
+    assert delay == expected_delay
+    assert kwargs.get("name") == "gateway-post-teardown-exit-backstop"
+    # No done_event: unlike the drain-scoped watchdog, nothing should be able to disarm this one.
+    assert "done_event" not in kwargs
+
+
+def test_stop_persist_exit_state_skips_backstop_under_pytest(monkeypatch):
+    """Under pytest (PYTEST_CURRENT_TEST set, as it normally is in this suite) the backstop must not
+    arm — an os._exit thread left running past a test's lifetime would eventually kill the runner."""
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "gateway/test_post_teardown_exit_backstop.py::dummy")
+    runner = _make_bare_runner()
+    ctx = _make_ctx()
+
+    with patch("gateway.status.remove_pid_file"), \
+         patch("gateway.status.release_gateway_runtime_lock"), \
+         patch("gateway.run.GatewayRunner._update_runtime_status"), \
+         patch("gateway.run_shutdown.arm_shutdown_watchdog") as arm_mock:
+        GatewayRunner._stop_persist_exit_state(runner, ctx)
+
+    arm_mock.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes #108729: `hermes update` can burn its entire drain budget (reported: 1875s / ~31 min) even though the gateway's own graceful teardown completed in ~11s with zero active sessions.

The reporter's `sample` output showed the main thread still idle in `kevent` (the asyncio selector) long after "Gateway stopped" was logged, and a platform-SDK worker thread (Feishu/DingTalk) blocked in an untimed `SSL_read`. Tracing the shutdown path on current `main`:

- `_stop_impl`'s own watchdog (`gateway/shutdown_watchdog.py::arm_shutdown_watchdog`) is disarmed the instant it finishes and logs "Gateway stopped" (`gateway/run_shutdown.py::_stop_persist_exit_state`).
- Adapter teardown (`gateway/run_adapters.py::_wait_or_detach`) *detaches* (cancels, doesn't await) a disconnect task once it times out — but cancelling an `asyncio.Task` blocked on a `loop.run_in_executor()` future whose underlying thread is already running a synchronous, non-cancellable call (a raw SDK socket read) does not stop it. The task stays pending on the loop.
- `asyncio.run()`'s own internal `_cancel_all_tasks()` (invoked once `start_gateway()`'s coroutine returns) re-cancels every remaining task and then blocks in `run_until_complete(gather(...))` until they all finish — including that un-killable orphaned task. If the underlying blocking read never returns, the loop itself never returns, and the process's post-`asyncio.run()` `os._exit` backstop (`_exit_after_graceful_shutdown` in `gateway/run.py`) is never reached because the code never gets that far.

This exactly matches the issue's own diagnosis: "the event loop itself never stopped, so [the existing] backstop is unreachable" — and its suggested direction #1: *"A timer-based exit backstop started when teardown begins: a daemon thread that `os._exit`s ... if the process is still alive N seconds after 'Gateway stopped'."*

## Fix

Arm an independent, never-disarmed watchdog (reusing the existing `arm_shutdown_watchdog` machinery with no `done_event`, so nothing can cancel it) right where `_stop_persist_exit_state` logs "Gateway stopped". Its delay is `_CRON_SHUTDOWN_DRAIN_TIMEOUT + _HOUSEKEEPING_SHUTDOWN_DRAIN_TIMEOUT + DEFAULT_POST_TEARDOWN_EXIT_GRACE_S` (65s + 35s + 20s = 120s): the first two terms cover the bounded cron-ticker/housekeeping-thread joins that `_start_gateway_shutdown_tail` can still be legitimately running *concurrently* with `_stop_impl` (that chain isn't sequenced behind it, so a naive short delay would risk force-exiting a healthy gateway mid-drain), and the last term is genuine extra grace for MCP shutdown / the planned-stop-watcher join / `asyncio.run()`'s own cleanup. Skipped under `PYTEST_CURRENT_TEST`, matching the existing drain-scoped watchdog.

Net effect: a wedge like the one reported now force-exits the process after ~120s instead of the caller's full drain budget (1875s in the report), and `launchd`/`systemd` relaunch immediately as they already do today once the old PID actually dies.

## Files changed

- `gateway/shutdown_watchdog.py`: new `DEFAULT_POST_TEARDOWN_EXIT_GRACE_S` constant.
- `gateway/run_shutdown.py`: arm the backstop in `_stop_persist_exit_state`.
- `tests/gateway/test_post_teardown_exit_backstop.py`: new tests.

## Test plan

Added `tests/gateway/test_post_teardown_exit_backstop.py`:
- `test_stop_persist_exit_state_arms_post_teardown_backstop`: outside pytest, calling `_stop_persist_exit_state` must arm the backstop with the expected combined delay and no `done_event`.
- `test_stop_persist_exit_state_skips_backstop_under_pytest`: under `PYTEST_CURRENT_TEST` (as in normal test runs), it must not arm.

Verified the first test fails without the fix (`ImportError: cannot import name 'DEFAULT_POST_TEARDOWN_EXIT_GRACE_S'`) by stashing the source changes and re-running:

```
$ git stash push -- gateway/run_shutdown.py gateway/shutdown_watchdog.py
$ scripts/run_tests.sh tests/gateway/test_post_teardown_exit_backstop.py -v
...
ImportError: cannot import name 'DEFAULT_POST_TEARDOWN_EXIT_GRACE_S' from 'gateway.shutdown_watchdog'
=== Summary: 1 files, 0 tests passed, 0 failed ===
$ git stash pop
```

With the fix restored:

```
$ scripts/run_tests.sh tests/gateway/test_post_teardown_exit_backstop.py tests/gateway/test_shutdown_watchdog.py tests/gateway/test_gateway_shutdown.py tests/gateway/test_clean_shutdown_marker.py -v
=== Summary: 4 files, 26 tests passed, 0 failed (100% complete) in 3.2s (8 workers) ===
```

Also ran the broader related suite (lifecycle ledger, loop-liveness watchdog, memory status, update-wedged-gateway):

```
$ scripts/run_tests.sh tests/gateway/test_lifecycle_ledger.py tests/gateway/test_loop_liveness_watchdog.py tests/gateway/test_memory_status.py tests/hermes_cli/test_update_wedged_gateway.py -q
=== Summary: 4 files, 72 tests passed, 0 failed, 1 skipped (100% complete) in 17.8s (8 workers) ===
```

`ruff check` on all changed files: `All checks passed!`

(The full `tests/gateway/` suite has 786 files and did not complete within the time available in this session; the subsets above cover every test that imports `gateway.run_shutdown` or `gateway.shutdown_watchdog`, plus the directly related shutdown/watchdog/update-wedge suites.)

## AI disclosure

This PR was prepared with AI assistance (Claude), including the root-cause trace through `asyncio.run()`'s task-cancellation sweep, the fix, and the tests. All changes were verified by running the project's real test suite and lint locally as shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
