### PR TITLE
fix(tools): resolve symlinks before the binary-document write guard

### DIFF
--- a/tests/tools/test_binary_document_write_guard.py
+++ b/tests/tools/test_binary_document_write_guard.py
@@ -183,3 +183,61 @@ class TestPatchToolGuard:
         )
         assert not result.get("error")
         assert target.read_text() == "hello there"
+
+
+class TestSymlinkAliasGuard:
+    """Regression for #108715: a text-suffixed symlink to a binary document
+    must not bypass the guard — the write follows the link and corrupts the
+    target while the given path reads as plain text."""
+
+    def test_write_file_via_text_suffix_symlink_rejected(self, tmp_path: Path):
+        docx = tmp_path / "document.docx"
+        _make_minimal_docx(docx)
+        original = docx.read_bytes()
+        alias = tmp_path / "alias.txt"
+        alias.symlink_to(docx)
+
+        result = json.loads(write_file_tool(str(alias), "edited text"))
+
+        assert result.get("error"), "text write via symlink alias must be refused"
+        assert "document.docx" in result["error"], "refusal should surface the resolved target"
+        assert docx.read_bytes() == original, "document bytes must be untouched"
+        assert zipfile.is_zipfile(docx), "document must remain a valid container"
+
+    def test_patch_replace_via_text_suffix_symlink_rejected(self, tmp_path: Path):
+        docx = tmp_path / "document.docx"
+        _make_minimal_docx(docx)
+        original = docx.read_bytes()
+        alias = tmp_path / "alias.txt"
+        alias.symlink_to(docx)
+
+        result = json.loads(
+            patch_tool(mode="replace", path=str(alias),
+                       old_string="good", new_string="great")
+        )
+
+        assert result.get("error")
+        assert docx.read_bytes() == original
+
+    def test_pdf_overwrite_via_symlink_rejected(self, tmp_path: Path):
+        pdf = tmp_path / "report.pdf"
+        pdf.write_bytes(b"%PDF-1.4\n1 0 obj\nendobj\n%%EOF")
+        original = pdf.read_bytes()
+        alias = tmp_path / "alias.txt"
+        alias.symlink_to(pdf)
+
+        result = json.loads(write_file_tool(str(alias), "not a pdf"))
+
+        assert result.get("error"), "PDF overwrite via symlink alias must be refused"
+        assert pdf.read_bytes() == original
+
+    def test_symlink_to_plain_text_still_allowed(self, tmp_path: Path):
+        target = tmp_path / "notes.txt"
+        target.write_text("hello")
+        alias = tmp_path / "link.md"
+        alias.symlink_to(target)
+
+        result = json.loads(write_file_tool(str(alias), "replaced"))
+
+        assert not result.get("error")
+        assert target.read_text() == "replaced"

--- a/tools/file_tools_write_guards.py
+++ b/tools/file_tools_write_guards.py
@@ -12,7 +12,7 @@ import fnmatch
 import os
 from pathlib import Path
 
-from tools.binary_extensions import has_opaque_document_extension, is_pdf_path
+from tools.binary_extensions import OPAQUE_DOCUMENT_EXTENSIONS, is_pdf_path
 from tools.file_tools_paths import _expand_tilde, _resolve_path_for_task
 
 # Prefixes matched after realpath. macOS: /private/var mirrors /var — block the
@@ -378,25 +378,36 @@ def _check_binary_document_write(filepath: str, task_id: str = "default") -> str
     plausibly believes it holds the file's contents and tries to write the edited text back with
     write_file/patch. A plain-text write can never produce a valid OOXML/OLE/ODF container, so that write
     silently destroys the document (port of nearai/ironclaw#7109).
+
+    Symlinks are resolved before the extension checks: a text-suffixed alias
+    (``alias.txt -> document.docx``) would otherwise read as plain text here and
+    follow the link on write, corrupting the binary target (#108715).
     """
-    if has_opaque_document_extension(filepath):
-        ext = filepath[filepath.rfind("."):].lower()
+    try:
+        resolved = Path(_resolve_path_for_task(filepath, task_id))
+    except Exception:
+        resolved = Path(_expand_tilde(filepath))
+    target = str(resolved)
+    given_ext = Path(filepath).suffix.lower()
+    target_ext = resolved.suffix.lower()
+    # Only annotate when the link actually changes the extension — a direct
+    # .docx write keeps the original message shape.
+    suffix_note = "" if target_ext == given_ext else f" — resolves to '{target}'"
+
+    if given_ext in OPAQUE_DOCUMENT_EXTENSIONS or target_ext in OPAQUE_DOCUMENT_EXTENSIONS:
+        ext = given_ext if given_ext in OPAQUE_DOCUMENT_EXTENSIONS else target_ext
         return (
-            f"Refusing to write plain text to binary document '{filepath}' ({ext}). "
+            f"Refusing to write plain text to binary document '{filepath}'{suffix_note} ({ext}). "
             "A text write cannot produce a valid document container and would "
             "corrupt the file (read_file showed you EXTRACTED text, not the real "
             "bytes). Use the docx/xlsx/powerpoint skills or a library like "
             "python-docx/openpyxl/python-pptx via the terminal to create or edit "
             "this document.")
-    if is_pdf_path(filepath):
-        try:
-            resolved = Path(_resolve_path_for_task(filepath, task_id))
-        except Exception:
-            resolved = Path(_expand_tilde(filepath))
+    if is_pdf_path(filepath) or is_pdf_path(target):
         try:
             if resolved.is_file():
                 return (
-                    f"Refusing to overwrite existing PDF '{filepath}' with plain text. "
+                    f"Refusing to overwrite existing PDF '{filepath}'{suffix_note} with plain text. "
                     "read_file showed you EXTRACTED text, not the real bytes — writing "
                     "text back would destroy the document. Use the pdf skill or a PDF "
                     "library via the terminal to modify it. (Creating a NEW .pdf file "


### PR DESCRIPTION
Fixes #108715.

## What & why

`_check_binary_document_write()` checked the extension of the **given path** only. A text-suffixed symlink (`alias.txt -> document.docx`) therefore read as plain text, passed the guard, and the write followed the link and corrupted the binary target — reported in #108715 with a repro against current main. The same bypass applied to:
- replace-mode `patch` (same guard entry),
- the PDF-overwrite branch (`is_pdf_path()` also only saw the alias, so `alias.txt -> report.pdf` skipped the overwrite refusal).

The guard now resolves the path first (via `_resolve_path_for_task()`, with the same `_expand_tilde()` fallback the PDF branch already used) and checks the **target's** extension in addition to the given path's. Refusals keep the caller's path and append a `— resolves to '<target>'` note only when the link actually changes the extension, so direct `.docx` writes keep the original message shape byte-for-byte. A symlink between two plain-text files still writes through normally.

## How to test

```python
# on main: returns success and corrupts document.docx
# with this PR: refused with the resolved target named
import json, zipfile
from pathlib import Path
from tools.file_tools import write_file_tool
docx = Path("document.docx")  # any OOXML zip
(docx.parent / "alias.txt").symlink_to(docx)
print(json.loads(write_file_tool(str(docx.parent / "alias.txt"), "edited text"))["error"])
```

New regressions in `tests/tools/test_binary_document_write_guard.py` (`TestSymlinkAliasGuard`): write/patch via `.txt` alias to `.docx` refused with target bytes untouched, PDF overwrite via alias refused, and a symlink between plain-text files still allowed. All four fail on `main` (3 refusals missing) and pass here.

## Platforms tested

Linux (symlink semantics identical on macOS; the resolution uses `pathlib`/`_resolve_path_for_task` only — no POSIX-only APIs, so Windows junction behavior is unchanged from the status quo). `scripts/check-windows-footguns.py` clean on the touched file.

## Notes

- Security hardening (defense-in-depth, SECURITY.md §3.2 class — matches the issue's framing): prevents silent corruption of protected/binary documents through an aliased path.
- Full suite (`scripts/run_tests.sh`): the failures present are the known pre-existing/flaky set (`update_head_moved_gate`, `voice_mode`, `tui_gateway_server`, `openviking` reproduce on clean main; the rest pass in isolation on this branch).