### PR TITLE
fix(computer-use): leave a user-customized cua-driver-serve task action alone on driver refresh

### DIFF
--- a/hermes_cli/tools_config_cua.py
+++ b/hermes_cli/tools_config_cua.py
@@ -14,6 +14,7 @@ import sys
 import time
 from pathlib import Path
 from typing import List, Optional
+from xml.etree import ElementTree
 
 from hermes_cli.cli_output import (
     print_info as _print_info, print_success as _print_success, print_warning as _print_warning)
@@ -47,6 +48,13 @@ _CUA_INSTALL_SH_URL = (
     "https://raw.githubusercontent.com/trycua/cua/main/libs/cua-driver/scripts/install.sh")
 _CUA_MANUAL_README = "https://github.com/trycua/cua/blob/main/libs/cua-driver/README.md"
 _UPGRADE_CMD = "hermes computer-use install --upgrade"
+
+# Logon task install.ps1 / `cua-driver autostart enable` register for `cua-driver serve`.
+_WINDOWS_CUA_TASK_NAME = "cua-driver-serve"
+# The installer always wraps the daemon in a PowerShell launcher
+# (`powershell.exe -NoProfile -WindowStyle Hidden … Start-Process <cua-driver> serve`), so a task
+# action whose executable is anything else was swapped in by the user.
+_WINDOWS_CUA_TASK_LAUNCHERS = frozenset({"powershell", "powershell.exe", "pwsh", "pwsh.exe"})
 
 
 def _run_text(cmd: list, *, timeout, capture_output: bool = True,
@@ -501,11 +509,82 @@ def _cua_driver_autostart_registered_windows() -> bool:
     if sys.platform != "win32":
         return False
     try:
-        return subprocess.run(["schtasks.exe", "/Query", "/TN", "cua-driver-serve"],
+        return subprocess.run(["schtasks.exe", "/Query", "/TN", _WINDOWS_CUA_TASK_NAME],
                               stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
                               timeout=10).returncode == 0
     except Exception:
         return False
+
+
+def _decode_windows_task_xml(raw) -> str:
+    """Decode ``schtasks /XML`` output, which is UTF-16 (with or without a BOM) on Windows.
+    A probe result that is neither text nor bytes (`schtasks` can only produce those) decodes to
+    "" — the task definition is unreadable, which callers treat as "no task to preserve"."""
+    if not isinstance(raw, (str, bytes, bytearray)):
+        return ""
+    if isinstance(raw, str):
+        return raw
+    if raw[:2] in (b"\xff\xfe", b"\xfe\xff"):
+        return raw.decode("utf-16", "replace")
+    text = raw.decode("utf-8-sig", "replace")
+    # A BOM-less UTF-16 document decodes to NUL-stuffed ASCII above; retry it as UTF-16.
+    return raw.decode("utf-16", "replace") if "\x00" in text else text
+
+
+def _cua_task_xml_windows() -> Optional[str]:
+    """The registered `cua-driver-serve` definition, or None when it is not registered.
+    Read-only query: a failure (usually "task not found") reports no task."""
+    try:
+        result = subprocess.run(["schtasks.exe", "/Query", "/TN", _WINDOWS_CUA_TASK_NAME, "/XML"],
+                                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=10)
+    except Exception as e:
+        logger.debug("cua-driver task XML query failed: %s", e)
+        return None
+    if result.returncode != 0:
+        return None
+    return _decode_windows_task_xml(result.stdout or "")
+
+
+def _cua_task_action_windows(xml: str) -> Optional[tuple]:
+    """``(Command, Arguments)`` of the task's first Exec action, or None when it cannot be read.
+    The document carries an encoding declaration that ElementTree rejects on str input, and the
+    element namespace is not worth matching exactly, so strip the declaration and compare local
+    names."""
+    if not xml:
+        return None
+    try:
+        root = ElementTree.fromstring(re.sub(r"^\s*<\?xml[^>]*\?>", "", xml, count=1))
+    except ElementTree.ParseError as e:
+        logger.debug("cua-driver task XML parse failed: %s", e)
+        return None
+    actions = [el for el in root.iter() if el.tag.rsplit("}", 1)[-1] == "Exec"]
+    if not actions:
+        return None
+    command, arguments = "", ""
+    for child in actions[0]:
+        local, text = child.tag.rsplit("}", 1)[-1], (child.text or "")
+        if local == "Command":
+            command = text
+        elif local == "Arguments":
+            arguments = text
+    return command, arguments
+
+
+def _cua_driver_task_user_modified_windows() -> bool:
+    """Whether the registered task holds an action the user replaced.
+    Hermes refreshes the driver by re-running upstream's installer, and install.ps1 re-registers an
+    existing task even under ``-NoAutoStart`` (#108400) — which reverts a hand-swapped action (e.g.
+    a windowless ``wscript.exe`` launcher silencing the logon console flash) to the installer's
+    visible one. An action the installer registered is a PowerShell launcher; anything else is a
+    user edit that must survive. An action we cannot classify counts as user-owned: a definition we
+    cannot read must not be silently rewritten either."""
+    xml = _cua_task_xml_windows()
+    if not xml:
+        return False  # no task registered — nothing to preserve
+    action = _cua_task_action_windows(xml)
+    if action is None:
+        return True
+    return os.path.basename(action[0].strip().strip('"')).lower() not in _WINDOWS_CUA_TASK_LAUNCHERS
 
 
 def _repair_cua_driver_autostart_windows(driver_cmd: str, *, verbose: bool) -> bool:
@@ -668,10 +747,18 @@ def _unattended_installer_preflight(install_cmd: list, is_windows: bool):
                     "(will retry on the next update).")
         return None
     if is_windows:
-        # -NoAutoStart skips Register-CuaDriverAutostart — the ONLY branch of install.ps1 that
-        # self-elevates (UAC). Cost: an existing cua-driver-serve task keeps pointing at the
-        # previous binary until the next interactive upgrade. Scriptblock invocation (not `| iex`)
-        # is what lets us pass the parameter.
+        # install.ps1 re-registers an existing cua-driver-serve task even under -NoAutoStart, which
+        # reverts an action the user swapped in (#108400). Look at the task first: a customized
+        # action makes this refresh skip, because no installer flag can be trusted to leave it
+        # alone and re-registering it needs the elevation an unattended run must not request.
+        if _cua_driver_task_user_modified_windows():
+            _print_info("    cua-driver-serve task holds a customized action — skipping this "
+                        "refresh so the installer cannot re-register it.")
+            _print_info("    Upstream's install.ps1 rewrites an existing task even under "
+                        f"-NoAutoStart. Refresh with: {_UPGRADE_CMD}")
+            return None
+        # -NoAutoStart keeps the installer out of its self-elevating -AutoStart branch (UAC).
+        # Scriptblock invocation (not `| iex`) is what lets us pass the parameter.
         install_cmd = [
             "powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command",
             f"$sc = irm {_CUA_INSTALL_PS1_URL}; & ([scriptblock]::Create($sc)) -NoAutoStart"]

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -1758,3 +1758,147 @@ class TestUnattendedRefreshPreflights:
         joined = " ".join(cmd)
         assert "-NoAutoStart" not in joined
         assert "| iex" in joined
+
+
+class TestCustomizedAutostartTaskSurvivesRefresh:
+    """#108400: an existing `cua-driver-serve` task is re-registered by
+    install.ps1's `-NoAutoStart` branch, which reverts the action a user
+    swapped in (the windowless `wscript.exe` launcher that silences the logon
+    console flash). An unattended refresh must look at the task first and
+    leave a customized action alone — no argv it can pass upstream is trusted
+    to, and re-registering needs the elevation an unattended run must not ask
+    for.
+    """
+
+    # Task name / trigger / RunLevel untouched; only the action differs — the
+    # workaround from the issue, reduced to the Exec block that matters.
+    _USER_LAUNCHER_XML = (
+        '<?xml version="1.0" encoding="UTF-16"?>\n'
+        '<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">\n'
+        ' <Principals><Principal id="Author"><LogonType>InteractiveToken</LogonType>'
+        "<RunLevel>HighestAvailable</RunLevel></Principal></Principals>\n"
+        ' <Actions Context="Author"><Exec>\n'
+        "    <Command>wscript.exe</Command>\n"
+        '    <Arguments>"C:\\Users\\demo\.cua-driver\\launcher-hidden.vbs"</Arguments>\n'
+        "  </Exec></Actions>\n"
+        "</Task>\n"
+    )
+    # What install.ps1 / `cua-driver autostart enable` register.
+    _INSTALLER_LAUNCHER_XML = (
+        '<?xml version="1.0" encoding="UTF-16"?>\n'
+        '<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">\n'
+        ' <Actions Context="Author"><Exec>\n'
+        "    <Command>powershell.exe</Command>\n"
+        "    <Arguments>-NoProfile -WindowStyle Hidden -NonInteractive -Command "
+        '"Start-Process -FilePath ' "'C:\\Users\\demo\\.cua-driver\\packages\\current\\cua-driver.exe'"
+        " -ArgumentList 'serve' -WindowStyle Hidden\"</Arguments>\n"
+        "  </Exec></Actions>\n"
+        "</Task>\n"
+    )
+
+    @staticmethod
+    def _refresh(task_xml):
+        """Run an unattended Windows refresh with `task_xml` registered (None = no task)."""
+        from unittest.mock import MagicMock
+
+        from hermes_cli import tools_config_cua as tools_config
+
+        proc = MagicMock()
+        proc.communicate.return_value = ("ok", None)
+        proc.returncode = 0
+        info_calls, schtasks_calls = [], []
+
+        def fake_run(cmd, **kwargs):
+            if "schtasks.exe" in cmd:
+                schtasks_calls.append((list(cmd), kwargs))
+                return SimpleNamespace(returncode=0 if task_xml is not None else 1,
+                                       stdout=task_xml or "", stderr="")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with patch("platform.system", return_value="Windows"), \
+             patch.object(tools_config, "_cua_install_lock_held", return_value=False), \
+             patch.object(tools_config, "_cua_release_endpoint_reachable", return_value=True), \
+             patch.object(tools_config, "_clear_stale_cua_install_lock"), \
+             patch.object(tools_config.shutil, "which", side_effect=lambda n: "/x/" + n), \
+             patch("subprocess.run", side_effect=fake_run), \
+             patch.object(tools_config.subprocess, "Popen", return_value=proc) as popen, \
+             patch.object(tools_config, "_print_success"), \
+             patch.object(tools_config, "_print_warning"), \
+             patch.object(tools_config, "_print_info",
+                          side_effect=lambda message: info_calls.append(message)):
+            ok = tools_config._run_cua_driver_installer(
+                label="Refreshing", verbose=False, show_progress=False, installer_timeout=120)
+        return ok, popen, info_calls, schtasks_calls
+
+    def test_customized_action_skips_the_refresh(self):
+        """The installer is never launched, and the only Task Scheduler call
+        is the read-only query: nothing overwrites the action."""
+        ok, popen, info, schtasks_calls = self._refresh(self._USER_LAUNCHER_XML)
+
+        assert ok is False
+        popen.assert_not_called()
+        assert [cmd for cmd, _ in schtasks_calls] == [
+            ["schtasks.exe", "/Query", "/TN", "cua-driver-serve", "/XML"]
+        ]
+        assert any("customized action" in message for message in info)
+        assert any("install --upgrade" in message for message in info)
+
+    def test_installer_registered_action_still_refreshes(self):
+        ok, popen, _, _ = self._refresh(self._INSTALLER_LAUNCHER_XML)
+
+        assert ok is True
+        popen.assert_called_once()
+        assert "-NoAutoStart" in " ".join(popen.call_args.args[0])
+
+    def test_absent_task_still_refreshes(self):
+        ok, popen, _, _ = self._refresh(None)
+
+        assert ok is True
+        popen.assert_called_once()
+
+
+class TestCuaTaskActionClassification:
+    """`schtasks /XML` decoding and the installer-launcher-vs-user-edit rule."""
+
+    @staticmethod
+    def _modified(xml):
+        from hermes_cli import tools_config_cua as tools_config
+
+        with patch.object(tools_config, "_cua_task_xml_windows", return_value=xml):
+            return tools_config._cua_driver_task_user_modified_windows()
+
+    def test_wscript_action_is_user_modified(self):
+        assert self._modified(TestCustomizedAutostartTaskSurvivesRefresh._USER_LAUNCHER_XML) is True
+
+    def test_powershell_action_is_installer_owned(self):
+        assert self._modified(
+            TestCustomizedAutostartTaskSurvivesRefresh._INSTALLER_LAUNCHER_XML) is False
+
+    def test_absent_task_is_not_modified(self):
+        assert self._modified(None) is False
+
+    def test_unparseable_action_is_treated_as_user_owned(self):
+        """A definition we cannot read must not be silently rewritten either."""
+        assert self._modified("<Task><Actions><Exec>") is True
+        assert self._modified("<Task><Settings/></Task>") is True
+
+    def test_action_ignores_the_encoding_declaration(self):
+        xml = TestCustomizedAutostartTaskSurvivesRefresh._USER_LAUNCHER_XML
+        from hermes_cli import tools_config_cua as tools_config
+
+        assert tools_config._cua_task_action_windows(xml) == (
+            "wscript.exe", '"C:\\Users\\demo\\.cua-driver\\launcher-hidden.vbs"')
+
+    def test_utf16_query_output_is_decoded(self):
+        from hermes_cli import tools_config_cua as tools_config
+
+        xml = TestCustomizedAutostartTaskSurvivesRefresh._USER_LAUNCHER_XML
+        assert tools_config._decode_windows_task_xml(xml.encode("utf-16")) == xml
+        assert tools_config._decode_windows_task_xml(xml.encode("utf-8")) == xml
+
+    def test_unusable_probe_result_reports_no_task(self):
+        """Neither text nor bytes cannot be a task definition, and a probe we
+        cannot read must not be mistaken for a registered task."""
+        from hermes_cli import tools_config_cua as tools_config
+
+        assert tools_config._decode_windows_task_xml(object()) == ""


### PR DESCRIPTION
## What Problem This Solves

`hermes update` refreshes the Computer Use driver by re-running upstream's `install.ps1` with
`-NoAutoStart`. That flag only skips upstream's *registration* branch. install.ps1's `else` branch
still queries `schtasks /Query /TN cua-driver-serve` and, when the task exists, calls
`Register-CuaDriverAutostart` anyway, which rewrites the task's action. So a user who silenced the
logon console flash by swapping the action for a windowless launcher gets the visible-PowerShell
action silently restored on every driver-bumping update.

Hermes never looked at the existing task before starting that refresh, so it had no way to notice it
was about to destroy a user edit.

The unattended Windows refresh now inspects the task first:

- task absent: unchanged (install.ps1 skips registration under `-NoAutoStart`);
- task action is the PowerShell launcher the installer owns: unchanged refresh, exactly as before;
- task action was replaced by the user (`wscript.exe … cua-driver-launcher-hidden.vbs` in the
  issue's workaround): the refresh is skipped with an explicit message naming why, and the only Task
  Scheduler call made is the read-only `/Query /TN cua-driver-serve /XML`. Nothing re-registers the
  task, so the windowless registration survives `hermes update`.

An action Hermes cannot read or classify counts as user-owned: a definition we cannot parse must not
be silently rewritten either.

### Why skip instead of "repair afterwards"

The task is registered with `RunLevel=HighestAvailable`, and writing that run level requires
elevation (upstream's own `Register-CuaDriverAutostart` checks `Test-IsElevated` and re-launches
itself with `Start-Process -Verb RunAs` for exactly this reason). An unattended `hermes update` must
not raise UAC, so there is no repair it could perform after the installer has already rewritten the
action. The only way to honor "do not touch my task" is to not run the refresh that rewrites it. The
message points at `hermes computer-use install --upgrade` for when the user is at the keyboard and
can re-apply their launcher.

Partial fix for #108400.

## Evidence

New tests in `tests/hermes_cli/test_install_cua_driver.py`:
`TestCustomizedAutostartTaskSurvivesRefresh` (refresh behavior through the `subprocess` boundary)
and `TestCuaTaskActionClassification` (XML decode + launcher classification). 10 tests total. The
behavioral one registers a user-swapped `wscript.exe` action, exactly as
`schtasks /Query /TN cua-driver-serve /XML` returns it, and asserts the installer is never launched
and no write to the task is ever issued.

Pre-fix (source change stashed, new tests present), whole file:

```
>       assert ok is False
E       assert True is False

tests\hermes_cli\test_install_cua_driver.py:1838: AssertionError
================= 13 failed, 55 passed, 19 skipped in 58.76s ==================
```

The behavioral assertion is the point: pre-fix the refresh ran (`ok is True`) and would have
triggered upstream's re-registration. The other 7 new failures are the not-yet-existing helpers.

Post-fix, new tests only:

```
=== Summary: 1 files, 10 tests passed, 0 failed (100% complete) in 24.5s (40 workers) ===
```

Post-fix, whole file:

```
============= 5 failed, 63 passed, 19 skipped in 84.11s (0:01:24) =============
```

The 5 remaining failures are pre-existing on a Windows host and unrelated to this change: they
assume a POSIX host (they only fake `curl` as the fetch tool, and `test_posix_default_unchanged`
asserts the POSIX check timeout). The exact same 5 failed in the pre-fix run above. They exercise
neither the touched function nor the new helpers.

Related modules (`test_computer_use_cli.py`, `test_memory_setup_provider_arg.py`,
`test_web_routers_tools_install_on_enable.py`):

```
=== Summary: 3 files, 10 tests passed, 0 failed (100% complete) in 300.2s (40 workers) ===
```

One of those files was reported FLAKY by the runner: `test_spawn_failure_does_not_fail_the_toggle`
failed its first attempt with `RuntimeError: can't start new thread` and
`runner crashed: OSError(22, ...)`, then passed on retry. That is host resource exhaustion under
the 40-worker parallel runner, not a code regression.

## Validation limits

- The Task Scheduler interaction is exercised only through the process boundary
  (`subprocess.run`), against `schtasks /XML` documents matching the shapes upstream's
  `autostart.rs` / install.ps1 register. No scheduled task was created, modified or deleted on the
  test machine.
- The elevation requirement for `RunLevel=HighestAvailable` is taken from upstream's own code
  (`Register-CuaDriverAutostart` → `Test-IsElevated` → `Start-Process -Verb RunAs`), not re-measured
  here.
- The explicit interactive `hermes computer-use install --upgrade` still lets upstream's installer
  re-register the task. Covering it needs an elevation decision (a second UAC prompt) that is out of
  scope for this fix; `-NoAutoStart` semantics in trycua/cua are unchanged.
- A task whose action is still a PowerShell launcher but hand-edited inside that launcher is treated
  as installer-owned and will still be re-registered by upstream. Only a swapped launcher executable
  is detected.
