### PR TITLE
fix(config,gateway): a blocked read is not broken YAML; quiet the duplicate-risk false positive

### DIFF
--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -3727,9 +3727,12 @@ class GatewayTurnMixin:
                     ok=("Edited streamed message %s for session %s to include plugin-transformed content.", _sc.message_id, _sk),
                     fail_result=None, fail_exc="Failed to edit streamed message for session %s: %s",
                 )
-        elif _sc is not None:
+        elif _sc is not None and getattr(_sc, "receives_deltas", True):
             # DUPLICATE-RISK DIAGNOSTIC: a stream consumer existed but suppression did NOT fire; log the
-            # decision inputs ("signal never set" vs "ack-pending race").
+            # decision inputs ("signal never set" vs "ack-pending race"). Only meaningful for a consumer
+            # deltas were actually routed to: a commentary-only consumer (text streaming off, interim
+            # assistant messages on) never receives the final, so its flags are False every turn by
+            # construction and the warning would be a permanent false positive.
             logger.warning(
                 "Normal final-send NOT suppressed despite active stream consumer for session %s: "
                 "streamed=%s previewed=%s content_delivered=%s transformed=%s final_len=%d — "

--- a/gateway/run_turn_runner.py
+++ b/gateway/run_turn_runner.py
@@ -869,6 +869,10 @@ class TurnRunner:
                         on_before_finalize=pause_typing_before_finalize,
                         initial_reply_to_id=ctx.event_message_id, run_still_current=ctx._run_still_current,
                     )
+                    # The consumer can exist for interim commentary alone (text streaming off);
+                    # without deltas it never carries the turn final — see the duplicate-risk
+                    # diagnostic in run_turn.py.
+                    stream_consumer.receives_deltas = want_stream_deltas
                     ctx.stream_consumer_holder[0] = stream_consumer
             except Exception as err:
                 logger.debug("Could not set up stream consumer: %s", err)

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -161,6 +161,10 @@ class GatewayStreamConsumer(StreamTransportMixin, StreamFallbackMixin, StreamThi
         # Transports, resolved in run().  Draft: animated frames via adapter.send_draft;
         # the final still uses first-send; the first failure disables drafts.  Native
         # (WeCom msgtype "stream"): the ONLY channel — any failure falls back to edit/send.
+        # Whether the gateway routed stream deltas here. False = this consumer exists only for
+        # interim commentary (text streaming off, interim assistant messages on), so it can never
+        # carry the turn final and the gateway's duplicate-risk diagnostic must ignore it.
+        self.receives_deltas = False
         self._use_draft_streaming = False
         self._draft_id: Optional[int] = None
         self._draft_failures = 0

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -30,7 +30,7 @@ from hermes_cli.default_soul import DEFAULT_SOUL_MD, is_legacy_template_soul
 from hermes_cli.secret_prompt import masked_secret_prompt
 # Re-export from hermes_constants — canonical definition lives there.
 from hermes_constants import get_hermes_home, get_process_hermes_home  # noqa: F401
-from utils import atomic_replace, atomic_yaml_write, fast_safe_load
+from utils import atomic_replace, atomic_yaml_write, fast_safe_load, open_text_with_retry
 
 logger = logging.getLogger(__name__)
 
@@ -79,9 +79,16 @@ def _warn_config_parse_failure(
     if key in _CONFIG_PARSE_WARNED:
         return
     _CONFIG_PARSE_WARNED.add(key)
-    from hermes_cli.config_backups import backup_config
-    backup_path = backup_config(config_path, "corrupt")
-    msg = f"Failed to parse {config_path}: {exc}. " + _PARSE_FAILURE_FALLBACK_MSG.get(
+    # A blocked read (EACCES/EPERM while another process rewrites the file, or a scanner holds it)
+    # is NOT a broken YAML — the bytes on disk are intact. Snapshotting them as "corrupt" misleads
+    # the user and litters backups/config/, so only a real parse failure takes a snapshot.
+    _read_failure = isinstance(exc, OSError)
+    backup_path = None
+    if not _read_failure:
+        from hermes_cli.config_backups import backup_config
+        backup_path = backup_config(config_path, "corrupt")
+    msg = (f"Could not read {config_path}: {exc}. " if _read_failure
+           else f"Failed to parse {config_path}: {exc}. ") + _PARSE_FAILURE_FALLBACK_MSG.get(
         fallback, _PARSE_FAILURE_DEFAULTS_MSG)
     if backup_path is not None:
         msg += f" A copy of the corrupted file was saved to {backup_path}."
@@ -476,7 +483,7 @@ def require_parseable_user_config(*, ignore_user_config: bool = False) -> None:
 
     config_path = get_config_path()
     try:
-        with open(config_path, encoding="utf-8") as f:
+        with open_text_with_retry(config_path) as f:
             data = fast_safe_load(f)
     except FileNotFoundError:
         return
@@ -994,7 +1001,7 @@ def check_config_version(*, raise_on_parse_error: bool = False) -> Tuple[int, in
         return latest, latest
 
     try:
-        with open(config_path, encoding="utf-8") as f:
+        with open_text_with_retry(config_path) as f:
             config = fast_safe_load(f)
     except Exception as e:
         _warn_config_parse_failure(config_path, e)
@@ -1871,7 +1878,7 @@ def _read_raw_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
             return copy.deepcopy(cached[2]) if want_deepcopy else cached[2]
 
         try:
-            with open(config_path, encoding="utf-8") as f:
+            with open_text_with_retry(config_path) as f:
                 data = fast_safe_load(f) or {}
         except Exception as e:
             _warn_config_parse_failure(config_path, e)
@@ -1899,7 +1906,7 @@ def read_user_config_raw(config_path: Optional[Path] = None) -> Dict[str, Any]:
     if config_path is None:
         config_path = get_config_path()
     try:
-        with open(config_path, encoding="utf-8") as f:
+        with open_text_with_retry(config_path) as f:
             data = fast_safe_load(f) or {}
     except FileNotFoundError:
         return {}
@@ -1937,7 +1944,7 @@ def require_readable_config_before_write(config_path: Optional[Path] = None) -> 
         raise _refuse_overwrite(config_path, "cannot be accessed", exc, _FIX_PERMS) from exc
 
     try:
-        with open(config_path, encoding="utf-8") as f:
+        with open_text_with_retry(config_path) as f:
             loaded = fast_safe_load(f)
     except OSError as exc:
         raise _refuse_overwrite(config_path, "cannot be read", exc, _FIX_PERMS) from exc
@@ -2172,7 +2179,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
 
         if user_sig is not None:
             try:
-                with open(config_path, encoding="utf-8") as f:
+                with open_text_with_retry(config_path) as f:
                     user_config = fast_safe_load(f) or {}
 
                 if "max_turns" in user_config:

--- a/tests/gateway/test_duplicate_send_diagnostic.py
+++ b/tests/gateway/test_duplicate_send_diagnostic.py
@@ -1,0 +1,76 @@
+"""The duplicate-risk diagnostic must only speak for consumers that could carry the turn final.
+
+A stream consumer is created whenever text streaming OR interim assistant messages are on. With
+text streaming off (``streaming.enabled: false``) and interim messages on (Telegram's default)
+the consumer exists for commentary alone: no deltas are ever routed to it, so its
+``final_response_sent`` / ``final_content_delivered`` flags are False every single turn and the
+normal final send is the only delivery. Logging "possible duplicate send" there is a permanent
+false positive (live: 3 warnings on 2026-09-12 with zero user-visible duplicates).
+
+Contract: a commentary-only consumer does not claim duplicate risk AND still lets the final
+through; a delta-fed consumer without a confirmed final still warns.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+
+from gateway.run import GatewayRunner
+
+
+class _LogCapture(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.WARNING)
+        self.messages: list[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.messages.append(record.getMessage())
+
+
+def _mark(response, consumer):
+    runner = object.__new__(GatewayRunner)
+    turn_ctx = SimpleNamespace(
+        stream_consumer_holder=[consumer],
+        source=SimpleNamespace(chat_id="123", platform=None),
+        session_key="agent:main:telegram:dm:123",
+    )
+    asyncio.run(GatewayRunner._run_agent_mark_streamed_delivery(runner, response, turn_ctx))
+
+
+def _consumer(*, receives_deltas: bool):
+    return SimpleNamespace(
+        receives_deltas=receives_deltas,
+        message_id=None,
+        adapter=None,
+        final_response_sent=False,
+        final_content_delivered=False,
+    )
+
+
+def _capture(fn) -> list[str]:
+    handler = _LogCapture()
+    root = logging.getLogger()
+    root.addHandler(handler)
+    try:
+        fn()
+    finally:
+        root.removeHandler(handler)
+    return handler.messages
+
+
+def test_commentary_only_consumer_is_not_reported_as_a_duplicate_risk():
+    response = {"final_response": "the answer"}
+    messages = _capture(lambda: _mark(response, _consumer(receives_deltas=False)))
+
+    assert not any("NOT suppressed" in m for m in messages), messages
+    assert not response.get("already_sent"), "the final must still be sent on this path"
+
+
+def test_delta_fed_consumer_without_a_confirmed_final_still_warns():
+    response = {"final_response": "the answer"}
+    messages = _capture(lambda: _mark(response, _consumer(receives_deltas=True)))
+
+    assert any("NOT suppressed" in m for m in messages), messages
+    assert not response.get("already_sent")

--- a/tests/hermes_cli/test_config_read_share_retry.py
+++ b/tests/hermes_cli/test_config_read_share_retry.py
@@ -1,0 +1,79 @@
+"""A transient sharing violation on config.yaml must not degrade the config to defaults.
+
+Live evidence (TONY, 2026-09-12): a read denied with ``[Errno 13] Permission denied`` while
+another process held config.yaml reached the parse-failure funnel, warned "Failed to parse …
+Fix the YAML", fell back to ``DEFAULT_CONFIG`` (dropping the user's fallback chain and model
+routing) and snapshotted a "corrupt" copy that was byte-identical to the live file.
+
+Contract asserted here:
+
+  1. A lock that clears on retry is not a parse failure — the user's overrides survive and no
+     snapshot is taken.
+  2. A genuinely unparseable file still takes the parse-failure path (loud warning + snapshot),
+     because that is what tells the user what is actually wrong.
+"""
+
+from __future__ import annotations
+
+import builtins
+import errno
+
+import pytest
+
+from hermes_cli import config as config_mod
+
+
+@pytest.fixture
+def config_home(tmp_path):
+    """Temp config.yaml plus a clean loader cache/state for this path."""
+    path = config_mod.get_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    config_mod._CONFIG_PARSE_FAILURES.clear()
+    config_mod._CONFIG_PARSE_WARNED.clear()
+    config_mod._LOAD_CONFIG_CACHE.clear()
+    config_mod._RAW_CONFIG_CACHE.clear()
+    return path
+
+
+def _corrupt_snapshots(path) -> list:
+    backups = path.parent / "backups" / "config"
+    return sorted(backups.glob("*.corrupt.*")) if backups.exists() else []
+
+
+def test_transient_share_violation_is_retried_not_treated_as_broken_yaml(
+    config_home, monkeypatch, caplog,
+):
+    config_home.write_text("display:\n  skin: usertheme\n", encoding="utf-8")
+    real_open = builtins.open
+    denied = {"count": 0}
+
+    def flaky_open(file, *args, **kwargs):
+        # Only the first read of config.yaml is denied; the file itself is perfectly valid.
+        if str(file) == str(config_home) and denied["count"] == 0:
+            denied["count"] += 1
+            raise PermissionError(errno.EACCES, "Permission denied", str(config_home))
+        return real_open(file, *args, **kwargs)
+
+    # Patch the BUILTIN, not ``utils.open``: the point is that the loader's read is denied and the
+    # retry has to absorb it — a module-attribute seam would only prove the helper exists.
+    monkeypatch.setattr(builtins, "open", flaky_open)
+
+    with caplog.at_level("WARNING"):
+        cfg = config_mod.load_config()
+
+    assert denied["count"] == 1, "the blocked read was not retried"
+    assert cfg["display"]["skin"] == "usertheme", "user override lost to DEFAULT_CONFIG"
+    assert config_mod._CONFIG_PARSE_FAILURES == {}, "a cleared lock was recorded as a parse failure"
+    assert "Failed to parse" not in caplog.text
+    assert _corrupt_snapshots(config_home) == [], "a valid config was snapshotted as corrupt"
+
+
+def test_unparseable_yaml_still_reports_a_parse_failure(config_home, caplog):
+    config_home.write_text("display: [unclosed\n", encoding="utf-8")
+
+    with caplog.at_level("WARNING"):
+        config_mod.load_config()
+
+    assert "Failed to parse" in caplog.text, "a real YAML error must stay loud"
+    assert config_mod._CONFIG_PARSE_FAILURES, "provider auto-resolution relies on this record"
+    assert _corrupt_snapshots(config_home), "a real parse failure still snapshots the file"

--- a/utils.py
+++ b/utils.py
@@ -100,6 +100,41 @@ def _is_contended_windows_replace_error(exc: OSError) -> bool:
     return _IS_WINDOWS and getattr(exc, "winerror", None) in _WINDOWS_CONTENDED_REPLACE_ERRORS
 
 
+_TRANSIENT_READ_ERRNOS = (errno.EACCES, errno.EPERM, errno.EBUSY)
+_READ_RETRY_ATTEMPTS = 6
+_READ_RETRY_BASE_DELAY_S = 0.05
+_READ_RETRY_MAX_DELAY_S = 0.8
+
+
+def open_text_with_retry(path: Union[str, Path], *, encoding: str = "utf-8",
+                         attempts: int = _READ_RETRY_ATTEMPTS):
+    """Open *path* for reading, retrying a transient sharing violation.
+
+    A plain read is denied (errno EACCES/EPERM/EBUSY, Windows winerror 5/32/33) while another
+    process holds the file without FILE_SHARE_READ — the window around a Hermes atomic rewrite,
+    or an antivirus/indexer scanner. Config callers treat ANY read failure as "the YAML is
+    broken" and fall back to defaults, which silently drops the user's overrides (``approvals.deny``,
+    fallback chain, model routing), so a lock that clears in milliseconds must not reach them.
+    Non-transient errors (missing file, directory, ACL denial) still raise on the first attempt;
+    a persistent EACCES costs the retry budget once and then reports the real error.
+    """
+    last_exc = None
+    for attempt in range(attempts + 1):
+        try:
+            return open(path, encoding=encoding)
+        except OSError as exc:
+            transient = (getattr(exc, "errno", None) in _TRANSIENT_READ_ERRNOS
+                         or _is_contended_windows_replace_error(exc))
+            if not transient or attempt == attempts:
+                raise
+            last_exc = exc
+            # Lazy: keeps ``utils`` free of a package-level dependency on ``agent``.
+            from agent.retry_utils import jittered_backoff
+            time.sleep(jittered_backoff(attempt + 1, base_delay=_READ_RETRY_BASE_DELAY_S,
+                                        max_delay=_READ_RETRY_MAX_DELAY_S))
+    raise last_exc  # pragma: no cover - the loop returns or raises
+
+
 def _rewrite_in_place(tmp_str: str, real_path: str) -> None:
     """Overwrite *real_path* through the existing file — last resort for a still-held target.
 


### PR DESCRIPTION
## What

Two independent defects, found together in one live gateway log.

### 1. A transient read denial silently degrades the config to `DEFAULT_CONFIG`

`hermes_cli/config.py` opens `config_path` inside the same `try` that parses it, so an I/O failure
takes the parse-failure path:

```
2026-09-12 11:22:55 WARNING hermes_cli.config: Failed to parse .../config.yaml:
[Errno 13] Permission denied: '...\\config.yaml'. Falling back to default config — every user
override (auxiliary providers, fallback chain, model settings) is being IGNORED.
```

- The file was intact. The "corrupted" snapshot the funnel saved was **byte-identical** to the live
  file (`cmp -s` → identical; both parse to the same 35 keys). Only the read was blocked — the
  window around another process's atomic rewrite, or a scanner holding the file.
- Effect: `DEFAULT_CONFIG` for that process, i.e. the user's `approvals.deny`, fallback chain and
  model routing are dropped without any indication that the config, not the YAML, is the problem.
- This is the read-side twin of the Windows contention retry already in `utils.atomic_replace`
  (winerror 5/32/33). A write is retried; a read was fatal.

### 2. "possible duplicate send" fires on every final send

`gateway/run_turn.py` warns when a stream consumer exists but suppression did not fire. With
`streaming.enabled: false` + `interim_assistant_messages: true` (Telegram's default) the consumer
is created for commentary only (`_setup_stream_consumer`: `if want_stream_deltas or
want_interim_messages`), `delta_sinks` is empty because `want_stream_deltas` is False, so no delta
is ever routed to it and both delivery flags stay False by construction. The diagnostic's premise —
an active stream consumer that *should* have carried the turn final — never holds, so it warns on
every delivery. Live: 3 warnings in one afternoon, 0 user-visible duplicates (`inbound message` →
exactly one `Sending response` per turn).

## Changes

- `utils.open_text_with_retry()` — retries a transient sharing violation (EACCES/EPERM/EBUSY,
  winerror 5/32/33) with jittered backoff; a non-transient error (missing file, directory, ACL
  denial) still raises on the first attempt, and a persistent lock costs the retry budget once.
- all six `config.yaml` read sites in `hermes_cli/config.py` use it.
- `_warn_config_parse_failure()` — no "corrupt" snapshot for a file whose only problem was being
  locked, and an I/O failure is worded as a read failure ("Could not read …") instead of
  "Failed to parse …".
- `GatewayStreamConsumer.receives_deltas` (set by `_setup_stream_consumer`, default False) + the
  diagnostic now only fires for a consumer deltas were actually routed to.

## Tests

`tests/hermes_cli/test_config_read_share_retry.py` and `tests/gateway/test_duplicate_send_diagnostic.py`
(2 each, run with `scripts/run_tests.sh`).

- **RED on base**: `AssertionError: user override lost to DEFAULT_CONFIG` /
  `assert 'default' == 'usertheme'`, and the warning is emitted for a commentary-only consumer.
- **GREEN with the fix**; 364 neighboring tests pass (config, config_backups, set_config_value,
  loader e2e, guard surfaces, utils atomic, retry_utils, stream_final_contract, stream_consumer,
  stale_finalize_suppression, queued_final_ledger).

Both tests assert a behavior relationship (a blocked read is retried and the override survives; a
commentary-only consumer does not claim duplicate risk) — no snapshots, no source-reading.

## Environment

Windows 11, Python 3.11.16, Hermes 0.21.2 (`044a77b3b6`) + this commit re-applied; the failure was
observed on 0.21.1 and the affected code is unchanged between the two.
