### PR TITLE
fix(desktop): show the prompt rail from the first user turn

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/timeline-idle.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline-idle.test.tsx
@@ -123,13 +123,21 @@ describe('ThreadTimeline popover', () => {
   })
 })
 
-describe('ThreadTimeline below the threshold', () => {
-  it('renders nothing for a short thread', () => {
-    messages = transcript(2)
+describe('ThreadTimeline with no user turns yet', () => {
+  it('renders nothing before the first prompt', () => {
+    messages = []
 
     const { container } = renderTimeline()
 
     expect(container.querySelector('[data-slot="thread-timeline"]')).toBeNull()
+  })
+
+  it('renders the rail from the very first prompt', () => {
+    messages = transcript(1)
+
+    const { container } = renderTimeline()
+
+    expect(container.querySelector('[data-slot="thread-timeline"]')).not.toBeNull()
   })
 })
 

--- a/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/timeline.tsx
@@ -13,7 +13,7 @@ import {
   type TimelineSourceMessage
 } from './timeline-data'
 
-const MIN_ENTRIES = 4
+const MIN_ENTRIES = 1
 const VIEWPORT = '[data-slot="aui_thread-viewport"]'
 const HOVER_CLOSE_MS = 140
 
@@ -125,7 +125,7 @@ function scrollToPrompt(root: HTMLElement | null, id: string) {
 }
 
 /**
- * Right-edge prompt rail — hover previews, click to jump. ≥4 user turns only.
+ * Right-edge prompt rail — hover previews, click to jump. Any user turn.
  *
  * Everything here is DEFERRED until it can actually be seen. A chat surface
  * stays mounted while its tab is in the background (keep-alive, see
@@ -137,7 +137,7 @@ function scrollToPrompt(root: HTMLElement | null, id: string) {
  *     selector, the scroll listener, and the popover markup all stand down.
  *  2. ACTIVE BUT UNHOVERED → the ticks paint, but the popover's rows are not
  *     built at all; the previews only exist once the pointer opens it.
- *  3. BELOW THE THRESHOLD → the rail renders null, so the measure effect never
+ *  3. NO ENTRIES YET → the rail renders null, so the measure effect never
  *     touches layout for it.
  *  4. FOLLOWING THE BOTTOM → the active prompt is the last one by definition,
  *     answered from data instead of a rect walk (see compute() below).
@@ -250,7 +250,7 @@ const ActiveThreadTimeline: FC = () => {
   useEffect(() => () => window.clearTimeout(closeTimerRef.current), [])
 
   useEffect(() => {
-    // Below the threshold the rail renders null, so measuring prompt offsets
+    // No entries yet: the rail renders null, so measuring prompt offsets
     // buys nothing — bail before touching layout at all.
     if (entries.length < MIN_ENTRIES) {
       return


### PR DESCRIPTION
## What does this PR do?

The right-edge prompt rail (`thread-timeline`: hover a tick to preview one of your prompts, click to jump) only rendered once a conversation reached **4+ user turns**. For the first three prompts there was no way to jump back to an earlier prompt, and the rail then popped into existence mid-conversation on the 4th — which reads as a rendering glitch rather than a deliberate gate.

This lowers `MIN_ENTRIES` in `apps/desktop/src/components/assistant-ui/thread/timeline.tsx` from `4` to `1`, so the rail is available from the very first user turn. All of the component's existing deferral guarantees are unchanged:

- an inactive pane still renders null and subscribes to nothing
- an active-but-unhovered rail still paints ticks without building the popover rows
- the measure effect still bails out before touching layout when there are no entries yet
- "following the bottom" is still answered from data instead of a rect walk

Only the threshold itself changes (`entries.length < MIN_ENTRIES`, `4` → `1`), matching the "render the rail from the first user turn" option proposed in the issue.

## Related Issue

Fixes #108922

## Changes Made

- `apps/desktop/src/components/assistant-ui/thread/timeline.tsx`: `MIN_ENTRIES` 4 → 1; updated the two comments that described the old ≥4 threshold.
- `apps/desktop/src/components/assistant-ui/thread/timeline-idle.test.tsx`: replaced the "below the threshold" test (which asserted a 2-prompt thread renders nothing) with two tests — zero user turns still renders nothing, and a single user turn now renders the rail.

## How to Test

1. Start a new chat and send one prompt.
2. Hover the right edge of the transcript — the rail (a single tick) should now appear, with the hover popover showing that one prompt.
3. Previously this required 4 prompts before anything appeared.

Also verified by proving the new test fails without the fix:

```
$ git checkout HEAD~1 -- apps/desktop/src/components/assistant-ui/thread/timeline.tsx
$ npx vitest run --project ui src/components/assistant-ui/thread/timeline-idle.test.tsx
 × ThreadTimeline with no user turns yet > renders the rail from the very first prompt
   AssertionError: expected null not to be null
 Test Files  1 failed (1)
      Tests  1 failed | 7 passed (8)

$ git checkout HEAD -- apps/desktop/src/components/assistant-ui/thread/timeline.tsx
$ npx vitest run --project ui src/components/assistant-ui/thread/timeline-idle.test.tsx src/components/assistant-ui/thread/timeline.test.ts src/components/assistant-ui/thread/timeline-data.test.ts
 Test Files  3 passed (3)
      Tests  20 passed (20)
```

Full verification with the fix applied:

- `npx vitest run --project ui src/components/assistant-ui/thread/` → 34 files, 193 tests passed
- `npx tsc -p . --noEmit` (root desktop tsconfig) → clean
- `npx eslint src/components/assistant-ui/thread/timeline.tsx src/components/assistant-ui/thread/timeline-idle.test.tsx` → clean
- `npx vitest run --project ui` (full desktop UI suite) → 797/798 files, 7580/7582 tests passed. The 2 failures are in `src/store/voice-prefs.test.ts`, a file untouched by this change; they reproduce identically on an unmodified checkout and are called out as a pre-existing, unrelated failure in PR #106169's own verification notes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've added/updated a test for my change
- [x] I've tested on my platform: Linux (CI-style headless run via vitest/jsdom)

## AI assistance disclosure

This change was prepared with the assistance of an AI coding agent (Claude), including investigation, the code change, and the test update. All test output above was actually executed and captured from this checkout, not fabricated.
