### PR TITLE
fix(delegation): resolve bare custom-provider names to their credential pool

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1281,6 +1281,32 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
         result = _resolve_child_credential_pool("openrouter", parent)
         self.assertIs(result, mock_pool)
 
+    def test_bare_custom_provider_name_resolves_to_its_pool(self):
+        """A bare custom-provider name (e.g. delegation.provider: deepseek-subagent)
+        must resolve the same pool as its canonical "custom:<name>" key, instead of
+        silently returning None and making the child inherit the parent's credential.
+        See issue #108951."""
+        parent = _make_mock_parent()
+        parent.provider = "anthropic"
+        parent._credential_pool = MagicMock()  # parent's own pool must NOT be returned
+
+        child_pool = MagicMock()
+        child_pool.has_credentials.return_value = True
+        with patch(
+            "agent.credential_pool.custom_provider_pool_key_candidates",
+            return_value=["custom:deepseek-subagent"],
+        ), patch("agent.credential_pool.load_pool") as mock_load_pool:
+            def _load(key):
+                return child_pool if key == "custom:deepseek-subagent" else MagicMock(has_credentials=lambda: False)
+            mock_load_pool.side_effect = _load
+
+            result = _resolve_child_credential_pool(
+                "deepseek-subagent", parent, "https://api.example.com/v1",
+            )
+
+        self.assertIs(result, child_pool)
+        self.assertIsNot(result, parent._credential_pool)
+
     # --- Custom-endpoint identity resolution (issue #7833) ---
 
 

--- a/tools/delegate_tool_config.py
+++ b/tools/delegate_tool_config.py
@@ -237,7 +237,20 @@ def _resolve_child_credential_pool(
             return _loaded_pool(child_key)
         if parent_pool is not None and effective_provider == parent_provider:
             return parent_pool
-        return _loaded_pool(effective_provider)
+        pool = _loaded_pool(effective_provider)
+        if pool is not None:
+            return pool
+        # A bare custom-provider name (e.g. "deepseek-subagent") never equals the literal
+        # "custom" and has no pool of its own under that name — the real key is
+        # "custom:<name>". Try the same name/endpoint matching the "custom" branch above
+        # uses before giving up, so a pinned bare name doesn't silently fall back to the
+        # parent's credential. See #108951.
+        from agent.credential_pool import custom_provider_pool_key_candidates
+        for candidate_key in custom_provider_pool_key_candidates(effective_base_url, effective_provider):
+            pool = _loaded_pool(candidate_key)
+            if pool is not None:
+                return pool
+        return None
     except Exception as exc:
         if effective_provider == "custom":
             logger.debug("Could not resolve custom credential pool for child endpoint '%s': %s", effective_base_url, exc)


### PR DESCRIPTION
Fixes #108951.

## Bug

When `delegation.provider` names a **custom** provider by its bare name
(e.g. `deepseek-subagent`, exactly as the `custom_providers[]` entry is
named) rather than the canonical runtime form `custom:deepseek-subagent`,
`tools/delegate_tool_config.py::_resolve_child_credential_pool()` silently
returns `None` for the child's credential pool. The child is then
constructed with no pool of its own and runs on the **parent session's
credential** — the child's spend is attributed to the parent's key, and
the child gets no pool to rotate or refresh. Nothing is logged above
DEBUG, so this reads exactly like "no pool configured".

Root cause: the function only special-cases the *literal* string
`"custom"`:

```python
if effective_provider == "custom":
    ...
if parent_pool is not None and effective_provider == parent_provider:
    return parent_pool
return _loaded_pool(effective_provider)   # bare name never reaches "custom:<name>"
```

A bare custom name (e.g. `"deepseek-subagent"`) misses the `== "custom"`
case, fails the parent-equality check, and hits
`_loaded_pool("deepseek-subagent")` → `load_pool("deepseek-subagent")`
finds no such pool key → `None`.

The normalizer that closes this gap already exists in the same package
and was simply not used on this path:
`agent/credential_pool.py::custom_provider_pool_key_candidates(base_url,
provider_name)` does name-first matching against `custom_providers[]`
entries and yields the canonical `custom:<name>` key.

## Fix

In `_resolve_child_credential_pool()`, after the exact-name lookup fails
(and after the existing `"custom"`/parent-provider-equality branches),
fall back to `custom_provider_pool_key_candidates(effective_base_url,
effective_provider)` and try `_loaded_pool()` on each candidate key. This
reuses the exact same name/endpoint matching the pre-existing `"custom"`
branch already relies on, so a pinned bare custom name resolves to its
own pool the same way the canonical `custom:<name>` form already does.

## Test plan

Added `test_bare_custom_provider_name_resolves_to_its_pool` in
`tests/tools/test_delegate.py`, which pins a bare custom name against a
parent on a different provider and asserts the child gets its own pool
(not `None`, and not the parent's pool).

Confirmed it fails without the fix:

```
$ git stash push -- tools/delegate_tool_config.py
$ python -m pytest tests/tools/test_delegate.py -k test_bare_custom_provider_name_resolves_to_its_pool -v
...
FAILED tests/tools/test_delegate.py::TestChildCredentialPoolResolution::test_bare_custom_provider_name_resolves_to_its_pool
AssertionError: None is not <MagicMock id='...'>
$ git stash pop
```

And passes with the fix restored:

```
$ python -m pytest tests/tools/test_delegate.py -k "test_bare_custom_provider_name_resolves_to_its_pool or test_same_provider_shares_parent_pool" -v
tests/tools/test_delegate.py::TestChildCredentialPoolResolution::test_bare_custom_provider_name_resolves_to_its_pool PASSED
tests/tools/test_delegate.py::TestChildCredentialPoolResolution::test_same_provider_shares_parent_pool PASSED
2 passed in 2.37s
```

Full test file plus the related credential-pool/runtime-provider suites,
all green:

```
$ python -m pytest tests/tools/test_delegate.py -q
82 passed in 10.64s

$ python -m pytest tests/agent/test_credential_pool_provider_boundary.py \
    tests/agent/test_custom_pool_mismatch_guard.py \
    tests/run_agent/test_primary_runtime_restore.py \
    tests/hermes_cli/test_runtime_provider_resolution.py \
    tests/hermes_cli/test_anthropic_oauth_routes_to_messages_api.py -q
119 passed in 10.15s
```

`ruff check` on both changed files: all checks passed.

## AI assistance disclosure

This PR was written with Claude Code (Anthropic), with the change and
test verified by running the repo's own test suite as shown above.
