### PR TITLE
fix(cli): custom-provider wizard reports the auto-detected context length when left blank (#2513)

### DIFF
--- a/hermes_cli/model_setup_flows_custom.py
+++ b/hermes_cli/model_setup_flows_custom.py
@@ -30,6 +30,28 @@ def _parse_context_length(text: str):
     return value if value > 0 else None
 
 
+def _report_context_length_detection(model_name: str, base_url: str, api_key: str) -> None:
+    """Tell the user what the auto-detect resolver found for *model_name* at *base_url* (#2513).
+
+    The runtime resolver (``get_model_context_length``) probes /models, local servers and the
+    catalogs, then falls back to ``DEFAULT_FALLBACK_CONTEXT``; without this line a blank
+    context-length prompt gave no hint whether the saved endpoint runs on a detected value or
+    the silent default that shapes compression and cache windows. Feedback only — the value
+    is NOT written to config, which would freeze a probe result into a permanent override.
+    """
+    try:
+        from agent.model_metadata import DEFAULT_FALLBACK_CONTEXT, get_model_context_length
+        from hermes_cli.banner import _format_context_length
+        detected = get_model_context_length(model_name, base_url=base_url, api_key=api_key or "")
+    except Exception:  # a failing probe must never block the save
+        return
+    if detected and detected != DEFAULT_FALLBACK_CONTEXT:
+        print(f"  Context length auto-detected: {_format_context_length(detected)} tokens")
+    else:
+        print(f"  Context length: not detected — using the default {_format_context_length(DEFAULT_FALLBACK_CONTEXT)} tokens "
+              f"(set model.context_length in config.yaml to override)")
+
+
 def _probe_custom_endpoint(effective_key: str, effective_url: str) -> tuple[dict, str]:
     """Verify a custom endpoint via ``probe_api_models`` and report; returns
     ``(probe, effective_url)`` where the URL may be the working fallback base."""
@@ -136,6 +158,8 @@ def _model_flow_custom(config):
         print("\nCancelled.")
         return
     context_length = _parse_context_length(context_length_str)
+    if context_length is None and model_name:
+        _report_context_length_detection(model_name, effective_url, effective_key)
 
     # The key goes to .env and config.yaml only references it. Keyed on host:port
     # so two servers on one machine keep separate credentials.

--- a/tests/hermes_cli/test_custom_provider_context_feedback.py
+++ b/tests/hermes_cli/test_custom_provider_context_feedback.py
@@ -1,0 +1,26 @@
+"""#2513: a blank context-length prompt in the custom-endpoint wizard tells the user whether the
+runtime resolver detected a value or will run on the silent default."""
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import model_setup_flows_custom as flows
+
+
+@pytest.mark.parametrize("resolved, expect", [
+    (200_000, "auto-detected"),
+    (None, "using the default"),
+])
+def test_blank_context_length_reports_detection_outcome(capsys, resolved, expect):
+    from agent.model_metadata import DEFAULT_FALLBACK_CONTEXT
+    with patch("agent.model_metadata.get_model_context_length",
+               return_value=resolved if resolved is not None else DEFAULT_FALLBACK_CONTEXT) as probe:
+        flows._report_context_length_detection("some-model", "http://localhost:8000/v1", "k")
+    probe.assert_called_once_with("some-model", base_url="http://localhost:8000/v1", api_key="k")
+    assert expect in capsys.readouterr().out
+
+
+def test_probe_failure_never_blocks_the_save(capsys):
+    with patch("agent.model_metadata.get_model_context_length", side_effect=RuntimeError("boom")):
+        flows._report_context_length_detection("some-model", "http://x/v1", "")
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
Leaving "Context length in tokens [leave blank for auto-detect]" empty in the custom-endpoint wizard now prints what the runtime resolver actually found — `Context length auto-detected: 131.1K tokens` or `Context length: not detected — using the default 128K tokens (set model.context_length in config.yaml to override)` — instead of going silent.

- `hermes_cli/model_setup_flows_custom.py::_report_context_length_detection`: runs `agent.model_metadata.get_model_context_length(model, base_url=…, api_key=…)` (the same 9-step resolver the runtime uses, endpoint-aware) and distinguishes a real hit from `DEFAULT_FALLBACK_CONTEXT`.
- Feedback only: nothing is persisted (a probe result written to config would freeze into a permanent override); a failing probe never blocks the save.
- Approach from #2522 (@ygd58) and #85499 (@Luna161), both written against the pre-decomposition `model_setup_flows.py`; re-implemented on the current custom-flow sibling with `Co-authored-by` credit. 2 tests (detected vs default line; probe exception → save proceeds silently).

| Check | Before (`origin/main`) | After |
|---|---|---|
| wizard run with blank context length (scripted stdin, resolver stubbed to 131072) | no line after the prompt | `Context length auto-detected: 131.1K tokens`; resolver called with `base_url='http://127.0.0.1:9/v1'` |
| `scripts/run_tests.sh tests/hermes_cli/test_custom_provider_context_feedback.py tests/hermes_cli/test_custom_provider_model_switch.py tests/cli/test_cli_provider_resolution.py` | — | 31 passed |

Root cause: `_save_custom_provider` stores `context_length=None` and the runtime resolves it later; the wizard never showed which branch of that resolution the endpoint would land on.

Fixes #2513. Supersedes #85499.

## Infographic

![context-feedback](https://v3b.fal.media/files/b/0aaa1907/cRVWPa_LGmzOxU3qrs3mI_f3yJJJ8S.png)
