### PR TITLE
fix(migrate): shared-ingress adapters count as served, not blocked, in the multiplex preflight

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -108,6 +108,8 @@ def _ok():
 
 
 class BlueBubblesAdapter(BasePlatformAdapter):
+    # Answers /p/<profile>/... on the default listener for a served secondary (shared_ingress).
+    serves_profile_prefix: bool = True
     platform = Platform.BLUEBUBBLES
     SUPPORTS_MESSAGE_EDITING = False
     MAX_MESSAGE_LENGTH = MAX_TEXT_LENGTH

--- a/gateway/platforms/msgraph_webhook.py
+++ b/gateway/platforms/msgraph_webhook.py
@@ -98,6 +98,8 @@ def _render_template(template: str, payload: Dict[str, Any]) -> str:
 
 class MSGraphWebhookAdapter(BasePlatformAdapter):
     """Receive Microsoft Graph change notifications and surface them internally."""
+    # Answers /p/<profile>/... on the default listener for a served secondary (shared_ingress).
+    serves_profile_prefix: bool = True
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.MSGRAPH_WEBHOOK)

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -155,6 +155,8 @@ def check_whatsapp_cloud_requirements() -> bool:
 class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     """Outbound: Graph ``/<api_version>/<phone_id>/messages``; inbound: aiohttp webhook
     server. The mixin comes first so its ``format_message`` overrides the base one."""
+    # Answers /p/<profile>/... on the default listener for a served secondary (shared_ingress).
+    serves_profile_prefix: bool = True
 
     splits_long_messages = True  # send() chunks via truncate_message()
 

--- a/hermes_cli/gateway_migrate.py
+++ b/hermes_cli/gateway_migrate.py
@@ -312,6 +312,10 @@ def platform_serves_profile_prefix(platform_value: str) -> bool:
             adapter_cls, _ok = _builtin_adapter_import(spec[0], spec[1], spec[2])
             return _declares(adapter_cls)
     with contextlib.suppress(Exception):
+        # Plugin-shipped adapters (sms, line, teams, feishu, wecom, ...) only exist in the registry
+        # after discovery; a bare CLI process has not run it yet.
+        from hermes_cli.plugins import discover_plugins
+        discover_plugins()  # idempotent
         from gateway.platform_registry import platform_registry
         entry = platform_registry.get(platform_value)
         if entry is not None:

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1195,6 +1195,8 @@ def _sdk_build(request_cls: Any, **fields: Any) -> Any:
 
 class FeishuAdapter(BasePlatformAdapter):
     """Feishu/Lark bot adapter."""
+    # Answers /p/<profile>/... on the default listener for a served secondary (shared_ingress).
+    serves_profile_prefix: bool = True
 
     supports_code_blocks = True  # Feishu renders fenced code blocks
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -383,6 +383,8 @@ _ENV_SEED_KEYS = (("LINE_HOST", "host"), ("LINE_PUBLIC_URL", "public_url"), ("LI
 
 class LineAdapter(BasePlatformAdapter):
     """LINE Messaging API gateway adapter (no message editing → REQUIRES_EDIT_FINALIZE stays False)."""
+    # Answers /p/<profile>/... on the default listener for a served secondary (shared_ingress).
+    serves_profile_prefix: bool = True
 
     def __init__(self, config, **kwargs):
         super().__init__(config=config, platform=Platform("line"))

--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -83,6 +83,8 @@ def check_sms_requirements() -> bool:
 
 class SmsAdapter(BasePlatformAdapter):
     """Twilio SMS <-> Hermes: one session per inbound number; replies always from TWILIO_PHONE_NUMBER."""
+    # Answers /p/<profile>/... on the default listener for a served secondary (shared_ingress).
+    serves_profile_prefix: bool = True
 
     MAX_MESSAGE_LENGTH = MAX_SMS_LENGTH
 

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -341,6 +341,8 @@ def _approval_body(cmd: str, desc: str, *, always: bool = False) -> list:
 
 class TeamsAdapter(BasePlatformAdapter):
     """Microsoft Teams adapter using the microsoft-teams-apps SDK."""
+    # Answers /p/<profile>/... on the default listener for a served secondary (shared_ingress).
+    serves_profile_prefix: bool = True
 
     MAX_MESSAGE_LENGTH = 28000  # Teams text message limit (~28 KB)
     splits_long_messages = True  # send() chunks via truncate_message()

--- a/plugins/platforms/wecom/callback_adapter.py
+++ b/plugins/platforms/wecom/callback_adapter.py
@@ -81,6 +81,8 @@ def _ack():
 
 
 class WecomCallbackAdapter(BasePlatformAdapter):
+    # Answers /p/<profile>/... on the default listener for a served secondary (shared_ingress).
+    serves_profile_prefix: bool = True
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.WECOM_CALLBACK)
         extra = config.extra or {}

--- a/tests/hermes_cli/test_gateway_migrate_multiplex.py
+++ b/tests/hermes_cli/test_gateway_migrate_multiplex.py
@@ -140,7 +140,12 @@ def test_serves_profile_prefix_is_read_from_adapter_classes():
     assert APIServerAdapter.serves_profile_prefix and WebhookAdapter.serves_profile_prefix
     assert gm.platform_serves_profile_prefix("api_server") is True
     assert gm.platform_serves_profile_prefix("webhook") is True
-    assert gm.platform_serves_profile_prefix("sms") is False
+    # Every adapter that binds through shared_ingress.bind_listener is served at /p/<profile>/
+    # for a secondary, so migrate must report it as a notice, never a blocker.
+    for platform in ("sms", "line", "teams", "bluebubbles", "whatsapp_cloud", "msgraph_webhook"):
+        assert gm.platform_serves_profile_prefix(platform) is True, platform
+    # An outbound-only adapter never declares it (and never needs to).
+    assert gm.platform_serves_profile_prefix("telegram") is False
 
 
 def test_update_hook_migrates_when_unblocked_and_only_warns_when_blocked(fleet, capsys):


### PR DESCRIPTION
## Symptom
`hermes gateway migrate --multiplex` (and the `hermes update` hook, #108928) decides whether a secondary's inbound-port platform blocks migration by reading the adapter class's `serves_profile_prefix`. #108952 added `/p/<profile>/` shared-listener ingress for Twilio SMS, LINE, Teams, BlueBubbles, WhatsApp Cloud, MS Graph, Feishu webhook and WeCom callback but did not set that flag, and the preflight consulted the platform registry before plugin discovery had run. Result after both merged: a profile with a LINE or Twilio bot was reported as **BLOCKED** ("no `/p/<profile>/` ingress") even though the gateway now serves it.

## Change
- Each shared-ingress adapter declares `serves_profile_prefix = True` (same declaration `APIServerAdapter`/`WebhookAdapter` already carry).
- `platform_serves_profile_prefix()` runs `discover_plugins()` (idempotent) before the registry lookup so plugin-shipped adapters are visible from a bare CLI process.

## Behaviour
Before: `platform_serves_profile_prefix("sms"|"line"|"teams") -> False` → blocker. After: `True` → the URL-change notice. Outbound-only adapters (`telegram`) stay `False`; `api_server`/`webhook` unchanged.

## Tests
`tests/hermes_cli/test_gateway_migrate_multiplex.py::test_serves_profile_prefix_is_read_from_adapter_classes` now asserts the shared-ingress set is served (was asserting `sms` is not — red on base for the right reason after #108952). 92 tests across migrate, shared ingress and the touched adapters pass.