### PR TITLE
fix(telegram): command menu no longer rejected for Unicode dashes in descriptions (#2925, salvage #106899)

### DIFF
--- a/hermes_cli/commands_platforms.py
+++ b/hermes_cli/commands_platforms.py
@@ -38,6 +38,15 @@ def _sanitize_telegram_name(raw: str) -> str:
     return _TG_MULTI_UNDERSCORE.sub("_", name).strip("_")
 
 
+_TG_DASHES = re.compile("[\u2012\u2013\u2014\u2015\u2212]")
+
+
+def _normalize_telegram_desc(desc: str) -> str:
+    """Fold Unicode dashes (em/en/figure/horizontal-bar/minus) to ASCII ``-``.
+    BotFather rejects setMyCommands descriptions containing them (#2925)."""
+    return _TG_DASHES.sub("-", desc)
+
+
 def _truncate_desc(desc: str, limit: int) -> str:
     """Clamp a menu description to *limit* chars with a ``...`` tail."""
     return desc if len(desc) <= limit else desc[:limit - 3] + "..."
@@ -80,7 +89,7 @@ def telegram_bot_commands(*, include_plugins: bool = True) -> list[tuple[str, st
     if include_plugins:
         pairs += [(n, d) for n, d, hint in _iter_plugin_command_entries()
                   if not _requires_argument(hint)]
-    return [(tg, desc) for name, desc in pairs if (tg := _sanitize_telegram_name(name))]
+    return [(tg, _normalize_telegram_desc(desc)) for name, desc in pairs if (tg := _sanitize_telegram_name(name))]
 
 
 # Telegram allows 100 BotCommands; the 60-slot default keeps every built-in plus common skill
@@ -279,7 +288,7 @@ def telegram_menu_commands(max_commands: int = 100) -> tuple[list[tuple[str, str
                    for name, desc, cmd_key, raw in entries]
     candidates = _prioritize_telegram_menu_candidates(candidates)
     overflow_count = max(0, len(candidates) - max_commands)
-    menu = [(name, desc) for name, desc, _source, _raw_name in candidates[:max_commands]]
+    menu = [(name, _normalize_telegram_desc(desc)) for name, desc, _source, _raw_name in candidates[:max_commands]]
     return menu, hidden_count + overflow_count
 
 

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -172,6 +172,23 @@ class TestTelegramBotCommands:
         for name, _ in telegram_bot_commands():
             assert "-" not in name, f"Telegram command '{name}' contains a hyphen"
 
+    def test_no_unicode_dashes_in_descriptions(self):
+        """BotFather rejects setMyCommands descriptions with em/en dashes (#2925)."""
+        for name, desc in telegram_bot_commands():
+            assert not any(c in desc for c in "\u2012\u2013\u2014\u2015\u2212"), (
+                f"Telegram command '{name}' description has a Unicode dash: {desc!r}")
+
+    def test_unicode_dashes_folded_to_hyphen(self, monkeypatch):
+        """Stubbed registry entry with em/en dashes comes back hyphenated."""
+        fake = CommandDef(name="dashy", description="does a \u2014 b \u2013 c",
+                          category="Session")
+        monkeypatch.setattr("hermes_cli.commands_platforms._gateway_available_commands",
+                            lambda: [fake])
+        monkeypatch.setattr("hermes_cli.commands_platforms._iter_plugin_command_entries",
+                            lambda: iter([]))
+        assert ("dashy", "does a - b - c") in telegram_bot_commands(
+            include_plugins=False)
+
 
     def test_includes_builtin_commands_with_required_args(self):
         """Built-in arg-taking commands (e.g. /queue, /steer, /bg, /btw)


### PR DESCRIPTION
The Telegram command menu registers again when a built-in, plugin or skill description contains an em/en dash: descriptions are folded to ASCII `-` at the merged-menu boundary before `setMyCommands`.

- `hermes_cli/commands_platforms.py`: `_normalize_telegram_desc()` folds U+2012/2013/2014/2015/2212 to `-`; applied in `telegram_bot_commands()` and in `telegram_menu_commands()` after built-ins + plugins + skills are merged, so every description source shares the invariant.
- 2 invariant tests: the live registry produces no Unicode dash, and a stubbed dashed description comes back hyphenated.
- Cherry-picked from #106899 by @nikkoxgonzales. Earlier attempts (#2927, #62754 partial; #62885 / #68498 boundary-level by @ygd58) normalised individual collection paths or targeted the pre-decomposition `hermes_cli/commands.py`.

| Check | Before (`origin/main`) | After |
|---|---|---|
| `telegram_menu_commands()` entries containing a Unicode dash | `[('fast', 'Fast mode — OpenAI Priority Processing / …')]` | `[]` |
| `scripts/run_tests.sh tests/hermes_cli/test_commands.py` | — | 60 passed |

Root cause: the `/fast` built-in description carries an em dash and reached both `set_my_commands` call sites in `plugins/platforms/telegram/adapter.py` unmodified; the reporter's BotFather rejection ("the list of commands is invalid") is the same constraint hit when the menu text is pasted into `/setcommands`.

Fixes #2925. Supersedes #106899, #68498.

## Infographic

![telegram-dashes](https://v3b.fal.media/files/b/0aaa1915/iJCwwU5s_07gpCISebIl8_t8im2B6q.png)
