### PR TITLE
fix(usage): support user pricing overrides and resolve relay models (#108775)

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -565,6 +565,8 @@ def finalize_turn(
         ).get("service_tier"),
         "session_id": agent.session_id,
     }
+    if result.get("cost_status") == "unknown" and result.get("estimated_cost_usd") == 0.0:
+        result["estimated_cost_usd"] = None
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()
     # Persistence failures already set failed=True; also stamp `error` so the gateway

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -312,9 +312,11 @@ def _first_nonzero(obj: Any, *paths: tuple[str, ...]) -> int:
 
 
 # Picker slugs → snapshot provider key ("openai-api" is the slug for direct
+# Picker slugs → snapshot provider key ("openai-api" is the slug for direct
 # api.openai.com). Google and Fireworks are matched by name OR host below.
 _SNAPSHOT_PROVIDER_ALIASES = {
     "anthropic": "anthropic", "openai": "openai", "openai-api": "openai", "minimax": "minimax", "minimax-cn": "minimax-cn",
+    "deepseek": "deepseek", "deepseek-api": "deepseek", "bedrock": "bedrock",
 }
 # AI Studio and Vertex host the same Gemini models (the Vertex "google/" vendor
 # prefix is stripped with the rest of the path).
@@ -329,7 +331,7 @@ def resolve_billing_route(
     model = (model_name or "").strip()
     if not provider_name and "/" in model:
         inferred_provider, bare_model = model.split("/", 1)
-        if inferred_provider in {"anthropic", "openai", "google"}:
+        if inferred_provider in {"anthropic", "openai", "google", "deepseek", "minimax", "minimax-cn", "bedrock", "fireworks"}:
             provider_name = inferred_provider
             model = bare_model
 
@@ -356,6 +358,10 @@ def resolve_billing_route(
             snapshot_provider = "google"
         elif provider_name == "fireworks" or host("api.fireworks.ai"):
             snapshot_provider = "fireworks"
+        elif provider_name == "deepseek" or host("api.deepseek.com"):
+            snapshot_provider = "deepseek"
+        elif provider_name == "bedrock":
+            snapshot_provider = "bedrock"
     if snapshot_provider:
         return BillingRoute(provider=snapshot_provider, model=bare, base_url=url, billing_mode="official_docs_snapshot")
     if provider_name in {"custom", "local"} or (base and base_url_hostname(base) in ("localhost", "127.0.0.1")):
@@ -393,6 +399,30 @@ def _normalize_anthropic_model_name(model: str) -> str:
 _MODEL_NORMALIZERS = {"anthropic": _normalize_anthropic_model_name, "bedrock": _normalize_bedrock_model_name}
 
 
+def _infer_canonical_provider(model: str) -> Optional[str]:
+    """Infer the upstream model provider from canonical model names or prefixes.
+    Used as a fallback for relays, proxies, and transit model ids."""
+    m = (model or "").lower().strip()
+    if "/" in m:
+        prefix, rest = m.split("/", 1)
+        if prefix in {"anthropic", "openai", "google", "deepseek", "minimax", "bedrock", "fireworks"}:
+            return prefix
+        m = rest
+    if m.startswith("claude-") or "claude-" in m:
+        return "anthropic"
+    if m.startswith(("gpt-", "o1-", "o3-", "o4-", "o1", "o3", "o4")) or "-gpt-" in m:
+        return "openai"
+    if m.startswith("gemini-") or "gemini-" in m:
+        return "google"
+    if m.startswith("deepseek-") or "deepseek-" in m:
+        return "deepseek"
+    if m.startswith("minimax-") or "minimax-" in m:
+        return "minimax"
+    if m.startswith("amazon.nova-") or m.startswith("anthropic.claude-"):
+        return "bedrock"
+    return None
+
+
 def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]:
     model = route.model.lower()
     entry = _OFFICIAL_DOCS_PRICING.get((route.provider, model))
@@ -400,7 +430,129 @@ def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]
         return entry
     normalize = _MODEL_NORMALIZERS.get(route.provider)
     normalized = normalize(model) if normalize else model
-    return _OFFICIAL_DOCS_PRICING.get((route.provider, normalized)) if normalized != model else None
+    if normalized != model:
+        entry = _OFFICIAL_DOCS_PRICING.get((route.provider, normalized))
+        if entry:
+            return entry
+
+    # Relay / transit / alias fallback: if provider lookup failed (e.g. model routed
+    # via an OpenAI-compatible relay, custom proxy, or alias), check the canonical
+    # provider inferred from the model id.
+    inferred_provider = _infer_canonical_provider(model) or _infer_canonical_provider(route.model)
+    if inferred_provider and inferred_provider != route.provider:
+        canon_entry = _OFFICIAL_DOCS_PRICING.get((inferred_provider, model))
+        if canon_entry:
+            return canon_entry
+        canon_norm = _MODEL_NORMALIZERS.get(inferred_provider)
+        canon_normalized = canon_norm(model) if canon_norm else model
+        if canon_normalized != model:
+            canon_entry = _OFFICIAL_DOCS_PRICING.get((inferred_provider, canon_normalized))
+            if canon_entry:
+                return canon_entry
+    return None
+
+
+def get_user_pricing_entry(
+    model_name: str, provider: Optional[str] = None, config: Optional[dict] = None
+) -> Optional[PricingEntry]:
+    """Look up user-configured pricing override from config.yaml.
+
+    Supports:
+    model_pricing:
+      "provider/model": {input: ..., output: ..., cache_read: ..., cache_write: ..., request: ..., source: ..., version: ...}
+      "model": {input: ..., output: ...}
+    Also tolerates `pricing.overrides`, `pricing.models`, or `pricing_overrides`.
+    """
+    if config is None:
+        try:
+            from hermes_cli.config import load_config_readonly
+            config = load_config_readonly()
+        except Exception:
+            config = None
+    if not isinstance(config, dict):
+        return None
+
+    overrides = (
+        config.get("model_pricing")
+        or (config.get("pricing") or {}).get("overrides")
+        or (config.get("pricing") or {}).get("models")
+        or config.get("pricing_overrides")
+    )
+    if not isinstance(overrides, dict):
+        return None
+
+    model = (model_name or "").strip()
+    provider_str = (provider or "").strip().lower()
+    bare_model = model.split("/")[-1]
+
+    candidates: list[str] = []
+    if provider_str and model:
+        candidates.append(f"{provider_str}/{model}")
+        if bare_model != model:
+            candidates.append(f"{provider_str}/{bare_model}")
+    if model:
+        candidates.append(model)
+    if bare_model != model:
+        candidates.append(bare_model)
+
+    raw_entry: Optional[dict[str, Any]] = None
+    for cand in candidates:
+        if cand in overrides and isinstance(overrides[cand], dict):
+            raw_entry = overrides[cand]
+            break
+        cand_lower = cand.lower()
+        for k, v in overrides.items():
+            if isinstance(k, str) and k.lower() == cand_lower and isinstance(v, dict):
+                raw_entry = v
+                break
+        if raw_entry is not None:
+            break
+
+    if raw_entry is None:
+        return None
+
+    def get_rate(*keys: str) -> Optional[Decimal]:
+        for k in keys:
+            if k in raw_entry and raw_entry[k] is not None:
+                dec = _to_decimal(raw_entry[k])
+                if dec is not None:
+                    return dec
+        return None
+
+    input_cost = get_rate("input", "input_cost_per_million", "prompt", "input_cost")
+    output_cost = get_rate("output", "output_cost_per_million", "completion", "output_cost")
+    cache_read = get_rate("cache_read", "cache_read_cost_per_million", "cached_prompt", "cache_read_cost")
+    cache_write = get_rate("cache_write", "cache_write_cost_per_million", "cache_creation", "cache_write_cost")
+    request_cost = get_rate("request", "request_cost")
+
+    if input_cost is None and output_cost is None and request_cost is None:
+        return None
+
+    raw_source = str(raw_entry.get("source") or "").strip().lower()
+    source: CostSource = "custom_contract" if raw_source == "custom_contract" else "user_override"
+    version = str(raw_entry.get("version") or raw_entry.get("pricing_version") or "user-override").strip()
+
+    tier_threshold = raw_entry.get("tier_threshold_tokens")
+    try:
+        tier_threshold_tokens = int(tier_threshold) if tier_threshold is not None else None
+    except (ValueError, TypeError):
+        tier_threshold_tokens = None
+
+    return PricingEntry(
+        input_cost_per_million=input_cost,
+        output_cost_per_million=output_cost,
+        cache_read_cost_per_million=cache_read,
+        cache_write_cost_per_million=cache_write,
+        request_cost=request_cost,
+        source=source,
+        pricing_version=version,
+        source_url=raw_entry.get("url") or raw_entry.get("source_url"),
+        tier_threshold_tokens=tier_threshold_tokens,
+        input_cost_per_million_above=get_rate("input_cost_per_million_above", "input_above"),
+        output_cost_per_million_above=get_rate("output_cost_per_million_above", "output_above"),
+        cache_read_cost_per_million_above=get_rate("cache_read_cost_per_million_above", "cache_read_above"),
+        cache_write_cost_per_million_above=get_rate("cache_write_cost_per_million_above", "cache_write_above"),
+    )
 
 
 def _openrouter_pricing_entry(route: BillingRoute) -> Optional[PricingEntry]:
@@ -441,8 +593,13 @@ def _pricing_entry_from_metadata(
 
 def get_pricing_entry(
     model_name: str, provider: Optional[str] = None, base_url: Optional[str] = None,
-    api_key: Optional[str] = None,
+    api_key: Optional[str] = None, config: Optional[dict] = None,
 ) -> Optional[PricingEntry]:
+    # 1. User pricing override has highest priority
+    user_entry = get_user_pricing_entry(model_name, provider=provider, config=config)
+    if user_entry:
+        return user_entry
+
     route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
     if route.billing_mode == "subscription_included":
         return _INCLUDED_ENTRY
@@ -546,12 +703,19 @@ def normalize_usage(
 
 
 def _unknown_cost(source: CostSource, *notes: str) -> CostResult:
-    return CostResult(amount_usd=None, status="unknown", source=source, label="n/a", notes=notes)
+    return CostResult(
+        amount_usd=None,
+        status="unknown",
+        source=source,
+        label="unpriced",
+        notes=notes or ("Pricing snapshot not available",),
+    )
 
 
 def estimate_usage_cost(
     model_name: str, usage: CanonicalUsage, *, provider: Optional[str] = None,
     base_url: Optional[str] = None, api_key: Optional[str] = None,
+    config: Optional[dict] = None,
 ) -> CostResult:
     route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
     if route.billing_mode == "subscription_included":
@@ -560,7 +724,7 @@ def estimate_usage_cost(
             pricing_version="included-route", notes=(_INCLUDED_NOTE,),
         )
 
-    entry = get_pricing_entry(model_name, provider=provider, base_url=base_url, api_key=api_key)
+    entry = get_pricing_entry(model_name, provider=provider, base_url=base_url, api_key=api_key, config=config)
     if not entry:
         return _unknown_cost("none")
 
@@ -605,10 +769,10 @@ def estimate_usage_cost(
 
 def has_known_pricing(
     model_name: str, provider: Optional[str] = None, base_url: Optional[str] = None,
-    api_key: Optional[str] = None,
+    api_key: Optional[str] = None, config: Optional[dict] = None,
 ) -> bool:
     """True if pricing data exists for this model+route (direct lookup, no dummy usage)."""
-    return get_pricing_entry(model_name, provider=provider, base_url=base_url, api_key=api_key) is not None
+    return get_pricing_entry(model_name, provider=provider, base_url=base_url, api_key=api_key, config=config) is not None
 
 
 def format_duration_compact(seconds: float) -> str:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -251,6 +251,33 @@ model:
 #         stale_timeout_seconds: 1800  # Longer non-stream stale timeout for slow large-context turns
 
 # =============================================================================
+# Custom Model Pricing Overrides
+# =============================================================================
+# Override or provide rates for models that are unpriced, relayed, or under custom
+# enterprise contracts. Rates are USD per million tokens ($/1M).
+#
+# Supported fields:
+#   input: USD per million input/prompt tokens
+#   output: USD per million output/completion tokens
+#   cache_read: USD per million cached prompt tokens read (optional)
+#   cache_write: USD per million cache creation tokens written (optional)
+#   request: USD fixed cost per API request (optional)
+#   source: "user_override" (default) or "custom_contract"
+#   version: Custom contract or version identifier label (optional)
+#
+# Keys can match "provider/model", full model name, or bare model name:
+# model_pricing:
+#   "openai/custom-gpt-5":
+#     input: 2.00
+#     output: 8.00
+#     cache_read: 0.50
+#   "my-relay-model":
+#     input: 1.50
+#     output: 6.00
+#     source: "custom_contract"
+#     version: "contract-q3-2026"
+
+# =============================================================================
 # Unified Timeouts (operation deadlines)
 # =============================================================================
 # One place to override Hermes's internal operation deadlines (seconds).

--- a/hermes_cli/cli_info_mixin.py
+++ b/hermes_cli/cli_info_mixin.py
@@ -712,6 +712,16 @@ class CLIInfoMixin:
         print(f"  Total tokens:              {agent.session_total_tokens:>10,}")
         print(f"  API calls:                 {calls:>10,}")
         print(f"  Session duration:          {elapsed:>10}")
+        cost_status = getattr(agent, "session_cost_status", "unknown")
+        cost_usd = getattr(agent, "session_estimated_cost_usd", 0.0)
+        if cost_status == "unknown" and cost_usd == 0.0:
+            print(f"  Estimated cost:            {'unpriced (unknown)':>10}")
+        elif cost_status == "included":
+            print(f"  Estimated cost:            {'included':>10}")
+        else:
+            from decimal import Decimal
+            from agent.usage_pricing import format_cost_label
+            print(f"  Estimated cost:            {format_cost_label(Decimal(str(cost_usd))):>10}")
         print(f"  {'─' * 40}")
         from agent.context_breakdown import context_display_source
         mark = "~" if context_display_source(compressor) != "provider_usage" else ""

--- a/hermes_cli/model_cost_guard.py
+++ b/hermes_cli/model_cost_guard.py
@@ -62,8 +62,10 @@ def _can_trust_model_info_pricing(
 def _can_trust_pricing_lookup(
     model_name: str, *, provider: Optional[str], base_url: Optional[str]) -> bool:
     try:
-        from agent.usage_pricing import resolve_billing_route
+        from agent.usage_pricing import get_user_pricing_entry, resolve_billing_route
 
+        if get_user_pricing_entry(model_name, provider=provider) is not None:
+            return True
         route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
     except Exception:
         return False

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -149,6 +149,8 @@ def _write_usage_file(path: Optional[str], result: dict, failure: Optional[str] 
         return
     try:
         report = {key: result.get(key) for key in _USAGE_KEYS}
+        if report.get("cost_status") == "unknown" and report.get("estimated_cost_usd") == 0.0:
+            report["estimated_cost_usd"] = None
         report["failed"] = bool(result.get("failed")) or failure is not None
         report["service_tier"] = result.get("service_tier")
         if failure is not None:

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -962,3 +962,108 @@ def test_flat_entries_unaffected_by_tier_machinery():
     )
     # 250k * $0.25/M + 10k * $1.50/M
     assert result.amount_usd == Decimal("0.0775")
+
+
+def test_user_pricing_override_precedence():
+    """User-configured pricing in config.yaml overrides built-in snapshots."""
+    from agent.usage_pricing import get_user_pricing_entry
+
+    cfg = {
+        "model_pricing": {
+            "openai/custom-gpt": {
+                "input": "1.50",
+                "output": "6.00",
+                "cache_read": "0.20",
+                "cache_write": "1.00",
+                "request": "0.01",
+                "source": "custom_contract",
+                "version": "contract-v1",
+            },
+            "claude-sonnet-4-6": {
+                "input": "2.50",
+                "output": "12.50",
+            },
+        }
+    }
+
+    # Custom model lookup
+    custom_entry = get_user_pricing_entry("custom-gpt", provider="openai", config=cfg)
+    assert custom_entry is not None
+    assert custom_entry.input_cost_per_million == Decimal("1.50")
+    assert custom_entry.output_cost_per_million == Decimal("6.00")
+    assert custom_entry.cache_read_cost_per_million == Decimal("0.20")
+    assert custom_entry.cache_write_cost_per_million == Decimal("1.00")
+    assert custom_entry.request_cost == Decimal("0.01")
+    assert custom_entry.source == "custom_contract"
+    assert custom_entry.pricing_version == "contract-v1"
+
+    # Built-in model override takes precedence over official docs snapshot
+    override_entry = get_pricing_entry("claude-sonnet-4-6", provider="anthropic", config=cfg)
+    assert override_entry is not None
+    assert override_entry.input_cost_per_million == Decimal("2.50")
+    assert override_entry.output_cost_per_million == Decimal("12.50")
+    assert override_entry.source == "user_override"
+
+    # Cost estimate uses user pricing
+    res = estimate_usage_cost(
+        "claude-sonnet-4-6",
+        CanonicalUsage(input_tokens=1_000_000, output_tokens=100_000),
+        provider="anthropic",
+        config=cfg,
+    )
+    # 1M * 2.50 + 0.1M * 12.50 = 2.50 + 1.25 = 3.75
+    assert res.amount_usd == Decimal("3.75")
+    assert res.source == "user_override"
+
+
+def test_deepseek_and_bedrock_direct_routes():
+    """Direct provider calls to deepseek and bedrock resolve correctly (#108775)."""
+    route_ds = resolve_billing_route("deepseek-chat", provider="deepseek")
+    assert route_ds.provider == "deepseek"
+    assert route_ds.billing_mode == "official_docs_snapshot"
+
+    entry_ds = get_pricing_entry("deepseek-chat", provider="deepseek")
+    assert entry_ds is not None
+    assert entry_ds.input_cost_per_million == Decimal("0.15")
+
+    route_bedrock = resolve_billing_route("anthropic.claude-sonnet-4-6", provider="bedrock")
+    assert route_bedrock.provider == "bedrock"
+    assert route_bedrock.billing_mode == "official_docs_snapshot"
+
+    entry_bedrock = get_pricing_entry("anthropic.claude-sonnet-4-6", provider="bedrock")
+    assert entry_bedrock is not None
+    assert entry_bedrock.input_cost_per_million == Decimal("3.00")
+
+
+def test_relay_and_proxy_canonical_provider_fallback():
+    """Relays, proxies, and transit model ids fall back to canonical model pricing (#108775)."""
+    # Relay running Claude through an OpenAI-compatible relay
+    entry = get_pricing_entry("claude-sonnet-4-6", provider="relay-proxy")
+    assert entry is not None
+    assert entry.input_cost_per_million == Decimal("3.00")
+    assert entry.output_cost_per_million == Decimal("15.00")
+
+    # Relay with vendor prefix e.g. "anthropic/claude-opus-4-6"
+    entry_prefixed = get_pricing_entry("anthropic/claude-opus-4-6", provider="custom-gw")
+    assert entry_prefixed is not None
+    assert entry_prefixed.input_cost_per_million == Decimal("5.00")
+    assert entry_prefixed.output_cost_per_million == Decimal("25.00")
+
+    # DeepSeek model via generic OpenAI-compatible provider
+    entry_ds = get_pricing_entry("deepseek-v4-flash", provider="openai-relay")
+    assert entry_ds is not None
+    assert entry_ds.input_cost_per_million == Decimal("0.15")
+
+
+def test_unpriced_models_labeled_unpriced_and_null_usd():
+    """Unpriced models never return $0.0 silently; they return status='unknown', label='unpriced', amount_usd=None."""
+    res = estimate_usage_cost(
+        "totally-unpriced-mock-model",
+        CanonicalUsage(input_tokens=5000, output_tokens=1000),
+        provider="unknown-provider",
+    )
+    assert res.status == "unknown"
+    assert res.amount_usd is None
+    assert res.label == "unpriced"
+    assert "Pricing snapshot not available" in res.notes[0]
+

--- a/tests/hermes_cli/test_model_cost_guard.py
+++ b/tests/hermes_cli/test_model_cost_guard.py
@@ -171,3 +171,27 @@ def test_openai_gpt55_pro_warns_for_nous_portal_pricing(monkeypatch):
     assert warning.input_cost_per_million == Decimal("25.000000")
     assert warning.output_cost_per_million == Decimal("125.000000")
     assert "did you mean to select openai/gpt-5.5?" in warning.message
+
+
+def test_warns_when_user_pricing_override_exceeds_threshold(monkeypatch):
+    monkeypatch.setattr("agent.models_dev.get_model_info", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {
+            "model_pricing": {
+                "custom-giant-model": {
+                    "input": "25.00",
+                    "output": "150.00",
+                    "source": "custom_contract",
+                }
+            }
+        },
+    )
+
+    warning = expensive_model_warning("custom-giant-model", provider="custom-provider")
+    assert warning is not None
+    assert warning.input_cost_per_million == Decimal("25.00")
+    assert warning.output_cost_per_million == Decimal("150.00")
+    assert warning.source == "custom_contract"
+    assert "$25.00/M" in warning.message
+

--- a/tests/hermes_cli/test_oneshot_usage_file.py
+++ b/tests/hermes_cli/test_oneshot_usage_file.py
@@ -54,4 +54,13 @@ class TestWriteUsageFile:
         # Missing result fields serialize as null, not KeyError.
         assert report["estimated_cost_usd"] is None
 
+    def test_unpriced_model_writes_null_cost(self, tmp_path):
+        # Issue #108775: Unpriced models must not be silently recorded as $0.0
+        path = tmp_path / "usage.json"
+        _write_usage_file(str(path), _result(estimated_cost_usd=0.0, cost_status="unknown"))
+        report = json.loads(path.read_text())
+        assert report["estimated_cost_usd"] is None
+        assert report["cost_status"] == "unknown"
+
+
 


### PR DESCRIPTION
## Summary

Fixes #108775.

When running models without built-in pricing records or when using transit/relay endpoints (such as OpenAI-compatible proxies serving Claude or DeepSeek models), Hermes previously exhibited multiple silent failure modes:
1. **Silent $0.0 Recording**: Unpriced models returned `status="unknown"` with `amount_usd=None` during estimate, but session totals defaulted to `0.0`, resulting in `--usage-file` and turn outcomes silently reporting `estimated_cost_usd: 0.0` instead of `null`.
2. **Missing Provider Aliases in Snapshots**: `deepseek` and `bedrock` existed in `_SNAPSHOTS` but were omitted from `_SNAPSHOT_PROVIDER_ALIASES`, causing direct provider calls to return `billing_mode="unknown"`.
3. **Transit & Relay Model Disconnect**: OpenAI-compatible relays (e.g. `atalk`, Cline, or custom enterprise gateways) routing canonical models like `claude-sonnet-4-6` or `deepseek-v4-flash` failed route lookup because the table was strictly keyed on `("anthropic", "claude-sonnet-4-6")` or `("deepseek", ...)`.
4. **No User Pricing Override**: Users had no mechanism in `config.yaml` to specify pricing rates for unpriced models, internal relays, or custom enterprise contracts.

---

## Root Cause Analysis

- **`agent/usage_pricing.py`**:
  - `_SNAPSHOT_PROVIDER_ALIASES` lacked `"deepseek": "deepseek"`, `"deepseek-api": "deepseek"`, and `"bedrock": "bedrock"`, so `resolve_billing_route` marked direct calls to these providers as `billing_mode="unknown"`.
  - `_lookup_official_docs_pricing` only matched `(route.provider, route.model)`. For relay/proxy configurations (`provider: relay-gw`, `model: claude-sonnet-4-6`), no entry was found even though the upstream model is known and documented.
  - `get_pricing_entry` had no config-aware lookup to read user overrides.
  - `_unknown_cost` defaulted label to `"n/a"` rather than `"unpriced"`.
- **`agent/turn_finalizer.py` & `hermes_cli/oneshot.py`**:
  - When pricing is unknown and `session_estimated_cost_usd == 0.0`, `result["estimated_cost_usd"]` retained `0.0`, causing downstream batch pipelines reading `--usage-file` to record `$0.0` spend instead of `null`.
- **`hermes_cli/model_cost_guard.py`**:
  - `_can_trust_pricing_lookup` only checked `route.billing_mode != "unknown"`, bypassing user pricing overrides and failing to warn users if a custom model rate exceeded the safety budget threshold.

---

## Proposed Changes

### 1. User Pricing Overrides in `config.yaml`
Implemented `get_user_pricing_entry(model_name, provider=None, config=None)` in `agent/usage_pricing.py`.
Users can now configure custom rates in `config.yaml`:
```yaml
model_pricing:
  "openai/custom-gpt-5":
    input: 2.00
    output: 8.00
    cache_read: 0.50
    cache_write: 2.50
    request: 0.01
  "my-relay-model":
    input: 1.50
    output: 6.00
    source: "custom_contract"
    version: "contract-q3-2026"
```
Supports:
- Candidates: `provider/model`, `provider/bare_model`, `model`, `bare_model`.
- Rates: `input`, `output`, `cache_read`, `cache_write`, `request_cost`.
- Source tracking: `"user_override"` (default) or `"custom_contract"`.
- Version tracking: custom version strings.
- Wired as highest priority in `get_pricing_entry(...)`.

### 2. Provider Alias & Relay Fallback Resolution
- Registered `"deepseek": "deepseek"`, `"deepseek-api": "deepseek"`, `"bedrock": "bedrock"` in `_SNAPSHOT_PROVIDER_ALIASES`.
- Registered `api.deepseek.com` and `bedrock` host route matching in `resolve_billing_route`.
- Implemented `_infer_canonical_provider(model)`: extracts model vendor prefix or infers upstream provider (Anthropic, OpenAI, Google, DeepSeek, MiniMax, Bedrock).
- `_lookup_official_docs_pricing` falls back to the canonical provider snapshot if direct route lookup fails, seamlessly resolving OpenAI-compatible relays and proxies.

### 3. Transparent Unpriced Accounting & Display
- `_unknown_cost` returns `label="unpriced"`, `status="unknown"`, `amount_usd=None`.
- `agent/turn_finalizer.py` sets `result["estimated_cost_usd"] = None` when `cost_status == "unknown"` and cost is `0.0`.
- `hermes_cli/oneshot.py` ensures `--usage-file` serializes `estimated_cost_usd: null` when unpriced.
- `hermes_cli/cli_info_mixin.py` `/usage` prints `Estimated cost: unpriced (unknown)` when unpriced.
- `hermes_cli/model_cost_guard.py` trusts `get_user_pricing_entry` so expensive user overrides trigger confirmation guards.
- Documented `model_pricing` with examples in `cli-config.yaml.example`.

---

## Alternative Solutions Considered

1. **SQL-level COALESCE / UPDATE patch in state DB (similar to PR #71128 approach)**:
   - *Rejected*: Modifying DB triggers or adding raw queries does not solve in-memory accounting, `/usage`, `--usage-file`, or API route resolution, and would duplicate other authors' proposals. The root cause is in `usage_pricing.py` and `turn_finalizer.py`.
2. **Hardcoding static pricing maps for all third-party proxy names**:
   - *Rejected*: New proxies and relays are created constantly. Inferring the canonical upstream model family from the model id (`_infer_canonical_provider`) provides general, maintenance-free relay coverage while user overrides handle non-standard model IDs.

---

## Verification & Tests

Executed the targeted pytest test suite:
```bash
pytest tests/agent/test_usage_pricing.py tests/hermes_cli/test_model_cost_guard.py tests/hermes_cli/test_oneshot_usage_file.py
```
**Results: 70 passed in 2.72s**.

Specific test coverage added:
- `test_user_pricing_override_precedence`: Verifies user-configured pricing overrides built-in snapshots, supports `custom_contract`, cache read/write, request costs, and custom version tags.
- `test_deepseek_and_bedrock_direct_routes`: Verifies direct provider routes to `deepseek` and `bedrock` resolve `official_docs_snapshot` without falling to `unknown`.
- `test_relay_and_proxy_canonical_provider_fallback`: Verifies models routed through arbitrary proxies (e.g. `relay-proxy/claude-sonnet-4-6`) fall back to official snapshots.
- `test_unpriced_models_labeled_unpriced_and_null_usd`: Verifies unpriced models return `label="unpriced"`, `status="unknown"`, `amount_usd=None`.
- `test_unpriced_model_writes_null_cost`: Verifies `--usage-file` writes `"estimated_cost_usd": null` instead of `$0.0`.
- `test_warns_when_user_pricing_override_exceeds_threshold`: Verifies user pricing overrides trigger expensive model warning when exceeding thresholds.
