### PR TITLE
fix(install): detect real host arch for managed Node on Windows ARM64

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -570,6 +570,45 @@ def _swap_node_tree(target: Path, staged: Path) -> bool | None:
     return True
 
 
+def _windows_native_machine_code() -> int | None:
+    """Raw ``SYSTEM_INFO.wProcessorArchitecture`` from ``GetNativeSystemInfo``, or ``None``.
+
+    Unlike ``PROCESSOR_ARCHITECTURE``/``PROCESSOR_ARCHITEW6432``, this reflects the true host CPU
+    even when the calling process runs under WOW64 / Prism x64 emulation (#108893) -- there is no
+    emulated view to report, because the kernel answers the query directly.
+    """
+    try:
+        import ctypes
+
+        class _SystemInfo(ctypes.Structure):
+            _fields_ = [
+                ("wProcessorArchitecture", ctypes.c_uint16),
+                ("wReserved", ctypes.c_uint16),
+                ("dwPageSize", ctypes.c_uint32),
+                ("lpMinimumApplicationAddress", ctypes.c_void_p),
+                ("lpMaximumApplicationAddress", ctypes.c_void_p),
+                ("dwActiveProcessorMask", ctypes.c_void_p),
+                ("dwNumberOfProcessors", ctypes.c_uint32),
+                ("dwProcessorType", ctypes.c_uint32),
+                ("dwAllocationGranularity", ctypes.c_uint32),
+                ("wProcessorLevel", ctypes.c_uint16),
+                ("wProcessorRevision", ctypes.c_uint16),
+            ]
+
+        info = _SystemInfo()
+        ctypes.windll.kernel32.GetNativeSystemInfo(ctypes.byref(info))
+    except (OSError, AttributeError, ValueError):
+        return None
+    return info.wProcessorArchitecture
+
+
+def _windows_native_arch() -> str | None:
+    """Emulation-invariant host arch (``"x86"``/``"amd64"``/``"arm64"``), mirroring ``install.ps1``'s
+    ``Get-WindowsArch``; ``None`` when the native query is unavailable and callers should fall back
+    to the env-var pair."""
+    return {0: "x86", 9: "amd64", 12: "arm64"}.get(_windows_native_machine_code())
+
+
 def _heal_managed_node_windows(home: Path | None = None) -> bool | None:
     """Redownload the portable Node zip into ``%HERMES_HOME%\\node`` on Windows.
 
@@ -588,7 +627,9 @@ def _heal_managed_node_windows(home: Path | None = None) -> bool | None:
     """
     import time
 
-    arch = (os.environ.get("PROCESSOR_ARCHITEW6432") or os.environ.get("PROCESSOR_ARCHITECTURE", "")).lower()
+    arch = _windows_native_arch() or (
+        os.environ.get("PROCESSOR_ARCHITEW6432") or os.environ.get("PROCESSOR_ARCHITECTURE", "")
+    ).lower()
     node_arch = {"amd64": "x64", "x86_64": "x64", "arm64": "arm64", "x86": "x86"}.get(arch)
     if node_arch is None:
         return False
@@ -667,8 +708,24 @@ def heal_hermes_managed_node() -> bool:
     return bool(result)
 
 
+def _windows_node_arch_mismatched(node_path: Path) -> bool:
+    """True when an existing Windows managed-node binary's compiled arch doesn't match the real
+    host arch (#108893). ``process.arch`` reflects how the binary was built, not the emulated
+    process view ``PROCESSOR_ARCHITECTURE`` reports under Prism, so a wrong-arch node from a prior
+    heal is caught here even though it runs fine under emulation."""
+    expected = _windows_native_arch()
+    if expected is None:
+        return False
+    expected_node_arch = {"amd64": "x64", "arm64": "arm64", "x86": "x86"}[expected]
+    result = _run_version_probe([str(node_path), "-p", "process.arch"])
+    if result is None:
+        return False
+    return result.stdout.decode().strip() != expected_node_arch
+
+
 def _managed_node_tree_outdated(home: Path | None = None) -> bool:
-    """True when the managed node runs but is below the target major (heals like a broken tree)."""
+    """True when the managed node runs but is below the target major, is a pre-release, or (Windows
+    only) was provisioned for the wrong CPU arch (heals like a broken tree)."""
     for candidate in _iter_managed_node_candidates(_candidate_node_command_names("node"), home):
         result = _run_version_probe([str(candidate), "--version"])
         if result is None:
@@ -682,7 +739,9 @@ def _managed_node_tree_outdated(home: Path | None = None) -> bool:
         # final releases, so node-gyp cannot build node-pty. Mirrors node_satisfies_build() in install.sh.
         if "-" in version:
             return True
-        return major < _HERMES_NODE_TARGET_MAJOR
+        if major < _HERMES_NODE_TARGET_MAJOR:
+            return True
+        return sys.platform == "win32" and _windows_node_arch_mismatched(candidate)
     return False
 
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -571,42 +571,63 @@ def _swap_node_tree(target: Path, staged: Path) -> bool | None:
 
 
 def _windows_native_machine_code() -> int | None:
-    """Raw ``SYSTEM_INFO.wProcessorArchitecture`` from ``GetNativeSystemInfo``, or ``None``.
+    """Raw ``IMAGE_FILE_MACHINE_*`` code for the true host CPU, from ``IsWow64Process2``'s
+    ``pNativeMachine`` out-parameter, or ``None`` when the query is unavailable.
 
-    Unlike ``PROCESSOR_ARCHITECTURE``/``PROCESSOR_ARCHITEW6432``, this reflects the true host CPU
-    even when the calling process runs under WOW64 / Prism x64 emulation (#108893) -- there is no
-    emulated view to report, because the kernel answers the query directly.
+    ``GetNativeSystemInfo`` looks like the obvious fit here but is a trap: per Microsoft's own docs,
+    when called from an x86 or x64 process on a 64-bit system that lacks an Intel64/x64 processor --
+    i.e. an x64 process running under Prism emulation on ARM64, exactly #108893's scenario -- it
+    "will return information as if the system is x86 [...] (or x64 if x64 emulation is also
+    supported)": the *emulated* view, not the real host. ``IsWow64Process2`` was added in Windows 10
+    1709 specifically to give callers a way to see past that; its ``pNativeMachine`` out-param always
+    reports the true host architecture, regardless of emulation.
+
+    ``GetCurrentProcess``'s and ``IsWow64Process2``'s HANDLE types are bound explicitly on both ends
+    (restype on the former, argtypes on the latter): ctypes' default ``c_int`` for an untyped HANDLE
+    truncates the ``(HANDLE)-1`` pseudo-handle to 32 bits, which fails ``IsWow64Process2`` with
+    ``ERROR_INVALID_HANDLE`` on Win64 -- the same pitfall ``hermes_cli/main_desktop.py``'s
+    ``_windows_native_machine_from_iswow64`` documents (#71218).
     """
     try:
         import ctypes
+        from ctypes import wintypes
 
-        class _SystemInfo(ctypes.Structure):
-            _fields_ = [
-                ("wProcessorArchitecture", ctypes.c_uint16),
-                ("wReserved", ctypes.c_uint16),
-                ("dwPageSize", ctypes.c_uint32),
-                ("lpMinimumApplicationAddress", ctypes.c_void_p),
-                ("lpMaximumApplicationAddress", ctypes.c_void_p),
-                ("dwActiveProcessorMask", ctypes.c_void_p),
-                ("dwNumberOfProcessors", ctypes.c_uint32),
-                ("dwProcessorType", ctypes.c_uint32),
-                ("dwAllocationGranularity", ctypes.c_uint32),
-                ("wProcessorLevel", ctypes.c_uint16),
-                ("wProcessorRevision", ctypes.c_uint16),
-            ]
-
-        info = _SystemInfo()
-        ctypes.windll.kernel32.GetNativeSystemInfo(ctypes.byref(info))
+        kernel32 = ctypes.windll.kernel32
+        kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+        kernel32.GetCurrentProcess.argtypes = []
+        kernel32.IsWow64Process2.argtypes = [
+            wintypes.HANDLE,
+            ctypes.POINTER(wintypes.USHORT),
+            ctypes.POINTER(wintypes.USHORT),
+        ]
+        kernel32.IsWow64Process2.restype = wintypes.BOOL
+        process_machine = wintypes.USHORT()
+        native_machine = wintypes.USHORT()
+        ok = kernel32.IsWow64Process2(
+            kernel32.GetCurrentProcess(),
+            ctypes.pointer(process_machine),
+            ctypes.pointer(native_machine),
+        )
+        if not ok:
+            return None
     except (OSError, AttributeError, ValueError):
         return None
-    return info.wProcessorArchitecture
+    return native_machine.value
+
+
+# IMAGE_FILE_MACHINE_* values (winnt.h), as reported by IsWow64Process2's pNativeMachine.
+_WINDOWS_NATIVE_MACHINE_ARCH = {
+    0x014C: "x86",
+    0x8664: "amd64",
+    0xAA64: "arm64",
+}
 
 
 def _windows_native_arch() -> str | None:
     """Emulation-invariant host arch (``"x86"``/``"amd64"``/``"arm64"``), mirroring ``install.ps1``'s
     ``Get-WindowsArch``; ``None`` when the native query is unavailable and callers should fall back
     to the env-var pair."""
-    return {0: "x86", 9: "amd64", 12: "arm64"}.get(_windows_native_machine_code())
+    return _WINDOWS_NATIVE_MACHINE_ARCH.get(_windows_native_machine_code())
 
 
 def _heal_managed_node_windows(home: Path | None = None) -> bool | None:

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -1130,6 +1130,108 @@ class TestWindowsHealStageSwap:
         assert fresh_backup.exists()
 
 
+class TestWindowsNodeArchDetection:
+    """The managed node's architecture must track the real host CPU, not the emulated view
+    ``PROCESSOR_ARCHITECTURE`` reports under Prism x64 emulation on Windows ARM64 (#108893)."""
+
+    def test_heal_prefers_native_arch_over_emulated_env_vars(self, tmp_path, monkeypatch):
+        home = tmp_path / "hermes"
+        home.mkdir()
+        monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
+        # Prism reports the emulated x64 view in both env vars...
+        monkeypatch.setenv("PROCESSOR_ARCHITECTURE", "AMD64")
+        monkeypatch.delenv("PROCESSOR_ARCHITEW6432", raising=False)
+        # ...but GetNativeSystemInfo sees the real ARM64 host (12 = PROCESSOR_ARCHITECTURE_ARM64).
+        monkeypatch.setattr(hermes_constants, "_windows_native_machine_code", lambda: 12)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(hermes_constants, "managed_node_tree_in_use", lambda _home=None: False)
+
+        captured = {}
+
+        def fake_stage(_home, node_arch):
+            captured["node_arch"] = node_arch
+            return None
+
+        monkeypatch.setattr(hermes_constants, "_stage_windows_node_zip", fake_stage)
+
+        hermes_constants._heal_managed_node_windows()
+
+        assert captured["node_arch"] == "arm64"
+
+    def test_heal_falls_back_to_env_vars_when_native_query_unavailable(self, tmp_path, monkeypatch):
+        home = tmp_path / "hermes"
+        home.mkdir()
+        monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
+        monkeypatch.setenv("PROCESSOR_ARCHITECTURE", "ARM64")
+        monkeypatch.delenv("PROCESSOR_ARCHITEW6432", raising=False)
+        monkeypatch.setattr(hermes_constants, "_windows_native_machine_code", lambda: None)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(hermes_constants, "managed_node_tree_in_use", lambda _home=None: False)
+
+        captured = {}
+
+        def fake_stage(_home, node_arch):
+            captured["node_arch"] = node_arch
+            return None
+
+        monkeypatch.setattr(hermes_constants, "_stage_windows_node_zip", fake_stage)
+
+        hermes_constants._heal_managed_node_windows()
+
+        assert captured["node_arch"] == "arm64"
+
+    def test_outdated_check_flags_wrong_arch_binary_on_windows(self, tmp_path, monkeypatch):
+        """A pre-existing wrong-arch node from an earlier (unpatched) heal must be flagged so it
+        gets re-provisioned, even though it runs fine under Prism emulation."""
+        home = tmp_path / "hermes"
+        node_dir = home / "node"
+        node_dir.mkdir(parents=True)
+        node_exe = node_dir / "node.exe"
+        node_exe.write_text("fake-x64-node", encoding="utf-8")
+        monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(hermes_constants, "_windows_native_machine_code", lambda: 12)  # real ARM64 host
+
+        def fake_probe(argv, **kwargs):
+            class _Result:
+                pass
+
+            r = _Result()
+            if argv[1:] == ["--version"]:
+                r.stdout = f"v{hermes_constants._HERMES_NODE_TARGET_MAJOR}.5.1".encode()
+            else:
+                r.stdout = b"x64"  # the binary's own compiled arch, unaffected by emulation
+            return r
+
+        monkeypatch.setattr(hermes_constants, "_run_version_probe", fake_probe)
+
+        assert hermes_constants._managed_node_tree_outdated(home) is True
+
+    def test_outdated_check_passes_matching_arch_binary_on_windows(self, tmp_path, monkeypatch):
+        home = tmp_path / "hermes"
+        node_dir = home / "node"
+        node_dir.mkdir(parents=True)
+        (node_dir / "node.exe").write_text("fake-arm64-node", encoding="utf-8")
+        monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(hermes_constants, "_windows_native_machine_code", lambda: 12)
+
+        def fake_probe(argv, **kwargs):
+            class _Result:
+                pass
+
+            r = _Result()
+            if argv[1:] == ["--version"]:
+                r.stdout = f"v{hermes_constants._HERMES_NODE_TARGET_MAJOR}.5.1".encode()
+            else:
+                r.stdout = b"arm64"
+            return r
+
+        monkeypatch.setattr(hermes_constants, "_run_version_probe", fake_probe)
+
+        assert hermes_constants._managed_node_tree_outdated(home) is False
+
+
 class TestHealAttemptFlagSemantics:
     """An in-use deferral must not record the once-per-process heal attempt,
     so a later call can retry once the tree is free (#80926)."""

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -1,5 +1,6 @@
 """Tests for hermes_constants module."""
 
+import ctypes
 import os
 from pathlib import Path
 from types import SimpleNamespace
@@ -1141,8 +1142,8 @@ class TestWindowsNodeArchDetection:
         # Prism reports the emulated x64 view in both env vars...
         monkeypatch.setenv("PROCESSOR_ARCHITECTURE", "AMD64")
         monkeypatch.delenv("PROCESSOR_ARCHITEW6432", raising=False)
-        # ...but GetNativeSystemInfo sees the real ARM64 host (12 = PROCESSOR_ARCHITECTURE_ARM64).
-        monkeypatch.setattr(hermes_constants, "_windows_native_machine_code", lambda: 12)
+        # ...but IsWow64Process2's pNativeMachine sees the real ARM64 host (IMAGE_FILE_MACHINE_ARM64).
+        monkeypatch.setattr(hermes_constants, "_windows_native_machine_code", lambda: 0xAA64)
         monkeypatch.setenv("HERMES_HOME", str(home))
         monkeypatch.setattr(hermes_constants, "managed_node_tree_in_use", lambda _home=None: False)
 
@@ -1190,7 +1191,7 @@ class TestWindowsNodeArchDetection:
         node_exe.write_text("fake-x64-node", encoding="utf-8")
         monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
         monkeypatch.setenv("HERMES_HOME", str(home))
-        monkeypatch.setattr(hermes_constants, "_windows_native_machine_code", lambda: 12)  # real ARM64 host
+        monkeypatch.setattr(hermes_constants, "_windows_native_machine_code", lambda: 0xAA64)  # real ARM64 host (IMAGE_FILE_MACHINE_ARM64)
 
         def fake_probe(argv, **kwargs):
             class _Result:
@@ -1214,7 +1215,7 @@ class TestWindowsNodeArchDetection:
         (node_dir / "node.exe").write_text("fake-arm64-node", encoding="utf-8")
         monkeypatch.setattr(hermes_constants.sys, "platform", "win32")
         monkeypatch.setenv("HERMES_HOME", str(home))
-        monkeypatch.setattr(hermes_constants, "_windows_native_machine_code", lambda: 12)
+        monkeypatch.setattr(hermes_constants, "_windows_native_machine_code", lambda: 0xAA64)
 
         def fake_probe(argv, **kwargs):
             class _Result:
@@ -1230,6 +1231,62 @@ class TestWindowsNodeArchDetection:
         monkeypatch.setattr(hermes_constants, "_run_version_probe", fake_probe)
 
         assert hermes_constants._managed_node_tree_outdated(home) is False
+
+
+class TestWindowsNativeMachineCodeQuery:
+    """_windows_native_machine_code must go through IsWow64Process2's pNativeMachine out-param,
+    not GetNativeSystemInfo -- which, per Microsoft's own docs, reports the *emulated* view (not
+    the true host) when called from an x86/x64 process under Prism emulation on ARM64, i.e. the
+    exact #108893 scenario. These drive the real ctypes marshaling code (not a monkeypatched
+    wrapper) so a regression back to GetNativeSystemInfo-only behavior fails here."""
+
+    @staticmethod
+    def _fake_kernel32(*, native_machine=None, include_get_native_system_info=False):
+        kernel32 = SimpleNamespace(GetCurrentProcess=lambda: -1)
+        if native_machine is not None:
+
+            def fake_iswow64process2(_handle, process_machine_ptr, native_machine_ptr):
+                process_machine_ptr.contents.value = 0x8664  # running as x64 under emulation
+                native_machine_ptr.contents.value = native_machine
+                return 1
+
+            kernel32.IsWow64Process2 = fake_iswow64process2
+        if include_get_native_system_info:
+            kernel32.GetNativeSystemInfo = lambda *_a, **_k: (_ for _ in ()).throw(
+                AssertionError("GetNativeSystemInfo must not be called; it reports the emulated view")
+            )
+        return kernel32
+
+    def test_reads_native_machine_from_iswow64process2(self, monkeypatch):
+        fake_windll = SimpleNamespace(kernel32=self._fake_kernel32(native_machine=0xAA64))  # IMAGE_FILE_MACHINE_ARM64
+        monkeypatch.setattr(ctypes, "windll", fake_windll, raising=False)
+
+        assert hermes_constants._windows_native_machine_code() == 0xAA64
+        assert hermes_constants._windows_native_arch() == "arm64"
+
+    def test_ignores_getnativesysteminfo_even_when_present(self, monkeypatch):
+        """A fake environment where GetNativeSystemInfo exists (and would raise if called) proves
+        the real host arch is read via IsWow64Process2, not GetNativeSystemInfo."""
+        fake_windll = SimpleNamespace(
+            kernel32=self._fake_kernel32(native_machine=0xAA64, include_get_native_system_info=True)
+        )
+        monkeypatch.setattr(ctypes, "windll", fake_windll, raising=False)
+
+        assert hermes_constants._windows_native_machine_code() == 0xAA64
+
+    def test_returns_none_when_iswow64process2_unavailable(self, monkeypatch):
+        fake_windll = SimpleNamespace(kernel32=self._fake_kernel32())  # no IsWow64Process2 attribute
+        monkeypatch.setattr(ctypes, "windll", fake_windll, raising=False)
+
+        assert hermes_constants._windows_native_machine_code() is None
+
+    def test_returns_none_when_iswow64process2_fails(self, monkeypatch):
+        kernel32 = self._fake_kernel32()
+        kernel32.IsWow64Process2 = lambda _handle, _pm, _nm: 0  # BOOL FALSE
+        fake_windll = SimpleNamespace(kernel32=kernel32)
+        monkeypatch.setattr(ctypes, "windll", fake_windll, raising=False)
+
+        assert hermes_constants._windows_native_machine_code() is None
 
 
 class TestHealAttemptFlagSemantics:


### PR DESCRIPTION
Fixes #108893.

## What / why

On Windows 11 ARM64, `_heal_managed_node_windows()` in `hermes_constants.py`
picked the managed-Node download architecture from
`PROCESSOR_ARCHITEW6432` / `PROCESSOR_ARCHITECTURE`:

```python
arch = (os.environ.get("PROCESSOR_ARCHITEW6432") or os.environ.get("PROCESSOR_ARCHITECTURE", "")).lower()
```

Under Prism x64 emulation (the default for the x64 `hermes.exe`/venv), both
env vars report the *emulated* process view (`AMD64`), not the real host.
The heal therefore downloaded an x64 Node onto ARM64 machines, and because
`with_hermes_node_path()` puts the managed Node first on PATH, every
subsequent local desktop rebuild (`hermes update` / `hermes desktop`) ran
under that x64 Node and emitted `win-unpacked` (x64) instead of
`win-arm64-unpacked`. `_managed_node_tree_outdated()` also never checked
architecture, so an already-wrong-arch tree from a prior heal was never
flagged for re-provisioning — the bug was silent and self-perpetuating.

`install.ps1`'s `Get-WindowsArch` already avoids this trap by reading
`Win32_Processor.Architecture` (an emulation-invariant source) before
falling back to the env-var pair; the Python heal path never received
the same treatment.

## Fix

- Added `_windows_native_arch()` / `_windows_native_machine_code()`,
  backed by `IsWow64Process2`'s `pNativeMachine` out-parameter (via
  `ctypes`). An earlier version of this PR used `GetNativeSystemInfo`
  instead — that was wrong: per Microsoft's own docs, `GetNativeSystemInfo`
  reports the *emulated* view (not the true host) when called from an
  x86/x64 process on a system without an Intel64/x64 processor, i.e.
  exactly the Prism-on-ARM64 scenario this bug is about. `IsWow64Process2`
  is the API Windows actually added (Windows 10 1709) to see past that.
  `GetCurrentProcess`'s/`IsWow64Process2`'s HANDLE types are bound
  explicitly on both ends (mirroring `hermes_cli/main_desktop.py`'s
  existing `_windows_native_machine_from_iswow64`) to avoid a
  `(HANDLE)-1` pseudo-handle truncation bug documented there (#71218).
- `_heal_managed_node_windows()` now prefers this native-arch query over
  the env-var pair, falling back to the env vars only when the native
  query is unavailable — mirroring `Get-WindowsArch`'s own fallback order.
- `_managed_node_tree_outdated()` now also flags a Windows managed node
  whose own `process.arch` (baked in at build time, so Prism can't mask
  it) doesn't match the real host arch, so a tree that was already
  mis-provisioned by an older build gets healed instead of sticking
  around forever.

## Testing

`TestWindowsNodeArchDetection` in `tests/test_hermes_constants.py` covers:
- the heal path picks the native arch (`arm64`) over env vars that report
  the emulated view (`AMD64`) — simulating Prism on a real ARM64 host
- the heal path falls back to the env-var pair when the native query is
  unavailable
- `_managed_node_tree_outdated()` flags a pre-existing x64 node on an
  ARM64 host
- `_managed_node_tree_outdated()` does not flag a correctly-provisioned
  arm64 node

`TestWindowsNativeMachineCodeQuery` (new) drives the real ctypes
marshaling in `_windows_native_machine_code()` itself — not a
monkeypatched wrapper — by faking `ctypes.windll.kernel32`:
- asserts the native machine code comes from `IsWow64Process2`'s
  `pNativeMachine` out-param
- asserts this holds even when a `GetNativeSystemInfo` is present on the
  fake kernel32 (it raises if called, proving it's never invoked)
- covers `IsWow64Process2` being unavailable or returning `FALSE`

Confirmed the tests fail without the fix by reverting only
`hermes_constants.py` to its pre-fix state (keeping the new/updated
tests) and rerunning:

```
$ git stash push -- hermes_constants.py
$ scripts/run_tests.sh tests/test_hermes_constants.py \
    -k "TestWindowsNodeArchDetection or TestWindowsNativeMachineCodeQuery" -q
4 failed, 4 passed, 69 deselected
$ git stash pop
```

The 4 failures are exactly the ones that assert the corrected behavior
(native arch resolves correctly under emulation, and `GetNativeSystemInfo`
is never called); restoring the fix makes all of them pass.

Full suite for the touched file:

```
$ scripts/run_tests.sh tests/test_hermes_constants.py -q
=== Summary: 1 files, 72 tests passed, 0 failed, 5 skipped (100% complete) in 0.7s (8 workers) ===
  note: windows_only tests (in 1 file) were SKIPPED on this host (linux); they run on the tests-os CI lane (windows-latest).
```

Also ran `ruff check hermes_constants.py tests/test_hermes_constants.py`
(`All checks passed!`) and confirmed via `ty check` that this diff
introduces no new type diagnostics versus `HEAD~1`.

## Platforms tested

Logic verified on Linux via a fake `ctypes.windll.kernel32` (this sandbox
has no Windows host) that exercises the real argument/return marshaling
`IsWow64Process2` needs (HANDLE restype/argtypes, pointer out-params).
The actual Win32 call only executes on `win32` and degrades to the
previous env-var behavior everywhere else, so non-Windows behavior is
unchanged. This has not been run on real Windows-on-ARM64 hardware.

## AI assistance disclosure

This PR was prepared by an autonomous Claude Code agent (Anthropic)
working from the issue description and the referenced `install.ps1`
precedent. An independent review caught that the first version's use of
`GetNativeSystemInfo` was a no-op for the emulated-ARM64 case it claimed
to fix (verified against Microsoft's official API docs); this revision
switches to `IsWow64Process2` and adds tests that exercise the real
ctypes call path so a regression back to `GetNativeSystemInfo` fails
the suite. Diff, tests, and test output verified by running the repo's
real test suite before pushing.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
