### PR TITLE
fix(desktop): equalize flexible panes on sash double click

### DIFF
--- a/apps/desktop/DESIGN.md
+++ b/apps/desktop/DESIGN.md
@@ -322,6 +322,11 @@ so glass and message-bubble transparency do not reveal scrolling text.
 
 ## Direct manipulation & performance
 
+Double clicking a pane sash distributes the visible flexible tracks in that
+split evenly, subject to their size constraints. Fixed tracks return to their
+declared sizes. Hidden and minimized tracks retain their state; nested split
+weights and sizes on the other axis stay independent. The result persists.
+
 The app should feel instant under real load — long transcripts, several panes,
 live streams. Design toward that:
 

--- a/apps/desktop/src/components/pane-shell/tree/renderer/track-model.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/track-model.ts
@@ -122,33 +122,6 @@ export function computedPx(value: string, fallback: number): number {
   return Number.isFinite(n) ? n : fallback
 }
 
-/** Resolve an AUTHORED CSS length ("237px", "38vh", "clamp(18rem,36vw,32rem)")
- *  to px by measuring a probe inside `container` — handles every unit and
- *  math function the browser does. */
-export function resolveCssPx(container: HTMLElement, css: number | string, horizontal: boolean): number | null {
-  if (typeof css === 'number') {
-    return css
-  }
-
-  const probe = document.createElement('div')
-  probe.style.position = 'absolute'
-  probe.style.visibility = 'hidden'
-  probe.style.pointerEvents = 'none'
-
-  if (horizontal) {
-    probe.style.width = css
-  } else {
-    probe.style.height = css
-  }
-
-  container.appendChild(probe)
-  const rect = probe.getBoundingClientRect()
-  probe.remove()
-  const px = horizontal ? rect.width : rect.height
-
-  return Number.isFinite(px) && px > 0 ? px : null
-}
-
 /** Everything fixed-track resolution needs about the current view state. */
 export interface TrackContext {
   paneFor: (id: string) => Contribution | undefined

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-split-equalize.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-split-equalize.test.tsx
@@ -1,0 +1,145 @@
+import { useStore } from '@nanostores/react'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+
+import { registry } from '@/contrib/registry'
+import { readJson } from '@/lib/storage'
+import { $paneStates } from '@/store/panes'
+import { stubResizeObserver } from '@/test/jsdom'
+
+import { group, type LayoutNode, split } from '../model'
+import { $hiddenTreePanes, $layoutTree, persistTree } from '../store'
+
+import { TreeSplit } from './tree-split'
+
+const disposers: (() => void)[] = []
+
+beforeEach(() => {
+  window.localStorage.clear()
+  stubResizeObserver()
+  vi.stubGlobal('CSS', { ...globalThis.CSS, escape: (value: string) => value })
+
+  for (const [id, data] of [
+    ['sidebar', { placement: 'left', width: '200px', height: '120px' }],
+    ['workspace', { placement: 'main', minWidth: '22vw', minHeight: '100px' }],
+    ['files', { placement: 'right', width: '200px', height: '120px' }],
+    ['session', { placement: 'main', minWidth: '20rem', minHeight: '80px' }],
+    ['tools', { placement: 'right', width: '160px', height: '100px' }],
+    ['hidden', { placement: 'right', width: '160px', height: '100px' }],
+    ['minimized', { placement: 'right', width: '160px', height: '100px' }],
+    ['nested-minimized', { placement: 'right', width: '160px', height: '100px' }],
+    ['nested-a', { placement: 'main' }],
+    ['nested-b', { placement: 'main' }]
+  ] as const) {
+    disposers.push(registry.register({ area: 'panes', data, id, render: () => null, title: id }))
+  }
+
+  $hiddenTreePanes.set(new Set(['hidden']))
+  $paneStates.set(
+    Object.fromEntries(
+      ['sidebar', 'files', 'tools', 'hidden', 'minimized', 'nested-minimized'].map(id => [
+        id,
+        { open: true, widthOverride: 350, heightOverride: 250 }
+      ])
+    )
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  $layoutTree.set(null)
+  $hiddenTreePanes.set(new Set())
+  $paneStates.set({})
+  disposers.splice(0).forEach(dispose => dispose())
+  vi.unstubAllGlobals()
+})
+
+function LiveSplit() {
+  const tree = useStore($layoutTree)
+
+  return tree?.type === 'split' ? <TreeSplit node={tree} root rootRow /> : null
+}
+
+function wrapper(groupId: string): HTMLElement {
+  const element = window.document.querySelector<HTMLElement>(`[data-tree-group="${groupId}"]`)?.parentElement
+
+  if (!element) {
+    throw new Error(`Missing group ${groupId}`)
+  }
+
+  return element
+}
+
+it.each(['row', 'column'] as const)(
+  'double click equalizes the %s flex siblings and persists their sizes without changing other axes or splits',
+  orientation => {
+    const nested = split(
+      orientation === 'row' ? 'column' : 'row',
+      [
+        split(orientation, [group(['nested-a']), group(['nested-minimized'], { minimized: true })], [2, 3]),
+        group(['nested-b'])
+      ],
+      [2, 5],
+      'nested'
+    )
+
+    const tree = split(
+      orientation,
+      [
+        group(['sidebar'], { id: 'sidebar-zone' }),
+        group(['workspace', 'files'], { id: 'workspace-zone' }),
+        group(['session'], { id: 'session-zone' }),
+        group(['tools'], { id: 'tools-zone' }),
+        group(['hidden'], { id: 'hidden-zone' }),
+        group(['minimized'], { id: 'minimized-zone', minimized: true }),
+        nested
+      ],
+      [9, 8, 4, 7, 2, 6, 3],
+      'root'
+    )
+
+    if (orientation === 'row') {
+      disposers.push(registry.register({ area: 'layouts', data: tree, id: 'uneven-preset', title: 'Uneven' }))
+    }
+
+    $layoutTree.set(tree)
+    persistTree()
+    const { getAllByRole } = render(<LiveSplit />)
+
+    fireEvent.doubleClick(getAllByRole('separator')[1])
+
+    const updated = $layoutTree.get()
+
+    if (updated?.type !== 'split') {
+      throw new Error('Expected the root split')
+    }
+
+    const flexWeights = [1, 2, 6].map(index => updated.weights[index])
+    expect(flexWeights.every(weight => weight === flexWeights[0])).toBe(true)
+    expect(wrapper('workspace-zone').style.flexGrow).toBe(wrapper('session-zone').style.flexGrow)
+
+    const axisOverride = orientation === 'row' ? 'widthOverride' : 'heightOverride'
+    const otherOverride = orientation === 'row' ? 'heightOverride' : 'widthOverride'
+    const otherSize = orientation === 'row' ? 250 : 350
+
+    for (const id of ['sidebar', 'files', 'tools']) {
+      expect($paneStates.get()[id]?.[axisOverride]).toBeUndefined()
+      expect($paneStates.get()[id]?.[otherOverride]).toBe(otherSize)
+    }
+
+    expect(wrapper('sidebar-zone').style.flexBasis).toBe(orientation === 'row' ? '200px' : '120px')
+    expect(wrapper('tools-zone').style.flexBasis).toBe(orientation === 'row' ? '160px' : '100px')
+
+    for (const index of [0, 3, 4, 5]) {
+      expect(updated.weights[index]).toBe(tree.weights[index])
+    }
+
+    expect(wrapper('hidden-zone').style.display).toBe('none')
+    expect(updated.children[5]).toEqual(tree.children[5])
+    expect(updated.children[6]).toEqual(nested)
+    expect($paneStates.get().hidden?.widthOverride).toBe(350)
+    expect($paneStates.get().minimized?.heightOverride).toBe(250)
+    expect($paneStates.get()['nested-minimized']).toEqual({ open: true, widthOverride: 350, heightOverride: 250 })
+    expect(readJson<LayoutNode>('hermes.desktop.layoutTree.v2')).toEqual(updated)
+  }
+)

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
@@ -26,7 +26,6 @@ import {
   isCollapsePane,
   paneRootSide,
   persistTree,
-  presetSplitWeights,
   setTreeGroupMinimized,
   setTreeSplitWeights
 } from '../store'
@@ -42,7 +41,6 @@ import {
   MINIMIZED_TRACK,
   paneChrome,
   type PaneSizing,
-  resolveCssPx,
   shownPaneIds,
   subtreeGone,
   type TrackContext
@@ -527,83 +525,6 @@ export function TreeSplit({
     [axis, editMode, horizontal, node.children, node.id, node.weights, hiddenPanes, narrow, overrides, panes]
   )
 
-  // Double-click a sash: every neighbor returns to its DEFAULT size.
-  //  - fixed zones (sidebar stacks): clear the drag override -> the declared
-  //    width (237px etc.) comes back;
-  //  - flex zones fronted by a size-declaring pane (a sidebar in a mixed
-  //    stack): pin the weight so the zone lands EXACTLY on that size;
-  //  - everything else: the preset's weights for this split (rearranging
-  //    panes keeps the applied preset's split ids), else even distribution.
-  const resetBoundary = useCallback(
-    (aIndex: number, bIndex: number) => {
-      const container = containerRef.current
-
-      if (!container) {
-        return
-      }
-
-      const setOverride = horizontal ? setPaneWidthOverride : setPaneHeightOverride
-
-      for (const [child, edge] of [
-        [node.children[aIndex], 'end'],
-        [node.children[bIndex], 'start']
-      ] as const) {
-        const zone = edgeFixedZone(child, edge, axis, trackCtx)
-
-        for (const paneId of zone ? shownPaneIds(zone, trackCtx) : []) {
-          setOverride(paneId, undefined)
-        }
-      }
-
-      const preset = presetSplitWeights(node.id, node.weights.length)
-      const weights = preset ?? [...node.weights]
-
-      const rect = container.getBoundingClientRect()
-      const totalPx = horizontal ? rect.width : rect.height
-      let pinned = false
-
-      for (const i of [aIndex, bIndex]) {
-        const child = node.children[i]
-
-        // Fixed tracks size themselves from the declared width (override
-        // cleared above) — weights only matter for FLEX zones.
-        if (child.type !== 'group' || fixedTrackSize(child, axis, trackCtx) !== null) {
-          continue
-        }
-
-        // The zone's natural default = the largest size any of its panes
-        // declares along this axis (a sessions+terminal stack is still a
-        // 237px sidebar at heart, whichever chip is fronted).
-        let px: number | null = null
-
-        for (const paneId of shownPaneIds(child, trackCtx)) {
-          const sizing = (paneFor(paneId)?.data ?? {}) as PaneSizing
-          const css = horizontal ? sizing.width : sizing.height
-          const resolved = css ? resolveCssPx(container, css, horizontal) : null
-
-          if (resolved !== null) {
-            px = Math.max(px ?? 0, resolved)
-          }
-        }
-
-        if (px === null || px <= 0 || px >= totalPx) {
-          continue
-        }
-
-        const others = weights.reduce((sum, w, j) => (j === i ? sum : sum + w), 0)
-
-        if (others > 0) {
-          weights[i] = (px * others) / (totalPx - px)
-          pinned = true
-        }
-      }
-
-      setTreeSplitWeights(node.id, !preset && !pinned ? weights.map(() => 1) : weights)
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [axis, editMode, horizontal, node.children, node.id, node.weights, hiddenPanes, narrow, overrides, panes]
-  )
-
   // A run of ONLY fixed tracks can't fill the container (grow-0 all around
   // leaves dead space — e.g. terminal + logs split into two 38vh zones with
   // the rail above them collapsed). An UNCAPPED last track absorbs the
@@ -640,6 +561,37 @@ export function TreeSplit({
 
     return { child, collapsed, minimized, narrowCollapsed, sizing, track }
   })
+
+  // Equalize the visible flex siblings; fixed tracks return to their declared
+  // size. Nested split weights and sizes on the other axis stay independent.
+  const equalizeSplit = () => {
+    const setOverride = horizontal ? setPaneWidthOverride : setPaneHeightOverride
+
+    const clearSizeOverrides = (child: LayoutNode) => {
+      if (isCollapsed(child) || isMinimized(child)) {
+        return
+      }
+
+      if (child.type === 'split') {
+        child.children.forEach(clearSizeOverrides)
+      } else {
+        shownPaneIds(child, trackCtx).forEach(paneId => setOverride(paneId, undefined))
+      }
+    }
+
+    const weights = tracks.map(({ child, collapsed, minimized, track }, i) => {
+      if (collapsed || minimized) {
+        return node.weights[i]
+      }
+
+      clearSizeOverrides(child)
+
+      return track === null ? 1 : node.weights[i]
+    })
+
+    setTreeSplitWeights(node.id, weights)
+    persistTree()
+  }
 
   const growable = tracks.map((_, i) => i).filter(i => !tracks[i].collapsed && !tracks[i].minimized)
   const allFixed = growable.length > 0 && growable.every(i => tracks[i].track !== null)
@@ -726,7 +678,7 @@ export function TreeSplit({
               <Sash
                 disabled={minimized || tracks[partner].minimized}
                 horizontal={horizontal}
-                onDoubleClick={() => resetBoundary(partner, i)}
+                onDoubleClick={equalizeSplit}
                 onPointerDown={e => startSash(partner, i, e)}
               />
             )}

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -2006,48 +2006,6 @@ export function setTreeSplitWeights(splitId: string, weights: number[]) {
   }
 }
 
-function findSplitWeights(node: LayoutNode, splitId: string): number[] | null {
-  if (node.type !== 'split') {
-    return null
-  }
-
-  if (node.id === splitId) {
-    return node.weights
-  }
-
-  for (const child of node.children) {
-    const hit = findSplitWeights(child, splitId)
-
-    if (hit) {
-      return hit
-    }
-  }
-
-  return null
-}
-
-/**
- * The weights a layout preset declares for `splitId` — the ACTIVE preset
- * first, then any other preset that knows the id. (Rearranging panes marks
- * the active preset 'custom' but zone STRUCTURE — and so split ids — comes
- * from whichever preset was applied, so the original baseline stays
- * findable.) Null when no preset has a matching-shape split.
- */
-export function presetSplitWeights(splitId: string, length: number): number[] | null {
-  const activeId = $activePresetId.get()
-  const presets = [...registry.getArea('layouts')].sort((a, b) => Number(b.id === activeId) - Number(a.id === activeId))
-
-  for (const preset of presets) {
-    const weights = preset.data && isLayoutNode(preset.data) ? findSplitWeights(preset.data, splitId) : null
-
-    if (weights && weights.length === length) {
-      return [...weights]
-    }
-  }
-
-  return null
-}
-
 export function persistTree() {
   persist($layoutTree.get())
 }


### PR DESCRIPTION
Double clicking a sash now gives every visible flexible track in that split equal weight, instead of restoring preset weights or pinning a mixed group to a declared size. Size overrides on the current axis are cleared across the split, fixed tracks return to their declared sizes, and minimum and maximum constraints still apply.

Hidden and minimized groups retain their state, including nested minimized groups. Nested split weights and sizes on the other axis stay independent. The final layout is persisted after the gesture.

To verify, resize several session panes to different widths and double click any sash between them. Repeat with a column split and with a sidebar resized from its default width.

Validated on macOS: all 179 pane shell tests pass, along with desktop type checks, ESLint and Prettier. The two new regression cases fail on the original implementation. A Chromium fixture using the real renderer, stores and CSS also passes both row and column gestures, including clicks inside the existing 8 pixel sash target and fixed size restoration.

Fixes #108751
