### PR TITLE
fix(mcp): read read_only_hint (MCP SDK 2.x) alongside readOnlyHint

### DIFF
--- a/tests/tools/test_mcp_trust_gating.py
+++ b/tests/tools/test_mcp_trust_gating.py
@@ -247,3 +247,56 @@ class TestAnnotationCaptureAtDiscovery:
         assert _mcp_registration._annotation_read_only_hint(
             SimpleNamespace()
         ) is False
+
+    def test_snake_case_annotations_are_honoured(self):
+        """MCP SDK 2.x exposes ``read_only_hint``; the wire/cache uses camelCase.
+
+        Reading only ``readOnlyHint`` classified every tool of an SDK-2.x
+        server as write-capable, so ``trust: untrusted`` gated read-only tools
+        and consulted the approval path for them as well.
+        """
+        assert _mcp_registration._annotation_read_only_hint(
+            SimpleNamespace(annotations=SimpleNamespace(read_only_hint=True))
+        ) is True
+        assert _mcp_registration._annotation_read_only_hint(
+            SimpleNamespace(annotations={"read_only_hint": True})
+        ) is True
+        # camelCase keeps working, and anything not exactly True stays
+        # write-capable (fail closed).
+        assert _mcp_registration._annotation_read_only_hint(
+            SimpleNamespace(
+                annotations=SimpleNamespace(readOnlyHint=True, read_only_hint=False)
+            )
+        ) is True
+        assert _mcp_registration._annotation_read_only_hint(
+            SimpleNamespace(annotations=SimpleNamespace(read_only_hint=False))
+        ) is False
+        assert _mcp_registration._annotation_read_only_hint(
+            SimpleNamespace(annotations=SimpleNamespace(read_only_hint="yes"))
+        ) is False
+
+    def test_registration_records_snake_case_hints(self):
+        """Discovery stores the hint of an SDK-2.x-only server as read-only."""
+        from tools.registry import ToolRegistry
+
+        server = mcp_tool.MCPServerTask("srv")
+        server.session = MagicMock()
+        server._tools = [
+            self._make_tool(
+                "get_dataset", SimpleNamespace(read_only_hint=True)
+            ),
+            self._make_tool(
+                "upsert_dataset", SimpleNamespace(read_only_hint=False)
+            ),
+        ]
+        config = {
+            "trust": "untrusted",
+            "tools": {"resources": False, "prompts": False},
+        }
+        with patch("tools.registry.registry", ToolRegistry()), \
+             patch("tools.mcp_tool_registration._track_mcp_tool_server"):
+            _mcp_registration._register_server_tools("srv", server, config)
+
+        hints = mcp_tool._tool_read_only_hints["srv"]
+        assert hints.get("get_dataset") is True
+        assert not hints.get("upsert_dataset")

--- a/tools/mcp_tool_registration.py
+++ b/tools/mcp_tool_registration.py
@@ -45,9 +45,25 @@ def _normalize_server_trust(value: Any) -> str:
 
 
 def _annotation_read_only_hint(mcp_tool: Any) -> bool:
-    """True only when annotations (SDK object or cache dict) carry ``readOnlyHint is True``; unknown = write-capable."""
+    """True only when annotations (SDK object or cache dict) carry ``readOnlyHint is True``; unknown = write-capable.
+
+    Both spellings are checked: MCP wire/JSON uses the camelCase ``readOnlyHint``,
+    while the MCP SDK 2.x annotation model exposes the snake_case
+    ``read_only_hint`` attribute. Checking only camelCase made every tool of an
+    SDK-2.x server look write-capable, so ``trust: untrusted`` gated read-only
+    tools too (homelab patch 2026-09-11).
+    """
     annotations = getattr(mcp_tool, "annotations", None)
-    hint = annotations.get("readOnlyHint") if isinstance(annotations, dict) else getattr(annotations, "readOnlyHint", None)
+    if annotations is None:
+        return False
+    if isinstance(annotations, dict):
+        hint = annotations.get("readOnlyHint")
+        if hint is None:
+            hint = annotations.get("read_only_hint")
+    else:
+        hint = getattr(annotations, "readOnlyHint", None)
+        if hint is None:
+            hint = getattr(annotations, "read_only_hint", None)
     return hint is True
 
 


### PR DESCRIPTION
Fixes #108972

## What

`_annotation_read_only_hint` now reads `read_only_hint` (MCP SDK 2.x annotation model)
alongside `readOnlyHint` (MCP wire format / schema cache), for both the dict and the SDK
object path.

## Why

An SDK-2.x MCP server that correctly annotates its read tools was classified entirely
write-capable, so with `trust: untrusted` the approval path was consulted for every
read-only call (observed with a self-hosted Langfuse MCP server whose `tools/list` returns
`{"readOnlyHint": true}` for `queryMetrics`/`listObservations`/…).

## Test

`tests/tools/test_mcp_trust_gating.py::TestAnnotationCaptureAtDiscovery`:

```
# without the fix
FAILED tests/tools/test_mcp_trust_gating.py::TestAnnotationCaptureAtDiscovery::test_snake_case_annotations_are_honoured
FAILED tests/tools/test_mcp_trust_gating.py::TestAnnotationCaptureAtDiscovery::test_registration_records_snake_case_hints
2 failed, 11 deselected in 2.73s

# with the fix
13 passed in 3.36s
```

Happy to drop the new tests if you prefer — the fix itself is two lines per path.
