### PR TITLE
fix(desktop): keep a tiled main pane's tab strip

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.test.ts
@@ -23,6 +23,37 @@ describe('auto (no stored choice)', () => {
   it('has nothing to draw for an empty zone', () => {
     expect(resolveTabStripVisible({ shown: [] })).toBe(false)
   })
+
+  // The multi-session view: the zone is one window of several, so it keeps the
+  // strip its siblings all have (chips + ✕ + "+"). Without this it was the one
+  // window with no title bar at all, and nothing on it to click to get one.
+  it('keeps the strip for a lone MAIN pane in a tiled layout', () => {
+    expect(resolveTabStripVisible({ shown: [workspace()], tiled: true })).toBe(true)
+    expect(resolveTabStripVisible({ shown: [tile()], tiled: true })).toBe(true)
+  })
+
+  it('still gives a tiled lone SIDE-CHROME zone no strip', () => {
+    expect(resolveTabStripVisible({ shown: [sideChrome()], tiled: true })).toBe(false)
+    expect(resolveTabStripVisible({ shown: [toolPanel()], tiled: true })).toBe(true)
+  })
+
+  it('leaves the solo layout chromeless — one chat in one window is not a tab', () => {
+    expect(resolveTabStripVisible({ shown: [workspace()], tiled: false })).toBe(false)
+    expect(resolveTabStripVisible({ shown: [workspace()] })).toBe(false)
+  })
+})
+
+// Same last-handle invariant as the lone tile: in a tiled layout the strip's ✕
+// is the workspace zone's ONLY Close control (⌘W refuses the workspace, the
+// chat header's title menu has no Close row), so "Hide tabs" must not take it.
+describe('a tiled lone workspace against a stored choice', () => {
+  it('keeps the strip even when the zone says never', () => {
+    expect(resolveTabStripVisible({ mode: 'never', shown: [workspace()], tiled: true })).toBe(true)
+  })
+
+  it('honors never on the solo layout, where nothing is stranded', () => {
+    expect(resolveTabStripVisible({ mode: 'never', shown: [workspace()] })).toBe(false)
+  })
 })
 
 describe('the stored choice', () => {

--- a/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.ts
@@ -34,16 +34,19 @@ export interface StripZone {
   /** Panes currently rendered as chips — chrome-hidden and narrow-collapsed
    *  panes are already filtered out. */
   shown: readonly StripPane[]
+  /** The layout holds MORE THAN ONE session-bearing zone — this zone is one
+   *  window of a tiled arrangement, not the whole app. */
+  tiled?: boolean
 }
 
 /**
  * A pane is STRANDED without a strip when the strip is the only thing carrying
  * its handle: a lone closeable tile needs its ✕, a lone tool panel needs a chip
- * to grab. The uncloseable workspace is not strandable — it cannot be closed
- * or lost, so a lone chat is free to be chromeless. Hide-only chrome (sessions
- * / Bots) is the same: the panes stay, Show/Hide is a separate verb, and a
- * hidden strip comes back via ⌘⌥T. Treating it as stranded at any count made
- * Hide tabs a silent no-op on the sessions sidebar.
+ * to grab, and a lone MAIN pane needs one too once the layout is TILED (see
+ * `stranded`). Hide-only chrome (sessions / Bots) is the other exempt case: the
+ * panes stay, Show/Hide is a separate verb, and a hidden strip comes back via
+ * ⌘⌥T. Treating it as stranded at any count made Hide tabs a silent no-op on
+ * the sessions sidebar.
  *
  * This outranks an explicit `never` on purpose. "Hide the strip" is a request
  * about chrome, never a request to make a surface unreachable, and a zone that
@@ -57,14 +60,31 @@ export interface StripZone {
  * accumulates tabs: unscoped, one session tab in main pinned the strip on and
  * both the menu row and ⌘⌥T became silent no-ops.
  */
-function stranded(shown: readonly StripPane[]): boolean {
+function stranded(shown: readonly StripPane[], tiled: boolean): boolean {
   if (shown.length !== 1) {
     return false
   }
 
   const [only] = shown
 
-  return only.collapsePane || (!only.uncloseable && only.placement === 'main')
+  if (only.collapsePane) {
+    return true
+  }
+
+  if (only.placement !== 'main') {
+    return false
+  }
+
+  // A lone CLOSEABLE main pane always keeps its ✕. So does the uncloseable
+  // workspace ONCE THE LAYOUT IS TILED: the zone is then one window among
+  // several, every sibling window of which shows a strip, and the strip is the
+  // only Close control the workspace has left — ⌘W refuses it
+  // (closeFocusedSessionTab) and the chat header's title menu carries no Close
+  // row, so a chromeless main zone in a tiled layout is a window with no way to
+  // close it or add a tab to it. One chat in ONE window is still free to be
+  // chromeless: with no sibling zone there is nothing to switch to, and the
+  // sidebar / ⌘T / ⌘W still reach the session.
+  return !only.uncloseable || tiled
 }
 
 export function resolveTabStripVisible(zone: StripZone): boolean {
@@ -79,7 +99,7 @@ export function resolveTabStripVisible(zone: StripZone): boolean {
     return false
   }
 
-  if (stranded(zone.shown)) {
+  if (stranded(zone.shown, Boolean(zone.tiled))) {
     return true
   }
 
@@ -107,6 +127,8 @@ export function tabStripVisibleForZone(zone: {
   paneFor: (id: string) => Contribution | undefined
   /** Panes currently rendered as chips. */
   shown: readonly string[]
+  /** The layout holds more than one session-bearing zone (see StripZone). */
+  tiled?: boolean
 }): boolean {
   return resolveTabStripVisible({
     headerVeto: paneChrome(zone.paneFor(zone.active)).headerVeto,
@@ -119,6 +141,7 @@ export function tabStripVisibleForZone(zone: {
         placement: chrome.placement,
         uncloseable: chrome.uncloseable
       }
-    })
+    }),
+    tiled: zone.tiled
   })
 }

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tiled-main-strip.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tiled-main-strip.test.tsx
@@ -132,6 +132,30 @@ describe('a lone workspace in a tiled layout', () => {
 
     expect(zone('grp-files')!.querySelector('[role="tablist"]')).toBeNull()
   })
+
+  // "Tiled" is about MAIN tiles, not about sessions specifically: a workspace
+  // parked beside a preview / page / Browser pane is the same shape of window,
+  // and its strip is just as much that zone's only Close handle.
+  it('counts a non-session main tile (a preview pane) as a sibling window', () => {
+    disposers.push(
+      registry.register({
+        area: 'panes',
+        data: { minWidth: '22rem', placement: 'main' },
+        id: 'preview-tile:peek',
+        render: () => <div>Preview</div>,
+        title: 'Peek'
+      })
+    )
+
+    $layoutTree.set(
+      split('row', [group(['workspace'], { id: 'grp-main' }), group(['preview-tile:peek'], { id: 'g-preview' })])
+    )
+
+    render(<TreeGroup node={group(['workspace'], { active: 'workspace', id: 'grp-main' })} parentAxis="row" />)
+
+    expect(zone('grp-main')!.querySelector('[role="tablist"]')).toBeTruthy()
+    expect(zone('grp-main')!.querySelector('button[aria-label="New session tab"]')).toBeTruthy()
+  })
 })
 
 // The behaviour the auto rung was written for, which must survive: ONE chat in

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tiled-main-strip.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tiled-main-strip.test.tsx
@@ -1,0 +1,149 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { registry } from '@/contrib/registry'
+
+import { group, split } from '../model'
+import { $layoutTree, $newSessionTabAction, registerPaneCloser } from '../store'
+
+import { TreeGroup } from './tree-group'
+
+/**
+ * A LONE MAIN zone inside a TILED layout — the multi-session view.
+ *
+ * Reported: "with several sessions open, one session window has no title bar,
+ * so I can't close it or add tabs to it". That window is the zone holding only
+ * the workspace: sitting among sibling session zones, every one of which shows
+ * a tab strip (chips + ✕ + "+"), while it alone renders none — no chip to grab,
+ * no Close, no "+", nothing to click to get any of them back.
+ *
+ * The auto rung ("a lone pane is not a tab") is about ONE CHAT IN ONE WINDOW.
+ * In a tiled layout the zone is not the app — it is one window of several, and
+ * its siblings all carry the strip's handles.
+ */
+
+class TestResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture ??= () => false
+  Element.prototype.setPointerCapture ??= () => undefined
+  Element.prototype.releasePointerCapture ??= () => undefined
+  HTMLElement.prototype.scrollIntoView ??= () => undefined
+})
+
+const disposers: (() => void)[] = []
+
+beforeEach(() => {
+  window.localStorage.clear()
+  vi.stubGlobal('ResizeObserver', TestResizeObserver)
+  // jsdom lacks CSS.escape, which the tab-strip scroll effect uses. Stubbed per
+  // test (not in beforeAll): afterEach restores the globals.
+  vi.stubGlobal('CSS', { ...globalThis.CSS, escape: (value: string) => value })
+
+  disposers.push(
+    registry.register({
+      area: 'panes',
+      data: { minWidth: '20rem', placement: 'main', uncloseable: true },
+      id: 'workspace',
+      render: () => <div>Chat</div>,
+      title: 'Hermes'
+    }),
+    registry.register({
+      area: 'panes',
+      data: { minWidth: '20rem', placement: 'main' },
+      id: 'session-tile:a',
+      render: () => <div>Tile</div>,
+      title: 'Tile A'
+    })
+  )
+
+  // The workspace tab closes (to a draft) even though the pane itself cannot
+  // leave the tree — that closer is what puts the ✕ on its tab.
+  registerPaneCloser('workspace', () => undefined)
+  $newSessionTabAction.set(() => undefined)
+})
+
+afterEach(() => {
+  cleanup()
+  disposers.splice(0).forEach(dispose => dispose())
+  $layoutTree.set(null)
+  $newSessionTabAction.set(null)
+  vi.unstubAllGlobals()
+})
+
+const zone = (id: string) => globalThis.document.querySelector(`[data-tree-group="${id}"]`)
+
+describe('a lone workspace in a tiled layout', () => {
+  /** The reported arrangement: the main chat zone beside session-tile zones. */
+  const tiledTree = () =>
+    split('row', [
+      group(['workspace'], { id: 'grp-main' }),
+      group(['session-tile:a'], { id: 'g-tile' }),
+      group(['workspace'], { id: 'grp-other' })
+    ])
+
+  it('keeps its title bar, so Close and + stay reachable', () => {
+    const tree = tiledTree()
+
+    $layoutTree.set(tree)
+
+    render(<TreeGroup node={group(['workspace'], { active: 'workspace', id: 'grp-main' })} parentAxis="row" />)
+
+    const main = zone('grp-main')!
+
+    expect(main.querySelector('[role="tablist"]')).toBeTruthy()
+    expect(main.querySelector('[data-tree-tab="workspace"]')).toBeTruthy()
+    expect(main.querySelector('button[aria-label="Close"]')).toBeTruthy()
+    expect(main.querySelector('button[aria-label="New session tab"]')).toBeTruthy()
+  })
+
+  it('keeps its title bar even when the zone was told to hide tabs', () => {
+    $layoutTree.set(tiledTree())
+
+    render(
+      <TreeGroup
+        node={group(['workspace'], { active: 'workspace', id: 'grp-main', tabStrip: 'never' })}
+        parentAxis="row"
+      />
+    )
+
+    expect(zone('grp-main')!.querySelector('[role="tablist"]')).toBeTruthy()
+    expect(zone('grp-main')!.querySelector('button[aria-label="New session tab"]')).toBeTruthy()
+  })
+
+  it('leaves a lone SIDE-CHROME zone chromeless in the same layout', () => {
+    $layoutTree.set(tiledTree())
+
+    disposers.push(
+      registry.register({
+        area: 'panes',
+        data: { placement: 'right', width: '20rem' },
+        id: 'files',
+        render: () => <div>Files</div>,
+        title: 'Files'
+      })
+    )
+
+    render(<TreeGroup node={group(['files'], { active: 'files', id: 'grp-files' })} parentAxis="row" />)
+
+    expect(zone('grp-files')!.querySelector('[role="tablist"]')).toBeNull()
+  })
+})
+
+// The behaviour the auto rung was written for, which must survive: ONE chat in
+// ONE window is not a tab, so the lone workspace stays chromeless.
+describe('a lone workspace as the whole layout', () => {
+  it('renders no strip at all', () => {
+    const solo = split('row', [group(['workspace'], { id: 'grp-main' })])
+
+    $layoutTree.set(solo)
+
+    render(<TreeGroup node={group(['workspace'], { active: 'workspace', id: 'grp-main' })} parentAxis="row" />)
+
+    expect(zone('grp-main')!.querySelector('[role="tablist"]')).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -59,6 +59,7 @@ import {
   closeTabPane,
   closeTreeTabsToRight,
   collapseTreePane,
+  hasTiledSessionZones,
   hideOnlyZoneTabs,
   hostsSessionDropTarget,
   isCollapsePane,
@@ -342,7 +343,8 @@ export function TreeGroup({
     isCollapsePane,
     mode: node.tabStrip,
     paneFor,
-    shown
+    shown,
+    tiled: hasTiledSessionZones()
   })
 
   // A group collapses ALONG its parent split's axis. In a row that means the

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -541,6 +541,34 @@ export const isMainStripPane = (paneId: string): boolean =>
 export const hostsSessionDropTarget = (paneIds: readonly string[]): boolean =>
   paneIds.some(isSessionStripPane) || paneIds.some(isMainStripPane)
 
+/**
+ * Is this layout TILED — more than one zone carrying a chat tab strip?
+ *
+ * It answers one question for the strip resolver: whether a zone holding a
+ * lone main pane is the APP or one window of several (see
+ * renderer/strip-visibility.ts — a tiled lone main pane keeps its title bar,
+ * so its Close and "+" stay reachable). Read with `.get()`, deliberately: both
+ * callers already re-render with the tree (the root renders the zones from it),
+ * and subscribing would wire every zone to the whole tree — the sash-drag
+ * render storm that comment in tree-group.tsx exists to avoid.
+ */
+export function hasTiledSessionZones(): boolean {
+  const tree = $layoutTree.get()
+
+  if (!tree) {
+    return false
+  }
+
+  const zones = (node: typeof tree): number =>
+    node.type === 'group'
+      ? node.panes.some(isSessionStripPane)
+        ? 1
+        : 0
+      : node.children.reduce((count, child) => count + zones(child), 0)
+
+  return zones(tree) > 1
+}
+
 /** The zone the session-tab verbs (⌘T / ⌘⇧T / the strip's "+") act on: the
  *  first of hovered / focused / workspace that hosts a chat strip. Same ladder
  *  ⌘1…⌘9 indexes, so the number keys and the tab verbs can't disagree about
@@ -772,7 +800,8 @@ export function tabStripVisibleForGroup(group: GroupNode): boolean {
     isCollapsePane,
     mode: group.tabStrip,
     paneFor: (id: string) => registered.find(c => c.id === id),
-    shown: shownPanesInGroup(group)
+    shown: shownPanesInGroup(group),
+    tiled: hasTiledSessionZones()
   })
 }
 

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -542,15 +542,24 @@ export const hostsSessionDropTarget = (paneIds: readonly string[]): boolean =>
   paneIds.some(isSessionStripPane) || paneIds.some(isMainStripPane)
 
 /**
- * Is this layout TILED — more than one zone carrying a chat tab strip?
+ * Is this layout TILED — more than one zone carrying a MAIN tile?
  *
  * It answers one question for the strip resolver: whether a zone holding a
  * lone main pane is the APP or one window of several (see
  * renderer/strip-visibility.ts — a tiled lone main pane keeps its title bar,
- * so its Close and "+" stay reachable). Read with `.get()`, deliberately: both
- * callers already re-render with the tree (the root renders the zones from it),
- * and subscribing would wire every zone to the whole tree — the sash-drag
- * render storm that comment in tree-group.tsx exists to avoid.
+ * so its Close and "+" stay reachable).
+ *
+ * A MAIN TILE IS ANY MAIN TILE, not just a session: the zone the report came
+ * from held session tiles, but a workspace tiled beside a preview / page /
+ * Browser pane is the same shape of window and must not read as solo. So this
+ * counts through `hostsSessionDropTarget` — the same main-tile predicate the
+ * drop resolvers and the zone overlay use — instead of the session-only
+ * `isSessionStripPane`.
+ *
+ * Read with `.get()`, deliberately: both callers already re-render with the
+ * tree (the root renders the zones from it), and subscribing would wire every
+ * zone to the whole tree — the sash-drag render storm that comment in
+ * tree-group.tsx exists to avoid.
  */
 export function hasTiledSessionZones(): boolean {
   const tree = $layoutTree.get()
@@ -561,7 +570,7 @@ export function hasTiledSessionZones(): boolean {
 
   const zones = (node: typeof tree): number =>
     node.type === 'group'
-      ? node.panes.some(isSessionStripPane)
+      ? hostsSessionDropTarget(node.panes)
         ? 1
         : 0
       : node.children.reduce((count, child) => count + zones(child), 0)


### PR DESCRIPTION
## What does this PR do?

Fixes the "one window in my multi-session layout has no title bar" report: in a **tiled** layout, the zone holding only the main workspace resolved to *no tab strip* on `auto`, while every sibling session zone showed one — leaving exactly one window with no chip, no ✕ and no "+", and nothing on that surface to click to get any of them back.

The strip is that zone's only Close control: ⌘W refuses the uncloseable workspace (`closeFocusedSessionTab`) and the chat header's title menu carries no Close row. So a chromeless main zone in a tiled layout is a window you cannot close from, or add a tab to.

`stranded()` already protects the last handle of a lone closeable tile (its ✕) and a lone tool panel (its chip). This extends the same invariant to a lone MAIN pane **once the layout is tiled** — more than one zone holding a main tile (session, page, preview or Browser). Repro layout (the reporter's, read from `hermes.desktop.layoutTree.v2`): `[sessions+bots] [tile] [workspace] [tile tile] [tile tile] [review|files] [terminal]` — every zone rendered a strip except `grp-main`.

One chat in ONE window is deliberately unchanged: with no sibling zone there is nothing to switch to, and the sidebar / ⌘T / ⌘W still reach the session. That keeps the single-chat default (no top tab bar) intact — which is why this is scoped to tiled layouts rather than making the workspace strip unconditional (see Related).

## Related Issue

No issue filed for this exact shape. It is the tiled counterpart of #89350 (a lone workspace's strip gone and staying gone) and overlaps the unconditional proposal in #107444. If the maintainers prefer the unconditional rule, this PR folds in easily — the difference is one condition in `stranded()`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.ts` — `stranded()` takes the layout's `tiled` flag; a lone `placement: 'main'` pane keeps its strip while the layout is tiled (it outranks a stored `never`, exactly as the lone-tile rung already does).
- `apps/desktop/src/components/pane-shell/tree/store.ts` — `hasTiledSessionZones()`: a pure walk of the persisted tree counting the zones that hold a main tile — any of session / page / preview / Browser, via the `hostsSessionDropTarget` predicate the drop resolvers and the zone overlay already share. `tabStripVisibleForGroup` passes it too, so the ⌘⌥T toggle and the strip on screen cannot disagree.
- `apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx` — passes the same flag from the zone's render inputs (read with `.get()`, never subscribed: wiring every zone to the whole tree is the sash-drag render storm the file's own comment warns about).
- Tests — `renderer/tiled-main-strip.test.tsx` (DOM repro of the reported layout: the main zone renders a chip, a Close button and "+"; the tiled side-chrome zone stays chromeless; a workspace zone beside a `preview-tile:*` zone renders its strip, since a non-session main tile is a sibling window too; the solo layout stays chromeless) plus resolver cases in `renderer/strip-visibility.test.ts`, including the solo behaviour that must not change.

## How to Test

1. `cd apps/desktop && npx vitest run src/components/pane-shell` → 34 files, 187 passed.
2. In the app, open a second session as a tile (`⌘T`, then dock it into a zone of its own) so the main zone holds only the workspace.
3. Before: that zone renders no tab strip at all (no chip, no ✕, no "+"). After: it renders its session chip, the hover ✕, and "+".
4. Guard the intent: collapse back to a single zone holding only the workspace — no strip renders, unchanged.
5. Verified on a Windows 11 packaged build in a 4-zone tiled layout: the main zone now shows its own chip and "+" beside its siblings.

`npx tsc -p tsconfig.json --noEmit`, `npx eslint` and `prettier --check` are clean on the touched files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#107444 is the unconditional variant of the same invariant — different scope, noted above)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: renderer-only change, no Python touched. Ran the desktop suite instead (step 1 above).
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (packaged desktop build)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (docblocks on the resolver updated in place)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A: resolver is platform-agnostic, no platform-specific code paths touched
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

