### PR TITLE
feat(catalog): add hermes-rss community plugin

### DIFF
--- a/plugin-catalog/hermes-rss.yaml
+++ b/plugin-catalog/hermes-rss.yaml
@@ -1,0 +1,13 @@
+name: hermes-rss
+repo: https://github.com/Adolanium/hermes-rss
+sha: 8053056094f8a232babe029e2336cb8118d8ba7a
+description: Read RSS and Atom feeds and discuss articles in Hermes Desktop.
+maintainer: Adolanium
+tier: community
+docs_url: https://github.com/Adolanium/hermes-rss#readme
+capabilities:
+  provides_tools: []
+  provides_hooks: []
+  provides_middleware: []
+  requires_env: []
+subdir: catalog


### PR DESCRIPTION
## What does this PR do?

Adds `hermes-rss` as a community plugin. I own and maintain [Adolanium/hermes-rss](https://github.com/Adolanium/hermes-rss).

Read RSS and Atom feeds and discuss articles in Hermes Desktop.

## Release and pin maturity

- Release: [catalog-v0.0.2-1](https://github.com/Adolanium/hermes-rss/releases/tag/catalog-v0.0.2-1)
- Exact pin: `8053056094f8a232babe029e2336cb8118d8ba7a`
- Published: 2026-09-12T04:29:54Z
- Earliest two-week release maturity: 2026-09-26T04:29:54+00:00

This PR is intentionally a draft until the release has settled for two weeks. Please do not merge before that date. No maturity exception is requested.

## Desktop packaging

Uses the documented combined-package layout in `subdir: catalog`, with a native manifest, an Agent entry point that registers no tools or hooks, and `desktop/plugin.js`. All functionality is in the Desktop component. The empty Agent capability lists describe actual registration; they do not mean the Desktop code is sandboxed or has no host access.

The root standalone distribution is retained. This package has no in-app self-updater. Companion files are included where required. Desktop users enable the component in Capabilities > Plugins after a restart or rescan. Existing manual installs must be migrated, since Hermes intentionally preserves their folders.

## Validation

- Upstream structural catalog validator passed.
- Upstream manifest validation and isolated capability probe passed at the released source.
- Exact-commit installation and real Agent plugin loading passed on Windows.
- Real Desktop detection/materialization functions verified plugin bytes, catalog provenance, repeat scans, removal, and manual-install protection.
- Packaging CI verifies the committed package against its source.

These checks cover installation and packaging, not a new visual acceptance test of every Desktop feature. Requires Desktop combined-package support.

## Installation dependency

Blocked on #108811 or an equivalent maintainer-approved scanner correction. Current main hard-blocks a legitimate JS capability reference. The exact-install test used that patch and explicitly accepted the resulting caution finding. Manifest/catalog CI alone does not cover this installer gate. Please keep this PR in draft until the installation blocker is resolved as well as the maturity period.

## Checklist

- [x] Owner-submitted public repository with a release and a full SHA pin.
- [x] Community tier; capability declarations match the released manifest.
- [x] One catalog entry only; no core changes in this PR.
- [ ] Two-week release maturity reached.
- [ ] Upstream admission CI completed and maintainer review approved.

## Catalog review follow-up

Rechecked the existing pinned package against the review. It contains no in-app self-updater and requires no code changes for this feedback. The original SHA and release-maturity date are retained. This PR remains a draft until that date.

Upstream manifest validation and `hermes plugins doctor --ci` passed for this package in an isolated Hermes home. The maintainer’s review reported no further implementation blockers beyond maturity.

The installer-scanner dependency on #108811 remains a separate merge gate. This follow-up does not claim that plugin doctor resolves that installation blocker.

Scanner follow-up, September 14: #108811 now integrates current upstream and passes 62 scanner tests, including real-clone confirmation tests. The exact catalog pin in this PR was also tested through the actual installer and Agent loader: declining the caution prompt blocks installation, and explicitly accepting it installs and loads successfully. This resolves the implementation conflict in the proposed fix; admission still depends on a maintainer approving and merging #108811. The plugin SHA, release and maturity date are unchanged.
