### PR TITLE
feat(multiplex): serve inbound-port platforms for secondary profiles via /p/<profile>/ on the shared listener

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -237,15 +237,18 @@ class Platform(Enum):
 # Built-in values snapshotted before any dynamic _missing_ lookup.
 _BUILTIN_PLATFORM_VALUES = frozenset(m.value for m in Platform.__members__.values())
 
-# Platforms that bind a host TCP port. In a multiplexer only the default profile owns the
-# shared listener, so a SECONDARY profile enabling one is a misconfiguration (single source
-# of truth for gateway/run.py and hermes_cli/web_server.py validation).
+# Platforms that bind a host TCP port. In a multiplexer only the default profile binds: a SECONDARY
+# profile's port-binder is built in shared-listener mode and served at /p/<profile>/<path> on the
+# default's listener (gateway/platforms/shared_ingress.py); api_server/webhook are mirrored there.
 PORT_BINDING_PLATFORM_VALUES = frozenset({
     "webhook", "api_server", "msgraph_webhook", "feishu", "wecom_callback",
     "bluebubbles", "sms", "whatsapp_cloud", "line", "teams",
 })
 # Platforms that only bind in one connection mode (Feishu's default websocket mode is outbound).
 PORT_BINDING_CONDITIONAL_MODES: dict[str, str] = {"feishu": "webhook"}
+# Port-binders whose /p/<profile>/ surface is a MIRROR served by the default's own adapter; a secondary
+# never gets an instance of these (api_server: /p/<profile>/v1/..., webhook: profile-bound routes).
+SHARED_LISTENER_MIRROR_PLATFORMS = frozenset({"api_server", "webhook"})
 
 
 def platform_binds_port(platform_value: str, extra: Optional[dict] = None) -> bool:

--- a/gateway/config_env.py
+++ b/gateway/config_env.py
@@ -21,7 +21,7 @@ from gateway.config import (
     PlatformConfig,
     _getenv_str,
     _has_usable_api_server_key,
-    platform_binds_port,
+    SHARED_LISTENER_MIRROR_PLATFORMS,
 )
 from utils import is_truthy_value
 
@@ -183,11 +183,10 @@ def _enable_from_env(
 ) -> PlatformConfig:
     """Enable *platform* on env credentials unless config.yaml explicitly disabled it.
 
-    A multiplex secondary profile pins ``enabled: false`` to share the default profile's listener
-    yet inherits the process env; without this guard env presence would force-enable it and trip
-    MultiplexConfigError. By default the ``_enabled_explicit`` marker is READ (the plugin-enable
-    and relay passes still need it) and the disable is warned once; port-binding platforms POP it
-    (terminal branch) and stay silent.
+    A multiplex secondary profile may pin ``enabled: false`` yet inherit the process env; without
+    this guard env presence would force-enable it. By default the ``_enabled_explicit`` marker is
+    READ (the plugin-enable and relay passes still need it) and the disable is warned once;
+    api_server/webhook POP it (terminal branch) and stay silent.
     """
     platform_config = config.platforms.setdefault(platform, PlatformConfig())
     extra = platform_config.extra
@@ -195,12 +194,12 @@ def _enable_from_env(
     if platform_config.enabled:
         return platform_config
     if not explicit and not (
-        platform_binds_port(platform.value, extra) and _loading_secondary_under_multiplexer()
+        platform.value in SHARED_LISTENER_MIRROR_PLATFORMS and _loading_secondary_under_multiplexer()
     ):
-        # A secondary's port-binding credential (the docs require API_SERVER_KEY in its .env for
-        # /p/<profile>/ auth) must not turn into listener intent: the default profile owns the one
-        # shared listener and ``_load_secondary_profile_config`` skips the WHOLE profile for it (#100397).
-        # The credential itself still lands in ``extra`` for the shared adapter to authenticate with.
+        # A secondary's API_SERVER_KEY / WEBHOOK_ENABLED (the docs require the key in its .env for
+        # /p/<profile>/ auth) must not turn into listener intent: the default profile's listener already
+        # mirrors those two at /p/<profile>/ (#100397). The credential still lands in ``extra`` for it.
+        # Every other inbound-port platform IS enabled for a secondary: it runs in shared-listener mode.
         platform_config.enabled = True
     elif warn:
         _warn_explicit_disable_beats_env(platform)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1485,6 +1485,14 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         from hermes_cli.profiles import get_profile_dir
         return _profile_runtime_scope(get_profile_dir(profile))
 
+    async def _handle_profile_ingress(self, request: "web.Request") -> "web.StreamResponse":
+        """``/p/<profile>/<tail>`` → the served profile's shared-listener adapter (already scoped by the
+        prefix middleware); a profile with no adapter for the path is a 404, never the default's."""
+        from gateway.platforms.shared_ingress import dispatch_profile_ingress
+        return await dispatch_profile_ingress(
+            self.gateway_runner, _api_request_profile.get(), request.match_info.get("tail", ""), request,
+            scoped=True)
+
     def _make_profile_prefix_middleware(self):
         """Reject unknown /p/<profile>/ prefixes and scope the request home."""
 
@@ -3894,6 +3902,9 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             for method, path, handler in self._http_route_table():
                 self._app.router.add_route(method, path, handler)
                 self._app.router.add_route(method, f"/p/{{profile}}{path}", handler)
+            # Registered LAST so every native mirror above wins: anything else under /p/<profile>/ is a
+            # secondary profile's inbound-port platform (Twilio, LINE, Teams, ...) served on this listener.
+            self._app.router.add_route("*", "/p/{profile}/{tail:.*}", self._handle_profile_ingress)
             # After native routes: Relay bootstrap shims feature-detect on this key and must
             # no-op rather than shadow the native session-control handlers.
             self._app["api_server_adapter"] = self

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1879,6 +1879,9 @@ class BasePlatformAdapter(ABC):
         self._busy_session_handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]] = None
         # Owning multiplex profile (None on primary); see _session_key_profile.
         self._owner_profile: Optional[str] = None
+        # Set by the runner on a secondary's port-binding adapter: serve via the default profile's
+        # shared listener (/p/<profile>/...) instead of binding a port (gateway/platforms/shared_ingress.py).
+        self._shared_listener_profile: Optional[str] = None
         # Registered by GatewayRunner (see set_authorization_check).
         self._authorization_check: Optional[Callable[[str, Optional[str], Optional[str]], bool]] = None
         # Auto-TTS on voice input: ``voice.auto_tts`` default plus per-chat /voice on|tts / off.

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -226,13 +226,14 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         app.router.add_post(self.webhook_path, self._handle_webhook)
         # The webhook auth value rides in the query string (BlueBubbles cannot send custom headers)
         # — keep it out of aiohttp access logs.
-        self._runner = web.AppRunner(app, access_log=None)
-        await self._runner.setup()
-        site = web.TCPSite(self._runner, self.webhook_host, self.webhook_port)
-        await site.start()
+        # Shared-listener mode (multiplex secondary): no bind; served at /p/<profile>/<webhook_path>.
+        from gateway.platforms.shared_ingress import bind_listener
+        self._runner = await bind_listener(
+            self, app, self.webhook_host, self.webhook_port, self.webhook_path, access_log=None)
         self._mark_connected()
-        logger.info("[bluebubbles] webhook listening on http://%s:%s%s", self.webhook_host, self.webhook_port,
-                    self.webhook_path)
+        if self._runner is not None:
+            logger.info("[bluebubbles] webhook listening on http://%s:%s%s", self.webhook_host, self.webhook_port,
+                        self.webhook_path)
         await self._register_webhook()  # the server only sends events to webhooks registered via its API
         # Plugin-registered native handlers (ctx.register_platform_handler).
         self._wire_plugin_handlers(None)
@@ -253,7 +254,11 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
     @property
     def _webhook_url(self) -> str:
-        """External webhook URL for BlueBubbles registration (local binds → localhost)."""
+        """External webhook URL for BlueBubbles registration (local binds → localhost). In
+        shared-listener mode it is the default listener's ``/p/<profile>/`` URL."""
+        shared = getattr(self, "_shared_ingress_url", None)
+        if shared:
+            return shared
         host = "localhost" if self.webhook_host in _LOCAL_HOSTS else self.webhook_host
         return f"http://{host}:{self.webhook_port}{self.webhook_path}"
 

--- a/gateway/platforms/msgraph_webhook.py
+++ b/gateway/platforms/msgraph_webhook.py
@@ -143,12 +143,12 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         app.router.add_post(self._webhook_path, self._handle_notification)
         # Plugin-registered native routes; wired before AppRunner.setup() freezes the router.
         self._wire_plugin_handlers(app)
-        self._runner = web.AppRunner(app)
-        await self._runner.setup()
-        site = web.TCPSite(self._runner, self._host, self._port)
-        await site.start()
+        # Shared-listener mode (multiplex secondary): no bind; served at /p/<profile>/<webhook_path>.
+        from gateway.platforms.shared_ingress import bind_listener
+        self._runner = await bind_listener(self, app, self._host, self._port, self._webhook_path)
         self._mark_connected()
-        logger.info("[msgraph_webhook] Listening on %s:%d%s", self._host, self._port, self._webhook_path)
+        if self._runner is not None:
+            logger.info("[msgraph_webhook] Listening on %s:%d%s", self._host, self._port, self._webhook_path)
         return True
 
     async def disconnect(self) -> None:

--- a/gateway/platforms/shared_ingress.py
+++ b/gateway/platforms/shared_ingress.py
@@ -1,0 +1,141 @@
+"""Shared-listener ingress for inbound-port platforms under ``gateway.multiplex_profiles``.
+
+The default profile owns the ONE HTTP listener (api_server, and the webhook adapter's port). A
+secondary profile's port-binding adapter (Twilio SMS, LINE, Teams, BlueBubbles, Microsoft Graph,
+WhatsApp Cloud, WeCom callback, Feishu webhook mode) therefore cannot bind its own port; instead the
+runner constructs it in *shared-listener mode*: ``bind_listener`` publishes the adapter's fully wired
+``web.Application`` instead of starting a ``TCPSite``, and the default listener forwards
+``/p/<profile>/<path>`` to it through ``dispatch_profile_ingress``.
+
+Invariants: the forwarded request runs under the NAMED profile's runtime scope and is verified by
+that profile's adapter with that profile's secret; the un-prefixed path keeps serving the default
+profile untouched; a profile with no adapter for the path gets a 404, never the default's adapter.
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:  # aiohttp is an optional dependency of every adapter using this module
+    from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+_WILDCARD_HOSTS = frozenset({"", "0.0.0.0", "::", "*"})
+
+
+def shared_ingress_profile(adapter: Any) -> Optional[str]:
+    """Profile name when *adapter* was constructed in shared-listener mode, else None."""
+    return getattr(adapter, "_shared_listener_profile", None) or None
+
+
+def shared_listener_base(runner: Any) -> Optional[str]:
+    """``http://host:port`` of the default profile's live listener (api_server first, then webhook)."""
+    from gateway.config import Platform
+    adapters = getattr(runner, "adapters", None) or {}
+    for platform in (Platform.API_SERVER, Platform.WEBHOOK):
+        adapter = adapters.get(platform)
+        if adapter is None:
+            continue
+        host = getattr(adapter, "_host", None)
+        host = "127.0.0.1" if host is None or str(host).strip() in _WILDCARD_HOSTS else str(host)
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        return f"http://{host}:{getattr(adapter, '_port', 0)}"
+    return None
+
+
+async def bind_listener(
+    adapter: Any, app: "web.Application", host: Optional[str], port: int, ingress_path: str, *,
+    reuse_address: Optional[bool] = None, access_log: Any = ...,
+) -> Optional["web.AppRunner"]:
+    """Start *app* on ``host:port`` and return its ``AppRunner`` — or, in shared-listener mode,
+    publish *app* for ``/p/<profile>/`` forwarding and return None (nothing bound). ``ingress_path``
+    is the adapter's primary callback path, used for the log line and runtime status."""
+    from aiohttp import web
+    profile = shared_ingress_profile(adapter)
+    if profile:
+        publish_shared_ingress(adapter, app, ingress_path)
+        return None
+    runner = web.AppRunner(app) if access_log is ... else web.AppRunner(app, access_log=access_log)
+    await runner.setup()
+    site = web.TCPSite(runner, host, port, reuse_address=reuse_address)
+    try:
+        await site.start()
+    except BaseException:
+        await runner.cleanup()
+        raise
+    return runner
+
+
+def publish_shared_ingress(adapter: Any, app: "web.Application", ingress_path: str) -> None:
+    """Freeze *app* and expose it to the default listener; records the ``/p/<profile>/`` URL."""
+    profile = shared_ingress_profile(adapter)
+    app.freeze()
+    adapter._shared_ingress_app = app
+    base = shared_listener_base(getattr(adapter, "gateway_runner", None))
+    prefix = f"/p/{profile}"
+    adapter._shared_ingress_base = f"{base}{prefix}" if base else prefix
+    adapter._shared_ingress_url = f"{adapter._shared_ingress_base}{ingress_path}"
+    platform = getattr(getattr(adapter, "platform", None), "value", "adapter")
+    if base:
+        logger.info(
+            "[%s] profile '%s' is served on the default profile's shared listener: %s "
+            "(point the vendor's callback URL at this path behind your public host)",
+            platform, profile, adapter._shared_ingress_url,
+        )
+    else:
+        logger.warning(
+            "[%s] profile '%s' is in shared-listener mode but the default profile has no live api_server "
+            "or webhook listener yet; it will be reachable at <listener>%s%s once one is up",
+            platform, profile, prefix, ingress_path,
+        )
+    write = getattr(adapter, "_write_runtime_status_safe", None)
+    if callable(write):
+        write("shared_ingress", ingress_url=adapter._shared_ingress_url)
+
+
+def shared_ingress_apps(runner: Any, profile: Optional[str]) -> list[tuple[Any, "web.Application"]]:
+    """``(adapter, app)`` for every shared-listener adapter of a NAMED served profile. ``default`` and
+    unknown profiles yield nothing: the default's port-binders own their own ports, and a profile
+    without a live adapter must never fall back to another profile's."""
+    if not profile or profile == "default":
+        return []
+    adapters = (getattr(runner, "_profile_adapters", None) or {}).get(profile) or {}
+    return [
+        (adapter, app) for adapter in adapters.values()
+        if (app := getattr(adapter, "_shared_ingress_app", None)) is not None
+    ]
+
+
+async def dispatch_profile_ingress(
+    runner: Any, profile: Optional[str], tail: str, request: "web.Request", *, scoped: bool = False,
+) -> "web.StreamResponse":
+    """Forward ``/p/<profile>/<tail>`` to the served profile's adapter app that routes ``/<tail>``,
+    under that profile's runtime scope (``scoped=True`` when the caller already entered it). 404 when
+    no adapter of *profile* serves the path."""
+    from aiohttp import web
+    from aiohttp.web_urldispatcher import MatchInfoError
+    candidates = shared_ingress_apps(runner, profile)
+    if not profile or not candidates:
+        raise web.HTTPNotFound(text="Unknown or unconfigured profile")
+    rel_url = request.rel_url.with_path("/" + tail.lstrip("/"), keep_query=True, keep_fragment=True)
+    forwarded = request.clone(rel_url=rel_url)
+    chosen = None
+    for _adapter, app in candidates:
+        match = await app.router.resolve(forwarded)
+        # A 404 means "not my path": try the profile's next adapter; 405 and real matches belong here.
+        if isinstance(match, MatchInfoError) and match.http_exception.status == 404:
+            continue
+        chosen = app
+        break
+    if chosen is None:
+        raise web.HTTPNotFound(text="No adapter serves this path for the profile")
+    # Each adapter chose its own body cap when it built its Application; honour it for the forwarded read.
+    forwarded = request.clone(rel_url=rel_url, client_max_size=chosen._client_max_size)
+    if scoped:
+        return await chosen._handle(forwarded)
+    from gateway.run import _profile_runtime_scope
+    from hermes_cli.profiles import get_profile_dir
+    with _profile_runtime_scope(get_profile_dir(profile)):
+        return await chosen._handle(forwarded)

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -215,6 +215,9 @@ class WebhookAdapter(BasePlatformAdapter):
         app.router.add_post("/webhooks/{route_name}", self._handle_webhook)
         # /p/<profile>/ routes the event to that profile (honored only under gateway.multiplex_profiles).
         app.router.add_post("/p/{profile}/webhooks/{route_name}", self._handle_webhook)
+        # Without an api_server listener this port is the shared listener: forward a secondary's
+        # inbound-port platforms (Twilio, LINE, Teams, ...) registered in shared-listener mode.
+        app.router.add_route("*", "/p/{profile}/{tail:.*}", self._handle_profile_ingress)
         self._runner = web.AppRunner(app)
         await self._runner.setup()
         # SO_REUSEADDR: on macOS (BSD) two wildcard/specific sockets can silently split traffic while
@@ -371,6 +374,14 @@ class WebhookAdapter(BasePlatformAdapter):
                         ", ".join(self._dynamic_routes.keys()) or "(none)")
         except Exception as e:
             logger.error("[webhook] Failed to reload dynamic routes: %s", e)
+
+    async def _handle_profile_ingress(self, request: "web.Request") -> "web.StreamResponse":
+        profile = self._resolve_request_profile(request)
+        if profile is _PROFILE_REJECTED or profile is None:
+            return _json_error("Unknown or unconfigured profile", 404)
+        from gateway.platforms.shared_ingress import dispatch_profile_ingress
+        return await dispatch_profile_ingress(
+            self.gateway_runner, profile, request.match_info.get("tail", ""), request)
 
     def _resolve_request_profile(self, request: "web.Request"):
         """Resolve + validate the /p/<profile>/ URL prefix: None (no prefix, or multiplexing off and the

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -270,14 +270,15 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         app.router.add_get(self._health_path, self._handle_health)
         app.router.add_get(self._webhook_path, self._handle_verify)
         app.router.add_post(self._webhook_path, self._handle_webhook)
-        self._runner = web.AppRunner(app)
-        await self._runner.setup()
-        await web.TCPSite(self._runner, self._webhook_host, self._webhook_port).start()
+        # Shared-listener mode (multiplex secondary): no bind; served at /p/<profile>/<webhook_path>.
+        from gateway.platforms.shared_ingress import bind_listener
+        self._runner = await bind_listener(self, app, self._webhook_host, self._webhook_port, self._webhook_path)
         self._mark_connected()
-        logger.info(
-            "[whatsapp_cloud] Listening on %s:%d%s (Graph %s, phone_id=%s)",
-            self._webhook_host, self._webhook_port, self._webhook_path, self._api_version, self._phone_number_id,
-        )
+        if self._runner is not None:
+            logger.info(
+                "[whatsapp_cloud] Listening on %s:%d%s (Graph %s, phone_id=%s)",
+                self._webhook_host, self._webhook_port, self._webhook_path, self._api_version, self._phone_number_id,
+            )
         if not self._verify_token:
             logger.warning("[whatsapp_cloud] WHATSAPP_CLOUD_VERIFY_TOKEN is not set — the GET subscription handshake will fail until it is.")
         if not self._app_secret:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1650,11 +1650,6 @@ class MultiplexConfigError(RuntimeError):
     startup guard instead of being treated as retryable adapter-connect noise."""
 
 
-class SecondaryPortBindingConfigError(MultiplexConfigError):
-    """A secondary profile enabled a port-binding platform: the default profile owns the single shared
-    listener (/p/<profile>/), so this is always a misconfiguration and is skipped, not fatal."""
-
-
 class HygieneTurnHoldExceeded(Exception):
     """Hygiene-compression turn-hold budget elapsed mid-stream. Availability boundary, not a failure:
     must NOT take the idle-timeout path (AGENT_COMPRESSION_TIMEOUT, "no output", failure cooldown)."""

--- a/gateway/run_adapters.py
+++ b/gateway/run_adapters.py
@@ -19,7 +19,7 @@ import weakref as _weakref
 from agent.async_utils import consume_detached_task_result
 from contextvars import Context
 from datetime import datetime, timedelta, timezone
-from gateway.config import Platform, platform_binds_port as _platform_binds_port
+from gateway.config import SHARED_LISTENER_MIRROR_PLATFORMS, Platform, platform_binds_port as _platform_binds_port
 from gateway.platforms.base import BasePlatformAdapter
 from gateway.restart import is_global_startup_conflict
 from gateway.run_shutdown import _log_suppressed
@@ -826,9 +826,7 @@ class GatewayAdapterLifecycleMixin:
         """Bring up adapters for every non-active profile (multiplex only); returns connected count.
         Each profile connects under its own HERMES_HOME + secret scope; credential/listener collisions
         are refused here — the only point seeing every profile's credentials together."""
-        from gateway.run import (
-            MultiplexConfigError, SecondaryPortBindingConfigError, _multiplex_profile_homes
-        )
+        from gateway.run import MultiplexConfigError, _multiplex_profile_homes
         if not self._multiplex_on():
             return 0
         try:
@@ -844,10 +842,6 @@ class GatewayAdapterLifecycleMixin:
                 continue  # handled by the primary startup loop
             try:
                 connected += await self._start_one_profile_adapters(profile_name, profile_home, claimed)
-            except SecondaryPortBindingConfigError as e:
-                logger.warning(
-                    "Skipping secondary profile '%s' due to port-binding config error: %s", profile_name, e,
-                )
             except MultiplexConfigError:
                 raise
             except Exception as e:
@@ -888,10 +882,11 @@ class GatewayAdapterLifecycleMixin:
 
     async def _load_secondary_profile_config(self, profile_name: str, profile_home: "Path"):
         """Hydrate + enter ``profile_home``'s scope once; return its gateway config. Raises
-        ``MultiplexConfigError`` (open dm/group policy) or ``SecondaryPortBindingConfigError`` (the
-        default profile owns the single shared HTTP listener)."""
+        ``MultiplexConfigError`` (open dm/group policy). Port-binding platforms are NOT refused: the
+        default profile owns the single shared listener and a secondary's port-binders are built in
+        shared-listener mode (``/p/<profile>/...``) by ``_start_one_profile_adapters``."""
         from gateway.run import (
-            MultiplexConfigError, SecondaryPortBindingConfigError, _load_gateway_runtime_config,
+            MultiplexConfigError, _load_gateway_runtime_config,
             _own_policy_open_startup_violation, _profile_runtime_scope,
         )
         from gateway.config import load_gateway_config
@@ -914,20 +909,6 @@ class GatewayAdapterLifecycleMixin:
                 f"Profile '{profile_name}' enables {violation}. "
                 "Enable GATEWAY_ALLOW_ALL_USERS or the platform allow-all flag "
                 "for that profile, or change dm_policy/group_policy away from 'open'."
-            )
-        port_binding_platforms = sorted(
-            platform.value
-            for platform, platform_config in profile_cfg.platforms.items()
-            if platform_config.enabled and _platform_binds_port(platform.value, platform_config.extra)
-        )
-        if port_binding_platforms:
-            raise SecondaryPortBindingConfigError(
-                f"Profile '{profile_name}' enables port-binding platform(s) "
-                f"{', '.join(port_binding_platforms)}, but gateway.multiplex_profiles is on. The default "
-                f"profile owns the single shared HTTP listener and serves every "
-                f"profile through the /p/{profile_name}/ URL prefix. Remove "
-                f"these platform entries from profile '{profile_name}'s config.yaml "
-                f"or configure them only on the default profile."
             )
         return profile_cfg
 
@@ -984,6 +965,14 @@ class GatewayAdapterLifecycleMixin:
                 continue
             # Relay/WhatsApp are shared process-level ingress under multiplex; a secondary would retry-loop.
             if multiplex and platform in (Platform.RELAY, Platform.WHATSAPP):
+                continue
+            # api_server / webhook: the default's listener already mirrors them at /p/<profile>/; a second
+            # instance here would fight the default for the port (#100397).
+            if multiplex and platform.value in SHARED_LISTENER_MIRROR_PLATFORMS:
+                logger.info(
+                    "[MULTIPLEX] Profile '%s': %s is served by the default profile's listener at /p/%s/ — "
+                    "not starting a second listener", profile_name, platform.value, profile_name,
+                )
                 continue
             adapter = None
             with _log_suppressed(
@@ -1083,6 +1072,11 @@ class GatewayAdapterLifecycleMixin:
         # Secondary adapters carry their profile so prune paths namespace topic bindings correctly.
         # See #76423.
         adapter._hermes_profile_name = profile_name
+        # A secondary's port-binding adapter never binds: the default profile owns the one shared
+        # listener, which forwards /p/<profile>/<path> to this adapter's app (shared_ingress.py).
+        if self._multiplex_on() and platform.value not in SHARED_LISTENER_MIRROR_PLATFORMS \
+                and _platform_binds_port(platform.value, getattr(getattr(adapter, "config", None), "extra", None)):
+            adapter._shared_listener_profile = profile_name
 
     async def _secondary_reconnect_attempt(self, profile_name: str, platform: Platform):
         """One scoped attempt to rebuild+connect a secondary adapter → ``(adapter, success)``;

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -804,7 +804,7 @@ def write_runtime_status(
     active_agents: Any = _UNSET, platform: Any = _UNSET, platform_state: Any = _UNSET,
     error_code: Any = _UNSET, error_message: Any = _UNSET, needs_attention: Any = _UNSET,
     retrying_since: Any = _UNSET, served_profiles: Any = _UNSET, session_store: Any = _UNSET,
-    clear_profile_platforms: bool = False,
+    ingress_url: Any = _UNSET, clear_profile_platforms: bool = False,
 ) -> None:
     """Persist gateway runtime health information for diagnostics/status."""
     path = _get_runtime_status_path()
@@ -842,6 +842,8 @@ def write_runtime_status(
             ("needs_attention", needs_attention, bool),
             # ISO start of the current retry episode; None clears it.
             ("retrying_since", retrying_since, None),
+            # Shared-listener secondaries: the /p/<profile>/ callback URL the vendor console must target.
+            ("ingress_url", ingress_url, None),
         ))
         # Per-entry writer provenance: top-level pid/start_time only identify the most recent
         # writer; /api/status tells "live" from "preserved" by exact (pid, start_time) equality.

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1477,6 +1477,23 @@ def _print_gateway_process_mismatch(snapshot: GatewayRuntimeSnapshot) -> None:
         print("  can refuse to start another copy until this process stops.")
 
 
+def _print_served_ingress_urls(profile: str | None = None) -> None:
+    """Callback URLs of inbound-port platforms the live multiplexer serves for secondary profiles
+    (the value to paste into the Twilio / LINE / Teams / BlueBubbles console)."""
+    try:
+        from hermes_cli.gateway_multiplex_served import format_ingress_url_lines, served_profile_ingress_urls
+        urls = served_profile_ingress_urls(profile)
+    except Exception:
+        return
+    if not urls:
+        return
+    print()
+    print("Inbound callback URLs on the shared listener:")
+    for name, per_platform in sorted(urls.items()):
+        for line in format_ingress_url_lines(per_platform, indent=f"  {name}/" if not profile else "  "):
+            print(line)
+
+
 def _print_other_profiles_gateway_status() -> None:
     """Print other profiles' running gateways at the bottom of ``hermes gateway status``."""
     try:
@@ -6295,12 +6312,14 @@ def _cmd_status(args):
     full = getattr(args, "full", False)
     system = getattr(args, "system", False)
     snapshot = get_gateway_runtime_snapshot(system=system)
+    from hermes_cli.profiles import get_active_profile_name
 
     _windows_service_installed = is_windows() and _gw_windows().is_installed()
     if not snapshot.running and named_profile_served_by_running_multiplexer():
         # Satellite profile: the default multiplexer is the live inbound process for it.
         print("✓ Gateway is running via the default-profile multiplexer")
         print("  Manage it from the default profile: hermes gateway status")
+        _print_served_ingress_urls(get_active_profile_name())
     elif (kind := _installed_service_kind_for(lambda: _windows_service_installed)) is not None:
         if kind == "systemd":
             systemd_status(deep, system=system, full=full)
@@ -6309,12 +6328,14 @@ def _cmd_status(args):
         else:
             _gw_windows().status(deep=deep)
         _print_gateway_process_mismatch(snapshot)
+        _print_served_ingress_urls()
     else:
         pids = list(snapshot.gateway_pids)
         if pids:
             print(f"✓ Gateway is running (PID: {', '.join(map(str, pids))})")
             print("  (Running manually, not as a system service)")
             _print_runtime_health()
+            _print_served_ingress_urls()
             print()
             _print_lines(*_STATUS_RUNNING_HINTS[_status_host_kind()])
         else:

--- a/hermes_cli/gateway_multiplex_served.py
+++ b/hermes_cli/gateway_multiplex_served.py
@@ -41,3 +41,34 @@ def recorded_served_profiles(default_root: Optional[Path] = None) -> Optional[li
 def multiplexer_served_secondaries() -> list[str]:
     """Named profiles the live default multiplexer serves (excludes ``default``); empty when none."""
     return [p for p in (recorded_served_profiles() or []) if p and p != "default"]
+
+
+def served_profile_ingress_urls(profile: Optional[str] = None) -> dict[str, dict[str, str]]:
+    """``{profile: {platform: url}}`` for every secondary inbound-port platform the live multiplexer
+    serves on its shared listener (``<profile>:<platform>`` entries carrying ``ingress_url``). This is
+    what the user pastes into the vendor console (Twilio, LINE, Teams, ...). ``profile`` narrows the map."""
+    from hermes_constants import get_default_hermes_root
+    from gateway.status import read_runtime_status
+    if live_default_gateway_pid() is None:
+        return {}
+    runtime = read_runtime_status(get_default_hermes_root() / "gateway_state.json") or {}
+    platforms = runtime.get("platforms")
+    if not isinstance(platforms, dict):
+        return {}
+    urls: dict[str, dict[str, str]] = {}
+    for key, entry in platforms.items():
+        if not (isinstance(key, str) and ":" in key and isinstance(entry, dict)):
+            continue
+        url = entry.get("ingress_url")
+        if not url or entry.get("state") in ("fatal", "disconnected", "stopped"):
+            continue
+        name, platform = key.split(":", 1)
+        if profile and name != profile:
+            continue
+        urls.setdefault(name, {})[platform] = str(url)
+    return urls
+
+
+def format_ingress_url_lines(urls: dict[str, str], indent: str = "  ") -> list[str]:
+    """One ``<indent><platform>: <url>`` line per platform, sorted."""
+    return [f"{indent}{platform}: {url}" for platform, url in sorted(urls.items())]

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -234,6 +234,10 @@ def _render_gateway(ctx):
             _kv("PID(s):", _format_gateway_pids(snapshot.gateway_pids))
         if snapshot.running and (served := multiplexer_served_secondaries()):
             _kv("Serves:", ", ".join(served))
+            from hermes_cli.gateway_multiplex_served import served_profile_ingress_urls
+            for name, per_platform in sorted(served_profile_ingress_urls().items()):
+                for platform, url in sorted(per_platform.items()):
+                    _kv(f"  {name}/{platform}:", url)
         if snapshot.has_process_service_mismatch:
             _kv("Service:", "installed but not managing the current running gateway")
         elif _is_termux() and not snapshot.gateway_pids:

--- a/hermes_cli/web_routers/messaging.py
+++ b/hermes_cli/web_routers/messaging.py
@@ -259,6 +259,8 @@ def _messaging_platform_payload(
         "gateway_running": gateway_running, "state": state, "error_code": error_code,
         "error_message": error_message, "updated_at": runtime_platform.get("updated_at"),
         "home_channel": home_channel, "env_vars": env_vars,
+        # Multiplex secondary served on the default's shared listener: the vendor callback URL.
+        "ingress_url": runtime_platform.get("ingress_url") if gateway_running else None,
     }
     if platform_id == "whatsapp":
         whatsapp_mode = env_value("WHATSAPP_MODE").strip()
@@ -794,19 +796,17 @@ async def get_messaging_platforms(profile: Optional[str] = None):
 
 
 def _multiplex_port_binding_conflict(platform_id: str, requested_profile: Optional[str]) -> Optional[str]:
-    """Reason enabling ``platform_id`` on the target profile would break a
-    multiplexed gateway, or ``None`` when allowed.
+    """Reason enabling ``platform_id`` on the target profile is pointless under a multiplexed
+    gateway, or ``None`` when allowed.
 
-    Mirrors ``_start_one_profile_adapters`` (gateway/run.py): with
-    ``gateway.multiplex_profiles`` on, the default profile owns the single shared
-    HTTP listener (``/p/<profile>/``), so a SECONDARY profile must never enable a
-    port-binding platform or the shared gateway dies with ``MultiplexConfigError``
-    for ALL profiles. Only *enabling* is blocked; disabling/clearing stays allowed
-    so users can repair an invalid profile.
+    With ``gateway.multiplex_profiles`` on, the default profile's listener already mirrors
+    ``api_server`` and ``webhook`` at ``/p/<profile>/`` for every profile, so a SECONDARY must not
+    enable a second one. Every other inbound-port platform (Twilio, LINE, Teams, ...) IS allowed on a
+    secondary: the gateway serves it on the shared listener at ``/p/<profile>/<path>``.
     """
-    from gateway.config import PORT_BINDING_PLATFORM_VALUES, load_gateway_config
+    from gateway.config import SHARED_LISTENER_MIRROR_PLATFORMS, load_gateway_config
 
-    if platform_id not in PORT_BINDING_PLATFORM_VALUES:
+    if platform_id not in SHARED_LISTENER_MIRROR_PLATFORMS:
         return None
 
     requested = (requested_profile or "").strip()
@@ -829,10 +829,9 @@ def _multiplex_port_binding_conflict(platform_id: str, requested_profile: Option
             return None
 
     return (
-        f"Cannot enable '{platform_id}' on profile '{target}': it binds its own listener port, "
-        "and gateway.multiplex_profiles is on, so the default profile owns the single shared HTTP "
-        "listener for every profile. Configure this channel on the default profile instead "
-        "(disabling or clearing it here is still allowed)."
+        f"Cannot enable '{platform_id}' on profile '{target}': gateway.multiplex_profiles is on and the "
+        f"default profile's listener already serves it for every profile at /p/{target}/. Configure it "
+        "on the default profile instead (disabling or clearing it here is still allowed)."
     )
 
 

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -3737,10 +3737,9 @@ class FeishuAdapter(BasePlatformAdapter):
         # See #58536, #58902, #59180.
         app = web.Application(client_max_size=_FEISHU_WEBHOOK_MAX_BODY_BYTES)
         app.router.add_post(self._webhook_path, self._handle_webhook_request)
-        self._webhook_runner = web.AppRunner(app)
-        await self._webhook_runner.setup()
-        self._webhook_site = web.TCPSite(self._webhook_runner, self._webhook_host, self._webhook_port)
-        await self._webhook_site.start()
+        # Shared-listener mode (multiplex secondary): no bind; served at /p/<profile>/<webhook_path>.
+        from gateway.platforms.shared_ingress import bind_listener
+        self._webhook_runner = await bind_listener(self, app, self._webhook_host, self._webhook_port, self._webhook_path)
 
     def _prepare_client(self) -> Any:
         """Build the lark client + event dispatcher for this adapter's domain; returns the SDK domain."""

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -461,15 +461,14 @@ class LineAdapter(BasePlatformAdapter):
         self._app.router.add_get(f"{DEFAULT_MEDIA_PATH_PREFIX}/{{token}}/{{filename}}", self._handle_media)
         # Plugin-registered routes must be wired before AppRunner.setup() freezes the router.
         self._wire_plugin_handlers(self._app)
-        self._runner = web.AppRunner(self._app)
+        from gateway.platforms.shared_ingress import bind_listener
         try:
-            await self._runner.setup()
             # SO_REUSEADDR: on macOS/BSD two sockets with it can silently split traffic →
             # disable; on Linux it only allows rebinding past TIME_WAIT → keep default.
-            self._site = web.TCPSite(
-                self._runner, self.webhook_host, self.webhook_port,
+            # Shared-listener mode (multiplex secondary): no bind; served at /p/<profile>/line/webhook.
+            self._runner = await bind_listener(
+                self, self._app, self.webhook_host, self.webhook_port, self.webhook_path,
                 reuse_address=False if sys.platform == "darwin" else None)
-            await self._site.start()
         except OSError as exc:
             return self._fail(
                 "bind_failed",
@@ -477,12 +476,13 @@ class LineAdapter(BasePlatformAdapter):
                 f"{self.webhook_port}: {exc}",
                 retryable=True)
         self._mark_connected()
-        logger.info(
-            "LINE: webhook listening on %s:%s%s%s",
-            self.webhook_host or "* (all interfaces, IPv4+IPv6)",
-            self.webhook_port,
-            self.webhook_path,
-            f" (public: {self.public_base_url})" if self.public_base_url else "")
+        if self._runner is not None:
+            logger.info(
+                "LINE: webhook listening on %s:%s%s%s",
+                self.webhook_host or "* (all interfaces, IPv4+IPv6)",
+                self.webhook_port,
+                self.webhook_path,
+                f" (public: {self.public_base_url})" if self.public_base_url else "")
         return True
 
     async def disconnect(self) -> None:
@@ -765,6 +765,8 @@ class LineAdapter(BasePlatformAdapter):
     def _media_url(self, token: str, filename: str) -> str:
         if self.public_base_url:
             base = self.public_base_url
+        elif getattr(self, "_shared_ingress_base", None):
+            base = self._shared_ingress_base  # default listener's /p/<profile> prefix (multiplex secondary)
         else:
             # Wildcard/dual-stack binds have no fetchable hostname (the _missing_public_url
             # guard should have fired); fall back to localhost so the URL is well-formed.
@@ -777,7 +779,9 @@ class LineAdapter(BasePlatformAdapter):
 
     def _missing_public_url(self) -> bool:
         """True when no LINE_PUBLIC_URL is set and the bind host is wildcard/dual-stack ``None``."""
-        return not self.public_base_url and (self.webhook_host is None or self.webhook_host in _WILDCARD_HOSTS)
+        if self.public_base_url or getattr(self, "_shared_ingress_base", None):
+            return False
+        return self.webhook_host is None or self.webhook_host in _WILDCARD_HOSTS
 
     def _check_media_file(self, kind: str, file_path: str) -> Tuple[Optional[Path], Optional[SendResult]]:
         """Shared preflight for send_image_file/send_voice/send_video → ``(path, error)``."""

--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -129,15 +129,15 @@ class SmsAdapter(BasePlatformAdapter):
         app = web.Application(client_max_size=_TWILIO_WEBHOOK_MAX_BODY_BYTES)
         app.router.add_post("/webhooks/twilio", self._handle_webhook)
         app.router.add_get("/health", lambda _: web.Response(text="ok"))
-        self._runner = web.AppRunner(app)
-        await self._runner.setup()
-        site = web.TCPSite(self._runner, self._webhook_host, self._webhook_port)
-        await site.start()
+        # Shared-listener mode (multiplex secondary): no bind; served at /p/<profile>/webhooks/twilio.
+        from gateway.platforms.shared_ingress import bind_listener
+        self._runner = await bind_listener(self, app, self._webhook_host, self._webhook_port, "/webhooks/twilio")
         self._http_session = _new_session(trust_env=gateway_trust_env())
         self._running = True
-        logger.info(
-            "[sms] Twilio webhook server listening on %s:%d, from: %s",
-            self._webhook_host, self._webhook_port, redact_phone(self._from_number))
+        if self._runner is not None:
+            logger.info(
+                "[sms] Twilio webhook server listening on %s:%d, from: %s",
+                self._webhook_host, self._webhook_port, redact_phone(self._from_number))
         self._wire_plugin_handlers(None)
         return True
 

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -401,15 +401,15 @@ class TeamsAdapter(BasePlatformAdapter):
 
             self._wire_plugin_handlers(self._app)
             await self._app.initialize()
-            self._runner = web.AppRunner(aiohttp_app)
-            await self._runner.setup()
-            site = web.TCPSite(self._runner, self._host, self._port)
-            await site.start()
+            # Shared-listener mode (multiplex secondary): no bind; served at /p/<profile>/api/messages.
+            from gateway.platforms.shared_ingress import bind_listener
+            self._runner = await bind_listener(self, aiohttp_app, self._host, self._port, _WEBHOOK_PATH)
             self._running = True
             self._mark_connected()
-            logger.info(
-                "[teams] Webhook server listening on %s:%d%s",
-                self._host or "* (all interfaces, IPv4+IPv6)", self._port, _WEBHOOK_PATH)
+            if self._runner is not None:
+                logger.info(
+                    "[teams] Webhook server listening on %s:%d%s",
+                    self._host or "* (all interfaces, IPv4+IPv6)", self._port, _WEBHOOK_PATH)
             return True
         except Exception as e:
             self._set_fatal_error("CONNECT_FAILED", f"Teams connection failed: {e}", retryable=True)

--- a/plugins/platforms/wecom/callback_adapter.py
+++ b/plugins/platforms/wecom/callback_adapter.py
@@ -117,14 +117,16 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         if not check_wecom_callback_requirements():
             logger.warning("[WecomCallback] aiohttp/httpx not installed")
             return False
-        try:  # quick port-in-use check
-            with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as sock:
-                sock.settimeout(1)
-                sock.connect(("127.0.0.1", self._port))
-            logger.error("[WecomCallback] Port %d already in use", self._port)
-            return False
-        except (ConnectionRefusedError, OSError):
-            pass
+        from gateway.platforms.shared_ingress import bind_listener, shared_ingress_profile
+        if not shared_ingress_profile(self):
+            try:  # quick port-in-use check
+                with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as sock:
+                    sock.settimeout(1)
+                    sock.connect(("127.0.0.1", self._port))
+                logger.error("[WecomCallback] Port %d already in use", self._port)
+                return False
+            except (ConnectionRefusedError, OSError):
+                pass
         try:
             # Tighter keepalive so idle CLOSE_WAIT drains promptly (#18451).
             from gateway.platforms._http_client_limits import platform_httpx_limits
@@ -134,13 +136,12 @@ class WecomCallbackAdapter(BasePlatformAdapter):
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get(self._path, self._handle_verify)
             self._app.router.add_post(self._path, self._handle_callback)
-            self._runner = web.AppRunner(self._app)
-            await self._runner.setup()
-            self._site = web.TCPSite(self._runner, self._host, self._port)
-            await self._site.start()
+            # Shared-listener mode (multiplex secondary): no bind; served at /p/<profile>/<path>.
+            self._runner = await bind_listener(self, self._app, self._host, self._port, self._path)
             self._poll_task = asyncio.create_task(self._poll_loop())
             self._mark_connected()
-            logger.info("[WecomCallback] HTTP server listening on %s:%s%s", self._host, self._port, self._path)
+            if self._runner is not None:
+                logger.info("[WecomCallback] HTTP server listening on %s:%s%s", self._host, self._port, self._path)
             for app in self._apps:
                 try:
                     await self._refresh_access_token(app)

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -679,36 +679,45 @@ class TestSecondaryProfileConfigHandling:
 
 
     @pytest.mark.asyncio
-    async def test_secondary_reports_all_port_binding_platforms(self, monkeypatch):
-        from gateway.run import SecondaryPortBindingConfigError
+    async def test_secondary_port_binders_run_in_shared_listener_mode(self, monkeypatch):
+        """A secondary's inbound-port platforms are NOT refused: they are built without a port and
+        served at /p/<profile>/ by the default's listener; api_server/webhook (already mirrored
+        there) are skipped, never a second instance."""
         from gateway.config import GatewayConfig, Platform, PlatformConfig
 
         runner = GatewayRunner.__new__(GatewayRunner)
         runner.config = GatewayConfig(multiplex_profiles=True)
         runner._profile_adapters = {}
+        runner.adapters = {}
 
         reviewer_cfg = GatewayConfig(multiplex_profiles=True)
         reviewer_cfg.platforms = {
             # connection_mode=webhook: with #52563's conditional check merged,
-            # default (websocket) Feishu no longer binds a port — only webhook
-            # mode should be reported here.
-            Platform.FEISHU: PlatformConfig(
-                enabled=True, extra={"connection_mode": "webhook"}
-            ),
+            # default (websocket) Feishu does not bind a port.
+            Platform.FEISHU: PlatformConfig(enabled=True, extra={"connection_mode": "webhook"}),
             Platform.WEBHOOK: PlatformConfig(enabled=True, extra={"port": 8644}),
             Platform.TELEGRAM: PlatformConfig(enabled=True, token="t"),
         }
-        monkeypatch.setattr(
-            "gateway.config.load_gateway_config", lambda: reviewer_cfg
-        )
+        monkeypatch.setattr("gateway.config.load_gateway_config", lambda: reviewer_cfg)
+        created = {}
 
-        with pytest.raises(SecondaryPortBindingConfigError) as ei:
-            await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
-        message = str(ei.value)
-        assert "feishu" in message
-        assert "webhook" in message
-        assert "telegram" not in message
-        assert "reviewer" not in runner._profile_adapters
+        def fake_create(platform, platform_config):
+            created[platform] = _FakeAdapter(token=platform_config.token or None)
+            created[platform].config = platform_config
+            return created[platform]
+
+        monkeypatch.setattr(runner, "_create_adapter", fake_create)
+        monkeypatch.setattr(runner, "_wire_adapter_handlers", lambda *a, **k: None)
+        monkeypatch.setattr(runner, "_bind_voice_input_callback", lambda *a, **k: None)
+        monkeypatch.setattr(runner, "_sync_voice_mode_state_to_adapter", lambda *a, **k: None)
+        monkeypatch.setattr(runner, "_connect_initial_adapter_with_timeout", AsyncMock(return_value=True))
+
+        connected = await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
+
+        assert connected == 2
+        assert set(created) == {Platform.FEISHU, Platform.TELEGRAM}  # webhook is a default-listener mirror
+        assert created[Platform.FEISHU]._shared_listener_profile == "reviewer"
+        assert getattr(created[Platform.TELEGRAM], "_shared_listener_profile", None) is None
 
     def test_configured_secondary_adapter_namespaces_runtime_status(self):
         runner = _secondary_recovery_runner()
@@ -820,8 +829,7 @@ class TestSecondaryProfileConfigHandling:
 
         async def fake_start_one(profile_name, profile_home, claimed):
             if profile_name == "bad":
-                from gateway.run import SecondaryPortBindingConfigError
-                raise SecondaryPortBindingConfigError("bad enables webhook")
+                raise RuntimeError("bad profile blew up at startup")
             runner._profile_adapters[profile_name] = {}
             return 2
 
@@ -855,7 +863,7 @@ class TestSecondaryProfileConfigHandling:
         assert status["served_profiles"] == ["default", "bad", "good"]
         assert "good" in runner._profile_adapters
         assert "bad" not in runner._profile_adapters
-        assert "Skipping secondary profile 'bad'" in caplog.text
+        assert "Failed to start adapters for profile 'bad'" in caplog.text
 
     @pytest.mark.asyncio
     async def test_multiplexer_propagates_security_config_error(self, monkeypatch):
@@ -1006,29 +1014,6 @@ class TestSecondaryProfileConfigHandling:
         assert failed.disconnected is True
         assert second == 1
         assert runner._profile_adapters["later"][photon] is later
-
-    @pytest.mark.asyncio
-    async def test_secondary_teams_uses_degradable_error(self, monkeypatch):
-        from gateway.config import GatewayConfig, Platform, PlatformConfig
-        from gateway.run import SecondaryPortBindingConfigError
-
-        runner = GatewayRunner.__new__(GatewayRunner)
-        runner.config = GatewayConfig(multiplex_profiles=True)
-        runner._profile_adapters = {}
-
-        reviewer_cfg = GatewayConfig(multiplex_profiles=True)
-        reviewer_cfg.platforms = {
-            Platform("teams"): PlatformConfig(enabled=True, extra={"port": 3978}),
-        }
-        monkeypatch.setattr(
-            "gateway.config.load_gateway_config", lambda: reviewer_cfg
-        )
-
-        with pytest.raises(SecondaryPortBindingConfigError) as exc_info:
-            await runner._start_one_profile_adapters("reviewer", "/tmp/x", {})
-        assert "teams" in str(exc_info.value)
-        assert "reviewer" in str(exc_info.value)
-        assert "reviewer" not in runner._profile_adapters
 
     @pytest.mark.asyncio
     async def test_secondary_profile_adapter_start_skips_whatsapp(self, monkeypatch):

--- a/tests/gateway/test_multiplex_shared_ingress.py
+++ b/tests/gateway/test_multiplex_shared_ingress.py
@@ -1,0 +1,137 @@
+"""Inbound-port platforms of a SECONDARY profile are served on the default profile's shared listener
+at ``/p/<profile>/<path>`` (gateway/platforms/shared_ingress.py).
+
+Invariants: the forwarded request is verified by the NAMED profile's adapter with that profile's
+secret and runs under that profile's runtime scope; the un-prefixed path is untouched; a profile
+without an adapter for the path is a 404 rather than the default's adapter; a shared-listener
+adapter binds no port of its own.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("aiohttp")
+from aiohttp import web  # noqa: E402
+from aiohttp.test_utils import TestClient, TestServer  # noqa: E402
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig  # noqa: E402
+
+
+def _line_sig(body: bytes, secret: str) -> str:
+    return base64.b64encode(hmac.new(secret.encode(), body, hashlib.sha256).digest()).decode()
+
+
+class _Runner:
+    """Just enough GatewayRunner for shared_ingress: the served-profile adapter map."""
+
+    def __init__(self, adapters: dict[str, dict[Platform, Any]]):
+        self.config = GatewayConfig(multiplex_profiles=True)
+        self._profile_adapters = adapters
+        self.adapters: dict = {}
+
+
+def _line_adapter(secret: str, profile: str):
+    from plugins.platforms.line.adapter import LineAdapter
+    adapter = LineAdapter(PlatformConfig(enabled=True, extra={
+        "channel_access_token": f"tok-{profile}", "channel_secret": secret, "port": 1}))
+    adapter._shared_listener_profile = profile
+    adapter.set_owner_profile(profile)
+    return adapter
+
+
+async def _publish_line(adapter, runner) -> list[tuple[str, Path]]:
+    """Wire the LINE webhook app the way ``connect()`` does, without the LINE API or a bind, and
+    record the HERMES_HOME the handler ran under."""
+    from gateway.platforms.shared_ingress import bind_listener
+    from hermes_constants import get_hermes_home
+    seen: list[tuple[str, Path]] = []
+    adapter.gateway_runner = runner
+
+    async def dispatch(event):
+        seen.append((event.get("type"), Path(get_hermes_home())))
+
+    adapter._dispatch_event = dispatch
+    app = web.Application(client_max_size=1024)
+    app.router.add_post(adapter.webhook_path, adapter._handle_webhook)
+    bound = await bind_listener(adapter, app, "127.0.0.1", 1, adapter.webhook_path)
+    assert bound is None  # shared-listener mode never binds
+    return seen
+
+
+@pytest.fixture
+def mux_home(tmp_path, monkeypatch):
+    root = tmp_path / "hermes"
+    for name in ("coder", "ops"):
+        (root / "profiles" / name).mkdir(parents=True)
+        (root / "profiles" / name / ".env").write_text(f"LINE_CHANNEL_SECRET=secret-{name}\n")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    import hermes_constants
+    monkeypatch.setattr(hermes_constants, "_default_hermes_root_memo", None)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    from agent import secret_scope
+    monkeypatch.setattr(secret_scope, "_MULTIPLEX_ACTIVE", True)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve",
+        lambda multiplex: [("default", root), ("coder", root / "profiles" / "coder"), ("ops", root / "profiles" / "ops")])
+    return root
+
+
+async def _shared_listener(runner) -> TestClient:
+    """The default profile's listener as the webhook adapter builds it: bare routes + /p/ forwarding."""
+    from gateway.platforms.webhook import WebhookAdapter
+    listener = WebhookAdapter(PlatformConfig(enabled=True, extra={"port": 1, "routes": {}}))
+    listener.gateway_runner = runner
+    app = web.Application()
+    app.router.add_post("/webhooks/{route_name}", listener._handle_webhook)
+    app.router.add_post("/p/{profile}/webhooks/{route_name}", listener._handle_webhook)
+    app.router.add_route("*", "/p/{profile}/{tail:.*}", listener._handle_profile_ingress)
+    return TestClient(TestServer(app))
+
+
+@pytest.mark.asyncio
+async def test_prefixed_line_webhook_is_verified_by_the_named_profiles_secret_under_its_scope(mux_home):
+    coder, ops = _line_adapter("secret-coder", "coder"), _line_adapter("secret-ops", "ops")
+    runner = _Runner({"coder": {Platform("line"): coder}, "ops": {Platform("line"): ops}})
+    coder_seen, ops_seen = await _publish_line(coder, runner), await _publish_line(ops, runner)
+    body = b'{"events":[{"type":"probe"}]}'
+    async with await _shared_listener(runner) as client:
+        ok = await client.post("/p/coder/line/webhook", data=body,
+                               headers={"X-Line-Signature": _line_sig(body, "secret-coder")})
+        assert ok.status == 200
+        # ops' secret is rejected at coder's URL — the adapter is per profile, so is the secret.
+        wrong = await client.post("/p/coder/line/webhook", data=body,
+                                  headers={"X-Line-Signature": _line_sig(body, "secret-ops")})
+        assert wrong.status == 401
+        # The un-prefixed path keeps serving only the default profile's own routes.
+        bare = await client.post("/line/webhook", data=body,
+                                 headers={"X-Line-Signature": _line_sig(body, "secret-coder")})
+        assert bare.status == 404
+        # An unserved profile, and a served profile without that platform, are 404 — never another adapter.
+        assert (await client.post("/p/nope/line/webhook", data=body)).status == 404
+        runner._profile_adapters["ops"] = {}
+        assert (await client.post("/p/ops/line/webhook", data=body,
+                                  headers={"X-Line-Signature": _line_sig(body, "secret-ops")})).status == 404
+    assert [t for t, _ in coder_seen] == ["probe"] and ops_seen == []
+    assert coder_seen[0][1] == mux_home / "profiles" / "coder"
+
+
+@pytest.mark.asyncio
+async def test_shared_listener_adapter_records_its_public_ingress_url(mux_home, monkeypatch):
+    """Runtime status carries the /p/<profile>/ URL so `gateway status` / the dashboard can show it."""
+    writes: list[dict] = []
+    monkeypatch.setattr("gateway.status.write_runtime_status", lambda **kw: writes.append(kw))
+    coder = _line_adapter("secret-coder", "coder")
+    coder._runtime_status_platform_key = "coder:line"
+    runner = _Runner({"coder": {Platform("line"): coder}})
+    runner.adapters = {Platform.API_SERVER: type("L", (), {"_host": "0.0.0.0", "_port": 8642})()}
+    await _publish_line(coder, runner)
+    assert coder._shared_ingress_url == "http://127.0.0.1:8642/p/coder/line/webhook"
+    assert {"platform": "coder:line", "ingress_url": coder._shared_ingress_url} == {
+        k: v for k, v in writes[-1].items() if k in ("platform", "ingress_url")}
+    assert coder._media_url("tok", "a.png").startswith("http://127.0.0.1:8642/p/coder/line/media/")

--- a/tests/hermes_cli/test_web_server_messaging_profiles.py
+++ b/tests/hermes_cli/test_web_server_messaging_profiles.py
@@ -202,13 +202,9 @@ def _enable_multiplex(default_home):
 
 
 class TestMultiplexPortBindingGuard:
-    """Enabling a port-binding channel on a secondary multiplexed profile
-    must be rejected BEFORE anything is persisted.
-
-    The gateway fail-fasts with ``MultiplexConfigError`` when a secondary
-    profile enables a port-binding platform under
-    ``gateway.multiplex_profiles`` — but the dashboard used to persist that
-    exact config, so the next gateway start died for EVERY profile (#62791).
+    """Enabling api_server/webhook on a secondary multiplexed profile is rejected BEFORE anything
+    is persisted: the default profile's listener already mirrors them at ``/p/<profile>/`` (#62791).
+    Every other inbound-port platform is allowed — the gateway serves it on the shared listener.
     """
 
     @pytest.fixture(autouse=True)
@@ -217,21 +213,25 @@ class TestMultiplexPortBindingGuard:
         # multiplex flag under test comes from the default profile's config.
         monkeypatch.delenv("GATEWAY_MULTIPLEX_PROFILES", raising=False)
 
-    def test_rejects_every_port_binding_platform_on_secondary(
+    def test_rejects_only_mirrored_listeners_on_secondary(
         self, client, isolated_profiles
     ):
-        from gateway.config import PORT_BINDING_PLATFORM_VALUES
+        from gateway.config import PORT_BINDING_PLATFORM_VALUES, SHARED_LISTENER_MIRROR_PLATFORMS
 
         _enable_multiplex(isolated_profiles["default"])
-        assert PORT_BINDING_PLATFORM_VALUES  # guard set must not be empty
-        for platform_id in sorted(PORT_BINDING_PLATFORM_VALUES):
+        assert SHARED_LISTENER_MIRROR_PLATFORMS  # guard set must not be empty
+        catalog = {p["id"] for p in client.get("/api/messaging/platforms").json()["platforms"]}
+        for platform_id in sorted(PORT_BINDING_PLATFORM_VALUES & catalog):
             resp = client.put(
                 f"/api/messaging/platforms/{platform_id}",
                 params={"profile": "worker_alpha"},
                 json={"enabled": True},
             )
-            assert resp.status_code == 409, platform_id
-            assert "default profile" in resp.json()["detail"]
+            if platform_id in SHARED_LISTENER_MIRROR_PLATFORMS:
+                assert resp.status_code == 409, platform_id
+                assert "default profile" in resp.json()["detail"]
+            else:  # served at /p/worker_alpha/<path> on the shared listener
+                assert resp.status_code == 200, (platform_id, resp.text)
 
 
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1576,6 +1576,8 @@ export interface MessagingPlatform {
   error_message: string | null;
   updated_at: string | null;
   home_channel: { platform: string; chat_id: string; name: string; thread_id?: string } | null;
+  /** Multiplex secondary served on the default profile's shared listener: the vendor callback URL. */
+  ingress_url?: string | null;
   whatsapp_setup?: {
     mode?: string;
     allowed_users_set?: boolean;

--- a/web/src/pages/ChannelsPage.tsx
+++ b/web/src/pages/ChannelsPage.tsx
@@ -567,6 +567,12 @@ export default function ChannelsPage() {
                           {platform.error_message}
                         </span>
                       )}
+                      {platform.ingress_url && (
+                        <span className="text-xs text-muted-foreground break-all">
+                          Callback URL (shared listener):{" "}
+                          <code className="font-mono">{platform.ingress_url}</code>
+                        </span>
+                      )}
                     </div>
                   </div>
 

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -147,8 +147,8 @@ multiplex mode — you only manage the default gateway.
 
 #### 2. HTTP-inbound platforms are reached via a `/p/<profile>/` URL prefix
 
-Webhook (and other HTTP-inbound) traffic for a secondary profile arrives on the
-default listener under a profile prefix, **not** a second port:
+HTTP-inbound traffic for a secondary profile arrives on the default profile's
+**one** listener under a profile prefix, **not** a second port:
 
 ```
 # default profile
@@ -157,24 +157,22 @@ POST http://host:8644/webhooks/<route>
 POST http://host:8644/p/coder/webhooks/<route>
 ```
 
-An unknown or unconfigured profile in the prefix returns `404`. Because the one
-shared listener already serves every profile this way, a **secondary profile
-must not enable a port-binding platform itself** — doing so is a config error
-that skips the entire secondary profile while the default and other healthy
-profiles continue. The warning names the skipped profile and every conflicting
-platform:
+An unknown or unconfigured profile in the prefix returns `404`. The shared
+listener is the default profile's `api_server` port (or its `webhook` port when
+no API server is enabled); it serves three kinds of profile-prefixed paths:
 
-```
-Skipping secondary profile 'coder' due to port-binding config error: Profile
-'coder' enables port-binding platform(s) webhook, but gateway.multiplex_profiles
-is on. ... Remove these platform entries from profile 'coder's config.yaml or
-configure them only on the default profile.
-```
-
-Port-binding platforms covered by this rule: `webhook`, `api_server`,
-`msgraph_webhook`, `feishu`, `wecom_callback`, `bluebubbles`, `sms`,
-`whatsapp_cloud`, `line`, `teams`. Configure any of these **only on the default profile**;
-every profile is reachable through its `/p/<profile>/` prefix.
+- **`api_server` and `webhook` are mirrored**, never duplicated. `/p/coder/v1/...`
+  and `/p/coder/webhooks/<route>` are answered by the default profile's own
+  adapter under coder's scope. A secondary must therefore **not** enable
+  `api_server` or `webhook` itself (the dashboard refuses with `409`; an
+  `API_SERVER_KEY` or `WEBHOOK_ENABLED` in the secondary's `.env` wires the
+  credential without starting a listener).
+- **Every other inbound-port platform runs in shared-listener mode.** A
+  secondary that configures Twilio SMS, LINE, Teams, BlueBubbles, Microsoft
+  Graph, WhatsApp Cloud, WeCom callback or Feishu webhook mode gets its **own**
+  adapter instance built without a port; the default listener forwards
+  `/p/<profile>/<the adapter's usual path>` to it. See
+  [Inbound-port platforms under the multiplexer](#inbound-port-platforms-under-the-multiplexer).
 
 Authentication follows the profile named in the URL. Unprefixed endpoints keep
 using the default listener's existing credentials.
@@ -182,9 +180,8 @@ using the default listener's existing credentials.
 - `/p/coder/...` API-server requests must use `API_SERVER_KEY` from
   `~/.hermes/profiles/coder/.env`; the default listener key is rejected. Under
   the multiplexer that key only authenticates the prefix — it does not turn on a
-  second `api_server` listener in the secondary profile (which would otherwise be
-  the port-binding conflict described below), so you do not need to pin
-  `platforms.api_server.enabled: false` in the secondary's `config.yaml`.
+  second `api_server` listener in the secondary profile, so you do not need to
+  pin `platforms.api_server.enabled: false` in the secondary's `config.yaml`.
 - A webhook route that targets `coder` must declare `profile: coder` beside
   its existing route-specific `secret` in the default profile's
   `config.yaml`. That secret is then accepted only at
@@ -202,16 +199,65 @@ using the default listener's existing credentials.
 - `/p/coder/api/platforms/<platform>/events` callbacks are verified and
   dispatched by coder's adapter; when coder has none the callback is a 503.
 
-Keep port-binding platforms disabled in secondary profile configs. The shared
-listener and its route definitions stay on the default profile; profile
-binding controls which profile each authenticated webhook route may execute.
 Named API requests fail closed when the target profile has no
-`API_SERVER_KEY`.
+`API_SERVER_KEY`. Security configuration errors remain fatal: for example, an
+`open` own-policy platform without `GATEWAY_ALLOW_ALL_USERS` or its
+platform-specific allow-all opt-in still aborts gateway startup rather than
+silently dropping the unsafe profile.
 
-Only this shared-listener conflict degrades to a skipped profile. Security
-configuration errors remain fatal: for example, an `open` own-policy platform
-without `GATEWAY_ALLOW_ALL_USERS` or its platform-specific allow-all opt-in
-still aborts gateway startup rather than silently dropping the unsafe profile.
+#### Inbound-port platforms under the multiplexer
+
+A standalone `hermes -p coder gateway run` binds coder's Twilio, LINE, Teams,
+… webhook servers on their own ports. Under the multiplexer those adapters are
+still coder's — same credentials from `profiles/coder/.env`, same
+`config.yaml`, replies sent through coder's channel — but they bind **no port**.
+The default profile's shared listener forwards `/p/coder/<path>` to them, where
+`<path>` is exactly the path the adapter would serve standalone. The request is
+verified by **coder's** adapter with **coder's** secret (Twilio auth token, LINE
+channel secret, Teams app credentials, BlueBubbles password, …) and runs under
+coder's runtime scope; the default profile's own `/path` is untouched, and a
+profile that has no adapter for a path gets `404`, never another profile's bot.
+
+| Platform | Secondary profile's callback URL on the shared listener | Verified with the named profile's |
+|---|---|---|
+| Twilio SMS (`sms`) | `https://<host>/p/<profile>/webhooks/twilio` | `TWILIO_AUTH_TOKEN` signature (`SMS_WEBHOOK_URL` must be this URL) |
+| LINE (`line`) | `https://<host>/p/<profile>/line/webhook` (media: `/p/<profile>/line/media/...`) | `LINE_CHANNEL_SECRET` |
+| Microsoft Teams (`teams`) | `https://<host>/p/<profile>/api/messages` | Bot Framework token for `TEAMS_CLIENT_ID` |
+| BlueBubbles (`bluebubbles`) | `http://<host>/p/<profile>/bluebubbles-webhook` (registered with the server automatically) | `BLUEBUBBLES_PASSWORD` |
+| Microsoft Graph (`msgraph_webhook`) | `https://<host>/p/<profile>/msgraph/webhook` | `extra.client_state` |
+| WhatsApp Cloud (`whatsapp_cloud`) | `https://<host>/p/<profile>/whatsapp/webhook` | `WHATSAPP_CLOUD_APP_SECRET` / verify token |
+| WeCom callback (`wecom_callback`) | `https://<host>/p/<profile>/wecom/callback` | the app's callback token / AES key |
+| Feishu webhook mode (`feishu`) | `https://<host>/p/<profile>/feishu/webhook` | `FEISHU_VERIFICATION_TOKEN` / `FEISHU_ENCRYPT_KEY` |
+
+`<host>` is the public hostname (tunnel, reverse proxy) in front of the default
+profile's listener; a custom `webhook_path` in the profile's config moves the
+path after `/p/<profile>` accordingly. The gateway logs the exact URL at
+startup:
+
+```
+[sms] profile 'coder' is served on the default profile's shared listener:
+http://127.0.0.1:8642/p/coder/webhooks/twilio (point the vendor's callback URL at this path ...)
+```
+
+and every status surface repeats it, so you know what to paste into the vendor
+console:
+
+```
+$ hermes -p coder gateway status
+✓ Gateway is running via the default-profile multiplexer
+  Manage it from the default profile: hermes gateway status
+
+Inbound callback URLs on the shared listener:
+  line: http://127.0.0.1:8642/p/coder/line/webhook
+  sms: http://127.0.0.1:8642/p/coder/webhooks/twilio
+```
+
+`hermes gateway status` and `hermes status` on the default profile list the same
+URLs per served profile, and the dashboard's Channels page shows them as each
+platform's `ingress_url` when viewing that profile. A per-profile
+`SMS_WEBHOOK_PORT`, `LINE_PORT`, `TEAMS_PORT`, … in a secondary's `.env` is
+ignored under the multiplexer (nothing binds); it applies again the moment that
+profile runs its own standalone gateway.
 
 #### 3. Per-credential platforms still need their own token per profile
 
@@ -342,6 +388,7 @@ profile and never shares with the default or any sibling:
 | Provider keys, bot tokens, `${VAR}` refs in `config.yaml` | The profile's own `.env` (its secret scope) | Unresolved / no adapter — never the default profile's value |
 | Authorization (`GATEWAY_ALLOW_ALL_USERS`, `GATEWAY_ALLOWED_USERS`, per-platform allowlists and allow-all opt-ins) | The owning profile's `.env` and `config.yaml` | Closed — a default-profile opt-in never opens a secondary's bot |
 | HTTP endpoints (`/p/<profile>/api/...`, `/p/<profile>/webhooks/...`, platform event callbacks) | The named profile's `API_SERVER_KEY`, `profile:`-bound webhook routes, and its own adapter | `401`/`404`; delivery without an adapter is `502`/`503`, never another profile's bot |
+| Inbound-port platforms (`/p/<profile>/webhooks/twilio`, `/p/<profile>/line/webhook`, `/p/<profile>/api/messages`, …) | The named profile's own adapter and its secret (Twilio auth token, LINE channel secret, Teams app, BlueBubbles password, …); replies leave through that adapter | `401`/`403` on a wrong secret, `404` when the profile has no such adapter — never the default profile's adapter |
 | Adapter settings (`*_REQUIRE_MENTION`, `*_REACTIONS`, `*_PROXY`, webhook host/port/URL, Matrix thread/session/E2EE policy, Discord backfill/attachment caps, Buzz reply mode, A2A agent card) | The owning profile's `.env` and `config.yaml` | The adapter's documented default — never the default profile's setting |
 | `MEDIA:` attachment denylist | Every home under `profiles/` plus the default home, enumerated at check time | A turn can never attach another profile's `.env`, `auth.json`, `state.db`, sessions or token stores |
 | stdio MCP child environment | Safe baseline + the profile's scoped values for secret-source names + the server's own `env:` | A name the profile lacks is absent from the child — no default-profile fallthrough |


### PR DESCRIPTION
A secondary profile under `gateway.multiplex_profiles` can now run Twilio SMS, LINE, Teams, BlueBubbles, Microsoft Graph, WhatsApp Cloud, WeCom callback and Feishu-webhook: its adapter is served at `/p/<profile>/<path>` on the default profile's one listener instead of the whole profile being refused as a port-binding conflict.

## Symptom → change → behaviour

**Symptom.** Adapters that *listen* on a port cannot be started for a secondary profile: `_load_secondary_profile_config` raised `SecondaryPortBindingConfigError` and skipped the **entire** profile (`Skipping secondary profile 'coder' due to port-binding config error: ... line, sms ...`), so a profile with Twilio + Telegram lost Telegram too. The docs told users to configure these platforms "only on the default profile" — i.e. that profile's Twilio number could not be its own. (Parity lane finding F-17.)

**Change.** New `gateway/platforms/shared_ingress.py`. The runner stamps `_shared_listener_profile` on a secondary's port-binding adapter (`_configure_profile_adapter`); every inbound-port adapter builds its aiohttp app exactly as before and hands it to `bind_listener()`, which starts a `TCPSite` as usual — or, in shared-listener mode, freezes and publishes the app and binds nothing. The default listener (`api_server`, or the `webhook` adapter when no API server is enabled) registers a last-resort `/p/{profile}/{tail:.*}` route that resolves `/<tail>` against the served profile's published apps and forwards the request under that profile's `_profile_runtime_scope` (aiohttp `request.clone(rel_url=..., client_max_size=<the adapter's own cap>)` → `app._handle`). `api_server` and `webhook` remain **mirrors** answered by the default's adapter and are the only port-binders a secondary may not enable (`SHARED_LISTENER_MIRROR_PLATFORMS`).

**Behaviour.** The request is verified by the **named** profile's adapter with **its** secret (Twilio auth token, LINE channel secret, Teams app, BlueBubbles password, Graph `client_state`, WhatsApp app secret/verify token, WeCom token, Feishu verification token) and replies go out through that profile's adapter. The un-prefixed path serves the default profile byte-for-byte. An unknown profile, or a served profile with no adapter for the path, is `404` — never another profile's adapter. Each adapter logs its URL once and records `ingress_url` in `gateway_state.json`; `hermes -p <name> gateway status`, `hermes gateway status`, `hermes status` (under `Serves:`) and the dashboard Channels page show it.

## Live repro (real `gateway run`, temp HOME, default `api_server` + secondary `coder` with Twilio/LINE/BlueBubbles creds)

| Probe | before (`origin/main`) | after |
|---|---|---|
| gateway log for coder | `Skipping secondary profile 'coder' due to port-binding config error: ... line, sms` | `✓ sms connected (profile: coder)`, `✓ line connected (profile: coder)`, `[sms] profile 'coder' is served on the default profile's shared listener: http://127.0.0.1:8642/p/coder/webhooks/twilio` |
| `POST /p/coder/webhooks/twilio` signed with coder's `TWILIO_AUTH_TOKEN` | 404 | 200 (TwiML) |
| same, signed with another profile's token | 404 | 403 |
| `POST /p/coder/line/webhook` with coder's `LINE_CHANNEL_SECRET` / ops' secret / `/p/ops/...` with ops' | 404 | 200 / 401 / 200 |
| `GET /p/coder/whatsapp/webhook?hub.verify_token=` coder's / ops' | 404 | 200 / 403 |
| `GET /p/coder/msgraph/webhook?validationToken=xyz` | 404 | 200 `xyz` |
| `POST /webhooks/twilio` (bare path) | 404 | 404 (default untouched) |
| `POST /p/nope/line/webhook`, `POST /p/coder/not/a/thing` | 404 | 404 / 404 |
| coder's own ports 18080/18646/18645 | not bound | not bound |
| `/p/coder/v1/models` with the default's key | 401 | 401 |
| `hermes -p coder gateway status` | `Gateway is running via the default-profile multiplexer` | + `Inbound callback URLs on the shared listener:` `line: http://.../p/coder/line/webhook`, `sms: http://.../p/coder/webhooks/twilio`, … |
| `hermes status` (default) | `Serves: coder` | `Serves: coder` + `coder/line: http://.../p/coder/line/webhook` |
| dashboard `/api/messaging/platforms?profile=coder` → `line` | `gateway_stopped` | `state: connected, ingress_url: http://.../p/coder/line/webhook` |

## Adapter table

| Adapter | Secondary before | Secondary after (URL on the shared listener) | Verified with the profile's |
|---|---|---|---|
| `sms` (Twilio) | profile refused whole | `/p/<profile>/webhooks/twilio` | `TWILIO_AUTH_TOKEN` signature |
| `line` | refused | `/p/<profile>/line/webhook` (+ `/line/media/...`, `/line/webhook/health`) | `LINE_CHANNEL_SECRET` |
| `teams` | refused | `/p/<profile>/api/messages` | Bot Framework token for `TEAMS_CLIENT_ID` |
| `bluebubbles` | refused | `/p/<profile>/bluebubbles-webhook` (auto-registered with the server) | `BLUEBUBBLES_PASSWORD` |
| `msgraph_webhook` | refused | `/p/<profile>/msgraph/webhook` | `extra.client_state` |
| `whatsapp_cloud` | refused | `/p/<profile>/whatsapp/webhook` | `WHATSAPP_CLOUD_APP_SECRET` / verify token |
| `wecom_callback` | refused | `/p/<profile>/wecom/callback` | callback token / AES key |
| `feishu` (webhook mode) | refused | `/p/<profile>/feishu/webhook` | `FEISHU_VERIFICATION_TOKEN` / `FEISHU_ENCRYPT_KEY` |
| `api_server`, `webhook` | `api_server` key wired, listener not started (#100397) | unchanged: mirrored by the default's adapter at `/p/<profile>/`; still the only pair a secondary must not enable (dashboard 409) | — |
| `homeassistant`, `dingtalk`, `wecom` (poll), `matrix`, `a2a`, `raft`, `email` | outbound / already fine or not port-binding under multiplex | unchanged | — |

## Files

- `gateway/platforms/shared_ingress.py` (new): `bind_listener`, `publish_shared_ingress`, `dispatch_profile_ingress`, `shared_listener_base`.
- `gateway/run_adapters.py`: no `SecondaryPortBindingConfigError`; stamp shared-listener mode; skip mirror platforms on secondaries. `gateway/run.py`: error class removed. `gateway/config.py`: `SHARED_LISTENER_MIRROR_PLATFORMS`. `gateway/config_env.py`: the #100397 "credential without listener intent" rule narrowed to the mirror pair.
- `gateway/platforms/api_server.py`, `webhook.py`: `/p/{profile}/{tail:.*}` forwarding route (registered last). `gateway/status.py`: `ingress_url` field. `gateway/platforms/base.py`: `_shared_listener_profile`.
- Adapters: `plugins/platforms/{sms,line,teams,wecom/callback_adapter,feishu}`, `gateway/platforms/{bluebubbles,msgraph_webhook,whatsapp_cloud}`.
- Status: `hermes_cli/gateway_multiplex_served.py::served_profile_ingress_urls`, `hermes_cli/gateway.py`, `hermes_cli/status.py`, `hermes_cli/web_routers/messaging.py` (+ guard narrowed), `web/src/lib/api.ts`, `web/src/pages/ChannelsPage.tsx`.
- Docs: `website/docs/user-guide/multi-profile-gateways.md` — "Inbound-port platforms under the multiplexer" with the URL table.

## Tests

`tests/gateway/test_multiplex_shared_ingress.py` (2 invariants, red on base: `ModuleNotFoundError` / 404): prefixed LINE webhook verified with the named profile's secret under its scope, other profile's secret 401, bare path 404, unknown profile / no adapter 404; shared-listener adapter binds nothing and records its `ingress_url`. Existing `test_multiplex_adapter_registry.py` refusal tests rewritten to the new contract; `test_web_server_messaging_profiles.py` guard test narrowed to the mirror pair. `scripts/run_tests.sh tests/gateway tests/hermes_cli tests/plugins`: 1839 files, 19476 passed, 1 failed — `test_update_head_moved_gate.py::test_update_success_when_head_moves`, which fails identically on `origin/main` on this host (the live-system guard blocks `os.kill` of the real running gateway; unrelated). `web/`: `tsc --noEmit` clean.

## Not done / notes

- `HERMES_*_PORT` / `SMS_WEBHOOK_PORT` in a secondary's `.env` is ignored under the multiplexer (nothing binds); documented.
- Community PR sweep (`multiplex line|teams|twilio|bluebubbles`, `shared listener`, `port-binding secondary`, `SecondaryPortBindingConfigError`): no open PR implements this ingress; #100466 (@astraltrekkin, pin secondary api_server off at profile create) targets the mirrored pair and stays independent.
- Compatibility with #106742: touches `gateway/run_adapters.py`, `run_startup.py`-adjacent code, `gateway/status.py`, `webhook.py`, `api_server.py`, `hermes_cli/gateway.py`, `hermes_cli/status.py` in hunks disjoint from that PR's (checked against its diff: its `run_adapters.py` hunks are at `_redeliver`/reconnect lines 760/1296+, `status.py` at the lock helpers, `webhook.py` at delivery/ingress split, `hermes_cli/gateway.py` at the wizard/install sections).

## Infographic

![shared listener ingress](https://v3b.fal.media/files/b/0aaa1b2e/xEJDkcR-MGNTpMPRc7-mm_EQY6qhRV.png)
