### PR TITLE
feat(plugins): add Hermes Talk to the plugin catalog

### DIFF
--- a/plugin-catalog/hermes-talk.yaml
+++ b/plugin-catalog/hermes-talk.yaml
@@ -1,0 +1,17 @@
+name: hermes-talk
+repo: https://github.com/TheSmokeDev/hermes-talk
+sha: efebeebfe26f6d1ea9b79dd3e7da80a2f8f418b8
+description: Realtime voice for Hermes through terminal, Discord, and dashboard interfaces.
+maintainer: TheSmokeDev
+tier: community
+docs_url: https://github.com/TheSmokeDev/hermes-talk/blob/efebeebfe26f6d1ea9b79dd3e7da80a2f8f418b8/README.md
+capabilities:
+  provides_tools: []
+  provides_hooks:
+    - on_session_end
+    - subagent_start
+    - subagent_stop
+    - post_tool_call
+    - pre_approval_request
+  provides_middleware: []
+  requires_env: []

--- a/plugin-catalog/hermes-talk.yaml
+++ b/plugin-catalog/hermes-talk.yaml
@@ -1,10 +1,10 @@
 name: hermes-talk
 repo: https://github.com/TheSmokeDev/hermes-talk
-sha: efebeebfe26f6d1ea9b79dd3e7da80a2f8f418b8
+sha: 8aeac6a6e1bf6f95dd3b9ed6ee53389883746253
 description: Realtime voice for Hermes through terminal, Discord, and dashboard interfaces.
 maintainer: TheSmokeDev
 tier: community
-docs_url: https://github.com/TheSmokeDev/hermes-talk/blob/efebeebfe26f6d1ea9b79dd3e7da80a2f8f418b8/README.md
+docs_url: https://github.com/TheSmokeDev/hermes-talk/blob/8aeac6a6e1bf6f95dd3b9ed6ee53389883746253/README.md
 capabilities:
   provides_tools: []
   provides_hooks:


### PR DESCRIPTION
## What does this PR do?

Adds Hermes Talk to the community plugin catalog, making its terminal, Discord, and dashboard voice interfaces discoverable through the existing catalog commands.

## Changes Made

Adds only `plugin-catalog/hermes-talk.yaml`, pinned to commit `8aeac6a6e1bf6f95dd3b9ed6ee53389883746253` in `TheSmokeDev/hermes-talk`. The entry declares the five registered hooks, with no registered Hermes tools, middleware, or mandatory environment variables.

## Pin age

This is a newly published pin, committed on September 12, 2026 at 04:10:30 UTC. It has not reached the catalog's recommended two-week age. Submitting it for maintainer review with that timing disclosed.

## Validation

- Upstream structural validator: all 11 catalog files valid.
- Upstream `validate_plugin_dir()` against the archived pinned source: all 10 checks passed, including isolated execution of `register()`; no warnings.
- Catalog capability declarations match the pinned manifest; the pin is publicly reachable on GitHub.

Signed-off-by: SmokeDev <degensmoke@gmail.com>
