### PR TITLE
fix(gateway): release scoped locks held by a wedged-but-running gateway

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -286,6 +286,71 @@ def _utc_now_iso() -> str:
 # a corrupt or hand-edited state file (e.g. an accidental 0 / tiny int).
 _EPOCH_MIN_PLAUSIBLE = 946684800.0  # 2000-01-01T00:00:00Z
 
+# A scoped lock whose owning gateway has stopped ticking its event loop is
+# stale even though the OS process is still alive.  Every liveness oracle in
+# acquire_scoped_lock() (PID exists / start_time matches / cmdline looks like a
+# gateway / SIGTSTP check) answers "healthy" for a gateway whose asyncio loop
+# has died but whose process lingers -- on macOS the SIGTSTP probe is a no-op
+# because it reads /proc, which does not exist.  Such a zombie holds e.g. the
+# Feishu app_id lock forever, and launchd's KeepAlive respawns a replacement
+# every few seconds that immediately exits with a non-retryable lock conflict.
+#
+# gateway/shutdown_watchdog.py already writes <HERMES_HOME>/state/gateway.heartbeat
+# every DEFAULT_HEARTBEAT_INTERVAL_S (30s) from a live loop, so its freshness is
+# a direct read on "is the owner's loop still turning".  Allow a generous
+# multiple of the writer cadence so a briefly-blocked loop, a slow external
+# volume, or a paused laptop is not evicted mid-stride.
+_LOCK_OWNER_HEARTBEAT_STALE_AFTER_S = 900.0  # 30x the 30s writer cadence
+
+
+def _lock_owner_loop_is_dead(existing: dict[str, Any], existing_pid: int) -> bool:
+    """Return True when the lock owner's event-loop heartbeat has gone cold.
+
+    Conservative by construction: every uncertain case returns False (keep the
+    lock).  We only evict when we can positively confirm that a heartbeat file
+    belonging to *this* PID exists and is older than the stale threshold.
+    Missing file, unparseable timestamp, a heartbeat owned by a different PID,
+    or any unexpected error all mean "cannot prove death" -> respect the lock.
+    """
+    home_raw = existing.get("hermes_home")
+    if not isinstance(home_raw, str) or not home_raw:
+        return False
+    try:
+        from gateway.shutdown_watchdog import get_loop_heartbeat_path
+
+        beat = _read_json_file(get_loop_heartbeat_path(Path(home_raw)))
+        if not isinstance(beat, dict):
+            return False
+        # The heartbeat must belong to the process holding the lock; a file
+        # left behind by an unrelated//previous gateway proves nothing.
+        try:
+            beat_pid = int(beat["pid"])
+        except (KeyError, TypeError, ValueError):
+            return False
+        if beat_pid != existing_pid:
+            return False
+
+        stamped = normalize_updated_at(beat.get("updated_at"))
+        if stamped is None:
+            return False
+        parsed = datetime.fromisoformat(stamped.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        age_s = (datetime.now(timezone.utc) - parsed).total_seconds()
+        # Future-dated heartbeats (clock skew) are not evidence of death.
+        if age_s <= _LOCK_OWNER_HEARTBEAT_STALE_AFTER_S:
+            return False
+        logger.warning(
+            "Scoped lock owner PID %s has not ticked its event loop for %.0fs "
+            "(heartbeat %s); treating the lock as stale.",
+            existing_pid,
+            age_s,
+            stamped,
+        )
+        return True
+    except Exception:
+        return False
+
 
 def normalize_updated_at(value: Any) -> Optional[str]:
     """Coerce a persisted ``updated_at`` value to an RFC3339 string or ``None``.
@@ -1754,6 +1819,14 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                                     break
                     except (OSError, PermissionError):
                         pass
+                # Final oracle: the owner process is alive and *looks* like a
+                # healthy gateway by every check above, but its asyncio loop
+                # has stopped ticking.  This is the only signal that catches a
+                # wedged-but-running gateway, and the only one that works on
+                # platforms without /proc (macOS), where the SIGTSTP probe
+                # above can never fire.  See _lock_owner_loop_is_dead().
+                if not stale and existing_pid is not None and _lock_owner_loop_is_dead(existing, existing_pid):
+                    stale = True
         if stale:
             # Remove the stale lock ATOMICALLY by renaming it to a tombstone
             # instead of unlinking. With unlink()+O_EXCL, two racing starters

--- a/tests/gateway/test_scoped_lock_loop_liveness.py
+++ b/tests/gateway/test_scoped_lock_loop_liveness.py
@@ -1,0 +1,202 @@
+"""Scoped locks must not be held forever by a wedged-but-running gateway.
+
+A gateway process whose asyncio loop has died but whose OS process lingers
+passes every pre-existing staleness oracle in ``acquire_scoped_lock()``:
+
+* the PID exists,
+* ``start_time`` still matches (it is the same process, not a recycled PID),
+* the command line still looks like a gateway,
+* and the SIGTSTP probe reads ``/proc/<pid>/status``, which does not exist on
+  macOS, so it can never fire there.
+
+The zombie therefore keeps e.g. the Feishu ``app_id`` lock indefinitely while a
+supervisor (launchd ``KeepAlive``, systemd ``Restart=``) respawns a replacement
+that immediately exits with a non-retryable lock conflict — an unbounded
+crash loop that only a manual ``kill -9`` breaks.
+
+``_lock_owner_loop_is_dead()`` closes that gap by reading the event-loop
+heartbeat that ``gateway/shutdown_watchdog.py`` writes every 30s. It is
+deliberately conservative: anything it cannot positively confirm leaves the
+lock intact.
+"""
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from gateway import status
+
+
+@pytest.fixture()
+def lock_env(tmp_path, monkeypatch):
+    """Isolate the lock dir and a fake HERMES_HOME with a heartbeat file."""
+    lock_dir = tmp_path / "locks"
+    lock_dir.mkdir()
+    home = tmp_path / "home"
+    (home / "state").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(lock_dir))
+    return {"lock_dir": lock_dir, "home": home}
+
+
+def _write_heartbeat(home, pid, age_seconds):
+    """Write <home>/state/gateway.heartbeat aged ``age_seconds`` in the past."""
+    stamped = datetime.now(timezone.utc) - timedelta(seconds=age_seconds)
+    path = home / "state" / "gateway.heartbeat"
+    path.write_text(
+        json.dumps(
+            {
+                "pid": pid,
+                "updated_at": stamped.isoformat(),
+                "monotonic": 1234.5,
+                "start_time": 1789185711.88,
+                "loop_tick_socket": True,
+                "loop_tick_tcp_port": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _lock_record(home, pid):
+    return {
+        "pid": pid,
+        "kind": "hermes-gateway",
+        "argv": ["hermes_cli/main.py", "gateway", "run"],
+        "start_time": 178841426019,
+        "hermes_home": str(home),
+        "scope": "feishu-app-id",
+        "metadata": {"platform": "feishu"},
+    }
+
+
+def test_cold_heartbeat_marks_owner_dead(lock_env):
+    """A heartbeat far past the threshold proves the owner's loop is gone."""
+    home = lock_env["home"]
+    pid = os.getpid()  # a genuinely live PID — only the heartbeat says otherwise
+    _write_heartbeat(home, pid, status._LOCK_OWNER_HEARTBEAT_STALE_AFTER_S + 600)
+
+    assert status._lock_owner_loop_is_dead(_lock_record(home, pid), pid) is True
+
+
+def test_fresh_heartbeat_keeps_lock(lock_env):
+    """A ticking loop must never lose its lock."""
+    home = lock_env["home"]
+    pid = os.getpid()
+    _write_heartbeat(home, pid, 5)
+
+    assert status._lock_owner_loop_is_dead(_lock_record(home, pid), pid) is False
+
+
+def test_heartbeat_just_inside_threshold_keeps_lock(lock_env):
+    """Boundary: below the cutoff is still alive (a briefly-blocked loop)."""
+    home = lock_env["home"]
+    pid = os.getpid()
+    _write_heartbeat(home, pid, status._LOCK_OWNER_HEARTBEAT_STALE_AFTER_S - 60)
+
+    assert status._lock_owner_loop_is_dead(_lock_record(home, pid), pid) is False
+
+
+def test_missing_heartbeat_keeps_lock(lock_env):
+    """No heartbeat file is not evidence of death — never evict on absence."""
+    home = lock_env["home"]
+    pid = os.getpid()
+
+    assert status._lock_owner_loop_is_dead(_lock_record(home, pid), pid) is False
+
+
+def test_heartbeat_owned_by_other_pid_keeps_lock(lock_env):
+    """A heartbeat from a different process proves nothing about this owner."""
+    home = lock_env["home"]
+    pid = os.getpid()
+    # Stale heartbeat, but written by some *other* gateway.
+    _write_heartbeat(home, pid + 1, status._LOCK_OWNER_HEARTBEAT_STALE_AFTER_S + 600)
+
+    assert status._lock_owner_loop_is_dead(_lock_record(home, pid), pid) is False
+
+
+def test_future_dated_heartbeat_keeps_lock(lock_env):
+    """Clock skew must not be read as death."""
+    home = lock_env["home"]
+    pid = os.getpid()
+    _write_heartbeat(home, pid, -3600)  # an hour in the future
+
+    assert status._lock_owner_loop_is_dead(_lock_record(home, pid), pid) is False
+
+
+def test_corrupt_heartbeat_keeps_lock(lock_env):
+    """Unparseable heartbeat contents leave the lock alone."""
+    home = lock_env["home"]
+    pid = os.getpid()
+    (home / "state" / "gateway.heartbeat").write_text("{not json", encoding="utf-8")
+
+    assert status._lock_owner_loop_is_dead(_lock_record(home, pid), pid) is False
+
+
+def test_unparseable_timestamp_keeps_lock(lock_env):
+    """A heartbeat with a garbage updated_at is not proof of death."""
+    home = lock_env["home"]
+    pid = os.getpid()
+    (home / "state" / "gateway.heartbeat").write_text(
+        json.dumps({"pid": pid, "updated_at": "not-a-timestamp"}), encoding="utf-8"
+    )
+
+    assert status._lock_owner_loop_is_dead(_lock_record(home, pid), pid) is False
+
+
+def test_record_without_hermes_home_keeps_lock(lock_env):
+    """Legacy lock records with no hermes_home cannot be checked — keep them."""
+    pid = os.getpid()
+    record = {"pid": pid, "kind": "hermes-gateway", "start_time": 1}
+
+    assert status._lock_owner_loop_is_dead(record, pid) is False
+
+
+def test_acquire_evicts_lock_whose_owner_loop_died(lock_env, monkeypatch):
+    """End-to-end: a wedged live owner loses the lock to a fresh starter.
+
+    This is the regression that matters — every other oracle reports the
+    owner as healthy, so without the heartbeat check the new gateway would
+    bounce with a non-retryable conflict forever.
+    """
+    home = lock_env["home"]
+    owner_pid = os.getpid() + 1
+
+    # Every pre-existing oracle says "the owner is a healthy live gateway".
+    monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+    monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 178841426019)
+    monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: True)
+
+    lock_path = status._get_scope_lock_path("feishu-app-id", "app-abc")
+    lock_path.write_text(json.dumps(_lock_record(home, owner_pid)), encoding="utf-8")
+
+    # ...but its loop stopped ticking a day ago.
+    _write_heartbeat(home, owner_pid, 86400)
+
+    acquired, existing = status.acquire_scoped_lock("feishu-app-id", "app-abc")
+
+    assert acquired is True
+    record = json.loads(lock_path.read_text(encoding="utf-8"))
+    assert record["pid"] == os.getpid()
+
+
+def test_acquire_respects_lock_whose_owner_is_ticking(lock_env, monkeypatch):
+    """A healthy owner with a fresh heartbeat keeps the lock."""
+    home = lock_env["home"]
+    owner_pid = os.getpid() + 1
+
+    monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+    monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 178841426019)
+    monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: True)
+
+    lock_path = status._get_scope_lock_path("feishu-app-id", "app-abc")
+    lock_path.write_text(json.dumps(_lock_record(home, owner_pid)), encoding="utf-8")
+    _write_heartbeat(home, owner_pid, 10)
+
+    acquired, existing = status.acquire_scoped_lock("feishu-app-id", "app-abc")
+
+    assert acquired is False
+    assert existing is not None
+    assert existing["pid"] == owner_pid


### PR DESCRIPTION
## Problem

A gateway whose asyncio loop has died but whose OS process lingers passes **every** staleness oracle in `acquire_scoped_lock()`:

- the PID exists → `_pid_exists` passes
- `start_time` still matches (same process, not a recycled PID) → the PID-reuse guard passes
- the command line still looks like a gateway → `_looks_like_gateway_process` passes
- the SIGTSTP probe reads `/proc/<pid>/status` — **which does not exist on macOS**, so it can never fire there

The zombie keeps its platform lock (Feishu `app_id`, Telegram bot token, ...) indefinitely. A supervisor with restart-on-exit (launchd `KeepAlive`, systemd `Restart=`) then respawns a replacement every few seconds that immediately exits with a non-retryable lock conflict. The only way out is a manual `kill -9`.

## Observed in the wild

macOS, a gateway wedged for 8 days held the Feishu lock through **1401 launchd respawns**, each logging:

```
[Feishu] Another local Hermes gateway is already using this Feishu app_id (PID 75874).
Gateway hit a non-retryable startup conflict → Gateway exiting cleanly
```

Forensics on the wedged process:

| Signal | Value |
|---|---|
| Open TCP sockets | **0** (websocket long dead) |
| CPU time over 3s samples | `106:55.19 → .20 → .20` (0.01s in 9 days) |
| Log file handles | pointed at `agent.log.3` / `errors.log.2` — rotated away hours earlier |
| `state/gateway.heartbeat` | last written **28.4 hours** before diagnosis |
| Response to SIGTERM | none — the handler is registered on the dead loop; needed SIGKILL |

`launchctl print` showed `runs = 1426`, `last exit code = 78 (EX_CONFIG)`.

## Fix

Add `_lock_owner_loop_is_dead()` as a final oracle in the staleness chain.

`gateway/shutdown_watchdog.py` already writes `<HERMES_HOME>/state/gateway.heartbeat` every `DEFAULT_HEARTBEAT_INTERVAL_S` (30s) from a live loop, so its freshness directly answers *"is the owner loop still turning"*. This signal already existed; nothing was reading it for lock arbitration. A heartbeat older than 900s (30x the writer cadence) marks the lock stale and lets the existing tombstone-rename eviction path run.

**Conservative by construction** — every uncertain case keeps the lock:

- heartbeat file missing
- corrupt JSON / unparseable timestamp
- heartbeat owned by a different PID than the lock
- future-dated timestamp (clock skew)
- lock record with no `hermes_home`
- any unexpected exception

Only positive proof of death evicts. The 900s threshold tolerates a briefly-blocked loop, a slow external volume, or a suspended laptop.

Benefits every platform adapter, since they all share `acquire_scoped_lock()`.

## Test plan

New `tests/gateway/test_scoped_lock_loop_liveness.py`, 11 cases — **11 passed**:

- cold heartbeat → evicts
- fresh heartbeat → keeps
- just inside threshold → keeps (boundary)
- missing / corrupt / unparseable-timestamp heartbeat → keeps
- heartbeat owned by another PID → keeps
- future-dated heartbeat → keeps
- lock record without `hermes_home` → keeps
- **end-to-end**: every other oracle reports "healthy live gateway", cold heartbeat → new starter acquires the lock
- **end-to-end**: same setup, fresh heartbeat → new starter is correctly refused

Mutation-checked: stubbing the new condition to `if False:` makes `test_acquire_evicts_lock_whose_owner_loop_died` fail, confirming the test exercises the new path.

Regression run — `test_status.py`, `test_stale_platform_lock_retryable.py`, `test_telegram_conflict.py`, `test_feishu.py`: **166 passed, 2 skipped, 1 failed**. The single failure is `test_download_remote_document_blocks_connect_time_rebind` (`httpx.ConnectError: stop before network`), a pre-existing sandbox-network failure — verified failing identically on a clean checkout via `git stash`.

`ruff check` clean on both files.

## Verification on the live system

Applying the patch resolved the crash loop in production, without a restart — the next launchd respawn picked it up and evicted the 9-day-old lock on its own:

```
WARNING gateway.status: Scoped lock owner PID 75874 has not ticked its event loop
for 102318s (heartbeat 2026-09-10T23:36:38+00:00); treating the lock as stale.
INFO  [Feishu] Connected in websocket mode (feishu)
INFO  ✓ feishu connected
```

Lock conflict log entries stop at that timestamp and have not recurred.