### PR TITLE
fix: strip llama.cpp media markers from outgoing messages

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -23,6 +23,16 @@ _SURROGATE_RE = re.compile(r'[\ud800-\udfff]')
 # Keys handled explicitly by _sanitize_messages; every OTHER key is swept generically.
 _MESSAGE_CORE_KEYS = frozenset({"content", "name", "tool_calls", "role"})
 
+# llama-server's multimodal placeholder. It randomizes the suffix per process start
+# (``media_marker`` in /props) so a prompt cannot forge one, then splits every prompt
+# on that exact string before tokenizing and demands an attached bitmap per piece.
+# Text carrying a marker with no image behind it fails in mtmd, and the server answers
+# HTTP 400 "Failed to tokenize prompt" in ~0.2s — before the model runs, non-retryable,
+# and identical on every endpoint of that server, so failover cannot route around it.
+# A session poisons itself just by reading the server's own /props into a tool result.
+# ``<__media__>`` / ``<__image__>`` are the fixed spellings older builds use.
+_MEDIA_MARKER_RE = re.compile(r'<__(?:media|image)(?:_[A-Za-z0-9_-]+)?__>')
+
 
 def _sanitize_surrogates(text: str) -> str:
     """Replace lone surrogate code points with U+FFFD; no-op when none present."""
@@ -32,6 +42,16 @@ def _sanitize_surrogates(text: str) -> str:
 def _strip_non_ascii(text: str) -> str:
     """Drop non-ASCII characters — last resort for ASCII-only system encodings (LANG=C)."""
     return text.encode('ascii', errors='ignore').decode('ascii')
+
+
+def _neutralize_media_markers(text: str) -> str:
+    """Drop llama.cpp media placeholders from *text*; no-op when none present.
+
+    Removed rather than escaped: the only thing that reaches this is text quoting a
+    marker (a /props dump, a log line), never a real image reference — genuine images
+    travel as structured ``image_url`` parts and the server inserts its own marker.
+    """
+    return _MEDIA_MARKER_RE.sub('[media-marker removed]', text)
 
 
 def _fix_str_field(container: Any, key: Any, fix: Callable[[str], str]) -> bool:
@@ -93,6 +113,9 @@ _sanitize_messages_surrogates = partial(_sanitize_messages, fix=_sanitize_surrog
 _sanitize_structure_non_ascii = partial(_sanitize_structure, fix=_strip_non_ascii)
 _sanitize_messages_non_ascii = partial(_sanitize_messages, fix=_strip_non_ascii, deep=False)
 _sanitize_tools_non_ascii = _sanitize_structure_non_ascii
+# Deep: a marker quoted inside tool_call arguments wedges the prompt exactly as one in
+# message content does.
+_sanitize_messages_media_markers = partial(_sanitize_messages, fix=_neutralize_media_markers, deep=True)
 
 
 def _escape_invalid_chars_in_json_strings(raw: str) -> str:
@@ -289,6 +312,7 @@ __all__ = [
     "_sanitize_surrogates", "_sanitize_structure_surrogates", "_sanitize_messages_surrogates",
     "_escape_invalid_chars_in_json_strings", "_repair_tool_call_arguments",
     "_strip_non_ascii", "_sanitize_messages_non_ascii", "_sanitize_tools_non_ascii",
+    "_neutralize_media_markers", "_sanitize_messages_media_markers",
     "_strip_images_from_messages", "_sanitize_structure_non_ascii",
     # call_id policy owners
     "deterministic_call_id", "coalesce_tool_call_id", "tool_call_id_variants",

--- a/agent/turn_request_assembly.py
+++ b/agent/turn_request_assembly.py
@@ -13,7 +13,10 @@ from dataclasses import dataclass
 import logging
 from typing import Any
 
-from agent.message_sanitization import _sanitize_messages_surrogates
+from agent.message_sanitization import (
+    _sanitize_messages_media_markers,
+    _sanitize_messages_surrogates,
+)
 from agent.usage_anchor import anchored_context_tokens
 from agent.prompt_caching import build_prompt_cache_plan, effective_cache_ttl
 from agent.turn_context import build_api_messages
@@ -181,6 +184,15 @@ def assemble_api_request(
     # Strip lone surrogates (U+D800-U+DFFF) that some Ollama-served models emit;
     # they crash json.dumps() inside the OpenAI SDK and trigger the 3-retry cycle.
     _sanitize_messages_surrogates(api_messages)
+
+    # Drop llama.cpp media placeholders quoted in transcript text (a /props dump read
+    # into a tool result is the usual way one gets there). The server splits the prompt
+    # on its own marker before tokenizing and rejects a marker with no bitmap behind it
+    # with a non-retryable HTTP 400 "Failed to tokenize prompt", identically on every
+    # endpoint it serves — so one poisoned message wedges the session and failover
+    # cannot route around it. API copy only: the stored transcript keeps the real text.
+    if _sanitize_messages_media_markers(api_messages):
+        logger.debug("Neutralized llama.cpp media marker(s) in outgoing messages")
 
     # No send-time pad loop here: ``repair_empty_non_final_messages`` (inside
     # ``_sanitize_api_messages``) is the single owner of empty-turn repair.

--- a/tests/agent/test_media_marker_neutralization.py
+++ b/tests/agent/test_media_marker_neutralization.py
@@ -1,0 +1,61 @@
+"""llama.cpp media-marker regression tests.
+
+llama-server randomizes its multimodal placeholder per process start
+(``media_marker`` in ``/props``, e.g. ``<__media_CROZLhoWqzum1cQTzZQKMYA9gqWTHJ3E__>``)
+so a prompt cannot forge one. Before any prompt is tokenized the server splits
+it on that exact string and expects one attached bitmap per piece; a marker in
+plain text with no image behind it makes ``mtmd`` throw and the request comes
+back ``HTTP 400 {"message": "Failed to tokenize prompt"}`` in ~0.2s, before the
+model runs. Retrying and failing over cannot help — every endpoint of the same
+server shares the marker — so the whole session wedges.
+
+A session poisons itself simply by reading the server's own ``/props`` into a
+tool result, which is exactly how this was hit: one ``curl .../props`` dump
+landed in the transcript and every subsequent turn 400'd.
+
+The marker is neutralized on the API copy only, at the same chokepoint that
+strips lone surrogates, so the stored transcript keeps what the tool actually
+returned.
+"""
+
+import pytest
+
+from agent.message_sanitization import (
+    _neutralize_media_markers,
+    _sanitize_messages_media_markers,
+)
+
+# The live marker from the 2026-09-12 incident, and the fixed fallback spelling
+# older llama.cpp builds use when randomization is off.
+RANDOM_MARKER = "<__media_CROZLhoWqzum1cQTzZQKMYA9gqWTHJ3E__>"
+FIXED_MARKER = "<__media__>"
+LEGACY_MARKER = "<__image__>"
+
+
+@pytest.mark.parametrize("marker", [RANDOM_MARKER, FIXED_MARKER, LEGACY_MARKER])
+def test_marker_is_removed_from_text(marker):
+    out = _neutralize_media_markers(f"  media_marker: {marker}\n  model_alias: qwen-27b")
+    assert marker not in out
+    assert "model_alias: qwen-27b" in out
+
+
+def test_non_marker_text_is_untouched():
+    """Only the placeholder shape is rewritten; neighbouring angle-bracket
+    tokens (chat-template specials quoted in a props dump) must survive."""
+    text = "bos_token: <|endoftext|> eos_token: <|im_end|> <__mediaish__x>"
+    assert _neutralize_media_markers(text) == text
+
+
+def test_marker_neutralized_in_tool_result_content():
+    messages = [
+        {"role": "user", "content": "dump props"},
+        {"role": "tool", "tool_call_id": "c1", "content": f"media_marker: {RANDOM_MARKER}"},
+    ]
+    assert _sanitize_messages_media_markers(messages) is True
+    assert RANDOM_MARKER not in messages[1]["content"]
+    assert messages[0]["content"] == "dump props"
+
+
+def test_returns_false_when_no_marker_present():
+    messages = [{"role": "user", "content": "no markers here"}]
+    assert _sanitize_messages_media_markers(messages) is False


### PR DESCRIPTION
## What does this PR do?

Strips llama.cpp / llama-server multimodal media markers from the **outgoing API copy** of messages, at the same chokepoint where lone surrogates are already stripped (`agent/turn_request_assembly.py`).

The server randomizes its `media_marker` per process start, splits every prompt on that exact string before tokenizing, and demands an attached bitmap per piece. When the marker lands in the transcript **as plain text** (e.g. a `curl .../props` dump, which returns the live marker value), every subsequent turn 400s with a non-retryable `{"message": "Failed to tokenize prompt"}` in ~0.2s. All endpoints on that server share the marker, so failover can't route around it and the session wedges.

Removing (rather than escaping) is correct: the only thing that reaches this path is text quoting a marker, never a real image reference — genuine images travel as structured `image_url` parts and the server inserts its own marker. The fix runs on the API copy only, so the stored transcript keeps the real text the tool returned.

## Related Issue

Fixes #108760

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/message_sanitization.py`:
  - Added `_MEDIA_MARKER_RE` matching the randomized marker plus the fixed `<__media__>` / `<__image__>` spellings older builds use.
  - Added `_neutralize_media_markers(text)` → replaces matches with `[media-marker removed]`.
  - Added `_sanitize_messages_media_markers` partial (`deep=True` so a marker quoted inside a `tool_call` argument is caught too, not just message content).
  - Exported both new symbols.
- `agent/turn_request_assembly.py`:
  - Imported `_sanitize_messages_media_markers` and invoked it on `api_messages` right after the existing `_sanitize_messages_surrogates` call.
- `tests/agent/test_media_marker_neutralization.py`: 6 regression tests (randomized + fixed + legacy spellings, non-marker text untouched, tool-result content neutralized, returns False when no marker present).

## How to Test

1. Configure Hermes with a llama.cpp / llama-server endpoint as the (or a) provider.
2. In a session, run a tool that dumps the server's `/props` (the result includes the live `media_marker`).
3. Send any further message.
   - **Before:** every turn returns `HTTP 400 {"message": "Failed to tokenize prompt"}` (primary and fallback).
   - **After:** the turn completes normally.
4. Unit tests: `python -m pytest tests/agent/test_media_marker_neutralization.py -q` → 6 passed.
5. Affected-module regression run (sanitization, message content, compressor media stripping/historical media) → 89 passed.
6. Live receipt: the exact triggering request replayed against the live server went 400 before → 200 after (50481 prompt tokens).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (distinct from #66558 — that one is real image attachments on the Ollama vision path; this is a marker quoted as text)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant `pytest` tests and they pass (6 new + 89 in affected modules)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux (zen kernel), Python 3.11.15, Hermes v0.21.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstrings added; no user-facing docs affected)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure string/regex change, no platform-specific syscalls)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

The 400 body is the single-line JSON above; it fires in ~0.2s (before model execution), which is why it is non-retryable and why failover cannot help.
