### PR TITLE
fix(delegation): keep named custom child credentials isolated

### DIFF
--- a/tests/tools/test_delegate_custom_provider_pool.py
+++ b/tests/tools/test_delegate_custom_provider_pool.py
@@ -72,8 +72,8 @@ def test_bare_and_canonical_custom_names_resolve_the_same_pool(tmp_path, monkeyp
     assert all(pool is not None for pool in pools)
     assert {pool.provider for pool in pools} == {"custom:child-custom"}
     assert [{entry.id for entry in pool.entries()} for pool in pools] == [
-        ["child-key"],
-        ["child-key"],
+        {"child-key"},
+        {"child-key"},
     ]
 
 
@@ -95,4 +95,4 @@ def test_named_custom_child_does_not_inherit_another_endpoint_pool(
     assert child_pool is not None
     assert child_pool is not parent_pool
     assert child_pool.provider == "custom:child-custom"
-    assert [entry.id for entry in child_pool.entries()] == ["child-key"]
+    assert {entry.id for entry in child_pool.entries()} == {"child-key"}

--- a/tests/tools/test_delegate_custom_provider_pool.py
+++ b/tests/tools/test_delegate_custom_provider_pool.py
@@ -1,0 +1,98 @@
+"""Delegated named-custom routes use their endpoint-scoped credential pool."""
+
+import json
+from types import SimpleNamespace
+
+import yaml
+
+from tools.delegate_tool_config import _resolve_child_credential_pool
+
+
+CHILD_URL = "https://child.example/v1"
+PARENT_URL = "https://parent.example/v1"
+
+
+def _write_named_custom_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    (home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "custom_providers": [
+                    {"name": "parent-custom", "base_url": PARENT_URL},
+                    {"name": "child-custom", "base_url": CHILD_URL},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (home / "auth.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "providers": {},
+                "credential_pool": {
+                    "custom:parent-custom": [
+                        {
+                            "id": "parent-key",
+                            "auth_type": "api_key",
+                            "source": "manual",
+                            "access_token": "parent-secret",
+                        }
+                    ],
+                    "custom:child-custom": [
+                        {
+                            "id": "child-key",
+                            "auth_type": "api_key",
+                            "source": "manual",
+                            "access_token": "child-secret",
+                        }
+                    ],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_bare_and_canonical_custom_names_resolve_the_same_pool(tmp_path, monkeypatch):
+    _write_named_custom_home(tmp_path, monkeypatch)
+    parent = SimpleNamespace(
+        provider="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+        _credential_pool=None,
+    )
+
+    pools = [
+        _resolve_child_credential_pool(name, parent, CHILD_URL)
+        for name in ("child-custom", "custom:child-custom")
+    ]
+
+    assert all(pool is not None for pool in pools)
+    assert {pool.provider for pool in pools} == {"custom:child-custom"}
+    assert [{entry.id for entry in pool.entries()} for pool in pools] == [
+        ["child-key"],
+        ["child-key"],
+    ]
+
+
+def test_named_custom_child_does_not_inherit_another_endpoint_pool(
+    tmp_path, monkeypatch
+):
+    _write_named_custom_home(tmp_path, monkeypatch)
+    from agent.credential_pool import load_pool
+
+    parent_pool = load_pool("custom:parent-custom")
+    parent = SimpleNamespace(
+        provider="parent-custom",
+        base_url=PARENT_URL,
+        _credential_pool=parent_pool,
+    )
+
+    child_pool = _resolve_child_credential_pool("child-custom", parent, CHILD_URL)
+
+    assert child_pool is not None
+    assert child_pool is not parent_pool
+    assert child_pool.provider == "custom:child-custom"
+    assert [entry.id for entry in child_pool.entries()] == ["child-key"]

--- a/tools/delegate_tool_config.py
+++ b/tools/delegate_tool_config.py
@@ -210,16 +210,14 @@ def _resolve_child_credential_pool(
     effective_provider: Optional[str], parent_agent, effective_base_url: Optional[str] = None,
 ):
     """Credential pool for the child: parent's pool (same provider), that provider's own pool, or None (child keeps
-    its fixed credential). Custom endpoints all collapse to ``provider="custom"``, so they are matched by endpoint
-    identity (the ``custom:<name>`` pool key) — sharing the parent's pool across different custom endpoints would
-    overwrite the child's delegated base_url on lease; an unregistered custom endpoint (no custom_providers entry)
-    keeps the child's fixed credential rather than inherit the parent's.
+    its fixed credential). Direct custom endpoints collapse to ``provider="custom"`` while named custom providers
+    retain their configured alias, so both forms are normalized to an endpoint-scoped pool key. Sharing the parent's
+    pool across different custom endpoints would overwrite the child's delegated base_url on lease; an unregistered
+    custom endpoint (no custom_providers entry) keeps the child's fixed credential rather than inherit the parent's.
 
-    Custom endpoints are a special case: every direct ``delegation.base_url`` runtime collapses to
-    ``provider="custom"``, so bare provider equality would treat two *different* custom endpoints as
-    interchangeable and let the child inherit the parent's pool. We therefore resolve custom runtimes by
-    endpoint identity (the ``custom:<name>`` pool key derived from the base_url) and only share the parent's
-    pool when both resolve to the *same* custom endpoint. See #7833.
+    Custom endpoints are a special case: bare provider equality can treat two *different* custom endpoints as
+    interchangeable and let the child inherit the parent's pool. We therefore resolve custom runtimes by endpoint
+    identity and only share the parent's pool when both resolve to the *same* custom endpoint. See #7833.
     """
     if not effective_provider:
         return getattr(parent_agent, "_credential_pool", None)

--- a/tools/delegate_tool_config.py
+++ b/tools/delegate_tool_config.py
@@ -221,28 +221,32 @@ def _resolve_child_credential_pool(
     endpoint identity (the ``custom:<name>`` pool key derived from the base_url) and only share the parent's
     pool when both resolve to the *same* custom endpoint. See #7833.
     """
-    parent_pool = getattr(parent_agent, "_credential_pool", None)
     if not effective_provider:
-        return parent_pool
+        return getattr(parent_agent, "_credential_pool", None)
+
     parent_provider = getattr(parent_agent, "provider", None) or ""
+    parent_pool = getattr(parent_agent, "_credential_pool", None)
     try:
-        if effective_provider == "custom":
-            from agent.credential_pool import get_custom_provider_pool_key
-            child_key = get_custom_provider_pool_key(effective_base_url)
-            if child_key is None:
-                return None
-            parent_key = get_custom_provider_pool_key(getattr(parent_agent, "base_url", None))
-            if parent_pool is not None and parent_provider == "custom" and parent_key is not None and parent_key == child_key:
-                return parent_pool
-            return _loaded_pool(child_key)
-        if parent_pool is not None and effective_provider == parent_provider:
+        from agent.credential_pool import resolve_runtime_pool_key
+
+        child_key = resolve_runtime_pool_key(effective_provider, effective_base_url)
+        # An unregistered direct endpoint has no scoped pool identity. It must
+        # keep the child's fixed credential rather than borrow another custom
+        # endpoint's pool. See #7833.
+        if str(effective_provider).strip().lower() == "custom" and child_key == "custom":
+            return None
+
+        parent_key = resolve_runtime_pool_key(
+            parent_provider, getattr(parent_agent, "base_url", None)
+        )
+        if parent_pool is not None and child_key == parent_key:
             return parent_pool
-        return _loaded_pool(effective_provider)
+        return _loaded_pool(child_key)
     except Exception as exc:
-        if effective_provider == "custom":
-            logger.debug("Could not resolve custom credential pool for child endpoint '%s': %s", effective_base_url, exc)
-        else:
-            logger.debug("Could not load credential pool for child provider '%s': %s", effective_provider, exc)
+        logger.debug(
+            "Could not resolve credential pool for child provider '%s' at '%s': %s",
+            effective_provider, effective_base_url, exc,
+        )
     return None
 
 def _merge_request_overrides(runtime_overrides, explicit_overrides):


### PR DESCRIPTION
## What does this PR do?

A delegated child configured with a bare named custom provider now receives that provider's credential pool instead of silently running without one. The resolver uses the existing canonical runtime pool-key normalizer, preserving endpoint scoping so credentials cannot be borrowed across custom providers.

### Symptom

With `delegation.provider: child-custom`, runtime provider resolution succeeds but child pool resolution returns `None`; the child loses credential rotation and refresh even though `custom:child-custom` has credentials.

### Impact

Delegated requests can use a fixed credential without the configured child pool's rotation, refresh, and accounting identity. Operators using bare named custom providers are affected; the broader blast radius is unknown.

### Bug Cause

**Trigger:** `tools/delegate_tool_config.py:229` / `_resolve_child_credential_pool()` / a bare named custom provider.

**Causal chain:**
1. Delegation runtime resolution intentionally retains the configured bare provider identity.
2. Child pool resolution special-cases only the literal `custom` identity and otherwise calls `load_pool()` with the bare name.
3. Credentials stored under the canonical custom pool key are missed, leaving the child without its configured pool.

**Why it is wrong:** Runtime provider aliases and credential-pool keys are distinct identities for named custom providers, but this call path skipped the existing canonical mapping between them.

**Working sibling / contrast:** The canonical `custom:<name>` spelling already loads its pool directly, and other runtime paths use `resolve_runtime_pool_key()` to normalize aliases while enforcing endpoint boundaries.

**Ruled out:** Runtime provider resolution is not failing; it deliberately preserves the configured name for correct client routing. Changing that identity would regress named-provider retries and fallbacks.

### Fix

Resolve both child and parent pool identities through `resolve_runtime_pool_key()` before deciding whether to share or load a pool. Preserve the existing fail-closed behavior for an unregistered direct custom endpoint. Add real temporary-home tests for bare/canonical equivalence and isolation between two named custom endpoints.

## Related Issue

Closes #108951

## Why this PR vs existing PR #108958

This change uses `resolve_runtime_pool_key()` in `tools/delegate_tool_config.py`, which validates both the provider alias and endpoint through `credential_pool_matches_provider()`. PR #108958 calls `custom_provider_pool_key_candidates()` directly; its name-first branch can return a pool candidate without validating the supplied endpoint, weakening the existing custom-endpoint isolation boundary. This PR also exercises real `config.yaml`, `auth.json`, and `load_pool()` behavior and explicitly verifies that a child cannot inherit another named custom endpoint's pool, rather than mocking both candidate selection and pool loading.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/delegate_tool_config.py` - normalize child and parent credential-pool identities through the endpoint-scoped runtime resolver.
- `tests/tools/test_delegate_custom_provider_pool.py` - verify bare/canonical resolution and cross-provider isolation with real credential stores.

## How to Test

1. Run the focused delegation credential-pool regression tests.
2. Run the existing credential-pool provider-boundary tests.

```bash
scripts/run_tests.sh tests/tools/test_delegate_custom_provider_pool.py tests/agent/test_credential_pool_provider_boundary.py
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] Relevant documentation is N/A; behavior and invariants are documented in code and tests
- [x] `cli-config.yaml.example` is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no architecture or workflow changed
- [x] Cross-platform impact is limited to provider identity normalization and filesystem-independent credential loading
- [x] Tool descriptions and schemas are N/A; no model-facing tool contract changed
