### PR TITLE
feat(kanban): goal-judge delivery fallback for transport failures

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -806,17 +806,13 @@ def _worker_run_id_for(task_id: str) -> Optional[int]:
 def _goal_mode_handoff_rejection(task: Optional[kb.Task], evidence: str):
     """Goal judge for every terminal worker handoff (including review).
 
-    Returns ``(verdict, reason_or_None)``: ``"done"`` allows; ``"blocked"`` = judge ruled the goal
-    unachievable; ``"continue"``/``"wait"`` reject with the judge's reason. Judge failures allow
-    the handoff (logged).
-
-    See #100954.
-    ``{"done", None}`` means the judge allows the handoff; anything else is a rejection whose verdict
-    disambiguates the guidance the caller gives the worker (``continue`` = not done yet, ``blocked`` =
-    judged unachievable — see #100954).
+    Returns ``(verdict, reason_or_None, transport_failed)``: ``"done"`` allows; ``"blocked"`` = judge
+    ruled the goal unachievable; ``"continue"``/``"wait"`` reject with the judge's reason. Judge
+    failures allow the handoff (logged). ``transport_failed`` marks an infra failure (the judge was
+    unreachable), which callers distinguish from a content rejection — see #100954.
     """
     if task is None or not task.goal_mode:
-        return ("done", None)
+        return ("done", None, False)
     try:
         from agent.auxiliary_client import get_text_auxiliary_client
 
@@ -824,34 +820,56 @@ def _goal_mode_handoff_rejection(task: Optional[kb.Task], evidence: str):
     except Exception:
         client, model = None, None
     if client is None or not model:
-        return ("done", None)
+        return ("done", None, False)
 
     from hermes_cli.goals import judge_goal
 
-    verdict, reason = "done", ""
+    verdict, reason, transport_failed = "done", "", False
     try:
-        verdict, reason, _, _, _ = judge_goal(goal=f"{task.title}\n\n{task.body or ''}".strip(),
-                                              last_response=evidence.strip())
+        verdict, reason, _, _, transport_failed = judge_goal(
+            goal=f"{task.title}\n\n{task.body or ''}".strip(),
+            last_response=evidence.strip())
     except Exception as judge_exc:
         import logging as _logging
 
         _logging.getLogger(__name__).warning("goal judge check failed, allowing lifecycle handoff: %s",
                                              judge_exc, exc_info=True)
-    return (verdict, None if verdict == "done" else reason)
+    return (verdict, None if verdict == "done" else reason, transport_failed)
 
 
 def _goal_gate_error(conn, tid: str, evidence: str, handoff: str, blocked_hint: str,
-                     continue_hint: str) -> Optional[str]:
+                     continue_hint: str) -> tuple[Optional[str], Optional[dict]]:
     """Goal-mode judge gate shared by ``complete`` / ``request-review`` (mirrors tools/kanban_tools.py);
-    applied to every terminal handoff so request-review can't bypass it. Returns the error line, or
-    None to allow."""
-    verdict, rejection = _goal_mode_handoff_rejection(kb.get_task(conn, tid), evidence)
+    applied to every terminal handoff so request-review can't bypass it. Returns
+    ``(error_line_or_None, delivery_fallback_stamp_or_None)``.
+
+    A judge *transport* failure is infra, not content (#100954): for ``completion`` only, when a
+    live downstream child owned by a different profile exists, the handoff is allowed and a
+    ``goal_delivery_fallback`` payload is returned for the caller to stamp into the completion
+    metadata (audit trail; ``recompute_ready`` promotes the child so verification still happens).
+    Every other non-done verdict — and a transport failure without an eligible child — rejects
+    exactly as before."""
+    task = kb.get_task(conn, tid)
+    verdict, rejection, transport_failed = _goal_mode_handoff_rejection(task, evidence)
+    if verdict == "done":
+        return None, None
+    if transport_failed and handoff == "completion":
+        children = kb.eligible_delivery_children(conn, tid, task.assignee) if task else []
+        if children:
+            return None, {
+                "trigger": "goal_judge_transport_failed",
+                "judge_error": rejection,
+                "released_children": children,
+            }
+        return (f"kanban: goal {handoff} of {tid} rejected: judge unreachable (transport "
+                f"failure) — {rejection}. No eligible downstream child to hand verification to; "
+                f"retry later or record the block with kanban block. {continue_hint}"), None
     if verdict == "blocked":
         return (f"kanban: goal {handoff} of {tid} rejected: judge ruled "
-                f"the goal unachievable — {rejection}. {blocked_hint}")
+                f"the goal unachievable — {rejection}. {blocked_hint}"), None
     if rejection is not None:
-        return f"kanban: goal {handoff} of {tid} rejected by judge: {rejection}. {continue_hint}"
-    return None
+        return f"kanban: goal {handoff} of {tid} rejected by judge: {rejection}. {continue_hint}", None
+    return None, None
 
 
 def _cmd_complete(args: argparse.Namespace) -> int:
@@ -872,15 +890,21 @@ def _cmd_complete(args: argparse.Namespace) -> int:
     fail_msg: dict[str, str] = {}
     with kbc.connect_closing() as conn:
         def op(tid):
-            gate_err = _goal_gate_error(
+            gate_err, delivery_stamp = _goal_gate_error(
                 conn, tid, (summary or args.result or "").strip(), "completion",
                 "Re-scope with kanban edit, or record the block with kanban block instead of completing.",
                 "Provide evidence matching the task's acceptance criteria.")
             if gate_err:
                 fail_msg[tid] = gate_err
                 return False
+            if delivery_stamp:
+                merged = dict(metadata) if isinstance(metadata, dict) else {}
+                # System-owned audit key: overwrite any caller-supplied value.
+                merged["goal_delivery_fallback"] = delivery_stamp
+            else:
+                merged = metadata
             fail_msg[tid] = f"cannot complete {tid} (unknown id or terminal state)"
-            return kb.complete_task(conn, tid, result=args.result, summary=summary, metadata=metadata,
+            return kb.complete_task(conn, tid, result=args.result, summary=summary, metadata=merged,
                                     expected_run_id=_worker_run_id_for(tid))
 
         return _bulk_apply(ids, op, lambda tid: f"Completed {tid}", fail_msg.__getitem__)
@@ -960,10 +984,12 @@ def _cmd_request_review(args: argparse.Namespace) -> int:
     if rc:
         return rc
     with kbc.connect_closing() as conn:
-        gate_err = _goal_gate_error(
+        gate_err, _delivery_stamp = _goal_gate_error(
             conn, tid, summary or "", "review handoff",
             "Record the block with kanban block instead of requesting review.",
             "Provide acceptance evidence matching the task.")
+        # review handoff never gets the transport-failure fallback (only ``completion``
+        # does — see _goal_gate_error), so the stamp is always None here.
         if gate_err:
             return _err(gate_err)
         ok, reason = kb.request_review(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1644,6 +1644,32 @@ def child_ids(conn: sqlite3.Connection, task_id: str) -> list[str]:
     return _linked_ids(conn, "child_id", "parent_id", task_id)
 
 
+def eligible_delivery_children(
+    conn: sqlite3.Connection, parent_id: str, exclude_assignee: Optional[str],
+) -> list[str]:
+    """Children a goal-judge transport failure may release the parent over.
+
+    The goal judge cannot be asked whether the parent's goal was met (infra
+    down), so completion would otherwise wedge a goal_mode worker forever
+    (#100954: judge errors are indistinguishable from "not done yet"). The
+    fallback is: hand the decision to a pre-created downstream card instead of
+    the broken judge. A child qualifies only when it is (a) linked to the
+    completing parent, (b) still live — not done/archived — and (c) owned by a
+    *different* profile than the parent's assignee, so the worker cannot
+    rubber-stamp itself; the released child re-runs verification.
+    """
+    candidates = child_ids(conn, parent_id)
+    if not candidates:
+        return []
+    placeholders = ",".join("?" for _ in candidates)
+    rows = conn.execute(
+        f"SELECT id, assignee FROM tasks WHERE id IN ({placeholders}) "
+        "AND status NOT IN ('done', 'archived') AND assignee IS NOT NULL AND assignee != ''",
+        tuple(candidates),
+    ).fetchall()
+    return [r["id"] for r in rows if not (exclude_assignee and r["assignee"] == exclude_assignee)]
+
+
 def task_graph_contexts(conn: sqlite3.Connection, task_ids: Iterable[str]) -> dict[str, dict]:
     """Bulk-load compact direct graph state for graph-aware diagnostics."""
     ordered_ids = list(dict.fromkeys(str(task_id) for task_id in task_ids if task_id))

--- a/tests/hermes_cli/test_goal_delivery_fallback.py
+++ b/tests/hermes_cli/test_goal_delivery_fallback.py
@@ -1,0 +1,367 @@
+"""Goal-judge delivery fallback (#100954): a judge *transport* failure on a
+terminal handoff is infra, not content. ``kanban_complete`` may hand verification
+to live downstream children owned by another profile; everything else stays
+fail-closed (content rejections, review handoffs, no-eligible-child cases)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+
+
+# ---------------------------------------------------------------------------
+# eligible_delivery_children (DB layer)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def board(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    with kbc.connect() as conn:
+        yield conn
+
+
+def test_eligible_delivery_children_filters(board) -> None:
+    conn = board
+    parent = kb.create_task(conn, title="p", assignee="builder")
+    live = kb.create_task(conn, title="qa-child", assignee="qa", parents=[parent])
+    # A done child must have reached a completable state first; complete_task
+    # requires satisfied parents, so complete it BEFORE linking the edge.
+    done = kb.create_task(conn, title="done-child", assignee="reviewer",
+                          initial_status="running")
+    kb.claim_task(conn, done)
+    assert kb.complete_task(conn, done, summary="done")
+    kb.link_tasks(conn, parent, done)
+    same = kb.create_task(conn, title="self-child", assignee="builder", parents=[parent])
+    unassigned = kb.create_task(conn, title="orphan-child", parents=[parent])
+
+    eligible = kb.eligible_delivery_children(conn, parent, "builder")
+    assert live in eligible
+    assert done not in eligible          # terminal: cannot carry verification
+    assert same not in eligible          # same assignee: self-approval
+    assert unassigned not in eligible    # no owner to run it
+
+
+def test_eligible_delivery_children_no_children(board) -> None:
+    conn = board
+    parent = kb.create_task(conn, title="lonely", assignee="builder")
+    assert kb.eligible_delivery_children(conn, parent, "builder") == []
+
+
+def test_eligible_delivery_children_archived(board) -> None:
+    conn = board
+    parent = kb.create_task(conn, title="p", assignee="builder")
+    child = kb.create_task(conn, title="c", assignee="qa", parents=[parent])
+    kb.archive_task(conn, child)
+    assert kb.eligible_delivery_children(conn, parent, "builder") == []
+
+
+# ---------------------------------------------------------------------------
+# Tool surface (kanban_complete / kanban_request_review gates)
+# ---------------------------------------------------------------------------
+
+def _make_goal_worker(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *,
+                      child_assignee: str | None = "qa") -> tuple[str, str | None]:
+    """Isolated HERMES_HOME, claimed goal_mode parent (+ optional child)."""
+    home = tmp_path / ".home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kbc.connect()
+    try:
+        parent = kb.create_task(conn, title="ship X", assignee="test-worker",
+                                body="Must achieve X.", goal_mode=True)
+        kb.claim_task(conn, parent)
+        child = None
+        if child_assignee is not None:
+            child = kb.create_task(conn, title="verify X", assignee=child_assignee,
+                                   parents=[parent])
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", parent)
+    return parent, child
+
+
+def _stub_tool_judge(monkeypatch: pytest.MonkeyPatch, *, transport_failed: bool,
+                     verdict: str = "continue", reason: str = "judge error: BadRequestError") -> None:
+    monkeypatch.setattr(
+        "tools.kanban_tools.judge_goal",
+        lambda *a, **k: (verdict, reason, False, None, transport_failed))
+    monkeypatch.setattr("tools.kanban_tools._goal_judge_available", lambda: True)
+
+
+def test_tool_complete_transport_failure_with_child_releases(monkeypatch, tmp_path) -> None:
+    from tools import kanban_tools as kt
+
+    parent, child = _make_goal_worker(monkeypatch, tmp_path)
+    _stub_tool_judge(monkeypatch, transport_failed=True)
+
+    out = json.loads(kt._handle_complete({"summary": "X shipped, evidence attached."}))
+    assert out.get("ok") is True
+    assert "goal_delivery_fallback" in out
+    assert child in out["goal_delivery_fallback"]
+
+    conn = kbc.connect()
+    try:
+        task = kb.get_task(conn, parent)
+        assert task.status == "done"
+        run = kb.latest_run(conn, parent)
+        stamp = (run.metadata or {})["goal_delivery_fallback"]
+        assert stamp["trigger"] == "goal_judge_transport_failed"
+        assert stamp["judge_error"] == "judge error: BadRequestError"
+        assert stamp["released_children"] == [child]
+        # The child was RELEASED for verification, not marked done by the fallback.
+        assert kb.get_task(conn, child).status not in ("done", "archived")
+    finally:
+        conn.close()
+
+
+def test_tool_complete_transport_failure_without_child_rejects(monkeypatch, tmp_path) -> None:
+    from tools import kanban_tools as kt
+
+    parent, _ = _make_goal_worker(monkeypatch, tmp_path, child_assignee=None)
+    _stub_tool_judge(monkeypatch, transport_failed=True)
+
+    out = json.loads(kt._handle_complete({"summary": "X shipped."}))
+    assert "error" in out
+    assert "transport failure" in out["error"]
+
+    conn = kbc.connect()
+    try:
+        assert kb.get_task(conn, parent).status == "running"
+    finally:
+        conn.close()
+
+
+def test_tool_complete_same_assignee_child_is_not_a_fallback(monkeypatch, tmp_path) -> None:
+    from tools import kanban_tools as kt
+
+    parent, _ = _make_goal_worker(monkeypatch, tmp_path, child_assignee="test-worker")
+    _stub_tool_judge(monkeypatch, transport_failed=True)
+
+    out = json.loads(kt._handle_complete({"summary": "X shipped."}))
+    assert "error" in out and "transport failure" in out["error"]
+    conn = kbc.connect()
+    try:
+        assert kb.get_task(conn, parent).status == "running"
+    finally:
+        conn.close()
+
+
+def test_tool_complete_content_rejection_is_not_masked(monkeypatch, tmp_path) -> None:
+    """A judge that answers ("continue", transport ok) rejects even with an
+    eligible child — the fallback routes around infra, never around verdicts."""
+    from tools import kanban_tools as kt
+
+    parent, child = _make_goal_worker(monkeypatch, tmp_path)
+    _stub_tool_judge(monkeypatch, transport_failed=False, verdict="continue",
+                     reason="missing verification evidence")
+
+    out = json.loads(kt._handle_complete({"summary": "I did some stuff."}))
+    assert "error" in out
+    assert "rejected by judge" in out["error"]
+    assert "missing verification evidence" in out["error"]
+    assert f"parents=[{parent}]" in out["error"]
+    conn = kbc.connect()
+    try:
+        assert kb.get_task(conn, parent).status == "running"
+    finally:
+        conn.close()
+
+
+def test_tool_request_review_transport_failure_stays_closed(monkeypatch, tmp_path) -> None:
+    """The fallback exists only on ``kanban_complete``; a review handoff on a
+    dead judge rejects (the review lane would bypass verification entirely)."""
+    from tools import kanban_tools as kt
+
+    _make_goal_worker(monkeypatch, tmp_path)
+    _stub_tool_judge(monkeypatch, transport_failed=True)
+
+    out = json.loads(kt._handle_request_review({"summary": "Looks ready."}))
+    assert "error" in out
+    assert "rejected" in out["error"]
+
+
+# ---------------------------------------------------------------------------
+# CLI surface (hermes kanban complete / request-review)
+# ---------------------------------------------------------------------------
+
+def _stub_cli_judge(monkeypatch: pytest.MonkeyPatch, *, transport_failed: bool,
+                    reason: str = "judge error: PermissionDenied") -> None:
+    import agent.auxiliary_client as auxiliary_client
+    from hermes_cli import goals
+
+    monkeypatch.setattr(auxiliary_client, "get_text_auxiliary_client",
+                        lambda purpose: (object(), "judge-model"))
+    monkeypatch.setattr(
+        goals, "judge_goal",
+        lambda *a, **k: ("continue", reason, False, None, transport_failed))
+
+
+def test_cli_complete_transport_failure_with_child_releases(monkeypatch, tmp_path) -> None:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_PROFILE", "builder")
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    with kbc.connect() as conn:
+        parent = kb.create_task(conn, title="ship Y", assignee="builder",
+                                body="Must achieve Y.", goal_mode=True)
+        kb.claim_task(conn, parent)
+        child = kb.create_task(conn, title="verify Y", assignee="qa", parents=[parent])
+    _stub_cli_judge(monkeypatch, transport_failed=True)
+
+    output = kc.run_slash(f"complete {parent} --summary 'Y shipped'")
+    assert "Completed" in output
+
+    with kbc.connect() as conn:
+        assert kb.get_task(conn, parent).status == "done"
+        run = kb.latest_run(conn, parent)
+        stamp = (run.metadata or {})["goal_delivery_fallback"]
+        assert stamp["trigger"] == "goal_judge_transport_failed"
+        assert stamp["released_children"] == [child]
+        assert kb.get_task(conn, child).status not in ("done", "archived")
+
+
+def test_cli_complete_transport_failure_without_child_rejects(monkeypatch, tmp_path) -> None:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_PROFILE", "builder")
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    with kbc.connect() as conn:
+        parent = kb.create_task(conn, title="ship Z", assignee="builder",
+                                body="Must achieve Z.", goal_mode=True)
+        kb.claim_task(conn, parent)
+    _stub_cli_judge(monkeypatch, transport_failed=True)
+
+    output = kc.run_slash(f"complete {parent} --summary 'Z shipped'")
+    assert "rejected" in output
+    assert "transport failure" in output
+
+    with kbc.connect() as conn:
+        assert kb.get_task(conn, parent).status == "running"
+
+
+def test_cli_complete_content_rejection_is_not_masked(monkeypatch, tmp_path) -> None:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_PROFILE", "builder")
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    with kbc.connect() as conn:
+        parent = kb.create_task(conn, title="ship W", assignee="builder",
+                                body="Must achieve W.", goal_mode=True)
+        kb.claim_task(conn, parent)
+        kb.create_task(conn, title="verify W", assignee="qa", parents=[parent])
+    _stub_cli_judge(monkeypatch, transport_failed=False, reason="tests are missing")
+
+    output = kc.run_slash(f"complete {parent} --summary 'W shipped'")
+    assert "rejected by judge" in output
+    assert "tests are missing" in output
+
+    with kbc.connect() as conn:
+        assert kb.get_task(conn, parent).status == "running"
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed invariants the fallback must NOT weaken
+# ---------------------------------------------------------------------------
+
+def test_tool_fallback_pr_contract_still_enforced(monkeypatch, tmp_path) -> None:
+    """A PR-contract task with a dead judge + eligible child still cannot
+    complete without exact-head acceptance evidence — the fallback routes the
+    decision around the judge, never around the PR contract."""
+    from tools import kanban_tools as kt
+
+    home = tmp_path / ".home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kbc.connect()
+    try:
+        parent = kb.create_task(conn, title="ship PR", assignee="test-worker",
+                                body="Must publish.", goal_mode=True,
+                                completion_contract="acme/repo",
+                                initial_status="running")
+        kb.claim_task(conn, parent)
+        kb.create_task(conn, title="verify PR", assignee="qa", parents=[parent])
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", parent)
+    _stub_tool_judge(monkeypatch, transport_failed=True)
+
+    # No published_pr / no green CI: acceptance fails, card stays in-flight.
+    out = json.loads(kt._handle_complete({"summary": "PR ready."}))
+    assert "error" in out
+    conn = kbc.connect()
+    try:
+        assert kb.get_task(conn, parent).status != "done"
+    finally:
+        conn.close()
+
+
+def test_tool_fallback_cas_mismatch_rejected(monkeypatch, tmp_path) -> None:
+    """A stale/replaced run (CAS via expected_run_id) still rejects on the
+    fallback path — a reclaimed run cannot complete the card."""
+    from tools import kanban_tools as kt
+
+    parent, _child = _make_goal_worker(monkeypatch, tmp_path)
+    # Worker env pins run 999999 while the DB carries the real claimed run id.
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "999999")
+    _stub_tool_judge(monkeypatch, transport_failed=True)
+
+    out = json.loads(kt._handle_complete({"summary": "X shipped."}))
+    assert "error" in out
+    conn = kbc.connect()
+    try:
+        assert kb.get_task(conn, parent).status == "running"
+    finally:
+        conn.close()
+
+
+def test_tool_fallback_stamp_overrides_caller_supplied(monkeypatch, tmp_path) -> None:
+    """The audit stamp is system-owned: a model-supplied goal_delivery_fallback
+    key is overwritten by the real trigger/judge_error/children, never trusted."""
+    from tools import kanban_tools as kt
+
+    parent, child = _make_goal_worker(monkeypatch, tmp_path)
+    _stub_tool_judge(monkeypatch, transport_failed=True,
+                     reason="judge error: RealReason")
+
+    out = json.loads(kt._handle_complete({
+        "summary": "X shipped.",
+        "metadata": {"goal_delivery_fallback": {"trigger": "forged"}, "own": "kept"}}))
+    assert out.get("ok") is True
+    conn = kbc.connect()
+    try:
+        run = kb.latest_run(conn, parent)
+        stamp = (run.metadata or {})["goal_delivery_fallback"]
+        assert stamp["trigger"] == "goal_judge_transport_failed"
+        assert stamp["judge_error"] == "judge error: RealReason"
+        assert stamp["released_children"] == [child]
+        assert (run.metadata or {})["own"] == "kept"
+    finally:
+        conn.close()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -361,7 +361,14 @@ _GOAL_GATE_MESSAGES = {
         "continue": (
             "Goal completion rejected by judge: {reason}. To proceed, either: (1) provide "
             "explicit acceptance evidence in your summary matching the task's criteria, or (2) "
-            "create continuation tasks with parents=[{tid}] and keep this task alive.")},
+            "create continuation tasks with parents=[{tid}] and keep this task alive."),
+        "transport_failed": (
+            "Goal judge is unreachable (transport failure — {reason}), so completion cannot be "
+            "verified. When an eligible downstream child (linked via parents, still open, "
+            "assigned to a different profile) exists, completion is allowed and the child "
+            "carries verification forward; the release is stamped in the task's metadata "
+            "(goal_delivery_fallback) for audit. Without such a child, retry later or record "
+            "the block with kanban_block.")},
     "kanban_request_review": {
         "blocked": (
             "Goal review handoff rejected: judge ruled the goal unachievable — {reason}. "
@@ -371,15 +378,32 @@ _GOAL_GATE_MESSAGES = {
             "matching the card before requesting review.")}}
 
 
-def _goal_gate(tool_name: str, task, tid: str, evidence: str) -> None:
+class _GoalDeliveryFallback(Exception):
+    """A goal-judge *transport* failure on ``kanban_complete`` where eligible
+    downstream children exist: the caller may complete with the
+    ``goal_delivery_fallback`` audit stamp instead of treating infra failure
+    as a content rejection (#100954). Carries the stamp payload."""
+
+    def __init__(self, children: list[str], reason: str):
+        self.children = list(children)
+        self.reason = reason
+        super().__init__(
+            _GOAL_GATE_MESSAGES["kanban_complete"]["transport_failed"].format(
+                reason=reason, tid=""))
+
+
+def _goal_gate(tool_name: str, task, tid: str, evidence: str, conn: Any) -> None:
     """Goal-mode pre-handoff judge gate: a worker must not complete / request
     review before acceptance criteria are met. ``blocked`` gets its own
     guidance; any other non-``done`` verdict gets the ``continue`` guidance.
-    A broken judge fails open (logged) so it cannot permanently wedge work."""
+    A broken judge fails open (logged) so it cannot permanently wedge work.
+    On a judge *transport* failure the ``kanban_complete`` handoff may go to
+    pre-created downstream children (raises :class:`_GoalDeliveryFallback`);
+    every other handoff stays fail-closed."""
     if not task or not task.goal_mode or not _goal_judge_available():
         return
     try:
-        verdict, reason, _, _, _ = judge_goal(
+        verdict, reason, _, _, transport_failed = judge_goal(
             goal=f"{task.title}\n\n{task.body or ''}".strip(), last_response=evidence.strip())
     except Exception as judge_exc:
         logger.warning(
@@ -387,6 +411,15 @@ def _goal_gate(tool_name: str, task, tid: str, evidence: str) -> None:
         return
     if verdict == "done":
         return
+    if transport_failed and tool_name == "kanban_complete":
+        # Infra, not content (#100954). Fail-closed unless the terminal decision
+        # can be handed to live downstream children owned by another profile.
+        from hermes_cli import kanban_db as kb
+        children = kb.eligible_delivery_children(conn, tid, task.assignee)
+        if children:
+            raise _GoalDeliveryFallback(children, reason)
+        raise _Reject(_GOAL_GATE_MESSAGES["kanban_complete"]["transport_failed"].format(
+            reason=reason, tid=tid))
     key = "blocked" if verdict == "blocked" else "continue"
     raise _Reject(_GOAL_GATE_MESSAGES[tool_name][key].format(reason=reason, tid=tid))
 
@@ -561,7 +594,38 @@ def _handle_complete(args: dict, **kw) -> str:
         # judge by calling kanban_complete before acceptance criteria are met. Only enforce when a judge is
         # actually reachable — see _goal_judge_available for why an unavailable judge fails open.
         task = kb.get_task(conn, tid)
-        _goal_gate("kanban_complete", task, tid, (summary or result or "").strip())
+        try:
+            _goal_gate("kanban_complete", task, tid, (summary or result or "").strip(), conn)
+        except _GoalDeliveryFallback as fallback:
+            # Judge transport failure (#100954) with live downstream children: complete
+            # HERE, in the caller's connection context, with the audit stamp merged into
+            # the handoff metadata. The stamp key is system-owned: it overwrites any
+            # caller-supplied value so the audit trail cannot be forged from the model.
+            # complete_task keeps every other invariant: PR acceptance (exact-head CI),
+            # CAS (expected_run_id), artifact preservation, phantom-card checks — a
+            # failure there leaves the card in-flight exactly as on the judged path.
+            merged = dict(metadata) if isinstance(metadata, dict) else {}
+            merged["goal_delivery_fallback"] = {
+                "trigger": "goal_judge_transport_failed",
+                "judge_error": fallback.reason,
+                "released_children": fallback.children,
+            }
+            ok = kb.complete_task(
+                conn, tid, result=result, summary=summary, metadata=merged,
+                created_cards=created_cards, expected_run_id=_worker_run_id(tid))
+            if not ok:
+                task = kb.get_task(conn, tid)
+                raise _Reject(
+                    (task.last_failure_error if task else None) or
+                    f"could not complete {tid} via the goal-judge delivery fallback "
+                    f"(unknown id, stale run, PR acceptance failure, or already terminal)")
+            run = kb.latest_run(conn, tid)
+            children_note = ", ".join(fallback.children)
+            return _ok(
+                task_id=tid, run_id=run.id if run else None,
+                goal_delivery_fallback=(
+                    f"goal judge unreachable ({fallback.reason}); verification handed to "
+                    f"downstream child card(s): {children_note}"))
         try:
             ok = kb.complete_task(
                 conn, tid, result=result, summary=summary, metadata=metadata,
@@ -649,7 +713,7 @@ def _handle_request_review(args: dict, **kw) -> str:
                f"reviewer profile {reviewer!r} is not installed. "
                f"Installed profiles: {', '.join(list_profile_names())}")
     with _board(args.get("board")) as (kb, conn):
-        _goal_gate("kanban_request_review", kb.get_task(conn, tid), tid, summary)
+        _goal_gate("kanban_request_review", kb.get_task(conn, tid), tid, summary, conn)
         ok, fail_reason = kb.request_review(
             conn, tid, summary=summary, metadata=metadata, reviewer=reviewer,
             expected_run_id=_worker_run_id(tid), with_reason=True)

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -577,6 +577,10 @@ hermes kanban create "Translate the docs site to French" \
 
 Use it for open-ended, multi-step, or "keep going until X is true" cards. Skip it for cheap one-shot work — the per-turn judge overhead isn't worth it, and the dispatcher's existing retry/circuit-breaker already handles transient worker failures. The judge is only as good as your goal text, so write the body as **explicit acceptance criteria**.
 
+:::tip Judge outage ≠ "not done yet" — the delivery fallback
+When the judge itself is unreachable (provider transport/auth errors), a completion request can't be judged at all. Because goal-mode workers finish *only* through `kanban_complete`, treating that infra failure as a content rejection would wedge the card forever. So on a judge **transport** failure, `kanban_complete` may instead hand the terminal decision to pre-created **downstream children**: cards linked with `parents=[<this card>]`, still open, and assigned to a *different* profile (so the worker can't rubber-stamp itself — the child re-runs verification). The completion is stamped with `goal_delivery_fallback` metadata (trigger, judge error, released children) for audit. Fail-closed everywhere else: no eligible child, a judge that answers with a real verdict, or a `kanban request-review` handoff all reject exactly as before. Practical consequence: if you run goal-mode cards behind a flaky auxiliary provider, pre-create the verification child (`assignee qa`, `parents=[implementation-card]`) so a judge outage releases work to QA instead of parking it.
+:::
+
 :::note Goal-mode cards borrow the `/goal` engine — they don't connect to it
 `--goal` runs the continuation loop *inside that one card's worker session*. It shares the engine with the [`/goal` slash command](./goals), not the state: setting a `/goal` in a chat session never creates, claims, or moves a kanban card, and a goal-mode card's loop is invisible to any chat session's `/goal status`. If you want this conversation to keep iterating, use [`/goal`](./goals); if you want work on the board, create a card.
 :::


### PR DESCRIPTION
## Summary

A goal-mode worker finishes **only** through `kanban_complete`, and `judge_goal`'s transport/auth errors fail-open to `"continue"` — indistinguishable from a real *"not done yet"* rejection (#100954). When the auxiliary provider is down (401 / DNS / timeout), the worker can never complete or block: every attempt is rejected as missing acceptance evidence, the goal loop burns its turn budget on nudges the judge cannot evaluate, and the card lands in triage. Historical occurrences: repeated `BadRequestError` loops, and a PermissionDenied wedge on seo-site/t_4efd8468 run 33.

**Fix:** `judge_goal` already returns `transport_failed=True` on infra errors, but all three consumers discarded the flag. Now, on `kanban_complete` only, a transport failure hands the terminal decision to pre-created **downstream children** instead of the broken judge:

- `hermes_cli/kanban_db.py` — `eligible_delivery_children()`: linked children, not `done`/`archived`, assigned to a **different profile** (no self-approval; the child re-runs verification).
- `tools/kanban_tools.py` — `_goal_gate` raises `_GoalDeliveryFallback` when `transport_failed` and eligible children exist; `_handle_complete` stamps `goal_delivery_fallback` metadata (`trigger` / `judge_error` / `released_children`) and completes through the normal `kb.complete_task` path, so **PR acceptance (exact-head CI), CAS (`expected_run_id`), artifact preservation and phantom-card checks all still apply**. The stamp key is system-owned: a caller-supplied value is overwritten (no audit forgery from the model).
- `hermes_cli/kanban.py` — `_goal_mode_handoff_rejection` returns `transport_failed`; `_goal_gate_error` returns `(error, stamp)` so the CLI `complete` command applies the same fallback. `request-review` never gets it and stays fail-closed.

**Fail-closed everywhere else:** no eligible child, a real judge verdict (content rejection), and every `request-review` handoff reject exactly as before. No gate is disabled; `recompute_ready` promotes the released child so verification *happens*, it is not *asserted*.

## Tests

`tests/hermes_cli/test_goal_delivery_fallback.py` (14 tests):

- eligibility filters: live/different-assignee only (done, archived, same-assignee, unassigned excluded)
- tool + CLI transport-failure release paths; released child promoted `todo → ready`
- content rejection is **not** masked on either surface (tool + CLI)
- review handoff never gets the fallback
- stamp forgery: caller-supplied `goal_delivery_fallback` overwritten, sibling metadata keys kept
- PR contract still enforced on the fallback path (no published_pr → rejected, card in-flight)
- CAS mismatch (`expected_run_id`) still rejected on the fallback path

Neighbor suites green: `test_kanban_tools`, `test_kanban_review_surfaces`, `test_kanban_goal_mode`, `test_goal_dispatch`, `test_goals`, `test_kanban_cli`, `test_kanban_block_kinds` — **168 passed** via `scripts/run_tests.sh`.

## Docs

`website/docs/user-guide/features/kanban.md` — goal-mode section gains a tip documenting the fallback semantics and the practical consequence (pre-create the verification child for goal-mode cards behind a flaky auxiliary provider).
