### PR TITLE
fix(config): escalate the drop to DEFAULTS and leave a countable trace

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -93,6 +93,32 @@ def _warn_config_parse_failure(
         pass
 
 
+_CONFIG_DEGRADATION_LOG = "config-degraded.log"
+
+
+def _record_config_degradation(config_path: Path, exc: Exception) -> None:
+    """Record the one config failure that silently drops EVERY user override.
+
+    No last-known-good plus an unreadable config leaves the process on ``DEFAULT_CONFIG``:
+    ``approvals.deny``, the fallback chain and model routing are gone, and nothing else in the
+    system can tell afterwards. Log at ERROR and append a durable line to
+    ``logs/config-degraded.log`` so a monitoring job can count events after log rotation.
+    Best-effort — failing to record must never mask the original failure.
+    """
+    logger.error(
+        "config.yaml unreadable and no last-known-good config in this process: running on "
+        "DEFAULTS without user overrides (approvals.deny, fallback chain, model routing). "
+        "path=%s error=%s", config_path, exc)
+    try:
+        logs_dir = get_hermes_home() / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        with open(logs_dir / _CONFIG_DEGRADATION_LOG, "a", encoding="utf-8") as fh:
+            fh.write(f"{time.strftime('%Y-%m-%dT%H:%M:%S%z')} path={config_path} "
+                     f"{type(exc).__name__}: {exc}\n")
+    except Exception:
+        logger.debug("could not append the config degradation marker", exc_info=True)
+
+
 def get_active_config_parse_failure() -> Optional[str]:
     """Return the recorded parse error while the ACTIVE config.yaml is still byte-identical
     (mtime_ns + size) to the file that failed to parse; else None."""
@@ -2120,6 +2146,7 @@ def _last_known_good_fallback(config_path: Path, path_key: str, cache_sig, exc: 
     _warn_config_parse_failure(
         config_path, exc, fallback="last-known-good" if lkg is not None else "defaults")
     if lkg is None:
+        _record_config_degradation(config_path, exc)
         return None
     # save_config() stores the pre-expansion dict (templates preserved); the load path stores the
     # expanded one. Expand defensively — idempotent when already expanded.

--- a/tests/hermes_cli/test_config_degradation_alert.py
+++ b/tests/hermes_cli/test_config_degradation_alert.py
@@ -1,0 +1,87 @@
+"""A config load that falls back to DEFAULTS must leave a countable trace.
+
+Live evidence (TONY, 2026-09-12): a blocked read dropped the whole user config while the only
+signal was a WARNING naming a YAML problem that did not exist. The mis-wording is fixed; this pins
+the escalation that makes the event unmistakable and countable by monitoring.
+
+Contract:
+
+  1. No last-known-good config in the process + unreadable config.yaml → ERROR record *and* a line
+     in ``logs/config-degraded.log``.
+  2. A last-known-good config keeps serving (the #31188 behaviour) and records no degradation.
+"""
+
+from __future__ import annotations
+
+import builtins
+import errno
+import logging
+
+import pytest
+
+from hermes_cli import config as config_mod
+
+
+@pytest.fixture
+def config_home(tmp_path):
+    """Temp config.yaml plus clean loader state for this path."""
+    path = config_mod.get_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    config_mod._CONFIG_PARSE_FAILURES.clear()
+    config_mod._CONFIG_PARSE_WARNED.clear()
+    config_mod._LOAD_CONFIG_CACHE.clear()
+    config_mod._RAW_CONFIG_CACHE.clear()
+    config_mod._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+    return path
+
+
+def _marker_lines(path) -> list:
+    marker = path.parent / "logs" / "config-degraded.log"
+    return marker.read_text(encoding="utf-8").splitlines() if marker.exists() else []
+
+
+def _deny_config_reads(path, monkeypatch) -> None:
+    real_open = builtins.open
+
+    def denied(file, *args, **kwargs):
+        if str(file) == str(path):
+            raise PermissionError(errno.EACCES, "Permission denied", str(path))
+        return real_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", denied)
+
+
+def _degradation_records(caplog) -> list:
+    return [r for r in caplog.records
+            if r.levelno >= logging.ERROR and "no last-known-good" in r.getMessage()]
+
+
+def test_running_on_defaults_is_recorded_when_there_is_nothing_to_fall_back_to(
+    config_home, monkeypatch, caplog,
+):
+    config_home.write_text("display:\n  skin: usertheme\n", encoding="utf-8")
+    _deny_config_reads(config_home, monkeypatch)
+
+    with caplog.at_level(logging.ERROR):
+        cfg = config_mod.load_config()
+
+    assert cfg["display"]["skin"] != "usertheme", "precondition: defaults really are in effect"
+    assert _degradation_records(caplog), "the drop to DEFAULTS was not escalated"
+    assert _marker_lines(config_home), "monitoring has no countable trace of the degradation"
+
+
+def test_last_known_good_keeps_serving_and_records_no_degradation(
+    config_home, monkeypatch, caplog,
+):
+    config_home.write_text("display:\n  skin: usertheme\n", encoding="utf-8")
+    assert config_mod.load_config()["display"]["skin"] == "usertheme"  # seeds last-known-good
+
+    config_mod._LOAD_CONFIG_CACHE.clear()
+    _deny_config_reads(config_home, monkeypatch)
+
+    with caplog.at_level(logging.ERROR):
+        cfg = config_mod.load_config()
+
+    assert cfg["display"]["skin"] == "usertheme", "the last-known-good config must keep serving"
+    assert not _degradation_records(caplog), "a served last-known-good is not a degradation"
+    assert _marker_lines(config_home) == []


### PR DESCRIPTION
## What

Follow-up to #108980. The `#31188` fallback keeps serving the last-known-good config when a load
fails — but only inside a process that already loaded one. With **no** last-known-good (the case in
the live incident) the load continues on `DEFAULT_CONFIG`: `approvals.deny`, the fallback chain and
model routing are silently gone, and the only signal was a WARNING whose wording pointed at a YAML
problem that did not exist (`Failed to parse … [Errno 13] Permission denied`, on a file that was
byte-identical to the last good one).

## Change

`_record_config_degradation()` — called only from the no-last-known-good branch of
`_last_known_good_fallback`:

- `logger.error` naming exactly what is no longer in effect;
- one appended line in `logs/config-degraded.log`, so an event is countable after log rotation
  (a monitoring job can alert on the increment; there was previously nothing to count).

Best-effort by design: a failure to record never masks the load failure.

## Test

`tests/hermes_cli/test_config_degradation_alert.py` (2 tests, `scripts/run_tests.sh`):

- **RED without this change**: `AssertionError: the drop to DEFAULTS was not escalated`.
- GREEN with it, and the last-known-good path still serves the user's config and records nothing.

Environment: Windows 11, Python 3.11.16, Hermes 0.21.2 (`044a77b3b6`).
