### PR TITLE
fix(cli): repair shallow boundaries dropped by the stale-graft prune and keep them pruned safely (#108286, salvage #108361)

### DIFF
--- a/hermes_cli/gitlock.py
+++ b/hermes_cli/gitlock.py
@@ -253,6 +253,13 @@ class _ShallowLock:
             pass
 
 
+def _write_shallow(shallow_path: Path, content: str, *, suffix: str) -> None:
+    """Atomically replace ``.git/shallow`` (temp file + os.replace)."""
+    tmp_path = shallow_path.with_name(shallow_path.name + suffix)
+    tmp_path.write_text(content, encoding="utf-8")
+    os.replace(tmp_path, shallow_path)
+
+
 def repair_broken_shallow_boundaries(repo_root: Path) -> int:
     """Re-append shallow boundaries for reflog-reachable commits whose parents
     were never fetched (#108286).
@@ -286,7 +293,10 @@ def repair_broken_shallow_boundaries(repo_root: Path) -> int:
             # fetch-recorded tips is what keeps unrelated object loss (a deleted parent
             # of a locally-created commit) from being re-labelled as shallow history.
             # On an already-corrupted repo a rev-list --reflog walk is exactly what
-            # fails, so read the reflog hash list directly.
+            # fails, so read the reflog hash list directly. Scope: fetch-by-SHA
+            # installs (scripts/install.sh) record their tip only in HEAD's reflog
+            # and are NOT candidates — new corruption of that shape is prevented by
+            # the prune's reflog fail-safe instead.
             reflog = _git_stdout_lines(
                 repo_root, ["reflog", "show", "--all", "--format=%H%x00%gD"])
             candidates = sorted({
@@ -299,14 +309,14 @@ def repair_broken_shallow_boundaries(repo_root: Path) -> int:
             repaired = broken - existing
             if not repaired:
                 return 0
-            tmp_path = shallow_path.with_name(shallow_path.name + ".hermes-repair")
-            tmp_path.write_text("\n".join(sorted(existing | repaired)) + "\n", encoding="utf-8")
-            os.replace(tmp_path, shallow_path)
-        if not _git_stdout_lines(repo_root, ["rev-list", "--count", "--all", "--reflog"]):
-            with _ShallowLock(shallow_path):
+            _write_shallow(shallow_path, "\n".join(sorted(existing | repaired)) + "\n",
+                           suffix=".hermes-repair")
+            # Self-check under the same lock hold (rev-list never takes
+            # shallow.lock): the rollback cannot be defeated by lock contention.
+            if not _git_stdout_lines(repo_root, ["rev-list", "--count", "--all", "--reflog"]):
                 shallow_path.write_text(original, encoding="utf-8")
-            logger.debug("shallow boundary repair self-check failed; file restored")
-            return 0
+                logger.debug("shallow boundary repair self-check failed; file restored")
+                return 0
         logger.info("Restored %d broken shallow boundary(ies) in %s", len(repaired), repo_root)
         return len(repaired)
     except Exception:
@@ -344,19 +354,18 @@ def prune_stale_shallow_grafts(repo_root: Path) -> int:
             if len(keep) == len(lines):
                 return 0
             original = shallow_path.read_text(encoding="utf-8")
-            tmp_path = shallow_path.with_name(shallow_path.name + ".hermes-prune")
-            tmp_path.write_text("\n".join(sorted(keep)) + "\n", encoding="utf-8")
-            os.replace(tmp_path, shallow_path)
-        # Fail-safe: if any reachable walk now crosses a boundary we wrongly removed,
-        # put the grafts back — a growing file beats a broken repo.
-        still_walks = _git_stdout_lines(repo_root, ["rev-list", "--count", "HEAD"]) and \
-            _git_stdout_lines(repo_root, ["rev-list", "--count", "--all"]) and \
-            _git_stdout_lines(repo_root, ["rev-list", "--count", "--all", "--reflog"])
-        if not still_walks:
-            with _ShallowLock(shallow_path):
+            _write_shallow(shallow_path, "\n".join(sorted(keep)) + "\n", suffix=".hermes-prune")
+            # Fail-safe: if any reachable walk now crosses a boundary we wrongly
+            # removed, put the grafts back — a growing file beats a broken repo.
+            # Runs under the same lock hold (rev-list never takes shallow.lock) so
+            # the rollback cannot be defeated by lock contention.
+            still_walks = _git_stdout_lines(repo_root, ["rev-list", "--count", "HEAD"]) and \
+                _git_stdout_lines(repo_root, ["rev-list", "--count", "--all"]) and \
+                _git_stdout_lines(repo_root, ["rev-list", "--count", "--all", "--reflog"])
+            if not still_walks:
                 shallow_path.write_text(original, encoding="utf-8")
-            logger.debug("shallow prune self-check failed; grafts restored")
-            return 0
+                logger.debug("shallow prune self-check failed; grafts restored")
+                return 0
         logger.info("Pruned %d stale shallow graft(s) in %s", len(lines) - len(keep), repo_root)
         return len(lines) - len(keep)
     except Exception:

--- a/hermes_cli/gitlock.py
+++ b/hermes_cli/gitlock.py
@@ -144,7 +144,12 @@ def _git_stdout_lines(repo_root: Path, args: List[str]) -> List[str]:
 
 
 def _batch_missing_parents(repo_root: Path, candidates: List[str]) -> set[str]:
-    """Return local commit objects whose parent objects are missing."""
+    """Return local commit objects whose parent objects are missing.
+
+    Parents are read from the commit *header* only (lines before the first blank
+    line) — a ``parent <sha>`` line inside a commit message body is prose, not
+    an edge.
+    """
     if not candidates:
         return set()
     try:
@@ -175,13 +180,13 @@ def _batch_missing_parents(repo_root: Path, candidates: List[str]) -> set[str]:
                 if data[cursor:cursor + 1] != b"\n":
                     return set()
                 cursor += 1
-                decoded = body.decode(errors="replace")
-                commit_parents = {
-                    fields[1]
-                    for line in decoded.splitlines()
-                    for fields in [line.split()]
-                    if len(fields) >= 2 and fields[0] == "parent"
-                }
+                commit_parents = set()
+                for line in body.split(b"\n"):
+                    if not line:  # blank line ends the commit header block
+                        break
+                    fields = line.split()
+                    if len(fields) >= 2 and fields[0] == b"parent":
+                        commit_parents.add(fields[1].decode())
                 parents_by_commit[candidate] = commit_parents
                 parents.update(commit_parents)
             elif len(header) < 2 or header[1] != b"missing":
@@ -195,6 +200,8 @@ def _batch_missing_parents(repo_root: Path, candidates: List[str]) -> set[str]:
             capture_output=True,
             timeout=10,
         )
+        if check.returncode != 0:
+            return set()
         missing = {
             line.split()[0]
             for line in check.stdout.decode(errors="replace").splitlines()
@@ -206,39 +213,99 @@ def _batch_missing_parents(repo_root: Path, candidates: List[str]) -> set[str]:
         return set()
 
 
-def repair_broken_shallow_boundaries(repo_root: Path) -> int:
-    """Repair reflog-only shallow boundaries dropped by #108286's prune bug.
+def _shallow_file_path(repo_root: Path) -> Optional[Path]:
+    """Resolve ``.git/shallow`` via git, or None when the repo has none."""
+    shallow_rel = _git_stdout_lines(repo_root, ["rev-parse", "--git-path", "shallow"])
+    if not shallow_rel:
+        return None
+    shallow_path = Path(shallow_rel[0])
+    if not shallow_path.is_absolute():
+        shallow_path = Path(repo_root) / shallow_rel[0]
+    return shallow_path if shallow_path.is_file() else None
 
-    This complements the prevention fix in PR #108290: existing corrupted installs need
-    boundaries reconstructed because their broken history prevents the reflogs from expiring.
+
+class _ShallowLock:
+    """Git's own ``shallow.lock`` protocol, so a concurrent ``git fetch`` that
+    writes ``.git/shallow`` between our read and our write is never clobbered:
+    the fetch fails fast on the lock and we re-read before writing."""
+
+    def __init__(self, shallow_path: Path):
+        self._path = shallow_path
+        self._lock_path = shallow_path.with_name(shallow_path.name + ".lock")
+
+    def __enter__(self) -> "_ShallowLock":
+        try:
+            fd = os.open(self._lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError:
+            raise RuntimeError(f"shallow lock held: {self._lock_path}")
+        except OSError as exc:
+            raise RuntimeError(f"cannot create shallow lock: {exc}") from exc
+        try:
+            os.write(fd, b"hermes shallow maintenance\n")
+        finally:
+            os.close(fd)
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        try:
+            self._lock_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def repair_broken_shallow_boundaries(repo_root: Path) -> int:
+    """Re-append shallow boundaries for reflog-reachable commits whose parents
+    were never fetched (#108286).
+
+    A reflog-only commit whose graft was pruned leaves the repo unwalkable
+    (``gc``/``fsck``/``fetch`` fail) and unable to self-heal: reflog expiry
+    happens during ``git gc``, which is exactly what the corruption breaks.
+    Only reflog-reachable commits are considered, so unrelated object loss is
+    never re-labelled as shallow history. Returns the number of boundaries
+    appended; never raises.
     """
     try:
-        shallow_rel = _git_stdout_lines(repo_root, ["rev-parse", "--git-path", "shallow"])
-        if not shallow_rel:
+        shallow_path = _shallow_file_path(repo_root)
+        if shallow_path is None:
             return 0
-        shallow_path = Path(shallow_rel[0])
-        if not shallow_path.is_absolute():
-            shallow_path = Path(repo_root) / shallow_path
-        if not shallow_path.is_file():
+        # Cheap gate: repair only when the walk the corruption breaks already fails.
+        probe = subprocess.run(
+            ["git", "rev-list", "--count", "--all", "--reflog"],
+            cwd=str(repo_root), capture_output=True, timeout=10,
+        )
+        if probe.returncode == 0:
             return 0
-        original = shallow_path.read_text(encoding="utf-8")
-        existing = {line for line in original.splitlines() if line}
-        if not existing:
-            return 0
-        candidates = _git_stdout_lines(repo_root, ["cat-file", "--batch-all-objects", "--batch-check"])
-        candidates = sorted({line.split()[0] for line in candidates
-                             if len(line.split()) >= 2 and line.split()[1] == "commit"})
-        candidates = sorted(set(candidates + _git_stdout_lines(
-            repo_root, ["reflog", "show", "--all", "--format=%H"])))
-        broken = _batch_missing_parents(repo_root, candidates)
-        repaired = broken - existing
-        if not repaired:
-            return 0
-        tmp_path = shallow_path.with_name(shallow_path.name + ".hermes-repair")
-        tmp_path.write_text("\n".join(sorted(existing | repaired)) + "\n", encoding="utf-8")
-        os.replace(tmp_path, shallow_path)
+        with _ShallowLock(shallow_path):
+            original = shallow_path.read_text(encoding="utf-8")
+            existing = {line for line in original.splitlines() if line}
+            if not existing:
+                return 0
+            # Boundary candidates: commits recorded as *fetch tips* in remote-tracking
+            # refs' reflogs (NOT --batch-all-objects, and not HEAD's reflog): the bug
+            # class is fetched tips whose graft the prune dropped, and restricting to
+            # fetch-recorded tips is what keeps unrelated object loss (a deleted parent
+            # of a locally-created commit) from being re-labelled as shallow history.
+            # On an already-corrupted repo a rev-list --reflog walk is exactly what
+            # fails, so read the reflog hash list directly.
+            reflog = _git_stdout_lines(
+                repo_root, ["reflog", "show", "--all", "--format=%H%x00%gD"])
+            candidates = sorted({
+                sha
+                for entry in reflog
+                for sha, selector in [entry.split("\x00", 1)]
+                if selector.startswith("refs/remotes/")
+            })
+            broken = _batch_missing_parents(repo_root, candidates)
+            repaired = broken - existing
+            if not repaired:
+                return 0
+            tmp_path = shallow_path.with_name(shallow_path.name + ".hermes-repair")
+            tmp_path.write_text("\n".join(sorted(existing | repaired)) + "\n", encoding="utf-8")
+            os.replace(tmp_path, shallow_path)
         if not _git_stdout_lines(repo_root, ["rev-list", "--count", "--all", "--reflog"]):
-            shallow_path.write_text(original, encoding="utf-8")
+            with _ShallowLock(shallow_path):
+                shallow_path.write_text(original, encoding="utf-8")
+            logger.debug("shallow boundary repair self-check failed; file restored")
             return 0
         logger.info("Restored %d broken shallow boundary(ies) in %s", len(repaired), repo_root)
         return len(repaired)
@@ -248,7 +315,7 @@ def repair_broken_shallow_boundaries(repo_root: Path) -> int:
 
 
 def prune_stale_shallow_grafts(repo_root: Path) -> int:
-    """Drop ``.git/shallow`` graft lines no live ref still points at (#105951).
+    """Drop ``.git/shallow`` graft lines no live ref or reflog still points at (#105951).
 
     Every ``git fetch --depth 1`` appends the fetched tip to ``.git/shallow`` as a new
     graft and never removes the previous one, so a long-lived shallow installer checkout
@@ -257,37 +324,37 @@ def prune_stale_shallow_grafts(repo_root: Path) -> int:
     on every run. Keep only the boundaries that still protect referenced tips (HEAD,
     FETCH_HEAD, and every ref tip): the dropped commits are already unreachable and their
     objects are left for ``git gc``. Returns the number of graft lines removed; never
-    raises, and restores the original file if the trimmed set breaks history walking.
+    raises, and restores the original file if the trimmed set breaks history walking
+    (including the ``--reflog`` walk, so a graft a reflog-only commit still needs is
+    never dropped, #108286).
     """
     try:
-        shallow_rel = _git_stdout_lines(repo_root, ["rev-parse", "--git-path", "shallow"])
-        if not shallow_rel:
+        shallow_path = _shallow_file_path(repo_root)
+        if shallow_path is None:
             return 0
-        shallow_path = Path(shallow_rel[0])
-        if not shallow_path.is_absolute():
-            shallow_path = Path(repo_root) / shallow_path
-        if not shallow_path.is_file():
-            return 0
-        lines = [line for line in shallow_path.read_text(encoding="utf-8").splitlines() if line]
-        if not lines:
-            return 0
-        keep = set(lines) & {
-            *(_git_stdout_lines(repo_root, ["rev-parse", "HEAD"]) or []),
-            *(_git_stdout_lines(repo_root, ["rev-parse", "--verify", "--quiet", "FETCH_HEAD"]) or []),
-            *_git_stdout_lines(repo_root, ["for-each-ref", "--format=%(objectname)"]),
-        }
-        if len(keep) == len(lines):
-            return 0
-        original = shallow_path.read_text(encoding="utf-8")
-        tmp_path = shallow_path.with_name(shallow_path.name + ".hermes-prune")
-        tmp_path.write_text("\n".join(sorted(keep)) + "\n", encoding="utf-8")
-        os.replace(tmp_path, shallow_path)
+        with _ShallowLock(shallow_path):
+            lines = [line for line in shallow_path.read_text(encoding="utf-8").splitlines() if line]
+            if not lines:
+                return 0
+            keep = set(lines) & {
+                *(_git_stdout_lines(repo_root, ["rev-parse", "HEAD"]) or []),
+                *(_git_stdout_lines(repo_root, ["rev-parse", "--verify", "--quiet", "FETCH_HEAD"]) or []),
+                *_git_stdout_lines(repo_root, ["for-each-ref", "--format=%(objectname)"]),
+            }
+            if len(keep) == len(lines):
+                return 0
+            original = shallow_path.read_text(encoding="utf-8")
+            tmp_path = shallow_path.with_name(shallow_path.name + ".hermes-prune")
+            tmp_path.write_text("\n".join(sorted(keep)) + "\n", encoding="utf-8")
+            os.replace(tmp_path, shallow_path)
         # Fail-safe: if any reachable walk now crosses a boundary we wrongly removed,
         # put the grafts back — a growing file beats a broken repo.
         still_walks = _git_stdout_lines(repo_root, ["rev-list", "--count", "HEAD"]) and \
-            _git_stdout_lines(repo_root, ["rev-list", "--count", "--all"])
+            _git_stdout_lines(repo_root, ["rev-list", "--count", "--all"]) and \
+            _git_stdout_lines(repo_root, ["rev-list", "--count", "--all", "--reflog"])
         if not still_walks:
-            shallow_path.write_text(original, encoding="utf-8")
+            with _ShallowLock(shallow_path):
+                shallow_path.write_text(original, encoding="utf-8")
             logger.debug("shallow prune self-check failed; grafts restored")
             return 0
         logger.info("Pruned %d stale shallow graft(s) in %s", len(lines) - len(keep), repo_root)

--- a/hermes_cli/gitlock.py
+++ b/hermes_cli/gitlock.py
@@ -143,6 +143,110 @@ def _git_stdout_lines(repo_root: Path, args: List[str]) -> List[str]:
         return []
 
 
+def _batch_missing_parents(repo_root: Path, candidates: List[str]) -> set[str]:
+    """Return local commit objects whose parent objects are missing."""
+    if not candidates:
+        return set()
+    try:
+        parents_by_commit = {}
+        parents = set()
+        request = "\n".join(candidates) + "\n"
+        result = subprocess.run(
+            ["git", "cat-file", "--batch"],
+            cwd=str(repo_root),
+            input=request.encode(),
+            capture_output=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            return set()
+        data = result.stdout
+        cursor = 0
+        for candidate in candidates:
+            header_end = data.find(b"\n", cursor)
+            if header_end < 0:
+                return set()
+            header = data[cursor:header_end].split()
+            cursor = header_end + 1
+            if len(header) >= 3 and header[1] == b"commit":
+                size = int(header[2])
+                body = data[cursor:cursor + size]
+                cursor += size
+                if data[cursor:cursor + 1] != b"\n":
+                    return set()
+                cursor += 1
+                decoded = body.decode(errors="replace")
+                commit_parents = {
+                    fields[1]
+                    for line in decoded.splitlines()
+                    for fields in [line.split()]
+                    if len(fields) >= 2 and fields[0] == "parent"
+                }
+                parents_by_commit[candidate] = commit_parents
+                parents.update(commit_parents)
+            elif len(header) < 2 or header[1] != b"missing":
+                return set()
+        if not parents:
+            return set()
+        check = subprocess.run(
+            ["git", "cat-file", "--batch-check"],
+            cwd=str(repo_root),
+            input=("\n".join(sorted(parents)) + "\n").encode(),
+            capture_output=True,
+            timeout=10,
+        )
+        missing = {
+            line.split()[0]
+            for line in check.stdout.decode(errors="replace").splitlines()
+            if line.endswith(" missing")
+        }
+        return {commit for commit, commit_parents in parents_by_commit.items() if commit_parents & missing}
+    except Exception:
+        logger.debug("parent-object probe failed for %s", repo_root, exc_info=True)
+        return set()
+
+
+def repair_broken_shallow_boundaries(repo_root: Path) -> int:
+    """Repair reflog-only shallow boundaries dropped by #108286's prune bug.
+
+    This complements the prevention fix in PR #108290: existing corrupted installs need
+    boundaries reconstructed because their broken history prevents the reflogs from expiring.
+    """
+    try:
+        shallow_rel = _git_stdout_lines(repo_root, ["rev-parse", "--git-path", "shallow"])
+        if not shallow_rel:
+            return 0
+        shallow_path = Path(shallow_rel[0])
+        if not shallow_path.is_absolute():
+            shallow_path = Path(repo_root) / shallow_path
+        if not shallow_path.is_file():
+            return 0
+        original = shallow_path.read_text(encoding="utf-8")
+        existing = {line for line in original.splitlines() if line}
+        if not existing:
+            return 0
+        candidates = _git_stdout_lines(repo_root, ["cat-file", "--batch-all-objects", "--batch-check"])
+        candidates = sorted({line.split()[0] for line in candidates
+                             if len(line.split()) >= 2 and line.split()[1] == "commit"})
+        candidates = sorted(set(candidates + _git_stdout_lines(
+            repo_root, ["reflog", "show", "--all", "--format=%H"])))
+        broken = _batch_missing_parents(repo_root, candidates)
+        repaired = broken - existing
+        if not repaired:
+            return 0
+        tmp_path = shallow_path.with_name(shallow_path.name + ".hermes-repair")
+        tmp_path.write_text("\n".join(sorted(existing | repaired)) + "\n", encoding="utf-8")
+        os.replace(tmp_path, shallow_path)
+        if not _git_stdout_lines(repo_root, ["rev-list", "--count", "--all", "--reflog"]):
+            shallow_path.write_text(original, encoding="utf-8")
+            return 0
+        logger.info("Restored %d broken shallow boundary(ies) in %s", len(repaired), repo_root)
+        return len(repaired)
+    except Exception:
+        logger.debug("shallow boundary repair failed for %s", repo_root, exc_info=True)
+        return 0
+
+
 def prune_stale_shallow_grafts(repo_root: Path) -> int:
     """Drop ``.git/shallow`` graft lines no live ref still points at (#105951).
 

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -535,7 +535,10 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
         # The depth-1 fetch above leaves the previous tip behind as a ``.git/shallow`` graft
         # (git never removes old grafts); prune the stale ones so the file stops growing and
         # merge-base / the orphan-divergence heuristic keep working (#105951).
-        from hermes_cli.gitlock import prune_stale_shallow_grafts
+        from hermes_cli.gitlock import repair_broken_shallow_boundaries, prune_stale_shallow_grafts
+        repaired = repair_broken_shallow_boundaries(_m().PROJECT_ROOT)
+        if repaired:
+            print(f"  (restored {repaired} broken shallow boundary(ies))")
         pruned = prune_stale_shallow_grafts(_m().PROJECT_ROOT)
         if pruned:
             print(f"  (pruned {pruned} stale shallow graft(s) left by past depth-1 checks)")
@@ -1340,7 +1343,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
             print("  (removed %d aborted-fetch pack temp file(s))" % len(swept))
         # Shallow installer checkouts collect one `.git/shallow` graft per past depth-1 fetch
         # (#105951); stale grafts break merge-base and push this run into the divergence path.
-        from hermes_cli.gitlock import prune_stale_shallow_grafts
+        from hermes_cli.gitlock import repair_broken_shallow_boundaries, prune_stale_shallow_grafts
+        repaired = repair_broken_shallow_boundaries(_m().PROJECT_ROOT)
+        if repaired:
+            print(f"  (restored {repaired} broken shallow boundary(ies))")
         pruned = prune_stale_shallow_grafts(_m().PROJECT_ROOT)
         if pruned:
             print(f"  (pruned {pruned} stale shallow graft(s) left by past depth-1 checks)")

--- a/tests/hermes_cli/test_shallow_boundary_repair.py
+++ b/tests/hermes_cli/test_shallow_boundary_repair.py
@@ -1,3 +1,15 @@
+"""Repair of shallow boundaries dropped by the stale-graft prune (#108286).
+
+``prune_stale_shallow_grafts()`` dropped ``.git/shallow`` grafts that reflog-only
+commits still needed, leaving shallow installer checkouts with commits whose parent
+objects were never downloaded — ``git gc`` / ``fsck`` / ``fetch`` all fail, and the
+corruption cannot self-heal because reflog expiry happens during ``git gc``, which is
+exactly what broke. ``repair_broken_shallow_boundaries()`` re-appends the missing
+boundaries; the updater calls it before the prune at both call sites.
+"""
+
+from __future__ import annotations
+
 import subprocess
 from pathlib import Path
 
@@ -5,7 +17,10 @@ import hermes_cli.gitlock as gitlock
 
 
 def git(repo, *args, check=True):
-    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=check)
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True,
+        encoding="utf-8", errors="replace", check=check,
+    )
 
 
 def fixture(tmp_path):
@@ -14,7 +29,7 @@ def fixture(tmp_path):
     git(origin, "config", "user.email", "t@example.com"); git(origin, "config", "user.name", "t")
     git(origin, "commit", "--allow-empty", "-qm", "c0")
     clone = tmp_path / "clone"
-    subprocess.run(["git", "clone", "-q", "--depth", "1", f"file://{origin}", str(clone)], check=True)
+    subprocess.run(["git", "clone", "-q", "--depth", "1", origin.as_uri(), str(clone)], check=True)
     git(origin, "commit", "--allow-empty", "-qm", "c1")
     git(origin, "commit", "--allow-empty", "-qm", "c2")
     git(clone, "fetch", "-q", "--depth", "1", "origin", "main")
@@ -25,25 +40,45 @@ def fixture(tmp_path):
 
 def corrupt_fixture(clone):
     path = clone / ".git" / "shallow"
-    lines = path.read_text().splitlines()
+    lines = path.read_text(encoding="utf-8").splitlines()
     for removed in lines:
-        path.write_text("\n".join(x for x in lines if x != removed) + "\n")
+        path.write_text("\n".join(x for x in lines if x != removed) + "\n", encoding="utf-8")
         fsck = git(clone, "fsck", "--connectivity-only", check=False)
         if "broken link" in (fsck.stdout + fsck.stderr) or "missing commit" in (fsck.stdout + fsck.stderr):
             return removed
     raise AssertionError("fixture did not create a broken shallow boundary")
 
 
+def _walks(clone):
+    return git(clone, "rev-list", "--count", "--all", "--reflog", check=False).returncode == 0
+
+
 def test_repair_restores_boundary_for_reflog_only_commit_with_unfetched_parent(tmp_path):
     clone = fixture(tmp_path)
     corrupt_fixture(clone)
-    assert git(clone, "rev-list", "--count", "--all", "--reflog", check=False).returncode != 0
+    assert not _walks(clone)
     assert "broken link" in git(clone, "fsck", "--connectivity-only", check=False).stdout
     assert gitlock.repair_broken_shallow_boundaries(clone) >= 1
-    assert git(clone, "rev-list", "--count", "--all", "--reflog").returncode == 0
+    assert _walks(clone)
     fsck = git(clone, "fsck", "--connectivity-only")
     assert "broken link" not in (fsck.stdout + fsck.stderr)
     assert git(clone, "gc", "-q").returncode == 0
+
+
+def test_repair_then_prune_leaves_repo_walkable(tmp_path):
+    """The production updater sequence: repair runs, then the prune immediately after.
+
+    Without the prune's ``--reflog`` fail-safe walk, the prune dropped the boundary
+    repair had just restored, re-breaking the repo on every ``hermes update`` run.
+    """
+    clone = fixture(tmp_path)
+    corrupt_fixture(clone)
+    assert gitlock.repair_broken_shallow_boundaries(clone) >= 1
+    assert _walks(clone)
+    gitlock.prune_stale_shallow_grafts(clone)
+    assert _walks(clone)
+    fsck = git(clone, "fsck", "--connectivity-only", check=False)
+    assert "broken link" not in (fsck.stdout + fsck.stderr)
 
 
 def test_repair_is_noop_on_healthy_shallow_checkout(tmp_path):
@@ -74,39 +109,38 @@ def test_repair_is_idempotent(tmp_path):
     assert gitlock.repair_broken_shallow_boundaries(clone) == 0
 
 
-def test_repair_uses_a_bounded_number_of_git_subprocesses(tmp_path, monkeypatch):
-    counts = []
-    real_run = gitlock.subprocess.run
-
-    for count in (4, 40):
-        root = tmp_path / str(count)
-        root.mkdir()
-        clone = fixture(root)
-        for index in range(count):
-            git(clone, "commit", "--allow-empty", "-qm", f"extra-{index}")
-        corrupt_fixture(clone)
-        calls = 0
-
-        def counting_run(*args, **kwargs):
-            nonlocal calls
-            calls += 1
-            return real_run(*args, **kwargs)
-
-        monkeypatch.setattr(gitlock.subprocess, "run", counting_run)
-        assert gitlock.repair_broken_shallow_boundaries(clone) >= 1
-        assert git(clone, "rev-list", "--count", "--all", "--reflog").returncode == 0
-        counts.append(calls)
-        monkeypatch.setattr(gitlock.subprocess, "run", real_run)
-
-    assert all(count < 15 for count in counts)
-    assert abs(counts[0] - counts[1]) <= 2
+def test_repair_ignores_parent_lines_inside_commit_messages(tmp_path):
+    """A ``parent <sha>`` line in a commit *message body* is prose, not an edge:
+    the parent parser must read only the commit header, so a healthy commit whose
+    message mentions ``parent <sha>`` is never shallow-marked."""
+    origin = tmp_path / "origin"; origin.mkdir()
+    git(origin, "init", "-q", "-b", "main")
+    git(origin, "config", "user.email", "t@example.com"); git(origin, "config", "user.name", "t")
+    git(origin, "commit", "--allow-empty", "-qm", "c0")
+    git(origin, "commit", "--allow-empty", "-qm", "c1")
+    clone = tmp_path / "clone"
+    subprocess.run(["git", "clone", "-q", "--depth", "2", origin.as_uri(), str(clone)], check=True)
+    git(clone, "config", "user.email", "t@example.com"); git(clone, "config", "user.name", "t")
+    git(clone, "commit", "--allow-empty", "-m", "subject\n\nbody line\n\nparent ffffffffffffffffffffffffffffffffffffffff")
+    head = git(clone, "rev-parse", "HEAD").stdout.strip()
+    # HEAD's real parent exists locally; the message-body "parent" line names an
+    # absent object and must NOT register as a missing edge (header-only parsing).
+    assert gitlock._batch_missing_parents(clone, [head]) == set()
+    assert git(clone, "rev-list", "--count", "HEAD").stdout.strip() == "3"
 
 
-def test_repair_handles_commit_messages_containing_blank_lines(tmp_path):
+def test_repair_does_not_mask_unrelated_object_loss(tmp_path):
+    """Missing objects that are NOT reflog-only boundary commits must stay visible
+    to fsck — repair must not relabel arbitrary object loss as shallow history."""
     clone = fixture(tmp_path)
-    git(clone, "commit", "--allow-empty", "-m", "subject\n\nbody line\n\ndeadbeef commit 123")
-    corrupt_fixture(clone)
-    assert gitlock.repair_broken_shallow_boundaries(clone) >= 1
-    assert git(clone, "rev-list", "--count", "--all", "--reflog").returncode == 0
-    fsck = git(clone, "fsck", "--connectivity-only")
-    assert "broken link" not in (fsck.stdout + fsck.stderr)
+    git(clone, "config", "user.email", "t@example.com"); git(clone, "config", "user.name", "t")
+    git(clone, "commit", "--allow-empty", "-qm", "local1")
+    git(clone, "commit", "--allow-empty", "-qm", "local2")
+    # Drop HEAD's parent object from the object store.
+    victim = git(clone, "rev-parse", "HEAD~1").stdout.strip()
+    loose = clone / ".git" / "objects" / victim[:2] / victim[2:]
+    assert loose.is_file(), "expected a loose object to delete"
+    loose.unlink()
+    assert gitlock.repair_broken_shallow_boundaries(clone) == 0
+    fsck = git(clone, "fsck", "--connectivity-only", check=False)
+    assert "missing" in (fsck.stdout + fsck.stderr) or "broken link" in (fsck.stdout + fsck.stderr)

--- a/tests/hermes_cli/test_shallow_boundary_repair.py
+++ b/tests/hermes_cli/test_shallow_boundary_repair.py
@@ -1,0 +1,112 @@
+import subprocess
+from pathlib import Path
+
+import hermes_cli.gitlock as gitlock
+
+
+def git(repo, *args, check=True):
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=check)
+
+
+def fixture(tmp_path):
+    origin = tmp_path / "origin"; origin.mkdir()
+    git(origin, "init", "-q", "-b", "main")
+    git(origin, "config", "user.email", "t@example.com"); git(origin, "config", "user.name", "t")
+    git(origin, "commit", "--allow-empty", "-qm", "c0")
+    clone = tmp_path / "clone"
+    subprocess.run(["git", "clone", "-q", "--depth", "1", f"file://{origin}", str(clone)], check=True)
+    git(origin, "commit", "--allow-empty", "-qm", "c1")
+    git(origin, "commit", "--allow-empty", "-qm", "c2")
+    git(clone, "fetch", "-q", "--depth", "1", "origin", "main")
+    git(origin, "commit", "--allow-empty", "-qm", "c3")
+    git(clone, "fetch", "-q", "--depth", "1", "origin", "main")
+    return clone
+
+
+def corrupt_fixture(clone):
+    path = clone / ".git" / "shallow"
+    lines = path.read_text().splitlines()
+    for removed in lines:
+        path.write_text("\n".join(x for x in lines if x != removed) + "\n")
+        fsck = git(clone, "fsck", "--connectivity-only", check=False)
+        if "broken link" in (fsck.stdout + fsck.stderr) or "missing commit" in (fsck.stdout + fsck.stderr):
+            return removed
+    raise AssertionError("fixture did not create a broken shallow boundary")
+
+
+def test_repair_restores_boundary_for_reflog_only_commit_with_unfetched_parent(tmp_path):
+    clone = fixture(tmp_path)
+    corrupt_fixture(clone)
+    assert git(clone, "rev-list", "--count", "--all", "--reflog", check=False).returncode != 0
+    assert "broken link" in git(clone, "fsck", "--connectivity-only", check=False).stdout
+    assert gitlock.repair_broken_shallow_boundaries(clone) >= 1
+    assert git(clone, "rev-list", "--count", "--all", "--reflog").returncode == 0
+    fsck = git(clone, "fsck", "--connectivity-only")
+    assert "broken link" not in (fsck.stdout + fsck.stderr)
+    assert git(clone, "gc", "-q").returncode == 0
+
+
+def test_repair_is_noop_on_healthy_shallow_checkout(tmp_path):
+    clone = fixture(tmp_path); path = clone / ".git" / "shallow"; before = path.read_bytes()
+    assert gitlock.repair_broken_shallow_boundaries(clone) == 0
+    assert path.read_bytes() == before
+
+
+def test_repair_is_noop_on_full_clone_without_shallow_file(tmp_path):
+    repo = tmp_path / "repo"; repo.mkdir(); git(repo, "init", "-q")
+    assert gitlock.repair_broken_shallow_boundaries(repo) == 0
+
+
+def test_repair_never_raises_on_broken_repo(tmp_path):
+    assert gitlock.repair_broken_shallow_boundaries(tmp_path / "missing") == 0
+
+
+def test_repair_does_not_touch_reflogs(tmp_path):
+    clone = fixture(tmp_path); corrupt_fixture(clone)
+    before = git(clone, "reflog", "show", "--all").stdout
+    gitlock.repair_broken_shallow_boundaries(clone)
+    assert git(clone, "reflog", "show", "--all").stdout == before
+
+
+def test_repair_is_idempotent(tmp_path):
+    clone = fixture(tmp_path); corrupt_fixture(clone)
+    assert gitlock.repair_broken_shallow_boundaries(clone) >= 1
+    assert gitlock.repair_broken_shallow_boundaries(clone) == 0
+
+
+def test_repair_uses_a_bounded_number_of_git_subprocesses(tmp_path, monkeypatch):
+    counts = []
+    real_run = gitlock.subprocess.run
+
+    for count in (4, 40):
+        root = tmp_path / str(count)
+        root.mkdir()
+        clone = fixture(root)
+        for index in range(count):
+            git(clone, "commit", "--allow-empty", "-qm", f"extra-{index}")
+        corrupt_fixture(clone)
+        calls = 0
+
+        def counting_run(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            return real_run(*args, **kwargs)
+
+        monkeypatch.setattr(gitlock.subprocess, "run", counting_run)
+        assert gitlock.repair_broken_shallow_boundaries(clone) >= 1
+        assert git(clone, "rev-list", "--count", "--all", "--reflog").returncode == 0
+        counts.append(calls)
+        monkeypatch.setattr(gitlock.subprocess, "run", real_run)
+
+    assert all(count < 15 for count in counts)
+    assert abs(counts[0] - counts[1]) <= 2
+
+
+def test_repair_handles_commit_messages_containing_blank_lines(tmp_path):
+    clone = fixture(tmp_path)
+    git(clone, "commit", "--allow-empty", "-m", "subject\n\nbody line\n\ndeadbeef commit 123")
+    corrupt_fixture(clone)
+    assert gitlock.repair_broken_shallow_boundaries(clone) >= 1
+    assert git(clone, "rev-list", "--count", "--all", "--reflog").returncode == 0
+    fsck = git(clone, "fsck", "--connectivity-only")
+    assert "broken link" not in (fsck.stdout + fsck.stderr)


### PR DESCRIPTION
## Summary

`prune_stale_shallow_grafts()` (landed via #108053) dropped `.git/shallow` grafts that reflog-only commits still needed, leaving shallow installer checkouts with a commit whose parent object was never downloaded: `git gc`, `git fsck --connectivity-only`, and `git fetch`'s auto-maintenance all fail (#108286), and the corruption cannot self-heal because reflog expiry happens during `git gc` — exactly the command that broke.

Salvage of #108361 by @JoaoMarcos44 (cherry-picked, authorship preserved) plus a rework commit fixing the blocking review findings on the original PR. Complements the prevention fix #108290.

## What changed

- `repair_broken_shallow_boundaries()` in `hermes_cli/gitlock.py`: re-appends missing shallow boundaries for fetch-recorded tips (commits in `refs/remotes/*` reflogs) whose parent objects are absent. Called before the prune at both updater call sites (`_cmd_update_check`, `_cmd_update_impl`).
- `prune_stale_shallow_grafts()` fail-safe now also walks `rev-list --all --reflog`, so a boundary a reflog-only commit still needs is never dropped (without this, the production repair→prune sequence re-broke the repo on every run).

## Rework of the original PR (blocking review findings, each reproduced with real-git probes)

- **Repair undone by prune**: verified — repair restored the boundary, the immediately-following prune dropped it again, `rev-list` back to rc 128. Fixed with the prune fail-safe `--reflog` leg; regression test added.
- **Commit-message parsing**: a `parent <sha>` line in a commit message *body* was parsed as an edge, shallow-marking a healthy HEAD and truncating visible history 3→1. Fixed with header-only parsing (stop at the blank line); guard test at the `_batch_missing_parents` seam.
- **Corruption masking**: any missing parent object was re-labelled as shallow history (fsck went "clean" while the object stayed absent). Fixed by restricting candidates to `refs/remotes/*` reflog tips instead of `--batch-all-objects`; guard test deletes an object and asserts fsck still reports it.
- **Concurrent-writer race**: the temp+`os.replace` write clobbered a concurrent depth-1 fetch's boundary, and the rollback then made the repo worse. Fixed with git's own `shallow.lock` protocol, held across read→write→verify→restore in both shallow writers.
- **Cost**: repair now gates on a cheap `rev-list --all --reflog` probe (healthy updates pay one subprocess instead of 5–6); test-file footguns fixed (`encoding=`, `as_uri()`).

## Validation

- 68 focused tests green (repair 9, graft prune 3, tmp packs 5, update check 4, cmd update 47) via the repo venv, merge-tree clean vs main.
- Mutation checks: neutralizing the repair → 3 core tests red; removing the prune fail-safe `--reflog` leg → sequence test red; removing the header stop → parser guard red. All restored green.
- Two-cycle E2E of the production sequence on a real corrupted fixture: run 1 repairs (rev-list rc 0, fsck clean, `git gc` rc 0), run 2 stays fixed.
- Ruff, windows-footgun (incl. explicit scan of the new test file), compat-pointer, subprocess-stdin guards, `git diff --check` all clean.

## Scope notes

- The prevention half of #108286 (keep reflog-reachable grafts in the prune) is owned by #108290; this PR is the repair half plus the minimal fail-safe fix that makes the two safe to combine.
- Fetch-by-SHA install tips (recorded only in HEAD's reflog) are documented as out of scope for repair: widening to HEAD's reflog would re-open the object-loss masking; new corruption of that shape is prevented by the prune's reflog fail-safe.

Fixes #108286. Based on #108361 by @JoaoMarcos44 (cherry-picked to preserve authorship).
