### PR TITLE
fix(desktop): strip invisible Unicode from project names

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/project-dialog.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/project-dialog.test.tsx
@@ -156,4 +156,35 @@ describe('ProjectDialog', () => {
 
     expect(createProject.mock.calls[0]?.[0]).toMatchObject({ dropPlacement: undefined })
   })
+
+  it('strips invisible characters from the name before creating', async () => {
+    const { createProject } = vi.mocked(await import('@/store/projects'))
+
+    vi.mocked(createProject).mockClear()
+    render(<ProjectDialog />)
+    fireEvent.change(screen.getByPlaceholderText('Project name'), { target: { value: 'AttendanceSync\u200cBot' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add folder' }))
+    await screen.findByText('/Users/test/my-folder')
+
+    const create = screen.getByRole('button', { name: 'Create' }) as HTMLButtonElement
+    await waitFor(() => expect(create.disabled).toBe(false))
+    fireEvent.click(create)
+
+    await waitFor(() => expect(createProject).toHaveBeenCalledOnce())
+    expect(createProject.mock.calls[0]?.[0]).toMatchObject({ name: 'AttendanceSyncBot' })
+  })
+
+  it('sanitizes a legacy name prefilled into the rename dialog', async () => {
+    const { renameProject } = vi.mocked(await import('@/store/projects'))
+
+    vi.mocked(renameProject).mockClear()
+    $projectDialog.set({ mode: 'rename', name: 'Old\u200bName', projectId: 'p1' })
+    render(<ProjectDialog />)
+
+    await waitFor(() => expect((screen.getByPlaceholderText('Project name') as HTMLInputElement).value).toBe('OldName'))
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(renameProject).toHaveBeenCalledOnce())
+    expect(renameProject).toHaveBeenCalledWith('p1', 'OldName')
+  })
 })

--- a/apps/desktop/src/app/chat/sidebar/project-dialog.tsx
+++ b/apps/desktop/src/app/chat/sidebar/project-dialog.tsx
@@ -13,11 +13,12 @@ import {
   DialogTitle
 } from '@/components/ui/dialog'
 import { GenerateButton } from '@/components/ui/generate-button'
-import { Input } from '@/components/ui/input'
+import { SanitizedInput } from '@/components/ui/sanitized-input'
 import { Textarea } from '@/components/ui/textarea'
 import { Tip } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { type ProjectIdeaTemplate, randomIdeaTemplates } from '@/lib/project-idea-templates'
+import { projectName } from '@/lib/sanitize'
 import { cn } from '@/lib/utils'
 import { notifyError } from '@/store/notifications'
 import {
@@ -68,7 +69,7 @@ export function ProjectDialog() {
 
   useEffect(() => {
     if (open) {
-      setName(state?.name ?? '')
+      setName(projectName(state?.name ?? ''))
       setFolders([])
       setIdea('')
       setTemplates(randomIdeaTemplates())
@@ -186,10 +187,9 @@ export function ProjectDialog() {
         </DialogHeader>
 
         {mode !== 'add-folder' && (
-          <Input
+          <SanitizedInput
             autoFocus
             disabled={submitting}
-            onChange={event => setName(event.target.value)}
             onKeyDown={event => {
               if (event.key === 'Enter') {
                 event.preventDefault()
@@ -198,8 +198,10 @@ export function ProjectDialog() {
                 onOpenChange(false)
               }
             }}
+            onValueChange={setName}
             placeholder={p.namePlaceholder}
             ref={nameRef}
+            sanitize={projectName}
             value={name}
           />
         )}

--- a/apps/desktop/src/lib/sanitize.test.ts
+++ b/apps/desktop/src/lib/sanitize.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { gitRef, slug } from './sanitize'
+import { gitRef, projectName, slug } from './sanitize'
 
 describe('gitRef', () => {
   it('turns spaces into hyphens and keeps slashes', () => {
@@ -28,5 +28,33 @@ describe('slug', () => {
   it('strips a leading separator but keeps a trailing one while typing', () => {
     expect(slug('--x')).toBe('x')
     expect(slug('work ')).toBe('work-')
+  })
+})
+
+describe('projectName', () => {
+  it('drops zero-width/format characters that silently break name matching', () => {
+    expect(projectName('AttendanceSync\u200cBot')).toBe('AttendanceSyncBot') // ZWNJ
+    expect(projectName('a\u200bb')).toBe('ab') // ZWSP
+    expect(projectName('a\u200db')).toBe('ab') // ZWJ — splits emoji sequences too, by design
+    expect(projectName('a\ufeffb')).toBe('ab') // BOM
+    expect(projectName('a\u00adb')).toBe('ab') // soft hyphen
+    expect(projectName('a\u202eb')).toBe('ab') // RTL override
+  })
+
+  it('drops control characters and the trailing specials block', () => {
+    expect(projectName('a\u0000b')).toBe('ab')
+    expect(projectName('a\u0007b')).toBe('ab')
+    expect(projectName('a\u007fb')).toBe('ab')
+    expect(projectName('a\u2028b')).toBe('ab')
+    expect(projectName('a\ufffbb')).toBe('ab')
+  })
+
+  it('keeps visible text — ASCII, CJK, spaces, emoji — intact', () => {
+    expect(projectName('My 项目 🚀')).toBe('My 项目 🚀')
+    expect(projectName(' plain spaced ')).toBe(' plain spaced ')
+  })
+
+  it('empties an invisible-only name so submit stays disabled', () => {
+    expect(projectName('\u200b\u200c\u200d\ufeff')).toBe('')
   })
 })

--- a/apps/desktop/src/lib/sanitize.ts
+++ b/apps/desktop/src/lib/sanitize.ts
@@ -19,3 +19,14 @@ export const slug = (raw: string): string =>
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+/, '')
+
+// Invisible Unicode that renders as nothing but still lands in projects.db rows
+// and folder names, where it silently breaks string comparison (session
+// routing/grouping) and path matching: control, format (ZWSP/ZWNJ/ZWJ, bidi
+// marks, BOM, soft hyphen), private-use, line/paragraph separators, and the
+// trailing specials block. Surrogates can't occur here — an input's value is a
+// USVString.
+const INVISIBLE = /[\p{Cc}\p{Cf}\p{Co}\p{Zl}\p{Zp}\uFFF0-\uFFFF]/gu
+
+/** A display-safe project name: invisible characters dropped as you type. */
+export const projectName = (raw: string): string => raw.replace(INVISIBLE, '')


### PR DESCRIPTION
## What does this PR do?

A project name containing zero-width/invisible characters (ZWSP `U+200B`, ZWNJ `U+200C`, ZWJ `U+200D`, BOM `U+FEFF`, bidi marks, control bytes, …) renders identically to the clean name but never matches it in string comparison, so sessions silently fail to route or group under the project, and folder-name/path matching breaks — the exact failure mode described in #108982.

This routes the project create/rename dialog's name field through the existing `SanitizedInput` + `lib/sanitize` formatter pattern (the same one the worktree dialog uses with `gitRef`), adding a `projectName` formatter that drops invisible Unicode (categories `Cc`, `Cf`, `Co`, `Zl`, `Zp`, plus the trailing specials block) as you type. The prefilled legacy name is also cleaned when the rename dialog opens, so an already-dirty name gets fixed on the next rename. Visible text — ASCII, CJK, spaces, emoji — is untouched.

## Related Issue

Fixes #108982

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/sanitize.ts` — add `projectName` formatter dropping invisible Unicode categories (`Cc`/`Cf`/`Co`/`Zl`/`Zp` + specials tail)
- `apps/desktop/src/app/chat/sidebar/project-dialog.tsx` — swap the name `<Input>` for `<SanitizedInput sanitize={projectName}>`; clean the prefilled name on dialog open
- `apps/desktop/src/lib/sanitize.test.ts` — unit tests: zero-width/format chars, control chars, specials, visible-text preservation, invisible-only input empties
- `apps/desktop/src/app/chat/sidebar/project-dialog.test.tsx` — dialog tests: ZWNJ-laced create name arrives clean at `createProject`; legacy dirty name is sanitized in the rename prefill

## How to Test

1. `cd apps/desktop && npx vitest run src/lib/sanitize.test.ts src/app/chat/sidebar/project-dialog.test.tsx --project ui` — should pass (16 tests, including the 2 new dialog tests and 4 new formatter tests)
2. `npx tsc -p . --noEmit` — should pass
3. Manual: open the New project dialog, paste `AttendanceSync\u200cBot` (with a ZWNJ) as the name — the field holds `AttendanceSyncBot`, creation succeeds, and sessions route under it (Observed result: formatter strips the char per keystroke; invisible-only names leave the Create button disabled)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A: desktop renderer change only, no Python touched; ran `vitest --project ui` (16 passed) and `tsc -p . --noEmit` (clean) instead
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A: pure JS string handling, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A

## Screenshots / Logs

```
$ npx vitest run src/lib/sanitize.test.ts src/app/chat/sidebar/project-dialog.test.tsx --project ui
 Test Files  2 passed (2)
      Tests  16 passed (16)
```