### PR TITLE
feat(plugin-catalog): add Hermes Telegram UX community entry

### DIFF
--- a/plugin-catalog/hermes-telegram-ux.yaml
+++ b/plugin-catalog/hermes-telegram-ux.yaml
@@ -1,0 +1,34 @@
+name: hermes-telegram-ux
+repo: https://github.com/pler1y/hermes-telegram-ux
+sha: 6f58572dc319efafbc7b4659e1c39d3d46315341
+description: Immediate Telegram feedback, editable task progress, mid-task instructions
+  and natural controls.
+maintainer: pler1y
+tier: community
+requires_hermes: '>=0.21.0,<0.22.0'
+docs_url: https://github.com/pler1y/hermes-telegram-ux/blob/6f58572dc319efafbc7b4659e1c39d3d46315341/docs/NATIVE-INSTALL.md
+platforms:
+- linux
+- macos
+capabilities:
+  provides_tools:
+  - interaction_update
+  - interaction_actions
+  provides_hooks:
+  - pre_api_request
+  - post_api_request
+  - api_request_error
+  - pre_tool_call
+  - post_tool_call
+  - on_session_end
+  - on_session_reset
+  - pre_gateway_dispatch
+  - pre_approval_request
+  - post_approval_response
+  - subagent_start
+  - subagent_stop
+  - post_llm_call
+  provides_middleware:
+  - llm_request
+  - tool_request
+  requires_env: []

--- a/plugin-catalog/hermes-telegram-ux.yaml
+++ b/plugin-catalog/hermes-telegram-ux.yaml
@@ -1,12 +1,12 @@
 name: hermes-telegram-ux
 repo: https://github.com/pler1y/hermes-telegram-ux
-sha: 6f58572dc319efafbc7b4659e1c39d3d46315341
+sha: ce04bee333776360d4de42a9aa7c084b13a23d7e
 description: Immediate Telegram feedback, editable task progress, mid-task instructions
   and natural controls.
 maintainer: pler1y
 tier: community
 requires_hermes: '>=0.21.0,<0.22.0'
-docs_url: https://github.com/pler1y/hermes-telegram-ux/blob/6f58572dc319efafbc7b4659e1c39d3d46315341/docs/NATIVE-INSTALL.md
+docs_url: https://github.com/pler1y/hermes-telegram-ux/blob/ce04bee333776360d4de42a9aa7c084b13a23d7e/docs/NATIVE-INSTALL.md
 platforms:
 - linux
 - macos

--- a/plugin-catalog/hermes-telegram-ux.yaml
+++ b/plugin-catalog/hermes-telegram-ux.yaml
@@ -1,12 +1,12 @@
 name: hermes-telegram-ux
 repo: https://github.com/pler1y/hermes-telegram-ux
-sha: ce04bee333776360d4de42a9aa7c084b13a23d7e
+sha: 04ea7e89ecbf8616c1ab686730bc0f22e4e2e342
 description: Immediate Telegram feedback, editable task progress, mid-task instructions
   and natural controls.
 maintainer: pler1y
 tier: community
 requires_hermes: '>=0.21.0,<0.22.0'
-docs_url: https://github.com/pler1y/hermes-telegram-ux/blob/ce04bee333776360d4de42a9aa7c084b13a23d7e/docs/NATIVE-INSTALL.md
+docs_url: https://github.com/pler1y/hermes-telegram-ux/blob/04ea7e89ecbf8616c1ab686730bc0f22e4e2e342/docs/NATIVE-INSTALL.md
 platforms:
 - linux
 - macos


### PR DESCRIPTION
## Summary

Add **Hermes Telegram UX** as a `community` catalog entry maintained by pler1y, the plugin repository owner. This PR adds one catalog YAML; plugin source stays in its own repository.

Telegram users get immediate intake feedback, editable task progress, mid-task instruction receipts, foreground/background stop handling, final answers/files, follow-up buttons and Chinese/English interface text. Users explicitly install and enable it. This is a catalog entry, not a request to change default Telegram behavior or replace related core work (#80262 / #69885).

## Published pin and maturity

- Release: [1.8.1](https://github.com/pler1y/hermes-telegram-ux/releases/tag/v1.8.1).
- Exact pin: `04ea7e89ecbf8616c1ab686730bc0f22e4e2e342`.
- GitHub publication time: **2026-09-12T07:51:10+00:00**.
- Two-week maturity date under the documented guideline: **2026-09-26T07:51:10+00:00**.

The implementation and automated checks are ready for review. The pin is newly released and has not yet reached two weeks; this is disclosed for maintainer admission/timing decisions. No policy waiver or acceptance is assumed. Please flag any further requirements.

## Integration improvements in the pinned release

- Full Python syntax fingerprints permit formatting/comment-only core changes. Code, scope, literal values, defaults, decorators and docstrings still have to match one complete reviewed baseline. Checking does not import or execute the inspected module.
- Partial platform wiring rolls back, repeat wiring is idempotent, and unload restores inherited methods while preserving wrappers added later by another plugin. Any retained UX wrapper becomes an inert forwarding layer. Finished stream consumers are not retained by bound-method backups.
- Button delivery and callback authorization are tied to the originating Telegram adapter. Cross-bot callbacks cannot consume the valid menu. Background send lookup is adapter-scoped.
- Installation no longer changes global notification intervals or acknowledgement toggles. Upgrades retire older installer-owned defaults while preserving user edits; dry-run explicitly reports restored paths.
- The previous release's displaced-turn fixes remain: old finalizers cannot consume successor actions, delete a successor bubble or mark the successor interrupted.

## Validation

[Release-commit CI](https://github.com/pler1y/hermes-telegram-ux/actions/runs/34681576647).

- **164 plugin tests, zero skips per core**, on `b499ab11fe8b081470e269f2fb27abae03000da5`, `a84a2223f82c3d9906fd4a9d778a188774e7a08e`, `436ec489854b7110b4c5506b1f52c514fa4c3ace` and `044a77b3b6af4ce16138d42762f812a20b9f7a89`.
- Native Git install/enable/discovery, actual Telegram adapter wiring/unwiring, configure/restore/remove and metadata preservation passed. Both language ZIP install/reinstall/uninstall checks passed.
- Official `plugins validate` passed on all three 0.21.2 baselines; 0.21.0 predates that command. Native security scanning stays enabled and reports caution for documented service/subprocess operations.
- Python 3.11 and 3.12 CI validate current upstream interfaces and exercise a disposable real-core copy: added comments pass; added executable syntax fails.
- On `044a77b3b6af`, the canonical upstream runner passed all **12** tests across duplicate-user-message, failure-writer-ownership and incomplete-turn regression files. The loopback-only provider probe uses synthetic data and discards inherited credentials. This is not the full Hermes test suite.
- Official catalog structure validation passes for the submission entry and existing catalog files.

[Versioned validation record](https://github.com/pler1y/hermes-telegram-ux/blob/04ea7e89ecbf8616c1ab686730bc0f22e4e2e342/docs/VALIDATION-1.8.1.md).

## Remaining boundaries

The entry declares two tools, thirteen hooks and two middleware handlers, matching actual registration. The plugin still uses internal gateway/Telegram wrappers; all 23 guarded files must match one tested baseline by raw bytes or complete Python syntax. The outer `>=0.21.0,<0.22.0` range is not blanket compatibility. Core source is not modified. Compatibility with every third-party wrapper combination is not claimed.

The recommended preset retains Hermes' profile/global busy-input mode choice of `steer`; shared-platform users can choose `keep-display` to preserve their existing routing. The native manifest remains v1. Its optional `requires_hermes` is omitted because the examined validator imports its version helpers from an obsolete module; the mandatory content guard and catalog range remain active.

Fresh full Telegram/model acceptance on the new core is **not** recorded. The above controlled tests are distinct from [historical 1.7.0 client acceptance](https://github.com/pler1y/hermes-telegram-ux/blob/04ea7e89ecbf8616c1ab686730bc0f22e4e2e342/docs/ACCEPTANCE-1.7.0.md). Further review requests can be addressed in this PR.

[Installation/removal](https://github.com/pler1y/hermes-telegram-ux/blob/04ea7e89ecbf8616c1ab686730bc0f22e4e2e342/docs/NATIVE-INSTALL.md) · [Compatibility](https://github.com/pler1y/hermes-telegram-ux/blob/04ea7e89ecbf8616c1ab686730bc0f22e4e2e342/docs/COMPATIBILITY.md)
