### PR TITLE
feat(agent): let a skill declare the reasoning effort for its turn

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1594,21 +1594,32 @@ def run_conversation(
     """
     from agent.turn_context import export_current_turn_boundary
 
-    result = _run_conversation_turn(
-        agent,
-        user_message,
-        system_message=system_message,
-        conversation_history=conversation_history,
-        task_id=task_id,
-        stream_callback=stream_callback,
-        persist_user_message=persist_user_message,
-        persist_user_timestamp=persist_user_timestamp,
-        persist_user_display_kind=persist_user_display_kind,
-        persist_user_display_metadata=persist_user_display_metadata,
-        persist_user_platform_id=persist_user_platform_id,
-        moa_config=moa_config,
-        turn_author=turn_author,
-    )
+    try:
+        result = _run_conversation_turn(
+            agent,
+            user_message,
+            system_message=system_message,
+            conversation_history=conversation_history,
+            task_id=task_id,
+            stream_callback=stream_callback,
+            persist_user_message=persist_user_message,
+            persist_user_timestamp=persist_user_timestamp,
+            persist_user_display_kind=persist_user_display_kind,
+            persist_user_display_metadata=persist_user_display_metadata,
+            persist_user_platform_id=persist_user_platform_id,
+            moa_config=moa_config,
+            turn_author=turn_author,
+        )
+    finally:
+        # Restore the pre-skill reasoning level for the next turn (issue #108770). Every exit
+        # path above goes through here, so an error/interrupt cannot strand the raise.
+        try:
+            from agent.skill_reasoning import restore_skill_reasoning_override
+
+            restore_skill_reasoning_override(agent, getattr(agent, "_skill_reasoning_snapshot", None))
+            agent._skill_reasoning_snapshot = None
+        except Exception:
+            logger.debug("skill reasoning restore skipped", exc_info=True)
     return export_current_turn_boundary(agent, result, user_message)
 
 

--- a/agent/skill_reasoning.py
+++ b/agent/skill_reasoning.py
@@ -1,0 +1,158 @@
+"""Skill-declared reasoning effort (issue #108770).
+
+A skill may declare ``metadata.hermes.reasoning_effort`` in its frontmatter to raise (or lower)
+the turn's thinking level while it is active; the previous level is restored when the turn ends.
+The feature is strictly opt-in: a skill without the key leaves ``agent.reasoning_config``
+untouched, so existing behavior is unchanged.
+
+Resolution is per-turn, not per-session: the invoked-skill scaffold that the slash-command
+builders put at the head of the user message is the trigger, so nothing is cached on the agent
+and no long-lived state can leak into the next turn. This mirrors the cron per-job pin
+(``cron.scheduler._resolve_job_reasoning_config``) and reuses the same ladder parsing, so a
+declared level is validated by ``hermes_constants.parse_reasoning_effort`` rather than by a
+second vocabulary.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+#: ``metadata.hermes`` key a skill declares its reasoning tier under.
+SKILL_REASONING_KEY = "reasoning_effort"
+
+#: Turns a declared level may apply to. ``"turn"`` (default) scopes the raise to the invocation
+#: turn and restores afterwards; ``"session"`` keeps it for the rest of the session.
+VALID_SCOPES: tuple[str, ...] = ("turn", "session")
+
+
+def _frontmatter_reasoning_effort(frontmatter: dict) -> Optional[object]:
+    """Raw ``metadata.hermes.reasoning_effort`` value, or None when undeclared.
+
+    Tolerant of the string-valued form the frontmatter linter accepts (``"high"``) and of an
+    explicit mapping (``{effort: high, scope: turn}``), which is how a skill pins a scope.
+    """
+    metadata = frontmatter.get("metadata")
+    hermes = metadata.get("hermes") if isinstance(metadata, dict) else None
+    if not isinstance(hermes, dict):
+        return None
+    value = hermes.get(SKILL_REASONING_KEY)
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return value.get("effort") or value.get("level") or None
+    return value
+
+
+def _frontmatter_reasoning_scope(frontmatter: dict) -> str:
+    """Declared scope for the effort, defaulting to ``"turn"`` (unrecognized values default)."""
+    metadata = frontmatter.get("metadata")
+    hermes = metadata.get("hermes") if isinstance(metadata, dict) else None
+    if not isinstance(hermes, dict):
+        return "turn"
+    value = hermes.get(SKILL_REASONING_KEY)
+    scope = value.get("scope") if isinstance(value, dict) else None
+    if scope is None:
+        scope = hermes.get("reasoning_scope")
+    scope = str(scope or "").strip().lower()
+    return scope if scope in VALID_SCOPES else "turn"
+
+
+def declared_reasoning_effort(frontmatter: dict) -> Optional[dict]:
+    """``{"enabled": True, "effort": <level>}`` for a skill's declared tier, or None.
+
+    None covers every "do not change anything" case: no declaration, an unparseable level, and
+    an explicit disable that is not a level (``none`` parses to ``{"enabled": False}`` and IS
+    returned, since a skill may legitimately ask for thinking off).
+    """
+    from hermes_constants import parse_reasoning_effort
+
+    raw = _frontmatter_reasoning_effort(frontmatter)
+    if raw is None:
+        return None
+    parsed = parse_reasoning_effort(raw)
+    if parsed is None:
+        logger.warning(
+            "Skill declares an unknown metadata.hermes.reasoning_effort %r; ignoring it "
+            "(valid: none, minimal, low, medium, high, xhigh, max, ultra).",
+            raw,
+        )
+        return None
+    return parsed
+
+
+def _embedded_frontmatters(message: str):
+    """Frontmatter dicts embedded in a skill scaffold, in the order they appear.
+
+    The scaffold carries each skill's SKILL.md text verbatim — that is the text the model actually
+    reads — so the declaration is resolved from the message itself. No second disk read, and no
+    window where the file on disk disagrees with what was injected this turn.
+    """
+    from agent.skill_utils import parse_frontmatter
+
+    for match in re.finditer(r"(?m)^---[ \t]*$", message):
+        try:
+            frontmatter, _ = parse_frontmatter(message[match.start():])
+        except Exception:
+            logger.debug("Could not parse embedded skill frontmatter", exc_info=True)
+            continue
+        if frontmatter:
+            yield frontmatter
+
+
+def declaration_for_message(message) -> Optional[dict]:
+    """Resolve the skill-declared reasoning config for a user message, or None.
+
+    None means "this turn does not opt in": the message is not a skill scaffold, no loaded skill
+    declares anything, or every declaration is unparseable. The scaffold prefix is the gate, so an
+    ordinary message that happens to quote frontmatter is never treated as opt-in.
+    """
+    if not isinstance(message, str):
+        return None
+    from agent import skill_commands as sc
+
+    if not message.startswith(sc._SKILL_INVOCATION_PREFIX):
+        return None
+    for frontmatter in _embedded_frontmatters(message):
+        config = declared_reasoning_effort(frontmatter)
+        if config is None:
+            continue
+        return {"config": config, "scope": _frontmatter_reasoning_scope(frontmatter)}
+    return None
+
+
+def apply_skill_reasoning_override(agent, message) -> Optional[dict]:
+    """Raise the turn's reasoning tier to a skill's declared level.
+
+    Returns the snapshot to hand back to :func:`restore_skill_reasoning_override`, or None when
+    the turn does not opt in (no declaration, or the feature is disabled by config). The previous
+    ``agent.reasoning_config`` is preserved verbatim in the snapshot, so the restore is exact.
+    """
+    declaration = declaration_for_message(message)
+    if declaration is None:
+        return None
+    config = declaration["config"]
+    scope = declaration["scope"]
+    previous = getattr(agent, "reasoning_config", None)
+    agent.reasoning_config = dict(config)
+    # A scope="session" declaration must survive the per-turn restore, so it is kept as the
+    # restore target: the next turn's turn-end puts the same level back rather than the
+    # pre-skill value. Turn scope restores the original immediately.
+    restore_to = dict(config) if scope == "session" else (
+        dict(previous) if isinstance(previous, dict) else previous
+    )
+    logger.info(
+        "Skill-declared reasoning effort applied for this turn: %s (scope=%s, previous=%s)",
+        config, scope, previous,
+    )
+    return {"previous": restore_to, "applied": config, "scope": scope}
+
+
+def restore_skill_reasoning_override(agent, snapshot) -> None:
+    """Put ``agent.reasoning_config`` back to the snapshot's ``previous`` value (no-op on None)."""
+    if not snapshot:
+        return
+    agent.reasoning_config = snapshot.get("previous")

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -535,6 +535,22 @@ def _reset_per_turn_agent_state(agent: Any) -> None:
             scrubber.reset()
 
 
+def _apply_skill_reasoning(agent: Any, user_message: Any) -> None:
+    """Raise this turn's reasoning tier to a skill's declared level; never fatal.
+
+    The snapshot is stashed on the agent so the turn end can restore the pre-skill value
+    (``agent._skill_reasoning_snapshot``). A skill declaring nothing leaves the agent's config
+    untouched — this feature only ever changes behavior for opted-in skills.
+    """
+    agent._skill_reasoning_snapshot = None
+    try:
+        from agent.skill_reasoning import apply_skill_reasoning_override
+
+        agent._skill_reasoning_snapshot = apply_skill_reasoning_override(agent, user_message)
+    except Exception:
+        logger.debug("skill reasoning override skipped", exc_info=True)
+
+
 def _stage_turn_user_message(
     agent: Any, user_message: Any, persist_user_message: Any,
     persist_user_timestamp: Optional[float], persist_user_platform_id: Optional[str],
@@ -905,6 +921,11 @@ def build_turn_context(
         persist_user_timestamp, persist_user_platform_id,
     )
     _reset_per_turn_agent_state(agent)
+
+    # A skill that declares metadata.hermes.reasoning_effort raises (or lowers) this turn's
+    # thinking level; the turn end restores the previous value (issue #108770). Applied here,
+    # before any request is assembled, so the raise covers the whole turn.
+    _apply_skill_reasoning(agent, user_message)
 
     _preview_text = summarize_user_message_for_log(user_message)
     _msg_preview = _preview_text[:80] + ("..." if len(_preview_text) > 80 else "")

--- a/tests/agent/test_skill_reasoning_effort.py
+++ b/tests/agent/test_skill_reasoning_effort.py
@@ -1,0 +1,185 @@
+"""Skill-declared reasoning effort (issue #108770).
+
+A skill that declares ``metadata.hermes.reasoning_effort`` raises the thinking level for the
+turn it is invoked in, and the previous value is restored when the turn ends. The feature is
+opt-in: a skill that declares nothing must not change ``agent.reasoning_config``.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from agent.skill_commands import (
+    build_skill_invocation_message,
+    build_stacked_skill_invocation_message,
+    scan_skill_commands,
+)
+from agent.skill_reasoning import (
+    apply_skill_reasoning_override,
+    declaration_for_message,
+    declared_reasoning_effort,
+    restore_skill_reasoning_override,
+)
+
+
+def _make_skill(skills_dir, name, frontmatter_extra="", body="Do the thing."):
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    content = f"""\
+---
+name: {name}
+description: Description for {name}.
+{frontmatter_extra}---
+
+# {name}
+
+{body}
+"""
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+    return skill_dir
+
+
+def _declaring(name, level="high"):
+    return f"metadata:\n  hermes:\n    reasoning_effort: {level}\n"
+
+
+class _FakeAgent:
+    def __init__(self, reasoning_config):
+        self.reasoning_config = reasoning_config
+
+
+class TestDeclaredReasoningEffort:
+    def test_frontmatter_string_form_parses_to_a_level(self):
+        fm = {"metadata": {"hermes": {"reasoning_effort": "high"}}}
+        assert declared_reasoning_effort(fm) == {"enabled": True, "effort": "high"}
+
+    def test_frontmatter_mapping_form_yields_its_effort(self):
+        fm = {"metadata": {"hermes": {"reasoning_effort": {"effort": "max", "scope": "turn"}}}}
+        assert declared_reasoning_effort(fm) == {"enabled": True, "effort": "max"}
+
+    def test_undeclared_skill_returns_none(self):
+        assert declared_reasoning_effort({"metadata": {"hermes": {"tags": []}}}) is None
+        assert declared_reasoning_effort({}) is None
+        assert declared_reasoning_effort({"metadata": "oops"}) is None
+
+    def test_unknown_level_is_ignored(self):
+        fm = {"metadata": {"hermes": {"reasoning_effort": "galaxy-brain"}}}
+        assert declared_reasoning_effort(fm) is None
+
+    def test_explicit_disable_is_honored(self):
+        fm = {"metadata": {"hermes": {"reasoning_effort": "none"}}}
+        assert declared_reasoning_effort(fm) == {"enabled": False}
+
+
+class TestOverrideLifecycle:
+    """Entering a declaring skill raises the level; leaving it restores the old one."""
+
+    def _message_for(self, tmp_path, name):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            message = build_skill_invocation_message(f"/{name}")
+        assert message is not None
+        return message
+
+    def test_entering_raises_and_exiting_restores(self, tmp_path):
+        _make_skill(tmp_path, "deep-research", frontmatter_extra=_declaring("deep-research", "high"))
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            scan_skill_commands()
+            message = build_skill_invocation_message("/deep-research", "write the thesis")
+        assert message is not None
+
+        agent = _FakeAgent({"enabled": True, "effort": "medium"})
+        baseline = dict(agent.reasoning_config)
+
+        snapshot = apply_skill_reasoning_override(agent, message)
+        assert agent.reasoning_config == {"enabled": True, "effort": "high"}
+        assert snapshot["previous"] == baseline
+
+        restore_skill_reasoning_override(agent, snapshot)
+        assert agent.reasoning_config == baseline
+
+    def test_skill_without_declaration_leaves_config_untouched(self, tmp_path):
+        _make_skill(tmp_path, "plain", frontmatter_extra="")
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            scan_skill_commands()
+            message = build_skill_invocation_message("/plain", "do a thing")
+        assert message is not None
+
+        agent = _FakeAgent({"enabled": True, "effort": "medium"})
+        snapshot = apply_skill_reasoning_override(agent, message)
+
+        assert snapshot is None
+        assert agent.reasoning_config == {"enabled": True, "effort": "medium"}
+
+    def test_non_skill_message_never_raises(self):
+        agent = _FakeAgent({"enabled": True, "effort": "low"})
+        assert apply_skill_reasoning_override(agent, "just a normal question") is None
+        assert apply_skill_reasoning_override(agent, None) is None
+        assert agent.reasoning_config == {"enabled": True, "effort": "low"}
+
+    def test_session_scope_survives_the_restore(self, tmp_path):
+        _make_skill(
+            tmp_path,
+            "long-haul",
+            frontmatter_extra=(
+                "metadata:\n  hermes:\n    reasoning_effort:\n      effort: max\n      scope: session\n"
+            ),
+        )
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            scan_skill_commands()
+            message = build_skill_invocation_message("/long-haul")
+        assert message is not None
+
+        agent = _FakeAgent({"enabled": True, "effort": "medium"})
+        snapshot = apply_skill_reasoning_override(agent, message)
+        assert agent.reasoning_config == {"enabled": True, "effort": "max"}
+
+        restore_skill_reasoning_override(agent, snapshot)
+        # The session-scoped level is what a later turn restores, not the pre-skill level.
+        assert agent.reasoning_config == {"enabled": True, "effort": "max"}
+
+
+class TestMessageDetection:
+    def test_single_skill_scaffold_is_detected(self, tmp_path):
+        _make_skill(tmp_path, "deep-research", frontmatter_extra=_declaring("deep-research", "high"))
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            scan_skill_commands()
+            message = build_skill_invocation_message("/deep-research", "go")
+        declaration = declaration_for_message(message)
+        assert declaration is not None
+        assert declaration["config"] == {"enabled": True, "effort": "high"}
+        assert declaration["scope"] == "turn"
+
+    def test_declaration_bypasses_idempotence_cache(self, tmp_path):
+        """Two builds of the same scaffold must both resolve their declaration."""
+        _make_skill(tmp_path, "deep-research", frontmatter_extra=_declaring("deep-research", "high"))
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            scan_skill_commands()
+            first = declaration_for_message(build_skill_invocation_message("/deep-research", "one"))
+            second = declaration_for_message(build_skill_invocation_message("/deep-research", "two"))
+        assert first is not None and second is not None
+        assert first["config"] == second["config"]
+
+    def test_plain_text_is_not_a_scaffold(self, tmp_path):
+        assert declaration_for_message("hello there") is None
+        assert declaration_for_message("") is None
+
+    def test_plain_skill_scaffold_is_not_opt_in(self, tmp_path):
+        """A scaffold whose skill declares nothing must not be treated as opted in."""
+        _make_skill(tmp_path, "plain")
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            scan_skill_commands()
+            message = build_skill_invocation_message("/plain", "go")
+        assert message is not None
+        assert declaration_for_message(message) is None
+
+    def test_stacked_bundle_resolves_the_declaring_skill(self, tmp_path):
+        """A stacked `/a /b` scaffold declares per block; the declaring one wins."""
+        _make_skill(tmp_path, "plain")
+        _make_skill(tmp_path, "deep-research", frontmatter_extra=_declaring("deep-research", "max"))
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            scan_skill_commands()
+            built = build_stacked_skill_invocation_message(["/plain", "/deep-research"], "go")
+        assert built is not None
+        declaration = declaration_for_message(built[0])
+        assert declaration == {"config": {"enabled": True, "effort": "max"}, "scope": "turn"}


### PR DESCRIPTION
## What Problem This Solves

`reasoning_effort` is a session/agent-level setting today, so a skill that needs deep thinking (thesis building, research) gets whatever level the session happens to run at, and the user has to raise it by hand before invoking the skill and lower it afterwards — the report also points out that the heavy phase is precisely the part nobody remembers to configure (#108770).

A skill can now declare its own tier in frontmatter:

```yaml
metadata:
  hermes:
    reasoning_effort: high           # or {effort: max, scope: session}
```

When such a skill is invoked, `build_turn_context` raises `agent.reasoning_config` **before any request is assembled**, so the raise covers the whole turn, and `run_conversation` restores the previous value in a `finally` — an error or an interrupt cannot strand the raised level. `scope: turn` (default) restores at turn end; `scope: session` makes the declared level the thing later restores, for a skill that owns the rest of the session.

Design notes:

- **Opt-in only.** A skill without the key changes nothing, and the declaration is validated through the existing `hermes_constants.parse_reasoning_effort` ladder rather than a second vocabulary — an unknown value is logged and ignored. `reasoning_effort: none` is honoured (a skill may legitimately want thinking off).
- **Resolved from the injected scaffold, not from disk.** The slash-command scaffold already carries each skill's SKILL.md verbatim, so the declaration is read from the message the model actually received: no second disk read, no TOCTOU between the file and the turn, and it works for stacked `/a /b` bundles (each block declares for itself).

## Evidence

```
$ HERMES_PYTHON=<venv>/python.exe bash scripts/run_tests.sh tests/agent/test_skill_reasoning_effort.py
=== Summary: 1 files, 14 tests passed, 0 failed (100% complete) in 3.1s (40 workers) ===
```

The 14 cases pin behaviour rather than implementation: string and mapping frontmatter forms, an unknown level ignored, an explicit `none` honoured, enter-raises/exit-restores, session scope surviving the restore, a declaring skill inside a stacked bundle, and three negative cases (plain skill scaffold, plain text, `None`) that must leave `agent.reasoning_config` untouched.

Not covered here: the level is a per-turn raise, not a scheduler — a skill cannot hand a tier to a *later* turn other than through `scope: session`, and delegated/sub-agent turns inherit the agent they run on.

Closes #108770
