### PR TITLE
fix(toolsets): get_distribution annotation uses typing.Any, not builtin any (#2139, salvage #20812)

### DIFF
--- a/toolset_distributions.py
+++ b/toolset_distributions.py
@@ -6,7 +6,7 @@ A distribution maps toolset names to the % chance each is enabled for a prompt
 be a "+"-grouped compound ("browser+search") that rolls once for all members.
 """
 
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 import random
 from toolsets import validate_toolset
 
@@ -46,7 +46,7 @@ DISTRIBUTIONS = {
 }
 
 
-def get_distribution(name: str) -> Optional[Dict[str, any]]:
+def get_distribution(name: str) -> Optional[Dict[str, Any]]:
     """Distribution definition (description + toolsets), or None if unknown."""
     return DISTRIBUTIONS.get(name)
 


### PR DESCRIPTION
`toolset_distributions.get_distribution` is annotated with `typing.Any` instead of the builtin `any()` function, so static checkers stop rejecting the signature.

- `from typing import Any, Dict, List, Optional` + `-> Optional[Dict[str, Any]]` (2 lines, no runtime change)
- Cherry-picked from #20812 by @ms-alan; the commit carried an empty author email so it is re-authored to their GitHub noreply identity (misconfigured local git). #23556, #51929 and #98727 are the same two-line fix filed later.

| Check | Result |
|---|---|
| `get_distribution.__annotations__["return"]` on `origin/main` | `Optional[Dict[str, <built-in function any>]]` |
| after | `Optional[Dict[str, typing.Any]]` |
| `scripts/run_tests.sh tests/test_toolset_distributions.py` | green |

Root cause: lowercase `any` in the annotation was the builtin, never imported from `typing`.

Fixes #2139. Supersedes #20812, #23556, #51929, #98727.

## Infographic

![typing-any](https://v3b.fal.media/files/b/0aaa190d/3PiqCi4-JOhrtwHbAdGeE_lUSAegBV.png)
