### PR TITLE
fix(gateway): suppress redirect-mode busy-ack when busy_steer_ack_enabled=false

### DIFF
--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -738,7 +738,7 @@ class GatewayBusySessionMixin:
         if now - (_busy_state.turn.busy_ack_ts if _busy_state else 0) < 30:
             return True  # interrupt sent (if not queue), ack already delivered recently
 
-        if is_steer_mode and not self._busy_steer_ack_enabled(event, session_key):
+        if (is_steer_mode or is_redirect_mode) and not self._busy_steer_ack_enabled(event, session_key):
             return True
 
         self._session_state(session_key).turn.busy_ack_ts = now


### PR DESCRIPTION
## What

The busy-steer ack suppression gate in `gateway/run_busy.py` only checked `is_steer_mode`, so a mid-run REDIRECT (`↪ Redirected current run. I'll adjust using your correction.`) still emitted its acknowledgment bubble even on platforms that set `busy_steer_ack_enabled=false`.

## Why it matters

On a customer-facing messaging line (e.g. WhatsApp Business Cloud lead intake) that configures silent steering, the bot's *internal* redirect acknowledgment was being sent to the customer as a real chat message — the lead saw `↪ Redirected current run. I'll adjust using your correction.`

The `busy_steer_ack_enabled` flag's documented intent (see `_busy_steer_ack_enabled`: "Some mobile chat setups want silent steering — keep the behavior, drop the bubble") clearly covers redirect mode; the gate just missed it.

## Change

```diff
-if is_steer_mode and not self._busy_steer_ack_enabled(event, session_key):
+if (is_steer_mode or is_redirect_mode) and not self._busy_steer_ack_enabled(event, session_key):
```

## Testing

- `python -c "import ast; ast.parse(...)"` passes.
- Behavior verified on a live WhatsApp Cloud lead line: after this change (plus `display.platforms.whatsapp_cloud.busy_steer_ack_enabled=false`), the redirect ack no longer appears to the customer.
- No existing tests cover the redirect branch of this gate; the change extends an existing suppression condition.