### PR TITLE
fix(gateway): filter benign macOS malloc warning

### DIFF
--- a/hermes_cli/stderr_timestamp.py
+++ b/hermes_cli/stderr_timestamp.py
@@ -16,6 +16,21 @@ from typing import BinaryIO, Sequence, TextIO
 EXTERNAL_SUPERVISOR_FLAG = "--external-supervisor"
 
 _TIMESTAMP_PREFIX = re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3}(?:\s|$)")
+_BENIGN_MALLOC_STACK_LOGGING = re.compile(
+    r"^(?:[Pp]ython\([0-9]+\) )?"
+    r"MallocStackLogging: can't turn off malloc stack logging "
+    r"because it was not enabled\.$"
+)
+
+
+def _is_benign_darwin_malloc_stack_logging_line(
+    line: str, *, platform: str | None = None
+) -> bool:
+    """Match only the known-benign whole-line Darwin libmalloc diagnostic."""
+    if (sys.platform if platform is None else platform) != "darwin":
+        return False
+    rendered = line.removesuffix("\n").removesuffix("\r")
+    return bool(_BENIGN_MALLOC_STACK_LOGGING.fullmatch(rendered))
 
 
 def _timestamp() -> str:
@@ -38,7 +53,10 @@ def _open_log(log_path: Path) -> TextIO:
 def _copy_stderr_with_timestamps(stderr: BinaryIO, log_path: Path) -> None:
     with _open_log(log_path) as log_file:
         for raw_line in iter(stderr.readline, b""):
-            _write_timestamped_line(log_file, raw_line.decode("utf-8", errors="replace"))
+            line = raw_line.decode("utf-8", errors="replace")
+            if _is_benign_darwin_malloc_stack_logging_line(line):
+                continue
+            _write_timestamped_line(log_file, line)
 
 
 def _install_signal_forwarders(proc: subprocess.Popen[bytes]) -> dict[int, object]:

--- a/tests/hermes_cli/test_stderr_timestamp.py
+++ b/tests/hermes_cli/test_stderr_timestamp.py
@@ -49,6 +49,60 @@ def test_main_timestamps_each_stderr_line(tmp_path):
     assert lines[2] == "2026-07-15 12:34:56,789 already timestamped"
 
 
+_MALLOC_STACK_LOGGING_WARNING = (
+    "MallocStackLogging: can't turn off malloc stack logging because it was not enabled."
+)
+
+
+def test_benign_malloc_warning_exact_match_contract():
+    accepted = [
+        _MALLOC_STACK_LOGGING_WARNING,
+        f"Python(12345) {_MALLOC_STACK_LOGGING_WARNING}",
+        f"python(67890) {_MALLOC_STACK_LOGGING_WARNING}\r\n",
+    ]
+    for line in accepted:
+        assert stderr_timestamp._is_benign_darwin_malloc_stack_logging_line(
+            line, platform="darwin"
+        )
+        assert not stderr_timestamp._is_benign_darwin_malloc_stack_logging_line(
+            line, platform="linux"
+        )
+
+    rejected = [
+        f"ERROR: {_MALLOC_STACK_LOGGING_WARNING}",
+        f"{_MALLOC_STACK_LOGGING_WARNING} extra context",
+        "MallocStackLogging: malloc stack logging enabled.",
+        f"Python(not-a-pid) {_MALLOC_STACK_LOGGING_WARNING}",
+    ]
+    for line in rejected:
+        assert not stderr_timestamp._is_benign_darwin_malloc_stack_logging_line(
+            line, platform="darwin"
+        )
+
+
+@pytest.mark.macos_only
+def test_main_drops_only_benign_malloc_warning_on_darwin(tmp_path):
+    log_path = tmp_path / "gateway.error.log"
+    code = (
+        "import sys\n"
+        "sys.stderr.write('real failure\\n')\n"
+        f"sys.stderr.write({('Python(12345) ' + _MALLOC_STACK_LOGGING_WARNING + chr(10))!r})\n"
+        f"sys.stderr.write({('ERROR: ' + _MALLOC_STACK_LOGGING_WARNING + chr(10))!r})\n"
+        "sys.stderr.write('another real failure\\n')\n"
+    )
+
+    rc = stderr_timestamp.main(
+        ["--error-log", str(log_path), "--", sys.executable, "-c", code]
+    )
+
+    assert rc == 0
+    body = log_path.read_text(encoding="utf-8")
+    assert f"Python(12345) {_MALLOC_STACK_LOGGING_WARNING}" not in body
+    assert "real failure" in body
+    assert f"ERROR: {_MALLOC_STACK_LOGGING_WARNING}" in body
+    assert "another real failure" in body
+
+
 def test_prepare_upgrades_stale_gateway_argv_under_launchd():
     upgraded = stderr_timestamp._prepare_child_command(
         _STALE_GATEWAY_ARGV, _LAUNCHD_ENV


### PR DESCRIPTION
## What

Filters one known-benign macOS libmalloc teardown line at the existing launchd gateway stderr timestamp boundary:

```
Python(<pid>) MallocStackLogging: can't turn off malloc stack logging because it was not enabled.
```

The match is deliberately narrow:

- Darwin only
- exact whole line only
- optional observed `Python(<digits>)` / `python(<digits>)` prefix
- every near miss and all ordinary stderr remain visible

## Why this boundary

`generate_launchd_plist()` already runs the gateway through `hermes_cli.stderr_timestamp`, which owns the child stderr stream before it reaches `gateway.error.log`. Filtering there fixes the launchd gateway noise without setting `OS_ACTIVITY_MODE=disable`, which would suppress unrelated Apple Unified Logging for the gateway and its descendants.

This is a focused current-`main` extraction of the gateway-boundary portion of #100508. It does not replace that PR's broader Desktop and tool-capture work.

Addresses #54833.

## Verification

- Proved RED first: the added contract failed before implementation.
- `scripts/run_tests.sh tests/hermes_cli/test_stderr_timestamp.py tests/hermes_cli/test_gateway_service.py -q`
  - 120 passed
  - 0 failed
  - 1 unrelated Linux-only skip on macOS
- Real subprocess E2E on the macOS lane verifies the exact warning is dropped while normal and near-miss stderr survive.
- `git diff --check` passed.
- `py_compile` passed.
- Independent fail-closed review found no security or logic concerns.
