### PR TITLE
fix(desktop): open a sidebar session into the focused pane, not always main

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
@@ -1,10 +1,18 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { atom } from 'nanostores'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { openSessionTile } from '@/store/session-states'
 
 import { SessionActionsMenu, SessionContextMenu } from './session-actions-menu'
 
 afterEach(cleanup)
+
+const openSessionTileMock = vi.mocked(openSessionTile)
+
+beforeEach(() => {
+  openSessionTileMock.mockClear()
+})
 
 // Exercises the real SessionActionsMenu end-to-end (no DropdownMenu mock) so
 // a broken asChild composition on the kebab trigger fails here — the menu
@@ -55,6 +63,7 @@ vi.mock('@/i18n', () => ({
           export: 'Export',
           hideTabBar: 'Hide tab bar',
           markRead: 'Mark as read',
+          openInSplit: 'Open in split',
           pin: 'Pin',
           rename: 'Rename',
           renameDesc: 'Leave empty to clear.',
@@ -286,5 +295,21 @@ describe('SessionActionsMenu', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
     expect(await screen.findByText('Session deleted')).toBeTruthy()
     expect(onDelete).toHaveBeenCalledTimes(1)
+  })
+
+  it('offers 在分屏中打开 and docks the session on the chosen edge', async () => {
+    renderMenu()
+
+    const trigger = screen.getByRole('button', { name: 'Session actions' })
+    fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.click(trigger)
+
+    const sub = await screen.findByRole('menuitem', { name: /open in split/i })
+    fireEvent.keyDown(sub, { key: 'ArrowRight' })
+
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Right' }))
+
+    expect(openSessionTileMock).toHaveBeenCalledWith('s1', 'right')
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
@@ -2,6 +2,8 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-li
 import { atom } from 'nanostores'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { lastChatZoneSessionAnchor } from '@/components/pane-shell/tree/store'
+import { $selectedStoredSessionId } from '@/store/session'
 import { openSessionTile } from '@/store/session-states'
 
 import { SessionActionsMenu, SessionContextMenu } from './session-actions-menu'
@@ -9,9 +11,11 @@ import { SessionActionsMenu, SessionContextMenu } from './session-actions-menu'
 afterEach(cleanup)
 
 const openSessionTileMock = vi.mocked(openSessionTile)
+const lastChatZoneSessionAnchorMock = vi.mocked(lastChatZoneSessionAnchor)
 
 beforeEach(() => {
   openSessionTileMock.mockClear()
+  lastChatZoneSessionAnchorMock.mockReturnValue(null)
 })
 
 // Exercises the real SessionActionsMenu end-to-end (no DropdownMenu mock) so
@@ -22,6 +26,7 @@ vi.mock('@/components/pane-shell/tree/store', () => ({
   closeAllTreeTabs: vi.fn(),
   closeOtherTreeTabs: vi.fn(),
   closeTreeTabsToRight: vi.fn(),
+  lastChatZoneSessionAnchor: vi.fn(() => null),
   treeTabCloseTargets: vi.fn(() => null)
 }))
 vi.mock('@/hermes', () => ({
@@ -298,6 +303,7 @@ describe('SessionActionsMenu', () => {
   })
 
   it('offers 在分屏中打开 and docks the session on the chosen edge', async () => {
+    lastChatZoneSessionAnchorMock.mockReturnValue('session-tile:worked-in')
     renderMenu()
 
     const trigger = screen.getByRole('button', { name: 'Session actions' })
@@ -310,6 +316,46 @@ describe('SessionActionsMenu', () => {
 
     fireEvent.click(await screen.findByRole('menuitem', { name: 'Right' }))
 
-    expect(openSessionTileMock).toHaveBeenCalledWith('s1', 'right')
+    // The anchor is the zone the user last worked in — not the ladder's answer,
+    // which a real right-click (pointer on the sidebar's own zone) would send to
+    // main.
+    expect(openSessionTileMock).toHaveBeenCalledWith('s1', 'right', 'session-tile:worked-in')
+  })
+
+  it('leaves the anchor to the ladder when no chat zone has been touched', async () => {
+    renderMenu()
+
+    const trigger = screen.getByRole('button', { name: 'Session actions' })
+    fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
+    fireEvent.click(trigger)
+
+    const sub = await screen.findByRole('menuitem', { name: /open in split/i })
+    fireEvent.keyDown(sub, { key: 'ArrowRight' })
+
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Right' }))
+
+    expect(openSessionTileMock).toHaveBeenCalledWith('s1', 'right', undefined)
+  })
+
+  it('disables the split entry for the session that already owns main', async () => {
+    $selectedStoredSessionId.set('s1')
+
+    try {
+      renderMenu()
+
+      const trigger = screen.getByRole('button', { name: 'Session actions' })
+      fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+      fireEvent.pointerUp(trigger, { button: 0, pointerType: 'mouse' })
+      fireEvent.click(trigger)
+
+      const sub = await screen.findByRole('menuitem', { name: /open in split/i })
+
+      // A main session cannot also be a tile, so the entry says so instead of
+      // silently doing nothing.
+      expect(sub.getAttribute('aria-disabled') === 'true' || sub.hasAttribute('data-disabled')).toBe(true)
+    } finally {
+      $selectedStoredSessionId.set(null)
+    }
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -44,11 +44,13 @@ import {
   setSessions
 } from '@/store/session'
 import { $sessionColorOverrides, setSessionColorOverride } from '@/store/session-color'
-import { $sessionTiles, closeAllOpenSessionTiles } from '@/store/session-states'
+import { $sessionTiles, closeAllOpenSessionTiles, openSessionTile } from '@/store/session-states'
 import { ackStoredSessionId } from '@/store/session-unread'
 import { canOpenSessionInTerminal, canOpenSessionWindow, openSessionInTerminal } from '@/store/windows'
 
 import type { SessionTitleResponse } from '../../types'
+
+import { SplitSubmenu } from './split-submenu'
 
 // Rename a session, preferring the gateway's session.title RPC over REST.
 //
@@ -462,6 +464,17 @@ function useSessionActions({
   const renderItems = (kit: MenuKit) => (
     <>
       {openItems.map(item => renderActionItem(kit, item))}
+      <SplitSubmenu
+        disabled={!sessionId}
+        kit={kit}
+        label={t.sidebar.row.openInSplit}
+        onSplit={dir => {
+          // Dock relative to the focused chat zone (anchor omitted →
+          // focusedSessionTabAnchor()); an already-open tile MOVES there, the
+          // same gesture the sidebar drag performs.
+          openSessionTile(sessionId, dir)
+        }}
+      />
       {openItems.length > 0 && <kit.Separator />}
       {identityItems.map(item => renderActionItem(kit, item))}
       <kit.Sub>

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -7,6 +7,7 @@ import {
   closeAllTreeTabs,
   closeOtherTreeTabs,
   closeTreeTabsToRight,
+  lastChatZoneSessionAnchor,
   reloadTreePane,
   treeTabCloseTargets
 } from '@/components/pane-shell/tree/store'
@@ -465,14 +466,18 @@ function useSessionActions({
     <>
       {openItems.map(item => renderActionItem(kit, item))}
       <SplitSubmenu
-        disabled={!sessionId}
+        // A session that IS main's cannot become a tile — one conversation is
+        // either main or a tile, never both — so say so instead of offering an
+        // item that would silently do nothing.
+        disabled={!sessionId || sessionId === selectedStoredSessionId}
         kit={kit}
         label={t.sidebar.row.openInSplit}
         onSplit={dir => {
-          // Dock relative to the focused chat zone (anchor omitted →
-          // focusedSessionTabAnchor()); an already-open tile MOVES there, the
-          // same gesture the sidebar drag performs.
-          openSessionTile(sessionId, dir)
+          // Dock beside the zone the user last worked in. The ladder answer is
+          // wrong here: a real right-click lands the pointer (and the focusin)
+          // on the sidebar's own zone, which falls through to main. An
+          // already-open tile MOVES there, the gesture the sidebar drag makes.
+          openSessionTile(sessionId, dir, lastChatZoneSessionAnchor() ?? undefined)
         }}
       />
       {openItems.length > 0 && <kit.Separator />}

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -1055,7 +1055,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
         requestSessionResume(sessionId)
       }
 
-      openSession(sessionId, navigate)
+      openSession(sessionId, navigate, 'focused')
     },
     onRetryResume: sessionId => void resumeSession(sessionId, true),
     onSteer: steerPrompt,

--- a/apps/desktop/src/app/open-session.test.ts
+++ b/apps/desktop/src/app/open-session.test.ts
@@ -27,6 +27,12 @@ vi.mock('./routes', () => ({
   sessionRoute: (id: string) => `/c/${encodeURIComponent(id)}`
 }))
 
+const sidePaneGet = vi.fn(() => false)
+
+vi.mock('@/components/pane-shell/tree/store', () => ({
+  focusedChatZoneIsSidePane: () => sidePaneGet()
+}))
+
 import { $activeSessionId, $selectedStoredSessionId } from '@/store/session'
 
 import { mainChatOccupied, openSession, openSessionIntentFromModifiers } from './open-session'
@@ -92,6 +98,7 @@ describe('openSession', () => {
     workspaceIsPageGet.mockReturnValue(false)
     reuseBlankDraftTile.mockReset()
     setSessionTileWorkspaceScope.mockReset()
+    sidePaneGet.mockReturnValue(false)
     $activeSessionId.set(null)
     $selectedStoredSessionId.set(null)
   })
@@ -128,6 +135,26 @@ describe('openSession', () => {
     openSession('s1', navigate, 'main')
     expect(navigate).toHaveBeenCalledWith('/c/s1')
     expect(focusOpenSession).not.toHaveBeenCalled()
+    expect(openSessionTile).not.toHaveBeenCalled()
+  })
+
+  it('focused opens a tab in the focused pane when a side pane has the attention', () => {
+    sidePaneGet.mockReturnValue(true)
+    focusOpenSession.mockReturnValue(null)
+
+    openSession('s1', navigate, 'focused')
+
+    expect(openSessionTile).toHaveBeenCalledWith('s1', 'center')
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('focused degrades to the classic in-place resume when main is the target', () => {
+    sidePaneGet.mockReturnValue(false)
+    focusOpenSession.mockReturnValue(null)
+
+    openSession('s1', navigate, 'focused')
+
+    expect(navigate).toHaveBeenCalledWith('/c/s1')
     expect(openSessionTile).not.toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/app/open-session.test.ts
+++ b/apps/desktop/src/app/open-session.test.ts
@@ -28,9 +28,11 @@ vi.mock('./routes', () => ({
 }))
 
 const sidePaneGet = vi.fn(() => false)
+const chatAnchorGet = vi.fn<() => null | string>(() => null)
 
 vi.mock('@/components/pane-shell/tree/store', () => ({
-  focusedChatZoneIsSidePane: () => sidePaneGet()
+  focusedChatZoneIsSidePane: () => sidePaneGet(),
+  lastChatZoneSessionAnchor: () => chatAnchorGet()
 }))
 
 import { $activeSessionId, $selectedStoredSessionId } from '@/store/session'
@@ -99,6 +101,7 @@ describe('openSession', () => {
     reuseBlankDraftTile.mockReset()
     setSessionTileWorkspaceScope.mockReset()
     sidePaneGet.mockReturnValue(false)
+    chatAnchorGet.mockReturnValue(null)
     $activeSessionId.set(null)
     $selectedStoredSessionId.set(null)
   })
@@ -138,14 +141,27 @@ describe('openSession', () => {
     expect(openSessionTile).not.toHaveBeenCalled()
   })
 
-  it('focused opens a tab in the focused pane when a side pane has the attention', () => {
+  it('focused opens a tab BESIDE the zone the user last worked in', () => {
     sidePaneGet.mockReturnValue(true)
+    chatAnchorGet.mockReturnValue('session-tile:worked-in')
     focusOpenSession.mockReturnValue(null)
 
     openSession('s1', navigate, 'focused')
 
-    expect(openSessionTile).toHaveBeenCalledWith('s1', 'center')
+    // Explicit anchor: openSessionTile's own fallback asks the hovered → focused
+    // → workspace ladder, which a real press on a session row sends to main.
+    expect(openSessionTile).toHaveBeenCalledWith('s1', 'center', 'session-tile:worked-in')
     expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('focused leaves the anchor to the ladder when no chat zone was touched', () => {
+    sidePaneGet.mockReturnValue(true)
+    chatAnchorGet.mockReturnValue(null)
+    focusOpenSession.mockReturnValue(null)
+
+    openSession('s1', navigate, 'focused')
+
+    expect(openSessionTile).toHaveBeenCalledWith('s1', 'center', undefined)
   })
 
   it('focused degrades to the classic in-place resume when main is the target', () => {
@@ -154,6 +170,20 @@ describe('openSession', () => {
 
     openSession('s1', navigate, 'focused')
 
+    expect(navigate).toHaveBeenCalledWith('/c/s1')
+    expect(openSessionTile).not.toHaveBeenCalled()
+  })
+
+  it('focused pulls the chat back when the row is main\u2019s own session and the workspace shows a page', () => {
+    sidePaneGet.mockReturnValue(true) // a side chat zone is where the user worked…
+    focusOpenSession.mockReturnValue('main') // …but the clicked row IS main's session
+    workspaceIsPageGet.mockReturnValue(true) // and main is showing a page
+    $selectedStoredSessionId.set('s1')
+
+    openSession('s1', navigate, 'focused')
+
+    // 'tab' would front the workspace tab and return, leaving the page up — the
+    // dead click this case exists to avoid.
     expect(navigate).toHaveBeenCalledWith('/c/s1')
     expect(openSessionTile).not.toHaveBeenCalled()
   })
@@ -169,7 +199,7 @@ describe('openSession', () => {
   it('tab opens a stacked session tile when not on screen', () => {
     focusOpenSession.mockReturnValue(null)
     openSession('s1', navigate, 'tab')
-    expect(openSessionTile).toHaveBeenCalledWith('s1', 'center')
+    expect(openSessionTile).toHaveBeenCalledWith('s1', 'center', undefined)
     expect(navigate).not.toHaveBeenCalled()
   })
 
@@ -196,7 +226,7 @@ describe('openSession', () => {
     $selectedStoredSessionId.set('s0')
     focusOpenSession.mockReturnValue(null)
     openSession('s1', navigate, 'stack')
-    expect(openSessionTile).toHaveBeenCalledWith('s1', 'center')
+    expect(openSessionTile).toHaveBeenCalledWith('s1', 'center', undefined)
     expect(navigate).not.toHaveBeenCalled()
   })
 
@@ -223,7 +253,7 @@ describe('openSession', () => {
     $activeSessionId.set('runtime-a')
     focusOpenSession.mockReturnValue(null)
     openSession('s1', navigate, 'stack')
-    expect(openSessionTile).toHaveBeenCalledWith('s1', 'center')
+    expect(openSessionTile).toHaveBeenCalledWith('s1', 'center', undefined)
   })
 
   it('stack loads into main when it holds only a blank draft', () => {
@@ -244,7 +274,7 @@ describe('openSession', () => {
     focusOpenSession.mockReturnValue(null)
     openSession('s1', navigate, 'window')
     expect(openSessionInNewWindow).not.toHaveBeenCalled()
-    expect(openSessionTile).toHaveBeenCalledWith('s1', 'center')
+    expect(openSessionTile).toHaveBeenCalledWith('s1', 'center', undefined)
   })
 
   it('no-ops on an empty id', () => {

--- a/apps/desktop/src/app/open-session.ts
+++ b/apps/desktop/src/app/open-session.ts
@@ -14,6 +14,7 @@
  *   - `window` (⇧⌘-click) — pop into its own window; falls back to `tab` when
  *     the bridge has no session-window support.
  */
+import { focusedChatZoneIsSidePane } from '@/components/pane-shell/tree/store'
 import type { WorkspaceMode } from '@/contrib/types'
 import { $activeSessionId, $selectedStoredSessionId, markSessionRead } from '@/store/session'
 import type { SessionProfileRoute } from '@/store/session-request-router'
@@ -28,7 +29,7 @@ import { canOpenSessionWindow, openSessionInNewWindow } from '@/store/windows'
 
 import { $workspaceIsPage, sessionRoute } from './routes'
 
-export type OpenSessionIntent = 'in-place' | 'main' | 'stack' | 'tab' | 'window'
+export type OpenSessionIntent = 'focused' | 'in-place' | 'main' | 'stack' | 'tab' | 'window'
 
 export type OpenSessionNavigate = (to: string, options?: { replace?: boolean }) => void
 
@@ -117,6 +118,15 @@ export function openSession(
     navigate(sessionRoute(storedSessionId))
 
     return
+  }
+
+  // `focused` — a sidebar row click in a multi-pane workspace: land in the chat
+  // zone the user is actually working in (the same hovered → focused → workspace
+  // ladder ⌘T / ⌘1…⌘9 use). When that zone IS main's, or nothing in a side zone
+  // has the attention, this degrades to the classic 'in-place' resume, so
+  // single-pane layouts keep replacing main exactly as before.
+  if (resolved === 'focused') {
+    resolved = focusedChatZoneIsSidePane() ? 'tab' : 'in-place'
   }
 
   // A `stack` open arrives from outside the workspace, so unlike a sidebar

--- a/apps/desktop/src/app/open-session.ts
+++ b/apps/desktop/src/app/open-session.ts
@@ -14,9 +14,9 @@
  *   - `window` (⇧⌘-click) — pop into its own window; falls back to `tab` when
  *     the bridge has no session-window support.
  */
-import { focusedChatZoneIsSidePane } from '@/components/pane-shell/tree/store'
+import { focusedChatZoneIsSidePane, lastChatZoneSessionAnchor } from '@/components/pane-shell/tree/store'
 import type { WorkspaceMode } from '@/contrib/types'
-import { $activeSessionId, $selectedStoredSessionId, markSessionRead } from '@/store/session'
+import { $activeSessionId, $selectedStoredSessionId, $sessions, lineageAliases, markSessionRead } from '@/store/session'
 import type { SessionProfileRoute } from '@/store/session-request-router'
 import {
   focusedSessionNeedsRoute,
@@ -121,12 +121,28 @@ export function openSession(
   }
 
   // `focused` — a sidebar row click in a multi-pane workspace: land in the chat
-  // zone the user is actually working in (the same hovered → focused → workspace
-  // ladder ⌘T / ⌘1…⌘9 use). When that zone IS main's, or nothing in a side zone
-  // has the attention, this degrades to the classic 'in-place' resume, so
-  // single-pane layouts keep replacing main exactly as before.
+  // zone the user last worked in. When that zone is main's (or no chat zone has
+  // been touched), this degrades to the classic 'in-place' resume, so
+  // single-pane layouts keep replacing main exactly as before. A session that is
+  // ALREADY main's takes that path too: it is the one that pulls the chat back
+  // when the workspace is showing a page, whereas 'tab' would front the
+  // workspace tab and leave the page up (a dead click).
+  //
+  // The dock target is passed EXPLICITLY rather than left to `openSessionTile`'s
+  // fallback: that fallback asks the hovered → focused → workspace ladder, and a
+  // real press on a session row lands that ladder on the sidebar's own zone,
+  // which falls through to main — the row click would then dock into main again.
+  let focusedDockAnchor: string | undefined
+
   if (resolved === 'focused') {
-    resolved = focusedChatZoneIsSidePane() ? 'tab' : 'in-place'
+    const mainOwned = lineageAliases(storedSessionId, $sessions.get()).includes($selectedStoredSessionId.get() ?? '')
+    const inWorkingPane = focusedChatZoneIsSidePane() && !mainOwned
+
+    if (inWorkingPane) {
+      focusedDockAnchor = lastChatZoneSessionAnchor() ?? undefined
+    }
+
+    resolved = inWorkingPane ? 'tab' : 'in-place'
   }
 
   // A `stack` open arrives from outside the workspace, so unlike a sidebar
@@ -163,9 +179,9 @@ export function openSession(
     }
 
     if (botWorkspaceScope) {
-      openSessionTile(storedSessionId, 'center', undefined, undefined, botWorkspaceScope)
+      openSessionTile(storedSessionId, 'center', focusedDockAnchor, undefined, botWorkspaceScope)
     } else {
-      openSessionTile(storedSessionId, 'center')
+      openSessionTile(storedSessionId, 'center', focusedDockAnchor)
     }
 
     return

--- a/apps/desktop/src/components/pane-shell/tree/focused-session-tab.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/focused-session-tab.test.ts
@@ -67,6 +67,30 @@ describe('focused chat zone drives the tab verbs', () => {
     expect(tree.closeFocusedSessionTab()).toBe(false)
   })
 
+  it('a side chat zone is the target; main is not', async () => {
+    const { tree } = await setup()
+
+    tree.noteActiveTreeGroup('grp-side')
+    expect(tree.focusedChatZoneIsSidePane()).toBe(true)
+
+    tree.noteActiveTreeGroup('grp-main')
+    expect(tree.focusedChatZoneIsSidePane()).toBe(false)
+  })
+
+  it('non-chat focus (files) falls through to main, so it is not a side pane', async () => {
+    const { model, tree } = await setup()
+
+    tree.declareDefaultTree(
+      model.split('row', [
+        model.group(['workspace'], { active: 'workspace', id: 'grp-main' }),
+        model.group(['files'], { active: 'files', id: 'grp-files' })
+      ])
+    )
+    tree.noteActiveTreeGroup('grp-files')
+
+    expect(tree.focusedChatZoneIsSidePane()).toBe(false)
+  })
+
   it('⌘W closes the focused zone active tab and leaves the workspace alone', async () => {
     const { model, tree } = await setup()
 

--- a/apps/desktop/src/components/pane-shell/tree/focused-session-tab.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/focused-session-tab.test.ts
@@ -91,6 +91,33 @@ describe('focused chat zone drives the tab verbs', () => {
     expect(tree.focusedChatZoneIsSidePane()).toBe(false)
   })
 
+  it('a press or hover on a zone without a chat strip keeps the last chat zone', async () => {
+    const { model, tree } = await setup()
+
+    tree.$layoutTree.set(
+      model.split('row', [
+        model.group(['workspace', 'session-tile:a'], { active: 'workspace', id: 'grp-main' }),
+        model.group(['session-tile:b'], { active: 'session-tile:b', id: 'grp-side' }),
+        model.group(['sessions'], { active: 'sessions', id: 'grp-sessions' })
+      ])
+    )
+
+    // The user works in the side chat zone…
+    tree.noteActiveTreeGroup('grp-side')
+    expect(tree.focusedChatZoneIsSidePane()).toBe(true)
+
+    // …then reaches for a session row: the pointer crossed the sidebar, whose
+    // zone hosts no chat strip. That press IS the click this path serves, so it
+    // must not move the answer back to main.
+    tree.noteHoveredTreeGroup('grp-sessions')
+    tree.noteActiveTreeGroup('grp-sessions')
+    expect(tree.focusedChatZoneIsSidePane()).toBe(true)
+
+    // Fronting main explicitly is the one thing that moves it back.
+    tree.noteActiveTreeGroup(null)
+    expect(tree.focusedChatZoneIsSidePane()).toBe(false)
+  })
+
   it('⌘W closes the focused zone active tab and leaves the workspace alone', async () => {
     const { model, tree } = await setup()
 

--- a/apps/desktop/src/components/pane-shell/tree/hovered-zone-tabs.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/hovered-zone-tabs.test.ts
@@ -88,10 +88,12 @@ describe('hovered zone retargets the tab verbs', () => {
     expect(model.allPaneIds(tree.$layoutTree.get()!)).toContain('workspace')
   })
 
-  // Hovering chrome that is not a zone at all (the sidebar, the titlebar, the
-  // statusbar) reports no group. The keys must fall through to focus rather
+  // Hovering chrome that cannot serve the verb must fall through to focus rather
   // than dead-ending — pointing away from the panes is not a reason to stop
-  // switching tabs.
+  // switching tabs. Note that the sidebar IS a zone like any other in the wide
+  // layout: it falls through because it hosts no chat strip, not because it
+  // reports no group. Only chrome genuinely outside the tree (the titlebar, the
+  // statusbar) reports null.
   it('hovering non-pane chrome falls through to the focused zone', async () => {
     const { activeOf, tree } = await setup()
 

--- a/apps/desktop/src/components/pane-shell/tree/sidebar-press-keeps-chat-zone.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/sidebar-press-keeps-chat-zone.test.tsx
@@ -1,0 +1,176 @@
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { registry } from '@/contrib/registry'
+
+import { TreeGroup } from './renderer/tree-group'
+
+// The zone trackers (`store.ts`: `trackActiveTreeGroup`, installed once by the
+// renderer root) resolve the `[data-tree-group]` ancestor of every pointerdown.
+// The sidebar is a zone in the tree like any other, so the press that opens a
+// session from a session row reports the SIDEBAR's own zone — the store-level
+// tests call `noteActiveTreeGroup('grp-sessions')` directly, which ASSUMES that
+// precondition instead of asserting it. This file asserts it against the DOM,
+// and with it the invariant it protects: reaching for a session row must not
+// move "the chat zone I was working in" back to main.
+
+/** jsdom has no real pointer events; PointerEvent falls back to MouseEvent. */
+function pointer(target: Element, type: string) {
+  const event = new MouseEvent(type, { bubbles: true, cancelable: true, button: 0 })
+  Object.defineProperty(event, 'pointerId', { value: 1 })
+
+  act(() => {
+    target.dispatchEvent(event)
+  })
+}
+
+let root: null | Root = null
+let container: HTMLDivElement | null = null
+const disposers: Array<() => void> = []
+
+function render(ui: ReactNode) {
+  if (!container) {
+    container = globalThis.document.createElement('div')
+    globalThis.document.body.append(container)
+    root = createRoot(container)
+  }
+
+  act(() => {
+    root!.render(ui)
+  })
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+  vi.resetModules()
+})
+
+afterEach(() => {
+  if (root) {
+    act(() => root!.unmount())
+  }
+
+  container?.remove()
+
+  for (const dispose of disposers.splice(0)) {
+    dispose()
+  }
+
+  root = null
+  container = null
+  vi.resetModules()
+})
+
+async function setup() {
+  const tree = await import('@/components/pane-shell/tree/store')
+  const model = await import('@/components/pane-shell/tree/model')
+
+  for (const id of ['workspace', 'session-tile:a', 'session-tile:b']) {
+    disposers.push(
+      registry.register({
+        area: 'panes',
+        data: id === 'workspace' ? { placement: 'main', uncloseable: true } : { placement: 'main' },
+        id,
+        render: () => null,
+        title: id
+      })
+    )
+  }
+
+  // A stand-in for the sidebar: the real one is a whole app view, and all this
+  // test needs from it is a session row inside the zone's DOM subtree.
+  disposers.push(
+    registry.register({
+      area: 'panes',
+      data: { placement: 'left', uncloseable: true },
+      id: 'sessions',
+      render: () => <button data-slot="row-button">session row</button>,
+      title: 'sessions'
+    })
+  )
+
+  const main = model.group(['workspace'], { active: 'workspace', id: 'grp-main' })
+  const side = model.group(['session-tile:a', 'session-tile:b'], { active: 'session-tile:b', id: 'grp-side' })
+  const sessions = model.group(['sessions'], { active: 'sessions', id: 'grp-sessions' })
+
+  tree.$layoutTree.set(model.split('row', [main, side, sessions]))
+
+  // Same wiring the renderer root does (`useEffect(trackActiveTreeGroup, [])`).
+  disposers.push(tree.trackActiveTreeGroup())
+
+  return { sessions, side, tree }
+}
+
+describe('a press inside the sidebar zone keeps the chat-zone memory', () => {
+  it('reports the sidebar zone for a press on a session row, and keeps the chat target', async () => {
+    const { sessions, tree } = await setup()
+
+    // The user is working in the side chat zone — this is what a press in it
+    // reports, through the same tracker.
+    tree.noteActiveTreeGroup('grp-side')
+    expect(tree.focusedChatZoneIsSidePane()).toBe(true)
+    expect(tree.lastChatZoneSessionAnchor()).toBe('session-tile:b')
+
+    render(<TreeGroup node={sessions} parentAxis="column" />)
+    const row = container!.querySelector('[data-slot="row-button"]')!
+    expect(row).not.toBeNull()
+
+    pointer(row, 'pointerdown')
+
+    // The precondition: the press reports the SIDEBAR's zone, not the chat zone.
+    expect(tree.$activeTreeGroup.get()).toBe('grp-sessions')
+
+    // The invariant: opening a session from that row still targets the chat zone
+    // the user was working in — the sidebar's zone is not a chat strip, however
+    // recently it was pressed.
+    expect(tree.focusedChatZoneIsSidePane()).toBe(true)
+    expect(tree.lastChatZoneSessionAnchor()).toBe('session-tile:b')
+  })
+
+  it('a pointer crossing a chat zone on its way to the sidebar does not move the memory', async () => {
+    const { tree } = await setup()
+
+    // The user is working in the side chat zone.
+    tree.noteActiveTreeGroup('grp-side')
+    expect(tree.lastChatZoneSessionAnchor()).toBe('session-tile:b')
+
+    // The tracker reports EVERY zone the pointer crosses (pointerover), and the
+    // path from a side pane to the session list usually crosses main. That pass
+    // must not rewrite "the chat zone I was working in" to main — which is the
+    // exact answer that sends a session opened from a row into the initial pane.
+    for (const id of ['grp-main', 'grp-sessions']) {
+      const el = globalThis.document.createElement('div')
+      el.dataset.treeGroup = id
+      globalThis.document.body.append(el)
+      disposers.push(() => el.remove())
+      pointer(el, 'pointerover')
+    }
+
+    expect(tree.$hoveredTreeGroup.get()).toBe('grp-sessions')
+    expect(tree.lastChatZoneSessionAnchor()).toBe('session-tile:b')
+    expect(tree.focusedChatZoneIsSidePane()).toBe(true)
+  })
+
+  it('still moves the target when the press lands in a chat zone (control)', async () => {
+    const { tree } = await setup()
+
+    // No chat zone touched yet: the memory is empty rather than pointing at main
+    // — callers fall back to the focused-zone anchor.
+    tree.noteActiveTreeGroup(null)
+    expect(tree.lastChatZoneSessionAnchor()).toBeNull()
+
+    // The tracker resolves the `[data-tree-group]` ancestor of the press, so this
+    // stands in for a press anywhere in that zone; rendering the whole strip is
+    // not what this control is about.
+    const zone = globalThis.document.createElement('div')
+    zone.dataset.treeGroup = 'grp-side'
+    globalThis.document.body.append(zone)
+    disposers.push(() => zone.remove())
+
+    pointer(zone, 'pointerdown')
+
+    expect(tree.$activeTreeGroup.get()).toBe('grp-side')
+    expect(tree.lastChatZoneSessionAnchor()).toBe('session-tile:b')
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -403,9 +403,10 @@ export const $activeTreeGroup = atom<null | string>(null)
  *  zone. In-memory, like the other trackers: a relaunch falls back to main. */
 export const $lastChatZoneGroup = atom<null | string>(null)
 
-/** Mirror an interacted zone into the chat-zone memory, but only when the zone
- *  can host a chat strip: a pointerdown (or hover) on the sidebar / files /
- *  terminal must leave the answer at "the chat zone I was working in". */
+/** Mirror a PRESSED zone into the chat-zone memory, but only when the zone can
+ *  host a chat strip: a pointerdown on the sidebar / files / terminal must leave
+ *  the answer at "the chat zone I was working in". Hover is deliberately not a
+ *  signal here — see `noteHoveredTreeGroup`. */
 function rememberChatZone(groupId: string) {
   const tree = $layoutTree.get()
   const group = tree ? findGroup(tree, groupId) : null
@@ -446,13 +447,12 @@ export function noteHoveredTreeGroup(groupId: null | string) {
     $hoveredTreeGroup.set(groupId)
   }
 
-  // Hovering a chat zone is the same "I'm working here" signal as clicking into
-  // it — it is what makes ⌘T / ⌘1…⌘9 land in the pane under the pointer. Leaving
-  // the panes must NOT clear the memory, though: the pointer crosses the sidebar
-  // on its way to a session row.
-  if (groupId !== null) {
-    rememberChatZone(groupId)
-  }
+  // Hover must NOT mirror into the chat-zone memory. The path from a side pane
+  // to the session list usually CROSSES main, so mirroring on hover rewrites
+  // "the chat zone I was working in" to main on the way past — which sends a
+  // session opened from a session row into the initial pane, the very outcome
+  // the memory exists to prevent. The ⌘T / ⌘1…⌘9 ladder above still follows the
+  // pointer; that answer is transient and lifts when the pointer leaves.
 }
 
 /** The zone every keyboard tab verb acts on, as an ELIGIBILITY LADDER: the
@@ -583,8 +583,14 @@ function sessionStripAnchorOf(group: GroupNode): null | string {
 function lastChatZoneGroup(): GroupNode | null {
   const tree = $layoutTree.get()
   const groupId = $lastChatZoneGroup.get()
+  const group = tree && groupId ? findGroup(tree, groupId) : null
 
-  return tree && groupId ? findGroup(tree, groupId) : null
+  // Only a zone that can STILL host a chat strip counts. A remembered zone whose
+  // last session tile was closed or dragged away would otherwise answer "open it
+  // into that pane" while `lastChatZoneSessionAnchor` finds no tab there and the
+  // caller falls back to main's strip — the same zone asked two questions with
+  // two different answers.
+  return group && sessionStripAnchorOf(group) !== null ? group : null
 }
 
 /** The pane a NEW session tab should dock beside (⌘T): the focused chat zone's

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -545,6 +545,24 @@ export function focusedSessionTabAnchor(): null | string {
   return active && isSessionStripPane(active) ? active : (group.panes.find(isSessionStripPane) ?? null)
 }
 
+/** True when the attention ladder (hovered → focused → workspace) lands on a
+ *  chat zone OTHER than the one holding the main workspace tab — i.e. the user
+ *  is working in a side pane. False for single-pane layouts, for a pointer
+ *  parked on non-chat chrome, and when the ladder falls through to main, so a
+ *  caller can read `false` as "main is still the target". */
+export function focusedChatZoneIsSidePane(): boolean {
+  const tree = $layoutTree.get()
+  const target = tree ? focusedSessionGroup() : null
+
+  if (!tree || !target) {
+    return false
+  }
+
+  const main = findGroupOfPane(tree, 'workspace')
+
+  return main !== null && target.id !== main.id
+}
+
 /** ⌘W: close the FOCUSED tile zone's active tab, unless it's the uncloseable
  *  workspace itself. Any main-strip zone qualifies — a session stack, a lone
  *  Browser/page tile — while side chrome (files / terminal) in a zone of its

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -395,11 +395,43 @@ export function registerLayoutResetHandler(fn: () => void): () => void {
  *  click lands on a non-focusable surface). Tracked by trackActiveTreeGroup. */
 export const $activeTreeGroup = atom<null | string>(null)
 
+/** The last zone the user WORKED IN that can host a chat strip — the sidebar,
+ *  files and terminal zones never move it. `$activeTreeGroup` above tracks the
+ *  ⌘W/⌘T target, and its ladder FALLS THROUGH to main when the pointer is on
+ *  chrome by design; "open this session where I'm working" cannot use that
+ *  answer, because the press on a session row itself lands on the sidebar's own
+ *  zone. In-memory, like the other trackers: a relaunch falls back to main. */
+export const $lastChatZoneGroup = atom<null | string>(null)
+
+/** Mirror an interacted zone into the chat-zone memory, but only when the zone
+ *  can host a chat strip: a pointerdown (or hover) on the sidebar / files /
+ *  terminal must leave the answer at "the chat zone I was working in". */
+function rememberChatZone(groupId: string) {
+  const tree = $layoutTree.get()
+  const group = tree ? findGroup(tree, groupId) : null
+
+  if (group?.panes.some(isSessionStripPane) && $lastChatZoneGroup.get() !== groupId) {
+    $lastChatZoneGroup.set(groupId)
+  }
+}
+
 /** Record the interacted zone (pointerdown / focusin). Idempotent. */
 export function noteActiveTreeGroup(groupId: null | string) {
   if (groupId !== $activeTreeGroup.get()) {
     $activeTreeGroup.set(groupId)
   }
+
+  // Mirror it into the chat-zone memory — where an explicit null (main was just
+  // fronted) is the one signal that clears it back to main.
+  if (groupId === null) {
+    if ($lastChatZoneGroup.get() !== null) {
+      $lastChatZoneGroup.set(null)
+    }
+
+    return
+  }
+
+  rememberChatZone(groupId)
 }
 
 /** The zone the pointer is currently over, or null off every zone. Transient —
@@ -412,6 +444,14 @@ export const $hoveredTreeGroup = atom<null | string>(null)
 export function noteHoveredTreeGroup(groupId: null | string) {
   if (groupId !== $hoveredTreeGroup.get()) {
     $hoveredTreeGroup.set(groupId)
+  }
+
+  // Hovering a chat zone is the same "I'm working here" signal as clicking into
+  // it — it is what makes ⌘T / ⌘1…⌘9 land in the pane under the pointer. Leaving
+  // the panes must NOT clear the memory, though: the pointer crosses the sidebar
+  // on its way to a session row.
+  if (groupId !== null) {
+    rememberChatZone(groupId)
   }
 }
 
@@ -530,37 +570,65 @@ function focusedSessionGroup(): GroupNode | null {
   return tabTargetGroup(group => group.panes.some(isSessionStripPane))
 }
 
+/** The chat pane a new tab docks beside inside `group`: its active session
+ *  pane, else its first. Null when the zone hosts no chat strip. */
+function sessionStripAnchorOf(group: GroupNode): null | string {
+  const active = group.active
+
+  return active && isSessionStripPane(active) ? active : (group.panes.find(isSessionStripPane) ?? null)
+}
+
+/** The group the user last worked in that can host a chat strip, or null before
+ *  any chat zone was touched (and when the tree no longer holds it). */
+function lastChatZoneGroup(): GroupNode | null {
+  const tree = $layoutTree.get()
+  const groupId = $lastChatZoneGroup.get()
+
+  return tree && groupId ? findGroup(tree, groupId) : null
+}
+
 /** The pane a NEW session tab should dock beside (⌘T): the focused chat zone's
  *  active session pane, else its first. Null when no zone hosts a chat strip —
  *  the caller falls back to the workspace. */
 export function focusedSessionTabAnchor(): null | string {
   const group = focusedSessionGroup()
 
-  if (!group) {
-    return null
-  }
-
-  const active = group.active
-
-  return active && isSessionStripPane(active) ? active : (group.panes.find(isSessionStripPane) ?? null)
+  return group ? sessionStripAnchorOf(group) : null
 }
 
-/** True when the attention ladder (hovered → focused → workspace) lands on a
- *  chat zone OTHER than the one holding the main workspace tab — i.e. the user
- *  is working in a side pane. False for single-pane layouts, for a pointer
- *  parked on non-chat chrome, and when the ladder falls through to main, so a
- *  caller can read `false` as "main is still the target". */
+/** The pane a session opened from the LAST CHAT ZONE should dock beside — the
+ *  split-menu sibling of `focusedSessionTabAnchor`. Read off the zone memory
+ *  instead of the ladder, because a real right-click on a sidebar row lands the
+ *  pointer (and the `focusin`) on the sidebar's own zone, which the ladder
+ *  deliberately falls through to main: splitting from the row menu would then
+ *  dock beside main rather than beside the pane the user is working in. Null
+ *  before any chat zone was touched; callers fall back to
+ *  `focusedSessionTabAnchor()`. */
+export function lastChatZoneSessionAnchor(): null | string {
+  const group = lastChatZoneGroup()
+
+  return group ? sessionStripAnchorOf(group) : null
+}
+
+/** True when the chat zone the user last WORKED IN (see `$lastChatZoneGroup`)
+ *  is a SIDE zone — a chat zone other than the one holding the main workspace
+ *  tab. This is the question "does a session opened from the sidebar belong in a
+ *  pane or in main?", and it deliberately does NOT ask the hovered → focused →
+ *  workspace ladder: a press on a session row lands on the sidebar's own zone,
+ *  and the ladder's fall-through to main is exactly the answer that made the row
+ *  click a no-op for pane users. False for single-pane layouts, before any chat
+ *  zone has been touched, and whenever main was explicitly fronted. */
 export function focusedChatZoneIsSidePane(): boolean {
   const tree = $layoutTree.get()
-  const target = tree ? focusedSessionGroup() : null
+  const group = lastChatZoneGroup()
 
-  if (!tree || !target) {
+  if (!tree || !group) {
     return false
   }
 
   const main = findGroupOfPane(tree, 'workspace')
 
-  return main !== null && target.id !== main.id
+  return main !== null && group.id !== main.id
 }
 
 /** ⌘W: close the FOCUSED tile zone's active tab, unless it's the uncloseable

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1494,6 +1494,12 @@ export function openSessionTile(
     // Adoption is async via the registry — order sync runs after the move path
     // below; a brand-new tile's strip slot is already in `before`.
 
+    // Front it anyway: "open this session in a tab" has to mean the tab the
+    // user lands on, not one appended behind whatever the zone was showing.
+    // `revealTreePane` adopts the registered pane when the tree hasn't caught
+    // up yet, exactly like the session-create path in use-session-actions.
+    revealTreePane(`${TILE_PANE_PREFIX}${storedSessionId}`)
+
     return
   }
 


### PR DESCRIPTION
## Problem

In a multi-pane workspace, a plain click on a sidebar session row always resumed the conversation into the **workspace (main) pane** — it replaced whatever was in the top-left pane and ignored the pane the user was actually working in. Only the modifier-click path (`⌘`/`Ctrl`-click, middle click, `⌘K`) docked into the focused chat zone.

Session rows and tile tabs also had no way to split an existing conversation: 「在分屏中打开」 existed only on the nav rows (new session / page).

Reproduction: 2×2 pane layout, focus the bottom-right pane, click a sidebar row → the conversation lands in the top-left pane.

## Why the first cut was not enough (worth reading before the diff)

A pointerdown on a session row lands on the **sidebar's own zone**: the sidebar is a tree pane like any other, and both `tree-group.tsx`'s `onPointerDownCapture` and the window-capture tracker record it. That zone hosts no chat strip, so the `hovered → focused → workspace` attention ladder falls through to main — by design (it keeps ⌘W / ⌘T / ⌘1…⌘9 from acting on the file tree). Two consequences:

1. Asking the ladder "is a side chat zone focused?" always answers *main*, so the row click keeps going home;
2. `openSessionTile()`'s own dock fallback asks the same ladder, so even a correct routing decision docks next to main.

Both are fixed here: a small **last-worked-in chat zone** memory that non-chat zones can't move, and an **explicit** dock anchor for this path. The ladder itself is untouched — its fall-through semantics are deliberate and its callers (⌘W/⌘T/⌘1…⌘9) rely on them.

## Changes

**1. `fix(desktop): open a sidebar session into the focused pane, not always main`** — `openSession()` gains a `'focused'` intent: it opens into the zone the user last worked in, and degrades to the previous `'in-place'` resume otherwise (single-pane layouts and "main is the target" keep behaving exactly as before). `app/contrib/wiring.tsx` passes it from `onResumeSession` — the only call site changed; the artifacts page, session switcher and notification clicks keep their old semantics.

**2. `feat(desktop): add 'open in split' to the session row/tab menu`** — `useSessionActions().renderItems` now renders the existing `SplitSubmenu`, which is shared by the row menu, the row context menu, the tab kebab and the tab context menu, so all four surfaces get the entry from one insertion.

**3. `fix(desktop): front a session tab that is newly docked as a tile`** — `openSessionTile()`'s new-tile branch stopped after `saveTiles(...)`, so adoption added the pane **without taking its group's active slot**: "open in a new tab" appended a background tab behind whatever the zone was showing. It now calls `revealTreePane(...)`, the same thing the session-create path in `app/session/hooks/use-session-actions/index.ts` already does. Flagged separately because it changes behavior for every `openSessionTile` caller (for the five pre-existing new-tile call sites it is a no-op — they already revealed on the next line).

**4. `fix(desktop): dock a sidebar-opened session beside the last chat zone`** — the memory (`$lastChatZoneGroup` in `components/pane-shell/tree/store.ts`, mirrored from the pointer/focus trackers, cleared only when main is fronted explicitly, hover-mirrored but not hover-cleared) plus `lastChatZoneSessionAnchor()`, the explicit anchor, the "main's own session stays on the in-place path" guard (that is the flow which pulls the chat back when the workspace shows a page), and a disabled row-menu entry for the session that already owns main (it cannot also be a tile).

**5. `docs(desktop): the sidebar is a zone — say why it still falls through`** — a comment in `hovered-zone-tabs.test.ts` claimed the sidebar reports no group at all. It does. That wrong comment is what made a session-row click look like it could never move the tab target.

## Verification

```
cd apps/desktop
npx vitest run --project ui \
  src/app/open-session.test.ts \
  src/components/pane-shell/tree/focused-session-tab.test.ts \
  src/app/chat/sidebar/session-actions-menu.test.tsx
→ Test Files 3 passed (3) / Tests 45 passed (45)

npx vitest run --project ui src/components/pane-shell/tree \
  src/app/open-session.test.ts src/app/chat/sidebar src/store/session-states.test.ts
→ 31 files / 199 tests passed

npx vitest run --project ui src/store/session-states.test.ts src/store/session-pane-focus.test.ts \
  src/app/open-session.test.ts src/components/pane-shell/tree src/app/chat/session-drag.test.ts \
  src/app/chat/sidebar
→ 65 files / 532 tests passed

npm run typecheck → clean (three tsconfig projects)
npx eslint <changed files> → clean
```

Behavior was checked with **real mouse input** in a dev-server instance over CDP (`Input.dispatchMouseEvent` — synthesizes the pointer events a plain `.click()` does not). In a 2×2 layout:

- focus the bottom-right pane by clicking it, then click a sidebar row → the conversation becomes **that** pane's active tab (`aria-selected="true"`, its chat surface anchored inside that pane); every other pane is untouched, no pane gained a column/zone;
- focus the workspace pane instead, then click a row → the conversation loads into main and no other pane gains a tab.

Note: an earlier attempt verified this with `element.click()`, which fires no pointer events and therefore never exercised the tracker above — that evidence was worthless and has been discarded. The first independent review round caught exactly that.

Note also: `src/store/voice-prefs.test.ts` fails on this checkout independently of these changes — its transitive module graph (25 modules) contains none of the files touched here.

## Notes for review

- Behavior change to be aware of: an already-open tile is *moved* by the split menu entry (same semantics as dragging a session into a pane edge), not duplicated; and a newly docked tile now becomes its zone's active tab (commit 3).
- Known residual, deliberately out of scope: the `⌘`/`Ctrl`-click path still takes its dock target from the ladder, so a modifier-click on a sidebar row docks beside main. Same for `app/artifacts/index.tsx`, `app/session-switcher.tsx`, the resume keybind and notification clicks.
- The split submenu's direction labels are hard-coded English (`Right/Down/Left/Up`) in `split-submenu.tsx`; this change brings them to session rows but does not localize them.
