### PR TITLE
fix(models): a malformed context-length cache no longer breaks agent init

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1035,17 +1035,51 @@ def _get_context_cache_path() -> Path:
     return get_hermes_home() / "context_length_cache.yaml"
 
 
+_CACHE_SHAPE_WARNED = False  # one-shot: a malformed cache must not warn on every resolution
+
+
+def _warn_malformed_context_cache(path: Path, reason: str) -> None:
+    """Warn once per process about an unusable cache file (it is re-read on every resolution)."""
+    global _CACHE_SHAPE_WARNED
+    if _CACHE_SHAPE_WARNED:
+        return
+    _CACHE_SHAPE_WARNED = True
+    logger.warning(
+        "Ignoring malformed context length cache at %s (%s). Delete the file to rebuild it.",
+        path, reason,
+    )
+
+
 def _load_context_cache() -> Dict[str, int]:
-    """Load the model+provider -> context_length cache from disk."""
+    """Load the model+provider -> context_length cache from disk.
+
+    Only a ``str -> int`` mapping is ever returned. The cache is a scratch file that
+    callers treat as ``Dict[str, int]``, so a malformed one used to escape as-is and
+    break agent initialization with ``'str' object has no attribute 'get'`` — and
+    because both writers start from this loader, one bad value was re-persisted on
+    every save instead of healing.
+    """
     path = _get_context_cache_path()
     if not path.exists():
         return {}
     try:
         with open(path, encoding="utf-8") as f:
-            return (yaml.safe_load(f) or {}).get("context_lengths") or {}
+            data = yaml.safe_load(f)
     except Exception as e:
         logger.debug("Failed to load context length cache: %s", e)
         return {}
+    if not isinstance(data, dict):
+        if data is not None:
+            _warn_malformed_context_cache(path, f"top level is {type(data).__name__}, expected a mapping")
+        return {}
+    lengths = data.get("context_lengths")
+    if lengths is None:
+        return {}
+    if not isinstance(lengths, dict):
+        _warn_malformed_context_cache(
+            path, f"'context_lengths' is {type(lengths).__name__} ({lengths!r}), expected a mapping")
+        return {}
+    return lengths
 
 
 def _write_context_cache(cache: Dict[str, int]) -> None:

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1547,6 +1547,53 @@ class TestContextLengthCache:
 
 
 
+    def test_scalar_context_lengths_value_is_ignored(self, tmp_path, monkeypatch):
+        """A ``context_lengths`` value that is not a mapping must load as an empty
+        cache instead of escaping as-is: every caller does ``cache.get(...)``, and
+        both writers re-persist what they loaded, so one bad value (hand edit, or a
+        write that stored the model name instead of the mapping) poisoned the file
+        permanently and killed agent init with
+        ``'str' object has no attribute 'get'``."""
+        import agent.model_metadata as mm
+        cache_file = tmp_path / "cache.yaml"
+        cache_file.write_text("context_lengths: deepseek-flash\n", encoding="utf-8")
+        monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_file)
+        monkeypatch.setattr(mm, "_CACHE_SHAPE_WARNED", False, raising=False)
+
+        assert mm._load_context_cache() == {}
+        # The exact call that died in the field (agent init → context compressor).
+        assert get_cached_context_length("deepseek-flash", "https://api.deepseek.com/v1") is None
+        # A later save must repair the file, not re-persist the poison.
+        save_context_length("deepseek-flash", "https://api.deepseek.com/v1", 1_000_000)
+        assert get_cached_context_length("deepseek-flash", "https://api.deepseek.com/v1") == 1_000_000
+        assert yaml.safe_load(cache_file.read_text(encoding="utf-8")) == {
+            "context_lengths": {"deepseek-flash@https://api.deepseek.com/v1": 1_000_000}
+        }
+
+    @pytest.mark.parametrize("payload", ["just-a-string", "42", "- a\n- b\n"])
+    def test_non_mapping_cache_file_is_ignored(self, payload, tmp_path, monkeypatch):
+        """A top-level YAML value that is not a mapping loads as an empty cache."""
+        import agent.model_metadata as mm
+        cache_file = tmp_path / "cache.yaml"
+        cache_file.write_text(payload, encoding="utf-8")
+        monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_file)
+        monkeypatch.setattr(mm, "_CACHE_SHAPE_WARNED", False, raising=False)
+
+        assert mm._load_context_cache() == {}
+        assert get_cached_context_length("m", "http://x") is None
+
+    def test_mapping_cache_file_still_loads(self, tmp_path, monkeypatch):
+        """The shape guard must not change behaviour for a healthy cache."""
+        import agent.model_metadata as mm
+        cache_file = tmp_path / "cache.yaml"
+        cache_file.write_text(
+            "context_lengths:\n  m@http://x: 32768\n  other@http://y: 128000\n", encoding="utf-8"
+        )
+        monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_file)
+
+        assert mm._load_context_cache() == {"m@http://x": 32768, "other@http://y": 128000}
+        assert get_cached_context_length("m", "http://x") == 32768
+
     def test_idempotent_save(self, tmp_path):
         cache_file = tmp_path / "cache.yaml"
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):


### PR DESCRIPTION
## Symptom

A single malformed context-length cache entry made **every** agent fail to initialize, with an error that points nowhere near the cache:

```
File "agent/model_metadata.py", line 1085, in get_cached_context_length
    return next((hit for hit in map(cache.get, (key, f"{model}@{base_url}", f"{key}/")) if hit is not None), None)
AttributeError: 'str' object has no attribute 'get'
```

On the desktop app this surfaced as a generic `Local runtime error` banner; the background memory/skill review reported `Auxiliary background review failed: 'str' object has no attribute 'get'`. No session could start.

## Root cause

`_load_context_cache()` returned whatever `context_lengths` held:

```python
return (yaml.safe_load(f) or {}).get("context_lengths") or {}
```

The cache file in the field contained a bare scalar

```yaml
context_lengths: deepseek-flash
```

instead of the expected `model@base_url -> tokens` mapping. The loader has no `isinstance` guard, so it handed a `str` to callers that treat the result as `Dict[str, int]` — `get_cached_context_length` does `cache.get(...)`, which is the line above.

It could not self-heal. Both writers seed from the same loader and re-persist what they loaded:

- `save_context_length()` → `cache = _load_context_cache()` … `_write_context_cache(cache)`
- `_invalidate_cached_context_length()` → same shape

So one bad value (a stray write, an interrupted tool, a hand edit) was written back on every subsequent save. The install stayed broken until the file was deleted by hand.

## Repro

```bash
printf 'context_lengths: deepseek-flash\n' > "$HERMES_HOME/context_length_cache.yaml"
hermes chat -q "hi"     # → Failed to initialize agent: 'str' object has no attribute 'get'
```

## Fix

`_load_context_cache()` now returns a mapping or `{}` — never a non-mapping value:

- non-mapping top level → `{}` (a bare `str`/`int`/`list` file; previously only covered by the loader's broad `except`)
- missing/`None` `context_lengths` → `{}` (unchanged behaviour)
- non-mapping `context_lengths` → `{}`, with a **once-per-process** warning naming the file and the unexpected type (the file is re-read on every resolution, so warning per call would spam the log)

The warning matters for diagnosability: the reason this took so long to find is that the failure surfaced three call frames away from the bad data.

Not changed: entry *values* are left alone. `TestContextLengthCache.test_non_positive_cached_entry_dropped_and_reresolved` asserts a cached `0` is returned by `get_cached_context_length` so step 1 can invalidate and re-resolve it — that behaviour is deliberate and preserved.

## Tests

Three cases in `tests/agent/test_model_metadata.py::TestContextLengthCache`:

- `test_scalar_context_lengths_value_is_ignored` — the field repro, including the assertion that a later `save_context_length()` **repairs** the file rather than re-persisting the poison
- `test_non_mapping_cache_file_is_ignored` — parametrized over `str` / `int` / `list` top levels
- `test_mapping_cache_file_still_loads` — the guard is behaviour-neutral for a healthy cache

Verified against the unpatched loader (test fails with `assert 'deepseek-flash' == {}`) and with the fix:

```
tests/agent/test_model_metadata.py tests/agent/test_probe_cache_followups.py tests/run_agent/test_moa_loop_mode.py
=== 3 files, 170 tests passed, 0 failed ===
```
