### PR TITLE
fix(tui): kanban completions reach the conversation after a session rotation

### DIFF
--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -14,6 +14,7 @@ unsubscribe) and ``_format_kanban_event_text``.
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import tui_gateway.server as server
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_db_connect as kbc
 from hermes_cli import kanban_db_notify as kbn
@@ -192,6 +193,41 @@ class TestCollectKanbanNotifications:
         assert _collect_kanban_notifications({"session_key": ""}) == []
         assert _collect_kanban_notifications({"session_key": None}) == []
         assert len(_sub_rows(tid)) == 1
+
+    def test_completion_created_before_compression_replays_on_the_continuation(self, monkeypatch, tmp_path):
+        """A task created by a session that later rotated must still notify that conversation.
+
+        ``kanban_create`` binds the subscription's ``chat_id`` to ``HERMES_SESSION_KEY`` at creation
+        time. Context compression ends that session and forks a continuation, and every resume path
+        follows the tip (``session.resume`` answers with the child as ``session_key``), so after a
+        reconnect the live session key is the continuation while the subscription still names the
+        rotated-out parent. Claiming on exact equality left the completion unclaimed forever: the
+        cursor stayed at the creation event and the completion never replayed.
+        """
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("parent_root", source="tui")
+        db.end_session("parent_root", "compression")
+        db.create_session("cont_tip", source="tui", parent_session_id="parent_root")
+        monkeypatch.setattr(server, "_get_db", lambda: db)
+        try:
+            tid = _create_subscribed_task(chat_id="parent_root")
+            pre_cursor = _sub_rows(tid)[0]["last_event_id"]
+            _complete(tid, summary="survived the rotation")
+
+            texts = _collect_kanban_notifications(_session("cont_tip"))
+
+            assert len(texts) == 1, texts
+            assert tid in texts[0]
+            assert "survived the rotation" in texts[0]
+            # Claimed exactly once: the continuation now owns the subscription's cursor.
+            assert _collect_kanban_notifications(_session("cont_tip")) == []
+            rows = _sub_rows(tid)
+            assert len(rows) == 1
+            assert rows[0]["last_event_id"] > pre_cursor
+        finally:
+            db.close()
 
     def test_profile_scoped_session_reads_the_shared_board(self, tmp_path):
         """The kanban board is shared across profiles BY DESIGN (see the

--- a/tui_gateway/session_notifications.py
+++ b/tui_gateway/session_notifications.py
@@ -296,14 +296,16 @@ def _kb_board_key(_kb, board_meta) -> tuple[str, str]:
         return slug, f"slug:{slug}"
 
 
-def _kb_poll_board(_kb, slug: str, session_key: str) -> list:
+def _kb_poll_board(_kb, slug: str, session_key: "str | list[str]") -> list:
     """Claim + format this session's unseen events on one board. One poller per live session: the board is not opened
-    writable unless it has a subscription owned by this exact session (a failed read-only probe — locked/corrupt DB —
-    falls through so delivery is preserved)."""
+    writable unless it has a subscription owned by this session or by a session it descends from — the rotation
+    counterpart of ``session_key`` (a failed read-only probe — locked/corrupt DB — falls through so delivery is
+    preserved). Each subscription is claimed at most once no matter how many of those keys match it."""
     from hermes_cli import kanban_db_connect as _kbc
     from hermes_cli import kanban_db_notify as _kbn
+    claim_keys = [session_key] if isinstance(session_key, str) else list(session_key)
     with contextlib.suppress(Exception):
-        if _kbn.count_notify_subs(board=slug, platform="tui", chat_id=session_key) == 0:
+        if not any(_kbn.count_notify_subs(board=slug, platform="tui", chat_id=key) for key in claim_keys):
             return []
     try:
         conn = _kbc.connect(board=slug)
@@ -316,7 +318,7 @@ def _kb_poll_board(_kb, slug: str, session_key: str) -> list:
         except Exception:
             return []
         for sub in subs:
-            if (sub.get("platform") or "").lower() != "tui" or sub.get("chat_id") != session_key:
+            if (sub.get("platform") or "").lower() != "tui" or sub.get("chat_id") not in claim_keys:
                 continue
             sub_ident = dict(task_id=sub["task_id"], platform=sub["platform"], chat_id=sub["chat_id"],
                              thread_id=sub.get("thread_id") or "")
@@ -333,12 +335,43 @@ def _kb_poll_board(_kb, slug: str, session_key: str) -> list:
     return texts
 
 
+def _kanban_claim_keys(session_key: str) -> list:
+    """The live key first, then the rotation chain it descends from.
+
+    ``kanban_create`` binds a subscription to the key of the session that created the task. Context
+    compression ends that session and forks a continuation, and every resume path follows the tip, so
+    after a reconnect the live key is the child while the subscription still names the rotated-out
+    parent — claiming on exact equality left those completions unclaimed forever (#108410). The walk
+    is bounded and cycle-safe: a rotation chain is short, and corrupt lineage must not spin.
+    """
+    keys = [session_key]
+    try:
+        from tui_gateway.server import _get_db
+
+        db = _get_db()
+        seen = {session_key}
+        key = session_key
+        for _ in range(16):
+            row = db.get_session(key) if hasattr(db, "get_session") else None
+            parent = str((row or {}).get("parent_session_id") or "")
+            if not parent or parent in seen:
+                break
+            seen.add(parent)
+            keys.append(parent)
+            key = parent
+    except Exception:
+        pass
+    return keys
+
+
 def _collect_kanban_notifications(session: dict) -> list:
     """Claim unseen terminal kanban events for this session's ``platform="tui"`` subscriptions (``kanban_create``
     auto-subscribes with ``chat_id=HERMES_SESSION_KEY``; no "tui" messaging adapter exists, so this poller is the
-    delivery path). Same atomic cursor-claim as the gateway notifier: exactly-once even if a gateway polls the same DB.
+    delivery path). A subscription is matched by the live session key or by any session it descends from, so a
+    completion created before context compression still reaches the conversation after the continuation takes over.
+    Same atomic cursor-claim as the gateway notifier: exactly-once even if a gateway polls the same DB.
 
-    See #59890.
+    See #59890, #108410.
     """
     session_key = str(session.get("session_key") or "")
     if not session_key or session.get("_finalized"):
@@ -358,7 +391,8 @@ def _collect_kanban_notifications(session: dict) -> list:
     unique = {}
     for slug, resolved in (_kb_board_key(_kb, board_meta) for board_meta in boards):
         unique.setdefault(resolved, slug)
-    return [t for slug in unique.values() for t in _kb_poll_board(_kb, slug, session_key)]
+    claim_keys = _kanban_claim_keys(session_key)
+    return [t for slug in unique.values() for t in _kb_poll_board(_kb, slug, claim_keys)]
 
 
 def _notif_poll_kanban(sid: str, session: dict) -> None:


### PR DESCRIPTION
## What Problem This Solves

A kanban task created from a conversation completes, its terminal event is persisted — and the conversation never hears about it (#108410). `kanban_create` binds the subscription's `chat_id` to `HERMES_SESSION_KEY` **at creation time**, and this poller claimed on exact equality. Context compression ends that session and forks a continuation, and every resume path follows the tip (a resume answers with the child as `session_key`), so after a reconnect the live key is the continuation while the subscription still names the rotated-out parent. Nothing ever matched it again: the cursor stayed at the creation event and the completion could not replay.

The claim now resolves the session's **rotation chain** — the live key first, then the sessions it descends from — and matches a subscription against all of them:

- `_kanban_claim_keys(session_key)` walks `parent_session_id` from `_get_db()`; the walk is bounded (16) and cycle-safe, and any failure degrades to the single live key, i.e. the old behaviour rather than a broken poller.
- `_kb_poll_board(..., session_key | [keys])` accepts the chain: the cheap "has this board got a subscription for me" probe checks every key, and the claim loop matches `chat_id in claim_keys`. Each subscription is still claimed **at most once** per poll, no matter how many keys match it — the cursor advance inside `claim_unseen_events_for_sub` remains the exactly-once guarantee it was.

Nothing about delivery semantics changes for an unrotated session: with no parent, the chain is just `[session_key]`.

## Evidence

Green, with the new case (1 file, 15 tests):

```
$ HERMES_PYTHON=<venv>/python.exe bash scripts/run_tests.sh tests/tui_gateway/test_kanban_notify_poller.py
=== Summary: 1 files, 15 tests passed, 0 failed (100% complete) in 12.4s (40 workers) ===
```

Red without the source change — the test is a real specification, not a description of the patch (source file stashed, test kept):

```
$ python -m pytest tests/tui_gateway/test_kanban_notify_poller.py::TestCollectKanbanNotifications::test_completion_created_before_compression_replays_on_the_continuation
E   AssertionError: []
    assert 0 == 1
     +  where 0 = len([])
1 failed in 1.09s
```

That case builds the real shape: a task subscribed by `parent_root`, the parent ended with reason `compression`, a continuation `cont_tip` created with `parent_session_id=parent_root`, then a completion — and asserts the completion replays to `cont_tip` exactly once (the second poll returns nothing and the subscription's cursor has advanced, so it is not re-delivered).

Closes #108410
