### PR TITLE
fix(desktop): keep overflowing split panes reachable

### DIFF
--- a/apps/desktop/DESIGN.md
+++ b/apps/desktop/DESIGN.md
@@ -204,6 +204,10 @@ Sizes: `default`, `xs`, `overlay` (titlebar glyph counts).
 
 ## Panel titlebars
 
+Splits scroll when their panels' minimum sizes exceed the available space,
+including after a sidebar is restored. Scrolling preserves panel sizes and
+keeps headers and composers reachable; titlebar reservations follow the panels.
+
 Top-edge panels extend into the native titlebar band. Their tab strips remain
 inside their own zones so tab drops, focus, and split boundaries use the same
 geometry. Panels without room beside the measured window controls place their

--- a/apps/desktop/src/components/pane-shell/geometry-scroll.test.tsx
+++ b/apps/desktop/src/components/pane-shell/geometry-scroll.test.tsx
@@ -1,0 +1,128 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { useRef } from 'react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+
+import { $connection } from '@/store/session'
+import { stubResizeObserver } from '@/test/jsdom'
+
+import { publishWorkspaceGeometry, useWindowControlsOverlap } from './geometry'
+import { usePanelTitlebar } from './tree/renderer/panel-titlebar'
+
+let panelRect: DOMRect
+let stopGeometry: (() => void) | undefined
+
+beforeEach(() => {
+  stubResizeObserver()
+  panelRect = new DOMRect(280, 0, 400, 600)
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+    if (this.dataset.titlebarCluster === 'left') {
+      return new DOMRect(0, 0, 180, 34)
+    }
+
+    if (this.dataset.titlebarCluster === 'right') {
+      return new DOMRect(window.innerWidth - 74, 0, 74, 34)
+    }
+
+    return panelRect
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  stopGeometry?.()
+  stopGeometry = undefined
+  $connection.set(null)
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+function Panel({ titlebar = false }: { titlebar?: boolean }) {
+  const ref = useRef<HTMLDivElement>(null)
+  const belowControls = usePanelTitlebar(ref, titlebar, false)
+  const overlap = useWindowControlsOverlap(ref, !titlebar)
+
+  return (
+    <div aria-label="Panels" role="region">
+      <div aria-label="Nested split" role="region">
+        <div
+          aria-label="Session"
+          data-below-controls={belowControls}
+          data-session-anchor="workspace"
+          ref={ref}
+          role="region"
+          style={{ paddingTop: overlap ? overlap.y + overlap.height : 0 }}
+        >
+          <div aria-label="Transcript" role="log" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+it('keeps panel tabs clear of fixed titlebar controls when ancestor splits scroll', () => {
+  render(
+    <>
+      <div data-titlebar-cluster="left" />
+      <div data-titlebar-cluster="right" />
+      <Panel titlebar />
+    </>
+  )
+
+  const panel = screen.getByRole('region', { name: 'Session' })
+  expect(panel.style.getPropertyValue('--panel-titlebar-left')).toBe('0px')
+  expect(panel.dataset.belowControls).toBe('false')
+
+  panelRect = new DOMRect(-100, 0, panelRect.width, panelRect.height)
+  fireEvent.scroll(screen.getByRole('region', { name: 'Panels' }))
+
+  const reserved = Number.parseFloat(panel.style.getPropertyValue('--panel-titlebar-left'))
+  expect(panelRect.left + reserved).toBeGreaterThan(180)
+  expect(panel.dataset.belowControls).toBe('true')
+
+  panelRect = new DOMRect(280, 0, panelRect.width, panelRect.height)
+  fireEvent.scroll(screen.getByRole('region', { name: 'Nested split' }))
+  expect(panel.style.getPropertyValue('--panel-titlebar-left')).toBe('0px')
+  expect(panel.dataset.belowControls).toBe('false')
+
+  vi.mocked(HTMLElement.prototype.getBoundingClientRect).mockClear()
+  fireEvent.scroll(screen.getByRole('log', { name: 'Transcript' }))
+  expect(HTMLElement.prototype.getBoundingClientRect).not.toHaveBeenCalled()
+})
+
+it('updates workspace alignment and native control clearance without a resize', () => {
+  vi.stubGlobal('hermesDesktop', {})
+  $connection.set({
+    baseUrl: 'http://localhost',
+    isFullscreen: false,
+    logs: [],
+    mode: 'local',
+    nativeOverlayWidth: 74,
+    token: '',
+    windowButtonPosition: null,
+    wsUrl: 'ws://localhost'
+  })
+  render(<Panel />)
+  stopGeometry = publishWorkspaceGeometry()
+
+  const panel = screen.getByRole('region', { name: 'Session' })
+  const rootStyle = globalThis.document.documentElement.style
+  expect(panel.style.paddingTop).toBe('0px')
+
+  panelRect = new DOMRect(window.innerWidth - 100, 0, panelRect.width, panelRect.height)
+  fireEvent.scroll(screen.getByRole('region', { name: 'Panels' }))
+
+  expect(panel.style.paddingTop).toBe('34px')
+  expect(rootStyle.getPropertyValue('--workspace-left')).toBe(`${panelRect.left}px`)
+  expect(rootStyle.getPropertyValue('--workspace-right')).toBe(`${window.innerWidth - panelRect.right}px`)
+
+  panelRect = new DOMRect(280, 0, panelRect.width, panelRect.height)
+  fireEvent.scroll(screen.getByRole('region', { name: 'Nested split' }))
+
+  expect(panel.style.paddingTop).toBe('0px')
+  expect(rootStyle.getPropertyValue('--workspace-left')).toBe(`${panelRect.left}px`)
+  expect(rootStyle.getPropertyValue('--workspace-right')).toBe(`${window.innerWidth - panelRect.right}px`)
+
+  vi.mocked(HTMLElement.prototype.getBoundingClientRect).mockClear()
+  fireEvent.scroll(screen.getByRole('log', { name: 'Transcript' }))
+  expect(HTMLElement.prototype.getBoundingClientRect).not.toHaveBeenCalled()
+})

--- a/apps/desktop/src/components/pane-shell/geometry.ts
+++ b/apps/desktop/src/components/pane-shell/geometry.ts
@@ -189,8 +189,8 @@ const sashDragging = () => sashDragDepth > 0
  *   --workspace-right : px from the main zone's right to the viewport's right
  *
  * Measured once per relevant change (zone resize via ResizeObserver, layout
- * mutations via $layoutTree, window resize) and consumed in plain CSS — the
- * measured-var idiom (--composer-measured-height), not per-component JS
+ * mutations via $layoutTree, window resize, ancestor scrolling) and consumed
+ * in plain CSS — the measured-var idiom (--composer-measured-height), not per-component JS
  * geometry. Call once from the tree root; returns the disposer.
  */
 export function publishWorkspaceGeometry(): () => void {
@@ -245,17 +245,26 @@ export function publishWorkspaceGeometry(): () => void {
 
   // Tree mutations move zones without resizing them (⌘\ flip) — re-measure a
   // frame later, after the DOM committed. RO covers width changes (sash drags,
-  // side collapses); window resize covers the rest.
+  // side collapses); scrolling an ancestor moves the zone without a resize.
   const unsubTree = $layoutTree.listen(() => requestAnimationFrame(measure))
+
+  const onScroll = (event: Event) => {
+    if (event.target instanceof HTMLElement && el && event.target.contains(el)) {
+      measure()
+    }
+  }
+
   // Drag released → publish the final geometry the deferral above skipped.
   onSashDragEnd = () => requestAnimationFrame(measure)
   window.addEventListener('resize', measure)
+  window.addEventListener('scroll', onScroll, { capture: true, passive: true })
   measure()
 
   return () => {
     unsubTree()
     onSashDragEnd = null
     window.removeEventListener('resize', measure)
+    window.removeEventListener('scroll', onScroll, true)
     ro.disconnect()
     root.style.removeProperty('--workspace-left')
     root.style.removeProperty('--workspace-right')
@@ -291,16 +300,23 @@ export function useWindowControlsOverlap(ref: RefObject<HTMLElement | null>, ena
 
     update()
 
-    // Size changes fire the observer; cross-window moves fire `resize`. A pane
-    // shifted only by a sibling's resize re-measures on its own grid reflow
-    // (its track width changes), so this covers the shell's real cases.
+    // Scrolling a split moves its panes without resizing them. Ignore scrolls
+    // inside the pane: they do not change its intersection with native chrome.
+    const onScroll = (event: Event) => {
+      if (event.target instanceof HTMLElement && event.target.contains(el)) {
+        update()
+      }
+    }
+
     const ro = new ResizeObserver(update)
     ro.observe(el)
     window.addEventListener('resize', update)
+    window.addEventListener('scroll', onScroll, { capture: true, passive: true })
 
     return () => {
       ro.disconnect()
       window.removeEventListener('resize', update)
+      window.removeEventListener('scroll', onScroll, true)
     }
   }, [controls, enabled, ref])
 

--- a/apps/desktop/src/components/pane-shell/tree/renderer/panel-titlebar.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/panel-titlebar.ts
@@ -50,13 +50,21 @@ export function usePanelTitlebar(ref: RefObject<HTMLElement | null>, enabled: bo
       observer.observe(element)
     }
 
+    const onScroll = (event: Event) => {
+      if (event.target instanceof HTMLElement && ref.current && event.target.contains(ref.current)) {
+        measure()
+      }
+    }
+
     window.addEventListener('resize', measure)
+    window.addEventListener('scroll', onScroll, { capture: true, passive: true })
 
     return () => {
       observer.disconnect()
       window.removeEventListener('resize', measure)
+      window.removeEventListener('scroll', onScroll, true)
     }
-  }, [enabled, measure])
+  }, [enabled, measure, ref])
 
   return enabled && belowControls
 }

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
@@ -686,7 +686,7 @@ export function TreeSplit({
 
   return (
     <div
-      className={cn('flex min-h-0 min-w-0 flex-1', horizontal ? 'flex-row' : 'flex-col')}
+      className={cn('flex min-h-0 min-w-0 flex-1 overflow-auto', horizontal ? 'flex-row' : 'flex-col')}
       data-tree-split={node.id}
       ref={containerRef}
     >


### PR DESCRIPTION
When panel minimum sizes exceed the available space, the split now provides scrolling so the last panel remains reachable after the sidebar is restored. This applies to rows, columns and nested splits while preserving panel sizes and the saved layout.

Titlebar reservations, native control clearance and workspace alignment also update when an ancestor scrolls. Scrolling inside a transcript does not trigger those measurements.

To verify, open five sessions in separate panes, collapse and expand the sidebar in a narrow window, then scroll to the last session and use its composer. Repeat with vertically stacked panes and a nested layout.

Validated on macOS: all 179 pane shell tests pass, along with desktop type checks, ESLint and Prettier. Both new geometry regressions fail on the original implementation. A Chromium fixture using the real renderer, stores and CSS passes sidebar restoration at 1800 and 1400 pixels, vertical overflow and nested titlebar alignment. The final composer accepts clicks and input after scrolling, and layout state remains intact. All four browser scenarios fail on the original implementation.

Fixes #108746
