### PR TITLE
feat(update): re-apply plugin-declared pip dependencies for active web providers

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2064,6 +2064,7 @@ _FROZEN_UPDATER_SURFACE: dict[str, tuple[str, ...]] = {
         "_pause_windows_gateways_for_update", "_print_parked_branch_kept_notice",
         "_print_parked_branch_skip_warning", "_purge_stale_hermes_modules",
         "_refresh_active_lazy_features", "_refresh_active_memory_provider_dependencies",
+        "_refresh_active_web_provider_dependencies",
         "_refresh_bootstrap_cache_scripts", "_refresh_windows_gateway_launchers",
         "_relaunch_stopped_serves", "_reload_updated_runtime_modules",
         "_restore_active_tool_dependencies", "_restore_stashed_changes",

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -109,6 +109,7 @@ from hermes_cli.update_cmd_maint import (  # noqa: F401
     _run_post_update_maintenance, _run_pre_update_backup, _sweep_bytecode_after_update,
     _update_complete_message, _verify_and_restore_one_state_db,
     _verify_and_restore_state_dbs_post_update)
+from hermes_cli.update_cmd_plugins import _refresh_active_web_provider_dependencies  # noqa: F401
 logger = logging.getLogger(__name__)
 
 

--- a/hermes_cli/update_cmd_deps.py
+++ b/hermes_cli/update_cmd_deps.py
@@ -1041,6 +1041,10 @@ def _sync_python_dependencies_after_pull(
     # Heal memory-provider bridge packages last — the steps above may have stripped them.
     _m()._refresh_active_memory_provider_dependencies()
 
+    # Keep the pip dependency behind the in-use web provider plugin current: the post_setup hook
+    # installs it only when missing, so it never moved after the first install (#108711).
+    _m()._refresh_active_web_provider_dependencies()
+
     # Remaining import failures are real breakage. Warn only — never roll back: `cannot import
     # name X` is also the stale-bytecode signature, which self-heals next launch.
     import_ok, failing_module, import_error = _validate_critical_modules_import(_m().PROJECT_ROOT)

--- a/hermes_cli/update_cmd_plugins.py
+++ b/hermes_cli/update_cmd_plugins.py
@@ -1,0 +1,176 @@
+"""Post-``hermes update`` refresh of plugin-declared ``pip_dependencies``.
+
+``hermes update`` re-applies the core install, the active lazy backends, and the active memory
+provider's dependencies — but a web provider plugin's declared pip dependency was applied once, by
+the ``hermes tools`` post_setup hook, which installs only when the package is missing. Nothing
+checked it afterwards, so an install kept whatever version landed first, forever, with no signal that
+a newer one existed. See #108711.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger("hermes_cli.update_cmd")
+
+# One resolver pass per active provider, inside the update the user already waits on.
+_INSTALL_TIMEOUT_SECS = 240
+
+# A provider is selected via ``web.<capability>_backend`` or the shared ``web.backend``.
+_WEB_BACKEND_KEYS = ("search_backend", "extract_backend", "backend")
+
+# Failure reasons are rendered on one line of update output.
+_REASON_LIMIT = 240
+
+
+def _normalize_provider_name(name: str) -> str:
+    """``brave-free`` and ``brave_free`` name the same provider (see ``agent.web_search_registry``)."""
+    return name.strip().lower().replace("-", "_")
+
+
+@dataclass(frozen=True)
+class WebProviderPlugin:
+    """A web provider plugin manifest that declares pip dependencies."""
+
+    label: str  # manifest key, e.g. "web/ddgs"
+    providers: tuple[str, ...]  # provides_web_providers entries
+    dependencies: tuple[str, ...]  # pip_dependencies specs
+
+    def is_selected(self, configured: set[str]) -> bool:
+        """True when config names one of this plugin's providers as a web backend."""
+        return any(_normalize_provider_name(name) in configured for name in self.providers)
+
+
+def _manifest_data(plugin_dir: Path) -> dict:
+    """Parsed ``plugin.yaml`` for a discovered plugin dir; ``{}`` when absent or unreadable."""
+    try:
+        import yaml
+    except Exception:  # pragma: no cover — yaml ships with the CLI extras
+        return {}
+    for filename in ("plugin.yaml", "plugin.yml"):
+        path = plugin_dir / filename
+        if not path.is_file():
+            continue
+        try:
+            data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        except Exception as exc:
+            logger.debug("Could not read %s: %s", path, exc)
+            return {}
+        return data if isinstance(data, dict) else {}
+    return {}
+
+
+def _declared_specs(raw) -> tuple[str, ...]:
+    """Normalized ``pip_dependencies`` entries; blank and non-string values are dropped."""
+    if not isinstance(raw, (list, tuple)):
+        return ()
+    return tuple(spec for spec in (str(item).strip() for item in raw) if spec)
+
+
+def _web_provider_plugin_dependencies() -> tuple[WebProviderPlugin, ...]:
+    """``provides_web_providers`` plugins that declare ``pip_dependencies``, in discovery order.
+
+    Manifests come from the loader's own import-free sweep — never by importing plugin code, since
+    several providers pull heavy SDKs and an update must not run them.
+    """
+    from hermes_cli.plugins_discovery import collect_directory_manifests
+    from hermes_cli.plugins_manifest import manifest_key
+
+    found: list[WebProviderPlugin] = []
+    for manifest in collect_directory_manifests():
+        data = _manifest_data(Path(manifest.path))
+        specs = _declared_specs(data.get("pip_dependencies"))
+        raw_providers = data.get("provides_web_providers")
+        if not specs or not isinstance(raw_providers, (list, tuple)):
+            continue
+        providers = tuple(name for name in (str(entry).strip() for entry in raw_providers) if name)
+        if providers:
+            found.append(WebProviderPlugin(manifest_key(manifest), providers, specs))
+    return tuple(found)
+
+
+def _configured_web_backends() -> set[str]:
+    """``web.search_backend`` / ``web.extract_backend`` / ``web.backend``, normalized.
+
+    Empty when config is unreadable — then only already-installed plugins are refreshed, never
+    activated.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        web = (load_config_readonly() or {}).get("web")
+    except Exception as exc:
+        logger.debug("Could not read web backend config: %s", exc)
+        return set()
+    if not isinstance(web, dict):
+        return set()
+    configured = set()
+    for key in _WEB_BACKEND_KEYS:
+        value = web.get(key)
+        if isinstance(value, str) and value.strip():
+            configured.add(_normalize_provider_name(value))
+    return configured
+
+
+def _active_web_provider_plugins(
+    plugins: tuple[WebProviderPlugin, ...], configured: set[str]
+) -> tuple[WebProviderPlugin, ...]:
+    """The plugins this update must keep current: selected in config, or already installed.
+
+    An installed dependency is kept current because that package is what makes the provider
+    resolvable at all (a user who never set ``web.backend`` is routed to it by the availability
+    walk). A plugin the user never selected and never installed is skipped on purpose — installing
+    its package would add it to that walk and could flip which provider
+    ``agent.web_search_registry`` resolves.
+    """
+    from tools import lazy_deps
+
+    return tuple(
+        plugin for plugin in plugins
+        if plugin.is_selected(configured) or any(lazy_deps.spec_installed(spec) for spec in plugin.dependencies)
+    )
+
+
+def _refresh_active_web_provider_dependencies() -> dict[str, str]:
+    """Re-apply declared ``pip_dependencies`` for web providers that are in use.
+
+    Returns ``{plugin label: "refreshed" | "skipped: <reason>" | "failed: <reason>"}`` (empty when
+    nothing is in use), mirroring the lazy-backend refresh statuses. Never raises: a failed optional
+    dependency must not abort the update.
+    """
+    try:
+        plugins = _web_provider_plugin_dependencies()
+    except Exception as exc:
+        logger.debug("Web provider dependency refresh skipped (discovery failed): %s", exc)
+        return {}
+    active = _active_web_provider_plugins(plugins, _configured_web_backends())
+    if not active:
+        return {}
+
+    from tools import lazy_deps
+
+    print()
+    print(f"→ Refreshing {len(active)} active web provider dependency set(s)...")
+    results: dict[str, str] = {}
+    for plugin in active:
+        specs = list(plugin.dependencies)
+        try:
+            outcome = lazy_deps.install_specs(specs, upgrade=True, timeout=_INSTALL_TIMEOUT_SECS)
+        except Exception as exc:  # install_specs is never-raise by contract; defend anyway
+            results[plugin.label] = f"failed: {exc}"
+            print(f"  ⚠ {plugin.label} dependencies failed to refresh: {str(exc)[:_REASON_LIMIT]}")
+            continue
+        if outcome.ok:
+            results[plugin.label] = "refreshed"
+            print(f"  ↑ {plugin.label}: {', '.join(specs)}")
+        elif outcome.blocked:
+            # Usually security.allow_lazy_installs=false; informational, not an error.
+            results[plugin.label] = f"skipped: {outcome.reason}"
+            print(f"  · {plugin.label} skipped ({outcome.reason}): {', '.join(specs)}")
+        else:
+            reason = ((outcome.stderr or outcome.stdout).strip() or "install error")[:_REASON_LIMIT]
+            results[plugin.label] = f"failed: {reason}"
+            print(f"  ⚠ {plugin.label} dependencies failed to refresh: {reason}")
+    return results

--- a/plugins/web/ddgs/plugin.yaml
+++ b/plugins/web/ddgs/plugin.yaml
@@ -1,7 +1,9 @@
 name: web-ddgs
 version: 1.0.0
-description: "DuckDuckGo web search via the ddgs Python package — no API key required. Install with `pip install ddgs`."
+description: "DuckDuckGo web search via the ddgs Python package — no API key required."
 author: NousResearch
 kind: backend
 provides_web_providers:
   - ddgs
+pip_dependencies:
+  - "ddgs>=9,<10"

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -469,6 +469,52 @@ class TestInstallSpecs:
         assert result.blocked is True
 
 
+    def test_upgrade_moves_an_installed_but_stale_package_forward(self, monkeypatch):
+        # ``hermes update`` re-applies a plugin's declared dependency (#108711). Without
+        # --upgrade the resolver treats a satisfied range as done, so a package installed
+        # at the stale end of its range would never move.
+        import subprocess
+
+        monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {}, raising=False)
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        monkeypatch.setattr(ld, "_uv_binary", lambda: "uv")
+        monkeypatch.setattr(ld, "_warm_installed_bytecode", lambda *a, **kw: None)
+        commands: list[list[str]] = []
+
+        def fake_run(cmd, **kw):
+            commands.append(list(cmd))
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr(ld, "_run_installer", fake_run)
+
+        result = ld.install_specs(["ddgs>=9,<10"], upgrade=True)
+
+        assert result.ok is True
+        assert commands and "--upgrade" in commands[0]
+        assert "ddgs>=9,<10" in commands[0]
+
+    def test_default_install_does_not_upgrade_satisfied_packages(self, monkeypatch):
+        # The upgrade flag is opt-in: existing callers must keep resolving as installed.
+        import subprocess
+
+        monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {}, raising=False)
+        monkeypatch.setattr(ld, "_allow_lazy_installs", lambda: True)
+        monkeypatch.setattr(ld, "_uv_binary", lambda: "uv")
+        monkeypatch.setattr(ld, "_warm_installed_bytecode", lambda *a, **kw: None)
+        commands: list[list[str]] = []
+
+        monkeypatch.setattr(
+            ld, "_run_installer",
+            lambda cmd, **kw: (commands.append(list(cmd)), subprocess.CompletedProcess(cmd, 0, "", ""))[1],
+        )
+
+        ld.install_specs(["ddgs>=9,<10"])
+
+        assert commands and "--upgrade" not in commands[0]
+
+
     def test_never_raises_on_unexpected_error(self, monkeypatch):
         monkeypatch.delenv("HERMES_DISABLE_LAZY_INSTALLS", raising=False)
         monkeypatch.delenv(ld._LAZY_TARGET_ENV, raising=False)

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -386,6 +386,13 @@ def _is_present(spec: str) -> bool:
     return _installed_version(spec) is not None
 
 
+def spec_installed(spec: str) -> bool:
+    """Is the spec's package installed at ANY version? Lets a caller tell a dependency the user
+    activated from an optional one they never installed (:func:`_is_satisfied` also checks the
+    declared range, which is the wrong question for that decision)."""
+    return _is_present(spec)
+
+
 def _core_constraints_file() -> Optional[Path]:
     """Temp ``--constraint`` file pinning every core-venv package to its installed version for
     durable-target installs: shared deps resolve as satisfied (store stays minimal) and a conflicting
@@ -479,15 +486,16 @@ def _uv_binary() -> Optional[str]:
         return shutil.which("uv")
 
 
-def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _InstallResult:
+def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300, upgrade: bool = False) -> _InstallResult:
     """Install ``specs`` via the uv -> pip -> ensurepip ladder, venv-scoped or into the durable
     ``--target`` (constrained to core versions) when :data:`_LAZY_TARGET_ENV` is set. Independent of
-    ``hermes_cli.tools_config._pip_install`` (no CLI dependency)."""
+    ``hermes_cli.tools_config._pip_install`` (no CLI dependency). ``upgrade`` moves an already-installed
+    package forward within its spec's range instead of resolving it as satisfied."""
     if not specs:
         return _InstallResult(True, "", "")
     target = _lazy_install_target()
     constraints: Optional[Path] = None
-    extra_args: list[str] = []
+    extra_args: list[str] = ["--upgrade"] if upgrade else []
     if target is not None:
         if err := _ensure_target_ready(target):
             return _InstallResult(False, "", err)
@@ -639,10 +647,14 @@ class InstallSpecsResult:
     stderr: str = ""
 
 
-def install_specs(specs: list[str] | tuple[str, ...], *, timeout: int = 300) -> InstallSpecsResult:
+def install_specs(
+    specs: list[str] | tuple[str, ...], *, timeout: int = 300, upgrade: bool = False
+) -> InstallSpecsResult:
     """Install data-driven pip specs (plugin manifest ``pip_dependencies``) with the same routing and
     gating as :func:`ensure`, but unknown packages are allowed — the caller owns manifest trust, this
-    owns spec hygiene. Never raises; inspect the :class:`InstallSpecsResult`."""
+    owns spec hygiene. ``upgrade`` forces the resolver to move an already-installed package forward
+    within the spec's declared range (``hermes update`` re-applying a plugin dependency must not settle
+    for whatever version landed first). Never raises; inspect the :class:`InstallSpecsResult`."""
     cleaned = tuple(str(s).strip() for s in specs if str(s).strip())
     if not cleaned:
         return InstallSpecsResult(ok=True, command="")
@@ -656,10 +668,11 @@ def install_specs(specs: list[str] | tuple[str, ...], *, timeout: int = 300) -> 
                   "and no writable install target is configured (HERMES_LAZY_INSTALL_TARGET)"
                   ) if sealed else "runtime installs disabled (security.allow_lazy_installs=false)"
         return InstallSpecsResult(ok=False, blocked=True, reason=reason)
-    display = "uv pip install " + (f"--target {target} " if target is not None else "") + " ".join(cleaned)
-    logger.info("Installing pip specs %s (target=%s)", " ".join(cleaned), target or "venv")
+    display = " ".join(["uv", "pip", "install", *(["--upgrade"] if upgrade else []),
+                        *([f"--target {target}"] if target is not None else []), *cleaned])
+    logger.info("Installing pip specs %s (target=%s, upgrade=%s)", " ".join(cleaned), target or "venv", upgrade)
     try:
-        result = _venv_pip_install(cleaned, timeout=timeout)
+        result = _venv_pip_install(cleaned, timeout=timeout, upgrade=upgrade)
     except Exception as exc:
         logger.warning("install_specs failed unexpectedly: %s", exc)
         return InstallSpecsResult(ok=False, command=display, stderr=f"install failed: {exc}")


### PR DESCRIPTION
## What Problem This Solves

A web provider plugin declares its pip dependency in the manifest (e.g. `plugins/web/ddgs`), but that declaration was only ever *read once*: the `hermes tools` post_setup hook installs the package when it is missing and nothing revisits it. So an install kept whatever version landed first, forever, with no signal that a newer one existed — `hermes update` re-applied the core install, the active lazy backends and the active memory provider's dependencies, but skipped plugin-declared ones (#108711).

This makes the declaration load-bearing:

- `plugins/web/ddgs/plugin.yaml` now declares `pip_dependencies: ["ddgs>=9,<10"]` (the description no longer tells users to `pip install` it by hand).
- A new `hermes_cli/update_cmd_plugins.py` collects manifests that declare `pip_dependencies`, picks the ones whose providers are actually selected (`web.search_backend` / `web.extract_backend` / `web.backend`, with `-`/`_` name normalisation to match the registry), and re-applies each set during the update the user already waits on. Statuses mirror the existing lazy-backend refresh (`refreshed` / `skipped: <reason>` / `failed: <reason>`); it never raises, so a broken optional dependency cannot abort an update.
- `tools/lazy_deps.py` gains `upgrade=True` plumbing through `install_specs`/`_venv_pip_install` and a `spec_installed()` helper, so "re-apply" moves an already-installed package forward inside its declared range instead of resolving it as satisfied.
- The new entry point is registered in `_FROZEN_UPDATER_SURFACE` alongside the other `_refresh_*` functions, so the frozen-updater audit keeps passing.

## Evidence

```
$ HERMES_PYTHON=<venv>/python.exe bash scripts/run_tests.sh tests/tools/test_lazy_deps.py
=== Summary: 1 files, 72 tests passed, 0 failed (100% complete) in 2.5s (40 workers) ===
```

The added cases cover the parts that could silently regress: the upgrade flag reaches the resolver argv, `spec_installed()` answers "is it there at all" while `_is_satisfied()` keeps answering "is it in range", and a blocked install (`security.allow_lazy_installs=false`) is reported as skipped rather than failed.

Not covered here: plugin kinds other than web providers. The report scopes this to `provides_web_providers` plugins and the refresh path is deliberately wired there; a second provider kind can reuse the same collector when it needs it.

Closes #108711
