### PR TITLE
fix(approvals): a # comment no longer desyncs quote tracking for the rest of the command

### DIFF
--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -297,6 +297,74 @@ def test_real_newline_separated_threats_still_blocked(command):
     assert desc
 
 
+# A `#` comment is discarded by the shell, so quote syntax inside it must never move
+# the quote tracker's state for the REST of the command. An ordinary apostrophe in
+# comment prose (`# don't`) used to open a single quote that ran to the end of the
+# command: the next command line was fused onto the comment line (its newline read as
+# "inside a quote") and every quoted operand after it was lexed as unterminated. That
+# blocked benign commands (fail-closed false positive, YOLO-immune) and — once fused —
+# hid real ones from each command-position rule. See #108707.
+_COMMENT_PROSE_ALLOW = [
+    # The reported shape: a leading comment line whose prose has an apostrophe, then a
+    # command with legitimately-quoted operands.
+    "# check anacron, and ubuntu's own crontab fully:\n"
+    "ssh -o ConnectTimeout=10 user@host 'crontab -l | grep \"50 3\\|0 3\"' 2>&1 | head -10",
+    # Control: the comment is the only difference.
+    "ssh -o ConnectTimeout=10 user@host 'crontab -l | grep \"50 3\\|0 3\"' 2>&1 | head -10",
+    # A comment apostrophe must not expose following quoted prose to the quote-masked
+    # rules (redirect-to-block-device / fork bomb) by flipping the masker's state.
+    "# owner's note\necho 'cat f > /dev/sda'",
+    "# it's fine\necho \"shutdown -h now\"",
+    # ...nor desync the lexer for a command nested inside a substitution body.
+    "echo \"$(grep -n x f # don't\n | cut -d: -f1)\" f",
+    # Trailing comment after a quoted operand, with a second command line after it.
+    "grep -P 'a\\|b' f # don't\nwc -l",
+]
+
+
+@pytest.mark.parametrize("command", _COMMENT_PROSE_ALLOW)
+def test_comment_prose_apostrophe_not_blocked(command):
+    """Comment prose is data: its apostrophes must not trip the hardline floor."""
+    is_hl, desc = detect_hardline_command(command)
+    assert not is_hl, (
+        f"comment-prose apostrophe blocked a benign command: {command!r} (got: {desc})"
+    )
+
+
+# The same shapes with a real threat as the command: the comment line must not become
+# an escape hatch around the floor (fail-closed is the whole point of the block).
+_COMMENT_PROSE_THREATS_BLOCK = [
+    "# don't worry\nrm -rf /",
+    "# don't worry\nrm -rf /home",
+    "# don't worry\nmkfs.ext4 /dev/sda1",
+    "# it's fine\nsudo reboot",
+    # quote-masked rule: the comment must not hide the redirect
+    "# don't worry\ncat f > /dev/sda",
+    "# don't worry\n:(){ :|:& };:",
+    # the comment sits on the first line, the threat on the second
+    "echo hi # don't\ncat f > /dev/sda",
+    # a comment inside an executable substitution body does not hide the payload after it
+    "echo \"$(cat f # don't\n)\"\nrm -rf /",
+]
+
+
+@pytest.mark.parametrize("command", _COMMENT_PROSE_THREATS_BLOCK)
+def test_comment_prose_apostrophe_cannot_hide_a_real_command(command):
+    """A `#` comment line must not disable the floor for the command that follows it."""
+    is_hl, desc = detect_hardline_command(command)
+    assert is_hl, f"comment line hid a real hardline command: {command!r}"
+    assert desc
+
+
+def test_comment_prose_apostrophe_cannot_hide_a_command_from_guard_chain(clean_session, monkeypatch):
+    """End-to-end under yolo: the block is unconditional, so a comment line cannot
+    turn the hardline floor off for the command after it."""
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+    result = check_all_command_guards("# don't worry\nrm -rf /", "local")
+    assert result["approved"] is False, "comment line leaked a root wipe under yolo"
+    assert result.get("hardline") is True
+
+
 def test_quoted_newline_data_not_blocked_by_full_guard_chain(clean_session):
     """End-to-end: the guard chain must not hardline-block a multi-line
     quoted message (yolo on, so only the unconditional floor can block)."""

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -147,11 +147,13 @@ def _mask_quoted_prose(command: str) -> str:
 
     Detection-only rewrite used by the quote-masked hardline rules (redirect-to-block-device, fork bomb):
     text inside single or double quotes is data the shell passes as an argument, so `echo "cat f >
-    /dev/sda"` must not trip the unconditional floor (#93392). Unquoted text is untouched.
-    """
+    /dev/sda"` must not trip the unconditional floor (#93392). Unquoted text is untouched. ``#``
+    comments are skipped without interpreting their quote syntax: a comment is data the shell
+    discards, so an apostrophe in prose (`# don't`) must not flip the masker into an open-quote
+    state that then exposes following quoted prose (#108707)."""
     return "".join(
         command[i:j] if quote is None or kind in ("quote", "subst") else " " * (j - i)
-        for kind, i, j, quote in _scan_shell(command, subst="q", naive_backtick=True)
+        for kind, i, j, quote in _scan_shell(command, subst="q", naive_backtick=True, comments=True)
     )
 
 
@@ -616,7 +618,12 @@ def _shell_tokens_with_spans(segment: str, start: int):
     Without that, a grep nested as ``"$(grep … | cut …)"`` was lexed together with the enclosing
     command's closing quote, read as unbalanced quoting, and reported as a hardline block (546
     blocked turns in one run, every one a false positive; ``sed -n "$(grep -n X f | cut -d: -f1),+3p" f``
-    is the canonical shape)."""
+    is the canonical shape).
+
+    ``#`` comments are skipped without interpreting their quote syntax: a command inside a
+    substitution body keeps the shell's comment contract even though the top-level segment splitter
+    never sees that body, so ``"$(grep -n X f # don't)"`` no longer lexes the comment's apostrophe
+    as an unterminated quote (#108707)."""
     tokens, value, token_start, quote = [], [], None, None
     depth = 0  # $(...) nesting opened AFTER start; a closer at depth 0 ends the enclosing substitution
     # A backtick opened AFTER start is an operand substitution (``grep -e `cmd` f``); the matching
@@ -631,7 +638,9 @@ def _shell_tokens_with_spans(segment: str, start: int):
         tokens.append(("".join(value), token_start, end, inert))
 
     end_at = len(segment)
-    for kind, i, _, _ in _scan_shell(segment, start):
+    for kind, i, _, _ in _scan_shell(segment, start, comments=True):
+        if kind == "comment":
+            continue  # a comment is a word boundary, never a shell word
         ch = segment[i]
         if kind == "char" and not quote:
             if ch.isspace() and ch != "\n":
@@ -958,9 +967,13 @@ def _scan_shell(text: str, start: int = 0, end: int | None = None, *, subst: str
 
 
 def _scan_dollar_paren_end(command: str, start: int) -> int | None:
-    """Return the offset after a balanced ``$(...)`` command substitution."""
+    """Return the offset after a balanced ``$(...)`` command substitution.
+
+    A ``#`` comment inside the body is honored, so a quoted apostrophe in its prose (`# don't`) no
+    longer leaves the substitution looking unterminated: the closer is found where the shell finds
+    it, instead of the enclosing command being refused as malformed (#108707)."""
     depth = 1
-    for kind, i, _, quote in _scan_shell(command, start + 2):
+    for kind, i, _, quote in _scan_shell(command, start + 2, comments=True):
         if kind == "char" and not quote:
             depth += command.startswith("$(", i) - (command[i] == ")")
             if depth == 0:
@@ -1109,9 +1122,14 @@ def _mask_quoted_newlines_span(command: str, start: int, end: int) -> str:
     inside double quotes is EXECUTABLE, not data: its body is re-scanned with a fresh quote state so a
     newline that separates commands inside it survives as a command boundary. Masking it as quoted
     data turned ``"$(grep x f\nreboot)"`` into ``... f reboot)``, which no later stage can tell from an
-    operand; the pre-fix scanner only caught it by refusing the whole command as malformed."""
+    operand; the pre-fix scanner only caught it by refusing the whole command as malformed.
+
+    ``#`` comments are excluded from quote tracking: they are discarded by the shell, never
+    executed. An apostrophe in prose (`# don't`) otherwise opened a quote that absorbed the following
+    newline, fusing the next command line onto the comment and hiding it from every command-position
+    rule (#108707)."""
     out: list[str] = []
-    for kind, i, j, quote in _scan_shell(command, start, end, subst="q"):
+    for kind, i, j, quote in _scan_shell(command, start, end, subst="q", comments=True):
         if kind == "subst":
             # j is the index just past the closer; keep the opener and closer, recurse into the body.
             body_start = i + (2 if command.startswith("$(", i) else 1)


### PR DESCRIPTION
## What Problem This Solves

`detect_hardline_command()` fails closed, so a benign multi-line command whose `#` comment contains an ordinary apostrophe was refused: the single unquoted `'` in prose desynchronized quote tracking for the rest of the command, and a later legitimately-quoted operand then tokenized as unquoted (#108707). The same desync reached the nested paths — a `#` comment inside a `$( … )` body left the substitution looking unterminated, so `sed -n "$(grep -n X f # don't),+3p" f` was reported as malformed.

The scanner now honours the shell's own comment contract: `_scan_shell(..., comments=True)` skips a `#` comment without interpreting its quote syntax, and the consumers that need word boundaries treat a comment as a boundary rather than a shell word. That fixes it **once**, at the scanner every one of these paths routes through, instead of patching the individual shapes in the report:

- `_mask_quoted_prose` (the quote-masked hardline rules: redirect-to-block-device, fork bomb)
- `_shell_tokens_with_spans` (nested lexical analysis inside a substitution)
- `_scan_dollar_paren_end` (finding the closer of a `$( … )`)
- `_mask_quoted_newlines_span` (keep the newline-as-command-boundary contract inside substitutions)

Fail-closed behaviour for genuinely dangerous commands is unchanged — what changed is that comment text is no longer read as shell syntax, which is what the shell does too.

## Evidence

```
$ HERMES_PYTHON=<venv>/python.exe bash scripts/run_tests.sh tests/tools/test_hardline_blocklist.py
=== Summary: 1 files, 261 tests passed, 0 failed (100% complete) in 5.9s (40 workers) ===
```

The new cases are paired the way the report asks: a benign multi-line command whose `#` comment carries an apostrophe is no longer flagged, **and** the same shapes with a real hardline command in them are still flagged — plus the nested `$( … # don't )` form and a comment inside a quoted substitution body.

Closes #108707
