### PR TITLE
fix(update): isolate PowerShell installer processes

### DIFF
--- a/hermes_cli/dep_ensure.py
+++ b/hermes_cli/dep_ensure.py
@@ -99,7 +99,11 @@ def ensure_dependency(dep: str, interactive: bool = True) -> bool:
             if interactive:
                 print("  PowerShell not found. Install PowerShell or run install.ps1 manually.")
             return False
-        cmd = [ps_bin, "-ExecutionPolicy", "Bypass", "-File", str(script), "-Ensure", dep, "-HermesHome", str(get_hermes_home())]
+        cmd = [ps_bin, "-NoProfile"]
+        if not interactive:
+            cmd.append("-NonInteractive")
+        cmd.extend(["-ExecutionPolicy", "Bypass", "-File", str(script), "-Ensure", dep,
+                    "-HermesHome", str(get_hermes_home())])
     else:
         cmd = ["bash", str(script), "--ensure", dep]
     run_env = {**hermes_subprocess_env(inherit_credentials=False), "IS_INTERACTIVE": "false"}

--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -1006,8 +1006,9 @@ def _install_uv_windows(env: dict[str, str]) -> None:
     """Invoke the PowerShell installer."""
     cmd = "irm https://astral.sh/uv/install.ps1 | iex"
     subprocess.run(
-        ["powershell", "-ExecutionPolicy", "Bypass", "-c", cmd], env=env, check=True,
-        capture_output=True)
+        ["powershell", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
+         "-Command", cmd],
+        env=env, check=True, capture_output=True, timeout=300)
 
 
 def rebuild_venv(uv_bin: str, venv_dir: Path, python_version: str = "3.11") -> bool:

--- a/tests/hermes_cli/test_dep_ensure.py
+++ b/tests/hermes_cli/test_dep_ensure.py
@@ -97,7 +97,13 @@ def test_find_agent_browser_lazy_install_cycle_terminates(monkeypatch):
 
 
 @pytest.mark.windows_only
-def test_ensure_dependency_uses_powershell_on_windows(tmp_path):
+@pytest.mark.parametrize(
+    ("interactive", "expected_prefix"),
+    [(False, ["-NoProfile", "-NonInteractive"]), (True, ["-NoProfile"])],
+)
+def test_ensure_dependency_uses_powershell_on_windows(
+    tmp_path, interactive, expected_prefix
+):
     """``windows_only``: the assertion is that we shell out to a real
     PowerShell. Faking ``_IS_WINDOWS`` on Linux also required faking
     ``shutil.which`` into inventing a powershell.exe that isn't there."""
@@ -114,9 +120,11 @@ def test_ensure_dependency_uses_powershell_on_windows(tmp_path):
         mock_shutil.which.side_effect = lambda name: "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe" if name == "powershell" else None
         mock_stdin.isatty.return_value = False
         mock_run.return_value = type("R", (), {"returncode": 0})()
-        ensure_dependency("node", interactive=False)
+        ensure_dependency("node", interactive=interactive)
         cmd = mock_run.call_args[0][0]
         assert "powershell" in cmd[0].lower()
+        assert cmd[1:1 + len(expected_prefix)] == expected_prefix
+        assert ("-NonInteractive" in cmd) is (not interactive)
         assert "-Ensure" in cmd
         assert cmd[cmd.index("-Ensure") + 1] == "node"
         assert "-HermesHome" in cmd

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -720,6 +720,19 @@ class TestInstallUvInternals:
         if sys.platform != "win32":
             assert call_env["UV_UNMANAGED_INSTALL"] == str(tmp_path / "bin")
 
+    def test_windows_installer_is_profile_free_noninteractive_and_bounded(self, monkeypatch):
+        import hermes_cli.managed_uv as managed_uv
+
+        run = SimpleNamespace(returncode=0)
+        monkeypatch.setattr(managed_uv.subprocess, "run", MagicMock(return_value=run))
+
+        managed_uv._install_uv_windows({"UV_INSTALL_DIR": "C:/managed"})
+
+        argv = managed_uv.subprocess.run.call_args.args[0]
+        assert argv[:3] == ["powershell", "-NoProfile", "-NonInteractive"]
+        assert argv[-2:] == ["-Command", "irm https://astral.sh/uv/install.ps1 | iex"]
+        assert managed_uv.subprocess.run.call_args.kwargs["timeout"] == 300
+
 
 class TestRuntimeRequestMinorLine:
     """The repair must request the CPython minor line, not the exact patch.


### PR DESCRIPTION
## Summary

Windows PowerShell loads the user's profile before executing Hermes' installer commands. A profile that launches an interactive child can therefore wedge `hermes update` before the managed uv installer starts, while captured output makes the wait appear silent and unbounded.

This change:

- starts both Python-owned PowerShell installer paths with `-NoProfile`
- adds `-NonInteractive` to the always-noninteractive managed uv bootstrap and to dependency installs only when their caller is noninteractive
- bounds the managed uv PowerShell process to 300 seconds so a wedged installer becomes an actionable failure
- adds focused argv and timeout behavior contracts

## Why this PR vs existing PR #108740

PR #108740 intentionally leaves the managed uv subprocess unbounded and never adds `-NonInteractive` to noninteractive dependency installs. This PR closes both gaps: `hermes_cli/managed_uv.py` has a 300-second timeout, and `hermes_cli/dep_ensure.py` preserves interactive calls while making `interactive=False` explicitly noninteractive.

## Why this PR vs existing PR #108741

PR #108741 does not fix the second reported Python call site in `hermes_cli/dep_ensure.py` and does not bound the silent managed uv subprocess. This PR covers both call sites identified by the issue and includes the requested timeout guard.

## Tests

- `scripts/run_tests.sh tests/hermes_cli/test_managed_uv.py tests/hermes_cli/test_dep_ensure.py` — 44 passed, 12 skipped

## Related Issue

N/A
