### PR TITLE
fix: add opt-in shared root memory overlay

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1250,6 +1250,7 @@ def _init_memory(agent, _agent_cfg, skip_memory, platform):
         with suppress(Exception):
             from tools.memory_tool import (
                 MemoryStore, get_builtin_memory_config, get_builtin_memory_store_flags,
+                get_shared_root_memory_path,
             )
             mem_config = get_builtin_memory_config(_agent_cfg)
             agent._memory_enabled, agent._user_profile_enabled = get_builtin_memory_store_flags(
@@ -1262,6 +1263,7 @@ def _init_memory(agent, _agent_cfg, skip_memory, platform):
                     user_char_limit=mem_config.get("user_char_limit", 1375),
                     memory_enabled=agent._memory_enabled,
                     user_profile_enabled=agent._user_profile_enabled,
+                    shared_memory_path=get_shared_root_memory_path(),
                 )
                 agent._memory_store.load_from_disk()
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -905,6 +905,10 @@ memory:
   memory_char_limit: 2200   # ~800 tokens
   user_char_limit: 1375     # ~500 tokens
 
+  # Fleet opt-in: named profiles read the root MEMORY.md as additional,
+  # read-only prompt context. Profile writes remain profile-local.
+  shared_root_memory_enabled: false
+
   # Periodic memory nudge: remind the agent to consider saving memories
   # every N user turns. Set to 0 to disable. Only active when memory is enabled.
   nudge_interval: 10        # Nudge every 10 user turns (0 = disabled)

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -109,6 +109,28 @@ def store(tmp_path, monkeypatch):
 
 
 class TestMemoryStoreAdd:
+    def test_shared_root_memory_is_prompt_only_and_never_written(self, tmp_path, monkeypatch):
+        profile_memory = tmp_path / "profile" / "memories"
+        root_memory = tmp_path / "root" / "memories" / "MEMORY.md"
+        profile_memory.mkdir(parents=True)
+        root_memory.parent.mkdir(parents=True)
+        profile_memory.joinpath("MEMORY.md").write_text("profile-local fact", encoding="utf-8")
+        root_memory.write_text("root-only fleet sentinel", encoding="utf-8")
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: profile_memory)
+
+        store = MemoryStore(shared_memory_path=root_memory)
+        store.load_from_disk()
+
+        assert store.memory_entries == ["profile-local fact"]
+        assert store.shared_memory_entries == ["root-only fleet sentinel"]
+        prompt = store.format_for_system_prompt("memory")
+        assert "root-only fleet sentinel" in prompt
+        assert "profile-local fact" in prompt
+
+        assert store.add("memory", "new profile-local fact")["success"] is True
+        assert root_memory.read_text(encoding="utf-8") == "root-only fleet sentinel"
+        assert "new profile-local fact" in profile_memory.joinpath("MEMORY.md").read_text(encoding="utf-8")
+
     def test_add_entry(self, store):
         result = store.add("memory", "Python 3.12 project")
         assert result["success"] is True

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -9,7 +9,7 @@ import json
 import logging
 from contextvars import ContextVar
 from pathlib import Path
-from hermes_constants import get_hermes_home
+from hermes_constants import get_default_hermes_root, get_hermes_home
 from typing import Dict, Any, List, Optional, Tuple
 
 from utils import is_truthy_value
@@ -40,6 +40,28 @@ def get_memory_dir() -> Path:
     return get_hermes_home() / "memories"
 
 
+def get_shared_root_memory_path() -> Optional[Path]:
+    """Return an opt-in, read-only fleet MEMORY.md for named profiles.
+
+    The switch lives in the root config so one explicit fleet decision applies
+    consistently to every profile.  Local profile memories remain writable and
+    isolated; the root file is prompt context only.
+    """
+    try:
+        root = get_default_hermes_root().resolve()
+        if get_hermes_home().resolve() == root:
+            return None
+        import yaml
+        config = yaml.safe_load((root / "config.yaml").read_text(encoding="utf-8")) or {}
+        section = config.get("memory") if isinstance(config, dict) else None
+        enabled = section.get("shared_root_memory_enabled") if isinstance(section, dict) else None
+        if is_truthy_value(enabled, default=False):
+            return root / "memories" / "MEMORY.md"
+    except Exception:
+        logger.debug("Could not resolve shared root memory", exc_info=True)
+    return None
+
+
 from tools.memory_tool_store import (  # noqa: E402,F401  (re-exports)
     ENTRY_DELIMITER, MEMORY_BLOCK_HEADERS, MemoryStore, _scan_memory_content)
 
@@ -54,7 +76,8 @@ def load_on_disk_store() -> "MemoryStore":
         mem_cfg = get_builtin_memory_config(config)
         memory_enabled, user_profile_enabled = get_builtin_memory_store_flags(config)
         store = MemoryStore(int(mem_cfg.get("memory_char_limit", 2200)), int(mem_cfg.get("user_char_limit", 1375)),
-                            memory_enabled=memory_enabled, user_profile_enabled=user_profile_enabled)
+                            memory_enabled=memory_enabled, user_profile_enabled=user_profile_enabled,
+                            shared_memory_path=get_shared_root_memory_path())
     except Exception:
         store = MemoryStore()  # config optional — fall back to defaults rather than break /memory
     store.load_from_disk()

--- a/tools/memory_tool_store.py
+++ b/tools/memory_tool_store.py
@@ -75,11 +75,16 @@ class MemoryStore:
     _MAX_CONSOLIDATION_FAILURES_PER_TURN = 3
 
     def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375, *,
-                 memory_enabled: bool = True, user_profile_enabled: bool = True):
+                 memory_enabled: bool = True, user_profile_enabled: bool = True,
+                 shared_memory_path: Optional[Path] = None):
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
         self.memory_char_limit, self.user_char_limit = memory_char_limit, user_char_limit
         self.memory_enabled, self.user_profile_enabled = memory_enabled, user_profile_enabled
+        # Optional fleet memory is read-only prompt context.  It must never be
+        # folded into ``memory_entries``: memory-tool writes are profile-local.
+        self.shared_memory_path = shared_memory_path
+        self.shared_memory_entries: List[str] = []
         self._system_prompt_snapshot: Dict[str, str] = {"memory": "", "user": ""}
         self._consolidation_failures = 0  # per turn; reset by reset_consolidation_failures()
 
@@ -130,7 +135,14 @@ class MemoryStore:
             # Deduplicate (order-preserving, first occurrence wins).
             entries = list(dict.fromkeys(self._read_file(path)))
             self._set_entries(target, entries)
-            self._system_prompt_snapshot[target] = self._render_block(target, [_sanitize(e, path.name) for e in entries])
+            prompt_entries = entries
+            if target == "memory" and self.shared_memory_path is not None:
+                shared_entries = list(dict.fromkeys(self._read_file(self.shared_memory_path)))
+                self.shared_memory_entries = shared_entries
+                # Shared facts come first and retain first-wins deduplication.
+                prompt_entries = list(dict.fromkeys(shared_entries + entries))
+            self._system_prompt_snapshot[target] = self._render_block(
+                target, [_sanitize(e, path.name) for e in prompt_entries])
 
     @staticmethod
     @contextmanager


### PR DESCRIPTION
Summary:
- adds a disabled-by-default shared-root MEMORY.md overlay for named profiles
- preserves profile-local memory writes and precedence
- includes a focused behavior test

Verification:
- isolated named-profile harness passed
- py_compile passed for changed Python modules
- git diff --check passed
- canonical test runner is currently blocked because the available venv lacks pytest

Activation remains opt-in through memory.shared_root_memory_enabled: true.