### PR TITLE
feat(voice): add Codex subscription billing to native GPT-Live

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -6,13 +6,13 @@ import { chatMessageText, collectUnspokenTurnSpeech } from '@/lib/chat-messages'
 import { triggerHaptic } from '@/lib/haptics'
 import { adoptSpokenReplySession, markAssistantIdSpoken, resolveSpokenReply } from '@/lib/spoken-reply'
 import { CONVERSATION_LEASE, READ_ALOUD_LEASE, syncTtsLease } from '@/lib/tts-lease'
-import { toLiveHistory } from '@/lib/voice-live'
+import { resolveVoiceConversationStart, toLiveHistory } from '@/lib/voice-live'
 import { clearWakeIndicator, syncWakeIndicatorWithVoice } from '@/lib/wake-indicator'
 import { $voiceConversationStartRequest, takeVoiceConversationStart } from '@/store/composer'
 import { resetBrowseState } from '@/store/composer-input-history'
 import { $gateway } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
-import { $voiceLiveStatus, refreshVoiceLiveStatus, selectedVoiceChatMode } from '@/store/voice-live'
+import { refreshVoiceLiveStatus } from '@/store/voice-live'
 import { $autoSpeakReplies, $voiceStopPhrase, setAutoSpeakReplies } from '@/store/voice-prefs'
 import { resumeWakeAfterVoice } from '@/store/wake-word'
 
@@ -216,25 +216,25 @@ export function useComposerVoice({
   /** Turn the conversation on with the engine `voice.voice_chat_mode` selects,
    *  decided in the same state batch so the other engine never sees a frame of
    *  `enabled`. gpt-live selected but not startable (no OpenAI key on the
-   *  gateway) falls back to chained with a notice rather than a dead button. */
-  const activateConversation = useCallback(() => {
-    const status = $voiceLiveStatus.get()
-    let live = false
+   *  gateway) falls back to chained with a notice only for API mode. Explicit
+   *  subscription mode refuses to activate a different billed engine. */
+  const activateConversation = useCallback(async () => {
+    try {
+      const { mode, fallbackReason } = await resolveVoiceConversationStart()
 
-    if (selectedVoiceChatMode(status) === 'gpt-live') {
-      if (status?.available) {
-        live = true
-      } else {
+      if (fallbackReason) {
         notify({
           id: 'voice-live-unavailable',
           kind: 'warning',
-          message: t.notifications.voice.liveUnavailable(status?.reason ?? 'not configured')
+          message: t.notifications.voice.liveUnavailable(fallbackReason)
         })
       }
-    }
 
-    setLiveEngineActive(live)
-    setVoiceConversationActive(true)
+      setLiveEngineActive(mode === 'gpt-live')
+      setVoiceConversationActive(true)
+    } catch (error) {
+      notifyError(error)
+    }
   }, [t])
 
   useEffect(() => {

--- a/apps/desktop/src/lib/voice-live-subscription.test.ts
+++ b/apps/desktop/src/lib/voice-live-subscription.test.ts
@@ -1,0 +1,190 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { hermesApi } from '@/hermes'
+import { fetchVoiceLiveStatus, resolveVoiceConversationStart, VoiceLiveSession } from '@/lib/voice-live'
+
+vi.mock('@/api/client', () => ({ profileScoped: () => ({ profile: 'test' }) }))
+vi.mock('@/hermes', () => ({ hermesApi: vi.fn() }))
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.resetAllMocks()
+  vi.restoreAllMocks()
+})
+
+function media() {
+  const sent: Array<Record<string, unknown>> = []
+  const events = Object.assign(new EventTarget(), {
+    readyState: 'open',
+    close: vi.fn(),
+    send: (raw: string) => sent.push(JSON.parse(raw))
+  })
+  const track = { enabled: true, stop: vi.fn() }
+  vi.stubGlobal('navigator', {
+    mediaDevices: {
+      getUserMedia: async () => ({ getAudioTracks: () => [track], getTracks: () => [track] })
+    }
+  })
+  vi.stubGlobal(
+    'Audio',
+    class {
+      autoplay = false
+      srcObject = null
+      pause() {}
+    }
+  )
+  vi.stubGlobal(
+    'RTCPeerConnection',
+    class extends EventTarget {
+      iceGatheringState = 'complete'
+      localDescription = { sdp: 'v=0 offer', type: 'offer' }
+      addTrack() {}
+      close() {}
+      createDataChannel() {
+        return events
+      }
+      async createOffer() {
+        return this.localDescription
+      }
+      async setLocalDescription() {}
+      async setRemoteDescription() {}
+    }
+  )
+  return {
+    events,
+    sent,
+    track,
+    receive: (event: unknown) => events.dispatchEvent(new MessageEvent('message', { data: JSON.stringify(event) }))
+  }
+}
+
+describe('native Live explicit billing', () => {
+  it.each(['api', 'subscription'] as const)(
+    'keeps %s voice events and Hermes replies on the selected protocol',
+    async auth => {
+      const wire = media()
+      const onDelegation = vi.fn()
+      const onTranscript = vi.fn()
+      const onClosed = vi.fn()
+      vi.mocked(hermesApi).mockResolvedValueOnce({
+        ok: true,
+        auth,
+        session: { id: 'rtc_fixture' },
+        transport: { type: 'webrtc', sdp: 'v=0 answer' }
+      })
+      const session = new VoiceLiveSession({ onDelegation, onTranscript, onClosed, onError: vi.fn() })
+      await session.start([])
+      wire.receive({ type: 'session.started', session: { id: 'rtc_fixture' } })
+      expect(session.connected).toBe(true)
+      const delegation =
+        auth === 'subscription'
+          ? {
+              type: 'delegation.created',
+              item: {
+                id: 'provider-delegation',
+                type: 'delegation',
+                target: 'client',
+                content: [{ type: 'input_text', text: 'provider paraphrase is not the user transcript' }]
+              }
+            }
+          : {
+              type: 'session.delegation.created',
+              delegation: { id: 'provider-delegation', type: 'delegation', target: 'client' }
+            }
+      wire.receive(
+        auth === 'subscription'
+          ? { type: 'input_transcript.added', item: { text: 'Read the project status.' } }
+          : { type: 'session.input_transcript.delta', delta: 'Read the project status.', start_ms: 1, end_ms: 5 }
+      )
+      wire.receive(delegation)
+      wire.receive(delegation)
+      expect(onDelegation).toHaveBeenCalledTimes(1)
+      expect(onDelegation.mock.calls[0][0]).toBe('provider-delegation')
+      expect(onDelegation.mock.calls[0][1].map((part: { text: string }) => part.text)).toEqual([
+        'Read the project status.'
+      ])
+      expect(onTranscript).toHaveBeenCalledTimes(1)
+      if (auth === 'subscription') {
+        vi.spyOn(performance, 'now').mockReturnValue(performance.now() + 6 * 60_000)
+        wire.receive({ type: 'input_transcript.added', item: { text: 'Use only this fresh request.' } })
+        expect(session.contextWindow().map(part => part.text)).toEqual(['Use only this fresh request.'])
+        expect(session.contextWindow()[0].timestampSource).toBe('arrival')
+      }
+
+      const answer = 'Project ready. ' + '✅漢字'.repeat(180)
+      session.speak('provider-delegation', answer)
+      session.think('provider-delegation', 'Hermes is checking.')
+      session.instruct('Speak briefly.')
+      const commandCount = wire.sent.length
+      session.setMuted(true)
+      expect(wire.track.enabled).toBe(false)
+      if (auth === 'subscription') {
+        const spoken = wire.sent.filter(event => event.channel === 'speakable')
+        const contents = spoken.map(event => (event.content as Array<{ text: string }>)[0].text)
+        expect(contents.join('')).toBe(answer)
+        expect(contents.every(text => new TextEncoder().encode(text).length <= 500)).toBe(true)
+        expect(
+          spoken.every(
+            event => event.type === 'delegation.context.append' && event.delegation_item_id === 'provider-delegation'
+          )
+        ).toBe(true)
+        expect(wire.sent.at(-1)).toMatchObject({ type: 'session.context.append', channel: 'commentary' })
+        expect(wire.sent).toHaveLength(commandCount)
+      } else {
+        expect(wire.sent[0]).toMatchObject({ type: 'session.commentary.append', delegation_id: 'provider-delegation' })
+        expect(wire.sent.at(-1)?.type).toBe('session.input_audio.mute')
+      }
+      wire.receive({ type: 'session.closed', reason: 'closed' })
+      expect(onClosed).toHaveBeenCalledOnce()
+      expect(wire.track.stop).toHaveBeenCalledOnce()
+    }
+  )
+
+  it('waits for authoritative billing and never selects a fallback for subscription, invalid or unknown status', async () => {
+    let resolveStatus!: (value: unknown) => void
+    vi.mocked(hermesApi).mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveStatus = resolve
+        })
+    )
+    const pending = resolveVoiceConversationStart()
+    let settled = false
+    void pending.then(
+      () => {
+        settled = true
+      },
+      () => {
+        settled = true
+      }
+    )
+    await Promise.resolve()
+    expect(settled).toBe(false)
+    resolveStatus({ ok: true, mode: 'gpt-live', auth: 'subscription', available: true })
+    await expect(pending).resolves.toEqual({ mode: 'gpt-live', fallbackReason: null })
+
+    const unavailable = {
+      ok: true,
+      mode: 'gpt-live',
+      auth: 'subscription',
+      available: false,
+      reason: 'Codex sign-in needed',
+      model: 'gpt-live-1-codex',
+      voice: 'cove'
+    }
+    vi.mocked(hermesApi).mockResolvedValueOnce(unavailable)
+    expect((await fetchVoiceLiveStatus())?.auth).toBe('subscription')
+    for (const result of [unavailable, { ...unavailable, auth: 'invalid' }, null]) {
+      vi.mocked(hermesApi).mockResolvedValueOnce(result)
+      await expect(resolveVoiceConversationStart()).rejects.toThrow()
+    }
+    vi.mocked(hermesApi).mockResolvedValueOnce({ ...unavailable, auth: 'api' })
+    await expect(resolveVoiceConversationStart()).resolves.toEqual({
+      mode: 'chained',
+      fallbackReason: unavailable.reason
+    })
+    vi.mocked(hermesApi).mockResolvedValueOnce({ ...unavailable, mode: 'chained' })
+    await expect(resolveVoiceConversationStart()).resolves.toEqual({ mode: 'chained', fallbackReason: null })
+  })
+})

--- a/apps/desktop/src/lib/voice-live.ts
+++ b/apps/desktop/src/lib/voice-live.ts
@@ -23,6 +23,8 @@ export type VoiceChatMode = 'chained' | 'gpt-live'
 
 export interface VoiceLiveStatus {
   mode: VoiceChatMode
+  /** Server-selected billing; invalid values remain visible as unavailable. */
+  auth?: string
   available: boolean
   reason: null | string
   model: string
@@ -43,6 +45,7 @@ interface LiveServerEvent {
   start_ms?: number
   end_ms?: number
   delegation?: { id: string; type: string; target: string }
+  item?: { id?: string; type?: string; target?: string; text?: string }
   error?: { type?: string; code?: null | string; message?: string; client_event_id?: string }
   usage?: { seconds?: number }
   reason?: string
@@ -54,6 +57,8 @@ export interface LiveTranscriptFragment {
   text: string
   startMs: number
   endMs: number
+  /** Frameless timing is local arrival, not provider audio timestamps. */
+  timestampSource?: 'arrival'
 }
 
 export interface VoiceLiveHandlers {
@@ -90,6 +95,7 @@ export async function fetchVoiceLiveStatus(): Promise<null | VoiceLiveStatus> {
     }
 
     return {
+      auth: response.auth ?? 'api',
       available: Boolean(response.available),
       mode: response.mode === 'gpt-live' ? 'gpt-live' : 'chained',
       model: response.model,
@@ -100,6 +106,52 @@ export async function fetchVoiceLiveStatus(): Promise<null | VoiceLiveStatus> {
     // Older backend without the endpoint → chained.
     return null
   }
+}
+
+/** Resolve billing before opening any microphone or selecting a voice engine. */
+export async function resolveVoiceConversationStart(): Promise<{ mode: VoiceChatMode; fallbackReason: null | string }> {
+  const status = await fetchVoiceLiveStatus()
+
+  if (!status) {
+    throw new Error('Voice settings are unavailable. Reconnect and try again; no voice session was started.')
+  }
+
+  if (status.mode !== 'gpt-live' || status.available) {
+    return { mode: status.mode, fallbackReason: null }
+  }
+
+  if (status.auth !== 'api') {
+    throw new Error(status.reason ?? 'GPT-Live subscription is unavailable; no API fallback was used')
+  }
+
+  return { mode: 'chained', fallbackReason: status.reason ?? 'not configured' }
+}
+
+// The Codex frameless protocol caps context appends at 500 UTF-8 bytes.
+function subscriptionChunks(text: string): string[] {
+  const chunks: string[] = []
+  const encoder = new TextEncoder()
+  let chunk = ''
+  let bytes = 0
+
+  for (const character of text.trim()) {
+    const size = encoder.encode(character).length
+
+    if (bytes + size > 500) {
+      chunks.push(chunk)
+      chunk = ''
+      bytes = 0
+    }
+
+    chunk += character
+    bytes += size
+  }
+
+  if (chunk) {
+    chunks.push(chunk)
+  }
+
+  return chunks
 }
 
 /** Split a reply into append-sized chunks on sentence boundaries. */
@@ -220,6 +272,8 @@ export class VoiceLiveSession {
   private finalized = false
   private started = false
   private eventCounter = 0
+  private subscription = false
+  private delegationIds = new Set<string>()
   private transcript: LiveTranscriptFragment[] = []
   private speakingProbe: null | number = null
   private analyser: null | AnalyserNode = null
@@ -318,6 +372,7 @@ export class VoiceLiveSession {
 
     const response = await hermesApi<{
       ok: boolean
+      auth?: string
       session?: { id: string }
       transport?: { sdp: string; type: string }
     }>({
@@ -332,6 +387,7 @@ export class VoiceLiveSession {
       throw new Error('GPT-Live session creation failed')
     }
 
+    this.subscription = response.auth === 'subscription'
     this.sessionId = response.session?.id ?? null
     await connection.setRemoteDescription({ sdp: response.transport.sdp, type: 'answer' })
   }
@@ -379,6 +435,39 @@ export class VoiceLiveSession {
       return
     }
 
+    if (this.subscription) {
+      if (event.type === 'input_transcript.added' || event.type === 'output_transcript.added') {
+        if (typeof event.item?.text !== 'string') {
+          return
+        }
+
+        // Frameless fragments have no audio timestamps. Local monotonic arrival time
+        // preserves the five-minute context window without claiming provider timing/finality.
+        const arrivedAt = performance.now()
+        event = {
+          start_ms: arrivedAt,
+          end_ms: arrivedAt,
+          delta: event.item.text,
+          type:
+            event.type === 'input_transcript.added'
+              ? 'session.input_transcript.delta'
+              : 'session.output_transcript.delta'
+        }
+      } else if (event.type === 'delegation.created') {
+        const item = event.item
+
+        if (!item?.id || item.type !== 'delegation' || item.target !== 'client') {
+          return
+        }
+
+        // Keep the provider's actual ID; work is derived from captured user words.
+        event = {
+          type: 'session.delegation.created',
+          delegation: { id: item.id, type: item.type, target: item.target }
+        }
+      }
+    }
+
     switch (event.type) {
       case 'session.started':
         this.started = true
@@ -392,7 +481,8 @@ export class VoiceLiveSession {
           endMs: event.end_ms ?? 0,
           speaker: event.type === 'session.input_transcript.delta' ? 'user' : 'assistant',
           startMs: event.start_ms ?? 0,
-          text: event.delta ?? ''
+          text: event.delta ?? '',
+          ...(this.subscription ? { timestampSource: 'arrival' as const } : {})
         }
 
         this.transcript.push(fragment)
@@ -409,7 +499,8 @@ export class VoiceLiveSession {
       case 'session.delegation.created': {
         const id = event.delegation?.id
 
-        if (id) {
+        if (id && !this.delegationIds.has(id)) {
+          this.delegationIds.add(id)
           this.activeDelegationId = id
           this.handlers.onDelegation(id, this.contextWindow())
         }
@@ -440,8 +531,25 @@ export class VoiceLiveSession {
     }
   }
 
+  private appendSubscription(delegationId: null | string, content: string, channel: 'commentary' | 'speakable'): void {
+    for (const chunk of subscriptionChunks(content)) {
+      this.send({
+        channel,
+        content: [{ text: chunk, type: 'input_text' }],
+        ...(delegationId ? { delegation_item_id: delegationId } : {}),
+        type: delegationId ? 'delegation.context.append' : 'session.context.append'
+      })
+    }
+  }
+
   /** Quiet progress for the live model ("Hermes is running the tests…"). */
   think(delegationId: null | string, content: string): void {
+    if (this.subscription) {
+      this.appendSubscription(delegationId, content, 'commentary')
+
+      return
+    }
+
     const text = content.replace(/\s+/g, ' ').trim().slice(0, APPEND_CHAR_LIMIT)
 
     if (text) {
@@ -456,6 +564,12 @@ export class VoiceLiveSession {
 
   /** A result the voice should say aloud (paraphrased). */
   speak(delegationId: null | string, content: string): void {
+    if (this.subscription) {
+      this.appendSubscription(delegationId, content, 'speakable')
+
+      return
+    }
+
     for (const chunk of chunkForCommentary(content)) {
       this.send({
         content: chunk,
@@ -468,6 +582,12 @@ export class VoiceLiveSession {
 
   /** Steer the live persona mid-conversation (session-wide). */
   instruct(content: string): void {
+    if (this.subscription) {
+      this.appendSubscription(null, content, 'commentary')
+
+      return
+    }
+
     const text = content.trim().slice(0, APPEND_CHAR_LIMIT)
 
     if (text) {
@@ -483,6 +603,11 @@ export class VoiceLiveSession {
   setMuted(muted: boolean): void {
     for (const track of this.microphone?.getAudioTracks() ?? []) {
       track.enabled = !muted
+    }
+
+    // Subscription WebRTC mutes the microphone track; it has no API mute event.
+    if (this.subscription) {
+      return
     }
 
     this.send({

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1558,6 +1558,19 @@ stt:
   #   # live result. Pin only when you need a specific Whisper variant.
   #   model: ""
 
+# Desktop full-duplex voice, with Hermes as the delegation backend.
+# Sign in with `hermes auth` -> OpenAI Codex on this host before choosing subscription.
+# API remains the default. Subscription never falls back to API or chained STT/TTS.
+# voice:
+#   voice_chat_mode: gpt-live   # chained (default) | gpt-live
+#   gpt_live:
+#     auth: subscription       # api (default) | subscription
+#     subscription_model: gpt-live-1-codex
+#     subscription_voice: cove
+#     model: gpt-live-1         # API mode only
+#     voice: marin             # API mode only
+#     instructions: ""         # optional persona additions for either mode
+
 # Text-to-speech. Only the deepinfra block is documented here — the
 # remaining providers (edge, openai, xai, minimax, mistral, gemini,
 # elevenlabs, neutts, kittentts, piper) inherit sensible defaults from

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1120,9 +1120,12 @@ DEFAULT_CONFIG = {
         #   chained  — STT → Hermes turn → TTS (the stt.* / tts.* providers below)
         #   gpt-live — one full-duplex voice model (OpenAI GPT-Live) owns the mic and speaker and
         #              DELEGATES every real request to Hermes (any model / provider you have
-        #              selected); needs an OpenAI API key. $0.05/min voice layer billing.
+        #              selected); API billing by default, or explicitly use a Codex subscription.
         "voice_chat_mode": "chained",
         "gpt_live": {
+            "auth": "api",  # api | subscription; never automatically switches billing
+            "subscription_model": "gpt-live-1-codex",
+            "subscription_voice": "cove",
             "model": "gpt-live-1",
             "voice": "marin",  # marin | quartz | ripple | vesper | willow | stone | gleam | meridian | ...
             # Extra sentences appended to the live model's conversation persona (tone, pacing, language).

--- a/tests/tools/test_voice_live_subscription.py
+++ b/tests/tools/test_voice_live_subscription.py
@@ -1,0 +1,104 @@
+"""Native Live billing selection keeps Codex OAuth private and never falls back."""
+
+import base64
+import json
+
+import httpx
+import pytest
+import yaml
+
+from hermes_cli import auth_codex
+from hermes_cli.auth_constants import AuthError
+from tools import voice_live
+
+
+def _token(account="account-fixture"):
+    claims = {"https://api.openai.com/auth": {"chatgpt_account_id": account}}
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    return f"fixture.{payload}.fixture"
+
+
+def _configure(monkeypatch, tmp_path, **live):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump({
+        "voice": {"voice_chat_mode": "gpt-live", "gpt_live": live},
+    }), encoding="utf-8")
+
+
+def test_subscription_request_uses_hermes_oauth_and_its_own_wire(monkeypatch, tmp_path):
+    _configure(monkeypatch, tmp_path, auth="subscription", model="api-model", voice="marin",
+               subscription_model="gpt-live-1-codex", subscription_voice="cove")
+    token = _token()
+    refresh = []
+    requests = []
+    history = [{"type": "message", "role": "user", "content": [
+        {"type": "input_text", "text": "Keep the existing Hermes conversation."}]}]
+
+    def credentials(**kwargs):
+        refresh.append(kwargs["refresh_if_expiring"])
+        return {"api_key": token, "auth_mode": "chatgpt"}
+
+    def transport(request):
+        requests.append(request)
+        return httpx.Response(201, text="v=0\r\nanswer", headers={
+            "Location": "/realtime/calls/rtc_fixture", "Content-Type": "application/sdp"})
+
+    client = httpx.Client
+    monkeypatch.setattr(auth_codex, "resolve_codex_runtime_credentials", credentials)
+    monkeypatch.setattr(httpx, "Client", lambda **kwargs: client(
+        transport=httpx.MockTransport(transport), **kwargs))
+    monkeypatch.setattr(voice_live, "_resolve_credentials", lambda *_: pytest.fail("paid API resolver"))
+    status = voice_live.resolve_gpt_live_status()
+    result = voice_live.create_webrtc_session("v=0 offer", history)
+
+    assert status["auth"] == result["auth"] == "subscription"
+    assert status["available"] and refresh == [False, True]
+    request, = requests
+    assert str(request.url) == (
+        "https://chatgpt.com/backend-api/codex/realtime/calls?intent=quicksilver&architecture=avas")
+    assert request.headers["Authorization"] == f"Bearer {token}"
+    assert request.headers["ChatGPT-Account-Id"] == "account-fixture"
+    assert request.headers["OpenAI-Alpha"] == "quicksilver=v2"
+    payload = json.loads(request.content)
+    assert payload["sdp"] == "v=0 offer" and "transport" not in payload
+    assert payload["session"]["initial_items"] == history and "input" not in payload["session"]
+    assert payload["session"]["delegation"] == {"type": "client"}
+    assert payload["session"]["model"] == status["model"] == "gpt-live-1-codex"
+    assert payload["session"]["audio"]["output"]["voice"] == status["voice"] == "cove"
+    assert result["session"]["id"] == "rtc_fixture"
+    assert result["transport"] == {"type": "webrtc", "sdp": "v=0\r\nanswer"}
+    assert token not in json.dumps([status, result])
+    assert "account-fixture" not in json.dumps([status, result])
+
+
+@pytest.mark.parametrize("failure", ["missing", "account", "invalid-auth", "redirect", "rejected", "sdp"])
+def test_subscription_failure_cannot_select_paid_api(monkeypatch, tmp_path, failure):
+    _configure(monkeypatch, tmp_path, auth="automatic" if failure == "invalid-auth" else "subscription")
+    attempted = []
+    private = "private-provider-detail"
+
+    def credentials(**_kwargs):
+        if failure == "missing":
+            raise AuthError(provider="openai-codex", message=private, code="codex_auth_missing")
+        return {"api_key": _token(None if failure == "account" else "account-fixture")}
+
+    def transport(request):
+        attempted.append(request)
+        if failure == "redirect":
+            return httpx.Response(307, headers={"Location": "https://other.example/collect"})
+        return httpx.Response(403 if failure == "rejected" else 200, text=private)
+
+    client = httpx.Client
+    monkeypatch.setattr(auth_codex, "resolve_codex_runtime_credentials", credentials)
+    monkeypatch.setattr(httpx, "Client", lambda **kwargs: client(
+        transport=httpx.MockTransport(transport), **kwargs))
+    monkeypatch.setattr(voice_live, "_resolve_credentials", lambda *_: pytest.fail("paid API resolver"))
+    monkeypatch.setattr(voice_live.urllib.request, "urlopen", lambda *a, **kw: pytest.fail("paid API request"))
+    with pytest.raises((ValueError, RuntimeError)) as error:
+        voice_live.create_webrtc_session("v=0 offer")
+    assert private not in str(error.value)
+    assert len(attempted) == (0 if failure in {"missing", "account", "invalid-auth"} else 1)
+    if not attempted:
+        status = voice_live.resolve_gpt_live_status()
+        assert status["available"] is False
+        assert private not in json.dumps(status)

--- a/tools/voice_live.py
+++ b/tools/voice_live.py
@@ -1,7 +1,7 @@
 """GPT-Live voice chat mode: the full-duplex voice frontend that delegates to Hermes.
 
 ``voice.voice_chat_mode: gpt-live`` replaces the chained STT → turn → TTS loop with ONE
-full-duplex voice model (OpenAI ``gpt-live-1``) that owns the microphone and the speaker and
+full-duplex voice model (OpenAI GPT-Live) that owns the microphone and the speaker and
 delegates every real request to Hermes as its *client-delegation* backend. Hermes stays the
 agent: whatever model/provider the session has selected answers, with the full toolset.
 
@@ -10,23 +10,29 @@ Division of labour (the Live API has no tools of its own in client mode):
 * the desktop renderer holds the WebRTC media session (mic in, speech out) and the data channel;
 * this module resolves WHICH credentials/voice/persona to use and performs the one server-side
   step the API requires — exchanging the browser's SDP offer for an answer with the project key
-  (``POST /v1/live/sessions``), so the key never reaches the client;
+  (``POST /v1/live/sessions``), or using Hermes Codex OAuth for explicit subscription mode;
+  long-lived credentials and the subscription account identity never reach the client;
 * the renderer turns each ``session.delegation.created`` into a normal ``prompt.submit`` on the
   active session (surface ``voice-live``) and streams the reply back as
   ``session.commentary.append`` — Hermes' answer is what the voice speaks.
 
 Vendor contract: https://developers.openai.com/api/docs/guides/live (+ live-delegation,
-voice-webrtc). Billing is $0.05/min of session time on the OpenAI key, separate from the
-Hermes turn.
+voice-webrtc). API billing is separate from the Hermes turn. Subscription mode uses the
+Codex frameless WebRTC contract (OpenAI Codex c4017a87aacc7558002b7cb510025e967c1d765e,
+realtime_call.rs and realtime_websocket/methods_frameless_bidi.rs); it never falls back to API.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import re
 import urllib.error
 import urllib.request
 from typing import Any, Dict, Optional
+from urllib.parse import urlparse
+
+import httpx
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +41,11 @@ CHAINED_MODE = "chained"
 DEFAULT_LIVE_MODEL = "gpt-live-1"
 DEFAULT_LIVE_VOICE = "marin"
 DEFAULT_LIVE_BASE_URL = "https://api.openai.com/v1"
+DEFAULT_SUBSCRIPTION_MODEL = "gpt-live-1-codex"
+DEFAULT_SUBSCRIPTION_VOICE = "cove"
+CODEX_LIVE_URL = (
+    "https://chatgpt.com/backend-api/codex/realtime/calls?intent=quicksilver&architecture=avas"
+)
 # Voices the vendor lists for gpt-live-1 (live-conversations guide) plus the realtime defaults it
 # accepts; free text stays allowed for custom voices.
 GPT_LIVE_VOICES = (
@@ -123,40 +134,106 @@ def _resolve_credentials(live: Dict[str, Any]) -> tuple[str, str]:
     return api_key, base_url
 
 
+def _live_auth(live: Dict[str, Any]) -> str:
+    auth = str(live.get("auth", "api")).strip().lower()
+    if auth not in {"api", "subscription"}:
+        raise ValueError("voice.gpt_live.auth must be api or subscription; no fallback was used")
+    return auth
+
+
+def _live_model_voice(live: Dict[str, Any], auth: str) -> tuple[str, str]:
+    if auth == "subscription":
+        return (str(live.get("subscription_model") or DEFAULT_SUBSCRIPTION_MODEL),
+                str(live.get("subscription_voice") or DEFAULT_SUBSCRIPTION_VOICE))
+    return str(live.get("model") or DEFAULT_LIVE_MODEL), str(live.get("voice") or DEFAULT_LIVE_VOICE)
+
+
+def _subscription_credentials(*, refresh_if_expiring: bool = True) -> tuple[str, str]:
+    from hermes_cli.auth_codex import resolve_codex_runtime_credentials
+    from hermes_cli.auth_constants import AuthError, _decode_jwt_claims
+
+    try:
+        credentials = resolve_codex_runtime_credentials(refresh_if_expiring=refresh_if_expiring)
+    except AuthError:
+        raise ValueError(
+            "GPT-Live subscription needs a working Codex sign-in on the Hermes host. "
+            "Run `hermes auth` and choose OpenAI Codex. No API fallback was used."
+        ) from None
+    token = str(credentials.get("api_key") or "").strip()
+    claims = _decode_jwt_claims(token).get("https://api.openai.com/auth", {})
+    account = claims.get("chatgpt_account_id") if isinstance(claims, dict) else None
+    if (not token or not isinstance(account, str) or not account.strip()
+            or any(c in token + account for c in "\r\n")):
+        raise ValueError("GPT-Live subscription needs Codex OAuth with an account identity; no API fallback was used")
+    return token, account.strip()
+
+
 def live_instructions(live: Optional[Dict[str, Any]] = None) -> str:
     extra = str((live if live is not None else _live_section()).get("instructions") or "").strip()
     return f"{LIVE_PERSONA}\n\n{extra}" if extra else LIVE_PERSONA
 
 
 def resolve_gpt_live_status() -> Dict[str, Any]:
-    """Non-secret readiness verdict for the client: which mode is selected and whether GPT-Live
-    can start (a key resolves). Never returns the key."""
+    """Credential readiness only; subscription entitlement is checked when the call starts."""
     voice = _voice_section()
-    mode = voice_chat_mode(voice)
     live = _live_section(voice)
-    api_key, _base = _resolve_credentials(live)
+    auth = str(live.get("auth", "api")).strip().lower()
+    reason = None
+    try:
+        auth = _live_auth(live)
+        if auth == "subscription":
+            _subscription_credentials(refresh_if_expiring=False)
+        elif not _resolve_credentials(live)[0]:
+            reason = "no OpenAI API key (set OPENAI_API_KEY or voice.gpt_live.api_key)"
+    except ValueError as exc:
+        reason = str(exc)
+    model, selected_voice = _live_model_voice(live, auth)
     return {
-        "mode": mode,
-        "available": bool(api_key),
-        "reason": None if api_key else "no OpenAI API key (set OPENAI_API_KEY or voice.gpt_live.api_key)",
-        "model": str(live.get("model") or DEFAULT_LIVE_MODEL),
-        "voice": str(live.get("voice") or DEFAULT_LIVE_VOICE),
+        "mode": voice_chat_mode(voice), "auth": auth,
+        "available": reason is None, "reason": reason,
+        "model": model, "voice": selected_voice,
     }
 
 
-def build_session_config(history: Optional[list] = None) -> Dict[str, Any]:
-    """The ``session`` object for ``POST /v1/live/sessions`` (client delegation, WebRTC — the
-    transport negotiates the audio format, so none is set)."""
-    live = _live_section()
+def build_session_config(history: Optional[list] = None, *, live: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Client delegation and history for the explicitly selected Live protocol."""
+    live = _live_section() if live is None else live
+    auth = _live_auth(live)
+    model, selected_voice = _live_model_voice(live, auth)
     config: Dict[str, Any] = {
-        "model": str(live.get("model") or DEFAULT_LIVE_MODEL),
+        "model": model,
         "instructions": live_instructions(live),
-        "audio": {"output": {"voice": str(live.get("voice") or DEFAULT_LIVE_VOICE)}},
+        "audio": {"output": {"voice": selected_voice}},
         "delegation": {"type": "client"},
     }
     if history:
-        config["input"] = history
+        config["initial_items" if auth == "subscription" else "input"] = history
     return config
+
+
+def _create_subscription_session(sdp_offer: str, config: Dict[str, Any]) -> Dict[str, Any]:
+    token, account = _subscription_credentials()
+    # Codex frameless WebRTC: the bearer and its account identity never reach the renderer.
+    # Do not follow redirects with subscription credentials or retry through the API route.
+    try:
+        with httpx.Client(timeout=30, follow_redirects=False) as client:
+            response = client.post(CODEX_LIVE_URL, json={"sdp": sdp_offer, "session": config}, headers={
+                "Authorization": f"Bearer {token}", "ChatGPT-Account-Id": account,
+                "OpenAI-Alpha": "quicksilver=v2",
+            })
+    except httpx.RequestError:
+        raise RuntimeError("GPT-Live subscription connection failed; no API fallback was used") from None
+    if not response.is_success:
+        raise RuntimeError(
+            f"GPT-Live subscription session was rejected (HTTP {response.status_code}); "
+            "check Codex sign-in and voice access. No API fallback was used."
+        )
+    sdp = response.text
+    call_id = urlparse(response.headers.get("Location", "")).path.rstrip("/").rsplit("/", 1)[-1]
+    if not sdp.startswith("v=0") or not re.fullmatch(r"rtc_[A-Za-z0-9_-]+|[0-9a-fA-F-]{36}", call_id):
+        raise RuntimeError("GPT-Live subscription returned an invalid WebRTC answer; no API fallback was used")
+    return {"auth": "subscription", "session": {"id": call_id},
+            "transport": {"type": "webrtc", "sdp": sdp}}
 
 
 def create_webrtc_session(sdp_offer: str, history: Optional[list] = None) -> Dict[str, Any]:
@@ -167,11 +244,15 @@ def create_webrtc_session(sdp_offer: str, history: Optional[list] = None) -> Dic
     status/detail) for a rejected request.
     """
     live = _live_section()
+    auth = _live_auth(live)
+    config = build_session_config(history, live=live)
+    if auth == "subscription":
+        return _create_subscription_session(sdp_offer, config)
     api_key, base_url = _resolve_credentials(live)
     if not api_key:
         raise ValueError("GPT-Live needs an OpenAI API key (OPENAI_API_KEY or voice.gpt_live.api_key)")
     body = json.dumps({
-        "session": build_session_config(history),
+        "session": config,
         "transport": {"type": "webrtc", "sdp": sdp_offer},
     }).encode("utf-8")
     req = urllib.request.Request(
@@ -179,7 +260,9 @@ def create_webrtc_session(sdp_offer: str, history: Optional[list] = None) -> Dic
         headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"})
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
-            return json.loads(resp.read().decode("utf-8"))
+            result = json.loads(resp.read().decode("utf-8"))
+            result["auth"] = "api"
+            return result
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode("utf-8", "replace")[:600]
         logger.warning("GPT-Live session creation failed: %s %s", exc.code, detail)

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -201,15 +201,31 @@ The chained loop above is one of two voice chat modes in the desktop app. The ot
 voice:
   voice_chat_mode: gpt-live     # chained (default) | gpt-live
   gpt_live:
+    auth: api                   # api (default) | subscription; never switches automatically
     voice: marin                # marin, cedar, quartz, ripple, vesper, willow, stone, gleam, meridian, …
     instructions: ""            # optional extra persona sentences (tone, pace, language)
 ```
 
 Requirements: an OpenAI API key (`OPENAI_API_KEY`, `VOICE_TOOLS_OPENAI_KEY`, or `voice.gpt_live.api_key`). The voice layer is billed by OpenAI at **$0.05 per minute of session time** (idle time counts); the Hermes turn is billed on its own provider as always. The mode is also in Settings → Voice → *Voice Chat Mode*.
 
-How it works: pressing the voice button opens a WebRTC session from the desktop to GPT-Live; the desktop only ever receives a session id and an SDP answer — the key stays on the gateway host, which performs the session creation (`POST /api/audio/voice-live/session`). Each `session.delegation.created` becomes a normal turn on the open chat (the bubble shows what you said; the recent spoken exchange rides the model input as a per-turn note, never the system prompt, so the reply is speakable prose). Tool activity is fed to the voice as quiet context ("Hermes is working: terminal") so it can tell you what is happening if you ask; the final answer is streamed back sentence by sentence. Saying the stop phrase ends the conversation. If `gpt-live` is selected but no key resolves, the button falls back to the chained mode with a notice.
+To use an existing **ChatGPT/Codex subscription**, first sign in to OpenAI Codex with `hermes auth` on the Hermes host. Then explicitly select subscription billing in that profile's `config.yaml`:
 
-Not supported in this mode: the Nous-managed audio proxy (direct key only), the CLI/TUI (`/voice` keeps the chained loop), and the `tts` tool (it keeps using `tts.provider`).
+```yaml
+voice:
+  voice_chat_mode: gpt-live
+  gpt_live:
+    auth: subscription
+    subscription_model: gpt-live-1-codex
+    subscription_voice: cove
+```
+
+The subscription route uses Hermes's existing Codex OAuth credentials and their account identity, both kept on the host. It uses the Codex voice service, so access depends on the signed-in account's voice entitlement and quota. The readiness indicator checks credentials; the service verifies access when you start the call. An authentication, quota, or connection failure stops startup: **it never switches to API billing or chained STT/TTS**. API `model`, `voice`, `api_key`, and `base_url` settings are separate from `subscription_model` and `subscription_voice`. Set `auth: api` explicitly to return to API billing. The Hermes agent turn still uses your selected model/provider independently of voice billing.
+
+How it works: pressing the voice button opens a WebRTC session from the desktop to GPT-Live; the desktop only ever receives a session id and an SDP answer — the key stays on the gateway host, which performs the session creation (`POST /api/audio/voice-live/session`). Each client delegation becomes a normal turn on the open chat (the bubble shows what you said; the recent spoken exchange rides the model input as a per-turn note, never the system prompt, so the reply is speakable prose). Tool activity is fed to the voice as quiet context ("Hermes is working: terminal") so it can tell you what is happening if you ask; the final answer is streamed back sentence by sentence. Saying the stop phrase ends the conversation. In API mode, if no key resolves, the button retains its existing chained-mode fallback with a notice. Subscription mode has no fallback.
+
+Not supported in this mode: the Nous-managed audio proxy, the CLI/TUI (`/voice` keeps the chained loop), and the `tts` tool (it keeps using `tts.provider`).
+
+The subscription transport follows the [public Codex WebRTC implementation](https://github.com/openai/codex/blob/c4017a87aacc7558002b7cb510025e967c1d765e/codex-rs/codex-api/src/endpoint/realtime_call.rs) and its [frameless context protocol](https://github.com/openai/codex/blob/c4017a87aacc7558002b7cb510025e967c1d765e/codex-rs/codex-api/src/endpoint/realtime_websocket/methods_frameless_bidi.rs). Hermes maps actual provider delegation IDs and captured transcript fragments into its existing conversation path. Subscription replies use the protocol's 500-byte UTF-8 context appends; credentials and provider error bodies are never sent to the desktop.
 
 ### Barge-in
 


### PR DESCRIPTION
## What does this PR do?

Adds an explicit ChatGPT/Codex subscription option to the native GPT-Live mode merged in #108137. Set `voice.gpt_live.auth: subscription` to use the Hermes host's existing Codex OAuth sign-in. API billing remains the default; subscription authentication or transport failures never select the API route or chained STT/TTS.

The server keeps the OAuth bearer and matching account identity private. The desktop uses the subscription WebRTC event format and returns Hermes replies through the corresponding context-append protocol. Hermes remains the agent, with the conversation's existing model, tools, memory and approvals.

## Related Issue

Builds on the native GPT-Live mode merged in #108137.

## Type of Change

- [x] New feature (non-breaking explicit billing option)

## Changes Made

- Reuse `hermes_cli.auth_codex.resolve_codex_runtime_credentials`; keep API and subscription model/voice settings separate.
- Add the Codex WebRTC request/SDP response format, real call/delegation IDs, captured transcript fragments and 500-byte UTF-8 context appends. Do not follow authenticated redirects or expose provider error bodies.
- Fetch authoritative voice status before opening an engine. Unknown or unavailable subscription status fails closed; resolved API mode retains its existing chained fallback.
- Ignore repeated delegation IDs and label subscription transcript timing as local arrival so the existing five-minute context window still expires.
- Document configuration and the subscription access requirement. No new dependency, plugin, tool, worker stack or login flow.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_voice_live_subscription.py tests/tui_gateway/test_voice_live_delegation.py -j 1 -q` — **12 passed** on Windows, Python 3.11.13.
2. Desktop targeted regression: `cd apps/desktop && npx vitest run src/lib/voice-live-subscription.test.ts --project ui`. The same committed test file passed **3 cases** locally with existing Vitest 4.1.10 and a temporary Node/module-alias configuration. It exercises the actual session/start-selection code with fake media and mocked network boundaries. The full desktop workspace configuration/build/typecheck was not run locally because this worktree has no installed workspace dependencies.
3. Red-on-base proof: the 7 new Python cases called the API resolver on the unmodified base; the renderer cases found duplicate dispatch, no subscription event handling, and discarded auth metadata. The five-minute transcript case also failed before its arrival-time fix. Ruff and `git diff --check` pass.
4. Manual provider/microphone test remains to be run: sign in through `hermes auth`, select subscription mode, start native Desktop voice, delegate a request to Hermes, hear the answer, mute/unmute and close. Repeat with explicit API mode. No live provider or microphone calls were made for this PR's local tests.

## Checklist

- [x] Read the contribution guide and searched overlapping PRs.
- [x] Conventional, signed-off SmokeDev commit; one native Live feature.
- [x] Focused behavioral regressions and existing API/delegation regressions pass.
- [x] Updated operating docs and `cli-config.yaml.example`.
- [x] Considered cross-platform behavior: browser WebRTC and existing Python OAuth/HTTP dependencies; no shell or OS-specific runtime changes.
- [ ] Full Python/desktop suites and live provider/microphone smoke test.

## Protocol Evidence

Wire shapes were verified against OpenAI Codex commit `c4017a87aacc7558002b7cb510025e967c1d765e`: [WebRTC call exchange](https://github.com/openai/codex/blob/c4017a87aacc7558002b7cb510025e967c1d765e/codex-rs/codex-api/src/endpoint/realtime_call.rs), [frameless events](https://github.com/openai/codex/blob/c4017a87aacc7558002b7cb510025e967c1d765e/codex-rs/codex-api/src/endpoint/realtime_websocket/protocol_frameless_bidi.rs), [context appends/history](https://github.com/openai/codex/blob/c4017a87aacc7558002b7cb510025e967c1d765e/codex-rs/codex-api/src/endpoint/realtime_websocket/methods_frameless_bidi.rs), and [subscription model/headers](https://github.com/openai/codex/blob/c4017a87aacc7558002b7cb510025e967c1d765e/codex-rs/core/src/realtime_conversation.rs).

Signed-off-by: SmokeDev <degensmoke@gmail.com>
