### PR TITLE
fix(cron): surface reclaimed (unknown) executions through incident + failure lane

### DIFF
--- a/cron/executions.py
+++ b/cron/executions.py
@@ -14,11 +14,14 @@ import time
 import uuid
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional
 
 from cron.ledger import ledger_transaction, open_ledger, prepare_ledger
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
+
+import logging
+logger = logging.getLogger(__name__)
 
 # Optional test override. Production resolves the path at transaction time so dashboard operations
 # that temporarily enter another profile cannot leak that profile's records into the import-time
@@ -261,8 +264,13 @@ def finish_execution(
     return record
 
 
-def recover_interrupted_executions() -> int:
-    """Mark provably abandoned attempts unknown without scheduling retries."""
+def recover_interrupted_executions(*, on_recovered: Optional[Callable[[Dict[str, Any]], None]] = None) -> int:
+    """Mark provably abandoned attempts unknown without scheduling retries.
+
+    ``on_recovered`` (optional) runs after the store commit with each reaped
+    record — the scheduler surfaces the reclaimed-unknown outcome through it
+    (incident + failure-lane notice, #108802). Handler exceptions are logged
+    and swallowed: recovery must never fail because notification did."""
     now = _hermes_now().isoformat()
     changed = 0
     recovered: List[Dict[str, Any]] = []
@@ -307,6 +315,12 @@ def recover_interrupted_executions() -> int:
         if changed:
             _prune_unlocked(conn)
     for record in recovered:
+        if on_recovered is not None:
+            try:
+                on_recovered(record)
+            except Exception:
+                logger.debug("on_recovered handler failed for execution %s",
+                             record.get("id"), exc_info=True)
         _emit_execution_state(record)
     return changed
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3477,7 +3477,30 @@ def _release_tick_lock(lock_fd) -> None:
     lock_fd.close()
 
 
-def _maybe_reap_dead_owners() -> None:
+def _handle_reclaimed_unknown_execution(record: dict, *, adapters=None, loop=None) -> None:
+    """Surface a reclaimed (``unknown``) execution instead of staying silent (#108802):
+    its owner died before a durable terminal state, so neither the run path nor the crash
+    path ever reported it. Reuses the crash-failure delivery — incident upsert, acked
+    suppression, failure-lane notice, alerted marking — with the record's own error text,
+    which carries the unknown-outcome caveat ('whether side effects ran is unknown')."""
+    job_id = str((record or {}).get("job_id") or "")
+    if not job_id:
+        return
+    try:
+        from cron.jobs import get_job
+        job = get_job(job_id)
+    except Exception as exc:
+        logger.debug("Reclaimed-execution job lookup failed for %s: %s", job_id, exc)
+        return
+    if not isinstance(job, dict) or not job:
+        return
+    with contextlib.suppress(Exception):
+        _deliver_crash_failure(
+            job, str(record.get("error") or "execution reclaimed unknown"),
+            adapters=adapters, loop=loop)
+
+
+def _maybe_reap_dead_owners(*, adapters=None, loop=None) -> None:
     """Dead-owner reclaim: a run that died mid-flight would leave its row 'claimed' forever. Only
     rows whose owner process is proved gone are touched (_owner_is_live). Throttled."""
     # Dead-owner claim reclaim (#86721): execution rows carry their owner pid + process start time, but
@@ -3497,7 +3520,9 @@ def _maybe_reap_dead_owners() -> None:
     try:
         from cron.executions import recover_interrupted_executions
 
-        _reclaimed = recover_interrupted_executions()
+        _reclaimed = recover_interrupted_executions(
+            on_recovered=lambda record: _handle_reclaimed_unknown_execution(
+                record, adapters=adapters, loop=loop))
         if _reclaimed:
             logger.warning(
                 "Reclaimed %d cron execution(s) whose owner process died "
@@ -3707,7 +3732,7 @@ def tick(
             logger.debug("Cron dispatch paused while gateway drains existing work")
             return 0
 
-        _maybe_reap_dead_owners()
+        _maybe_reap_dead_owners(adapters=adapters, loop=loop)
         # Periodic worktree GC (6h, threaded) — the only sweep gateway-only boxes get.
         try:
             _maybe_run_worktree_maintenance()

--- a/tests/cron/test_dead_owner_claim_reclaim.py
+++ b/tests/cron/test_dead_owner_claim_reclaim.py
@@ -118,8 +118,9 @@ class TestTickReapsDeadOwnerClaims:
     def test_reap_is_throttled_between_ticks(self, monkeypatch, executions):
         calls = []
         monkeypatch.setattr(
+            # on_recovered: the reclaimed-unknown visibility hook (#108802).
             "cron.executions.recover_interrupted_executions",
-            lambda: calls.append(1) or 0,
+            lambda *args, **kwargs: calls.append(1) or 0,
         )
 
         _run_tick()

--- a/tests/cron/test_reclaimed_unknown_visibility.py
+++ b/tests/cron/test_reclaimed_unknown_visibility.py
@@ -1,0 +1,87 @@
+"""Reclaimed (unknown) cron executions must not disappear silently (#108802).
+
+An owner that dies before a durable terminal state leaves its execution row to
+``recover_interrupted_executions()``; the reaper only marked the row ``unknown``
+— no incident, no failure-deliver — so a broken job stayed invisible in
+``hermes cron incidents`` and never reached the operator's failure lane.
+"""
+from cron import scheduler as sched
+from cron.executions import (
+    create_execution,
+    mark_execution_running,
+    recover_interrupted_executions,
+)
+
+
+def _seed_dead_owner_execution(monkeypatch, job_id="job-reclaimed"):
+    """Create a claimed/running execution whose owner looks provably gone."""
+    monkeypatch.setattr(sched, "_last_dead_owner_reap_at", None)
+    executions_mod = __import__("cron.executions", fromlist=["executions"])
+    monkeypatch.setattr(executions_mod, "_PROCESS_ID", "proc-other")
+    record = create_execution(job_id, source="direct")
+    mark_execution_running(record["id"])
+    # From the reaper's point of view: a different process, owner proved dead.
+    monkeypatch.setattr(executions_mod, "_PROCESS_ID", "proc-current")
+    monkeypatch.setattr(executions_mod, "_owner_is_live", lambda pid, started: False)
+    return record
+
+
+def test_recover_invokes_on_recovered_with_record(monkeypatch):
+    from cron import executions as ex
+
+    record = _seed_dead_owner_execution(monkeypatch)
+    seen = []
+    count = recover_interrupted_executions(on_recovered=seen.append)
+
+    assert count == 1
+    assert len(seen) == 1
+    assert seen[0]["id"] == record["id"]
+    assert seen[0]["job_id"] == "job-reclaimed"
+    assert seen[0]["status"] == "unknown"
+
+
+def test_recover_without_callback_is_backward_compatible(monkeypatch):
+    _seed_dead_owner_execution(monkeypatch)
+    assert recover_interrupted_executions() == 1
+
+
+def test_maybe_reap_dead_owners_delivers_and_opens_incident(monkeypatch):
+    delivered = []
+
+    def fake_recover(*, on_recovered=None):
+        on_recovered({"id": "exec-1", "job_id": "job-x", "status": "unknown",
+                      "error": "Scheduler restarted after this execution's owner exited"})
+        return 1
+
+    monkeypatch.setattr(sched, "_last_dead_owner_reap_at", None)
+    monkeypatch.setattr("cron.executions.recover_interrupted_executions", fake_recover)
+    monkeypatch.setattr(
+        sched, "_deliver_crash_failure",
+        lambda job, err, *, adapters=None, loop=None:
+            delivered.append((job["id"], err)) or (None, "delivered"))
+    monkeypatch.setattr("cron.jobs.get_job", lambda job_id: {"id": job_id, "name": "weekly"})
+
+    sched._maybe_reap_dead_owners(adapters=object(), loop=None)
+
+    assert delivered, "reclaimed-unknown execution must reach the failure lane"
+    assert delivered[0][0] == "job-x"
+    assert "owner exited" in delivered[0][1]
+
+
+def test_maybe_reap_dead_owners_job_missing_is_safe(monkeypatch):
+    delivered = []
+
+    def fake_recover(*, on_recovered=None):
+        on_recovered({"id": "exec-2", "job_id": "gone", "status": "unknown", "error": "x"})
+        return 1
+
+    monkeypatch.setattr(sched, "_last_dead_owner_reap_at", None)
+    monkeypatch.setattr("cron.executions.recover_interrupted_executions", fake_recover)
+    monkeypatch.setattr(
+        sched, "_deliver_crash_failure",
+        lambda job, err, *, adapters=None, loop=None: delivered.append(job) or (None, "delivered"))
+    monkeypatch.setattr("cron.jobs.get_job", lambda job_id: None)
+
+    sched._maybe_reap_dead_owners(adapters=object(), loop=None)
+
+    assert delivered == []


### PR DESCRIPTION
Fixes #108802.

## What & why

`recover_interrupted_executions()` marked provably-abandoned attempts `unknown` but stayed silent — no incident, no `failure_deliver` — so an owner that died mid-run (the issue's case: a `hermes cron run` CLI that timed out during a long agent job) left the job **invisible**: nothing in `hermes cron incidents`, nothing delivered, and `cron doctor` only flags terminal `failed` rows. The same job fired by the ticker completed fine, masking the breakage.

- `cron/executions.py`: the reaper accepts an optional `on_recovered` callback, invoked with each reaped record after the store commit. Handler exceptions are logged and swallowed — recovery must never fail because notification did. No-callback behavior is unchanged (the provider-base `recover_interrupted()` keeps working as before).
- `cron/scheduler.py`: the tick's throttled dead-owner reap (`_maybe_reap_dead_owners`) now receives the tick's `adapters`/`loop` and passes a handler that reuses `_deliver_crash_failure` — incident upsert grouped by job + error signature, acked suppression, failure-lane delivery (`failure_deliver` override honored, NS-788 lane resolution included), and alerted marking on success. The record's own error text ("Scheduler restarted after this execution's owner exited before a durable terminal state; whether side effects ran is unknown") rides through the summarizer, so the notice honestly says the outcome is unknown. The second recovery site (adopted external worker died, scheduler.py:3014) is already followed by the crash-failure path and is untouched.

## How to test

`tests/cron/test_reclaimed_unknown_visibility.py` (new): `on_recovered` fires per reaped record with the right job_id/status; no-callback behavior unchanged; the tick reap delivers through the failure lane with the record's error text; a missing job row is non-fatal. `test_dead_owner_claim_reclaim.py`'s throttle fake gains `**kwargs` for the new callback parameter (throttle semantics unchanged). New tests fail on `main` (callback unsupported → TypeError; nothing delivered) and pass here.

## Platforms tested

Linux. Store work stays in the existing ledger transaction paths; delivery reuses the existing crash-failure lane. Full suite (`scripts/run_tests.sh`): only the known pre-existing/flaky failure set (`update_head_moved_gate`, `voice_mode`, `openviking`, `tui_gateway_server`, `compression_stall_fallback` — reproduce on clean main); no cron files affected.