### PR TITLE
Desktop update relaunches on Linux when the install root is a symlink (#108867, salvage #91617)

### DIFF
--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -319,14 +319,14 @@ stop_ui() { # error/manual outcomes keep the window up briefly so a watching
 GATE="" GATE_MSG=""
 linux_gate() {
   local unpacked="$INSTALL_ROOT/apps/desktop/release/linux-unpacked" sb arg
-  # LOCAL (mhines 2026-08-21): canonicalize both sides before the prefix
-  # compare. On this Fedora host /home is a symlink to /var/home; the
-  # relaunch target is read from /proc/<pid>/exe (kernel-canonicalised to
-  # /var/home/...) while INSTALL_ROOT is spelled /home/..., so the raw
-  # prefix match false-gates as "skew" and tells the user to reinstall.
-  # readlink -m canonicalises existing leading components without
-  # requiring the full path to exist (unlike -f); no-op when both sides
-  # already agree. Upstream issue drafted (not yet filed).
+  # Canonicalise both sides before the prefix compare. On some distros
+  # (e.g. Fedora/ostree) /home is a symlink to /var/home; the relaunch
+  # target is read from /proc/<pid>/exe, which the kernel canonicalises
+  # through symlinks, while INSTALL_ROOT keeps the original spelling —
+  # the raw prefix match then false-gates as "skew" and tells the user
+  # to reinstall an app that is fine. readlink -m canonicalises existing
+  # leading components without requiring the full path to exist (unlike
+  # -f); a no-op when both sides are already spelled the same.
   unpacked="$(readlink -m -- "$unpacked")"
   [ -n "$RELAUNCH_TARGET" ] && RELAUNCH_TARGET="$(readlink -m -- "$RELAUNCH_TARGET")"
   case "$RELAUNCH_TARGET" in

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -319,6 +319,16 @@ stop_ui() { # error/manual outcomes keep the window up briefly so a watching
 GATE="" GATE_MSG=""
 linux_gate() {
   local unpacked="$INSTALL_ROOT/apps/desktop/release/linux-unpacked" sb arg
+  # LOCAL (mhines 2026-08-21): canonicalize both sides before the prefix
+  # compare. On this Fedora host /home is a symlink to /var/home; the
+  # relaunch target is read from /proc/<pid>/exe (kernel-canonicalised to
+  # /var/home/...) while INSTALL_ROOT is spelled /home/..., so the raw
+  # prefix match false-gates as "skew" and tells the user to reinstall.
+  # readlink -m canonicalises existing leading components without
+  # requiring the full path to exist (unlike -f); no-op when both sides
+  # already agree. Upstream issue drafted (not yet filed).
+  unpacked="$(readlink -m -- "$unpacked")"
+  [ -n "$RELAUNCH_TARGET" ] && RELAUNCH_TARGET="$(readlink -m -- "$RELAUNCH_TARGET")"
   case "$RELAUNCH_TARGET" in
     "$unpacked"/*) ;;
     *) GATE=skew GATE_MSG="Backend updated, but the desktop app package (AppImage/deb/rpm) was not changed. Update or reinstall it to match."; return ;;

--- a/tests/test_desktop_update_linux_gate.py
+++ b/tests/test_desktop_update_linux_gate.py
@@ -1,0 +1,138 @@
+"""The linux_gate prefix check, exercised against the real posix.sh function.
+
+On a Fedora host /home is a symlink to /var/home. The updater reads the
+running desktop's path from /proc/<pid>/exe, which the kernel canonicalises
+to the /var/home spelling, while INSTALL_ROOT is spelled /home/... (the
+symlink). The raw prefix match then false-gates as "skew" and tells the user
+to reinstall an app that is actually fine.
+
+The fix canonicalises both sides with `readlink -m` before the prefix
+compare. These tests extract the *real* `linux_gate` from posix.sh (no copy,
+no mock) and drive it through the symlink case plus the controls that must
+still behave the same way.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+POSIX_SH = REPO_ROOT / "scripts" / "desktop-update" / "posix.sh"
+
+requires_bash = pytest.mark.skipif(
+    not (Path("/bin/bash").exists() and Path("/usr/bin/readlink").exists()),
+    reason="linux_gate test needs /bin/bash and GNU readlink",
+)
+
+
+def extract_linux_gate(src: str) -> str:
+    """Return the text of the `linux_gate() { ... }` function from posix.sh.
+
+    The function's terminator is the first line that is exactly `}`; every
+    inner brace (case/esac, `&& { ...; }`, for/done) sits mid-line, so this
+    is unambiguous. We assert on marker lines so a malformed extraction
+    fails loudly rather than testing a partial function.
+    """
+    m = re.search(r"^linux_gate\(\) \{", src, re.M)
+    assert m, "linux_gate() not found in posix.sh"
+    lines = src[m.start():].splitlines(keepends=True)
+    end = next(i for i, l in enumerate(lines) if l.strip() == "}")
+    fn = "".join(lines[: end + 1])
+    # Sanity: we grabbed the whole body, not a fragment.
+    assert "GATE=manual" in fn, "extraction missing the GATE=manual terminator"
+    assert "GATE=skew" in fn, "extraction missing the GATE=skew branch"
+    return fn
+
+
+def run_gate(fn: str, install_root: str, relaunch_target: str) -> str:
+    """Drive the extracted function once in a clean bash and return GATE."""
+    driver = f"""
+set -u
+INSTALL_ROOT="{install_root}"
+RELAUNCH_TARGET="{relaunch_target}"
+SANDBOX_FALLBACK=0
+ELECTRON_DISABLE_SANDBOX=""
+RELAUNCH_ARGS=()
+GATE="" GATE_MSG=""
+{fn}
+linux_gate
+printf '%s' "$GATE"
+"""
+    with tempfile.TemporaryDirectory() as td:
+        fn_path = Path(td) / "gate.sh"
+        fn_path.write_text(driver)
+        out = subprocess.run(
+            ["/bin/bash", str(fn_path)],
+            capture_output=True,
+            text=True,
+        )
+        assert out.returncode == 0, out.stderr
+        return out.stdout.strip()
+
+
+def make_tree(root: Path) -> Path:
+    """Create <root>/apps/desktop/release/linux-unpacked and return it."""
+    unpacked = root / "apps" / "desktop" / "release" / "linux-unpacked"
+    unpacked.mkdir(parents=True)
+    return unpacked
+
+
+@requires_bash
+def test_clean_match_relays_relaunch(tmp_path):
+    """Target inside the real install dir, no sandbox helper -> relaunch."""
+    src = POSIX_SH.read_text()
+    fn = extract_linux_gate(src)
+    base = tmp_path / "install"
+    unpacked = make_tree(base)
+    target = unpacked / "hermes"
+    assert run_gate(fn, str(base), str(target)) == "relaunch"
+
+
+@requires_bash
+def test_fedora_symlink_spelling_is_not_false_skew(tmp_path):
+    """The regression: INSTALL_ROOT spelled via a symlink that points at the
+    canonical dir, target read from the canonical side. Raw prefix match
+    (unpatched) false-gates 'skew'; canonicalised compare gives 'relaunch'."""
+    src = POSIX_SH.read_text()
+    fn = extract_linux_gate(src)
+    canonical = tmp_path / "varhome"
+    unpacked = make_tree(canonical)
+    # A symlink standing in for /home -> /var/home.
+    symlink_root = tmp_path / "home"
+    symlink_root.symlink_to(canonical)
+    # Target is spelled with the canonical (kernel) side, like /proc/<pid>/exe.
+    target = unpacked / "hermes"
+    assert run_gate(fn, str(symlink_root), str(target)) == "relaunch"
+
+
+@requires_bash
+def test_genuinely_external_target_still_skew(tmp_path):
+    """A target outside the install dir must still gate 'skew' (no over-fix)."""
+    src = POSIX_SH.read_text()
+    fn = extract_linux_gate(src)
+    base = tmp_path / "install"
+    make_tree(base)
+    elsewhere = tmp_path / "other-app"
+    (elsewhere / "apps" / "desktop").mkdir(parents=True)
+    target = elsewhere / "apps" / "desktop" / "hermes"
+    assert run_gate(fn, str(base), str(target)) == "skew"
+
+
+@requires_bash
+def test_gate_canonicalises_the_patch_is_present():
+    """Guard the fix itself: the function must canonicalise both sides.
+
+    If the readlink lines are ever removed, the symlink test above regresses
+    to 'skew'; this asserts the mechanism is present so the failure is
+    localisable.
+    """
+    src = POSIX_SH.read_text()
+    fn = extract_linux_gate(src)
+    assert 'readlink -m' in fn, "linux_gate no longer canonicalises paths"
+    # Both sides must be canonicalised, not just one.
+    assert fn.count("readlink -m") >= 2, "expected both sides canonicalised"

--- a/tests/test_desktop_update_linux_gate.py
+++ b/tests/test_desktop_update_linux_gate.py
@@ -136,3 +136,19 @@ def test_gate_canonicalises_the_patch_is_present():
     assert 'readlink -m' in fn, "linux_gate no longer canonicalises paths"
     # Both sides must be canonicalised, not just one.
     assert fn.count("readlink -m") >= 2, "expected both sides canonicalised"
+
+
+@requires_bash
+def test_empty_relaunch_target_falls_to_skew(tmp_path):
+    """An unset/empty RELaunch_TARGET must still gate 'skew'.
+
+    The canonicalisation line is guarded with [ -n "$RELAUNCH_TARGET" ] so
+    an empty value skips readlink and the raw empty string falls through
+    the case to the skew branch. This pins that behavior so the guard
+    cannot be "simplified" away without a visible test failure.
+    """
+    src = POSIX_SH.read_text()
+    fn = extract_linux_gate(src)
+    base = tmp_path / "install"
+    make_tree(base)
+    assert run_gate(fn, str(base), "") == "skew"

--- a/tests/test_desktop_update_linux_gate.py
+++ b/tests/test_desktop_update_linux_gate.py
@@ -1,154 +1,59 @@
-"""The linux_gate prefix check, exercised against the real posix.sh function.
+"""The linux relaunch gate must compare canonical paths, not spellings.
 
-On a Fedora host /home is a symlink to /var/home. The updater reads the
-running desktop's path from /proc/<pid>/exe, which the kernel canonicalises
-to the /var/home spelling, while INSTALL_ROOT is spelled /home/... (the
-symlink). The raw prefix match then false-gates as "skew" and tells the user
-to reinstall an app that is actually fine.
+``--install-root`` keeps whatever spelling the app's Hermes root had (a symlinked
+``~/.hermes/hermes-agent``, or ``/home`` on Fedora/ostree where it is a link to
+``/var/home``), while ``--relaunch-target`` comes from ``process.execPath`` /
+``/proc/<pid>/exe`` and is already resolved.  A raw prefix compare then reads the
+binary the rebuild just replaced as a foreign AppImage/deb and refuses to relaunch.
 
-The fix canonicalises both sides with `readlink -m` before the prefix
-compare. These tests extract the *real* `linux_gate` from posix.sh (no copy,
-no mock) and drive it through the symlink case plus the controls that must
-still behave the same way.
+Drives the real ``--self-test-gate`` entry point of ``posix.sh`` (the same one
+``scripts/desktop-update/repro.sh gate`` uses).
 """
-
 from __future__ import annotations
 
-import re
 import subprocess
-import tempfile
 from pathlib import Path
 
 import pytest
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
-POSIX_SH = REPO_ROOT / "scripts" / "desktop-update" / "posix.sh"
+POSIX_SH = Path(__file__).resolve().parent.parent / "scripts" / "desktop-update" / "posix.sh"
 
-requires_bash = pytest.mark.skipif(
-    not (Path("/bin/bash").exists() and Path("/usr/bin/readlink").exists()),
-    reason="linux_gate test needs /bin/bash and GNU readlink",
-)
+pytestmark = pytest.mark.linux_only
 
 
-def extract_linux_gate(src: str) -> str:
-    """Return the text of the `linux_gate() { ... }` function from posix.sh.
-
-    The function's terminator is the first line that is exactly `}`; every
-    inner brace (case/esac, `&& { ...; }`, for/done) sits mid-line, so this
-    is unambiguous. We assert on marker lines so a malformed extraction
-    fails loudly rather than testing a partial function.
-    """
-    m = re.search(r"^linux_gate\(\) \{", src, re.M)
-    assert m, "linux_gate() not found in posix.sh"
-    lines = src[m.start():].splitlines(keepends=True)
-    end = next(i for i, l in enumerate(lines) if l.strip() == "}")
-    fn = "".join(lines[: end + 1])
-    # Sanity: we grabbed the whole body, not a fragment.
-    assert "GATE=manual" in fn, "extraction missing the GATE=manual terminator"
-    assert "GATE=skew" in fn, "extraction missing the GATE=skew branch"
-    return fn
+def _gate(install_root: Path, relaunch_target: Path) -> str:
+    out = subprocess.run(
+        ["bash", str(POSIX_SH), "--self-test-gate", "--install-root", str(install_root),
+         "--relaunch-target", str(relaunch_target)],
+        capture_output=True, text=True, check=True,
+    )
+    return out.stdout.strip().split(":", 1)[0]
 
 
-def run_gate(fn: str, install_root: str, relaunch_target: str) -> str:
-    """Drive the extracted function once in a clean bash and return GATE."""
-    driver = f"""
-set -u
-INSTALL_ROOT="{install_root}"
-RELAUNCH_TARGET="{relaunch_target}"
-SANDBOX_FALLBACK=0
-ELECTRON_DISABLE_SANDBOX=""
-RELAUNCH_ARGS=()
-GATE="" GATE_MSG=""
-{fn}
-linux_gate
-printf '%s' "$GATE"
-"""
-    with tempfile.TemporaryDirectory() as td:
-        fn_path = Path(td) / "gate.sh"
-        fn_path.write_text(driver)
-        out = subprocess.run(
-            ["/bin/bash", str(fn_path)],
-            capture_output=True,
-            text=True,
-        )
-        assert out.returncode == 0, out.stderr
-        return out.stdout.strip()
-
-
-def make_tree(root: Path) -> Path:
-    """Create <root>/apps/desktop/release/linux-unpacked and return it."""
+def _checkout(root: Path) -> Path:
     unpacked = root / "apps" / "desktop" / "release" / "linux-unpacked"
     unpacked.mkdir(parents=True)
+    (unpacked / "Hermes").touch()
     return unpacked
 
 
-@requires_bash
-def test_clean_match_relays_relaunch(tmp_path):
-    """Target inside the real install dir, no sandbox helper -> relaunch."""
-    src = POSIX_SH.read_text()
-    fn = extract_linux_gate(src)
-    base = tmp_path / "install"
-    unpacked = make_tree(base)
-    target = unpacked / "hermes"
-    assert run_gate(fn, str(base), str(target)) == "relaunch"
+@pytest.mark.parametrize("root_spelling,target_spelling", [("link", "real"), ("real", "link")])
+def test_symlinked_spelling_on_either_side_still_relaunches(tmp_path, root_spelling, target_spelling):
+    real = tmp_path / "real"
+    _checkout(real)
+    (tmp_path / "link").symlink_to(real)
+    root = tmp_path / root_spelling
+    target = tmp_path / target_spelling / "apps" / "desktop" / "release" / "linux-unpacked" / "Hermes"
+    assert _gate(root, target) == "relaunch"
 
 
-@requires_bash
-def test_fedora_symlink_spelling_is_not_false_skew(tmp_path):
-    """The regression: INSTALL_ROOT spelled via a symlink that points at the
-    canonical dir, target read from the canonical side. Raw prefix match
-    (unpatched) false-gates 'skew'; canonicalised compare gives 'relaunch'."""
-    src = POSIX_SH.read_text()
-    fn = extract_linux_gate(src)
-    canonical = tmp_path / "varhome"
-    unpacked = make_tree(canonical)
-    # A symlink standing in for /home -> /var/home.
-    symlink_root = tmp_path / "home"
-    symlink_root.symlink_to(canonical)
-    # Target is spelled with the canonical (kernel) side, like /proc/<pid>/exe.
-    target = unpacked / "hermes"
-    assert run_gate(fn, str(symlink_root), str(target)) == "relaunch"
-
-
-@requires_bash
-def test_genuinely_external_target_still_skew(tmp_path):
-    """A target outside the install dir must still gate 'skew' (no over-fix)."""
-    src = POSIX_SH.read_text()
-    fn = extract_linux_gate(src)
-    base = tmp_path / "install"
-    make_tree(base)
-    elsewhere = tmp_path / "other-app"
-    (elsewhere / "apps" / "desktop").mkdir(parents=True)
-    target = elsewhere / "apps" / "desktop" / "hermes"
-    assert run_gate(fn, str(base), str(target)) == "skew"
-
-
-@requires_bash
-def test_gate_canonicalises_the_patch_is_present():
-    """Guard the fix itself: the function must canonicalise both sides.
-
-    If the readlink lines are ever removed, the symlink test above regresses
-    to 'skew'; this asserts the mechanism is present so the failure is
-    localisable.
-    """
-    src = POSIX_SH.read_text()
-    fn = extract_linux_gate(src)
-    assert 'readlink -m' in fn, "linux_gate no longer canonicalises paths"
-    # Both sides must be canonicalised, not just one.
-    assert fn.count("readlink -m") >= 2, "expected both sides canonicalised"
-
-
-@requires_bash
-def test_empty_relaunch_target_falls_to_skew(tmp_path):
-    """An unset/empty RELaunch_TARGET must still gate 'skew'.
-
-    The canonicalisation line is guarded with [ -n "$RELAUNCH_TARGET" ] so
-    an empty value skips readlink and the raw empty string falls through
-    the case to the skew branch. This pins that behavior so the guard
-    cannot be "simplified" away without a visible test failure.
-    """
-    src = POSIX_SH.read_text()
-    fn = extract_linux_gate(src)
-    base = tmp_path / "install"
-    make_tree(base)
-    assert run_gate(fn, str(base), "") == "skew"
+def test_target_outside_the_checkout_is_still_skew(tmp_path):
+    real = tmp_path / "real"
+    unpacked = _checkout(real)
+    (tmp_path / "link").symlink_to(real)
+    foreign = tmp_path / "opt" / "Hermes"
+    foreign.mkdir(parents=True)
+    (foreign / "hermes").touch()
+    assert _gate(tmp_path / "link", foreign / "hermes") == "skew"
+    # A sibling directory sharing the prefix must not be mistaken for the checkout either.
+    assert _gate(tmp_path / "link", Path(str(unpacked) + "-evil") / "Hermes") == "skew"


### PR DESCRIPTION
The Linux desktop updater relaunches the app again when the install root (or the running binary) is reached through a symlink, instead of closing the window and blaming an AppImage/deb that was never involved.

Salvage of #91617 by @MatthewHines (cherry-picked, authorship preserved). Fixes #108867 (reported by @gysyl); also the Fedora/ostree `/home -> /var/home` variant from #107155 (confirmed by @mmsmsy).

## Changes

- `scripts/desktop-update/posix.sh::linux_gate` — canonicalise `$unpacked` and `$RELAUNCH_TARGET` with `readlink -m` before the prefix compare. `--install-root` carries the app's Hermes-root spelling (the installer's own `~/.hermes/hermes-agent` symlink), `--relaunch-target` is `process.execPath` / `/proc/<pid>/exe`, already resolved; the raw string compare misread the just-rebuilt binary as foreign, took the `skew` branch, and never reached the sandbox opt-out preflight.
- `tests/test_desktop_update_linux_gate.py` (ours, `linux_only`) — drives the script's real `--self-test-gate` entry point rather than regex-lifting the function body and asserting the text contains `readlink -m`. Two invariants: symlink spelling on either side → `relaunch`; foreign target and `linux-unpacked-evil` sibling prefix → `skew`.

## Validation

| Case (`--self-test-gate`) | main | after |
|---|---|---|
| symlink root + real target (the report) | skew | relaunch |
| real root + symlink target | skew | relaunch |
| `/opt/Hermes/hermes` | skew | skew |
| `linux-unpacked-evil/Hermes` | skew | skew |

`scripts/desktop-update/repro.sh gate`: the 7 gate rows behave the same before/after (the two rows that FAIL on this host — `sandbox not root/setuid` and result-JSON escaping — fail identically on untouched `origin/main`; they depend on host userns/`unshare` state and a full non-UI run, unrelated to this change).

**Live repro:** the issue's `--self-test-gate` command prints `skew:...` on `origin/main` and `relaunch` after; swapping `posix.sh` back to base re-reddens the new test file.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aaa18b0/vcalBna9qdDKG7AUUgbTB_52HyOaKC.png)
