### PR TITLE
fix(cli): show unknown admissions and discard guidance on resume

### DIFF
--- a/hermes_cli/gateway_chat_view.py
+++ b/hermes_cli/gateway_chat_view.py
@@ -13,6 +13,7 @@ class GatewayChatView:
         self.session_id = snapshot["stored_session_id"]
         self.generation = snapshot.get("execution_generation", 0)
         self.prompts = {p["prompt_id"]: p for p in snapshot.get("prompts", [])}
+        self.pending = snapshot.get("pending", [])
         self.quiet = quiet
         self.finite = False
         self.streams = {}
@@ -21,6 +22,19 @@ class GatewayChatView:
         self.failure = None
         from hermes_cli.gateway_mutations import PreparedMutations
         self.mutations = PreparedMutations()
+
+    def show_pending(self):
+        unknown = any(row["status"] == "unknown" for row in self.pending)
+        if unknown:
+            print("Execution outcome unknown after restart. Discard acknowledges the lost turn "
+                  "without replaying it; queued work may then continue.", file=sys.stderr)
+        for row in self.pending:
+            admission = row["admission_id"]
+            if row["status"] == "unknown":
+                print(f"Unknown admission: {admission}\n/discard {admission}", file=sys.stderr)
+            elif row["status"] == "queued":
+                context = "waiting behind unknown work" if unknown else "waiting to run"
+                print(f"Queued admission: {admission} ({context})", file=sys.stderr)
 
     def show_prompt(self, prompt):
         print(f"\n{prompt.get('description') or prompt.get('question') or 'Approval required'}", file=sys.stderr)
@@ -131,6 +145,7 @@ class GatewayChatView:
     async def run(self, query=None, *, oneshot=False):
         self.quiet = self.quiet or oneshot
         self.finite = oneshot
+        self.show_pending()
         for prompt in self.prompts.values():
             self.show_prompt(prompt)
         renderer = asyncio.create_task(self.render())

--- a/tests/hermes_cli/test_gateway_chat_unknown.py
+++ b/tests/hermes_cli/test_gateway_chat_unknown.py
@@ -1,0 +1,85 @@
+"""Resume must expose the admission needed by the existing fenced discard control."""
+import argparse
+import asyncio
+from contextlib import nullcontext
+import json
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_resume_displays_unknown_and_queue_then_discards_with_refreshed_generation(monkeypatch, capsys):
+    from websockets.asyncio.server import serve
+
+    from hermes_cli import gateway_chat
+
+    unknown_id = "admission-unknown-0123456789abcdef0123456789abcdef"
+    queued_id = "admission-queued-fedcba9876543210fedcba9876543210"
+    snapshot = {
+        "stored_session_id": "stored",
+        "execution_generation": 9,
+        "pending": [
+            {"admission_id": unknown_id, "status": "unknown", "execution_generation": 4},
+            {"admission_id": queued_id, "status": "queued", "execution_generation": None},
+        ],
+    }
+    refreshed = {
+        **snapshot,
+        "execution_generation": 10,
+        "pending": [{**snapshot["pending"][0], "execution_generation": 5}, snapshot["pending"][1]],
+    }
+    calls = []
+
+    async def peer(ws):
+        async for raw in ws:
+            request = json.loads(raw)
+            method, params = request["method"], request["params"]
+            calls.append((method, params))
+            result = {}
+            if method == "session.resume":
+                resumes = sum(name == "session.resume" for name, _ in calls)
+                result = snapshot if resumes == 1 else refreshed
+            await ws.send(json.dumps({"jsonrpc": "2.0", "id": request["id"], "result": result}))
+
+    class Input:
+        submitted = False
+
+        async def prompt_async(self, _prompt):
+            if self.submitted:
+                return "/quit"
+            output = capsys.readouterr()
+            # The user must be able to copy the full admission ID, not guess it
+            # from the session ID or inspect the gateway's storage.
+            commands = [line.strip() for line in output.err.splitlines() if line.strip().startswith("/discard ")]
+            assert commands == [f"/discard {unknown_id}"]
+            assert "unknown" in output.err.lower()
+            assert any(queued_id in line and "queued" in line.lower() for line in output.err.splitlines())
+            assert "waiting" in output.err.lower()
+            assert "without replay" in output.err.lower()
+            assert output.out == ""
+            assert calls == [
+                ("runtime.describe", {}),
+                ("session.resume", {"session_id": snapshot["stored_session_id"]}),
+            ], "Rendering recovery controls must not submit or resolve any work"
+            self.submitted = True
+            return commands[0]
+
+    monkeypatch.setattr("prompt_toolkit.PromptSession", Input)
+    monkeypatch.setattr("prompt_toolkit.patch_stdout.patch_stdout", nullcontext)
+    async with serve(peer, "127.0.0.1", 0) as server:
+        port = server.sockets[0].getsockname()[1]
+        monkeypatch.setenv("HERMES_TUI_GATEWAY_URL", f"ws://127.0.0.1:{port}")
+        assert await asyncio.wait_for(
+            gateway_chat.run_gateway_chat(argparse.Namespace(resume=snapshot["stored_session_id"])), 5
+        ) == 0
+
+    assert calls == [
+        ("runtime.describe", {}),
+        ("session.resume", {"session_id": snapshot["stored_session_id"]}),
+        ("session.resume", {"session_id": snapshot["stored_session_id"]}),
+        ("prompt.resolve_unknown", {
+            "session_id": snapshot["stored_session_id"],
+            "admission_id": unknown_id,
+            "execution_generation": refreshed["pending"][0]["execution_generation"],
+        }),
+    ]


### PR DESCRIPTION
## Why
Follow-up to #106742, targeting `feat/unified-gateway-runtime`, not `main`.

A resumed CLI session can have unknown execution blocking queued work after a gateway restart. The existing `/discard` command requires an admission ID, but the view did not display the pending snapshot's IDs. Operators therefore could not discover the recovery command from the CLI itself.

## Change
- Display full unknown admission IDs and copyable `/discard <admission_id>` commands at view startup/resume.
- Display queued IDs and whether they are waiting behind unknown work.
- Explain that discard acknowledges the lost turn without replaying it.
- Write control guidance to stderr, preserving stdout.

The existing discard implementation is unchanged: it refreshes the snapshot and uses the selected unknown admission's current generation. No automatic resolution, replay, reconnect journal, new API, or permission changes.

Only `hermes_cli/gateway_chat_view.py` and one regression test change. Independent of the other client fixes for #106742.

## Validation
Base: `0203b4f3de71b05fc32328a3cb87a82b4a10bf84`, verified still the gateway PR head before publication.

- Behavioral regression demonstrated RED on the missing displayed command, then GREEN.
- Exercises the real CLI/client over loopback WebSocket: reads the displayed command, submits it, and verifies the refreshed admission generation rather than stale view/session generations.
- **Nine tests across four CLI/authority files passed**, independently rerun with the repository's isolated runner and retries disabled.
- Ruff and whitespace checks passed.

The new test uses a deterministic loopback protocol peer, not a crashing daemon. Adjacent existing authority tests cover SQLite restart state, queue release, duplicate resolution refusal, and generation fencing. No native PTY or full repository suite is claimed.
