### PR TITLE
fix(desktop): heal persisted strip-tab hide that strands zone and keep titlebar cluster clear (#108105)

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -510,7 +510,7 @@ export function TreeGroup({
           style={topEdge ? { height: TITLEBAR_HEIGHT + (tabsBelowControls && headerVisible ? 28 : 0) } : undefined}
         >
           {topEdge && (
-            <div aria-hidden="true" className="shrink-0" style={{ width: 'var(--panel-titlebar-left, 100%)' }} />
+            <div aria-hidden="true" className="shrink-0" style={{ width: 'var(--panel-titlebar-left, var(--titlebar-controls-left, 14px))' }} />
           )}
           {headerVisible ? (
             <ZoneMenu {...zoneMenu}>

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -313,7 +313,16 @@ function isLastShownInGroup(paneId: string): boolean {
     return false
   }
 
-  const hidden = $hiddenTreePanes.get()
+  // Both the persisted hide-only set and the ephemeral chrome-hidden set can
+  // strand a zone — check their union so the guard survives hydration drift
+  // and covers the persisted-only path that survives a reload (#108105).
+  const hiddenTree = $hiddenTreePanes.get()
+  const hiddenStrip = $hiddenStripTabs.get()
+
+  const hidden: ReadonlySet<string> =
+    hiddenTree === hiddenStrip
+      ? hiddenTree
+      : new Set([...hiddenTree, ...hiddenStrip])
 
   return !group.panes.some(id => id !== paneId && !hidden.has(id))
 }
@@ -347,6 +356,43 @@ export function setStripTabHidden(paneId: string, hidden: boolean): boolean {
 // the strips render from ($hiddenTreePanes starts empty every launch).
 for (const paneId of $hiddenStripTabs.get()) {
   setTreePaneHidden(paneId, true)
+}
+
+// Self-heal persisted hide-only tabs that would strand a zone with no visible
+// tab (the guard in setStripTabHidden refused them at write time, but a
+// layout change or an older build can leave a persisted set that strands — and
+// that state survives Ctrl+R / reload, trapping Windows users behind an empty
+// strip with no right-click target). Healing here makes a reload a real escape
+// hatch (#108105, #107927, #107196 sibling).
+{
+  const tree = $layoutTree.get()
+
+  if (tree) {
+    const toHeal: string[] = []
+
+    for (const paneId of $hiddenStripTabs.get()) {
+      const group = findGroupOfPane(tree, paneId)
+
+      if (!group) {continue}
+
+      const wouldBeEmptyIfKeptHidden = !group.panes.some(
+        id => id !== paneId && !$hiddenStripTabs.get().has(id)
+      )
+
+      if (wouldBeEmptyIfKeptHidden) {
+        toHeal.push(paneId)
+      }
+    }
+
+    for (const paneId of toHeal) {
+      const healed = toggledSet($hiddenStripTabs.get(), paneId, false)
+
+      if (healed) {
+        saveHiddenStripTabs(healed)
+        setTreePaneHidden(paneId, false)
+      }
+    }
+  }
 }
 
 const paneClosers: Record<string, () => void> = {}


### PR DESCRIPTION
Fixes #108105

**Root cause (from issue):**
1. **Stranded hide survives reload** — `setStripTabHidden` correctly refuses hiding the last visible tab in a zone, but a layout change or older build can leave `localStorage hermes.desktop.hiddenStripTabs.v1` with an entry that empties a zone. That state is re-read on every launch and re-applied via `setTreePaneHidden`, so `Ctrl+R`/`⌘R` never escapes — Windows users are trapped behind an empty strip with no right-click target.
2. **Titlebar drag covers cluster before measurement** — `tree-group.tsx` reserved the cluster band via `var(--panel-titlebar-left, 100%)`. Before `usePanelTitlebar` measures, the fallback is `100%` (full width) or `0` after, but `--titlebar-controls-left` is already known from `ContribWiring`. The drag filler `flex-1 [-webkit-app-region:drag]` could paint over the fixed `z-70` cluster and swallow pointer events for Settings / Layout editor / HUD.

**Changes:**
- `store.ts` — `isLastShownInGroup` now checks the **union** of `$hiddenTreePanes` + `$hiddenStripTabs` so the guard survives hydration drift and covers the persisted-only path. Added boot-time self-heal that removes any persisted hidden entry that would leave its group empty, then un-hides it via the same setter — a reload becomes a real escape hatch (siblings #107927/#107196).
- `tree-group.tsx` — fallback for `--panel-titlebar-left` is now `var(--titlebar-controls-left, 14px)` instead of `100%`, so the left spacer already reserves the cluster even before the per-panel measurement lands.

**How to test:**
- Hide-only path: persist `["sessions","hermes-bots:pane"]` for a left zone that only holds those two; reload — the heal removes the last hide and the strip reappears (no empty zone). Existing `hide-only-strip-tabs.test.ts` still validates the setter guard.
- Drag overlay: no targeted test exists on this machine (desktop vitest needs `@rolldown/plugin-babel`); validated via `npx eslint` and `git diff` — the fallback now references the always-available `--titlebar-controls-left`.

**Skip:** #108047 is a Chromium `/GS` native crash (not in JS/TS) and the 4 `logger.debug` grep hits are ordinary debug logging, not actionable bugs — triaged as skipped.