### PR TITLE
fix(desktop): give the pool idle reaper a backend work signal

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -292,6 +292,7 @@ import {
   undialedSshRouteSeeds
 } from './plugin-profile-routes'
 import { evictPoolEntries } from './pool-eviction'
+import { reapIdleBackends } from './pool-idle-reap'
 import { clampPoolLimits, parsePoolLimits, POOL_LIMITS_DEFAULTS } from './pool-limits'
 import {
   isBackgroundSlotWaitTimeout,
@@ -12349,6 +12350,29 @@ async function evictLruPoolBackends(keep) {
   )
 }
 
+// Ask a pooled backend whether it has in-flight work (an agent turn or a
+// cron job) before the idle reaper acts on `lastActiveAt` alone — that field
+// only reflects renderer attention and cannot see backend-side work (#108863).
+// Process-less descriptor entries (remote/cloud registry sources) have
+// nothing local to probe and are left to the existing lastActiveAt behavior.
+// A probe that cannot reach the backend fails closed (reports busy): an
+// indeterminate answer must not read as "safe to kill".
+async function isPoolBackendBusy(entry): Promise<boolean> {
+  if (!entry || !entry.process || !entry.port || !entry.token) {
+    return false
+  }
+
+  try {
+    const response: any = await fetchJson(`http://127.0.0.1:${entry.port}/api/desktop/pool-busy`, entry.token, {
+      timeoutMs: 5_000
+    })
+
+    return response?.busy !== false
+  } catch {
+    return true
+  }
+}
+
 function startPoolIdleReaper() {
   if (poolIdleReaper) {
     return
@@ -12357,12 +12381,16 @@ function startPoolIdleReaper() {
   poolIdleReaper = setInterval(() => {
     const now = Date.now()
 
-    for (const [profile, entry] of [...backendPool.entries()]) {
-      if (now - (entry.lastActiveAt || 0) > poolIdleMs()) {
+    void reapIdleBackends(
+      backendPool.entries(),
+      now,
+      poolIdleMs(),
+      profile => isPoolBackendBusy(backendPool.get(profile)),
+      async profile => {
         rememberLog(`Reaping idle profile backend "${profile}" (idle > ${Math.round(poolIdleMs() / 1000)}s)`)
-        stopPoolBackend(profile)
+        await stopPoolBackend(profile)
       }
-    }
+    )
 
     if (backendPool.size === 0 && poolIdleReaper) {
       clearInterval(poolIdleReaper)

--- a/apps/desktop/electron/pool-idle-reap.test.ts
+++ b/apps/desktop/electron/pool-idle-reap.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for electron/pool-idle-reap.ts — the desktop backend pool's idle
+ * reaper, gated on a backend-side busy signal (#108863).
+ *
+ * `lastActiveAt` only reflects renderer attention (chat WS open/streaming
+ * keepalive); it says nothing about a backend running a cron job with no
+ * window attached. Before this gate, the reaper killed such a backend mid-run
+ * whenever it looked idle by that signal alone.
+ */
+
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { reapIdleBackends, selectIdleReapCandidates } from './pool-idle-reap'
+
+const NOW = 1_000_000
+const IDLE_MS = 10 * 60_000
+
+const entry = (idleMs: number) => ({ lastActiveAt: NOW - idleMs })
+
+test('selectIdleReapCandidates only picks entries past the idle threshold', () => {
+  const entries: [string, ReturnType<typeof entry>][] = [
+    ['idle', entry(IDLE_MS + 1_000)],
+    ['fresh', entry(IDLE_MS - 1_000)]
+  ]
+
+  assert.deepEqual(selectIdleReapCandidates(entries, NOW, IDLE_MS), ['idle'])
+})
+
+test('#108863: an idle-by-lastActiveAt backend running a cron job is not stopped', async () => {
+  const entries: [string, ReturnType<typeof entry>][] = [['default', entry(IDLE_MS + 1_000)]]
+  const stopped: string[] = []
+
+  const reaped = await reapIdleBackends(
+    entries,
+    NOW,
+    IDLE_MS,
+    async () => true, // the backend reports in-flight work (cron run)
+    async key => {
+      stopped.push(key)
+    }
+  )
+
+  assert.deepEqual(stopped, [], 'a backend with in-flight work must not be stopped')
+  assert.deepEqual(reaped, [])
+})
+
+test('a genuinely idle backend (no in-flight work) is still reaped', async () => {
+  const entries: [string, ReturnType<typeof entry>][] = [['default', entry(IDLE_MS + 1_000)]]
+  const stopped: string[] = []
+
+  const reaped = await reapIdleBackends(
+    entries,
+    NOW,
+    IDLE_MS,
+    async () => false,
+    async key => {
+      stopped.push(key)
+    }
+  )
+
+  assert.deepEqual(stopped, ['default'])
+  assert.deepEqual(reaped, ['default'])
+})
+
+test('a fresh backend is never probed or reaped regardless of its busy signal', async () => {
+  const entries: [string, ReturnType<typeof entry>][] = [['default', entry(1_000)]]
+  let probed = false
+
+  const reaped = await reapIdleBackends(
+    entries,
+    NOW,
+    IDLE_MS,
+    async () => {
+      probed = true
+
+      return true
+    },
+    async () => {
+      throw new Error('must not stop a fresh backend')
+    }
+  )
+
+  assert.equal(probed, false)
+  assert.deepEqual(reaped, [])
+})

--- a/apps/desktop/electron/pool-idle-reap.ts
+++ b/apps/desktop/electron/pool-idle-reap.ts
@@ -1,0 +1,57 @@
+/**
+ * pool-idle-reap.ts
+ *
+ * Idle-reap selection for the desktop backend pool, gated on backend-side
+ * work rather than `lastActiveAt` alone.
+ *
+ * `lastActiveAt` is refreshed only by renderer attention (chat WS open /
+ * streaming keepalive) — the main process has no visibility into work a
+ * pooled backend does on its own (a cron job, a long agent turn with no
+ * window attached). A backend running such work with no renderer attached
+ * looks idle by `lastActiveAt` alone and was reaped mid-run, killing the
+ * in-flight execution (#108863). `isBusy` gives the reaper a real work
+ * signal to check before it acts on the renderer-attention proxy.
+ */
+
+export interface PoolIdleEntry {
+  lastActiveAt?: null | number
+}
+
+/** Pool keys idle beyond `idleMs` by the `lastActiveAt` renderer-attention signal alone. */
+export function selectIdleReapCandidates<K>(
+  entries: Iterable<[K, PoolIdleEntry]>,
+  now: number,
+  idleMs: number
+): K[] {
+  return [...entries].filter(([, entry]) => now - (entry.lastActiveAt || 0) > idleMs).map(([key]) => key)
+}
+
+/**
+ * Reap every pool entry idle past `idleMs`, but only after `isBusy` confirms
+ * the backend itself has no in-flight work. `isBusy` must fail closed — a
+ * probe that cannot tell must report busy, since "can't tell" is exactly the
+ * previously-unguarded case that let a cron run get reaped mid-flight.
+ */
+export async function reapIdleBackends<K>(
+  entries: Iterable<[K, PoolIdleEntry]>,
+  now: number,
+  idleMs: number,
+  isBusy: (key: K) => Promise<boolean>,
+  stop: (key: K) => Promise<void>
+): Promise<K[]> {
+  const candidates = selectIdleReapCandidates(entries, now, idleMs)
+  const reaped: K[] = []
+
+  await Promise.all(
+    candidates.map(async key => {
+      if (await isBusy(key)) {
+        return
+      }
+
+      reaped.push(key)
+      await stop(key)
+    })
+  )
+
+  return reaped
+}

--- a/hermes_cli/web_routers/status.py
+++ b/hermes_cli/web_routers/status.py
@@ -116,6 +116,20 @@ async def get_health():
             "auth_required": bool(getattr(app.state, "auth_required", False))}
 
 
+@router.get("/api/desktop/pool-busy")
+async def get_desktop_pool_busy(request: Request):
+    """Backend-side work signal for Electron's pooled-backend idle reaper (#108863).
+
+    The reaper's only prior signal, `lastActiveAt`, is refreshed by renderer attention
+    (chat WS open/streaming) and cannot see a cron job running with no window attached,
+    so it reaped backends mid-run. Reuses the same turn-or-cron probe the SSH-isolated
+    idle-exit watchdog already relies on for the identical class of blind spot.
+    """
+    _require_token(request)
+    from hermes_cli.web_server_idle_exit import turn_in_flight
+    return {"busy": await run_in_threadpool(turn_in_flight)}
+
+
 # Profile segment mirrors hermes_cli.profiles._PROFILE_ID_RE. Platform segment mirrors the
 # Platform enum's normalized values: built-in members plus plugin directory names
 # (lowercased), which allow hyphens as well as underscores (e.g. ``reviewer:foo-bar``).

--- a/tests/hermes_cli/test_desktop_pool_busy_endpoint.py
+++ b/tests/hermes_cli/test_desktop_pool_busy_endpoint.py
@@ -1,0 +1,58 @@
+from fastapi.testclient import TestClient
+
+from hermes_cli import web_server
+from hermes_cli import web_server_idle_exit
+
+
+def test_pool_busy_endpoint_requires_token(monkeypatch):
+    token = "t" * 64
+    monkeypatch.setattr(web_server, "_SESSION_TOKEN", token)
+    web_server.app.state.auth_required = False
+    client = TestClient(web_server.app)
+
+    assert client.get("/api/desktop/pool-busy").status_code == 401
+
+
+def test_pool_busy_endpoint_reports_running_cron_job(monkeypatch):
+    """#108863: the Electron pool idle reaper's only signal (`lastActiveAt`) can't
+    see a cron job running with no chat window attached. This endpoint must report
+    busy so the reaper does not reap the backend mid-run."""
+    token = "t" * 64
+    monkeypatch.setattr(web_server, "_SESSION_TOKEN", token)
+    web_server.app.state.auth_required = False
+    monkeypatch.setattr(web_server_idle_exit, "turn_in_flight", lambda: True)
+    client = TestClient(web_server.app)
+
+    response = client.get("/api/desktop/pool-busy", headers={"X-Hermes-Session-Token": token})
+
+    assert response.status_code == 200
+    assert response.json() == {"busy": True}
+
+
+def test_pool_busy_endpoint_reports_idle_when_no_turn_or_cron_running(monkeypatch):
+    token = "t" * 64
+    monkeypatch.setattr(web_server, "_SESSION_TOKEN", token)
+    web_server.app.state.auth_required = False
+    monkeypatch.setattr(web_server_idle_exit, "turn_in_flight", lambda: False)
+    client = TestClient(web_server.app)
+
+    response = client.get("/api/desktop/pool-busy", headers={"X-Hermes-Session-Token": token})
+
+    assert response.status_code == 200
+    assert response.json() == {"busy": False}
+
+
+def test_pool_busy_endpoint_fails_closed_when_probe_is_indeterminate(monkeypatch):
+    """An indeterminate probe (e.g. the gateway session table is unreadable) must
+    report busy=null, never busy=false — the caller (main.ts's isPoolBackendBusy)
+    treats anything but an explicit `false` as busy."""
+    token = "t" * 64
+    monkeypatch.setattr(web_server, "_SESSION_TOKEN", token)
+    web_server.app.state.auth_required = False
+    monkeypatch.setattr(web_server_idle_exit, "turn_in_flight", lambda: None)
+    client = TestClient(web_server.app)
+
+    response = client.get("/api/desktop/pool-busy", headers={"X-Hermes-Session-Token": token})
+
+    assert response.status_code == 200
+    assert response.json() == {"busy": None}


### PR DESCRIPTION
### What changed

Closes #108863.

`apps/desktop`'s pool idle reaper (`startPoolIdleReaper` in `electron/main.ts`)
reaps a pooled backend once `Date.now() - entry.lastActiveAt > poolIdleMs()`.
`lastActiveAt` is refreshed **only** by `touchPoolBackend()`, which the
renderer calls when it opens a profile's chat WS or streams — it is a
renderer-attention signal, not a work signal. A pooled backend actively
running a scheduled (cron) job with no chat window open therefore looks idle
and gets SIGTERM'd mid-run; the in-flight execution dies and is booked as a
hard failure (`Interrupted by shutdown before terminal completion.`).

This gives the reaper a real backend-side work signal before it acts on that
proxy, per the issue's smallest proposed option ("probe before reaping"):

- **`hermes_cli/web_routers/status.py`**: new `GET /api/desktop/pool-busy`,
  gated by the existing `_require_token`. It reuses
  `hermes_cli.web_server_idle_exit.turn_in_flight()` — the same
  turn-or-cron-running probe the SSH-isolated idle-exit watchdog already
  relies on for the identical class of blind spot (added for #107485). No new
  liveness logic; this just exposes the existing probe over the loopback API
  the desktop pool already talks to.
- **`apps/desktop/electron/pool-idle-reap.ts`** (new): pure, DI-testable
  `selectIdleReapCandidates` / `reapIdleBackends`, mirroring the existing
  `pool-eviction.ts` pattern. `reapIdleBackends` only stops a candidate after
  an injected `isBusy(key)` check returns `false`.
- **`apps/desktop/electron/main.ts`**: `startPoolIdleReaper` now calls
  `reapIdleBackends`, with `isPoolBackendBusy(entry)` calling the new endpoint
  over the pooled entry's already-known port + token
  (`fetchJson('http://127.0.0.1:<port>/api/desktop/pool-busy', entry.token)`).
  The probe fails closed: an unreachable backend or a `busy: null`
  (indeterminate) response is treated as busy, matching the fail-closed
  convention `web_server_idle_exit.py` already uses for this exact class of
  probe. Process-less descriptor entries (remote/cloud registry sources,
  `entry.process === null`) are left untouched — they have no local process to
  probe or protect, and the LRU-cap code already carves them out of this cap
  for the same reason.

### Why this shape

- Reuses `turn_in_flight()` rather than inventing a second work-liveness
  check — it already answers "is this backend running a turn or a cron job"
  and is exactly what the SSH-isolated idle-exit watchdog uses for the sibling
  bug (#107485).
- `pool-idle-reap.ts` follows the same DI-testable-module pattern as
  `pool-eviction.ts`/`pool-stop.ts` so the reap-vs-busy decision is unit
  tested directly instead of asserted against `main.ts` source text (`main.ts`
  itself has no exports and is never imported by tests).

### Testing

`apps/desktop/electron/pool-idle-reap.test.ts` (new):

```
$ npx vitest run --project electron electron/pool-idle-reap.test.ts
 ✓ selectIdleReapCandidates only picks entries past the idle threshold
 ✓ #108863: an idle-by-lastActiveAt backend running a cron job is not stopped
 ✓ a genuinely idle backend (no in-flight work) is still reaped
 ✓ a fresh backend is never probed or reaped regardless of its busy signal

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Proved the regression test is real by temporarily removing the `isBusy` gate
from `reapIdleBackends` (i.e. reverting to the pre-fix "reap by lastActiveAt
alone" behavior): the `#108863` test failed with the busy backend stopped
anyway (`AssertionError: a backend with in-flight work must not be stopped`).
Restored the fix and re-ran — green.

Full electron suite unaffected:

```
$ npx vitest run --project electron
 Test Files  175 passed | 2 skipped (177)
      Tests  2215 passed | 6 skipped (2221)
```

`tsc -p tsconfig.electron.json --noEmit` and `npm run typecheck` (full,
including `src`/e2e configs) both pass. `npm run lint` (`eslint src/
electron/`) reports 0 errors (159 pre-existing warnings, none in touched
files).

`tests/hermes_cli/test_desktop_pool_busy_endpoint.py` (new), for the backend
endpoint:

```
$ scripts/run_tests.sh tests/hermes_cli/test_desktop_pool_busy_endpoint.py -v
 ✓ test_pool_busy_endpoint_requires_token
 ✓ test_pool_busy_endpoint_reports_running_cron_job
 ✓ test_pool_busy_endpoint_reports_idle_when_no_turn_or_cron_running
 ✓ test_pool_busy_endpoint_fails_closed_when_probe_is_indeterminate
=== Summary: 1 files, 4 tests passed, 0 failed ===
```

Proved these fail without the fix: reverted `hermes_cli/web_routers/status.py`
to `HEAD` (endpoint absent) and reran — all three behavioral tests failed with
`404`. Restored the endpoint — green again.

Also ran the adjacent existing suites to check for regressions:

```
$ scripts/run_tests.sh tests/hermes_cli/test_ssh_ownership_endpoint.py \
    tests/hermes_cli/test_web_server_idle_exit.py tests/hermes_cli/test_status.py \
    tests/hermes_cli/test_web_server.py tests/hermes_cli/test_dashboard_auth_middleware.py \
    tests/hermes_cli/test_dashboard_auth_status_endpoint.py
=== Summary: 6 files, 229 tests passed, 0 failed, 1 skipped ===
```

`ruff check` and `python -m py_compile` on the touched Python files both pass.

### AI-assistance disclosure

This PR was prepared with AI assistance (Claude Code / Claude Sonnet 5). All
code was reviewed, and the tests above were run and their output verified,
before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
