### PR TITLE
fix(send_message): re-validate media paths at telegram/signal I/O (salvage of #34350)

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -468,6 +468,148 @@ class TestSendTelegramMediaDelivery:
 
 
 # ---------------------------------------------------------------------------
+# Defense-in-depth: per-platform send sites validate media paths (#34270)
+# ---------------------------------------------------------------------------
+
+
+class TestSendTelegramRevalidatesMediaPaths:
+    """Regression tests for #34270 (salvage of #34350)."""
+
+    def test_send_telegram_rejects_path_outside_safe_roots(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_MEDIA_DELIVERY_STRICT", "1")
+        monkeypatch.setenv("HERMES_MEDIA_TRUST_RECENT_FILES", "0")
+
+        unsafe = tmp_path / "leaked.pdf"
+        unsafe.write_bytes(b"%PDF leaked")
+        other = tmp_path / "safe-zone"
+        other.mkdir()
+        monkeypatch.setattr(
+            "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+            (str(other),),
+        )
+
+        bot = MagicMock()
+        bot.send_message = AsyncMock()
+        bot.send_photo = AsyncMock()
+        bot.send_video = AsyncMock()
+        bot.send_voice = AsyncMock()
+        bot.send_audio = AsyncMock()
+        bot.send_document = AsyncMock()
+        _install_telegram_mock(monkeypatch, bot)
+
+        result = asyncio.run(
+            _send_telegram(
+                "token",
+                "12345",
+                "caption",
+                media_files=[(str(unsafe), False)],
+            )
+        )
+
+        # Caption may ride on the media bubble; skipped unsafe media must
+        # not send the file. Text send is optional depending on caption split.
+        bot.send_document.assert_not_awaited()
+        bot.send_photo.assert_not_awaited()
+        bot.send_video.assert_not_awaited()
+
+        assert result.get("warnings"), (
+            f"expected a warning about unsafe media path, got {result!r}"
+        )
+        joined = "\n".join(result["warnings"])
+        assert "unsafe" in joined.lower() or "allowed roots" in joined.lower()
+
+    def test_send_telegram_accepts_path_inside_safe_roots(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+            (str(tmp_path),),
+        )
+        ok = tmp_path / "ok.pdf"
+        ok.write_bytes(b"%PDF safe")
+
+        bot = MagicMock()
+        bot.send_message = AsyncMock()
+        bot.send_photo = AsyncMock()
+        bot.send_video = AsyncMock()
+        bot.send_voice = AsyncMock()
+        bot.send_audio = AsyncMock()
+        bot.send_document = AsyncMock(return_value=SimpleNamespace(message_id=42))
+        _install_telegram_mock(monkeypatch, bot)
+
+        result = asyncio.run(
+            _send_telegram(
+                "token",
+                "12345",
+                "",
+                media_files=[(str(ok), False)],
+            )
+        )
+
+        assert not result.get("warnings"), result
+        bot.send_document.assert_awaited_once()
+
+
+class TestSendSignalRevalidatesMediaPaths:
+    """Mirror of the Telegram test for the Signal path (#34270)."""
+
+    def test_send_signal_rejects_path_outside_safe_roots(self, tmp_path, monkeypatch, caplog):
+        import logging
+
+        monkeypatch.setenv("HERMES_MEDIA_DELIVERY_STRICT", "1")
+        monkeypatch.setenv("HERMES_MEDIA_TRUST_RECENT_FILES", "0")
+
+        unsafe = tmp_path / "leaked.pdf"
+        unsafe.write_bytes(b"%PDF leaked")
+        other = tmp_path / "safe-zone"
+        other.mkdir()
+        monkeypatch.setattr(
+            "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+            (str(other),),
+        )
+
+        captured_payloads = []
+
+        class _FakeResp:
+            status_code = 200
+            def json(self):
+                return {"result": {"timestamp": 1}}
+            def raise_for_status(self):
+                pass
+
+        class _FakeClient:
+            def __init__(self, *a, **kw): pass
+            async def __aenter__(self): return self
+            async def __aexit__(self, *a): return False
+            async def post(self, *a, **kw):
+                captured_payloads.append(kw.get("json"))
+                return _FakeResp()
+
+        import httpx
+        monkeypatch.setattr(httpx, "AsyncClient", _FakeClient)
+
+        with caplog.at_level(logging.WARNING):
+            result = asyncio.run(
+                _send_signal(
+                    {"http_url": "http://127.0.0.1:8080", "account": "+15555550000"},
+                    "+15555551111",
+                    "hi",
+                    media_files=[(str(unsafe), False)],
+                )
+            )
+
+        warned = any("unsafe media path" in r.getMessage().lower()
+                     or "outside allowed roots" in r.getMessage().lower()
+                     for r in caplog.records)
+        assert warned, [r.getMessage() for r in caplog.records]
+
+        for payload in captured_payloads:
+            params = (payload or {}).get("params", {})
+            attachments = params.get("attachments") or []
+            assert str(unsafe) not in attachments, (
+                f"unsafe path leaked into Signal attachments: {attachments}"
+            )
+
+
+# ---------------------------------------------------------------------------
 # Regression: long messages are chunked before platform dispatch
 # ---------------------------------------------------------------------------
 

--- a/tools/send_message_senders.py
+++ b/tools/send_message_senders.py
@@ -260,6 +260,22 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         for chunk in BasePlatformAdapter.truncate_message(formatted, 4096, len_fn=utf16_len) if formatted.strip() else ():
             last_msg = await _telegram_send_text_chunk(bot, int_chat_id, chunk, send_parse_mode, _has_html, text_kwargs)
         for media_path, is_voice in media_files:
+            # Defense-in-depth: validate the media path against the safe-roots
+            # allowlist before opening the file. See #34270 / salvage of #34350.
+            try:
+                from gateway.platforms.base import validate_media_delivery_path
+                _safe_path = validate_media_delivery_path(media_path)
+            except Exception:
+                _safe_path = None
+            if not _safe_path:
+                warning = (
+                    f"Skipping unsafe media path outside allowed roots: {media_path}"
+                )
+                logger.warning(warning)
+                warnings.append(warning)
+                continue
+            media_path = _safe_path
+
             if not os.path.exists(media_path):
                 warnings.append(f"Media file not found, skipping: {media_path}")
                 logger.warning(warnings[-1])
@@ -435,7 +451,25 @@ async def _send_signal(extra, chat_id, message, media_files=None):
             return {"error": "Signal account not configured"}
         valid_media = media_files or []
         attachment_paths = []
+        try:
+            from gateway.platforms.base import validate_media_delivery_path
+        except Exception:
+            validate_media_delivery_path = None  # type: ignore
         for media_path, _is_voice in valid_media:
+            if validate_media_delivery_path is None:
+                logger.warning(
+                    "Signal: media path validator unavailable, skipping %s",
+                    media_path,
+                )
+                continue
+            safe_path = validate_media_delivery_path(media_path)
+            if not safe_path:
+                logger.warning(
+                    "Signal: skipping unsafe media path outside allowed roots: %s",
+                    media_path,
+                )
+                continue
+            media_path = safe_path
             if os.path.exists(media_path):
                 attachment_paths.append(media_path)
             else:


### PR DESCRIPTION
Salvage of #34350 onto current `main` after `_send_telegram`/`_send_signal` moved to `tools/send_message_senders.py`.

## Context
Top-level `send_message_tool` still filters via `BasePlatformAdapter.filter_media_delivery_paths()`, but per-platform I/O sites opened/attached files with no local allowlist. Defense-in-depth: validate at the send sites (fail-closed on import error).

## Tests
```
python3 -m pytest tests/tools/test_send_message_tool.py -k Revalidates
# 3 passed
```

Closes the stale #34350 (conflicts). Related: #34270 (already closed).