### PR TITLE
fix(install): pass -NoProfile so a user PowerShell profile cannot wedge hermes update

### DIFF
--- a/hermes_cli/dep_ensure.py
+++ b/hermes_cli/dep_ensure.py
@@ -99,7 +99,11 @@ def ensure_dependency(dep: str, interactive: bool = True) -> bool:
             if interactive:
                 print("  PowerShell not found. Install PowerShell or run install.ps1 manually.")
             return False
-        cmd = [ps_bin, "-ExecutionPolicy", "Bypass", "-File", str(script), "-Ensure", dep, "-HermesHome", str(get_hermes_home())]
+        # -NoProfile: the user's profile must not run ahead of install.ps1 — one that
+        # blocks on input hangs this step with no output at all (#108735). Left
+        # interactive so install.ps1 can still prompt when the caller asked it to.
+        cmd = [ps_bin, "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", str(script),
+               "-Ensure", dep, "-HermesHome", str(get_hermes_home())]
     else:
         cmd = ["bash", str(script), "--ensure", dep]
     run_env = {**hermes_subprocess_env(inherit_credentials=False), "IS_INTERACTIVE": "false"}

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -1003,11 +1003,19 @@ def _install_uv_posix(env: dict[str, str]) -> None:
 
 
 def _install_uv_windows(env: dict[str, str]) -> None:
-    """Invoke the PowerShell installer."""
+    """Invoke the PowerShell installer.
+
+    ``-NoProfile``/``-NonInteractive`` are load-bearing, not hygiene: without them the
+    user's Windows PowerShell profile runs before the installer, and a profile that
+    blocks on stdin (e.g. the common "Windows PowerShell 5.1 hands off to an
+    interactive pwsh 7" snippet) hangs this child forever. Because the output is
+    captured, the caller only ever sees a silent stall — no error to act on (#108735).
+    """
     cmd = "irm https://astral.sh/uv/install.ps1 | iex"
     subprocess.run(
-        ["powershell", "-ExecutionPolicy", "Bypass", "-c", cmd], env=env, check=True,
-        capture_output=True)
+        ["powershell", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
+         "-Command", cmd],
+        env=env, check=True, capture_output=True)
 
 
 def rebuild_venv(uv_bin: str, venv_dir: Path, python_version: str = "3.11") -> bool:

--- a/scripts/check-windows-footguns.py
+++ b/scripts/check-windows-footguns.py
@@ -320,6 +320,40 @@ FOOTGUNS: list[Footgun] = [
         ),
     ),
     Footgun(
+        name="PowerShell shell-out without -NoProfile",
+        # An internal step must never load the user's $PROFILE: a profile that
+        # blocks on input, or is merely slow (the common "Windows PowerShell 5.1
+        # hands off to an interactive pwsh 7" snippet does both), wedges the child
+        # before our command ever runs. With capture_output=True the caller reads
+        # that as a silent stall rather than an error, so it retries instead of
+        # failing (#108735: hermes update looped on the uv install for hours).
+        #
+        # Matches the host name — quoted literal, or the ps_bin/ps_exe/... variable
+        # an argv is usually built around — on a line that also carries a PowerShell
+        # switch but never -NoProfile. Bare probes (shutil.which("powershell")) are
+        # skipped by GUARD_HINTS and by the switch requirement.
+        pattern=re.compile(
+            r"""['"](?:powershell|pwsh)(?:\.exe)?['"]|\bps(?:_bin|_exe|_host|_path)\b"""
+        ),
+        message=(
+            "Shelling out to PowerShell without -NoProfile runs the user's "
+            "$PROFILE first. A profile that blocks on stdin or is slow (e.g. "
+            "handing off to an interactive pwsh 7) hangs the child forever, and "
+            "with capture_output=True the caller sees a silent stall, not an error."
+        ),
+        fix=(
+            "subprocess.run(['powershell', '-NoProfile', '-NonInteractive',\n"
+            "                '-ExecutionPolicy', 'Bypass', '-Command', cmd], ...)"
+        ),
+        post_filter=lambda m, line: (
+            "-NoProfile" not in line
+            and any(
+                switch in line
+                for switch in ("-ExecutionPolicy", "-EncodedCommand", "-Command", "-File", "-c ")
+            )
+        ),
+    ),
+    Footgun(
         name="hardcoded ~/Desktop (OneDrive trap)",
         pattern=re.compile(
             r"""['"](?:~|~/|[A-Z]:[/\\]Users[/\\][^/\\'"]+[/\\])Desktop\b"""

--- a/tests/hermes_cli/test_dep_ensure.py
+++ b/tests/hermes_cli/test_dep_ensure.py
@@ -117,6 +117,9 @@ def test_ensure_dependency_uses_powershell_on_windows(tmp_path):
         ensure_dependency("node", interactive=False)
         cmd = mock_run.call_args[0][0]
         assert "powershell" in cmd[0].lower()
+        # The user's profile must not run ahead of install.ps1 — one that blocks
+        # on input hangs this step with no output at all (#108735).
+        assert "-NoProfile" in cmd
         assert "-Ensure" in cmd
         assert cmd[cmd.index("-Ensure") + 1] == "node"
         assert "-HermesHome" in cmd

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -720,6 +720,24 @@ class TestInstallUvInternals:
         if sys.platform != "win32":
             assert call_env["UV_UNMANAGED_INSTALL"] == str(tmp_path / "bin")
 
+    def test_windows_installer_ignores_the_user_profile(self):
+        """A blocking $PROFILE must not be able to wedge the uv install (#108735).
+
+        Behaviour contract for the argv: without -NoProfile the user's Windows
+        PowerShell profile runs before the installer, and one that waits on stdin
+        hangs this child for good — silently, because stdout/stderr are captured.
+        """
+        import hermes_cli.managed_uv as managed_uv
+
+        with patch("subprocess.run") as mock_run:
+            managed_uv._install_uv_windows({"UV_INSTALL_DIR": "C:\\fake\\bin"})
+
+        argv = mock_run.call_args[0][0]
+        assert argv[0] == "powershell"
+        assert "-NoProfile" in argv
+        assert "-NonInteractive" in argv
+        assert "https://astral.sh/uv/install.ps1" in " ".join(argv)
+
 
 class TestRuntimeRequestMinorLine:
     """The repair must request the CPython minor line, not the exact patch.


### PR DESCRIPTION
## What & why

`hermes update` on Windows can hang **forever**, silently, at:

```text
→ Installing managed uv into C:\Users\<user>\AppData\Local\hermes\bin ...
```

Two PowerShell shell-outs omitted `-NoProfile`, so the user's Windows PowerShell 5.1 profile ran before the installer. With the common "5.1 hands off to an interactive pwsh 7" profile the process tree stalls before our command ever executes:

```text
python -m hermes_cli.main update
└── powershell -ExecutionPolicy Bypass -c "irm https://astral.sh/uv/install.ps1 | iex"
    └── pwsh.exe -NoLogo        <-- blocked on stdin, zero stdout, forever
```

The same command with `-NoProfile` finishes in **5.7s** on the affected machine (network verified healthy — 17.6 MB archive in 2.5s), so this is not a download problem. It is CONTRIBUTING "Critical rules" #2, which already prescribes `["powershell", "-NoProfile", "-Command", ...]`: these were the only two Python call sites in the tree that violated it (`grep -rn -ExecutionPolicy`).

Because the uv installer's output is captured (`capture_output=True`, no `timeout=`), the caller sees a **silent stall rather than a failure**: the desktop updater kills the process tree after its idle timeout, retries, stalls again — and since `resolve_uv()` only checks the managed path (#41534), every retry re-enters the same dead end while the managed uv never lands.

Reported as #108735; the fail-fast version of the same symptom is #38617.

## Changes

| File | Change |
|---|---|
| `hermes_cli/managed_uv.py` | `-NoProfile -NonInteractive`, and `-Command` instead of its `-c` alias (matches every other call site) |
| `hermes_cli/dep_ensure.py` | `-NoProfile` only — that path may legitimately prompt for an interactive install, so `-NonInteractive` was deliberately not added |
| `scripts/check-windows-footguns.py` | new rule: PowerShell shell-out without `-NoProfile` |
| `tests/hermes_cli/test_managed_uv.py` | argv behaviour contract for the Windows installer |
| `tests/hermes_cli/test_dep_ensure.py` | extends the existing `windows_only` test with the same contract |

## How to test

```bash
scripts/run_tests.sh tests/hermes_cli/test_managed_uv.py tests/hermes_cli/test_dep_ensure.py
python scripts/check-windows-footguns.py --all
```

Red on base / green with the fix (source fix stashed, tests kept in the tree):

```text
RED  : 2 failed — assert '-NoProfile' in ['powershell', '-ExecutionPolicy', 'Bypass', '-c', 'irm https://astral.sh/uv/install.ps1 | iex']
GREEN: 43 passed, 0 failed, 12 skipped (linux_only on win32)
```

`--all`: `✓ No Windows footguns found (1532 file(s) scanned)`.

## Platforms tested

Windows 11 Pro 25H2 (build 26200), Windows PowerShell 5.1.26100.9444 + PowerShell 7.6.6, Python 3.11.16, Hermes v0.21.2 @ `1021a032`.

No POSIX behaviour is touched: `_install_uv_posix` is unchanged, and `-NoProfile` is a Windows-PowerShell flag on a Windows-only branch.

## Notes / follow-up

- Hardening the user's profile is not the fix — any profile may legitimately do work, and the call site is what must not depend on it.
- Not included here, happy to follow up: a bounded `timeout=` on the installer subprocess, so a wedged child surfaces as an error instead of an indistinguishable silent stall (also noted in #108735).

Fixes #108735
