### PR TITLE
Fix password manager enable toggle persistence

### DIFF
--- a/tests/tui_gateway/test_vault_methods.py
+++ b/tests/tui_gateway/test_vault_methods.py
@@ -112,3 +112,23 @@ def test_remove_is_idempotent(home):
 def test_remove_requires_id(home):
     err = _error(srv._methods["vault.remove"](1, {}))
     assert err["code"] == 5095
+
+
+def test_external_source_toggle_persists_and_changes_reported_state(home):
+    fake_bw = home / "bin" / "bw"
+    fake_bw.parent.mkdir()
+    fake_bw.touch()
+    (home / "config.yaml").write_text(
+        f"vault:\n  bitwarden:\n    enabled: false\n    binary_path: {fake_bw}\n",
+        encoding="utf-8",
+    )
+
+    enabled = _result(srv._methods["vault.source.set"](1, {"name": "bitwarden", "enabled": True}))
+    assert enabled == {"name": "bitwarden", "enabled": True}
+    enabled_sources = _result(srv._methods["vault.sources"](2, {}))["sources"]
+    assert next(source for source in enabled_sources if source["name"] == "bitwarden")["enabled"] is True
+
+    disabled = _result(srv._methods["vault.source.set"](3, {"name": "bitwarden", "enabled": False}))
+    assert disabled == {"name": "bitwarden", "enabled": False}
+    disabled_sources = _result(srv._methods["vault.sources"](4, {}))["sources"]
+    assert next(source for source in disabled_sources if source["name"] == "bitwarden")["enabled"] is False

--- a/tui_gateway/methods_vault.py
+++ b/tui_gateway/methods_vault.py
@@ -97,10 +97,9 @@ def _(rid, params: dict) -> dict:
     enabled = bool(params.get("enabled"))
     cfg = load_config()
     section = cfg.setdefault("vault", {}).setdefault(name, {})
-    if enabled:
-        section.pop("enabled", None)  # detected managers are on by default; this removes the opt-out
-    else:
-        section["enabled"] = False
+    # Persist both states explicitly. The schema default is disabled, so removing the key while
+    # enabling only makes the next config load restore ``False`` and the UI switch snap back off.
+    section["enabled"] = enabled
     if not enabled:
         lock(name)
     save_config(cfg)


### PR DESCRIPTION
## Summary

- Persist the external password-manager enabled state explicitly.
- Prevent Bitwarden and 1Password switches from reverting after configuration reload.
- Add regression coverage for enabling and disabling an external vault source.

## Tests

- `pytest tests/agent/test_vault_backends.py tests/tui_gateway/test_vault_methods.py -q` — 8 passed
- `ruff check tui_gateway/methods_vault.py tests/tui_gateway/test_vault_methods.py` — all checks passed