### PR TITLE
fix(aux): honor model.default_headers on Kimi /coding aux clients; exact-path /coding URL detection

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -302,6 +302,22 @@ def _attribution_headers() -> Dict[str, str]:
     }
 
 
+def _user_model_default_headers() -> Dict[str, str]:
+    """User ``model.default_headers`` from config.yaml (``{}`` when unset or unreadable).
+
+    Anthropic-wire clients never see the provider-profile headers the OpenAI-wire paths merge,
+    so a user override (e.g. a User-Agent a gateway requires for client attribution) must be
+    merged at build time. Read-only config load; header values are never logged."""
+    try:
+        from hermes_cli.config import cfg_get, load_config_readonly
+        user_headers = cfg_get(load_config_readonly(), "model", "default_headers")
+    except Exception:
+        return {}
+    if not isinstance(user_headers, dict):
+        return {}
+    return {str(k): str(v) for k, v in user_headers.items() if v is not None}
+
+
 def _client_timeout(timeout):
     """httpx.Timeout with the caller's read timeout (default 900s) and a 10s connect."""
     from httpx import Timeout
@@ -400,7 +416,8 @@ def build_anthropic_client(api_key, base_url: str = None, timeout: float = None,
     kwargs["auth_token" if style in ("bearer", "oauth") else "api_key"] = api_key
     headers = _beta_header(common_betas + _OAUTH_ONLY_BETAS if style == "oauth" else common_betas)
     if style == "kimi":
-        headers = {**_attribution_headers(), **headers}
+        # User model.default_headers win over attribution, as on the OpenAI-wire paths.
+        headers = {**_attribution_headers(), **headers, **_user_model_default_headers()}
     elif style == "oauth":
         headers["user-agent"] = f"claude-code/{_get_claude_code_version()} (external, cli)"
         headers["x-app"] = "cli"

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1792,16 +1792,19 @@ class AsyncBedrockAuxiliaryClient(_AsyncAuxiliaryClientBase):
 def _endpoint_speaks_anthropic_messages(base_url: str) -> bool:
     """True if ``base_url`` speaks Anthropic Messages, not OpenAI chat.completions.
 
-    Mirrors ``hermes_cli.runtime_provider._detect_api_mode_for_url`` so aux and main agree: any
-    ``/anthropic`` URL (MiniMax, Zhipu, LiteLLM), ``api.kimi.com/coding`` (chat 404s), ``api.anthropic.com``.
+    Any ``/anthropic`` URL (MiniMax, Zhipu, LiteLLM), ``api.anthropic.com``, and Kimi Coding
+    Plan's bare ``/coding`` path (its /chat/completions 404s — #77256). The ``/coding/v1``
+    subpath is Kimi's OpenAI-compatible mount and must stay on chat.completions, so the kimi
+    match is the exact ``/coding`` path (trailing slash tolerated), never a substring.
     """
     normalized = (base_url or "").strip().lower().rstrip("/")
     if not normalized:
         return False
-    if urlparse(normalized).path.rstrip("/").endswith(("/anthropic", "/anthropic/v1")):
+    path = urlparse(normalized).path.rstrip("/")
+    if path.endswith(("/anthropic", "/anthropic/v1")):
         return True
     hostname = base_url_hostname(normalized)
-    return hostname == "api.anthropic.com" or bool(hostname == "api.kimi.com" and "/coding" in normalized)
+    return hostname == "api.anthropic.com" or (hostname == "api.kimi.com" and path == "/coding")
 
 
 def _maybe_wrap_anthropic(

--- a/tests/agent/test_anthropic_kimi_default_headers.py
+++ b/tests/agent/test_anthropic_kimi_default_headers.py
@@ -1,0 +1,60 @@
+"""User ``model.default_headers`` must reach Kimi /coding Anthropic-wire clients.
+
+The OpenAI-wire client builders merge ``model.default_headers`` (main agent and
+auxiliary alike), but the Anthropic-wire ``build_anthropic_client`` never saw the
+profile, so the kimi branch sent only the built-in attribution headers and any
+user override — e.g. a custom ``User-Agent`` an endpoint requires for client
+attribution — was silently dropped on title/compression/vision aux calls.
+"""
+
+import pytest
+
+from agent.anthropic_adapter import build_anthropic_client
+
+KIMI_CODING_URL = "https://api.kimi.com/coding"
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    """Redirect HERMES_HOME so config loads read our test config.yaml."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    (hermes_home / "config.yaml").write_text("model:\n  default: test-model\n")
+
+
+def _write_config(tmp_path, config_dict):
+    import yaml
+    (tmp_path / ".hermes" / "config.yaml").write_text(yaml.dump(config_dict))
+
+
+def _wire_headers(client) -> dict:
+    """Headers the SDK would put on a /v1/messages POST."""
+    from anthropic._models import FinalRequestOptions
+
+    return dict(client._build_headers(FinalRequestOptions(method="post", url="/v1/messages", json_data={})))
+
+
+def test_kimi_client_merges_user_default_headers(tmp_path):
+    """User headers reach the wire and win over built-in attribution."""
+    pytest.importorskip("anthropic")
+    _write_config(tmp_path, {
+        "model": {
+            "default": "m",
+            "default_headers": {"User-Agent": "user-ua/1.0", "X-Extra": "1", "X-Drop": None},
+        },
+    })
+    client = build_anthropic_client("sk-test", base_url=KIMI_CODING_URL)
+    headers = _wire_headers(client)
+    assert headers.get("user-agent") == "user-ua/1.0"  # user wins over attribution
+    assert headers.get("x-extra") == "1"
+    assert "x-drop" not in headers  # None values skipped
+
+
+def test_kimi_client_without_config_keeps_attribution(tmp_path):
+    """No configured default_headers: behavior unchanged (attribution UA only)."""
+    pytest.importorskip("anthropic")
+    client = build_anthropic_client("sk-test", base_url=KIMI_CODING_URL)
+    headers = _wire_headers(client)
+    assert headers.get("user-agent", "").startswith("HermesAgent/")
+    assert headers.get("x-title") == "Hermes Agent"

--- a/tests/agent/test_auxiliary_transport_autodetect.py
+++ b/tests/agent/test_auxiliary_transport_autodetect.py
@@ -34,8 +34,10 @@ def _clean_env(monkeypatch):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("url,expected,label", [
-    ("https://api.kimi.com/coding/v1", True, "Kimi Coding Plan /v1"),
-    ("https://api.kimi.com/coding", True, "Kimi Coding Plan no /v1"),
+    ("https://api.kimi.com/coding", True, "Kimi Coding Plan bare /coding"),
+    ("https://api.kimi.com/coding/", True, "Kimi Coding Plan trailing slash"),
+    ("https://api.kimi.com/coding/v1", False, "Kimi Coding Plan OpenAI-compatible /coding/v1"),
+    ("https://api.kimi.com/coding/v1/", False, "Kimi /coding/v1 trailing slash"),
     ("https://api.moonshot.ai/v1", False, "Moonshot legacy"),
     ("https://api.minimax.io/anthropic", True, "MiniMax /anthropic"),
     ("https://litellm.example.com/v1/anthropic", True, "/anthropic suffix"),


### PR DESCRIPTION
## Symptoms

On Kimi Coding Plan endpoints, auxiliary (side-LLM: title generation, compression, vision, session_search) requests are built on the wrong wire and/or with the wrong headers:

1. **URL misdetection.** `_endpoint_speaks_anthropic_messages()` matches `"/coding"` as a bare substring, so `https://api.kimi.com/coding/v1` — Kimi's OpenAI-compatible mount — is misclassified as Anthropic Messages. Aux clients for that base URL get wrapped in `AnthropicAuxiliaryClient` and POST `/v1/messages` to a chat-completions endpoint.
2. **Dropped user headers.** `build_anthropic_client()`'s kimi branch builds headers from `_attribution_headers()` only. User `model.default_headers` — merged by every OpenAI-wire path, main (#40033) and aux (`_apply_user_default_headers`) alike — are silently discarded on the Anthropic wire. Users who rely on a custom `User-Agent` for client attribution on the /coding endpoint get the built-in UA instead, on aux calls only.

## Reproduction

```python
from agent.auxiliary_client import _endpoint_speaks_anthropic_messages
_endpoint_speaks_anthropic_messages("https://api.kimi.com/coding/v1")  # True (wrong: OpenAI mount)

# config.yaml: model.default_headers: {User-Agent: custom-ua/1.0, X-Custom: hello}
from agent.anthropic_adapter import build_anthropic_client
c = build_anthropic_client("sk-test", base_url="https://api.kimi.com/coding")
# wire headers: user-agent == "HermesAgent/<ver>", x-custom absent (user config dropped)
```

## Root cause

- `agent/auxiliary_client.py:1804` — `bool(hostname == "api.kimi.com" and "/coding" in normalized)`: substring test also matches `/coding/v1`.
- `agent/anthropic_adapter.py:402-403` — kimi style does `headers = {**_attribution_headers(), **headers}` and never merges user `model.default_headers`; unlike the OpenAI-wire builders this route never sees the provider profile.

## Fix

- `_endpoint_speaks_anthropic_messages`: match the exact `/coding` path (trailing slash tolerated) instead of a substring. `/coding` → True, `/coding/v1` → False, `/coding/v1/` → False; `/anthropic`, MiniMax/ZAI/LiteLLM suffixes, and `api.anthropic.com` are unchanged.
- `build_anthropic_client` kimi branch: merge `model.default_headers` (read via `load_config_readonly()`, user values win, `None` values skipped). No signature change; with no configured headers the behavior is byte-identical to before.

## Scope note

The main-line detectors `hermes_cli/runtime_provider.py::_detect_api_mode_for_url` and `hermes_cli/providers.py::host_mandated_api_mode` carry the same `/coding` substring. They are intentionally untouched here to keep this PR minimal (the existing fallback test `test_kimi_coding_hint_uses_the_messages_wire` pins their current behavior); happy to follow up if wanted.

## Tests

- `tests/agent/test_auxiliary_transport_autodetect.py`: corrected the `/coding/v1` row (now False) and added trailing-slash rows both ways (`/coding/` → True, `/coding/v1/` → False).
- `tests/agent/test_anthropic_kimi_default_headers.py` (new): user `default_headers` reach the wire and win over attribution; without config the client keeps attribution-only headers.

`scripts/run_tests.sh` on both files plus 16 adjacent suites (aux client, anthropic adapter/auth, fallback api_mode, attribution headers): all green. The 7 async failures in `test_auxiliary_client.py`/`test_auxiliary_relay.py` are a pre-existing local-env artifact (pytest-asyncio absent); verified identical on unpatched main.
