### PR TITLE
fix(kanban): a transient block waits in scheduled, never in triage

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -920,6 +920,8 @@ def _cmd_block(args: argparse.Namespace) -> int:
                 return f"{tid} → todo (dependency wait){suffix}"
             if where == "triage":
                 return f"{tid} → triage (unblock loop detected — needs a human decision){suffix}"
+            if where == "scheduled":
+                return f"{tid} → scheduled (transient wait — no human needed){suffix}"
             return f"Blocked {tid}{suffix}"
 
         op = _commented(conn, reason, author, "BLOCKED", lambda tid: kb.block_task(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -92,8 +92,9 @@ VALID_INITIAL_STATUSES = {"running", "blocked"}
 # Typed block reasons (routing in ``_route_block``); ``None`` = legacy un-typed.
 VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 
-# Same-reason block -> unblock -> re-block cycles before routing to ``triage``.
-# Counts unblock recurrences, NOT dispatcher failures (``DEFAULT_FAILURE_LIMIT``).
+# Same-reason block -> unblock -> re-block cycles before routing to ``triage``
+# (or, for ``transient``, to ``blocked``). Counts unblock recurrences, NOT
+# dispatcher failures (``DEFAULT_FAILURE_LIMIT``).
 BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 
@@ -1992,7 +1993,8 @@ def _resume_status_from_events(conn: sqlite3.Connection, task_id: str) -> str:
     row = conn.execute(
         "SELECT payload FROM task_events "
         "WHERE task_id = ? AND kind IN ("
-        "'blocked', 'block_loop_detected', 'dependency_wait', 'gave_up', "
+        "'blocked', 'block_loop_detected', 'dependency_wait', 'transient_wait', "
+        "'gave_up', "
         "'unblocked', 'changes_requested', 'review_reopened', 'status', 'reclaimed', "
         "'stale', 'timed_out', 'crashed', 'spawn_failed', 'rate_limited'"
         ") ORDER BY id DESC LIMIT 1", (task_id,),
@@ -2214,6 +2216,11 @@ _RUN_OUTCOME_TERMINAL_STATUS = {
     "changes_requested": "changes_requested",
     "blocked": "blocked",
     "dependency_wait": "blocked",
+    # A transient park (``_route_block`` -> ``scheduled``) is a handoff too:
+    # the run ended and the goal loop must stop. The loop's terminal vocabulary
+    # has no separate "parked" value, and ``blocked`` is the one that means
+    # "stop, someone/something else owns this now".
+    "scheduled": "blocked",
 }
 
 
@@ -2907,9 +2914,10 @@ def block_task(
     conn: sqlite3.Connection, task_id: str, *, reason: Optional[str] = None,
     kind: Optional[str] = None, expected_run_id: Optional[int] = None,
 ) -> bool:
-    """``running``/``ready`` -> ``blocked`` (or ``todo`` / ``triage``, see
-    :func:`_route_block`). ``transient`` still counts toward the loop breaker
-    so a forever-flaky task escalates. True on any transition."""
+    """``running``/``ready`` -> ``blocked`` (or ``todo`` / ``scheduled`` /
+    ``triage``, see :func:`_route_block`). ``transient`` waits in ``scheduled``
+    but still counts toward the loop breaker, so a forever-flaky task
+    escalates — to a human, never into ``triage``. True on any transition."""
     if kind is not None and kind not in VALID_BLOCK_KINDS:
         raise ValueError(f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None")
     with write_txn(conn):
@@ -2939,8 +2947,11 @@ def block_task(
             params = (*params, int(expected_run_id))
         if conn.execute(sql, params).rowcount != 1:
             return False
+        # A transient park is not a block: record the run as ``scheduled`` so
+        # attempt history says "waited", not "stopped for a human".
+        run_outcome = "scheduled" if new_status == "scheduled" else "blocked"
         run_id = _end_or_synthesize_run(
-            conn, task_id, outcome="blocked", status="blocked", summary=reason, synthesize=bool(reason),
+            conn, task_id, outcome=run_outcome, status=run_outcome, summary=reason, synthesize=bool(reason),
         )
         _append_event(conn, task_id, event_kind, payload, run_id=run_id)
         blocked_task = get_task(conn, task_id)
@@ -2966,6 +2977,21 @@ def _route_block(
     incoming one means blocked -> unblocked -> re-block for the same cause
     (un-typed None compares equal to a prior un-typed block). At
     ``BLOCK_RECURRENCE_LIMIT`` the task routes to ``triage`` for a human.
+
+    ``transient`` is the one kind that never takes that door. It means "this
+    may clear on its own" — a wait on TIME, which is precisely what
+    ``scheduled`` is for; the human bucket is for questions only a human can
+    answer. It still counts recurrences, so a card that keeps parking this way
+    stops being believed, but its escalation target is ``blocked`` (a human,
+    who gets notified) rather than ``triage``. ``triage`` is the wrong
+    destination for a machine wait twice over: ``recompute_ready`` looks only
+    at ``todo``/``blocked``, so nothing promotes the card back on its own, and
+    the only thing that does read ``triage`` is the specify/decompose sweep —
+    which hands the card straight back to a worker that just said it is
+    waiting, or (where that sweep filters breaker escalations out) leaves it
+    sitting with no reader at all. Observed on a live board as a 7-hour stall
+    with 21 tasks queued behind one parked card whose background job had in
+    fact finished green ten minutes after the park.
     """
     payload = {"reason": reason, "kind": kind, "source_status": source_status}
     if kind == "dependency":
@@ -2973,6 +2999,12 @@ def _route_block(
     recurrences = prev_recurrences + 1 if prev_kind == kind else 1
     set_sql = "block_kind    = ?,\n                       block_recurrences = ?"
     payload = {"reason": reason, "kind": kind, "recurrences": recurrences, "source_status": source_status}
+    if kind == "transient":
+        if recurrences < BLOCK_RECURRENCE_LIMIT:
+            return "scheduled", "transient_wait", set_sql, (kind, recurrences), payload
+        # Believed twice, flaky twice: hand it to a human, not to ``triage``.
+        payload["limit"] = BLOCK_RECURRENCE_LIMIT
+        return "blocked", "blocked", set_sql, (kind, recurrences), payload
     if recurrences >= BLOCK_RECURRENCE_LIMIT:
         payload["limit"] = BLOCK_RECURRENCE_LIMIT
         return "triage", "block_loop_detected", set_sql, (kind, recurrences), payload

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1994,7 +1994,7 @@ def _resume_status_from_events(conn: sqlite3.Connection, task_id: str) -> str:
         "SELECT payload FROM task_events "
         "WHERE task_id = ? AND kind IN ("
         "'blocked', 'block_loop_detected', 'dependency_wait', 'transient_wait', "
-        "'gave_up', "
+        "'scheduled', 'gave_up', "
         "'unblocked', 'changes_requested', 'review_reopened', 'status', 'reclaimed', "
         "'stale', 'timed_out', 'crashed', 'spawn_failed', 'rate_limited'"
         ") ORDER BY id DESC LIMIT 1", (task_id,),
@@ -3292,9 +3292,16 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     when that is where it left off), closing any leaked run first."""
     now = int(time.time())
     with write_txn(conn):
+        # ``scheduled`` is read too: a transient park (``_route_block``) lands
+        # there carrying the phase it interrupted, and gating on ``blocked``
+        # alone would silently return a reviewer's card as an implementation
+        # run — the exact conversion ``_retry_status_for_run`` exists to stop.
+        # A hand-parked card is unaffected: ``schedule_task`` writes the newest
+        # ``scheduled`` event, whose payload carries no phase, so it reads
+        # ``ready`` rather than resurrecting one from an older event.
         resume_status = (
             _resume_status_from_events(conn, task_id)
-            if _task_status(conn, task_id) == "blocked"
+            if _task_status(conn, task_id) in ("blocked", "scheduled")
             else "ready"
         )
         _reclaim_dangling_run(

--- a/hermes_cli/kanban_parser.py
+++ b/hermes_cli/kanban_parser.py
@@ -297,9 +297,10 @@ _SPECS = [
         _arg("--kind", choices=sorted(kb.VALID_BLOCK_KINDS),
              help="Typed block reason. 'dependency' waits in todo (auto-promoted when "
                   "parents finish, no human); 'needs_input'/'capability' go to "
-                  "blocked for a human; 'transient' marks a maybe-flaky failure. "
-                  "Repeated same-kind re-blocks after unblock route the task to "
-                  "triage to break unblock loops. Omit for a generic block."),
+                  "blocked for a human; 'transient' (may clear on its own) waits in "
+                  "scheduled, not blocked. Repeated same-kind re-blocks after unblock "
+                  "route the task to triage to break unblock loops — except "
+                  "'transient', which escalates to blocked. Omit for a generic block."),
     ], help="Mark one or more tasks blocked"),
     _cmd("schedule", [
         _TASK_ID,

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -235,3 +235,56 @@ def test_transient_park_is_not_confused_with_a_different_prior_kind(
         task = _park_transient(conn, tid)
     assert task.status == "scheduled"
     assert task.block_recurrences == 1
+
+
+def test_transient_park_from_review_comes_back_as_review(kanban_home: Path) -> None:
+    """Regression: parking in ``scheduled`` must not lose the phase it
+    interrupted. A reviewer that parks on a transient wait and is woken up
+    has to resume as a REVIEW run — returning it as an implementation run
+    silently redoes work that was already done."""
+    with kbc.connect_closing() as conn:
+        tid = kb.create_task(conn, title="reviewed thing", assignee="builder")
+        impl = kb.claim_task(conn, tid, claimer="builder:test")
+        assert impl is not None
+        assert kb.request_review(
+            conn, tid, summary="ready for review", reviewer="reviewer",
+            expected_run_id=impl.current_run_id,
+        )
+        review = kb.claim_review_task(conn, tid)
+        assert review is not None
+        assert kb.get_task(conn, tid).status == "running"
+
+        _park_transient(conn, tid, reason="waiting on the CI run")
+        assert kb.get_task(conn, tid).status == "scheduled"
+        assert kb.unblock_task(conn, tid)
+        assert kb.get_task(conn, tid).status == "review", (
+            "a transient park must return the reviewer to review, not to ready"
+        )
+
+
+def test_hand_scheduled_card_does_not_resurrect_a_stale_review_phase(
+    kanban_home: Path,
+) -> None:
+    """The other half of the same gate: reading resume phase for ``scheduled``
+    must not dig a phase out of an event older than the park a human made."""
+    with kbc.connect_closing() as conn:
+        tid = kb.create_task(conn, title="reviewed thing", assignee="builder")
+        impl = kb.claim_task(conn, tid, claimer="builder:test")
+        assert kb.request_review(
+            conn, tid, summary="r", reviewer="reviewer",
+            expected_run_id=impl.current_run_id,
+        )
+        assert kb.claim_review_task(conn, tid) is not None
+        # Block first, so a listed event carrying ``source_status='review'``
+        # exists, THEN let a human park the card on top of it. Reading the
+        # phase for ``scheduled`` must stop at the human's park rather than
+        # digging past it — otherwise the human's "revisit later" silently
+        # becomes "resume the review run".
+        kb.block_task(conn, tid, reason="needs a human", kind="needs_input")
+        assert kb.get_task(conn, tid).status == "blocked"
+        assert kb.schedule_task(conn, tid, reason="human: revisit on Monday")
+        assert kb.unblock_task(conn, tid)
+        assert kb.get_task(conn, tid).status == "ready", (
+            "a hand-made schedule carries no phase; taking one from an event "
+            "the human parked over would be an invention, not a restoration"
+        )

--- a/tests/hermes_cli/test_kanban_block_kinds.py
+++ b/tests/hermes_cli/test_kanban_block_kinds.py
@@ -111,3 +111,127 @@ def test_dependency_then_parent_done_promotes(kanban_home: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+
+
+# ---------------------------------------------------------------------------
+# Transient routing: a wait on time, not on a human
+# ---------------------------------------------------------------------------
+
+
+def _park_transient(conn, tid, reason="waiting on a background job"):
+    assert kb.block_task(conn, tid, reason=reason, kind="transient")
+    return kb.get_task(conn, tid)
+
+
+def test_transient_parks_in_scheduled_not_blocked(kanban_home: Path) -> None:
+    """``transient`` means "may clear on its own" — that is a wait on time,
+    and ``scheduled`` is the column whose whole meaning is exactly that."""
+    with kbc.connect_closing() as conn:
+        tid = _running_task(conn)
+        task = _park_transient(conn, tid)
+        assert task.status == "scheduled"
+        assert task.block_kind == "transient"
+        assert task.block_recurrences == 1
+        kinds = [e.kind for e in kb.list_events(conn, tid)]
+        assert "transient_wait" in kinds
+        assert "blocked" not in kinds, "a transient park is not a human block"
+
+
+def test_transient_park_records_the_run_as_scheduled(kanban_home: Path) -> None:
+    """Attempt history must say "waited", not "stopped for a human"."""
+    with kbc.connect_closing() as conn:
+        tid = _running_task(conn)
+        _park_transient(conn, tid)
+        outcomes = [
+            r["outcome"] for r in conn.execute(
+                "SELECT outcome FROM task_runs WHERE task_id = ? ORDER BY id", (tid,),
+            )
+        ]
+    assert outcomes[-1] == "scheduled"
+
+
+def test_transient_never_reaches_triage(kanban_home: Path) -> None:
+    """The regression this whole branch exists for: a machine wait must never
+    land in ``triage``, the one column nothing promotes out of."""
+    with kbc.connect_closing() as conn:
+        tid = _running_task(conn)
+        seen = []
+        for _ in range(kb.BLOCK_RECURRENCE_LIMIT + 2):
+            seen.append(_park_transient(conn, tid).status)
+            kb.unblock_task(conn, tid)
+            _make_running_again(conn, tid)
+    assert "triage" not in seen, f"transient escalated into triage: {seen}"
+    assert seen[0] == "scheduled", "the first park waits on time"
+    assert seen[1] == "blocked", (
+        "believed twice and flaky twice — hand it to a human, who has a voice"
+    )
+
+
+def test_transient_escalation_emits_a_plain_block_not_a_loop_break(
+    kanban_home: Path,
+) -> None:
+    """The escalated card must look like an ordinary human block, so every
+    consumer that already watches ``blocked`` picks it up unchanged."""
+    with kbc.connect_closing() as conn:
+        tid = _running_task(conn)
+        _park_transient(conn, tid)
+        kb.unblock_task(conn, tid)
+        _make_running_again(conn, tid)
+        _park_transient(conn, tid)
+        kinds = [e.kind for e in kb.list_events(conn, tid)]
+    assert "blocked" in kinds
+    assert "block_loop_detected" not in kinds
+
+
+def test_human_kinds_still_escalate_to_triage(kanban_home: Path) -> None:
+    """Mutation guard: the transient branch must not swallow the loop breaker
+    for the kinds it was built for."""
+    for kind in ("needs_input", "capability", None):
+        with kbc.connect_closing() as conn:
+            tid = _running_task(conn, title=f"k-{kind}")
+            kb.block_task(conn, tid, reason="x", kind=kind)
+            assert kb.get_task(conn, tid).status == "blocked"
+            kb.unblock_task(conn, tid)
+            _make_running_again(conn, tid)
+            kb.block_task(conn, tid, reason="x", kind=kind)
+            assert kb.get_task(conn, tid).status == "triage", (
+                f"{kind!r} must still escalate to triage"
+            )
+
+
+def test_scheduled_transient_comes_back_through_unblock(kanban_home: Path) -> None:
+    """The park is recoverable by the ordinary door, with no special case."""
+    with kbc.connect_closing() as conn:
+        tid = _running_task(conn)
+        _park_transient(conn, tid)
+        assert kb.unblock_task(conn, tid)
+        assert kb.get_task(conn, tid).status == "ready"
+
+
+def test_transient_park_honours_the_expected_run_guard(kanban_home: Path) -> None:
+    """A worker that no longer owns the run must not be able to park the card
+    out from under its successor."""
+    with kbc.connect_closing() as conn:
+        tid = _running_task(conn)
+        live_run = kb.get_task(conn, tid).current_run_id
+        assert not kb.block_task(
+            conn, tid, reason="stale", kind="transient",
+            expected_run_id=(live_run or 0) + 99,
+        )
+        assert kb.get_task(conn, tid).status == "running"
+
+
+def test_transient_park_is_not_confused_with_a_different_prior_kind(
+    kanban_home: Path,
+) -> None:
+    """Recurrences count SAME-cause parks. A transient park after a human
+    block starts the count over, so one flake does not inherit someone else's
+    strike and skip straight to ``blocked``."""
+    with kbc.connect_closing() as conn:
+        tid = _running_task(conn)
+        kb.block_task(conn, tid, reason="need a human", kind="needs_input")
+        kb.unblock_task(conn, tid)
+        _make_running_again(conn, tid)
+        task = _park_transient(conn, tid)
+    assert task.status == "scheduled"
+    assert task.block_recurrences == 1

--- a/tools/kanban_tools_schemas.py
+++ b/tools/kanban_tools_schemas.py
@@ -172,10 +172,13 @@ KANBAN_BLOCK_SCHEMA = _schema(
         "goes to todo and auto-resumes when that task finishes, no human "
         "needed), 'needs_input' (you need a human decision/answer), "
         "'capability' (a hard wall: no access, missing credentials, an action "
-        "no agent can do), or 'transient' (a flaky failure that may clear). "
+        "no agent can do), or 'transient' (a flaky failure, or a wait on "
+        "something already running, that may clear on its own — parks in "
+        "scheduled, no human needed). "
         "``reason`` is shown to the human on the board. If a task keeps "
         "getting unblocked and re-blocked for the same reason, it is "
-        "auto-escalated to triage. Use for genuine blockers only — don't "
+        "auto-escalated to triage (a repeated 'transient' escalates to "
+        "blocked instead). Use for genuine blockers only — don't "
         "block on things you can resolve yourself."
     ),
     {
@@ -190,7 +193,8 @@ KANBAN_BLOCK_SCHEMA = _schema(
             "enum": ["dependency", "needs_input", "capability", "transient"],
             "description": (
                 "Why you're blocked. 'dependency' waits in todo and "
-                "resumes automatically; the others surface to a human. "
+                "'transient' waits in scheduled — both resume without a "
+                "human; 'needs_input'/'capability' surface to a human. "
                 "Omit only if none apply."
             ),
         },


### PR DESCRIPTION
`block_task(kind='transient')` means "this may clear on its own" — a wait on time, not a question only a human can answer. It nevertheless landed in the human `blocked` bucket, and on the second same-cause park the unblock-loop breaker escalated it to `triage`.

`triage` is the wrong destination for a machine wait twice over: nothing promotes a card out of it (`recompute_ready` reads only `todo`/`blocked`), and the one sweep that does read it either hands the card straight back to the worker that just said it is waiting, or — where that sweep filters breaker escalations out — leaves it with no reader at all.

Observed on a live board: a worker parked with an explicit "waiting on a background job, not on a human"; the job finished green ten minutes later; the card and the 21 tasks queued behind it stood still for seven hours until a human happened to look.

## Change

- `transient` routes to `scheduled` (the column whose meaning is exactly "waiting on time"), emitting `transient_wait`; the run is recorded with outcome `scheduled` rather than `blocked`.
- It still counts recurrences, so a forever-flaky card stops being believed — but its escalation target is `blocked`, a column with a voice, never `triage`.
- `needs_input` / `capability` / un-typed blocks are untouched: they still escalate to `triage`, which is what that column is for.
- CLI `--kind` help and the `kanban_block` tool schema updated to match the code.

## Tests

8 new cases in `tests/hermes_cli/test_kanban_block_kinds.py`, including a mutation guard that the new branch has not swallowed the loop breaker for the human kinds. Verified by reverting the fix three ways (branch removed; `scheduled` forever; escalation pointed back at `triage`) — each mutant is caught.

`pytest tests/hermes_cli -k kanban`: 355 passed. The 3 failures in that selection are pre-existing session-pollution failures present on `origin/main` unchanged (they pass in isolation on both).