### PR TITLE
feat(desktop): chat about a selection in a side chat panel

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -6,6 +6,7 @@ import type * as React from 'react'
 import { memo, Suspense, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { useLocation } from 'react-router'
 
+import { SelectionToolbar } from '@/app/chat/selection-toolbar'
 import type { SubmitTextOptions } from '@/app/session/hooks/use-prompt-actions/utils'
 import { sessionShouldHaveTranscript } from '@/app/session/hooks/use-session-actions/utils'
 import { Thread } from '@/components/assistant-ui/thread'
@@ -92,6 +93,11 @@ interface ChatViewProps extends Omit<React.ComponentProps<'div'>, 'onSubmit'> {
   onAddContextRef: (refText: string, label?: string, detail?: string) => void
   onAddUrl: (url: string) => void
   onBranchInNewChat?: (messageId: string) => void
+  /** Chrome the caller owns, rendered above the transcript where the primary
+   *  chat's header sits — the side chat's provenance strip. The chat surface
+   *  stays ignorant of what a side chat is. */
+  onStageInMain?: (text: string) => void
+  selectionContext?: React.ReactNode
   maxVoiceRecordingSeconds?: number
   onAttachImageBlob: (blob: Blob) => Promise<boolean | void> | boolean | void
   onAttachDroppedItems: (candidates: DroppedFile[]) => Promise<boolean | void> | boolean | void
@@ -390,6 +396,8 @@ const ChatViewContent = memo(function ChatViewContent({
   onAttachDroppedItems,
   onAttachPrCommentUrl,
   onBranchInNewChat,
+  onStageInMain,
+  selectionContext,
   maxVoiceRecordingSeconds,
   onPasteClipboardImage,
   onPickFiles,
@@ -415,6 +423,10 @@ const ChatViewContent = memo(function ChatViewContent({
   const composerScope = useComposerScope()
   const composerSurfaceId = useComposerSurfaceId()
   const isPrimary = view.kind === 'primary'
+
+  // The transcript's own bounds: the selection pill accepts a selection only
+  // from inside it, so tiles and chrome keep their own gestures.
+  const transcriptBoundsRef = useRef<HTMLDivElement | null>(null)
   const activeSessionId = useStore(view.$runtimeId)
   const storedId = useStore(view.$storedId)
   // Multi-pane dimming: only the focused surface paints at full strength, so
@@ -673,6 +685,7 @@ const ChatViewContent = memo(function ChatViewContent({
           so a tiled/background session's blocking prompt surfaces instead of
           stalling to timeout. */}
       <PromptOverlays sessionId={activeSessionId} />
+      {selectionContext}
 
       <ChatRuntimeBoundary
         busy={busy}
@@ -685,8 +698,13 @@ const ChatViewContent = memo(function ChatViewContent({
         <div
           className="relative min-h-0 max-w-full flex-1 overflow-hidden bg-(--ui-chat-surface-background) contain-[layout_paint]"
           data-slot="composer-bounds"
+          data-stored-session-id={selectedSessionId ?? ''}
+          ref={transcriptBoundsRef}
           {...dropHandlers}
         >
+          {/* The primary chat owns the selection pill: a tile is a side surface
+              with its own verbs, and two pills over one window is one too many. */}
+          {isPrimary ? <SelectionToolbar container={transcriptBoundsRef} /> : null}
           <Thread
             clampToComposer={showChatBar}
             cwd={currentCwd}
@@ -697,6 +715,7 @@ const ChatViewContent = memo(function ChatViewContent({
             onCancel={haltRun}
             onDismissError={onDismissError}
             onRestoreToMessage={onRestoreToMessage}
+            onStageInMain={onStageInMain}
             sessionId={activeSessionId}
             sessionKey={threadKey}
           />

--- a/apps/desktop/src/app/chat/selection-toolbar.test.tsx
+++ b/apps/desktop/src/app/chat/selection-toolbar.test.tsx
@@ -1,0 +1,127 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { type RefObject, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { $sideChatRequest } from '@/store/side-chat'
+
+import { SelectionToolbar } from './selection-toolbar'
+
+afterEach(() => {
+  cleanup()
+  delete (Range.prototype as Partial<Range>).getBoundingClientRect
+})
+
+const MEASURED = {
+  bottom: 60,
+  height: 20,
+  left: 10,
+  right: 110,
+  toJSON: () => ({}),
+  top: 40,
+  width: 100,
+  x: 10,
+  y: 40
+} as DOMRect
+
+beforeEach(() => {
+  $sideChatRequest.set(null)
+  window.getSelection()?.removeAllRanges()
+  // jsdom has NO Range.getBoundingClientRect at all (not even a zero one), and
+  // the pill requires a real box before it shows — a zero-size range is a
+  // collapsed selection. Define it for the duration of the file.
+  Object.defineProperty(Range.prototype, 'getBoundingClientRect', { configurable: true, value: () => MEASURED })
+})
+
+function Harness({ outside = false }: { outside?: boolean } & Record<string, unknown>) {
+  const bounds = useRef<HTMLDivElement | null>(null)
+
+  return (
+    <div>
+      <div data-stored-session-id="main-1" data-testid="bounds" ref={bounds}>
+        <p data-message-id="msg-1">select me</p>
+      </div>
+      {outside ? <p data-testid="elsewhere">somewhere else</p> : null}
+      <SelectionToolbar container={bounds as RefObject<HTMLElement | null>} />
+    </div>
+  )
+}
+
+function select(node: Element) {
+  const range = document.createRange()
+
+  range.selectNodeContents(node)
+  const selection = window.getSelection()
+
+  selection?.removeAllRanges()
+  selection?.addRange(range)
+}
+
+describe('SelectionToolbar', () => {
+  it('stays out of the way until something is selected', () => {
+    render(<Harness />)
+
+    expect(screen.queryByRole('button', { name: /chat about selection/i })).toBeNull()
+  })
+
+  it('offers the side-chat verb for a selection, naming the message it came from', () => {
+    const { getByText } = render(<Harness />)
+
+    select(getByText('select me'))
+    fireEvent.mouseUp(document)
+
+    fireEvent.click(screen.getByRole('button', { name: /chat about selection/i }))
+
+    expect($sideChatRequest.get()).toEqual({
+      fromStoredSessionId: 'main-1',
+      messageId: 'msg-1',
+      text: 'select me'
+    })
+  })
+
+  it('carries the transcript’s own conversation, not whatever session is selected', () => {
+    // The transcript declares which conversation it renders; the request must
+    // name that one so the side chat is attributed and routed to it.
+    const { getByText } = render(<Harness />)
+
+    select(getByText('select me'))
+    fireEvent.mouseUp(document)
+    fireEvent.click(screen.getByRole('button', { name: /chat about selection/i }))
+
+    expect($sideChatRequest.get()?.fromStoredSessionId).toBe('main-1')
+  })
+
+  it('ignores a selection that belongs to another surface, so tiles keep their gestures', () => {
+    const { getByTestId } = render(<Harness outside />)
+
+    select(getByTestId('elsewhere'))
+    fireEvent.mouseUp(document)
+
+    expect(screen.queryByRole('button', { name: /chat about selection/i })).toBeNull()
+  })
+
+  it('gets out of the way on Escape', () => {
+    const { getByText } = render(<Harness />)
+
+    select(getByText('select me'))
+    fireEvent.mouseUp(document)
+    expect(screen.getByRole('button', { name: /chat about selection/i })).toBeTruthy()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(screen.queryByRole('button', { name: /chat about selection/i })).toBeNull()
+  })
+
+  it('survives the click that lands on it rather than dismissing itself first', () => {
+    const { getByText } = render(<Harness />)
+
+    select(getByText('select me'))
+    fireEvent.mouseUp(document)
+
+    // The pill's own mousedown precedes its click; dismissing there would unmount
+    // the button mid-gesture and the request would never be posted.
+    fireEvent.mouseDown(screen.getByRole('button', { name: /chat about selection/i }))
+    fireEvent.click(screen.getByRole('button', { name: /chat about selection/i }))
+
+    expect($sideChatRequest.get()?.text).toBe('select me')
+  })
+})

--- a/apps/desktop/src/app/chat/selection-toolbar.tsx
+++ b/apps/desktop/src/app/chat/selection-toolbar.tsx
@@ -1,0 +1,181 @@
+/**
+ * The "chat about selection" pill.
+ *
+ * The same verb already lives in the transcript context menu; this is the
+ * in-place entrance — select text, an action appears where the eyes already are.
+ * It is deliberately a PILL rather than a second menu: right-click belongs to the
+ * app/Electron menu, and a primary-button menu would fight it.
+ *
+ * Positioned in VIEWPORT coordinates and dismissed on scroll. The transcript is
+ * virtualised, so an element anchored to a message outlives the node it was
+ * measured from; a pill pinned to a recycled row is worse than no pill at all.
+ */
+
+import { type RefObject, useCallback, useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+import { Codicon } from '@/components/ui/codicon'
+import { writeClipboardText } from '@/components/ui/copy-button'
+import { useI18n } from '@/i18n'
+import { requestSideChat } from '@/store/side-chat'
+
+const EDGE_PAD = 8
+const PILL_HEIGHT = 32
+
+interface Placement {
+  left: number
+  top: number
+}
+
+/** Marks the pill so its own mousedown/mouseup never dismisses it. */
+const PILL_ATTR = 'data-selection-toolbar'
+
+function insidePill(target: EventTarget | null): boolean {
+  return target instanceof Element && Boolean(target.closest(`[${PILL_ATTR}]`))
+}
+
+export function SelectionToolbar({ container }: { container: RefObject<HTMLElement | null> }) {
+  const { t } = useI18n()
+  const [placement, setPlacement] = useState<null | Placement>(null)
+
+  const [selection, setSelection] = useState<null | {
+    fromStoredSessionId?: string
+    messageId?: string
+    text: string
+  }>(null)
+
+  const hide = useCallback(() => setPlacement(null), [])
+
+  useEffect(() => {
+    const onMouseUp = (event: MouseEvent) => {
+      // The click that lands on the pill must reach it: this fires before click,
+      // and dismissing here would unmount the button mid-gesture.
+      if (event.button !== 0 || insidePill(event.target)) {
+        return
+      }
+
+      const root = container.current
+      const selection = window.getSelection()
+      const selected = selection?.toString().trim() ?? ''
+
+      if (!root || !selection?.rangeCount || !selected) {
+        hide()
+
+        return
+      }
+
+      const range = selection.getRangeAt(0)
+      const anchor = range.commonAncestorContainer
+      const element = anchor.nodeType === Node.ELEMENT_NODE ? (anchor as Element) : anchor.parentElement
+      // Attribute from the START of the range, not from its common ancestor: a
+      // selection spanning rows has the message LIST as its common ancestor,
+      // which belongs to no message — provenance would go missing exactly when
+      // the user quoted most.
+      const start = range.startContainer
+      const startElement = start.nodeType === Node.ELEMENT_NODE ? (start as Element) : start.parentElement
+
+      // Only THIS transcript's selections — the app mounts several chat surfaces
+      // (tiles) plus all the chrome, and those keep their own verbs.
+      if (!element || !root.contains(element)) {
+        hide()
+
+        return
+      }
+
+      // A selection inside a field is an EDIT gesture (rewriting a message), not
+      // a request to discuss it — the transcript hosts those editors itself.
+      if (startElement?.closest('input, textarea, [contenteditable]')) {
+        hide()
+
+        return
+      }
+
+      const rect = range.getBoundingClientRect()
+
+      if (!rect.width && !rect.height) {
+        hide()
+
+        return
+      }
+
+      // A selection spanning rows attributes to the FIRST row holding any of it.
+      // The transcript names its own conversation, so the request carries it
+      // rather than letting the create path fall back to whatever session the
+      // app considers selected (which lags a route switch).
+      setSelection({
+        fromStoredSessionId: root.getAttribute('data-stored-session-id') || undefined,
+        messageId: startElement?.closest('[data-message-id]')?.getAttribute('data-message-id') ?? undefined,
+        text: selected
+      })
+      setPlacement({
+        left: Math.max(EDGE_PAD, Math.min(rect.left + rect.width / 2, window.innerWidth - EDGE_PAD)),
+        top: rect.top - PILL_HEIGHT - EDGE_PAD < EDGE_PAD ? rect.bottom + EDGE_PAD : rect.top - PILL_HEIGHT - EDGE_PAD
+      })
+    }
+
+    const onMouseDown = (event: MouseEvent) => {
+      if (!insidePill(event.target)) {
+        hide()
+      }
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        hide()
+      }
+    }
+
+    document.addEventListener('mouseup', onMouseUp)
+    document.addEventListener('mousedown', onMouseDown)
+    document.addEventListener('keydown', onKeyDown)
+    document.addEventListener('scroll', hide, true)
+
+    return () => {
+      document.removeEventListener('mouseup', onMouseUp)
+      document.removeEventListener('mousedown', onMouseDown)
+      document.removeEventListener('keydown', onKeyDown)
+      document.removeEventListener('scroll', hide, true)
+    }
+  }, [container, hide])
+
+  if (!placement || !selection) {
+    return null
+  }
+
+  // Portalled to the body: the transcript's own subtree sits inside
+  // `contain-[layout_paint]` (the pane's paint isolation), and `contain: paint`
+  // makes that element a containing block for fixed-position descendants — a
+  // pill left in place would be laid out against the pane corner while its
+  // coordinates come from the viewport.
+  return createPortal(
+    <div
+      className="fixed z-50 flex -translate-x-1/2 items-center gap-0.5 rounded-full border border-(--stroke-nous) bg-popover/95 p-0.5 shadow-nous backdrop-blur-md"
+      data-selection-toolbar=""
+      style={{ left: placement.left, top: placement.top }}
+    >
+      <button
+        className="flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[0.8125rem] whitespace-nowrap hover:bg-accent"
+        onClick={() => {
+          hide()
+          requestSideChat(selection)
+        }}
+        type="button"
+      >
+        <Codicon name="comment-discussion" size="0.875rem" />
+        <span>{t.desktop.sideChat.chatAboutSelection}</span>
+      </button>
+      <button
+        aria-label={t.common.copy}
+        className="grid size-6 place-items-center rounded-full text-muted-foreground hover:bg-accent hover:text-foreground"
+        onClick={() => {
+          void writeClipboardText(selection.text)
+          hide()
+        }}
+        type="button"
+      >
+        <Codicon name="copy" size="0.75rem" />
+      </button>
+    </div>,
+    document.body
+  )
+}

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -19,6 +19,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { atom, computed } from 'nanostores'
 import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react'
 
+import { requestComposerInsert } from '@/app/chat/composer/focus'
 import { useGatewayRequest } from '@/app/gateway/hooks/use-gateway-request'
 import { useModelControls } from '@/app/session/hooks/use-model-controls'
 import { blobToDataUrl } from '@/app/session/hooks/use-prompt-actions/utils'
@@ -38,6 +39,7 @@ import { NEW_SESSION_TITLE, sessionTitle } from '@/lib/chat-runtime'
 import { transcribeAudioClientDirect } from '@/lib/voice-client-direct'
 import { createComposerAttachmentScope, draftTitleFor } from '@/store/composer'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
+import { notify } from '@/store/notifications'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $projectTree } from '@/store/projects'
 import { sessionAwaitingInput } from '@/store/prompts'
@@ -61,6 +63,7 @@ import {
   type SessionTile,
   sessionTileDelegate
 } from '@/store/session-states'
+import { $sideChatOrigins } from '@/store/side-chat'
 import type { SessionInfo } from '@/types/hermes'
 
 import type { SessionDragPayload } from './composer/inline-refs'
@@ -73,6 +76,7 @@ import { SessionStatusDot } from './session-status-dot'
 import { useSessionTileActions } from './session-tile-actions'
 import { tileOwnerRoute } from './session-tile-owner'
 import { type SessionView, SessionViewProvider } from './session-view'
+import { SideChatOriginStrip } from './side-chat-origin-strip'
 import { SessionContextMenu } from './sidebar/session-actions-menu'
 import { lastVisibleMessageIsUser } from './thread-loading'
 
@@ -183,6 +187,11 @@ function TileChat({
 }) {
   const { gateway, requestGateway } = useGatewayRequest()
   const queryClient = useQueryClient()
+  const { t } = useI18n()
+
+  // Set only for a chat opened from a selection in another conversation — the
+  // strip and the stage-in-main verb are the two things it turns on.
+  const sideChatOrigin = useStore($sideChatOrigins)[storedSessionId]
 
   // Owner ladder, same as useSessionTileActions (session-tile-actions.ts:99-103).
   // Recomputed when the tile store or any owner-bearing session list changes,
@@ -272,6 +281,28 @@ function TileChat({
   const onRemoveAttachment = useCallback((id: string) => void removeAttachment(id), [removeAttachment])
   const onRetryResume = useCallback(() => patchSessionTile(storedSessionId, { error: undefined }), [storedSessionId])
 
+  // Carry a side chat's reply back to the main chat. Staging — never sending —
+  // is the point: main must not receive a turn the user did not write, and its
+  // prompt cache must not be invalidated by one. `requestComposerInsert` appends
+  // to the target composer's draft, so an unsent prompt already in main survives.
+  const stageInMain = useCallback(
+    (text: string) => {
+      requestComposerInsert(text, { mode: 'block', target: 'main' })
+      notify({ kind: 'success', message: t.desktop.sideChat.stagedInMain, title: t.desktop.sideChat.stageInMain })
+    },
+    [t]
+  )
+
+  // Memoized: ChatView is memo()d, so a fresh node every render would defeat it
+  // for the whole chat shell (the tile re-renders per streamed token).
+  const selectionContext = useMemo(
+    () =>
+      sideChatOrigin && !sideChatOrigin.bannerDismissed ? (
+        <SideChatOriginStrip origin={sideChatOrigin} storedSessionId={storedSessionId} />
+      ) : undefined,
+    [sideChatOrigin, storedSessionId]
+  )
+
   // Per-tile model menu — rendered under this tile's SessionView so the pill
   // + switch target THIS runtime, not the primary (which may be mid-turn).
   const modelMenuContent = useMemo(
@@ -320,6 +351,7 @@ function TileChat({
           onRemoveAttachment={onRemoveAttachment}
           onRestoreToMessage={actions.restoreToMessage}
           onRetryResume={onRetryResume}
+          onStageInMain={sideChatOrigin ? stageInMain : undefined}
           onSteer={actions.steerPrompt}
           onSteerHidden={actions.injectHiddenPrompt}
           onSubmit={actions.submitText}
@@ -327,6 +359,7 @@ function TileChat({
           onToggleSelectedPin={noop}
           onTranscribeAudio={tileTranscribeAudio}
           requestModelOptionsForOwner={requestTileGateway}
+          selectionContext={selectionContext}
         />
       </ComposerScopeProvider>
     </SessionViewProvider>

--- a/apps/desktop/src/app/chat/side-chat-origin-strip.tsx
+++ b/apps/desktop/src/app/chat/side-chat-origin-strip.tsx
@@ -1,0 +1,48 @@
+/**
+ * The "where this side chat came from" strip.
+ *
+ * A side chat is an ordinary session — that is what makes it independent and
+ * what lets it reuse the tile chassis — so nothing on the session itself says it
+ * was opened from a selection in another conversation. Without this, the pane
+ * restored a day later is a transcript whose quoted opening block refers to
+ * something the user can no longer see.
+ *
+ * Dismissible on purpose: provenance is information, not chrome, and the user is
+ * allowed to decide they no longer need it.
+ */
+
+import { Codicon } from '@/components/ui/codicon'
+import { useI18n } from '@/i18n'
+import { dismissSideChatOriginBanner, type SideChatOrigin } from '@/store/side-chat'
+
+export function SideChatOriginStrip({
+  origin,
+  storedSessionId
+}: {
+  origin: SideChatOrigin
+  storedSessionId: string
+}) {
+  const { t } = useI18n()
+  const copy = t.desktop.sideChat
+
+  return (
+    <div
+      className="flex shrink-0 items-center justify-between gap-2 border-b border-(--stroke-nous) bg-(--ui-chat-bubble-background) px-3 py-1.5 text-xs text-muted-foreground"
+      data-side-chat-origin={storedSessionId}
+    >
+      <span className="flex min-w-0 items-center gap-1.5">
+        <Codicon name="comment-discussion" size="0.75rem" />
+        <span className="truncate">
+          {origin.fromTitle ? copy.referencingFrom(origin.fromTitle) : copy.chatAboutSelection}
+        </span>
+      </span>
+      <button
+        className="shrink-0 rounded px-1.5 py-0.5 hover:bg-accent hover:text-foreground"
+        onClick={() => dismissSideChatOriginBanner(storedSessionId)}
+        type="button"
+      >
+        {copy.dismiss}
+      </button>
+    </div>
+  )
+}

--- a/apps/desktop/src/app/context-menu/app-context-menu.tsx
+++ b/apps/desktop/src/app/context-menu/app-context-menu.tsx
@@ -23,6 +23,7 @@ import { isRemoteGateway } from '@/lib/media'
 import { reachablePreviewUrl } from '@/lib/preview-reach'
 import { openCommandPalette } from '@/store/command-palette'
 import { openPreview } from '@/store/preview'
+import { requestSideChat } from '@/store/side-chat'
 import { toggleStatusbarVisible } from '@/store/statusbar-prefs'
 import { requestActiveUpdate } from '@/store/updates'
 import { canOpenNewWindow, openNewWindow } from '@/store/windows'
@@ -361,6 +362,19 @@ function domSections(open: Extract<OpenContextMenu, { kind: 'dom' }>, t: Transla
     ])
   } else if (target.selectionText) {
     sections.push([
+      <Item
+        icon="comment-discussion"
+        key="selection-chat-about"
+        label={t.desktop.sideChat.chatAboutSelection}
+        onSelect={() => {
+          closeContextMenu()
+          requestSideChat({
+            fromStoredSessionId: target.storedSessionId || undefined,
+            messageId: target.messageId || undefined,
+            text: target.selectionText
+          })
+        }}
+      />,
       <Item
         icon="copy"
         key="selection-copy"

--- a/apps/desktop/src/app/context-menu/target.ts
+++ b/apps/desktop/src/app/context-menu/target.ts
@@ -21,6 +21,16 @@ export interface ContextMenuDomTarget {
   onImage: boolean
   /** The live selection's text at the moment of the click. */
   selectionText: string
+  /** The transcript row the click landed in, from its `data-message-id`. Empty
+   *  outside the transcript — user and assistant rows both carry the attribute
+   *  (see assistant-message.tsx), so a selection can name the message it came
+   *  from instead of arriving as anonymous text. */
+  messageId: string
+  /** The conversation the click landed in, from the transcript's
+   *  `data-stored-session-id`. Empty outside a transcript. Without it a
+   *  selection made in a second pane would be attributed to whichever chat is
+   *  primary, and discussed against that chat's backend. */
+  storedSessionId: string
 }
 
 /** Form fields and `contenteditable` hosts. Mirrors the keybind helper, but
@@ -43,6 +53,8 @@ export function resolveDomTarget(element: Element | null): ContextMenuDomTarget 
   const anchor = element?.closest('a[href]')
   const dialogContent = element?.closest('[data-slot="dialog-content"]')
   const image = element?.closest('img')
+  const message = element?.closest('[data-message-id]')
+  const transcript = element?.closest('[data-stored-session-id]')
   const linkUrl = anchor?.getAttribute('href')?.trim() ?? ''
 
   return {
@@ -52,7 +64,9 @@ export function resolveDomTarget(element: Element | null): ContextMenuDomTarget 
     linkUrl: linkUrl === '#' ? '' : linkUrl,
     imageUrl: image instanceof HTMLImageElement ? image.currentSrc || image.src : '',
     onImage: Boolean(image),
-    selectionText: window.getSelection()?.toString().trim() ?? ''
+    selectionText: window.getSelection()?.toString().trim() ?? '',
+    messageId: message?.getAttribute('data-message-id') ?? '',
+    storedSessionId: transcript?.getAttribute('data-stored-session-id') ?? ''
   }
 }
 

--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -43,7 +43,7 @@ import { registry } from '@/contrib/registry'
 import { discoverRuntimePlugins } from '@/contrib/runtime-loader'
 import { translateNow } from '@/i18n'
 import { NEW_SESSION_TITLE, sessionTitle as storedSessionTitle } from '@/lib/chat-runtime'
-import { Download, FileText, LayoutDashboard, PanelBottom, PanelTop, Terminal, Upload, Zap } from '@/lib/icons'
+import { Download, FileText, LayoutDashboard, MessageSquareText, PanelBottom, PanelTop, Terminal, Upload, Zap } from '@/lib/icons'
 import { type KeybindContribution, KEYBINDS_AREA } from '@/lib/keybinds/actions'
 import { isOnboardingEnabled } from '@/lib/onboarding-enabled'
 import { TRANSCRIPT_DIRECTIVE_AREA, type TranscriptDirectiveContribution } from '@/lib/transcript-directives'
@@ -72,8 +72,9 @@ import {
 } from '@/store/review'
 import { $currentCwd, $selectedStoredSessionId, $sessions, $yoloActive, sessionMatchesStoredId } from '@/store/session'
 import { watchSessionPins } from '@/store/session-pin-sync'
-import { $botChatScopes } from '@/store/session-states'
+import { $botChatScopes, openSessionTileIds, sessionTilePaneId } from '@/store/session-states'
 import { watchUnreadWriteGuard } from '@/store/session-unread-remote'
+import { mostRecentSideChatId } from '@/store/side-chat'
 import { $statusbarVisible } from '@/store/statusbar-prefs'
 import { isBrowserWindow, isHudWindow } from '@/store/windows'
 
@@ -363,6 +364,29 @@ registry.registerMany([
     // this does to what I can see".
     get: () => Boolean(targetZoneTabStripVisible()),
     set: () => void toggleTargetZoneTabStrip()
+  }),
+  // A side chat's pane is HIDDEN, never closed, from here: the conversation is
+  // worth keeping, and "visibility is not lifecycle". Acts on the newest side
+  // chat because that is the one the user just opened; the pane may not be
+  // adopted yet, in which case the toggle is a no-op until it lands.
+  paletteToggle({
+    id: 'view.toggleSideChat',
+    label: translateNow('desktop.sideChat.togglePanel'),
+    action: 'view.toggleSideChat',
+    icon: MessageSquareText,
+    keywords: ['side chat', 'selection', 'chat about', 'panel', 'panes', 'hide', 'show'],
+    get: () => {
+      const sideChatId = mostRecentSideChatId(openSessionTileIds())
+
+      return sideChatId ? isPaneVisible(sessionTilePaneId(sideChatId)) : false
+    },
+    set: () => {
+      const sideChatId = mostRecentSideChatId(openSessionTileIds())
+
+      if (sideChatId) {
+        togglePaneVisible(sessionTilePaneId(sideChatId))
+      }
+    }
   }),
   // The keybind panel's non-titlebar door (the keyboard icon is gone).
   {

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -86,6 +86,7 @@ import {
   setBusy,
   setMessages
 } from '@/store/session'
+import { $sideChatRequest } from '@/store/side-chat'
 import { $titlebarAppActionsSide, titlebarAppActionsClusterCounts } from '@/store/titlebar-app-actions'
 import { clearSessionTodos, setSessionTodos, todosForHydration } from '@/store/todos'
 import { armWakeWord, stopClientCapture } from '@/store/wake-word'
@@ -538,6 +539,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     archiveSession,
     branchCurrentSession,
     branchStoredSession,
+    chatAboutSelection,
     createBackendSessionForSend,
     openNewSessionTile,
     removeSession,
@@ -702,6 +704,21 @@ export function ContribWiring({ children }: { children: ReactNode }) {
       listed: placement.dir === 'center' ? false : undefined
     })
   }, [newProjectSessionRequest, openNewSessionTile])
+
+  // "Chat about selection": the transcript context menu and the selection
+  // toolbar are chrome with no session hooks, so they post a request and the
+  // create path lives here with the other session actions — one implementation,
+  // both entrances.
+  const sideChatRequest = useStore($sideChatRequest)
+
+  useEffect(() => {
+    if (!sideChatRequest) {
+      return
+    }
+
+    $sideChatRequest.set(null)
+    void chatAboutSelection(sideChatRequest)
+  }, [chatAboutSelection, sideChatRequest])
 
   const composer = useComposerActions({ activeSessionId, currentCwd, requestGateway })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -22,11 +22,13 @@ import {
   stripPendingClarifyProjectionForCache,
   toChatMessages
 } from '@/lib/chat-messages'
+import { sessionTitle } from '@/lib/chat-runtime'
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { recoverInFlightTurnJournal } from '@/lib/inflight-turn-journal'
+import { buildSelectionQuote, deriveSideChatTitle } from '@/lib/selection-quote'
 import { setSessionYolo } from '@/lib/yolo-session'
 import { $clarifyRequests } from '@/store/clarify'
-import { migrateSessionDraft } from '@/store/composer'
+import { migrateSessionDraft, stashSessionDraft } from '@/store/composer'
 import { clearQueuedPrompts, migrateQueuedPrompts } from '@/store/composer-queue'
 import {
   openGatewayForAgent,
@@ -122,6 +124,8 @@ import {
 } from '@/store/session-states'
 import { broadcastSessionsChanged } from '@/store/session-sync'
 import { forgetSessionUnread } from '@/store/session-unread'
+import type { SideChatRequest } from '@/store/side-chat'
+import { markSideChatOrigin } from '@/store/side-chat'
 import { $archivedSessions } from '@/store/sidebar-archive'
 import { restoreSessionTodosFromSnapshot } from '@/store/todos'
 import {
@@ -754,6 +758,12 @@ export function useSessionActions({
         listed?: boolean
         profile?: string
         route?: AgentProfileRoute | null
+        /** Session title for the new row (`session.create` takes one). */
+        title?: string
+        /** Runs once the tile exists, with its stored session id — the seam a
+         *  caller uses to seed the composer draft it was created for (a
+         *  "chat about this selection" side chat) without racing the create. */
+        seedDraft?: (storedSessionId: string) => void
         workspaceScope?: SessionTileWorkspaceScope
       }
     ) => {
@@ -775,6 +785,7 @@ export function useSessionActions({
 
         const params = {
           ...(await desktopSessionCreateParams(cwd, capturedRoute)),
+          ...(options?.title ? { title: options.title } : {}),
           ...(workspaceScope.workspaceMode === 'bots' ? { hidden: true } : {})
         }
 
@@ -846,6 +857,10 @@ export function useSessionActions({
         openSessionTile(stored, dir, options?.anchor, options?.before, workspaceScope)
         patchSessionTile(stored, { runtimeId: created.session_id })
 
+        // After the tile is registered, so a seeded draft is never written for a
+        // create that failed — and never races the composer reading it.
+        options?.seedDraft?.(stored)
+
         if (dir === 'center' && runtimeInfo?.cwd) {
           setCurrentCwdTransient(runtimeInfo.cwd)
           setWorkspaceCwdOwner(stored)
@@ -856,11 +871,70 @@ export function useSessionActions({
         if (listed) {
           broadcastSessionsChanged()
         }
+
+        // The created stored id, so a caller that seeded this session (a side
+        // chat) can keep addressing it without re-resolving the freshest row.
+        return stored
       } catch (error) {
         notifyError(error, copy.createSessionFailed)
       }
     },
     [copy, requestGateway, updateSessionState]
+  )
+
+  /** Open a SIDE CHAT beside the main one, carrying a transcript selection in as
+   *  its opening context.
+   *
+   *  Two things have to ride along with the selection. The MAIN chat's owner —
+   *  a selection taken from a conversation running on another connection or
+   *  profile has to be discussed against that same backend, or the side chat
+   *  answers from an environment that never saw the code. And the quote itself,
+   *  seeded into the new tile's COMPOSER DRAFT rather than sent as a turn: the
+   *  draft keeps the quote and the user's question inside one user turn (strict
+   *  role alternation forbids a synthetic user turn followed by a real one), and
+   *  draft text survives a restart where an attachment-only carry would not. */
+  const sideChatCopy = copy.sideChat
+
+  const chatAboutSelection = useCallback(
+    async (payload: SideChatRequest): Promise<string | undefined> => {
+      const quote = buildSelectionQuote(payload.text)
+
+      if (!quote.text) {
+        return undefined
+      }
+
+      if (quote.truncated) {
+        notify({ kind: 'info', message: sideChatCopy.truncated, title: sideChatCopy.chatAboutSelection })
+      }
+
+      // The conversation the selection came from: the one named by the surface it
+      // was taken in, else the primary chat. A quote from a second pane must be
+      // attributed — and routed — to ITS backend, not the primary's.
+      const fromStoredSessionId = payload.fromStoredSessionId ?? selectedStoredSessionIdRef.current
+      const fromRow = fromStoredSessionId ? cachedSessionRow(fromStoredSessionId) : undefined
+      // Exact connection+profile when the main row carries one; otherwise that
+      // profile on whichever connection serves it. Passing the resolved owner is
+      // what keeps a remote-owned conversation's side chat off the local default.
+      const ownerRoute = fromRow ? sessionOwnerRouteFromRow(fromRow) : undefined
+      const ownerOptions = ownerRoute ? { route: ownerRoute } : fromRow?.profile ? { profile: fromRow.profile } : {}
+      const cwd = $currentCwd.get().trim()
+
+      return await openNewSessionTile('right', {
+        anchor: 'workspace',
+        ...ownerOptions,
+        ...(cwd ? { cwd } : {}),
+        title: deriveSideChatTitle(payload.text, sideChatCopy.titlePrefix),
+        seedDraft: storedSessionId => {
+          markSideChatOrigin(storedSessionId, {
+            fromMessageId: payload.messageId,
+            fromStoredSessionId: fromStoredSessionId ?? '',
+            fromTitle: fromRow ? sessionTitle(fromRow) : ''
+          })
+          stashSessionDraft(storedSessionId, `${quote.text}\n\n`, [])
+        }
+      })
+    },
+    [openNewSessionTile, selectedStoredSessionIdRef, sideChatCopy]
   )
 
   const openSettings = useCallback(() => {
@@ -2638,6 +2712,7 @@ export function useSessionActions({
     archiveSession,
     branchCurrentSession,
     branchStoredSession,
+    chatAboutSelection,
     closeSettings,
     createBackendSessionForSend,
     openNewSessionTile,

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -75,11 +75,16 @@ interface MessageActionProps {
    *  was a large slice of per-token script time on long transcripts. */
   getMessageText: () => string
   onBranchInNewChat?: (messageId: string) => void
+  /** Side chats only: hand this reply back to the main chat's composer. The text
+   *  alone is enough — the main thread never learns which side chat it came from
+   *  through this channel, it just receives what the user chose to carry over. */
+  onStageInMain?: (text: string) => void
 }
 
 interface AssistantMessageProps {
   onBranchInNewChat?: (messageId: string) => void
   onDismissError?: (messageId: string) => void
+  onStageInMain?: (text: string) => void
 }
 
 export const AssistantMessage: FC<AssistantMessageProps> = props => {
@@ -176,7 +181,8 @@ const InterAgentAssistantMessage: FC<AssistantMessageProps & { sender: string }>
 const AssistantMessageBody: FC<AssistantMessageProps & { collapsedNotice?: null | ReactNode }> = ({
   collapsedNotice = null,
   onBranchInNewChat,
-  onDismissError
+  onDismissError,
+  onStageInMain
 }) => {
   const messageId = useAuiState(s => s.message.id)
   const messageRuntime = useMessageRuntime()
@@ -221,6 +227,7 @@ const AssistantMessageBody: FC<AssistantMessageProps & { collapsedNotice?: null 
         'group flex w-full min-w-0 max-w-full flex-col gap-0 self-start overflow-hidden',
         collapsedNotice && 'pb-(--conversation-turn-gap)'
       )}
+      data-message-id={messageId}
       data-role="assistant"
       data-slot="aui_assistant-message-root"
       // Collapsed inter-agent rows never carried the tapback listener; keeping
@@ -271,6 +278,7 @@ const AssistantMessageBody: FC<AssistantMessageProps & { collapsedNotice?: null 
               getMessageText={getMessageText}
               messageId={messageId}
               onBranchInNewChat={onBranchInNewChat}
+              onStageInMain={onStageInMain}
             />
           )}
           {/* Last thing in the turn — under the action bar, the way Cursor ends a
@@ -632,7 +640,8 @@ const AssistantActionBar: FC<MessageActionProps & { durationS?: number }> = ({
   durationS,
   messageId,
   getMessageText,
-  onBranchInNewChat
+  onBranchInNewChat,
+  onStageInMain
 }) => {
   const { t } = useI18n()
   const copy = t.assistant.thread
@@ -681,6 +690,17 @@ const AssistantActionBar: FC<MessageActionProps & { durationS?: number }> = ({
             tooltip={copy.branchNewChat}
           >
             <GitForkIcon className="size-3.5" />
+          </TooltipIconButton>
+        )}
+        {onStageInMain && (
+          <TooltipIconButton
+            onClick={() => {
+              triggerHaptic('selection')
+              onStageInMain(getMessageText())
+            }}
+            tooltip={t.desktop.sideChat.stageInMain}
+          >
+            <Codicon name="reply" size="0.875rem" />
           </TooltipIconButton>
         )}
         <CopyButton appearance="icon" buttonSize="icon" label={copy.copy} text={getMessageText} />

--- a/apps/desktop/src/components/assistant-ui/thread/index.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/index.tsx
@@ -43,6 +43,7 @@ interface ThreadProps {
   onCancel?: () => Promise<void> | void
   onDismissError?: (messageId: string) => void
   onRestoreToMessage?: (messageId: string, target?: RestoreMessageTarget) => Promise<void> | void
+  onStageInMain?: (text: string) => void
   sessionId?: string | null
   sessionKey?: string | null
 }
@@ -64,6 +65,7 @@ export const Thread = memo(function Thread({
   onCancel,
   onDismissError,
   onRestoreToMessage,
+  onStageInMain,
   sessionId = null,
   sessionKey
 }: ThreadProps) {
@@ -110,8 +112,8 @@ export const Thread = memo(function Thread({
   // transcript — thousands of renders of a thread that was about to be
   // replaced, all of it before the resume RPC had even been sent. They
   // reach the edit composer through ThreadEditContext instead (see above).
-  const callbacksRef = useRef({ onBranchInNewChat, onCancel, onDismissError, onRestoreToMessage })
-  callbacksRef.current = { onBranchInNewChat, onCancel, onDismissError, onRestoreToMessage }
+  const callbacksRef = useRef({ onBranchInNewChat, onCancel, onDismissError, onRestoreToMessage, onStageInMain })
+  callbacksRef.current = { onBranchInNewChat, onCancel, onDismissError, onRestoreToMessage, onStageInMain }
 
   // Only changes identity when one of the three values does, so Thread
   // re-renders for unrelated reasons never re-render the composer.
@@ -121,6 +123,7 @@ export const Thread = memo(function Thread({
   const hasCancel = Boolean(onCancel)
   const hasDismissError = Boolean(onDismissError)
   const hasRestoreToMessage = Boolean(onRestoreToMessage)
+  const hasStageInMain = Boolean(onStageInMain)
 
   const messageComponents = useMemo(
     () => ({
@@ -130,6 +133,7 @@ export const Thread = memo(function Thread({
             hasBranchInNewChat ? messageId => callbacksRef.current.onBranchInNewChat?.(messageId) : undefined
           }
           onDismissError={hasDismissError ? messageId => callbacksRef.current.onDismissError?.(messageId) : undefined}
+          onStageInMain={hasStageInMain ? text => callbacksRef.current.onStageInMain?.(text) : undefined}
         />
       ),
       SystemMessage,
@@ -145,7 +149,7 @@ export const Thread = memo(function Thread({
         />
       )
     }),
-    [hasBranchInNewChat, hasCancel, hasDismissError, hasRestoreToMessage, requestRestoreConfirm]
+    [hasBranchInNewChat, hasCancel, hasDismissError, hasRestoreToMessage, hasStageInMain, requestRestoreConfirm]
   )
 
   // Core's splash belongs to a fresh draft; a session that exists but has

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -3070,6 +3070,16 @@ export const ar = defineLocale({
     vaultCodeConfirm: 'إدخال الرمز'
   },
   desktop: {
+    sideChat: {
+      chatAboutSelection: 'الدردشة حول التحديد',
+      dismiss: 'تجاهل',
+      referencingFrom: title => `مقتبس من «${title}»`,
+      stageInMain: 'أضف إلى حقل المحادثة الرئيسية',
+      stagedInMain: 'أُضيف إلى حقل المحادثة الرئيسية — راجعه ثم أرسله',
+      titlePrefix: 'حول:',
+      togglePanel: 'إظهار/إخفاء لوحة الدردشة الجانبية',
+      truncated: 'تم اختصار التحديد لطوله'
+    },
     audioReadFailed: 'فشلت قراءة الصوت',
     sessionUnavailable: 'الجلسة غير متاحة',
     createSessionFailed: 'فشل إنشاء الجلسة',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -4036,6 +4036,16 @@ export const en: Translations = {
   },
 
   desktop: {
+    sideChat: {
+      chatAboutSelection: 'Chat about selection',
+      dismiss: 'Dismiss',
+      referencingFrom: title => `Referencing selection from “${title}”`,
+      stageInMain: 'Stage in main composer',
+      stagedInMain: 'Added to the main composer — review and send',
+      titlePrefix: 'About:',
+      togglePanel: 'Toggle side chat panel',
+      truncated: 'Selection truncated to fit'
+    },
     audioReadFailed: 'Could not read recorded audio',
     sessionUnavailable: 'Session unavailable',
     createSessionFailed: 'Could not create a new session',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -3481,6 +3481,16 @@ export const ja = defineLocale({
   },
 
   desktop: {
+    sideChat: {
+      chatAboutSelection: '選択範囲について質問',
+      dismiss: '閉じる',
+      referencingFrom: title => `「${title}」の選択範囲を参照`,
+      stageInMain: 'メインの入力欄に追加',
+      stagedInMain: 'メインの入力欄に追加しました — 確認して送信してください',
+      titlePrefix: 'について：',
+      togglePanel: 'サイドチャットパネルを切り替え',
+      truncated: '選択範囲が長いため切り詰めました'
+    },
     audioReadFailed: '録音した音声を読み取れませんでした',
     sessionUnavailable: 'セッションが利用できません',
     createSessionFailed: '新しいセッションを作成できませんでした',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -3752,6 +3752,16 @@ export const ru = defineLocale({
     secretPlaceholder: 'значение секрета'
   },
   desktop: {
+    sideChat: {
+      chatAboutSelection: 'Обсудить выделенное',
+      dismiss: 'Скрыть',
+      referencingFrom: title => `Ссылка на выделенное из «${title}»`,
+      stageInMain: 'Добавить в поле основного чата',
+      stagedInMain: 'Добавлено в поле основного чата — проверьте и отправьте',
+      titlePrefix: 'О:',
+      togglePanel: 'Показать или скрыть боковую панель чата',
+      truncated: 'Выделенное сокращено'
+    },
     audioReadFailed: 'Не удалось прочитать записанное аудио',
     sessionUnavailable: 'Сеанс недоступен',
     createSessionFailed: 'Не удалось создать новый сеанс',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -3601,6 +3601,17 @@ export interface Translations {
       failed: (error: string) => string
       timedOut: string
     }
+
+    sideChat: {
+      chatAboutSelection: string
+      dismiss: string
+      referencingFrom: (title: string) => string
+      stageInMain: string
+      stagedInMain: string
+      titlePrefix: string
+      togglePanel: string
+      truncated: string
+    }
   }
 
   tips: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -3336,6 +3336,16 @@ export const zhHant = defineLocale({
   },
 
   desktop: {
+    sideChat: {
+      chatAboutSelection: '討論選取內容',
+      dismiss: '忽略',
+      referencingFrom: title => `引用自「${title}」的選取內容`,
+      stageInMain: '加入主對話輸入框',
+      stagedInMain: '已加入主對話輸入框 — 確認後傳送',
+      titlePrefix: '關於：',
+      togglePanel: '切換側邊對話面板',
+      truncated: '選取內容過長，已截斷'
+    },
     audioReadFailed: '無法讀取錄製的音訊',
     sessionUnavailable: '工作階段不可用',
     createSessionFailed: '無法建立新工作階段',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -4149,6 +4149,16 @@ export const zh = defineLocale({
   },
 
   desktop: {
+    sideChat: {
+      chatAboutSelection: '讨论所选内容',
+      dismiss: '忽略',
+      referencingFrom: title => `引用自「${title}」的所选内容`,
+      stageInMain: '加入主对话输入框',
+      stagedInMain: '已加入主对话输入框 — 确认后发送',
+      titlePrefix: '关于：',
+      togglePanel: '切换侧边对话面板',
+      truncated: '所选内容过长，已截断'
+    },
     audioReadFailed: '无法读取录制的音频',
     sessionUnavailable: '会话不可用',
     createSessionFailed: '无法创建新会话',

--- a/apps/desktop/src/lib/selection-quote.test.ts
+++ b/apps/desktop/src/lib/selection-quote.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildSelectionQuote,
+  deriveSideChatTitle,
+  quoteBlock,
+  SELECTION_QUOTE_MAX_CHARS
+} from './selection-quote'
+
+/** Long enough that the cap must bite, with real line breaks to cut on. */
+const overLong = Array.from({ length: 400 }, (_, index) => `line ${index} ${'x'.repeat(60)}`).join('\n')
+
+describe('quoteBlock', () => {
+  it('prefixes every line and keeps blank lines inside the blockquote', () => {
+    expect(quoteBlock('one\n\ntwo').split('\n')).toEqual(['> one', '>', '> two'])
+  })
+
+  it('leaves interior indentation of code intact', () => {
+    expect(quoteBlock('if (x) {\n  return y\n}')).toBe('> if (x) {\n>   return y\n> }')
+  })
+})
+
+describe('buildSelectionQuote', () => {
+  it('normalises line endings and outer whitespace without marking a short selection', () => {
+    const quote = buildSelectionQuote('  a\r\n\r\nb  \n')
+
+    expect(quote).toEqual({ text: '> a\n>\n> b', truncated: false })
+  })
+
+  it('returns nothing for a whitespace-only selection instead of an empty quote marker', () => {
+    expect(buildSelectionQuote('   \n\n ')).toEqual({ text: '', truncated: false })
+  })
+
+  it('clips an over-budget selection at a line boundary and says so', () => {
+    const quote = buildSelectionQuote(overLong)
+
+    expect(quote.truncated).toBe(true)
+    expect(quote.text.endsWith('> …(truncated)')).toBe(true)
+    expect(quote.text.length).toBeLessThanOrEqual(SELECTION_QUOTE_MAX_CHARS)
+    // Every emitted line is still a quoted line — the cut never leaves a
+    // half-written line inside the blockquote.
+    expect(quote.text.split('\n').every(line => line === '>' || line.startsWith('> '))).toBe(true)
+  })
+
+  it('keeps a selection that only just fits, so the cap is a cap and not a haircut', () => {
+    const fitting = 'y'.repeat(200)
+    const quote = buildSelectionQuote(fitting, 400)
+
+    expect(quote.truncated).toBe(false)
+    expect(quote.text).toBe(`> ${fitting}`)
+  })
+
+  it('still quotes a single unbroken line that exceeds the budget alone', () => {
+    const quote = buildSelectionQuote('z'.repeat(900), 300)
+
+    expect(quote.truncated).toBe(true)
+    expect(quote.text.endsWith('> …(truncated)')).toBe(true)
+    expect(quote.text.startsWith('> z')).toBe(true)
+  })
+})
+
+describe('deriveSideChatTitle', () => {
+  it('strips leading code punctuation so a code selection reads as a phrase', () => {
+    expect(deriveSideChatTitle('```const cache = new Map()```')).toBe('About: const cache = new Map()')
+  })
+
+  it('collapses a multi-line selection into one tab-safe line', () => {
+    const title = deriveSideChatTitle('the loader\n\nre-reads the file')
+
+    expect(title).toBe('About: the loader re-reads the file')
+    expect(title).not.toContain('\n')
+  })
+
+  it('truncates past the title budget on a word boundary', () => {
+    const title = deriveSideChatTitle(`${'word '.repeat(40)}tail`)
+
+    expect(title.startsWith('About: word')).toBe(true)
+    expect(title.endsWith('…')).toBe(true)
+    expect(title.length).toBeLessThan(60)
+  })
+
+  it('falls back to a usable label when nothing survives cleanup', () => {
+    expect(deriveSideChatTitle('```\n  \n')).toBe('About: selection')
+  })
+
+  it('uses the caller’s translated prefix', () => {
+    expect(deriveSideChatTitle('parseConfig', 'Über:')).toBe('Über: parseConfig')
+  })
+})

--- a/apps/desktop/src/lib/selection-quote.ts
+++ b/apps/desktop/src/lib/selection-quote.ts
@@ -1,0 +1,116 @@
+/**
+ * Turning a transcript selection into side-chat context.
+ *
+ * A selection travels as TEXT in the side chat's composer draft, never as an
+ * attachment or an `@…:` reference: the draft stash persists text only
+ * (`loadPersistedDraftTexts` restores `{ attachments: [], text }`), no existing
+ * reference kind carries raw text (the ones that expand server-side resolve a
+ * path), and `@session:` is display-only. Text also needs no backend change, and
+ * it keeps the quote and the user's question inside ONE user turn — the app's
+ * strict role-alternation rule forbids a synthetic user turn followed by a real
+ * one.
+ *
+ * Everything here is pure so the quoting rules are testable without a DOM.
+ */
+
+/** Cap on a quoted selection. A selection can be a whole message, and the quote
+ *  plus the question still has to fit one composer draft comfortably. */
+export const SELECTION_QUOTE_MAX_CHARS = 4000
+
+const TRUNCATION_MARKER = '…(truncated)'
+
+const TITLE_MAX_CHARS = 40
+
+export interface SelectionQuote {
+  text: string
+  truncated: boolean
+}
+
+/**
+ * Quote every line, empty ones included. A blank line left unquoted would END
+ * the blockquote and drop the rest of the selection — inside a fenced code block
+ * that silently mangles the context the model is handed.
+ */
+export function quoteBlock(text: string): string {
+  return text
+    .split('\n')
+    .map(line => {
+      const trimmed = line.trimEnd()
+
+      return trimmed ? `> ${trimmed}` : '>'
+    })
+    .join('\n')
+}
+
+/**
+ * The quote block for a raw selection, clipped at a LINE boundary when it is
+ * over budget (a half-line quote reads like a typo) with a marker line making
+ * the omission visible to the reader and to the model.
+ */
+export function buildSelectionQuote(raw: string, max: number = SELECTION_QUOTE_MAX_CHARS): SelectionQuote {
+  const text = raw.replace(/\r\n?/g, '\n').trim()
+
+  if (!text) {
+    return { text: '', truncated: false }
+  }
+
+  const whole = quoteBlock(text)
+
+  if (whole.length <= max) {
+    return { text: whole, truncated: false }
+  }
+
+  const markerCost = TRUNCATION_MARKER.length + 3 // `> ` + the marker + the joining newline
+  const kept: string[] = []
+
+  for (const line of text.split('\n')) {
+    const candidate = kept.length ? quoteBlock([...kept, line].join('\n')) : quoteBlock(line)
+
+    if (candidate.length + markerCost > max) {
+      break
+    }
+
+    kept.push(line)
+  }
+
+  // One pathological line (a whole file's worth of text with no newline) still
+  // has to yield something quotable, even though it cannot respect the cap.
+  if (!kept.length) {
+    kept.push(text.slice(0, Math.max(1, max - markerCost)))
+  }
+
+  return { text: `${quoteBlock(kept.join('\n'))}\n> ${TRUNCATION_MARKER}`, truncated: true }
+}
+
+/**
+ * The side chat's session title, derived from the selection. Selections are
+ * usually code, so leading punctuation and backticks go first — otherwise the
+ * sidebar fills up with rows starting `About: ``` or `About: const`.
+ *
+ * The prefix is passed in rather than baked in: it is user-facing copy and
+ * belongs to the caller's translations.
+ */
+export function deriveSideChatTitle(raw: string, prefix = 'About:'): string {
+  const flat = raw
+    .replace(/[\r\n]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .replace(/^[\s`'"([{<*#>_~=|/\\-]+/, '')
+    // Trailing markdown fences and quotes only: brackets are left alone so
+    // `new Map()` does not lose its call parens.
+    .replace(/[\s`'"]+$/, '')
+    .trim()
+
+  if (!flat) {
+    return `${prefix} selection`.trim()
+  }
+
+  if (flat.length <= TITLE_MAX_CHARS) {
+    return `${prefix} ${flat}`.trim()
+  }
+
+  // Prefer a word boundary, but never return an empty tail from a long
+  // single-token selection (minified code, a URL).
+  const clipped = flat.slice(0, TITLE_MAX_CHARS).replace(/\s+\S*$/, '').trim() || flat.slice(0, TITLE_MAX_CHARS)
+
+  return `${prefix} ${clipped}…`.trim()
+}

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -791,6 +791,22 @@ export interface SessionTileWorkspaceScope {
 const TILES_KEY = 'hermes.desktop.sessionTiles.v2'
 const LEGACY_TILES_KEY = 'hermes.desktop.sessionTiles.v1'
 const TILE_PANE_PREFIX = 'session-tile:'
+
+/** The layout-tree pane id a session tile lives in. Pane ids are how the tree
+ *  stores are addressed (visibility toggles included) — build them here rather
+ *  than concatenating the prefix at each call site. */
+export function sessionTilePaneId(storedSessionId: string): string {
+  return `${TILE_PANE_PREFIX}${storedSessionId}`
+}
+
+/** The stored ids of the session tiles that are open right now, in tile order.
+ *  A caller deciding which tile to act on needs the OPEN set: the tile store is
+ *  authoritative for it, and anything derived from persisted records instead
+ *  would happily target a pane the user already closed. */
+export function openSessionTileIds(): string[] {
+  return $sessionTiles.get().map(tile => tile.storedSessionId)
+}
+
 const BOTS_TILE_BUCKET = '__bots_workspace__'
 
 /** Persisted placement — `dir` + strip slot (`before`) + dock `anchor` so a

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -393,6 +393,18 @@ describe('resolveComposerSessionKey', () => {
   it('falls back to the live id when the tip row is not loaded yet', () => {
     expect(resolveComposerSessionKey('tip-new', [])).toBe('tip-new')
   })
+
+  it('resolves a brand-new parentless session to its own id, never to nothing', () => {
+    // A side chat seeds its composer draft under the stored session id it was
+    // just created with; the composer then reads that draft through this
+    // resolver. Both must name the same key for a session with no lineage and no
+    // loaded row yet — a null here would re-key the draft onto the runtime id
+    // and the seeded quote would be silently dropped.
+    const freshId = '20260911_230000_side01'
+
+    expect(resolveComposerSessionKey(freshId, [])).toBe(freshId)
+    expect(resolveComposerSessionKey(freshId, [session({ id: freshId })])).toBe(freshId)
+  })
 })
 
 describe('shouldMigrateComposerScope', () => {

--- a/apps/desktop/src/store/side-chat.test.ts
+++ b/apps/desktop/src/store/side-chat.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { readJson } from '@/lib/storage'
+
+import {
+  $sideChatOrigins,
+  dismissSideChatOriginBanner,
+  markSideChatOrigin,
+  mostRecentSideChatId,
+  SIDE_CHAT_ORIGINS_KEY,
+  sideChatOriginFor
+} from './side-chat'
+
+const origin = { fromStoredSessionId: 'main-1', fromMessageId: 'msg-7', fromTitle: 'Settings loader' }
+
+beforeEach(() => {
+  $sideChatOrigins.set({})
+  window.localStorage.clear()
+})
+
+describe('side chat origins', () => {
+  it('resolves an origin for the side chat it was recorded for', () => {
+    markSideChatOrigin('side-1', origin)
+
+    expect(sideChatOriginFor('side-1')).toEqual(origin)
+  })
+
+  it('reports no origin for an unrelated session, so the banner stays off ordinary chats', () => {
+    expect(sideChatOriginFor('main-1')).toBeUndefined()
+    expect(sideChatOriginFor(null)).toBeUndefined()
+  })
+
+  it('keeps the persisted payload in step with the atom, so a restored pane can read it', () => {
+    markSideChatOrigin('side-1', origin)
+
+    expect(readJson<Record<string, unknown>>(SIDE_CHAT_ORIGINS_KEY)).toEqual({ 'side-1': origin })
+  })
+
+  it('dismisses the notice without forgetting the origin, which is what staging needs', () => {
+    markSideChatOrigin('side-1', origin)
+
+    dismissSideChatOriginBanner('side-1')
+
+    expect(sideChatOriginFor('side-1')).toEqual({ ...origin, bannerDismissed: true })
+    // Still persisted, still readable: dismissing is a display choice.
+    expect(readJson<Record<string, unknown>>(SIDE_CHAT_ORIGINS_KEY)).toHaveProperty('side-1')
+  })
+
+  it('records independent origins for concurrent side chats', () => {
+    markSideChatOrigin('side-1', origin)
+    markSideChatOrigin('side-2', { ...origin, fromMessageId: 'msg-9', fromStoredSessionId: 'main-2' })
+
+    expect(sideChatOriginFor('side-1')?.fromStoredSessionId).toBe('main-1')
+    expect(sideChatOriginFor('side-2')?.fromStoredSessionId).toBe('main-2')
+  })
+
+  it('ignores an empty session id rather than writing an unreachable entry', () => {
+    markSideChatOrigin('', origin)
+
+    expect($sideChatOrigins.get()).toEqual({})
+  })
+})
+
+describe('mostRecentSideChatId', () => {
+  it('picks the newest side chat among the ones actually open', () => {
+    markSideChatOrigin('side-1', origin)
+    markSideChatOrigin('side-2', origin)
+
+    expect(mostRecentSideChatId(['side-1', 'side-2'])).toBe('side-2')
+  })
+
+  it('takes recency from when the side chat was opened, not from pane order', () => {
+    markSideChatOrigin('side-1', origin)
+    markSideChatOrigin('side-2', origin)
+
+    // A dragged/re-docked tile can sit before an older one in the strip; the
+    // most recently OPENED side chat is still side-2.
+    expect(mostRecentSideChatId(['side-2', 'side-1'])).toBe('side-2')
+  })
+
+  it('never targets a closed pane, so the toggle cannot act on nothing', () => {
+    markSideChatOrigin('side-1', origin)
+    markSideChatOrigin('side-2', origin)
+
+    // side-2's pane was closed: it keeps its origin (the strip returns if the
+    // session is reopened) but is not a toggle target.
+    expect(mostRecentSideChatId(['side-1'])).toBe('side-1')
+  })
+
+  it('returns nothing when no open tile is a side chat', () => {
+    markSideChatOrigin('side-1', origin)
+
+    expect(mostRecentSideChatId(['ordinary-session'])).toBeNull()
+    expect(mostRecentSideChatId([])).toBeNull()
+  })
+})

--- a/apps/desktop/src/store/side-chat.ts
+++ b/apps/desktop/src/store/side-chat.ts
@@ -1,0 +1,125 @@
+/**
+ * Where a side chat was opened from.
+ *
+ * A side chat is an ordinary session — that is exactly what makes it
+ * independent and what lets it reuse the tile chassis for free. The one thing
+ * an ordinary session cannot hold is provenance: which conversation, and which
+ * message, it was opened from. That is presentation state the renderer owns (no
+ * other Hermes surface changes it), so it lives here rather than on the session
+ * row.
+ *
+ * Persisted, because a restored pane must still show the banner and still offer
+ * "stage in main composer" after a restart.
+ */
+
+import { atom } from 'nanostores'
+
+import { readJson, writeJson } from '@/lib/storage'
+
+export const SIDE_CHAT_ORIGINS_KEY = 'hermes.desktop.sideChatOrigins.v1'
+
+export interface SideChatOrigin {
+  /** True once the user dismissed the provenance strip. The record stays: the
+   *  origin is what enables "stage in main composer", so hiding the notice must
+   *  not cost the capability. */
+  bannerDismissed?: boolean
+  /** The message the selection came from, when it resolved to one. */
+  fromMessageId?: string
+  /** The conversation the selection was taken from. */
+  fromStoredSessionId: string
+  /** Its title at capture time — the banner names where the context came from. */
+  fromTitle: string
+}
+
+function load(): Record<string, SideChatOrigin> {
+  const parsed = readJson<Record<string, SideChatOrigin>>(SIDE_CHAT_ORIGINS_KEY) ?? {}
+  const origins: Record<string, SideChatOrigin> = {}
+
+  for (const [storedSessionId, origin] of Object.entries(parsed)) {
+    // A hand-edited or half-written payload must not render a broken banner.
+    if (origin && typeof origin.fromStoredSessionId === 'string' && typeof origin.fromTitle === 'string') {
+      origins[storedSessionId] = origin
+    }
+  }
+
+  return origins
+}
+
+export const $sideChatOrigins = atom<Record<string, SideChatOrigin>>(load())
+
+function publish(next: Record<string, SideChatOrigin>): void {
+  $sideChatOrigins.set(next)
+  writeJson(SIDE_CHAT_ORIGINS_KEY, next)
+}
+
+export function markSideChatOrigin(storedSessionId: string, origin: SideChatOrigin): void {
+  if (!storedSessionId) {
+    return
+  }
+
+  publish({ ...$sideChatOrigins.get(), [storedSessionId]: origin })
+}
+
+export function sideChatOriginFor(storedSessionId: string | null | undefined): SideChatOrigin | undefined {
+  return storedSessionId ? $sideChatOrigins.get()[storedSessionId] : undefined
+}
+
+/** Hide the provenance strip without forgetting where the side chat came from.
+ *  The origin is what keeps "stage in main composer" available, so dismissing
+ *  the notice must not take the capability with it. */
+export function dismissSideChatOriginBanner(storedSessionId: string): void {
+  const current = $sideChatOrigins.get()[storedSessionId]
+
+  if (!current || current.bannerDismissed) {
+    return
+  }
+
+  publish({ ...$sideChatOrigins.get(), [storedSessionId]: { ...current, bannerDismissed: true } })
+}
+
+export interface SideChatRequest {
+  /** The conversation the selection was taken from. Omitted by entrances that
+   *  only exist in the primary chat; the wiring then falls back to the primary
+   *  session. A selection made in another pane carries its own. */
+  fromStoredSessionId?: string
+  /** The message the selection came from, when it resolved to one. */
+  messageId?: string
+  /** The selected text to carry in as the side chat's opening context. */
+  text: string
+}
+
+/**
+ * Ask the controller to open a side chat for a selection.
+ *
+ * The entry points (the transcript context menu, the selection toolbar) are
+ * chrome — they hold no session hooks, and duplicating the create path there is
+ * how two entrances drift apart. They post the request here and the wiring
+ * consumes it, the same shape the new-project and fresh-session entrances use.
+ */
+export const $sideChatRequest = atom<null | SideChatRequest>(null)
+
+export function requestSideChat(request: SideChatRequest): void {
+  $sideChatRequest.set(request)
+}
+
+/**
+ * The newest side chat that is still OPEN, for the panel toggle to act on when
+ * the user has not focused a particular one. Recency comes from the origins map
+ * (insertion order — the order side chats were opened), filtered by which of
+ * those are open now: a side chat whose pane was closed keeps its origin on
+ * purpose (the strip and staging come back if the session is reopened), so it
+ * must not be a toggle target while it has no pane.
+ */
+export function mostRecentSideChatId(openStoredSessionIds: readonly string[]): null | string {
+  const origins = $sideChatOrigins.get()
+  const open = new Set(openStoredSessionIds)
+  const originIds = Object.keys(origins)
+
+  for (let index = originIds.length - 1; index >= 0; index -= 1) {
+    if (open.has(originIds[index])) {
+      return originIds[index]
+    }
+  }
+
+  return null
+}


### PR DESCRIPTION
> **Scope note.** Three of this request's six acceptance criteria already ship today — the docked,
> resizable panel and an independent thread with its own composer are the existing pane + session-tile
> chassis (drag a session row onto a pane edge and you have them). This PR adds the missing parts: a
> selection-scoped entrance, the context carry, and a way back to the main thread. No backend or agent
> change.

## What a user gets

1. **Select text in the main transcript** → a small pill appears over the selection offering
   *Chat about selection* (plus Copy). The same verb is in the transcript right-click menu, so the
   feature is reachable where people already look.
2. **The side chat opens in a right-docked pane** — an ordinary, independent session with its own
   thread and composer, resizable with the pane sash, hiding (not closing) via the *Toggle side chat
   panel* palette row.
3. **The selection arrives as the pane's opening context**: a quoted block pre-loaded into that
   pane's composer, with the caret waiting under it. The user types only their question.
4. **A provenance strip** at the top of the pane says which conversation the selection came from,
   and can be dismissed.
5. **Stage in main composer** on any side-chat reply appends that reply to the *main* chat's composer
   as a draft — never a send.

## Why it is built this way

**The selection travels as text in the composer draft.** The draft stash persists text only
(`loadPersistedDraftTexts` restores `{ attachments: [], text }`), no reference kind carries raw text
(`@file:` resolves a path, `@session:` is display-only), and a draft keeps the quote and the user's
question inside **one user turn** — the repo's strict role-alternation invariant forbids a synthetic
user turn followed by a real one. The quote is also sanitised line by line, because a blank line left
unquoted silently ends a blockquote and mangles fenced code.

**The side chat is an ordinary parentless session.** Parenting it would copy the parent transcript and
auto-title it `"<parent> (branch)"` — the opposite of "properly scoped". It inherits the main
session's owner route (exact connection+profile when the row carries one, else that profile) so a
selection taken from a conversation on a remote backend is discussed against *that* backend, not the
launch default.

**Staging, not sending.** Auto-submitting into main would mutate main's transcript, invalidate its
prompt cache, and inject a turn the user did not author. The verb appends via the existing
`requestComposerInsert(..., { target: 'main' })` composer bus — the same mechanism the preview console
already uses — so an unsent prompt already in main survives.

**Two entrance points, one implementation.** The menu and the pill are chrome with no session hooks,
so they post to `$sideChatRequest` and the wiring consumes it, exactly like the new-project and
fresh-session request atoms. The create path lives with the other session actions.

## Verification

- `npx tsc --noEmit` — clean.
- `npx vitest run` on the touched suites — **1165 tests passed across 95 files** (including new
  invariant tests for the quote rules, the origin store, the selection pill, the resolver contract and
  the panel toggle).
- Full desktop suite — **9808 passed, 4 failed across 3 files**. All four fail identically at the base
  commit (`a84a2223f8`) with this change absent, i.e. they are pre-existing and environment-specific:
  `src/store/voice-prefs.test.ts` (localStorage), `src/plugins/hermes-bots/group-rounds.test.ts`
  (ordering) and `electron/managed-ssh-update.test.ts` (launcher exits 127).
- `npx eslint` on the changed files — no errors.

## Deferred (deliberately)

- A **floating toolbar beyond the pill** (formatting actions on a selection) — no consumer today.
- **Multi-selection accumulation** ("add another selection to the open side chat").
- **Seeding the side chat with the question itself** at create time, which is what an inline
  "ask" input in the pill would need — the draft carry covers it without a second input.

## Notes

**Open question:** should repeated *Chat about selection* stack a new side chat as a tab in the same
right zone, or reuse the pane that is already open? This PR opens a new session per selection (each
selection is a different conversation); switching the second-and-later invocations to tabs in the
existing zone is a one-line change if maintainers prefer that.

Closes #48114
