### PR TITLE
fix(redact): case-insensitive gate for the Authorization header pass

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -370,6 +370,12 @@ _JSON_FIELD_RE = re.compile(rf'("{_JSON_KEY_NAMES}")\s*:\s*"([^"]+)"', re.IGNORE
 # (unterminated quote → shell EOF / SyntaxError).
 _AUTH_HEADER_RE = re.compile(r"((?:Proxy-)?Authorization:\s*)([A-Za-z][\w.+-]*\s+)?([^\s\"']+)", re.IGNORECASE)
 
+# Gate for the pass above: case-insensitive scan, no allocation (a text.lower()
+# copy would be O(n) on every log line). A case-sensitive `in` gate let
+# mixed-case header names (e.g. "aUtHoRiZaTiOn:") skip masking entirely even
+# though the masking regex itself is case-insensitive.
+_AUTH_HEADER_GATE_RE = re.compile(r"uthorization", re.IGNORECASE)
+
 # API-key style headers (single opaque value, no scheme word): non-vendor-prefix
 # values would otherwise leak when a curl command is echoed into tool output.
 _SECRET_HEADER_NAMES = r"(?:x-api-key|x-goog-api-key|api-key|apikey|x-api-token|x-auth-token|x-access-token)"
@@ -696,7 +702,7 @@ def redact_sensitive_text(text: str, *, force: bool = False, code_file: bool = F
     if not code_file:
         text = _redact_assignments(text)
 
-    if "uthorization" in text or "UTHORIZATION" in text:  # cheapest gate over every casing
+    if _AUTH_HEADER_GATE_RE.search(text):
         text = _AUTH_HEADER_RE.sub(lambda m: m.group(1) + (m.group(2) or "") + _mask_token(m.group(3)), text)
 
     if ":" in text:

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -305,6 +305,17 @@ class TestAuthHeaders:
         assert result.count('"') == 2, result  # both quotes survive
         assert result.endswith('"'), result
 
+    def test_mixed_case_authorization_header_masked(self):
+        # Regression for #108807: the cheap pre-mask gate was case-sensitive
+        # ("uthorization" / "UTHORIZATION" `in` checks) while the masking regex
+        # itself is case-insensitive — a mixed-case header name skipped masking
+        # entirely and the credential leaked verbatim.
+        for header in ("aUtHoRiZaTiOn", "PrOxY-aUtHoRiZaTiOn", "authorization", "PROXY-AUTHORIZATION"):
+            secret = "SyntheticOpaqueCredential92837465"
+            result = redact_sensitive_text(f"{header}: Bearer {secret}")
+            assert secret not in result, header
+            assert f"{header}: Bearer" in result, header  # name and scheme preserved
+
 
 
 class TestApiKeyHeaders:


### PR DESCRIPTION
Fixes #108807.

## What & why

The cheap pre-mask gate in `agent/redact.py` tested `"uthorization" in text or "UTHORIZATION" in text` — case-sensitive `in` checks — while the masking regex itself (`_AUTH_HEADER_RE`) is `re.IGNORECASE`. A mixed-case header name (`aUtHoRiZaTiOn: Bearer <token>`, or the same for `Proxy-Authorization`) contains neither probe, so the gate skipped the pass entirely and the credential leaked verbatim. Reproduced on current `main` exactly as reported in the issue.

The gate is now a precompiled case-insensitive scan (`re.compile(r"uthorization", re.IGNORECASE)`). This keeps the cheapest-gate intent — a C-level search with **no allocation** — instead of the tempting `text.lower()` copy, which would be O(n) allocation on every log line in a hot formatter.

## How to test

```python
from agent.redact import redact_sensitive_text
out = redact_sensitive_text("aUtHoRiZaTiOn: Bearer SyntheticOpaqueCredential92837465")
assert "SyntheticOpaqueCredential92837465" not in out  # leaked on main
```

New regression `TestAuthHeaders.test_mixed_case_authorization_header_masked` pins the invariant across four casings (canonical, mixed, all-caps, mixed Proxy-), asserting the secret is masked **and** the header name + scheme stay readable. Verified red on unpatched `main`, green here.

## Platforms tested

Linux. Pure string-processing change — no platform surface. Full suite (`scripts/run_tests.sh`) shows only the known pre-existing/flaky set (`update_head_moved_gate`, `voice_mode`, `openviking` reproduce on clean main; `fuzzy_match`, `hindsight_provider`, `codex_aux_timeout_fd_ownership`, `transcription`, `delegate_timeout_cleanup`, `compression_stall_fallback` pass in isolation on this branch).

## Security note

This is a redaction-correctness fix (SECURITY.md §3.2 class, per the issue's own framing): it closes a masking bypass for mixed-case Authorization/Proxy-Authorization headers. No other behavior changes.