### PR TITLE
fix(tools): actionable error + debug trace for tool_call bridge self-invocation

### DIFF
--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -413,6 +413,30 @@ class TestBridgeDispatch:
         assert err is not None
         assert "bridge tool" in err.lower()
 
+    def test_resolve_underlying_call_recursion_error_is_actionable(self):
+        """Regression (#5149 follow-up): a bridge self-invocation must return an error
+        message that tells the model to call the tool directly instead of retrying the
+        same malformed tool_call wrapper — the root cause of the outline MCP failures was
+        the model repeating the wrapped call after an opaque rejection."""
+        from tools.tool_search import resolve_underlying_call, TOOL_SEARCH_NAME
+        name, args, err = resolve_underlying_call({
+            "name": TOOL_SEARCH_NAME,
+            "arguments": {"queries": ["x"]},
+        })
+        assert name is None
+        assert err is not None
+        assert "call it directly" in err.lower()
+
+    def test_resolve_underlying_call_recursion_is_logged_for_diagnosis(self, caplog):
+        """Regression (#5149 follow-up): self-invocation rejections must be logged with the
+        raw args so a future failure is diagnosable instead of leaving no trace (the original
+        incident had no persisted raw payload to confirm the malformed call's exact shape)."""
+        import logging
+        from tools.tool_search import resolve_underlying_call, TOOL_CALL_NAME
+        with caplog.at_level(logging.DEBUG, logger="tools.tool_search"):
+            resolve_underlying_call({"name": TOOL_CALL_NAME, "arguments": {"name": "tool_call"}})
+        assert any("self-invocation" in rec.message for rec in caplog.records)
+
 
 # ---------------------------------------------------------------------------
 # End-to-end via the real handle_function_call (smoke test).

--- a/tools/tool_search_validation.py
+++ b/tools/tool_search_validation.py
@@ -164,7 +164,13 @@ def normalize_tool_call_entries(args: Dict[str, Any]) -> Tuple[List[Dict[str, An
         if not name:
             return [], f"tool_call calls[{position}] requires a 'name'"
         if name in BRIDGE_TOOL_NAMES:
-            return [], f"tool_call cannot invoke '{name}' (it is itself a bridge tool)"
+            logger.debug(
+                "tool_call rejected calls[%d]: self-invocation of bridge tool '%s'; raw=%r",
+                position, name, raw)
+            return [], (
+                f"tool_call cannot invoke '{name}' (it is itself a bridge tool). "
+                f"'{name}' is already a top-level tool — call it directly, do not wrap it "
+                "in tool_call.")
         raw_args = raw.get("arguments")
         if raw_args is None:
             raw_args = {}


### PR DESCRIPTION
Root cause investigation (internal kanban task): 4 outline MCP tool call failures were all client-side "Model generated invalid tool call" rejections, never a transport/session/protocol issue (outline.tabinas.ch was 100% healthy throughout). Logs showed a bridge self-invocation error (`tool_call cannot invoke tool_call`) immediately preceding a malformed real call in the same turn — the model wrapped a native/bridge tool name in another `tool_call`, got an opaque rejection, and repeated the same malformed shape.

This PR:
- Makes the self-invocation error message explicitly instruct the model to call the tool directly instead of wrapping it in `tool_call` (previously just stated the fact, gave no corrective action).
- Adds a DEBUG log of the raw rejected `tool_call` payload on self-invocation, so a repeat of this failure mode leaves a diagnosable trace (the original incident had no persisted raw payload to confirm the exact malformed shape).
- Adds two regression tests: message wording, and presence of the debug log record.

No gateway/connection changes — this narrowly targets the actual root cause (client-side call validation), not the ruled-out theories (connection pooling, stale sessions, timeouts, transport).

Tests: `scripts/run_tests.sh tests/tools/test_tool_search.py` (47 passed) and `scripts/run_tests.sh tests/tools/` (189 passed, 0 failed — one unrelated pre-existing collection error for a missing optional `aiohttp` messaging dependency, not touched by this change).