### PR TITLE
fix(tools): tool_describe/tool_call distinguish disabled toolsets from lookup misses

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -711,7 +711,8 @@ def _dispatch_bridge_tool(function_name: str, function_args: Dict[str, Any],
         return ts.dispatch_tool_search(args, current_tool_defs=current_defs), None
     if function_name == ts.TOOL_DESCRIBE_NAME:
         return ts.dispatch_tool_describe(args, current_tool_defs=current_defs), None
-    underlying_name, underlying_args, err = ts.resolve_underlying_call(args)
+    underlying_name, underlying_args, err = ts.resolve_underlying_call(
+        args, current_tool_defs=current_defs)
     if err or not underlying_name:
         return tool_error(err or "tool_call could not be resolved"), None
     if underlying_name == ts.CONNECTOR_BATCH_SENTINEL:

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -930,3 +930,50 @@ class TestDeferredCallSchemaProbe:
         }, calls)
 
         assert validate_deferred_call_args(name, {"payload": {"anything": True}}) is None
+
+
+class TestSessionScopeGuidance:
+    """#108663: the 'call it directly' guidance must only fire when the tool is
+    actually in THIS session's function list; a globally-registered tool whose
+    toolset is disabled for the session gets the not-enabled message instead,
+    or the model retries a call that can never succeed."""
+
+    def test_describe_disabled_toolset_gets_not_enabled_message(self):
+        import json as _json
+        from tools.tool_search import ToolSearchConfig, dispatch_tool_describe
+
+        result = _json.loads(dispatch_tool_describe(
+            {"names": ["terminal"]},
+            current_tool_defs=[_td("some_other_tool")],
+            config=ToolSearchConfig.from_raw({}),
+        ))
+        assert "not_found" not in result
+        assert "toolset isn't enabled for this session" in result["errors"]["terminal"]
+
+    def test_describe_tool_in_session_list_keeps_direct_call_message(self):
+        import json as _json
+        from tools.tool_search import ToolSearchConfig, dispatch_tool_describe
+
+        result = _json.loads(dispatch_tool_describe(
+            {"names": ["terminal"]},
+            current_tool_defs=[_td("terminal")],
+            config=ToolSearchConfig.from_raw({}),
+        ))
+        assert "not a deferrable tool" in result["errors"]["terminal"]
+        assert "toolset isn't enabled" not in result["errors"]["terminal"]
+
+    def test_unwrap_disabled_toolset_gets_not_enabled_message(self):
+        from tools.tool_search import resolve_underlying_call
+
+        _, _, err = resolve_underlying_call(
+            {"name": "terminal", "arguments": {}}, current_tool_defs=[_td("some_other_tool")])
+        assert err is not None
+        assert "toolset isn't enabled for this session" in err
+
+    def test_unwrap_in_session_list_keeps_direct_call_message(self):
+        from tools.tool_search import resolve_underlying_call
+
+        _, _, err = resolve_underlying_call(
+            {"name": "terminal", "arguments": {}}, current_tool_defs=[_td("terminal")])
+        assert err is not None
+        assert "not a deferrable" in err

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -489,6 +489,7 @@ def dispatch_tool_describe(args: Dict[str, Any], *, current_tool_defs: List[Dict
     deferrable = _deferrable_in(current_tool_defs)
     by_name = {name: _fn(td) for td, name in zip(deferrable, _tool_def_names(deferrable)) if name}
     remote_schemas = remote_schemas_for(names, current_tool_defs, connector_describe)
+    session_names = frozenset(_tool_def_names(current_tool_defs))
 
     tools: Dict[str, Dict[str, Any]] = {}
     not_found: List[str] = []
@@ -504,12 +505,21 @@ def dispatch_tool_describe(args: Dict[str, Any], *, current_tool_defs: List[Dict
                            "parameters": remote_fn.get("parameters", {})}
         elif is_connector_name(name):
             not_found.append(name)
-        elif _registry_entry(name) is not None and not is_deferrable_tool_name(
-            name, load_config_readonly().effective_defer_tools):
-            # Registered but bridge/core/GUI-surface: a real name, wrong door.
+        elif name in session_names:
+            # Present in THIS session's function list (a non-deferrable surface):
+            # the direct-call guidance is accurate here.
             errors[name] = (
                 f"'{name}' is not a deferrable tool. If you see it in the tools list "
                 "already, call it directly; otherwise check the spelling against tool_search.")
+        elif _registry_entry(name) is not None and not is_deferrable_tool_name(
+            name, load_config_readonly().effective_defer_tools):
+            # Registered globally but absent from this session's assembled list —
+            # usually a disabled toolset (platform_toolsets / agent.disabled_toolsets),
+            # not a lookup miss. Direct-call guidance would start a failed-retry loop:
+            # the tool is not in the model's function list this turn (#108663).
+            errors[name] = (
+                f"'{name}' is a known tool, but its toolset isn't enabled for this "
+                "session/platform, so it isn't callable this turn.")
         else:
             not_found.append(name)
     result: Dict[str, Any] = {"tools": tools}
@@ -530,13 +540,20 @@ def scoped_deferrable_names(tool_defs: List[Dict[str, Any]]) -> frozenset[str]:
                      if n and is_deferrable_tool_name(n, defer_tools))
 
 
-def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[str, Any], Optional[str]]:
+def resolve_underlying_call(args: Dict[str, Any], *, current_tool_defs: Optional[List[Dict[str, Any]]] = None,
+                            ) -> Tuple[Optional[str], Dict[str, Any], Optional[str]]:
     """Parse a ``tool_call`` invocation into (underlying_name, args, error_msg).
 
     Used by:
     * the dispatcher in ``model_tools.handle_function_call``,
     * the display layer (so the activity feed shows the underlying tool),
     * the trajectory recorder.
+
+    When ``current_tool_defs`` is provided (the dispatcher's session-scoped
+    assembly), a globally-registered tool absent from that list gets a
+    "toolset isn't enabled" error instead of the direct-call guidance — the
+    direct-call advice loops when the tool is not in the model's function
+    list this turn (#108663).
 
     A connector-only batch resolves
     to ``(CONNECTOR_BATCH_SENTINEL, {"calls": [...]}, None)``: the batch is
@@ -560,6 +577,12 @@ def resolve_underlying_call(args: Dict[str, Any]) -> Tuple[Optional[str], Dict[s
     name = entries[0]["name"]
     raw_args = entries[0]["arguments"]
     if not is_deferrable_tool_name(name, load_config_readonly().effective_defer_tools):
+        if (current_tool_defs is not None and name not in set(_tool_def_names(current_tool_defs))
+                and _registry_entry(name) is not None):
+            return None, {}, (
+                f"'{name}' is a known tool, but its toolset isn't enabled for this "
+                "session/platform, so it isn't callable this turn."
+            )
         return None, {}, (
             f"'{name}' is not a deferrable tool. If it appears in the model-facing tools "
             "list already, call it directly instead of via tool_call."


### PR DESCRIPTION
Fixes #108663.

## What & why

Both bridge tools decided "known, just call it directly" from the **global** registry, not the session's actual assembled tool list (`platform_toolsets.<platform>` / `agent.disabled_toolsets` filtering happens at assembly). A tool registered in the codebase but disabled for the active platform still resolved as "known", so the model was told to call it directly — a call that can never succeed because the tool isn't in its function list this turn, driving the failed-retry guardrail loop the issue describes.

- `dispatch_tool_describe`: the error chain now checks the session's assembled `current_tool_defs` **first** (the direct-call guidance stays byte-identical there), and reports the globally-registered-but-absent case as "'X' is a known tool, but its toolset isn't enabled for this session/platform, so it isn't callable this turn."
- `resolve_underlying_call`: same distinction via an optional `current_tool_defs` parameter. The dispatcher in `model_tools.handle_function_call` passes the session assembly; the display/trajectory callers (which have no assembly in hand) keep the legacy behavior through the default `None` — no behavior change outside the dispatcher.

The scoped executor gate (`scoped_deferrable_names`) already blocked out-of-scope `tool_call` invocations; this PR fixes the **guidance** so the model stops retrying instead of just failing later with a generic error.

## How to test

`tests/tools/test_tool_search.py::TestSessionScopeGuidance` pins the four cases: a registered-but-disabled tool (`terminal` absent from the session defs) gets the not-enabled message from both bridges; the same tool present in the session defs keeps the original direct-call message; the no-`current_tool_defs` legacy path is unchanged (existing `test_unwrap_rejects_core_tool_attempt` still passes). New tests fail on `main` (message never mentions the disabled toolset) and pass here.

## Platforms tested

Linux. Pure message-routing change in the bridge layer — no I/O or platform surface. Full suite (`scripts/run_tests.sh`): only the known pre-existing/flaky failure set (documented on #108861/#108876); no tool-search files affected.