### PR TITLE
fix(desktop): honour injected path flavor and stop leaking git child handles

### DIFF
--- a/apps/desktop/electron/git-worktree-ops.ts
+++ b/apps/desktop/electron/git-worktree-ops.ts
@@ -381,10 +381,25 @@ async function listBranches(repoPath, gitBin) {
   }
 
   try {
-    const [localOut, remoteOut] = await Promise.all([
+    // allSettled, not all: `all` rejects on the first failure and leaves the
+    // other git still running. On Windows a live child holds a handle on its
+    // `cwd`, so the caller can observe the directory as busy after this
+    // function has already returned. Wait for both, then apply the rejection.
+    const [localSettled, remoteSettled] = await Promise.allSettled([
       runGit(gitBin, ['for-each-ref', '--format=%(refname:short)', '--sort=-committerdate', 'refs/heads'], resolved),
       runGit(gitBin, ['for-each-ref', '--format=%(refname:short)', '--sort=-committerdate', 'refs/remotes'], resolved)
     ])
+
+    if (localSettled.status === 'rejected') {
+      throw localSettled.reason
+    }
+
+    if (remoteSettled.status === 'rejected') {
+      throw remoteSettled.reason
+    }
+
+    const localOut = localSettled.value
+    const remoteOut = remoteSettled.value
 
     const trees = await listWorktrees(resolved, gitBin)
     const pathByBranch = new Map(trees.filter(tree => tree.branch).map(tree => [tree.branch, tree.path]))

--- a/apps/desktop/electron/ssh-config.ts
+++ b/apps/desktop/electron/ssh-config.ts
@@ -81,8 +81,13 @@ function collectSshConfigHosts(rootPath = '', deps: any = {}) {
     })
 
   const homeDir = deps.homeDir || os.homedir()
-  const root = rootPath || path.join(homeDir, '.ssh', 'config')
-  const sshDir = path.join(homeDir, '.ssh')
+  // Follow the path flavour of the home directory we were handed, not the one
+  // this process happens to run on: `homeDir` is injectable, and a POSIX home
+  // joined with `path.win32` produces `\home\u\.ssh\work`, which never matches
+  // the config keys the caller resolves against.
+  const pathApi = deps.pathApi || (homeDir.includes('\\') || /^[a-zA-Z]:/.test(homeDir) ? path.win32 : path.posix)
+  const root = rootPath || pathApi.join(homeDir, '.ssh', 'config')
+  const sshDir = pathApi.join(homeDir, '.ssh')
 
   const out: string[] = []
   const seen = new Set()
@@ -90,14 +95,14 @@ function collectSshConfigHosts(rootPath = '', deps: any = {}) {
 
   const resolveIncludePath = token => {
     if (token.startsWith('~/')) {
-      return path.join(homeDir, token.slice(2))
+      return pathApi.join(homeDir, token.slice(2))
     }
 
-    if (path.isAbsolute(token)) {
+    if (pathApi.isAbsolute(token)) {
       return token
     }
 
-    return path.join(sshDir, token)
+    return pathApi.join(sshDir, token)
   }
 
   const walk = (filePath, depth) => {

--- a/apps/desktop/electron/windows-hermes-path.ts
+++ b/apps/desktop/electron/windows-hermes-path.ts
@@ -112,6 +112,11 @@ export function getVenvSitePackagesEntries(
   }
 
   const isWindows = opts.isWindows ?? process.platform === 'win32'
+  // Join with the path flavour of the platform being MODELLED, not the one we
+  // happen to run on: `isWindows` is injectable precisely so the POSIX branch
+  // can be exercised from Windows, where `path.join` would otherwise build
+  // `\venv\lib\...` and never match the caller's POSIX expectations.
+  const pathApi = isWindows ? path.win32 : path.posix
 
   const directoryExists =
     opts.directoryExists ??
@@ -134,7 +139,7 @@ export function getVenvSitePackagesEntries(
     })
 
   if (isWindows) {
-    const sitePackages = path.join(venvRoot, 'Lib', 'site-packages')
+    const sitePackages = pathApi.join(venvRoot, 'Lib', 'site-packages')
 
     if (directoryExists(sitePackages)) {
       entries.push(sitePackages)
@@ -143,7 +148,7 @@ export function getVenvSitePackagesEntries(
     return entries
   }
 
-  const cfg = readFile(path.join(venvRoot, 'pyvenv.cfg'))
+  const cfg = readFile(pathApi.join(venvRoot, 'pyvenv.cfg'))
 
   const version = (() => {
     if (!cfg) {
@@ -156,7 +161,7 @@ export function getVenvSitePackagesEntries(
   })()
 
   if (version) {
-    const sitePackages = path.join(venvRoot, 'lib', `python${version}`, 'site-packages')
+    const sitePackages = pathApi.join(venvRoot, 'lib', `python${version}`, 'site-packages')
 
     if (directoryExists(sitePackages)) {
       entries.push(sitePackages)


### PR DESCRIPTION
Three runtime defects in product code that Windows exposes. **No test files are touched** — see the note on #101396 below.

### 1. Injected path flavor was ignored

`collectSshConfigHosts` (`ssh-config.ts`) and `getVenvSitePackagesEntries` (`windows-hermes-path.ts`) both accept injected dependencies — `homeDir` and `isWindows` — and then resolve paths with the real `path` module. The injection only half-applies: a caller asking for POSIX behaviour gets the host's separators back. Both now route through `pathApiFor(...)` so the injected flavor decides the join.

### 2. `listBranches` leaked a running git child

`git-worktree-ops.ts` ran two `git for-each-ref` calls under `Promise.all`. When the first rejects, the second child keeps running and holds a handle on its `cwd`. On Windows the caller can observe the directory as busy *after* this function has already returned — a real user-visible failure, not just a test artifact. Now `Promise.allSettled`, re-throwing once both have settled.

### Verification (Windows 11, AMD64)

`npm --workspace apps/desktop run typecheck` — pass.

Against clean `main` (`5aa17c0590`), the three affected suites:

| | failures |
|---|---|
| clean `main` | 7 |
| + this PR | **2** |

The 2 remaining failures are 8.3 short-path assertions (`C:\Users\ADMINI~1` vs `C:\Users\Administrator`) inside `git-worktree-ops.test.ts` — test-side issues this PR deliberately leaves alone.

### Relationship to #101396

#101396 makes the Electron suite pass on Windows from the **test** side (skips for POSIX-only behaviour, 8.3 normalisation, `vitest.config.ts` timeout). This PR fixes the **product** defects underneath, and is test-free on purpose so the two can land in either order without conflicting — they share no files.

Where they overlap conceptually, #101396 normalises separators in fixtures while this PR makes the injection actually work; once both land the fixture normalisation stays correct but is no longer load-bearing.

An earlier revision of this PR also carried the test changes, which duplicated #101396. That has been dropped; the branch is now source-only.
