### PR TITLE
Drop the unverified retry claim from the kanban crash/timeout notices (TUI + desktop)

### DIFF
--- a/apps/desktop/src/plugins/kanban/completion-notify.test.ts
+++ b/apps/desktop/src/plugins/kanban/completion-notify.test.ts
@@ -550,6 +550,6 @@ describe('i18n routing', () => {
 
     await m.onKanbanEventsFrame('smoke', [ev(101, 'timed_out')])
 
-    expect(lastNotify().title).toBe('Task timed out — will retry')
+    expect(lastNotify().title).toBe('Task timed out')
   })
 })

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -416,8 +416,8 @@ export const en: KanbanMessages = {
     blockedTitle: 'Task blocked — needs your input',
     blockLoopTitle: 'Task routed to triage — needs a decision',
     gaveUpTitle: 'Task gave up',
-    crashedTitle: 'Worker crashed — will retry',
-    timedOutTitle: 'Task timed out — will retry',
+    crashedTitle: 'Worker crashed',
+    timedOutTitle: 'Task timed out',
     openKanban: 'Open Kanban',
     artifacts: (n: number) => `${n} artifacts`
   }
@@ -627,8 +627,8 @@ const ja: KanbanMessages = {
     blockedTitle: 'タスクがブロック中 — 入力が必要です',
     blockLoopTitle: 'タスクをトリアージへ移動 — 判断が必要です',
     gaveUpTitle: 'タスクを断念しました',
-    crashedTitle: 'ワーカーがクラッシュ — 再試行します',
-    timedOutTitle: 'タスクがタイムアウト — 再試行します',
+    crashedTitle: 'ワーカーがクラッシュ',
+    timedOutTitle: 'タスクがタイムアウト',
     openKanban: 'かんばんを開く',
     artifacts: (n: number) => `成果物 ${n} 件`
   }
@@ -835,8 +835,8 @@ const zh: KanbanMessages = {
     blockedTitle: '任务受阻 — 需要你的输入',
     blockLoopTitle: '任务已转入分类 — 需要人工决定',
     gaveUpTitle: '任务已放弃',
-    crashedTitle: '工作单元崩溃 — 将重试',
-    timedOutTitle: '任务超时 — 将重试',
+    crashedTitle: '工作单元崩溃',
+    timedOutTitle: '任务超时',
     openKanban: '打开看板',
     artifacts: (n: number) => `${n} 个产物`
   }
@@ -1043,8 +1043,8 @@ const zhHant: KanbanMessages = {
     blockedTitle: '任務受阻 — 需要你的輸入',
     blockLoopTitle: '任務已轉入分類 — 需要人工決定',
     gaveUpTitle: '任務已放棄',
-    crashedTitle: '工作單元當機 — 將重試',
-    timedOutTitle: '任務逾時 — 將重試',
+    crashedTitle: '工作單元當機',
+    timedOutTitle: '任務逾時',
     openKanban: '開啟看板',
     artifacts: (n: number) => `${n} 個產物`
   }

--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -263,6 +263,14 @@ class TestFormatKanbanEventText:
         ev = SimpleNamespace(kind="timed_out", payload={"limit_seconds": "not-a-number"})
         text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
         assert "timed out" in text
+        # Emitted before the give-up decision: never promise a retry.
+        assert "retry" not in text
+
+    def test_crashed_states_the_fact_without_promising_retry(self):
+        ev = SimpleNamespace(kind="crashed", payload={"pid": 4242, "exit_kind": "signal"})
+        text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
+        assert "worker crashed (pid gone)" in text
+        assert "retry" not in text
 
 
 class TestNotificationPollerLoopKanbanWiring:

--- a/tui_gateway/session_notifications.py
+++ b/tui_gateway/session_notifications.py
@@ -256,9 +256,10 @@ def _kb_completed(task, payload: dict, title: str) -> str:
 
 
 def _kb_timed_out(task, payload: dict, title: str) -> str:
+    # Emitted before the breaker/give-up decision, so no retry promise here.
     with contextlib.suppress(TypeError, ValueError):
-        return f" timed out (max_runtime={int(payload.get('limit_seconds') or 0)}s); will retry"
-    return " timed out (max_runtime=0s); will retry"
+        return f" timed out (max_runtime={int(payload.get('limit_seconds') or 0)}s)"
+    return " timed out (max_runtime=0s)"
 
 
 # kind -> (glyph, suffix after "Kanban <id>"); silent kinds (archived/unblocked) are absent → None.
@@ -267,7 +268,7 @@ _KANBAN_EVENT_FORMATTERS = {
     "blocked": ("⏸", lambda t, p, title: " blocked" + (f": {str(p.get('reason'))[:160]}" if p.get("reason") else "")),
     "gave_up": ("✖", lambda t, p, title: " gave up after repeated spawn failures"
                 + (f"\n{str(p.get('error'))[:200]}" if p.get("error") else "")),
-    "crashed": ("✖", lambda t, p, title: " worker crashed (pid gone); dispatcher will retry"),
+    "crashed": ("✖", lambda t, p, title: " worker crashed (pid gone)"),
     "timed_out": ("⏱", _kb_timed_out),
     "status": ("🔄", lambda t, p, title: f" → {p.get('status') or ''}"),
 }


### PR DESCRIPTION
Drop the unverified retry claim from the kanban crash/timeout notices (TUI + desktop)

## Summary

The `crashed` / `timed_out` kanban notifications state that the dispatcher will retry
*before* anything has decided whether it will. `hermes_cli/kanban_db_dispatch.py` appends
the event inside the reclaim write transaction (timeout path `:487`, crash path `:847`),
and `_record_task_failure` only runs after that transaction commits (`:493`, `:906`/`:923`)
— so when the failure breaker trips, the task flips to `blocked` and a `gave_up` event is
layered on top of the ping that just promised the retry.

This PR makes the two surfaces that still assert that promise state only what has already
happened. The gateway-side renderer is handled separately (see Related work).

## Changes

- `tui_gateway/session_notifications.py:260-261` — `_kb_timed_out()` drops the trailing
  `; will retry` (both the normal and the bad-payload fallback branch).
- `tui_gateway/session_notifications.py:270` — the `crashed` formatter drops
  `; dispatcher will retry`.
- `apps/desktop/src/plugins/kanban/i18n.ts:419-420`, `:630-631`, `:838-839`, `:1046-1047`
  — the toast / OS-notification titles for `crashed` and `timed_out` drop the same claim
  in all four bundles (en / ja / zh-Hans / zh-Hant). Both kinds are mapped in
  `apps/desktop/src/plugins/kanban/completion-notify.ts:52` and `:54`.
- Tests: `tests/tui_gateway/test_kanban_notify_poller.py` pins that the delivered text
  carries no retry claim; the `completion-notify.test.ts:553` expectation is updated with
  the copy.

No payload, schema, contract or dispatch change: the copy stops asserting a future it
cannot know.

## Validation

`HERMES_PYTHON=<repo>/.venv/bin/python scripts/run_tests.sh tests/tui_gateway/test_kanban_notify_poller.py`

- RED (new assertions only, implementation untouched): `2 failed, 13 passed in 2.84s`
  — `TestFormatKanbanEventText::test_timed_out_with_bad_payload_does_not_raise`,
    `TestFormatKanbanEventText::test_crashed_states_the_fact_without_promising_retry`
- GREEN (with the formatter change): `1 files, 15 tests passed, 0 failed (100% complete) in 2.9s (32 workers)`
- Base: `origin/main` `28326a6ccd7484f37bbcd19c9f32658c2368b370`; `ruff check` clean.

Not tested locally: the desktop vitest suite (this checkout has no `apps/desktop/node_modules`
and the config-time dependency `@rolldown/plugin-babel` cannot be resolved), so CI is its
first run for this change. The assertion update is included.

## Related work

- `Part of #84059` — the gateway-side renderer is being addressed separately in #107315.
- An earlier attempt at the same issue (#84087) predates the formatter split: the code its
  hunks target now lives in `tui_gateway/session_notifications.py` and
  `gateway/kanban_watchers_notifier.py`, so it no longer applies to current `main`.

## References

- `hermes_cli/kanban_db_dispatch.py:487`, `:493` (`enforce_max_runtime`), `:847`
  (`_reclaim_dead_workers`), `:906`/`:923` (`_account_crashes`) — event emitted
  before the retry decision exists.
- `gateway/kanban_watchers_notifier.py:354`, `:356` — the sibling (gateway) copies; out of
  scope here.
