### PR TITLE
fix(tui): await canonical interrupt acknowledgement

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -1522,6 +1522,147 @@ describe('createGatewayEventHandler', () => {
     expect(getTurnState().activity.filter(a => a.text.includes('/agents'))).toHaveLength(0)
   })
 
+  it('keeps a canonical turn live when interrupt is pending or rejected, without retrying', async () => {
+    vi.useFakeTimers()
+
+    try {
+      for (const error of [new Error('stale_generation'), new Error('transport disconnected')]) {
+        turnController.fullReset()
+        const appended: Msg[] = []
+        const ctx = buildCtx(appended)
+        let reject!: (error: Error) => void
+        ctx.gateway.gw.isCanonical = true
+        ctx.gateway.gw.request = vi.fn(() => new Promise((_, fail) => { reject = fail }))
+        const onEvent = createGatewayEventHandler(ctx)
+        const info = { model: 'test', tools: {}, skills: {}, execution_epoch: 'owner', execution_generation: 2 }
+        patchUiState({ sid: 'sess-1', info })
+
+        const emit = (type: string, payload = {}) =>
+          onEvent({ type, session_id: 'sess-1', payload: { ...info, ...payload } } as any)
+
+        emit('message.start')
+        emit('reasoning.delta', { text: 'working' })
+        emit('tool.start', { name: 'search', tool_id: 't-1' })
+        emit('message.delta', { text: 'partial' })
+        emit('approval.request', { request_id: 'approval', command: 'test' })
+        const live = getTurnState()
+        const overlay = getOverlayState().approval
+
+        const pending = turnController.interruptTurn({
+          appendMessage: ctx.transcript.appendMessage, gw: ctx.gateway.gw, sid: 'sess-1', sys: ctx.system.sys
+        }, { keepBusy: true })
+
+        expect(turnController.interrupted).toBe(false)
+        expect(getUiState().busy).toBe(true)
+        expect(getTurnState()).toEqual(live)
+        expect(getOverlayState().approval).toBe(overlay)
+        expect(appended).toEqual([])
+        reject(error)
+        await pending
+
+        expect(ctx.gateway.gw.request).toHaveBeenCalledExactlyOnceWith('session.interrupt', {
+          session_id: 'sess-1', execution_generation: info.execution_generation
+        })
+        expect(ctx.system.sys).toHaveBeenCalledExactlyOnceWith(`interrupt failed: ${error.message}`)
+        expect(turnController.interrupted).toBe(false)
+        expect(getUiState()).toMatchObject({ sid: 'sess-1', busy: true, info })
+        expect(getTurnState()).toEqual(live)
+        expect(getOverlayState().approval).toBe(overlay)
+        emit('message.delta', { text: ' continues' })
+        expect(turnController.bufRef).toBe('partial continues')
+        emit('message.complete', { text: 'legitimate completion' })
+        expect(getUiState().busy).toBe(false)
+        expect(appended.some(msg => msg.text === 'legitimate completion')).toBe(true)
+        expect(appended.some(msg => msg.text.includes('[interrupted]'))).toBe(false)
+      }
+    } finally {
+      turnController.fullReset()
+      vi.clearAllTimers()
+      vi.useRealTimers()
+    }
+  })
+
+  it('applies canonical interrupt acknowledgement only to the still-active turn, letting completion win', async () => {
+    vi.useFakeTimers()
+
+    try {
+      for (const race of ['none', 'completion', 'idle snapshot', 'settled acknowledgement', 'session', 'generation', 'epoch']) {
+        for (const keepBusy of [false, true]) {
+          turnController.fullReset()
+          const appended: Msg[] = []
+          const ctx = buildCtx(appended)
+          let resolve!: (result: unknown) => void
+          ctx.gateway.gw.isCanonical = true
+          ctx.gateway.gw.request = vi.fn(() => new Promise(done => { resolve = done }))
+          const onEvent = createGatewayEventHandler(ctx)
+          const info = { model: 'test', tools: {}, skills: {}, execution_epoch: 'owner', execution_generation: 2 }
+          patchUiState({ sid: 'sess-1', info })
+
+          const emit = (type: string, payload = {}) =>
+            onEvent({ type, session_id: 'sess-1', payload: { ...info, ...payload } } as any)
+
+          emit('message.start')
+          emit('message.delta', { text: 'partial' })
+
+          const pending = turnController.interruptTurn({
+            appendMessage: ctx.transcript.appendMessage, gw: ctx.gateway.gw, sid: 'sess-1', sys: ctx.system.sys
+          }, { keepBusy })
+
+          expect(turnController.interrupted).toBe(false)
+          expect(getUiState().busy).toBe(true)
+          expect(appended).toEqual([])
+
+          if (race === 'completion') {
+            emit('message.complete', { text: 'completed before acknowledgement' })
+            expect(appended).toContainEqual({ role: 'assistant', text: 'completed before acknowledgement' })
+          } else if (race === 'idle snapshot') {
+            emit('session.info', { running: false })
+          } else if (race !== 'none' && race !== 'settled acknowledgement') {
+            patchUiState({
+              sid: race === 'session' ? 'sess-2' : 'sess-1',
+              info: { ...info, execution_epoch: race === 'epoch' ? 'replacement' : info.execution_epoch,
+                execution_generation: race === 'generation' ? 3 : info.execution_generation }
+            })
+            turnController.startMessage()
+            turnController.hydrateStreamingText('new active turn')
+          }
+
+          const beforeAck = { ui: getUiState(), turn: getTurnState(), messages: [...appended] }
+          // Canonical success is a SessionHandle, not the legacy {ok: true}.
+          resolve({ ref: { profile_id: 'default', session_id: 'sess-1' }, instance_id: 'instance',
+            authority_epoch: 1, revision: 3, execution_generation: 2,
+            execution_state: race === 'settled acknowledgement' ? 'idle' : 'running' })
+          await pending
+
+          expect(ctx.gateway.gw.request).toHaveBeenCalledTimes(1)
+          expect(ctx.system.sys).not.toHaveBeenCalled()
+
+          if (race === 'none') {
+            expect(turnController.interrupted).toBe(true)
+            expect(getUiState()).toMatchObject({ busy: keepBusy, status: keepBusy ? 'interrupting…' : 'interrupted' })
+            expect(appended).toEqual([{ role: 'assistant', text: 'partial\n\n*[interrupted]*' }])
+            emit('message.complete', { text: 'cancelled turn response' })
+            expect(getUiState().busy).toBe(false)
+            expect(appended).toHaveLength(1)
+          } else {
+            expect(turnController.interrupted).toBe(false)
+            expect({ ui: getUiState(), turn: getTurnState(), messages: appended }).toEqual(beforeAck)
+          }
+
+          if (race === 'settled acknowledgement') {
+            emit('message.complete', { text: 'completed before the interrupt reached the server' })
+            expect(appended).toEqual([{ role: 'assistant', text: 'completed before the interrupt reached the server' }])
+            expect(getUiState().busy).toBe(false)
+          }
+        }
+      }
+    } finally {
+      turnController.fullReset()
+      vi.clearAllTimers()
+      vi.useRealTimers()
+    }
+  })
+
   it('drops stale reasoning/tool/todos events after ctrl-c until the next message starts', () => {
     // Repro for the discord report: ctrl-c interrupts, but late reasoning/tool
     // events from the still-winding-down agent loop kept populating the UI for

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -8,6 +8,7 @@ import {
 import type { SessionInterruptResponse, SubagentEventPayload } from '../gatewayTypes.js'
 import { appendToolShelfMessage, isToolShelfMessage } from '../lib/liveProgress.js'
 import { hasReasoningTag, splitReasoning } from '../lib/reasoning.js'
+import { rpcErrorMessage } from '../lib/rpc.js'
 import {
   boundedLiveRenderText,
   buildToolTrailLine,
@@ -22,6 +23,7 @@ import type { ActiveTool, ActivityItem, Msg, SubagentProgress, TodoItem } from '
 import type { Notice } from './interfaces.js'
 import { resetFlowOverlays } from './overlayStore.js'
 import { pushSnapshot } from './spawnHistoryStore.js'
+import { captureDestination, isCurrentDestination } from './submissionDestination.js'
 import { archiveDoneTodos, getTurnState, patchTurnState, resetTurnState } from './turnStore.js'
 import { getUiState, patchUiState } from './uiStore.js'
 
@@ -306,9 +308,45 @@ class TurnController {
   // while `interrupted`) instead of racing the still-unwinding turn — the race
   // duplicated the user bubble, leaked a "queued: …" note, and surfaced the
   // cancelled turn's "[interrupted]" reply.
-  interruptTurn({ appendMessage, gw, sid, sys }: InterruptDeps, opts: { keepBusy?: boolean } = {}) {
+  async interruptTurn({ appendMessage, gw, sid, sys }: InterruptDeps, opts: { keepBusy?: boolean } = {}) {
+    if (gw.isCanonical) {
+      const destination = captureDestination()
+      const info = getUiState().info
+
+      const isActiveTurn = () => {
+        const current = getUiState()
+
+        return current.sid === sid && isCurrentDestination(destination) && current.busy && !this.interrupted &&
+          current.info?.execution_epoch === info?.execution_epoch &&
+          current.info?.execution_generation === info?.execution_generation
+      }
+
+      try {
+        const response = await gw.request<SessionInterruptResponse>('session.interrupt', {
+          session_id: sid, execution_generation: info?.execution_generation
+        })
+
+        // An already-settled handle is a successful no-op, not a cancelled turn.
+        if (response.execution_state !== 'running' || response.execution_generation !== info?.execution_generation) {
+          return
+        }
+      } catch (error) {
+        if (isActiveTurn()) {
+          sys(`interrupt failed: ${rpcErrorMessage(error)}`)
+        }
+
+        return
+      }
+
+      // Completion or navigation may win the RPC race; never cancel its successor.
+      if (!isActiveTurn()) {
+        return
+      }
+    } else {
+      gw.request<SessionInterruptResponse>('session.interrupt', { session_id: sid }).catch(() => {})
+    }
+
     this.interrupted = true
-    gw.request<SessionInterruptResponse>('session.interrupt', { session_id: sid, ...(gw.isCanonical ? { execution_generation: getUiState().info?.execution_generation } : {}) }).catch(() => {})
 
     this.closeReasoningSegment()
 

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -335,6 +335,8 @@ export interface SessionCloseResponse {
 }
 
 export interface SessionInterruptResponse {
+  execution_generation?: number
+  execution_state?: string
   ok?: boolean
 }
 


### PR DESCRIPTION
## Why
Follow-up to #106742, targeting `feat/unified-gateway-runtime`, not `main`.

With the gateway owning execution, Ink must not claim a turn was interrupted when the gateway refused the request or its acknowledgement was lost. The canonical interrupt path previously swallowed the RPC error and immediately cleared local live state.

## Change
- Await the canonical interrupt response before marking the turn interrupted.
- Surface request failures without stopping streaming or automatically retrying ambiguous controls.
- Fence late responses to the captured destination, authority epoch, and execution generation.
- Preserve legitimate completion when the returned handle is already settled.
- Leave legacy interrupt behavior unchanged.

Three files change: the existing turn controller, response type, and behavioral tests. No server, auth, session-ownership, or architectural changes. Independent of #108838 and #108839.

## Validation
Base: `0203b4f3de71b05fc32328a3cb87a82b4a10bf84`, verified still the gateway PR head before publication.

- Two behavioral regressions demonstrated RED before the fix, then GREEN; includes rejection, acknowledgement, destination/generation changes, and completion races.
- All **1,825 Ink tests across 187 files passed**, independently rerun after implementation.
- Typecheck, build, bundle syntax, and whitespace checks passed.
- Lint: zero errors, seven pre-existing warnings in untouched files.

No live cross-host/PTY end-to-end run is claimed. This is a bounded client acknowledgement fix, not a new cancellation or reconnect protocol.
