### PR TITLE
fix(backup): make special-file filtering fail-safe (#93347)

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -216,18 +216,47 @@ def _collect_memory_provider_external_paths() -> List[Path]:
     return list(out.values())
 
 
-def _iter_external_files(base: Path) -> List[Path]:
-    """Regular files under *base* (a file or a directory), skipping symlinks, caches, and pyc."""
-    if base.is_file() and not base.is_symlink():
+def _lstat_backup_path(path: Path) -> Tuple[Optional[os.stat_result], Optional[OSError]]:
+    """Return the non-following metadata for *path*, or its inspection error."""
+    try:
+        return path.lstat(), None
+    except OSError as exc:
+        return None, exc
+
+
+def _record_backup_scan_error(
+    scan_errors: Optional[List[str]], path: Path, exc: OSError,
+) -> None:
+    """Keep an inspection failure visible without passing an unknown path to the archiver."""
+    if scan_errors is not None:
+        scan_errors.append(f"{path}: {exc}")
+
+
+def _iter_external_files(base: Path, scan_errors: Optional[List[str]] = None) -> List[Path]:
+    """Regular files under *base*, skipping symlinks, caches, and special nodes."""
+    base_stat, stat_error = _lstat_backup_path(base)
+    if stat_error is not None:
+        _record_backup_scan_error(scan_errors, base, stat_error)
+        return []
+    if stat.S_ISREG(base_stat.st_mode):
         return [base]
-    if not base.is_dir():
+    if not stat.S_ISDIR(base_stat.st_mode):
         return []
     files: List[Path] = []
     for dirpath, dirnames, filenames in os.walk(base, followlinks=False):
         dirnames[:] = [d for d in dirnames if d not in _EXCLUDED_DIRS]
-        files.extend(fp for fp in (Path(dirpath) / f for f in filenames)
-                     if not (fp.is_symlink() or fp.name in _EXCLUDED_NAMES
-                             or fp.name.endswith(_EXCLUDED_SUFFIXES)))
+        for fname in filenames:
+            fpath = Path(dirpath) / fname
+            fpath_stat, stat_error = _lstat_backup_path(fpath)
+            if stat_error is not None:
+                _record_backup_scan_error(scan_errors, fpath, stat_error)
+                continue
+            if not stat.S_ISREG(fpath_stat.st_mode):
+                continue
+            if (fpath.name in _EXCLUDED_NAMES
+                    or fpath.name.endswith(_EXCLUDED_SUFFIXES)):
+                continue
+            files.append(fpath)
     return files
 
 
@@ -243,12 +272,16 @@ def _should_exclude(rel_path: Path) -> bool:
     return name in _EXCLUDED_NAMES or name.startswith(_EXCLUDED_PREFIXES) or name.endswith(_EXCLUDED_SUFFIXES)
 
 
-def _iter_backup_files(hermes_root: Path, out_path: Path, skipped_dirs: Optional[set] = None):
+def _iter_backup_files(
+    hermes_root: Path, out_path: Path, skipped_dirs: Optional[set] = None,
+    scan_errors: Optional[List[str]] = None,
+):
     """Yield ``(abs_path, rel_path)`` for every file a full backup should hold.
 
     The one owner of the walk policy (directory pruning so os.walk never descends a multi-GB
     excluded tree, the root-only ``hermes-agent`` carve-out, root runtime trees, per-file rules),
     shared by ``hermes backup`` and the pre-update / pre-migration path so they can never drift.
+    ``scan_errors`` receives paths whose types could not be inspected; those paths are not yielded.
     """
     for dirpath, dirnames, filenames in os.walk(hermes_root, followlinks=False):
         rel_dir = Path(dirpath).relative_to(hermes_root)
@@ -263,9 +296,16 @@ def _iter_backup_files(hermes_root: Path, out_path: Path, skipped_dirs: Optional
         for fname in filenames:
             rel = rel_dir / fname
             fpath = hermes_root / rel
-            # zipfile.write() follows file symlinks, so skip links before any archive write can
-            # copy data from outside HERMES_HOME; never archive the output zip into itself.
-            if _should_exclude(rel) or fpath.is_symlink():
+            # zipfile.write() follows links and cannot archive special nodes. Inspect without
+            # following links before any archive write; an inspection failure is not proof that
+            # the path is safe, so report it instead of handing an unknown path to zipfile.
+            if _should_exclude(rel):
+                continue
+            fpath_stat, stat_error = _lstat_backup_path(fpath)
+            if stat_error is not None:
+                _record_backup_scan_error(scan_errors, rel, stat_error)
+                continue
+            if not stat.S_ISREG(fpath_stat.st_mode):
                 continue
             with suppress(OSError, ValueError):
                 if fpath.resolve() == out_path.resolve():
@@ -598,7 +638,9 @@ def _resolve_backup_output_path(output: Optional[str]) -> Path:
     return out_path
 
 
-def _collect_external_entries() -> tuple[list[tuple[Path, str]], list[str]]:
+def _collect_external_entries(
+    scan_errors: Optional[List[str]] = None,
+) -> tuple[list[tuple[Path, str]], list[str]]:
     """``([(abs_path, arcname)], [skipped])`` for the memory provider's external state, arc-named
     ``_external/<home-relative>``; paths outside home are skipped (security + portability)."""
     home_dir = Path.home().resolve()
@@ -610,7 +652,7 @@ def _collect_external_entries() -> tuple[list[tuple[Path, str]], list[str]]:
         except (ValueError, OSError):
             skipped_external.append(str(base))
             continue
-        for fpath in _iter_external_files(base):
+        for fpath in _iter_external_files(base, scan_errors):
             with suppress(ValueError, OSError):
                 rel_to_home = fpath.resolve().relative_to(home_dir)
                 external_to_add.append((fpath, _EXTERNAL_PREFIX + rel_to_home.as_posix()))
@@ -640,11 +682,17 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
     logger.info("backup phase=scan status=started")
     print(f"Scanning {display_hermes_home()} ...")
     skipped_dirs: set = set()
-    files_to_add: list[tuple[Path, Path]] = list(_iter_backup_files(hermes_root, out_path, skipped_dirs))
-    external_to_add, skipped_external = _collect_external_entries()
+    scan_errors: List[str] = []
+    files_to_add: list[tuple[Path, Path]] = list(
+        _iter_backup_files(hermes_root, out_path, skipped_dirs, scan_errors)
+    )
+    external_to_add, skipped_external = _collect_external_entries(scan_errors)
+    errors = list(scan_errors)
     if not files_to_add and not external_to_add:
         logger.info("backup phase=scan status=empty duration_ms=%.1f", (time.monotonic() - scan_started) * 1000)
         print("No files to back up.")
+        if errors:
+            _print_capped(f"\n  Warnings ({len(errors)} files skipped):", errors, "  ")
         return
 
     file_count = len(files_to_add) + len(external_to_add)
@@ -652,7 +700,6 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
                 (time.monotonic() - scan_started) * 1000, file_count)
     logger.info("backup phase=archive status=started files=%d", file_count)
     print(f"Backing up {file_count} files ...")
-    errors = []
     t0 = time.monotonic()
 
     def _progress(i: int) -> None:
@@ -1556,10 +1603,17 @@ def _write_full_zip_backup(out_path: Path, hermes_root: Path) -> Optional[Path]:
 def _write_full_zip_backup_locked(out_path: Path, hermes_root: Path) -> Optional[Path]:
     scan_started = time.monotonic()
     logger.info("automatic backup phase=scan status=started")
+    scan_errors: List[str] = []
     try:
-        files_to_add = list(_iter_backup_files(hermes_root, out_path))
+        files_to_add = list(_iter_backup_files(hermes_root, out_path, scan_errors=scan_errors))
     except OSError as exc:
         logger.warning("Full-zip backup: walk failed: %s", exc)
+        return None
+    if scan_errors:
+        logger.warning(
+            "Full-zip backup: could not inspect %d path(s): %s",
+            len(scan_errors), "; ".join(scan_errors[:10]),
+        )
         return None
     if not files_to_add:
         return None

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1,6 +1,7 @@
 """Tests for hermes backup and import commands."""
 
 import json
+import logging
 import os
 import sqlite3
 import stat
@@ -245,6 +246,91 @@ class TestIterBackupFiles:
         list(_iter_backup_files(root, tmp_path / "out.zip", skipped))
         assert "models" in skipped
         assert "hermes-agent" in skipped
+
+    def test_skips_non_regular_files_before_manual_and_automatic_archive(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Sockets/FIFOs are filtered before either shared archive path sees them."""
+        root = tmp_path / ".hermes"
+        root.mkdir()
+        (root / "config.yaml").write_text("model: {}\n")
+        socket_path = root / "gateway.sock"
+        fifo_path = root / "runtime.fifo"
+        socket_path.write_bytes(b"socket placeholder")
+        fifo_path.write_bytes(b"fifo placeholder")
+
+        real_lstat = Path.lstat
+        special_modes = {
+            socket_path: stat.S_IFSOCK | 0o600,
+            fifo_path: stat.S_IFIFO | 0o600,
+        }
+
+        def _lstat(path):
+            result = real_lstat(path)
+            mode = special_modes.get(path)
+            if mode is None:
+                return result
+            values = list(result)
+            values[stat.ST_MODE] = mode
+            return os.stat_result(values)
+
+        monkeypatch.setattr(Path, "lstat", _lstat)
+        monkeypatch.setenv("HERMES_HOME", str(root))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        from hermes_cli.backup import _write_full_zip_backup, run_backup
+
+        manual_zip = tmp_path / "manual.zip"
+        run_backup(Namespace(output=str(manual_zip)))
+        assert "Backup complete:" in capsys.readouterr().out
+        with zipfile.ZipFile(manual_zip) as archive:
+            names = set(archive.namelist())
+            assert "config.yaml" in names
+            assert not {"gateway.sock", "runtime.fifo"} & names
+
+        automatic_zip = tmp_path / "automatic.zip"
+        assert _write_full_zip_backup(automatic_zip, root) == automatic_zip
+        with zipfile.ZipFile(automatic_zip) as archive:
+            names = set(archive.namelist())
+            assert "config.yaml" in names
+            assert not {"gateway.sock", "runtime.fifo"} & names
+
+    def test_lstat_failure_is_reported_without_archiving_unknown_path(
+        self, tmp_path, monkeypatch, capsys, caplog
+    ):
+        """An unknown file type is visible as an error and never follows a link."""
+        root = tmp_path / ".hermes"
+        root.mkdir()
+        (root / "config.yaml").write_text("model: {}\n")
+        uninspectable = root / "uninspectable.json"
+        uninspectable.write_text("{}")
+
+        real_lstat = Path.lstat
+
+        def _raising_lstat(path):
+            if path == uninspectable:
+                raise OSError("simulated lstat failure")
+            return real_lstat(path)
+
+        monkeypatch.setattr(Path, "lstat", _raising_lstat)
+        monkeypatch.setenv("HERMES_HOME", str(root))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        caplog.set_level(logging.WARNING, logger="hermes_cli.backup")
+
+        from hermes_cli.backup import _write_full_zip_backup, run_backup
+
+        manual_zip = tmp_path / "manual.zip"
+        run_backup(Namespace(output=str(manual_zip)))
+        output = capsys.readouterr().out
+        assert "Backup incomplete:" in output
+        assert "uninspectable.json: simulated lstat failure" in output
+        with zipfile.ZipFile(manual_zip) as archive:
+            assert archive.namelist() == ["config.yaml"]
+
+        automatic_zip = tmp_path / "automatic.zip"
+        assert _write_full_zip_backup(automatic_zip, root) is None
+        assert not automatic_zip.exists()
+        assert "could not inspect 1 path(s)" in caplog.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix full-backup selection so filesystem entries that are proven to be non-regular (including Unix sockets and FIFOs) are excluded before `zipfile.write()` sees them. This prevents a live gateway control socket from turning an otherwise usable archive into `Backup incomplete`.

This is an independently authored replacement/carry-forward for the backup-selection scope of #108569. It does not rewrite, close, or modify #108569, and no commit from another contributor was cherry-picked. The prior work by @mrwanstudio in #108569 and @rudidev08 in #93374 is explicitly credited and remains intact.

## Ownership and supersede boundary

- Issue: #93347 — https://github.com/NousResearch/hermes-agent/issues/93347
- Prior exact-scope PR: #108569 — https://github.com/NousResearch/hermes-agent/pull/108569
- Earlier issue-author implementation: #93374 — https://github.com/NousResearch/hermes-agent/pull/93374
- This PR supersedes the functional scope of #108569 only because the open candidate leaves an `lstat()` failure path unsafe; it does not claim or rewrite that contributor's branch, commit, or authorship.
- The original PR remains read-only and is not closed by this change.

## Observed problem

- Current base: `284d220ba48e25f2e3623b3afe72db8f24a4c2db`
- `hermes_cli/backup.py:_iter_backup_files()` excluded configured names and symlinks, but assumed every remaining directory entry could be archived.
- A running POSIX gateway creates `$HERMES_HOME/gateway.sock`; the walker passed it to `_write_zip_entries()`, where `zipfile.write()` raised an `OSError`.
- The exception was collected in `errors`, so the summary became `Backup incomplete` even though the remaining ZIP members were usable. The pre-archive count also included the socket.
- The same class occurs for dynamically named runtime sockets such as `state/gateway.loop-tick.<pid>.sock`, so excluding only the literal `gateway.sock` is insufficient.
- The issue's Linux/macOS reports provide the platform-specific reproductions. A live POSIX socket could not be created locally because this validation host is Windows and its Python runtime has no `socket.AF_UNIX`.

Expected behavior: skip entries whose filesystem type is demonstrably non-regular before archiving; preserve regular files and the existing symlink safety policy; make inspection failures visible instead of silently discarding or following an unknown path.

## Root cause

The selection policy was based on path names plus `Path.is_symlink()`, not on the filesystem type. In the shared path:

- `hermes_cli/backup.py:_iter_backup_files()` selected non-symlink entries without checking whether they were regular files.
- `_write_zip_entries()` then attempted to archive every selected entry.
- Manual, pre-update, and pre-migration full backups all rely on this shared iterator.
- The external memory-provider directory walk had the same assumption.

The old `is_symlink()` call also performed an implicit `lstat()`. On filesystems where that operation raises for a socket, the exception escaped during scanning before the writer's error handler could provide an honest result.

## Impact and scope

Affected:

- Full manual backups while a POSIX gateway or another special filesystem node exists under the Hermes home.
- Automatic full ZIP backups that use `_write_full_zip_backup_locked()`.
- Directory-based external memory-provider paths selected by the full-backup path.

Not affected:

- Quick state snapshots; they use a separate, explicit candidate list and SQLite-safe-copy lifecycle.
- Windows named-pipe transport itself; a named pipe is not a filesystem entry walked under `HERMES_HOME`.
- Existing path exclusions, SQLite safe-copy behavior, archive format, import format, or configuration schema.

Operational impact:

- Normal sockets/FIFOs/devices no longer generate archive warnings or false incomplete status.
- An entry whose type cannot be inspected is not archived and remains visible as an error. Manual backups can still publish the safe members but report `Backup incomplete`; automatic backups return `None` and retain any previous valid destination.
- The walk remains linear in the number of visited entries. The change adds one non-following metadata lookup per candidate and does not add a second full tree traversal. Extra memory is limited to scan-error strings for paths that could not be inspected.

Security impact:

- `lstat()` classifies symlinks without following them, so a symlink is still excluded before archive I/O.
- Unknown entries are not handed to `zipfile.write()`, avoiding a fallback that could follow a symlink when metadata inspection fails.
- No credentials, `.env` contents, or user data are included in this PR body.

## Solution

The change adds a single `_lstat_backup_path()` seam and a shared scan-error recorder:

1. Successful `lstat()` + `stat.S_ISREG(mode)` selects the entry.
2. Successful `lstat()` with any other type excludes the entry before archive I/O. This covers sockets, FIFOs, devices, and symlinks without name-based special cases.
3. Failed `lstat()` records the relative/path-qualified error and does not yield the path. The manual path includes the error in its existing warning summary; the automatic path logs the scan failure and preserves the previous backup.
4. The same policy is applied to the external memory-provider directory walk.
5. `file_count` is calculated only from entries that passed selection, so excluded sockets cannot inflate the archive count.

Alternatives considered:

- Adding `gateway.sock` or `gateway.sock.path` to `_EXCLUDED_NAMES`: rejected because it misses dynamic sockets, FIFOs, devices, and future runtime nodes; the pointer file is regular and does not explain the archive failure.
- Using only `Path.is_file()`: rejected because a false result can conflate a non-regular entry with a failed metadata lookup and silently hide unreadable durable files.
- Keeping the candidate PR's `lstat()`-error fallback that returns “regular enough”: rejected because it sends an unknown path to `zipfile.write()`, preserves the reported failure on unsupported filesystems, and weakens the symlink boundary.
- Catching the writer exception and suppressing it: rejected because it leaves selection/count semantics inconsistent and hides whether a durable file was lost.

## Compatibility and residual risks

- The public function signatures remain compatible; the new scan-error parameters are optional.
- Existing symlinks remain excluded. Regular files remain eligible.
- Filesystem changes between scan and archive are an existing TOCTOU limitation of the archive walk; this patch removes the unsafe `lstat()`-failure fallback but does not claim atomic filesystem snapshots.
- Exact POSIX socket execution remains unverified on this Windows host and must run in the repository's Linux/macOS CI lanes.
- `uvx ruff format --check` reports that both legacy files would be reformatted at pre-existing locations. No whole-file reformat was applied; `uvx ruff check` passes.

## Tests and verification

| Command/test | Objective | Result |
|---|---|---|
| `scripts/run_tests.sh tests/hermes_cli/test_backup.py -k 'skips_non_regular_files_before_manual_and_automatic_archive or lstat_failure_is_reported_without_archiving_unknown_path' -q` with production fix | Regression and error-path GREEN | 2 passed, 0 failed |
| Same command with only the production hunk reverted | Prove RED on the base behavior | 0 passed, 2 failed for the expected reasons: special nodes entered the ZIP and `is_symlink()` propagated the simulated `lstat` error |
| `scripts/run_tests.sh tests/hermes_cli/test_backup.py -q` | Full affected test file | 68 passed, 4 failed, 9 skipped. The four failures are the same Windows/environment failures reproduced on the clean base: gateway-service installation, profile wrapper path, Kanban path spelling, and POSIX mode bits on Windows |
| Same full test file on clean `origin/main` | Baseline comparison | 66 passed, 4 failed, 9 skipped; the same four failures occurred |
| `scripts/run_tests.sh tests/hermes_cli/test_backup_path_errors.py tests/hermes_cli/test_backup_stability.py tests/hermes_cli/test_backup_all_profiles.py -q` | Sibling backup paths | 15 passed, 1 failed |
| Same three files on clean `origin/main` | Baseline comparison | 15 passed, 1 failed; the failure is the existing `config.yaml` manifest-size expectation (`10` vs actual `11` bytes) in `test_backup_stability.py` |
| `uvx ruff check hermes_cli/backup.py tests/hermes_cli/test_backup.py` | Lint | All checks passed |
| `python -m compileall -q hermes_cli/backup.py tests/hermes_cli/test_backup.py` | Syntax/bytecode compilation | Passed |
| `scripts/check_compat_pointers.py` | Internal import compatibility gate | Passed: no in-tree dependency on the 2091 plugin-compat pointers |
| `git diff --check` | Whitespace | Passed |
| Graphify query/path using the existing read-only graph | Bound the shared call path | `_iter_backup_files()` → `hermes_cli/backup.py` → `_write_zip_entries()`; two hops |
| `graphify update . --no-cluster` after edits | Required graph refresh | Timed out after 420 seconds in the isolated worktree; no generated graph artifact is included in this PR |

## Files and documentation

Changed:

- `hermes_cli/backup.py` — shared non-following filesystem classification, scan-error propagation, and manual/automatic handling.
- `tests/hermes_cli/test_backup.py` — two behavior-contract regressions covering non-regular entries across manual/automatic archives and failed metadata inspection.

No configuration, public documentation, gateway transport, import, or quick-snapshot changes are required for this internal backup-selection fix. The complete investigation, ownership boundary, test limitations, and residual risks are documented here.

## Publication receipt

- Replacement branch: `fix/backup-nonregular-files-93347-supersede`
- Replacement commit: `fbaaca36e15f1bded046bd139bac2786fcfcf0d1`
- Parent/base: `284d220ba48e25f2e3623b3afe72db8f24a4c2db`
- Commit author and committer: `joaomarcos <joaomarcosdias444@gmail.com>`
- Intended head repository: `JoaoMarcos44/hermes-agent`
- Intended base repository: `NousResearch/hermes-agent`, branch `main`
- CI status at authoring time: no checks were reported by `gh pr checks 108803`; local results above are not a substitute for remote checks.
- Post-publication focused verification at the exact head `fbaaca36e15f1bded046bd139bac2786fcfcf0d1`: `scripts/run_tests.sh tests/hermes_cli/test_backup.py -k 'skips_non_regular_files_before_manual_and_automatic_archive or lstat_failure_is_reported_without_archiving_unknown_path' -q` → 2 passed, 0 failed.
