### PR TITLE
fix(desktop): stop the idle HUD resize frame from swallowing clicks underneath

### DIFF
--- a/apps/desktop/src/app/hud/resize-frame.test.ts
+++ b/apps/desktop/src/app/hud/resize-frame.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const SRC = dirname(fileURLToPath(import.meta.url))
+const css = readFileSync(join(SRC, '../../styles.css'), 'utf8')
+
+/** The declaration block of the first rule whose selector list contains
+ *  `selector` — enough machine for these one-property rules without a CSS
+ *  parser. */
+function ruleBody(selector: string): string {
+  const start = css.indexOf(selector)
+  expect(start, `styles.css must still carry the rule: ${selector}`).toBeGreaterThanOrEqual(0)
+
+  const open = css.indexOf('{', start)
+  const close = css.indexOf('}', open)
+
+  return css.slice(open + 1, close)
+}
+
+describe('the HUD resize frame and click-through', () => {
+  // The bug this replaces (#108793): the frame was unconditionally
+  // hit-testable, so a collapsed HUD kept an invisible ring of window —
+  // nothing painted, every click and drag eaten — while the rest of the
+  // rectangle fell through to the app underneath.
+  it('keeps the resize frame out of the hit test while the HUD is idle', () => {
+    const body = ruleBody('[data-hud-shell] [data-hud-resize] {')
+
+    expect(body).toContain('pointer-events: none')
+    expect(body).not.toContain('pointer-events: auto')
+  })
+
+  // Engagement is the same gate the band answers: the caret in the composer,
+  // or a held band that must take clicks without focus. Solid-input hosts
+  // (X11) never give the window away, so their frame stays live regardless.
+  it('re-arms the frame exactly where the HUD is being used', () => {
+    const body = ruleBody('[data-hud-shell]:has([data-slot=\'composer-rich-input\']:focus) [data-hud-resize]')
+
+    expect(body).toContain('pointer-events: auto')
+  })
+
+  it('keeps the frame live on solid-input hosts where nothing falls through anyway', () => {
+    const body = ruleBody('[data-hud-shell][data-hud-input=\'solid\'] [data-hud-resize]')
+
+    expect(body).toContain('pointer-events: auto')
+  })
+})

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -3460,12 +3460,29 @@ button[data-slot='aui_msg-reactions'] svg {
 
    CanvasTTY grammar: four edge strips + four larger corner targets, each with
    its native resize cursor and each preserving the opposite edge. Deliberately
-   invisible chrome: no glyph or border over whatever app is below the HUD. */
+   invisible chrome: no glyph or border over whatever app is below the HUD.
+
+   Invisible chrome that is ALWAYS hit-testable is also a dead zone: an idle
+   HUD is just the bar, the window hands every other point to the app
+   underneath, and the only thing left answering the cursor was this frame —
+   a thin invisible border that swallowed clicks and drags aimed at the app
+   behind it (#108793). So the frame rides the band's engagement gate: while
+   the HUD is being used (caret in the composer, or a held band waiting on an
+   answer) its edges may be grabbed; an in-flight resize is unaffected either
+   way, because `data-hud-grabbing` pins the window solid and pointer capture
+   routes the moves. Solid-input hosts never hand the window away in the first
+   place, so their frame stays live unconditionally. */
 [data-hud-shell] [data-hud-resize] {
   position: absolute;
   z-index: 20;
-  pointer-events: auto;
+  pointer-events: none;
   touch-action: none;
+}
+
+[data-hud-shell]:has([data-slot='composer-rich-input']:focus) [data-hud-resize],
+[data-hud-shell][data-hud-held] [data-hud-resize],
+[data-hud-shell][data-hud-input='solid'] [data-hud-resize] {
+  pointer-events: auto;
 }
 
 [data-hud-shell] [data-hud-resize='n'] {


### PR DESCRIPTION
## What does this PR do?

In HUD mode, the resize frame's edge/corner strips were unconditionally `pointer-events: auto`, so they were always hit-testable. A collapsed HUD is just the Spotlight bar — the rest of the window rectangle falls through to the app underneath — but the invisible resize ring kept answering the cursor, leaving a thin, invisible border around the bar that swallowed clicks and drags meant for the application behind it (#108793).

This gates the resize frame on the same engagement states the band already uses (`styles.css` uses this exact grammar for the band's own `pointer-events`):

- **idle**: frame is `pointer-events: none` — the whole rectangle except the bar hands the mouse to the app underneath
- **engaged** (caret in the composer, or a held band with clarify/approval waiting): frame re-arms and the edges can be grabbed
- **solid-input hosts** (`data-hud-input='solid'`, X11): the frame stays live unconditionally — those hosts never hand the window away in the first place, so disarming the frame there would only lose resize ability without fixing any click-through

An in-flight resize is unaffected by the gate: `data-hud-grabbing` pins the window solid for the whole gesture (checked first in `hudIgnoresMouse`) and the handle takes `setPointerCapture`, so the moves keep routing after the strip itself stops being hit-testable.

## Related Issue

Fixes #108793

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/styles.css` — the `[data-hud-resize]` base rule flips from `pointer-events: auto` to `pointer-events: none`, and a new rule re-arms it for `[data-hud-shell]:has([data-slot='composer-rich-input']:focus)`, `[data-hud-shell][data-hud-held]`, and `[data-hud-shell][data-hud-input='solid']`, mirroring the band's existing engagement gates
- `apps/desktop/src/app/hud/resize-frame.test.ts` — new regression test asserting the idle rule stays out of the hit test and the engagement rules re-arm it (follows the node-environment stylesheet-assertion pattern of `src/hover-variant.test.ts`)

## How to Test

1. `cd apps/desktop && npx vitest run src/app/hud/ --project ui`
   - Observed result: 10 test files, 35 tests passed, including the 3 new `resize-frame.test.ts` assertions
2. Manual (macOS/Windows, HUD floating mode): collapse the HUD to the bar, park another app's window underneath, and click/drag along the HUD's former border — the events should reach the app underneath (previously swallowed by the invisible resize ring)
3. Manual: focus the composer (band opens), then drag an edge/corner strip — the window still resizes; resizing remains smooth through the whole gesture

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A: CSS + frontend-only change; ran the desktop vitest suite instead (`src/app/hud/`, all green) plus `eslint` on the new file
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-visibility) — the gate keeps the frame live on `data-hud-input='solid'` hosts (X11), where click-through never applies
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable — the changed region is invisible chrome by design; the observable difference is that clicks pass through where they previously vanished.
