### PR TITLE
fix(mcp): refuse to overwrite OAuth client with unresolved placeholder (#108253)

### DIFF
--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -934,6 +934,21 @@ def _maybe_preregister_client(storage: "HermesTokenStorage", cfg: dict, client_m
     client_id = cfg.get("client_id")
     if not client_id:
         return
+    # Guard: never persist an unresolved ${VAR} placeholder as client_id
+    # and never discard a valid token on its behalf. A real client_id never
+    # contains a literal "${...}"; the placeholder survives only when the
+    # profile's secret scope was unavailable during interpolation (unified
+    # dashboard serving a secondary profile without its .env scope, #108253).
+    # Keeping the existing .client.json preserves the minted token; the
+    # stale-placeholder session will simply reuse it or fall back to DCR.
+    if isinstance(client_id, str) and "${" in client_id:
+        logger.warning(
+            "MCP OAuth '%s': refusing to overwrite client registration with "
+            "unresolved placeholder client_id %r; keeping existing "
+            "registration and cached token (resolve env interpolation or "
+            "re-run hermes mcp login %s)",
+            storage._server_name, client_id, storage._server_name)
+        return
     info_cls = _sdk_class("OAuthClientInformationFull")
     _invalidate_tokens_on_client_change(storage, client_id, cfg.get("client_secret"))
     info_dict: dict[str, Any] = {


### PR DESCRIPTION
Fixes #108253.

**Problem:** Profile-scoped OAuth MCP servers (e.g. `ha_mcp` with `${HA_MCP_CLIENT_ID}` in `.env`) lose their cached token whenever a session for that profile is opened on the unified dashboard. The dashboard process runs without the target profile's secret scope, so `${VAR}` interpolation keeps the literal placeholder. `_maybe_preregister_client` then writes that literal into `.client.json` and `_invalidate_tokens_on_client_change` deletes the valid token (client_id mismatch).

**Fix:** Guard `_maybe_preregister_client` (tools/mcp_oauth.py) — if `client_id` still contains `${` (unresolved placeholder), log a warning and return without overwriting `.client.json` or invalidating tokens. A real `client_id` never contains a literal `${...}`, so this is a safe invariant. The existing registration and cached token are preserved; the session reuses them.

The broader secret-scope propagation for multiplexed discovery is tracked in #104607 / #104534 / #67605; this guard is the residual non-destructive invariant noted in the issue's code review comment (no open PR covers it).

**Tests:** `tests/tools/test_mcp_oauth*` — 105 passed. Manual verification: placeholder `client_id` is blocked and existing token preserved; real client change still correctly invalidates tokens.