### PR TITLE
fix(gateway): keep platform dependency installs off the event loop

### DIFF
--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -7,6 +7,7 @@ registry first, then the legacy built-in path. Plugin side: ``platform_registry
 .register(PlatformEntry(...))``; gateway side: ``create_adapter("irc", platform_config)``.
 """
 
+import asyncio
 import logging
 import sys
 import threading
@@ -349,6 +350,20 @@ class PlatformRegistry:
     def create_adapter(self, name: str, config: Any) -> Optional[Any]:
         """Create an adapter instance for *name*; None when no entry exists, deps are missing
         and cannot be installed, ``validate_config`` fails, or the factory raises."""
+        return self._construct_adapter(self._prepare_adapter(name), config)
+
+    async def create_adapter_async(self, name: str, config: Any) -> Optional[Any]:
+        """Prepare SDK dependencies off-loop, then construct on the caller's loop.
+
+        Deferred plugin imports and installers can block on disk/network I/O. Keep
+        their profile ContextVars via to_thread, while factories may bind asyncio
+        resources to the gateway loop and must stay on it.
+        """
+        entry = await asyncio.to_thread(self._prepare_adapter, name)
+        return self._construct_adapter(entry, config)
+
+    def _prepare_adapter(self, name: str) -> Optional[PlatformEntry]:
+        """Resolve the plugin and make its dependencies available before construction."""
         entry = self.get(name)
         if entry is None:
             return None
@@ -367,6 +382,12 @@ class PlatformRegistry:
         if not deps_ok:
             hint = f" ({entry.install_hint})" if entry.install_hint else ""
             logger.warning("Platform '%s' requirements not met%s", entry.label, hint)
+            return None
+        return entry
+
+    @staticmethod
+    def _construct_adapter(entry: Optional[PlatformEntry], config: Any) -> Optional[Any]:
+        if entry is None:
             return None
         if entry.validate_config is not None:
             try:

--- a/gateway/run_adapters.py
+++ b/gateway/run_adapters.py
@@ -710,7 +710,7 @@ class GatewayAdapterLifecycleMixin:
         logger.info("Reconnecting %s (attempt %d)...", platform.value, attempt)
         adapter = None
         try:
-            adapter = self._create_adapter(platform, platform_config)
+            adapter = await self._create_adapter(platform, platform_config)
             if not adapter:
                 self._drop_from_reconnect_queue(platform, "adapter creation returned None")
                 return
@@ -991,7 +991,7 @@ class GatewayAdapterLifecycleMixin:
                 platform.value, exc_info=True,
             ):
                 with _profile_runtime_scope(profile_home, hydrate_secrets=False):
-                    adapter = self._create_adapter(platform, platform_config)
+                    adapter = await self._create_adapter(platform, platform_config)
                 if not adapter:
                     logger.warning(
                         "[MULTIPLEX] Profile '%s': skipping platform '%s' - adapter creation returned None",
@@ -1109,7 +1109,7 @@ class GatewayAdapterLifecycleMixin:
                     platform.value, profile_name,
                 )
                 return None, None
-            adapter = self._create_adapter(platform, profile_config)
+            adapter = await self._create_adapter(platform, profile_config)
             if adapter is None:
                 logger.warning(
                     "Secondary %s reconnect skipped: adapter unavailable (profile: %s)",
@@ -1470,15 +1470,15 @@ class GatewayAdapterLifecycleMixin:
                 return hashlib.sha256(("hermes-mux:" + val.strip()).encode("utf-8")).hexdigest()[:16]
         return None
 
-    def _create_adapter(self, platform: Platform, config: Any) -> Optional[BasePlatformAdapter]:
+    async def _create_adapter(self, platform: Platform, config: Any) -> Optional[BasePlatformAdapter]:
         """Create an adapter bound to this runner (every lifecycle path goes through here so
         adapters can resolve inbound profile routes before handlers or connect())."""
-        adapter = self._instantiate_adapter(platform, config)
+        adapter = await self._instantiate_adapter(platform, config)
         if adapter is not None:
             adapter.gateway_runner = self
         return adapter
 
-    def _instantiate_adapter(self, platform: Platform, config: Any) -> Optional[BasePlatformAdapter]:
+    async def _instantiate_adapter(self, platform: Platform, config: Any) -> Optional[BasePlatformAdapter]:
         """Instantiate the adapter for a platform: plugin registry first, then built-ins."""
         from gateway.run import _instantiate_builtin_adapter
         if hasattr(config, "extra") and isinstance(config.extra, dict):
@@ -1489,7 +1489,7 @@ class GatewayAdapterLifecycleMixin:
         with _log_suppressed(logging.DEBUG, "Platform registry lookup for '%s' failed: %s", platform.value):
             from gateway.platform_registry import platform_registry
             if platform_registry.is_registered(platform.value):
-                adapter = platform_registry.create_adapter(platform.value, config)
+                adapter = await platform_registry.create_adapter_async(platform.value, config)
                 if adapter is None:  # registered but failed — never fall through to built-ins
                     logger.error(
                         "Platform '%s' is registered but adapter creation failed "

--- a/gateway/run_startup.py
+++ b/gateway/run_startup.py
@@ -1001,7 +1001,7 @@ class GatewayStartupMixin:
                 _multiplex_skipped_platforms.append(platform)
                 continue
             enabled_platform_count += 1
-            adapter = self._create_adapter(platform, platform_config)
+            adapter = await self._create_adapter(platform, platform_config)
             if not adapter:
                 # Distinguish between missing builtin deps and missing plugin
                 if platform.value in {m.value for m in Platform.__members__.values()}:

--- a/tests/gateway/test_64674_multiplex_primary_token_scope.py
+++ b/tests/gateway/test_64674_multiplex_primary_token_scope.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -201,7 +201,7 @@ class TestPrimaryStartupSkipsEmptyTokenUnderMultiplex:
             created.append(platform)
             return MagicMock()
 
-        runner._create_adapter = _fake_create  # type: ignore[method-assign]
+        runner._create_adapter = AsyncMock(side_effect=_fake_create)  # type: ignore[method-assign]
         runner._abort_startup_if_shutdown_requested = MagicMock(return_value=False)  # type: ignore
         runner._update_platform_runtime_status = MagicMock()  # type: ignore
         runner._start_secondary_profile_adapters = MagicMock(return_value=0)  # type: ignore

--- a/tests/gateway/test_adapter_dependency_liveness.py
+++ b/tests/gateway/test_adapter_dependency_liveness.py
@@ -1,0 +1,111 @@
+"""Slow platform preparation must leave the gateway loop and profile scope intact."""
+
+import asyncio
+import threading
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platform_registry import PlatformEntry, PlatformRegistry
+from gateway.run import GatewayRunner, _profile_runtime_scope
+from hermes_constants import get_hermes_home
+
+
+def _startup_runner(monkeypatch):
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.FEISHU: PlatformConfig(enabled=True, token="fixture-token")}
+    )
+    runner._restart_requested = runner._draining = False
+    runner._shutdown_event = asyncio.Event()
+    # Handler wiring follows construction; no dependency/registry/factory step is replaced.
+    runner._wire_adapter_handlers = Mock()
+    registry = PlatformRegistry()
+    monkeypatch.setattr("gateway.platform_registry.platform_registry", registry)
+    return runner, registry
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stage", ["load", "probe", "install"])
+@pytest.mark.parametrize("profile", ["default", "secondary"])
+async def test_startup_preparation_yields_and_preserves_profile(tmp_path, monkeypatch, stage, profile):
+    runner, registry = _startup_runner(monkeypatch)
+    home = tmp_path / profile
+    home.mkdir()
+    (home / "config.yaml").write_text("{}\n", encoding="utf-8")
+    loop = asyncio.get_running_loop()
+    released = threading.Event()
+    observations = []
+    responsive = []
+    adapter = SimpleNamespace()
+
+    def prepare_step(name):
+        observations.append((name, get_hermes_home()))
+        if name == stage:
+            # Only the gateway event loop can release the simulated blocking SDK work.
+            # The timeout makes the unfixed synchronous path fail instead of deadlocking.
+            loop.call_soon_threadsafe(released.set)
+            responsive.append(released.wait(5))
+
+    def probe():
+        prepare_step("probe")
+        return False
+
+    def install():
+        prepare_step("install")
+        return True
+
+    def factory(config):
+        observations.append(("factory", get_hermes_home()))
+        assert asyncio.get_running_loop() is loop
+        return adapter
+
+    def load():
+        prepare_step("load")
+        registry.register(PlatformEntry(
+            name="feishu", label="Fixture", check_fn=probe,
+            ensure_deps_fn=install, adapter_factory=factory,
+        ))
+
+    with _profile_runtime_scope(home, hydrate_secrets=False):
+        registry.register_deferred("feishu", load)
+        aborted, enabled, skipped, pending = await runner._start_prefilter_platforms()
+
+    assert responsive == [True], "platform preparation blocked the gateway event loop"
+    assert [name for name, _ in observations] == ["load", "probe", "install", "factory"]
+    assert all(path == home for _, path in observations)
+    assert not aborted and enabled == 1 and skipped == []
+    assert pending[0][2] is adapter and adapter.gateway_runner is runner
+    runner._wire_adapter_handlers.assert_called_once_with(adapter)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("raises", [False, True])
+async def test_failed_install_does_not_construct_or_fall_back(monkeypatch, raises):
+    runner, registry = _startup_runner(monkeypatch)
+    factory = Mock()
+    builtin = Mock(side_effect=AssertionError("registered platforms must not fall back"))
+    monkeypatch.setattr("gateway.run._instantiate_builtin_adapter", builtin)
+    loop = asyncio.get_running_loop()
+    released = threading.Event()
+    responsive = []
+
+    def install():
+        loop.call_soon_threadsafe(released.set)
+        responsive.append(released.wait(5))
+        if raises:
+            raise RuntimeError("package download failed")
+        return False
+
+    registry.register(PlatformEntry(
+        name="feishu", label="Fixture", check_fn=lambda: False,
+        ensure_deps_fn=install, adapter_factory=factory,
+    ))
+    aborted, enabled, skipped, pending = await runner._start_prefilter_platforms()
+
+    assert responsive == [True], "failed installation blocked the gateway event loop"
+    assert not aborted and enabled == 1 and skipped == [] and pending == []
+    factory.assert_not_called()
+    builtin.assert_not_called()

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -255,7 +255,7 @@ def _install_secondary_reconnect_context(
             },
         ),
     )
-    monkeypatch.setattr(runner, "_create_adapter", lambda platform, config: adapter)
+    monkeypatch.setattr(runner, "_create_adapter", AsyncMock(side_effect=lambda platform, config: adapter))
 
 
 class TestSecondaryProfileFatalRecovery:
@@ -447,7 +447,7 @@ class TestSecondaryStartupFailureRecovery:
         # Startup creates `failed`; the reconnect runner creates `replacement`.
         created = [failed, replacement]
         monkeypatch.setattr(
-            runner, "_create_adapter", lambda platform, config: created.pop(0)
+            runner, "_create_adapter", AsyncMock(side_effect=lambda platform, config: created.pop(0))
         )
 
         async def fail_initial_connect(adapter, platform):
@@ -512,7 +512,7 @@ class TestSecondaryStartupFailureRecovery:
 
         created = [failed, replacement]
         monkeypatch.setattr(
-            runner, "_create_adapter", lambda platform, config: created.pop(0)
+            runner, "_create_adapter", AsyncMock(side_effect=lambda platform, config: created.pop(0))
         )
 
         async def explode(adapter, platform):
@@ -559,7 +559,7 @@ class TestSecondaryStartupFailureRecovery:
         _install_secondary_reconnect_context(
             monkeypatch, runner, _SecondaryRecoveryAdapter()
         )
-        monkeypatch.setattr(runner, "_create_adapter", lambda platform, config: failed)
+        monkeypatch.setattr(runner, "_create_adapter", AsyncMock(side_effect=lambda platform, config: failed))
 
         async def fail_initial_connect(adapter, platform):
             return False
@@ -592,7 +592,7 @@ class TestSecondaryStartupFailureRecovery:
         _install_secondary_reconnect_context(
             monkeypatch, runner, _SecondaryRecoveryAdapter()
         )
-        monkeypatch.setattr(runner, "_create_adapter", lambda platform, config: failed)
+        monkeypatch.setattr(runner, "_create_adapter", AsyncMock(side_effect=lambda platform, config: failed))
         statuses = []
         monkeypatch.setattr(
             runner,
@@ -635,7 +635,7 @@ class TestSecondaryStartupFailureRecovery:
         _install_secondary_reconnect_context(
             monkeypatch, runner, _SecondaryRecoveryAdapter()
         )
-        monkeypatch.setattr(runner, "_create_adapter", lambda platform, config: failed)
+        monkeypatch.setattr(runner, "_create_adapter", AsyncMock(side_effect=lambda platform, config: failed))
 
         async def fail_initial_connect(adapter, platform):
             return False
@@ -736,7 +736,7 @@ class TestSecondaryProfileConfigHandling:
         writes = []
 
         monkeypatch.setattr("gateway.config.load_gateway_config", lambda: config)
-        monkeypatch.setattr(runner, "_create_adapter", lambda _p, _c: adapter)
+        monkeypatch.setattr(runner, "_create_adapter", AsyncMock(side_effect=lambda _p, _c: adapter))
         monkeypatch.setattr(
             runner,
             "_update_platform_runtime_status",
@@ -784,7 +784,7 @@ class TestSecondaryProfileConfigHandling:
         writes = []
 
         monkeypatch.setattr("gateway.config.load_gateway_config", lambda: config)
-        monkeypatch.setattr(runner, "_create_adapter", lambda _p, _c: adapter)
+        monkeypatch.setattr(runner, "_create_adapter", AsyncMock(side_effect=lambda _p, _c: adapter))
         monkeypatch.setattr(
             runner,
             "_update_platform_runtime_status",
@@ -935,7 +935,7 @@ class TestSecondaryProfileConfigHandling:
             return True
 
         monkeypatch.setattr("gateway.config.load_gateway_config", lambda: reviewer_cfg)
-        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: secondary)
+        monkeypatch.setattr(runner, "_create_adapter", AsyncMock(side_effect=lambda p, c: secondary))
         monkeypatch.setattr(runner, "_connect_adapter_with_timeout", _connect)
         monkeypatch.setattr(
             runner, "_make_adapter_auth_check", lambda p, **kwargs: None
@@ -993,7 +993,7 @@ class TestSecondaryProfileConfigHandling:
             return adapter.should_connect
 
         monkeypatch.setattr("gateway.config.load_gateway_config", lambda: profile_cfg)
-        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: next(adapters))
+        monkeypatch.setattr(runner, "_create_adapter", AsyncMock(side_effect=lambda p, c: next(adapters)))
         monkeypatch.setattr(runner, "_connect_adapter_with_timeout", _connect)
         monkeypatch.setattr(
             runner, "_make_adapter_auth_check", lambda p, **kwargs: None
@@ -1058,7 +1058,7 @@ class TestSecondaryProfileConfigHandling:
         async def _connect(adapter, platform):
             return True
 
-        monkeypatch.setattr(runner, "_create_adapter", _create_adapter)
+        monkeypatch.setattr(runner, "_create_adapter", AsyncMock(side_effect=_create_adapter))
         monkeypatch.setattr(runner, "_connect_initial_adapter_with_timeout", _connect)
 
         connected = await runner._start_one_profile_adapters("clientbot", "/tmp/x", {})
@@ -1136,7 +1136,7 @@ class TestFeishuPortBindingConditional:
             ),
         }
         monkeypatch.setattr("gateway.config.load_gateway_config", lambda: reviewer_cfg)
-        monkeypatch.setattr(runner, "_create_adapter", lambda p, c: None)
+        monkeypatch.setattr(runner, "_create_adapter", AsyncMock(side_effect=lambda p, c: None))
 
         connected = await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
         assert connected == 0  # no error, just nothing connected
@@ -1168,7 +1168,7 @@ class TestSecondarySkipsCredentiallessPlatforms:
             return _FakeAdapter(token=platform_config.token or None)
 
         monkeypatch.setattr("gateway.config.load_gateway_config", lambda: profile_cfg)
-        monkeypatch.setattr(runner, "_create_adapter", fake_create)
+        monkeypatch.setattr(runner, "_create_adapter", AsyncMock(side_effect=fake_create))
         monkeypatch.setattr(runner, "_configure_profile_adapter", lambda *a, **k: None)
         monkeypatch.setattr(
             runner,

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -104,7 +104,7 @@ class TestStartupPlatformIsolation:
             Platform.TELEGRAM: StubAdapter(platform=Platform.TELEGRAM),
             Platform.FEISHU: StubAdapter(platform=Platform.FEISHU),
         }
-        runner._create_adapter = MagicMock(
+        runner._create_adapter = AsyncMock(
             side_effect=lambda platform, _config: adapters[platform]
         )
         runner._connect_adapter_with_timeout = AsyncMock(

--- a/tests/gateway/test_profile_resolution.py
+++ b/tests/gateway/test_profile_resolution.py
@@ -246,7 +246,8 @@ class TestGatewayRunnerInjection:
         assert hasattr(BasePlatformAdapter, "gateway_runner")
         assert BasePlatformAdapter.gateway_runner is None
 
-    def test_factory_binds_every_adapter_to_runner(self, monkeypatch):
+    @pytest.mark.asyncio
+    async def test_factory_binds_every_adapter_to_runner(self, monkeypatch):
         """``_create_adapter`` binds the runner regardless of which branch
         built the adapter (plugin registry OR built-in if/elif) — every
         lifecycle path (startup, reconnect, secondary profiles) goes through
@@ -256,11 +257,11 @@ class TestGatewayRunnerInjection:
 
         runner = object.__new__(GatewayRunner)
         adapter = MagicMock(spec=BasePlatformAdapter)
-        monkeypatch.setattr(runner, "_instantiate_adapter", lambda platform, config: adapter)
-        assert runner._create_adapter(Platform.SIGNAL, PlatformConfig(enabled=True)) is adapter
+        monkeypatch.setattr(runner, "_instantiate_adapter", AsyncMock(side_effect=lambda platform, config: adapter))
+        assert await runner._create_adapter(Platform.SIGNAL, PlatformConfig(enabled=True)) is adapter
         assert adapter.gateway_runner is runner
-        monkeypatch.setattr(runner, "_instantiate_adapter", lambda platform, config: None)
-        assert runner._create_adapter(Platform.SIGNAL, PlatformConfig(enabled=True)) is None
+        monkeypatch.setattr(runner, "_instantiate_adapter", AsyncMock(side_effect=lambda platform, config: None))
+        assert await runner._create_adapter(Platform.SIGNAL, PlatformConfig(enabled=True)) is None
 
     @pytest.mark.asyncio
     async def test_real_signal_factory_routes_inbound_group_event(self, monkeypatch):
@@ -278,7 +279,7 @@ class TestGatewayRunnerInjection:
                 ProfileRoute(name="signal", platform="signal", profile="ops", chat_id=f"group:{group_id}"),
             ],
         )
-        adapter = runner._create_adapter(
+        adapter = await runner._create_adapter(
             Platform.SIGNAL,
             PlatformConfig(enabled=True, extra={"http_url": "http://127.0.0.1:18080", "account": "+15555550123"}),
         )
@@ -444,5 +445,4 @@ class TestMultiplexGate:
         discord_source.profile = None
 
         assert mock_runner._profile_name_for_source(discord_source) is None
-
 

--- a/tests/gateway/test_runner_startup_failures.py
+++ b/tests/gateway/test_runner_startup_failures.py
@@ -357,7 +357,7 @@ async def test_runner_degrades_gracefully_when_all_adapters_missing(monkeypatch,
 
     # Simulate _create_adapter returning None for ALL platforms (missing library /
     # missing credentials — no connection attempt ever made).
-    monkeypatch.setattr(runner, "_create_adapter", lambda platform, cfg: None)
+    monkeypatch.setattr(runner, "_create_adapter", AsyncMock(side_effect=lambda platform, cfg: None))
 
     import logging
     with caplog.at_level(logging.WARNING):
@@ -414,7 +414,7 @@ async def test_runner_exits_with_ex_config_on_nonretryable_startup_error(monkeyp
     )
     runner = GatewayRunner(config)
 
-    monkeypatch.setattr(runner, "_create_adapter", lambda platform, platform_config: _NonRetryableFailureAdapter())
+    monkeypatch.setattr(runner, "_create_adapter", AsyncMock(side_effect=lambda platform, platform_config: _NonRetryableFailureAdapter()))
 
     ok = await runner.start()
 
@@ -514,7 +514,7 @@ async def test_live_foreign_token_lock_at_startup_exits_ex_config(monkeypatch, t
     )
     runner = GatewayRunner(config)
     monkeypatch.setattr(
-        runner, "_create_adapter", lambda platform, platform_config: _ForeignTokenLockAdapter()
+        runner, "_create_adapter", AsyncMock(side_effect=lambda platform, platform_config: _ForeignTokenLockAdapter())
     )
 
     ok = await runner.start()
@@ -558,9 +558,9 @@ async def test_token_lock_plus_retryable_peer_stays_alive(monkeypatch, tmp_path)
     monkeypatch.setattr(
         runner,
         "_create_adapter",
-        lambda platform, cfg: (
+        AsyncMock(side_effect=lambda platform, cfg: (
             _ForeignTokenLockAdapter() if platform is Platform.TELEGRAM else _DiscordBlip()
-        ),
+        )),
     )
 
     ok = await runner.start()

--- a/tests/gateway/test_startup_connect_parallel.py
+++ b/tests/gateway/test_startup_connect_parallel.py
@@ -25,6 +25,7 @@ resolution -- ``time.monotonic()`` has only ~15 ms resolution on Windows
 wall-clock comparison. Event ordering cannot be defeated by a coarse clock.
 """
 
+from unittest.mock import AsyncMock
 import asyncio
 
 import pytest
@@ -105,7 +106,7 @@ async def test_startup_connects_platforms_concurrently(monkeypatch, tmp_path):
         sleep = 0.3 if platform is Platform.TELEGRAM else 0.0
         return _TimingAdapter(platform, sleep)
 
-    monkeypatch.setattr(runner, "_create_adapter", _make_adapter)
+    monkeypatch.setattr(runner, "_create_adapter", AsyncMock(side_effect=_make_adapter))
     # Keep the rest of startup lightweight / non-fatal.
     monkeypatch.setattr(runner, "_start_secondary_profile_adapters", lambda: 0)
 
@@ -172,7 +173,7 @@ async def test_startup_one_failing_platform_does_not_block_others(monkeypatch, t
             return _FailingSlowAdapter()
         return _TimingAdapter(platform, 0.0)
 
-    monkeypatch.setattr(runner, "_create_adapter", _make_adapter)
+    monkeypatch.setattr(runner, "_create_adapter", AsyncMock(side_effect=_make_adapter))
     monkeypatch.setattr(runner, "_start_secondary_profile_adapters", lambda: 0)
 
     await runner.start()
@@ -277,7 +278,7 @@ class TestTelegramColdStartCap:
                 return _WedgedAdapter()
             return _TimingAdapter(platform, 0.0)
 
-        monkeypatch.setattr(runner, "_create_adapter", _make_adapter)
+        monkeypatch.setattr(runner, "_create_adapter", AsyncMock(side_effect=_make_adapter))
         monkeypatch.setattr(runner, "_start_secondary_profile_adapters", lambda: 0)
 
         await asyncio.wait_for(runner.start(), timeout=30)

--- a/tests/gateway/test_startup_restart_race.py
+++ b/tests/gateway/test_startup_restart_race.py
@@ -146,7 +146,7 @@ async def test_startup_aborts_when_restart_begins_during_platform_connect(tmp_pa
         first_disconnected.set()
 
     telegram.disconnect = disconnect_and_release
-    runner._create_adapter = MagicMock(side_effect=[telegram, slack])
+    runner._create_adapter = AsyncMock(side_effect=[telegram, slack])
 
     result = await asyncio.wait_for(runner.start(), timeout=30)
 

--- a/tests/test_yuanbao_integration.py
+++ b/tests/test_yuanbao_integration.py
@@ -127,7 +127,8 @@ class TestGatewayRunnerRegistration:
         runner._session_model_overrides = {}
         return runner, GatewayRunner
 
-    def test_runner_creates_yuanbao_adapter(self):
+    @pytest.mark.asyncio
+    async def test_runner_creates_yuanbao_adapter(self):
         """GatewayRunner._create_adapter 能为 YUANBAO 返回 YuanbaoAdapter 实例"""
         from gateway.config import GatewayConfig
         config = make_config(enabled=True)
@@ -137,7 +138,7 @@ class TestGatewayRunnerRegistration:
             runner, _ = self._make_minimal_runner(gw_config)
             # websockets 在测试环境可能未安装，mock 掉 WEBSOCKETS_AVAILABLE
             with patch("gateway.platforms.yuanbao.WEBSOCKETS_AVAILABLE", True):
-                adapter = runner._create_adapter(Platform.YUANBAO, config)
+                adapter = await runner._create_adapter(Platform.YUANBAO, config)
         except ImportError as e:
             pytest.skip(f"run.py import unavailable in test env: {e}")
 

--- a/website/docs/developer-guide/adding-platform-adapters.md
+++ b/website/docs/developer-guide/adding-platform-adapters.md
@@ -635,7 +635,7 @@ Three touchpoints:
 
 Six touchpoints:
 
-1. **`_BUILTIN_ADAPTERS` table** (`gateway/run.py`) — Add a `Platform.NEWPLAT: (module, class, check_fn, error_msg)` entry; `_instantiate_adapter()` (`gateway/run_adapters.py`) consults the plugin registry, then this table — there is no `elif` chain to extend. The `_create_adapter()` wrapper binds every successful adapter to its gateway runner.
+1. **`_BUILTIN_ADAPTERS` table** (`gateway/run.py`) — Add a `Platform.NEWPLAT: (module, class, check_fn, error_msg)` entry; `_instantiate_adapter()` (`gateway/run_adapters.py`) consults the plugin registry, then this table — there is no `elif` chain to extend. Await `_create_adapter()` to prepare registered plugins and SDK dependencies off-loop, construct the adapter on the gateway loop, and bind it to its gateway runner. The registry retains synchronous `create_adapter()` for synchronous callers.
 2. **`_is_user_authorized()` allowed_users map** — `Platform.NEWPLAT: "NEWPLAT_ALLOWED_USERS"`
 3. **`_is_user_authorized()` allow_all map** — `Platform.NEWPLAT: "NEWPLAT_ALLOW_ALL_USERS"`
 4. **Startup access-policy check** (`gateway/run_startup.py`) — Add `"NEWPLAT"` to `_ALLOWLIST_ENV_PLATFORMS` (derives both `NEWPLAT_ALLOWED_USERS` and `NEWPLAT_ALLOW_ALL_USERS`)


### PR DESCRIPTION
## What does this PR do?

A slow platform dependency install currently runs synchronously inside the gateway's async startup/reconnect path. It can stop the event-loop heartbeat long enough for the watchdog to terminate the gateway with exit 75, as reported for Feishu.

Run deferred plugin loading, dependency checks and installation in a worker thread with `asyncio.to_thread()`. Keep config validation and adapter construction on the gateway loop, where SDK factories may bind asyncio resources. Profile ContextVars are copied into the worker.

## Related Issue

Addresses the event-loop-blocking cause in #107318. This is independent of the Feishu SDK version updates in #78268 and #103980; it does not change dependency pins.

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `gateway/platform_registry.py`: share preparation/construction between the existing synchronous `create_adapter()` API and a new async entry point. Preserve failure handling.
- `gateway/run_adapters.py`, `gateway/run_startup.py`: await preparation during primary startup, primary reconnect, secondary-profile startup and secondary reconnect. Continue binding the runner before connecting; failed registered platforms still cannot fall through to built-ins.
- Add two invariant tests (8 parameterized cases), update existing async call sites/mocks, and document the adapter lifecycle contract.

## How to Test

Use `scripts/run_tests.sh`, as required by `AGENTS.md`, with the locked Python 3.11 environment and CI extras from `.github/workflows/tests.yml`.

```bash
scripts/run_tests.sh tests/gateway/test_adapter_dependency_liveness.py -q --tb=short
scripts/run_tests.sh tests/gateway/test_platform_registry.py tests/gateway/test_profile_resolution.py tests/gateway/test_platform_reconnect.py tests/gateway/test_platform_reconnect_fd_leak.py tests/gateway/test_multiplex_adapter_registry.py tests/gateway/test_64674_multiplex_primary_token_scope.py tests/gateway/test_startup_connect_parallel.py tests/gateway/test_runner_startup_failures.py tests/gateway/test_startup_restart_race.py tests/test_yuanbao_integration.py -j4 -q --tb=short
scripts/run_tests.sh tests/e2e/ -j2 -q --tb=short
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh -j12 -q --tb=short
```

Validation on macOS 26.6.2 arm64 / Python 3.11.14, using separately installed editable environments for base `284d220` and this branch:

| Check | Result |
| --- | --- |
| New invariant cases copied onto unchanged base | 8 failed: preparation blocks the loop |
| All 11 affected test files on final content (`81b04c9`) | 192 passed, 0 failed |
| E2E directory | 63 passed, 7 skipped, 0 failed |
| Deferred plugin + real child-process fixture | Both profile scopes passed; gateway heartbeat released the child while preparation was pending |
| Ruff, Windows-footgun check, compatibility-pointer check, `git diff --check` | Passed |

The regression tests enter the actual startup/registry path. An event released only by the gateway loop must unblock the simulated SDK work; adapter construction must see the original loop and profile. The failure cases check that an unsuccessful or raising installer never constructs an adapter or invokes the built-in fallback. No live Feishu credentials were used.

### Full-suite result and baseline comparison

The default Python suite completed at `ef338f4`: **4,011 files, 47,423 passed, 63 failed, 574 skipped, 3 xfailed, 1 xpassed, 0 errors**, in 888.3 seconds. Automatic file retries were disabled so failures remained visible.

All 29 failing files were rerun against unchanged base `284d220` in its own locked environment:

- **58 of the same failing test IDs reproduced on base.** They include macOS/native-tool assumptions, host proxy/fake-DNS effects, existing mock/expectation failures, and subprocess cleanup races.
- **4 remaining search failures passed fresh reruns on both revisions** (24/24 cases in the two affected files). The original logs show `ProcessLookupError` during `rg` cleanup. These are recorded as nondeterministic failures, not evidence of a fully green suite.
- **1 Yuanbao test needed an awaited call** after the runner method became async. That test-only correction is `81b04c9`; all 11 affected files were then rerun successfully (192/192). Production code is unchanged from the completed full run. The entire suite was not rerun after this test-only correction.

This PR is ready for review; upstream CI approval and results are still pending. The local full suite is **not green**, and the baseline comparison does not guarantee that Linux CI will pass. Local `rg` is 15.2.0; CI pins 15.1.0. The local interpreter wrapper only bypasses proxies for loopback addresses and sets `TMPDIR=/private/tmp`; it does not alter test assertions or emulate another OS.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the full test suite and all tests pass — completed with failures analyzed above; upstream CI pending
- [x] I've added invariant tests and proved them red on base
- [x] I've tested on my platform: macOS 26.6.2 arm64

### Documentation & Housekeeping

- [x] Updated adapter development documentation and relevant docstrings
- [x] Config example updates: N/A (no config keys changed)
- [x] Contributor workflow updates: N/A; the async adapter contract is documented in the adapter guide
- [x] Considered cross-platform impact; uses standard `asyncio.to_thread()` and preserves loop-bound construction
- [x] Tool description/schema updates: N/A

AI assistance: Codex assisted with implementation, investigation and validation.
