### PR TITLE
fix(memory): rebind RetainDB state on session switches

### DIFF
--- a/plugins/memory/retaindb/__init__.py
+++ b/plugins/memory/retaindb/__init__.py
@@ -310,6 +310,7 @@ class RetainDBMemoryProvider(MemoryProvider):
         self._user_id, self._session_id, self._agent_id = "default", "", "hermes"
         self._lock = threading.Lock()  # guards the prefetch caches below
         self._context_result, self._dialectic_result, self._agent_model = "", "", {}
+        self._prefetch_generation = 0
         self._prefetch_threads: list[threading.Thread] = []  # tracked so rapid turns don't pile up threads
 
     @property
@@ -348,6 +349,18 @@ class RetainDBMemoryProvider(MemoryProvider):
             seed = lambda: self._client.seed_agent_identity(self._agent_id, soul, source="soul_md")  # noqa: E731
             threading.Thread(target=_quiet, args=("soul seed", seed), name="retaindb-soul-seed", daemon=True).start()
 
+    def on_session_switch(self, new_session_id: str, *, parent_session_id: str = "", reset: bool = False, **kwargs) -> None:
+        """Rebind live tools/recall; queued writes keep their explicitly captured session."""
+        new_id = str(new_session_id or "").strip()
+        if not new_id:
+            return
+        with self._lock:
+            self._session_id = new_id
+            # Also invalidate a same-id rewind: an old in-flight result must not
+            # repopulate the cache after its transcript has been truncated.
+            self._prefetch_generation += 1
+            self._context_result, self._dialectic_result, self._agent_model = "", "", {}
+
     def system_prompt_block(self) -> str:
         project = self._client.project if self._client else "retaindb"
         return (f"# RetainDB Memory\nActive. Project: {project}.\nUse retaindb_search to find memories, retaindb_remember to store facts, "
@@ -357,36 +370,42 @@ class RetainDBMemoryProvider(MemoryProvider):
         """Fire context + dialectic + agent model prefetches in background (turn-end); prefetch() consumes them next turn."""
         if not self._client:
             return
+        with self._lock:
+            owner = session_id or self._session_id
+            if owner != self._session_id:
+                return  # A delayed manager task still belongs to the previous session.
+            generation = self._prefetch_generation
         for t in self._prefetch_threads:  # wait for the previous batch so threads don't accumulate on rapid turns
             t.join(timeout=2.0)
         if any(t.is_alive() for t in self._prefetch_threads):
             logger.debug("RetainDB prefetch still running; skipping new batch")
             return
         jobs = (  # (thread name, log label, cache attr, fetch) — fetch returns None to leave the cache untouched
-            ("retaindb-ctx", "context", "_context_result", lambda: self._context_overlay(query)["context"]),
+            ("retaindb-ctx", "context", "_context_result", lambda: self._context_overlay(query, session_id=owner)["context"]),
             ("retaindb-dialectic", "dialectic", "_dialectic_result", lambda: str(
                 self._client.ask_user(self._user_id, query, reasoning_level=self._reasoning_level(query)).get("answer") or "") or None),
             ("retaindb-agent-model", "agent model", "_agent_model", lambda: self._agent_model_or_none(self._client.get_agent_model(self._agent_id))),
         )
-        self._prefetch_threads = [threading.Thread(target=self._store, args=(label, attr, fetch), name=name, daemon=True)
+        self._prefetch_threads = [threading.Thread(target=self._store, args=(label, attr, fetch, generation), name=name, daemon=True)
                                   for name, label, attr, fetch in jobs]
         for t in self._prefetch_threads:
             t.start()
 
-    def _context_overlay(self, query: str) -> dict:
-        query_result = self._client.query_context(self._user_id, self._session_id, query)
+    def _context_overlay(self, query: str, *, session_id: str = "") -> dict:
+        query_result = self._client.query_context(self._user_id, session_id or self._session_id, query)
         return {"context": _build_overlay(self._client.get_profile(self._user_id), query_result), "raw": query_result}
 
     @staticmethod
     def _agent_model_or_none(model: dict) -> dict | None:
         return model if model.get("memory_count", 0) > 0 else None
 
-    def _store(self, label: str, attr: str, fetch: Callable[[], Any]) -> None:
+    def _store(self, label: str, attr: str, fetch: Callable[[], Any], generation: int) -> None:
         """Run one prefetch job; cache its value under the lock unless None (failures log at debug)."""
         value = _quiet(f"{label} prefetch", fetch)
         if value is not None:
             with self._lock:
-                setattr(self, attr, value)
+                if generation == self._prefetch_generation:
+                    setattr(self, attr, value)
 
     @staticmethod
     def _reasoning_level(query: str) -> str:
@@ -395,6 +414,8 @@ class RetainDBMemoryProvider(MemoryProvider):
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         """Consume prefetched results and return them as a context block."""
         with self._lock:
+            if session_id and session_id != self._session_id:
+                return ""
             context, dialectic, agent_model = self._context_result, self._dialectic_result, self._agent_model
             self._context_result, self._dialectic_result, self._agent_model = "", "", {}
         model_lines = [fmt(agent_model[k]) for k, fmt in _AGENT_MODEL_FIELDS if agent_model.get(k)] if agent_model.get("memory_count", 0) > 0 else []

--- a/tests/plugins/memory/test_retaindb_session_switch.py
+++ b/tests/plugins/memory/test_retaindb_session_switch.py
@@ -1,0 +1,173 @@
+"""RetainDB session ownership through real discovery, manager hooks and HTTP payloads."""
+
+import json
+import threading
+from urllib.parse import urlsplit
+
+import pytest
+import requests
+
+from agent.memory_manager import MemoryManager
+from plugins.memory import load_memory_provider
+
+
+def _response(payload):
+    response = requests.Response()
+    response.status_code = 200
+    response._content = json.dumps(payload).encode()
+    return response
+
+
+@pytest.fixture
+def memory(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("RETAINDB_API_KEY", "offline-test-key")
+    monkeypatch.setenv("RETAINDB_BASE_URL", "https://memory.invalid")
+    monkeypatch.setenv("RETAINDB_PROJECT", "test-project")
+    provider = load_memory_provider("retaindb", register_skills=False)
+    assert provider is not None
+    manager = MemoryManager()
+    manager.add_provider(provider)
+    manager.initialize_all("parent", hermes_home=str(home), platform="cli", user_id="user")
+    try:
+        yield manager, provider
+    finally:
+        manager.shutdown_all()
+
+
+def test_session_switch_rebinds_tools_without_relabeling_accepted_turns(memory, monkeypatch):
+    manager, _ = memory
+    requests_seen = []
+    parent_started = threading.Event()
+    release_parent = threading.Event()
+    child_written = threading.Event()
+
+    def request(method, url, **kwargs):
+        path, body = urlsplit(url).path, kwargs.get("json")
+        requests_seen.append((path, body))
+        if path == "/v1/memory/ingest/session":
+            content = body["messages"][0]["content"]
+            if content == "queued parent turn":
+                parent_started.set()
+                assert release_parent.wait(5)
+            if content == "child turn":
+                child_written.set()
+        return _response({"id": "memory-id", "memories": [], "results": []})
+
+    monkeypatch.setattr(requests, "request", request)
+    try:
+        manager.sync_all("queued parent turn", "answer", session_id="parent")
+        assert parent_started.wait(5)
+        manager.on_session_switch("child", parent_session_id="parent", reason="compression")
+        for tool, args in (
+            ("retaindb_remember", {"content": "child fact"}),
+            ("retaindb_search", {"query": "child fact"}),
+            ("retaindb_context", {"query": "child fact"}),
+        ):
+            assert "error" not in json.loads(manager.handle_tool_call(tool, args))
+        manager.on_memory_write("add", "memory", "child mirror")
+        # Work accepted by the manager before a boundary can reach the provider
+        # afterwards. Its explicit session parameter must still own the write.
+        manager.sync_all("delayed parent turn", "answer", session_id="parent")
+        manager.sync_all("child turn", "answer", session_id="child")
+        release_parent.set()
+        assert child_written.wait(5)
+        manager.on_session_switch("reset-session", reset=True)
+        assert "error" not in json.loads(manager.handle_tool_call("retaindb_remember", {"content": "reset fact"}))
+    finally:
+        release_parent.set()
+        manager.shutdown_all()
+
+    expected_owners = {
+        ("/v1/memory", "child fact"): "child",
+        ("/v1/memory/search", "child fact"): "child",
+        ("/v1/context/query", "child fact"): "child",
+        ("/v1/memory", "child mirror"): "child",
+        ("/v1/memory", "reset fact"): "reset-session",
+        ("/v1/memory/ingest/session", "queued parent turn"): "parent",
+        ("/v1/memory/ingest/session", "delayed parent turn"): "parent",
+        ("/v1/memory/ingest/session", "child turn"): "child",
+    }
+    scoped_paths = {path for path, _ in expected_owners}
+    observed = set()
+    for path, body in requests_seen:
+        if path not in scoped_paths:
+            continue
+        assert isinstance(body, dict), (path, body)
+        assert {"session_id", "user_id", "project"} <= body.keys(), (path, body)
+        if path == "/v1/memory/ingest/session":
+            content = body["messages"][0]["content"]
+        else:
+            content = body.get("content", body.get("query"))
+        operation = (path, content)
+        assert operation in expected_owners
+        assert body["session_id"] == expected_owners[operation]
+        assert body["user_id"] == "user"
+        assert body["project"] == "test-project"
+        observed.add(operation)
+    assert observed == expected_owners.keys()
+
+
+def test_session_switch_and_rewind_discard_prior_prefetch_results(memory, monkeypatch):
+    manager, provider = memory
+    requests_seen = []
+    recall_started = threading.Event()
+    release_recall = threading.Event()
+
+    def request(method, url, **kwargs):
+        path, body = urlsplit(url).path, kwargs.get("json") or {}
+        requests_seen.append((path, body))
+        if path == "/v1/context/query":
+            query = body["query"]
+            if query in {"before switch", "before undo"}:
+                recall_started.set()
+                assert release_recall.wait(5)
+            return _response({"results": [{"content": query}]})
+        if path.endswith("/ask"):
+            return _response({"answer": body["query"]})
+        if path.endswith("/model"):
+            return _response({"memory_count": 1, "persona": "remembered persona"})
+        return _response({"memories": []})
+
+    def finish_prefetch():
+        for thread in provider._prefetch_threads:
+            thread.join(timeout=5)
+            assert not thread.is_alive()
+
+    monkeypatch.setattr(requests, "request", request)
+    try:
+        provider.queue_prefetch("before switch", session_id="parent")
+        assert recall_started.wait(5)
+        manager.on_session_switch("child", reset=True)
+        release_recall.set()
+        finish_prefetch()
+        assert provider.prefetch("after switch", session_id="child") == ""
+
+        # An old manager task arriving after the boundary must not recall its
+        # old query against the new owner or fill that owner's cache.
+        provider.queue_prefetch("delayed parent query", session_id="parent")
+        finish_prefetch()
+        assert provider.prefetch("after switch", session_id="child") == ""
+
+        provider.queue_prefetch("child fact", session_id="child")
+        finish_prefetch()
+        assert provider.prefetch("delayed parent read", session_id="parent") == ""
+        assert "child fact" in provider.prefetch("child fact", session_id="child")
+        recall_started.clear()
+        release_recall.clear()
+        provider.queue_prefetch("before undo", session_id="child")
+        assert recall_started.wait(5)
+        manager.on_session_switch("child", rewound=True)
+        release_recall.set()
+        finish_prefetch()
+        assert provider.prefetch("after undo", session_id="child") == ""
+    finally:
+        release_recall.set()
+        finish_prefetch()
+
+    for path, body in requests_seen:
+        if path == "/v1/context/query":
+            expected = "parent" if body["query"] in {"before switch", "delayed parent query"} else "child"
+            assert body["session_id"] == expected


### PR DESCRIPTION
## What does this PR do?

After Hermes switches sessions during compression or `/new`, RetainDB's explicit memory tools keep using the session saved at initialization. Automatic turn sync receives the new session id, so a single conversation can write its transcript to one session and its remembered facts to another.

Implement RetainDB's existing `on_session_switch` hook so subsequent tools and memory mirrors use the current session. Clear ready recall data and discard results from prefetches already in flight when the session changes or is rewound. Delayed work for another session is ignored. Already accepted writes keep their original session ids and continue to drain normally.

## Related Issue

Found while checking the existing memory-provider session-switch contract on current main; no separate issue was opened.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/retaindb/__init__.py`: rebind the active session and invalidate recall from the previous session; capture the owner of background context requests.
- `tests/plugins/memory/test_retaindb_session_switch.py`: two behavior tests through real provider discovery, manager hooks, API payload construction and SQLite queue.

## How to Test

Run from the repository root:

```sh
scripts/run_tests.sh tests/plugins/memory/test_retaindb_session_switch.py tests/plugins/memory/test_retaindb_provider.py tests/plugins/test_retaindb_plugin.py tests/agent/test_memory_provider.py tests/agent/test_memory_session_switch.py tests/agent/test_memory_async_sync.py tests/agent/test_memory_user_id.py tests/agent/test_memory_boundary_commit.py tests/plugins/memory/test_provider_threads_inherit_profile.py
```

Both new invariants fail on main and pass with this change. After syncing with current main, the related suite passed **146 tests across 9 files** on macOS arm64 with Python 3.12.14; Ruff and whitespace checks passed. The final two invariants also pass with an in-flight same-id rewind and explicit checks for every expected scoped request, including missing identity fields.

The updated prefetch workers retain main's profile-context propagation as well as this fix's session-generation checks. An additional offline A → B → A profile round trip verified home, secret scope and session ownership through real provider discovery and HTTP payload construction.

The session-switch tests replace only HTTP transport. They verify that queued old turns still target their old session, new explicit operations use the new session, and late recall cannot populate or consume another session's cache. No live RetainDB server or model is used. The full repository suite was not run.

## Checklist

- [x] Read the Contributing Guide and plugin guidelines.
- [x] Searched existing PRs. #62381 concerns shared writers and #55849 query/topic matching; this change addresses session rebinding.
- [x] Kept the change in the existing provider and its tests.
- [x] Added two behavior invariants and proved them failing before the fix.
- [x] Tested on macOS arm64.
- [x] No new configuration, dependencies, tool schemas or documentation are needed.
- [x] Considered cross-platform impact; no platform-specific behavior is changed.
