### PR TITLE
fix(computer_use): fail closed when dispatch races a backend release

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -2671,3 +2671,75 @@ class TestBoundsScaleField:
         assert _bounds_scale(elems, 1455, 791) is None
         assert _bounds_scale([], 1455, 791) is None
         assert _bounds_scale(elems, 0, 0) is None
+
+
+class TestReleasedBackendRace:
+    """#108813: a backend selected before its call lock can outlive a concurrent
+    release_computer_use_session. Dispatching the detached backend reanimates the
+    stopped driver session, so the dispatcher must re-check backend identity under
+    the call lock and fail closed."""
+
+    def test_dispatch_after_release_fails_closed(self, monkeypatch):
+        import threading
+
+        from tools.computer_use import tool as cu_tool
+
+        dispatches: list = []
+        monkeypatch.setattr(
+            cu_tool, "_dispatch",
+            lambda backend, action, args: dispatches.append((action, args)) or "{}",
+        )
+        selected = threading.Event()
+        release_done = threading.Event()
+        real_get = cu_tool._get_backend
+
+        def staged_get(session_id=""):
+            backend = real_get(session_id=session_id)
+            selected.set()
+            assert release_done.wait(5), "release never ran during the window"
+            return backend
+
+        monkeypatch.setattr(cu_tool, "_get_backend", staged_get)
+
+        result: Dict[str, Any] = {}
+
+        def call():
+            result["r"] = cu_tool.handle_computer_use(
+                {"action": "list_apps"}, session_id="race-sid")
+
+        t = threading.Thread(target=call)
+        t.start()
+        assert selected.wait(5), "backend never selected"
+        assert cu_tool.release_computer_use_session("race-sid") is True
+        release_done.set()
+        t.join(5)
+        assert not t.is_alive(), "handler thread hung"
+        payload = json.loads(result["r"])
+        assert "error" in payload, payload
+        assert dispatches == [], "stale backend was dispatched after release returned"
+
+    def test_released_backend_folded_back_dispatches_again(self, monkeypatch):
+        # The empty-session fold contract: release detaches (and stops) the cached
+        # alias of the host-injected ``_backend``, but the next call folds that same
+        # object back into the cache — install revives membership, so it dispatches
+        # normally instead of being rejected as detached.
+        from tools.computer_use import tool as cu_tool
+
+        dispatches: list = []
+        monkeypatch.setattr(
+            cu_tool, "_dispatch",
+            lambda backend, action, args: dispatches.append(action) or "{}",
+        )
+        # Warm up: install("") also mirrors the backend onto the ``_backend`` hook.
+        cu_tool.handle_computer_use({"action": "list_apps"})
+        dispatches.clear()
+        assert cu_tool.release_computer_use_session("") is True
+        result = json.loads(cu_tool.handle_computer_use({"action": "list_apps"}))
+        assert "error" not in result, result
+        assert dispatches == ["list_apps"]
+
+    def test_normal_dispatch_unaffected_by_identity_check(self):
+        from tools.computer_use.tool import handle_computer_use
+        result = json.loads(handle_computer_use(
+            {"action": "list_apps"}, session_id="steady-sid"))
+        assert "error" not in result, result

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -15,6 +15,7 @@ import re
 import sys
 import threading
 import uuid
+import weakref
 from collections import namedtuple
 from functools import partial
 from types import SimpleNamespace
@@ -77,6 +78,11 @@ def _input_target_mismatch(backend, requested_app: str) -> Optional[str]:
 _backend_lock = threading.Lock()
 _backend: Optional[ComputerUseBackend] = None  # backward-compatible empty-session injection hook (older tests)
 _backends: Dict[str, ComputerUseBackend] = {}
+# Backends evicted by _detach_locked (release / mode-toggle / cache fold). Dispatch must never
+# reanimate one: its driver session was stopped, and the driver would restart it for a stale
+# call (#108813). _install_backend revives membership, so a host-injected ``_backend`` folded
+# back into the cache dispatches normally again. Weak: identity only, no lifecycle retention.
+_detached_backends: "weakref.WeakSet[ComputerUseBackend]" = weakref.WeakSet()
 _backend_call_locks: Dict[str, threading.RLock] = {}
 _backend_permission_modes: Dict[str, str] = {}
 _AUX_VISION_ROUTE_CACHE: Dict[Tuple[str, str], bool] = {}  # process-scoped: (provider, model) → bool
@@ -133,6 +139,7 @@ def _install_backend(sid: str, backend: ComputerUseBackend, permission_mode: str
     global _backend
     _backends[sid], _backend_permission_modes[sid] = backend, permission_mode
     _backend_call_locks[sid] = threading.RLock()
+    _detached_backends.discard(backend)  # cache membership is the liveness contract
     _backend = backend if sid == "" else _backend
     return backend
 
@@ -145,6 +152,8 @@ def _detach_locked(sid: str) -> Tuple[Optional[ComputerUseBackend], Optional[thr
     if sid == "":
         backend = _backend if backend is None else backend
         _backend = None if _backend is backend else _backend
+    if backend is not None:
+        _detached_backends.add(backend)
     return backend, call_lock
 
 def _stop_backend(backend: ComputerUseBackend, call_lock: Optional[threading.RLock], on_error: Callable[[Exception], None]) -> None:
@@ -206,6 +215,7 @@ def _shutdown_backend_atexit() -> None:
             unique.setdefault(id(_backend), (_backend, _backend_call_locks.get("")))
         _backend = None
         _backends.clear(), _backend_call_locks.clear(), _backend_permission_modes.clear()
+        _detached_backends.clear()
     with _approval_lock:
         _session_auto_approve.clear(), _always_allow.clear(), _escalation_warned.clear()
     for backend, call_lock in unique.values():
@@ -263,6 +273,13 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
         with _backend_lock:
             call_lock = _backend_call_locks.setdefault(session_id, threading.RLock())
         with call_lock:
+            # The backend was selected before this lock was held: a concurrent
+            # release/mode-toggle detaches (and stops) it in that gap, and the
+            # driver would reanimate the stopped session for this stale call
+            # (#108813). Fail closed; the caller retries against a fresh backend.
+            if backend in _detached_backends:
+                return json.dumps({"error": f"computer_use {action} aborted: "
+                                            "session backend was released concurrently; retry the call"})
             return _dispatch(backend, action, args)
     except Exception as e:
         logger.exception("computer_use %s failed", action)


### PR DESCRIPTION
## What does this PR do?

`handle_computer_use` selects a backend, then takes the session call lock in a second step. If another thread runs `release_computer_use_session` in that gap, the backend is detached from the cache and its driver session is stopped — yet the first thread proceeds to dispatch the now-detached object, and `CuaDriverSession.call_tool` restarts the stopped session for that stale call (`cua-driver session not active on ...; (re)starting before call`). The same stale-dispatch window exists for the mode-toggle replacement path in `_get_backend`.

This PR makes the dispatcher fail closed instead of reanimating a detached backend:

- `_detach_locked` records every evicted backend in `_detached_backends`, a `weakref.WeakSet` (identity only, no lifecycle retention).
- `_install_backend` discards from the set, so a host-injected `_backend` folded back into the empty-session cache dispatches normally again — the install/fold contract is preserved.
- `handle_computer_use` checks membership under the call lock, after the race window closes, and returns a retryable error instead of dispatching.

Backends injected by patching the `_get_backend` seam (the established test style) are never in the set, so they keep dispatching normally — the check is exact, not heuristic.

## Related Issue

Fixes #108813

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/computer_use/tool.py`: added `_detached_backends` WeakSet; `_detach_locked` adds evicted backends; `_install_backend` revives membership on (re)install; `_shutdown_backend_atexit` clears the set; `handle_computer_use` rejects a detached backend under the call lock with a retryable error.
- `tests/tools/test_computer_use.py`: new `TestReleasedBackendRace` — deterministic Event-orchestrated interleave proving the stale dispatch is rejected (fails on main: the dispatch goes through), a control test that normal dispatch is unaffected, and a fold-revival test pinning the `_backend` re-install contract.

## How to Test

1. Run the race test on current main — observed result: fails with the stale dispatch going through (`dispatches` records `list_apps` after `release_computer_use_session` returned).
2. With this PR: `pytest tests/tools/test_computer_use.py -q` — observed result: 103 passed (100 pre-existing + 3 new).
3. Ripple check on the lifecycle/adjacent suites: `pytest tests/tools/test_computer_use_delivery_ladder.py tests/tools/test_computer_use_approval_isolation.py tests/tools/test_computer_use_cua_backend_linux.py tests/tools/test_computer_use_vision_routing.py tests/tools/test_computer_use_input_target_guard.py -q` — observed result: 51 passed, 2 skipped.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run `pytest tests/ -q` and all tests pass (targeted computer_use suites listed under How to Test)
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15.4 (arm64), Python 3.11

### Documentation & Housekeeping

- [ ] I have updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I have considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (threading/WeakSet are platform-neutral)
- [x] I have updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/tools/test_computer_use.py -q
103 passed in 2.26s
```
