### PR TITLE
fix(memory/openviking): run background workers in the spawner's context

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -22,6 +22,7 @@ import socket
 import stat
 import subprocess
 import tempfile
+import contextvars
 import threading
 import time
 import uuid
@@ -1316,9 +1317,12 @@ class OpenVikingMemoryProvider(MemoryProvider):
         # Caller holds _runtime_start_lock and reserved ownership via _runtime_start_pending.
         if self._runtime_start_thread and self._runtime_start_thread.is_alive():
             return
+        from functools import partial
         self._runtime_start_thread = threading.Thread(
-            target=self._finish_runtime_openviking_start, daemon=True, name="openviking-runtime-start",
-            kwargs={"endpoint": endpoint, "status_callback": status_callback, "warning_callback": warning_callback})
+            target=contextvars.copy_context().run,
+            args=(partial(self._finish_runtime_openviking_start, endpoint=endpoint,
+                          status_callback=status_callback, warning_callback=warning_callback),),
+            daemon=True, name="openviking-runtime-start")
         self._runtime_start_thread.start()
 
     def _settings_tuple(self, endpoint: Optional[str] = None) -> tuple:
@@ -2078,7 +2082,13 @@ class OpenVikingMemoryProvider(MemoryProvider):
                     if after_discard is not None:
                         after_discard()
 
-        thread = threading.Thread(target=_run, daemon=True, name=name)
+        # Threads start with an EMPTY Context, but profile isolation IS contextvars: the
+        # HERMES_HOME override and the per-turn secret scope. Unbound, a worker that resolves
+        # anything through get_secret hits the fail-closed path (UnscopedSecretError) under
+        # gateway.multiplex_profiles and the turn is lost to a logger.warning. Same rule as
+        # hindsight's _context_thread (#93028) and MemoryManager._ctx_bound.
+        thread = threading.Thread(target=contextvars.copy_context().run, args=(_run,),
+                                  daemon=True, name=name)
         with lock:
             if skip_if is not None and skip_if():
                 return

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1905,3 +1905,89 @@ class TestOpenVikingEnvWriter:
         assert env.read_text(encoding="utf-8").splitlines() == [
             "A=1", "OPENAI_API_KEY=new", "B=2",
         ]
+
+
+class TestWorkerThreadProfileContext:
+    """Background workers must run in a snapshot of the spawner's contextvars.
+
+    Profile isolation IS contextvars — the HERMES_HOME override and the per-turn secret scope.
+    A thread started bare begins with an EMPTY Context, so anything the worker resolves through
+    ``get_secret`` takes the fail-closed path under ``gateway.multiplex_profiles`` and the turn's
+    memory is lost to a ``logger.warning``. Same rule as hindsight's ``_context_thread`` (#93028)
+    and ``MemoryManager._ctx_bound``.
+    """
+
+    @staticmethod
+    def _run_worker(provider_cls, body):
+        import threading
+
+        lock, workers = threading.Lock(), set()
+        provider = provider_cls.__new__(provider_cls)
+        provider_cls._spawn_tracked(provider, "openviking-sync", body, lock, lambda: workers)
+        for thread in list(workers):
+            thread.join(5)
+
+    def test_a_worker_resolves_identity_under_a_multiplexed_secondary_profile(self, monkeypatch, tmp_path):
+        import plugins.memory.openviking as ov
+        from agent import secret_scope
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("OPENVIKING_ACCOUNT", "acct-default")  # the DEFAULT profile's value
+        monkeypatch.setenv("OPENVIKING_USER", "user-default")
+
+        box = {}
+
+        def body():
+            try:
+                client = ov._VikingClient("http://ov.local", "key", account="", user="", agent=None)
+                box["account"], box["user"] = client._account, client._user
+            except BaseException as exc:  # noqa: BLE001 - the failure under test
+                box["error"] = f"{type(exc).__name__}"
+
+        secret_scope.set_multiplex_active(True)
+        token = secret_scope.set_secret_scope({"OPENVIKING_API_KEY": "key-b"})  # no ACCOUNT/USER/AGENT
+        try:
+            self._run_worker(ov.OpenVikingMemoryProvider, body)
+        finally:
+            secret_scope.reset_secret_scope(token)
+            secret_scope.set_multiplex_active(False)
+
+        assert "error" not in box, f"worker raised {box.get('error')} — it ran with an empty Context"
+        # The scope defines neither, so the provider's own defaults apply — never the default
+        # profile's os.environ values.
+        assert (box["account"], box["user"]) == ("default", "default")
+
+    def test_a_worker_sees_the_spawner_secret_scope(self, monkeypatch, tmp_path):
+        import plugins.memory.openviking as ov
+        from agent import secret_scope
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("OPENVIKING_ACCOUNT", "acct-default")
+        box = {}
+
+        def body():
+            box["value"] = ov.get_secret("OPENVIKING_ACCOUNT", "")
+
+        secret_scope.set_multiplex_active(True)
+        token = secret_scope.set_secret_scope({"OPENVIKING_ACCOUNT": "acct-b"})
+        try:
+            self._run_worker(ov.OpenVikingMemoryProvider, body)
+        finally:
+            secret_scope.reset_secret_scope(token)
+            secret_scope.set_multiplex_active(False)
+
+        assert box.get("value") == "acct-b"
+
+    def test_single_profile_workers_are_unaffected(self, monkeypatch, tmp_path):
+        """No multiplexing: os.environ IS this profile's own env and must still be read."""
+        import plugins.memory.openviking as ov
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("OPENVIKING_ACCOUNT", "solo-account")
+        box = {}
+
+        def body():
+            box["value"] = ov.get_secret("OPENVIKING_ACCOUNT", "")
+
+        self._run_worker(ov.OpenVikingMemoryProvider, body)
+        assert box.get("value") == "solo-account"


### PR DESCRIPTION
## What does this PR do?

`_spawn_tracked` started every OpenViking background worker as a bare thread:

```python
thread = threading.Thread(target=_run, daemon=True, name=name)
```

Threads begin with an **empty** `Context`, and profile isolation in Hermes *is* contextvars — the
`HERMES_HOME` override plus the per-turn secret scope. So the worker ran unscoped, and under
`gateway.multiplex_profiles` `get_secret` is fail-closed:

```
caller thread, scope installed            : account='default'          <- correct
worker, _spawn_tracked shape (unbound)    : UnscopedSecretError: get_secret('OPENVIKING_ACCOUNT') ...
worker, bound with copy_context()         : account='default' user='default'
worker unbound, snapshot carries values   : account='acct-b' user='user-b'   <- why it is intermittent
```

The path is `_TurnUpload.run` → `provider._new_client()` (`:1510-1515`) → `_VikingClient.__init__`
(`:243-245`), where `account` / `user` / `agent` fall back to `get_secret` when the connection
snapshot doesn't carry them — exactly the multiplexed secondary-profile shape
`tests/plugins/memory/test_multiplex_memory_identity_scope.py` already pins as `("", "", "")`.
`run()` catches, retries, catches again, and ends at `logger.warning("OpenViking sync_turn failed")`:
the turn's memory is dropped silently, and recall for that profile stays empty because nothing was
ever written. The deferred-commit, memory-write and owner-recovery workers use the same spawn, as
does `_start_runtime_openviking_waiter`.

### The fix

Both spawn sites run their body through `contextvars.copy_context().run`, matching hindsight's
`_context_thread` (#93028) and `MemoryManager._ctx_bound`. OpenViking was the last memory provider
spawning unbound.

**`copy_context()` is evaluated on the spawning thread.** Writing
`target=lambda: contextvars.copy_context().run(_run)` copies the *worker's* own empty context and
fixes nothing — I wrote that variant first and it still raised, so it is pinned by a sabotage test.

Single-profile deployments are unchanged: with no scope installed `get_secret` still reads the
process env, where the value IS this profile's own.

## Related Issue

Fixes #108995

Independent of #83647 ("bind identity to the initialized profile"), which does not touch the thread
spawn, `copy_context`, or those three `get_secret` defaults — the two compose.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/openviking/__init__.py` — `import contextvars`; `_spawn_tracked` and
  `_start_runtime_openviking_waiter` run their target through `contextvars.copy_context().run`, with
  a comment naming the rule and the two precedents.
- `tests/plugins/memory/test_openviking_provider.py::TestWorkerThreadProfileContext` — three tests
  driving the **real** `_spawn_tracked`: a worker under a multiplexed secondary profile resolves to
  the provider's own defaults instead of raising; a worker sees the spawner's scope
  (`OPENVIKING_ACCOUNT` → `acct-b`, not the default profile's `acct-default`); and a single-profile
  worker still reads the process env.

## How to Test

1. `pytest tests/plugins/memory/test_openviking_provider.py -q` → **68 passed**.
2. Reproduce on `main`: install a scope with only `OPENVIKING_API_KEY`, multiplex on, and run a body
   through `_spawn_tracked` that builds `_VikingClient(endpoint, key, account="", user="", agent=None)`
   — the worker raises `UnscopedSecretError`. With this change it returns `account='default'`.
3. Neighbouring suites, one file at a time — `tests/openviking_plugin/test_openviking.py`,
   `tests/plugins/memory/test_openviking_shutdown.py`, `test_openviking_optional_peer.py`,
   `test_openviking_endpoint_always_blocked.py`, `test_multiplex_memory_identity_scope.py`,
   `tests/agent/test_secret_scope.py` → **190 passed, 1 skipped** in total with the file above.
4. `scripts/check-windows-footguns.py --all` → clean (1537 files).

Sabotage-checked:

| Sabotage | Result |
| --- | --- |
| `_spawn_tracked` back to a bare thread (the bug) | 2 fail |
| `copy_context()` evaluated **inside** the worker (the subtle wrong fix) | 2 fail |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate — "openviking background thread
      UnscopedSecretError contextvars" returns only hindsight's #93028; #83647 touches this file but
      not the spawn sites or those `get_secret` defaults.
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the affected and neighbouring suites (above) rather than the full tree.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6 (Darwin 25.6.0), Apple Silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the comment at the spawn states the rule, the failure it
      prevents, and that `copy_context()` must be evaluated on the spawning thread
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — contextvars only, no platform branch
