### PR TITLE
fix(desktop): answer pending clarify before transcript hydration lands

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -2940,6 +2940,91 @@ describe('resumeSession warm-cache mapping integrity', () => {
     expect($clarifyRequests.get()['rt-A']).toMatchObject({ requestId: 'req-warm' })
   })
 
+  it('publishes an answerable pending clarify row before transcript hydration resolves (#108718)', async () => {
+    // A proven warm cache (matching provenance) is what makes the view sync
+    // paint the live state directly instead of holding it behind the
+    // unproven-cache suppression — the realistic "switch back to a session
+    // you were just on" shape the report describes.
+    setSessions([storedSession({ id: 'stored-A', message_count: 1 })])
+
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-A']])
+    }
+
+    const state = clientState('stored-A')
+    state.messages = [{ id: 'cached-user', role: 'user', parts: [{ type: 'text', text: 'help me choose' }] }]
+    state.transcriptProvenance = {
+      connectionId: '',
+      coverage: 'latest-page',
+      lineageRootId: null,
+      profile: 'default',
+      source: 'persisted-display',
+      storedSessionId: 'stored-A'
+    }
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-A', state]])
+    }
+
+    const persistedTranscript = deferred<Awaited<ReturnType<typeof getLatestSessionMessages>>>()
+    vi.mocked(getLatestSessionMessages).mockReturnValue(persistedTranscript.promise)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate') {
+        return {
+          info: {},
+          message_count: 1,
+          messages: [],
+          messages_omitted: true,
+          pending_clarify: {
+            choices: ['safe', 'fast'],
+            question: 'Which path?',
+            request_id: 'req-navigation'
+          },
+          resumed: 'stored-A',
+          running: true,
+          session_id: 'rt-A',
+          session_key: 'stored-A'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    const viewSyncs: ClientSessionState[] = []
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        onViewSync={(_sessionId, syncedState) => viewSyncs.push(syncedState)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+
+    const resumePromise = resume!('stored-A', true)
+
+    // The REST transcript promise never resolves in this assertion window, so
+    // any answerable row seen here was published before hydration settled.
+    await waitFor(() => expect(viewSyncs.some(syncedState => syncedState.needsInput)).toBe(true))
+
+    const preHydrationState = viewSyncs.find(syncedState => syncedState.needsInput)
+
+    const answerableBeforeRest =
+      preHydrationState?.messages.filter(
+        message =>
+          message.pending && message.parts.some(part => part.type === 'tool-call' && part.toolName === 'clarify')
+      ) ?? []
+
+    expect(answerableBeforeRest).toHaveLength(1)
+
+    persistedTranscript.resolve({ messages: [], session_id: 'stored-A' } as never)
+    await resumePromise
+  })
+
   it.each([
     ['with a stale request-store entry', true],
     ['after the request store was already cleared', false]

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -3025,6 +3025,85 @@ describe('resumeSession warm-cache mapping integrity', () => {
     await resumePromise
   })
 
+  it('publishes an answerable pending clarify row even when the warm cache has no validated provenance (#108718)', async () => {
+    // Unlike the proven-cache case above, this cache carries no
+    // transcriptProvenance at all — the realistic shape for a session whose
+    // warm cache was never hydrated with a matching persisted-display
+    // provenance. That gap suppresses the whole pre-hydration transcript
+    // (suppressTranscriptForView), which must not also hide the answerable
+    // clarify row.
+    setSessions([storedSession({ id: 'stored-A', message_count: 1 })])
+
+    const runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>> = {
+      current: new Map([['stored-A', 'rt-A']])
+    }
+
+    const state = clientState('stored-A')
+    state.messages = [{ id: 'cached-user', role: 'user', parts: [{ type: 'text', text: 'help me choose' }] }]
+
+    const sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>> = {
+      current: new Map([['rt-A', state]])
+    }
+
+    const persistedTranscript = deferred<Awaited<ReturnType<typeof getLatestSessionMessages>>>()
+    vi.mocked(getLatestSessionMessages).mockReturnValue(persistedTranscript.promise)
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.activate') {
+        return {
+          info: {},
+          message_count: 1,
+          messages: [],
+          messages_omitted: true,
+          pending_clarify: {
+            choices: ['safe', 'fast'],
+            question: 'Which path?',
+            request_id: 'req-navigation'
+          },
+          resumed: 'stored-A',
+          running: true,
+          session_id: 'rt-A',
+          session_key: 'stored-A'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    const viewSyncs: ClientSessionState[] = []
+
+    let resume: ((storedSessionId: string, replaceRoute?: boolean) => Promise<unknown>) | null = null
+    render(
+      <ResumeHarness
+        onReady={ready => (resume = ready)}
+        onViewSync={(_sessionId, syncedState) => viewSyncs.push(syncedState)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).not.toBeNull())
+
+    const resumePromise = resume!('stored-A', true)
+
+    // The REST transcript promise never resolves in this assertion window, so
+    // any answerable row seen here was published before hydration settled.
+    await waitFor(() => expect(viewSyncs.some(syncedState => syncedState.needsInput)).toBe(true))
+
+    const preHydrationState = viewSyncs.find(syncedState => syncedState.needsInput)
+
+    const answerableBeforeRest =
+      preHydrationState?.messages.filter(
+        message =>
+          message.pending && message.parts.some(part => part.type === 'tool-call' && part.toolName === 'clarify')
+      ) ?? []
+
+    expect(answerableBeforeRest).toHaveLength(1)
+
+    persistedTranscript.resolve({ messages: [], session_id: 'stored-A' } as never)
+    await resumePromise
+  })
+
   it.each([
     ['with a stale request-store entry', true],
     ['after the request store was already cleared', false]

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -1291,9 +1291,27 @@ export function useSessionActions({
               busyRef.current = running
               setBusy(running)
               setAwaitingResponse(running && !pendingClarify)
+
+              // View-only: project the pending clarify onto the pre-hydration
+              // transcript for this publish so `needsInput: true` is never
+              // shown ahead of an answerable row (#108718). The cache entry
+              // above stays unprojected — hydration below re-derives the
+              // authoritative transcript from scratch, and folding this
+              // synthetic row into that pipeline would leave a duplicate
+              // once the persisted transcript carries the same call under a
+              // different message id.
+              const earlyClarifyProjection = pendingClarify
+                ? restorePendingClarifyToolCall(activatedMessages, pendingClarifyToolPayload(pendingClarify))
+                : null
+
               syncSessionStateToView(
                 cachedRuntimeId,
-                suppressTranscriptForView(activatedLivenessState, suppressUnprovenWarmTranscript)
+                suppressTranscriptForView(
+                  earlyClarifyProjection
+                    ? { ...activatedLivenessState, messages: earlyClarifyProjection.messages }
+                    : activatedLivenessState,
+                  suppressUnprovenWarmTranscript
+                )
               )
 
               // session.activate is the ordering barrier for reconnect recovery:

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -1300,18 +1300,24 @@ export function useSessionActions({
               // synthetic row into that pipeline would leave a duplicate
               // once the persisted transcript carries the same call under a
               // different message id.
+              //
+              // An unproven warm cache (no matching persisted-display
+              // provenance) still has its history suppressed pending REST
+              // proof, but the clarify projection must survive that gate: it
+              // is derived from the just-returned activate snapshot, not from
+              // the unverified cache, so it is projected onto the (possibly
+              // empty) suppressed transcript rather than being wiped with it.
+              const earlyClarifyBase = suppressUnprovenWarmTranscript ? [] : activatedMessages
+
               const earlyClarifyProjection = pendingClarify
-                ? restorePendingClarifyToolCall(activatedMessages, pendingClarifyToolPayload(pendingClarify))
+                ? restorePendingClarifyToolCall(earlyClarifyBase, pendingClarifyToolPayload(pendingClarify))
                 : null
 
               syncSessionStateToView(
                 cachedRuntimeId,
-                suppressTranscriptForView(
-                  earlyClarifyProjection
-                    ? { ...activatedLivenessState, messages: earlyClarifyProjection.messages }
-                    : activatedLivenessState,
-                  suppressUnprovenWarmTranscript
-                )
+                earlyClarifyProjection
+                  ? { ...activatedLivenessState, messages: earlyClarifyProjection.messages }
+                  : suppressTranscriptForView(activatedLivenessState, suppressUnprovenWarmTranscript)
               )
 
               // session.activate is the ordering barrier for reconnect recovery:


### PR DESCRIPTION
Fixes #108718.

## Problem

On Desktop, switching back to a session that is warm-cached (already has a
live runtime binding) goes through the `session.activate` resume path in
`useSessionActions.resumeSession`. When the activation snapshot carries an
authoritative `pending_clarify`, the hook immediately publishes
`needsInput: true` to the view — but at that point the transcript published
alongside it is still whatever was cached, because the code that projects
the clarify request onto the transcript (`restorePendingClarifyToolCall`)
only ran *after* the REST transcript-hydration promise (`getLatestSessionMessages`)
resolved.

If that REST call is slow, the user sees "needs input" with no visible
question/choices to answer until hydration settles — the same shape
reported in #108718 (switching away from session A while it needs
clarification, then switching back).

## Fix

`apps/desktop/src/app/session/hooks/use-session-actions/index.ts`: project
the pending clarify onto the pre-hydration transcript for the *view-only*
publish that happens immediately after `session.activate` returns, so an
answerable row is always present whenever `needsInput` is true.

The cached session state itself is left unprojected. The existing
post-hydration code already re-derives the authoritative transcript from
the persisted REST page and re-projects the clarify onto it under a
(possibly different) message id; folding the early, view-only projection
into that same cache pipeline caused a duplicate clarify row once REST
hydration produced the same tool call under a new message id (caught by
the existing test `re-arms a pending clarify in place on the warm
session.activate path`, see Testing below).

## Testing

Added `publishes an answerable pending clarify row before transcript
hydration resolves (#108718)` to
`apps/desktop/src/app/session/hooks/use-session-actions.test.tsx`. It seeds
a warm, provenance-matched cache for session `stored-A`/`rt-A`, resumes it
with a `session.activate` response carrying `pending_clarify`, holds the
`getLatestSessionMessages` REST promise unresolved, and asserts the
view-synced state published in that window already has `needsInput: true`
*and* one pending clarify tool-call row.

Confirmed the test fails without the fix (reverted just the source file):

```
$ git checkout HEAD~1 -- apps/desktop/src/app/session/hooks/use-session-actions/index.ts
$ npx vitest run --project=ui src/app/session/hooks/use-session-actions.test.tsx -t "108718"
...
 FAIL  ... > publishes an answerable pending clarify row before transcript hydration resolves (#108718)
AssertionError: expected [] to have a length of 1 but got +0
$ git checkout HEAD -- apps/desktop/src/app/session/hooks/use-session-actions/index.ts
```

With the fix applied:

```
$ npx vitest run --project=ui src/app/session/hooks/use-session-actions.test.tsx
 Test Files  1 passed (1)
      Tests  98 passed (98)
```

Also ran, all passing:

```
$ npx vitest run --project=ui src/app/session/
 Test Files  54 passed (54)
      Tests  805 passed (805)

$ npx vitest run --project=ui src/lib/chat-messages
 Test Files  3 passed (3)
      Tests  78 passed (78)

$ npx tsc -p . --noEmit                 # clean
$ npx eslint src/app/session/hooks/use-session-actions/index.ts \
             src/app/session/hooks/use-session-actions.test.tsx   # clean
```

## AI-assistance disclosure

This PR was prepared by an autonomous coding agent (Claude, via an
OSS-contribution pipeline) that located the issue, read the affected code,
implemented the fix, and wrote/verified the test. A human reviews and
authorizes the branch before it is opened as a PR.
