### PR TITLE
fix(cron): keep restart-safe worker out of the repo cwd without losing module path

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3042,6 +3042,18 @@ def _wait_for_external_cron_worker(
                 pass
 
 
+def _worker_env_with_repo_path(worker_env: dict) -> dict:
+    """Ensure the repo root is importable by a restart-safe cron worker spawned with
+    cwd=HERMES_HOME. ``python -m cron.scheduler`` resolves from sys.path[0]=cwd only when
+    cwd happens to be the checkout; under a HERMES_HOME cwd it must find the package via
+    PYTHONPATH instead — the editable-install finder does not cover every top-level layout
+    for ``-m`` resolution, so prepend the repo root explicitly (idempotent)."""
+    repo_root = str(Path(__file__).resolve().parent.parent)
+    existing = worker_env.get("PYTHONPATH") or ""
+    parts = [repo_root] + [p for p in existing.split(os.pathsep) if p and p != repo_root]
+    return {**worker_env, "PYTHONPATH": os.pathsep.join(parts)}
+
+
 def _launch_external_cron_worker(job: dict) -> bool:
     """Launch *job* outside a managed gateway cgroup when required.
 
@@ -3125,11 +3137,17 @@ def _launch_external_cron_worker(job: dict) -> bool:
     finally:
         reset_secret_scope(secret_token)
     worker_env = systemd_user_bus_env(worker_env)
+    # cwd must be the profile's HERMES_HOME, not the repo dir: the worker inherits this
+    # process's cwd for any terminal-tool call that finds no explicit TERMINAL_CWD/
+    # MESSAGING_CWD signal (tools/terminal_tool_config.py's _safe_getcwd() falls back to
+    # os.getcwd()) — a repo-dir cwd poisons that job's Docker /workspace mount for the
+    # container's whole persistent lifetime. `-m cron.scheduler` then resolves via
+    # PYTHONPATH instead (see _worker_env_with_repo_path).
     try:
         process = subprocess.Popen(
             scoped_command,
-            cwd=str(Path(__file__).resolve().parent.parent),
-            env=worker_env,
+            cwd=str(_get_hermes_home().resolve()),
+            env=_worker_env_with_repo_path(worker_env),
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,

--- a/tests/cron/test_restart_safe_worker.py
+++ b/tests/cron/test_restart_safe_worker.py
@@ -521,6 +521,7 @@ def test_managed_gateway_restart_preserves_active_worker_and_single_side_effect(
         )
     payload = tmp_path / "job.json"
     launched = tmp_path / "launched.json"
+    worker_inv = tmp_path / "worker_inv.json"
     payload.write_text(json.dumps(job), encoding="utf-8")
 
     sent = []
@@ -554,18 +555,32 @@ def test_managed_gateway_restart_preserves_active_worker_and_single_side_effect(
     assert replacement_loop.is_running()
 
     harness = (
-        "import json, os, pathlib, time\n"
+        "import json, os, pathlib, subprocess, time\n"
         f"os.environ['HERMES_HOME'] = {str(home)!r}\n"
         "os.environ['INVOCATION_ID'] = 'restart-fixture'\n"
         "from cron import scheduler\n"
         "from tools import process_registry\n"
         "process_registry._is_supervised_gateway_process = lambda: True\n"
+        # Spy the real worker spawn to assert its cwd/env invariants; the worker itself runs
+        # with stdout/stderr on DEVNULL, so report through a side-channel file. The spy only
+        # observes and delegates — it must not break the ack/wait protocol.
+        "_real_popen = subprocess.Popen\n"
+        "class _SpyPopen(_real_popen):\n"
+        "    def __init__(s, cmd, *a, **k):\n"
+        "        _ip = os.environ.get('HERMES_WORKER_INV', '')\n"
+        "        if _ip:\n"
+        "            _pp = (k.get('env') or {}).get('PYTHONPATH', '')\n"
+        "            pathlib.Path(_ip).write_text(json.dumps({'cwd': k.get('cwd'), 'PYTHONPATH': _pp}), encoding='utf-8')\n"
+        "        super().__init__(cmd, *a, **k)\n"
+        "subprocess.Popen = _SpyPopen\n"
+        "scheduler.subprocess.Popen = _SpyPopen\n"
         f"job = json.loads(pathlib.Path({str(payload)!r}).read_text())\n"
         "if not scheduler.run_one_job(job, adapters=None, loop=None):\n"
         "    raise SystemExit('worker was not isolated')\n"
         f"pathlib.Path({str(launched)!r}).write_text('returned')\n"
     )
-    parent = subprocess.Popen([sys.executable, "-c", harness])
+    parent = subprocess.Popen([sys.executable, "-c", harness],
+                              env={**os.environ, "HERMES_WORKER_INV": str(worker_inv)})
     worker_pid = None
     try:
         deadline = time.monotonic() + 10
@@ -602,6 +617,17 @@ def test_managed_gateway_restart_preserves_active_worker_and_single_side_effect(
                 break
             time.sleep(0.05)
         assert executions.latest_execution(job["id"])["status"] == "completed"
+
+        import pathlib as _pathlib
+        # Invariant: the restart-safe worker left the repo checkout behind (a repo-dir cwd
+        # leaks into terminal-tool calls with no explicit TERMINAL_CWD signal and poisons
+        # that job's persistent Docker /workspace mount) and can still resolve
+        # `-m cron.scheduler` via PYTHONPATH.
+        _inv = json.loads(worker_inv.read_text(encoding="utf-8"))
+        _repo_root = str(_pathlib.Path(scheduler.__file__).resolve().parents[1])
+        assert _inv["cwd"] != _repo_root, f"worker cwd leaked the repo checkout: {_inv['cwd']}"
+        assert _repo_root in _inv["PYTHONPATH"].split(os.pathsep), \
+            "repo root missing from worker PYTHONPATH"
         assert side_effect.read_text(encoding="utf-8").splitlines() == ["once"]
         assert delivery_queue.get_status(execution["id"])["status"] == "delivered"
         assert len(sent) == 1


### PR DESCRIPTION
## Problem

The restart-safe external cron worker (`_launch_external_cron_worker`) is spawned with `cwd=<repo checkout>`. Inside that worker, any terminal-tool call that finds no explicit `TERMINAL_CWD`/`MESSAGING_CWD` signal falls back to `os.getcwd()` — so the **gateway's own source tree becomes the job's Docker `/workspace` mount**, and because docker containers are persistent, that wrong mount outlives the single command that triggered it. Observed on a production deploy: a scheduled job's container permanently mounted the hermes-agent repo until manually rebuilt.

Simply moving the worker to its profile `HERMES_HOME` cwd breaks `python -m cron.scheduler`: under a non-repo cwd the package resolves from `sys.path[0]=cwd`, and the editable-install finder does not cover every top-level layout — the managed-restart integration test fails with `worker exited before ownership acknowledgement (exit 1)` (A/B confirmed 5/5 fail vs 5/5 pass).

## Fix

- Spawn the worker with `cwd=str(_get_hermes_home().resolve())` (profile home, where its data actually lives).
- New `_worker_env_with_repo_path()` prepends the repo root to the worker `PYTHONPATH`, so `-m cron.scheduler` resolves regardless of cwd (idempotent; keeps existing PYTHONPATH entries after the repo root).

## Test

Extended `test_managed_gateway_restart_preserves_active_worker_and_single_side_effect` with a Popen spy inside the existing harness that records the **real** spawn kwargs to a side-channel file, then asserts both invariants in the parent:

- `worker cwd != repo root`
- `repo root in worker PYTHONPATH`

**Proven red on current `main`**: `AssertionError: worker cwd leaked the repo checkout: <repo>`; green with the fix (`19 passed`). One invariant test, behavior contract (not a change-detector), per repo testing rules. No new core tools/env vars/config knobs.
