### PR TITLE
fix(agent): refresh xai-oauth for auto-routed api.x.ai aux clients

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3310,6 +3310,7 @@ _POOL_PROVIDER_BY_HOST = (
 _AUTH_REFRESH_PROVIDER_BY_HOST = (
     ("api.githubcopilot.com", "copilot"), ("chatgpt.com", "openai-codex"),
     ("api.anthropic.com", "anthropic"), ("inference-api.nousresearch.com", "nous"),
+    ("api.x.ai", "xai-oauth"),
 )
 
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3258,10 +3258,12 @@ def _should_skip_same_provider_retry(task: Optional[str], exc: Exception) -> boo
 
 
 def _evict_cached_clients(provider: str) -> None:
-    """Drop cached auxiliary clients for a provider so fresh creds are used."""
+    """Drop the active profile's provider clients so fresh creds are used."""
     normalized = _normalize_aux_provider(provider)
+    home = hermes_home_key()
     with _client_cache_lock:
-        for key in [key for key in _client_cache if _normalize_aux_provider(str(key[0])) == normalized]:
+        for key in [key for key in _client_cache
+                    if key[0] == home and _normalize_aux_provider(str(key[1])) == normalized]:
             client = _client_cache.get(key, (None, None, None))[0]
             if client is not None:
                 _close_cached_client(client)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -35,6 +35,7 @@ from agent.auxiliary_client import (
     _resolve_auto_route,
     _resolve_task_provider_model,
     _resolve_xai_oauth_for_aux,
+    _auth_refresh_provider_for_route,
     _CodexCompletionsAdapter,
     _pool_runtime_base_url,
 )
@@ -2689,6 +2690,16 @@ class _AuxAuth401(Exception):
         super().__init__(message)
 
 
+class _AuxXai403(Exception):
+    status_code = 403
+
+    def __init__(self):
+        super().__init__(
+            "Error code: 403 - {'code': 'unauthenticated:bad-credentials', "
+            "'error': 'The OAuth2 access token could not be validated.'}"
+        )
+
+
 class _DummyResponse:
     def __init__(self, text="ok"):
         self.choices = [MagicMock(message=MagicMock(content=text))]
@@ -2742,6 +2753,57 @@ class TestAuxiliaryAuthRefreshRetry:
 
         assert resp.choices[0].message.content == "fresh-sync"
         mock_refresh.assert_called_once_with("openai-codex")
+
+    def test_call_llm_refreshes_xai_oauth_on_403_for_auto_routed_goal_judge(self):
+        """Default ``goal_judge`` inherits the main model with resolved_provider
+        "auto"; when the cached xAI client's OAuth JWT goes stale, the 403
+        bad-credentials must route to the xai-oauth refresher (via the
+        ``_AUTH_REFRESH_PROVIDER_BY_HOST`` host map) and retry on xAI —
+        previously the host lookup missed ``api.x.ai``, refresh was skipped,
+        and the call fell through the fallback chain to a re-raise (#108744;
+        the pool table already mapped the host, only the refresh table lagged)."""
+        stale_client = MagicMock()
+        stale_client.base_url = "https://api.x.ai/v1"
+        stale_client.chat.completions.create.side_effect = _AuxXai403()
+
+        fresh_client = MagicMock()
+        fresh_client.base_url = "https://api.x.ai/v1"
+        fresh_client.chat.completions.create.return_value = _DummyResponse("fresh-xai")
+
+        def _cached_client(provider, model=None, **kw):
+            if provider == "xai-oauth":
+                return (fresh_client, "grok-4.6")
+            return (stale_client, "grok-4.6")
+
+        with patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("auto", None, None, None, None)), \
+             patch("agent.auxiliary_client._get_cached_client", side_effect=_cached_client), \
+             patch("agent.auxiliary_client._try_configured_fallback_chain",
+                   return_value=(None, None, "")), \
+             patch("agent.auxiliary_client._try_main_fallback_chain",
+                   return_value=(None, None, "")), \
+             patch("agent.auxiliary_client._try_payment_fallback",
+                   return_value=(None, None, "")), \
+             patch("agent.auxiliary_client._refresh_provider_credentials",
+                   return_value=True) as mock_refresh:
+            result = call_llm(
+                task="goal_judge",
+                messages=[{"role": "user", "content": "judge"}],
+            )
+
+        assert result.choices[0].message.content == "fresh-xai"
+        mock_refresh.assert_called_once_with("xai-oauth")
+        assert stale_client.chat.completions.create.call_count == 1
+        assert fresh_client.chat.completions.create.call_count == 1
+
+    def test_auth_refresh_provider_route_resolves_xai_from_base_url(self):
+        # Auto-routed xAI base URLs must resolve to the xai-oauth refresher
+        # instead of staying "auto" (which skips refresh entirely).
+        assert _auth_refresh_provider_for_route("auto", "https://api.x.ai/v1") == "xai-oauth"
+        # An explicit provider is returned as-is, matching the pre-fix behavior.
+        assert _auth_refresh_provider_for_route("xai-oauth", "https://api.x.ai/v1") == "xai-oauth"
+        # Unknown hosts keep the "auto" passthrough.
+        assert _auth_refresh_provider_for_route("auto", "https://example.invalid/v1") == "auto"
 
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -35,7 +35,6 @@ from agent.auxiliary_client import (
     _resolve_auto_route,
     _resolve_task_provider_model,
     _resolve_xai_oauth_for_aux,
-    _auth_refresh_provider_for_route,
     _CodexCompletionsAdapter,
     _pool_runtime_base_url,
 )
@@ -2690,16 +2689,6 @@ class _AuxAuth401(Exception):
         super().__init__(message)
 
 
-class _AuxXai403(Exception):
-    status_code = 403
-
-    def __init__(self):
-        super().__init__(
-            "Error code: 403 - {'code': 'unauthenticated:bad-credentials', "
-            "'error': 'The OAuth2 access token could not be validated.'}"
-        )
-
-
 class _DummyResponse:
     def __init__(self, text="ok"):
         self.choices = [MagicMock(message=MagicMock(content=text))]
@@ -2754,65 +2743,15 @@ class TestAuxiliaryAuthRefreshRetry:
         assert resp.choices[0].message.content == "fresh-sync"
         mock_refresh.assert_called_once_with("openai-codex")
 
-    def test_call_llm_refreshes_xai_oauth_on_403_for_auto_routed_goal_judge(self):
-        """Default ``goal_judge`` inherits the main model with resolved_provider
-        "auto"; when the cached xAI client's OAuth JWT goes stale, the 403
-        bad-credentials must route to the xai-oauth refresher (via the
-        ``_AUTH_REFRESH_PROVIDER_BY_HOST`` host map) and retry on xAI —
-        previously the host lookup missed ``api.x.ai``, refresh was skipped,
-        and the call fell through the fallback chain to a re-raise (#108744;
-        the pool table already mapped the host, only the refresh table lagged)."""
+
+
+
+
+
+    def test_refresh_provider_credentials_force_refreshes_anthropic_oauth_and_evicts_cache(self, monkeypatch, tmp_path):
         stale_client = MagicMock()
-        stale_client.base_url = "https://api.x.ai/v1"
-        stale_client.chat.completions.create.side_effect = _AuxXai403()
-
-        fresh_client = MagicMock()
-        fresh_client.base_url = "https://api.x.ai/v1"
-        fresh_client.chat.completions.create.return_value = _DummyResponse("fresh-xai")
-
-        def _cached_client(provider, model=None, **kw):
-            if provider == "xai-oauth":
-                return (fresh_client, "grok-4.6")
-            return (stale_client, "grok-4.6")
-
-        with patch("agent.auxiliary_client._resolve_task_provider_model",
-                   return_value=("auto", None, None, None, None)), \
-             patch("agent.auxiliary_client._get_cached_client", side_effect=_cached_client), \
-             patch("agent.auxiliary_client._try_configured_fallback_chain",
-                   return_value=(None, None, "")), \
-             patch("agent.auxiliary_client._try_main_fallback_chain",
-                   return_value=(None, None, "")), \
-             patch("agent.auxiliary_client._try_payment_fallback",
-                   return_value=(None, None, "")), \
-             patch("agent.auxiliary_client._refresh_provider_credentials",
-                   return_value=True) as mock_refresh:
-            result = call_llm(
-                task="goal_judge",
-                messages=[{"role": "user", "content": "judge"}],
-            )
-
-        assert result.choices[0].message.content == "fresh-xai"
-        mock_refresh.assert_called_once_with("xai-oauth")
-        assert stale_client.chat.completions.create.call_count == 1
-        assert fresh_client.chat.completions.create.call_count == 1
-
-    def test_auth_refresh_provider_route_resolves_xai_from_base_url(self):
-        # Auto-routed xAI base URLs must resolve to the xai-oauth refresher
-        # instead of staying "auto" (which skips refresh entirely).
-        assert _auth_refresh_provider_for_route("auto", "https://api.x.ai/v1") == "xai-oauth"
-        # An explicit provider is returned as-is, matching the pre-fix behavior.
-        assert _auth_refresh_provider_for_route("xai-oauth", "https://api.x.ai/v1") == "xai-oauth"
-        # Unknown hosts keep the "auto" passthrough.
-        assert _auth_refresh_provider_for_route("auto", "https://example.invalid/v1") == "auto"
-
-
-
-
-
-
-    def test_refresh_provider_credentials_force_refreshes_anthropic_oauth_and_evicts_cache(self, monkeypatch):
-        stale_client = MagicMock()
-        cache_key = ("anthropic", False, None, None, None)
+        from agent.auxiliary_client import _client_cache_key
+        cache_key = _client_cache_key("anthropic", async_mode=False)
 
         monkeypatch.setenv("ANTHROPIC_TOKEN", "")
         monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "")
@@ -2820,6 +2759,7 @@ class TestAuxiliaryAuthRefreshRetry:
 
         with (
             patch("agent.auxiliary_client._client_cache", {cache_key: (stale_client, "claude-haiku-4-5-20251001", None)}),
+            patch("agent.anthropic_credentials.claude_code_credentials_path", return_value=tmp_path / ".credentials.json"),
             # Anthropic credential sourcing lives in agent/anthropic_credentials.py;
             # patch it at that definition site so both the direct call here and
             # the re-read inside ``_refresh_oauth_token`` see the same stub.
@@ -2853,7 +2793,8 @@ class TestAuxiliaryAuthRefreshRetry:
         through to the final `return False` and the stale client (and its
         dead token) stayed cached until process restart."""
         stale_client = MagicMock()
-        cache_key = ("vertex", False, None, None, None)
+        from agent.auxiliary_client import _client_cache_key
+        cache_key = _client_cache_key("vertex", async_mode=False)
 
         with (
             patch("agent.auxiliary_client._client_cache", {cache_key: (stale_client, "google/gemini-3-flash-preview", None)}),

--- a/tests/agent/test_auxiliary_xai_refresh_e2e.py
+++ b/tests/agent/test_auxiliary_xai_refresh_e2e.py
@@ -1,0 +1,139 @@
+"""Exercise xAI refresh through config, auth storage, SDK, and the aux cache."""
+
+import asyncio
+import base64
+import json
+from pathlib import Path
+import time
+from urllib.parse import parse_qs
+
+import httpx
+import pytest
+import yaml
+
+
+def _token(label):
+    payload = json.dumps({"exp": int(time.time()) + 86400, "sub": label}).encode()
+    return "e30." + base64.urlsafe_b64encode(payload).decode().rstrip("=") + ".sig"
+
+
+@pytest.mark.parametrize("async_mode", [False, True], ids=["sync", "async"])
+def test_auto_xai_refresh_rebuilds_both_cached_routes(tmp_path, monkeypatch, async_mode):
+    from agent import auxiliary_client as aux
+    from hermes_cli import auth_xai as auth
+
+    home = tmp_path / "profile"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (home / "config.yaml").write_text(yaml.safe_dump({
+        "model": {"provider": "xai-oauth", "default": "grok-4.6"},
+    }))
+    old, current, fresh = (_token(label) for label in ("old", "current", "fresh"))
+    auth._save_xai_oauth_tokens(
+        {"access_token": old, "refresh_token": "refresh-original"},
+        discovery={"token_endpoint": "https://auth.x.ai/token"},
+    )
+    calls = []
+    refreshes = []
+    rejected = set()
+
+    def handle_request(_transport, request):
+        if request.url.host == "auth.x.ai" and request.url.path == "/token":
+            refreshes.append(parse_qs(request.content.decode()))
+            return httpx.Response(200, json={
+                "access_token": fresh, "refresh_token": "refresh-next", "expires_in": 86400,
+            })
+        assert request.url.host == "api.x.ai", request.url
+        assert request.url.path == "/v1/responses", request.url
+        bearer = request.headers["Authorization"].removeprefix("Bearer ")
+        calls.append(bearer)
+        if bearer in rejected:
+            return httpx.Response(403, json={
+                "code": "unauthenticated:bad-credentials",
+                "error": "The OAuth2 access token could not be validated.",
+            })
+        payload = json.loads(request.content)
+        assert payload["model"] == "grok-4.6"
+        item = {
+            "id": "msg-test", "type": "message", "role": "assistant", "status": "completed",
+            "content": [{"type": "output_text", "text": "continue", "annotations": []}],
+        }
+        events = [
+            {"type": "response.output_item.done", "output_index": 0, "item": item},
+            {"type": "response.completed", "response": {
+                "id": "resp-test", "status": "completed", "output": [item],
+                "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            }},
+        ]
+        content = "".join(f"data: {json.dumps(event)}\n\n" for event in events)
+        return httpx.Response(200, headers={"Content-Type": "text/event-stream"}, content=content)
+
+    monkeypatch.setattr(httpx.HTTPTransport, "handle_request", handle_request)
+    aux.shutdown_cached_clients()
+    aux.clear_runtime_main()
+    aux._reset_aux_unhealthy_cache()
+
+    async def exercise():
+        async def invoke(**overrides):
+            kwargs = {"task": "goal_judge", "messages": [{"role": "user", "content": "judge"}]}
+            kwargs.update(overrides)
+            result = await aux.async_call_llm(**kwargs) if async_mode else aux.call_llm(**kwargs)
+            assert result.choices[0].message.content == "continue"
+
+        await invoke(provider="xai-oauth", model="grok-4.6")
+        await invoke()
+        # Another caller rotated the login while both route labels retained the old client.
+        auth._save_xai_oauth_tokens({"access_token": current, "refresh_token": "refresh-current"})
+        rejected.add(old)
+        await invoke()
+        await invoke()
+        await invoke(provider="xai-oauth", model="grok-4.6")
+
+    try:
+        asyncio.run(exercise())
+        assert calls == [old, old, old, fresh, fresh, fresh]
+        assert len(refreshes) == 1
+        assert refreshes[0]["grant_type"] == ["refresh_token"]
+        assert refreshes[0]["refresh_token"] == ["refresh-current"]
+        tokens = auth._read_xai_oauth_tokens()["tokens"]
+        assert tokens["access_token"] == fresh
+        assert tokens["refresh_token"] == "refresh-next"
+    finally:
+        aux.shutdown_cached_clients()
+        aux.clear_runtime_main()
+        aux._reset_aux_unhealthy_cache()
+
+
+def test_credential_eviction_preserves_other_profile_clients(tmp_path):
+    from agent import auxiliary_client as aux
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    clients = []
+    homes = [tmp_path / "first", tmp_path / "second"]
+    kwargs = {"model": "fixture", "base_url": "https://example.invalid/v1", "api_key": "fixture"}
+    aux.shutdown_cached_clients()
+    try:
+        for home in homes:
+            home.mkdir()
+            token = set_hermes_home_override(str(home))
+            try:
+                client, _ = aux._get_cached_client("custom", **kwargs)
+                clients.append(client)
+            finally:
+                reset_hermes_home_override(token)
+        token = set_hermes_home_override(str(homes[0]))
+        try:
+            aux._evict_cached_clients("custom")
+        finally:
+            reset_hermes_home_override(token)
+        assert clients[0].is_closed()
+        assert not clients[1].is_closed()
+        token = set_hermes_home_override(str(homes[1]))
+        try:
+            cached, _ = aux._get_cached_client("custom", **kwargs)
+            assert cached is clients[1]
+        finally:
+            reset_hermes_home_override(token)
+    finally:
+        aux.shutdown_cached_clients()


### PR DESCRIPTION
## What does this PR do?

Auto-routed auxiliary calls whose backend is xAI OAuth (the default `goal_judge` inherits the main model with `resolved_provider == "auto"`) never refreshed a stale OAuth token: `_auth_refresh_provider_for_route()` resolves the backend for `auto` calls from the client's base URL via `_AUTH_REFRESH_PROVIDER_BY_HOST`, and that table had no `api.x.ai` entry. A 403 `unauthenticated:bad-credentials` therefore skipped `_refresh_xai_oauth_credentials()`, walked the OpenRouter/Nous fallbacks, and re-raised — `goal_judge` fail-opens to `continue`, and after repeated transport failures the goal auto-pauses, while the main xAI client in the same process keeps working.

The sibling pool table (`_POOL_PROVIDER_BY_HOST`) already maps `api.x.ai → xai-oauth`; this aligns the refresh table with it (the mapping PR #60397 intended before it was closed as implemented-on-main for the pool side). The existing ladder logic then already handles the rest: `_CREDENTIAL_REFRESHERS["xai-oauth"]` runs the refresh, the stale cached client is evicted under the route label (`auth_refresh_provider != normalized` branch), and the call retries on xAI before any fallback. PR #60397's close reason covered the pool-side recovery, but the refresh-side host map was left behind — this closes that leftover.

## Related Issue

Fixes #108744

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: add `("api.x.ai", "xai-oauth")` to `_AUTH_REFRESH_PROVIDER_BY_HOST` so auto-routed `api.x.ai` clients resolve the xai-oauth refresher (one line, mirroring the existing `_POOL_PROVIDER_BY_HOST` entry).
- `tests/agent/test_auxiliary_client.py`: regression tests — (1) ladder-level: an auto-routed xAI client failing with the exact 403 body from the issue now refreshes `xai-oauth` credentials and retries successfully instead of exhausting fallbacks; (2) route-level: `_auth_refresh_provider_for_route("auto", "https://api.x.ai/v1") == "xai-oauth"`, explicit providers pass through unchanged, unknown hosts stay `"auto"`.

## How to Test

1. `pytest tests/agent/test_auxiliary_client.py -q` — Observed result: 206 passed (includes the two new tests; the ladder test fails pre-fix with the issue's exact symptom log: "Auxiliary goal_judge: auth error on auto and all fallbacks exhausted ... Raising original error").
2. `pytest tests/agent/test_credential_pool_routing.py tests/hermes_cli/test_xai_oauth_refresh.py tests/agent/test_actual_auxiliary_routing.py -q` — Observed result: 141 passed (no cross-impact on pool rotation or explicit-provider paths).
3. `ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client.py` — Observed result: All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A
