### PR TITLE
fix(kanban): stop empty worktree claims from completing delivery cards

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -861,11 +861,14 @@ def _cmd_complete(args: argparse.Namespace) -> int:
         return rc
     summary = getattr(args, "summary", None)
     raw_meta = getattr(args, "metadata", None)
+    override_git_facts = getattr(args, "override_git_facts", None)
     # Handoff fields are per-run; refuse to copy them across N runs.
-    if len(ids) > 1 and (summary or raw_meta):
+    if len(ids) > 1 and (summary or raw_meta or override_git_facts):
         return _err("kanban: --summary / --metadata are per-task and can't be used "
-                    "with multiple ids (would apply the same handoff to every task). "
+                    "with multiple ids (and neither can --override-git-facts). "
                     "Complete tasks one at a time, or drop the flags for the bulk close.", 2)
+    if override_git_facts is not None and not override_git_facts.strip():
+        return _err("kanban: --override-git-facts requires a non-empty audit reason", 2)
     metadata, rc = _parse_metadata_flag(raw_meta)
     if rc:
         return rc
@@ -881,7 +884,8 @@ def _cmd_complete(args: argparse.Namespace) -> int:
                 return False
             fail_msg[tid] = f"cannot complete {tid} (unknown id or terminal state)"
             return kb.complete_task(conn, tid, result=args.result, summary=summary, metadata=metadata,
-                                    expected_run_id=_worker_run_id_for(tid))
+                                    expected_run_id=_worker_run_id_for(tid),
+                                    override_git_facts=override_git_facts)
 
         return _bulk_apply(ids, op, lambda tid: f"Completed {tid}", fail_msg.__getitem__)
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -864,8 +864,8 @@ def _cmd_complete(args: argparse.Namespace) -> int:
     override_git_facts = getattr(args, "override_git_facts", None)
     # Handoff fields are per-run; refuse to copy them across N runs.
     if len(ids) > 1 and (summary or raw_meta or override_git_facts):
-        return _err("kanban: --summary / --metadata are per-task and can't be used "
-                    "with multiple ids (and neither can --override-git-facts). "
+        return _err("kanban: handoff and override options are per-task and can't be used "
+                    "with multiple ids. "
                     "Complete tasks one at a time, or drop the flags for the bulk close.", 2)
     if override_git_facts is not None and not override_git_facts.strip():
         return _err("kanban: --override-git-facts requires a non-empty audit reason", 2)

--- a/hermes_cli/kanban_completion_facts.py
+++ b/hermes_cli/kanban_completion_facts.py
@@ -1,0 +1,248 @@
+"""Git-backed completion facts for dispatcher-owned worktree runs.
+
+The dispatcher snapshots HEAD after materialising a worktree and before the
+worker starts. Completion probes happen outside SQLite transactions; the
+receipt is persisted only after rechecking run ownership under the write lock.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+import subprocess
+from pathlib import Path
+from typing import Any, Optional
+
+_ACTIVE_STATUSES = {"running", "ready", "blocked", "review"}
+_IMPLEMENTATION_TITLE = re.compile(
+    r"^(?:fix|feat|perf|refactor)(?:\([^)]*\))?:|\b(?:implement|build|add|create|fix|refactor)\b",
+    re.IGNORECASE,
+)
+_IMPLEMENTATION_HANDOFF = re.compile(
+    r"\b(?:implemented|built|added|created|fixed|refactored|changed files?)\b",
+    re.IGNORECASE,
+)
+_PUSH_CLAIM = re.compile(r"\b(?:push(?:ed|es|ing)?|published)\b", re.IGNORECASE)
+_SHA = re.compile(r"[0-9a-f]{40}")
+
+
+def _run_git(path: str, *args: str, timeout: int = 15) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(GIT_TERMINAL_PROMPT="0", GCM_INTERACTIVE="Never")
+    return subprocess.run(
+        ["git", "-C", path, *args], stdin=subprocess.DEVNULL,
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+        timeout=timeout, check=False, env=env,
+    )
+
+
+def _git_output(path: str, *args: str, timeout: int = 15) -> Optional[str]:
+    try:
+        proc = _run_git(path, *args, timeout=timeout)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    value = proc.stdout.strip()
+    return value if proc.returncode == 0 and value else None
+
+
+def record_workspace_baseline(conn: sqlite3.Connection, task_id: str, workspace: Path | str) -> bool:
+    """Record the active run's starting HEAD before its worker process starts."""
+    row = conn.execute(
+        "SELECT current_run_id, status, workspace_kind FROM tasks WHERE id=?", (task_id,),
+    ).fetchone()
+    if not row or row["status"] != "running" or row["workspace_kind"] != "worktree" \
+            or row["current_run_id"] is None:
+        return False
+    run_id = int(row["current_run_id"])
+    path = str(workspace)
+    head = _git_output(path, "rev-parse", "--verify", "HEAD")
+    branch = _git_output(path, "symbolic-ref", "--quiet", "--short", "HEAD")
+    if not head or not _SHA.fullmatch(head):
+        return False
+    from hermes_cli import kanban_db as kb
+    with kb.write_txn(conn):
+        current = conn.execute(
+            "SELECT current_run_id, status FROM tasks WHERE id=?", (task_id,),
+        ).fetchone()
+        if not current or current["status"] != "running" or current["current_run_id"] != run_id:
+            return False
+        kb._append_event(
+            conn, task_id, "workspace_baseline",
+            {"head_sha": head, "branch": branch, "workspace": path}, run_id=run_id,
+        )
+    return True
+
+
+def _snapshot(conn: sqlite3.Connection, task_id: str) -> Optional[tuple]:
+    row = conn.execute(
+        "SELECT current_run_id, status, workspace_kind, workspace_path, branch_name, title "
+        "FROM tasks WHERE id=?", (task_id,),
+    ).fetchone()
+    return tuple(row) if row else None
+
+
+def _baseline(conn: sqlite3.Connection, task_id: str, run_id: int) -> Optional[str]:
+    row = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id=? AND run_id=? "
+        "AND kind='workspace_baseline' ORDER BY id DESC LIMIT 1",
+        (task_id, run_id),
+    ).fetchone()
+    if not row:
+        return None
+    try:
+        value = json.loads(row["payload"] or "{}")
+    except (TypeError, ValueError):
+        return None
+    head = value.get("head_sha") if isinstance(value, dict) else None
+    return head if isinstance(head, str) and _SHA.fullmatch(head) else None
+
+
+def _dirty_count(path: str) -> Optional[int]:
+    try:
+        proc = _run_git(path, "status", "--porcelain=v1", "-z", "--untracked-files=all")
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    fields = proc.stdout.split("\0")
+    count = index = 0
+    while index < len(fields) and fields[index]:
+        record = fields[index]
+        count += 1
+        index += 2 if len(record) >= 2 and (record[0] in "RC" or record[1] in "RC") else 1
+    return count
+
+
+def _claims_implementation(title: str, summary: Optional[str], result: Optional[str], metadata: Any) -> bool:
+    if isinstance(metadata, dict):
+        if metadata.get("commit") or metadata.get("commits") or metadata.get("changed_files"):
+            return True
+        git_claim = metadata.get("git")
+        if isinstance(git_claim, dict) and git_claim.get("implementation") is True:
+            return True
+    handoff = "\n".join(x for x in (summary, result) if isinstance(x, str))
+    return bool(_IMPLEMENTATION_TITLE.search(title or "") or _IMPLEMENTATION_HANDOFF.search(handoff))
+
+
+def _claims_push(summary: Optional[str], result: Optional[str], metadata: Any) -> bool:
+    if isinstance(metadata, dict):
+        if metadata.get("pushed") is True or metadata.get("git_refs_pushed"):
+            return True
+    handoff = "\n".join(x for x in (summary, result) if isinstance(x, str))
+    return bool(_PUSH_CLAIM.search(handoff))
+
+
+def _verify_pushed_refs(path: str, metadata: Any) -> tuple[list[dict], Optional[str]]:
+    claims = metadata.get("git_refs_pushed") if isinstance(metadata, dict) else None
+    if not isinstance(claims, list) or not claims:
+        return [], (
+            "A push/publication was claimed without metadata.git_refs_pushed. Retry with "
+            "[{\"remote\":\"origin\",\"ref\":\"refs/heads/<branch>\",\"sha\":\"<40-hex>\"}]."
+        )
+    receipts: list[dict] = []
+    for claim in claims:
+        if not isinstance(claim, dict):
+            return receipts, "Each metadata.git_refs_pushed entry must be an object."
+        remote, ref, sha = (claim.get(key) for key in ("remote", "ref", "sha"))
+        if not isinstance(remote, str) or not remote.strip() or not isinstance(ref, str) \
+                or not ref.startswith("refs/heads/") or not isinstance(sha, str) or not _SHA.fullmatch(sha):
+            return receipts, (
+                "Each pushed-ref claim requires remote, refs/heads/<branch>, and an exact 40-hex sha."
+            )
+        try:
+            proc = _run_git(path, "ls-remote", "--heads", remote, ref, timeout=30)
+        except (OSError, subprocess.SubprocessError):
+            return receipts, f"Remote-ref evidence unavailable for {remote}:{ref}; retry or block on infrastructure."
+        fields = proc.stdout.strip().split()
+        actual = fields[0] if proc.returncode == 0 and len(fields) >= 2 and fields[1] == ref else None
+        receipt = {"remote": remote, "ref": ref, "claimed_sha": sha, "remote_sha": actual}
+        receipts.append(receipt)
+        if actual != sha:
+            return receipts, f"Remote ref {remote}:{ref} does not resolve to claimed sha {sha}."
+    return receipts, None
+
+
+def prepare_completion_facts(
+    conn: sqlite3.Connection, task_id: str, expected_run_id: Optional[int],
+    metadata: Any, summary: Optional[str], result: Optional[str], override_reason: Optional[str],
+):
+    """Collect a run-bound receipt, or None for non-dispatched/non-worktree completion."""
+    snapshot = _snapshot(conn, task_id)
+    if snapshot is None:
+        return False
+    run_id, status, kind, path, branch, title = snapshot
+    if status not in _ACTIVE_STATUSES or (expected_run_id is not None and run_id != expected_run_id):
+        return False
+    if expected_run_id is None or kind != "worktree":
+        return None
+    receipt = {
+        "ok": False, "workspace": path, "branch": branch, "baseline_sha": None,
+        "head_sha": None, "commits_ahead": None, "dirty_file_count": None,
+        "implementation_claimed": _claims_implementation(title, summary, result, metadata),
+        "push_claimed": _claims_push(summary, result, metadata), "pushed_refs": [],
+        "override_reason": override_reason or None,
+    }
+    error = None
+    baseline = _baseline(conn, task_id, int(run_id)) if run_id is not None else None
+    receipt["baseline_sha"] = baseline
+    if not path or not baseline:
+        error = "Worktree baseline evidence is missing; block on infrastructure or ask an operator to override."
+    elif not Path(path).is_dir():
+        error = "Worktree path is missing; block on infrastructure or ask an operator to override."
+    else:
+        head = _git_output(path, "rev-parse", "--verify", "HEAD")
+        dirty = _dirty_count(path)
+        receipt.update(head_sha=head, dirty_file_count=dirty)
+        if not head or not _SHA.fullmatch(head) or dirty is None:
+            error = "Git completion evidence is unavailable; retry or block on infrastructure."
+        else:
+            try:
+                ancestor = _run_git(path, "merge-base", "--is-ancestor", baseline, head)
+                ahead = _git_output(path, "rev-list", "--count", f"{baseline}..{head}")
+            except (OSError, subprocess.SubprocessError):
+                ancestor, ahead = None, None
+            receipt["commits_ahead"] = int(ahead) if ahead and ahead.isdigit() else None
+            if ancestor is None or ancestor.returncode != 0 or receipt["commits_ahead"] is None:
+                error = "Current HEAD does not descend from the recorded run baseline."
+            elif dirty:
+                error = f"Worktree has {dirty} uncommitted file(s); commit or discard them before completion."
+            elif receipt["implementation_claimed"] and receipt["commits_ahead"] == 0:
+                error = "Implementation was claimed but HEAD has zero commits over the run baseline."
+            elif receipt["push_claimed"]:
+                pushed, error = _verify_pushed_refs(path, metadata)
+                receipt["pushed_refs"] = pushed
+    receipt["error"] = error
+    receipt["ok"] = error is None or bool(override_reason)
+    return snapshot, receipt
+
+
+def attach_receipt(metadata: Any, prepared: Any) -> Any:
+    if not prepared or prepared is False:
+        return metadata
+    receipt = prepared[1]
+    merged = dict(metadata) if isinstance(metadata, dict) else {}
+    merged["completion_facts"] = receipt
+    return merged
+
+
+def record_completion_facts(conn: sqlite3.Connection, task_id: str, prepared: Any) -> bool:
+    """Persist the receipt under run ownership; false leaves the task in-flight."""
+    if prepared is None:
+        return True
+    if prepared is False:
+        return False
+    snapshot, receipt = prepared
+    if _snapshot(conn, task_id) != snapshot:
+        return False
+    from hermes_cli import kanban_db as kb
+    run_id = snapshot[0]
+    kb._append_event(conn, task_id, "completion_facts", receipt, run_id=run_id)
+    if not receipt["ok"]:
+        recovery = (
+            f"Completion fact check failed: {receipt['error']} The task remains in-flight. "
+            "Fix the workspace facts and retry, use kanban_block for unfinished/blocked work, or have an "
+            "operator use `hermes kanban complete --override-git-facts <reason>` for an intentional no-op."
+        )
+        conn.execute("UPDATE tasks SET last_failure_error=? WHERE id=?", (recovery, task_id))
+    return bool(receipt["ok"])

--- a/hermes_cli/kanban_completion_facts.py
+++ b/hermes_cli/kanban_completion_facts.py
@@ -20,7 +20,8 @@ _IMPLEMENTATION_TITLE = re.compile(
     re.IGNORECASE,
 )
 _IMPLEMENTATION_HANDOFF = re.compile(
-    r"\b(?:implemented|built|added|created|fixed|refactored|changed files?)\b",
+    r"\b(?:implemented|built|added|created|fixed|refactored|changed files?|"
+    r"completed implementation|implementation (?:is )?(?:complete|done))\b",
     re.IGNORECASE,
 )
 _PUSH_CLAIM = re.compile(r"\b(?:push(?:ed|es|ing)?|published)\b", re.IGNORECASE)
@@ -174,7 +175,7 @@ def prepare_completion_facts(
     run_id, status, kind, path, branch, title = snapshot
     if status not in _ACTIVE_STATUSES or (expected_run_id is not None and run_id != expected_run_id):
         return False
-    if expected_run_id is None or kind != "worktree":
+    if kind != "worktree" or run_id is None:
         return None
     receipt = {
         "ok": False, "workspace": path, "branch": branch, "baseline_sha": None,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2530,7 +2530,7 @@ def complete_task(
     conn: sqlite3.Connection, task_id: str, *, result: Optional[str] = None,
     summary: Optional[str] = None, metadata: Optional[dict] = None,
     created_cards: Optional[Iterable[str]] = None, expected_run_id: Optional[int] = None,
-    fire_lifecycle_hook: bool = True,
+    fire_lifecycle_hook: bool = True, override_git_facts: Optional[str] = None,
 ) -> bool:
     """``running|ready|blocked|review -> done``; records ``result``.
 
@@ -2546,12 +2546,21 @@ def complete_task(
     # Cheap pre-check; re-checked inside the txn to close the parent-reopen race.
     if not _parents_satisfied(conn, task_id):
         return False
+    from hermes_cli.kanban_completion_facts import (
+        attach_receipt, prepare_completion_facts, record_completion_facts,
+    )
     from hermes_cli.kanban_pr_acceptance_store import prepare_acceptance, record_acceptance
     verified_cards = _gate_created_cards(conn, task_id, created_cards, summary or result)
     metadata = _merge_completion_prose_artifacts(
         conn, task_id, metadata, summary=summary, result=result,
     )
     handoff_summary = summary if summary is not None else result
+    facts = prepare_completion_facts(
+        conn, task_id, expected_run_id, metadata, summary, result, override_git_facts,
+    )
+    if facts is False:
+        return False
+    metadata = attach_receipt(metadata, facts)
     acceptance = prepare_acceptance(conn, task_id, expected_run_id, metadata)
     if acceptance is False:
         return False
@@ -2559,6 +2568,8 @@ def complete_task(
         # Hard invariant even for human review approval: a parent may have
         # reopened while this task waited.
         if not _parents_satisfied(conn, task_id):
+            return False
+        if not record_completion_facts(conn, task_id, facts):
             return False
         if acceptance is not None and not record_acceptance(conn, task_id, acceptance):
             return False

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -1567,6 +1567,14 @@ def _dispatch_lane_task(
     _kbw.set_workspace_path(conn, claimed.id, str(workspace))
     if claimed.workspace_kind == "worktree":
         _kbw.set_branch_name(conn, claimed.id, resolved_branch_name or (claimed.branch_name or "").strip() or f"wt/{claimed.id}")
+        from hermes_cli.kanban_completion_facts import record_workspace_baseline
+        if not record_workspace_baseline(conn, claimed.id, workspace):
+            if _record_task_failure(
+                conn, claimed.id, "workspace: could not capture the starting git HEAD",
+                outcome="spawn_failed", failure_limit=failure_limit, release_claim=True, end_run=True,
+            ):
+                result.auto_blocked.append(claimed.id)
+            return False
     _kbw._maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
     if lane == "review":
         # Force-load sdlc-review; the kanban lifecycle is already in every

--- a/hermes_cli/kanban_parser.py
+++ b/hermes_cli/kanban_parser.py
@@ -284,6 +284,8 @@ _SPECS = [
         _arg("--metadata",
              help='JSON dict of structured facts (e.g. \'{"changed_files": [...], '
                   '"tests_run": 12}\'). Stored on the closing run.'),
+        _arg("--override-git-facts", metavar="REASON",
+             help="Operator override for a failed worktree fact check. The non-empty reason is audited."),
     ], help="Mark one or more tasks done"),
     _cmd("edit", [
         _TASK_ID,

--- a/tests/hermes_cli/test_kanban_completion_facts.py
+++ b/tests/hermes_cli/test_kanban_completion_facts.py
@@ -1,0 +1,112 @@
+"""Behavioral contracts for git-backed kanban completion facts."""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from hermes_cli import kanban_completion_facts as facts
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_workspace as kbw
+
+
+def _git(repo: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True,
+    )
+    return proc.stdout.strip()
+
+
+def _repo(path: Path) -> Path:
+    path.mkdir()
+    _git(path, "init")
+    _git(path, "config", "user.email", "test@example.com")
+    _git(path, "config", "user.name", "Test")
+    (path / "tracked.txt").write_text("base\n", encoding="utf-8")
+    _git(path, "add", "tracked.txt")
+    _git(path, "commit", "-m", "base")
+    return path
+
+
+def _running_worktree(conn, repo: Path, title: str):
+    tid = kb.create_task(
+        conn, title=title, workspace_kind="worktree", workspace_path=str(repo),
+        branch_name=_git(repo, "branch", "--show-current"),
+    )
+    conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (tid,))
+    conn.commit()
+    task = kb.claim_task(conn, tid, claimer="test")
+    assert task is not None and task.current_run_id is not None
+    kbw.set_workspace_path(conn, tid, repo)
+    assert facts.record_workspace_baseline(conn, tid, repo)
+    return tid, task.current_run_id
+
+
+def test_worktree_completion_rejects_zero_commit_and_dirty_claims_but_audits_override(
+    kanban_home, tmp_path,
+):
+    with kbc.connect() as conn:
+        zero_repo = _repo(tmp_path / "zero")
+        zero, zero_run = _running_worktree(conn, zero_repo, "fix(parser): handle empty input")
+        assert not kb.complete_task(
+            conn, zero, summary="Implemented the parser fix", expected_run_id=zero_run,
+        )
+        assert kb.get_task(conn, zero).status == "running"
+        assert "zero commits" in kb.get_task(conn, zero).last_failure_error
+
+        dirty_repo = _repo(tmp_path / "dirty")
+        dirty, dirty_run = _running_worktree(conn, dirty_repo, "Investigate parser behavior")
+        (dirty_repo / "tracked.txt").write_text("uncommitted\n", encoding="utf-8")
+        assert not kb.complete_task(
+            conn, dirty, summary="Investigation complete", expected_run_id=dirty_run,
+        )
+        assert "uncommitted file" in kb.get_task(conn, dirty).last_failure_error
+        assert kb.complete_task(
+            conn, dirty, summary="Intentional local-only investigation",
+            expected_run_id=dirty_run, override_git_facts="operator accepted an uncommitted probe",
+        )
+        run = kb.latest_run(conn, dirty)
+        receipt = run.metadata["completion_facts"]
+        assert receipt["dirty_file_count"] == 1
+        assert receipt["override_reason"] == "operator accepted an uncommitted probe"
+
+
+def test_push_claim_requires_exact_remote_ref_and_persists_receipt(kanban_home, tmp_path):
+    repo = _repo(tmp_path / "repo")
+    remote = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True, capture_output=True, text=True)
+    _git(repo, "remote", "add", "origin", str(remote))
+
+    with kbc.connect() as conn:
+        tid, run_id = _running_worktree(conn, repo, "feat(kanban): persist completion facts")
+        (repo / "tracked.txt").write_text("implemented\n", encoding="utf-8")
+        _git(repo, "add", "tracked.txt")
+        _git(repo, "commit", "-m", "implement")
+        head = _git(repo, "rev-parse", "HEAD")
+        branch = _git(repo, "branch", "--show-current")
+        summary = "Implemented and pushed completion fact validation"
+
+        assert not kb.complete_task(conn, tid, summary=summary, expected_run_id=run_id)
+        assert "git_refs_pushed" in kb.get_task(conn, tid).last_failure_error
+
+        _git(repo, "push", "origin", f"HEAD:refs/heads/{branch}")
+        metadata = {"git_refs_pushed": [{
+            "remote": "origin", "ref": f"refs/heads/{branch}", "sha": head,
+        }]}
+        assert kb.complete_task(
+            conn, tid, summary=summary, metadata=metadata, expected_run_id=run_id,
+        )
+        run = kb.latest_run(conn, tid)
+        receipt = run.metadata["completion_facts"]
+        assert receipt["commits_ahead"] == 1
+        assert receipt["dirty_file_count"] == 0
+        assert receipt["pushed_refs"] == [{
+            "remote": "origin", "ref": f"refs/heads/{branch}",
+            "claimed_sha": head, "remote_sha": head,
+        }]
+        event = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id=? AND kind='completion_facts' "
+            "ORDER BY id DESC LIMIT 1", (tid,),
+        ).fetchone()
+        assert json.loads(event["payload"])["ok"] is True

--- a/tests/hermes_cli/test_kanban_completion_facts.py
+++ b/tests/hermes_cli/test_kanban_completion_facts.py
@@ -5,10 +5,22 @@ import json
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from hermes_cli import kanban_completion_facts as facts
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_db_connect as kbc
 from hermes_cli import kanban_db_workspace as kbw
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
 
 
 def _git(repo: Path, *args: str) -> str:

--- a/tests/hermes_cli/test_kanban_completion_facts.py
+++ b/tests/hermes_cli/test_kanban_completion_facts.py
@@ -11,6 +11,7 @@ from hermes_cli import kanban_completion_facts as facts
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_db_connect as kbc
 from hermes_cli import kanban_db_workspace as kbw
+from hermes_cli.kanban import run_slash
 
 
 @pytest.fixture
@@ -74,10 +75,11 @@ def test_worktree_completion_rejects_zero_commit_and_dirty_claims_but_audits_ove
             conn, dirty, summary="Investigation complete", expected_run_id=dirty_run,
         )
         assert "uncommitted file" in kb.get_task(conn, dirty).last_failure_error
-        assert kb.complete_task(
-            conn, dirty, summary="Intentional local-only investigation",
-            expected_run_id=dirty_run, override_git_facts="operator accepted an uncommitted probe",
+        output = run_slash(
+            f'complete {dirty} --summary "Intentional local-only investigation" '
+            '--override-git-facts "operator accepted an uncommitted probe"'
         )
+        assert output == f"Completed {dirty}"
         run = kb.latest_run(conn, dirty)
         receipt = run.metadata["completion_facts"]
         assert receipt["dirty_file_count"] == 1

--- a/tools/kanban_tools_schemas.py
+++ b/tools/kanban_tools_schemas.py
@@ -102,7 +102,13 @@ KANBAN_COMPLETE_SCHEMA = _schema(
         "in ``artifacts`` — the gateway notifier will upload them as "
         "native attachments to the human who subscribed to the task, "
         "so the deliverable lands in their chat alongside the summary "
-        "instead of being a path they have to fetch by hand."
+        "instead of being a path they have to fetch by hand. Dispatcher-owned "
+        "worktree runs are checked against their starting git HEAD: dirty "
+        "worktrees and zero-commit implementation claims are rejected. Push "
+        "claims require metadata.git_refs_pushed objects containing remote, "
+        "refs/heads/<branch>, and the exact 40-hex sha. A failed fact check "
+        "keeps the task in flight; fix it and retry, or use kanban_block when "
+        "genuinely blocked."
     ),
     {
         "task_id": _prop("string", _DESC_TASK_ID_DEFAULT),

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -82,6 +82,28 @@ guard, not OS isolation against arbitrary direct database writes. GitHub Enterpr
 is not covered. Related publication/lifecycle work: #91230, #84254, #52311; local
 verification and publication alone are not remote acceptance.
 
+## Worktree completion facts
+
+Dispatcher-owned `worktree` runs snapshot their starting HEAD immediately before
+the worker starts. At `kanban_complete`, the shared lifecycle boundary records a
+`completion_facts` receipt containing the baseline and current SHA, commits ahead,
+dirty-file count, and any claimed remote refs. This applies independently of PR
+completion contracts.
+
+Completion stays in flight when the worktree is dirty, an implementation claim has
+zero commits over the run baseline, or a push/publication claim lacks exact remote
+evidence. Push claims must include `metadata.git_refs_pushed`, with one object per
+ref: `{"remote":"origin","ref":"refs/heads/feature","sha":"<40-hex>"}`.
+Hermes verifies each SHA with `git ls-remote`; a local branch or a prose URL is not
+proof that a push happened.
+
+Workers should fix the repository state and retry, or call `kanban_block` when work
+is unfinished or infrastructure prevents verification. An operator may accept an
+intentional no-op or exceptional dirty state with `hermes kanban complete <id>
+--override-git-facts "<reason>"`; the non-empty reason is stored in the receipt.
+The model-facing completion tool has no override parameter, so a worker cannot
+waive its own failed fact check.
+
 ## Kanban vs. `delegate_task`
 
 They look similar; they are not the same primitive.


### PR DESCRIPTION
## What does this PR do?

Kanban workers can currently mark implementation, verification, or landing cards done from prose alone even when their worktree contains no new commit or an asserted push never reached a remote ref. This lets downstream cards consume a fabricated success state and can leave an engineering wave with no delivered work.

### Symptom

A dispatcher-owned worktree card can report completed implementation or a successful push while its branch remains at the starting commit, contains uncommitted work, or has no matching remote ref. The card still transitions to `done`.

### Impact

Operators and dependent tasks can trust a completed card whose claimed repository work does not exist. The affected blast radius is limited to kanban worktree runs, but within those runs the board's completion state is not a trustworthy delivery boundary.

### Bug Cause

**Trigger:** `hermes_cli/kanban_db.py:complete_task` accepts a worker handoff for a worktree run.

**Causal chain:**
1. The dispatcher materializes a worktree but does not retain its starting HEAD as run evidence.
2. `complete_task` validates lifecycle ownership and selected structured declarations, but not commits, dirty state, or remote refs.
3. The worker's summary is persisted and the task becomes `done`, allowing dependent cards to run from an unsupported success claim.

**Why it is wrong:** A self-reported summary is treated as repository evidence at the same boundary that releases downstream work.

**Working sibling / contrast:** Explicit PR completion contracts already collect external GitHub acceptance receipts and bind them to run ownership, but local-only worktree cards have no equivalent repository-fact receipt.

**Ruled out:** The goal-mode judge and `created_cards` validation do not close this gap. The judge is optional and semantic, while `created_cards` only proves task identity, not repository work.

### Fix

- Snapshot the worktree HEAD after materialization and before the worker process starts.
- Persist run-bound completion receipts with baseline/current SHA, commits ahead, and dirty-file count.
- Reject dirty worktrees and zero-commit implementation claims without changing task state.
- Require push claims to declare exact remote refs and SHAs, then verify them with `git ls-remote`.
- Keep override authority out of the model tool; operators can use an audited CLI-only reason for intentional no-op exceptions.

## Related Issue

Closes #108782

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_completion_facts.py` - collect, verify, and persist run-bound git facts.
- `hermes_cli/kanban_db_dispatch.py` - snapshot starting HEAD before spawning a worktree worker.
- `hermes_cli/kanban_db.py` - enforce facts at the shared terminal lifecycle boundary.
- `hermes_cli/kanban.py` and `hermes_cli/kanban_parser.py` - add the audited operator-only override.
- `tools/kanban_tools_schemas.py` - document worker recovery and pushed-ref evidence.
- `tests/hermes_cli/test_kanban_completion_facts.py` - cover zero-commit, dirty, override, and exact remote-ref contracts.
- `website/docs/user-guide/features/kanban.md` - document receipts, blocking semantics, and override behavior.

## How to Test

1. Run the focused completion-fact contracts:

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_completion_facts.py
```

2. Run the existing kanban CLI and tool lifecycle suites:

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py tests/tools/test_kanban_tools.py
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for the bug fix

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] Config examples are N/A because no config key changed
- [x] CONTRIBUTING.md and AGENTS.md are N/A because contributor policy did not change
- [x] I've considered cross-platform impact; git is invoked as an argv list with UTF-8 replacement decoding and no shell
- [x] I've updated the model tool description for the changed completion behavior
