### PR TITLE
feat(catalog): add hermes-resetwatch community plugin

### DIFF
--- a/plugin-catalog/hermes-resetwatch.yaml
+++ b/plugin-catalog/hermes-resetwatch.yaml
@@ -1,6 +1,6 @@
 name: hermes-resetwatch
 repo: https://github.com/Adolanium/hermes-resetwatch
-sha: ecd19c62fa987ff3de9cd617d07dc6983b1800f2
+sha: 2dbc6d8926e64b37ddc54e494e8554ae1e2bd991
 description: Track subscription quotas and reset times in Hermes Desktop.
 maintainer: Adolanium
 tier: community

--- a/plugin-catalog/hermes-resetwatch.yaml
+++ b/plugin-catalog/hermes-resetwatch.yaml
@@ -1,0 +1,13 @@
+name: hermes-resetwatch
+repo: https://github.com/Adolanium/hermes-resetwatch
+sha: ecd19c62fa987ff3de9cd617d07dc6983b1800f2
+description: Track subscription quotas and reset times in Hermes Desktop.
+maintainer: Adolanium
+tier: community
+docs_url: https://github.com/Adolanium/hermes-resetwatch#readme
+capabilities:
+  provides_tools: []
+  provides_hooks: []
+  provides_middleware: []
+  requires_env: []
+subdir: catalog


### PR DESCRIPTION
## What does this PR do?

Adds `hermes-resetwatch` as a community plugin. I own and maintain [Adolanium/hermes-resetwatch](https://github.com/Adolanium/hermes-resetwatch).

Track subscription quotas and reset times in Hermes Desktop.

## Release and pin maturity

- Release: [catalog-v0.2.17-2](https://github.com/Adolanium/hermes-resetwatch/releases/tag/catalog-v0.2.17-2)
- Exact pin: `3be783290fd66c6070af8eaf7a2286c7ef5e71c5`
- Published: 2026-09-14T20:28:08Z
- Earliest two-week release maturity: 2026-09-28T20:28:08.000Z

This PR is intentionally a draft until the release has settled for two weeks. Please do not merge before that date. No maturity exception is requested.

## Desktop packaging

Uses the documented combined-package layout in `subdir: catalog`, with a native manifest, an Agent entry point that registers no tools or hooks, and `desktop/plugin.js`. All functionality is in the Desktop component. The empty Agent capability lists describe actual registration; they do not mean the Desktop code is sandboxed or has no host access.

The root standalone distribution is retained. The packaged Desktop code contains no in-app updater UI, release downloader, verification, backup/restore, or code-replacement helpers. The build removes the complete updater implementation and rejects unexpected updater layouts. Companion files are included where required. Desktop users enable the component in Capabilities > Plugins after a restart or rescan. Existing manual installs must be migrated, since Hermes intentionally preserves their folders.

## DeepSeek pricing correction

The pinned release applies DeepSeek peak pricing only Monday-Friday at 01:00-04:00 and 06:00-10:00 UTC. Weekends are off-peak, and the displayed schedule includes Mon-Fri.

## Validation

- All 27 plugin tests passed, including UTC boundaries, weekends, timezone conversions and profile routing. Source CI passed on the new release commit.
- Upstream structural catalog validator passed.
- Upstream manifest validation and isolated capability probe passed at the released source.
- Exact-commit installation and real Agent plugin loading passed on Windows.
- Real Desktop detection/materialization functions verified plugin bytes, catalog provenance, repeat scans, removal, and manual-install protection.
- Packaged updater actions completed without access to network or filesystem APIs and directed users to Hermes updates.
- Packaging CI verifies the committed package against its source and catalog policy.

These checks cover installation and packaging, not a new visual acceptance test of every Desktop feature. Requires Desktop combined-package support.

## Checklist

- [x] Owner-submitted public repository with a release and a full SHA pin.
- [x] Community tier; capability declarations match the released manifest.
- [x] One catalog entry only; no core changes in this PR.
- [ ] Two-week release maturity reached.
- [ ] Upstream admission CI completed and maintainer review approved.

## Catalog review follow-up

The complete catalog self-updater has been removed, including its check/install/restore UI and unreachable download, verification, backup, and file-replacement helpers. Catalog updates require a reviewed SHA-bump PR and `hermes plugins update hermes-resetwatch`. The standalone Desktop distribution remains separate. The new release restarts the two-week maturity period; this PR remains a draft until 2026-09-28T20:28:08.000Z.

The catalog probe is read-only for all login credentials. Kimi/Grok token-exchange and login-file-write implementations are removed, and expired tokens produce a sign-in message. Hermes OAuth resolver calls and Cursor CLI execution are excluded to prevent indirect refreshes. It still reads existing login tokens and calls the disclosed private usage APIs; only usage/rate-limit caches may be written. Mocked successful and 401 responses confirm credential bytes remain unchanged and no refresh request is made.

Upstream manifest validation and `hermes plugins doctor --ci` passed for this package in an isolated Hermes home. The new release also passed its repository’s Catalog package CI, including generated-file freshness, JavaScript syntax, and updater-policy regression tests.
