### PR TITLE
fix(cron): fire one catch-up for a slot missed during a restart gap (#107485)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -359,6 +359,9 @@ kanban:
 # Working directory behavior:
 #   - CLI (`hermes` command): Uses "." (current directory where you run hermes)
 #   - Gateway/messaging/cron: Uses terminal.cwd here; legacy .env cwd values are deprecated
+cron:
+  catch_up_missed: true  # False skips past-grace recurring misses after planned downtime.
+
 terminal:
   backend: "local"
   cwd: "."  # For local backend: "." = current directory. Ignored for remote backends unless a backend documents otherwise.

--- a/cron/AGENTS.md
+++ b/cron/AGENTS.md
@@ -17,6 +17,11 @@ loaded), multi-platform delivery.
 Hardening invariants — each guards a real failure; don't weaken without answering for it:
 - **3-minute hard interrupt** on cron sessions: runaway loops cannot monopolise the scheduler.
 - Catch-up window = half the period, clamped to 120s–2h; 120s grace for missed one-shots.
+- Every recurring occurrence is accounted for: `tick()` advances `next_run_at` BEFORE dispatch
+  (at-most-once across a mid-run crash) and stamps `pending_slot` in the same save; a scan that
+  finds the stamp with a dead owner restores the instant ONCE (`cron/occurrences.py`), the
+  executions ledger's `scheduled_instant` blocks a second fire, `cron.catch_up_missed: false`
+  skips past-grace misses with a logged reason. Never drop a slot silently (#107485).
 - File lock `~/.hermes/cron/.tick.lock` prevents duplicate ticks across processes.
 - Cron sessions pass `skip_memory=True`; memory providers intentionally do not run during cron.
 - Cron execution has its own session. Eligible continuable deliveries may mirror or seed the

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2883,8 +2883,8 @@ def _reanchor_stale_cron(d: _DueJob) -> bool:
     return False
 
 
-def _fast_forward_missed_recurring(d: _DueJob, grace: int) -> None:
-    """Recurring job past its grace window: skip the accumulated misses, fire once now.
+def _fast_forward_missed_recurring(d: _DueJob, grace: int) -> bool:
+    """Re-anchor accumulated misses; return whether catch-up was explicitly disabled.
 
     The fast-forward is persisted immediately — NOT redundant with advance_next_run/mark_job_run:
     it
@@ -2892,16 +2892,23 @@ def _fast_forward_missed_recurring(d: _DueJob, grace: int) -> None:
     calls advance_next_run. mark_job_run re-anchors on completion, so the value is provisional.
     """
     if (d.scan.now - d.next_run_dt).total_seconds() <= grace:
-        return
+        return False
     new_next = d.recompute_next()
     if not new_next:
-        return
+        return False
+    d.scan.persist(d.job["id"], next_run_at=new_next)
+    if not _cron_config_number("catch_up_missed", True, lambda value: value is not False):
+        logger.info(
+            "Job '%s' missed its scheduled time (%s, grace=%ds). "
+            "Skipping missed occurrence because cron.catch_up_missed is false; next run: %s",
+            d.label, d.next_run, grace, new_next)
+        return True
     logger.info(
         "Job '%s' missed its scheduled time (%s, grace=%ds). "
         "Running now; next run provisionally set to: %s (re-anchored on completion)",
         d.label, d.next_run, grace, new_next)
-    d.scan.persist(d.job["id"], next_run_at=new_next)
     record_catch_up_occurrence()
+    return False
 
 
 def _retire_expired_oneshot(d: _DueJob) -> bool:
@@ -3006,8 +3013,8 @@ def _evaluate_due_job(job: Dict[str, Any], scan: _DueScan, run_claim_ttl: float)
     if not manual_run and kind == "cron" and _reanchor_stale_cron(d):
         return False
     grace = _compute_grace_seconds(d.schedule)
-    if not manual_run and recurring:
-        _fast_forward_missed_recurring(d, grace)
+    if not manual_run and recurring and _fast_forward_missed_recurring(d, grace):
+        return False
     if kind == "once":
         if _retire_expired_oneshot(d) or _oneshot_dispatch_limit_reached(job, scan):
             return False

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2897,7 +2897,8 @@ def _fast_forward_missed_recurring(d: _DueJob, grace: int) -> bool:
     if not new_next:
         return False
     d.scan.persist(d.job["id"], next_run_at=new_next)
-    if not _cron_config_number("catch_up_missed", True, lambda value: value is not False):
+    if (_ensure_aware(datetime.fromisoformat(new_next)) > d.scan.now
+            and not _cron_config_number("catch_up_missed", True, lambda value: value is not False)):
         logger.info(
             "Job '%s' missed its scheduled time (%s, grace=%ds). "
             "Skipping missed occurrence because cron.catch_up_missed is false; next run: %s",

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1989,6 +1989,10 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
 
         if "schedule" in updates:
             _apply_schedule_update(updated, updates, job_id)
+        if {"schedule", "next_run_at", "enabled", "state"}.intersection(updates):
+            # An explicit schedule/lifecycle rewrite supersedes any occurrence the dispatcher
+            # left unclaimed — pause/resume/edit must not resurrect a slot from before the edit.
+            updated.pop("pending_slot", None)
         if inference_fields_changed:
             snapshots = _compute_provider_model_snapshots(
                 provider=updated.get("provider"),
@@ -2234,6 +2238,7 @@ def _record_run_outcome(
     job["last_delivery_error"] = delivery_error
     # Clear both claims: the run is over, so the job is claimable again.
     job["fire_claim"] = None
+    job.pop("pending_slot", None)
     if job.get("run_claim") is not None:  # keep key absence for legacy records
         job["run_claim"] = None
 
@@ -2581,6 +2586,8 @@ def claim_job_for_fire(
         # Per-acquisition token: a process may legitimately reclaim its own stale lease, and the
         # previous runner must not heartbeat the new claim merely because hostname + PID match.
         job["fire_claim"] = {"at": now.isoformat(), "by": f"{_machine_id()}:{uuid.uuid4().hex}"}
+        # Claimed: the occurrence is now owned by a run (its ledger row + fire claim carry it).
+        job.pop("pending_slot", None)
         if job.get("schedule", {}).get("kind") in {"cron", "interval"}:
             nxt = compute_next_run(job["schedule"], now.isoformat())
             if nxt:
@@ -2969,6 +2976,29 @@ def _oneshot_dispatch_limit_reached(job: Dict[str, Any], scan: _DueScan) -> bool
     return True
 
 
+def _restore_unclaimed_slot(job: Dict[str, Any], scan: _DueScan) -> Optional[str]:
+    """Put an occurrence the dispatcher advanced past but never claimed back on the schedule
+    (#107485); returns the restored ``next_run_at`` or None. Restored ONCE: the stamp is dropped
+    here, so the slot then meets the ordinary late / fast-forward / ``cron.catch_up_missed``
+    policy like any other overdue instant — never a replay of every missed slot."""
+    from cron.occurrences import unclaimed_pending_slot
+
+    slot = unclaimed_pending_slot(job, scan.now)
+    if slot is None:
+        return None
+    logger.warning(
+        "Job '%s' (%s): occurrence %s was taken off the schedule but never claimed "
+        "(scheduler stopped before dispatch); restoring it as the due instant (was %s).",
+        job.get("name", job.get("id")), job.get("id"), slot, job.get("next_run_at"))
+    job["next_run_at"] = slot
+    job.pop("pending_slot", None)
+    rj = scan.find(job["id"])
+    if rj is not None:
+        rj.pop("pending_slot", None)
+    scan.persist(job["id"], next_run_at=slot)
+    return slot
+
+
 def _evaluate_due_job(job: Dict[str, Any], scan: _DueScan, run_claim_ttl: float) -> bool:
     """Decide whether one enabled, non-terminal job fires this tick, persisting any repairs.
     Ordering matters: recover missing next_run_at, repair timezone shifts, re-arm stale-error
@@ -2984,7 +3014,7 @@ def _evaluate_due_job(job: Dict[str, Any], scan: _DueScan, run_claim_ttl: float)
     ):
         return False
 
-    next_run = job.get("next_run_at") or _recover_missing_next_run(job, scan)
+    next_run = _restore_unclaimed_slot(job, scan) or job.get("next_run_at") or _recover_missing_next_run(job, scan)
     if not next_run:
         return False
     raw_next_run_dt = datetime.fromisoformat(next_run)
@@ -3040,7 +3070,13 @@ def _evaluate_due_job(job: Dict[str, Any], scan: _DueScan, run_claim_ttl: float)
             "kind": _classify_dispatch_lateness(lateness, grace),
         }
         job["last_dispatch"] = dispatch_stamp
-        scan.persist(job["id"], last_dispatch=dispatch_stamp)
+        # The tick advances next_run_at past this occurrence before any fire claim exists; the
+        # stamp survives a process death in that window so the slot is restored, not lost.
+        from cron.occurrences import pending_slot_stamp
+
+        scan.persist(
+            job["id"], last_dispatch=dispatch_stamp,
+            pending_slot=pending_slot_stamp(next_run, now))
     return True
 
 

--- a/cron/occurrences.py
+++ b/cron/occurrences.py
@@ -34,3 +34,52 @@ def completed_occurrence(job, instant):
     except Exception:
         logger.warning("Cannot check completed occurrence for job %s", job['id'], exc_info=True)
         return False
+
+
+# --- Pending slot: the occurrence a tick took off the schedule but has not yet claimed ---
+#
+# The tick advances a recurring job's ``next_run_at`` BEFORE dispatch (at-most-once: a crash
+# mid-run must not re-fire on every restart). That leaves a window — advance done, fire claim
+# not yet taken (interpreter finalizing, executor refusing work, process killed) — in which the
+# process exiting loses the occurrence silently: the restarted scan sees a future ``next_run_at``
+# and nothing ever ran (#107485). ``pending_slot`` is the durable record of that window: the due
+# scan stamps it with the exact stored instant plus the stamping owner, ``claim_job_for_fire``
+# (the point after which side effects may exist) clears it, and any explicit rewrite of the
+# schedule drops it. A slot still pending once its owner is provably gone (or its lease has
+# expired) was never claimed, so it is restored ONCE as the due instant and then flows through
+# the ordinary late / fast-forward / ``cron.catch_up_missed`` policy — never N replays.
+
+def pending_slot_stamp(next_run, now):
+    """Store value for a recurring occurrence about to be handed to the dispatcher."""
+    from cron.jobs import _machine_id
+
+    return {"scheduled_at": next_run, "at": now.isoformat(), "by": _machine_id()}
+
+
+def unclaimed_pending_slot(job, now):
+    """Stored instant of a slot the dispatcher never claimed, or None.
+
+    None for non-recurring jobs and malformed stamps (never a fire) and for a job still in this
+    process's running set (its queued worker will claim and clear the slot itself). A stamp by
+    THIS process on a job not running here is orphaned (dispatch refused). A stamp by another
+    process is honoured while that owner may still be alive within the fire-claim lease — a
+    second live gateway on the same store is mid-dispatch, not dead."""
+    from cron.jobs import (
+        FIRE_CLAIM_TTL_SECONDS, _claim_is_live, _job_running_in_this_process, _machine_id,
+    )
+
+    pending = job.get("pending_slot")
+    if not isinstance(pending, dict):
+        return None
+    slot = pending.get("scheduled_at")
+    if job.get("schedule", {}).get("kind") not in {"cron", "interval"} or not isinstance(slot, str):
+        return None
+    try:
+        datetime.fromisoformat(slot)
+    except ValueError:
+        return None
+    if _job_running_in_this_process(str(job.get("id", ""))):
+        return None
+    if pending.get("by") != _machine_id() and _claim_is_live(pending, now, FIRE_CLAIM_TTL_SECONDS):
+        return None
+    return slot

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1633,6 +1633,7 @@ DEFAULT_CONFIG = {
     },
 
     "cron": {
+        "catch_up_missed": True,  # False skips recurring misses beyond the local grace window.
         # Let cron-spawned agents use the cronjob toolset (the "cron-librarian" pattern). Off by
         # default: policy-denied in cron context to prevent unattended scheduling loops. Jobs
         # created this way are user-owned in the same flat jobs table. Interactive toolsets

--- a/tests/cron/test_catchup_policy.py
+++ b/tests/cron/test_catchup_policy.py
@@ -1,0 +1,41 @@
+"""The local missed-run policy preserves grace and manual triggers."""
+from datetime import timedelta
+
+import pytest
+
+from cron import jobs
+
+
+@pytest.mark.parametrize("catch_up", [True, False])
+def test_missed_policy_preserves_grace_and_manual(tmp_path, monkeypatch, catch_up):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(f"cron:\n  catch_up_missed: {str(catch_up).lower()}\n", encoding="utf-8")
+    with jobs.use_cron_store(tmp_path / "cron"):
+        now = jobs._hermes_now()
+        for name, lag in [("stale", 14400), ("grace", 30), ("manual", 14400)]:
+            job = jobs.create_job(prompt=name, schedule="every 1h", model="fixture", deliver="local")
+            stored = jobs.load_jobs()
+            row = next(row for row in stored if row["id"] == job["id"])
+            row["next_run_at"] = (now - timedelta(seconds=lag)).isoformat()
+            if name == "manual":
+                row["manual_run_at"] = row["next_run_at"]
+            jobs.save_jobs(stored)
+        due = {job["prompt"] for job in jobs.get_due_jobs()}
+        assert due == ({"stale", "grace", "manual"} if catch_up else {"grace", "manual"})
+        stale = next(row for row in jobs.load_jobs() if row["prompt"] == "stale")
+        assert jobs._ensure_aware(jobs.datetime.fromisoformat(stale["next_run_at"])) > now
+
+
+@pytest.mark.parametrize("uncomputable", [False, True])
+def test_default_and_uncomputable_still_catch_up(tmp_path, monkeypatch, uncomputable):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    if uncomputable:
+        (tmp_path / "config.yaml").write_text("cron:\n  catch_up_missed: false\n", encoding="utf-8")
+    with jobs.use_cron_store(tmp_path / "cron"):
+        job = jobs.create_job(prompt="default", schedule="every 1h", model="fixture", deliver="local")
+        stored = jobs.load_jobs()
+        stored[0]["next_run_at"] = (jobs._hermes_now() - timedelta(hours=4)).isoformat()
+        jobs.save_jobs(stored)
+        if uncomputable:
+            monkeypatch.setattr(jobs, "compute_next_run", lambda *args: None)
+        assert [row["id"] for row in jobs.get_due_jobs()] == [job["id"]]

--- a/tests/cron/test_cron_timezone_migration_catchup.py
+++ b/tests/cron/test_cron_timezone_migration_catchup.py
@@ -85,13 +85,15 @@ def test_legacy_utc_offset_next_run_still_fires(temp_home, monkeypatch):
 def test_legacy_offset_catchup_fires_at_most_once(temp_home, monkeypatch):
     """The catch-up run is a single fire: once the scheduler advances the
     job, the legacy instant is gone and a second scan finds nothing due."""
-    from cron.jobs import advance_next_run, get_due_jobs, get_job
+    from cron.jobs import advance_next_run, claim_job_for_fire, get_due_jobs, get_job
 
     monkeypatch.setattr("cron.jobs._hermes_now", lambda: _BRUSSELS_NOW)
     jid = _write_cron_job(_DAILY_0400, _LEGACY_UTC_NEXT_RUN)
 
     assert jid in [j["id"] for j in get_due_jobs()]
     assert advance_next_run(jid) is True
+    # The fire claim is what commits the occurrence; without it a restart restores the slot.
+    assert claim_job_for_fire(jid)
 
     # Re-anchored to tomorrow's occurrence, expressed in the configured zone.
     assert get_job(jid)["next_run_at"] == "2026-09-03T04:00:00+02:00"

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -860,12 +860,15 @@ class TestAdvanceNextRun:
         due_before = get_due_jobs()
         assert len(due_before) == 1
 
-        # Advance (simulating what tick() does before run_job)
+        # Advance + claim (what tick() does before run_job); the claim is the point after which
+        # side effects may exist, so a restart after it must not re-fire (#3396). A restart
+        # BEFORE the claim restores the occurrence instead (#107485, test_missed_window_catchup).
         advance_next_run(job["id"])
+        assert claim_job_for_fire(job["id"])
 
-        # Now the job should NOT be due (simulates restart after crash)
+        # Now the job should NOT be due (simulates restart after a mid-run crash)
         due_after = get_due_jobs()
-        assert len(due_after) == 0, "Job should not be due after advance_next_run"
+        assert len(due_after) == 0, "Job should not be due after advance + claim"
 
 
 class TestGetDueJobs:

--- a/tests/cron/test_missed_window_catchup.py
+++ b/tests/cron/test_missed_window_catchup.py
@@ -1,0 +1,115 @@
+"""A recurring occurrence that a tick took off the schedule but never dispatched must fire once
+after the scheduler restarts — never be silently lost, never fire twice (#107485).
+
+The tick advances ``next_run_at`` BEFORE dispatch (at-most-once across a crash mid-run). When the
+process dies in the window between that advance and the fire claim — the interpreter was already
+finalizing, the executor refused work, SIGKILL — the restarted scan used to see only the future
+``next_run_at`` and the occurrence vanished: no execution row, no log line. The store now carries a
+``pending_slot`` stamp across that window and a later scan restores it as the due instant.
+
+Drives the REAL ``tick()`` against a throwaway HERMES_HOME with a ``no_agent`` script job that
+appends one line per fire. Process 1 is a real subprocess that dies inside the window, so the
+restarted scan sees a provably dead owner exactly as a gateway restart does.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+
+_CRASH_BEFORE_DISPATCH = """
+import os, sys
+sys.path.insert(0, sys.argv[1])
+import cron.scheduler as S
+S.create_execution = lambda *a, **k: os._exit(137)  # SIGKILL in the advance→claim window
+S.tick(verbose=False, sync=True)
+"""
+
+
+@pytest.fixture
+def slot_env(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    (home / "cron" / "output").mkdir(parents=True)
+    (home / "scripts").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_MACHINE_ID", raising=False)
+
+    import cron.executions as E
+    import cron.jobs as J
+    import cron.scheduler as S
+
+    monkeypatch.setattr(J, "HERMES_DIR", home)
+    monkeypatch.setattr(J, "CRON_DIR", home / "cron")
+    monkeypatch.setattr(J, "JOBS_FILE", home / "cron" / "jobs.json")
+    monkeypatch.setattr(J, "OUTPUT_DIR", home / "cron" / "output")
+    monkeypatch.setattr(E, "EXECUTIONS_FILE", home / "cron" / "executions.db")
+    monkeypatch.setattr(S, "_hermes_home", home)
+    S._running_job_ids.clear()
+    S._running_since.clear()
+    S._running_futures.clear()
+
+    counter = home / "fires.txt"
+    (home / "scripts" / "fire.sh").write_text(
+        f"#!/bin/sh\necho fired >> {counter}\necho fired\n", encoding="utf-8")
+    (home / "scripts" / "fire.sh").chmod(0o755)
+    job = J.create_job(prompt=None, schedule="every 1h", name="slot", script="fire.sh",
+                       no_agent=True, deliver="local")
+    slot = (J._hermes_now() - timedelta(minutes=1)).replace(microsecond=0).isoformat()
+    stored = J.load_jobs()
+    next(r for r in stored if r["id"] == job["id"])["next_run_at"] = slot
+    J.save_jobs(stored)
+
+    def fires() -> int:
+        return counter.read_text(encoding="utf-8").count("\n") if counter.exists() else 0
+
+    def crash_before_dispatch() -> None:
+        """Process 1: its tick advances the schedule, then it dies before any fire claim."""
+        env = dict(os.environ, HERMES_HOME=str(home))
+        proc = subprocess.run([sys.executable, "-c", _CRASH_BEFORE_DISPATCH, str(REPO)],
+                              env=env, cwd=str(REPO), capture_output=True, text=True, timeout=120)
+        assert proc.returncode == 137, proc.stderr[-2000:]
+
+    yield {"job_id": job["id"], "slot": slot, "fires": fires, "crash": crash_before_dispatch,
+           "S": S, "J": J, "E": E}
+    S._shutdown_parallel_pool()
+
+
+class TestMissedWindowCatchUp:
+    def test_slot_lost_before_dispatch_fires_once_after_restart(self, slot_env):
+        S, J, E = slot_env["S"], slot_env["J"], slot_env["E"]
+        job_id, slot = slot_env["job_id"], slot_env["slot"]
+
+        slot_env["crash"]()
+        after_crash = J.get_job(job_id)
+        assert J._ensure_aware(J.datetime.fromisoformat(after_crash["next_run_at"])) > J._hermes_now()
+        assert slot_env["fires"]() == 0
+
+        # Restarted scheduler: the occurrence must come back and run exactly once.
+        S.tick(verbose=False, sync=True)
+        assert slot_env["fires"]() == 1, "occurrence lost in the restart gap must fire once"
+        row = E.latest_execution(job_id)
+        assert row["status"] == "completed"
+        from cron.occurrences import scheduled_instant
+        assert row["scheduled_instant"] == scheduled_instant(slot), "restored slot keeps its identity"
+
+        S.tick(verbose=False, sync=True)
+        assert slot_env["fires"]() == 1
+        rec = J.get_job(job_id)
+        assert "pending_slot" not in rec
+        assert J._ensure_aware(J.datetime.fromisoformat(rec["next_run_at"])) > J._hermes_now()
+
+    def test_fired_slot_is_not_replayed_after_restart(self, slot_env):
+        """Contract half two: a slot that DID run before the restart stays run."""
+        S, J = slot_env["S"], slot_env["J"]
+        S.tick(verbose=False, sync=True)
+        assert slot_env["fires"]() == 1
+        S._running_job_ids.clear()  # what a restart forgets
+        S.tick(verbose=False, sync=True)
+        assert slot_env["fires"]() == 1
+        assert "pending_slot" not in J.get_job(slot_env["job_id"])

--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -114,6 +114,47 @@ tick()
   6. Release scheduler lock
 ```
 
+### Missed-occurrence contract (restart gaps)
+
+Recurring jobs are **at-most-once per occurrence, and every occurrence is
+accounted for**: it either runs (one execution row carrying its
+`scheduled_instant`), or its skip is logged with a reason. An occurrence is never
+dropped silently. The mechanics, in the order the due scan applies them
+(`cron/jobs.py::_evaluate_due_job`):
+
+1. **Pre-dispatch advance is provisional.** `tick()` advances `next_run_at` past
+   the due occurrence *before* dispatch so a crash mid-run cannot re-fire it on
+   every restart. Because that leaves a window — advanced, but no fire claim yet
+   (interpreter finalizing, executor refusing work, `SIGKILL`) — the due scan
+   stamps `pending_slot = {scheduled_at, at, by}` on the record in the same
+   save. `claim_job_for_fire` (the point after which side effects may exist)
+   and `mark_job_run` clear it; an explicit `schedule` / `next_run_at` /
+   `enabled` / `state` rewrite (edit, pause, resume, run-now) drops it.
+2. **Restore once.** A later scan that finds a `pending_slot` whose owner is
+   provably gone (this process and the job is not in its running set; another
+   process past the 300 s fire-claim lease or with a dead pid) puts
+   `scheduled_at` back as `next_run_at`, drops the stamp, and logs a WARNING
+   (`cron/occurrences.py::unclaimed_pending_slot`). This happens at most once
+   per lost occurrence — the restored instant then meets the ordinary rules
+   below like any other overdue slot, so there is never a replay of N slots.
+3. **Already fired → never twice.** `completed_occurrence()` consults the
+   executions ledger for a `completed` row with that exact `scheduled_instant`
+   before anything is due; a slot that ran before the restart advances without
+   firing. `failed` / `unknown` rows do not count as completion.
+4. **Late within grace → fire late.** Grace = half the period clamped to
+   `[120 s, 2 h]` (`_compute_grace_seconds`); the dispatch is stamped
+   `last_dispatch.kind = late`.
+5. **Past grace → collapse the backlog, fire once** (`kind = catch_up`), or skip
+   with a logged reason when the operator set `cron.catch_up_missed: false`
+   (planned downtime). One-shots past their 120 s grace are retired with a
+   diagnostic, never resurrected.
+6. **Paused / disabled / terminal jobs never catch up**; the due scan drops them
+   before any of the above, and pause/resume clears any pending slot.
+
+The same store fields drive every topology: a standalone `hermes -p X gateway
+run` and a profile served by the default multiplexer (`_start_multiplex` ticks
+each home under `_profile_cron_scope`) evaluate the identical record.
+
 ### Gateway Integration
 
 In gateway mode, the cron **trigger** (the part that decides *when* a due job

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -880,6 +880,24 @@ These misses are stamped on the job record as `last_fire_error` (timestamp + rea
 
 The stamp always reflects **current** auto-fire health: it is overwritten by newer misses and cleared automatically by the next successful run. If you see it, the job and its schedule are fine — the gateway side of the fire path needs attention (most commonly, restart the gateway through its supervisor so it loads the full profile environment: `hermes gateway restart`).
 
+### Local missed-run policy
+
+The local ticker normally runs each overdue recurring job **once**, not once per
+missed slot. To avoid catch-up load after a planned gateway stop, set:
+
+```yaml
+cron:
+  catch_up_missed: false   # default: true
+```
+
+Or run `hermes config set cron.catch_up_missed false`. With this opt-out, a recurring
+job later than its existing grace window (half its period, clamped to 120 seconds–2
+hours) is re-anchored to its next future occurrence without firing now. The skip is
+logged. Jobs inside grace and explicit manual triggers still run normally; if the
+next occurrence cannot be computed, the existing run-once fallback is preserved.
+This does not change one-shot expiry, resume behavior, or the hosted-provider sweep
+below. There is no per-job override.
+
 ### Misfire catch-up
 
 When an external scheduler provider is active (managed cron on hosted deployments), the gateway also runs a catch-up sweep: a job whose scheduled time passed with no fire delivered — and whose grace window has elapsed — is claimed and run locally, so an outage in the fire hand-off costs minutes instead of the whole day. The sweep is de-duplicated against late scheduler retries by the same store claim used for normal fires.

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -882,8 +882,14 @@ The stamp always reflects **current** auto-fire health: it is overwritten by new
 
 ### Local missed-run policy
 
-The local ticker normally runs each overdue recurring job **once**, not once per
-missed slot. To avoid catch-up load after a planned gateway stop, set:
+If the gateway was down (or restarting) when a recurring job's scheduled time
+passed, the job **catches up once** when the scheduler is back: a slot missed
+inside a restart gap fires exactly one time, a slot that already ran before the
+restart is never run again, and a long outage collapses into a single run rather
+than one run per missed slot. Paused jobs never catch up. Each catch-up shows in
+`hermes cron list` as `⚠ late` / `⚠ catch-up after missed fire`.
+
+To avoid that catch-up load after a planned gateway stop, set:
 
 ```yaml
 cron:


### PR DESCRIPTION
A recurring cron occurrence whose scheduled instant falls inside a gateway restart gap now fires **once** as a bounded catch-up instead of being silently skipped — on standalone and multiplexed gateways alike.

Tracker: #107485 (the idle-exit half landed in #108428; this is the slot-loss half teknium1 left open). Salvages #104981 (`cron.catch_up_missed` opt-out, @teknium1, cherry-picked with authorship).

## Symptom

`tick()` advances a recurring job's `next_run_at` **before** dispatch (at-most-once across a mid-run crash, #3396). If the process dies in the window between that advance and the fire claim — interpreter already finalizing (`cannot schedule new futures after interpreter shutdown`, the exact log in the issue), executor refusing work, `SIGKILL`, the Desktop idle-exit — the restarted scan sees only the future `next_run_at`. No execution row, no log line; a daily job skips a day. Root cause in one line: the pre-dispatch advance was the only record of the occurrence.

## Contract (new, documented in `cron-internals.md` → "Missed-occurrence contract")

Every recurring occurrence is accounted for: it runs once, or its skip is logged with a reason.

| Situation on restart | Behaviour |
|---|---|
| Slot advanced past but never claimed | restored as the due instant **once**, WARNING logged, fires |
| Slot already ran before the restart | never re-fired (`completed_occurrence()` on the executions ledger) |
| Slot missed within grace (½ period, 120 s–2 h) | fires, stamped `last_dispatch.kind = late` |
| Slot missed past grace | backlog collapses to **one** run (`kind = catch_up`); `cron.catch_up_missed: false` skips with a logged reason |
| Paused / disabled / terminal job | never catches up; pause/resume/edit/run-now drop any pending slot |

## Change

- `cron/occurrences.py::pending_slot_stamp` / `unclaimed_pending_slot` — the due scan stamps `pending_slot = {scheduled_at, at, by}` in the same save that writes `last_dispatch`; a later scan restores the slot when the owner is provably gone (this process and the job not in its running set; another process past the 300 s fire-claim lease or with a dead pid).
- `cron/jobs.py` — `_restore_unclaimed_slot` at the top of `_evaluate_due_job` (restore-once: stamp dropped when restored); `claim_job_for_fire` and `mark_job_run` clear the stamp; `update_job` drops it on `schedule`/`next_run_at`/`enabled`/`state` rewrites.
- Cherry-picked #104981: `cron.catch_up_missed` (default `true`) — the one config knob, no env var, no per-job field (the store already carried grace + lateness; the bug was the unrecorded window, not a missing field).
- Two crash-safety tests updated to model the real sequence (advance → claim) since the advance alone no longer commits an occurrence.
- Docs: `website/docs/developer-guide/cron-internals.md` (contract section), `website/docs/user-guide/features/cron.md` (catch-up-once behaviour above the opt-out), `cron/AGENTS.md` (hardening invariant).

## Live repro (real store, real `tick()`, fresh subprocess per "gateway process", `no_agent` script job counting fires; each scenario under both topologies — standalone `HERMES_HOME=<profile>` and served via `_profile_cron_scope` with multiplex on)

| Scenario | Before (`origin/main` a84a2223f82c) | After |
|---|---|---|
| tick advances, process SIGKILLed before dispatch, restart | `next_run_at` → +1 h, **0 fires**, no execution row | **1 fire**, `completed` row with the original `scheduled_instant`, `next_run_at` advanced |
| tick advances, executor refuses (interpreter shutdown), restart | `failed` row, **0 fires** | **1 fire** (`completed` beside the `failed`) |
| two crashes in the window, then restart | 0 fires | still exactly **1 fire** (restore-once) |
| process down from before T until 5 min after T | 1 fire (in-grace path already worked) | 1 fire |
| slot fired in process 1, restart | 1 fire total | 1 fire total (no double fire) |
| gap 200 min > grace, default policy | 1 fire | 1 fire (backlog collapsed) |
| gap 200 min, `catch_up_missed: false` | 1 fire | **0 fires**, `Skipping missed occurrence because cron.catch_up_missed is false` logged |
| paused job at T | 0 fires | 0 fires |

Identical results for standalone and served on every row.

## Tests

`tests/cron/test_missed_window_catchup.py` (2 invariants, real `tick()` with a subprocess that dies in the window): slot lost before dispatch fires once after restart and keeps its `scheduled_instant`; a fired slot is not replayed. Red on base (`assert 0 == 1` — occurrence lost), green with the fix. `tests/cron/test_catchup_policy.py` from #104981. `scripts/run_tests.sh tests/cron/` green.

Fixes #107485

## Infographic

![cron-missed-window-catchup](https://v3b.fal.media/files/b/0aaa1aed/wSzAKAz1sJjOGegsO5ciM_JjDC49tV.png)
