### PR TITLE
fix(desktop): Test on a saved custom endpoint uses the key on file instead of reporting it rejected

### DIFF
--- a/apps/desktop/src/api/config.ts
+++ b/apps/desktop/src/api/config.ts
@@ -182,7 +182,10 @@ export function saveCustomEndpoint(endpoint: CustomEndpointUpdate): Promise<Cust
 }
 
 export function validateCustomEndpoint(endpoint: CustomEndpointUpdate): Promise<CustomEndpointValidationResponse> {
+  // Profile-scoped like save/list: a blank api_key on a saved endpoint makes
+  // the backend probe with the key on file, which lives in that profile's .env.
   return hermesApi<CustomEndpointValidationResponse>({
+    ...profileScoped(),
     path: '/api/providers/custom-endpoints/validate',
     method: 'POST',
     body: endpoint

--- a/apps/desktop/src/app/settings/custom-endpoints-settings.test.tsx
+++ b/apps/desktop/src/app/settings/custom-endpoints-settings.test.tsx
@@ -1,0 +1,125 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { stubResizeObserver } from '@/test/jsdom'
+import type { CustomEndpoint, CustomEndpointsResponse } from '@/types/hermes'
+
+import { CustomEndpointsSettings } from './custom-endpoints-settings'
+
+stubResizeObserver()
+
+vi.mock('@/hermes', () => ({
+  activateCustomEndpoint: vi.fn(),
+  deleteCustomEndpoint: vi.fn(),
+  getCustomEndpoints: vi.fn(),
+  saveCustomEndpoint: vi.fn(),
+  validateCustomEndpoint: vi.fn()
+}))
+
+import * as hermes from '@/hermes'
+
+const mocked = vi.mocked(hermes)
+
+const SAVED_ENDPOINT: CustomEndpoint = {
+  api_key_preview: 'sk-s...kI0c',
+  base_url: 'https://spark.example.com/v1',
+  context_length: null,
+  discover_models: true,
+  has_api_key: true,
+  id: 'custom',
+  is_current: true,
+  model: 'qwen3.8-27b',
+  models: ['qwen3.8-27b'],
+  name: 'Custom',
+  source: 'providers'
+}
+
+function listing(endpoints: CustomEndpoint[], id?: string): CustomEndpointsResponse {
+  return {
+    current: { base_url: SAVED_ENDPOINT.base_url, model: SAVED_ENDPOINT.model, provider: 'custom' },
+    endpoints,
+    id,
+    ok: true
+  }
+}
+
+async function renderSettings() {
+  await act(async () => {
+    render(
+      <MemoryRouter>
+        <I18nProvider>
+          <CustomEndpointsSettings />
+        </I18nProvider>
+      </MemoryRouter>
+    )
+  })
+  await screen.findByText('Edit Endpoint')
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('CustomEndpointsSettings API key', () => {
+  it('tells the user a key is on file instead of showing an empty field', async () => {
+    mocked.getCustomEndpoints.mockResolvedValue(listing([SAVED_ENDPOINT]))
+
+    await renderSettings()
+
+    expect((screen.getByPlaceholderText('Leave blank to keep the saved key (sk-s...kI0c)') as HTMLInputElement).value).toBe('')
+    expect(screen.getByText('sk-s...kI0c')).toBeTruthy()
+  })
+
+  it('says when a saved endpoint has no key on file', async () => {
+    mocked.getCustomEndpoints.mockResolvedValue(
+      listing([{ ...SAVED_ENDPOINT, api_key_preview: null, has_api_key: false }])
+    )
+
+    await renderSettings()
+
+    expect(screen.getByPlaceholderText('No key saved for this endpoint (optional)')).toBeTruthy()
+  })
+
+  it('surfaces an unresolved key_env even though no key is usable', async () => {
+    mocked.getCustomEndpoints.mockResolvedValue(
+      listing([{ ...SAVED_ENDPOINT, api_key_preview: '${HERMES_CUSTOM_CUSTOM_API_KEY} (not set)', has_api_key: false }])
+    )
+
+    await renderSettings()
+
+    expect(screen.getByText('${HERMES_CUSTOM_CUSTOM_API_KEY} (not set)')).toBeTruthy()
+    expect(screen.getByPlaceholderText('No key saved for this endpoint (optional)')).toBeTruthy()
+  })
+
+  it('tests a saved endpoint by id with a blank key so the backend uses the key on file', async () => {
+    mocked.getCustomEndpoints.mockResolvedValue(listing([SAVED_ENDPOINT]))
+    mocked.validateCustomEndpoint.mockResolvedValue({ message: '', models: ['qwen3.8-27b'], ok: true, reachable: true })
+
+    await renderSettings()
+    fireEvent.click(screen.getByRole('button', { name: 'Test' }))
+
+    await waitFor(() => expect(mocked.validateCustomEndpoint).toHaveBeenCalledTimes(1))
+    expect(mocked.validateCustomEndpoint).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'custom', api_key: undefined, base_url: SAVED_ENDPOINT.base_url })
+    )
+  })
+
+  it('keeps the field blank after Save but shows the newly saved key preview', async () => {
+    const before: CustomEndpoint = { ...SAVED_ENDPOINT, api_key_preview: null, has_api_key: false }
+    mocked.getCustomEndpoints.mockResolvedValue(listing([before]))
+    mocked.saveCustomEndpoint.mockResolvedValue(listing([SAVED_ENDPOINT], 'custom'))
+
+    await renderSettings()
+    const field = screen.getByPlaceholderText('No key saved for this endpoint (optional)')
+    fireEvent.change(field, { target: { value: 'sk-typed-key' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(mocked.saveCustomEndpoint).toHaveBeenCalledTimes(1))
+    expect(mocked.saveCustomEndpoint).toHaveBeenCalledWith(expect.objectContaining({ api_key: 'sk-typed-key' }))
+    await screen.findByPlaceholderText('Leave blank to keep the saved key (sk-s...kI0c)')
+    expect((screen.getByPlaceholderText('Leave blank to keep the saved key (sk-s...kI0c)') as HTMLInputElement).value).toBe('')
+  })
+})

--- a/apps/desktop/src/app/settings/custom-endpoints-settings.tsx
+++ b/apps/desktop/src/app/settings/custom-endpoints-settings.tsx
@@ -33,6 +33,8 @@ interface EndpointForm {
   makeDefault: boolean
   model: string
   name: string
+  /** Masked preview of the key on file for a saved endpoint; null when none is saved. */
+  savedKeyPreview: null | string
 }
 
 const EMPTY_FORM: EndpointForm = {
@@ -43,7 +45,8 @@ const EMPTY_FORM: EndpointForm = {
   id: '',
   makeDefault: true,
   model: '',
-  name: ''
+  name: '',
+  savedKeyPreview: null
 }
 
 function formFromEndpoint(endpoint: CustomEndpoint): EndpointForm {
@@ -55,8 +58,22 @@ function formFromEndpoint(endpoint: CustomEndpoint): EndpointForm {
     id: endpoint.id,
     makeDefault: Boolean(endpoint.is_current),
     model: endpoint.model,
-    name: endpoint.name
+    name: endpoint.name,
+    savedKeyPreview: endpoint.has_api_key ? (endpoint.api_key_preview ?? 'API key set') : null
   }
+}
+
+/** Placeholder for the API Key field. The field is always blank for a saved
+ *  endpoint (the key lives in .env, never round-trips to the UI), so the
+ *  placeholder is the only place that says whether a key is on file. */
+function apiKeyPlaceholder(form: EndpointForm): string {
+  if (!form.id) {
+    return 'Optional'
+  }
+
+  return form.savedKeyPreview
+    ? `Leave blank to keep the saved key (${form.savedKeyPreview})`
+    : 'No key saved for this endpoint (optional)'
 }
 
 function toPayload(form: EndpointForm, models?: string[]): CustomEndpointUpdate {
@@ -259,7 +276,11 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
                     </div>
                     <div className="mt-1 flex flex-wrap gap-2 text-xs text-muted-foreground">
                       <span>{endpoint.model}</span>
-                      {endpoint.has_api_key && <span>{endpoint.api_key_preview ?? 'API key set'}</span>}
+                      {endpoint.api_key_preview ? (
+                        <span>{endpoint.api_key_preview}</span>
+                      ) : (
+                        endpoint.has_api_key && <span>API key set</span>
+                      )}
                     </div>
                   </button>
                   <div className="flex items-center gap-2 sm:justify-end">
@@ -351,7 +372,7 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
               API Key
               <Input
                 onChange={event => setForm(current => ({ ...current, apiKey: event.target.value }))}
-                placeholder={form.id ? 'Leave blank to keep current key' : 'Optional'}
+                placeholder={apiKeyPlaceholder(form)}
                 type="password"
                 value={form.apiKey}
               />

--- a/hermes_cli/web_routers/config_env.py
+++ b/hermes_cli/web_routers/config_env.py
@@ -20,7 +20,7 @@ from hermes_cli.web_server_profiles import (
     _approval_mode_of, _broadcast_gateway_session_info, _is_other_profile, _parse_model_ids,
 )
 from fastapi import HTTPException, Request
-from hermes_cli.config import DEFAULT_CONFIG, OPTIONAL_ENV_VARS, read_raw_config, custom_endpoint_key_env, coerce_provider_id, find_provider_entry, redact_key, _deep_merge
+from hermes_cli.config import DEFAULT_CONFIG, OPTIONAL_ENV_VARS, read_raw_config, custom_endpoint_key_env, coerce_provider_id, find_provider_entry, get_env_value, redact_key, _deep_merge
 from hermes_cli.web_models import ConfigUpdate, EnvVarUpdate, EnvVarDelete, EnvVarReveal, CustomEndpointUpdate
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -340,8 +340,44 @@ def _api_key_display(entry: Dict[str, Any]) -> Tuple[bool, Optional[str]]:
         return True, redact_key(plaintext)
     key_env = str(entry.get("key_env") or "").strip()
     if key_env:
-        return True, f"${{{key_env}}}"
+        # Show the masked value the var resolves to, not the bare ``${VAR}``
+        # template: after Save blanks the field, the template read as "the
+        # key is gone" even though it was sitting in .env. A var that does not
+        # resolve is reported as such so the row matches what requests do.
+        resolved = str(get_env_value(key_env) or "").strip()
+        if resolved:
+            return True, redact_key(resolved)
+        return False, f"${{{key_env}}} (not set)"
     return False, None
+
+
+def _stored_custom_endpoint_key(cfg: Dict[str, Any], endpoint_id: str) -> Optional[str]:
+    """The credential on file for a saved endpoint, or ``None``.
+
+    Mirrors the runtime's precedence for a named custom provider: inline
+    ``api_key`` (legacy plaintext, or a hand-written ``${VAR}`` that
+    ``load_config()`` already expanded), then ``key_env`` resolved through
+    ``.env`` (what Save writes, #69449). The synthesized ``direct-config``
+    row has no ``providers`` entry, so it falls back to the ``model`` block.
+    """
+    _stored, entry = find_provider_entry(cfg.get("providers"), endpoint_id)
+    if not isinstance(entry, dict):
+        model_cfg = cfg.get("model")
+        if (
+            endpoint_id == "custom"
+            and isinstance(model_cfg, dict)
+            and str(model_cfg.get("provider") or "").strip().lower() == "custom"
+        ):
+            entry = model_cfg
+        else:
+            return None
+    plaintext = str(entry.get("api_key") or "").strip()
+    if plaintext:
+        return plaintext
+    key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
+    if key_env:
+        return str(get_env_value(key_env) or "").strip() or None
+    return None
 
 
 def _raw_provider_api_key(endpoint_id: str) -> Any:
@@ -618,16 +654,33 @@ def delete_custom_endpoint(endpoint_id: str, profile: Optional[str] = None):
 
 
 @router.post("/api/providers/custom-endpoints/validate")
-async def validate_custom_endpoint(body: CustomEndpointUpdate):
-    """Probe a custom endpoint by calling its OpenAI-compatible /models URL."""
+async def validate_custom_endpoint(body: CustomEndpointUpdate, profile: Optional[str] = None):
+    """Probe a custom endpoint by calling its OpenAI-compatible /models URL.
+
+    A blank ``api_key`` on a saved endpoint (``id``) means "use the key on
+    file", the same contract the form states ("Leave blank to keep current
+    key"). Save writes the key to ``.env`` and clears the field, so without
+    this the very next Test went out with no ``Authorization`` header and
+    reported "rejected the API key" for a key that works. Profile-scoped like
+    the other custom-endpoint routes so the key is read from the profile
+    that saved it.
+    """
     base_url = (body.base_url or "").strip().rstrip("/")
     if not base_url:
         return {"ok": False, "reachable": True, "message": "Enter an endpoint URL first.", "models": []}
 
+    api_key = (body.api_key or "").strip()
+    key_source: Optional[str] = "submitted" if api_key else None
+    endpoint_id = _custom_endpoint_id(body.id) if (body.id or "").strip() else ""
+    if not api_key and endpoint_id:
+        with _config_profile_scope(profile):
+            api_key = _stored_custom_endpoint_key(load_config(), endpoint_id) or ""
+        key_source = "saved" if api_key else None
+
     url = base_url + "/models"
     headers = {"Accept": "application/json"}
-    if body.api_key and body.api_key.strip():
-        headers["Authorization"] = f"Bearer {body.api_key.strip()}"
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
 
     try:
         async with _endpoint_probe_client(url, 8.0) as client:
@@ -636,7 +689,13 @@ async def validate_custom_endpoint(body: CustomEndpointUpdate):
         return {"ok": False, "reachable": False, "message": f"Could not reach {url}.", "models": []}
 
     if resp.status_code in (401, 403):
-        return {"ok": False, "reachable": True, "message": "The endpoint rejected the API key.", "models": []}
+        if key_source is None:
+            message = "The endpoint requires an API key and none is saved for it. Enter one and test again."
+        elif key_source == "saved":
+            message = "The endpoint rejected the saved API key. Enter a new one and save again."
+        else:
+            message = "The endpoint rejected the API key."
+        return {"ok": False, "reachable": True, "message": message, "models": []}
     if not resp.is_success:
         return {"ok": False, "reachable": True, "message": f"Endpoint returned HTTP {resp.status_code}.", "models": []}
 

--- a/hermes_cli/web_routers/config_env.py
+++ b/hermes_cli/web_routers/config_env.py
@@ -20,8 +20,9 @@ from hermes_cli.web_server_profiles import (
     _approval_mode_of, _broadcast_gateway_session_info, _is_other_profile, _parse_model_ids,
 )
 from fastapi import HTTPException, Request
-from hermes_cli.config import DEFAULT_CONFIG, OPTIONAL_ENV_VARS, read_raw_config, custom_endpoint_key_env, coerce_provider_id, find_provider_entry, get_env_value, redact_key, _deep_merge
+from hermes_cli.config import DEFAULT_CONFIG, OPTIONAL_ENV_VARS, read_raw_config, custom_endpoint_key_env, coerce_provider_id, find_provider_entry, get_env_value, redact_key, _deep_merge, _ENV_REF_RE, _env_ref_var_name
 from hermes_cli.web_models import ConfigUpdate, EnvVarUpdate, EnvVarDelete, EnvVarReveal, CustomEndpointUpdate
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 _log = logging.getLogger("hermes_cli.web_server")
@@ -327,57 +328,109 @@ def _models_from_custom_endpoint_entry(entry: Dict[str, Any]) -> List[str]:
     return [model for model in models if model and not (model in seen or seen.add(model))]
 
 
-def _api_key_display(entry: Dict[str, Any]) -> Tuple[bool, Optional[str]]:
-    """Return ``(has_api_key, preview)`` for a provider or model config block.
+class _EndpointCredentials:
+    """Credential reads for the custom endpoints of ONE profile, from that profile's own files.
 
-    Keys live in ``.env`` behind ``key_env``; only older entries still carry a
-    plaintext ``api_key``. Checking both keeps the panel honest either way.
+    ``key_env`` and ``${VAR}`` refs resolve against ``<home>/.env`` (plus its external secret
+    sources, via ``build_profile_secret_scope``). Only the process's own profile also sees
+    ``os.environ`` — single-profile deployments inject credentials that way. A *requested*
+    profile (``?profile=worker``) never does: ``get_secret`` deliberately falls through to
+    ``os.environ`` when multiplexing is off, which is the right overlay for a turn but here
+    would send the parent profile's key to the worker's endpoint (or "find" a key the worker
+    never saved). Reads the RAW config so a hand-written ``api_key: ${VAR}`` is expanded here,
+    not by ``load_config()`` against the process environment.
 
-    See #69449.
+    Precedence is the runtime's (``runtime_provider_custom._match_new_style_provider``):
+    ``key_env`` first, the inline ``api_key`` only as a fallback. A different order here made
+    Test reject an entry that chat happily uses.
     """
-    plaintext = str(entry.get("api_key") or "").strip()
-    if plaintext:
-        return True, redact_key(plaintext)
-    key_env = str(entry.get("key_env") or "").strip()
-    if key_env:
-        # Show the masked value the var resolves to, not the bare ``${VAR}``
-        # template: after Save blanks the field, the template read as "the
-        # key is gone" even though it was sitting in .env. A var that does not
-        # resolve is reported as such so the row matches what requests do.
-        resolved = str(get_env_value(key_env) or "").strip()
-        if resolved:
-            return True, redact_key(resolved)
-        return False, f"${{{key_env}}} (not set)"
-    return False, None
 
+    def __init__(self, profile_dir: Optional[Path]):
+        from agent.secret_scope import build_profile_secret_scope
+        from hermes_constants import get_hermes_home
 
-def _stored_custom_endpoint_key(cfg: Dict[str, Any], endpoint_id: str) -> Optional[str]:
-    """The credential on file for a saved endpoint, or ``None``.
+        self._own_process = profile_dir is None
+        self._secrets = build_profile_secret_scope(Path(profile_dir) if profile_dir else get_hermes_home())
+        self._raw = read_raw_config()
 
-    Mirrors the runtime's precedence for a named custom provider: inline
-    ``api_key`` (legacy plaintext, or a hand-written ``${VAR}`` that
-    ``load_config()`` already expanded), then ``key_env`` resolved through
-    ``.env`` (what Save writes, #69449). The synthesized ``direct-config``
-    row has no ``providers`` entry, so it falls back to the ``model`` block.
-    """
-    _stored, entry = find_provider_entry(cfg.get("providers"), endpoint_id)
-    if not isinstance(entry, dict):
-        model_cfg = cfg.get("model")
+    def lookup(self, name: Any) -> Optional[str]:
+        name = str(name or "").strip()
+        if not name:
+            return None
+        val = self._secrets.get(name)
+        if val is None and self._own_process:
+            try:
+                val = get_env_value(name)
+            except Exception:  # fail-closed scope error under multiplexing: own files only
+                val = None
+        return str(val or "").strip() or None
+
+    def _expand(self, value: str) -> str:
+        def _sub(match):
+            var = _env_ref_var_name(match.group(1))
+            return (self.lookup(var) or "") if var else match.group(0)
+        return _ENV_REF_RE.sub(_sub, value)
+
+    def entry_key(self, entry: Dict[str, Any]) -> Optional[str]:
+        """The credential the runtime would use for a raw provider/model block, or ``None``."""
+        key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
+        if key_env:
+            resolved = self.lookup(key_env)
+            if resolved:
+                return resolved
+        inline = str(entry.get("api_key") or "").strip()
+        return (self._expand(inline).strip() or None) if inline else None
+
+    def raw_entry(self, endpoint_id: str) -> Optional[Dict[str, Any]]:
+        """The on-disk block behind an endpoint id: ``providers.<id>``, else the ``model`` block
+        for the synthesized ``direct-config`` row (``provider: custom`` with no providers entry)."""
+        _stored, entry = find_provider_entry(self._raw.get("providers"), endpoint_id)
+        if isinstance(entry, dict):
+            return entry
+        model_cfg = self._raw.get("model")
         if (
             endpoint_id == "custom"
             and isinstance(model_cfg, dict)
             and str(model_cfg.get("provider") or "").strip().lower() == "custom"
         ):
-            entry = model_cfg
-        else:
-            return None
-    plaintext = str(entry.get("api_key") or "").strip()
-    if plaintext:
-        return plaintext
-    key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
-    if key_env:
-        return str(get_env_value(key_env) or "").strip() or None
-    return None
+            return model_cfg
+        return None
+
+    def stored(self, endpoint_id: str) -> Tuple[Optional[str], str]:
+        """``(key, base_url)`` on file for a saved endpoint; ``(None, "")`` when unknown."""
+        entry = self.raw_entry(endpoint_id)
+        if entry is None:
+            return None, ""
+        base_url = str(entry.get("base_url") or entry.get("url") or entry.get("api") or "").strip()
+        return self.entry_key(entry), base_url
+
+    def display(self, endpoint_id: str, fallback_entry: Dict[str, Any]) -> Tuple[bool, Optional[str]]:
+        """``(has_api_key, preview)`` for the panel row.
+
+        Shows the masked value the entry resolves to (``sk-s...kI0c``), not the bare ``${VAR}``
+        template: after Save blanks the field, the template read as "the key is gone" even though
+        it was sitting in .env. A ``key_env`` that does not resolve is reported as such so the row
+        matches what a request would do. See #69449.
+        """
+        entry = self.raw_entry(endpoint_id) or fallback_entry
+        key = self.entry_key(entry)
+        if key:
+            return True, redact_key(key)
+        key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
+        if key_env:
+            return False, f"${{{key_env}}} (not set)"
+        return False, None
+
+
+def _destination(url: str) -> Tuple[str, str, str]:
+    parsed = urllib.parse.urlparse((url or "").strip())
+    return parsed.scheme.lower(), parsed.netloc.lower(), parsed.path.rstrip("/")
+
+
+def _same_destination(submitted: str, saved: str) -> bool:
+    """True when two base URLs name the same scheme, host[:port] and path (trailing slash and case
+    of the host ignored). The saved key is only ever attached to the destination it was saved for."""
+    return bool(submitted) and bool(saved) and _destination(submitted) == _destination(saved)
 
 
 def _raw_provider_api_key(endpoint_id: str) -> Any:
@@ -401,8 +454,9 @@ def _config_api_key_is_env_ref(endpoint_id: str) -> bool:
 def _endpoint_row(
     endpoint_id: str, name: str, base_url: str, model: str, models: List[str], context_length,
     discover_models: bool, key_entry: Dict[str, Any], is_current: bool, source: str,
+    credentials: _EndpointCredentials,
 ) -> Dict[str, Any]:
-    has_api_key, api_key_preview = _api_key_display(key_entry)
+    has_api_key, api_key_preview = credentials.display(endpoint_id, key_entry)
     return {
         "id": endpoint_id, "name": name, "base_url": base_url, "model": model, "models": models,
         "context_length": context_length, "discover_models": discover_models,
@@ -411,7 +465,7 @@ def _endpoint_row(
     }
 
 
-def _custom_endpoint_response(cfg: Dict[str, Any]) -> Dict[str, Any]:
+def _custom_endpoint_response(cfg: Dict[str, Any], credentials: _EndpointCredentials) -> Dict[str, Any]:
     model_cfg = cfg.get("model", {}) if isinstance(cfg.get("model"), dict) else {}
     current_provider = str(model_cfg.get("provider", "") or "")
     current_model = str(model_cfg.get("default", model_cfg.get("name", "")) or "")
@@ -432,13 +486,13 @@ def _custom_endpoint_response(cfg: Dict[str, Any]) -> Dict[str, Any]:
                 endpoint_id, str(raw_entry.get("name") or endpoint_id), base_url,
                 str(raw_entry.get("model") or raw_entry.get("default_model") or (models[0] if models else "")),
                 models, raw_entry.get("context_length"), bool(raw_entry.get("discover_models", True)),
-                raw_entry, endpoint_id == current_provider, "providers",
+                raw_entry, endpoint_id == current_provider, "providers", credentials,
             ))
 
     if current_provider.lower() == "custom" and current_base_url and not any(e["id"] == "custom" for e in endpoints):
         endpoints.insert(0, _endpoint_row(
             "custom", "Custom", current_base_url, current_model, [current_model] if current_model else [],
-            model_cfg.get("context_length"), True, model_cfg, True, "direct-config",
+            model_cfg.get("context_length"), True, model_cfg, True, "direct-config", credentials,
         ))
 
     return {
@@ -571,19 +625,19 @@ def list_custom_endpoints(profile: Optional[str] = None):
     rather than the process-level HERMES_HOME (mirrors ``/api/config``).
     """
     with http_failure("GET /api/providers/custom-endpoints failed", 500, detail="Failed to list custom endpoints"):
-        with _config_profile_scope(profile):
-            return _custom_endpoint_response(load_config())
+        with _config_profile_scope(profile) as profile_dir:
+            return _custom_endpoint_response(load_config(), _EndpointCredentials(profile_dir))
 
 
 @router.post("/api/providers/custom-endpoints")
 def upsert_custom_endpoint(body: CustomEndpointUpdate, profile: Optional[str] = None):
     """Create or update a v12+ ``providers`` custom endpoint entry."""
     with http_failure("POST /api/providers/custom-endpoints failed", 500, detail="Failed to save custom endpoint"):
-        with _config_profile_scope(profile):
+        with _config_profile_scope(profile) as profile_dir:
             cfg = load_config()
             endpoint_id, _entry = _write_custom_endpoint(cfg, body)
             save_config(cfg)
-            response = _custom_endpoint_response(cfg)
+            response = _custom_endpoint_response(cfg, _EndpointCredentials(profile_dir))
         response["ok"] = True
         response["id"] = endpoint_id
         return response
@@ -636,7 +690,7 @@ def delete_custom_endpoint(endpoint_id: str, profile: Optional[str] = None):
         f"DELETE /api/providers/custom-endpoints/{endpoint_id} failed", 500,
         detail="Failed to delete custom endpoint",
     ):
-        with _config_profile_scope(profile):
+        with _config_profile_scope(profile) as profile_dir:
             cfg = load_config()
             provider_key = _custom_endpoint_id(endpoint_id)
             providers = cfg.get("providers")
@@ -648,7 +702,7 @@ def delete_custom_endpoint(endpoint_id: str, profile: Optional[str] = None):
             _detach_main_model_from_provider(cfg, provider_key)
             remove_env_value(custom_endpoint_key_env(provider_key))
             save_config(cfg)
-            response = _custom_endpoint_response(cfg)
+            response = _custom_endpoint_response(cfg, _EndpointCredentials(profile_dir))
         response["ok"] = True
         return response
 
@@ -661,9 +715,13 @@ async def validate_custom_endpoint(body: CustomEndpointUpdate, profile: Optional
     file", the same contract the form states ("Leave blank to keep current
     key"). Save writes the key to ``.env`` and clears the field, so without
     this the very next Test went out with no ``Authorization`` header and
-    reported "rejected the API key" for a key that works. Profile-scoped like
-    the other custom-endpoint routes so the key is read from the profile
-    that saved it.
+    reported "rejected the API key" for a key that works.
+
+    The saved key is read from the requested profile's own files
+    (``_EndpointCredentials``) and only attached when the submitted URL is the
+    destination it was saved for: the form keeps ``id`` while the URL is
+    edited, so Test-before-Save on a new URL must not forward the old host's
+    secret there.
     """
     base_url = (body.base_url or "").strip().rstrip("/")
     if not base_url:
@@ -673,9 +731,12 @@ async def validate_custom_endpoint(body: CustomEndpointUpdate, profile: Optional
     key_source: Optional[str] = "submitted" if api_key else None
     endpoint_id = _custom_endpoint_id(body.id) if (body.id or "").strip() else ""
     if not api_key and endpoint_id:
-        with _config_profile_scope(profile):
-            api_key = _stored_custom_endpoint_key(load_config(), endpoint_id) or ""
-        key_source = "saved" if api_key else None
+        with _config_profile_scope(profile) as profile_dir:
+            stored_key, stored_url = _EndpointCredentials(profile_dir).stored(endpoint_id)
+        if stored_key and _same_destination(base_url, stored_url):
+            api_key, key_source = stored_key, "saved"
+        elif stored_key:
+            key_source = "destination-changed"
 
     url = base_url + "/models"
     headers = {"Accept": "application/json"}
@@ -691,6 +752,11 @@ async def validate_custom_endpoint(body: CustomEndpointUpdate, profile: Optional
     if resp.status_code in (401, 403):
         if key_source is None:
             message = "The endpoint requires an API key and none is saved for it. Enter one and test again."
+        elif key_source == "destination-changed":
+            message = (
+                "The URL differs from the saved endpoint, so its saved key was not sent. "
+                "Enter the key for this URL to test it."
+            )
         elif key_source == "saved":
             message = "The endpoint rejected the saved API key. Enter a new one and save again."
         else:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2222,6 +2222,122 @@ class TestWebServerEndpoints:
         assert endpoint["has_api_key"] is False
         assert endpoint["api_key_preview"] == "${HERMES_CUSTOM_PROXY_API_KEY} (not set)"
 
+    @staticmethod
+    def _write_profile(name, config, env):
+        """Create ``profiles/<name>`` with a config.yaml and .env written straight to disk (a POST
+        would also mirror the key into os.environ, which is exactly what these tests must not rely on)."""
+        import yaml
+        from hermes_cli import profiles as profiles_mod
+
+        home = profiles_mod.get_profile_dir(name)
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text(yaml.safe_dump(config), encoding="utf-8")
+        (home / ".env").write_text("".join(f"{k}={v}\n" for k, v in env.items()), encoding="utf-8")
+        return home
+
+    _PROXY_CFG = {
+        "providers": {"proxy": {"name": "Proxy", "base_url": "https://llm.worker.example/v1", "model": "m", "key_env": "HERMES_CUSTOM_PROXY_API_KEY"}},
+    }
+
+    def _validate(self, profile=None, **overrides):
+        body = {"id": "proxy", "name": "Proxy", "base_url": "https://llm.example.com/v1", "model": "m"}
+        body.update(overrides)
+        query = f"?profile={profile}" if profile else ""
+        return self.client.post(f"/api/providers/custom-endpoints/validate{query}", json=body).json()
+
+    def test_validate_uses_the_requested_profiles_key_not_the_process_profiles(self, monkeypatch):
+        """``?profile=worker`` must probe with the WORKER's saved key. The process profile has the
+        same env var (in its .env and in os.environ, as save_env_value publishes it); resolving
+        through the process environment sent the parent's key to the worker's endpoint."""
+        self._save_proxy(api_key="sk-parent-key-0123456789")
+        monkeypatch.setenv("HERMES_CUSTOM_PROXY_API_KEY", "sk-parent-key-0123456789")
+        self._write_profile("worker", self._PROXY_CFG, {"HERMES_CUSTOM_PROXY_API_KEY": "sk-worker-key-0123456789"})
+        captured = self._probe_stub(monkeypatch)
+
+        self._validate(profile="worker", base_url="https://llm.worker.example/v1")
+
+        assert captured["headers"]["Authorization"] == "Bearer sk-worker-key-0123456789"
+        listed = self.client.get("/api/providers/custom-endpoints?profile=worker").json()
+        row = next(e for e in listed["endpoints"] if e["id"] == "proxy")
+        assert row["api_key_preview"] == "sk-w...6789"
+
+    def test_validate_never_borrows_the_process_key_when_the_profile_has_none(self, monkeypatch):
+        """A worker whose .env lacks the var gets NO key — not the parent's os.environ value —
+        and the row says the var is unset. Same for a hand-written ``api_key: ${VAR}`` ref."""
+        monkeypatch.setenv("HERMES_CUSTOM_PROXY_API_KEY", "sk-parent-key-0123456789")
+        monkeypatch.setenv("WORKER_REF_KEY", "sk-parent-ref-0123456789")
+        self._write_profile("worker", self._PROXY_CFG, {})
+        captured = self._probe_stub(monkeypatch, status_code=401)
+
+        result = self._validate(profile="worker", base_url="https://llm.worker.example/v1")
+
+        assert "Authorization" not in captured["headers"]
+        assert "none is saved" in result["message"]
+        listed = self.client.get("/api/providers/custom-endpoints?profile=worker").json()
+        row = next(e for e in listed["endpoints"] if e["id"] == "proxy")
+        assert row["has_api_key"] is False
+        assert row["api_key_preview"] == "${HERMES_CUSTOM_PROXY_API_KEY} (not set)"
+
+        ref_cfg = {"providers": {"proxy": {"name": "Proxy", "base_url": "https://llm.worker.example/v1", "model": "m", "api_key": "${WORKER_REF_KEY}"}}}
+        self._write_profile("worker", ref_cfg, {})
+        captured = self._probe_stub(monkeypatch)
+        self._validate(profile="worker", base_url="https://llm.worker.example/v1")
+        assert "Authorization" not in captured["headers"]
+
+        self._write_profile("worker", ref_cfg, {"WORKER_REF_KEY": "sk-worker-ref-0123456789"})
+        captured = self._probe_stub(monkeypatch)
+        self._validate(profile="worker", base_url="https://llm.worker.example/v1")
+        assert captured["headers"]["Authorization"] == "Bearer sk-worker-ref-0123456789"
+
+    def test_validate_only_sends_the_saved_key_to_the_saved_destination(self, monkeypatch):
+        """Editing the URL keeps the form's ``id``; Test-before-Save must not forward the old
+        host's secret to the new host. Trailing slash / host case are not a different destination."""
+        self._save_proxy()
+        captured = self._probe_stub(monkeypatch, status_code=401)
+
+        result = self._validate(base_url="https://attacker.example.com/v1")
+
+        assert "Authorization" not in captured["headers"]
+        assert "URL differs from the saved endpoint" in result["message"]
+
+        for same in ("https://llm.example.com/v1/", "https://LLM.Example.com/v1"):
+            captured = self._probe_stub(monkeypatch)
+            self._validate(base_url=same)
+            assert captured["headers"]["Authorization"] == "Bearer sk-saved-key-0123456789", same
+
+        for other in ("http://llm.example.com/v1", "https://llm.example.com:8443/v1", "https://llm.example.com/v2"):
+            captured = self._probe_stub(monkeypatch)
+            self._validate(base_url=other)
+            assert "Authorization" not in captured["headers"], other
+
+    def test_validate_prefers_key_env_over_a_stale_inline_key_like_the_runtime(self, monkeypatch):
+        """``runtime_provider_custom._match_new_style_provider`` resolves key_env first and uses the
+        inline api_key only as a fallback; Test and the row preview must agree with it."""
+        import yaml
+
+        from hermes_cli.config import get_config_path, get_env_path
+
+        get_config_path().write_text(yaml.safe_dump({
+            "providers": {"proxy": {
+                "name": "Proxy", "base_url": "https://llm.example.com/v1", "model": "m",
+                "api_key": "sk-inline-stale-0123456789", "key_env": "PROXY_LIVE_KEY",
+            }},
+        }), encoding="utf-8")
+        get_env_path().write_text("PROXY_LIVE_KEY=sk-env-live-0123456789\n", encoding="utf-8")
+        captured = self._probe_stub(monkeypatch)
+
+        self._validate()
+
+        assert captured["headers"]["Authorization"] == "Bearer sk-env-live-0123456789"
+        row = next(e for e in self.client.get("/api/providers/custom-endpoints").json()["endpoints"] if e["id"] == "proxy")
+        assert row["api_key_preview"] == "sk-e...6789"
+
+        # Env var gone: the inline key is the runtime's fallback, so it is Test's too.
+        get_env_path().write_text("", encoding="utf-8")
+        captured = self._probe_stub(monkeypatch)
+        self._validate()
+        assert captured["headers"]["Authorization"] == "Bearer sk-inline-stale-0123456789"
+
     def test_get_sessions_rejects_negative_limit(self):
         """limit=-1 must be rejected (422), not passed through to SQLite as
         LIMIT -1 (unbounded) — issue #74316."""

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2070,6 +2070,158 @@ class TestWebServerEndpoints:
         model_cfg = load_config()["model"]
         assert model_cfg["api_key"] == "sk-legacy"
 
+    @staticmethod
+    def _probe_stub(monkeypatch, status_code=200, models=("m",)):
+        """Stub ``httpx.AsyncClient`` for the /validate probe; returns the captured request."""
+        captured = {}
+
+        class _Resp:
+            def __init__(self):
+                self.status_code = status_code
+                self.is_success = 200 <= status_code < 300
+
+            def json(self):
+                return {"data": [{"id": m} for m in models]}
+
+        class _Client:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+            async def get(self, url, *args, headers=None, **kwargs):
+                captured["url"] = url
+                captured["headers"] = headers
+                return _Resp()
+
+        monkeypatch.setattr("httpx.AsyncClient", _Client)
+        return captured
+
+    def _save_proxy(self, api_key="sk-saved-key-0123456789"):
+        self.client.post(
+            "/api/providers/custom-endpoints",
+            json={
+                "id": "proxy",
+                "name": "Proxy",
+                "base_url": "https://llm.example.com/v1",
+                "model": "m",
+                "api_key": api_key,
+            },
+        )
+
+    def test_validate_uses_the_saved_key_when_the_field_is_blank(self, monkeypatch):
+        """Save moves the key to .env and clears the form field ("Leave blank to
+        keep current key"); Test on that saved endpoint must send the saved key,
+        not go out unauthenticated and report the key as rejected."""
+        self._save_proxy()
+        captured = self._probe_stub(monkeypatch)
+
+        response = self.client.post(
+            "/api/providers/custom-endpoints/validate",
+            json={"id": "proxy", "name": "Proxy", "base_url": "https://llm.example.com/v1", "model": "m"},
+        )
+
+        assert response.json()["ok"] is True
+        assert captured["headers"]["Authorization"] == "Bearer sk-saved-key-0123456789"
+
+    def test_validate_prefers_a_submitted_key_over_the_saved_one(self, monkeypatch):
+        self._save_proxy(api_key="sk-old-key-0123456789")
+        captured = self._probe_stub(monkeypatch)
+
+        self.client.post(
+            "/api/providers/custom-endpoints/validate",
+            json={
+                "id": "proxy",
+                "name": "Proxy",
+                "base_url": "https://llm.example.com/v1",
+                "model": "m",
+                "api_key": "sk-new-key-0123456789",
+            },
+        )
+
+        assert captured["headers"]["Authorization"] == "Bearer sk-new-key-0123456789"
+
+    def test_validate_does_not_borrow_a_key_for_an_unsaved_endpoint(self, monkeypatch):
+        """No ``id`` means a new endpoint: never attach some other entry's key."""
+        self._save_proxy()
+        captured = self._probe_stub(monkeypatch)
+
+        self.client.post(
+            "/api/providers/custom-endpoints/validate",
+            json={"name": "Proxy", "base_url": "https://llm.example.com/v1", "model": "m"},
+        )
+
+        assert "Authorization" not in captured["headers"]
+
+    def test_validate_401_names_whether_a_key_was_sent(self, monkeypatch):
+        """Three different situations used to collapse into "rejected the API key"."""
+        self._probe_stub(monkeypatch, status_code=401)
+        unsaved = self.client.post(
+            "/api/providers/custom-endpoints/validate",
+            json={"name": "New", "base_url": "https://llm.example.com/v1", "model": "m"},
+        ).json()
+        assert unsaved["ok"] is False and unsaved["reachable"] is True
+        assert "none is saved" in unsaved["message"]
+
+        self._save_proxy()
+        self._probe_stub(monkeypatch, status_code=401)
+        saved = self.client.post(
+            "/api/providers/custom-endpoints/validate",
+            json={"id": "proxy", "name": "Proxy", "base_url": "https://llm.example.com/v1", "model": "m"},
+        ).json()
+        assert "rejected the saved API key" in saved["message"]
+
+        submitted = self.client.post(
+            "/api/providers/custom-endpoints/validate",
+            json={"id": "proxy", "name": "Proxy", "base_url": "https://llm.example.com/v1", "model": "m", "api_key": "sk-typed"},
+        ).json()
+        assert submitted["message"] == "The endpoint rejected the API key."
+
+    def test_validate_falls_back_to_the_direct_config_model_block(self, monkeypatch):
+        """The synthesized ``custom`` row (provider: custom on ``model``) has no
+        providers entry; its key lives on the model block."""
+        from hermes_cli.config import load_config, save_config
+
+        cfg = load_config()
+        cfg["model"] = {
+            "provider": "custom",
+            "default": "m",
+            "base_url": "https://llm.example.com/v1",
+            "api_key": "sk-direct-key-0123456789",
+        }
+        cfg.pop("providers", None)
+        save_config(cfg)
+        captured = self._probe_stub(monkeypatch)
+
+        self.client.post(
+            "/api/providers/custom-endpoints/validate",
+            json={"id": "custom", "name": "Custom", "base_url": "https://llm.example.com/v1", "model": "m"},
+        )
+
+        assert captured["headers"]["Authorization"] == "Bearer sk-direct-key-0123456789"
+
+    def test_custom_endpoint_response_masks_the_value_behind_key_env(self):
+        """The row shows what the key_env resolves to (masked), not the bare
+        ``${VAR}`` template, and says so when the var is missing."""
+        from hermes_cli.config import custom_endpoint_key_env, remove_env_value
+
+        self._save_proxy(api_key="sk-live-key-0123456789abcdef")
+        listed = self.client.get("/api/providers/custom-endpoints").json()
+        endpoint = next(e for e in listed["endpoints"] if e["id"] == "proxy")
+        assert endpoint["has_api_key"] is True
+        assert endpoint["api_key_preview"] == "sk-l...cdef"
+        assert "sk-live-key-0123456789abcdef" not in endpoint["api_key_preview"]
+
+        remove_env_value(custom_endpoint_key_env("proxy"))
+        listed = self.client.get("/api/providers/custom-endpoints").json()
+        endpoint = next(e for e in listed["endpoints"] if e["id"] == "proxy")
+        assert endpoint["has_api_key"] is False
+        assert endpoint["api_key_preview"] == "${HERMES_CUSTOM_PROXY_API_KEY} (not set)"
+
     def test_get_sessions_rejects_negative_limit(self):
         """limit=-1 must be rejected (422), not passed through to SQLite as
         LIMIT -1 (unbounded) — issue #74316."""


### PR DESCRIPTION
Fixes #108785

## What

In Hermes Desktop → Settings → Providers → Custom Endpoints, pressing **Save** on an endpoint with a freshly entered API key looked like it deleted the key: the field blanked, the row showed the bare `${HERMES_CUSTOM_CUSTOM_API_KEY}` template, and the very next **Test** reported "The endpoint rejected the API key" for a key that had just validated. The key was in fact written to `<profile>/.env` correctly (#69449); the problem was that nothing downstream of Save could see it.

Root cause: `POST /api/providers/custom-endpoints/validate` only ever read `body.api_key`. After Save the form field is (correctly) empty, `toPayload` sends `api_key: undefined`, and the probe goes out with **no `Authorization` header** at all. The 401 was then reported as a rejected key. The route was also the only custom-endpoint route without a `profile` parameter, so the desktop client (which is profile-scoped everywhere else) had no way to point it at the right `.env`.

## Changes

**`hermes_cli/web_routers/config_env.py`**
- `validate_custom_endpoint` takes `profile: Optional[str]` like its sibling routes. When `api_key` is blank and `id` names a saved endpoint it probes with the credential on file. A request with no `id` never borrows a key.
- Credentials come from a small per-profile resolver, `_EndpointCredentials` (added after review): `key_env` and `${VAR}` refs resolve against the requested profile's own `.env` (plus its external secret sources, via `build_profile_secret_scope`), reading the raw config so a hand-written `api_key: ${VAR}` is expanded there and not by `load_config()` against the process environment. Only the process's own profile falls through to `os.environ`; `?profile=worker` can never pick up the parent profile's key, nor "find" one the worker never saved.
- The saved key is attached only when the submitted URL is the destination it was saved for (`_same_destination`: scheme, host[:port], path; trailing slash and host case ignored). The form keeps the endpoint id while the URL is edited, so Test-before-Save on a new URL must not forward the old host's secret.
- Precedence matches `runtime_provider_custom._match_new_style_provider`: `key_env` first, inline `api_key` only as the fallback, for both the probe and the preview.
- The 401/403 message now says which of four things happened: no key was sent and none is saved, the URL differs from the saved endpoint so its key was not sent, the saved key was rejected, or the typed key was rejected.
- The row preview shows the masked value the entry resolves to (`sk-s...kI0c`) instead of the `${VAR}` template. A var that does not resolve returns `${VAR} (not set)` with `has_api_key: false`, so the row matches what a request would actually do.

**`apps/desktop/src/api/config.ts`**
- `validateCustomEndpoint` sends `...profileScoped()` like save/list/activate/delete.

**`apps/desktop/src/app/settings/custom-endpoints-settings.tsx`**
- The API Key placeholder states whether a key is on file: `Leave blank to keep the saved key (sk-s...kI0c)` vs `No key saved for this endpoint (optional)`. The field itself stays blank for saved endpoints; the secret still never round-trips to the renderer.
- The endpoint row shows the preview whenever the backend supplies one (including the `(not set)` case).

**Tests**
- `tests/hermes_cli/test_web_server.py`: ten new cases in `TestWebServerEndpoints`: saved key is used when the field is blank, a typed key wins over the saved one, no key is borrowed for an unsaved endpoint, the 401 messages, direct-config `model` block fallback, masked / `(not set)` previews; and from the review: a worker profile with its own key while the process holds the same var, a worker with no key (`key_env` and `${VAR}` forms), URL-bound reuse across equivalent and non-equivalent URLs, and an entry carrying both a stale inline key and a live `key_env`.
- `apps/desktop/src/app/settings/custom-endpoints-settings.test.tsx` (new): placeholder and row copy for saved / unsaved / unresolved keys, Test posts `id` with `api_key: undefined`, and Save keeps the field blank while the new preview appears.

## How to test

Automated (all run on this branch):

```bash
pytest tests/hermes_cli/test_web_server.py -q          # 199 passed
cd apps/desktop && npx vitest run --project ui src/app/settings/custom-endpoints-settings.test.tsx   # 5 passed
cd apps/desktop && npx tsc -p . --noEmit && npx eslint src/api/config.ts src/app/settings/custom-endpoints-settings.tsx src/app/settings/custom-endpoints-settings.test.tsx
ruff check hermes_cli/web_routers/config_env.py tests/hermes_cli/test_web_server.py
```

Manual reproduction of the bug (before) and the fix (after):

1. Desktop → Settings → Providers → Custom Endpoints, load an endpoint that requires a bearer token.
2. Paste a valid key, click **Test** → "Endpoint is reachable. Found N models."
3. Click **Save** → "Custom endpoint saved."
4. Click **Test** again with the field left blank.
   - Before: "The endpoint rejected the API key." (probe sent no `Authorization` header).
   - After: "Endpoint is reachable. Found N models." Row shows `sk-s...kI0c`; placeholder reads "Leave blank to keep the saved key (sk-s...kI0c)".
5. Delete `HERMES_CUSTOM_<ID>_API_KEY` from the profile's `.env` and reload the panel: row shows `${HERMES_CUSTOM_<ID>_API_KEY} (not set)`, placeholder reads "No key saved for this endpoint (optional)", and Test says "The endpoint requires an API key and none is saved for it."

What the probe does, checked outside the app against the endpoint from the issue: `GET /v1/models` with no `Authorization` → 401; with the key Save wrote to `.env` → 200 with the model listed.

## Platforms tested

macOS 26.5.2 (arm64), Hermes v0.21.2 at upstream `284d220b`, Python 3.11.15, Node 22.

## Verified in the packaged desktop app

Rebuilt the packaged app from this branch (`hermes desktop --build-only`, electron-builder `release/mac-arm64/Hermes.app`) and drove it with Playwright against my real `market-analyst` profile and the live endpoint from the issue. Every step below was asserted, not eyeballed:

1. Custom Endpoints row shows `sk-s...fNL0`, not `${HERMES_CUSTOM_CUSTOM_API_KEY}`; field placeholder reads `Leave blank to keep the saved key (sk-s...fNL0)`.
2. **Test with the field blank** → "Endpoint is reachable. Found 1 models." (no "rejected" toast).
3. The original repro, type key → Test → Save → Test: field blanks after Save, placeholder still names the saved key, second Test → "Endpoint is reachable. Found 1 models."
4. New endpoint, no key, Test → "The endpoint requires an API key and none is saved for it. Enter one and test again."

A 29 s screen capture of that run exists; I can attach it to the thread on request.

---

# Submitted with love from Team Reagent!

[![Team Reagent](https://avatars.githubusercontent.com/u/212725768?s=400&u=5f484710efb5662413f1d3a85a4f0077bb075e97&v=4)](https://github.com/reagent-systems)
