### PR TITLE
fix(tui): negotiate heartbeat on canonical gateway connections

### DIFF
--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -139,7 +139,8 @@ describe('GatewayClient websocket attach mode', () => {
     }
   })
 
-  it('publishes canonical readiness once, only after the creation contract arrives', async () => {
+  it('publishes canonical readiness once after discovery and arms the negotiated heartbeat', async () => {
+    vi.useFakeTimers()
     delete process.env.HERMES_TUI_GATEWAY_URL
     delete process.env.HERMES_TUI_SIDECAR_URL
     const gw = new GatewayClient(async () => ({ url: 'ws://gateway.test/api/ws', protocols: [], instance_id: 'owner', profile_id: 'fixture' }))
@@ -149,20 +150,27 @@ describe('GatewayClient websocket attach mode', () => {
     try {
       gw.start()
       gw.drain()
-      await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1))
+      await vi.advanceTimersByTimeAsync(0)
+      expect(FakeWebSocket.instances).toHaveLength(1)
       const socket = FakeWebSocket.instances[0]!
       socket.open()
-      socket.message(JSON.stringify({ jsonrpc: '2.0', method: 'event', params: { type: 'gateway.ready', payload: {} } }))
-      await vi.waitFor(() => expect(socket.sent).toHaveLength(1))
+      socket.message(JSON.stringify({ jsonrpc: '2.0', method: 'event', params: { type: 'gateway.ready', payload: { heartbeat: true } } }))
+      await vi.advanceTimersByTimeAsync(0)
       expect(events.filter(event => event.type === 'gateway.ready')).toHaveLength(0)
       const request = JSON.parse(socket.sent[0]!)
       expect(request.method).toBe('runtime.describe')
       socket.message(JSON.stringify({ jsonrpc: '2.0', id: request.id, result: {
         session_create: { sources: ['tui'], parameters: ['source', 'request_id'] }
       } }))
-      await vi.waitFor(() => expect(events.filter(event => event.type === 'gateway.ready')).toHaveLength(1))
+      await vi.advanceTimersByTimeAsync(0)
+      expect(events.filter(event => event.type === 'gateway.ready')).toHaveLength(1)
+
+      await vi.advanceTimersByTimeAsync(WS_HEARTBEAT_INTERVAL_MS)
+      expect(JSON.parse(socket.sent.at(-1) ?? '{}')).toMatchObject({ method: 'gateway.ping' })
     } finally {
       gw.kill()
+      expect(vi.getTimerCount()).toBe(0)
+      vi.useRealTimers()
     }
   })
 

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -672,8 +672,15 @@ export class GatewayClient extends EventEmitter {
 
       if (ev) {
         // The canonical client owns readiness after runtime.describe. Forwarding
-        // the listener's legacy ready as well creates two sessions/startup turns.
-        if (this.isCanonical && ev.type === 'gateway.ready') { return }
+        // the listener's legacy ready as well creates two sessions/startup turns,
+        // but its transport capabilities still have to be negotiated.
+        if (this.isCanonical && ev.type === 'gateway.ready') {
+          if (ev.payload?.heartbeat && this.ws?.readyState === WS_OPEN) {
+            this.startHeartbeat(this.ws)
+          }
+
+          return
+        }
 
         if (this.isCanonical) {
           const shared = ev as GatewayEvent & { authority_epoch?: number; execution_generation?: number }


### PR DESCRIPTION
## Why
Follow-up to #106742, targeting its `feat/unified-gateway-runtime` branch rather than `main`.

Ink suppresses the listener's `gateway.ready` on the canonical connection so application readiness is emitted only after `runtime.describe`. That avoids duplicate startup, but also discards the listener's advertised heartbeat capability. The replacement readiness event has an empty payload, so silent-drop detection never arms on that path even though ordinary close-triggered reconnect exists.

## Change
Consume the heartbeat capability on the current open socket while continuing to suppress duplicate application readiness. Preserve discovery ordering, legacy attach behavior, reconnect logic, and timer cleanup.

Only the Ink client and its existing client test file change. No server, Desktop, session ownership, or architecture changes.

## Validation
The extended regression failed on the base and passes with the fix: one application readiness event, a negotiated ping, and no timers after shutdown.

Rebased onto gateway head `fb50ebb39faf60243a93f3e0ddfeff78c43ad0c7` and reran:
- All 1,823 Ink tests passed (187 files).
- Ink TypeScript typecheck passed.
- Whitespace checks passed.

The Ink package build also passed before rebase; the upstream delta did not change Ink. Lint had zero errors and seven pre-existing warnings in untouched files. No live cross-host E2E is claimed.

This fix is independent of the shared replay-epoch and operator-access fixes.
