### PR TITLE
fix(web): forward only the new suffix on a revised composition commit (#108916)

### DIFF
--- a/web/src/lib/pty-composition.test.ts
+++ b/web/src/lib/pty-composition.test.ts
@@ -160,4 +160,35 @@ describe("createPtyCompositionForwarder", () => {
     expect(send).toHaveBeenNthCalledWith(1, "hello");
     expect(send).toHaveBeenNthCalledWith(2, "goodbye");
   });
+
+  it("sends a later, unrelated dictation in full even when it repeats an earlier phrase", () => {
+    vi.useFakeTimers();
+    const send = vi.fn();
+    const forwarder = createPtyCompositionForwarder(send);
+
+    forwarder.onCompositionEnd("hello");
+    vi.runAllTimers();
+    // A long gap (new mic tap, not a revision) separates the two utterances.
+    vi.advanceTimersByTime(5000);
+    forwarder.onCompositionEnd("hello");
+    vi.runAllTimers();
+
+    expect(send).toHaveBeenNthCalledWith(1, "hello");
+    expect(send).toHaveBeenNthCalledWith(2, "hello");
+  });
+
+  it("still diffs a revision that arrives just under the revision-window boundary", () => {
+    vi.useFakeTimers();
+    const send = vi.fn();
+    const forwarder = createPtyCompositionForwarder(send);
+
+    forwarder.onCompositionEnd("hello");
+    vi.runAllTimers();
+    vi.advanceTimersByTime(1000);
+    forwarder.onCompositionEnd("hello world");
+    vi.runAllTimers();
+
+    expect(send).toHaveBeenNthCalledWith(1, "hello");
+    expect(send).toHaveBeenNthCalledWith(2, " world");
+  });
 });

--- a/web/src/lib/pty-composition.test.ts
+++ b/web/src/lib/pty-composition.test.ts
@@ -132,4 +132,32 @@ describe("createPtyCompositionForwarder", () => {
 
     expect(send).not.toHaveBeenCalled();
   });
+
+  it("forwards only the new suffix when a later commit revises the whole prior phrase (iOS dictation)", () => {
+    vi.useFakeTimers();
+    const send = vi.fn();
+    const forwarder = createPtyCompositionForwarder(send);
+
+    forwarder.onCompositionEnd("hello");
+    vi.runAllTimers();
+    forwarder.onCompositionEnd("hello world");
+    vi.runAllTimers();
+
+    expect(send).toHaveBeenNthCalledWith(1, "hello");
+    expect(send).toHaveBeenNthCalledWith(2, " world");
+  });
+
+  it("sends the whole commit when a later revision is unrelated to the prior one", () => {
+    vi.useFakeTimers();
+    const send = vi.fn();
+    const forwarder = createPtyCompositionForwarder(send);
+
+    forwarder.onCompositionEnd("hello");
+    vi.runAllTimers();
+    forwarder.onCompositionEnd("goodbye");
+    vi.runAllTimers();
+
+    expect(send).toHaveBeenNthCalledWith(1, "hello");
+    expect(send).toHaveBeenNthCalledWith(2, "goodbye");
+  });
 });

--- a/web/src/lib/pty-composition.ts
+++ b/web/src/lib/pty-composition.ts
@@ -4,6 +4,15 @@
  * xterm is authoritative when it emits the commit. Browsers/layouts where it
  * does not emit onData still forward the compositionend text on the next turn.
  */
+// A revised dictation utterance re-fires compositionend within a second or
+// two of the previous one as the recognizer refines its guess. A gap longer
+// than this means the user moved on (a new, unrelated utterance, possibly
+// repeating an earlier word/phrase) rather than revising the same one, so
+// the diff baseline must not carry over — otherwise the new utterance gets
+// silently truncated or dropped entirely when it shares a prefix with
+// whatever was last committed.
+const REVISION_WINDOW_MS = 2000;
+
 export function createPtyCompositionForwarder(send: (data: string) => void) {
   let pending: string | null = null;
   let timer: ReturnType<typeof setTimeout> | null = null;
@@ -14,8 +23,10 @@ export function createPtyCompositionForwarder(send: (data: string) => void) {
   // composition re-fires compositionend with the whole revised utterance
   // rather than just the new suffix, so each commit is diffed against this
   // instead of being forwarded whole — otherwise the already-sent prefix
-  // gets duplicated.
+  // gets duplicated. Only valid as a baseline within REVISION_WINDOW_MS of
+  // the last commit; see above.
   let lastCommitted = "";
+  let lastCommittedAt = 0;
 
   const clearPending = () => {
     pending = null;
@@ -28,10 +39,12 @@ export function createPtyCompositionForwarder(send: (data: string) => void) {
   };
 
   const commit = (data: string) => {
-    const delta = data.startsWith(lastCommitted)
-      ? data.slice(lastCommitted.length)
-      : data;
+    const withinRevisionWindow =
+      lastCommittedAt !== 0 && Date.now() - lastCommittedAt <= REVISION_WINDOW_MS;
+    const baseline = withinRevisionWindow ? lastCommitted : "";
+    const delta = data.startsWith(baseline) ? data.slice(baseline.length) : data;
     lastCommitted = data;
+    lastCommittedAt = Date.now();
     if (delta) send(delta);
   };
 
@@ -58,6 +71,7 @@ export function createPtyCompositionForwarder(send: (data: string) => void) {
       const observed = matchedTerminalPrefix + data;
       if (observed.startsWith(pending)) {
         lastCommitted = pending;
+        lastCommittedAt = Date.now();
         clearPending();
       } else if (pending.startsWith(observed)) {
         matchedTerminalPrefix = observed;
@@ -68,6 +82,7 @@ export function createPtyCompositionForwarder(send: (data: string) => void) {
     dispose: () => {
       clearPending();
       lastCommitted = "";
+      lastCommittedAt = 0;
     },
   };
 }

--- a/web/src/lib/pty-composition.ts
+++ b/web/src/lib/pty-composition.ts
@@ -9,6 +9,13 @@ export function createPtyCompositionForwarder(send: (data: string) => void) {
   let timer: ReturnType<typeof setTimeout> | null = null;
   let matchedTerminalPrefix = "";
   let sawUnrelatedTerminalData = false;
+  // The full text already reflected in the PTY line via this forwarder (or
+  // confirmed to already be there by xterm's own onData). Dictation-style
+  // composition re-fires compositionend with the whole revised utterance
+  // rather than just the new suffix, so each commit is diffed against this
+  // instead of being forwarded whole — otherwise the already-sent prefix
+  // gets duplicated.
+  let lastCommitted = "";
 
   const clearPending = () => {
     pending = null;
@@ -20,18 +27,26 @@ export function createPtyCompositionForwarder(send: (data: string) => void) {
     }
   };
 
+  const commit = (data: string) => {
+    const delta = data.startsWith(lastCommitted)
+      ? data.slice(lastCommitted.length)
+      : data;
+    lastCommitted = data;
+    if (delta) send(delta);
+  };
+
   return {
     onCompositionEnd(data: string | null) {
       if (!data) return;
       // Preserve rapid consecutive commits instead of discarding the first.
       const previous = pending;
       clearPending();
-      if (previous) send(previous);
+      if (previous) commit(previous);
       pending = data;
       timer = setTimeout(() => {
         const committed = pending;
         clearPending();
-        if (committed) send(committed);
+        if (committed) commit(committed);
       }, 16);
     },
     noteTerminalData(data: string) {
@@ -42,6 +57,7 @@ export function createPtyCompositionForwarder(send: (data: string) => void) {
       // the fallback even if later callbacks happen to spell the composition.
       const observed = matchedTerminalPrefix + data;
       if (observed.startsWith(pending)) {
+        lastCommitted = pending;
         clearPending();
       } else if (pending.startsWith(observed)) {
         matchedTerminalPrefix = observed;
@@ -49,6 +65,9 @@ export function createPtyCompositionForwarder(send: (data: string) => void) {
         sawUnrelatedTerminalData = true;
       }
     },
-    dispose: clearPending,
+    dispose: () => {
+      clearPending();
+      lastCommitted = "";
+    },
   };
 }


### PR DESCRIPTION
Fixes #108916.

## Problem

On iPhone Safari, dictating into the dashboard TUI produces garbled,
duplicated text instead of the spoken phrase. The normal keyboard path is
unaffected.

`createPtyCompositionForwarder` (`web/src/lib/pty-composition.ts`) exists
as a fallback for browsers/layouts where xterm doesn't emit `onData` for a
composition commit — it listens for `compositionend` and forwards the
committed text to the PTY itself after a short delay (unless xterm's own
`onData` is observed to have already sent it).

iOS Safari's dictation doesn't commit incrementally: each `compositionend`
carries the *whole* utterance recognized so far, not just the newly added
words (dictation can also revise earlier words as later context arrives).
The forwarder treated every `compositionend` as an independent commit and
sent it in full, so a revision sequence like `"hello"` → `"hello world"`
sent `"hello"` to the PTY, then `"hello world"` again — duplicating the
already-sent prefix into `"hellohello world"`.

## Fix

Track the text already reflected in the PTY line (`lastCommitted`) across
composition commits — whether sent by the forwarder itself or confirmed
already-present via xterm's own `onData` — and forward only the new
suffix when a later commit extends it. An unrelated commit (doesn't start
with the tracked text) is still forwarded in full, so normal dead-key/IME
composition (the original purpose of this fallback) is unaffected.

**Revision addressed:** the first version of this fix kept `lastCommitted`
for the lifetime of the whole terminal session (only cleared on dispose),
so it was also used as the diff baseline for utterances that had nothing
to do with each other — e.g. a *second*, unrelated dictation later in the
same session that happened to repeat an earlier word would get silently
truncated or dropped entirely (delta computed against stale state). Fixed
by scoping `lastCommitted` to a `REVISION_WINDOW_MS` (2s) window from the
last commit: only commits that land within that window of each other are
treated as revisions of the same utterance and diffed against one
another; anything after a longer gap is forwarded in full, with the
baseline reset.

## Test plan

`web/src/lib/pty-composition.test.ts` covers:

- a later commit that revises the whole prior phrase (`"hello"` →
  `"hello world"`) now forwards only the delta (`" world"`)
- a later commit unrelated to the prior one is still forwarded whole
- a later, *unrelated* dictation utterance that repeats an earlier phrase
  after a gap (`"hello"` ... 5s ... `"hello"`) is forwarded in full both
  times, not swallowed by the stale baseline
- a genuine revision arriving just under the revision-window boundary is
  still diffed correctly

Verified each new/changed test is not a no-op by reverting only the
source file to its pre-fix state and rerunning:

- Against the original pre-fix code (`git checkout HEAD~2 --
  web/src/lib/pty-composition.ts`): "forwards only the new suffix..."
  fails (sends `"hello world"` instead of `" world"`).
- Against the first-round fix (`git checkout HEAD~1 --
  web/src/lib/pty-composition.ts`, the version an independent review
  blocked): "sends a later, unrelated dictation in full even when it
  repeats an earlier phrase" fails — the second `"hello"` is silently
  dropped (`send` called only once).
- With the current fix restored, all tests pass.

Full web suite:

```
 Test Files  41 passed (41)
      Tests  302 passed (302)
```

Also ran `tsc --noEmit` (clean) and `eslint` on the changed files (0
errors).

## AI assistance disclosure

This change was written with AI assistance (Claude Code), including the
root-cause analysis, the fix, and the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
