### PR TITLE
fix(tools): preserve sensitive path guards on Windows

### DIFF
--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -232,6 +232,11 @@ class TestSafeRootDenialMessageIntegration:
 class TestCheckSensitivePathMacOSBypass:
     """Verify _check_sensitive_path blocks /private/etc paths (issue #8734)."""
 
+    def test_windows_separators_are_compared_as_posix_paths(self):
+        from tools.file_tools_write_guards import _sensitive_path_match_form
+        assert _sensitive_path_match_form(r"\private\etc\hosts", windows=True) == "/private/etc/hosts"
+        assert _sensitive_path_match_form(r"C:\etc\hosts", windows=True) == "C:/etc/hosts"
+
     def test_etc_hosts_blocked(self):
         from tools.file_tools_write_guards import _check_sensitive_path
         assert _check_sensitive_path("/etc/hosts") is not None

--- a/tools/file_tools_write_guards.py
+++ b/tools/file_tools_write_guards.py
@@ -106,10 +106,24 @@ def _resolved_or_raw(filepath: str, task_id: str) -> str:
         return filepath
 
 
+def _sensitive_path_match_form(path: str, *, windows: bool | None = None) -> str:
+    """Return the separator form used by the POSIX sensitive-path denylist.
+
+    A leading POSIX path is accepted by the Windows CLI, but ``normpath`` and
+    task resolution turn its separators into backslashes.  Keep native paths
+    intact for every other guard and normalize only this lexical comparison.
+    """
+    if windows is None:
+        windows = os.name == "nt"
+    return path.replace("\\", "/") if windows else path
+
+
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     candidates = (_resolved_or_raw(filepath, task_id), os.path.normpath(_expand_tilde(filepath)))
-    if any(c.startswith(_SENSITIVE_PATH_PREFIXES) or c in _SENSITIVE_EXACT_PATHS for c in candidates):
+    sensitive_candidates = tuple(_sensitive_path_match_form(c) for c in candidates)
+    if any(c.startswith(_SENSITIVE_PATH_PREFIXES) or c in _SENSITIVE_EXACT_PATHS
+           for c in sensitive_candidates):
         return (
             f"Refusing to write to sensitive system path: {filepath}\n"
             "Use the terminal tool with sudo if you need to modify system files.")


### PR DESCRIPTION
## What does this PR do?

Keeps the POSIX sensitive-system-path denylist effective when Hermes runs on Windows. Windows path normalization converts inputs such as `/etc/hosts` and `/private/etc/hosts` to backslash-separated forms, so the existing prefix comparison missed them and five cross-platform safety tests failed.

The fix normalizes separators only for the lexical sensitive-path comparison. The original native candidates remain unchanged for the Hermes config and other guards, and drive-qualified paths such as `C:\etc\hosts` do not become POSIX system paths.

This intentionally does not add skips or sleeps. The two patch tests mentioned in #108825 could not be cleanly attributed to an atomic-write race here because the local environment first lacked a usable Bash; weakening persistence verification without a deterministic reproduction would hide a different failure.

## Related Issue

Addresses the five sensitive-path failures in #108825.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How to Test

- Before the fix on native Windows: `TestCheckSensitivePathMacOSBypass` reported 5 failures and 1 pass.
- After the fix: `pytest tests/tools/test_file_write_safety.py::TestCheckSensitivePathMacOSBypass -q` -> 7 passed.
- Adjacent focused suite: `pytest tests/tools/test_file_write_safety.py::TestStaticDenyList tests/tools/test_file_write_safety.py::TestCheckSensitivePathMacOSBypass -q` -> 9 passed.
- `ruff check tools/file_tools_write_guards.py tests/tools/test_file_write_safety.py` -> passed.
- `python -m compileall -q tools/file_tools_write_guards.py tests/tools/test_file_write_safety.py` -> passed.
- `git diff --check` -> passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched open, draft, closed, and merged PRs for duplicates
- [x] My PR contains only changes related to this fix
- [x] I've added a platform-independent regression assertion for separator normalization
- [x] I've tested on native Windows

### Documentation & Housekeeping

- [x] Documentation changes are not needed for this internal safety correction
- [x] Cross-platform impact was explicitly checked