### PR TITLE
fix(memory/mem0): trim a synced message at the last sentence boundary, not the first separator kind

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -42,6 +42,13 @@ _DEFAULT_USER_ID = "hermes-user"
 _SYNC_MSG_MAX_CHARS = 450
 
 
+# Sentence ends recognized when trimming a synced message. Deliberately unordered:
+# the LAST boundary of ANY kind wins, so one CJK stop early in a mixed-script turn
+# cannot outrank a Latin stop near the end of the window. ``".\n"`` is not listed —
+# its index can never exceed the bare ``"."`` it starts with.
+_SYNC_SENTENCE_ENDS = ("。", "！", "？", ".", "!", "?")
+
+
 def _truncate_for_sync(text: str, max_len: int = _SYNC_MSG_MAX_CHARS) -> str:
     """Cap a synced message at its last sentence boundary within ``max_len``.
 
@@ -52,10 +59,10 @@ def _truncate_for_sync(text: str, max_len: int = _SYNC_MSG_MAX_CHARS) -> str:
     """
     if len(text) <= max_len:
         return text
-    for sep in ("。", "！", "？", ".\n", ".", "!", "?"):
-        cut = text[:max_len].rfind(sep)
-        if cut > max_len // 3:
-            return text[:cut + 1]
+    window = text[:max_len]
+    cut = max(window.rfind(sep) for sep in _SYNC_SENTENCE_ENDS)
+    if cut > max_len // 3:
+        return text[:cut + 1]
     return text[:max_len]
 
 

--- a/tests/plugins/memory/test_mem0_v3.py
+++ b/tests/plugins/memory/test_mem0_v3.py
@@ -181,6 +181,36 @@ class TestSyncTurnTruncation:
         assert len(sent[1]["content"]) <= mem0_plugin._SYNC_MSG_MAX_CHARS and sent[1]["content"].endswith(".")
         assert provider._consecutive_failures == 0
 
+    def test_the_boundary_kept_is_the_last_one_in_the_window_whatever_its_script(self):
+        """A mixed-script turn must not be cut back to an early CJK stop.
+
+        The trim exists to keep as much of the turn as the embedder can take; picking the
+        first separator KIND that qualifies instead of the last boundary threw away most of
+        the allowed window whenever two kinds appeared — an early ``。`` (or ``.``, which
+        outranks ``!``/``?``) beat a boundary 240 characters later, so the facts stated in
+        the rest of the message never reached extraction.
+        """
+        cap = mem0_plugin._SYNC_MSG_MAX_CHARS
+        early, late = cap // 2, cap - 9
+
+        for early_sep, late_sep in (("。", "."), (".", "!"), ("？", "?"), ("！", ".")):
+            text = "a" * early + early_sep + "b" * (late - early - 1) + late_sep + "c" * cap
+            assert text[late] == late_sep and len(text) > cap  # both boundaries inside the window
+            kept = mem0_plugin._truncate_for_sync(text)
+            assert kept == text[:late + 1], f"{early_sep!r} before {late_sep!r} cut back to {len(kept)} chars"
+            assert kept.endswith(late_sep)
+
+    def test_a_boundary_only_in_the_first_third_still_falls_back_to_a_hard_cut(self):
+        """Unsegmented input keeps the whole window rather than a sliver of a sentence."""
+        cap = mem0_plugin._SYNC_MSG_MAX_CHARS
+        text = "a" * 10 + "." + "b" * (cap * 2)
+        assert mem0_plugin._truncate_for_sync(text) == text[:cap]
+
+    def test_a_message_inside_the_cap_is_never_touched(self):
+        cap = mem0_plugin._SYNC_MSG_MAX_CHARS
+        text = "Fine. Nothing to trim here! Really?"
+        assert len(text) <= cap and mem0_plugin._truncate_for_sync(text) == text
+
     def test_sync_max_chars_config_raises_cap(self, monkeypatch, tmp_path):
         """8k-token embedders should not be stuck at the 512-token default (#106235)."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## What does this PR do?

`_truncate_for_sync()` documents *"the last sentence boundary within `max_len`"*, but it loops over
separator **kinds** and returns on the first kind that qualifies:

```python
for sep in ("。", "！", "？", ".\n", ".", "!", "?"):
    cut = text[:max_len].rfind(sep)
    if cut > max_len // 3:
        return text[:cut + 1]
```

So one `。` early in a mixed-script turn outranks a `.` 240 characters later, and in pure ASCII a `.`
outranks a later `!` or `?` purely because it comes first in the tuple. With the 450-char default:

| Input (both boundaries inside the window) | `main` keeps | Available |
| --- | --- | --- |
| `"a"*200 + "。" + "b"*240 + "." + "c"*100` | 201 | 442 |
| `"d"*200 + "." + "e"*240 + "!" + "f"*100` | 201 | 442 |
| `"g"*200 + "." + "h"*240 + "." + "i"*100` (one kind — control) | 442 | 442 |

241 characters the embedder would have accepted are discarded, so any fact stated in the second half
of the turn never reaches extraction. Unlike #106235 the `add()` call **succeeds**, so nothing is
logged — the turn is simply remembered from its first sentence. `sync_max_chars` (#106542) does not
help: the loss scales with the window, so raising the cap for an 8k-token embedder widens the gap.

This is the common case, not a corner: CJK users writing code, paths or English fragments hit it on
almost every long turn, and so does any English turn whose first sentence ends before a later `!`/`?`.

### The fix

Take the max over every separator, from a named `_SYNC_SENTENCE_ENDS` tuple so the set is not buried
in the loop:

```python
window = text[:max_len]
cut = max(window.rfind(sep) for sep in _SYNC_SENTENCE_ENDS)
if cut > max_len // 3:
    return text[:cut + 1]
return text[:max_len]
```

`".\n"` is dropped from the set: `rfind(".\n") <= rfind(".")` always, so under a max it is
unreachable — and the old branch kept only the `.` anyway. The first-third guard and the hard-cut
fallback for unsegmented input are unchanged, and a message inside the cap is still returned
untouched.

## Related Issue

Fixes #108868

Introduced in `040742d06b` (#106542, salvage of #37427), which fixed the oversized-input drop from
#106235 / #37421. This corrects how that trim chooses its cut; the invariant that commit pinned
(`test_small_context_backend_never_sees_oversized_input`) still holds and is left untouched.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/mem0/__init__.py` — `_SYNC_SENTENCE_ENDS`; `_truncate_for_sync` takes the last
  boundary of any kind instead of the first qualifying kind.
- `tests/plugins/memory/test_mem0_v3.py::TestSyncTurnTruncation` — three tests: the last boundary
  wins across four early/late separator pairings (`。`/`.`, `.`/`!`, `？`/`?`, `！`/`.`); a boundary
  only in the first third still falls back to the hard cut; a message inside the cap is untouched.

## How to Test

1. `pytest tests/plugins/memory/test_mem0_v3.py -q` → **31 passed**.
2. Reproduce on `main`: `_truncate_for_sync("a"*200 + "。" + "b"*240 + "." + "c"*100, 450)` returns
   201 characters; with this change it returns 442, ending at the later `.`.
3. Neighbouring suites, one file at a time — `test_mem0_backend.py`, `test_mem0_providers.py`,
   `test_mem0_setup.py`, `test_mem0_backend_integration.py`, `test_multiplex_memory_identity_scope.py`,
   `tests/agent/test_memory_provider.py`, `tests/agent/test_memory_async_sync.py` → **154 passed,
   2 skipped** in total with the file above (the skips are `importorskip("mem0")`).
4. `scripts/check-windows-footguns.py --all` → clean (1534 files).

Sabotage-checked — each direction reverted alone fails a test:

| Sabotage | Result |
| --- | --- |
| Restore the first-kind-wins loop (the bug) | the last-boundary test fails |
| Drop the first-third guard | the unsegmented-input test fails |
| Ignore the boundary and always hard-cut | 2 fail, including the pinned `test_small_context_backend_never_sees_oversized_input` |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate — `_truncate_for_sync`,
      `_SYNC_MSG_MAX_CHARS`, `sync_max_chars` and "mem0 truncate sentence boundary" return only the
      closed chain that introduced this code (#37421, #37427, #106235, #106542); none touches which
      boundary is chosen.
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the affected and neighbouring suites (above) rather than the full tree.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6 (Darwin 25.6.0), Apple Silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the new constant carries the rule ("the LAST boundary of
      ANY kind wins") and why `".\n"` is absent; the function docstring already described this behaviour
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — pure string logic, no platform branch
