### PR TITLE
feat(catalog): add hermes-terminal community plugin

### DIFF
--- a/plugin-catalog/hermes-terminal.yaml
+++ b/plugin-catalog/hermes-terminal.yaml
@@ -1,0 +1,13 @@
+name: hermes-terminal
+repo: https://github.com/Adolanium/hermes-terminal
+sha: 49ed6b1c7430b6ef9b99c9bf2205b2c3f310241c
+description: Run the Hermes terminal interface in a Hermes Desktop workspace tab.
+maintainer: Adolanium
+tier: community
+docs_url: https://github.com/Adolanium/hermes-terminal#readme
+capabilities:
+  provides_tools: []
+  provides_hooks: []
+  provides_middleware: []
+  requires_env: []
+subdir: catalog


### PR DESCRIPTION
## What does this PR do?

Adds `hermes-terminal` as a community plugin. I own and maintain [Adolanium/hermes-terminal](https://github.com/Adolanium/hermes-terminal).

Run the Hermes terminal interface in a Hermes Desktop workspace tab.

## Release and pin maturity

- Release: [catalog-v0.0.3-2](https://github.com/Adolanium/hermes-terminal/releases/tag/catalog-v0.0.3-2)
- Exact pin: `43658bf3c883178bf035d2163f7f541500d17407`
- Published: 2026-09-14T20:28:11Z
- Earliest two-week release maturity: 2026-09-28T20:28:11.000Z

This PR is intentionally a draft until the release has settled for two weeks. Please do not merge before that date. No maturity exception is requested.

## Desktop packaging

Uses the documented combined-package layout in `subdir: catalog`, with a native manifest, an Agent entry point that registers no tools or hooks, and `desktop/plugin.js`. All functionality is in the Desktop component. The empty Agent capability lists describe actual registration; they do not mean the Desktop code is sandboxed or has no host access.

The root standalone distribution is retained. The packaged Desktop code contains no in-app updater UI, release downloader, verification, backup/restore, or code-replacement helpers. The build removes the complete updater implementation and rejects unexpected updater layouts. Companion files are included where required. Desktop users enable the component in Capabilities > Plugins after a restart or rescan. Existing manual installs must be migrated, since Hermes intentionally preserves their folders.

## Validation

- Structural catalog validation passed.
- Upstream manifest validation and plugin doctor passed in an isolated Hermes home.
- Generated-package freshness, JavaScript syntax and catalog updater-policy tests passed.
- Source repository Catalog package CI passed on the released commit.

These checks cover registration, packaging and the listed regression suites. A new visual acceptance test of every Desktop feature was not performed.

## Checklist

- [x] Owner-submitted public repository with a release and a full SHA pin.
- [x] Community tier; capability declarations match the released manifest.
- [x] One catalog entry only; no core changes in this PR.
- [ ] Two-week release maturity reached.
- [ ] Upstream admission CI completed and maintainer review approved.

## Catalog review follow-up

The complete catalog self-updater has been removed, including its check/install/restore UI and unreachable download, verification, backup, and file-replacement helpers. Catalog updates require a reviewed SHA-bump PR and `hermes plugins update hermes-terminal`. The standalone Desktop distribution remains separate. The new release restarts the two-week maturity period; this PR remains a draft until 2026-09-28T20:28:11.000Z.

Desktop shell/terminal access is part of this plugin’s intended functionality. Empty Agent tool/hook declarations do not imply a sandbox. The catalog currently has no Desktop shell-capability field, as noted in the review; no unsupported schema field is added.

Upstream manifest validation and `hermes plugins doctor --ci` passed for this package in an isolated Hermes home. The new release also passed its repository’s Catalog package CI, including generated-file freshness, JavaScript syntax, and updater-policy regression tests.
