### PR TITLE
fix(state): retire a lost-generation handle unclosed when setconfig raises

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -158,7 +158,7 @@ jobs:
           HERMES_TEST_FILE_RETRIES: "0"
         run: |
           scripts/run_tests.sh tests/hermes_state/test_deleted_wal_generation_guard.py \
-            -k setconfig_failure -m 'linux_only and not integration' \
+            -k setconfig_failure -m 'not macos_only and not windows_only and not integration' \
             -j 1 --file-timeout 120 --junitxml="$RUNNER_TEMP/wal-setconfig.xml"
           .venv/bin/python - "$RUNNER_TEMP/wal-setconfig.xml" <<'PY'
           import sqlite3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,6 +125,57 @@ jobs:
           OPENAI_API_KEY: ""
           NOUS_API_KEY: ""
 
+  wal-setconfig:
+    name: WAL settlement (Python 3.12)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
+        with:
+          version: "0.9.28"
+          enable-cache: true
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+
+      - name: Set up Python 3.12
+        uses: ./.github/actions/retry
+        with:
+          command: uv python install 3.12
+
+      - name: Install dependencies
+        # This focused SQLite witness does not exercise optional provider SDKs.
+        uses: ./.github/actions/retry
+        with:
+          command: uv sync --locked --python 3.12 --extra dev
+
+      - name: Run setconfig failure and interrupted-capture regressions
+        env:
+          HERMES_TEST_FILE_RETRIES: "0"
+        run: |
+          scripts/run_tests.sh tests/hermes_state/test_deleted_wal_generation_guard.py \
+            -k setconfig_failure -m 'linux_only and not integration' \
+            -j 1 --file-timeout 120 --junitxml="$RUNNER_TEMP/wal-setconfig.xml"
+          .venv/bin/python - "$RUNNER_TEMP/wal-setconfig.xml" <<'PY'
+          import sqlite3
+          import sys
+          import xml.etree.ElementTree as ET
+
+          assert sys.version_info[:2] == (3, 12), sys.version
+          assert hasattr(sqlite3.Connection, "setconfig")
+          cases = list(ET.parse(sys.argv[1]).getroot().iter("testcase"))
+          assert cases, "No WAL settlement regressions were collected"
+          for case in cases:
+              assert all(case.find(tag) is None for tag in ("skipped", "failure", "error")), (
+                  "Required WAL settlement regression did not pass", case.attrib
+              )
+          print(f"Verified {len(cases)} Python 3.12 WAL settlement regressions; none skipped")
+          PY
+
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1148,44 +1148,47 @@ class SessionDB(
         raise err from exc
 
     def _disable_close_time_checkpoint(self) -> bool:
-        """Best-effort SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE (Python 3.12+): sqlite3's
-        close() otherwise runs the internal last-connection checkpoint that wrote
-        the incident's pages under wrong page numbers (see StateDbCorruptError and
-        the generation-loss halts).
-        Where this returns False (no setconfig before 3.12, or a setconfig call
-        that raised) a lost-generation handle is retired unclosed instead (see
-        close()): closing its last descriptor could both run that checkpoint and
-        discard committed data present only in an unlinked WAL."""
-        flag = getattr(sqlite3, "SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE", None)
+        """Confirm checkpoint suppression, or pin a known lost generation when possible.
+
+        Pin before a failed/interrupted attempt leaves this helper, including on
+        the first write halt. Other quarantine states keep their caller's close
+        policy; merely having a fallback does not mean it was used.
+        """
         conn = self._conn
-        setconfig = getattr(conn, "setconfig", None)
-        if flag is None or setconfig is None:
-            # Same predicate as _close_time_checkpoint_configurable() plus the per-instance
-            # getattr; close() then retires the handle unclosed with the capability __init__ bound.
-            return False
+        disabled = False
         try:
+            flag = getattr(sqlite3, "SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE", None)
+            setconfig = getattr(conn, "setconfig", None)
+            if flag is None or setconfig is None:
+                return False
             setconfig(flag, True)
+            disabled = True
+            return True
         except Exception:
-            # close() falls back to retiring the handle unclosed; only without a bound retention
-            # capability (non-CPython) can SQLite still checkpoint, so say which case this is.
             logger.error(
-                "Could not disable SQLite's close-time checkpoint on the quarantined handle for %s; %s",
-                self.db_path,
-                "retaining it unclosed instead." if self._retire_connection is not None
-                else "closing it may checkpoint retired frames over the newer generation.",
+                "Could not disable SQLite's close-time checkpoint on the quarantined handle for %s; "
+                "an ordinary close may still checkpoint its WAL.", self.db_path,
                 exc_info=True,
             )
             return False
-        return True
+        finally:
+            # BaseException (KeyboardInterrupt/SystemExit) must propagate, but only
+            # after the exact lost-generation connection is protected from finalization.
+            if (not disabled and conn is not None and self._db_wal_generation_lost
+                    and self._retire_connection is not None):
+                self._pin_connection(conn)
 
     def _pin_connection(self, conn) -> None:
         """Retain the exact quarantined connection past GC and interpreter teardown (once per handle).
 
-        Takes the connection as a parameter: callers are lock-held close paths, and the
-        writer-conn thread-safety audit flags self._conn in functions outside `with self._lock`."""
-        if not self._connection_pinned:
+        The generation lock also serializes pins from interrupted halt paths. Pass the
+        exact connection observed by the caller rather than reading self._conn again."""
+        with self._retired_capture_lock:
+            if self._connection_pinned:
+                return
             self._retire_connection(conn)
             self._connection_pinned = True
+        logger.warning("Pinned the lost-generation connection for %s through interpreter shutdown.", self.db_path)
 
     def _settle_lost_generation_locked(self) -> bool:
         """Capture the retired generation; return whether the handle must be retired unclosed.
@@ -1217,11 +1220,6 @@ class SessionDB(
             "writers before reopening and inspect the capture before deciding its disposition.",
             self.db_path, artifact,
         )
-        if retire_without_close:
-            logger.warning(
-                "Retaining the quarantined connection for %s unclosed: SQLite's close-time "
-                "checkpoint could not be switched off on it.", self.db_path,
-            )
         return retire_without_close
 
     def _raise_if_db_corrupt(self) -> None:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -488,11 +488,15 @@ class SessionDB(
             if read_only:
                 self._open_read_only()
             else:
-                # Where SQLite's close-time checkpoint cannot be switched off, a lost-generation handle
-                # is retired unclosed (see close()). Resolve that capability before opening a writer:
-                # late cleanup must not import ctypes or look up it in a cleared module dictionary.
-                if not _close_time_checkpoint_configurable():
+                # Wherever SQLite's close-time checkpoint is not switched off -- no setconfig before
+                # 3.12, or a setconfig call that raises -- a lost-generation handle is retired unclosed
+                # (see close()). Resolve that capability before opening a writer: late cleanup must not
+                # import ctypes or look it up in a cleared module dictionary.
+                try:
                     self._retire_connection = _prepare_connection_retirement()
+                except RuntimeError:
+                    if not _close_time_checkpoint_configurable():
+                        raise  # nothing else could keep a lost-generation close from checkpointing
                 self._open_writer()
             self._record_db_file_identity()
             initialization_complete = True
@@ -1148,27 +1152,28 @@ class SessionDB(
         close() otherwise runs the internal last-connection checkpoint that wrote
         the incident's pages under wrong page numbers (see StateDbCorruptError and
         the generation-loss halts).
-        <3.12 has no setconfig, so a lost-generation handle is retired unclosed
-        instead (see close()): closing its last descriptor could both run that
-        checkpoint and discard committed data present only in an unlinked WAL."""
+        Where this returns False (no setconfig before 3.12, or a setconfig call
+        that raised) a lost-generation handle is retired unclosed instead (see
+        close()): closing its last descriptor could both run that checkpoint and
+        discard committed data present only in an unlinked WAL."""
         flag = getattr(sqlite3, "SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE", None)
         conn = self._conn
         setconfig = getattr(conn, "setconfig", None)
         if flag is None or setconfig is None:
             # Same predicate as _close_time_checkpoint_configurable() plus the per-instance
-            # getattr: __init__ binds no retirement capability when either half is missing,
-            # and close() must agree with that decision or the lost handle would neither
-            # setconfig nor pin.
+            # getattr; close() then retires the handle unclosed with the capability __init__ bound.
             return False
         try:
             setconfig(flag, True)
         except Exception:
-            # No retention capability is bound on this runtime, so close() will let SQLite run the
-            # checkpoint over the newer generation: say so where an operator can see it.
+            # close() falls back to retiring the handle unclosed; only without a bound retention
+            # capability (non-CPython) can SQLite still checkpoint, so say which case this is.
             logger.error(
-                "Could not disable SQLite's close-time checkpoint on the quarantined handle for %s; "
-                "closing it may checkpoint retired frames over the newer generation.",
-                self.db_path, exc_info=True,
+                "Could not disable SQLite's close-time checkpoint on the quarantined handle for %s; %s",
+                self.db_path,
+                "retaining it unclosed instead." if self._retire_connection is not None
+                else "closing it may checkpoint retired frames over the newer generation.",
+                exc_info=True,
             )
             return False
         return True
@@ -1185,12 +1190,12 @@ class SessionDB(
     def _settle_lost_generation_locked(self) -> bool:
         """Capture the retired generation; return whether the handle must be retired unclosed.
 
-        Where SQLite's close-time checkpoint cannot be switched off (no setconfig, Python < 3.12),
-        sqlite3_close would write the retired frames over the newer generation, so the exact
-        connection is retired unclosed instead. A failed capture leaves the handle open for a retry
-        -- but the pin is taken FIRST on such a runtime: every production caller reaches close()
-        through hermes_state_registry.release_or_close, which swallows the error, so an interpreter
-        exit before the retry must not be able to checkpoint the stale frames either."""
+        Where SQLite's close-time checkpoint is not switched off (no setconfig before Python 3.12, or
+        a setconfig call that raised), sqlite3_close would write the retired frames over the newer
+        generation, so the exact connection is retired unclosed instead. A failed capture leaves the
+        handle open for a retry -- but the pin is taken FIRST in that case: every production caller
+        reaches close() through hermes_state_registry.release_or_close, which swallows the error, so
+        an interpreter exit before the retry must not be able to checkpoint the stale frames either."""
         self._db_wal_generation_lost = True
         retire_without_close = not self._disable_close_time_checkpoint() and self._retire_connection is not None
         try:
@@ -1211,8 +1216,8 @@ class SessionDB(
         )
         if retire_without_close:
             logger.warning(
-                "Retaining the quarantined connection for %s unclosed: this runtime cannot "
-                "switch off SQLite's close-time checkpoint.", self.db_path,
+                "Retaining the quarantined connection for %s unclosed: SQLite's close-time "
+                "checkpoint could not be switched off on it.", self.db_path,
             )
         return retire_without_close
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1198,14 +1198,17 @@ class SessionDB(
         an interpreter exit before the retry must not be able to checkpoint the stale frames either."""
         self._db_wal_generation_lost = True
         retire_without_close = not self._disable_close_time_checkpoint() and self._retire_connection is not None
+        if retire_without_close:
+            # Capture may also raise an unwrapped exception or be interrupted. Its
+            # exception type must not decide whether interpreter exit can checkpoint.
+            self._pin_connection(self._conn)
         try:
             artifact = self._capture_retired_generation("close")
-        except RetiredGenerationCaptureError as exc:
-            if retire_without_close:
-                self._pin_connection(self._conn)
+        except BaseException as exc:
             logger.error(
                 "Could not capture the retired WAL generation of %s at close: %s. The handle stays open "
                 "and close() retries the capture; those frames are NOT yet preserved.", self.db_path, exc,
+                exc_info=True,
             )
             raise
         logger.warning(

--- a/tests/hermes_state/_wal_generation_harness.py
+++ b/tests/hermes_state/_wal_generation_harness.py
@@ -158,6 +158,24 @@ _GATEWAY_CHILD = textwrap.dedent(
                 emit(event="closed", error=repr(exc))
             del db
             gc.collect()
+        elif cmd == "break-setconfig":
+            # A setconfig call that raises (in the field: an already-invalid handle) via an op SQLite rejects.
+            import sqlite3
+            sqlite3.SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE = -1
+            emit(event="broken", what=cmd)
+        elif cmd == "break-capture":
+            import hermes_state
+            from hermes_state_dbfile import RetiredGenerationCaptureError
+
+            def refuse(*args, **kwargs):
+                raise RetiredGenerationCaptureError("no space left on device")
+
+            hermes_state.capture_retired_wal_generation = refuse
+            emit(event="broken", what=cmd)
+        elif cmd == "release":
+            from hermes_state_registry import release_or_close
+            release_or_close(db)  # the production close path: swallows close() errors
+            emit(event="released", open=db._conn is not None)
         elif cmd == "quit":
             break
     """

--- a/tests/hermes_state/_wal_generation_harness.py
+++ b/tests/hermes_state/_wal_generation_harness.py
@@ -163,14 +163,25 @@ _GATEWAY_CHILD = textwrap.dedent(
             import sqlite3
             sqlite3.SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE = -1
             emit(event="broken", what=cmd)
-        elif cmd == "break-capture":
+        elif cmd in ("break-capture", "break-copy-memory", "break-copy-interrupt"):
             import hermes_state
+            import hermes_state_dbfile
             from hermes_state_dbfile import RetiredGenerationCaptureError
 
-            def refuse(*args, **kwargs):
-                raise RetiredGenerationCaptureError("no space left on device")
+            error, message = {
+                "break-capture": (RetiredGenerationCaptureError, "no space left on device"),
+                "break-copy-memory": (MemoryError, "capture copy ran out of memory"),
+                "break-copy-interrupt": (KeyboardInterrupt, "capture copy interrupted"),
+            }[cmd]
 
-            hermes_state.capture_retired_wal_generation = refuse
+            def refuse(*args, _error=error, _message=message, **kwargs):
+                raise _error(_message)
+
+            if cmd == "break-capture":
+                hermes_state.capture_retired_wal_generation = refuse
+            else:
+                # Keep the real capture routine and its exception handling in the path.
+                hermes_state_dbfile._copy_range = refuse
             emit(event="broken", what=cmd)
         elif cmd == "release":
             from hermes_state_registry import release_or_close

--- a/tests/hermes_state/_wal_generation_harness.py
+++ b/tests/hermes_state/_wal_generation_harness.py
@@ -158,10 +158,21 @@ _GATEWAY_CHILD = textwrap.dedent(
                 emit(event="closed", error=repr(exc))
             del db
             gc.collect()
-        elif cmd == "break-setconfig":
-            # A setconfig call that raises (in the field: an already-invalid handle) via an op SQLite rejects.
+        elif cmd in ("break-setconfig", "interrupt-setconfig", "exit-setconfig"):
             import sqlite3
-            sqlite3.SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE = -1
+
+            if cmd == "break-setconfig":
+                # Force a real native setconfig call to reject its operation.
+                sqlite3.SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE = -1
+            else:
+                interruption = KeyboardInterrupt if cmd == "interrupt-setconfig" else SystemExit
+
+                def interrupted_setconfig(self, *args, _error=interruption):
+                    raise _error(73)  # preserve SystemExit's requested status too
+
+                # Override the Python TrackedConnection subclass, preserving the real
+                # connection object and its still-enabled native close checkpoint.
+                type(db._conn).setconfig = interrupted_setconfig
             emit(event="broken", what=cmd)
         elif cmd in ("break-capture", "break-copy-memory", "break-copy-interrupt"):
             import hermes_state

--- a/tests/hermes_state/test_deleted_wal_generation_guard.py
+++ b/tests/hermes_state/test_deleted_wal_generation_guard.py
@@ -437,23 +437,35 @@ def test_renamed_wal_generation_survives_close_and_clean_process_exit(tmp_path):
 # close() errors, and a normal interpreter exit, whether or not the capture succeeded.
 
 
-def _assert_new_generation_survives_setconfig_failure(tmp_path, *, rename_sidecars, capture_fails):
+def _assert_new_generation_survives_setconfig_failure(tmp_path, *, rename_sidecars, capture_failure):
     with gateway_writer(tmp_path) as gw:
         path = gw.path
         gw.next_event("ready")
-        for command in ("break-setconfig", "break-capture")[: 2 if capture_fails else 1]:
+        commands = ["break-setconfig"]
+        if capture_failure is not None:
+            commands.append({
+                "error": "break-capture",
+                "memory": "break-copy-memory",
+                "interrupt": "break-copy-interrupt",
+            }[capture_failure])
+        for command in commands:
             gw.send(command)
             gw.next_event("broken")
         lose_sidecars(path, rename=rename_sidecars)
         expected = write_second_generation(path, n_rows=400)
 
         gw.send("release")
-        assert gw.next_event("released")["open"] is capture_fails
-        assert integrity_ok_path(path), "release checkpointed the stale WAL over the main file"
-        assert message_count(path) == expected, "release rolled back the newer rows"
+        if capture_failure == "interrupt":
+            # Cancellation must still propagate; protecting the handle must not swallow it.
+            assert gw.wait_exit(timeout=20) != 0
+            assert "KeyboardInterrupt" in gw.stderr_text()
+        else:
+            assert gw.next_event("released")["open"] is (capture_failure is not None)
+            assert integrity_ok_path(path), "release checkpointed the stale WAL over the main file"
+            assert message_count(path) == expected, "release rolled back the newer rows"
 
-        gw.send("quit")
-        assert gw.wait_exit(timeout=20) == 0, gw.stderr_text()
+            gw.send("quit")
+            assert gw.wait_exit(timeout=20) == 0, gw.stderr_text()
         assert integrity_ok_path(path), "normal exit checkpointed the stale WAL over the main file"
         assert message_count(path) == expected, "normal exit rolled back the newer rows"
 
@@ -461,17 +473,19 @@ def _assert_new_generation_survives_setconfig_failure(tmp_path, *, rename_sideca
 @pytest.mark.linux_only
 @pytest.mark.skipif(not _close_time_checkpoint_configurable(),
                     reason="no setconfig: the retirement tests above cover this runtime")
-@pytest.mark.parametrize("capture_fails", [False, True], ids=["captured", "capture-failed"])
-def test_setconfig_failure_retires_unclosed_through_release_and_exit(tmp_path, capture_fails):
-    _assert_new_generation_survives_setconfig_failure(tmp_path, rename_sidecars=False, capture_fails=capture_fails)
+@pytest.mark.parametrize("capture_failure", [None, "error", "memory", "interrupt"],
+                         ids=["captured", "capture-failed", "capture-memory-error", "capture-interrupted"])
+def test_setconfig_failure_retires_unclosed_through_release_and_exit(tmp_path, capture_failure):
+    _assert_new_generation_survives_setconfig_failure(tmp_path, rename_sidecars=False, capture_failure=capture_failure)
 
 
 @pytest.mark.macos_only
 @pytest.mark.skipif(not _close_time_checkpoint_configurable(),
                     reason="no setconfig: the retirement tests above cover this runtime")
-@pytest.mark.parametrize("capture_fails", [False, True], ids=["captured", "capture-failed"])
-def test_setconfig_failure_retires_renamed_generation_unclosed_through_release_and_exit(tmp_path, capture_fails):
-    _assert_new_generation_survives_setconfig_failure(tmp_path, rename_sidecars=True, capture_fails=capture_fails)
+@pytest.mark.parametrize("capture_failure", [None, "error", "memory", "interrupt"],
+                         ids=["captured", "capture-failed", "capture-memory-error", "capture-interrupted"])
+def test_setconfig_failure_retires_renamed_generation_unclosed_through_release_and_exit(tmp_path, capture_failure):
+    _assert_new_generation_survives_setconfig_failure(tmp_path, rename_sidecars=True, capture_failure=capture_failure)
 
 
 @pytest.mark.skipif(

--- a/tests/hermes_state/test_deleted_wal_generation_guard.py
+++ b/tests/hermes_state/test_deleted_wal_generation_guard.py
@@ -20,7 +20,7 @@ import hermes_state_dbfile
 import hermes_state_readpool
 import hermes_state_wal
 from hermes_state import (
-    DeletedWalGenerationError, SessionDB, StateDbReplacedError, _close_time_checkpoint_configurable,
+    DeletedWalGenerationError, SessionDB, StateDbCorruptError, StateDbReplacedError, _close_time_checkpoint_configurable,
     classify_persistence_error, refuse_deleted_wal_generation,
 )
 from hermes_state_dbfile import _pread_db_header, iter_deleted_sqlite_sidecar_holders
@@ -437,11 +437,17 @@ def test_renamed_wal_generation_survives_close_and_clean_process_exit(tmp_path):
 # close() errors, and a normal interpreter exit, whether or not the capture succeeded.
 
 
-def _assert_new_generation_survives_setconfig_failure(tmp_path, *, rename_sidecars, capture_failure):
+def _assert_new_generation_survives_setconfig_failure(
+    tmp_path, *, rename_sidecars, capture_failure, setconfig_failure, operation,
+):
     with gateway_writer(tmp_path) as gw:
         path = gw.path
         gw.next_event("ready")
-        commands = ["break-setconfig"]
+        commands = [{
+            "error": "break-setconfig",
+            "interrupt": "interrupt-setconfig",
+            "exit": "exit-setconfig",
+        }[setconfig_failure]]
         if capture_failure is not None:
             commands.append({
                 "error": "break-capture",
@@ -454,8 +460,10 @@ def _assert_new_generation_survives_setconfig_failure(tmp_path, *, rename_sideca
         lose_sidecars(path, rename=rename_sidecars)
         expected = write_second_generation(path, n_rows=400)
 
-        gw.send("release")
-        if capture_failure == "interrupt":
+        gw.send(operation)
+        if setconfig_failure == "exit":
+            assert gw.wait_exit(timeout=20) == 73, gw.stderr_text()
+        elif setconfig_failure == "interrupt" or capture_failure == "interrupt":
             # Cancellation must still propagate; protecting the handle must not swallow it.
             assert gw.wait_exit(timeout=20) != 0
             assert "KeyboardInterrupt" in gw.stderr_text()
@@ -470,22 +478,73 @@ def _assert_new_generation_survives_setconfig_failure(tmp_path, *, rename_sideca
         assert message_count(path) == expected, "normal exit rolled back the newer rows"
 
 
+_SETCONFIG_FAILURE_CASES = [
+    pytest.param(None, "error", "release", id="captured"),
+    pytest.param("error", "error", "release", id="capture-failed"),
+    pytest.param("memory", "error", "release", id="capture-memory-error"),
+    pytest.param("interrupt", "error", "release", id="capture-interrupted"),
+    pytest.param(None, "interrupt", "release", id="setconfig-interrupted-release"),
+    pytest.param(None, "exit", "release", id="setconfig-exited-release"),
+    pytest.param(None, "interrupt", "write", id="setconfig-interrupted-halt"),
+    pytest.param(None, "exit", "write", id="setconfig-exited-halt"),
+]
+
+
 @pytest.mark.linux_only
 @pytest.mark.skipif(not _close_time_checkpoint_configurable(),
                     reason="no setconfig: the retirement tests above cover this runtime")
-@pytest.mark.parametrize("capture_failure", [None, "error", "memory", "interrupt"],
-                         ids=["captured", "capture-failed", "capture-memory-error", "capture-interrupted"])
-def test_setconfig_failure_retires_unclosed_through_release_and_exit(tmp_path, capture_failure):
-    _assert_new_generation_survives_setconfig_failure(tmp_path, rename_sidecars=False, capture_failure=capture_failure)
+@pytest.mark.parametrize("capture_failure,setconfig_failure,operation", _SETCONFIG_FAILURE_CASES)
+def test_setconfig_failure_retires_unclosed_through_release_and_exit(
+    tmp_path, capture_failure, setconfig_failure, operation,
+):
+    _assert_new_generation_survives_setconfig_failure(
+        tmp_path, rename_sidecars=False, capture_failure=capture_failure,
+        setconfig_failure=setconfig_failure, operation=operation,
+    )
 
 
 @pytest.mark.macos_only
 @pytest.mark.skipif(not _close_time_checkpoint_configurable(),
                     reason="no setconfig: the retirement tests above cover this runtime")
-@pytest.mark.parametrize("capture_failure", [None, "error", "memory", "interrupt"],
-                         ids=["captured", "capture-failed", "capture-memory-error", "capture-interrupted"])
-def test_setconfig_failure_retires_renamed_generation_unclosed_through_release_and_exit(tmp_path, capture_failure):
-    _assert_new_generation_survives_setconfig_failure(tmp_path, rename_sidecars=True, capture_failure=capture_failure)
+@pytest.mark.parametrize("capture_failure,setconfig_failure,operation", _SETCONFIG_FAILURE_CASES)
+def test_setconfig_failure_retires_renamed_generation_unclosed_through_release_and_exit(
+    tmp_path, capture_failure, setconfig_failure, operation,
+):
+    _assert_new_generation_survives_setconfig_failure(
+        tmp_path, rename_sidecars=True, capture_failure=capture_failure,
+        setconfig_failure=setconfig_failure, operation=operation,
+    )
+
+
+@pytest.mark.skipif(not _close_time_checkpoint_configurable(), reason="needs native setconfig")
+def test_setconfig_failure_does_not_report_retention_for_structural_quarantine(tmp_path, force_wal, monkeypatch, caplog):
+    db = make_db(tmp_path / "state.db", "s", "seed")
+    real_conn = db._conn
+
+    class MalformedWriter:
+        def execute(self, *args, **kwargs):
+            raise sqlite3.DatabaseError("database disk image is malformed")
+
+        def __getattr__(self, name):
+            return getattr(real_conn, name)
+
+    monkeypatch.setattr(sqlite3, "SQLITE_DBCONFIG_NO_CKPT_ON_CLOSE", -1)
+    try:
+        db._conn = MalformedWriter()
+        with caplog.at_level("ERROR", logger="hermes_state"):
+            with pytest.raises(StateDbCorruptError):
+                db.create_session("corrupt-write", "cli")
+        db._conn = real_conn
+        db.close()
+        assert not db._db_wal_generation_lost and not db._connection_pinned
+        with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+            real_conn.execute("SELECT 1")
+        assert "Could not disable SQLite's close-time checkpoint" in caplog.text
+        assert "ordinary close may" in caplog.text
+        assert "retaining it unclosed" not in caplog.text.lower()
+    finally:
+        db._conn = None
+        real_conn.close()
 
 
 @pytest.mark.skipif(

--- a/tests/hermes_state/test_deleted_wal_generation_guard.py
+++ b/tests/hermes_state/test_deleted_wal_generation_guard.py
@@ -432,6 +432,48 @@ def test_renamed_wal_generation_survives_close_and_clean_process_exit(tmp_path):
     _assert_new_generation_survives_retirement_and_exit(tmp_path, rename_sidecars=True)
 
 
+# A setconfig that exists but raises on the quarantined handle must retire it unclosed exactly as a
+# runtime without setconfig does -- through hermes_state_registry.release_or_close, which swallows
+# close() errors, and a normal interpreter exit, whether or not the capture succeeded.
+
+
+def _assert_new_generation_survives_setconfig_failure(tmp_path, *, rename_sidecars, capture_fails):
+    with gateway_writer(tmp_path) as gw:
+        path = gw.path
+        gw.next_event("ready")
+        for command in ("break-setconfig", "break-capture")[: 2 if capture_fails else 1]:
+            gw.send(command)
+            gw.next_event("broken")
+        lose_sidecars(path, rename=rename_sidecars)
+        expected = write_second_generation(path, n_rows=400)
+
+        gw.send("release")
+        assert gw.next_event("released")["open"] is capture_fails
+        assert integrity_ok_path(path), "release checkpointed the stale WAL over the main file"
+        assert message_count(path) == expected, "release rolled back the newer rows"
+
+        gw.send("quit")
+        assert gw.wait_exit(timeout=20) == 0, gw.stderr_text()
+        assert integrity_ok_path(path), "normal exit checkpointed the stale WAL over the main file"
+        assert message_count(path) == expected, "normal exit rolled back the newer rows"
+
+
+@pytest.mark.linux_only
+@pytest.mark.skipif(not _close_time_checkpoint_configurable(),
+                    reason="no setconfig: the retirement tests above cover this runtime")
+@pytest.mark.parametrize("capture_fails", [False, True], ids=["captured", "capture-failed"])
+def test_setconfig_failure_retires_unclosed_through_release_and_exit(tmp_path, capture_fails):
+    _assert_new_generation_survives_setconfig_failure(tmp_path, rename_sidecars=False, capture_fails=capture_fails)
+
+
+@pytest.mark.macos_only
+@pytest.mark.skipif(not _close_time_checkpoint_configurable(),
+                    reason="no setconfig: the retirement tests above cover this runtime")
+@pytest.mark.parametrize("capture_fails", [False, True], ids=["captured", "capture-failed"])
+def test_setconfig_failure_retires_renamed_generation_unclosed_through_release_and_exit(tmp_path, capture_fails):
+    _assert_new_generation_survives_setconfig_failure(tmp_path, rename_sidecars=True, capture_fails=capture_fails)
+
+
 @pytest.mark.skipif(
     not sys.platform.startswith("linux"),
     reason="deleted-WAL /proc scan is Linux-only",

--- a/tests/hermes_state/test_retired_wal_generation_capture.py
+++ b/tests/hermes_state/test_retired_wal_generation_capture.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import pytest
 
 import hermes_state
-from hermes_state import DeletedWalGenerationError, SessionDB
+from hermes_state import DeletedWalGenerationError, SessionDB, _close_time_checkpoint_configurable
 from hermes_state_dbfile import (
     RETIRED_GENERATION_MANIFEST, RetiredGenerationCaptureError, capture_retired_wal_generation,
 )
@@ -178,7 +178,8 @@ def test_failed_capture_still_pins_the_handle_and_surfaces_through_the_registry(
     _wal_only_sentinel(db, "gw-0")
     lose_sidecars(path, rename=False)
     pins = []
-    if db._retire_connection is not None:
+    retires_unclosed = not _close_time_checkpoint_configurable()
+    if retires_unclosed:
         monkeypatch.setattr(db, "_retire_connection", pins.append)
 
     def refuse(*args, **kwargs):
@@ -189,7 +190,7 @@ def test_failed_capture_still_pins_the_handle_and_surfaces_through_the_registry(
         release_or_close(db)  # must not raise
     assert db._conn is not None
     assert "no space left on device" in caplog.text
-    if db._retire_connection is not None:  # no setconfig: the pin must already be taken
+    if retires_unclosed:  # no setconfig: the pin must already be taken
         assert pins == [db._conn]
         monkeypatch.undo()
         monkeypatch.setattr(db, "_retire_connection", pins.append)


### PR DESCRIPTION
## What does this PR do?

Fixes the setconfig-failure path identified on #106840 ([review](https://github.com/NousResearch/hermes-agent/pull/106840#discussion_r3986068586), [follow-up requested by the merger](https://github.com/NousResearch/hermes-agent/pull/106840#discussion_r3995395487)). On Python 3.12+, the retirement fallback was prepared only when `setconfig` was absent. If disabling SQLite's close-time checkpoint failed, a lost-generation handle could still finalize with checkpointing enabled and overwrite the newer database generation.

Prepare the fallback during CPython writer initialization. When checkpoint suppression fails or is interrupted for a known lost generation and the fallback is available, pin the exact connection before the helper returns or unwinds. This protects both the first write halt and release/close, including `KeyboardInterrupt` and `SystemExit` raised inside `setconfig`. The pin also precedes generation capture, so capture exceptions cannot bypass it. Interruptions still propagate.

## Related Issue

Refs #105670. Follow-up to #106840 (salvage of #105726).

## Type of Change

- [x] Bug fix

## Changes Made

- Bind the retirement fallback on writer initialization while preserving the existing native-setconfig runtime compatibility boundary.
- Protect known lost-generation connections in the checkpoint-disable helper's `finally` block when suppression was not confirmed. Serialize the once-per-handle pin using the existing capture lock.
- Log retention only after an actual pin. Other quarantine states retain their existing close policies; a failed setter reports that an ordinary close may still checkpoint the WAL.
- Extend the Linux/macOS subprocess controls with setter interruptions during release and the first write halt. Add a structural-quarantine regression that verifies normal closure and truthful failure logging.
- Add a focused Ubuntu/Python 3.12 job using locked core + dev dependencies and `scripts/run_tests.sh`. Its selection includes the portable logging regression; its JUnit guard rejects empty or skipped coverage.

## Validation

Current head: **`b28a23fffc8e0727d3a9a153febc0afd1807b19c`**. The four files changed from reviewed head `2eb00c261c49ae64bcce8a60b610019361063385` match the Linux-verified candidate's recorded Git blobs. Candidate patch SHA-256: `5e5f37ec81c04ce02b15cd7432dd96faa8704c0c3e437868a5b0e45d7a9b6013`.

All runs used `scripts/run_tests.sh` with `HERMES_TEST_FILE_RETRIES=0` and isolated test data. Linux validation was run manually in my VM; these are not hosted CI results.

| Environment | Related scope | Result |
| --- | --- | --- |
| macOS arm64, Python 3.11 | `tests/hermes_state/ tests/state/`, 63 files | **511 passed, 0 failed, 40 skipped** |
| macOS arm64, Python 3.12 | Same scope, locked core + dev dependencies | **520 passed, 0 failed, 31 skipped** |
| Linux arm64, Python 3.12.14, SQLite 3.53.1 | Same scope, 63 files | **537 passed, 0 failed, 14 skipped**, 36.3 seconds |

Focused controls:

- **9 passed, 0 failed, 0 skipped** on each of native macOS/Python 3.12 and Linux/Python 3.12. They cover the four existing capture scenarios, four setter-interruption scenarios, and structural-quarantine logging.
- Reviewed `2eb00c261` production with the new tests: **5 intended failures**, covering the four setter-interruption preservation checks and the incorrect-log check. The Linux verifier checks exact test names and failure reasons and rejects setup errors or skips.
- The subprocess controls use real SQLite connections and interpreter exit, checking database integrity and preservation of the newer generation's messages. Earlier controls also establish the original setter-failure and capture-interruption regressions against their respective unfixed versions.
- Ruff, `git diff --check`, actionlint 1.7.12, Windows-footgun checks, and the JUnit all-skipped rejection check passed locally.

The full repository suite was not run locally. Platform/runtime-specific skips in the related suites are separate from the nine required controls, which all executed. Hosted CI results must be assessed on this exact head.

## Scope and Runtime Boundary

These are controlled exception-injection regressions. `sqlite3_db_config(NO_CKPT_ON_CLOSE)` normally succeeds on a valid live handle; these tests do not establish that healthy usage naturally produces the injected errors.

Python 3.12+ without a usable ctypes retirement fallback retains its existing compatibility behavior. If native `setconfig` also fails, no fallback is available. This PR does not provide an unconditional fail-closed guarantee for every Python implementation or extend unclosed retirement to unrelated quarantine states.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass. I ran `tests/hermes_state/` and `tests/state/` via `scripts/run_tests.sh` on Python 3.11 and 3.12, not the full suite.
- [x] I've added regression tests and verified the relevant controls fail without the fixes
- [x] I've tested on macOS arm64 and in a Linux arm64 VM

### Documentation & Housekeeping

- [x] I've updated relevant docstrings/comments
- [x] No tool schemas or user configuration changes
- [x] I've considered cross-platform impact: Linux uses real unlink and macOS uses real rename; Windows cannot unlink a held sidecar
