### PR TITLE
fix(error_classifier): a transport with no credential is auth, not unknown

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -291,6 +291,23 @@ _AUTH_PATTERNS = (
     "forbidden", "invalid token", "token expired", "token revoked", "access denied",
 )
 
+# A subprocess transport (ACP bridge and friends) that died before answering,
+# naming a missing/revoked subscription credential on stderr. The wording comes
+# from the launcher, not from the provider — no request was ever made, so there
+# is no status code and none of the provider-side verdicts apply.
+#
+# Left unmatched these land in ``unknown``: retryable with no credential
+# rotation, so the retry loop re-spawns the transport against the same empty
+# credential and the turn fails with a taxonomy that tells the caller nothing.
+# ``auth`` is the honest verdict, but with ``retryable=True`` (unlike the
+# status-code auth paths): every spawn re-resolves the credential, so a
+# transient refresh failure genuinely can differ on the next attempt.
+_TRANSPORT_CREDENTIAL_MISSING_PATTERNS = (
+    "no subscription token",
+    "revoked or missing subscription token",
+    "missing subscription token",
+)
+
 # Empty-response advisories (OpenRouter / nano-gpt). Checked before overflow
 # because the text often mentions "max_tokens" (caused compression spirals).
 _EMPTY_PROVIDER_RESPONSE_PATTERNS = (
@@ -371,6 +388,11 @@ _V_BILLING = _v(_R.billing, retryable=False, **_ROTATE_FALLBACK)
 _V_RATE_LIMIT = _v(_R.rate_limit, **_ROTATE_FALLBACK)
 _V_AUTH_ROTATE = _v(_R.auth, retryable=False, **_ROTATE_FALLBACK)
 _V_AUTH_FALLBACK = _v(_R.auth, **_ABORT_FALLBACK)
+# Transport could not obtain a credential: retry (the next spawn re-resolves it)
+# and rotate, but do NOT fall back to another model — one credential serves every
+# model behind a subscription, so the backup model meets the identical wall and
+# the downgrade only hides the cause.
+_V_AUTH_RETRY_NO_FALLBACK = _v(_R.auth, should_rotate_credential=True, should_fallback=False)
 _V_MODEL_NOT_FOUND = _v(_R.model_not_found, **_ABORT_FALLBACK)
 _V_CONTENT_BLOCKED = _v(_R.content_policy_blocked, **_ABORT_FALLBACK)
 _V_FORMAT_ERROR = _v(_R.format_error, **_ABORT_FALLBACK)
@@ -434,10 +456,15 @@ _400_TAIL_RULES = _OVERFLOW_AS_5XX_RULES + (
 _MESSAGE_HEAD_RULES = ((_MEMORY_CEILING_PATTERNS, _V_OVERLOADED),
                        (_PAYLOAD_TOO_LARGE_PATTERNS, _V_PAYLOAD_TOO_LARGE)) + _IMAGE_TOOL_RULES
 
-# Status-less tail. Overload before rate_limit/billing so "overloaded" backs off
-# instead of rotating; policy block before model_not_found; timeout/connection
-# wording last, classified as transport (never compression).
+# Status-less tail. A transport that never obtained a credential comes first:
+# nothing reached the provider, so no provider-side verdict can be true, and it
+# must outrank the generic _AUTH_PATTERNS entry below (same reason, but that one
+# is retryable=False + fallback). Then overload before rate_limit/billing so
+# "overloaded" backs off instead of rotating; policy block before
+# model_not_found; timeout/connection wording last, classified as transport
+# (never compression).
 _MESSAGE_TAIL_RULES = (
+    (_TRANSPORT_CREDENTIAL_MISSING_PATTERNS, _V_AUTH_RETRY_NO_FALLBACK),
     (_OVERLOADED_PATTERNS, _V_OVERLOADED), (_BILLING_PATTERNS, _billing_hints),
     (_RATE_LIMIT_PATTERNS, _V_RATE_LIMIT), (_EMPTY_PROVIDER_RESPONSE_PATTERNS, _V_SERVER_ERROR),
     (_CONTEXT_OVERFLOW_PATTERNS, _V_CONTEXT_OVERFLOW), (_AUTH_PATTERNS, _V_AUTH_ROTATE),

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -304,7 +304,9 @@ _AUTH_PATTERNS = (
 # transient refresh failure genuinely can differ on the next attempt.
 _TRANSPORT_CREDENTIAL_MISSING_PATTERNS = (
     "no subscription token",
-    "revoked or missing subscription token",
+    # The bridge also exits 0 having written nothing, and the client's own
+    # advisory names the cause; the longer "revoked or missing subscription
+    # token" wording is subsumed by this form.
     "missing subscription token",
 )
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1500,6 +1500,82 @@ class TestConnectionMessagePatterns:
         assert result.reason == FailoverReason.unknown
 
 
+# ── Test: subprocess transport could not obtain a credential ────────────
+
+class TestTransportCredentialMissing:
+    """A bridge that died before answering, naming a missing credential.
+
+    ``CopilotACPClient`` raises a bare ``RuntimeError("Copilot ACP process
+    exited early: <stderr>")`` when its subprocess dies during startup. When the
+    launcher's stderr says it had no subscription token, the failure is an auth
+    problem — but with no HTTP status to classify by, the message fell through
+    every rule into ``unknown``: retryable, yet with no credential rotation, so
+    the retry loop respawned the bridge against the same empty credential and
+    the turn ended with a taxonomy that told the caller nothing.
+    """
+
+    MESSAGES = [
+        # Wrapper writes this to stderr and exits 1; the client wraps it.
+        "Copilot ACP process exited early: claude-acp-run: no subscription token.\n"
+        "  Fix: ensure Claude Code is logged in, or run:\n"
+        "       claude setup-token > ~/.config/acp-token && chmod 600 ~/.config/acp-token",
+        # Bridge exits 0 without writing stderr — same cause, different shape.
+        "Copilot ACP process exited (rc=0) during 'session/prompt' without writing "
+        "to stderr — usually a revoked or missing subscription token.",
+        "acp-launcher: missing subscription token",
+    ]
+
+    @pytest.mark.parametrize("message", MESSAGES)
+    def test_missing_transport_credential_is_auth_not_unknown(self, message):
+        result = classify_api_error(RuntimeError(message), provider="copilot-acp")
+        assert result.reason == FailoverReason.auth, message
+        assert result.is_auth is True
+
+    @pytest.mark.parametrize("message", MESSAGES)
+    def test_retryable_because_the_next_spawn_re_resolves_the_credential(self, message):
+        # Unlike the 401/403 status paths (retryable=False — the same key will
+        # fail again), each transport spawn re-runs its credential resolution,
+        # so a transient refresh failure genuinely can differ next attempt.
+        result = classify_api_error(RuntimeError(message), provider="copilot-acp")
+        assert result.retryable is True
+        assert result.should_rotate_credential is True
+
+    @pytest.mark.parametrize("message", MESSAGES)
+    def test_does_not_fall_back_to_another_model(self, message):
+        # One credential serves every model behind a subscription, so the backup
+        # model meets the identical wall; a downgrade would only hide the cause.
+        result = classify_api_error(RuntimeError(message), provider="copilot-acp")
+        assert result.should_fallback is False
+        assert result.should_compress is False
+
+    def test_outranks_the_generic_auth_wording_in_the_same_message(self):
+        # The launcher hint says "logged in"/"authenticate"; _AUTH_PATTERNS would
+        # match that and return retryable=False + should_fallback=True, i.e. the
+        # exact downgrade this verdict exists to prevent. Order must hold.
+        result = classify_api_error(RuntimeError(
+            "Copilot ACP process exited early: no subscription token. "
+            "Fix: authentication required, please log in."
+        ))
+        assert result.reason == FailoverReason.auth
+        assert result.retryable is True
+        assert result.should_fallback is False
+
+    def test_a_real_provider_auth_refusal_is_unaffected(self):
+        # Control: the status-code and generic-wording auth paths keep their
+        # historical abort-and-fall-back verdict.
+        for err in (MockAPIError("Unauthorized", status_code=401),
+                    RuntimeError("Invalid API key provided")):
+            result = classify_api_error(err)
+            assert result.reason == FailoverReason.auth
+            assert result.retryable is False
+            assert result.should_fallback is True
+
+    def test_an_unrelated_token_error_does_not_match(self):
+        # Guard against over-matching on the word "token".
+        result = classify_api_error(RuntimeError("max_tokens must be positive"))
+        assert result.reason != FailoverReason.auth
+
+
 # ── Test: throttle vs overflow disambiguation + new overflow shapes ─────
 # Port of anomalyco/opencode#37848 (expand context overflow patterns +
 # rate-limit exclusion guard).


### PR DESCRIPTION
## Problem

`CopilotACPClient` raises a bare `RuntimeError` when its subprocess dies during
startup, wrapping whatever the launcher wrote to stderr:

```python
raise RuntimeError(f"Copilot ACP process exited early: {stderr_text}")
```

When that stderr says the launcher could not find a subscription token, the
resulting error has **no HTTP status code** and matches no pattern in
`classify_api_error`, so it lands in `FailoverReason.unknown`:

```
unknown   retryable=True  should_rotate_credential=False  should_fallback=False
```

That combination is the worst of both worlds. It is retryable, so the retry loop
respawns the bridge — but it does not ask for credential rotation, so every
attempt runs against the same empty credential and hits the identical wall. The
turn then fails with a reason that tells the caller nothing, which matters
because callers do branch on `failure_reason`: automation wrappers cannot tell
an infrastructure problem from a genuine task failure, so a credential outage
gets attributed to whatever work happened to be running.

On our fleet a single token-refresh outage produced 154 such failures in one
day, each one three pointless retries against a credential that was simply not
there.

## Fix

Classify "the transport never obtained a credential" as `auth`, matched ahead of
the generic `_AUTH_PATTERNS` entry, with two deliberate differences from the
401/403 verdicts:

* **`retryable=True`** — every transport spawn re-resolves its credential, so a
  transient refresh failure genuinely can differ on the next attempt. This is
  not true of a rejected API key, where the same key will be rejected again;
  that path keeps `retryable=False`.
* **`should_fallback=False`** — one credential serves every model behind a
  subscription, so the backup model meets the identical wall. Falling back only
  hides the cause.

The rule sits first in `_MESSAGE_TAIL_RULES`: nothing reached the provider, so no
provider-side verdict (overload, rate limit, billing) can be true of it. It also
has to outrank `_AUTH_PATTERNS`, because launcher hints often include wording
like "authenticate" or "logged in" that would otherwise match and return the
abort-and-fall-back verdict this change exists to avoid.

## Tests

`TestTransportCredentialMissing` in `tests/agent/test_error_classifier.py`,
17 cases: both stderr shapes plus the `rc=0`/no-stderr shape, the ordering
assertion against generic auth wording in the same message, and controls that a
real 401 and an `Invalid API key provided` keep `retryable=False` +
`should_fallback=True`.

`tests/agent/test_error_classifier.py`: 165 passed. Two named mutations were
checked: deleting the rule fails 7 of the new cases, and demoting it below
`_AUTH_PATTERNS` fails the ordering case. Four failures elsewhere in
`tests/agent` (`test_command_token_source`, `test_fallback_dynamic_credential`,
`test_nous_portal_anthropic_wire`, `test_relay_tools`) reproduce identically on
an unmodified checkout of the same base and are unrelated to this change.
