### PR TITLE
feat: add Kanban run execution receipts

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4067,15 +4067,21 @@ def _run_quiet_single_query(cli, effective_query):
     HERMES_TURN_AUTHOR (set only by a bot-to-bot dispatcher) is consumed here so tool subprocesses do not inherit it."""
     from agent.interrupt_compat import _accepts_keyword
     from agent.turn_author import take_turn_author_from_env
+    from hermes_cli.kanban_worker_receipts import (
+        begin_worker_receipt as _begin_worker_receipt,
+        finalize_worker_receipt as _finalize_worker_receipt,
+    )
 
     author = take_turn_author_from_env()
     author_kwargs = {"turn_author": author} if author is not None and _accepts_keyword(cli.agent.run_conversation, "turn_author") else {}
+    _run_receipt_state = _begin_worker_receipt(cli)
     try:
         result = cli.agent.run_conversation(
             user_message=effective_query, conversation_history=cli.conversation_history, **author_kwargs,
         )
     except KeyboardInterrupt:
         _emit_interrupted_session_end(cli, reason="keyboard_interrupt")
+        _finalize_worker_receipt(cli, _run_receipt_state)
         print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
         sys.exit(130)
     # The exit line below reports session_id to stderr for automation wrappers;
@@ -4100,6 +4106,7 @@ def _run_quiet_single_query(cli, effective_query):
         except Exception as _goal_exc:
             logger.debug("kanban goal loop failed: %s", _goal_exc)
 
+    _finalize_worker_receipt(cli, _run_receipt_state)
     print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
 
     # Exit code 0/1 for automation wrappers. Kanban workers that failed purely on

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -773,6 +773,7 @@ class Run:
     summary: Optional[str]
     metadata: Optional[dict]
     error: Optional[str]
+    receipt: Optional[dict[str, Any]] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Run":
@@ -996,6 +997,49 @@ CREATE TABLE IF NOT EXISTS task_runs (
     error               TEXT
 );
 
+-- One additive execution receipt per attempt. task_runs stays the lifecycle
+-- owner; this table records observable route, context, usage, and runner facts
+-- without making every historical run column nullable.
+CREATE TABLE IF NOT EXISTS task_run_receipts (
+    run_id                      INTEGER PRIMARY KEY REFERENCES task_runs(id) ON DELETE CASCADE,
+    task_id                     TEXT NOT NULL,
+    runner                      TEXT,
+    worker_session_id           TEXT,
+    session_lineage_root        TEXT,
+    profile                     TEXT,
+    requested_provider          TEXT,
+    requested_model             TEXT,
+    requested_reasoning         TEXT,
+    effective_provider          TEXT,
+    effective_model             TEXT,
+    effective_reasoning         TEXT,
+    system_prompt_hash          TEXT,
+    toolset_hash                TEXT,
+    skills_hash                 TEXT,
+    context_schema_version      INTEGER,
+    context_fingerprint         TEXT,
+    context_chars               INTEGER,
+    usage_start                 TEXT,
+    usage_end                   TEXT,
+    api_call_delta              INTEGER,
+    input_token_delta           INTEGER,
+    output_token_delta          INTEGER,
+    cache_read_token_delta      INTEGER,
+    cache_write_token_delta     INTEGER,
+    reasoning_token_delta       INTEGER,
+    estimated_cost_delta        REAL,
+    actual_cost_delta           REAL,
+    worktree_start_fingerprint  TEXT,
+    worktree_end_fingerprint    TEXT,
+    runner_metadata             TEXT,
+    receipt_completeness        TEXT NOT NULL DEFAULT 'started',
+    receipt_source              TEXT NOT NULL DEFAULT 'worker',
+    fresh_or_resumed            TEXT,
+    created_at                  INTEGER NOT NULL,
+    updated_at                  INTEGER NOT NULL,
+    finalized_at                INTEGER
+);
+
 -- Files attached to a task (PDFs, images, source documents). The blob
 -- lives on disk under ``attachments_root(board)/<task_id>/<stored_name>``;
 -- this row carries metadata + the absolute ``stored_path`` so the
@@ -1042,6 +1086,7 @@ CREATE INDEX IF NOT EXISTS idx_comments_task         ON task_comments(task_id, c
 CREATE INDEX IF NOT EXISTS idx_events_task           ON task_events(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, started_at);
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
+CREATE INDEX IF NOT EXISTS idx_run_receipts_task     ON task_run_receipts(task_id, run_id);
 CREATE INDEX IF NOT EXISTS idx_attachments_task      ON task_attachments(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
 """
@@ -1879,6 +1924,9 @@ def _end_run(
         """,
         (status or outcome, outcome, summary, error, _json_or_null(metadata), now, run_id),
     )
+    from hermes_cli.kanban_run_receipts import mark_run_receipt_partial
+
+    mark_run_receipt_partial(conn, task_id, run_id)
     conn.execute("UPDATE tasks SET current_run_id = NULL WHERE id = ?", (task_id,))
     return run_id
 
@@ -3973,12 +4021,22 @@ def list_runs(
         params.append(state_name)
     q += " ORDER BY started_at ASC, id ASC"
     rows = conn.execute(q, params).fetchall()
-    return [Run.from_row(r) for r in rows]
+    runs = [Run.from_row(r) for r in rows]
+    receipts = get_run_receipts(conn, [run.id for run in runs])
+    for run in runs:
+        receipt = receipts.get(run.id)
+        run.receipt = run_receipt_dict(receipt) if receipt else None
+    return runs
 
 
 def get_run(conn: sqlite3.Connection, run_id: int) -> Optional[Run]:
     row = conn.execute("SELECT * FROM task_runs WHERE id = ?", (int(run_id),)).fetchone()
-    return Run.from_row(row) if row else None
+    if row is None:
+        return None
+    run = Run.from_row(row)
+    receipt = get_run_receipt(conn, run.id)
+    run.receipt = run_receipt_dict(receipt) if receipt else None
+    return run
 
 
 def latest_run(conn: sqlite3.Connection, task_id: str) -> Optional[Run]:
@@ -3987,7 +4045,12 @@ def latest_run(conn: sqlite3.Connection, task_id: str) -> Optional[Run]:
         "SELECT * FROM task_runs WHERE task_id = ? "
         "ORDER BY started_at DESC, id DESC LIMIT 1", (task_id,),
     ).fetchone()
-    return Run.from_row(row) if row else None
+    if row is None:
+        return None
+    run = Run.from_row(row)
+    receipt = get_run_receipt(conn, run.id)
+    run.receipt = run_receipt_dict(receipt) if receipt else None
+    return run
 
 
 def latest_summary(conn: sqlite3.Connection, task_id: str) -> Optional[str]:
@@ -4037,6 +4100,18 @@ from hermes_cli.kanban_db_workspace import (  # noqa: E402
     _is_managed_scratch_path,
     _managed_scratch_path_info,
     _scratch_workspace,
+)
+from hermes_cli.kanban_run_receipts import (  # noqa: E402
+    RunReceipt,
+    aggregate_run_receipts,
+    finalize_run_usage,
+    get_run_receipt,
+    get_run_receipts,
+    mark_run_receipt_partial,
+    record_run_context_receipt,
+    record_run_runner_handle,
+    record_run_session,
+    run_receipt_dict,
 )
 from hermes_cli.kanban_db_dispatch import (  # noqa: E402
     DEFAULT_FAILURE_LIMIT,

--- a/hermes_cli/kanban_db_connect.py
+++ b/hermes_cli/kanban_db_connect.py
@@ -709,27 +709,30 @@ def connect(db_path: Optional[Path] = None, *, board: Optional[str] = None) -> s
             path,
         )
 
-    with _cross_process_init_lock(path):
-        # Read-only file/sidecar preflight first, so a stray read-only kanban.db
-        # fails actionably instead of "attempt to write a readonly database".
-        # See #12508.
-        from hermes_state import preflight_db_writability
-        preflight_db_writability(path, db_label=f"kanban.db ({path.name})")
-        # Cheap byte-level header check before any sqlite connection, then the
-        # full integrity probe (cached per path via _INITIALIZED_PATHS).
-        _validate_sqlite_header(path)
-        _guard_existing_db_is_healthy(path)
-        resolved = str(path.resolve())
+    # flock semantics do not consistently serialize separate file descriptions
+    # in one process. Hold the re-entrant thread lock across preflight too, or a
+    # sibling first-connect can mistake the first connection's live WAL setup
+    # for an unwritable sidecar.
+    with _INIT_LOCK:
+        with _cross_process_init_lock(path):
+            # Read-only file/sidecar preflight first, so a stray read-only kanban.db
+            # fails actionably instead of "attempt to write a readonly database".
+            # See #12508.
+            from hermes_state import preflight_db_writability
+            preflight_db_writability(path, db_label=f"kanban.db ({path.name})")
+            # Cheap byte-level header check before any sqlite connection, then the
+            # full integrity probe (cached per path via _INITIALIZED_PATHS).
+            _validate_sqlite_header(path)
+            _guard_existing_db_is_healthy(path)
+            resolved = str(path.resolve())
 
-        def _init_if_needed(conn: sqlite3.Connection) -> None:
-            # Idempotent; runs under _INIT_LOCK so same-process dispatcher
-            # threads can't race the ALTER TABLE pass with stale PRAGMA snapshots.
-            if resolved not in _INITIALIZED_PATHS:
-                conn.executescript(_kb.SCHEMA_SQL)
-                _migrate_add_optional_columns(conn)
-                _INITIALIZED_PATHS.add(resolved)
+            def _init_if_needed(conn: sqlite3.Connection) -> None:
+                if resolved not in _INITIALIZED_PATHS:
+                    conn.executescript(_kb.SCHEMA_SQL)
+                    _migrate_add_optional_columns(conn)
+                    _INITIALIZED_PATHS.add(resolved)
 
-        conn, _ = _open_configured(path, _init_if_needed)
+            conn, _ = _open_configured(path, _init_if_needed)
     return conn
 
 

--- a/hermes_cli/kanban_output.py
+++ b/hermes_cli/kanban_output.py
@@ -24,11 +24,11 @@ _TASK_DICT_FIELDS = (
 )
 _SHOW_RUN_FIELDS = (
     "id", "profile", "step_key", "status", "outcome", "summary", "error",
-    "metadata", "worker_pid", "started_at", "ended_at",
+    "metadata", "worker_pid", "started_at", "ended_at", "receipt",
 )
 _RUNS_RUN_FIELDS = (
     "id", "profile", "status", "outcome", "started_at", "ended_at",
-    "summary", "error", "metadata", "worker_pid", "step_key",
+    "summary", "error", "metadata", "worker_pid", "step_key", "receipt",
 )
 _ATTACHMENT_FIELDS = ("id", "filename", "content_type", "size", "uploaded_by", "stored_path", "created_at")
 

--- a/hermes_cli/kanban_run_receipts.py
+++ b/hermes_cli/kanban_run_receipts.py
@@ -1,0 +1,452 @@
+"""Per-attempt execution receipts for Hermes Kanban workers.
+
+Lifecycle state remains owned by ``task_runs``. This module adds observable,
+provider-neutral facts without widening that table or changing dispatch.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from dataclasses import asdict, dataclass
+from typing import Any, Mapping, Optional, cast
+
+
+_USAGE_KEYS = (
+    "api_calls",
+    "input_tokens",
+    "output_tokens",
+    "cache_read_tokens",
+    "cache_write_tokens",
+    "reasoning_tokens",
+    "estimated_cost_usd",
+    "actual_cost_usd",
+)
+_RUNNER_METADATA_KEYS = frozenset(("workspace_id", "pane_id", "agent_id", "runner_id"))
+_MAX_RUNNER_METADATA_VALUE_CHARS = 256
+
+
+def _json_dict(raw: Optional[str]) -> Optional[dict[str, Any]]:
+    if not raw:
+        return None
+    try:
+        value = json.loads(raw)
+    except (TypeError, ValueError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _usage_json(usage: Optional[Mapping[str, Any]]) -> Optional[str]:
+    if usage is None:
+        return None
+    bounded: dict[str, int | float] = {}
+    for key in _USAGE_KEYS:
+        value = usage.get(key)
+        if value is None:
+            continue
+        if key.endswith("cost_usd"):
+            bounded[key] = max(0.0, float(value))
+        else:
+            bounded[key] = max(0, int(value))
+    return json.dumps(bounded, sort_keys=True, separators=(",", ":"))
+
+
+@dataclass(frozen=True)
+class RunReceipt:
+    run_id: int
+    task_id: str
+    runner: Optional[str]
+    worker_session_id: Optional[str]
+    session_lineage_root: Optional[str]
+    profile: Optional[str]
+    requested_provider: Optional[str]
+    requested_model: Optional[str]
+    requested_reasoning: Optional[str]
+    effective_provider: Optional[str]
+    effective_model: Optional[str]
+    effective_reasoning: Optional[str]
+    system_prompt_hash: Optional[str]
+    toolset_hash: Optional[str]
+    skills_hash: Optional[str]
+    context_schema_version: Optional[int]
+    context_fingerprint: Optional[str]
+    context_chars: Optional[int]
+    usage_start: Optional[dict[str, Any]]
+    usage_end: Optional[dict[str, Any]]
+    api_call_delta: Optional[int]
+    input_token_delta: Optional[int]
+    output_token_delta: Optional[int]
+    cache_read_token_delta: Optional[int]
+    cache_write_token_delta: Optional[int]
+    reasoning_token_delta: Optional[int]
+    estimated_cost_delta: Optional[float]
+    actual_cost_delta: Optional[float]
+    worktree_start_fingerprint: Optional[str]
+    worktree_end_fingerprint: Optional[str]
+    runner_metadata: Optional[dict[str, Any]]
+    receipt_completeness: str
+    receipt_source: str
+    fresh_or_resumed: Optional[str]
+    created_at: int
+    updated_at: int
+    finalized_at: Optional[int]
+
+    @classmethod
+    def from_row(cls, row: sqlite3.Row) -> "RunReceipt":
+        values = cast(dict[str, Any], dict(row))
+        values["run_id"] = int(values["run_id"])
+        for key in ("context_schema_version", "context_chars", "api_call_delta",
+                    "input_token_delta", "output_token_delta", "cache_read_token_delta",
+                    "cache_write_token_delta", "reasoning_token_delta", "finalized_at"):
+            values[key] = int(values[key]) if values[key] is not None else None
+        values["created_at"] = int(values["created_at"])
+        values["updated_at"] = int(values["updated_at"])
+        values["usage_start"] = _json_dict(values["usage_start"])
+        values["usage_end"] = _json_dict(values["usage_end"])
+        values["runner_metadata"] = _json_dict(values["runner_metadata"])
+        return cls(**values)
+
+
+def get_run_receipt(conn: sqlite3.Connection, run_id: int) -> Optional[RunReceipt]:
+    row = conn.execute(
+        "SELECT * FROM task_run_receipts WHERE run_id = ?", (int(run_id),)
+    ).fetchone()
+    return RunReceipt.from_row(row) if row else None
+
+
+def get_run_receipts(
+    conn: sqlite3.Connection, run_ids: list[int],
+) -> dict[int, RunReceipt]:
+    if not run_ids:
+        return {}
+    placeholders = ",".join("?" for _ in run_ids)
+    rows = conn.execute(
+        f"SELECT * FROM task_run_receipts WHERE run_id IN ({placeholders})",
+        tuple(int(run_id) for run_id in run_ids),
+    ).fetchall()
+    receipts = [RunReceipt.from_row(row) for row in rows]
+    return {receipt.run_id: receipt for receipt in receipts}
+
+
+def _active_run_matches(
+    conn: sqlite3.Connection, task_id: str, run_id: int,
+) -> bool:
+    row = conn.execute(
+        """SELECT 1
+             FROM tasks AS t
+             JOIN task_runs AS r ON r.id = t.current_run_id
+            WHERE t.id = ? AND t.current_run_id = ?
+              AND r.task_id = ? AND r.ended_at IS NULL""",
+        (task_id, int(run_id), task_id),
+    ).fetchone()
+    return row is not None
+
+
+def record_run_session(
+    conn: sqlite3.Connection,
+    task_id: str,
+    run_id: int,
+    *,
+    worker_session_id: str,
+    session_lineage_root: Optional[str] = None,
+    profile: Optional[str] = None,
+    requested_provider: Optional[str] = None,
+    requested_model: Optional[str] = None,
+    requested_reasoning: Optional[str] = None,
+    effective_provider: Optional[str] = None,
+    effective_model: Optional[str] = None,
+    effective_reasoning: Optional[str] = None,
+    fresh_or_resumed: Optional[str] = None,
+    usage_start: Optional[Mapping[str, Any]] = None,
+    receipt_source: str = "worker",
+) -> bool:
+    """Start or enrich the active run's receipt; reject stale run identities."""
+    if not worker_session_id or not _active_run_matches(conn, task_id, run_id):
+        return False
+    now = int(time.time())
+    conn.execute(
+        """INSERT INTO task_run_receipts (
+               run_id, task_id, worker_session_id, session_lineage_root, profile,
+               requested_provider, requested_model, requested_reasoning,
+               effective_provider, effective_model, effective_reasoning,
+               usage_start, receipt_completeness, receipt_source,
+               fresh_or_resumed, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'started', ?, ?, ?, ?)
+           ON CONFLICT(run_id) DO UPDATE SET
+               worker_session_id = excluded.worker_session_id,
+               session_lineage_root = excluded.session_lineage_root,
+               profile = COALESCE(excluded.profile, task_run_receipts.profile),
+               requested_provider = excluded.requested_provider,
+               requested_model = excluded.requested_model,
+               requested_reasoning = excluded.requested_reasoning,
+               effective_provider = excluded.effective_provider,
+               effective_model = excluded.effective_model,
+               effective_reasoning = excluded.effective_reasoning,
+               usage_start = COALESCE(task_run_receipts.usage_start, excluded.usage_start),
+               receipt_source = excluded.receipt_source,
+               fresh_or_resumed = excluded.fresh_or_resumed,
+               updated_at = excluded.updated_at""",
+        (
+            int(run_id), task_id, worker_session_id, session_lineage_root, profile,
+            requested_provider, requested_model, requested_reasoning,
+            effective_provider, effective_model, effective_reasoning,
+            _usage_json(usage_start), receipt_source, fresh_or_resumed, now, now,
+        ),
+    )
+    return True
+
+
+def record_run_context_receipt(
+    conn: sqlite3.Connection,
+    task_id: str,
+    run_id: int,
+    *,
+    context_schema_version: int,
+    context_fingerprint: str,
+    context_chars: int,
+    system_prompt_hash: Optional[str] = None,
+    toolset_hash: Optional[str] = None,
+    skills_hash: Optional[str] = None,
+) -> bool:
+    """Record bounded context identity for the active run."""
+    if not _active_run_matches(conn, task_id, run_id):
+        return False
+    now = int(time.time())
+    conn.execute(
+        """INSERT INTO task_run_receipts (
+               run_id, task_id, context_schema_version, context_fingerprint,
+               context_chars, system_prompt_hash, toolset_hash, skills_hash,
+               created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(run_id) DO UPDATE SET
+               context_schema_version = excluded.context_schema_version,
+               context_fingerprint = excluded.context_fingerprint,
+               context_chars = excluded.context_chars,
+               system_prompt_hash = excluded.system_prompt_hash,
+               toolset_hash = excluded.toolset_hash,
+               skills_hash = excluded.skills_hash,
+               updated_at = excluded.updated_at""",
+        (
+            int(run_id), task_id, max(1, int(context_schema_version)),
+            str(context_fingerprint)[:128], max(0, int(context_chars)),
+            (str(system_prompt_hash)[:128] if system_prompt_hash else None),
+            (str(toolset_hash)[:128] if toolset_hash else None),
+            (str(skills_hash)[:128] if skills_hash else None), now, now,
+        ),
+    )
+    return True
+
+
+def _safe_runner_metadata(metadata: Optional[Mapping[str, Any]]) -> Optional[str]:
+    if not metadata:
+        return None
+    safe = {
+        key: str(metadata[key])[:_MAX_RUNNER_METADATA_VALUE_CHARS]
+        for key in sorted(_RUNNER_METADATA_KEYS & metadata.keys())
+        if metadata[key] is not None
+    }
+    return json.dumps(safe, sort_keys=True, separators=(",", ":")) if safe else None
+
+
+def record_run_runner_handle(
+    conn: sqlite3.Connection,
+    task_id: str,
+    run_id: int,
+    *,
+    runner: str,
+    runner_metadata: Optional[Mapping[str, Any]] = None,
+    worktree_start_fingerprint: Optional[str] = None,
+    receipt_source: str = "runner",
+) -> bool:
+    """Record a safe supervisor handle for the active run."""
+    runner_name = (runner or "").strip().lower()
+    if runner_name not in {"hermes", "herdr"}:
+        raise ValueError("runner must be 'hermes' or 'herdr'")
+    if not _active_run_matches(conn, task_id, run_id):
+        return False
+    now = int(time.time())
+    conn.execute(
+        """INSERT INTO task_run_receipts (
+               run_id, task_id, runner, runner_metadata,
+               worktree_start_fingerprint, receipt_source, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(run_id) DO UPDATE SET
+               runner = excluded.runner,
+               runner_metadata = excluded.runner_metadata,
+               worktree_start_fingerprint = excluded.worktree_start_fingerprint,
+               receipt_source = excluded.receipt_source,
+               updated_at = excluded.updated_at""",
+        (
+            int(run_id), task_id, runner_name, _safe_runner_metadata(runner_metadata),
+            (str(worktree_start_fingerprint)[:128] if worktree_start_fingerprint else None),
+            receipt_source, now, now,
+        ),
+    )
+    return True
+
+
+def _counter_delta(
+    start: Mapping[str, Any], end: Mapping[str, Any], key: str, *, cost: bool = False,
+) -> Optional[int | float]:
+    if key not in start or key not in end:
+        return None
+    value = float(end[key]) - float(start[key]) if cost else int(end[key]) - int(start[key])
+    if value < 0:
+        return None
+    return float(value) if cost else int(value)
+
+
+def finalize_run_usage(
+    conn: sqlite3.Connection,
+    task_id: str,
+    run_id: int,
+    *,
+    worker_session_id: str,
+    usage_end: Mapping[str, Any],
+    worktree_end_fingerprint: Optional[str] = None,
+    receipt_source: str = "worker",
+) -> bool:
+    """Finalize one exact run/session receipt using per-run usage deltas."""
+    row = conn.execute(
+        """SELECT rr.worker_session_id, rr.usage_start
+             FROM task_run_receipts AS rr
+             JOIN task_runs AS r ON r.id = rr.run_id
+            WHERE rr.run_id = ? AND rr.task_id = ? AND r.task_id = ?""",
+        (int(run_id), task_id, task_id),
+    ).fetchone()
+    if row is None or row["worker_session_id"] != worker_session_id:
+        return False
+    start = _json_dict(row["usage_start"])
+    if start is None:
+        return False
+    normalized_end_raw = _usage_json(usage_end)
+    normalized_end = _json_dict(normalized_end_raw)
+    if normalized_end is None:
+        return False
+    deltas = {
+        "api_call_delta": _counter_delta(start, normalized_end, "api_calls"),
+        "input_token_delta": _counter_delta(start, normalized_end, "input_tokens"),
+        "output_token_delta": _counter_delta(start, normalized_end, "output_tokens"),
+        "cache_read_token_delta": _counter_delta(start, normalized_end, "cache_read_tokens"),
+        "cache_write_token_delta": _counter_delta(start, normalized_end, "cache_write_tokens"),
+        "reasoning_token_delta": _counter_delta(start, normalized_end, "reasoning_tokens"),
+        "estimated_cost_delta": _counter_delta(start, normalized_end, "estimated_cost_usd", cost=True),
+        "actual_cost_delta": _counter_delta(start, normalized_end, "actual_cost_usd", cost=True),
+    }
+    completeness = "complete" if all(value is not None for value in deltas.values()) else "partial"
+    now = int(time.time())
+    cursor = conn.execute(
+        """UPDATE task_run_receipts
+              SET usage_end = ?, api_call_delta = ?, input_token_delta = ?,
+                  output_token_delta = ?, cache_read_token_delta = ?,
+                  cache_write_token_delta = ?, reasoning_token_delta = ?,
+                  estimated_cost_delta = ?, actual_cost_delta = ?,
+                  worktree_end_fingerprint = ?, receipt_completeness = ?,
+                  receipt_source = ?, updated_at = ?, finalized_at = ?
+           WHERE run_id = ? AND task_id = ? AND worker_session_id = ?
+             AND receipt_completeness != 'complete'""",
+        (
+            normalized_end_raw, deltas["api_call_delta"], deltas["input_token_delta"],
+            deltas["output_token_delta"], deltas["cache_read_token_delta"],
+            deltas["cache_write_token_delta"], deltas["reasoning_token_delta"],
+            deltas["estimated_cost_delta"], deltas["actual_cost_delta"],
+            (str(worktree_end_fingerprint)[:128] if worktree_end_fingerprint else None),
+            completeness, receipt_source, now, now, int(run_id), task_id, worker_session_id,
+        ),
+    )
+    return cursor.rowcount == 1
+
+
+def mark_run_receipt_partial(
+    conn: sqlite3.Connection,
+    task_id: str,
+    run_id: int,
+    *,
+    receipt_source: str = "lifecycle",
+) -> bool:
+    """Ensure a terminal run has an honest partial receipt after crashes or early exits."""
+    row = conn.execute(
+        "SELECT profile, started_at FROM task_runs WHERE id = ? AND task_id = ?",
+        (int(run_id), task_id),
+    ).fetchone()
+    if row is None:
+        return False
+    now = int(time.time())
+    conn.execute(
+        """INSERT INTO task_run_receipts (
+               run_id, task_id, profile, receipt_completeness, receipt_source,
+               created_at, updated_at, finalized_at
+           ) VALUES (?, ?, ?, 'partial', ?, ?, ?, ?)
+           ON CONFLICT(run_id) DO UPDATE SET
+               profile = COALESCE(task_run_receipts.profile, excluded.profile),
+               receipt_completeness = CASE
+                   WHEN task_run_receipts.receipt_completeness = 'complete'
+                   THEN 'complete' ELSE 'partial' END,
+               receipt_source = CASE
+                   WHEN task_run_receipts.receipt_completeness = 'complete'
+                   THEN task_run_receipts.receipt_source ELSE excluded.receipt_source END,
+               updated_at = excluded.updated_at,
+               finalized_at = COALESCE(task_run_receipts.finalized_at, excluded.finalized_at)""",
+        (
+            int(run_id), task_id, row["profile"], receipt_source,
+            int(row["started_at"]), now, now,
+        ),
+    )
+    return True
+
+
+def run_receipt_dict(receipt: RunReceipt) -> dict[str, Any]:
+    """Return the JSON-safe additive representation used by run views."""
+    return asdict(receipt)
+
+
+def aggregate_run_receipts(
+    conn: sqlite3.Connection, *, task_id: Optional[str] = None,
+) -> list[dict[str, Any]]:
+    """Aggregate usage by workflow, route, runner, and outcome dimensions."""
+    where = "WHERE r.task_id = ?" if task_id is not None else ""
+    params = (task_id,) if task_id is not None else ()
+    rows = conn.execute(
+        f"""SELECT r.task_id, r.step_key, COALESCE(rr.profile, r.profile) AS profile,
+                   rr.effective_provider, rr.effective_model, rr.runner, r.outcome,
+                   rr.fresh_or_resumed, COUNT(*) AS run_count,
+                   SUM(CASE WHEN rr.receipt_completeness = 'complete' THEN 1 ELSE 0 END)
+                       AS complete_receipt_count,
+                   SUM(rr.api_call_delta) AS api_calls,
+                   SUM(rr.input_token_delta) AS input_tokens,
+                   SUM(rr.output_token_delta) AS output_tokens,
+                   SUM(rr.cache_read_token_delta) AS cache_read_tokens,
+                   SUM(rr.cache_write_token_delta) AS cache_write_tokens,
+                   SUM(rr.reasoning_token_delta) AS reasoning_tokens,
+                   SUM(rr.estimated_cost_delta) AS estimated_cost_usd,
+                   SUM(rr.actual_cost_delta) AS actual_cost_usd
+              FROM task_runs AS r
+              LEFT JOIN task_run_receipts AS rr ON rr.run_id = r.id
+              {where}
+             GROUP BY r.task_id, r.step_key, COALESCE(rr.profile, r.profile),
+                      rr.effective_provider, rr.effective_model, rr.runner, r.outcome,
+                      rr.fresh_or_resumed
+             ORDER BY r.task_id, r.step_key, profile, rr.effective_provider,
+                      rr.effective_model, rr.runner, r.outcome, rr.fresh_or_resumed""",
+        params,
+    ).fetchall()
+    integer_fields = (
+        "run_count", "complete_receipt_count", "api_calls", "input_tokens",
+        "output_tokens", "cache_read_tokens", "cache_write_tokens", "reasoning_tokens",
+    )
+    result: list[dict[str, Any]] = []
+    for row in rows:
+        item = dict(row)
+        for key in integer_fields:
+            item[key] = int(item[key]) if item[key] is not None else None
+        item["estimated_cost_usd"] = (
+            float(item["estimated_cost_usd"])
+            if item["estimated_cost_usd"] is not None else None
+        )
+        item["actual_cost_usd"] = (
+            float(item["actual_cost_usd"])
+            if item["actual_cost_usd"] is not None else None
+        )
+        result.append(item)
+    return result

--- a/hermes_cli/kanban_worker_receipts.py
+++ b/hermes_cli/kanban_worker_receipts.py
@@ -1,0 +1,196 @@
+"""Bridge a dispatcher-owned worker session to its Kanban run receipt."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+
+
+log = logging.getLogger(__name__)
+_CONTEXT_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class WorkerReceiptState:
+    task_id: str
+    run_id: int
+    worker_session_id: str
+    workspace_path: Optional[str]
+
+
+def _hash_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8", errors="replace")).hexdigest()
+
+
+def _hash_json(value: Any) -> str:
+    return _hash_text(json.dumps(value, sort_keys=True, separators=(",", ":"), default=str))
+
+
+def _git_output(repo: Path, *args: str) -> Optional[bytes]:
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(repo), *args], capture_output=True, check=False, timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return completed.stdout if completed.returncode == 0 else None
+
+
+def _worktree_fingerprint(path: str | Path | None) -> Optional[str]:
+    """Return ``git-v1:<HEAD>:<delta digest>`` without retaining source content."""
+    if not path:
+        return None
+    repo = Path(path).expanduser()
+    head_raw = _git_output(repo, "rev-parse", "HEAD")
+    status = _git_output(repo, "status", "--porcelain=v1", "-z", "--untracked-files=all")
+    diff = _git_output(repo, "diff", "--binary", "HEAD", "--")
+    untracked = _git_output(repo, "ls-files", "--others", "--exclude-standard", "-z")
+    if head_raw is None or status is None or diff is None or untracked is None:
+        return None
+    digest = hashlib.sha256()
+    digest.update(status)
+    digest.update(diff)
+    for raw_name in sorted(name for name in untracked.split(b"\0") if name):
+        digest.update(b"\0untracked\0")
+        digest.update(raw_name)
+        candidate = repo / raw_name.decode("utf-8", errors="surrogateescape")
+        try:
+            if candidate.is_symlink():
+                digest.update(os.readlink(candidate).encode("utf-8", errors="surrogateescape"))
+            elif candidate.is_file():
+                digest.update(candidate.read_bytes())
+        except OSError:
+            return None
+    head = head_raw.decode("ascii", errors="strict").strip()
+    return f"git-v1:{head}:{digest.hexdigest()}"
+
+
+def _reasoning_config_label(config: Any) -> Optional[str]:
+    if not isinstance(config, dict):
+        return None
+    if config.get("enabled") is False:
+        return "disabled"
+    value = config.get("effort")
+    if value is not None:
+        return str(value)
+    return "enabled" if config.get("enabled") is True else None
+
+
+def _requested_reasoning_label(cli: Any, task: Any) -> Optional[str]:
+    if getattr(task, "reasoning_effort", None):
+        return str(task.reasoning_effort)
+    return _reasoning_config_label(getattr(cli, "reasoning_config", None))
+
+
+def _env_identity() -> tuple[str, Optional[int]]:
+    task_id = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    raw_run_id = (os.environ.get("HERMES_KANBAN_RUN_ID") or "").strip()
+    try:
+        run_id = int(raw_run_id) if raw_run_id else None
+    except ValueError:
+        run_id = None
+    return task_id, run_id
+
+
+def begin_worker_receipt(cli: Any) -> Optional[WorkerReceiptState]:
+    """Record the worker's actual session, route, and full-context baseline."""
+    task_id, run_id = _env_identity()
+    session_db = getattr(cli, "_session_db", None)
+    agent = getattr(cli, "agent", None)
+    session_id = str(getattr(agent, "session_id", None) or getattr(cli, "session_id", "") or "")
+    if not task_id or run_id is None or not session_id or session_db is None:
+        return None
+    try:
+        usage_start = session_db.session_lineage_usage_snapshot(session_id)
+        lineage_root = session_db.get_conversation_root(session_id)
+        with kbc.connect_closing() as conn:
+            task = kb.get_task(conn, task_id)
+            if task is None:
+                return None
+            workspace_path = (
+                (os.environ.get("HERMES_KANBAN_WORKSPACE") or "").strip()
+                or task.workspace_path
+            )
+            context = kb.build_worker_context(conn, task_id)
+            profile = (os.environ.get("HERMES_PROFILE") or task.assignee or "").strip() or None
+            requested_reasoning = _requested_reasoning_label(cli, task)
+            ok = kb.record_run_session(
+                conn, task_id, run_id,
+                worker_session_id=session_id,
+                session_lineage_root=lineage_root,
+                profile=profile,
+                requested_provider=(task.provider_override or getattr(cli, "requested_provider", None)),
+                requested_model=(task.model_override or getattr(cli, "model", None)),
+                requested_reasoning=requested_reasoning,
+                effective_provider=getattr(agent, "provider", None),
+                effective_model=getattr(agent, "model", None),
+                effective_reasoning=_reasoning_config_label(
+                    getattr(agent, "reasoning_config", None)
+                ),
+                fresh_or_resumed=("resumed" if getattr(cli, "_resumed", False) else "fresh"),
+                usage_start=usage_start,
+            )
+            if not ok:
+                return None
+            kb.record_run_context_receipt(
+                conn, task_id, run_id,
+                context_schema_version=_CONTEXT_SCHEMA_VERSION,
+                context_fingerprint=_hash_text(context),
+                context_chars=len(context),
+                system_prompt_hash=_hash_text(
+                    str(getattr(agent, "_cached_system_prompt", "") or "")
+                ),
+                toolset_hash=_hash_json(sorted(getattr(cli, "enabled_toolsets", None) or [])),
+                skills_hash=_hash_json(sorted(task.skills or [])),
+            )
+            kb.record_run_runner_handle(
+                conn, task_id, run_id,
+                runner=(
+                    os.environ.get("HERMES_KANBAN_RUNNER")
+                    or ("herdr" if os.environ.get("HERDR_ENV") == "1" else "hermes")
+                ),
+                runner_metadata={
+                    "workspace_id": os.environ.get("HERMES_HERDR_WORKSPACE_ID"),
+                    "pane_id": os.environ.get("HERMES_HERDR_PANE_ID"),
+                    "agent_id": os.environ.get("HERMES_HERDR_AGENT_ID"),
+                },
+                worktree_start_fingerprint=_worktree_fingerprint(workspace_path),
+            )
+        return WorkerReceiptState(task_id, run_id, session_id, workspace_path)
+    except Exception:
+        log.debug("kanban run receipt start failed", exc_info=True)
+        return None
+
+
+def finalize_worker_receipt(cli: Any, state: Optional[WorkerReceiptState]) -> bool:
+    """Flush token accounting and finalize one exact worker/run receipt."""
+    if state is None:
+        return False
+    session_db = getattr(cli, "_session_db", None)
+    if session_db is None:
+        return False
+    try:
+        current_session_id = str(
+            getattr(getattr(cli, "agent", None), "session_id", None)
+            or state.worker_session_id
+        )
+        usage_end = session_db.session_lineage_usage_snapshot(current_session_id)
+        with kbc.connect_closing() as conn:
+            return kb.finalize_run_usage(
+                conn, state.task_id, state.run_id,
+                worker_session_id=state.worker_session_id,
+                usage_end=usage_end,
+                worktree_end_fingerprint=_worktree_fingerprint(state.workspace_path),
+            )
+    except Exception:
+        log.debug("kanban run receipt finalization failed", exc_info=True)
+        return False

--- a/hermes_state_repair.py
+++ b/hermes_state_repair.py
@@ -555,6 +555,10 @@ def preflight_db_writability(db_path: Path, *, db_label: str = "state.db") -> No
     for p, is_dir in [(db_path.parent, True), *((p, False) for p in (db_path, *sidecars) if p.is_file())]:
         if (is_dir and not p.is_dir()) or os.access(p, os.R_OK | os.W_OK):
             continue
+        # A live connection may checkpoint and remove a sidecar between the
+        # is_file() snapshot above and os.access(); absence is not read-only.
+        if not is_dir and not p.exists():
+            continue
         x = "x" if is_dir else ""
         in_scope = False
         with contextlib.suppress(OSError, ValueError):
@@ -563,6 +567,8 @@ def preflight_db_writability(db_path: Path, *, db_label: str = "state.db") -> No
                 os.chmod(p, p.stat().st_mode | stat.S_IRUSR | stat.S_IWUSR | (stat.S_IXUSR if is_dir else 0))
         if in_scope and os.access(p, os.R_OK | os.W_OK):
             logger.info("%s preflight: repaired read-only %s (chmod u+rw%s)", db_label, p, x)
+            continue
+        if not is_dir and not p.exists():
             continue
         wal_note = (" Do NOT delete the -wal file — it contains committed data that "
                     "will be merged into the database once it is writable." if p.name.endswith("-wal") else "")

--- a/hermes_state_usage.py
+++ b/hermes_state_usage.py
@@ -174,6 +174,44 @@ class SessionUsageMixin:
             self._apply_claimed_batch(batch)
         return True
 
+    def _usage_snapshot_for_sessions(self, session_ids: List[str]) -> Dict[str, int | float]:
+        if not self.flush_token_counts():
+            raise TimeoutError("token accounting did not flush before usage snapshot")
+        placeholders = ",".join("?" for _ in session_ids)
+        row = self._read_one(
+            f"""SELECT COALESCE(SUM(api_call_count), 0) AS api_calls,
+                      COALESCE(SUM(input_tokens), 0) AS input_tokens,
+                      COALESCE(SUM(output_tokens), 0) AS output_tokens,
+                      COALESCE(SUM(cache_read_tokens), 0) AS cache_read_tokens,
+                      COALESCE(SUM(cache_write_tokens), 0) AS cache_write_tokens,
+                      COALESCE(SUM(reasoning_tokens), 0) AS reasoning_tokens,
+                      COALESCE(SUM(estimated_cost_usd), 0.0) AS estimated_cost_usd,
+                      COALESCE(SUM(actual_cost_usd), 0.0) AS actual_cost_usd
+                 FROM session_model_usage
+                WHERE session_id IN ({placeholders})""",
+            tuple(session_ids),
+        )
+        values = dict(row) if row is not None else {}
+        return {
+            "api_calls": int(values.get("api_calls") or 0),
+            "input_tokens": int(values.get("input_tokens") or 0),
+            "output_tokens": int(values.get("output_tokens") or 0),
+            "cache_read_tokens": int(values.get("cache_read_tokens") or 0),
+            "cache_write_tokens": int(values.get("cache_write_tokens") or 0),
+            "reasoning_tokens": int(values.get("reasoning_tokens") or 0),
+            "estimated_cost_usd": float(values.get("estimated_cost_usd") or 0.0),
+            "actual_cost_usd": float(values.get("actual_cost_usd") or 0.0),
+        }
+
+    def session_usage_snapshot(self, session_id: str) -> Dict[str, int | float]:
+        """Return a flushed, conserved usage snapshot for one session segment."""
+        return self._usage_snapshot_for_sessions([session_id])
+
+    def session_lineage_usage_snapshot(self, session_id: str) -> Dict[str, int | float]:
+        """Return usage for the root-to-current compression lineage, excluding siblings."""
+        lineage = getattr(self, "_session_lineage_root_to_tip")(session_id)
+        return self._usage_snapshot_for_sessions(lineage or [session_id])
+
     def _token_writer_loop(self) -> None:
         while True:
             with self._token_queue_cond:

--- a/tests/cli/test_quiet_turn_author.py
+++ b/tests/cli/test_quiet_turn_author.py
@@ -14,6 +14,7 @@ import pytest
 
 import cli
 from agent.turn_author import TURN_AUTHOR_ENV
+from hermes_cli import kanban_worker_receipts
 
 AUTHOR = {"id": "bot:coder", "name": "coder", "is_bot": True}
 
@@ -60,3 +61,23 @@ def test_quiet_one_shot_consumes_the_variable_before_the_turn(monkeypatch):
     _run(monkeypatch, json.dumps(AUTHOR), run_conversation)
     assert seen["env"] is None
     assert TURN_AUTHOR_ENV not in os.environ
+
+
+def test_quiet_one_shot_brackets_turn_with_kanban_run_receipt(monkeypatch):
+    events = []
+    state = object()
+    monkeypatch.setattr(
+        kanban_worker_receipts, "begin_worker_receipt",
+        lambda worker_cli: events.append(("begin", worker_cli.session_id)) or state,
+    )
+    monkeypatch.setattr(
+        kanban_worker_receipts, "finalize_worker_receipt",
+        lambda worker_cli, received: events.append(("finalize", received)) or True,
+    )
+
+    def run_conversation(**kwargs):
+        events.append(("run", kwargs["user_message"]))
+        return {"final_response": "ok"}
+
+    _run(monkeypatch, None, run_conversation)
+    assert events == [("begin", "s-1"), ("run", "hello"), ("finalize", state)]

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -170,6 +170,253 @@ def test_connect_migrates_legacy_db_before_optional_column_indexes(tmp_path):
     assert "idx_events_run" in indexes
 
 
+def test_run_receipt_schema_is_created_for_fresh_and_legacy_boards(tmp_path):
+    fresh = tmp_path / "fresh.db"
+    legacy = tmp_path / "legacy.db"
+    with kbc.connect(fresh) as conn:
+        fresh_columns = {
+            row["name"] for row in conn.execute("PRAGMA table_info(task_run_receipts)")
+        }
+
+    with kbc.connect(legacy) as conn:
+        conn.execute("DROP TABLE task_run_receipts")
+    kbc._INITIALIZED_PATHS.discard(str(legacy.resolve()))
+    with kbc.connect(legacy) as conn:
+        legacy_columns = {
+            row["name"] for row in conn.execute("PRAGMA table_info(task_run_receipts)")
+        }
+
+    required = {
+        "run_id", "task_id", "runner", "worker_session_id",
+        "session_lineage_root", "profile", "requested_provider",
+        "requested_model", "requested_reasoning", "effective_provider",
+        "effective_model", "effective_reasoning", "system_prompt_hash",
+        "toolset_hash", "skills_hash", "context_schema_version",
+        "context_fingerprint", "context_chars", "usage_start",
+        "usage_end", "api_call_delta", "input_token_delta",
+        "output_token_delta", "cache_read_token_delta",
+        "cache_write_token_delta", "reasoning_token_delta",
+        "estimated_cost_delta", "actual_cost_delta",
+        "worktree_start_fingerprint", "worktree_end_fingerprint",
+        "runner_metadata", "receipt_completeness", "receipt_source",
+        "fresh_or_resumed", "created_at", "updated_at", "finalized_at",
+    }
+    assert required <= fresh_columns
+    assert required <= legacy_columns
+
+
+def test_run_receipt_session_write_is_fenced_to_active_run(kanban_home):
+    with kbc.connect() as conn:
+        task_id = kb.create_task(conn, title="receipt", assignee="implementer")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None and claimed.current_run_id is not None
+        run_id = claimed.current_run_id
+
+        assert kb.record_run_session(
+            conn,
+            task_id,
+            run_id,
+            worker_session_id="session-1",
+            session_lineage_root="session-root",
+            profile="implementer",
+            requested_provider="configured-provider",
+            requested_model="configured-model",
+            requested_reasoning="medium",
+            effective_provider="actual-provider",
+            effective_model="actual-model",
+            effective_reasoning="high",
+            fresh_or_resumed="fresh",
+            usage_start={"api_calls": 2, "input_tokens": 100},
+        )
+        receipt = kb.get_run_receipt(conn, run_id)
+        assert receipt is not None
+        assert receipt.worker_session_id == "session-1"
+        assert receipt.effective_provider == "actual-provider"
+        assert receipt.usage_start == {"api_calls": 2, "input_tokens": 100}
+
+        kb.complete_task(conn, task_id, summary="done", expected_run_id=run_id)
+        assert not kb.record_run_session(
+            conn,
+            task_id,
+            run_id,
+            worker_session_id="stale-session",
+        )
+        assert kb.get_run_receipt(conn, run_id).worker_session_id == "session-1"
+
+
+def test_run_receipt_context_and_runner_metadata_are_bounded_and_redacted(kanban_home):
+    digest = "a" * 64
+    with kbc.connect() as conn:
+        task_id = kb.create_task(conn, title="observable", assignee="implementer")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None and claimed.current_run_id is not None
+        run_id = claimed.current_run_id
+
+        assert kb.record_run_context_receipt(
+            conn, task_id, run_id,
+            context_schema_version=1, context_fingerprint=digest, context_chars=4096,
+            system_prompt_hash="b" * 64, toolset_hash="c" * 64, skills_hash="d" * 64,
+        )
+        assert kb.record_run_runner_handle(
+            conn, task_id, run_id, runner="herdr",
+            runner_metadata={
+                "workspace_id": "w1", "pane_id": "p1", "agent_id": "a1",
+                "api_token": "must-not-persist", "raw_prompt": "must-not-persist",
+                "extra": "x" * 1000,
+            },
+            worktree_start_fingerprint="e" * 64,
+        )
+
+        receipt = kb.get_run_receipt(conn, run_id)
+        assert receipt is not None
+        assert receipt.context_fingerprint == digest
+        assert receipt.context_chars == 4096
+        assert receipt.runner == "herdr"
+        assert receipt.runner_metadata == {
+            "agent_id": "a1", "pane_id": "p1", "workspace_id": "w1",
+        }
+        stored = conn.execute(
+            "SELECT runner_metadata FROM task_run_receipts WHERE run_id = ?", (run_id,)
+        ).fetchone()[0]
+        assert "must-not-persist" not in stored
+        assert "raw_prompt" not in stored
+
+        kb.complete_task(conn, task_id, summary="done", expected_run_id=run_id)
+        assert not kb.record_run_context_receipt(
+            conn, task_id, run_id,
+            context_schema_version=1, context_fingerprint="f" * 64, context_chars=1,
+        )
+
+
+def test_finalize_run_usage_stores_deltas_and_fences_session_identity(kanban_home):
+    start = {
+        "api_calls": 2, "input_tokens": 100, "output_tokens": 20,
+        "cache_read_tokens": 70, "cache_write_tokens": 5,
+        "reasoning_tokens": 3, "estimated_cost_usd": 0.25,
+        "actual_cost_usd": 0.20,
+    }
+    end = {
+        "api_calls": 5, "input_tokens": 250, "output_tokens": 50,
+        "cache_read_tokens": 170, "cache_write_tokens": 8,
+        "reasoning_tokens": 13, "estimated_cost_usd": 0.55,
+        "actual_cost_usd": 0.44,
+    }
+    with kbc.connect() as conn:
+        task_id = kb.create_task(conn, title="usage", assignee="implementer")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None and claimed.current_run_id is not None
+        run_id = claimed.current_run_id
+        assert kb.record_run_session(
+            conn, task_id, run_id, worker_session_id="session-1", usage_start=start,
+        )
+        kb.complete_task(conn, task_id, summary="done", expected_run_id=run_id)
+
+        assert not kb.finalize_run_usage(
+            conn, task_id, run_id, worker_session_id="other-session", usage_end=end,
+        )
+        assert kb.finalize_run_usage(
+            conn, task_id, run_id, worker_session_id="session-1", usage_end=end,
+            worktree_end_fingerprint="f" * 64,
+        )
+        receipt = kb.get_run_receipt(conn, run_id)
+        assert receipt is not None
+        assert receipt.receipt_completeness == "complete"
+        assert receipt.api_call_delta == 3
+        assert receipt.input_token_delta == 150
+        assert receipt.output_token_delta == 30
+        assert receipt.cache_read_token_delta == 100
+        assert receipt.cache_write_token_delta == 3
+        assert receipt.reasoning_token_delta == 10
+        assert receipt.estimated_cost_delta == pytest.approx(0.30)
+        assert receipt.actual_cost_delta == pytest.approx(0.24)
+        assert receipt.worktree_end_fingerprint == "f" * 64
+        assert receipt.finalized_at is not None
+
+        duplicate_end = dict(end, input_tokens=9999)
+        assert not kb.finalize_run_usage(
+            conn, task_id, run_id, worker_session_id="session-1",
+            usage_end=duplicate_end, worktree_end_fingerprint="z" * 64,
+        )
+        unchanged = kb.get_run_receipt(conn, run_id)
+        assert unchanged is not None
+        assert unchanged.input_token_delta == 150
+        assert unchanged.worktree_end_fingerprint == "f" * 64
+        assert unchanged.finalized_at == receipt.finalized_at
+
+
+@pytest.mark.parametrize("outcome", ["spawn_failed", "crashed", "timed_out"])
+def test_ended_run_without_worker_finalization_gets_partial_receipt(kanban_home, outcome):
+    with kbc.connect() as conn:
+        task_id = kb.create_task(conn, title="crash", assignee="implementer")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None and claimed.current_run_id is not None
+        run_id = claimed.current_run_id
+
+        kbd._record_task_failure(
+            conn, task_id, "worker stopped", outcome=outcome,
+            release_claim=True, end_run=True,
+        )
+
+        receipt = kb.get_run_receipt(conn, run_id)
+        assert receipt is not None
+        assert receipt.task_id == task_id
+        assert receipt.profile == "implementer"
+        assert receipt.receipt_completeness == "partial"
+        assert receipt.receipt_source == "lifecycle"
+        assert receipt.finalized_at is not None
+        aggregate = kb.aggregate_run_receipts(conn, task_id=task_id)[0]
+        assert aggregate["api_calls"] is None
+        assert aggregate["input_tokens"] is None
+
+
+def test_run_serialization_and_aggregation_include_receipt_additively(kanban_home):
+    from hermes_cli.kanban_output import _RUNS_RUN_FIELDS, _SHOW_RUN_FIELDS, _obj_dict
+
+    zero = {
+        "api_calls": 0, "input_tokens": 0, "output_tokens": 0,
+        "cache_read_tokens": 0, "cache_write_tokens": 0,
+        "reasoning_tokens": 0, "estimated_cost_usd": 0, "actual_cost_usd": 0,
+    }
+    end = {
+        "api_calls": 2, "input_tokens": 100, "output_tokens": 10,
+        "cache_read_tokens": 80, "cache_write_tokens": 5,
+        "reasoning_tokens": 4, "estimated_cost_usd": 0.2, "actual_cost_usd": 0.15,
+    }
+    with kbc.connect() as conn:
+        task_id = kb.create_task(conn, title="json", assignee="implementer")
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None and claimed.current_run_id is not None
+        run_id = claimed.current_run_id
+        assert kb.record_run_session(
+            conn, task_id, run_id, worker_session_id="session-json",
+            effective_provider="provider", effective_model="model",
+            fresh_or_resumed="fresh", usage_start=zero,
+        )
+        kb.record_run_runner_handle(conn, task_id, run_id, runner="hermes")
+        kb.complete_task(conn, task_id, summary="done", expected_run_id=run_id)
+        kb.finalize_run_usage(
+            conn, task_id, run_id, worker_session_id="session-json", usage_end=end,
+        )
+
+        run = kb.list_runs(conn, task_id)[0]
+        assert "receipt" in _RUNS_RUN_FIELDS
+        assert "receipt" in _SHOW_RUN_FIELDS
+        assert _obj_dict(run, _RUNS_RUN_FIELDS)["receipt"]["worker_session_id"] == "session-json"
+
+        aggregates = kb.aggregate_run_receipts(conn, task_id=task_id)
+        assert aggregates == [{
+            "task_id": task_id, "step_key": None, "profile": "implementer",
+            "effective_provider": "provider", "effective_model": "model",
+            "runner": "hermes", "outcome": "completed",
+            "fresh_or_resumed": "fresh", "run_count": 1,
+            "complete_receipt_count": 1, "api_calls": 2,
+            "input_tokens": 100, "output_tokens": 10,
+            "cache_read_tokens": 80, "cache_write_tokens": 5,
+            "reasoning_tokens": 4, "estimated_cost_usd": pytest.approx(0.2),
+            "actual_cost_usd": pytest.approx(0.15),
+        }]
+
+
 # ---------------------------------------------------------------------------
 # Task creation + status inference
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db_init.py
+++ b/tests/hermes_cli/test_kanban_db_init.py
@@ -237,3 +237,28 @@ def test_healthy_fast_path_stays_lock_free(tmp_path, monkeypatch):
     with kbc.connect_closing(db_path):
         pass
     assert len(locks) == 1
+
+
+def test_concurrent_initialization_creates_run_receipt_schema(tmp_path, monkeypatch):
+    db_path = _default_board_db(tmp_path, monkeypatch)
+    barrier = threading.Barrier(6)
+    errors: list[BaseException] = []
+
+    def initialize() -> None:
+        try:
+            barrier.wait(timeout=5)
+            with kbc.connect_closing(db_path) as conn:
+                assert conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name='task_run_receipts'"
+                ).fetchone() is not None
+        except BaseException as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=initialize) for _ in range(6)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert not errors
+    assert all(not thread.is_alive() for thread in threads)

--- a/tests/hermes_cli/test_kanban_worker_receipts.py
+++ b/tests/hermes_cli/test_kanban_worker_receipts.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+from types import SimpleNamespace
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli.kanban_worker_receipts import (
+    _worktree_fingerprint,
+    begin_worker_receipt,
+    finalize_worker_receipt,
+)
+from hermes_state import SessionDB
+
+
+def test_worker_lifecycle_records_route_context_and_usage_delta(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+
+    with kbc.connect() as conn:
+        task_id = kb.create_task(
+            conn, title="instrument", body="measure this run", assignee="implementer",
+            skills=["test-driven-development"],
+        )
+        claimed = kb.claim_task(conn, task_id)
+        assert claimed is not None and claimed.current_run_id is not None
+        run_id = claimed.current_run_id
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    monkeypatch.setenv("HERDR_ENV", "1")
+    monkeypatch.setenv("HERMES_PROFILE", "implementer")
+
+    session_db = SessionDB(home / "state.db")
+    session_db.create_session("session-1", source="kanban")
+    session_db.update_token_counts(
+        "session-1", input_tokens=10, output_tokens=2, model="effective-model",
+        billing_provider="effective-provider", api_call_count=1,
+    )
+    agent = SimpleNamespace(
+        session_id="session-1", provider="effective-provider", model="effective-model",
+        reasoning_config={"enabled": True, "effort": "high"},
+        _cached_system_prompt="trusted system prompt",
+    )
+    cli = SimpleNamespace(
+        agent=agent, session_id="session-1", _session_db=session_db,
+        requested_provider="requested-provider", model="effective-model",
+        reasoning_config={"effort": "medium"}, enabled_toolsets=["file", "terminal"],
+        _resumed=True,
+    )
+
+    state = begin_worker_receipt(cli)
+    assert state is not None
+    with kbc.connect() as conn:
+        receipt = kb.get_run_receipt(conn, run_id)
+        assert receipt is not None
+        assert receipt.runner == "herdr"
+        assert receipt.worker_session_id == "session-1"
+        assert receipt.profile == "implementer"
+        assert receipt.requested_provider == "requested-provider"
+        assert receipt.effective_provider == "effective-provider"
+        assert receipt.effective_model == "effective-model"
+        assert receipt.requested_reasoning == "medium"
+        assert receipt.effective_reasoning == "high"
+        assert receipt.fresh_or_resumed == "resumed"
+        assert receipt.context_chars > 0
+        assert len(receipt.context_fingerprint or "") == 64
+        assert len(receipt.system_prompt_hash or "") == 64
+        assert len(receipt.toolset_hash or "") == 64
+        assert len(receipt.skills_hash or "") == 64
+
+    session_db.update_token_counts(
+        "session-1", input_tokens=90, output_tokens=18, cache_read_tokens=40,
+        reasoning_tokens=5, estimated_cost_usd=0.12, model="effective-model",
+        billing_provider="effective-provider", api_call_count=2,
+    )
+    session_db.create_session(
+        "session-2", source="compression", parent_session_id="session-1",
+    )
+    session_db.update_token_counts(
+        "session-2", input_tokens=7, output_tokens=3, cache_read_tokens=50,
+        reasoning_tokens=2, estimated_cost_usd=0.03, model="effective-model",
+        billing_provider="effective-provider", api_call_count=1,
+    )
+    agent.session_id = "session-2"
+    with kbc.connect() as conn:
+        kb.complete_task(conn, task_id, summary="done", expected_run_id=run_id)
+
+    assert finalize_worker_receipt(cli, state)
+    with kbc.connect() as conn:
+        receipt = kb.get_run_receipt(conn, run_id)
+        assert receipt is not None
+        assert receipt.receipt_completeness == "complete"
+        assert receipt.api_call_delta == 3
+        assert receipt.input_token_delta == 97
+        assert receipt.output_token_delta == 21
+        assert receipt.cache_read_token_delta == 90
+        assert receipt.reasoning_token_delta == 7
+
+    session_db.close()
+
+
+def test_worktree_fingerprint_tracks_head_diff_and_untracked_content(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "receipt@example.test"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Receipt Test"], cwd=repo, check=True)
+    tracked = repo / "tracked.txt"
+    tracked.write_text("one\n", encoding="utf-8")
+    subprocess.run(["git", "add", "tracked.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "base"], cwd=repo, check=True)
+
+    clean = _worktree_fingerprint(repo)
+    assert clean is not None and clean.startswith("git-v1:")
+    tracked.write_text("two\n", encoding="utf-8")
+    dirty = _worktree_fingerprint(repo)
+    assert dirty is not None and dirty != clean
+    untracked = repo / "new.txt"
+    untracked.write_text("first\n", encoding="utf-8")
+    first_untracked = _worktree_fingerprint(repo)
+    untracked.write_text("second\n", encoding="utf-8")
+    assert _worktree_fingerprint(repo) != first_untracked

--- a/tests/hermes_state/test_aux_usage_accounting.py
+++ b/tests/hermes_state/test_aux_usage_accounting.py
@@ -39,6 +39,51 @@ def _usage_rows(db, session_id):
     return [dict(r) for r in rows]
 
 
+def test_session_usage_snapshot_conserves_main_and_auxiliary_usage(db):
+    db.create_session("s1", source="cli")
+    db.update_token_counts(
+        "s1", input_tokens=100, output_tokens=10, cache_read_tokens=80,
+        cache_write_tokens=4, reasoning_tokens=3, estimated_cost_usd=0.25,
+        actual_cost_usd=0.20, model="main", billing_provider="provider",
+        api_call_count=1,
+    )
+    db.record_auxiliary_usage(
+        "s1", "review", input_tokens=30, output_tokens=5,
+        cache_read_tokens=20, cache_write_tokens=1, reasoning_tokens=2,
+        estimated_cost_usd=0.05, model="aux", billing_provider="provider",
+        api_call_count=2,
+    )
+
+    assert db.session_usage_snapshot("s1") == {
+        "api_calls": 3,
+        "input_tokens": 130,
+        "output_tokens": 15,
+        "cache_read_tokens": 100,
+        "cache_write_tokens": 5,
+        "reasoning_tokens": 5,
+        "estimated_cost_usd": pytest.approx(0.30),
+        "actual_cost_usd": pytest.approx(0.20),
+    }
+
+
+def test_session_lineage_usage_snapshot_excludes_sibling_segments(db):
+    db.create_session("root", source="test")
+    db.create_session("child", source="compression", parent_session_id="root")
+    db.create_session("sibling", source="compression", parent_session_id="root")
+    for session_id, input_tokens, output_tokens in (
+        ("root", 10, 1), ("child", 20, 2), ("sibling", 40, 4),
+    ):
+        db.update_token_counts(
+            session_id, input_tokens=input_tokens, output_tokens=output_tokens,
+            model="model", billing_provider="provider",
+        )
+
+    snapshot = db.session_lineage_usage_snapshot("child")
+
+    assert snapshot["input_tokens"] == 30
+    assert snapshot["output_tokens"] == 3
+
+
 class TestRecordAuxiliaryUsage:
     def test_records_task_row(self, db):
         db.create_session("s1", source="cli")


### PR DESCRIPTION
## Summary

- add one-to-one, run-fenced Kanban execution receipts without changing dispatch decisions
- record worker session lineage, requested/effective route, context hashes, Hermes/Herdr handles, worktree fingerprints, and per-run usage deltas
- expose receipts additively through run serialization and ticket-level aggregation
- preserve unknown usage on crash/timeout receipts and harden concurrent database initialization

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_worker_receipts.py -q` — 41 passed, 1 skipped
- focused Phase 1 suite — 71 passed, 1 skipped
- Python compilation — passed
- Ruff on changed files — passed
- `ty` on the new receipt modules — passed
- `git diff --check` — passed
- two independent reviews completed; final focused re-review approved the amended digest

## Review notes

The tests were observed red before the implementation/fixes and green afterward. Instrumentation is additive: no dispatch or review decision depends on receipt data in this phase.
