### PR TITLE
feat(skills): official x402-reader payment skill + MCP catalog

### DIFF
--- a/optional-mcps/x402-reader/manifest.yaml
+++ b/optional-mcps/x402-reader/manifest.yaml
@@ -1,0 +1,39 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: x402-reader
+description: >-
+  Probe or pay an x402 reader to fetch a public URL as markdown.
+source: https://www.npmjs.com/package/x402-reader-mcp
+
+transport:
+  type: stdio
+  command: npx
+  args:
+    - "-y"
+    - "x402-reader-mcp@0.1.2"
+  env:
+    READER_BASE_URL: "https://reader.outbid.sh"
+
+auth:
+  type: none
+
+tools:
+  default_enabled:
+    - scrape
+    - browse
+
+suggest:
+  keywords:
+    - x402
+    - scrape
+    - markdown
+  hosts:
+    - reader.outbid.sh
+
+post_install: |
+  Unarmed scrape/browse return a free 422 miss or a visible 402 quote.
+  To pay: set X402_READER_PAYMENTS_ENABLED=1 and SVM_PRIVATE_KEY_FILE
+  (or EVM_PRIVATE_KEY_FILE) in the server env, then start a new session.
+  Caps refuse above $0.05/call before signing. scrape never auto-opens browse.

--- a/optional-mcps/x402-reader/manifest.yaml
+++ b/optional-mcps/x402-reader/manifest.yaml
@@ -1,5 +1,11 @@
 # Nous-approved MCP catalog entry.
 # Presence in this directory = approval. Merged via PR review.
+#
+# First official `npx` pin. Version-locked (x402-reader-mcp@0.1.2) to satisfy
+# tests/hermes_cli/test_mcp_catalog.py. This is a protocol client for x402
+# (quote unarmed; pay opt-in), not a plugins/ SaaS connector. Stripe and n8n
+# already live in optional-mcps/. Transitive npm ranges resolve at `npx -y`
+# time; a git+SHA install is the conservative alternative if review prefers it.
 manifest_version: 1
 
 name: x402-reader
@@ -34,6 +40,8 @@ suggest:
 
 post_install: |
   Unarmed scrape/browse return a free 422 miss or a visible 402 quote.
-  To pay: set X402_READER_PAYMENTS_ENABLED=1 and SVM_PRIVATE_KEY_FILE
-  (or EVM_PRIVATE_KEY_FILE) in the server env, then start a new session.
+  Shell exports do not reach this MCP. To pay, set server env on
+  mcp_servers.x402-reader.env (X402_READER_PAYMENTS_ENABLED=1 and
+  SVM_PRIVATE_KEY_FILE or EVM_PRIVATE_KEY_FILE), then start a new session
+  and call the scrape tool — do not run npx as a pay command.
   Caps refuse above $0.05/call before signing. scrape never auto-opens browse.

--- a/optional-skills/payments/x402-reader/SKILL.md
+++ b/optional-skills/payments/x402-reader/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: x402-reader
 description: Pay x402 to read a public URL as markdown.
-version: 0.1.0
+version: 0.1.1
 author: twzrd (twzrd-sol), Hermes Agent
 license: MIT
 platforms: [linux, macos]
@@ -13,10 +13,10 @@ metadata:
 
 # X402 Reader Skill
 
-Turns a public URL into markdown by paying the live x402 reader
-(`https://reader.outbid.sh`). Quote is free. Live spend is opt-in and
-capped before sign. This is the Solana/Base USDC x402 path; MPP 402s
-belong to `mpp-agent`.
+Turns a public URL into markdown by paying an x402 reader
+(`https://reader.outbid.sh` by default). Quote is free. Live spend is
+opt-in and capped before sign. This is the Solana/Base USDC x402 path;
+MPP 402s belong to `mpp-agent`.
 
 Gated `[linux, macos]` while the npm client matures on Windows.
 
@@ -33,13 +33,12 @@ checkout (use `stripe-link-cli`), or adding 402 to your own API.
 
 - Node.js 20+ on `PATH` (`node --version` via `terminal`)
 - For live pay only: a funded Solana or Base USDC wallet file, plus
-  `X402_READER_PAYMENTS_ENABLED=1`
+  `X402_READER_PAYMENTS_ENABLED=1` in the MCP **server env**
 - No wallet is required to quote
 
 ## How to Run
 
-Install the official optional skill, then either add the MCP or quote
-with `terminal`:
+Install the official optional skill, then add the MCP:
 
 ```
 hermes skills install official/payments/x402-reader
@@ -48,7 +47,8 @@ hermes mcp install x402-reader
 
 `hermes mcp install` writes a stdio server (`npx -y x402-reader-mcp@0.1.2`)
 that exposes `scrape` ($0.005) and `browse` ($0.05). Unarmed, both tools
-return a free 422 miss or a visible 402 quote.
+return a free 422 miss or a visible 402 quote. Shell exports do **not**
+reach the MCP — put payment env in `mcp_servers.x402-reader.env`.
 
 ## Quick Reference
 
@@ -63,35 +63,38 @@ return a free 422 miss or a visible 402 quote.
 
 ### 1. Quote (no wallet)
 
-```
-curl -sS -D - "https://reader.outbid.sh/scrape?url=https://example.com/"
-```
-
-Expect HTTP 402 and an `accepts` array. Parse the body with this skill's
-`scripts/quote.py` (no network; stdin is the JSON body):
+Write headers and body to separate files so `quote.py` sees JSON only:
 
 ```
-python3 scripts/quote.py
+curl -sS -o /tmp/x402-body.json -D /tmp/x402-headers.txt \
+  "https://reader.outbid.sh/scrape?url=https://example.com/"
+python3 scripts/quote.py < /tmp/x402-body.json
 ```
 
-Prefer the `solana` / `solana:` row. Amount `5000` is $0.005 USDC.
+Expect HTTP 402 and an `accepts` array. `scripts/quote.py` is display-only
+(no network, no keys). Prefer the `solana` / `solana:` row. Amount `5000`
+is $0.005 USDC. The paying MCP settles from the `PAYMENT-REQUIRED` header,
+not from this parsed body.
 
 ### 2. Pay under a ceiling
 
-Arm payments only when the user wants the page:
+Arm payments only when the user wants the page. Edit the installed MCP
+block, then start a **new session** and call the MCP `scrape` tool
+(not `npx` — that starts the stdio server and hangs):
 
-- `X402_READER_PAYMENTS_ENABLED=1`
-- `SVM_PRIVATE_KEY_FILE` (Solana JSON keypair) or `EVM_PRIVATE_KEY_FILE`
-- Caps default to $0.05 per call and $1.00 per process; refuse above that
-  **before** signing
-
-Then call the MCP `scrape` tool, or:
-
+```yaml
+mcp_servers:
+  x402-reader:
+    env:
+      X402_READER_PAYMENTS_ENABLED: "1"
+      SVM_PRIVATE_KEY_FILE: "${SVM_PRIVATE_KEY_FILE}"
+      X402_READER_MAX_USDC_PER_CALL: "0.05"
+      X402_READER_MAX_USDC_TOTAL: "1"
 ```
-npx -y x402-reader-mcp@0.1.2
-```
 
-Do not `read_file` the key. Do not paste key material into the transcript.
+Use `EVM_PRIVATE_KEY_FILE` instead of `SVM_PRIVATE_KEY_FILE` for Base.
+Caps refuse above the limit **before** signing. Do not `read_file` the
+key. Do not paste key material into the transcript.
 
 ### 3. Verify
 
@@ -107,11 +110,13 @@ is a failed pay, not a quote.
 - **Do not curl a 402 and stop** when the user asked for the page — quote,
   then pay under the cap, or report the price and stop.
 - **Wallet keys stay out of context.** Point at a file path; never dump it.
+- **npx is the MCP launcher, not a pay command.**
 
 ## Verification
 
 ```
 hermes skills install official/payments/x402-reader
+hermes mcp install x402-reader
 hermes mcp test x402-reader
 ```
 

--- a/optional-skills/payments/x402-reader/SKILL.md
+++ b/optional-skills/payments/x402-reader/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: x402-reader
+description: Pay x402 to read a public URL as markdown.
+version: 0.1.0
+author: twzrd (twzrd-sol), Hermes Agent
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [Payments, HTTP-402, x402, Reader, Solana]
+    related_skills: [mpp-agent]
+---
+
+# X402 Reader Skill
+
+Turns a public URL into markdown by paying the live x402 reader
+(`https://reader.outbid.sh`). Quote is free. Live spend is opt-in and
+capped before sign. This is the Solana/Base USDC x402 path; MPP 402s
+belong to `mpp-agent`.
+
+Gated `[linux, macos]` while the npm client matures on Windows.
+
+## When to Use
+
+- Need page text and the origin is fat HTML, JS-walled, or already 402s
+- A fetch returns `HTTP 402` with x402 `accepts` (Solana or Base USDC)
+- User says "scrape", "read this URL", "pay the 402", or "x402 reader"
+
+Don't use for: MPP/`www-authenticate: tempo` (use `mpp-agent`), Stripe
+checkout (use `stripe-link-cli`), or adding 402 to your own API.
+
+## Prerequisites
+
+- Node.js 20+ on `PATH` (`node --version` via `terminal`)
+- For live pay only: a funded Solana or Base USDC wallet file, plus
+  `X402_READER_PAYMENTS_ENABLED=1`
+- No wallet is required to quote
+
+## How to Run
+
+Install the official optional skill, then either add the MCP or quote
+with `terminal`:
+
+```
+hermes skills install official/payments/x402-reader
+hermes mcp install x402-reader
+```
+
+`hermes mcp install` writes a stdio server (`npx -y x402-reader-mcp@0.1.2`)
+that exposes `scrape` ($0.005) and `browse` ($0.05). Unarmed, both tools
+return a free 422 miss or a visible 402 quote.
+
+## Quick Reference
+
+| Tool | Route | Price |
+|---|---|---:|
+| `scrape` | `GET /scrape?url=` | $0.005 USDC |
+| `browse` | `GET /browse?url=` | $0.05 USDC |
+
+`scrape` never auto-opens `browse`. A `needs_browser` 422 is terminal.
+
+## Procedure
+
+### 1. Quote (no wallet)
+
+```
+curl -sS -D - "https://reader.outbid.sh/scrape?url=https://example.com/"
+```
+
+Expect HTTP 402 and an `accepts` array. Parse the body with this skill's
+`scripts/quote.py` (no network; stdin is the JSON body):
+
+```
+python3 scripts/quote.py
+```
+
+Prefer the `solana` / `solana:` row. Amount `5000` is $0.005 USDC.
+
+### 2. Pay under a ceiling
+
+Arm payments only when the user wants the page:
+
+- `X402_READER_PAYMENTS_ENABLED=1`
+- `SVM_PRIVATE_KEY_FILE` (Solana JSON keypair) or `EVM_PRIVATE_KEY_FILE`
+- Caps default to $0.05 per call and $1.00 per process; refuse above that
+  **before** signing
+
+Then call the MCP `scrape` tool, or:
+
+```
+npx -y x402-reader-mcp@0.1.2
+```
+
+Do not `read_file` the key. Do not paste key material into the transcript.
+
+### 3. Verify
+
+A paid 200 is JSON `{ok, title, markdown, word_count}` plus a
+`PAYMENT-RESPONSE` header with `payer` and `transaction`. A leftover 402
+is a failed pay, not a quote.
+
+## Pitfalls
+
+- **MPP vs x402.** A `www-authenticate: tempo` header is `mpp-agent`, not
+  this skill.
+- **No silent browse upgrade.** `needs_browser` is free and terminal.
+- **Do not curl a 402 and stop** when the user asked for the page — quote,
+  then pay under the cap, or report the price and stop.
+- **Wallet keys stay out of context.** Point at a file path; never dump it.
+
+## Verification
+
+```
+hermes skills install official/payments/x402-reader
+hermes mcp test x402-reader
+```
+
+`hermes mcp test` must list `scrape` and `browse`. A quote against
+`https://example.com/` must show amount 5000.

--- a/optional-skills/payments/x402-reader/scripts/quote.py
+++ b/optional-skills/payments/x402-reader/scripts/quote.py
@@ -9,8 +9,31 @@ import sys
 USDC_DECIMALS = 6
 
 
+def extract_json_object(raw: str) -> str:
+    """Return the first JSON object, stripping curl -D - header blocks."""
+    text = raw.strip()
+    if not text:
+        raise ValueError("empty stdin")
+    if text.startswith("{") or text.startswith("["):
+        return text
+    sep = "\r\n\r\n" if "\r\n\r\n" in text else "\n\n"
+    rest = text
+    while True:
+        if sep not in rest:
+            break
+        rest = rest.split(sep, 1)[1].lstrip()
+        if rest.startswith("{") or rest.startswith("["):
+            return rest
+        if not rest.startswith("HTTP/"):
+            break
+    start = rest.find("{")
+    if start < 0:
+        raise ValueError("no JSON object in stdin")
+    return rest[start:]
+
+
 def load_body(raw: str) -> dict:
-    data = json.loads(raw)
+    data = json.loads(extract_json_object(raw))
     if not isinstance(data, dict):
         raise ValueError("402 body must be a JSON object")
     return data

--- a/optional-skills/payments/x402-reader/scripts/quote.py
+++ b/optional-skills/payments/x402-reader/scripts/quote.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Parse an x402 Payment Required JSON body. No network. No keys."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+USDC_DECIMALS = 6
+
+
+def load_body(raw: str) -> dict:
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise ValueError("402 body must be a JSON object")
+    return data
+
+
+def quote_rows(body: dict) -> list[dict]:
+    accepts = body.get("accepts") or []
+    if not isinstance(accepts, list):
+        raise ValueError("accepts must be a list")
+    rows = []
+    for item in accepts:
+        if not isinstance(item, dict):
+            continue
+        amount = item.get("amount") if item.get("amount") is not None else item.get("maxAmountRequired")
+        if amount is None or not str(amount).isdigit():
+            continue
+        micro = int(str(amount))
+        network = str(item.get("network") or "")
+        rows.append(
+            {
+                "network": network,
+                "payTo": item.get("payTo") or item.get("pay_to"),
+                "asset": item.get("asset"),
+                "amount_usdc": micro / 10**USDC_DECIMALS,
+                "preferred": network == "solana" or network.startswith("solana"),
+            }
+        )
+    return rows
+
+
+def pick_row(rows: list[dict]) -> dict | None:
+    for row in rows:
+        if row.get("preferred"):
+            return row
+    return rows[0] if rows else None
+
+
+def main(argv: list[str] | None = None) -> int:
+    _ = argv
+    raw = sys.stdin.read()
+    if not raw.strip():
+        print("usage: quote.py < 402.json", file=sys.stderr)
+        return 2
+    try:
+        rows = quote_rows(load_body(raw))
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    chosen = pick_row(rows)
+    json.dump({"ok": bool(chosen), "quote": chosen, "accepts": rows}, sys.stdout)
+    sys.stdout.write("\n")
+    return 0 if chosen else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/skills/test_x402_reader_skill.py
+++ b/tests/skills/test_x402_reader_skill.py
@@ -68,6 +68,44 @@ def test_accepts_caip_solana_network():
     assert chosen["amount_usdc"] == 0.05
 
 
+def test_empty_accepts_is_not_ok(capsys):
+    mod = load_mod()
+    old = sys.stdin
+    sys.stdin = type("S", (), {"read": lambda self: json.dumps({"accepts": []})})()
+    try:
+        code = mod.main([])
+    finally:
+        sys.stdin = old
+    out = json.loads(capsys.readouterr().out)
+    assert code == 1
+    assert out["ok"] is False
+    assert out["accepts"] == []
+
+
+def test_strips_curl_header_prefix():
+    mod = load_mod()
+    raw = (
+        "HTTP/2 402\r\n"
+        "payment-required: ignore\r\n"
+        "content-type: application/json\r\n"
+        "\r\n"
+        + json.dumps(
+            {
+                "accepts": [
+                    {
+                        "network": "solana",
+                        "maxAmountRequired": "5000",
+                        "payTo": "F1AbWuXJcBT9arW9wc6Xr2vom5NBtngWsz6Ht16jRBLM",
+                    }
+                ]
+            }
+        )
+    )
+    body = mod.load_body(raw)
+    chosen = mod.pick_row(mod.quote_rows(body))
+    assert chosen["amount_usdc"] == 0.005
+
+
 def test_main_prints_json(capsys):
     mod = load_mod()
     body = json.dumps(

--- a/tests/skills/test_x402_reader_skill.py
+++ b/tests/skills/test_x402_reader_skill.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "payments"
+    / "x402-reader"
+    / "scripts"
+    / "quote.py"
+)
+
+
+def load_mod():
+    spec = importlib.util.spec_from_file_location("x402_reader_quote", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_prefers_solana_v1_network_name():
+    mod = load_mod()
+    body = {
+        "accepts": [
+            {
+                "scheme": "exact",
+                "network": "base",
+                "maxAmountRequired": "5000",
+                "payTo": "0x14df772BD496bBb7f49Bc3E992Ce13B2c441177F",
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+            },
+            {
+                "scheme": "exact",
+                "network": "solana",
+                "maxAmountRequired": "5000",
+                "payTo": "F1AbWuXJcBT9arW9wc6Xr2vom5NBtngWsz6Ht16jRBLM",
+                "asset": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            },
+        ]
+    }
+    rows = mod.quote_rows(body)
+    chosen = mod.pick_row(rows)
+    assert chosen["network"] == "solana"
+    assert chosen["amount_usdc"] == 0.005
+
+
+def test_accepts_caip_solana_network():
+    mod = load_mod()
+    rows = mod.quote_rows(
+        {
+            "accepts": [
+                {
+                    "network": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+                    "amount": "50000",
+                    "payTo": "F1AbWuXJcBT9arW9wc6Xr2vom5NBtngWsz6Ht16jRBLM",
+                }
+            ]
+        }
+    )
+    chosen = mod.pick_row(rows)
+    assert chosen["preferred"] is True
+    assert chosen["amount_usdc"] == 0.05
+
+
+def test_main_prints_json(capsys):
+    mod = load_mod()
+    body = json.dumps(
+        {
+            "accepts": [
+                {
+                    "network": "solana",
+                    "maxAmountRequired": "5000",
+                    "payTo": "F1AbWuXJcBT9arW9wc6Xr2vom5NBtngWsz6Ht16jRBLM",
+                }
+            ]
+        }
+    )
+    old = sys.stdin
+    sys.stdin = type("S", (), {"read": lambda self: body})()
+    try:
+        code = mod.main([])
+    finally:
+        sys.stdin = old
+    out = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert out["ok"] is True
+    assert out["quote"]["amount_usdc"] == 0.005

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -198,6 +198,7 @@ hermes skills uninstall <skill-name>
 | Skill | Description |
 |-------|-------------|
 | [**mpp-agent**](/docs/user-guide/skills/optional/payments/payments-mpp-agent) | Pay HTTP 402 APIs via Machine Payments Protocol (MPP). |
+| [**x402-reader**](/docs/user-guide/skills/optional/payments/payments-x402-reader) | Pay x402 to read a public URL as markdown. |
 | [**stripe-link-cli**](/docs/user-guide/skills/optional/payments/payments-stripe-link-cli) | Agent payments via Stripe Link — cards, SPT, approvals. |
 | [**stripe-projects**](/docs/user-guide/skills/optional/payments/payments-stripe-projects) | Provision SaaS services + sync creds via Stripe Projects. |
 

--- a/website/docs/user-guide/skills/optional/payments/payments-x402-reader.md
+++ b/website/docs/user-guide/skills/optional/payments/payments-x402-reader.md
@@ -16,7 +16,7 @@ Pay x402 to read a public URL as markdown.
 |---|---|
 | Source | Optional — install with `hermes skills install official/payments/x402-reader` |
 | Path | `optional-skills/payments/x402-reader` |
-| Version | `0.1.0` |
+| Version | `0.1.1` |
 | Author | twzrd (twzrd-sol), Hermes Agent |
 | License | MIT |
 | Platforms | linux, macos |
@@ -31,10 +31,10 @@ The following is the complete skill definition that Hermes loads when this skill
 
 # X402 Reader Skill
 
-Turns a public URL into markdown by paying the live x402 reader
-(`https://reader.outbid.sh`). Quote is free. Live spend is opt-in and
-capped before sign. This is the Solana/Base USDC x402 path; MPP 402s
-belong to `mpp-agent`.
+Turns a public URL into markdown by paying an x402 reader
+(`https://reader.outbid.sh` by default). Quote is free. Live spend is
+opt-in and capped before sign. This is the Solana/Base USDC x402 path;
+MPP 402s belong to `mpp-agent`.
 
 Gated `[linux, macos]` while the npm client matures on Windows.
 
@@ -51,13 +51,12 @@ checkout (use `stripe-link-cli`), or adding 402 to your own API.
 
 - Node.js 20+ on `PATH` (`node --version` via `terminal`)
 - For live pay only: a funded Solana or Base USDC wallet file, plus
-  `X402_READER_PAYMENTS_ENABLED=1`
+  `X402_READER_PAYMENTS_ENABLED=1` in the MCP **server env**
 - No wallet is required to quote
 
 ## How to Run
 
-Install the official optional skill, then either add the MCP or quote
-with `terminal`:
+Install the official optional skill, then add the MCP:
 
 ```
 hermes skills install official/payments/x402-reader
@@ -66,7 +65,8 @@ hermes mcp install x402-reader
 
 `hermes mcp install` writes a stdio server (`npx -y x402-reader-mcp@0.1.2`)
 that exposes `scrape` ($0.005) and `browse` ($0.05). Unarmed, both tools
-return a free 422 miss or a visible 402 quote.
+return a free 422 miss or a visible 402 quote. Shell exports do **not**
+reach the MCP — put payment env in `mcp_servers.x402-reader.env`.
 
 ## Quick Reference
 
@@ -81,35 +81,38 @@ return a free 422 miss or a visible 402 quote.
 
 ### 1. Quote (no wallet)
 
-```
-curl -sS -D - "https://reader.outbid.sh/scrape?url=https://example.com/"
-```
-
-Expect HTTP 402 and an `accepts` array. Parse the body with this skill's
-`scripts/quote.py` (no network; stdin is the JSON body):
+Write headers and body to separate files so `quote.py` sees JSON only:
 
 ```
-python3 scripts/quote.py
+curl -sS -o /tmp/x402-body.json -D /tmp/x402-headers.txt \
+  "https://reader.outbid.sh/scrape?url=https://example.com/"
+python3 scripts/quote.py < /tmp/x402-body.json
 ```
 
-Prefer the `solana` / `solana:` row. Amount `5000` is $0.005 USDC.
+Expect HTTP 402 and an `accepts` array. `scripts/quote.py` is display-only
+(no network, no keys). Prefer the `solana` / `solana:` row. Amount `5000`
+is $0.005 USDC. The paying MCP settles from the `PAYMENT-REQUIRED` header,
+not from this parsed body.
 
 ### 2. Pay under a ceiling
 
-Arm payments only when the user wants the page:
+Arm payments only when the user wants the page. Edit the installed MCP
+block, then start a **new session** and call the MCP `scrape` tool
+(not `npx` — that starts the stdio server and hangs):
 
-- `X402_READER_PAYMENTS_ENABLED=1`
-- `SVM_PRIVATE_KEY_FILE` (Solana JSON keypair) or `EVM_PRIVATE_KEY_FILE`
-- Caps default to $0.05 per call and $1.00 per process; refuse above that
-  **before** signing
-
-Then call the MCP `scrape` tool, or:
-
+```yaml
+mcp_servers:
+  x402-reader:
+    env:
+      X402_READER_PAYMENTS_ENABLED: "1"
+      SVM_PRIVATE_KEY_FILE: "${SVM_PRIVATE_KEY_FILE}"
+      X402_READER_MAX_USDC_PER_CALL: "0.05"
+      X402_READER_MAX_USDC_TOTAL: "1"
 ```
-npx -y x402-reader-mcp@0.1.2
-```
 
-Do not `read_file` the key. Do not paste key material into the transcript.
+Use `EVM_PRIVATE_KEY_FILE` instead of `SVM_PRIVATE_KEY_FILE` for Base.
+Caps refuse above the limit **before** signing. Do not `read_file` the
+key. Do not paste key material into the transcript.
 
 ### 3. Verify
 
@@ -125,11 +128,13 @@ is a failed pay, not a quote.
 - **Do not curl a 402 and stop** when the user asked for the page — quote,
   then pay under the cap, or report the price and stop.
 - **Wallet keys stay out of context.** Point at a file path; never dump it.
+- **npx is the MCP launcher, not a pay command.**
 
 ## Verification
 
 ```
 hermes skills install official/payments/x402-reader
+hermes mcp install x402-reader
 hermes mcp test x402-reader
 ```
 

--- a/website/docs/user-guide/skills/optional/payments/payments-x402-reader.md
+++ b/website/docs/user-guide/skills/optional/payments/payments-x402-reader.md
@@ -1,0 +1,137 @@
+---
+title: "X402 Reader — Pay x402 to read a public URL as markdown"
+sidebar_label: "X402 Reader"
+description: "Pay x402 to read a public URL as markdown"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# X402 Reader
+
+Pay x402 to read a public URL as markdown.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/payments/x402-reader` |
+| Path | `optional-skills/payments/x402-reader` |
+| Version | `0.1.0` |
+| Author | twzrd (twzrd-sol), Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos |
+| Tags | `Payments`, `HTTP-402`, `x402`, `Reader`, `Solana` |
+| Related skills | [`mpp-agent`](/docs/user-guide/skills/optional/payments/payments-mpp-agent) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# X402 Reader Skill
+
+Turns a public URL into markdown by paying the live x402 reader
+(`https://reader.outbid.sh`). Quote is free. Live spend is opt-in and
+capped before sign. This is the Solana/Base USDC x402 path; MPP 402s
+belong to `mpp-agent`.
+
+Gated `[linux, macos]` while the npm client matures on Windows.
+
+## When to Use
+
+- Need page text and the origin is fat HTML, JS-walled, or already 402s
+- A fetch returns `HTTP 402` with x402 `accepts` (Solana or Base USDC)
+- User says "scrape", "read this URL", "pay the 402", or "x402 reader"
+
+Don't use for: MPP/`www-authenticate: tempo` (use `mpp-agent`), Stripe
+checkout (use `stripe-link-cli`), or adding 402 to your own API.
+
+## Prerequisites
+
+- Node.js 20+ on `PATH` (`node --version` via `terminal`)
+- For live pay only: a funded Solana or Base USDC wallet file, plus
+  `X402_READER_PAYMENTS_ENABLED=1`
+- No wallet is required to quote
+
+## How to Run
+
+Install the official optional skill, then either add the MCP or quote
+with `terminal`:
+
+```
+hermes skills install official/payments/x402-reader
+hermes mcp install x402-reader
+```
+
+`hermes mcp install` writes a stdio server (`npx -y x402-reader-mcp@0.1.2`)
+that exposes `scrape` ($0.005) and `browse` ($0.05). Unarmed, both tools
+return a free 422 miss or a visible 402 quote.
+
+## Quick Reference
+
+| Tool | Route | Price |
+|---|---|---:|
+| `scrape` | `GET /scrape?url=` | $0.005 USDC |
+| `browse` | `GET /browse?url=` | $0.05 USDC |
+
+`scrape` never auto-opens `browse`. A `needs_browser` 422 is terminal.
+
+## Procedure
+
+### 1. Quote (no wallet)
+
+```
+curl -sS -D - "https://reader.outbid.sh/scrape?url=https://example.com/"
+```
+
+Expect HTTP 402 and an `accepts` array. Parse the body with this skill's
+`scripts/quote.py` (no network; stdin is the JSON body):
+
+```
+python3 scripts/quote.py
+```
+
+Prefer the `solana` / `solana:` row. Amount `5000` is $0.005 USDC.
+
+### 2. Pay under a ceiling
+
+Arm payments only when the user wants the page:
+
+- `X402_READER_PAYMENTS_ENABLED=1`
+- `SVM_PRIVATE_KEY_FILE` (Solana JSON keypair) or `EVM_PRIVATE_KEY_FILE`
+- Caps default to $0.05 per call and $1.00 per process; refuse above that
+  **before** signing
+
+Then call the MCP `scrape` tool, or:
+
+```
+npx -y x402-reader-mcp@0.1.2
+```
+
+Do not `read_file` the key. Do not paste key material into the transcript.
+
+### 3. Verify
+
+A paid 200 is JSON `{ok, title, markdown, word_count}` plus a
+`PAYMENT-RESPONSE` header with `payer` and `transaction`. A leftover 402
+is a failed pay, not a quote.
+
+## Pitfalls
+
+- **MPP vs x402.** A `www-authenticate: tempo` header is `mpp-agent`, not
+  this skill.
+- **No silent browse upgrade.** `needs_browser` is free and terminal.
+- **Do not curl a 402 and stop** when the user asked for the page — quote,
+  then pay under the cap, or report the price and stop.
+- **Wallet keys stay out of context.** Point at a file path; never dump it.
+
+## Verification
+
+```
+hermes skills install official/payments/x402-reader
+hermes mcp test x402-reader
+```
+
+`hermes mcp test` must list `scrape` and `browse`. A quote against
+`https://example.com/` must show amount 5000.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -531,6 +531,7 @@ const sidebars: SidebarsConfig = {
                     'user-guide/skills/optional/payments/payments-mpp-agent',
                     'user-guide/skills/optional/payments/payments-stripe-link-cli',
                     'user-guide/skills/optional/payments/payments-stripe-projects',
+                    'user-guide/skills/optional/payments/payments-x402-reader',
                   ],
                 },
                 {


### PR DESCRIPTION
## Summary
- Adds `optional-skills/payments/x402-reader` as the x402 sibling of `mpp-agent`: quote a page scrape for free, pay Solana/Base USDC under a ceiling, never auto-upgrade scrape → browse.
- Adds a Nous MCP catalog entry (`optional-mcps/x402-reader`) so `hermes mcp install x402-reader` launches pinned `npx -y x402-reader-mcp@0.1.2` against `reader.outbid.sh`.
- Offline quote helper + tests; authoring standards and shipped-catalog pin contract pass.

## Test plan
- [x] `pytest tests/skills/test_authoring_standards.py tests/skills/test_x402_reader_skill.py` (1211 passed)
- [x] `pytest tests/hermes_cli/test_mcp_catalog.py::TestShippedCatalog` (2 passed)
- [ ] `hermes skills install official/payments/x402-reader`
- [ ] `hermes mcp install x402-reader` then `hermes mcp test x402-reader` lists `scrape` and `browse`
- [ ] Unarmed `scrape https://example.com/` returns a 402 quote with amount 5000


Made with [Cursor](https://cursor.com)