### PR TITLE
fix(anthropic): send explicit thinking-disable for the Qwen3.8 family

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -175,6 +175,15 @@ def _accepts_thinking_disable(model: str) -> bool:
     400 on it and keep the omit behavior. Legacy manual-thinking models are opt-in via
     budget_tokens, so omission is already off. Scoped to Claude: Kimi's documented disable is
     omission, and sending it a new parameter on the strength of Claude's contract is a guess."""
+    if _model_matches(model, ("qwen3.8",)):
+        # LOCAL-PROVEN: the Qwen3.8 family behind Anthropic-compatible endpoints
+        # (DashScope token-plan and mirrors) accepts an explicit
+        # ``thinking: {"type": "disabled"}`` cleanly — probed against both
+        # qwen3.8-flash and qwen3.8-max; tool_use is unaffected. Without the
+        # parameter these models think server-side by default, so a caller that
+        # asks for no reasoning silently pays full thinking-token cost (the
+        # request shape offers no cheaper off-switch). Verified on v0.21.2.
+        return True
     return (
         _is_claude_model(model)
         and _supports_adaptive_thinking(model)

--- a/tests/agent/test_anthropic_thinking_disable.py
+++ b/tests/agent/test_anthropic_thinking_disable.py
@@ -64,6 +64,16 @@ class TestThinkingOffIsSentExplicitly:
         assert kwargs["thinking"] == {"type": "disabled"}
         assert "output_config" not in kwargs
 
+    def test_qwen38_family_on_anthropic_compatible_endpoints_accepts_disable(self) -> None:
+        """Qwen3.8-family models served behind Anthropic-compatible endpoints
+        (DashScope token-plan and mirrors) accept an explicit disable and think
+        server-side by default when it is omitted — the same bill-the-user trap
+        this module exists to close for adaptive Claude. Probed live against
+        qwen3.8-flash / qwen3.8-max on v0.21.2; tool_use unaffected."""
+        for model in ("qwen3.8-flash", "qwen3.8-max", "alibaba/qwen3.8-max"):
+            kwargs = _kwargs(model, {"enabled": False})
+            assert kwargs["thinking"] == {"type": "disabled"}, model
+
     def test_mandatory_thinking_models_keep_the_omission(self) -> None:
         """claude-fable answers a disable with HTTP 400, so don't send one."""
         kwargs = _kwargs("anthropic/claude-fable-5", {"enabled": False})


### PR DESCRIPTION
## Problem

`_accepts_thinking_disable()` is scoped to Claude only, which is correct for everything upstream serves — except the **Qwen3.8 family behind Anthropic-compatible endpoints** (DashScope token-plan and mirrors). Those models:

1. think server-side by default (omission ≠ off), and
2. accept an explicit `thinking: {"type": "disabled"}` cleanly.

Result on a production deploy running `qwen3.8-flash` with reasoning effort minimal/off: every request silently kept the legacy thinking budget (8000) — the user pays full thinking-token cost for a knob that appears to be switched off. `reasoning_effort: minimal` has no mapping in `THINKING_BUDGET`, so it falls through to the default. This is the same bill-the-user trap this test module's docstring exists to close for adaptive Claude.

## Evidence (probed live, v0.21.2)

- `qwen3.8-flash` / `qwen3.8-max`: `thinking:{"type":"disabled"}` accepted, response shape + tool_use unaffected; omitting the param → model thinks server-side every turn.
- state.db `reasoning_tokens` cannot disprove this on these endpoints (it folds thinking into output_tokens) — billing was confirmed via provider usage instead.

## Fix

Early-return True for `_model_matches(model, ("qwen3.8",))` inside `_accepts_thinking_disable()`, with the probe record as the comment. No behavior change for any other family (Claude paths untouched; Kimi/GLM omission contracts untouched).

## Test

One invariant test added to `tests/agent/test_anthropic_thinking_disable.py` (`test_qwen38_family_on_anthropic_compatible_endpoints_accepts_disable`) asserting the disable IS sent for `qwen3.8-flash`, `qwen3.8-max`, and the portal-prefixed id. **Proven red on current main** (fails on all three ids), green with the guard; rest of the module passes unchanged (27 passed locally against both adapter variants side-by-side).
