### PR TITLE
fix(agent): strip tool controls from the codex iteration-limit summary call

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2075,6 +2075,8 @@ def _codex_summary_attempt(agent, api_messages: list, api_request_id: str):
     def _attempt(retry_count: int) -> str:
         codex_kwargs = agent._build_api_kwargs(api_messages)
         codex_kwargs.pop("tools", None)
+        codex_kwargs.pop("tool_choice", None)
+        codex_kwargs.pop("parallel_tool_calls", None)
         return _summary_text(agent, agent._run_codex_stream(codex_kwargs))
     return _attempt
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2905,6 +2905,48 @@ class TestHandleMaxIterations:
             for item in input_items
         )
 
+    def test_codex_summary_strips_tool_controls_when_tools_removed(self, agent):
+        agent.api_mode = "codex_responses"
+        agent.provider = "openai-codex"
+        agent.base_url = "https://chatgpt.com/backend-api/codex"
+        agent._base_url_lower = agent.base_url.lower()
+        agent._base_url_hostname = "chatgpt.com"
+        agent.model = "gpt-5.5"
+        agent._cached_system_prompt = "You are helpful."
+        captured = {}
+
+        monkey_kwargs = {
+            "model": "gpt-5.5",
+            "input": [{"role": "user", "content": "do stuff"}],
+            "tools": [{"type": "function", "name": "web_search"}],
+            "tool_choice": "auto",
+            "parallel_tool_calls": True,
+        }
+
+        def fake_run_codex_stream(kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                status="completed",
+                output=[
+                    SimpleNamespace(
+                        type="message",
+                        status="completed",
+                        content=[SimpleNamespace(type="output_text", text="Summary")],
+                    )
+                ],
+            )
+
+        with (
+            patch.object(agent, "_build_api_kwargs", return_value=monkey_kwargs.copy()),
+            patch.object(agent, "_run_codex_stream", side_effect=fake_run_codex_stream),
+        ):
+            result = agent._handle_max_iterations([{"role": "user", "content": "do stuff"}], 90)
+
+        assert result == "Summary"
+        assert "tools" not in captured
+        assert "tool_choice" not in captured
+        assert "parallel_tool_calls" not in captured
+
     def test_api_sanitizer_matches_responses_call_id_when_id_differs(self, agent):
         messages = [
             {

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2947,6 +2947,58 @@ class TestHandleMaxIterations:
         assert "tool_choice" not in captured
         assert "parallel_tool_calls" not in captured
 
+    def test_codex_summary_retry_also_strips_tool_controls(self, agent):
+        """The retry attempt must be as toolless as the first one.
+
+        Iteration-limit summaries retry once when the first summary comes back empty; both
+        attempts build their body through the same codex path, so both must drop the tool-control
+        block the transport emits alongside ``tools`` (agent/transports/codex.py).
+        """
+        agent.api_mode = "codex_responses"
+        agent.provider = "openai-codex"
+        agent.base_url = "https://chatgpt.com/backend-api/codex"
+        agent._base_url_lower = agent.base_url.lower()
+        agent._base_url_hostname = "chatgpt.com"
+        agent.model = "gpt-5.5"
+        agent._cached_system_prompt = "You are helpful."
+
+        bodies = []
+        tool_laden = {
+            "model": "gpt-5.5",
+            "input": [{"role": "user", "content": "do stuff"}],
+            "tools": [{"type": "function", "name": "web_search"}],
+            "tool_choice": "auto",
+            "parallel_tool_calls": True,
+        }
+
+        def fake_run_codex_stream(kwargs):
+            bodies.append(dict(kwargs))
+            # First attempt returns an empty summary so the caller takes the retry path.
+            text = "" if len(bodies) == 1 else "Summary"
+            return SimpleNamespace(
+                status="completed",
+                output=[
+                    SimpleNamespace(
+                        type="message",
+                        status="completed",
+                        content=[SimpleNamespace(type="output_text", text=text)],
+                    )
+                ],
+            )
+
+        with (
+            patch.object(agent, "_build_api_kwargs", return_value=tool_laden.copy()),
+            patch.object(agent, "_run_codex_stream", side_effect=fake_run_codex_stream),
+        ):
+            result = agent._handle_max_iterations([{"role": "user", "content": "do stuff"}], 90)
+
+        assert result == "Summary"
+        assert len(bodies) == 2, f"expected one retry after the empty summary, got {len(bodies)} attempts"
+        for attempt_index, sent in enumerate(bodies):
+            assert "tools" not in sent, f"attempt {attempt_index}: tools leaked into the summary call"
+            assert "tool_choice" not in sent, f"attempt {attempt_index}: tool_choice leaked"
+            assert "parallel_tool_calls" not in sent, f"attempt {attempt_index}: parallel_tool_calls leaked"
+
     def test_api_sanitizer_matches_responses_call_id_when_id_differs(self, agent):
         messages = [
             {


### PR DESCRIPTION
## What does this PR do?

Rebases the fix from #32777 onto current `main` and adds the retry-path coverage requested in that PR's review.

#32777's diff no longer applies: the iteration-limit summary builders were extracted into `agent/chat_completion_helpers.py::_codex_summary_attempt()`, selected through `_SUMMARY_ATTEMPT_BUILDERS`, so the two inline `handle_max_iterations` branches the original patch targeted no longer exist. This relocates the same two-line change onto the single new fix point — smaller than the original, and it covers the initial call and the retry at once, because both now run through the same `_attempt(retry_count)` closure.

The original commit is cherry-picked, so Julien Talbot stays the author (committer is me).

## Related Issue

Rebases and supersedes #32777 — that PR's diff no longer applies to `main`.

Also relates to:
- #94139 (filed against this exact symptom, triaged as a duplicate of #32777)
- #61777 and #95796 — both also fail `git apply` against current `main`
- #104377 — its production hunks still apply

No standalone issue is open for this; the bug reproduces on current `main`, so nothing has landed to date.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py` — `_codex_summary_attempt()` now pops `tool_choice` and `parallel_tool_calls` alongside `tools`. `agent/transports/codex.py` emits those three keys as one block whenever the request carries tools, so popping only `tools` put `tool_choice: "auto"` on the wire with no tools array. Strict Responses backends reject that shape (xAI: `Invalid request content: A tool_choice was set on the request but no tools were specified.`), and the user loses the summary the iteration limit was supposed to produce.
- `tests/run_agent/test_run_agent.py` — the original regression test (initial attempt omits all three keys), plus a retry-path test that forces an empty first summary and asserts the retry request is equally tool-free. That was the open review request on #32777.

## How to Test

1. **Live repro on `main`, before the fix** — force the iteration limit with a lookup-requiring query (`HERMES_MAX_ITERATIONS=2 hermes -p <profile> chat -Q --max-turns 2 -t web -q "<query>"`):

   ```
   ⚠️  Reached maximum iterations (2). Requesting summary...
   I reached the maximum iterations (2) but couldn't summarize. Error: Error code: 400 -
   {'code': 'invalid-argument', 'error': 'Invalid request content: A tool_choice was set on the request
   but no tools were specified.'}
   ```

   Matching log lines: `Turn ended: reason=max_iterations_reached(2/2) ...` in `agent.log`, and `Failed to get summary response: ... 400 ...` in `gateway.error.log`.

2. **Isolated against the provider** — three direct calls to `api.x.ai/v1/responses` (provider `xai-oauth`, `grok-4.6`):

   | request body | result |
   |---|---|
   | `tools` + `tool_choice:"auto"` + `parallel_tool_calls:true` | 200 |
   | same, `tools` removed (what the summary path sent) | **400** `A tool_choice was set on the request but no tools were specified.` |
   | all three keys stripped | 200 |

3. **Red/green on the tests** — `scripts/run_tests.sh tests/run_agent/test_run_agent.py -k test_codex_summary_strips_tool_controls_when_tools_removed` fails on base with `assert "tool_choice" not in captured` (captured still holds `{'tool_choice': 'auto', 'parallel_tool_calls': True}`) and passes with the fix. Same for the new retry test (`AssertionError: attempt 0: tool_choice leaked` on base).

4. **After the fix**, the same forced-exhaustion turn returns a real answer instead of the 400.

Tests run — every test file that exercises the iteration-summary path, via the repo's runner:

```
scripts/run_tests.sh tests/agent/test_api_content_sidecar.py \
  tests/agent/test_turn_finalizer_cleanup_guard.py \
  tests/agent/test_turn_finalizer_final_response_persistence.py \
  tests/agent/test_turn_finalizer_iteration_limit_exit.py \
  tests/run_agent/test_run_agent.py \
  tests/run_agent/test_verification_continuation_budget.py
→ 6 files, 341 tests passed, 0 failed (32.9s)
```

The full `tests/` tree was not run locally — the change is two kwargs pops in one summary builder, and these are the files that touch it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(codex):`, `test(agent):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — found #32777, #61777, #95796, #104377; three of the four no longer apply to `main`
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the 6 files covering this code path (341 tests, see "Tests run" above); I have not run the full suite on this machine
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6 (arm64), Python 3.11.15, provider `xai-oauth` (grok-4.6) over the codex transport path

### Documentation & Housekeeping

- [x] Documentation — N/A (no config keys, docstrings, or README surface changed)
- [x] `cli-config.yaml.example` — N/A (no config keys added or changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture or workflow change)
- [x] Cross-platform impact considered — N/A (pure request-kwargs manipulation, no OS-specific code)
- [x] Tool descriptions/schemas — N/A (no tool behavior change)

## Screenshots / Logs

```
# before (base 45a6101f36)
agent.log:          Turn ended: reason=max_iterations_reached(2/2) model=grok-4.6 api_calls=2/2 budget=2/2
gateway.error.log:  Failed to get summary response: Error code: 400 - {'code': 'invalid-argument',
                    'error': 'Invalid request content: A tool_choice was set on the request but no tools were specified.'}

# after (this branch), same query, same budget
Super Bowl XLII ended Giants 17, Patriots 14. The winning quarterback's full name is Elisha Nelson Manning.
```

## Same invariant in a sibling path

`agent/relay_llm.py:743` (`_codex_codec_tools`) pops `tools` when it is `None` and never touches `tool_choice` / `parallel_tool_calls`, so a body that has lost its tools but kept those controls passes through the Relay codec unchanged — same coupling, same strict-backend 400, reachable whenever the codex path runs via Relay. I left it out of this PR to keep the diff to the one verified repro; happy to fold it in if you'd prefer it here.
