### PR TITLE
fix(config): preserve YAML formatting on `hermes config set`

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3415,9 +3415,23 @@ def _exit_invalid(msg: str) -> None:
 
 
 def _write_user_config(config_path: Path, user_config: Dict[str, Any]) -> None:
-    """Write only the user's raw config back (never the merged defaults)."""
+    """Write only the user's raw config back (never the merged defaults).
+
+    Uses ruamel.yaml round-trip mode so untouched keys keep their original
+    quote style, indentation, surrounding blank lines, and trailing comments.
+    Falls back to the PyYAML emitter if the file is unreadable (e.g. locked
+    by another process) so the write still succeeds — the fallback path keeps
+    the old behavior rather than silently dropping the change.
+    """
     ensure_hermes_home()
-    atomic_yaml_write(config_path, user_config, sort_keys=False)
+    try:
+        from utils import atomic_roundtrip_yaml_save
+        atomic_roundtrip_yaml_save(config_path, user_config)
+    except Exception:
+        # Fallback to the legacy PyYAML emitter only when the round-trip
+        # path itself fails (parse error, file missing, ruamel import error,
+        # etc.) — preserves the existing "set still saves" guarantee.
+        atomic_yaml_write(config_path, user_config, sort_keys=False)
 
 
 def _print_unknown_key_notice(key: str, suggestion: Optional[str]) -> None:

--- a/tests/hermes_cli/test_config_set_preserves_formatting.py
+++ b/tests/hermes_cli/test_config_set_preserves_formatting.py
@@ -1,0 +1,138 @@
+"""Tests for config-write formatting preservation.
+
+Background: ``hermes config set <key> <value>`` was previously reformatting
+the entire ``config.yaml`` on every write (PyYAML default emitter). Single
+quotes became double quotes, long lines got wrapped, trailing comments
+disappeared. This is regression-prone for downstream code that patches the
+config or diffs it in git.
+
+The fix uses ``ruamel.yaml`` round-trip mode so untouched keys keep their
+quote style, indentation, and surrounding blank lines.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+def _set_config_value_in_tmp(monkeypatch, tmp_path: Path, key: str, value: str):
+    """Helper: import set_config_value and call it with HERMES_HOME pinned."""
+    # Reproduce the production-grade HERMES_HOME pinning the rest of the
+    # hermes_cli test suite uses (see tests/conftest.py / hermes_test_utils).
+    home = tmp_path
+    home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "default")
+    from hermes_cli.config import set_config_value
+    set_config_value(key, value)
+
+
+def test_config_set_preserves_quoting_style(tmp_path: Path, monkeypatch):
+    """Single-quoted scalars must stay single-quoted (no auto-flip to double)."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "agent:\n"
+        "  model: 'gpt-4o'\n"            # single-quoted
+        "  temperature: 0.7\n",
+        encoding="utf-8",
+    )
+    _set_config_value_in_tmp(monkeypatch, tmp_path, "agent.temperature", "0.9")
+    text = cfg.read_text(encoding="utf-8")
+    assert "'gpt-4o'" in text, f"single quotes flipped to double in: {text!r}"
+    assert '"gpt-4o"' not in text, f"double quotes appeared: {text!r}"
+    assert "temperature: 0.9" in text
+
+
+def test_config_set_preserves_trailing_comment(tmp_path: Path, monkeypatch):
+    """Comments after a known key survive an unrelated key update."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "agent:\n"
+        "  model: 'gpt-4o'\n"
+        "  # this is a useful annotation\n"
+        "  temperature: 0.7\n",
+        encoding="utf-8",
+    )
+    _set_config_value_in_tmp(monkeypatch, tmp_path, "agent.temperature", "0.9")
+    text = cfg.read_text(encoding="utf-8")
+    assert "# this is a useful annotation" in text, f"comment lost: {text!r}"
+
+
+def test_config_set_preserves_blank_line_between_sections(tmp_path: Path, monkeypatch):
+    """Blank lines between sections are formatting, not data — preserve them."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "agent:\n"
+        "  model: 'gpt-4o'\n"
+        "  temperature: 0.7\n"
+        "\n"
+        "gateway:\n"
+        "  port: 8644\n",
+        encoding="utf-8",
+    )
+    _set_config_value_in_tmp(monkeypatch, tmp_path, "agent.temperature", "0.9")
+    text = cfg.read_text(encoding="utf-8")
+    # The blank line between the agent section and gateway: must survive.
+    # Either: temperature line followed by blank line then gateway, OR
+    # blank line preserved somewhere between the two top-level sections.
+    assert "\n\ngateway:\n" in text, f"section separator blank line lost: {text!r}"
+
+
+def test_config_set_preserves_top_level_scalar_format(tmp_path: Path, monkeypatch):
+    """Top-level scalar ``key: value`` must stay as block scalar, not flow-style."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "model: anthropic/claude-3\n"
+        "gateway:\n"
+        "  port: 8644\n",
+        encoding="utf-8",
+    )
+    _set_config_value_in_tmp(monkeypatch, tmp_path, "gateway.port", "9000")
+    text = cfg.read_text(encoding="utf-8")
+    assert "model: anthropic/claude-3\n" in text, f"top-level scalar reformatted: {text!r}"
+    # Must NOT have become {model: anthropic/claude-3, gateway: ...}
+    assert "{model:" not in text
+
+
+def test_config_set_preserves_list_block_style(tmp_path: Path, monkeypatch):
+    """Multi-line ``- item`` lists stay block-style, not inline ``[...]``."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "agents:\n"
+        "  skills:\n"
+        "    - name: web\n"
+        "      enabled: true\n"
+        "    - name: git\n"
+        "      enabled: true\n",
+        encoding="utf-8",
+    )
+    _set_config_value_in_tmp(monkeypatch, tmp_path, "agents.skills.0.enabled", "false")
+    text = cfg.read_text(encoding="utf-8")
+    # Block style preserved
+    assert "    - name: web\n" in text
+    assert "      enabled: false\n" in text
+    assert "      enabled: true\n" in text
+    # No flow-style inline list for the skills list
+    skills_section = text[text.index("agents:"):text.index("gateway:") if "gateway:" in text else len(text)]
+    assert "[{" not in skills_section, "list reformatted as inline flow-style"
+
+
+def test_config_set_unknown_key_appends_without_disturbing_known_keys(
+    tmp_path: Path, monkeypatch
+):
+    """Adding a NEW key must not touch the existing keys' formatting."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "agent:\n"
+        "  model: 'gpt-4o'\n"
+        "  temperature: 0.7\n",
+        encoding="utf-8",
+    )
+    _set_config_value_in_tmp(monkeypatch, tmp_path, "agent.max_tokens", "4096")
+    text = cfg.read_text(encoding="utf-8")
+    assert "'gpt-4o'" in text
+    assert "temperature: 0.7" in text
+    assert "max_tokens: 4096" in text


### PR DESCRIPTION
## What this fixes

`hermes config set <key> <value>` routed through `atomic_yaml_write`, which uses PyYAML's default emitter — so every write reformatted the entire file: single-quoted scalars became double-quoted, long lines wrapped, and trailing comments disappeared. That is hostile to anyone tracking `config.yaml` in git, and it silently drops the comments Hermes itself writes into the file.

The fix routes `_write_user_config` (the `set_config_value` write path) through `atomic_roundtrip_yaml_save`, the ruamel round-trip helper that **already exists in this repo** (`utils.py`, also used by `tui_gateway/server.py`) and already handles the YAML 1.1/1.2 ambiguity (`off`/`yes`/`on` are quoted so they stay strings).

Scope is deliberately limited to that one writer. `atomic_config_write` and `_save_config` keep their PyYAML path — their contracts differ and deserve separate review.

Verified live: `hermes config set model.supports_vision false` against an 845-line `config.yaml` changed exactly one line, preserving every other line's formatting and all trailing comments.

## Scope change (2026-09-13)

This PR previously carried seven unrelated commits — which is why #108810 and #108517 were closed as "superseded by #108850", and what triage flagged here as unreviewable. Those commits are now split out, and this branch contains **only** the `config set` formatting fix:

| split out | status |
|---|---|
| authority profile (`hermes_cli/authority.py`) | own PR on `feat/authority-profile-v2` |
| PATH pollution dedup (`hermes_cli/stdio.py`, `tools/environments/*`) | own PR on `fix/path-pollution-dedup-v2` |
| relay `pop_relay_scope` stale-handle tolerance | own PR on `fix/relay-pop-scope-stale-handle` |
| desktop postinstall/browserslist pins, kanban complete-gate statuses, write_file duplicate-drive-prefix guard | evaluated separately — landed or dropped on their own merits |

Apologies for the original bundle; it was assembled by stacking local commits rather than by topic.

## Relation to the other PRs on this issue

#63039 is also targeted by #72581, #105271 and #107537 (all open, three different approaches). This one is distinguishable by reusing the round-trip helper already in `utils.py` instead of adding a new YAML path.

## Tests

`tests/hermes_cli/test_config_set_preserves_formatting.py` (new — single-quote preservation, trailing comments, section blank lines, top-level scalar style, list block style, unknown-key append) plus `test_set_config_value.py` and `test_config.py`:

- baseline (unmodified `main`, same suite minus the new file): **215 passed**
- this branch: **221 passed**

The +6 are the new tests. No failures on either side.
