### PR TITLE
fix(gateway): re-check provider config when setup.status's cached record says false

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -9002,6 +9002,26 @@ def test_setup_status_answers_from_the_bootstrap_record_once_it_exists(monkeypat
         fb.reset_for_tests()
 
 
+def test_setup_status_rechecks_a_false_bootstrap_record(monkeypatch):
+    """A boot-time record cached before ``config.yaml`` finished loading can wrongly say
+    ``provider_configured=False`` forever (the free-tier bootstrap runs on a background thread and
+    can race config load). A live probe that now finds a configured provider must override that
+    stale negative rather than being trusted permanently."""
+    from hermes_cli import free_tier_bootstrap as fb
+    fb.reset_for_tests()
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda **_kw: True)
+    with fb._lock:
+        fb._started = True
+        fb._record = fb.SetupRecord(provider_configured=False, inference_provider="", free_tier=False,
+                                    has_identity=False, other_providers=False)
+        fb._done.set()
+    try:
+        resp = server.handle_request({"id": "1", "method": "setup.status", "params": {}})
+        assert resp["result"]["provider_configured"] is True
+    finally:
+        fb.reset_for_tests()
+
+
 def test_probe_credentials_emits_exact_empty_key_warning():
     agent = types.SimpleNamespace(api_key="", provider="openrouter")
 

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -272,6 +272,10 @@ def _(rid, params: dict) -> dict:
     the call blocks up to ``SETUP_READY_WAIT_SECONDS`` for it, so a client's first poll lands after
     the free-tier identity exists (or has been refused) rather than racing the mint. If the record
     is still missing after the wait, or a named profile is asked about, today's live probe answers.
+    A record that says ``False`` is re-checked live before being trusted: the bootstrap can inventory
+    providers on a background thread ahead of ``config.yaml`` finishing its own load, which would
+    otherwise cache a false negative for the life of the process (a record that already says
+    ``True`` is never re-probed, so the answer can only move false->true here, never flap).
     The record's fields ride along additively (``ready``, ``free_tier``, ``other_providers``)."""
     try:
         from hermes_cli.main import _has_any_provider_configured
@@ -282,7 +286,9 @@ def _(rid, params: dict) -> dict:
             if record is None:
                 return {"provider_configured": bool(_has_any_provider_configured(strict_profile_scope=bool(profile))),
                         **scoped}
-            return {"provider_configured": record.provider_configured, "ready": True,
+            configured = record.provider_configured or bool(
+                _has_any_provider_configured(strict_profile_scope=bool(profile)))
+            return {"provider_configured": configured, "ready": True,
                     "free_tier": record.free_tier, "other_providers": record.other_providers,
                     "inference_provider": record.inference_provider, **scoped}
         return _readiness_check(rid, params, probe)


### PR DESCRIPTION
## What does this PR do?

Fixes `setup.status` permanently reporting `provider_configured: false` for a
correctly-configured custom provider, which leaves the dashboard's chat TUI
stuck on "Setup Required" forever even though sessions restore and use the
provider fine.

## Related Issue

Fixes #108768

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Root cause

`free_tier_bootstrap.run_bootstrap()` runs on a background daemon thread at
`hermes serve` boot ("a slow portal never delays the socket") and can race
`config.yaml` finishing its own load. When it wins that race, its provider
inventory (`_inventory_other_providers()` -> `resolve_provider("auto",
skip_free_tier=True)`) sees no provider yet and produces a `SetupRecord`
with `provider_configured=False`. That record is cached in-process and
broadcast via `setup.ready`.

`tui_gateway/methods_config.py`'s `setup.status` handler's `probe()` only
falls back to a live `_has_any_provider_configured()` check when
`wait_for_record()` returns `None`. Once a record exists — even a wrong one
— it is trusted for the life of the process and never re-evaluated, so the
dashboard reports "Setup Required" indefinitely, surviving both
dashboard-service and full gateway restarts.

## Changes Made

- `tui_gateway/methods_config.py` — `setup.status`'s `probe()` now ORs a
  cached record's `provider_configured=False` with a fresh
  `_has_any_provider_configured()` call before trusting it. A record that
  already says `True` is never re-probed (short-circuit `or`), preserving
  the existing "read the record, don't re-probe" behavior in the common
  case — only a stale negative gets corrected.
- `tests/test_tui_gateway_server.py` — added
  `test_setup_status_rechecks_a_false_bootstrap_record`, which seeds a
  `SetupRecord(provider_configured=False, ...)` directly (simulating the
  bootstrap losing the race) and a live probe that now finds a provider,
  asserting `setup.status` reports `True` instead of echoing the stale
  `False` forever.

## How to Test

1. `source <venv>/bin/activate && pip install -e ".[dev]"`
2. `TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0 python -m pytest tests/test_tui_gateway_server.py -k setup_status -v`

Before the fix (checked out `tui_gateway/methods_config.py` at `HEAD~1`,
i.e. without this change):

```
tests/test_tui_gateway_server.py::test_setup_status_reports_provider_config PASSED
tests/test_tui_gateway_server.py::test_setup_status_answers_from_the_bootstrap_record_once_it_exists PASSED
tests/test_tui_gateway_server.py::test_setup_status_rechecks_a_false_bootstrap_record FAILED
    assert resp["result"]["provider_configured"] is True
E   assert False is True
```

After the fix:

```
tests/test_tui_gateway_server.py::test_setup_status_reports_provider_config PASSED
tests/test_tui_gateway_server.py::test_setup_status_answers_from_the_bootstrap_record_once_it_exists PASSED
tests/test_tui_gateway_server.py::test_setup_status_rechecks_a_false_bootstrap_record PASSED
====================== 3 passed ==========================
```

Full file: `641 passed` (`tests/test_tui_gateway_server.py`).
`ruff check tui_gateway/methods_config.py tests/test_tui_gateway_server.py`: all checks passed.

The pre-existing test
`test_setup_status_answers_from_the_bootstrap_record_once_it_exists` (which
asserts `_has_any_provider_configured` is *not* called once a `True` record
exists) still passes unmodified: the new `or` short-circuits, so a record
that already says `True` is never re-probed.

## Platforms tested

Linux (CI container), Python 3.12.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/test_tui_gateway_server.py -q` and all tests pass
- [x] I've added a test for this change (fails without the fix, passes with it)
- [x] Tested on Linux

### Documentation & Housekeeping

- [x] No documentation update needed — internal RPC behavior, no user-facing config change
- [x] No `cli-config.yaml.example` change — no config keys added/changed
- [x] No `CONTRIBUTING.md`/`AGENTS.md` update needed — no architecture/workflow change
- [x] Cross-platform impact considered — pure Python logic, no platform-specific code
- [x] No tool description/schema change needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
