### PR TITLE
feat(catalog): add hermes-nous-prices community plugin

### DIFF
--- a/plugin-catalog/hermes-nous-prices.yaml
+++ b/plugin-catalog/hermes-nous-prices.yaml
@@ -1,6 +1,6 @@
 name: hermes-nous-prices
 repo: https://github.com/Adolanium/hermes-nous-prices
-sha: 738a89fbf366d8042940e3800b2a2a899811bd1e
+sha: 5455e90bad1f0656b649d9767fcac3bf874f559e
 description: Browse Nous Portal model prices and account balances in Hermes Desktop.
 maintainer: Adolanium
 tier: community

--- a/plugin-catalog/hermes-nous-prices.yaml
+++ b/plugin-catalog/hermes-nous-prices.yaml
@@ -1,0 +1,13 @@
+name: hermes-nous-prices
+repo: https://github.com/Adolanium/hermes-nous-prices
+sha: 738a89fbf366d8042940e3800b2a2a899811bd1e
+description: Browse Nous Portal model prices and account balances in Hermes Desktop.
+maintainer: Adolanium
+tier: community
+docs_url: https://github.com/Adolanium/hermes-nous-prices#readme
+capabilities:
+  provides_tools: []
+  provides_hooks: []
+  provides_middleware: []
+  requires_env: []
+subdir: catalog


### PR DESCRIPTION
## What does this PR do?

Adds `hermes-nous-prices` as a community plugin. I own and maintain [Adolanium/hermes-nous-prices](https://github.com/Adolanium/hermes-nous-prices).

Browse Nous Portal model prices and account balances in Hermes Desktop. The package includes a Gateway API backed by Hermes' model inventory and billing serializer, plus the Desktop UI. The Gateway companion was contributed by Richard Ahlquist (@rahlquist) in the plugin's PR #1; his original commit is preserved.

## Release and pin maturity

- Release: [catalog-v0.1.1-2](https://github.com/Adolanium/hermes-nous-prices/releases/tag/catalog-v0.1.1-2)
- Exact pin: `94f99436786e6fbbfcce161635d11c67bf094c8e`
- Published: 2026-09-14T20:28:07Z
- Earliest two-week release maturity: 2026-09-28T20:28:07.000Z

This PR remains a draft until the release has settled for two weeks. Please do not merge before that date. No maturity exception is requested.

## Package behavior

Uses `subdir: catalog` with a native manifest, an Agent entry point, `dashboard/manifest.json`, `dashboard/plugin_api.py`, and `desktop/plugin.js`. The catalog key is `hermes-nous-prices`; the installed package, enabled-plugin name, API namespace and Desktop ID are `nous-prices`.

The Gateway exposes read-only catalog, billing, default-model and health routes. It registers no Agent tools, hooks or middleware. The empty capability lists match actual registration; they do not describe a sandbox or remove Desktop host access.

Both packaged Desktop copies are generated from root `plugin.js` with the entire self-updater removed, including its UI and file-replacement helpers. The root standalone distribution retains signed updates and RPC fallback when the companion is absent. Authentication and backend failures are surfaced. Billing preserves the canonical usage payload, including plan, credit bars and renewal data, and requests respect the selected profile.

Enable `nous-prices` on the Gateway and restart it to mount the API. Enable the Desktop component after a restart or rescan. Remote deployments require a UI installation on the Desktop machine too. Manual installs must be backed up and moved aside when migrating. The README also covers migration from the earlier `hermes-nous-prices` package preview.

## Validation

- Structural catalog validation passed.
- Upstream manifest validation and plugin doctor passed in an isolated Hermes home.
- Generated-package freshness, JavaScript syntax and catalog updater-policy tests passed.
- 22 API tests and Desktop transport tests passed across the root and generated distributions.
- Source repository Catalog package CI passed on the released commit.

These checks cover registration, packaging and the listed regression suites. A new visual acceptance test of every Desktop feature was not performed.

## Checklist

- [x] Owner-submitted public repository with a release and full SHA pin.
- [x] Community tier; capability declarations match the released manifest.
- [x] One catalog entry only; no core changes in this PR.
- [ ] Two-week release maturity reached.
- [ ] Upstream admission CI completed and maintainer review approved.

## Catalog review follow-up

The complete catalog self-updater has been removed, including its check/install/restore UI and unreachable download, verification, backup, and file-replacement helpers. Catalog updates require a reviewed SHA-bump PR and `hermes plugins update nous-prices`. The standalone Desktop distribution remains separate. The new release restarts the two-week maturity period; this PR remains a draft until 2026-09-28T20:28:07.000Z.

Upstream manifest validation and `hermes plugins doctor --ci` passed for this package in an isolated Hermes home. The new release also passed its repository’s Catalog package CI, including generated-file freshness, JavaScript syntax, and updater-policy regression tests.

The new pin also includes the existing 0.1.1 release changes since the previous catalog pin: output-price sorting and Gateway/Desktop compatibility corrections. The contributor commits from plugin PR #2 remain intact. [Full source comparison](https://github.com/Adolanium/hermes-nous-prices/compare/5455e90bad1f0656b649d9767fcac3bf874f559e...94f99436786e6fbbfcce161635d11c67bf094c8e).
