### PR TITLE
fix(desktop): localize the Bot Mode group row's member count and availability

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/bot-row.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row.test.tsx
@@ -19,10 +19,15 @@ import type * as HermesSdk from '@hermes/plugin-sdk'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { BotRow } from './bot-row'
+import { BotRow, GroupRow } from './bot-row'
 import { $groupChats } from './group-chat'
-import { translateBots } from './i18n-test-helper'
-import type { RosterRow } from './types'
+import { translateBotsIn } from './i18n-test-helper'
+import type { GroupMember, RosterRow } from './types'
+
+// Which shipped bundle the rendered rows resolve their strings against. `en`
+// matches the literals this file once carried, so a case that has to prove a
+// string comes from the catalog reads the same row under `ja`.
+const locale = vi.hoisted(() => ({ current: 'en' as 'en' | 'ja' }))
 
 const { ensureAgent, ensureBotMetadata, notifyError, openRosterBot, requestProfile, warmAgent, warmProfile } =
   vi.hoisted(() => ({
@@ -43,7 +48,7 @@ vi.mock('@hermes/plugin-sdk', async importOriginal => {
     host: { ...sdk.host, ensureAgent, notifyError, requestProfile, warmAgent, warmProfile },
     // The plugin bundle normally lands via `ctx.i18n.register` at load, so
     // without this every localized label in the row renders empty.
-    usePluginI18n: () => translateBots
+    usePluginI18n: () => translateBotsIn(locale.current)
   }
 })
 
@@ -197,5 +202,28 @@ describe('context-menu mutations hydrate the alias first', () => {
 
     expect(route.profile).toBe('worker')
     expect(params).toMatchObject({ name: 'backend-worker', ui_meta: { 'hermes-bots': { pinned: false } } })
+  })
+})
+
+describe('a group row', () => {
+  const members = [{ name: 'alpha' }, { name: 'beta' }, { name: 'gamma' }] as GroupMember[]
+  const row = <GroupRow active={false} group="crew" members={members} needsYou={false} onDisband={noop} onOpen={noop} />
+
+  beforeEach(() => {
+    locale.current = 'en'
+  })
+
+  it('previews an empty room and describes it to assistive tech in the active language', () => {
+    const english = render(row)
+
+    expect(english.getByText('3 bots')).toBeTruthy()
+    expect(english.getByRole('button', { name: 'crew, 3 bots, 3 of 3 available' })).toBeTruthy()
+    english.unmount()
+
+    locale.current = 'ja'
+    const japanese = render(row)
+
+    expect(japanese.getByText('ボット3体')).toBeTruthy()
+    expect(japanese.getByRole('button', { name: 'crew, ボット3体, 3体中3体が利用可能' })).toBeTruthy()
   })
 })

--- a/apps/desktop/src/plugins/hermes-bots/bot-row.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row.tsx
@@ -480,14 +480,14 @@ export function GroupRow({ active, group, members, needsYou, onOpen, onDisband }
 
   const preview = last
     ? `${last.from?.kind === 'user' ? 'You' : `@${lastHandle}`}: ${stripPreviewMarkdown(last.text) || '…'}`
-    : `${members.length} bots`
+    : b.group.memberCount(members.length)
 
   const availableMembers = members.filter(member => botSourceStatus(member).available).length
-  const availabilityLabel = `${availableMembers} of ${members.length} available`
+  const availabilityLabel = b.group.availableCount(availableMembers, members.length)
 
   const row = (
     <RowButton
-      aria-label={`${group}, ${members.length} bots, ${availabilityLabel}`}
+      aria-label={`${group}, ${b.group.memberCount(members.length)}, ${availabilityLabel}`}
       className={cn(
         'flex w-full min-w-0 max-w-full items-center gap-2.5 overflow-hidden rounded-md px-2 py-2 text-left transition-colors',
         'hover:bg-(--chrome-action-hover)',

--- a/apps/desktop/src/plugins/hermes-bots/i18n-test-helper.ts
+++ b/apps/desktop/src/plugins/hermes-bots/i18n-test-helper.ts
@@ -9,17 +9,23 @@
 
 import { BOTS_LOCALES } from './i18n'
 
-export function translateBots(key: string, ...args: unknown[]): string {
-  const value = key
-    .split('.')
-    .reduce<unknown>(
-      (node, part) => (node && typeof node === 'object' ? (node as Record<string, unknown>)[part] : undefined),
-      BOTS_LOCALES.en
-    )
+/** The same resolver against another shipped locale, for a test that has to
+ *  tell a catalog string from an English literal that happens to match `en`. */
+export function translateBotsIn(locale: keyof typeof BOTS_LOCALES) {
+  return (key: string, ...args: unknown[]): string => {
+    const value = key
+      .split('.')
+      .reduce<unknown>(
+        (node, part) => (node && typeof node === 'object' ? (node as Record<string, unknown>)[part] : undefined),
+        BOTS_LOCALES[locale]
+      )
 
-  if (typeof value === 'function') {
-    return String((value as (...params: unknown[]) => string)(...args))
+    if (typeof value === 'function') {
+      return String((value as (...params: unknown[]) => string)(...args))
+    }
+
+    return typeof value === 'string' ? value : key
   }
-
-  return typeof value === 'string' ? value : key
 }
+
+export const translateBots = translateBotsIn('en')

--- a/apps/desktop/src/plugins/hermes-bots/i18n.ts
+++ b/apps/desktop/src/plugins/hermes-bots/i18n.ts
@@ -185,6 +185,8 @@ type BotsMessages = {
     pictureGenerationFailed: string
     nameTaken: (name: string) => string
     memberCount: (count: number) => string
+    /** How many of a room's members are reachable right now. */
+    availableCount: (available: number, total: number) => string
     settingsHint: (group: string) => string
     settingsLabel: (group: string) => string
     disbandHint: (group: string) => string
@@ -411,6 +413,7 @@ const en: BotsMessages = {
     pictureGenerationFailed: 'Group picture generation failed',
     nameTaken: name => `A group named “${name}” already exists.`,
     memberCount: count => `${count} bots`,
+    availableCount: (available, total) => `${available} of ${total} available`,
     settingsHint: group => `Group settings — rename ${group} or set a room picture`,
     settingsLabel: group => `Group settings for ${group}`,
     disbandHint: group => `Disband the ${group} group chat`,
@@ -630,6 +633,7 @@ const ja: BotsMessages = {
     pictureGenerationFailed: 'グループ画像の生成に失敗しました',
     nameTaken: name => `「${name}」という名前のグループはすでに存在します。`,
     memberCount: count => `ボット${count}体`,
+    availableCount: (available, total) => `${total}体中${available}体が利用可能`,
     settingsHint: group => `グループ設定 — ${group}の名前変更やルーム画像の設定`,
     settingsLabel: group => `${group}のグループ設定`,
     disbandHint: group => `${group}グループチャットを解散`,
@@ -844,6 +848,7 @@ const zh: BotsMessages = {
     pictureGenerationFailed: '群组图片生成失败',
     nameTaken: name => `已存在名为“${name}”的群聊。`,
     memberCount: count => `${count} 个机器人`,
+    availableCount: (available, total) => `${total} 个中 ${available} 个可用`,
     settingsHint: group => `群聊设置 — 重命名 ${group} 或设置房间图片`,
     settingsLabel: group => `${group} 的群聊设置`,
     disbandHint: group => `解散 ${group} 群聊`,
@@ -1058,6 +1063,7 @@ const zhHant: BotsMessages = {
     pictureGenerationFailed: '群組圖片產生失敗',
     nameTaken: name => `已存在名為「${name}」的群組聊天。`,
     memberCount: count => `${count} 個機器人`,
+    availableCount: (available, total) => `${total} 個中 ${available} 個可用`,
     settingsHint: group => `群組設定 — 重新命名 ${group} 或設定房間圖片`,
     settingsLabel: group => `${group} 的群組設定`,
     disbandHint: group => `解散 ${group} 群組聊天`,


### PR DESCRIPTION
## What does this PR do?

The Bot Mode group row spelled its empty-room preview (`${members.length} bots`) and its accessible name (`${group}, ${members.length} bots, ${available} of ${total} available`) as English literals, so a reader on ja, zh or zh-hant saw English in a row whose neighbours were translated, and a screen reader read English for the room the group chat pane names in the active language. The bundle already carries `group.memberCount` in all four locales (a7db531a2a moved it there) and `group-chat-view.tsx` renders through it; the row's rebuild (5afa487e93) reintroduced the literal next to the `useBots()` accessor the component already holds.

The preview and the aria-label's count now go through `group.memberCount`. The availability sentence had no key, so `group.availableCount(available, total)` is added in en, ja, zh and zh-hant, for the aria-label and the tooltip that share it. `'You'` in the last-message preview stays a literal on purpose: it is the persisted author sentinel the bundle's header describes.

## Related Issue

Fixes #108978

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/bot-row.tsx`: `GroupRow` renders the preview and the aria-label's count with `b.group.memberCount`, and the availability sentence with `b.group.availableCount`.
- `apps/desktop/src/plugins/hermes-bots/i18n.ts`: `group.availableCount(available, total)` in the type and in all four bundles.
- `apps/desktop/src/plugins/hermes-bots/i18n-test-helper.ts`: `translateBotsIn(locale)`; `translateBots` is `translateBotsIn('en')`, unchanged for existing callers.
- `apps/desktop/src/plugins/hermes-bots/bot-row.test.tsx`: the mock resolves against a chosen locale; one new case renders the same group row under `en` and `ja` and reads the preview and the button's accessible name.

## How to Test

1. `cd apps/desktop && npx vitest run --project ui src/plugins/hermes-bots/bot-row.test.tsx`. Observed: 8 passed.
2. Revert only `bot-row.tsx` and rerun. Observed: the new case fails on the Japanese preview (`ボット3体` not found), so it pins the fix rather than restating it.
3. `npx tsc -p . --noEmit`, `npx eslint` and `npx prettier --check` on the four files. Observed: clean.
4. Manual: switch the desktop to 日本語, open Bot Mode with an empty group; the row's second line reads `ボット3体` and the accessibility inspector shows the localized name.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux, Node v24.18.0

> The change is desktop TypeScript only, so I ran the affected Vitest file and the desktop typecheck and lint rather than the Python suite.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no documented surface changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer strings only, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ npx vitest run --project ui src/plugins/hermes-bots/bot-row.test.tsx
 Test Files  1 passed (1)
      Tests  8 passed (8)

# with bot-row.tsx reverted:
 FAIL  |ui| src/plugins/hermes-bots/bot-row.test.tsx > a group row > previews an empty room and describes it to assistive tech in the active language
      Tests  1 failed | 7 passed (8)
```
