### PR TITLE
feat(catalog): add hermes-office community plugin

### DIFF
--- a/plugin-catalog/hermes-office.yaml
+++ b/plugin-catalog/hermes-office.yaml
@@ -1,0 +1,13 @@
+name: hermes-office
+repo: https://github.com/Adolanium/hermes-office
+sha: e1e0255a48fe7a7549d8d0a5ef0747a41a0fb7e7
+description: View and manage Bot Mode agents in a shared office in Hermes Desktop.
+maintainer: Adolanium
+tier: community
+docs_url: https://github.com/Adolanium/hermes-office#readme
+capabilities:
+  provides_tools: []
+  provides_hooks: []
+  provides_middleware: []
+  requires_env: []
+subdir: catalog


### PR DESCRIPTION
## What does this PR do?

Adds `hermes-office` as a community plugin. I own and maintain [Adolanium/hermes-office](https://github.com/Adolanium/hermes-office).

View and manage Bot Mode agents in a shared office in Hermes Desktop.

## Release and pin maturity

- Release: [catalog-v0.1.0-1](https://github.com/Adolanium/hermes-office/releases/tag/catalog-v0.1.0-1)
- Exact pin: `e1e0255a48fe7a7549d8d0a5ef0747a41a0fb7e7`
- Published: 2026-09-12T04:29:51Z
- Earliest two-week release maturity: 2026-09-26T04:29:51+00:00

This PR is intentionally a draft until the release has settled for two weeks. Please do not merge before that date. No maturity exception is requested.

## Desktop packaging

Uses the documented combined-package layout in `subdir: catalog`, with a native manifest, an Agent entry point that registers no tools or hooks, and `desktop/plugin.js`. All functionality is in the Desktop component. The empty Agent capability lists describe actual registration; they do not mean the Desktop code is sandboxed or has no host access.

The root standalone distribution is retained. This package has no in-app self-updater. Companion files are included where required. Desktop users enable the component in Capabilities > Plugins after a restart or rescan. Existing manual installs must be migrated, since Hermes intentionally preserves their folders.

## Validation

- Upstream structural catalog validator passed.
- Upstream manifest validation and isolated capability probe passed at the released source.
- Exact-commit installation and real Agent plugin loading passed on Windows.
- Real Desktop detection/materialization functions verified plugin bytes, catalog provenance, repeat scans, removal, and manual-install protection.
- Packaging CI verifies the committed package against its source.

These checks cover installation and packaging, not a new visual acceptance test of every Desktop feature. Requires Desktop combined-package support.

The installer raises a caution finding on the `sudo.request` input-event label. The handler displays a pending input request; it does not grant approval. The install check reviewed and accepted that caution. No scanner change is required for Office.

## Checklist

- [x] Owner-submitted public repository with a release and a full SHA pin.
- [x] Community tier; capability declarations match the released manifest.
- [x] One catalog entry only; no core changes in this PR.
- [ ] Two-week release maturity reached.
- [ ] Upstream admission CI completed and maintainer review approved.

## Catalog review follow-up

Rechecked the existing pinned package against the review. It contains no in-app self-updater and requires no code changes for this feedback. The original SHA and release-maturity date are retained. This PR remains a draft until that date.

Upstream manifest validation and `hermes plugins doctor --ci` passed for this package in an isolated Hermes home. The maintainer’s review reported no further implementation blockers beyond maturity.
