### PR TITLE
fix(tui_gateway): persist Git metadata for desktop sessions

### DIFF
--- a/tests/tui_gateway/test_session_git_metadata_generation.py
+++ b/tests/tui_gateway/test_session_git_metadata_generation.py
@@ -81,6 +81,7 @@ def test_first_desktop_submit_enriches_explicit_cwd_git_metadata(monkeypatch, tm
     monkeypatch.setattr(server, "_get_db", lambda: db)
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
     monkeypatch.setattr(server, "_schedule_agent_build", lambda _sid: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
     monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
     monkeypatch.setattr(server.git_probe, "branch", lambda _cwd: "feature/session-metadata")
     monkeypatch.setattr(server.git_probe, "common_repo_root", lambda _cwd: str(repo))

--- a/tests/tui_gateway/test_session_git_metadata_generation.py
+++ b/tests/tui_gateway/test_session_git_metadata_generation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import tui_gateway.server as server
+from hermes_state import SessionDB
 
 
 class _ImmediateThread:
@@ -70,3 +71,36 @@ def test_missing_db_claim_never_starts_git_probe(monkeypatch):
 
     assert generation is None
     assert probed == []
+
+
+def test_lazy_desktop_row_with_explicit_cwd_is_enriched_on_hydration(monkeypatch, tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    session = {
+        "session_key": "desktop-session",
+        "source": "desktop",
+        "cwd": str(repo),
+        "explicit_cwd": True,
+    }
+    sid = "live-desktop-session"
+
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server.git_probe, "branch", lambda _cwd: "feature/session-metadata")
+    monkeypatch.setattr(server.git_probe, "common_repo_root", lambda _cwd: str(repo))
+    server._sessions[sid] = session
+    try:
+        assert server._ensure_session_db_row(session) is True
+        assert db.get_session("desktop-session")["git_branch"] is None
+
+        server._hydrate_session_cwd(sid, "desktop-session", db, None)
+
+        row = db.get_session("desktop-session")
+        assert row["cwd"] == str(repo)
+        assert row["git_branch"] == "feature/session-metadata"
+        assert row["git_repo_root"] == str(repo)
+    finally:
+        server._sessions.pop(sid, None)
+        db.close()

--- a/tests/tui_gateway/test_session_git_metadata_generation.py
+++ b/tests/tui_gateway/test_session_git_metadata_generation.py
@@ -73,31 +73,31 @@ def test_missing_db_claim_never_starts_git_probe(monkeypatch):
     assert probed == []
 
 
-def test_lazy_desktop_row_with_explicit_cwd_is_enriched_on_hydration(monkeypatch, tmp_path):
+def test_first_desktop_submit_enriches_explicit_cwd_git_metadata(monkeypatch, tmp_path):
     db = SessionDB(db_path=tmp_path / "state.db")
     repo = tmp_path / "repo"
     repo.mkdir()
-    session = {
-        "session_key": "desktop-session",
-        "source": "desktop",
-        "cwd": str(repo),
-        "explicit_cwd": True,
-    }
-    sid = "live-desktop-session"
 
     monkeypatch.setattr(server, "_get_db", lambda: db)
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda _sid: None)
     monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
     monkeypatch.setattr(server.git_probe, "branch", lambda _cwd: "feature/session-metadata")
     monkeypatch.setattr(server.git_probe, "common_repo_root", lambda _cwd: str(repo))
-    server._sessions[sid] = session
+
+    response = server.handle_request({
+        "id": "create",
+        "method": "session.create",
+        "params": {"source": "desktop", "cwd": str(repo)},
+    })
+    sid = response["result"]["session_id"]
+    key = response["result"]["stored_session_id"]
     try:
-        assert server._ensure_session_db_row(session) is True
-        assert db.get_session("desktop-session")["git_branch"] is None
+        assert db.get_session(key) is None
 
-        server._hydrate_session_cwd(sid, "desktop-session", db, None)
+        assert server._persist_session_row_for_submit("submit", server._sessions[sid]) is None
 
-        row = db.get_session("desktop-session")
+        row = db.get_session(key)
         assert row["cwd"] == str(repo)
         assert row["git_branch"] == "feature/session-metadata"
         assert row["git_repo_root"] == str(repo)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2322,7 +2322,7 @@ def _make_agent(
 
 
 def _hydrate_session_cwd(sid: str, key: str, session_db, profile_home: str | None) -> None:
-    """Adopt the stored row's cwd, or persist the fresh session's cwd (+ schedule git meta) when the row has none."""
+    """Adopt the stored row's cwd and fill missing Git metadata, or persist a fresh cwd."""
     owns_db, db = False, session_db
     if db is None and not profile_home:
         db = _get_db()
@@ -2342,6 +2342,16 @@ def _hydrate_session_cwd(sid: str, key: str, session_db, profile_home: str | Non
                 with _sessions_lock:
                     if sid in _sessions:
                         _sessions[sid]["cwd"] = row["cwd"]
+                # Lazy desktop rows already carry their explicitly chosen cwd, so they never reach the fresh-cwd
+                # branch below. Claim a generation before probing to keep an older probe from overwriting a later
+                # workspace move; complete rows do not need another probe on every resume.
+                if (not row.get("git_branch") or not row.get("git_repo_root")) and hasattr(
+                    db, "update_session_cwd"
+                ):
+                    try:
+                        _persist_session_cwd_and_schedule_git_meta(_sessions[sid], row["cwd"], db=db)
+                    except Exception:
+                        logger.debug("failed to enrich resumed session git metadata", exc_info=True)
             elif hasattr(db, "update_session_cwd"):
                 try:
                     _persist_session_cwd_and_schedule_git_meta(_sessions[sid], _sessions[sid]["cwd"], db=db)

--- a/tui_gateway/session_workdir.py
+++ b/tui_gateway/session_workdir.py
@@ -265,10 +265,11 @@ def _ensure_session_db_row(session: dict) -> bool:
             # deliberately absent) — that keeps the pinned best-effort contract and stays True. See #98924.
             return _db_error is None
         row_model, model_config = _workdir_row_model_config(session)
+        persisted_cwd = _persisted_session_cwd(session)
         try:
             db.create_session(
                 key, source=_session_source(session), model=row_model, model_config=model_config or None,
-                parent_session_id=session.get("parent_session_id") or None, cwd=_persisted_session_cwd(session),
+                parent_session_id=session.get("parent_session_id") or None, cwd=persisted_cwd,
                 # Self-describing rows: aggregators merging several profile DBs can't rely on which file a row came
                 # from; a NULL is only repaired by the one-shot backfill.
                 # Stamp the launch profile explicitly instead of leaving NULL — NULL is exactly what the
@@ -276,6 +277,11 @@ def _ensure_session_db_row(session: dict) -> bool:
                 # backfill ran stayed NULL forever: profile-keyed matching then drops them from the sidebar
                 # and deep links can't resolve them (#99222).
                 profile_name=profile_name_for_home(profile_home) or _current_profile_name())
+            row = db.get_session(key) if persisted_cwd and hasattr(db, "get_session") else None
+            if row and (not row.get("git_branch") or not row.get("git_repo_root")) and hasattr(
+                db, "update_session_cwd"
+            ):
+                _persist_session_cwd_and_schedule_git_meta(session, persisted_cwd, db=db)
             # Born hidden (session.create hidden=true, or set_hidden before the row existed): apply the deferred intent.
             if session.get("pending_hidden"):
                 try:


### PR DESCRIPTION
## Summary

- schedule Git metadata enrichment when a persisted session cwd is missing its branch or repository root
- preserve generation-scoped publication so an older probe cannot overwrite a later workspace move
- cover the lazy desktop row creation and hydration path with a real SessionDB regression test

## Related Issue

Closes #108784

## Testing

- `scripts/run_tests.sh tests/tui_gateway/test_session_git_metadata_generation.py` (3 passed)
- `scripts/run_tests.sh tests/test_tui_gateway_server.py -k 'ensure_session_db_row or hydrate_session_cwd'` (10 passed)
- `scripts/run_tests.sh tests/tui_gateway/test_projects_rpc.py -k 'terminal_session_persists_its_launch_cwd or desktop_launch_cwd'` (3 passed)
