### PR TITLE
fix(telegram): keep the polling Updater up through a server-side 5xx

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -338,6 +338,17 @@ _INITIAL_POLLING_PROGRESS_TIMEOUT = 60.0
 # ladder always advances toward the fatal-restart escalation. Matches _UPDATER_STOP_TIMEOUT. Refs:
 # NousResearch/hermes-agent#66377
 _DRAIN_TIMEOUT = 15.0
+# Telegram's own edge answers some polling calls with a 5xx (502 "Bad Gateway" in practice) while the local
+# path is healthy: PTB's request wrapper raises ``NetworkError`` carrying the HTTP reason phrase for every
+# status it does not map to BadRequest/Conflict. A 5xx is answered BY Telegram, so it is no evidence that the
+# poll socket or the Updater's lifecycle lock is broken. Give PTB's own retry loop this long to recover
+# before falling back to stop()/restart — the path that wedges when the failed request left the long-poll
+# socket in CLOSE-WAIT and burns the full _UPDATER_STOP_TIMEOUT, turning a few seconds of upstream downtime
+# into a whole-adapter rebuild.
+_SERVER_SIDE_ERROR_GRACE = 120.0
+_SERVER_SIDE_ERROR_MARKERS = (
+    "bad gateway", "service unavailable", "gateway timeout", "internal server error",
+)
 # Wedged-recovery watchdog: healthy worst case is stop + 2x drain + start + 60s backoff ≈ 135s, so
 # 300s in flight is unambiguously stuck and the heartbeat force-escalates.
 # Every recovery path (the reconnect ladder's re-entry, the pending-update probe, PTB's error callback)
@@ -469,6 +480,8 @@ class TelegramAdapter(BasePlatformAdapter):
         self._bot_identity_refresh_task: Optional[asyncio.Task] = None
         self._post_connect_task: Optional[asyncio.Task] = None  # command menu + DM topics, off the connect path
         self._polling_conflict_count = self._polling_network_error_count = self._polling_generation = 0
+        # Monotonic start of the current run of server-side 5xx answers on the polling path (None = not in one).
+        self._server_side_polling_error_since: Optional[float] = None
         self._polling_conflict_recovery_generation: Optional[int] = None
         self._polling_progress_event = asyncio.Event()
         self._polling_progress_accepting = self._polling_teardown_started = False
@@ -1173,6 +1186,24 @@ class TelegramAdapter(BasePlatformAdapter):
                 return True
         return False
 
+    @staticmethod
+    def _looks_like_server_side_error(error: Exception) -> bool:
+        """True when *Telegram* failed the request, not the local transport.
+
+        PTB's request wrapper raises ``NetworkError`` carrying the HTTP reason phrase for every status it
+        does not map to BadRequest/Conflict (``request/_baserequest.py``: 502 → ``NetworkError("Bad
+        Gateway")``). Matching the class name rather than the text alone keeps transport failures —
+        ``NetworkError("httpx.ConnectError: ...")``, ``TimedOut``, and the bare ``Exception("Bad Gateway")``
+        some callers pass on the local-recovery path — out of this branch.
+        """
+        for cur in _iter_exception_graph(error):
+            if cur.__class__.__name__.lower() != "networkerror":
+                continue
+            text = str(cur).lower()
+            if any(marker in text for marker in _SERVER_SIDE_ERROR_MARKERS):
+                return True
+        return False
+
     def _coerce_bool_extra(self, key: str, default: bool = False) -> bool:
         value = self.config.extra.get(key) if getattr(self.config, "extra", None) else None
         if value is None:
@@ -1610,6 +1641,7 @@ class TelegramAdapter(BasePlatformAdapter):
         self._polling_progress_event.set()
         self._polling_last_progress_monotonic = time.monotonic()
         self._polling_network_error_count = 0
+        self._server_side_polling_error_since = None
         if generation == self._polling_conflict_recovery_generation:
             self._polling_conflict_recovery_generation = None
         else:
@@ -1919,14 +1951,35 @@ class TelegramAdapter(BasePlatformAdapter):
         """Reconnect polling after a transient network interruption (NetworkError/TimedOut).
 
         Host connectivity loss (sleep, WiFi switch, VPN) kills the long-poll silently. Exponential back-off (5s→60s
-        cap) up to MAX_NETWORK_RETRIES, then retryable-fatal so the supervisor restarts the gateway."""
+        cap) up to MAX_NETWORK_RETRIES, then retryable-fatal so the supervisor restarts the gateway.
+
+        A server-side 5xx (Telegram answered, "Bad Gateway") is handled separately: it is not evidence that the
+        local poll socket is broken, and PTB's own ``network_retry_loop`` keeps polling through it, so the
+        Updater is only torn down once such a run outlives ``_SERVER_SIDE_ERROR_GRACE``."""
         if self._teardown_started or self.has_fatal_error:
             return
         MAX_NETWORK_RETRIES = 10
         BASE_DELAY = 5
         MAX_DELAY = 60
-        self._polling_network_error_count += 1
         self._send_path_degraded = True
+        if self._looks_like_server_side_error(error):
+            now = asyncio.get_running_loop().time()
+            if self._server_side_polling_error_since is None:
+                self._server_side_polling_error_since = now
+            if now - self._server_side_polling_error_since < _SERVER_SIDE_ERROR_GRACE:
+                # The request reached a Telegram edge that then failed, so stop()/restart would only wait on
+                # the long-poll socket that failure left in CLOSE-WAIT (the wedge that burns the stop
+                # deadline and forces a full adapter rebuild). PTB reconnects on its own; the heartbeat, stall
+                # watchdog and progress verifier still escalate a poll that is genuinely wedged.
+                logger.info(
+                    "[%s] Telegram server-side error on the polling path (attempt %d/%d, %s); leaving the "
+                    "polling retry loop to reconnect without an Updater restart", self.name,
+                    self._polling_network_error_count + 1, MAX_NETWORK_RETRIES,
+                    _redact_telegram_error_text(error))
+                return
+        else:
+            self._server_side_polling_error_since = None
+        self._polling_network_error_count += 1
         attempt = self._polling_network_error_count
         if attempt > MAX_NETWORK_RETRIES:
             message = (

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -1081,3 +1081,94 @@ async def test_drain_rebuild_does_not_block_loop_or_leak_cleanup_task(monkeypatc
         "stale-client cleanup must finish or abandon its own wedged close "
         "without accumulating a background task"
     )
+
+
+# ---------------------------------------------------------------------------
+# Server-side 5xx on the polling path — Telegram answered, so the local socket
+# and the Updater's lifecycle lock are not suspect.
+# ---------------------------------------------------------------------------
+
+
+class NetworkError(Exception):
+    """PTB's class name for a Bot API transport/status error, without importing the optional dep."""
+
+
+class TestServerSideErrorClassifier:
+    def test_bot_api_5xx_reason_phrases_match(self):
+        for text in ("Bad Gateway", "Service Unavailable", "Gateway Timeout", "Internal Server Error"):
+            assert TelegramAdapter._looks_like_server_side_error(NetworkError(text)) is True
+
+    def test_transport_failures_and_untyped_errors_do_not_match(self):
+        # PTB wraps transport errors in NetworkError too ("httpx.ConnectError: ...", "Timed out"), and
+        # callers on the local-recovery path pass bare Exceptions — neither proves Telegram answered.
+        assert TelegramAdapter._looks_like_server_side_error(
+            NetworkError("httpx.ConnectError: All connection attempts failed")
+        ) is False
+        assert TelegramAdapter._looks_like_server_side_error(NetworkError("Timed out")) is False
+        assert TelegramAdapter._looks_like_server_side_error(Exception("Bad Gateway")) is False
+
+    def test_wrapped_5xx_in_cause_graph_matches(self):
+        err = Exception("recovery failed")
+        err.__cause__ = NetworkError("Bad Gateway")
+        assert TelegramAdapter._looks_like_server_side_error(err) is True
+
+
+@pytest.mark.asyncio
+async def test_server_side_5xx_does_not_restart_the_updater():
+    """A 502 from Telegram's edge must not tear the Updater down.
+
+    PTB's ``network_retry_loop`` keeps polling through a 5xx and reconnects on its own. Stopping the
+    Updater here waits on the long-poll socket that failed request left in CLOSE-WAIT, burns
+    ``_UPDATER_STOP_TIMEOUT`` and escalates to a whole-adapter rebuild — turning a few seconds of
+    upstream downtime into ~30s of deaf ingress and two ERROR lines.
+    """
+    adapter = _make_adapter()
+    mock_app, _ = _make_mock_app()
+    adapter._app = mock_app
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await adapter._handle_polling_network_error(NetworkError("Bad Gateway"))
+
+    mock_app.updater.stop.assert_not_awaited()
+    mock_app.updater.start_polling.assert_not_awaited()
+    assert adapter._polling_network_error_count == 0, (
+        "a server-side 5xx must not consume the local restart ladder"
+    )
+    assert adapter._server_side_polling_error_since is not None
+
+
+@pytest.mark.asyncio
+async def test_server_side_5xx_restarts_only_after_the_grace(monkeypatch):
+    """The exemption is bounded: a 5xx run that outlives the grace still escalates."""
+    adapter = _make_adapter()
+    mock_app, _ = _make_mock_app()
+    adapter._app = mock_app
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await adapter._handle_polling_network_error(NetworkError("Bad Gateway"))
+        mock_app.updater.stop.assert_not_awaited()
+
+        monkeypatch.setattr(tg_adapter, "_SERVER_SIDE_ERROR_GRACE", 0.0)
+        await adapter._handle_polling_network_error(NetworkError("Bad Gateway"))
+
+    mock_app.updater.stop.assert_awaited_once()
+    assert adapter._polling_network_error_count == 1
+
+
+@pytest.mark.asyncio
+async def test_transport_error_keeps_the_restart_ladder_and_clears_the_grace():
+    """A transport failure is still treated as a broken local path."""
+    adapter = _make_adapter()
+    mock_app, _ = _make_mock_app()
+    adapter._app = mock_app
+    adapter._server_side_polling_error_since = 123.0  # stale run from an earlier 5xx blip
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await adapter._handle_polling_network_error(
+            NetworkError("httpx.ReadError: connection reset")
+        )
+
+    mock_app.updater.stop.assert_awaited_once()
+    mock_app.updater.start_polling.assert_awaited_once()
+    assert adapter._polling_network_error_count == 1
+    assert adapter._server_side_polling_error_since is None


### PR DESCRIPTION
## What does this PR do?

Keeps the Telegram polling `Updater` alive when **Telegram's edge** answers the long-poll with a 5xx, instead of tearing it down as though the local socket had broken.

`telegram/request/_baserequest.py` raises `NetworkError` carrying the HTTP reason phrase for every status it does not map to `BadRequest`/`Conflict` — a 502 becomes `NetworkError("Bad Gateway")`. PTB's own `network_retry_loop(max_retries=-1, repeat_on_success=True)` keeps polling with backoff and reconnects by itself. Hermes' polling error callback, however, scheduled a full recovery: sleep, then `updater.stop()` under the 15s `_UPDATER_STOP_TIMEOUT`. The long-poll socket the failed request left behind is in CLOSE-WAIT (epoll reports it readable, nothing ever arrives), so `stop()` never returns → `agent.deadline: 'telegram-init' timed out after 15.0s; task abandoned` → retryable-fatal `telegram_network_error` → the supervisor rebuilds the adapter.

Net effect on a live gateway: a few seconds of upstream 5xx became ~26–45s of deaf ingress plus two ERROR lines, once (sometimes twice) a day.

## Related Issue

No existing issue covers this symptom — `gh search issues` for "network-recovery deadline" returns only the unrelated #98228. Happy to file one first if the maintainers prefer that workflow.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/telegram/adapter.py`
  - `_SERVER_SIDE_ERROR_GRACE` (120s) and `_SERVER_SIDE_ERROR_MARKERS` module constants, alongside the other internal safety bounds.
  - `TelegramAdapter._looks_like_server_side_error()` — walks the cause/context graph and matches a `NetworkError` whose text carries a 5xx reason phrase. Matching the class name rather than the text alone keeps transport failures (`NetworkError("httpx.ConnectError: …")`, `TimedOut`) and bare `Exception("Bad Gateway")` out of this branch.
  - `_handle_polling_network_error()` — a 5xx inside the grace returns early with an INFO line and no Updater restart. The run's start time lives in `_server_side_polling_error_since`, cleared on confirmed polling progress or on any transport-class error. Past the grace the normal stop()/restart ladder runs unchanged.
- `tests/gateway/test_telegram_network_reconnect.py` — classifier tests plus the no-restart invariant, bounded-grace escalation, and a transport-path regression.

Escalation is unchanged where it matters: transport failures still stop/restart immediately, a 5xx run longer than the grace still takes the ladder, and the heartbeat probe, stall watchdog and progress verifier still declare a genuinely wedged poll.

## How to Test

Live evidence (Debian 13, gateway under systemd, python-telegram-bot long polling) — the daily event, verbatim:

```
11:10:51 WARNING [Telegram] Telegram network ..., scheduling reconnect: Bad Gateway
11:11:11 ERROR   [Telegram] Telegram updater.stop() did not finish before the network-recovery deadline; rebuilding ...
11:11:11 ERROR   gateway.run: Fatal telegram adapter error (telegram_network_error): ...
11:11:37 INFO    [Telegram] Connected to Telegram (polling mode)
```

26 instances in 14 days; 533 recovery triggers between May and September, 181 of them in the 11:00 hour. With this change the first line is INFO and the three that follow do not happen — polling never stops.

Unit-level:

```bash
scripts/run_tests.sh tests/gateway/test_telegram_network_reconnect.py   # 42 passed
```

The three behaviour tests fail on the base commit (verified by reverting `adapter.py` and re-running the file).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the full `tests/gateway/` suite locally; full-suite run left to CI
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13 (Linux), Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstrings updated in place)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (internal safety bound, not a user knob)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A (asyncio-only, no platform-specific code)
