### PR TITLE
fix(process): stop Windows PTY descendants from surviving kill

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1358,6 +1358,7 @@ class TestKillProcess:
                 raise psutil.AccessDenied(self.pid)
 
         monkeypatch.setattr(ProcessRegistry, "_host_pid_is_ours", lambda *_args: True)
+        monkeypatch.setattr(ProcessRegistry, "_daemon_term_grace_seconds", lambda: 0.0)
         monkeypatch.setattr(psutil, "Process", lambda _pid: _InaccessibleProcess())
         monkeypatch.setattr(
             pr.subprocess,

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1315,6 +1315,73 @@ class TestKillProcess:
         assert s.exited is False
         s._pty.terminate.assert_not_called()
 
+    @pytest.mark.windows_only
+    def test_windows_pty_identity_rejection_retains_session(self, registry, monkeypatch):
+        s = _make_session(sid="proc_windows_pty_identity", command="nested hermes")
+        s.pid = 424242
+        s.host_start_time = 99
+        s._pty = MagicMock()
+        registry._running[s.id] = s
+        monkeypatch.setattr(ProcessRegistry, "_host_pid_is_ours", lambda *_args: False)
+
+        result = registry.kill_process(s.id)
+
+        assert result["status"] == "error"
+        assert "root process is gone or its start time no longer matches" in result["error"]
+        assert registry._running[s.id] is s
+        assert s.id not in registry._finished
+        assert s.exited is False
+        s._pty.terminate.assert_not_called()
+
+    @pytest.mark.windows_only
+    def test_windows_pty_access_denied_retains_session(self, registry, monkeypatch):
+        from tools import process_registry as pr
+        import psutil
+
+        s = _make_session(sid="proc_windows_pty_denied", command="nested hermes")
+        s.pid = 424242
+        s.host_start_time = 99
+        s._pty = MagicMock()
+        registry._running[s.id] = s
+
+        class _InaccessibleProcess:
+            pid = 424242
+
+            def children(self, recursive=False):
+                assert recursive is True
+                return []
+
+            def is_running(self):
+                return True
+
+            def status(self):
+                raise psutil.AccessDenied(self.pid)
+
+        monkeypatch.setattr(ProcessRegistry, "_host_pid_is_ours", lambda *_args: True)
+        monkeypatch.setattr(psutil, "Process", lambda _pid: _InaccessibleProcess())
+        monkeypatch.setattr(
+            pr.subprocess,
+            "run",
+            lambda *_args, **_kwargs: MagicMock(
+                returncode=5, stdout="", stderr="Access is denied."
+            ),
+        )
+        monotonic = iter((0.0, 1.0))
+        monkeypatch.setattr(pr.time, "monotonic", lambda: next(monotonic))
+
+        result = registry.kill_process(s.id)
+
+        assert result["status"] == "error"
+        assert (
+            "liveness could not be verified for owned pids: 424242 (AccessDenied"
+            in result["error"]
+        )
+        assert "taskkill exited 5: Access is denied." in result["error"]
+        assert registry._running[s.id] is s
+        assert s.id not in registry._finished
+        assert s.exited is False
+        s._pty.terminate.assert_not_called()
+
 
 # =========================================================================
 # Tool handler

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1268,6 +1268,53 @@ class TestKillProcess:
         finally:
             registry._running.pop(s.id, None)
 
+    @pytest.mark.windows_only
+    def test_windows_pty_kill_verifies_tree_before_finishing(self, registry, monkeypatch):
+        s = _make_session(sid="proc_windows_pty", command="nested hermes")
+        s.pid = 424242
+        s.host_start_time = 99
+        s._pty = MagicMock()
+        registry._running[s.id] = s
+        calls = []
+
+        monkeypatch.setattr(
+            registry,
+            "_terminate_host_pid",
+            lambda pid, expected_start, *, verify=False: calls.append(
+                (pid, expected_start, verify)
+            ),
+        )
+
+        result = registry.kill_process(s.id)
+
+        assert result["status"] == "killed"
+        assert calls == [(424242, 99, True)]
+        s._pty.terminate.assert_called_once_with(force=True)
+
+    @pytest.mark.windows_only
+    def test_windows_pty_partial_tree_kill_retains_session(self, registry, monkeypatch):
+        s = _make_session(sid="proc_windows_pty", command="nested hermes")
+        s.pid = 424242
+        s.host_start_time = 99
+        s._pty = MagicMock()
+        registry._running[s.id] = s
+
+        monkeypatch.setattr(
+            registry,
+            "_terminate_host_pid",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                RuntimeError("live owned pids: 100, 101")
+            ),
+        )
+
+        result = registry.kill_process(s.id)
+
+        assert result == {"status": "error", "error": "live owned pids: 100, 101"}
+        assert registry._running[s.id] is s
+        assert s.id not in registry._finished
+        assert s.exited is False
+        s._pty.terminate.assert_not_called()
+
 
 # =========================================================================
 # Tool handler

--- a/tests/tools/test_process_registry_windows_live.py
+++ b/tests/tools/test_process_registry_windows_live.py
@@ -14,14 +14,14 @@ thread) — no mocked spawn.
 from __future__ import annotations
 
 import os
+from pathlib import Path
+import shlex
 import sys
 import time
 
 import pytest
 
-pytestmark = pytest.mark.skipif(
-    sys.platform != "win32", reason="live Windows background-executor E2E"
-)
+pytestmark = pytest.mark.windows_only
 
 
 @pytest.fixture()
@@ -46,6 +46,15 @@ def _wait_exit(reg, sid, timeout=60):
             return sess
         time.sleep(0.2)
     raise AssertionError(f"session {sid} did not exit within {timeout}s")
+
+
+def _wait_output(session, marker, timeout=30):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if marker in session.output_buffer:
+            return session.output_buffer
+        time.sleep(0.1)
+    raise AssertionError(f"session {session.id} did not emit {marker!r}: {session.output_buffer!r}")
 
 
 class TestWindowsSpawnParity:
@@ -101,3 +110,29 @@ class TestWindowsSpawnParity:
         result = registry.kill_process(session.id)
         assert result.get("status") in {"killed", "already_exited"}
         assert session.systemd_unit == ""
+
+    def test_kill_process_windows_pty_reaps_owned_tree(self, registry, tmp_path):
+        """The real pywinpty path must not leave descendants below its wrapper."""
+        import psutil
+
+        script = tmp_path / "pty-tree.py"
+        script.write_text(
+            "import os, subprocess, sys, time\n"
+            "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(120)'])\n"
+            "print(f'PTY_TREE_PIDS={os.getpid()},{child.pid}', flush=True)\n"
+            "time.sleep(120)\n",
+            encoding="utf-8",
+        )
+        command = f"{shlex.quote(sys.executable)} {shlex.quote(str(Path(script)))}"
+        session = registry.spawn_local(command, use_pty=True)
+        output = _wait_output(session, "PTY_TREE_PIDS=")
+        payload = output.split("PTY_TREE_PIDS=", 1)[1].splitlines()[0].strip()
+        owned = [psutil.Process(int(pid)) for pid in payload.split(",")]
+
+        result = registry.kill_process(session.id)
+
+        assert result["status"] == "killed"
+        deadline = time.time() + 5
+        while time.time() < deadline and any(registry._proc_alive(proc) for proc in owned):
+            time.sleep(0.1)
+        assert not [proc.pid for proc in owned if registry._proc_alive(proc)]

--- a/tests/tools/test_process_registry_windows_live.py
+++ b/tests/tools/test_process_registry_windows_live.py
@@ -14,7 +14,7 @@ thread) — no mocked spawn.
 from __future__ import annotations
 
 import os
-from pathlib import Path
+import re
 import shlex
 import sys
 import time
@@ -123,11 +123,12 @@ class TestWindowsSpawnParity:
             "time.sleep(120)\n",
             encoding="utf-8",
         )
-        command = f"{shlex.quote(sys.executable)} {shlex.quote(str(Path(script)))}"
+        command = f"{shlex.quote(sys.executable)} {shlex.quote(str(script))}"
         session = registry.spawn_local(command, use_pty=True)
         output = _wait_output(session, "PTY_TREE_PIDS=")
-        payload = output.split("PTY_TREE_PIDS=", 1)[1].splitlines()[0].strip()
-        owned = [psutil.Process(int(pid)) for pid in payload.split(",")]
+        match = re.search(r"PTY_TREE_PIDS=(\d+),(\d+)", output)
+        assert match is not None, output
+        owned = [psutil.Process(int(pid)) for pid in match.groups()]
 
         result = registry.kill_process(session.id)
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -754,7 +754,9 @@ class ProcessRegistry(ProcessCheckpointMixin):
         return ProcessRegistry._config_seconds("daemon_term_grace_seconds", 2.0)
 
     @classmethod
-    def _terminate_host_pid(cls, pid: int, expected_start: Optional[int] = None) -> None:
+    def _terminate_host_pid(
+        cls, pid: int, expected_start: Optional[int] = None, *, verify: bool = False,
+    ) -> None:
         """Terminate a host-visible PID and its descendants.
         ``expected_start`` (kernel start time at spawn) is re-validated first: a mismatch
         or dead PID means the number was recycled onto a stranger and we refuse to touch
@@ -762,7 +764,9 @@ class ProcessRegistry(ProcessCheckpointMixin):
         children before the parent (so trees aren't reparented to init and survive), then
         SIGKILLs survivors after ``terminal.daemon_term_grace_seconds``. Windows:
         ``taskkill /T /F`` (psutil's stale PPID links miss orphans there); ``os.kill``
-        is the fallback."""
+        is the fallback. ``verify`` snapshots the owned Windows tree before termination
+        and raises while any member survives, so callers do not discard retry/diagnostic
+        state after a partial tree kill."""
         if expected_start is not None and not cls._host_pid_is_ours(pid, expected_start):
             logger.warning(
                 "Refusing to terminate host pid %d: start-time mismatch — "
@@ -773,13 +777,40 @@ class ProcessRegistry(ProcessCheckpointMixin):
             with suppress(OSError, ProcessLookupError, PermissionError):
                 os.kill(pid, signal.SIGTERM)
         if _IS_WINDOWS:
+            targets = []
+            if verify:
+                import psutil
+                try:
+                    parent = psutil.Process(pid)
+                    targets = parent.children(recursive=True) + [parent]
+                except (psutil.NoSuchProcess, psutil.AccessDenied, OSError) as exc:
+                    raise RuntimeError(
+                        f"Could not snapshot Windows process tree rooted at pid {pid}: {exc}"
+                    ) from exc
+            result = None
             try:
-                subprocess.run(
+                result = subprocess.run(
                     ["taskkill", "/PID", str(pid), "/T", "/F"], capture_output=True, text=True,
                     encoding='utf-8', errors='replace', timeout=10, creationflags=windows_hide_flags(),
                     stdin=subprocess.DEVNULL)
             except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
                 _sigterm_quietly()
+            if verify:
+                grace = max(cls._daemon_term_grace_seconds(), 0.5)
+                deadline = time.monotonic() + grace
+                survivors = [proc for proc in targets if cls._proc_alive(proc)]
+                while survivors and time.monotonic() < deadline:
+                    time.sleep(0.05)
+                    survivors = [proc for proc in targets if cls._proc_alive(proc)]
+                if survivors:
+                    survivor_pids = ", ".join(str(proc.pid) for proc in survivors)
+                    detail = ""
+                    if result is not None and result.returncode != 0:
+                        detail = f"; taskkill exited {result.returncode}: {(result.stderr or result.stdout).strip()}"
+                    raise RuntimeError(
+                        f"Windows process tree rooted at pid {pid} still has live owned pids: "
+                        f"{survivor_pids}{detail}"
+                    )
             return
         import psutil
         gone = (psutil.NoSuchProcess, psutil.AccessDenied, OSError)
@@ -1761,6 +1792,15 @@ class ProcessRegistry(ProcessCheckpointMixin):
         PID. Returns a final result dict when the kill cannot proceed (recycled/dead
         recovered PID, or no runtime handle), else None."""
         if session._pty:
+            if _IS_WINDOWS and session.pid:
+                # pywinpty's terminate() only tears down the PTY wrapper. Snapshot and
+                # kill its host-visible tree first, then close the now-dead PTY handle.
+                self._terminate_host_pid(
+                    session.pid, session.host_start_time, verify=True,
+                )
+                with suppress(Exception):
+                    session._pty.terminate(force=True)
+                return None
             try:
                 session._pty.terminate(force=True)
             except Exception:

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -731,6 +731,15 @@ class ProcessRegistry(ProcessCheckpointMixin):
             return False
 
     @staticmethod
+    def _proc_alive_strict(proc) -> bool:
+        """Probe liveness without treating an inaccessible process as dead."""
+        import psutil
+        try:
+            return proc.is_running() and proc.status() != psutil.STATUS_ZOMBIE
+        except psutil.NoSuchProcess:
+            return False
+
+    @staticmethod
     def _config_value(section: str, key: str, fallback):
         """``config.yaml`` value for ``section.key``, else the DEFAULT_CONFIG value.
         Raises if config is unreadable; callers wrap with their own hard fallback so
@@ -771,6 +780,11 @@ class ProcessRegistry(ProcessCheckpointMixin):
             logger.warning(
                 "Refusing to terminate host pid %d: start-time mismatch — "
                 "PID was recycled onto an unrelated process.", pid)
+            if verify:
+                raise RuntimeError(
+                    f"Could not verify Windows process tree rooted at pid {pid}: "
+                    "the root process is gone or its start time no longer matches"
+                )
             return
 
         def _sigterm_quietly():
@@ -796,20 +810,44 @@ class ProcessRegistry(ProcessCheckpointMixin):
             except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
                 _sigterm_quietly()
             if verify:
+                def _probe_targets():
+                    survivors = []
+                    inconclusive = []
+                    for proc in targets:
+                        try:
+                            if cls._proc_alive_strict(proc):
+                                survivors.append(proc)
+                        except Exception as exc:
+                            inconclusive.append((proc, exc))
+                    return survivors, inconclusive
+
                 grace = max(cls._daemon_term_grace_seconds(), 0.5)
                 deadline = time.monotonic() + grace
-                survivors = [proc for proc in targets if cls._proc_alive(proc)]
-                while survivors and time.monotonic() < deadline:
+                survivors, inconclusive = _probe_targets()
+                while (survivors or inconclusive) and time.monotonic() < deadline:
                     time.sleep(0.05)
-                    survivors = [proc for proc in targets if cls._proc_alive(proc)]
-                if survivors:
+                    survivors, inconclusive = _probe_targets()
+                if survivors or inconclusive:
                     survivor_pids = ", ".join(str(proc.pid) for proc in survivors)
-                    detail = ""
-                    if result is not None and result.returncode != 0:
-                        detail = f"; taskkill exited {result.returncode}: {(result.stderr or result.stdout).strip()}"
+                    failures = []
+                    if survivors:
+                        failures.append(f"live owned pids: {survivor_pids}")
+                    if inconclusive:
+                        inaccessible = ", ".join(
+                            f"{proc.pid} ({type(exc).__name__}: {exc})"
+                            for proc, exc in inconclusive
+                        )
+                        failures.append(
+                            f"liveness could not be verified for owned pids: {inaccessible}"
+                        )
+                    if result is not None:
+                        failures.append(
+                            f"taskkill exited {result.returncode}: "
+                            f"{(result.stderr or result.stdout).strip()}"
+                        )
                     raise RuntimeError(
-                        f"Windows process tree rooted at pid {pid} still has live owned pids: "
-                        f"{survivor_pids}{detail}"
+                        f"Windows process tree rooted at pid {pid} was not verified terminated; "
+                        + "; ".join(failures)
                     )
             return
         import psutil


### PR DESCRIPTION
## What does this PR do?

Windows background PTY sessions now terminate and verify their full owned process tree before `process_manage` reports success. If any snapshotted descendant survives, the kill returns a diagnostic error and keeps the session in the running registry instead of making the leaked process tree unmanageable.

### Symptom

On native Windows, killing a background PTY can return `status: "killed"` and remove the session from `processes.json` while descendants below the PTY wrapper remain alive.

### Impact

Users can accumulate running bash, Python, and Node descendants that Hermes no longer exposes through `process_manage`, requiring manual OS-level cleanup.

### Bug Cause

**Trigger:** `tools/process_registry.py:1763` / `ProcessRegistry._signal_kill`

**Causal chain:**
1. A user starts a local background command with `pty=true` on Windows.
2. The explicit kill path calls only pywinpty's `terminate(force=True)`, which terminates the PTY wrapper without proving that its descendants exited.
3. `kill_process` unconditionally marks the session killed and moves it to the finished registry, even when descendants survive.

**Why it is wrong:** PTY teardown was treated as equivalent to an owned process-tree kill, and the success path had no post-termination ownership verification.

**Working sibling / contrast:** The non-PTY local process path already calls `_terminate_host_pid`, whose Windows implementation uses `taskkill /T /F` against the host-visible root PID.

**Ruled out:** The existing Popen Job Object work in PR #69076 does not cover this path because pywinpty bypasses Python's `subprocess.Popen` spawn mechanism.

### Fix

- Route native Windows PTY kills through the existing identity-checked host tree terminator before closing the PTY handle.
- Snapshot the owned tree with psutil and verify each original process identity is gone after `taskkill /T /F`.
- Raise a diagnostic error listing surviving owned PIDs so `kill_process` retains the running session instead of publishing false success.
- Add unit contracts for PTY routing and failure retention plus a real Windows pywinpty parent/child integration test.

## Related Issue

Closes #108987

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/process_registry.py` - tree-kill and verify native Windows PTY sessions before marking them finished.
- `tests/tools/test_process_registry.py` - cover verified routing and registry retention after partial failure.
- `tests/tools/test_process_registry_windows_live.py` - exercise a real Windows PTY process tree and assert all owned PIDs exit.

## How to Test

1. Run the focused process-registry unit tests.
2. Run the Windows-native process-registry integration file.
3. Start a nested background PTY command, kill it through `process_manage`, and confirm its snapshotted descendants are gone.

```bash
scripts/run_tests.sh tests/tools/test_process_registry.py
scripts/run_tests.sh tests/tools/test_process_registry_windows_live.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

N/A
