### PR TITLE
fix(lsp): tag versionless diagnostics with the version a didChange is advancing to

### DIFF
--- a/agent/lsp/client.py
+++ b/agent/lsp/client.py
@@ -501,12 +501,16 @@ class LSPClient:
         if self._sync_kind == 2:
             change["range"] = {"start": {"line": 0, "character": 0}, "end": _end_position(doc.text)}
         new_version = doc.version + 1
+        # Bump before the send resolves, like the didOpen branch above already does: a
+        # versionless publishDiagnostics that arrives while this await is suspended must
+        # be credited against the version it's actually replying to, not the one it is
+        # about to supersede. If the send itself fails, the version stays bumped anyway —
+        # same silent-failure handling didOpen already has.
+        doc.version, doc.text = new_version, text
         await self._send_notification(
             "textDocument/didChange",
             {"textDocument": {"uri": uri, "version": new_version}, "contentChanges": [change]},
         )
-        # Bumping the version is the whole invalidation story (see _DocState).
-        doc.version, doc.text = new_version, text
         return new_version
 
     async def save_file(self, path: str) -> None:

--- a/tests/agent/lsp/test_versionless_notification_race.py
+++ b/tests/agent/lsp/test_versionless_notification_race.py
@@ -1,0 +1,122 @@
+"""Regression test: a versionless publishDiagnostics reply arriving while
+``open_file``'s didChange send is still in flight must be tagged with the
+version that send is advancing to, not the one it's superseding — otherwise
+``wait_for_diagnostics`` rejects a genuinely fresh push as stale.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+PEER = r'''
+
+import json
+import sys
+import time
+
+
+def read_message():
+    headers = {}
+    while True:
+        line = sys.stdin.buffer.readline()
+        if not line:
+            return None
+        line = line.rstrip(b"\r\n")
+        if not line:
+            break
+        key, _, value = line.decode("ascii").partition(":")
+        headers[key.strip().lower()] = value.strip()
+    body = sys.stdin.buffer.read(int(headers["content-length"]))
+    return json.loads(body.decode("utf-8"))
+
+
+def send(message):
+    body = json.dumps(message, separators=(",", ":")).encode("utf-8")
+    sys.stdout.buffer.write(
+        f"Content-Length: {len(body)}\r\n\r\n".encode("ascii") + body
+    )
+    sys.stdout.buffer.flush()
+
+
+def publish(uri, version, diagnostics):
+    send({
+        "jsonrpc": "2.0",
+        "method": "textDocument/publishDiagnostics",
+        "params": {"uri": uri, "version": version, "diagnostics": diagnostics},
+    })
+
+
+error = [{
+    "range": {"start": {"line": 0, "character": 0},
+              "end": {"line": 0, "character": 1}},
+    "severity": 1,
+    "code": "OLD001",
+    "source": "audit-child",
+    "message": "stale version must not be treated as current",
+}]
+
+while True:
+    message = read_message()
+    if message is None:
+        break
+    method = message.get("method")
+    if method == "initialize":
+        send({"jsonrpc": "2.0", "id": message["id"], "result": {
+            "capabilities": {"textDocumentSync": 1},
+        }})
+    elif method == "initialized":
+        pass
+    elif method in {"textDocument/didOpen", "textDocument/didChange"}:
+        document = message.get("params", {}).get("textDocument", {})
+        uri = document.get("uri", "")
+        version = int(document.get("version", 0))
+        if method.endswith("didOpen"):
+            publish(uri, version, error)
+        else:
+            # Deliberately out-of-order: stale error first, current clean second.
+            publish(uri, max(0, version - 1), error)
+            time.sleep(0.03)
+            publish(uri, version, [])
+    elif method == "shutdown":
+        send({"jsonrpc": "2.0", "id": message["id"], "result": None})
+    elif method == "exit":
+        break
+
+'''
+
+
+@pytest.mark.asyncio
+async def test_versionless_reply_during_notification_is_fresh(tmp_path, monkeypatch):
+    from agent.lsp.client import LSPClient
+    m = SimpleNamespace(_SERVER=PEER)
+    text = m._SERVER.replace('"version": version, ', '').replace('publish(uri, max(0, version - 1), error)', 'pass').replace('time.sleep(0.03)', 'pass')
+    script = tmp_path / 'versionless.py'
+    script.write_text(text)
+    p = tmp_path / 'x.py'
+    p.write_text('bad\n')
+    c = LSPClient(server_id='audit-versionless', workspace_root=str(tmp_path), command=[sys.executable, str(script)], cwd=str(tmp_path))
+    await c.start()
+    try:
+        old = await c.open_file(str(p), language_id='python')
+        assert await c.wait_for_diagnostics(str(p), old, timeout=2)
+        send = c._send_notification
+
+        async def paused_send(method, params):
+            counter = c._push_counter
+            await send(method, params)
+            if method == 'textDocument/didChange':
+
+                async def seen():
+                    while c._push_counter == counter:
+                        await asyncio.sleep(0.001)
+                await asyncio.wait_for(seen(), 2)
+        monkeypatch.setattr(c, '_send_notification', paused_send)
+        p.write_text('clean\n')
+        version = await c.open_file(str(p), language_id='python')
+        assert await c.wait_for_diagnostics(str(p), version, timeout=0.3), 'Real versionless reply was tagged with old document version during legal I/O interleaving'
+    finally:
+        await c.shutdown()


### PR DESCRIPTION
## What does this PR do?

Fixes a scheduling race in `LSPClient.open_file()` where a versionless
`publishDiagnostics` reply can be mistagged as stale.

`open_file()`'s didChange branch only bumped `_DocState.version` (and
`.text`) *after* `await self._send_notification("textDocument/didChange", ...)`
returned. `_handle_publish_diagnostics()` tags a push with the server's
echoed `version` when present, otherwise falls back to `doc.version` at
receipt time:

```python
doc.push_version = version if isinstance(version, int) else doc.version
```

If a server omits `version` on its `publishDiagnostics` notification and
that notification is processed by the reader loop while the didChange
send is still suspended on `await`, it gets tagged with the *old*
`doc.version` — the one the didChange is in the process of superseding.
`wait_for_diagnostics()` then compares that stale tag against the new
version `open_file()` returns and times out waiting for data that
already arrived.

The didOpen branch two lines above already avoids this: it inserts the
new `_DocState` (with the new version) into `self._docs` *before*
awaiting the didOpen send, so anything arriving mid-send observes
current state. The didChange branch just didn't follow the same order.
This PR moves the version/text update above the `await`, matching that
existing precedent, so both branches commit state before the notification
is sent rather than after. Existing generation/stale-version/restart
checks (`_DocState.fresh_push`, `wait_for_diagnostics`'s connection-open
check, etc.) are untouched.

## Related Issue

Fixes #108881

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/lsp/client.py`: in `LSPClient.open_file()`'s didChange branch, bump `doc.version`/`doc.text` before awaiting the `textDocument/didChange` send instead of after.
- `tests/agent/lsp/test_versionless_notification_race.py`: new regression test (adapted from the issue's reproduction) using a real subprocess LSP peer, framing, and reader loop — no mocks of the client internals other than pausing `_send_notification` until the peer's reply has been processed, to deterministically land inside the original race window.

## How to Test

```
scripts/run_tests.sh tests/agent/lsp/test_versionless_notification_race.py -q
```

Verified the test fails without the fix and passes with it:

Without the fix (`git checkout HEAD~1 -- agent/lsp/client.py` before running):
```
FAILED tests/agent/lsp/test_versionless_notification_race.py::test_versionless_reply_during_notification_is_fresh
AssertionError: Real versionless reply was tagged with old document version during legal I/O interleaving
1 failed in 0.82s
```

With the fix restored:
```
[100.0% |     1/~1 | ✓1 | ✗0] ✓ tests/agent/lsp/test_versionless_notification_race.py (1✓, 1.2s)
=== Summary: 1 files, 1 tests passed, 0 failed (100% complete) in 1.2s (8 workers) ===
```

Full `tests/agent/lsp/` suite also passes (70 passed, 0 failed, 1 skipped — a `windows_only` test that runs on the Windows CI lane):
```
=== Summary: 17 files, 70 tests passed, 0 failed, 1 skipped (100% complete) in 6.3s (8 workers) ===
```

`ruff check agent/lsp/client.py tests/agent/lsp/test_versionless_notification_race.py` — all checks passed.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/agent/lsp/` and all tests pass
- [x] I've added a test for this change
- [x] Tested on Linux (this session's environment); the fix touches no OS-specific code paths

## AI assistance disclosure

This change was authored with the assistance of Claude Code (Anthropic), driven by an autonomous agent working from the issue text. The diff was verified locally: reproduced the failure against the original code, confirmed the fix resolves it, and ran the full `tests/agent/lsp/` suite plus `ruff check` before pushing.
