### PR TITLE
fix(lsp): resolve nested single-root client key in _current_diags_async

### DIFF
--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -358,8 +358,11 @@ class LSPService:
         srv = find_server_for_file(file_path)
         if not (ws and gated and srv):
             return []
+        root = srv.resolve_root(file_path, ws)
+        if root is None:
+            return []
         with self._state_lock:
-            client = self._clients.get(_client_key(srv, ws))
+            client = self._clients.get(_client_key(srv, root))
         return list(client.diagnostics_for(file_path, fresh_only=True)) if client else []
 
     async def _get_or_spawn(self, file_path: str) -> Optional[LSPClient]:

--- a/tests/agent/lsp/test_nested_root_current_diagnostics.py
+++ b/tests/agent/lsp/test_nested_root_current_diagnostics.py
@@ -1,0 +1,34 @@
+import dataclasses
+import sys
+from pathlib import Path
+
+
+def test_nested_server_root_keeps_current_diagnostics(tmp_path, monkeypatch):
+    from agent.lsp import manager, servers
+    repo = tmp_path / 'repo'
+    repo.mkdir()
+    (repo / '.git').mkdir()
+    nested = repo / 'package'
+    nested.mkdir()
+    (nested / 'package.json').write_text('{}')
+    p = nested / 'x.ts'
+    p.write_text('const x = 1;\n')
+    monkeypatch.chdir(repo)
+    original = next((s for s in servers.SERVERS if s.server_id == 'typescript'))
+    root = original.resolve_root(str(p), str(repo))
+    assert root == str(nested) and (not original.multi_root)
+    mock = Path(manager.__file__).resolve().parents[2] / 'tests/agent/lsp/_mock_lsp_server.py'
+
+    def spawn(root, ctx):
+        return servers.SpawnSpec(command=[sys.executable, str(mock)], workspace_root=root, cwd=root, env={'MOCK_LSP_SCRIPT': 'errors'}, initialization_options={})
+    replacement = dataclasses.replace(original, build_spawn=spawn)
+    monkeypatch.setattr(servers, 'SERVERS', [replacement if s is original else s for s in servers.SERVERS])
+    svc = manager.LSPService(enabled=True, wait_mode='document', wait_timeout=2, install_strategy='manual')
+    try:
+        svc.snapshot_baseline(str(p))
+        actual = svc.get_diagnostics_sync(str(p), delta=False)
+        assert actual
+        current = svc._loop.run(svc._current_diags_async(str(p)), timeout=3)
+        assert current == actual, 'A live single-root server must be looked up by its resolved nested root'
+    finally:
+        svc.shutdown()


### PR DESCRIPTION
## What does this PR do?

`_get_or_spawn()` keys single-root LSP clients by the resolved project root: `root = srv.resolve_root(file_path, ws_root)` then `_client_key(srv, root)`. But `_current_diags_async()` looked the client up with `_client_key(srv, ws)`, using the enclosing workspace root instead of the resolved single-root project root.

For a file under a nested project root (e.g. a `package.json` a few directories inside a larger git repo), the TypeScript client is spawned and cached under the nested root, but `_current_diags_async()` — used to fetch the current live diagnostic set to update the delta baseline after a read — looks it up under the outer workspace root, misses the cache, and silently returns `[]` even though the running client has diagnostics for the file.

The fix makes `_current_diags_async()` resolve the root the same way `_get_or_spawn()` does before building the lookup key, so both paths agree on which client owns the file.

## Related Issue

Fixes #108882

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/lsp/manager.py`: `_current_diags_async()` now calls `srv.resolve_root(file_path, ws)` and keys the client lookup by that resolved root (matching `_get_or_spawn`), instead of the raw workspace root.
- `tests/agent/lsp/test_nested_root_current_diagnostics.py`: new regression test. Creates a nested `package.json` project inside an enclosing git repo, spawns the real single-root TypeScript client (via the repo's mock LSP process), and asserts `_current_diags_async()` returns the same diagnostics as a direct live read.

## How to Test

```
scripts/run_tests.sh tests/agent/lsp/test_nested_root_current_diagnostics.py
```

Confirmed the test fails on the unmodified code and passes with the fix:

Before the fix (`git checkout HEAD~1 -- agent/lsp/manager.py`, i.e. this PR's parent commit):
```
AssertionError: A live single-root server must be looked up by its resolved nested root
assert [] == [{'range': {...}, 'severity': 1, 'code': 'MOCK001', 'source': 'mock-lsp', ...}]
1 failed in 0.27s
```

After the fix:
```
=== Summary: 1 files, 1 tests passed, 0 failed (100% complete) in 0.9s (8 workers) ===
```

Also ran the full `tests/agent/lsp/` suite (17 files, 70 tests) — all pass, 1 skipped (Windows-only test, expected on Linux):
```
=== Summary: 17 files, 70 tests passed, 0 failed, 1 skipped (100% complete) in 5.3s (8 workers) ===
```

`ruff check agent/lsp/manager.py tests/agent/lsp/test_nested_root_current_diagnostics.py` → `All checks passed!`

`ty check agent/lsp/manager.py` reports the same 4 pre-existing diagnostics as unmodified `main` (all in unrelated code in `_get_or_spawn`'s future-handling, lines ~395-411) — no new diagnostics introduced by this change.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the test suite and all tests pass
- [x] I've added tests for my changes
- [ ] I've tested on my platform — tested on Linux (CI covers macOS/Windows)

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or architecture changed

---

This fix (implementation, tests, and PR description) was written by an autonomous coding agent (Claude, via Anthropic's Claude Code) operating without a human in the loop, then reviewed for correctness before submission.
