### PR TITLE
fix(skills): external_dirs distinct provenance and read-only guard (#108032)

### DIFF
--- a/agent/learning_graph.py
+++ b/agent/learning_graph.py
@@ -85,6 +85,16 @@ def build_skill_nodes(skill_roots: list[tuple[str, Path]]) -> dict[str, SkillNod
         for skill_md in root.rglob("SKILL.md") if root.exists() else ():
             if _SKIP_PARTS.intersection(skill_md.parts):
                 continue
+            # External mounts are shared standards, not learned sediment —
+            # exclude them from the starmap/journey growth visualization
+            # (#108032). Check before reading so a large external checkout does
+            # not pay parse cost.
+            try:
+                from agent.skill_utils import is_external_dir_skill_path
+                if is_external_dir_skill_path(skill_md):
+                    continue
+            except Exception:
+                pass
             try:
                 text = skill_md.read_text(encoding="utf-8")[:4000]
             except OSError:

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -618,6 +618,41 @@ def is_external_skill_path(path) -> bool:
     return any(candidate.is_relative_to(_resolve_for_skill_ownership(root)) for root in roots)
 
 
+def is_external_dir_skill_path(path) -> bool:
+    """True when ``path`` lives under ``skills.external_dirs`` (not project).
+
+    Narrower than :func:`is_external_skill_path` which also covers trusted
+    project dirs. Used for the foreground write guard and ``external``
+    provenance: only external_dirs are the user-declared shared roots that
+    must default to read-only (#108032).
+    """
+    if path is None:
+        return False
+    candidate = _resolve_for_skill_ownership(path)
+    for root in get_external_skills_dirs():
+        try:
+            if candidate.is_relative_to(_resolve_for_skill_ownership(root)):
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def is_external_dirs_writes_allowed() -> bool:
+    """True when ``skills.external_dirs_allow_mutations`` opts into foreground edits."""
+    cfg = _skills_cfg()
+    if not isinstance(cfg, dict):
+        return False
+    # Canonical key per #108032; also honour the shorter alias.
+    for key in ("external_dirs_allow_mutations", "allow_external_edits", "allow_external_mutations"):
+        val = cfg.get(key)
+        if isinstance(val, bool):
+            return val
+        if isinstance(val, str) and val.strip().lower() in ("true", "1", "yes", "on"):
+            return True
+    return False
+
+
 def _hermes_metadata(frontmatter: Dict[str, Any]) -> Dict[str, Any]:
     """``metadata.hermes`` mapping from frontmatter, or ``{}`` when malformed."""
     metadata = frontmatter.get("metadata")

--- a/apps/desktop/src/app/skills/index.tsx
+++ b/apps/desktop/src/app/skills/index.tsx
@@ -137,6 +137,11 @@ function skillSubtitle(skill: SkillInfo): React.ReactNode {
           hub
         </Badge>
       )}
+      {provenance === 'external' && (
+        <Badge className="shrink-0 normal-case" variant="muted">
+          external
+        </Badge>
+      )}
     </>
   )
 }
@@ -1193,8 +1198,8 @@ function SkillDetail({
   skill: SkillInfo
 }) {
   const { t } = useI18n()
-  // Only learned/local skills are the user's to rewrite or archive — bundled
-  // and hub skills are managed by their sources.
+  // Only learned/local skills are the user's to rewrite or archive — bundled,
+  // hub and external (shared mount) skills are managed by their sources.
   const editable = skill.provenance === 'agent'
 
   // The FULL skill — frontmatter metadata + complete SKILL.md body — for any

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1614,7 +1614,8 @@ export const en: Translations = {
     provenance: {
       agent: 'Learned',
       bundled: 'Built-in',
-      hub: 'Hub'
+      hub: 'Hub',
+      external: 'External'
     },
     emptyNoneFound: noun => `No ${noun} found`,
     emptyNothingMatches: query => `Nothing matches “${query}”.`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -267,6 +267,7 @@ export const ja = defineLocale({
     handoffLead: '続きは次の場所で:',
     links: {
       github: 'GitHub Issues',
+      external: 'External',
       portal: 'Nous Portal サポート',
       discord: 'Discord'
     }
@@ -1456,7 +1457,8 @@ export const ja = defineLocale({
     provenance: {
       agent: '学習済み',
       bundled: '組み込み',
-      hub: 'ハブ'
+      hub: 'ハブ',
+      external: 'External'
     },
     emptyNoneFound: noun => `${noun} が見つかりません`,
     emptyNothingMatches: query => `「${query}」に一致するものはありません。`,

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -1557,7 +1557,8 @@ export const ru = defineLocale({
     provenance: {
       agent: 'Научен',
       bundled: 'Встроенный',
-      hub: 'Хаб'
+      hub: 'Хаб',
+      external: 'External'
     },
     emptyNoneFound: noun => `Не найдено: ${noun}`,
     emptyNothingMatches: query => `Ничего не подходит под «${query}».`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1421,7 +1421,7 @@ export interface Translations {
     bulkUpdated: (count: number) => string
     bulkNoChange: string
     usageCount: (count: number | string) => string
-    provenance: Record<'agent' | 'bundled' | 'hub', string>
+    provenance: Record<'agent' | 'bundled' | 'hub' | 'external', string>
     emptyNoneFound: (noun: string) => string
     emptyNothingMatches: (query: string) => string
     emptyNoneAvailable: (noun: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -258,6 +258,7 @@ export const zhHant = defineLocale({
     handoffLead: '在以下位置繼續討論:',
     links: {
       github: 'GitHub Issues',
+      external: 'External',
       portal: 'Nous Portal 支援',
       discord: 'Discord'
     }
@@ -1399,7 +1400,8 @@ export const zhHant = defineLocale({
     provenance: {
       agent: '已學習',
       bundled: '內建',
-      hub: '技能中心'
+      hub: '技能中心',
+      external: 'External'
     },
     emptyNoneFound: noun => `找不到${noun}`,
     emptyNothingMatches: query => `沒有符合「${query}」的內容。`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -292,6 +292,7 @@ export const zh: Translations = {
     handoffLead: '在以下位置继续讨论:',
     links: {
       github: 'GitHub Issues',
+      external: 'External',
       portal: 'Nous Portal 支持',
       discord: 'Discord'
     }
@@ -1793,7 +1794,8 @@ export const zh: Translations = {
     provenance: {
       agent: '习得',
       bundled: '内置',
-      hub: '技能中心'
+      hub: '技能中心',
+      external: 'External'
     },
     emptyNoneFound: noun => `未找到${noun}`,
     emptyNothingMatches: query => `没有匹配“${query}”的内容。`,

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1125,8 +1125,8 @@ export interface SkillInfo {
   name: string
   /** Total observed activity (use + view + patch). Absent on older backends. */
   usage?: number
-  /** 'agent' = learned/local (editable), 'bundled' = ships with Hermes, 'hub' = installed. */
-  provenance?: 'agent' | 'bundled' | 'hub'
+  /** 'agent' = learned/local (editable), 'bundled' = ships with Hermes, 'hub' = installed, 'external' = shared mount (read-only). */
+  provenance?: 'agent' | 'bundled' | 'hub' | 'external'
 }
 
 /** One entry of the built-in optional-skills catalog (optional-skills/ in the

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1337,6 +1337,10 @@ DEFAULT_CONFIG = {
     # and resolved; read-only — creation goes to ~/.hermes/skills/ unless create_dir redirects it.
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        # Foreground skill_manage edits to skills.external_dirs are refused by
+        # default; set true to allow in-place mutations of those externally
+        # owned roots (#108032).
+        "external_dirs_allow_mutations": False,
         # Where skill_manage-created skills go (empty = profile-local dir). When set, new skills
         # land here AND agent-facing instructions name this path; expanded (~, ${VAR}), relative to
         # HERMES_HOME, scanned alongside the local dir.

--- a/hermes_cli/web_routers/skills.py
+++ b/hermes_cli/web_routers/skills.py
@@ -354,17 +354,32 @@ async def get_skills(profile: Optional[str] = None):
             skills = _find_all_skills(skip_disabled=True)
             usage = load_usage()
             # Set-based provenance (same classification as skill_usage.provenance,
-            # without a per-skill manifest read): hub > bundled > agent, where
-            # "agent" covers agent-authored AND local hand-made skills — the ones
-            # the user may edit/delete from the UI.
+            # without a per-skill manifest read): hub > bundled > external > agent,
+            # where "agent" covers agent-authored AND local hand-made skills — the
+            # ones the user may edit/delete from the UI. "external" is the distinct
+            # shared-mount provenance (#108032).
             bundled_names = _read_bundled_manifest_names()
             hub_names = _read_hub_installed_names()
+            try:
+                from tools.skill_usage import _find_external_skill_dir
+                from agent.skill_utils import is_external_dir_skill_path
+                from tools.skill_manager_tool import _find_skill as _locate_skill
+
+                def _is_external(name: str) -> bool:
+                    if _find_external_skill_dir(name) is not None:
+                        return True
+                    found = _locate_skill(name)
+                    return found is not None and is_external_dir_skill_path(found["path"])
+            except Exception:
+                def _is_external(name: str) -> bool:  # type: ignore[no-redef]
+                    return False
         for s in skills:
             s["enabled"] = s["name"] not in disabled
             s["usage"] = activity_count(usage.get(s["name"], {}))
             s["provenance"] = (
                 "hub" if s["name"] in hub_names
                 else "bundled" if s["name"] in bundled_names
+                else "external" if _is_external(s["name"])
                 else "agent")
         return skills
 

--- a/tools/skill_manager_guards.py
+++ b/tools/skill_manager_guards.py
@@ -310,3 +310,32 @@ def _org_mirror_write_guard(name: str, skill_path: Path, action: str) -> Optiona
     except Exception:
         logger.debug("org mirror guard lookup failed for %s", name, exc_info=True)
     return None
+
+
+def _external_dir_write_guard(name: str, skill_path: Path, action: str) -> Optional[Dict[str, Any]]:
+    """Foreground + background guard for ``skills.external_dirs``.
+
+    Those roots are externally owned (team mounts, ``~/.agents/skills``). By
+    default they are read-only to ``skill_manage`` — including foreground
+    turns — so a hallucinated patch cannot corrupt a shared git checkout
+    (#108032). Opt in with ``skills.external_dirs_allow_mutations: true``.
+    """
+    if action not in {"edit", "patch", "delete", "write_file", "remove_file"}:
+        return None
+    try:
+        from agent.skill_utils import is_external_dir_skill_path, is_external_dirs_writes_allowed
+        if is_external_dirs_writes_allowed():
+            return None
+        if is_external_dir_skill_path(skill_path):
+            from hermes_constants import display_hermes_home
+            hint_dir = f"{display_hermes_home()}/skills/"
+            return _refusal(
+                f"Skill '{name}' lives in skills.external_dirs, which are read-only to "
+                f"skill_manage by default (external_dirs_allow_mutations is off). "
+                f"Refusing {action}. To iterate on it, copy it locally first "
+                f"(e.g. copy the directory into {hint_dir}) and edit the copy, or set "
+                f"skills.external_dirs_allow_mutations: true in config.yaml to allow "
+                f"in-place external edits.")
+    except Exception:
+        logger.debug("external dir guard lookup failed for %s", name, exc_info=True)
+    return None

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -29,8 +29,9 @@ from agent.skill_utils import (
     SKILL_PROMPT_DESC_LIMIT)
 from tools.skill_manager_guards import (
     _background_review_preflight, _background_review_read_before_write_guard, _background_review_write_guard,
-    _containing_skills_root, _curator_consolidation_delete_guard, _maybe_auto_propose_org_edit,
-    _org_mirror_write_guard, _pinned_guard, _validate_delete_target, _is_background_review, _refusal as _err)
+    _containing_skills_root, _curator_consolidation_delete_guard, _external_dir_write_guard,
+    _maybe_auto_propose_org_edit, _org_mirror_write_guard, _pinned_guard, _validate_delete_target,
+    _is_background_review, _refusal as _err)
 from tools.skill_manager_batch import _skill_manage_batch
 from tools.skills_guard import scan_skill, should_allow_install, format_scan_report
 
@@ -326,6 +327,7 @@ def _locate_for_write(name: str, action: str, not_found_suffix: str = "", *,
         return None, _err(_skill_not_found_error(name, not_found_suffix))
     skill_dir = existing["path"]
     guard = ((org_guard and _org_mirror_write_guard(name, skill_dir, action))
+             or _external_dir_write_guard(name, skill_dir, action)
              or _background_review_write_guard(name, skill_dir, action))
     return (None, guard) if guard else (skill_dir, None)
 

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -666,8 +666,29 @@ def curated_report() -> List[Dict[str, Any]]:
 
 
 def provenance(skill_name: str) -> str:
-    """'hub' | 'bundled' | 'agent' (the latter also covers local manually-authored skills)."""
-    return "hub" if is_hub_installed(skill_name) else "bundled" if is_bundled(skill_name) else "agent"
+    """'hub' | 'bundled' | 'external' | 'agent'.
+
+    ``external`` is the distinct provenance for skills that live under
+    ``skills.external_dirs`` (shared/team mounts). They are not agent-learned
+    sediment and must not render as ``learned`` or count toward the starmap
+    (#108032).
+    """
+    if is_hub_installed(skill_name):
+        return "hub"
+    if is_bundled(skill_name):
+        return "bundled"
+    # External dirs are the narrow check: project skills are a separate tier
+    # with their own precedence and trust gate, not the shared external mounts.
+    try:
+        from agent.skill_utils import is_external_dir_skill_path
+        if _find_external_skill_dir(skill_name) is not None:
+            return "external"
+        local_dir = _find_skill_dir(skill_name)
+        if local_dir is not None and is_external_dir_skill_path(local_dir):
+            return "external"
+    except Exception:
+        pass
+    return "agent"
 
 
 def usage_report() -> List[Dict[str, Any]]:


### PR DESCRIPTION
Fixes #108032.

**Provenance** — skills under `skills.external_dirs` (e.g. `~/.agents/skills`) were collapsed to `provenance='agent'`, so Desktop badged them `learned` (`习得`) and the starmap/journey counted shared team mounts as self-improved sediment. Now they report `external` in `skill_usage.provenance()` and `/api/skills`, render as an `external` badge, are non-editable in Desktop, and are excluded from the learning-graph starmap.

**Write guard (security)** — background curator was already blocked, but foreground `skill_manage` (`patch`/`edit`/`write_file`/`remove_file`/`delete`) mutated external checkouts in place with no permission check. Now `skill_manage` refuses in-place external mutations by default, with a local-copy hint. Opt in with `skills.external_dirs_allow_mutations: true` (also honours `allow_external_edits` / `allow_external_mutations` aliases).

**Tests**: `tests/tools/test_skill_usage.py`, `tests/agent/test_skill_utils.py`, `tests/tools/test_skill_manager_tool.py`, `tests/agent/test_learning_graph.py` — all green; manual verification of external provenance and read-only refusal with/without the opt-in.