### PR TITLE
fix(plugins): make `plugins validate` work on a manifest with requires_hermes

### DIFF
--- a/hermes_cli/plugin_validate.py
+++ b/hermes_cli/plugin_validate.py
@@ -78,7 +78,8 @@ def _requires_hermes_spec_valid(spec: str) -> bool:
     time), validation REJECTS clauses whose version segment doesn't parse —
     a typo'd spec should fail admission, not silently gate nothing.
     """
-    from hermes_cli.plugins import _VERSION_COMPARATOR_RE, _version_tuple
+    # The decomposition moved the spec helpers out of hermes_cli.plugins.
+    from hermes_cli.plugins_manifest import _VERSION_COMPARATOR_RE, _version_tuple
 
     for clause in spec.split(","):
         clause = clause.strip()

--- a/tests/hermes_cli/test_plugin_validate.py
+++ b/tests/hermes_cli/test_plugin_validate.py
@@ -112,3 +112,29 @@ class TestCapabilityProbe:
         )
         report = validate_plugin_dir(d)
         assert report.ok, report.failures
+
+
+class TestRequiresHermesSpec:
+    """A manifest that declares ``requires_hermes`` must still validate end to end.
+
+    The spec is checked by importing the version helpers; when that import goes
+    stale the whole command dies before any check runs, so a declared spec — valid
+    or typo'd — is the contract worth pinning here.
+    """
+
+    def test_valid_spec_passes_admission(self, tmp_path):
+        d = _make_plugin(tmp_path, manifest={**BASE_MANIFEST, "requires_hermes": ">=0.21.1"})
+        report = validate_plugin_dir(d)
+        assert report.ok, report.failures
+        assert ("requires_hermes", True, "spec '>=0.21.1' parses") in report.checks
+
+    def test_typoed_clause_fails_admission(self, tmp_path):
+        d = _make_plugin(
+            tmp_path, manifest={**BASE_MANIFEST, "requires_hermes": ">=0.21.1,<0.x"}
+        )
+        report = validate_plugin_dir(d)
+        assert not report.ok
+        assert any(
+            "requires_hermes" in f and "does not parse" in f for f in report.failures
+        ), report.failures
+


### PR DESCRIPTION
## Symptom

`hermes plugins validate <dir>` crashes for any plugin whose `plugin.yaml` declares
`requires_hermes`:

```
ImportError: cannot import name '_VERSION_COMPARATOR_RE' from 'hermes_cli.plugins'
```

## Cause — exact line

`hermes_cli/plugin_validate.py:81` (`_requires_hermes_spec_valid`) imports the spec helpers from
`hermes_cli.plugins`. Since the Sep 2026 decomposition they live in
`hermes_cli/plugins_manifest.py` — `_VERSION_COMPARATOR_RE` (line 374) and `_version_tuple`
(line 386). The import sits inside the function and is only reached when the field is present, so
validation kept working for every manifest without `requires_hermes` (including this repo's own
fixtures and catalog entries) and the whole command dies with a traceback for plugins that declare
one. `plugins doctor` is unaffected, which hides it further.

## Fix

Import from the defining module:

```diff
-    from hermes_cli.plugins import _VERSION_COMPARATOR_RE, _version_tuple
+    # The decomposition moved the spec helpers out of hermes_cli.plugins.
+    from hermes_cli.plugins_manifest import _VERSION_COMPARATOR_RE, _version_tuple
```

No compat pointer and no shim — `hermes_cli/plugins_manifest.py` is the canonical home.

## Tests (red on base, green with the fix)

Two invariant tests in `tests/hermes_cli/test_plugin_validate.py`:

- a valid spec (`>=0.21.1`) passes admission;
- a clause whose version segment does not parse (`>=0.21.1,<0.x`) fails admission — the strictness
  contract that separates this check from the permissive load-time gate.

Base `cbd03e6e4c`: `2 failed, 8 passed` — both new tests fail with the ImportError above.
With the fix: `10 passed`. Neighbouring suites (`test_plugin_manifest_v2.py`,
`test_validate_plugin_catalog.py`, `tests/website/test_extract_plugins.py`): `52 passed`.

Runner note: this machine's Hermes venv has no `pytest`, so `scripts/run_tests.sh` could not run
here. The file was run with pytest 9.1.1 against the worktree with CI-parity env (`TZ=UTC`,
`LANG=C.UTF-8`, `PYTHONHASHSEED=0`, credential vars unset, temp `HERMES_HOME`) and the Hermes
venv's site-packages on `PYTHONPATH`.

## Why it shipped

Nothing under `tests/` referenced `_requires_hermes_spec_valid` or validated a manifest declaring
the field, so the stale import had no coverage until a plugin started using `requires_hermes`.
