### PR TITLE
fix(desktop): restore stale queue expiry

### DIFF
--- a/apps/desktop/src/store/composer-queue.test.ts
+++ b/apps/desktop/src/store/composer-queue.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ComposerAttachment } from './composer'
 import {
@@ -13,6 +13,7 @@ import {
   parkQueuedPrompts,
   promoteQueuedPrompt,
   removeQueuedPrompt,
+  sanitizePersistedQueueState,
   shouldAutoDrain,
   unparkQueuedPrompts,
   updateQueuedPrompt,
@@ -21,6 +22,7 @@ import {
 
 const SESSION_KEY = 'session-abc'
 const QUEUE_STORAGE_KEY = 'hermes.desktop.composerQueue.v1'
+const DAY_MS = 24 * 60 * 60 * 1000
 
 function attachment(id: string, kind: ComposerAttachment['kind'] = 'file'): ComposerAttachment {
   return {
@@ -30,6 +32,54 @@ function attachment(id: string, kind: ComposerAttachment['kind'] = 'file'): Comp
     refText: `@file:${id}`
   }
 }
+
+describe('sanitizePersistedQueueState', () => {
+  it('drops expired turns while preserving fresh valid entries', () => {
+    const now = Date.UTC(2026, 8, 1)
+
+    const fresh = {
+      attachments: [],
+      displayKind: 'hidden' as const,
+      id: 'queued-fresh',
+      queuedAt: now - DAY_MS,
+      text: 'fresh setup note'
+    }
+
+    const expired = {
+      attachments: [attachment('old-image', 'image')],
+      id: 'queued-expired',
+      queuedAt: now - 8 * DAY_MS,
+      text: 'stale retry'
+    }
+
+    expect(
+      sanitizePersistedQueueState(
+        {
+          'session-expired': [expired],
+          'session-fresh': [fresh]
+        },
+        now
+      )
+    ).toEqual({ 'session-fresh': [fresh] })
+  })
+
+  it('writes the sanitized queue back during persisted-state load', async () => {
+    const now = Date.now()
+    const fresh = { attachments: [], id: 'fresh', queuedAt: now, text: 'send me' }
+    const expired = { attachments: [], id: 'expired', queuedAt: now - 8 * DAY_MS, text: 'do not retry' }
+
+    window.localStorage.setItem(
+      QUEUE_STORAGE_KEY,
+      JSON.stringify({ 'session-expired': [expired], 'session-fresh': [fresh] })
+    )
+    vi.resetModules()
+
+    const reloaded = await import('./composer-queue')
+
+    expect(reloaded.$queuedPromptsBySession.get()).toEqual({ 'session-fresh': [fresh] })
+    expect(JSON.parse(window.localStorage.getItem(QUEUE_STORAGE_KEY)!)).toEqual({ 'session-fresh': [fresh] })
+  })
+})
 
 describe('composer queue store', () => {
   beforeEach(() => {

--- a/apps/desktop/src/store/composer-queue.ts
+++ b/apps/desktop/src/store/composer-queue.ts
@@ -30,6 +30,50 @@ export const isSteerableEntry = (entry: Pick<QueuedPromptEntry, 'attachments' | 
 type QueueState = Record<string, QueuedPromptEntry[]>
 
 const STORAGE_KEY = 'hermes.desktop.composerQueue.v1'
+const QUEUE_ENTRY_TTL_MS = 7 * 24 * 60 * 60 * 1000
+
+const isQueuedPromptEntry = (value: unknown): value is QueuedPromptEntry => {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const entry = value as Partial<QueuedPromptEntry>
+
+  return (
+    typeof entry.id === 'string' &&
+    typeof entry.text === 'string' &&
+    (entry.displayText === undefined || typeof entry.displayText === 'string') &&
+    (entry.displayKind === undefined || entry.displayKind === 'hidden') &&
+    Array.isArray(entry.attachments) &&
+    typeof entry.queuedAt === 'number' &&
+    Number.isFinite(entry.queuedAt)
+  )
+}
+
+export const sanitizePersistedQueueState = (value: unknown, now = Date.now()): QueueState => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {}
+  }
+
+  const cutoff = now - QUEUE_ENTRY_TTL_MS
+  const state: QueueState = {}
+
+  for (const [sessionKey, entries] of Object.entries(value)) {
+    if (!sessionKey.trim() || !Array.isArray(entries)) {
+      continue
+    }
+
+    const liveEntries = entries.filter(
+      (entry): entry is QueuedPromptEntry => isQueuedPromptEntry(entry) && entry.queuedAt >= cutoff
+    )
+
+    if (liveEntries.length > 0) {
+      state[sessionKey] = liveEntries
+    }
+  }
+
+  return state
+}
 
 const load = (): QueueState => {
   if (typeof window === 'undefined') {
@@ -39,8 +83,18 @@ const load = (): QueueState => {
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY)
     const parsed = raw ? JSON.parse(raw) : null
+    const state = sanitizePersistedQueueState(parsed)
+    const sanitized = Object.keys(state).length > 0 ? JSON.stringify(state) : null
 
-    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as QueueState) : {}
+    if (sanitized !== raw) {
+      if (sanitized) {
+        window.localStorage.setItem(STORAGE_KEY, sanitized)
+      } else {
+        window.localStorage.removeItem(STORAGE_KEY)
+      }
+    }
+
+    return state
   } catch {
     return {}
   }


### PR DESCRIPTION
## What does this PR do?

Restores the seven-day expiry and shape validation for persisted Desktop composer queue entries. The working fix from `853a8229e9` was overwritten when `474a7f8b2a` updated `composer-queue.ts` from an older base.

The load path now writes sanitized state back, so stale turns stop retrying after restarts, while preserving the newer `displayKind: hidden` field.

## Verification

- Focused queue tests: 26 passed
- Desktop typecheck and ESLint: passed
- Production Desktop build: passed
- Full Desktop suite: 9,790 passed; 3 unrelated failures reproduced unchanged on `origin/main`
- Independent review: passed
