### PR TITLE
fix(redact): mask mixed-case Authorization headers behind a casing-agnostic gate

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -370,6 +370,11 @@ _JSON_FIELD_RE = re.compile(rf'("{_JSON_KEY_NAMES}")\s*:\s*"([^"]+)"', re.IGNORE
 # (unterminated quote → shell EOF / SyntaxError).
 _AUTH_HEADER_RE = re.compile(r"((?:Proxy-)?Authorization:\s*)([A-Za-z][\w.+-]*\s+)?([^\s\"']+)", re.IGNORECASE)
 
+# Gate for _AUTH_HEADER_RE: the header-name substring in ANY casing. A mixed-case
+# name (aUtHoRiZaTiOn) contains neither the all-lower nor the all-upper run, so
+# plain substring checks would never reach the IGNORECASE regex (issue #108807).
+_AUTH_GATE_RE = re.compile(r"uthorization", re.IGNORECASE)
+
 # API-key style headers (single opaque value, no scheme word): non-vendor-prefix
 # values would otherwise leak when a curl command is echoed into tool output.
 _SECRET_HEADER_NAMES = r"(?:x-api-key|x-goog-api-key|api-key|apikey|x-api-token|x-auth-token|x-access-token)"
@@ -696,7 +701,7 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
     if not code_file:
         text = _redact_assignments(text)
 
-    if "uthorization" in text or "UTHORIZATION" in text:  # cheapest gate over every casing
+    if _AUTH_GATE_RE.search(text):  # cheapest gate over every casing
         text = _AUTH_HEADER_RE.sub(lambda m: m.group(1) + (m.group(2) or "") + _mask_token(m.group(3)), text)
 
     if ":" in text:

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -294,6 +294,34 @@ class TestAuthHeaders:
         text = "the authorization model is fully open"
         assert redact_sensitive_text(text) == text
 
+    def test_mixed_case_authorization_header_masked(self):
+        # Regression for #108807: the gate checked exact all-lower/all-upper
+        # substring runs, so a mixed-case header name (aUtHoRiZaTiOn) skipped
+        # the IGNORECASE header regex and leaked Bearer/Basic credentials.
+        secret = "SyntheticOpaqueCredential92837465"
+        for name in ("aUtHoRiZaTiOn", "pRoXy-AuThOrIzAtIoN", "AUTHORIZATION", "authorization"):
+            for scheme in ("Bearer", "Basic"):
+                text = f"{name}: {scheme} {secret}"
+                result = redact_sensitive_text(text)
+                assert secret not in result, text
+                assert f"{name}: {scheme}" in result, result
+
+    def test_mixed_case_header_via_logging_formatter(self):
+        # Same failure through the real formatter path the reporter used.
+        formatter = RedactingFormatter("%(message)s")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="aUtHoRiZaTiOn: Bearer SyntheticOpaqueCredential92837465",
+            args=(),
+            exc_info=None,
+        )
+        result = formatter.format(record)
+        assert "SyntheticOpaqueCredential92837465" not in result
+        assert "aUtHoRiZaTiOn: Bearer" in result, result
+
     def test_token_flush_against_double_quote_preserves_quote(self):
         # Regression for #43083: a token sitting flush against a closing
         # double quote must NOT pull that quote into the mask. Greedy \S+


### PR DESCRIPTION
## What does this PR do?

The pre-gate guarding `_AUTH_HEADER_RE` in `agent/redact.py` matched only two exact casings: the all-lower run `uthorization` and the all-upper run `UTHORIZATION`. A mixed-case header name such as `aUtHoRiZaTiOn` or `pRoXy-AuThOrIzAtIoN` contains neither run, so the gate short-circuited and the (already `re.IGNORECASE`) header regex never ran — Bearer/Basic credentials in mixed-case headers passed through `redact_sensitive_text` and `RedactingFormatter` unmasked. This contradicts the function docstring contract that every regex gate "is never false-negative", and the case-insensitive header handling the regex itself implements.

The fix replaces the substring pair with a precompiled `re.IGNORECASE` gate regex (`_AUTH_GATE_RE = re.compile(r"uthorization", re.IGNORECASE)`). This keeps the cheap-gate structure (one C-level scan, no full-text `lower()` allocation on the hot logging path) while covering every casing of both `Authorization` and `Proxy-Authorization`.

## Related Issue

Fixes #108807

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/redact.py`: added `_AUTH_GATE_RE` (precompiled IGNORECASE gate for the `uthorization` substring) next to `_AUTH_HEADER_RE`, and replaced the case-sensitive substring pair at the gate site with `_AUTH_GATE_RE.search(text)`.
- `tests/agent/test_redact.py`: added `TestAuthHeaders.test_mixed_case_authorization_header_masked` (mixed/upper/lower × Bearer/Basic × Authorization/Proxy-Authorization; asserts the credential is masked and the header name + scheme word survive in original casing) and `TestRedactingFormatter-path` coverage via `test_mixed_case_header_via_logging_formatter` (real `RedactingFormatter.format` on a LogRecord, mirroring the issue reproduction).

## How to Test

1. Run the issue reproduction before the fix (fails on the mixed-case line):
```python
from agent.redact import redact_sensitive_text
secret = "SyntheticOpaque" + "Credential92837465"
assert secret not in redact_sensitive_text("Authorization: Bearer " + secret, force=True)
assert secret not in redact_sensitive_text("aUtHoRiZaTiOn: Bearer " + secret, force=True)  # failed pre-fix
```
Observed result: with this PR both assertions pass (mixed-case header value is masked, `aUtHoRiZaTiOn: Bearer` prefix preserved).
2. `pytest tests/agent/test_redact.py tests/tools/test_terminal_error_redaction.py -q` — observed result: 124 passed (122 pre-existing + 2 new).
3. Ripple check on other redaction consumers: `pytest tests/test_redaction_registry.py tests/tools/test_terminal_tool_exception_redaction.py tests/tools/test_terminal_output_transform_hook.py tests/tools/test_kanban_redaction.py tests/tools/test_browser_secret_exfil.py -q` — observed result: 47 passed.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run `pytest tests/ -q` and all tests pass (targeted redaction suites listed under How to Test)
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15.4 (arm64), Python 3.11

### Documentation & Housekeeping

- [ ] I have updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I have considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I have updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/agent/test_redact.py tests/tools/test_terminal_error_redaction.py -q
124 passed in 5.99s
```