### PR TITLE
fix(compression): partial /compress here N no longer adopts the full durable parent

### DIFF
--- a/agent/compression_facade.py
+++ b/agent/compression_facade.py
@@ -189,7 +189,7 @@ class CompressionFacadeMixin:
     def _compress_context(
         self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default",
         focus_topic: str = None, force: bool = False, bypass_cooldown: bool = False,
-        defer_context_engine_notification: bool = False, commit_fence=None,
+        defer_context_engine_notification: bool = False, commit_fence=None, partial_head: bool = False,
     ) -> tuple:
         """Forwarder — see ``agent.conversation_compression.compress_context``.
         ``force=True`` (manual /compress) bypasses the summary-failure cooldown; ``bypass_cooldown=True``
@@ -198,6 +198,10 @@ class CompressionFacadeMixin:
         ``force=True`` is passed by the manual ``/compress`` slash command so users can bypass the
         summary-failure cooldown after an auto-compress abort. Auto-compress callers use the default
         ``force=False``. See #100661.
+
+        ``partial_head=True`` marks ``messages`` as deliberately only the pre-boundary head of the transcript
+        (boundary-aware ``/compress here N``), so the rotation path does not adopt the longer durable parent
+        and summarize the tail the caller keeps verbatim. See #71991.
         """
         # Per-attempt timeout signal for turn-start preflight and in-loop consumers: a stalled
         # compression must not be mistaken for a structural no-op. Thread-local + per-agent lock.
@@ -248,6 +252,7 @@ class CompressionFacadeMixin:
                     approx_tokens=approx_tokens, task_id=task_id, focus_topic=focus_topic, force=force,
                     bypass_cooldown=bypass_cooldown,
                     defer_context_engine_notification=(defer_context_engine_notification), commit_fence=fence,
+                    partial_head=partial_head,
                 )
 
             # Callers that already own a progress-aware wait (gateway session

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2559,11 +2559,22 @@ def _adopt_if_parent_rotated(
     return messages, _existing_sp
 
 
-def _adopt_grown_durable_parent(agent: Any, lease: _CompressionLease, messages: list) -> Optional[list]:
+def _adopt_grown_durable_parent(
+    agent: Any, lease: _CompressionLease, messages: list, *, partial_head: bool = False
+) -> Optional[list]:
     """Return the durable parent transcript when it outgrew the in-memory snapshot.
     Rotation only (in-place never loses rows). The snapshot predates the lease: if durable grew, a writer
     committed a turn — ADOPT it (aborting wedged busy sessions forever). Length check only: in-memory edits of
-    past turns are legal."""
+    past turns are legal.
+
+    ``partial_head``: the caller deliberately handed over only the pre-boundary HEAD of the transcript
+    (boundary-aware ``/compress here N``) and keeps the recent exchanges verbatim, re-appending them after
+    compression. The durable parent is longer BY CONSTRUCTION — it still contains that tail — so a longer
+    snapshot is not evidence of a concurrent write: stand down and summarize the head exactly as given.
+    Adopting instead summarizes the tail the caller is preserving and duplicates it at the rejoin seam
+    (#71991). Length alone cannot separate the two cases, so the caller has to declare the intent."""
+    if partial_head:
+        return None
     if lease.db is None or not lease.sid:
         return None
     durable_loader = getattr(type(lease.db), "get_messages_as_conversation", None)
@@ -3390,7 +3401,7 @@ def _run_summary_phase(
     agent: Any, messages: list, *, lease: _CompressionLease, in_place: bool, checkpoint_required: bool,
     approx_tokens: Optional[int], focus_topic: Optional[str], force: bool, bypass_cooldown: bool,
     commit_fence: Optional[CompressionCommitFence], hard_cancel_event: Any, system_message: str,
-    attempt: _Attempt,
+    attempt: _Attempt, partial_head: bool = False,
 ) -> _SummaryPhase:
     """Adopt a grown durable parent, gather memory context and run the summarizer.
     A hard cancel restores the compressor snapshot + live list, records a stall backoff while the lease is
@@ -3408,7 +3419,9 @@ def _run_summary_phase(
     try:
         lease.start_refresher()
         if not in_place:
-            _adopted_parent = _adopt_grown_durable_parent(agent, lease, messages)
+            _adopted_parent = _adopt_grown_durable_parent(
+                agent, lease, messages, partial_head=partial_head
+            )
             if _adopted_parent is not None:
                 messages = _adopted_parent
                 pre_msg_count = len(messages)
@@ -3559,7 +3572,7 @@ def compress_context(
     agent: Any, messages: list, system_message: str, *, approx_tokens: Optional[int] = None,
     task_id: str = "default", focus_topic: Optional[str] = None, force: bool = False,
     bypass_cooldown: bool = False, defer_context_engine_notification: bool = False,
-    commit_fence: Optional[CompressionCommitFence] = None,
+    commit_fence: Optional[CompressionCommitFence] = None, partial_head: bool = False,
 ) -> Tuple[list, str]:
     """Compress conversation context and split the session in SQLite.
     ``force`` (manual /compress) clears the summary-failure cooldown; ``bypass_cooldown`` (provider-proven
@@ -3580,7 +3593,10 @@ def compress_context(
     failed attempt records its cooldown normally. defer_context_engine_notification: Delay the existing
     context-engine hook until a manual host commits its outer history transaction. commit_fence: Optional
     cooperative fence for executor callers that may time out. It prevents a late worker from mutating
-    session state after its caller has moved on.
+    session state after its caller has moved on. partial_head: True when ``messages`` is deliberately only
+    the pre-boundary head of the transcript (boundary-aware ``/compress here N``) rather than the whole
+    conversation, so the durable-parent adoption guard does not treat the still-present tail as a
+    concurrent write (#71991).
     """
     attempt = _begin_compression_attempt(agent, force=force, defer_notification=defer_context_engine_notification)
 
@@ -3659,6 +3675,7 @@ def compress_context(
         agent, messages, lease=lease, in_place=in_place, checkpoint_required=checkpoint_required,
         approx_tokens=approx_tokens, focus_topic=focus_topic, force=force, bypass_cooldown=bypass_cooldown,
         commit_fence=commit_fence, hard_cancel_event=_hard_cancel_event, system_message=system_message, attempt=attempt,
+        partial_head=partial_head,
     )
     if phase.abort_prompt is not None:
         return phase.messages, phase.abort_prompt

--- a/gateway/slash_commands_session.py
+++ b/gateway/slash_commands_session.py
@@ -580,7 +580,7 @@ class GatewaySessionCommandsMixin:
             compressed, _ = await self._run_in_executor_with_context(
                 lambda: tmp_agent._compress_context(
                     head, "", approx_tokens=approx_tokens, focus_topic=focus_topic, force=True,
-                    defer_context_engine_notification=True))
+                    defer_context_engine_notification=True, partial_head=partial))
             # A held compression lock returns unchanged; say so instead of the misleading no-op text.
             _lock_skipped = getattr(tmp_agent, "_compression_skipped_due_to_lock", None)
             if _lock_skipped is True or isinstance(_lock_skipped, str):

--- a/hermes_cli/cli_session_mixin.py
+++ b/hermes_cli/cli_session_mixin.py
@@ -1112,7 +1112,7 @@ class CLISessionMixin:
                 # identity block appearing twice (issue #15281).
                 compressed, _ = self.agent._compress_context(
                     head, None, approx_tokens=approx_tokens, focus_topic=focus_topic or None,
-                    force=True, defer_context_engine_notification=True)
+                    force=True, defer_context_engine_notification=True, partial_head=partial)
 
                 # Unchanged because a concurrent compression lock is held: say so instead of
                 # the misleading "No changes" no-op text. Type-pinned check (is True / str) —

--- a/tests/agent/test_partial_compress_head_not_adopted.py
+++ b/tests/agent/test_partial_compress_head_not_adopted.py
@@ -1,0 +1,151 @@
+"""Regression: a boundary-aware partial compress must not adopt the full parent.
+
+``_compress_context`` re-reads the durable parent under the per-session compression lock and, when
+that snapshot is longer than the transcript it was handed, ADOPTS it (the "grew before lease" path
+in ``conversation_compression.py``). That is right for a full ``/compress``: a longer durable
+parent means a concurrent writer committed a turn, and adopting keeps that turn in the summary
+instead of aborting forever.
+
+``/compress here N`` is different. The caller deliberately hands over only the pre-boundary HEAD
+and keeps the last ``N`` exchanges verbatim, re-appending them after compression
+(``rejoin_compressed_head_and_tail``). The durable parent is *necessarily* longer than that head —
+it still contains the tail — so the length comparison fires by construction: the whole transcript
+gets summarized, and the rejoin then appends the tail a second time. The user asks to keep the tail
+verbatim and gets it duplicated inside a summary of everything.
+
+The check cannot be fixed by inspecting the lists: "intentional head subset" and "a writer
+committed a row" are the same shape, because in-memory edits of past turns are legal. The caller's
+intent therefore has to be explicit (``partial_head=True``), and the guard must stand down.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from hermes_state import SessionDB
+
+
+def _build_agent_with_db(db: SessionDB, session_id: str):
+    """Build an AIAgent wired to ``db`` and pinned to ``session_id``.
+
+    Mirrors the helper in ``test_compression_adoption_preserves_live_tail.py``: stub the compressor
+    so it returns deterministic output without an LLM call, and pin ``compression_in_place=False``
+    so the legacy rotation path (which owns "grew before lease" adoption) is exercised.
+    """
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    compressor = MagicMock()
+    compressor.compress.return_value = [
+        {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+        {"role": "user", "content": "tail"},
+    ]
+    compressor.compression_count = 1
+    compressor.last_prompt_tokens = 0
+    compressor.last_completion_tokens = 0
+    compressor._last_summary_error = None
+    compressor._last_compress_aborted = False
+    compressor._last_aux_model_failure_model = None
+    compressor._last_aux_model_failure_error = None
+    agent.context_compressor = compressor
+    # One-time compression-model feasibility probe would resolve a REAL auxiliary provider;
+    # mark it done like test_compression_concurrent_fork.
+    agent._compression_feasibility_checked = True
+    agent.compression_in_place = False
+    return agent
+
+
+def _contents(rows) -> list:
+    return [r.get("content") for r in rows]
+
+
+def _seed_six_message_session(db: SessionDB, session_id: str) -> list:
+    """Three user/assistant exchanges, fully durable. Returns the loaded transcript."""
+    db.create_session(session_id, source="desktop")
+    for role, content in (
+        ("user", "q1"),
+        ("assistant", "a1"),
+        ("user", "q2"),
+        ("assistant", "a2"),
+        ("user", "q3"),
+        ("assistant", "a3"),
+    ):
+        db.append_message(session_id, role, content)
+    return db.get_messages_as_conversation(session_id)
+
+
+def test_partial_head_reaches_summarizer_unadopted(tmp_path: Path) -> None:
+    """``/compress here 2`` must summarize the head it was handed, not the full transcript.
+
+    The durable parent holds all six rows; the caller passes only the first two and keeps the last
+    two exchanges verbatim. Because the durable parent is longer by construction, the adoption
+    guard used to replace the head with the full six-row parent, so the summarizer saw — and
+    summarized — the tail the user asked to keep untouched.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "PARTIAL_HEAD_NOT_ADOPTED"
+    full = _seed_six_message_session(db, session_id)
+    head, tail = full[:2], full[2:]
+
+    agent = _build_agent_with_db(db, session_id)
+
+    seen: list = []
+
+    def _recording_compress(first_arg, **_kw):
+        seen.append(list(first_arg))
+        return [
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary"},
+            {"role": "user", "content": "tail"},
+        ]
+
+    agent.context_compressor.compress.side_effect = _recording_compress
+
+    agent._compress_context(
+        head, "sys", approx_tokens=120_000, force=True, partial_head=True
+    )
+
+    assert len(seen) == 1, f"expected exactly one summarizer call, got {len(seen)}"
+    assert _contents(seen[0]) == ["q1", "a1"], (
+        "A partial (/compress here N) call must summarize only the head it was handed. "
+        "The durable parent is longer by construction — it still holds the kept tail — so the "
+        "length-based adoption guard must stand down for an explicit head subset (#71991). "
+        f"Summarizer input contents: {_contents(seen[0])!r}"
+    )
+
+
+def test_partial_head_rejoin_does_not_duplicate_tail(tmp_path: Path) -> None:
+    """End-to-end: the kept tail must appear exactly once after the caller's rejoin.
+
+    This is the user-visible failure. Once the head is replaced by the full transcript, the
+    summary already covers the tail, and ``rejoin_compressed_head_and_tail`` appends it again.
+    """
+    from hermes_cli.partial_compress import rejoin_compressed_head_and_tail
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "PARTIAL_HEAD_REJOIN"
+    full = _seed_six_message_session(db, session_id)
+    head, tail = full[:2], full[2:]
+
+    agent = _build_agent_with_db(db, session_id)
+    compressed, _ = agent._compress_context(
+        head, "sys", approx_tokens=120_000, force=True, partial_head=True
+    )
+    rejoined = rejoin_compressed_head_and_tail(compressed, tail)
+
+    assert _contents(rejoined).count("q3") == 1, (
+        "The verbatim tail must be re-appended exactly once; summarizing it via durable-parent "
+        f"adoption duplicates it (#71991). Got {_contents(rejoined)!r}"
+    )

--- a/tui_gateway/session_compression.py
+++ b/tui_gateway/session_compression.py
@@ -229,6 +229,10 @@ def _compress_session_history(
     # split (empty tail) falls back to full compression so the user still gets an action.
     head, tail = split_history_for_partial_compress(history, keep_last) if partial else (history, [])
     if not tail:
+        # Degenerate split (nothing to summarize, or no user turn to keep): fall back to FULL compression
+        # like the CLI/gateway callers, and clear ``partial`` so the head handed to _compress_context is the
+        # whole transcript — otherwise partial_head would suppress adoption for a genuine full compress.
+        partial = False
         head = history
     if approx_tokens is None:
         # Include system prompt + tool schemas so the figure reflects real request pressure.
@@ -247,7 +251,7 @@ def _compress_session_history(
     try:
         compressed, _ = agent._compress_context(
             head, None, approx_tokens=approx_tokens, focus_topic=focus_topic or None, force=True,
-            defer_context_engine_notification=True,
+            defer_context_engine_notification=True, partial_head=partial,
         )
     except Exception:
         finalize_context_engine_compression_notification(agent, committed=False)


### PR DESCRIPTION
## What does this PR do?

Fixes a boundary-aware partial compress that summarizes the wrong transcript.

`/compress here N` hands `_compress_context` only the pre-boundary **head** and keeps the last `N` exchanges verbatim, re-appending them after the summary (`rejoin_compressed_head_and_tail`). By construction the head is therefore a strict prefix of the persisted session, so the durable parent is always longer than the transcript the caller passed.

The rotation path reads "durable parent is longer" as "a writer committed a turn in the meantime" and **adopts** that snapshot (`_adopt_grown_durable_parent`, which exists so a concurrent turn gets summarized instead of the attempt aborting forever). For a partial compress that condition is true by construction, so the head was replaced by the whole transcript: the summarizer consumed the tail the user asked to keep untouched, and the caller then re-appended it, duplicating it.

The check can't be tightened by inspecting the lists — an in-memory edit of a past turn and a concurrent append have the same shape, and the guard's own docstring is explicit that in-memory edits of past turns are legal — so the caller has to declare the intent.

## Related Issue

Fixes #71991 (analysis posted there: https://github.com/NousResearch/hermes-agent/issues/71991#issuecomment-5645036669)

Note on the report: the issue describes current `main` **aborting** (`changed before lease acquisition`) and no-op'ing. That abort no longer exists on today's `main` — the guard now adopts instead — so the symptom changed shape rather than disappearing: the command no longer no-ops, it silently ignores the requested boundary and duplicates the kept tail. This PR fixes the current manifestation.

I searched open and merged PRs for #71991 and its symptoms; nothing is linked to the issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_compression.py` — `compress_context()` and `_run_summary_phase()` accept `partial_head`; `_adopt_grown_durable_parent()` returns early when it is set, with the reasoning documented in its docstring.
- `agent/compression_facade.py` — `_compress_context()` forwards `partial_head`.
- `hermes_cli/cli_session_mixin.py`, `gateway/slash_commands_session.py`, `tui_gateway/session_compression.py` — the three partial-compress callers pass `partial_head=partial`. The TUI path now also clears `partial` on a degenerate split (empty tail), matching the CLI/gateway callers, so a fallback-to-full compress still adopts.
- `tests/agent/test_partial_compress_head_not_adopted.py` — new regression tests.

The default is `False`, so full-compress callers (auto-compaction, `/compress <focus>`, ACP) are unchanged and still adopt.

## How to Test

```bash
uv run pytest tests/agent/test_partial_compress_head_not_adopted.py -q
```

The two tests fail before the change because `partial_head` does not exist yet — and the behaviour they guard is real. Issuing the identical call **without** the flag (i.e. the pre-change code path), six durable rows and no concurrent writer, with the caller passing only `head=['q1','a1']`:

```text
force=True                  -> summarizer input ['q1', 'a1', 'q2', 'a2', 'q3', 'a3']
force=False                 -> summarizer input ['q1', 'a1', 'q2', 'a2', 'q3', 'a3']
partial_head=True           -> summarizer input ['q1', 'a1']
```

The head is replaced by the full parent, and the caller's rejoin then appends the kept tail a second time. Note the adoption is identical for `force=True` and `force=False`: `force` only bypasses the cooldown/automatic gates, it does not gate the adoption in `_run_summary_phase`.

Regression runs on this branch:

- `uv run pytest tests/agent -k "compress or compression" -q` → 654 passed, 1 skipped
- `uv run pytest tests/gateway -k compress -q` → 190 passed, 2 skipped
- `uv run pytest tests/test_tui_gateway_server.py -k compress -q` → 23 passed
- `uv run pytest tests/cli/test_partial_compress.py tests/cli/test_compress_flags.py tests/cli/test_compress_type_ahead.py tests/tui_gateway/test_compress_lock_skip.py -q` → 22 passed
- `uv run pytest tests/hermes_cli -k compress -q` → 11 passed
- `uv run pytest tests/agent/test_compression_adoption_preserves_live_tail.py -q` → 4 passed (full-compress adoption still behaves)
- `uv run ruff check <changed files>` → clean

Deliberately out of scope:

- `_adopt_if_parent_rotated()` (the "parent already rotated by another compression" recovery). It keys off `_session_was_rotated_by_compression`, not a length comparison, so a partial head cannot trigger it by construction.
- The raw-vs-repaired projection mismatch raised on the issue. That is a separate false-positive class in the full/automatic rotation path; `_adopt_grown_durable_parent` still compares length only (both sides from the same durable loader). Replacing that with a monotonic revision / message-identity fence is a sensible follow-up, but it is not what this report's partial-head case needs.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings updated where the behaviour is defined; no user-facing docs change (`/compress here N` already documents the keep-verbatim contract)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific code
