### PR TITLE
fix(gateway): sudo --system commands target the installed hermes-gateway unit again (#108674, salvage #108681 + #108706)

### DIFF
--- a/contributors/emails/129692708+huklaa@users.noreply.github.com
+++ b/contributors/emails/129692708+huklaa@users.noreply.github.com
@@ -1,0 +1,2 @@
+huklaa
+# PR #108681 salvage

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1097,11 +1097,8 @@ def _systemctl_show(properties: tuple[str, ...], *, system: bool) -> dict[str, s
     return _parse_kv_pairs(result.stdout.splitlines()) if result.returncode == 0 else {}
 
 
-def _hermes_home_from_systemd_unit_file(system: bool = False) -> str | None:
-    """``HERMES_HOME`` from the on-disk unit file — what refresh/compare already read, and reliable under ``sudo``."""
-    unit_path = get_systemd_unit_path(system=system)
-    if not unit_path.exists():
-        return None
+def _hermes_home_pinned_by_unit(unit_path: Path) -> str | None:
+    """``HERMES_HOME`` pinned by the unit file at *unit_path*, or None when absent/unreadable."""
     try:
         text = unit_path.read_text(encoding="utf-8")
     except OSError:
@@ -1113,6 +1110,11 @@ def _hermes_home_from_systemd_unit_file(system: bool = False) -> str | None:
             if body.startswith("HERMES_HOME="):
                 return body.split("=", 1)[1].strip().strip('"') or None
     return None
+
+
+def _hermes_home_from_systemd_unit_file(system: bool = False) -> str | None:
+    """``HERMES_HOME`` from the on-disk unit file - what refresh/compare already read, and reliable under ``sudo``."""
+    return _hermes_home_pinned_by_unit(get_systemd_unit_path(system=system))
 
 
 def _sync_hermes_home_from_systemd_unit(system: bool) -> None:
@@ -1937,6 +1939,8 @@ def _windows_gateway_breakaway_state() -> bool | None:
 _SERVICE_BASE = "hermes-gateway"
 SERVICE_DESCRIPTION = "Hermes Agent Gateway - Messaging Platform Integration"
 
+_SYSTEM_UNIT_DIR = Path("/etc/systemd/system")
+
 
 def _profile_name_from_home(home: Path, default: Path) -> str | None:
     """Profile name when ``home`` is ``<default>/profiles/<name>`` with a service-safe name, else None."""
@@ -1971,20 +1975,41 @@ def _native_service_homes() -> set[Path]:
     return homes
 
 
-def _profile_suffix() -> str:
-    """Service-name suffix for HERMES_HOME: "" for a native default home (``~/.hermes``), the profile
-    name for ``<root>/profiles/<name>``, else a short hash of the path.
+def _bare_unit_pinned_home() -> Path | None:
+    """Resolved ``HERMES_HOME`` pinned by an installed ``hermes-gateway.service``, or None.
 
-    The bare name is reserved for the process user's native default and, under sudo, the invoking user's
-    native default. It deliberately does not use ``get_default_hermes_root()``: that helper treats any
-    HERMES_HOME outside ``~/.hermes`` (Docker ``/opt/data``, a temp dir) as "the root itself", which let a
-    temp-home harness resolve to the default profile's ``hermes-gateway`` unit and uninstall the
-    production gateway. Service names are host-wide identities; only real default homes own the bare
-    one."""
+    The installed unit is the authority on which home owns the BARE name: under ``sudo`` the naming
+    basis moves MID-COMMAND (sudo strips HERMES_HOME and sets HOME=/root, then
+    ``_sync_hermes_home_from_systemd_unit()`` adopts the unit's own HERMES_HOME into ``os.environ``),
+    so a basis derived from the process would name one unit before the adoption and another after it.
+    Reading it from the unit is stable for every elevated identity, including ``sudo -i`` and cron
+    where SUDO_USER is absent.
+    """
+    pinned = _hermes_home_pinned_by_unit(_SYSTEM_UNIT_DIR / f"{_SERVICE_BASE}.service")
+    if not pinned:
+        return None
+    try:
+        return Path(pinned).expanduser().resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def _profile_suffix() -> str:
+    """Service-name suffix for HERMES_HOME: "" for a home that owns the bare name, the profile name for
+    ``<root>/profiles/<name>``, else a short hash of the path.
+
+    Bare-name owners: this process's platform-native default (``~/.hermes``), under sudo the invoking
+    user's native default, and the home pinned by an installed ``hermes-gateway.service``. The bare name
+    is deliberately NOT tied to ``get_default_hermes_root()``: that helper treats any HERMES_HOME outside
+    ``~/.hermes`` (Docker ``/opt/data``, a temp dir) as "the root itself", which let a temp-home harness
+    resolve to the default profile's ``hermes-gateway`` unit and uninstall the production gateway. Service
+    names are host-wide identities; a home with no installed bare unit and no native default keeps its
+    own suffix.
+    """
     import hashlib
     from hermes_constants import get_default_hermes_root
     home = get_hermes_home().resolve()
-    if home in _native_service_homes():
+    if home in _native_service_homes() or home == _bare_unit_pinned_home():
         return ""
     name = _profile_name_from_home(home, get_default_hermes_root().resolve())
     return name or hashlib.sha256(str(home).encode()).hexdigest()[:8]
@@ -2020,7 +2045,7 @@ def get_service_name() -> str:
 def get_systemd_unit_path(system: bool = False) -> Path:
     name = get_service_name()
     if system:
-        return Path("/etc/systemd/system") / f"{name}.service"
+        return _SYSTEM_UNIT_DIR / f"{name}.service"
     return Path.home() / ".config" / "systemd" / "user" / f"{name}.service"
 
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1955,10 +1955,8 @@ def _profile_name_from_home(home: Path, default: Path) -> str | None:
 
 
 def _native_service_homes() -> set[Path]:
-    """Homes whose service name is the bare ``hermes-gateway``: this process's native default and, under
-    sudo, the invoking user's. Under sudo the process default is ``/root/.hermes`` but
-    ``_sync_hermes_home_from_systemd_unit()`` rewrites HERMES_HOME mid-command to the unit's home — the
-    invoking user's ``~/.hermes`` — which would otherwise hash and target a unit that does not exist."""
+    """This process's native default home plus, when root under sudo, the invoking user's (see
+    ``_profile_suffix`` for why sudo matters)."""
     from hermes_constants import _get_platform_default_hermes_home, sudo_invoker_default_home
 
     homes = {_get_platform_default_hermes_home().resolve()}
@@ -1969,13 +1967,9 @@ def _native_service_homes() -> set[Path]:
 
 
 def _bare_unit_pinned_home() -> Path | None:
-    """Resolved ``HERMES_HOME`` pinned by an installed ``hermes-gateway.service``, or None.
-
-    Under ``sudo`` the process-derived naming basis moves MID-COMMAND: sudo strips HERMES_HOME and
-    sets HOME=/root, then ``_sync_hermes_home_from_systemd_unit()`` adopts the unit's own HERMES_HOME
-    into ``os.environ``, so a process-derived basis names one unit before the adoption and another
-    after it. The installed unit is the only basis that holds still, and it holds for every elevated
-    identity — ``sudo -i`` and cron included, where SUDO_USER is absent.
+    """Resolved ``HERMES_HOME`` pinned by an installed ``hermes-gateway.service``, or None. The unit is the
+    one naming basis that holds still across the sudo mid-command switch (see ``_profile_suffix``) and it
+    covers every elevated identity — ``sudo -i`` and cron included, where SUDO_USER is absent.
 
     Linux- and root-gated: a systemd unit is not an identity authority for launchd labels, Windows
     scheduled tasks, or s6 slots, which share ``_profile_suffix()``, and only an elevated process ever
@@ -2001,10 +1995,13 @@ def _profile_suffix() -> str:
     ``<root>/profiles/<name>``, else a short hash of the path.
 
     Bare-name owners: this process's platform-native default (``~/.hermes``), under sudo the invoking
-    user's native default, and the home pinned by an installed ``hermes-gateway.service``. The unit-pinned
-    check must precede the profile branch: ``sudo hermes gateway install --system`` resolves the BARE name
-    from root's default, then pins the invoking user's remapped home, so the bare unit legitimately carries
-    a ``<root>/profiles/<name>`` home and must keep answering with the bare name it was installed under.
+    user's native default, and the home pinned by an installed ``hermes-gateway.service``. Under sudo the
+    naming basis moves MID-COMMAND — sudo strips HERMES_HOME and sets HOME=/root, then
+    ``_sync_hermes_home_from_systemd_unit()`` adopts the unit's own HERMES_HOME into ``os.environ`` — so a
+    basis derived from the process alone names one unit before the adoption and another after it. The
+    unit-pinned check must precede the profile branch: ``sudo hermes gateway install --system`` resolves
+    the BARE name from root's default, then pins the invoking user's remapped home, so the bare unit
+    legitimately carries a ``<root>/profiles/<name>`` home.
 
     The bare name is deliberately NOT tied to ``get_default_hermes_root()``: that helper treats any
     HERMES_HOME outside ``~/.hermes`` (Docker ``/opt/data``, a temp dir) as "the root itself", which let a

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1977,19 +1977,22 @@ def _bare_unit_pinned_home() -> Path | None:
     after it. The installed unit is the only basis that holds still, and it holds for every elevated
     identity — ``sudo -i`` and cron included, where SUDO_USER is absent.
 
-    Linux-gated because a systemd unit is not an identity authority for launchd labels, Windows
-    scheduled tasks, or s6 slots, which share ``_profile_suffix()``. ``is_linux()`` is a plain
-    ``sys.platform`` test; ``supports_systemd_services()`` would be wrong here, since it can shell out
-    to ``systemctl is-system-running`` on WSL/containers and this runs on every name resolution.
+    Linux- and root-gated: a systemd unit is not an identity authority for launchd labels, Windows
+    scheduled tasks, or s6 slots, which share ``_profile_suffix()``, and only an elevated process ever
+    operates the system unit — an unprivileged user-scope command must keep naming its own units, or a
+    bare system unit pinning ``profiles/<name>`` would alias that profile onto the user's default unit.
+    ``is_linux()`` is a plain ``sys.platform`` test; ``supports_systemd_services()`` would be wrong here,
+    since it can shell out to ``systemctl is-system-running`` on WSL/containers and this runs on every
+    name resolution.
     """
-    if not is_linux():
+    if not is_linux() or os.geteuid() != 0:  # windows-footgun: ok — behind is_linux()
         return None
     pinned = _hermes_home_pinned_by_unit(_SYSTEM_UNIT_DIR / f"{_SERVICE_BASE}.service")
     if not pinned:
         return None
     try:
         return Path(pinned).expanduser().resolve()
-    except (OSError, RuntimeError, ValueError):
+    except (RuntimeError, ValueError):  # hand-edited unit: ``~nouser`` or an embedded NUL
         return None
 
 
@@ -2288,7 +2291,7 @@ _LEGACY_UNIT_EXECSTART_MARKERS: tuple[str, ...] = (
 
 def _legacy_unit_search_paths() -> list[tuple[bool, Path]]:
     """``[(is_system, base_dir), ...]`` to scan for legacy units; factored out so tests can monkeypatch."""
-    return [(False, Path.home() / ".config" / "systemd" / "user"), (True, Path("/etc/systemd/system"))]
+    return [(False, Path.home() / ".config" / "systemd" / "user"), (True, _SYSTEM_UNIT_DIR)]
 
 
 def _find_legacy_hermes_units() -> list[tuple[str, Path, bool]]:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1950,19 +1950,41 @@ def _profile_name_from_home(home: Path, default: Path) -> str | None:
     return None
 
 
-def _profile_suffix() -> str:
-    """Service-name suffix for HERMES_HOME: "" for the platform-native default home (``~/.hermes``), the
-    profile name for ``<root>/profiles/<name>``, else a short hash of the path.
+def _native_service_homes() -> set[Path]:
+    """Homes that own the bare native gateway service name in this process."""
+    from hermes_constants import _get_platform_default_hermes_home
+    from pathlib import Path as _Path
 
-    The bare name is reserved for the NATIVE default, not ``get_default_hermes_root()``: that helper
-    treats any HERMES_HOME outside ``~/.hermes`` (Docker ``/opt/data``, a temp dir) as "the root itself",
-    which let a temp-home harness resolve to the default profile's ``hermes-gateway`` unit and uninstall
-    the production gateway. Service names are host-wide identities; only the real default home owns the
-    bare one."""
+    homes = {_get_platform_default_hermes_home().resolve()}
+    if getattr(os, "geteuid", lambda: -1)() != 0:
+        return homes
+
+    sudo_user = os.environ.get("SUDO_USER", "").strip()
+    if not sudo_user or sudo_user == "root":
+        return homes
+    try:
+        import pwd
+
+        homes.add((_Path(pwd.getpwnam(sudo_user).pw_dir) / ".hermes").resolve())
+    except (ImportError, KeyError, AttributeError, TypeError):
+        pass
+    return homes
+
+
+def _profile_suffix() -> str:
+    """Service-name suffix for HERMES_HOME: "" for a native default home (``~/.hermes``), the profile
+    name for ``<root>/profiles/<name>``, else a short hash of the path.
+
+    The bare name is reserved for the process user's native default and, under sudo, the invoking user's
+    native default. It deliberately does not use ``get_default_hermes_root()``: that helper treats any
+    HERMES_HOME outside ``~/.hermes`` (Docker ``/opt/data``, a temp dir) as "the root itself", which let a
+    temp-home harness resolve to the default profile's ``hermes-gateway`` unit and uninstall the
+    production gateway. Service names are host-wide identities; only real default homes own the bare
+    one."""
     import hashlib
-    from hermes_constants import _get_platform_default_hermes_home, get_default_hermes_root
+    from hermes_constants import get_default_hermes_root
     home = get_hermes_home().resolve()
-    if home == _get_platform_default_hermes_home().resolve():
+    if home in _native_service_homes():
         return ""
     name = _profile_name_from_home(home, get_default_hermes_root().resolve())
     return name or hashlib.sha256(str(home).encode()).hexdigest()[:8]

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1978,13 +1978,19 @@ def _native_service_homes() -> set[Path]:
 def _bare_unit_pinned_home() -> Path | None:
     """Resolved ``HERMES_HOME`` pinned by an installed ``hermes-gateway.service``, or None.
 
-    The installed unit is the authority on which home owns the BARE name: under ``sudo`` the naming
-    basis moves MID-COMMAND (sudo strips HERMES_HOME and sets HOME=/root, then
-    ``_sync_hermes_home_from_systemd_unit()`` adopts the unit's own HERMES_HOME into ``os.environ``),
-    so a basis derived from the process would name one unit before the adoption and another after it.
-    Reading it from the unit is stable for every elevated identity, including ``sudo -i`` and cron
-    where SUDO_USER is absent.
+    Under ``sudo`` the process-derived naming basis moves MID-COMMAND: sudo strips HERMES_HOME and
+    sets HOME=/root, then ``_sync_hermes_home_from_systemd_unit()`` adopts the unit's own HERMES_HOME
+    into ``os.environ``, so a process-derived basis names one unit before the adoption and another
+    after it. The installed unit is the only basis that holds still, and it holds for every elevated
+    identity — ``sudo -i`` and cron included, where SUDO_USER is absent.
+
+    Linux-gated because a systemd unit is not an identity authority for launchd labels, Windows
+    scheduled tasks, or s6 slots, which share ``_profile_suffix()``. ``is_linux()`` is a plain
+    ``sys.platform`` test; ``supports_systemd_services()`` would be wrong here, since it can shell out
+    to ``systemctl is-system-running`` on WSL/containers and this runs on every name resolution.
     """
+    if not is_linux():
+        return None
     pinned = _hermes_home_pinned_by_unit(_SYSTEM_UNIT_DIR / f"{_SERVICE_BASE}.service")
     if not pinned:
         return None
@@ -1999,12 +2005,16 @@ def _profile_suffix() -> str:
     ``<root>/profiles/<name>``, else a short hash of the path.
 
     Bare-name owners: this process's platform-native default (``~/.hermes``), under sudo the invoking
-    user's native default, and the home pinned by an installed ``hermes-gateway.service``. The bare name
-    is deliberately NOT tied to ``get_default_hermes_root()``: that helper treats any HERMES_HOME outside
-    ``~/.hermes`` (Docker ``/opt/data``, a temp dir) as "the root itself", which let a temp-home harness
-    resolve to the default profile's ``hermes-gateway`` unit and uninstall the production gateway. Service
-    names are host-wide identities; a home with no installed bare unit and no native default keeps its
-    own suffix.
+    user's native default, and the home pinned by an installed ``hermes-gateway.service``. The unit-pinned
+    check must precede the profile branch: ``sudo hermes gateway install --system`` resolves the BARE name
+    from root's default, then pins the invoking user's remapped home, so the bare unit legitimately carries
+    a ``<root>/profiles/<name>`` home and must keep answering with the bare name it was installed under.
+
+    The bare name is deliberately NOT tied to ``get_default_hermes_root()``: that helper treats any
+    HERMES_HOME outside ``~/.hermes`` (Docker ``/opt/data``, a temp dir) as "the root itself", which let a
+    temp-home harness resolve to the default profile's ``hermes-gateway`` unit and uninstall the
+    production gateway. Service names are host-wide identities; a home with no installed bare unit and
+    no native default keeps its own suffix.
     """
     import hashlib
     from hermes_constants import get_default_hermes_root

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1955,23 +1955,16 @@ def _profile_name_from_home(home: Path, default: Path) -> str | None:
 
 
 def _native_service_homes() -> set[Path]:
-    """Homes that own the bare native gateway service name in this process."""
-    from hermes_constants import _get_platform_default_hermes_home
-    from pathlib import Path as _Path
+    """Homes whose service name is the bare ``hermes-gateway``: this process's native default and, under
+    sudo, the invoking user's. Under sudo the process default is ``/root/.hermes`` but
+    ``_sync_hermes_home_from_systemd_unit()`` rewrites HERMES_HOME mid-command to the unit's home — the
+    invoking user's ``~/.hermes`` — which would otherwise hash and target a unit that does not exist."""
+    from hermes_constants import _get_platform_default_hermes_home, sudo_invoker_default_home
 
     homes = {_get_platform_default_hermes_home().resolve()}
-    if getattr(os, "geteuid", lambda: -1)() != 0:
-        return homes
-
-    sudo_user = os.environ.get("SUDO_USER", "").strip()
-    if not sudo_user or sudo_user == "root":
-        return homes
-    try:
-        import pwd
-
-        homes.add((_Path(pwd.getpwnam(sudo_user).pw_dir) / ".hermes").resolve())
-    except (ImportError, KeyError, AttributeError, TypeError):
-        pass
+    sudo_home = sudo_invoker_default_home()
+    if sudo_home is not None:
+        homes.add(sudo_home.resolve())
     return homes
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -453,18 +453,15 @@ def _resolve_sudo_user_profile_env(name: str) -> str | None:
     sudo invocations the best signal is SUDO_USER: root is only doing the
     privileged install/start action; the profile store belongs to the user.
     """
-    if name == "default" or not hasattr(os, "geteuid") or os.geteuid() != 0:
+    if name == "default":
         return None
-    sudo_user = os.environ.get("SUDO_USER", "").strip()
-    if not sudo_user or sudo_user == "root":
-        return None
-    try:
-        import pwd
+    from hermes_constants import sudo_invoker_default_home
 
-        candidate = Path(pwd.getpwnam(sudo_user).pw_dir) / ".hermes" / "profiles" / name
-        return str(candidate) if candidate.is_dir() else None
-    except Exception:
+    sudo_home = sudo_invoker_default_home()
+    if sudo_home is None:
         return None
+    candidate = sudo_home / "profiles" / name
+    return str(candidate) if candidate.is_dir() else None
 
 
 def _under_gateway_supervisor(argv: list) -> bool:

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -62,7 +62,7 @@ def sudo_invoker_default_home() -> Path | None:
     sudo_user = os.environ.get("SUDO_USER", "").strip()
     if not sudo_user or sudo_user == "root":
         return None
-    import pwd  # windows-footgun: ok — unreachable without os.geteuid
+    import pwd
 
     try:
         return Path(pwd.getpwnam(sudo_user).pw_dir) / ".hermes"

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -51,6 +51,25 @@ def _get_platform_default_hermes_home() -> Path:
     return Path.home() / ".hermes"
 
 
+def sudo_invoker_default_home() -> Path | None:
+    """The invoking user's native ``~/.hermes`` when this process is root under ``sudo``, else None.
+
+    sudo strips HERMES_HOME and sets HOME=/root, so the process's own default is root's; the profile
+    store and the system service being operated on belong to SUDO_USER.
+    """
+    if not hasattr(os, "geteuid") or os.geteuid() != 0:
+        return None
+    sudo_user = os.environ.get("SUDO_USER", "").strip()
+    if not sudo_user or sudo_user == "root":
+        return None
+    import pwd  # windows-footgun: ok — unreachable without os.geteuid
+
+    try:
+        return Path(pwd.getpwnam(sudo_user).pw_dir) / ".hermes"
+    except KeyError:  # SUDO_USER not in passwd (chroot/container)
+        return None
+
+
 def _warn_profile_fallback_once() -> None:
     """Warn once when HERMES_HOME is unset but a non-default profile is sticky-active (wrong fallback)."""
     global _profile_fallback_warned

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -217,6 +217,40 @@ class TestServiceIdentityForForeignHome:
         monkeypatch.setenv("HERMES_HOME", str(default_home / "profiles" / "alpha"))
         assert gateway_cli.get_service_name() == "hermes-gateway-alpha"
 
+    def test_sudo_user_default_home_keeps_bare_service_name(self, machine_home, tmp_path, monkeypatch):
+        sudo_home = tmp_path / "alice"
+        sudo_default = sudo_home / ".hermes"
+        sudo_default.mkdir(parents=True)
+        monkeypatch.setattr(os, "geteuid", lambda: 0)
+        monkeypatch.setenv("SUDO_USER", "alice")
+        monkeypatch.setattr(pwd, "getpwnam", lambda user: SimpleNamespace(pw_dir=str(sudo_home)))
+
+        # Before unit sync, sudo resolves the root process's native home.
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        assert gateway_cli.get_service_name() == "hermes-gateway"
+
+        # After unit sync, HERMES_HOME points at the invoking user's native home.
+        monkeypatch.setenv("HERMES_HOME", str(sudo_default))
+        assert gateway_cli.get_service_name() == "hermes-gateway"
+
+    def test_sudo_user_named_and_custom_homes_remain_distinct(
+        self, machine_home, tmp_path, monkeypatch
+    ):
+        sudo_home = tmp_path / "alice"
+        named_home = sudo_home / ".hermes" / "profiles" / "alpha"
+        custom_home = tmp_path / "custom-hermes"
+        named_home.mkdir(parents=True)
+        custom_home.mkdir()
+        monkeypatch.setattr(os, "geteuid", lambda: 0)
+        monkeypatch.setenv("SUDO_USER", "alice")
+        monkeypatch.setattr(pwd, "getpwnam", lambda user: SimpleNamespace(pw_dir=str(sudo_home)))
+
+        monkeypatch.setenv("HERMES_HOME", str(named_home))
+        assert gateway_cli.get_service_name() == "hermes-gateway-alpha"
+
+        monkeypatch.setenv("HERMES_HOME", str(custom_home))
+        assert gateway_cli.get_service_name() not in {"hermes-gateway", "hermes-gateway-alpha"}
+
 
 class TestUninstallRefusesForeignUnit:
     """systemd_uninstall must not stop/disable/unlink a unit pinned to another HERMES_HOME."""

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+import hermes_constants
 
 pwd = pytest.importorskip("pwd")
 grp = pytest.importorskip("grp")
@@ -2770,3 +2771,72 @@ class TestTimeoutStopSecCoversCronFloor:
             env={"HERMES_CRON_DRAIN_TIMEOUT": "200"},
         )
         assert "TimeoutStopSec=240" in unit
+
+
+class TestUnitAnchoredServiceIdentity:
+    """The installed ``hermes-gateway.service`` owns the bare name: under ``sudo`` the naming basis moves
+    mid-command when ``_sync_hermes_home_from_systemd_unit()`` adopts the unit's HERMES_HOME (#108674)."""
+
+    def test_service_name_survives_hermes_home_adoption_from_unit(self, tmp_path, monkeypatch):
+        alice_home = tmp_path / "alice" / ".hermes"
+        alice_home.mkdir(parents=True)
+        root_home = tmp_path / "root" / ".hermes"
+        root_home.mkdir(parents=True)
+        unit_dir = tmp_path / "systemd"
+        unit_dir.mkdir()
+        unit_path = unit_dir / f"{gateway_cli._SERVICE_BASE}.service"
+        unit_path.write_text(f'[Service]\nEnvironment="HERMES_HOME={alice_home}"\n', encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
+        monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root_home)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        pre_name = gateway_cli.get_service_name()
+        monkeypatch.setenv("HERMES_HOME", str(alice_home))
+        assert gateway_cli.get_service_name() == pre_name
+
+    def test_unit_pinned_home_owns_the_bare_name(self, tmp_path, monkeypatch):
+        alice_home = tmp_path / "alice" / ".hermes"
+        alice_home.mkdir(parents=True)
+        root_home = tmp_path / "root" / ".hermes"
+        root_home.mkdir(parents=True)
+        unit_dir = tmp_path / "systemd"
+        unit_dir.mkdir()
+        unit_path = unit_dir / f"{gateway_cli._SERVICE_BASE}.service"
+        unit_path.write_text(f'[Service]\nEnvironment="HERMES_HOME={alice_home}"\n', encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
+        monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root_home)
+        monkeypatch.setenv("HERMES_HOME", str(alice_home))
+        assert gateway_cli.get_service_name() == gateway_cli._SERVICE_BASE
+        assert gateway_cli.get_systemd_unit_path(system=True) == unit_path
+
+    def test_foreign_home_without_installed_unit_keeps_its_suffix(self, tmp_path, monkeypatch):
+        unit_dir = tmp_path / "empty"
+        unit_dir.mkdir()
+        foreign = tmp_path / "elsewhere"
+        foreign.mkdir()
+        root_home = tmp_path / "root" / ".hermes"
+        root_home.mkdir(parents=True)
+        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
+        monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root_home)
+        monkeypatch.setenv("HERMES_HOME", str(foreign))
+        name = gateway_cli.get_service_name()
+        assert name != gateway_cli._SERVICE_BASE
+        assert name.startswith(gateway_cli._SERVICE_BASE + "-")
+
+    def test_home_not_pinned_by_unit_keeps_its_suffix(self, tmp_path, monkeypatch):
+        alice_home = tmp_path / "alice" / ".hermes"
+        alice_home.mkdir(parents=True)
+        bob_home = tmp_path / "bob" / ".hermes"
+        bob_home.mkdir(parents=True)
+        root_home = tmp_path / "root" / ".hermes"
+        root_home.mkdir(parents=True)
+        unit_dir = tmp_path / "systemd"
+        unit_dir.mkdir()
+        (unit_dir / f"{gateway_cli._SERVICE_BASE}.service").write_text(
+            f'[Service]\nEnvironment="HERMES_HOME={alice_home}"\n', encoding="utf-8"
+        )
+        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
+        monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root_home)
+        monkeypatch.setenv("HERMES_HOME", str(bob_home))
+        name = gateway_cli.get_service_name()
+        assert name != gateway_cli._SERVICE_BASE
+        assert name.startswith(gateway_cli._SERVICE_BASE + "-")

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2775,8 +2775,13 @@ class TestTimeoutStopSecCoversCronFloor:
 
 class TestUnitAnchoredServiceIdentity:
     """The installed ``hermes-gateway.service`` owns the bare name: under ``sudo`` the naming basis moves
-    mid-command when ``_sync_hermes_home_from_systemd_unit()`` adopts the unit's HERMES_HOME (#108674)."""
+    mid-command when ``_sync_hermes_home_from_systemd_unit()`` adopts the unit's HERMES_HOME (#108674).
 
+    ``linux_only`` because ``_bare_unit_pinned_home()`` is Linux-gated on purpose: a systemd unit is not
+    an identity authority for launchd labels, Windows tasks, or s6 slots, which share the same resolver.
+    """
+
+    @pytest.mark.linux_only
     def test_service_name_survives_hermes_home_adoption_from_unit(self, tmp_path, monkeypatch):
         alice_home = tmp_path / "alice" / ".hermes"
         alice_home.mkdir(parents=True)
@@ -2793,6 +2798,7 @@ class TestUnitAnchoredServiceIdentity:
         monkeypatch.setenv("HERMES_HOME", str(alice_home))
         assert gateway_cli.get_service_name() == pre_name
 
+    @pytest.mark.linux_only
     def test_unit_pinned_home_owns_the_bare_name(self, tmp_path, monkeypatch):
         alice_home = tmp_path / "alice" / ".hermes"
         alice_home.mkdir(parents=True)
@@ -2808,6 +2814,7 @@ class TestUnitAnchoredServiceIdentity:
         assert gateway_cli.get_service_name() == gateway_cli._SERVICE_BASE
         assert gateway_cli.get_systemd_unit_path(system=True) == unit_path
 
+    @pytest.mark.linux_only
     def test_foreign_home_without_installed_unit_keeps_its_suffix(self, tmp_path, monkeypatch):
         unit_dir = tmp_path / "empty"
         unit_dir.mkdir()
@@ -2822,6 +2829,7 @@ class TestUnitAnchoredServiceIdentity:
         assert name != gateway_cli._SERVICE_BASE
         assert name.startswith(gateway_cli._SERVICE_BASE + "-")
 
+    @pytest.mark.linux_only
     def test_home_not_pinned_by_unit_keeps_its_suffix(self, tmp_path, monkeypatch):
         alice_home = tmp_path / "alice" / ".hermes"
         alice_home.mkdir(parents=True)
@@ -2840,3 +2848,73 @@ class TestUnitAnchoredServiceIdentity:
         name = gateway_cli.get_service_name()
         assert name != gateway_cli._SERVICE_BASE
         assert name.startswith(gateway_cli._SERVICE_BASE + "-")
+
+    @pytest.mark.linux_only
+    def test_bare_unit_pinning_a_named_profile_home_keeps_the_bare_name(self, tmp_path, monkeypatch):
+        """``sudo ... install --system`` names the unit from root's default but pins the invoking user's
+        remapped home, so the BARE unit legitimately carries a ``profiles/<name>`` home. The unit-pinned
+        check therefore has to win over the profile branch, which would answer ``-kimi`` for a unit that
+        was installed bare."""
+        profile_home = tmp_path / "alice" / ".hermes" / "profiles" / "kimi"
+        profile_home.mkdir(parents=True)
+        root_home = tmp_path / "root" / ".hermes"
+        root_home.mkdir(parents=True)
+        unit_dir = tmp_path / "systemd"
+        unit_dir.mkdir()
+        unit_path = unit_dir / f"{gateway_cli._SERVICE_BASE}.service"
+        unit_path.write_text(f'[Service]\nEnvironment="HERMES_HOME={profile_home}"\n', encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
+        monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root_home)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        assert gateway_cli.get_service_name() == gateway_cli._SERVICE_BASE
+        # The profile branch, consulted against the home that owns the profile, would have answered
+        # with the readable suffix -- which is why the unit-pinned check has to be evaluated first.
+        assert gateway_cli._profile_name_from_home(profile_home, profile_home.parent.parent) == profile_home.name
+
+    @pytest.mark.linux_only
+    def test_real_unit_sync_keeps_the_name_it_validated(self, tmp_path, monkeypatch):
+        """Drive the production sync instead of simulating the adoption with setenv: the name resolved
+        before ``_sync_hermes_home_from_systemd_unit()`` must survive the mutation it performs."""
+        alice_home = tmp_path / "alice" / ".hermes"
+        alice_home.mkdir(parents=True)
+        root_home = tmp_path / "root" / ".hermes"
+        root_home.mkdir(parents=True)
+        unit_dir = tmp_path / "systemd"
+        unit_dir.mkdir()
+        (unit_dir / f"{gateway_cli._SERVICE_BASE}.service").write_text(
+            f'[Service]\nEnvironment="HERMES_HOME={alice_home}"\n', encoding="utf-8"
+        )
+        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
+        monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root_home)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+
+        pre_sync_name = gateway_cli.get_service_name()
+        gateway_cli._sync_hermes_home_from_systemd_unit(system=True)
+
+        assert os.environ["HERMES_HOME"] == str(alice_home)  # the sync really ran
+        assert gateway_cli.get_service_name() == pre_sync_name
+
+    @pytest.mark.linux_only
+    def test_unreadable_unit_does_not_grant_the_bare_name(self, tmp_path, monkeypatch):
+        """A unit we cannot read must not hand its bare name to an unrelated home: the parser returns
+        None on OSError, so resolution falls through to the suffix branches."""
+        foreign_home = tmp_path / "elsewhere"
+        foreign_home.mkdir()
+        root_home = tmp_path / "root" / ".hermes"
+        root_home.mkdir(parents=True)
+        unit_dir = tmp_path / "systemd"
+        unit_dir.mkdir()
+        unit_path = unit_dir / f"{gateway_cli._SERVICE_BASE}.service"
+        unit_path.write_text(f'[Service]\nEnvironment="HERMES_HOME={foreign_home}"\n', encoding="utf-8")
+        real_read_text = Path.read_text
+
+        def deny_unit(self, *args, **kwargs):
+            if self == unit_path:
+                raise PermissionError(13, "Permission denied")
+            return real_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
+        monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root_home)
+        monkeypatch.setattr(Path, "read_text", deny_unit)
+        monkeypatch.setenv("HERMES_HOME", str(foreign_home))
+        assert gateway_cli.get_service_name().startswith(gateway_cli._SERVICE_BASE + "-")

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2698,8 +2698,9 @@ class TestUnitAnchoredServiceIdentity:
     """The installed ``hermes-gateway.service`` owns the bare name: under ``sudo`` the naming basis moves
     mid-command when ``_sync_hermes_home_from_systemd_unit()`` adopts the unit's HERMES_HOME (#108674).
 
-    ``linux_only`` because ``_bare_unit_pinned_home()`` is Linux-gated on purpose: a systemd unit is not
-    an identity authority for launchd labels, Windows tasks, or s6 slots, which share the same resolver.
+    ``linux_only`` because ``_bare_unit_pinned_home()`` is Linux- and root-gated on purpose: a systemd unit
+    is not an identity authority for launchd labels, Windows tasks, or s6 slots, which share the same
+    resolver, and only an elevated process operates the system unit.
     """
 
     @pytest.mark.linux_only
@@ -2723,6 +2724,23 @@ class TestUnitAnchoredServiceIdentity:
         assert name.startswith(gateway_cli._SERVICE_BASE + "-")
 
     @pytest.mark.linux_only
+    def test_unprivileged_profile_command_ignores_the_system_unit(self, tmp_path, monkeypatch):
+        """A bare system unit pinning ``profiles/<name>`` must not alias that profile onto the user's
+        default unit when an unprivileged user-scope command resolves the name."""
+        profile_home = tmp_path / "alice" / ".hermes" / "profiles" / "kimi"
+        profile_home.mkdir(parents=True)
+        unit_dir = tmp_path / "systemd"
+        unit_dir.mkdir()
+        (unit_dir / f"{gateway_cli._SERVICE_BASE}.service").write_text(
+            f'[Service]\nEnvironment="HERMES_HOME={profile_home}"\n', encoding="utf-8"
+        )
+        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "alice")
+        monkeypatch.setattr(os, "geteuid", lambda: 1000)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        assert gateway_cli.get_service_name() == "hermes-gateway-kimi"
+
+    @pytest.mark.linux_only
     def test_bare_unit_pinning_a_named_profile_home_keeps_the_bare_name(self, tmp_path, monkeypatch):
         """``sudo ... install --system`` names the unit from root's default but pins the invoking user's
         remapped home, so the BARE unit legitimately carries a ``profiles/<name>`` home. The unit-pinned
@@ -2737,6 +2755,7 @@ class TestUnitAnchoredServiceIdentity:
         unit_path = unit_dir / f"{gateway_cli._SERVICE_BASE}.service"
         unit_path.write_text(f'[Service]\nEnvironment="HERMES_HOME={profile_home}"\n', encoding="utf-8")
         monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
+        monkeypatch.setattr(os, "geteuid", lambda: 0)
         monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root_home)
         monkeypatch.setenv("HERMES_HOME", str(profile_home))
         assert gateway_cli.get_service_name() == gateway_cli._SERVICE_BASE
@@ -2758,6 +2777,7 @@ class TestUnitAnchoredServiceIdentity:
             f'[Service]\nEnvironment="HERMES_HOME={alice_home}"\n', encoding="utf-8"
         )
         monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
+        monkeypatch.setattr(os, "geteuid", lambda: 0)
         monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root_home)
         monkeypatch.delenv("HERMES_HOME", raising=False)
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2716,7 +2716,7 @@ class TestUnitAnchoredServiceIdentity:
         (unit_dir / f"{gateway_cli._SERVICE_BASE}.service").write_text(
             f'[Service]\nEnvironment="HERMES_HOME={alice_home}"\n', encoding="utf-8"
         )
-        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
+        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir)
         monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root_home)
         monkeypatch.setenv("HERMES_HOME", str(bob_home))
         name = gateway_cli.get_service_name()
@@ -2734,7 +2734,7 @@ class TestUnitAnchoredServiceIdentity:
         (unit_dir / f"{gateway_cli._SERVICE_BASE}.service").write_text(
             f'[Service]\nEnvironment="HERMES_HOME={profile_home}"\n', encoding="utf-8"
         )
-        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
+        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir)
         monkeypatch.setattr(Path, "home", lambda: tmp_path / "alice")
         monkeypatch.setattr(os, "geteuid", lambda: 1000)
         monkeypatch.setenv("HERMES_HOME", str(profile_home))
@@ -2754,7 +2754,7 @@ class TestUnitAnchoredServiceIdentity:
         unit_dir.mkdir()
         unit_path = unit_dir / f"{gateway_cli._SERVICE_BASE}.service"
         unit_path.write_text(f'[Service]\nEnvironment="HERMES_HOME={profile_home}"\n', encoding="utf-8")
-        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
+        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir)
         monkeypatch.setattr(os, "geteuid", lambda: 0)
         monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root_home)
         monkeypatch.setenv("HERMES_HOME", str(profile_home))
@@ -2776,7 +2776,7 @@ class TestUnitAnchoredServiceIdentity:
         (unit_dir / f"{gateway_cli._SERVICE_BASE}.service").write_text(
             f'[Service]\nEnvironment="HERMES_HOME={alice_home}"\n', encoding="utf-8"
         )
-        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
+        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir)
         monkeypatch.setattr(os, "geteuid", lambda: 0)
         monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root_home)
         monkeypatch.delenv("HERMES_HOME", raising=False)

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -45,9 +45,6 @@ class TestUserSystemdPrivateSocketPreflight:
 
 class TestSystemdServiceRefresh:
 
-
-
-
     def test_systemd_restart_timeout_prints_status_guidance(self, monkeypatch, capsys):
         """`hermes gateway restart` must not surface a raw TimeoutExpired traceback.
 
@@ -86,7 +83,6 @@ class TestSystemdServiceRefresh:
         output = capsys.readouterr().out
         assert "still restarting after 90s" in output
         assert "hermes gateway status" in output
-
 
     def test_refresh_refuses_to_bake_pytest_tmpdir_into_real_user_unit(
         self, tmp_path, monkeypatch
@@ -143,7 +139,6 @@ class TestSystemdServiceRefresh:
         ), "daemon-reload must not run when write was refused"
 
 
-
 class TestTempHomeServiceDefinitionGuard:
     """_temp_home_in_service_definition() — structural temp-dir detection."""
 
@@ -154,16 +149,12 @@ class TestTempHomeServiceDefinitionGuard:
             == "/tmp/hermes-e2e-41264"
         )
 
-
     def test_detects_tempdir_env_home(self, monkeypatch, tmp_path):
         import tempfile as _tempfile
 
         monkeypatch.setattr(_tempfile, "gettempdir", lambda: str(tmp_path))
         unit = f'[Service]\nEnvironment="HERMES_HOME={tmp_path}/hermes-home"\n'
         assert gateway_cli._temp_home_in_service_definition(unit) is not None
-
-
-
 
 
 class TestRequireServiceInstalled:
@@ -233,24 +224,6 @@ class TestServiceIdentityForForeignHome:
         # After unit sync, HERMES_HOME points at the invoking user's native home.
         monkeypatch.setenv("HERMES_HOME", str(sudo_default))
         assert gateway_cli.get_service_name() == "hermes-gateway"
-
-    def test_sudo_user_named_and_custom_homes_remain_distinct(
-        self, machine_home, tmp_path, monkeypatch
-    ):
-        sudo_home = tmp_path / "alice"
-        named_home = sudo_home / ".hermes" / "profiles" / "alpha"
-        custom_home = tmp_path / "custom-hermes"
-        named_home.mkdir(parents=True)
-        custom_home.mkdir()
-        monkeypatch.setattr(os, "geteuid", lambda: 0)
-        monkeypatch.setenv("SUDO_USER", "alice")
-        monkeypatch.setattr(pwd, "getpwnam", lambda user: SimpleNamespace(pw_dir=str(sudo_home)))
-
-        monkeypatch.setenv("HERMES_HOME", str(named_home))
-        assert gateway_cli.get_service_name() == "hermes-gateway-alpha"
-
-        monkeypatch.setenv("HERMES_HOME", str(custom_home))
-        assert gateway_cli.get_service_name() not in {"hermes-gateway", "hermes-gateway-alpha"}
 
 
 class TestUninstallRefusesForeignUnit:
@@ -445,7 +418,6 @@ class TestGeneratedSystemdUnits:
         assert "SoftResourceLimits" not in plist
 
 
-
 class TestGatewayStopCleanup:
     @pytest.mark.linux_only
     def test_stop_only_kills_current_profile_by_default(self, tmp_path, monkeypatch):
@@ -499,8 +471,6 @@ class TestLaunchdServiceRecovery:
 
     def test_wait_for_pid_exit_ignores_nonpositive_pid(self):
         assert gateway_cli._wait_for_pid_exit(0, timeout=30) is True
-
-
 
     def test_refresh_defers_reload_when_running_inside_gateway_tree(self, tmp_path, monkeypatch):
         """#43842: when the refresh runs inside the gateway's own process tree,
@@ -622,7 +592,6 @@ class TestLaunchdServiceRecovery:
         assert popen_calls[0][:2] == ["launchctl", "submit"]
         assert not [c for c in run_calls if "bootout" in c or "bootstrap" in c]
 
-
     def test_deferred_reload_waits_for_old_gateway_pid_before_bootstrap(
         self, tmp_path, monkeypatch
     ):
@@ -675,7 +644,6 @@ class TestLaunchdServiceRecovery:
         )
         # The wait must be bounded, so a wedged gateway can't block the reload.
         assert "_wait_deadline" in script
-
 
     def test_refresh_falls_back_to_direct_reload_when_helper_cannot_spawn(
         self, tmp_path, monkeypatch
@@ -741,7 +709,6 @@ class TestLaunchdServiceRecovery:
         # Drained the old pid between bootout and bootstrap.
         assert waited and waited[0][0] == 4242
 
-
     def test_launchd_domain_uses_user_domain(self, monkeypatch):
         # The user/<uid> domain (not gui/<uid>) is the one reachable from
         # non-Aqua/background sessions on macOS 26+ (issue #23387).
@@ -760,10 +727,7 @@ class TestLaunchdServiceRecovery:
         assert gateway_cli._launchd_domain() == "user/501"
 
 
-
     # ── PID parsing ──────────────────────────────────────────────────────
-
-
 
 
     # ── Probe requires PID ───────────────────────────────────────────────
@@ -772,9 +736,7 @@ class TestLaunchdServiceRecovery:
     # ── Unsupport marker lifecycle ───────────────────────────────────────
 
 
-
     # ── launchd_status with active supervision ───────────────────────────
-
 
     def test_launchd_status_reports_fallback_when_unsupported_and_pid_running(self, tmp_path, monkeypatch, capsys):
         """When the unsupported marker exists and a fallback PID is running."""
@@ -835,7 +797,6 @@ class TestLaunchdDomainDetection:
         assert domain == "gui/501"
         # Should have probed gui first
         assert run_calls[0] == ["launchctl", "print", f"gui/501/{label}"]
-
 
     def test_managername_background_selects_user_domain(self, monkeypatch):
         """When managername is Background (non-Aqua), use user/<uid>."""
@@ -1216,11 +1177,6 @@ class TestGatewaySystemServiceRouting:
         assert "did not revive" in out
         assert "✓ Service restarted" in out
 
-
-
-
-
-
     @pytest.mark.macos_only
     def test_gateway_restart_does_not_fallback_to_foreground_when_launchd_restart_fails(self, tmp_path, monkeypatch):
         """macOS-gated: the branch under test is ``elif is_macos() and
@@ -1279,7 +1235,6 @@ class TestDetectVenvDir:
 
         result = gateway_cli._detect_venv_dir()
         assert result == dot_venv
-
 
     def test_returns_none_when_no_virtualenv(self, tmp_path, monkeypatch):
         monkeypatch.setattr("sys.prefix", "/usr")
@@ -1415,7 +1370,6 @@ class TestSystemUnitHermesHome:
 
         assert 'HERMES_HOME=/home/alice/.hermes' in unit
         assert '/root/.hermes' not in unit
-
 
     def test_user_unit_unaffected_by_change(self):
         # User-scope units should still use the calling user's HERMES_HOME
@@ -1567,8 +1521,6 @@ class TestHermesHomeForTargetUser:
         assert result == "/home/alice/.hermes"
 
 
-
-
 class TestGeneratedUnitUsesDetectedVenv:
     def test_systemd_unit_uses_dot_venv_when_detected(self, tmp_path, monkeypatch):
         dot_venv = tmp_path / ".venv"
@@ -1588,7 +1540,6 @@ class TestGeneratedUnitUsesDetectedVenv:
 
 class TestGeneratedUnitIncludesLocalBin:
     """~/.local/bin must be in PATH so uvx/pipx tools are discoverable."""
-
 
     def test_system_unit_includes_local_bin_in_path(self, monkeypatch):
         monkeypatch.setattr(
@@ -1642,7 +1593,6 @@ class TestSystemServiceIdentityRootHandling:
 class TestEnsureUserSystemdEnv:
     """Tests for _ensure_user_systemd_env() D-Bus session bus auto-detection."""
 
-
     def test_sets_dbus_address_when_bus_socket_exists(self, tmp_path, monkeypatch):
         runtime = tmp_path / "runtime"
         runtime.mkdir()
@@ -1656,8 +1606,6 @@ class TestEnsureUserSystemdEnv:
         gateway_cli._ensure_user_systemd_env()
 
         assert os.environ["DBUS_SESSION_BUS_ADDRESS"] == f"unix:path={bus_socket}"
-
-
 
     def test_systemctl_cmd_calls_ensure_for_user_mode(self, monkeypatch):
         calls = []
@@ -1675,7 +1623,6 @@ class TestPreflightUserSystemd:
     gateway via ``systemctl --user start`` in a shell with no user D-Bus session,
     which previously failed with a raw ``CalledProcessError`` and no remediation.
     """
-
 
     def test_raises_when_linger_disabled_and_loginctl_denied(self, monkeypatch):
         """Rick's scenario: no D-Bus, no linger, non-root SSH → clear error."""
@@ -1708,8 +1655,6 @@ class TestPreflightUserSystemd:
         assert "sudo loginctl enable-linger" in msg
         assert "hermes gateway run" in msg  # foreground fallback mentioned
         assert "Interactive authentication required" in msg
-
-
 
     def test_enable_linger_succeeds_and_socket_appears(self, monkeypatch, capsys):
         """Happy remediation path: polkit allows enable-linger, socket spawns."""
@@ -1747,12 +1692,6 @@ class TestPreflightUserSystemd:
 
 class TestProfileArg:
     """Tests for _profile_arg — returns '--profile <name>' for named profiles."""
-
-
-
-
-
-
 
     def test_systemd_unit_for_target_user_includes_named_profile(self, tmp_path, monkeypatch):
         """sudo system install must keep the target user's named profile in ExecStart."""
@@ -1959,11 +1898,6 @@ class TestLegacyHermesUnitDetection:
         )
         return user_dir, system_dir
 
-
-
-
-
-
     def test_detects_both_scopes_simultaneously(self, tmp_path, monkeypatch):
         """When a user has BOTH user-scope and system-scope legacy units,
         both are reported so the migration step can remove them together."""
@@ -2002,7 +1936,6 @@ class TestLegacyHermesUnitDetection:
             results = gateway_cli._find_legacy_hermes_units()
             assert len(results) == 1, f"Variant {i} not detected: {execstart!r}"
 
-
     def test_print_legacy_unit_warning_shows_migration_hint(self, tmp_path, monkeypatch, capsys):
         user_dir, _ = self._setup_search_paths(tmp_path, monkeypatch)
         (user_dir / "hermes.service").write_text(self._OUR_UNIT_TEXT, encoding="utf-8")
@@ -2013,7 +1946,6 @@ class TestLegacyHermesUnitDetection:
         assert "Legacy" in out
         assert "hermes.service" in out
         assert "hermes gateway migrate-legacy" in out
-
 
 
 class TestRemoveLegacyHermesUnits:
@@ -2046,8 +1978,6 @@ class TestRemoveLegacyHermesUnits:
         monkeypatch.setattr(gateway_cli.os, "geteuid", lambda: 0 if as_root else 1000)
         return user_dir, system_dir, systemctl_calls
 
-
-
     def test_removes_user_scope_legacy_unit(self, tmp_path, monkeypatch, capsys):
         user_dir, _, calls = self._setup(tmp_path, monkeypatch)
         legacy = user_dir / "hermes.service"
@@ -2063,8 +1993,6 @@ class TestRemoveLegacyHermesUnits:
         assert any("--user stop hermes.service" in c for c in cmds_joined)
         assert any("--user disable hermes.service" in c for c in cmds_joined)
         assert any("--user daemon-reload" in c for c in cmds_joined)
-
-
 
     def test_does_not_touch_profile_units_during_migration(
         self, tmp_path, monkeypatch, capsys
@@ -2085,7 +2013,6 @@ class TestRemoveLegacyHermesUnits:
         # Both the profile unit and the current default unit must survive
         assert profile_unit.exists()
         assert default_unit.exists()
-
 
 
 class TestMigrateLegacyCommand:
@@ -2156,7 +2083,6 @@ class TestGatewayStatusParser:
 
         assert result.returncode == 0
         assert "unrecognized arguments" not in result.stderr
-
 
     def test_migrate_legacy_on_unsupported_platform_prints_message(
         self, monkeypatch, capsys
@@ -2324,7 +2250,6 @@ class TestSystemScopeRequiresRootError:
         assert str(excinfo.value) == "System gateway start requires root. Re-run with sudo."
         assert f"Failed: {excinfo.value}" == "Failed: System gateway start requires root. Re-run with sudo."
 
-
     def test_error_is_runtime_error_subclass(self):
         """Wizards use ``except Exception`` guards — the error must be a
         ``RuntimeError`` (catchable by ``Exception``), NOT a ``SystemExit``
@@ -2363,7 +2288,6 @@ class TestSystemScopeWizardPreCheck:
         monkeypatch.setattr(gateway_cli.os, "geteuid", lambda: 1000)
 
         assert gateway_cli._system_scope_wizard_would_need_root() is True
-
 
     def test_non_root_with_explicit_system_arg_returns_true(self, tmp_path, monkeypatch):
         # Caller passed system=True explicitly (e.g. ``hermes gateway start --system``).
@@ -2431,8 +2355,6 @@ class TestServiceWorkingDirIsStable:
     (HERMES_HOME), never the source checkout / worktree, so a relocated or
     deleted checkout can't crash-loop the unit on CHDIR (status=200).
     """
-
-
 
     def test_user_unit_workingdirectory_is_hermes_home_not_checkout(self, tmp_path, monkeypatch):
         home = tmp_path / ".hermes"
@@ -2511,7 +2433,6 @@ class TestLaunchctlBootstrapEioRetry:
     PLIST = "/tmp/ai.hermes.gateway.plist"
     DOMAIN = "gui/501"
     LABEL = "ai.hermes.gateway"
-
 
     def test_eio_triggers_bootout_then_retry(self, monkeypatch):
         calls = []
@@ -2782,54 +2703,6 @@ class TestUnitAnchoredServiceIdentity:
     """
 
     @pytest.mark.linux_only
-    def test_service_name_survives_hermes_home_adoption_from_unit(self, tmp_path, monkeypatch):
-        alice_home = tmp_path / "alice" / ".hermes"
-        alice_home.mkdir(parents=True)
-        root_home = tmp_path / "root" / ".hermes"
-        root_home.mkdir(parents=True)
-        unit_dir = tmp_path / "systemd"
-        unit_dir.mkdir()
-        unit_path = unit_dir / f"{gateway_cli._SERVICE_BASE}.service"
-        unit_path.write_text(f'[Service]\nEnvironment="HERMES_HOME={alice_home}"\n', encoding="utf-8")
-        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
-        monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root_home)
-        monkeypatch.delenv("HERMES_HOME", raising=False)
-        pre_name = gateway_cli.get_service_name()
-        monkeypatch.setenv("HERMES_HOME", str(alice_home))
-        assert gateway_cli.get_service_name() == pre_name
-
-    @pytest.mark.linux_only
-    def test_unit_pinned_home_owns_the_bare_name(self, tmp_path, monkeypatch):
-        alice_home = tmp_path / "alice" / ".hermes"
-        alice_home.mkdir(parents=True)
-        root_home = tmp_path / "root" / ".hermes"
-        root_home.mkdir(parents=True)
-        unit_dir = tmp_path / "systemd"
-        unit_dir.mkdir()
-        unit_path = unit_dir / f"{gateway_cli._SERVICE_BASE}.service"
-        unit_path.write_text(f'[Service]\nEnvironment="HERMES_HOME={alice_home}"\n', encoding="utf-8")
-        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
-        monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root_home)
-        monkeypatch.setenv("HERMES_HOME", str(alice_home))
-        assert gateway_cli.get_service_name() == gateway_cli._SERVICE_BASE
-        assert gateway_cli.get_systemd_unit_path(system=True) == unit_path
-
-    @pytest.mark.linux_only
-    def test_foreign_home_without_installed_unit_keeps_its_suffix(self, tmp_path, monkeypatch):
-        unit_dir = tmp_path / "empty"
-        unit_dir.mkdir()
-        foreign = tmp_path / "elsewhere"
-        foreign.mkdir()
-        root_home = tmp_path / "root" / ".hermes"
-        root_home.mkdir(parents=True)
-        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
-        monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root_home)
-        monkeypatch.setenv("HERMES_HOME", str(foreign))
-        name = gateway_cli.get_service_name()
-        assert name != gateway_cli._SERVICE_BASE
-        assert name.startswith(gateway_cli._SERVICE_BASE + "-")
-
-    @pytest.mark.linux_only
     def test_home_not_pinned_by_unit_keeps_its_suffix(self, tmp_path, monkeypatch):
         alice_home = tmp_path / "alice" / ".hermes"
         alice_home.mkdir(parents=True)
@@ -2893,28 +2766,3 @@ class TestUnitAnchoredServiceIdentity:
 
         assert os.environ["HERMES_HOME"] == str(alice_home)  # the sync really ran
         assert gateway_cli.get_service_name() == pre_sync_name
-
-    @pytest.mark.linux_only
-    def test_unreadable_unit_does_not_grant_the_bare_name(self, tmp_path, monkeypatch):
-        """A unit we cannot read must not hand its bare name to an unrelated home: the parser returns
-        None on OSError, so resolution falls through to the suffix branches."""
-        foreign_home = tmp_path / "elsewhere"
-        foreign_home.mkdir()
-        root_home = tmp_path / "root" / ".hermes"
-        root_home.mkdir(parents=True)
-        unit_dir = tmp_path / "systemd"
-        unit_dir.mkdir()
-        unit_path = unit_dir / f"{gateway_cli._SERVICE_BASE}.service"
-        unit_path.write_text(f'[Service]\nEnvironment="HERMES_HOME={foreign_home}"\n', encoding="utf-8")
-        real_read_text = Path.read_text
-
-        def deny_unit(self, *args, **kwargs):
-            if self == unit_path:
-                raise PermissionError(13, "Permission denied")
-            return real_read_text(self, *args, **kwargs)
-
-        monkeypatch.setattr(gateway_cli, "_SYSTEM_UNIT_DIR", unit_dir, raising=False)
-        monkeypatch.setattr(hermes_constants, "_get_platform_default_hermes_home", lambda: root_home)
-        monkeypatch.setattr(Path, "read_text", deny_unit)
-        monkeypatch.setenv("HERMES_HOME", str(foreign_home))
-        assert gateway_cli.get_service_name().startswith(gateway_cli._SERVICE_BASE + "-")


### PR DESCRIPTION
`sudo hermes gateway start|stop|restart|status|uninstall --system` operates on the installed `hermes-gateway.service` again instead of a `hermes-gateway-<hash>` unit that does not exist (#108674, regression from #106611).

Salvage of #108681 (@huklaa) and #108706 (@JoaoMarcos44); contributor commits cherry-picked with authorship preserved. Design of the SUDO_USER basis credited to @Mintianzeyun (#108674 report).

## Root cause

Under sudo, `_sync_hermes_home_from_systemd_unit()` rewrites `HERMES_HOME` from `/root/.hermes` to the unit's pinned home mid-command. `_profile_suffix()` only granted the bare name to the process's own native default, so every `get_service_name()` after the sync hashed the adopted home.

## Changes

- `hermes_cli/gateway.py`
  - `_native_service_homes()` (#108681): the process's native default plus, when root under sudo, the invoking user's `~/.hermes`.
  - `_bare_unit_pinned_home()` (#108706): the `HERMES_HOME` pinned by an installed `/etc/systemd/system/hermes-gateway.service` (Linux, root only — an unprivileged user-scope command keeps naming its own units, so a bare system unit pinning `profiles/<name>` cannot alias that profile onto the user's default unit). Covers `--run-as-user <other>` and root shells with no `SUDO_USER` (`sudo -i`, cron), which the SUDO_USER basis cannot express — the blocker raised on #108681.
  - `_profile_suffix()` returns `""` for either; `_hermes_home_from_systemd_unit_file()` is a wrapper over the new path-taking `_hermes_home_pinned_by_unit()`; `_SYSTEM_UNIT_DIR` constant.
- `hermes_constants.sudo_invoker_default_home()` — one helper for the root+SUDO_USER → `pw_dir/.hermes` lookup that `_native_service_homes()` and `hermes_cli/main.py::_resolve_sudo_user_profile_env` both did by hand.
- Tests trimmed from the two PRs' nine to five, one per contract (SUDO_USER home survives the sync; unpinned home keeps its suffix — the #105525 guard; bare unit pinning a `profiles/<name>` home beats the profile branch; the production sync preserves the name; non-root ignores the system unit).

## Validation

Real root + systemd host (NixOS VM), unit pinned to `/home/kshitij/.hermes`, driving the production resolver across the sync:

| case | origin/main | this branch |
|---|---|---|
| `SUDO_USER` set, pre → post sync | `hermes-gateway` → `hermes-gateway-ae87e5a1` | `hermes-gateway` → `hermes-gateway` |
| no `SUDO_USER` (`sudo -i` / cron), unit home | `-ae87e5a1` | `hermes-gateway` |
| `SUDO_USER` ≠ unit user (`--run-as-user`) | `-ae87e5a1` | `hermes-gateway` |
| `/tmp/...`, `/srv/hermes` (guard from #105525) | hashed | hashed |
| `profiles/kimi` | `-kimi` | `-kimi` |

Guard tests fail with `origin/main`'s `gateway.py` swapped under the branch's tests (mutation check on the final stack, run on Linux for the `linux_only` ones); the non-root guard additionally fails against the stack without the root gate. `tests/hermes_cli/test_gateway_service.py` + the resolver's consumer test files: 0 new failures; ruff, windows-footguns, compat-pointers clean.

Closes #108674. Supersedes #108681 and #108706 (both credited above; closed with a pointer here).
