### PR TITLE
feat(catalog): add hermes-ssh community plugin

### DIFF
--- a/plugin-catalog/hermes-ssh.yaml
+++ b/plugin-catalog/hermes-ssh.yaml
@@ -1,0 +1,13 @@
+name: hermes-ssh
+repo: https://github.com/Adolanium/hermes-ssh
+sha: 97382f496e47cef544c3c6cc04aa580eac921137
+description: Manage SSH connections and remote workspaces in Hermes Desktop.
+maintainer: Adolanium
+tier: community
+docs_url: https://github.com/Adolanium/hermes-ssh#readme
+capabilities:
+  provides_tools: []
+  provides_hooks: []
+  provides_middleware: []
+  requires_env: []
+subdir: catalog


### PR DESCRIPTION
## What does this PR do?

Adds `hermes-ssh` as a community plugin. I own and maintain [Adolanium/hermes-ssh](https://github.com/Adolanium/hermes-ssh).

Manage SSH connections and remote workspaces in Hermes Desktop.

## Release and pin maturity

- Release: [catalog-v0.3.3-2](https://github.com/Adolanium/hermes-ssh/releases/tag/catalog-v0.3.3-2)
- Exact pin: `02c6b34ee604a30827df25a082cba03fbf6fdf17`
- Published: 2026-09-14T20:28:12Z
- Earliest two-week release maturity: 2026-09-28T20:28:12.000Z

This PR is intentionally a draft until the release has settled for two weeks. Please do not merge before that date. No maturity exception is requested.

## Desktop packaging

Uses the documented combined-package layout in `subdir: catalog`, with a native manifest, an Agent entry point that registers no tools or hooks, and `desktop/plugin.js`. All functionality is in the Desktop component. The empty Agent capability lists describe actual registration; they do not mean the Desktop code is sandboxed or has no host access.

The root standalone distribution is retained. The packaged Desktop code contains no in-app updater UI, release downloader, verification, backup/restore, or code-replacement helpers. The build removes the complete updater implementation and rejects unexpected updater layouts. Companion files are included where required. Desktop users enable the component in Capabilities > Plugins after a restart or rescan. Existing manual installs must be migrated, since Hermes intentionally preserves their folders.

## Validation

- Structural catalog validation passed.
- Upstream manifest validation and plugin doctor passed in an isolated Hermes home.
- Generated-package freshness, JavaScript syntax and catalog updater-policy tests passed.
- Source repository Catalog package CI passed on the released commit.

These checks cover registration, packaging and the listed regression suites. A new visual acceptance test of every Desktop feature was not performed.

## Installation dependency

Blocked on #108811 or an equivalent maintainer-approved scanner correction. Current main hard-blocks a legitimate JS capability reference. The exact-install test used that patch and explicitly accepted the resulting caution finding. Manifest/catalog CI alone does not cover this installer gate. Please keep this PR in draft until the installation blocker is resolved as well as the maturity period.

## Checklist

- [x] Owner-submitted public repository with a release and a full SHA pin.
- [x] Community tier; capability declarations match the released manifest.
- [x] One catalog entry only; no core changes in this PR.
- [ ] Two-week release maturity reached.
- [ ] Upstream admission CI completed and maintainer review approved.

## Catalog review follow-up

The complete catalog self-updater has been removed, including its check/install/restore UI and unreachable download, verification, backup, and file-replacement helpers. Catalog updates require a reviewed SHA-bump PR and `hermes plugins update hermes-ssh`. The standalone Desktop distribution remains separate. The new release restarts the two-week maturity period; this PR remains a draft until 2026-09-28T20:28:12.000Z.

Desktop shell/terminal access is part of this plugin’s intended functionality. Empty Agent tool/hook declarations do not imply a sandbox. The catalog currently has no Desktop shell-capability field, as noted in the review; no unsupported schema field is added.

Upstream manifest validation and `hermes plugins doctor --ci` passed for this package in an isolated Hermes home. The new release also passed its repository’s Catalog package CI, including generated-file freshness, JavaScript syntax, and updater-policy regression tests.

The installer-scanner dependency on #108811 remains a separate merge gate. This follow-up does not claim that plugin doctor resolves that installation blocker.

Scanner follow-up, September 14: #108811 now integrates current upstream and passes 62 scanner tests, including real-clone confirmation tests. The exact catalog pin in this PR was also tested through the actual installer and Agent loader: declining the caution prompt blocks installation, and explicitly accepting it installs and loads successfully. This resolves the implementation conflict in the proposed fix; admission still depends on a maintainer approving and merging #108811. The plugin SHA, release and maturity date are unchanged.
