### PR TITLE
fix(desktop): authenticate passive update-check API calls when credentials resolve

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -394,7 +394,14 @@ import {
   windowOpacityFor,
   windowOpacityOptions
 } from './translucency'
-import { branchTipApiUrl, cacheIsFresh, compareApiUrl, githubRepoSlug, parseCompare } from './update-api-check'
+import {
+  branchTipApiUrl,
+  cacheIsFresh,
+  compareApiUrl,
+  githubRepoSlug,
+  parseCompare,
+  resolveGitHubApiToken
+} from './update-api-check'
 import { waitForUpdateClearance } from './update-gate'
 import { readLiveUpdateMarker, updateHandoffConflict, writeUpdateMarker } from './update-marker'
 import { isOfficialSshRemote, OFFICIAL_REPO_HTTPS_URL } from './update-remote'
@@ -3383,13 +3390,41 @@ function describeUpdateCheckFailure(error) {
   return `api.github.com: ${error?.message || String(error)}`
 }
 
-function fetchGitHubApi(url, accept = 'application/vnd.github+json') {
+// `gh auth token` is the second credential source for passive update checks
+// (PAT env vars first, resolved in update-api-check.ts). Authenticated checks
+// get the per-user 5,000 req/hr budget instead of the shared 60 req/hr
+// anonymous bucket that shared/datacenter egress IPs exhaust constantly
+// (#108804). gh missing, logged out, or hung simply resolves null and the
+// request goes out anonymous, as before. The token stays off stderr and is
+// never logged.
+function ghAuthToken(): Promise<string | null> {
+  return new Promise(resolve => {
+    const child = spawn('gh', ['auth', 'token'], {
+      ...hiddenWindowsChildOptions(),
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5_000
+    })
+
+    let stdout = ''
+    child.stdout.on('data', chunk => {
+      stdout += chunk
+    })
+    child.once('error', () => resolve(null))
+    child.once('close', code => resolve(code === 0 && stdout.trim() ? stdout.trim() : null))
+  })
+}
+
+async function fetchGitHubApi(url, accept = 'application/vnd.github+json') {
+  const token = await resolveGitHubApiToken({ ghAuthToken })
+
   return new Promise((resolve, reject) => {
     const req = https.get(
       url,
       {
         headers: {
           Accept: accept,
+          ...(token ? { Authorization: `token ${token}` } : {}),
           // GitHub requires a UA on api.github.com; requests without one 403.
           'User-Agent': 'hermes-desktop-update-check'
         },

--- a/apps/desktop/electron/update-api-check.test.ts
+++ b/apps/desktop/electron/update-api-check.test.ts
@@ -18,6 +18,7 @@ import {
   cacheIsFresh,
   githubRepoSlug,
   parseCompare,
+  resolveGitHubApiToken,
   UPDATE_CHECK_FAILURE_TTL_MS,
   UPDATE_CHECK_TTL_MS
 } from './update-api-check'
@@ -77,5 +78,31 @@ test('compare payload maps to the behind count and a newest-first commit list; m
   assert.equal(
     branchTipApiUrl('nousresearch/hermes-agent', 'bb/gui'),
     'https://api.github.com/repos/nousresearch/hermes-agent/commits/bb%2Fgui'
+  )
+})
+
+test('token resolution: PAT env first, gh CLI second, anonymous on any failure', async () => {
+  // A PAT in the environment wins over gh, and is trimmed rather than sent raw.
+  assert.equal(
+    await resolveGitHubApiToken({ env: { GITHUB_TOKEN: ' ghp_pat ' }, ghAuthToken: async () => 'ghp_cli' }),
+    'ghp_pat'
+  )
+  // GH_TOKEN is the documented alias.
+  assert.equal(await resolveGitHubApiToken({ env: { GH_TOKEN: 'ghp_alias' } }), 'ghp_alias')
+
+  // Whitespace-only vars fall through to gh instead of sending a junk header.
+  assert.equal(
+    await resolveGitHubApiToken({ env: { GITHUB_TOKEN: '   ' }, ghAuthToken: async () => ' ghp_cli ' }),
+    'ghp_cli'
+  )
+
+  // No credentials anywhere (gh missing, logged out, or hung) resolves null:
+  // the request goes out anonymous — the pre-fix behavior, never an error the
+  // update check has to handle (#108804).
+  assert.equal(await resolveGitHubApiToken({ env: {}, ghAuthToken: async () => null }), null)
+  assert.equal(await resolveGitHubApiToken({ env: {} }), null)
+  assert.equal(
+    await resolveGitHubApiToken({ env: {}, ghAuthToken: async () => { throw new Error('ENOENT') } }),
+    null
   )
 })

--- a/apps/desktop/electron/update-api-check.ts
+++ b/apps/desktop/electron/update-api-check.ts
@@ -109,3 +109,38 @@ export function parseCompare(payload: unknown): { behind: number; commits: Compa
 
   return { behind: ahead, commits }
 }
+
+export interface GitHubTokenSources {
+  /** Environment to read PAT vars from; injected so tests never touch the real one. */
+  env?: NodeJS.ProcessEnv
+  /** Resolves a token via the gh CLI; injected so tests never spawn a process. */
+  ghAuthToken?: () => Promise<string | null>
+}
+
+/**
+ * Resolve a GitHub API token for passive update checks, mirroring the skills
+ * hub's priority order: GITHUB_TOKEN / GH_TOKEN, then `gh auth token`, then
+ * anonymous. Anonymous requests share one 60 req/hr per-IP bucket, which shared
+ * and datacenter egress IPs exhaust constantly, so every check behind them 403s
+ * (#108804); an authenticated check gets the per-user 5,000 req/hr budget. A
+ * token must never surface in logs or error copy: failure to resolve one simply
+ * means the request goes out anonymous, exactly as before.
+ */
+export async function resolveGitHubApiToken({
+  env = process.env,
+  ghAuthToken
+}: GitHubTokenSources = {}): Promise<string | null> {
+  const pat = (env.GITHUB_TOKEN || env.GH_TOKEN || '').trim()
+
+  if (pat) {
+    return pat
+  }
+
+  try {
+    const fromGh = ((await ghAuthToken?.()) ?? '').trim()
+
+    return fromGh || null
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Since the update-check rewrite in `6dfcf15685`, passive desktop update checks call `api.github.com` anonymously — no `Authorization` header, no credential resolution. Every user behind a shared/datacenter egress IP shares one 60 req/hr anonymous quota bucket, so the update panel regularly surfaces "GitHub API rate limit reached (HTTP 403) — try again in an hour" (and the 1h failure cache keeps showing it even after switching egress). This PR makes `fetchGitHubApi` attach an `Authorization` header whenever a token resolves, moving those checks onto the per-user 5,000 req/hr budget.

Credential resolution mirrors the priority order `tools/skills_hub_github.py` already uses: `GITHUB_TOKEN`/`GH_TOKEN` from the environment, then `gh auth token` from an installed gh CLI, then anonymous. The resolution lives in `update-api-check.ts` as an injected-dependency pure function (consistent with that file's "pure helpers, bounded calls injected" layering), and `main.ts` contributes only the real `gh` runner. This PR deliberately does **not** read the repo `.env` directly: the skills hub resolves secrets through `agent.secret_scope` precisely because a bare `.env` read breaks profile scoping — porting that machinery to Electron is out of scope for a small fix. `GITHUB_TOKEN` env (terminal/dev launches) plus the gh CLI cover the overwhelmingly common cases without any profile ambiguity.

Fail-safe properties: gh missing, logged out, or hung (5s timeout) resolves `null` and the request goes out anonymous exactly as before — no new failure mode reaches the update check. The token never appears in logs or error copy (`describeUpdateCheckFailure` only ever sees the status code).

## Related Issue

Fixes #108804

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/update-api-check.ts` — new `resolveGitHubApiToken({ env, ghAuthToken })` pure helper: PAT env vars first (trimmed; whitespace-only falls through), then the injected gh runner, then `null` = anonymous. Any resolver failure is swallowed into anonymous.
- `apps/desktop/electron/main.ts` — new `ghAuthToken()` runner (`gh auth token`, 5s timeout, Windows-hidden, stderr ignored) and `fetchGitHubApi` now awaits the token and attaches `Authorization: token <t>` when one resolved.
- `apps/desktop/electron/update-api-check.test.ts` — regression test pinning the priority order (PAT over gh, `GH_TOKEN` alias, whitespace-only falls through, missing/throwing gh resolves `null`).

## How to Test

1. `cd apps/desktop && ../../node_modules/.bin/vitest --project electron run electron/update-api-check.test.ts` — Observed result: 3 passed (3), including the new token-resolution test.
2. With gh installed and logged in: open the desktop update panel and trigger "Check now" — the tip/compare requests carry `Authorization: token …` (verifiable via a local proxy) and no longer count against the shared anonymous bucket.
3. With no credentials available (`env -i`, gh not installed) — the check behaves exactly as before: anonymous request, same 403 error copy on an exhausted shared egress IP. No new error path.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A (desktop/TS-only change; the desktop electron vitest suite and eslint/tsc cover it)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior is documented in code comments where it lives)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) (gh spawned via `hiddenWindowsChildOptions`, `stdio`/`timeout` cross-platform; no shell interpolation)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
