### PR TITLE
fix(state): self-heal cjk triggers that fire on a tokenizer-less writer

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -817,6 +817,11 @@ class SessionDB(
         # settlement unknown and must propagate — this helper owns non-idempotent transcript/counter
         # mutations, not just idempotent UPSERTs.
         ioerr_begin_retried = False
+        # One retry for a cjk trigger firing on a tokenizer-less writer (#108841):
+        # the heal drops the cjk triggers (breadcrumb first), after which the replayed
+        # callback runs trigger-free. The rollback above already undid the failed
+        # attempt, so replaying fn is exactly the locked/busy retry contract.
+        cjk_heal_attempted = False
         while True:
             self._raise_if_db_corrupt()
             # NOTE: the replaced/generation live probe runs INSIDE the lock below,
@@ -894,6 +899,13 @@ class SessionDB(
                         # Retry on the SAME connection: close()+reopen would cancel this process's
                         # POSIX locks for every sibling (howtocorrupt §2.2).
                         ioerr_begin_retried = True
+                        continue
+                    # A cjk trigger installed by a connection that could load the tokenizer
+                    # aborts THIS writer's INSERTs ("no such tokenizer" is not a lock): the
+                    # mismatch is a known, self-healable degradation, not a failed write
+                    # (#108841). Falls through to raise when the heal declines (or repeats).
+                    if not cjk_heal_attempted and self._enter_cjk_tokenizer_fail_open(exc):
+                        cjk_heal_attempted = True
                         continue
                     raise  # non-lock error, callback already ran, or patience exhausted
                 if isinstance(exc, sqlite3.DatabaseError):

--- a/hermes_state_fts.py
+++ b/hermes_state_fts.py
@@ -184,6 +184,14 @@ class SessionFtsSetupMixin:
         return "no such tokenizer: trigram" in err or "no such tokenizer: cjk_unicode61" in err
 
     @staticmethod
+    def _is_cjk_tokenizer_missing_error(exc: sqlite3.Error) -> bool:
+        """A cjk trigger fired on a connection that never registered cjk_unicode61 —
+        the cross-connection mismatch of #108841 (the trigram variant is a build
+        capability, not a loadable extension, and is not ours to detach)."""
+        err = str(exc).lower()
+        return "no such tokenizer" in err and "cjk_unicode61" in err
+
+    @staticmethod
     def _db_has_legacy_inline_fts(cursor: sqlite3.Cursor) -> bool:
         """messages_fts exists in ANY pre-v23 shape: every legacy shape lacks
         tool_name, so "stored CREATE lacks tool_name" catches them all. False when absent.
@@ -398,6 +406,57 @@ class SessionFtsSetupMixin:
             "state.db FTS indexes remain corrupt (%s); disabled FTS sync and "
             "retrying the canonical write. Search temporarily uses LIKE until "
             "a later SessionDB open rebuilds the indexes.",
+            exc,
+        )
+        return True
+
+    def _enter_cjk_tokenizer_fail_open(self, exc: sqlite3.OperationalError) -> bool:
+        """Drop the cjk triggers when they fire on a writer that never registered
+        cjk_unicode61, so canonical writes keep flowing (#108841).
+
+        FTS5 triggers are database-level objects but the tokenizer registers
+        per-connection: a writer opened before the extension existed caches
+        ``_fts_cjk_loaded = False`` (_open_writer_conn loads it exactly once),
+        and a connection opened after the install creates the index DDL +
+        triggers — after which every ``INSERT INTO messages`` on the old writer
+        aborts with "no such tokenizer" inside the trigger while all health
+        probes stay green (the open-time heal in _ensure_fts_cjk_schema cannot
+        help: at ITS moment the triggers did not exist yet). Same degradation
+        contract as that heal — breadcrumb first, drop the triggers, CJK search
+        falls back to trigram/LIKE until optimize-storage rebuilds — but only
+        the cjk index is detached; messages_fts and trigram keep syncing."""
+        if not SessionFtsSetupMixin._is_cjk_tokenizer_missing_error(exc):
+            return False
+        self._raise_if_db_corrupt()
+        self._halt_if_db_generation_changed()
+        try:
+            with self._lock:
+                self._conn.execute("BEGIN IMMEDIATE")
+                try:
+                    self._conn.execute(
+                        "INSERT INTO state_meta (key, value) VALUES (?, '1') "
+                        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                        (FTS_CJK_STALE_KEY,),
+                    )
+                    for trig in _FTS_CJK_TRIGGERS:
+                        self._conn.execute(f"DROP TRIGGER IF EXISTS {trig}")
+                    self._conn.commit()
+                except BaseException:
+                    self._conn.rollback()
+                    raise
+        except sqlite3.Error as detach_exc:
+            logger.error(
+                "Could not drop the cjk triggers after a tokenizer-less write; "
+                "the canonical write still cannot proceed: %s",
+                detach_exc,
+            )
+            return False
+        self._fts_cjk_available = False
+        logger.error(
+            "state.db cjk triggers fired on a writer without the cjk_unicode61 "
+            "tokenizer (%s); dropped them and retrying the canonical write. CJK "
+            "search falls back to trigram/LIKE until `hermes sessions "
+            "optimize-storage` rebuilds the index.",
             exc,
         )
         return True

--- a/tests/test_fts_cjk_bigram.py
+++ b/tests/test_fts_cjk_bigram.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import pytest
 
 from hermes_state import SessionDB
-from hermes_state_common import FTS_CJK_STALE_KEY
+from hermes_state_common import FTS_CJK_STALE_KEY, _FTS_CJK_TRIGGERS
 
 REPO = Path(__file__).resolve().parent.parent
 SRC = REPO / "native" / "fts5_cjk" / "fts5_cjk.c"
@@ -322,3 +322,47 @@ def test_integrity_after_lifecycle(db):
             "INSERT INTO messages_fts_cjk(messages_fts_cjk) "
             "VALUES('integrity-check')"
         )
+
+
+def test_writer_self_heals_when_cjk_triggers_outlive_the_tokenizer(cjk_so, tmp_path, monkeypatch):
+    """#108841: a writer opened before the .so existed keeps writing after a later,
+    tokenizer-capable connection installs the cjk triggers (database-level objects
+    firing on a connection that never registered cjk_unicode61). The write path
+    self-heals: breadcrumb, drop the cjk triggers, land the message — only the cjk
+    index degrades; messages_fts keeps syncing."""
+    db_path = tmp_path / "state.db"
+    # 1) The writer opens while the extension is absent: no cjk index is created.
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(tmp_path / "absent.so"))
+    writer = SessionDB(db_path=db_path)
+    assert not writer._fts_cjk_loaded
+    writer.create_session(session_id="s1", source="cli", model="m")
+    writer.append_message("s1", role="user", content="written before the extension existed")
+
+    # 2) A connection opened after the install creates the index DDL + triggers.
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
+    late = SessionDB(db_path=db_path)
+    assert late._fts_cjk_loaded
+    late.close()
+
+    probe = sqlite3.connect(str(db_path))
+    def triggers():
+        return {r[0] for r in probe.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'trigger'"
+        ).fetchall()}
+    assert triggers() & set(_FTS_CJK_TRIGGERS), "the late connection must have installed the cjk triggers"
+
+    # 3) The old writer's INSERT now fires a trigger its connection cannot parse.
+    writer.append_message("s1", role="user", content="must land despite the dead trigger")
+
+    stale = probe.execute(
+        "SELECT value FROM state_meta WHERE key = ?", (FTS_CJK_STALE_KEY,)
+    ).fetchone()
+    assert stale and stale[0] == "1"
+    assert not (triggers() & set(_FTS_CJK_TRIGGERS)), "the heal must drop the cjk triggers"
+    assert triggers(), "base FTS triggers must survive (only the cjk index degrades)"
+    n = probe.execute(
+        "SELECT COUNT(*) FROM messages WHERE session_id = ?", ("s1",)
+    ).fetchone()[0]
+    assert n == 2, "both messages must be in the transcript"
+    probe.close()
+    writer.close()


### PR DESCRIPTION
## What does this PR do?

Fixes a write-path kill switch reported in #108841: FTS5 triggers are database-level objects, but the `cjk_unicode61` tokenizer registers **per connection**. A long-lived writer opened before `libfts5_cjk.so` existed caches `_fts_cjk_loaded = False` (`_open_writer_conn` loads it exactly once). Once a later, tokenizer-capable connection (newly opened after the install) creates the cjk index DDL + triggers, every `INSERT INTO messages` on the old writer aborts with `no such tokenizer: cjk_unicode61` inside the AFTER INSERT trigger — the whole turn dies as `session_persistence_failed` while every health probe stays green (process active, `quick_check` ok, messages readable).

The open-time self-heal in `_ensure_fts_cjk_schema` ("NOT loaded + live triggers → drop them") cannot catch this: at *its* moment the triggers do not exist yet. This PR extends the write path with the same degradation contract: when `_execute_write` sees that specific OperationalError, it breadcrumbs `fts_cjk_stale`, drops the cjk triggers atomically, and retries the write once. Only the cjk index detaches — `messages_fts` and trigram keep syncing, and CJK search falls back to trigram/LIKE until `optimize-storage` rebuilds.

## Related Issue

Fixes #108841

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state_fts.py`: add `_is_cjk_tokenizer_missing_error` (narrow matcher — the trigram variant is a build capability, not ours to detach) and `_enter_cjk_tokenizer_fail_open` (breadcrumb + drop cjk triggers + `_fts_cjk_available = False`, mirroring `_enter_fts_fail_open`'s atomic structure).
- `hermes_state.py`: in `_execute_write`'s OperationalError branch (non-lock errors previously raised straight out of the turn), a one-shot attempt of the heal followed by the same whole-callback retry the locked/busy path already uses.
- `tests/test_fts_cjk_bigram.py`: regression test replaying the exact timeline — writer opens without the extension → a second connection installs the triggers → the old writer's INSERT self-heals and lands.

## How to Test

1. `pytest tests/test_fts_cjk_bigram.py::test_writer_self_heals_when_cjk_triggers_outlive_the_tokenizer -q` — Observed result: **1 passed** (gcc-built tokenizer fixture; the late connection's triggers are verified present before the healed write, and gone after, with `fts_cjk_stale = 1` and both messages in the transcript).
2. Mutation check: reverting only the two product files makes that test fail with `sqlite3.OperationalError: no such tokenizer: cjk_unicode61` from the write path — the exact production symptom — so the test genuinely locks the heal.
3. `pytest tests/hermes_state/ tests/test_fts_cjk_bigram.py tests/test_fts_tool_write_bounds.py tests/test_fts_update_of_narrowing.py tests/test_hermes_state_compression_busy_retry.py tests/test_hermes_state_wal_fallback.py -q` — Observed result: **383 passed, 18 skipped**.
4. `ruff check` on the three changed files — Observed result: **All checks passed**.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [ ] N/A
