### PR TITLE
fix(gateway): drop leftover include_editorial kwarg from GET /v1/skills

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2647,9 +2647,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         try:
             from tools.skills_tool import _find_all_skills, _sort_skills
             skills = _sort_skills(
-                _find_all_skills(
-                    skip_disabled=False, include_editorial=True
-                )
+                _find_all_skills(skip_disabled=False)
             )
         except Exception:
             logger.exception("GET /v1/skills failed")

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1017,6 +1017,30 @@ class TestSkillsEndpoint:
                 for entry in data["data"]:
                     assert set(entry.keys()) >= {"name", "description", "category"}
 
+    @pytest.mark.asyncio
+    async def test_skills_enumerates_real_catalog(self, adapter):
+        """Do not mock _find_all_skills. The kwargs-blind MagicMock above hid a
+        TypeError from a leftover include_editorial kwarg and made GET /v1/skills
+        a permanent 500."""
+        from hermes_constants import get_hermes_home
+
+        skill_dir = get_hermes_home() / "skills" / "api-skills-probe"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: api-skills-probe\ndescription: Probe skill for GET /v1/skills\n---\n\nBody.\n",
+            encoding="utf-8",
+        )
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/skills")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["object"] == "list"
+            names = [entry["name"] for entry in data["data"]]
+            assert "api-skills-probe" in names
+            for entry in data["data"]:
+                assert set(entry.keys()) >= {"name", "description", "category"}
+
 
 class TestToolsetsEndpoint:
     @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

`GET /v1/skills` always returned HTTP 500. The Collective Wisdom revert removed `include_editorial` from `_find_all_skills` but left it on the api_server handler, and a broad `except Exception` turned the TypeError into a generic 500. The existing test mocked the finder with a kwargs-blind MagicMock, so the mismatch never showed up.

This drops the leftover kwarg and adds a regression test that calls the real finder.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #108967

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `gateway/platforms/api_server.py`: `_handle_skills` calls `_find_all_skills(skip_disabled=False)` only.
- `tests/gateway/test_api_server.py`: `test_skills_enumerates_real_catalog` plants a skill under the isolated `HERMES_HOME` and hits `GET /v1/skills` without mocking the finder.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `scripts/run_tests.sh tests/gateway/test_api_server.py -k TestSkillsEndpoint -q`
2. On the base commit that test fails with `assert 500 == 200` and `TypeError: _find_all_skills() got an unexpected keyword argument 'include_editorial'`.
3. After this change both skills tests pass (2 passed).

Ran on Windows 11: `TestSkillsEndpoint` 2 passed. The full `test_api_server.py` file had 119 passed and 1 failed (`test_security_headers_present`). That failure rewrites CSP to `injections.adguard.org` and is unrelated local AdGuard injection, not this change.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

N/A
