### PR TITLE
feat(catalog): add shodan community plugin

### DIFF
--- a/plugin-catalog/shodan.yaml
+++ b/plugin-catalog/shodan.yaml
@@ -1,0 +1,27 @@
+name: shodan
+repo: https://github.com/Adolanium/hermes-plugin-shodan
+sha: c7d56211420438bd300c3526b7536f55aafb0fce
+description: Shodan tools with complete capability declarations.
+maintainer: Adolanium
+tier: community
+docs_url: https://github.com/Adolanium/hermes-plugin-shodan#readme
+capabilities:
+  provides_tools:
+  - shodan_host
+  - shodan_search
+  - shodan_count
+  - shodan_dns
+  - shodan_cve
+  - shodan_account
+  - shodan_meta
+  - shodan_scan
+  - shodan_alert
+  - shodan_exploits
+  - shodan_query
+  - shodan_trends
+  provides_hooks:
+  - on_session_start
+  - on_session_reset
+  provides_middleware: []
+  requires_env:
+  - SHODAN_API_KEY


### PR DESCRIPTION
## What does this PR do?

Adds `shodan` as a community plugin. I own and maintain [Adolanium/hermes-plugin-shodan](https://github.com/Adolanium/hermes-plugin-shodan).

Shodan tools with complete capability declarations.

## Release and pin maturity

- Release: [v0.1.1](https://github.com/Adolanium/hermes-plugin-shodan/releases/tag/v0.1.1)
- Exact pin: `c7d56211420438bd300c3526b7536f55aafb0fce`
- Published: 2026-09-12T04:29:59Z
- Earliest two-week release maturity: 2026-09-26T04:29:59+00:00

This PR is intentionally a draft until the release has settled for two weeks. Please do not merge before that date. No maturity exception is requested.

## Capabilities

Declares all twelve registered tools and the session-start/session-reset hooks. The default core profile and credential checks control visibility. Scanning requires explicit configuration. Also includes skills, CLI commands, and a slash command. SHODAN_API_KEY enables authenticated endpoints; keyless InternetDB and CVEDB lookups remain available.

## Validation

- Upstream structural catalog validator passed.
- Upstream manifest validation and isolated capability probe passed at the released source.
- Exact-commit installation and real Agent plugin loading passed on Windows.
- 130 plugin tests passed locally; the release commit's GitHub test workflow passed.

## Checklist

- [x] Owner-submitted public repository with a release and a full SHA pin.
- [x] Community tier; capability declarations match the released manifest.
- [x] One catalog entry only; no core changes in this PR.
- [ ] Two-week release maturity reached.
- [ ] Upstream admission CI completed and maintainer review approved.

## Catalog review follow-up

Rechecked the existing pinned package against the review. It contains no in-app self-updater and requires no code changes for this feedback. The original SHA and release-maturity date are retained. This PR remains a draft until that date.

The existing 12 tools and 2 hooks remain declared. Scanning still requires the full profile, `scan.enabled: true`, and a permitted CIDR. No scan-policy changes are needed.

Upstream manifest validation and `hermes plugins doctor --ci` passed for this package in an isolated Hermes home. The maintainer’s review reported no further implementation blockers beyond maturity.
