### PR TITLE
fix(desktop): transcript directives survive markdown, and the guide keeps its reasoning to itself

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
@@ -20,6 +20,7 @@ import { formatElapsed, useElapsedSeconds, useMeasuredDuration } from '@/compone
 import { ActivityTimerText } from '@/components/chat/activity-timer-text'
 import { GeneratedImage } from '@/components/chat/generated-image-result'
 import { SCAFFOLD_LABEL_CLASS, SCAFFOLD_META_CLASS, ScaffoldRow } from '@/components/chat/scaffold-row'
+import { useOnboardingChatActive } from '@/components/onboarding-chat/assembly'
 import { useI18n } from '@/i18n'
 import { connectorCalls } from '@/lib/connector-tools'
 import { generatedImageFromResult } from '@/lib/generated-images'
@@ -275,6 +276,10 @@ const ReasoningAccordionGroup: FC<{ children?: ReactNode; endIndex: number; star
 }) => {
   const messageId = useAuiState(s => s.message.id)
   const messageRunning = useAuiState(s => s.message.status?.type === 'running')
+  // The guide's reasoning is it reading its own runbook ("Now step 4: offer
+  // the tour with ::ask"), and a first-time user reading that alongside the
+  // greeting breaks the one conversation the guide is trying to have.
+  const guidedChat = useOnboardingChatActive()
 
   const pending = useAuiState(
     s =>
@@ -313,7 +318,7 @@ const ReasoningAccordionGroup: FC<{ children?: ReactNode; endIndex: number; star
     }, undefined)
   )
 
-  if (!hasContent) {
+  if (!hasContent || guidedChat) {
     return null
   }
 

--- a/apps/desktop/src/lib/markdown-preprocess.directives.test.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.directives.test.ts
@@ -1,0 +1,65 @@
+import remarkGfm from 'remark-gfm'
+import remarkParse from 'remark-parse'
+import { unified } from 'unified'
+import { describe, expect, it } from 'vitest'
+
+import { preprocessMarkdown } from './markdown-preprocess'
+
+/**
+ * A transcript directive (`::onboarding{...}`) is a card only while the parser
+ * hands the paragraph over as ONE text node; the moment an attribute value
+ * reads as markdown the paragraph splits into element children and the raw
+ * directive paints as the user's message. These are the shapes that leaked.
+ */
+
+// The paragraph's children as the renderer will see them, after preprocess.
+function paragraphChildren(markdown: string) {
+  const tree = unified().use(remarkParse).use(remarkGfm).parse(preprocessMarkdown(markdown)) as {
+    children: { children?: { type: string; value?: string }[] }[]
+  }
+
+  return tree.children[0]?.children ?? []
+}
+
+const briefs = [
+  'Track monarch sightings *by week* and plot them',
+  'Track a_b and c_d values across runs',
+  'Sync ~/notes to ~/backup nightly',
+  'Wrap the `run` command with retries',
+  'Compare <before> and <after> snapshots',
+  'Parse [id] tokens and \\n escapes'
+]
+
+describe('preprocessMarkdown / directive lines', () => {
+  it.each(briefs)('stays one text node with brief: %s', brief => {
+    const line = `::onboarding{step="handoff" task="Tracker" brief="${brief}" plan="build"}`
+    const children = paragraphChildren(line)
+
+    expect(children.map(child => child.type)).toEqual(['text'])
+    // The parser eats the escapes, so the directive arrives as written.
+    expect(children[0]?.value).toBe(line)
+  })
+
+  it('leaves the surrounding prose to markdown', () => {
+    const text = 'Perfect, that is *all* I needed.\n\n::onboarding{step="handoff" task="T" brief="a_b" plan="build"}'
+
+    const tree = unified().use(remarkParse).use(remarkGfm).parse(preprocessMarkdown(text)) as {
+      children: { children?: { type: string }[] }[]
+    }
+
+    expect(tree.children[0]?.children?.map(child => child.type)).toEqual(['text', 'emphasis', 'text'])
+    expect(tree.children[1]?.children?.map(child => child.type)).toEqual(['text'])
+  })
+
+  it('does not touch a directive inside a code fence', () => {
+    const text = '```\n::onboarding{step="handoff" brief="a_b"}\n```'
+
+    expect(preprocessMarkdown(text)).toBe(text)
+  })
+
+  it('does not touch prose that merely contains ::', () => {
+    const text = 'Use std::vector<int> for *speed*.'
+
+    expect(preprocessMarkdown(text)).toBe(text)
+  })
+})

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -56,6 +56,15 @@ const CITATION_MARKER_RE = /(?<=[\p{L}\p{N})\].,!?:;"'”’])\[(?:\d+(?:\s*,\s*
 // char class excludes `)`/whitespace, matching how LLMs actually emit these.
 const FILE_LINK_RE = /(?<!!)\[(?<label>[^\]\n]+)\]\((?<target><?(?:file:\/\/|\/|~\/|[a-z]:[\\/])[^)\s]*>?)\)/gi
 
+// A transcript directive on its own line: `::name{...}`. Attribute values are
+// prose the model wrote (a task brief, a question) and read as markdown to the
+// parser — `*by week*` becomes <em>, `a_b c_d` becomes <em>, `~/x` opens
+// strikethrough. Any of those splits the paragraph into element children, the
+// directive stops being text-only, and the raw line paints as the user's
+// message. Same shape as lib/transcript-directives.ts DIRECTIVE_RE.
+const DIRECTIVE_LINE_RE = /^([ \t]*)(::[a-z][a-z0-9-]{0,63}\{[^{}\n]{0,1024}\})[ \t]*$/gm
+const MARKDOWN_INLINE_META_RE = /[\\`*_~[\]<>]/g
+
 /**
  * Returns true when `body` contains a line that's exactly `marker` (modulo
  * leading/trailing horizontal whitespace) — i.e. an unambiguous close fence
@@ -200,6 +209,22 @@ function rewriteProseSegment(segment: string): string {
         segment.replace(/`{3,}/g, '').replace(LOCAL_PREVIEW_URL_RE, '$1').replace(CITATION_MARKER_RE, '')
       )
     )
+  )
+}
+
+/**
+ * Backslash-escape markdown inline syntax inside directive lines so the parser
+ * yields one text node. The escapes are consumed by the parser, so the
+ * directive the renderer sees is byte-for-byte what the model wrote.
+ */
+export function shieldDirectiveLines(text: string): string {
+  if (!text.includes('::')) {
+    return text
+  }
+
+  return text.replace(
+    DIRECTIVE_LINE_RE,
+    (_match, indent: string, directive: string) => indent + directive.replace(MARKDOWN_INLINE_META_RE, '\\$&')
   )
 }
 
@@ -641,7 +666,11 @@ export function preprocessMarkdown(text: string): string {
       // blocks stay intact. The HTML-depth clamp belongs here for the same
       // reason: a fenced block renders as code and never reaches rehype-raw,
       // so escaping tags inside one would corrupt the listing for nothing.
-      return clampHtmlNestingDepth(normalizeVisibleProse(stripPreviewTargets(normalizeProseMath(part))))
+      // Directive lines are shielded last, after the prose rewrites have had
+      // their look, so nothing re-introduces markdown into them.
+      return shieldDirectiveLines(
+        clampHtmlNestingDepth(normalizeVisibleProse(stripPreviewTargets(normalizeProseMath(part))))
+      )
     })
     .join('')
 }


### PR DESCRIPTION
## What does this PR do?

Two ways the guided first launch leaked its own machinery into the transcript, reported from the first external test run (Austin, 0.21.1) and reproduced live on `main` today.

**The raw directive as a user message.** After picking a first task, the tester saw `task="Butterfly migration tracker"}` in the chat. The handoff directive's `brief` attribute is prose the model writes, and markdown read it: `*by week*` became `<em>`, `a_b c_d` became `<em>`, `~/x` opened strikethrough. Any of those split the paragraph into element children, `paragraphPlainText` disqualified it, no card claimed it, and the line rendered as text. Directive lines are now backslash-shielded in `preprocessMarkdown`, beside the inline-code and math shields that already exist for the same reason. The parser consumes the escapes, so the directive the card sees is byte-for-byte what the model wrote. Prose around the directive is untouched; so is anything inside a code fence or a `std::vector` in a sentence.

**The runbook as reasoning.** Under each guide reply sat a "Thought briefly" disclosure containing `No apps. Move to layout.`, `Now step 4: offer the tour with ::ask…`, `step 6: ask ONE question then hand off`. That is the model following the setup script, and a first-time user reading it alongside the greeting is reading the wizard's stage directions. Reasoning disclosures are hidden on the guide thread only (`useOnboardingChatActive`); every other chat keeps them.

## Related Issue

Follow-up to #108292. Reported by @austinpickett during 0.21.1 testing.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/markdown-preprocess.ts`: `shieldDirectiveLines`, applied to prose segments after the other rewrites
- `apps/desktop/src/components/assistant-ui/thread/message-parts.tsx`: `ReasoningAccordionGroup` returns null on the guide thread
- `apps/desktop/src/lib/markdown-preprocess.directives.test.ts`: six leaking brief shapes stay one text node through the real remark pipeline; prose, fences and `::` in sentences untouched (3 red on `main`, 9 green)

## How to Test

1. `cd apps/desktop && npx vitest run src/lib/markdown-preprocess.directives.test.ts src/components/assistant-ui`
2. `HERMES_GUEST_ONBOARDING=1 HERMES_SKIP_INTRO=1` fresh home; run the guide to the first task and give it a brief with an underscore or asterisk in it. Expect the handoff card, not a `::onboarding{…}` line.
3. In the same guide, no "Thought briefly" rows appear under the guide's replies. Open any other chat: reasoning disclosures are still there.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs
- [x] My PR contains only changes related to this fix
- [x] Renderer tsc clean; 1766 desktop vitest (lib + assistant-ui) pass
- [x] I've added tests for my changes
- [x] Reproduced live on macOS 26.6 before the fix

### Documentation & Housekeeping

- [x] Documentation: N/A
- [x] `cli-config.yaml.example`: N/A
- [x] `AGENTS.md`: N/A
- [x] Cross-platform: renderer only
- [x] Tool descriptions/schemas: unchanged
