### PR TITLE
feat(desktop): expose confirmed native plugin submission

### DIFF
--- a/apps/desktop/src/AGENTS.md
+++ b/apps/desktop/src/AGENTS.md
@@ -46,6 +46,24 @@ user-activated extensions. If you tighten `desktop-slash-commands.ts`, keep
 `isDesktopSlashExtensionCommand` flowing into both paths. Test: from `apps/desktop`,
 `npx vitest run src/lib/desktop-slash-commands.test.ts` (workspace deps install at the repo root).
 
+## Plugin native text submission
+
+`host.submitPrompt` is the SDK door to a focused conversation's native composer.
+Keep the exact runtime/connection/profile check and synchronous single-surface
+claim: a stale or disabled target refuses without navigation. Preserve the local
+draft and attachments. Busy sends join the existing FIFO, never steer or cancel.
+Carry `confirmedExternal` through foreground/background drains: the native
+transport uses server-side queueing with no resume/busy/timeout retry. Persist
+and verify the queued entry's `dispatchStarted` before its one attempt; an
+uncertain entry stays held across reload and cannot be manually steered/resubmitted.
+Only a proven pre-transmission `false` may release the claim for later FIFO drain;
+accept both real server acknowledgement forms (`streaming` and `queued`).
+Acceptance, renderer queueing and agent completion are different observations;
+an unknown outcome is never retried automatically. Raw gateway `prompt.submit`
+is not a substitute for the native transcript projection. Contract and limits:
+`website/docs/developer-guide/desktop-plugin-sdk.md`; behavioral tests beside
+`use-composer-submit.ts`.
+
 ## Bot Mode (`src/plugins/hermes-bots/`) — one bot = ONE canonical forever-chat, identified by NAME
 
 Each bot is a Hermes **profile** with a persistent identity. This invariant regressed repeatedly,

--- a/apps/desktop/src/app/chat/composer/focus.ts
+++ b/apps/desktop/src/app/chat/composer/focus.ts
@@ -74,6 +74,16 @@ interface SubmitDetail {
   /** `hidden` types the persisted user row so no bubble renders — the
    *  off-screen path for widget intents. Omit for normal visible sends. */
   displayKind?: 'hidden'
+  native?: {
+    sessionId: string
+    claim: () => ((result: NativeComposerSubmitResult) => void) | null
+  }
+}
+
+export interface NativeComposerSubmitResult {
+  /** Acceptance is not completion. Unknown must never be retried automatically. */
+  status: 'accepted' | 'queued' | 'rejected' | 'unknown'
+  queueId?: string
 }
 
 let activeTarget: ComposerTarget = 'main'
@@ -328,6 +338,52 @@ export const requestComposerSubmit = (
   })
 
   return true
+}
+
+/** Confirmed plain text only. Claims synchronously so a missing/disabled or
+ * stale composer is an explicit refusal, not a successful fire-and-forget. */
+export function requestNativeComposerSubmit(
+  text: string,
+  { sessionId, target = 'active' }: { sessionId: string; target?: ComposerTarget | 'active' }
+): Promise<NativeComposerSubmitResult> {
+  const trimmed = text.trim()
+  const resolvedTarget = resolve(target)
+  const surfaceId = getVisibleComposerSurfaceId(resolvedTarget)
+
+  if (!sessionId || !trimmed || trimmed.startsWith('/') || !surfaceId) {
+    return Promise.resolve({ status: 'rejected' })
+  }
+
+  return new Promise(resolveResult => {
+    let claimed = false
+    const timeout = window.setTimeout(() => resolveResult({ status: 'unknown' }), 30_000)
+
+    const finish = (result: NativeComposerSubmitResult) => {
+      window.clearTimeout(timeout)
+      resolveResult(result)
+    }
+
+    dispatchNow<SubmitDetail>(SUBMIT_EVENT, {
+      surfaceId,
+      target: resolvedTarget,
+      text: trimmed,
+      native: {
+        sessionId,
+        claim: () => {
+          if (claimed) {
+            return null
+          }
+          claimed = true
+
+          return finish
+        }
+      }
+    })
+
+    if (!claimed) {
+      finish({ status: 'rejected' })
+    }
+  })
 }
 
 export const onComposerSubmitRequest = (handler: (detail: SubmitDetail) => void) =>

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
@@ -55,6 +55,30 @@ function renderQueueHook(overrides: { busy?: boolean; onCancel?: () => void; onS
 }
 
 describe('useComposerQueue park integration', () => {
+  it('never interrupts or replays a confirmed entry with an uncertain dispatch, including after reload', async () => {
+    const entry = enqueueQueuedPrompt(SESSION_KEY, {
+      attachments: [],
+      text: 'confirmed once',
+      confirmedExternal: true
+    })!
+    const { hook, onCancel, onSubmit } = renderQueueHook({ busy: true })
+    onSubmit.mockRejectedValue(new Error('lost acknowledgement'))
+    expect(hook.result.current.sendQueuedNow(entry.id)).toBe(false)
+    expect(onCancel).not.toHaveBeenCalled()
+    hook.rerender({ busy: false })
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
+    expect(onSubmit.mock.calls[0][1]).toMatchObject({ confirmedExternal: true, fromQueue: true })
+    const saved = window.localStorage.getItem('hermes.desktop.composerQueue.v1')!
+    expect(JSON.parse(saved)[SESSION_KEY][0].dispatchStarted).toBe(true)
+    hook.unmount()
+    $queuedPromptsBySession.set(JSON.parse(saved))
+    const restored = renderQueueHook()
+    await act(async () => {
+      await restored.hook.result.current.drainNextQueued()
+    })
+    expect(restored.onSubmit).not.toHaveBeenCalled()
+  })
+
   beforeEach(() => {
     window.localStorage.clear()
     $queuedPromptsBySession.set({})
@@ -125,6 +149,19 @@ describe('useComposerQueue park integration', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('releases only a proven pre-dispatch refusal so a confirmed entry can drain once idle', async () => {
+    enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'confirmed after busy', confirmedExternal: true })
+    const { hook, onSubmit } = renderQueueHook({ busy: true })
+    onSubmit.mockResolvedValueOnce(false)
+    await act(async () => {
+      expect(await hook.result.current.drainNextQueued()).toBe(false)
+    })
+    expect(getQueuedPrompts(SESSION_KEY)[0].dispatchStarted).toBe(false)
+    hook.rerender({ busy: false })
+    await waitFor(() => expect(getQueuedPrompts(SESSION_KEY)).toHaveLength(0))
+    expect(onSubmit).toHaveBeenCalledTimes(2)
   })
 
   it('auto-drains an unparked queue once idle', async () => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -9,6 +9,7 @@ import { resetBrowseState } from '@/store/composer-input-history'
 import {
   $parkedQueueSessions,
   $queuedPromptsBySession,
+  claimConfirmedQueuedPrompt,
   enqueueQueuedPrompt,
   getQueuedPrompts,
   isSteerableEntry,
@@ -16,6 +17,7 @@ import {
   migrateQueuedPrompts,
   promoteQueuedPrompt,
   type QueuedPromptEntry,
+  releaseConfirmedQueuedPrompt,
   removeQueuedPrompt,
   shouldAutoDrain,
   unparkQueuedPrompts,
@@ -215,6 +217,10 @@ export function useComposerQueue({
         return false
       }
 
+      if (entry.confirmedExternal && !claimConfirmedQueuedPrompt(drainQueueSessionKey, entry.id)) {
+        return false
+      }
+
       drainingQueueRef.current = true
 
       try {
@@ -224,12 +230,17 @@ export function useComposerQueue({
             ...(entry.displayText ? { displayText: entry.displayText } : {}),
             ...(entry.displayKind ? { displayKind: entry.displayKind } : {}),
             fromQueue: true,
+            ...(entry.confirmedExternal ? { confirmedExternal: true } : {}),
             sessionId: drainRuntimeSessionId,
             storedSessionId: drainQueueSessionKey
           })
         )
 
         if (accepted === false) {
+          if (entry.confirmedExternal) {
+            releaseConfirmedQueuedPrompt(drainQueueSessionKey, entry.id)
+          }
+
           return false
         }
 
@@ -264,6 +275,10 @@ export function useComposerQueue({
   const sendQueuedNow = useCallback(
     (id: string) => {
       if (!activeQueueSessionKey || id === queueEdit?.entryId) {
+        return false
+      }
+
+      if (busy && getQueuedPrompts(activeQueueSessionKey).find(entry => entry.id === id)?.confirmedExternal) {
         return false
       }
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { PaneVisibleContext } from '@/components/pane-shell/pane-visibility'
 import { $clarifyRequests } from '@/store/clarify'
 import type { ComposerAttachment } from '@/store/composer'
-import { clearQueuedPrompts, getQueuedPrompts } from '@/store/composer-queue'
+import { $queuedPromptsBySession, clearQueuedPrompts, getQueuedPrompts } from '@/store/composer-queue'
 import { $gateway } from '@/store/gateway'
 import {
   clearAllPrompts,
@@ -15,7 +15,7 @@ import {
   setSudoRequest
 } from '@/store/prompts'
 
-import { type ComposerTarget, requestComposerSubmit } from '../focus'
+import { type ComposerTarget, requestComposerSubmit, requestNativeComposerSubmit } from '../focus'
 import { ComposerScopeProvider, ComposerSurfaceProvider, MAIN_COMPOSER_SCOPE } from '../scope'
 
 import { useComposerSubmit } from './use-composer-submit'
@@ -147,6 +147,72 @@ function renderSubmitHook({
 }
 
 describe('useComposerSubmit external request routing', () => {
+  it('acknowledges only the addressed native submit without consuming the local draft or attachments', async () => {
+    const main = renderSubmitHook({
+      text: 'unsent local draft',
+      attachments: [{ id: 'private', kind: 'file', label: 'local.txt' }]
+    })
+
+    const hidden = renderSubmitHook({ visible: false })
+
+    const send = (sessionId = 'runtime-session') =>
+      requestNativeComposerSubmit('confirmed instruction', { sessionId, target: 'main' })
+
+    expect(await send('wrong-runtime')).toEqual({ status: 'rejected' })
+    expect(main.onSubmit).not.toHaveBeenCalled()
+    expect(await send()).toEqual({ status: 'accepted' })
+    expect(main.onSubmit).toHaveBeenCalledExactlyOnceWith(
+      'confirmed instruction',
+      expect.objectContaining({
+        attachments: [],
+        composerScope: 'stored-session',
+        confirmedExternal: true,
+        sessionId: 'runtime-session',
+        storedSessionId: 'stored-session'
+      })
+    )
+    expect(hidden.onSubmit).not.toHaveBeenCalled()
+    expect(main.clearDraft).not.toHaveBeenCalled()
+    main.onSubmit.mockRejectedValueOnce(new Error('connection lost after dispatch'))
+    expect(await send()).toEqual({ status: 'unknown' })
+    expect(main.onSubmit).toHaveBeenCalledTimes(2)
+    let release!: (accepted: boolean) => void
+    main.onSubmit.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          release = resolve
+        })
+    )
+    const pending = send()
+    expect((await send()).status).toBe('queued')
+    expect(main.onSubmit).toHaveBeenCalledTimes(3)
+    release(true)
+    expect((await pending).status).toBe('accepted')
+    $queuedPromptsBySession.set({})
+    act(() => main.setPaneVisible(false))
+    expect(await send()).toEqual({ status: 'rejected' })
+  })
+
+  it('queues native requests in order while busy without steering or bypassing disabled input', async () => {
+    $queuedPromptsBySession.set({})
+    const main = renderSubmitHook({ busy: true })
+    const first = await requestNativeComposerSubmit('first', { sessionId: 'runtime-session', target: 'main' })
+    const second = await requestNativeComposerSubmit('second', { sessionId: 'runtime-session', target: 'main' })
+    expect(first.status).toBe('queued')
+    expect(second.status).toBe('queued')
+    expect(getQueuedPrompts('stored-session').map(entry => entry.text)).toEqual(['first', 'second'])
+    expect(main.onSubmit).not.toHaveBeenCalled()
+    expect(main.onSteer).not.toHaveBeenCalled()
+    expect(main.onCancel).not.toHaveBeenCalled()
+    main.hook.unmount()
+    const disabled = renderSubmitHook({ inputDisabled: true })
+    expect(await requestNativeComposerSubmit('blocked', { sessionId: 'runtime-session', target: 'main' })).toEqual({
+      status: 'rejected'
+    })
+    expect(disabled.onSubmit).not.toHaveBeenCalled()
+    $queuedPromptsBySession.set({})
+  })
+
   afterEach(() => {
     cleanup()
     clearQueuedPrompts('stored-session')

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -6,7 +6,7 @@ import { triggerHaptic } from '@/lib/haptics'
 import { hasClarifyRequest, skipClarifyRequest } from '@/store/clarify'
 import { clearSessionDraft, type ComposerAttachment } from '@/store/composer'
 import { resetBrowseState } from '@/store/composer-input-history'
-import { enqueueQueuedPrompt, type QueuedPromptEntry } from '@/store/composer-queue'
+import { enqueueQueuedPrompt, getQueuedPrompts, type QueuedPromptEntry } from '@/store/composer-queue'
 import { hasMcpSetupRequest, skipMcpSetupRequest } from '@/store/mcp-setup'
 import { hasBlockingPromptRequest } from '@/store/prompts'
 
@@ -82,6 +82,7 @@ export function useComposerSubmit({
   const paneVisible = usePaneVisible()
   const scope = useComposerScope()
   const surfaceId = useComposerSurfaceId()
+  const nativeSubmitPending = useRef(false)
 
   // Shared send primitive: fire onSubmit, and if the gateway rejects (accepted
   // === false) or throws, re-load + re-stash the draft so the words survive.
@@ -127,7 +128,7 @@ export function useComposerSubmit({
 
   useLayoutEffect(
     () =>
-      onComposerSubmitRequest(({ surfaceId: requestedSurfaceId, target, text, displayKind }) => {
+      onComposerSubmitRequest(({ surfaceId: requestedSurfaceId, target, text, displayKind, native }) => {
         if (
           target === scope.target &&
           surfaceId !== null &&
@@ -135,6 +136,58 @@ export function useComposerSubmit({
           paneVisible &&
           !inputDisabled
         ) {
+          if (native) {
+            if (native.sessionId !== sessionId || disabled) {
+              return
+            }
+            const finish = native.claim()
+
+            if (!finish) {
+              return
+            }
+            const key = activeQueueSessionKeyRef.current
+
+            if (!key) {
+              finish({ status: 'rejected' })
+            } else if (nativeSubmitPending.current || busy || compacting || getQueuedPrompts(key).length > 0) {
+              const entry = enqueueQueuedPrompt(key, { text, attachments: [], confirmedExternal: true })
+              finish(entry ? { status: 'queued', queueId: entry.id } : { status: 'rejected' })
+            } else {
+              // Do not inherit attachments, clear a draft, or restore rejected
+              // remote text into a user's composer. The native onSubmit still
+              // owns optimistic transcript insertion and the gateway request.
+              nativeSubmitPending.current = true
+
+              void (async () => {
+                try {
+                  let queued = false
+
+                  const accepted = await onSubmit(text, {
+                    attachments: [],
+                    composerScope: key,
+                    confirmedExternal: true,
+                    sessionId,
+                    storedSessionId: key,
+                    onExternalAccepted: value => {
+                      queued = value
+                    }
+                  })
+
+                  finish({
+                    status:
+                      accepted === true ? (queued ? 'queued' : 'accepted') : accepted === false ? 'rejected' : 'unknown'
+                  })
+                } catch {
+                  finish({ status: 'unknown' })
+                } finally {
+                  nativeSubmitPending.current = false
+                }
+              })()
+            }
+
+            return
+          }
+
           const current = externalSubmitRef.current
 
           if (!current.busy) {
@@ -186,7 +239,18 @@ export function useComposerSubmit({
           }
         }
       }),
-    [activeQueueSessionKeyRef, inputDisabled, paneVisible, scope.target, sessionId, surfaceId]
+    [
+      inputDisabled,
+      paneVisible,
+      scope.target,
+      surfaceId,
+      sessionId,
+      disabled,
+      busy,
+      compacting,
+      activeQueueSessionKeyRef,
+      onSubmit
+    ]
   )
 
   const submitDraft = () => {

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.test.tsx
@@ -59,6 +59,23 @@ function Harness({
 }
 
 describe('useBackgroundQueueDrain', () => {
+  it('does not retry an uncertain confirmed entry after remount', async () => {
+    const runtimeMap = { current: new Map([['stored-session-a', 'rt-session-a']]) }
+    const submitText = vi.fn(async () => {
+      throw new Error('lost acknowledgement')
+    })
+    enqueueQueuedPrompt('stored-session-a', { text: 'confirmed once', attachments: [], confirmedExternal: true })
+    const view = render(<Harness runtimeMap={runtimeMap} submitText={submitText} />)
+    await waitFor(() => expect(submitText).toHaveBeenCalledTimes(1))
+    expect(submitText.mock.calls[0]).toEqual(['confirmed once', expect.objectContaining({ confirmedExternal: true })])
+    view.unmount()
+    await act(async () => {
+      render(<Harness runtimeMap={runtimeMap} submitText={submitText} />)
+    })
+    expect(submitText).toHaveBeenCalledTimes(1)
+    expect(getQueuedPrompts('stored-session-a')[0].dispatchStarted).toBe(true)
+  })
+
   beforeEach(() => {
     vi.useRealTimers()
     clearAllSessionStates()

--- a/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
+++ b/apps/desktop/src/app/session/hooks/use-background-queue-drain.ts
@@ -6,9 +6,11 @@ import { resetBrowseState } from '@/store/composer-input-history'
 import {
   $parkedQueueSessions,
   $queuedPromptsBySession,
+  claimConfirmedQueuedPrompt,
   getQueuedPrompts,
   MAX_AUTO_DRAIN_ATTEMPTS,
   type QueuedPromptEntry,
+  releaseConfirmedQueuedPrompt,
   removeQueuedPrompt,
   shouldAutoDrain
 } from '@/store/composer-queue'
@@ -117,18 +119,27 @@ export function useBackgroundQueueDrain({
             return true
           }
 
+          if (liveEntry.confirmedExternal && !claimConfirmedQueuedPrompt(sessionKey, liveEntry.id)) {
+            return true
+          }
+
           const runtimeSessionId = runtimeIdByStoredSessionIdRef.current.get(sessionKey) ?? null
 
           const accepted = await Promise.resolve(
             submitTextRef.current(liveEntry.text, {
               attachments: liveEntry.attachments,
               fromQueue: true,
+              ...(liveEntry.confirmedExternal ? { confirmedExternal: true } : {}),
               sessionId: runtimeSessionId,
               storedSessionId: sessionKey
             })
           )
 
           if (accepted === false) {
+            if (liveEntry.confirmedExternal) {
+              releaseConfirmedQueuedPrompt(sessionKey, liveEntry.id)
+            }
+
             return false
           }
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -427,6 +427,63 @@ function renderedSeedTexts(seeds: Record<string, unknown>[]): string[] {
 // The HUD floats over the app the user is really working in, so the gateway
 // turns this flag into a per-turn hint: read the window underneath and work in
 // it, rather than reaching for Hermes's own browser and panes.
+describe('usePromptActions confirmed external submission', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+  it.each(['accepted', 'timeout'])('sends once, with server FIFO and native projection: %s', async outcome => {
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method !== 'prompt.submit') {
+        throw new Error('unexpected RPC: ' + method)
+      }
+
+      if (outcome === 'timeout') {
+        throw new Error('request timed out')
+      }
+
+      return { status: 'queued' } as never
+    })
+
+    let handle: HarnessHandle | null = null
+    const projection = vi.fn()
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onUpdateState={projection}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+    const acknowledgement = vi.fn()
+    const send = handle!.submitText('confirmed companion text', {
+      attachments: [],
+      confirmedExternal: true,
+      onExternalAccepted: acknowledgement
+    })
+
+    if (outcome === 'timeout') {
+      await expect(send).rejects.toThrow('request timed out')
+      expect(acknowledgement).not.toHaveBeenCalled()
+    } else {
+      await expect(send).resolves.toBe(true)
+      expect(acknowledgement).toHaveBeenCalledWith(true)
+    }
+
+    expect(requestGateway).toHaveBeenCalledTimes(1)
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      expect.objectContaining({ queued: true, session_id: RUNTIME_SESSION_ID }),
+      expect.any(Number)
+    )
+    expect(
+      projection.mock.calls.some(
+        ([, , state]) => state.messages?.filter((message: { role: string }) => message.role === 'user').length === 1
+      )
+    ).toBe(true)
+  })
+})
+
 describe('usePromptActions HUD surface', () => {
   afterEach(() => {
     cleanup()

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -774,7 +774,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
           // the next turn untouched — without it, losing the settle race
           // (client saw idle, server still unwinding) redirects or interrupts
           // the live turn with text the user explicitly queued.
-          ...(options?.fromQueue && { queued: true })
+          ...((options?.fromQueue || options?.confirmedExternal) && { queued: true })
         })
 
         // On sleep/wake the gateway's in-memory session may have been cleared
@@ -787,40 +787,53 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         try {
           const recoverStoredSessionId = targetStoredSessionId ?? selectedStoredSessionIdRef.current
 
-          await withSessionNotFoundResume(
-            sessionId,
-            recoverStoredSessionId,
-            liveId =>
-              withSessionBusyRetry(() =>
-                requestGateway('prompt.submit', submitParams(liveId), PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
-              ),
-            {
-              requestGateway,
-              driftReason: sessionDriftReason,
-              onRecovered: recoveredId => {
-                if (onRuntimeRecovered) {
-                  onRuntimeRecovered(recoveredId)
-                } else {
-                  // Publish stored-to-runtime ownership before retrying the
-                  // session-scoped request. The window router needs this
-                  // binding to keep a recovered remote runtime on the gateway
-                  // that owns its durable session.
-                  if (recoverStoredSessionId) {
-                    updateSessionState(recoveredId, state => state, recoverStoredSessionId)
-                  }
+          if (options?.confirmedExternal) {
+            const result = await requestGateway<{ status?: string; queued?: boolean }>(
+              'prompt.submit',
+              submitParams(sessionId),
+              PROMPT_SUBMIT_REQUEST_TIMEOUT_MS
+            )
 
-                  if (targetIsCurrentView()) {
-                    activeSessionIdRef.current = recoveredId
-                    setActiveSessionId(recoveredId)
+            if (result?.status !== 'streaming' && result?.status !== 'queued') {
+              throw new Error('Native submission outcome unknown')
+            }
+            options.onExternalAccepted?.(result.status === 'queued' || result.queued === true)
+          } else {
+            await withSessionNotFoundResume(
+              sessionId,
+              recoverStoredSessionId,
+              liveId =>
+                withSessionBusyRetry(() =>
+                  requestGateway('prompt.submit', submitParams(liveId), PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
+                ),
+              {
+                requestGateway,
+                driftReason: sessionDriftReason,
+                onRecovered: recoveredId => {
+                  if (onRuntimeRecovered) {
+                    onRuntimeRecovered(recoveredId)
+                  } else {
+                    // Publish stored-to-runtime ownership before retrying the
+                    // session-scoped request. The window router needs this
+                    // binding to keep a recovered remote runtime on the gateway
+                    // that owns its durable session.
+                    if (recoverStoredSessionId) {
+                      updateSessionState(recoveredId, state => state, recoverStoredSessionId)
+                    }
+
+                    if (targetIsCurrentView()) {
+                      activeSessionIdRef.current = recoveredId
+                      setActiveSessionId(recoveredId)
+                    }
                   }
                 }
-              }
-            },
-            // A starved backend loop (#55578 symptom d) rejects the submit even
-            // though the stored session is fine — recover it like a dead id
-            // instead of erroring out and losing the session binding.
-            { alsoTimeout: true }
-          )
+              },
+              // A starved backend loop (#55578 symptom d) rejects the submit even
+              // though the stored session is fine — recover it like a dead id
+              // instead of erroring out and losing the session binding.
+              { alsoTimeout: true }
+            )
+          }
         } catch (firstErr) {
           if (firstErr instanceof SessionRecoveryAborted) {
             console.warn('[submit-drift-abort]', firstErr.reason, { phase: 'post-resume-retry' })
@@ -849,6 +862,13 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
         return true
       } catch (err) {
+        if (options?.confirmedExternal) {
+          // A lost acknowledgement cannot prove rejection. Do not recover,
+          // replay, restore a draft or release the live turn's busy state.
+          releaseSubmitLock()
+          throw err
+        }
+
         releaseBusy()
 
         // A queued drain that raced a not-yet-settled turn gets a transient

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -726,6 +726,9 @@ export interface SubmitTextOptions {
   /** With `surface: 'voice-live'`: the recent spoken exchange, appended to the
    *  model-bound note by the gateway (never persisted, never rendered). */
   voiceContext?: string
+  /** Confirmed plugin instruction: enqueue server-side, never interrupt/recover/replay. */
+  confirmedExternal?: boolean
+  onExternalAccepted?: (queued: boolean) => void
   fromQueue?: boolean
   /** Runtime session id to submit into. Queue drains pass this so a
    *  backgrounded/source session cannot be replaced by the current foreground

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -22,6 +22,7 @@ import { atom, computed, type ReadableAtom } from 'nanostores'
 import type { ReactNode } from 'react'
 
 import { capabilityScoped } from '@/api/client'
+import { type NativeComposerSubmitResult, requestNativeComposerSubmit } from '@/app/chat/composer/focus'
 import { PRIMARY_SESSION_VIEW } from '@/app/chat/session-view'
 import { openSession, type OpenSessionIntent } from '@/app/open-session'
 import type { ClientSessionState } from '@/app/types'
@@ -136,6 +137,14 @@ export interface PluginFocusedSessionOwner {
   connectionId: string
   profile: string
 }
+
+export interface PluginSubmitPromptOptions extends PluginFocusedSessionOwner {
+  /** Exact runtime id of the focused, already hydrated conversation. */
+  sessionId: string
+  text: string
+}
+
+export type PluginSubmitPromptResult = NativeComposerSubmitResult
 
 /**
  * Connection-qualified owner of the FOCUSED chat. The gateway-routing atom
@@ -1419,6 +1428,27 @@ export const host = {
       method: 'PATCH',
       body: { hidden: options.hidden, profile }
     })
+  },
+
+  /** Submit confirmed plain text through the visible conversation's native
+   * composer. Never navigates, inherits attachments, or interrupts a turn.
+   * A busy conversation queues it. Acceptance is NOT agent completion;
+   * unknown means possibly sent, and must not be retried automatically. */
+  submitPrompt: (options: PluginSubmitPromptOptions): Promise<PluginSubmitPromptResult> => {
+    const owner = $focusedSessionOwner.get()
+
+    if (
+      !owner ||
+      !options.sessionId ||
+      options.sessionId !== $focusedRuntimeId.get() ||
+      options.connectionId !== owner.connectionId ||
+      options.profile !== owner.profile ||
+      typeof options.text !== 'string'
+    ) {
+      return Promise.resolve({ status: 'rejected' })
+    }
+
+    return requestNativeComposerSubmit(options.text, { sessionId: options.sessionId })
   },
 
   /** Gateway JSON-RPC — sessions, config, skills, cron, kanban, everything

--- a/apps/desktop/src/store/composer-queue.ts
+++ b/apps/desktop/src/store/composer-queue.ts
@@ -16,15 +16,19 @@ export interface QueuedPromptEntry {
   displayKind?: 'hidden'
   attachments: ComposerAttachment[]
   queuedAt: number
+  confirmedExternal?: boolean
+  dispatchStarted?: boolean
 }
 
 /** Whether a queued entry can ride a mid-turn redirect: text-only, non-empty,
  *  not a slash command — the same gate `steerDraft` applies to the live draft
  *  (attachments can't ride a redirect; slash commands execute, not steer). */
-export const isSteerableEntry = (entry: Pick<QueuedPromptEntry, 'attachments' | 'text'>): boolean => {
+export const isSteerableEntry = (
+  entry: Pick<QueuedPromptEntry, 'attachments' | 'text' | 'confirmedExternal'>
+): boolean => {
   const text = entry.text.trim()
 
-  return Boolean(text) && entry.attachments.length === 0 && !SLASH_COMMAND_RE.test(text)
+  return !entry.confirmedExternal && Boolean(text) && entry.attachments.length === 0 && !SLASH_COMMAND_RE.test(text)
 }
 
 type QueueState = Record<string, QueuedPromptEntry[]>
@@ -128,7 +132,13 @@ export const getQueuedPrompts = (key: string | null | undefined): QueuedPromptEn
 
 export const enqueueQueuedPrompt = (
   key: string | null | undefined,
-  payload: { text: string; attachments: ComposerAttachment[]; displayText?: string; displayKind?: 'hidden' }
+  payload: {
+    text: string
+    attachments: ComposerAttachment[]
+    displayText?: string
+    displayKind?: 'hidden'
+    confirmedExternal?: boolean
+  }
 ): null | QueuedPromptEntry => {
   const sid = sidOf(key)
 
@@ -142,7 +152,8 @@ export const enqueueQueuedPrompt = (
     ...(payload.displayText ? { displayText: payload.displayText } : {}),
     ...(payload.displayKind ? { displayKind: payload.displayKind } : {}),
     attachments: cloneAttachments(payload.attachments),
-    queuedAt: Date.now()
+    queuedAt: Date.now(),
+    ...(payload.confirmedExternal ? { confirmedExternal: true } : {})
   }
 
   writeSession(sid, [...queueFor(sid), entry])
@@ -152,6 +163,63 @@ export const enqueueQueuedPrompt = (
   setParked(sid, false)
 
   return entry
+}
+
+/** Durable intent before dispatch; an uncertain confirmed instruction cannot be replayed. */
+export const claimConfirmedQueuedPrompt = (key: string, id: string): boolean => {
+  const entries = queueFor(key)
+  const entry = entries.find(item => item.id === id)
+
+  if (!entry || entry.dispatchStarted) {
+    return false
+  }
+  const next = {
+    ...$queuedPromptsBySession.get(),
+    [key]: entries.map(item => (item.id === id ? { ...item, dispatchStarted: true } : item))
+  }
+
+  try {
+    const payload = JSON.stringify(next)
+    window.localStorage.setItem(STORAGE_KEY, payload)
+
+    if (window.localStorage.getItem(STORAGE_KEY) !== payload) {
+      return false
+    }
+  } catch {
+    return false
+  }
+
+  $queuedPromptsBySession.set(next)
+
+  return true
+}
+
+/** Only a pre-dispatch false result may release a confirmed entry. Throws and
+ * lost acknowledgements must retain dispatchStarted forever until reconciled. */
+export const releaseConfirmedQueuedPrompt = (key: string, id: string): void => {
+  const entries = queueFor(key)
+  const entry = entries.find(item => item.id === id)
+
+  if (!entry?.confirmedExternal || !entry.dispatchStarted) {
+    return
+  }
+  const next = {
+    ...$queuedPromptsBySession.get(),
+    [key]: entries.map(item => (item.id === id ? { ...item, dispatchStarted: false } : item))
+  }
+
+  try {
+    const payload = JSON.stringify(next)
+    window.localStorage.setItem(STORAGE_KEY, payload)
+
+    if (window.localStorage.getItem(STORAGE_KEY) !== payload) {
+      return
+    }
+  } catch {
+    return
+  }
+
+  $queuedPromptsBySession.set(next)
 }
 
 export const dequeueQueuedPrompt = (key: string | null | undefined): null | QueuedPromptEntry => {

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -519,7 +519,31 @@ host.profileRoutes()                       // [{ profile, targetProfile, connect
 host.requestProfile<T>(route, method, params?)   // registry-routed RPC; no foreground swap
 host.requestProfile<T>(profile, method, params?) // legacy v1/local overload
 host.request<T>(method, params?)           // active-gateway JSON-RPC — the real power
+host.submitPrompt({connectionId, profile, sessionId, text}) // confirmed text through the native composer
 ```
+
+`host.submitPrompt` is the native text-send door for confirmed companion/plugin
+instructions. Pass the runtime `host.state.focusedSessionId` and its
+`focusedSessionOwner` captured for the confirmed target. The target must still
+be the focused, hydrated, visible conversation with the same owner; a stale,
+disabled or unavailable composer refuses. The call never opens a session,
+changes profiles, inherits local attachments, edits the draft, or interrupts a
+running turn. Slash commands and hidden sends are not supported.
+
+The returned promise reports `{status: 'accepted' | 'queued' | 'rejected' |
+'unknown', queueId?: string}`. An idle send uses the ordinary native submit
+pipeline (including the user bubble); a busy conversation or existing queue
+appends plain text to the native FIFO. `queued` is acceptance in either the
+renderer queue (`queueId` present) or the server queue; neither proves agent
+completion. Renderer persistence at enqueue is best-effort, but its one-attempt
+claim must be persisted and read back before dispatch. A proven pre-transmission
+refusal releases this claim; an uncertain outcome holds the entry across reload.
+`accepted` is
+submit acceptance, not agent completion. Observe the normal gateway events and
+transcript for completion. A timeout or thrown submit returns `unknown`: never
+retry it automatically. Callers own confirmation and cross-reconnection
+idempotency. Detect this method before use on older Desktop builds; raw
+`prompt.submit` is not a transcript-preserving fallback.
 
 `host.request` is the same JSON-RPC the app itself uses (sessions, config, skills,
 cron, kanban, …). `host.requestProfile` accepts a descriptor from


### PR DESCRIPTION
## What does this PR do?

Expose `host.submitPrompt({ connectionId, profile, sessionId, text })` for a companion plugin that submits **human-confirmed plain text to an existing focused Desktop conversation**.

A plugin can already call `host.request('prompt.submit', ...)` on Desktop's gateway connection, but that bypasses the native composer and its optimistic user-message projection. The agent can therefore receive the instruction while the visible transcript lacks the user message. The existing fire-and-forget composer event is not a public acknowledged plugin contract, and its interrupt/steer policy is not appropriate for this consumer.

This extends the existing composer path rather than creating another gateway connection, another agent, or editing conversation storage. It preserves the user's unfinished draft and attachments.

The API returns `accepted`, `queued`, `rejected`, or `unknown`. Acceptance is **not** proof of agent execution. `unknown` must not be retried automatically. The plugin remains responsible for confirmation and durable command-id deduplication.

## Related Issue

No issue filed. Searched open and merged PRs and the current SDK before adding this API. #105509 is adjacent native Voice callback work, not a public confirmed-plugin submission API.

## Type of Change

- [x] New feature (backward-compatible SDK capability)
- [x] Tests
- [x] Documentation

## Changes Made

- `src/sdk/index.ts`: public typed submission API with exact focused runtime, connection and profile checks; no implicit navigation.
- `src/app/chat/composer/focus.ts` and `hooks/use-composer-submit.ts`: synchronous single-surface claim and bounded acknowledgement; native transcript insertion with no draft/attachment inheritance. Concurrent confirmed submissions join the native FIFO.
- `src/app/session/hooks/use-prompt-actions/{utils,submit}.ts`: explicit `confirmedExternal` policy. Always request server-side queueing; do not interrupt a busy turn, recover/resume, or retry after an ambiguous RPC outcome. Recognize both `streaming` and `queued` acknowledgements.
- `src/store/composer-queue.ts` and both foreground/background drains: persist a dispatch claim before sending a confirmed queue entry. An exception or lost acknowledgement keeps it parked across remount/reload. Only a proven pre-dispatch `false` releases the claim. Confirmed entries are not steerable.
- SDK documentation and local architecture guidance; regression tests for target/draft isolation, same-render concurrency, queue order, non-interruption, ambiguous failures and both queue drains.

Existing typed sends, hidden setup notes, hidden steer and GPT/HUD surface behavior are preserved.

## How to Test

From `apps/desktop`:

```bash
npm run typecheck
npx vitest run src/sdk \
  src/app/chat/composer/hooks/use-composer-submit.test.tsx \
  src/app/chat/composer/hooks/use-composer-queue.test.tsx \
  src/app/session/hooks/use-background-queue-drain.test.tsx \
  src/app/session/hooks/use-prompt-actions \
  src/store/composer-queue.test.ts
npm run build
```

Results on this PR snapshot: **400 tests passed across 13 files**, TypeScript passed, build passed. ESLint reported no errors (one existing hook-dependency warning in the test harness); changed TypeScript files were formatted with Prettier. `git diff --check` passed.

### Actual Desktop canary

The implementation was first exercised in an isolated Electron client with a real backend and a disposable existing conversation, before porting it onto the current upstream base:

1. A real loaded plugin used the public API through its command-id deduplicating dispatcher.
2. Two confirmed instructions were submitted back-to-back: first accepted, second queued, duplicate refused.
3. User messages and assistant replies appeared in the native transcript in order. The second reply correctly recalled the first instruction's context.
4. The same runtime id and model were retained across both turns; the queue drained to empty.
5. Closing/reopening the renderer retained both user messages and replies. A read-only check of durable history confirmed one copy of each test turn.
6. No keyboard submission workaround, secondary transport, direct transcript edit, or business-data operation was used.

The live canary qualified the pre-port snapshot; this PR's upstream-adjusted snapshot was separately reviewed, typechecked, tested and built as above. Private canary captures are not attached because the Desktop sidebar contains unrelated private conversation titles. Windows/macOS and an end-to-end mobile microphone workflow were not tested.

## Checklist

### Code

- [x] Read the contributing guide and applicable Desktop engineering guidance.
- [x] Conventional commit; only this feature and its tests/docs are included.
- [x] Searched existing PRs and current source.
- [ ] Full Python suite — not run; no Python/backend change.
- [x] Added regression tests and tested on Linux, Node.js 24.

### Documentation & Housekeeping

- [x] Updated the public Desktop SDK documentation.
- [x] Updated the local Desktop architecture contract.
- [x] No config keys, core tools, runtime dependencies or environment variables added.
- [x] Considered cross-platform impact: renderer-only API and existing persistence/transport; native-platform canaries remain untested.

## Remaining limitations

- Focused visible existing conversation only; missing/disabled/mismatched targets are refused.
- Slash commands are refused; attachments and hidden instructions are outside this API.
- An ambiguous queued dispatch stays parked for explicit reconciliation, not an automatic resend.
- The companion plugin's pairing, authentication and voice UI remain outside this PR.
