### PR TITLE
fix(cron): drop fire-fence lock from heartbeat_fire_claim to break AB-BA deadlock (#106737)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2781,13 +2781,19 @@ def _sweep_completed_oneshots(
 
 
 def heartbeat_fire_claim(job_id: str, *, expected_owner: str) -> bool:
-    with _fire_job_lock(job_id) as acquired:
-        if not acquired:
-            return False
-        return _heartbeat_fire_claim_locked(
-            job_id,
-            expected_owner=expected_owner,
-        )
+    """Refresh an active ``fire_claim`` without extending another owner's lease.
+
+    This is a pure metadata timestamp update (no external side effects), so it
+    does NOT need the fire fence lock.  Holding ``_fire_job_lock`` here while
+    inside it acquiring ``_jobs_lock`` inverted the lock order relative to
+    ``mark_job_run`` (which takes ``_fire_job_lock`` while already holding
+    ``_jobs_lock`` via the gateway tick), causing a deadlock when the global
+    jobs-file flock was contended (#106737).
+    """
+    return _heartbeat_fire_claim_locked(
+        job_id,
+        expected_owner=expected_owner,
+    )
 
 
 def _heartbeat_fire_claim_locked(job_id: str, *, expected_owner: str) -> bool:


### PR DESCRIPTION
## Problem

`heartbeat_fire_claim()` acquires the per-job `_fire_job_lock` (fire fence) and then calls `_heartbeat_fire_claim_locked()` which acquires `_jobs_lock()`. Lock order: fire_fence → jobs_lock.

`mark_job_run()` — called from the gateway tick loop — also acquires `_fire_job_lock` but via a code path where `_jobs_lock` is already held upstream. Lock order: jobs_lock → fire_fence.

When the cross-process `.jobs.lock` flock is contended, the two paths deadlock:
- heartbeat holds fire_fence, waits for jobs_lock
- gateway tick holds jobs_lock, mark_job_run waits for fire_fence

Result: mark_job_run times out acquiring the fire fence → records a false `failed` status for a completed job.

## Fix

`heartbeat_fire_claim` is a pure timestamp refresh (no external side effects like delivery or network I/O). It does not need the fire fence lock at all — same pattern as `heartbeat_run_claim()` which already uses `_with_job()` directly.

Drop the `_fire_job_lock` wrapper from `heartbeat_fire_claim`, eliminating the inverted lock order entirely.

## Testing

- All existing cron tests pass
- The fix mirrors `heartbeat_run_claim()` which has been running lock-fence-free since its introduction

Fixes #106737