### PR TITLE
fix(cli): no more freeze between the banner and the first prompt (shared state.db handle)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2835,8 +2835,12 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
         self._session_db = None
         self._session_db_unavailable = False
         try:
-            from hermes_state import SessionDB
-            self._session_db = SessionDB()
+            # Registry handle, not a bare SessionDB(): goals/loops/heartbeat acquire the same
+            # path a moment later from the REPL thread, and a second writer repeats the full
+            # open (the /proc-wide deleted-WAL scan, ~4k readlinks) while the render thread
+            # holds the GIL — that repeat was the post-banner freeze before the first prompt.
+            from hermes_state_registry import acquire
+            self._session_db = acquire()
         except Exception as e:
             # Without a store the transcript is NOT persisted while the chat looks healthy,
             # so surface it prominently rather than only logging.

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -513,8 +513,8 @@ class CLIAgentSetupMixin:
             logger=logger, single_query=getattr(self, "_single_query_mode", False))
         if self._session_db is None:
             try:
-                from hermes_state import SessionDB
-                self._session_db = SessionDB()
+                from hermes_state_registry import acquire
+                self._session_db = acquire()
             except Exception as e:
                 logger.warning("SQLite session store not available — session will NOT be indexed: %s", e)
         if (

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1176,8 +1176,8 @@ class CLICommandsMixin:
             return _cp("  Agent is busy. Wait for the current turn to finish, then retry /handoff.")
         if not self._session_db:
             with suppress(Exception):
-                from hermes_state import SessionDB
-                self._session_db = SessionDB()
+                from hermes_state_registry import acquire
+                self._session_db = acquire()
         if not self._session_db:
             return _cp(_db_unavailable_line())
         # Ensure the session row exists (an empty session has flushed nothing yet): the gateway

--- a/tests/test_cli_session_store_shared_registry.py
+++ b/tests/test_cli_session_store_shared_registry.py
@@ -1,0 +1,37 @@
+"""The CLI's session store must be the registry's shared handle for state.db.
+
+``_init_session_store`` used to construct a bare ``SessionDB()``. The goal/loop/heartbeat
+managers acquire the same path through ``hermes_state_registry`` from the REPL thread a
+moment later, so a bare handle meant a SECOND full open — including the /proc-wide
+deleted-WAL sidecar scan (~4k readlinks, each a GIL round-trip against the busy startup
+threads) — which showed up as the post-banner freeze before the first prompt.
+"""
+
+from types import SimpleNamespace
+
+import hermes_cli.goals as goals
+from cli import HermesCLI
+
+
+def test_cli_session_store_is_the_registry_handle_goals_reuse(monkeypatch):
+    import hermes_state_registry
+
+    monkeypatch.setattr(goals, "_DB_CACHE", {})
+    constructed = []
+    real_open = hermes_state_registry._open_session_db
+
+    def recording_open(path):
+        constructed.append(path)
+        return real_open(path)
+
+    monkeypatch.setattr(hermes_state_registry, "_open_session_db", recording_open)
+
+    cli = SimpleNamespace()
+    try:
+        HermesCLI._init_session_store(cli)
+        assert cli._session_db is not None and not cli._session_db_unavailable
+        # goals/loops/heartbeat go through the registry: same object, no second open.
+        assert goals._get_session_db() is cli._session_db
+        assert len(constructed) == 1
+    finally:
+        hermes_state_registry.close_all()


### PR DESCRIPTION
The classic CLI no longer freezes between the banner and the first prompt: the session store is now the registry's shared `state.db` handle, so startup runs the deleted-WAL `/proc` scan once instead of twice.

## Symptom

`hermes` prints the banner, then the input bar takes another ~0.7–2 s (more under load) to appear.

## Root cause (one sentence)

`_init_session_store` built a bare `SessionDB()`, and the goal/loop/heartbeat managers acquired the same `state.db` via `hermes_state_registry` a moment later from the REPL thread — a second, separate handle, so the whole open repeated, including `refuse_deleted_wal_generation`'s `/proc/*/fd` readlink walk (~4.4k syscalls), each one a GIL round-trip against the busy startup threads (plugin discovery, MCP, skill sync, banner git). The second pass landed exactly where the prompt should have appeared.

## Changes

- `cli.py::_init_session_store` — `hermes_state_registry.acquire()` instead of `SessionDB()` (+ WHY comment).
- Same class at the two re-open sites: `cli_agent_setup_mixin.py::_init_agent` and `cli_commands_mixin.py::_handle_handoff_command`.
- `close()` on a registry handle releases the refcount, so `/quit`, `/snapshot restore` (closes before restore) and `/handoff` keep their semantics.
- 1 invariant test: `tests/test_cli_session_store_shared_registry.py` — the CLI handle IS the object `goals._get_session_db()` returns and the registry opened exactly once. Red on `origin/main`, green here.

## Validation

Traced with `py-spy record` + `strace -e readlink` on real tmux PTY startups (`hermes`, home profile, 5.3 GB state.db, ~480 processes).

| | `/proc` fd scans per startup | banner → prompt (plain, interleaved ×6) | banner → prompt (under strace) |
|---|---|---|---|
| before (`origin/main` a84a2223) | 2 (main thread + REPL thread), 1.3 s each | mean 0.37 s, max 0.38 s | 1.77 s |
| after | 1 | mean 0.15 s, max 0.18 s | 0.39 s |

Why 11 ms becomes 1.3 s: measured in isolation the scan takes 11 ms; with a single busy Python thread alive it takes 23–30 s (each `os.readlink` releases and re-acquires the GIL, and the 5 ms switch interval hands it to the burner every time). Startup has half a dozen such threads, so the second pass is what the user saw as the "hang on the prompt".

Live E2E (isolated `HERMES_HOME`, real turn): message + reply persisted to `state.db`, title auto-generated, session closed with `end_reason=cli_close` through the shared handle.

Tests: `tests/test_cli*`, `tests/hermes_cli/test_goals*`, `test_loops*`, `test_heartbeat*`, `test_session_handoff`, snapshot + registry files — 160 passed, 0 failed.

## Infographic

![one writer per state.db](https://v3b.fal.media/files/b/0aaa192a/yPMjqlzmcRoftBLa7oCY2_t9306WBG.png)
