### PR TITLE
fix(disk-cleanup): never let an unstatable path abort the post_tool_call hook

### DIFF
--- a/plugins/disk-cleanup/__init__.py
+++ b/plugins/disk-cleanup/__init__.py
@@ -60,12 +60,25 @@ def _on_post_tool_call(tool_name: str = "", args: Optional[Dict[str, Any]] = Non
     if not isinstance(args, dict) or extractor is None:
         return
     for path_str in extractor(args, result if isinstance(result, str) else ""):
+        # The whole probe sits inside the guard on purpose: ``Path.exists()`` does not
+        # swallow ``PermissionError`` (only ENOENT/ENOTDIR/EBADF/ELOOP), so a path under an
+        # unreadable directory — typically a container path such as ``/root/.local/share/uv/…``
+        # that a ``docker exec …`` command line mentions — would otherwise propagate out of
+        # ``_on_post_tool_call`` and abort the observer hook for the tool call it follows
+        # (seen live 2026-09-11; homelab patch 2026-09-12).
         try:
             p = Path(path_str).expanduser()
+            if not p.exists():
+                continue
+            category = dg.guess_category(p)
+            if category is None:
+                continue
+            newly = dg.track(str(p), category, silent=True)
+        except OSError:
+            continue  # unreadable/unstatable path — nothing to track
         except Exception:
-            continue
-        category = dg.guess_category(p) if p.exists() else None
-        if category is not None and dg.track(str(p), category, silent=True) and category == "test":
+            continue  # observer-hook contract: never break the caller
+        if newly and category == "test":
             with _lock:
                 _recent_test_tracks.setdefault(task_id or session_id or "default", set()).add(str(p))
 

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -14,6 +14,7 @@ Covers the bundled plugin at ``plugins/disk-cleanup/``:
 
 import importlib
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -325,6 +326,36 @@ class TestPostToolCallHook:
         # read_file should never trigger tracking.
         tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
         assert not tracked_file.exists() or tracked_file.read_text().strip() == "[]"
+
+    def test_unreadable_path_never_aborts_the_hook(self, _isolate_env, tmp_path):
+        """A path the process cannot stat must not escape the hook.
+
+        ``Path.exists()`` only swallows ENOENT/ENOTDIR/EBADF/ELOOP — a
+        PermissionError from an unreadable parent directory (typically a
+        container path such as ``/root/.local/share/uv/...`` mentioned in a
+        ``docker exec ...`` command line) used to propagate out of
+        ``_on_post_tool_call`` and abort the observer hook for the tool call
+        it followed. The hook contract is best-effort: never raise.
+        """
+        if os.geteuid() == 0:
+            pytest.skip("permission checks are not enforceable as root")
+        pi = _load_plugin_init()
+        blocked = tmp_path / "blocked"
+        blocked.mkdir()
+        target = blocked / "test_hidden.py"
+        target.write_text("x")
+        blocked.chmod(0o000)
+        try:
+            with pytest.raises(PermissionError):
+                Path(target).exists()  # the precondition the fix must survive
+            pi._on_post_tool_call(  # must not raise
+                tool_name="terminal",
+                args={"command": f"docker exec ctr rm {target}"},
+                result="",
+                task_id="t5", session_id="s5",
+            )
+        finally:
+            blocked.chmod(0o755)
 
 
 class TestOnSessionEndHook:


### PR DESCRIPTION
Fixes #108970

## What

`_on_post_tool_call` in `plugins/disk-cleanup/__init__.py` now keeps the whole path probe
inside one guard, so an unstatable candidate path can no longer abort the hook.

## Why

`Path.exists()` does not swallow `PermissionError` (only ENOENT/ENOTDIR/EBADF/ELOOP). A
`terminal` command line that mentions a container path under `/root/...` therefore made the
hook raise `PermissionError: [Errno 13]` out of the post-tool callback for that call.

## Test

`tests/plugins/test_disk_cleanup_plugin.py::TestPostToolCallHook::test_unreadable_path_never_aborts_the_hook`
(path under a `chmod 000` directory, skipped as root):

```
# without the fix
FAILED tests/plugins/test_disk_cleanup_plugin.py::TestPostToolCallHook::test_unreadable_path_never_aborts_the_hook
E   PermissionError: [Errno 13] Permission denied: '.../blocked/test_hidden.py'
1 failed, 27 deselected in 0.65s

# with the fix
28 passed in 4.19s
```
