### PR TITLE
fix(feishu): carry inbound message_id into the session source

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2535,6 +2535,7 @@ class FeishuAdapter(BasePlatformAdapter):
             thread_id=thread_id,
             user_id_alt=sender_profile["user_id_alt"],
             is_bot=is_bot,
+            message_id=message_id,
         )
         normalized = MessageEvent(
             text=text, message_type=inbound_type, source=source, raw_message=data,


### PR DESCRIPTION
## Problem

Feishu inbound messages never populate `SessionSource.message_id`, so
`get_session_env("HERMES_SESSION_MESSAGE_ID")` is always empty on Feishu.

Any tool that needs the triggering message id fails closed. Concretely, a native plugin
that registers an incident report rejected every real group message with:

```
{"status": "REJECTED", "detail": "no platform message context for this turn"}
```

while `HERMES_SESSION_USER_ID` / chat id were populated normally.

## Root cause

`build_source(...)` in the Feishu adapter omits `message_id=message_id`; the id only goes
on the `MessageEvent`:

- normal-message path: `build_source(...)` without `message_id`
- synthetic reaction/card path: same omission

`gateway/run.py:_set_session_env()` reads `context.source.message_id`, so
`HERMES_SESSION_MESSAGE_ID` is always empty for Feishu. Discord (`discord/adapter.py`) and
buzz pass it through; Feishu never has
(`git log -S'source.message_id' -- plugins/platforms/feishu/adapter.py` is empty).

## Fix

Pass the inbound message id into `build_source` for the normal-message path. One line,
no behavior change beyond making the session var correct.

## Verification

Real Feishu group message → gateway logs the inbound `message_id`; a native tool reading
`HERMES_SESSION_MESSAGE_ID` now receives it and completes; the persisted record's
`message_id`/`source_refs` equal the inbound id.
