### PR TITLE
docs(agents): reconcile Footprint Ladder rung 3 with the session-surface rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,10 @@ Choose the highest (least-footprint) rung that correctly solves the problem:
    `hermes <subcommand>` guided by a skill. Default for subscriptions, scheduled tasks,
    service setup (`hermes webhook`, `hermes cron`, `hermes tools`).
 3. **Service-gated tool (`check_fn`)** — needs structured params/returns AND only appears when
-   a prerequisite is configured (Home Assistant tools, memory-provider tools).
+   a prerequisite is configured (Home Assistant tools, memory-provider tools). This rung gates
+   reachability/opt-in process-wide; a capability that varies per SESSION (who is watching) is
+   a named toolset folded in by the toolset resolver, not a `check_fn` — see "Surface capability
+   is a property of the SESSION" below.
 4. **Plugin** — third-party/niche/user-specific; lives in `~/.hermes/plugins/` or a pip
    package, discovered at runtime.
 5. **MCP server (in the catalog)** — genuinely a tool but not core-fundamental. Zero permanent


### PR DESCRIPTION
## Why

The Footprint Ladder rung 3 reads:

> **Service-gated tool (`check_fn`)** — needs structured params/returns AND only appears when a prerequisite is configured

while the "Surface capability is a property of the SESSION" section later in the same file states the opposite half:

> **`check_fn` answers reachability or opt-in, not surface.** ... a per-session answer does not belong there.

Both statements are correct in their own context — but an agent that only ever loads the ladder (or a model skimming for the decision) sees "check_fn controls visibility" and can wire a per-session surface behind a `check_fn`, which is exactly the bug class the later section calls out. The two passages contradict at the ladder, not at the section.

## What

Adds one disambiguating sentence to rung 3, pointing at the SESSION-surface rule, so the ladder and the section resolve the same way from either reading order. Docs-only; no code, no behavior change.

Found while auditing the core `.md` files with an external review model (2026-09-12); I then verified both passages against `tools/registry.py` TTL caching and the `desktop_ui`/`project` toolset folding pattern described in the section — the section is the load-bearing one, so I clarified the ladder rather than the section.
