### PR TITLE
feat(catalog): add hermes-tailscale community plugin

### DIFF
--- a/plugin-catalog/hermes-tailscale.yaml
+++ b/plugin-catalog/hermes-tailscale.yaml
@@ -1,0 +1,13 @@
+name: hermes-tailscale
+repo: https://github.com/Adolanium/hermes-tailscale
+sha: 418eacfbad7ad0fffe600575c783c78b0405643d
+description: Browse Tailscale devices and connect to remote Hermes instances in Hermes Desktop.
+maintainer: Adolanium
+tier: community
+docs_url: https://github.com/Adolanium/hermes-tailscale#readme
+capabilities:
+  provides_tools: []
+  provides_hooks: []
+  provides_middleware: []
+  requires_env: []
+subdir: catalog


### PR DESCRIPTION
## What does this PR do?

Adds `hermes-tailscale` as a community plugin. I own and maintain [Adolanium/hermes-tailscale](https://github.com/Adolanium/hermes-tailscale).

Browse Tailscale devices and connect to remote Hermes instances in Hermes Desktop.

## Release and pin maturity

- Release: [catalog-v0.0.5-2](https://github.com/Adolanium/hermes-tailscale/releases/tag/catalog-v0.0.5-2)
- Exact pin: `6dad1d5aac443a196f7ba83736a1f4c9e3a75048`
- Published: 2026-09-14T20:28:09Z
- Earliest two-week release maturity: 2026-09-28T20:28:09.000Z

This PR is intentionally a draft until the release has settled for two weeks. Please do not merge before that date. No maturity exception is requested.

## Desktop packaging

Uses the documented combined-package layout in `subdir: catalog`, with a native manifest, an Agent entry point that registers no tools or hooks, and `desktop/plugin.js`. All functionality is in the Desktop component. The empty Agent capability lists describe actual registration; they do not mean the Desktop code is sandboxed or has no host access.

The root standalone distribution is retained. The packaged Desktop code contains no in-app updater UI, release downloader, verification, backup/restore, or code-replacement helpers. The build removes the complete updater implementation and rejects unexpected updater layouts. Companion files are included where required. Desktop users enable the component in Capabilities > Plugins after a restart or rescan. Existing manual installs must be migrated, since Hermes intentionally preserves their folders.

## Validation

- Structural catalog validation passed.
- Upstream manifest validation and plugin doctor passed in an isolated Hermes home.
- Generated-package freshness, JavaScript syntax and catalog updater-policy tests passed.
- Tailscale, Serve, shell quoting and xterm integrity tests passed against the generated Desktop package. The optional live-CDN check was skipped.
- Source repository Catalog package CI passed on the released commit.

These checks cover registration, packaging and the listed regression suites. A new visual acceptance test of every Desktop feature was not performed.

## Checklist

- [x] Owner-submitted public repository with a release and a full SHA pin.
- [x] Community tier; capability declarations match the released manifest.
- [x] One catalog entry only; no core changes in this PR.
- [ ] Two-week release maturity reached.
- [ ] Upstream admission CI completed and maintainer review approved.

## Catalog review follow-up

The complete catalog self-updater has been removed, including its check/install/restore UI and unreachable download, verification, backup, and file-replacement helpers. Catalog updates require a reviewed SHA-bump PR and `hermes plugins update hermes-tailscale`. The standalone Desktop distribution remains separate. The new release restarts the two-week maturity period; this PR remains a draft until 2026-09-28T20:28:09.000Z.

Desktop shell/terminal access is part of this plugin’s intended functionality. Empty Agent tool/hook declarations do not imply a sandbox. The catalog currently has no Desktop shell-capability field, as noted in the review; no unsupported schema field is added.

Upstream manifest validation and `hermes plugins doctor --ci` passed for this package in an isolated Hermes home. The new release also passed its repository’s Catalog package CI, including generated-file freshness, JavaScript syntax, and updater-policy regression tests.
