### PR TITLE
fix(kanban): reject worktree/dir cards with no resolvable workspace at creation

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1305,6 +1305,19 @@ def create_task(
         board_default = _board_meta_for(board).get("default_workdir")
         if board_default:
             workspace_path = str(board_default)
+        else:
+            # A dir/worktree card with no anchor (no explicit path, no project
+            # repo, no board default_workdir) can never resolve its workspace at
+            # dispatch — it would park in `blocked` forever while its request
+            # looks "handled". Refuse at creation so the error surfaces to the
+            # caller (dashboard 400 / CLI / tool) instead of silently creating
+            # a black hole.
+            raise ValueError(
+                f"workspace_kind={workspace_kind!r} requires a resolvable workspace: "
+                f"pass an explicit workspace_path, a project with a repo, or set a "
+                f"default_workdir on board {board!r}. Got none of these, so the task "
+                f"could never resolve its workspace at dispatch."
+            )
 
     # Retry once on the extremely unlikely id collision.
     for attempt in range(2):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -575,6 +575,22 @@ def test_worktree_workspace_explicit_target_materializes_linked_worktree(kanban_
     assert f"branch refs/heads/{branch}" in listed
 
 
+def test_worktree_without_path_or_board_workdir_fails_at_creation(kanban_home):
+    """A worktree card with no path, no project, and no board default_workdir can
+    never spawn — reject it at creation, not silently park it at dispatch."""
+    with kbc.connect() as conn:
+        with pytest.raises(ValueError):
+            kb.create_task(conn, title="ship", workspace_kind="worktree")
+
+
+def test_dir_without_path_fails_at_creation(kanban_home):
+    """A dir card with no path can never resolve its workspace — reject it at
+    creation rather than letting it die at dispatch."""
+    with kbc.connect() as conn:
+        with pytest.raises(ValueError):
+            kb.create_task(conn, title="ship", workspace_kind="dir")
+
+
 # ---------------------------------------------------------------------------
 # Scratch cleanup containment (#28818)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A card created with `workspace_kind=worktree` (or `dir`) and no `workspace_path`, no project repo, and no board `default_workdir` could never resolve its workspace at dispatch. It parked in `blocked` forever while its creation appeared to succeed — the request looked handled but silently produced a card that could never run.

## Fix

`create_task` now raises `ValueError` at creation when a persistent workspace kind (`worktree`/`dir`) has no anchor, so the error surfaces to the caller (dashboard HTTP 400 via the existing `_value_error_400` mapping, CLI, or tool) instead of silently creating a black hole.

The check sits inside the existing `workspace_path is None and project_repo is None and workspace_kind in {"dir","worktree"}` condition, so anchored cards are unaffected; only the previously-unsupported "null anchor" case changes from "silently stuck at dispatch" to "refused at creation."

## Tests

- Two new tests in `tests/hermes_cli/test_kanban_db.py` cover the creation-time rejection.
- Module passes 33 passed / 1 skipped, zero failures.
