### PR TITLE
feat(gateway): give lifecycle notices a channel of their own

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1301,6 +1301,16 @@ platform_toolsets:
 # platforms:
 #   telegram:
 #     reply_to_mode: "first"  # off | first | all
+#     # Where the two gateway lifecycle broadcasts go ("Gateway shutting down" /
+#     # "Gateway online"). Omit and they follow the home channel, as before.
+#     # Useful when the gateway restarts often and the notices crowd out the
+#     # traffic you actually read. A bare chat id is enough:
+#     # gateway_notice_channel: "123456789"
+#     # ...or the long form, when the destination is a thread:
+#     # gateway_notice_channel:
+#     #   chat_id: "123456789"
+#     #   name: "Gateway"      # optional label, defaults to "Gateway"
+#     #   thread_id: "42"      # optional, thread-aware platforms only
 #     # guest_mode lets explicit @mentions from non-allowlisted groups through.
 #     # Default false; ordinary messages, replies, and regex wake words stay blocked.
 #     guest_mode: false

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -363,6 +363,12 @@ class PlatformConfig:
     typing_indicator: bool = True  # drives _keep_typing; False where unwanted (Slack setStatus blocks compose)
     # Working-state text for text-rendering indicators (Slack status, Google Chat marker); None = platform default.
     typing_status_text: Optional[str] = None
+    # Destination for the two gateway lifecycle broadcasts ("Gateway shutting down" /
+    # "Gateway online"). Unset => they go to the home channel, which is the historical
+    # behaviour. A bare chat id or a mapping with chat_id / name / thread_id; normalised
+    # to a dict here and materialised as a HomeChannel by the gateway, which is where the
+    # Platform is known.
+    gateway_notice_channel: Optional[Dict[str, Any]] = None
     channel_overrides: Dict[str, ChannelOverride] = field(default_factory=dict)
     extra: Dict[str, Any] = field(default_factory=dict)  # Platform-specific settings
 
@@ -372,6 +378,7 @@ class PlatformConfig:
             "gateway_restart_notification": self.gateway_restart_notification,
             "typing_indicator": self.typing_indicator,
             **({"typing_status_text": self.typing_status_text} if self.typing_status_text is not None else {}),
+            **({"gateway_notice_channel": self.gateway_notice_channel} if self.gateway_notice_channel else {}),
             **{k: v for k in ("token", "api_key") if (v := getattr(self, k))},
         }
         if self.home_channel:
@@ -391,6 +398,27 @@ class PlatformConfig:
             value = data.get(key)
             return extra.get(key) if value is None else value
 
+        # gateway_notice_channel takes the same two routes as its siblings. A bare scalar
+        # is the common case ("send the notices here"), so it is widened to the mapping
+        # form; anything that is neither scalar nor mapping is dropped rather than
+        # half-parsed, so a malformed key cannot silently redirect the notices somewhere
+        # unintended.
+        notice = toplevel_or_extra("gateway_notice_channel")
+        if isinstance(notice, bool):  # bool is an int subclass; a flag is not a chat id
+            notice = None
+        elif isinstance(notice, (str, int)):
+            notice = {"chat_id": str(notice).strip()}
+        elif isinstance(notice, dict):
+            notice = {
+                k: str(v).strip()
+                for k, v in notice.items()
+                if k in ("chat_id", "name", "thread_id") and v not in (None, "")
+            }
+        else:
+            notice = None
+        if notice is not None and not notice.get("chat_id"):
+            notice = None
+
         raw_overrides = data.get("channel_overrides") or {}
         channel_overrides = {
             str(cid): ChannelOverride.from_dict(ov_data)
@@ -407,6 +435,7 @@ class PlatformConfig:
             gateway_restart_notification=_coerce_bool(toplevel_or_extra("gateway_restart_notification"), True),
             typing_indicator=_coerce_bool(toplevel_or_extra("typing_indicator"), True),
             typing_status_text=toplevel_or_extra("typing_status_text"),  # string passthrough, no coercion
+            gateway_notice_channel=notice,
             channel_overrides=channel_overrides,
             extra=extra,
         )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3934,6 +3934,45 @@ class GatewayRunner(
     def _status_action_gerund(self) -> str:
         return "restarting" if self._restart_requested else "shutting down"
 
+    # The home channel is where everything the agent says unprompted lands: cron
+    # deliveries, send_message "home", CLI handoffs. The two gateway lifecycle notices
+    # went there too for lack of a destination of their own, and on a deployment that
+    # restarts regularly they bury the traffic the operator actually reads. The existing
+    # knob (gateway_restart_notification) only silences them; it cannot redirect them.
+    def _gateway_notice_channel(self, platform, platform_cfg=None):
+        """Destination for the gateway lifecycle broadcasts (shutting down / online).
+
+        ``platforms.<name>.gateway_notice_channel`` wins; otherwise the platform home
+        channel, which is the historical behaviour. The config carries the normalised
+        mapping (see ``PlatformConfig.from_dict``) and the HomeChannel is built here,
+        where the Platform is known. Only the two lifecycle broadcasts call this —
+        cron deliver=home, send_message and CLI handoff keep targeting the home channel.
+        """
+        cfg = platform_cfg if platform_cfg is not None else self.config.platforms.get(platform)
+        home = cfg.home_channel if cfg is not None else None
+        notice = getattr(cfg, "gateway_notice_channel", None) if cfg is not None else None
+        if not notice:
+            return home
+        chat_id = str(notice.get("chat_id", "")).strip()
+        if not chat_id:
+            return home
+        from gateway.config import HomeChannel
+        return HomeChannel(
+            platform=platform,
+            chat_id=chat_id,
+            name=str(notice.get("name") or "").strip() or "Gateway",
+            thread_id=str(notice.get("thread_id") or "").strip() or None,
+            # Relay provenance is INHERITED from the platform home channel, never written
+            # by hand in config. A Relay-fronted platform re-attaches user_id/scope_id on
+            # egress, and the caches those fall back to are filled only by *inbound*
+            # events — a dedicated operations channel is one nobody speaks in, so the
+            # cache stays cold and the connector's fail-closed tenant guard declines the
+            # send. Inheriting keeps the authenticated discriminators of the same tenant
+            # without asking an operator to author security-relevant values.
+            user_id=getattr(home, "user_id", None),
+            scope_id=getattr(home, "scope_id", None),
+        )
+
     def _update_runtime_status(self, gateway_state: Optional[str] = None, exit_reason: Optional[str] = None) -> None:
         _write_runtime_status_quiet(
             gateway_state=gateway_state, exit_reason=exit_reason,

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -804,6 +804,9 @@ class GatewayNotificationsMixin:
         if free_tier_line:
             message = f"{message}\n{free_tier_line}"
         for platform, platform_cfg, home, transport in self._home_channel_transports():
+            # Lifecycle broadcast only: redirect to the notice channel when one is set.
+            # The transport is resolved per platform, not per chat, so it stays valid.
+            home = self._gateway_notice_channel(platform, platform_cfg) or home
             if not platform_cfg.gateway_restart_notification:
                 logger.info(
                     "Home-channel startup notification suppressed: %s has gateway_restart_notification=false",

--- a/gateway/run_shutdown.py
+++ b/gateway/run_shutdown.py
@@ -991,7 +991,7 @@ class GatewayShutdownMixin:
         # Snapshot adapters: adapter.send() can hit a fatal path (_handle_fatal) that pops the adapter
         # from self.adapters -> ``RuntimeError: dictionary changed size during iteration``.
         for platform, adapter in list(self.adapters.items()):
-            home = self.config.get_home_channel(platform)
+            home = self._gateway_notice_channel(platform)
             if not home or not home.chat_id:
                 continue
             if not self._notice_allowed(platform, "home channel"):

--- a/tests/gateway/test_gateway_notice_channel.py
+++ b/tests/gateway/test_gateway_notice_channel.py
@@ -1,0 +1,270 @@
+"""``gateway_notice_channel`` — lifecycle broadcasts leave the home channel.
+
+The home channel is where everything the agent says unprompted lands: cron
+deliveries, ``send_message "home"``, CLI handoffs. Gateway lifecycle notices
+("Gateway shutting down" / "Gateway online") went there too, for lack of a
+destination of their own. On a deployment that restarts regularly they bury the
+traffic the operator actually reads, and the only existing knob
+(``gateway_restart_notification``) silences them rather than redirecting them.
+
+``platforms.<name>.gateway_notice_channel`` gives those two notices a channel of
+their own without moving the home channel. Unset means unchanged behaviour — and
+the first tests below are exactly that control: if they fail, the change moved
+more than it promised.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import HomeChannel, Platform, PlatformConfig
+from gateway.platforms.base import SendResult
+from tests.gateway.restart_test_helpers import make_restart_runner
+
+
+def _runner_with_home(notice=None):
+    runner, adapter = make_restart_runner()
+    cfg = runner.config.platforms[Platform.TELEGRAM]
+    cfg.home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    cfg.gateway_notice_channel = notice
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="x"))
+    return runner, adapter
+
+
+# --------------------------------------------------------------- controls
+# These must pass with and without the change. They are what proves the
+# change moved the two lifecycle broadcasts and nothing else.
+
+@pytest.mark.asyncio
+async def test_control_without_config_shutdown_still_goes_to_home_channel():
+    runner, adapter = _runner_with_home(notice=None)
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_awaited_once()
+    assert adapter.send.await_args.args[0] == "home-42"
+
+
+@pytest.mark.asyncio
+async def test_control_without_config_startup_still_goes_to_home_channel(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, adapter = _runner_with_home(notice=None)
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == {("telegram", "home-42", None)}
+
+
+@pytest.mark.asyncio
+async def test_control_disabled_flag_still_silences_even_with_channel_set():
+    runner, adapter = _runner_with_home(notice={"chat_id": "gateway-99"})
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification = False
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_control_db_warning_broadcast_still_goes_to_home_channel():
+    """The state.db warning is NOT a lifecycle notice and must not be redirected.
+
+    ``home = platform_cfg.home_channel`` appears twice in run.py — once in the
+    startup notice loop and once here. This is the only test that fails if both
+    were changed instead of just the first.
+    """
+    runner, adapter = _runner_with_home(notice={"chat_id": "gateway-99"})
+    # the broadcast returns early unless an init error is recorded
+    runner._session_db_init_error = OSError("disk I/O error")
+
+    await runner._send_session_db_warning_notifications()
+
+    adapter.send.assert_awaited_once()
+    assert adapter.send.await_args.args[0] == "home-42"
+
+
+# --------------------------------------------------------------- behaviour
+
+@pytest.mark.asyncio
+async def test_shutdown_notice_goes_to_notice_channel_not_home():
+    runner, adapter = _runner_with_home(notice={"chat_id": "gateway-99"})
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_awaited_once()
+    chat_id, msg = adapter.send.await_args.args[0], adapter.send.await_args.args[1]
+    assert chat_id == "gateway-99"
+    assert "Gateway shutting down" in msg
+    # the home channel gets no copy: one notice, one destination
+    assert all(call.args[0] != "home-42" for call in adapter.send.await_args_list)
+
+
+@pytest.mark.asyncio
+async def test_startup_notice_goes_to_notice_channel(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, adapter = _runner_with_home(notice={"chat_id": "gateway-99"})
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == {("telegram", "gateway-99", None)}
+    adapter.send.assert_awaited_once()
+    assert adapter.send.await_args.args[0] == "gateway-99"
+    assert "Gateway online" in adapter.send.await_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_thread_id_reaches_metadata():
+    runner, adapter = _runner_with_home(
+        notice={"chat_id": "gateway-99", "thread_id": "t-7"}
+    )
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_awaited_once()
+    assert adapter.send.await_args.args[0] == "gateway-99"
+    metadata = adapter.send.await_args.kwargs.get("metadata") or {}
+    assert metadata.get("thread_id") == "t-7"
+
+
+@pytest.mark.asyncio
+async def test_blank_chat_id_falls_back_to_home():
+    runner, adapter = _runner_with_home(notice={"chat_id": "   "})
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_awaited_once()
+    assert adapter.send.await_args.args[0] == "home-42"
+
+
+# ------------------------------------------------------------ config parse
+
+def test_config_accepts_a_bare_chat_id():
+    cfg = PlatformConfig.from_dict(
+        {"enabled": True, "gateway_notice_channel": "gateway-99"}
+    )
+    assert cfg.gateway_notice_channel == {"chat_id": "gateway-99"}
+
+
+def test_config_accepts_a_mapping_with_name_and_thread():
+    cfg = PlatformConfig.from_dict(
+        {
+            "enabled": True,
+            "gateway_notice_channel": {
+                "chat_id": 12345,
+                "name": "Gateway",
+                "thread_id": "t-7",
+            },
+        }
+    )
+    assert cfg.gateway_notice_channel == {
+        "chat_id": "12345",
+        "name": "Gateway",
+        "thread_id": "t-7",
+    }
+
+
+def test_config_reads_the_key_bridged_into_extra():
+    """load_gateway_config() bridges shared keys into extra; both routes work."""
+    cfg = PlatformConfig.from_dict(
+        {"enabled": True, "extra": {"gateway_notice_channel": "gateway-99"}}
+    )
+    assert cfg.gateway_notice_channel == {"chat_id": "gateway-99"}
+
+
+def test_config_control_unset_key_is_none():
+    cfg = PlatformConfig.from_dict({"enabled": True})
+    assert cfg.gateway_notice_channel is None
+
+
+def test_config_drops_a_malformed_value_instead_of_half_parsing_it():
+    """A list is neither a chat id nor a mapping. Fail closed, do not guess."""
+    cfg = PlatformConfig.from_dict(
+        {"enabled": True, "gateway_notice_channel": ["gateway-99"]}
+    )
+    assert cfg.gateway_notice_channel is None
+
+
+def test_config_drops_unknown_subkeys():
+    cfg = PlatformConfig.from_dict(
+        {
+            "enabled": True,
+            "gateway_notice_channel": {"chat_id": "g-1", "platform": "slack"},
+        }
+    )
+    assert cfg.gateway_notice_channel == {"chat_id": "g-1"}
+
+
+def test_config_round_trips_through_to_dict():
+    cfg = PlatformConfig.from_dict(
+        {"enabled": True, "gateway_notice_channel": "gateway-99"}
+    )
+    assert PlatformConfig.from_dict(cfg.to_dict()).gateway_notice_channel == {
+        "chat_id": "gateway-99"
+    }
+
+
+# --------------------------------------------------- relay provenance
+# A Relay-fronted platform re-attaches user_id/scope_id on egress, and the caches
+# it falls back to are filled only by *inbound* events. A dedicated operations
+# channel is one nobody speaks in, so that cache stays cold and the connector's
+# fail-closed tenant guard declines the send. The override therefore inherits the
+# authenticated discriminators of the platform home channel rather than asking an
+# operator to author them.
+
+def _home_with_provenance():
+    return HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+        user_id="U123",
+        scope_id="S456",
+    )
+
+
+def test_notice_channel_inherits_relay_provenance_from_home():
+    runner, _ = make_restart_runner()
+    cfg = runner.config.platforms[Platform.TELEGRAM]
+    cfg.home_channel = _home_with_provenance()
+    cfg.gateway_notice_channel = {"chat_id": "gateway-99"}
+
+    target = runner._gateway_notice_channel(Platform.TELEGRAM)
+
+    assert target.chat_id == "gateway-99"
+    assert target.user_id == "U123"
+    assert target.scope_id == "S456"
+
+
+def test_control_provenance_is_inherited_not_invented():
+    """No provenance on the home channel means none on the override either."""
+    runner, _ = make_restart_runner()
+    cfg = runner.config.platforms[Platform.TELEGRAM]
+    cfg.home_channel = HomeChannel(
+        platform=Platform.TELEGRAM, chat_id="home-42", name="Ops Home"
+    )
+    cfg.gateway_notice_channel = {"chat_id": "gateway-99"}
+
+    target = runner._gateway_notice_channel(Platform.TELEGRAM)
+
+    assert target.chat_id == "gateway-99"
+    assert target.user_id is None
+    assert target.scope_id is None
+
+
+def test_config_does_not_accept_hand_authored_provenance():
+    """Provenance is security-relevant; config is not where it is authored."""
+    cfg = PlatformConfig.from_dict(
+        {
+            "enabled": True,
+            "gateway_notice_channel": {
+                "chat_id": "g-1",
+                "user_id": "spoofed",
+                "scope_id": "spoofed",
+            },
+        }
+    )
+    assert cfg.gateway_notice_channel == {"chat_id": "g-1"}

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -746,6 +746,46 @@ gateway:
 
 Disable it on noisy or low-priority platforms while leaving it on for your primary chat. The notification is sent once per restart, regardless of how many sessions were in flight.
 
+#### Sending the notices somewhere else
+
+`gateway_restart_notification` can only silence the notices. To keep them but move
+them off the home channel — where cron deliveries, `send_message "home"` and CLI
+handoffs also land — set `gateway_notice_channel` on the platform:
+
+```yaml
+gateway:
+  platforms:
+    discord:
+      home_chat_id: "987654321"
+      gateway_notice_channel: "111222333"   # lifecycle notices only
+```
+
+Only the two lifecycle broadcasts move. Cron `deliver: home`, `send_message` and CLI
+handoffs keep targeting the home channel, and so do other operational warnings such as
+the session-database alert. Omit the key and the notices follow the home channel
+exactly as before.
+
+The long form adds an optional label and thread:
+
+```yaml
+gateway:
+  platforms:
+    telegram:
+      gateway_notice_channel:
+        chat_id: "111222333"
+        name: "Gateway"
+        thread_id: "42"
+```
+
+`gateway_restart_notification: false` still wins: with it set, nothing is sent
+regardless of `gateway_notice_channel`.
+
+On a platform fronted by Relay, the notice channel inherits the authenticated
+routing provenance of that platform's home channel. You do not configure it, and
+`user_id`/`scope_id` written into `gateway_notice_channel` are ignored — a
+dedicated channel is one nobody speaks in, so its own routing cache would be
+cold, and provenance is not something config should author.
+
 ### Typing indicators
 
 While the agent is processing a message, the gateway shows a live typing status on platforms that support it — a "typing…" bubble on Telegram/Discord/Signal, or the "is thinking…" assistant status on Slack. This is controlled per-platform by the `typing_indicator` flag in `config.yaml`, which defaults to `true`:


### PR DESCRIPTION
Fixes #76780.

The home channel is the destination for everything the agent says unprompted: cron deliveries, `send_message "home"`, CLI handoffs. The two gateway lifecycle notices ("Gateway shutting down" / "Gateway online") land there too, for lack of a destination of their own. On a deployment that restarts regularly they crowd out the traffic the operator actually reads, and the only knob available today — `gateway_restart_notification` — silences them instead of redirecting them, so an operator who wants to keep the notices has no way to move them.

**This implements the downscoped contract @Malk13r proposed on #76780 (Aug 29):** redirect only the two lifecycle broadcasts, keep active-session notices in their source chat, fall back to the home channel when unset, keep `gateway_restart_notification` as the gate that wins. I opened this before finding that thread — I searched for my own key name rather than for the capability, which is the opposite of what CONTRIBUTING asks. #84874 implements the same capability under `gateway_restart_channel`; if a maintainer picks that one, or a fresh push of the downscoped version, I will close this and port the tests there.

```yaml
platforms:
  discord:
    gateway_notice_channel: "111222333"
```

The long form takes an optional name and thread_id. `PlatformConfig.from_dict` widens a bare chat id into the mapping form, drops unknown sub-keys, and fails closed on anything that is neither scalar nor mapping, so a malformed key cannot silently redirect the notices somewhere unintended. It reaches `PlatformConfig` by both routes the sibling keys use — top-level or bridged into `extra` — through the existing `toplevel_or_extra` helper.

`GatewayRunner._gateway_notice_channel(platform, platform_cfg=None)` resolves the destination at send time and falls back to the platform home channel when the key is unset or blank, so behaviour is unchanged unless an operator opts in.

### Relay provenance

A Relay-fronted platform re-attaches `user_id`/`scope_id` on egress, and the caches it falls back to are filled only by *inbound* events. A dedicated operations channel is one nobody speaks in, so that cache stays cold and the connector's fail-closed tenant guard declines the send — the gap the sweeper flagged on #76787.

The override therefore **inherits** the authenticated discriminators from the platform home channel rather than asking an operator to author them, and `from_dict` refuses them if they appear in config: provenance is security-relevant, and config is not where it is authored. A control test pins that (`test_config_does_not_accept_hand_authored_provenance`).

### Scope

**Only the two lifecycle broadcasts use it.** Cron `deliver: home`, `send_message` and CLI handoffs continue to target the home channel — and so does the session-database warning, which shares the `_home_channel_transports()` helper with the startup notice but is an operational alert rather than a lifecycle broadcast. A control test pins that boundary too.

One note on where the code lives. `_home_channel_transports()` resolves the transport per *platform*, not per chat, so redirecting `home` inside the loop leaves the transport valid — that is why the startup path is a one-line override rather than a second resolution path. The change is `+1/-1` in `run_shutdown.py` and `+3/-0` in `run_notifications.py`; `get_home_channel` has ten call sites and this touches one.

### Tests

`tests/gateway/test_gateway_notice_channel.py`, eighteen cases. Against `main` at 284d220: **13 failed, 5 passed**; with this branch applied: **18 passed**. The five that pass either way are the controls, and they are the point of the file:

- `test_control_without_config_shutdown_still_goes_to_home_channel`
- `test_control_without_config_startup_still_goes_to_home_channel`
- `test_control_disabled_flag_still_silences_even_with_channel_set` — `gateway_restart_notification: false` still wins
- `test_control_db_warning_broadcast_still_goes_to_home_channel` — the boundary above
- `test_blank_chat_id_falls_back_to_home`

Those five are controls in the strict sense — they pass against an empty change, which is what makes the other thirteen mean something. Two further cases guard the provenance rule rather than the absence of movement, so they need the resolver to exist and do fail without it: `test_control_provenance_is_inherited_not_invented` (no provenance on the home channel means none on the override — it is inherited, never invented) and the config refusal above.

For regression, the 80 `tests/gateway/` files touching config, restart, shutdown, notifications, relay and platform produce the **same 70 failures, name for name** — I captured the sorted `FAILED` list with the branch applied and without it and the two files hash identically, with an empty diff in both directions. Those 70 are pre-existing in my environment (optional platform dependencies I did not install), which is why I am reporting the comparison rather than the absolute number: what it establishes is that this change moves nothing, not that the suite is green.

One run did report 71 before I started capturing the lists; it did not reproduce across three further runs and is not in either captured set, so I am recording it as suite flakiness rather than claiming it away.

Documented in `cli-config.yaml.example` (Gateway Platform Settings) and in the messaging guide next to `gateway_restart_notification`.