### PR TITLE
fix(web): dedupe mobile dictation input

### DIFF
--- a/web/src/lib/pty-composition.test.ts
+++ b/web/src/lib/pty-composition.test.ts
@@ -160,6 +160,32 @@ describe("createPtyCompositionForwarder", () => {
     expect(send).not.toHaveBeenCalled();
   });
 
+  it("deduplicates native beforeinput text when xterm data arrived first", () => {
+    vi.useFakeTimers();
+    const send = vi.fn();
+    const forwarder = createPtyCompositionForwarder(send);
+
+    forwarder.noteTerminalData("hello from ");
+    forwarder.noteTerminalData("dictation");
+    forwarder.onBeforeInput("insertText", "hello from dictation", true);
+    vi.runAllTimers();
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("keeps the fallback when earlier xterm data is stale", () => {
+    vi.useFakeTimers();
+    const send = vi.fn();
+    const forwarder = createPtyCompositionForwarder(send);
+
+    forwarder.noteTerminalData("hello from dictation");
+    vi.advanceTimersByTime(32);
+    forwarder.onBeforeInput("insertText", "hello from dictation", true);
+    vi.runAllTimers();
+
+    expect(send).toHaveBeenCalledExactlyOnceWith("hello from dictation");
+  });
+
   it("ignores interim and replacement beforeinput events as fallback commits", () => {
     vi.useFakeTimers();
     const send = vi.fn();

--- a/web/src/lib/pty-composition.test.ts
+++ b/web/src/lib/pty-composition.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { createPtyCompositionForwarder } from "./pty-composition";
+import {
+  createPtyCompositionForwarder,
+  shouldForwardPtyBeforeInputCommit,
+} from "./pty-composition";
 
 describe("createPtyCompositionForwarder", () => {
   afterEach(() => vi.useRealTimers());
@@ -131,5 +134,81 @@ describe("createPtyCompositionForwarder", () => {
     vi.runAllTimers();
 
     expect(send).not.toHaveBeenCalled();
+  });
+
+  it("forwards iOS dictation beforeinput text when xterm emits no onData", () => {
+    vi.useFakeTimers();
+    const send = vi.fn();
+    const forwarder = createPtyCompositionForwarder(send);
+
+    forwarder.onBeforeInput("insertText", "hello from dictation", true);
+    vi.runAllTimers();
+
+    expect(send).toHaveBeenCalledExactlyOnceWith("hello from dictation");
+  });
+
+  it("deduplicates native beforeinput text when xterm emits the same commit", () => {
+    vi.useFakeTimers();
+    const send = vi.fn();
+    const forwarder = createPtyCompositionForwarder(send);
+
+    forwarder.onBeforeInput("insertText", "hello from dictation", true);
+    forwarder.noteTerminalData("hello from ");
+    forwarder.noteTerminalData("dictation");
+    vi.runAllTimers();
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("ignores interim and replacement beforeinput events as fallback commits", () => {
+    vi.useFakeTimers();
+    const send = vi.fn();
+    const forwarder = createPtyCompositionForwarder(send);
+
+    forwarder.onBeforeInput("insertCompositionText", "partial", true);
+    forwarder.onBeforeInput("insertReplacementText", "replacement", true);
+    vi.runAllTimers();
+
+    expect(send).not.toHaveBeenCalled();
+  });
+});
+
+describe("shouldForwardPtyBeforeInputCommit", () => {
+  it("recognizes final composition and mobile dictation-like insertions", () => {
+    expect(
+      shouldForwardPtyBeforeInputCommit(
+        "insertFromComposition",
+        "こんにちは",
+        false,
+      ),
+    ).toBe(true);
+    expect(shouldForwardPtyBeforeInputCommit("insertText", "hello", true)).toBe(
+      true,
+    );
+  });
+
+  it("rejects empty, interim, replacement, and desktop plain insertions", () => {
+    expect(
+      shouldForwardPtyBeforeInputCommit("insertFromComposition", "", true),
+    ).toBe(false);
+    expect(
+      shouldForwardPtyBeforeInputCommit(
+        "insertCompositionText",
+        "hello",
+        true,
+      ),
+    ).toBe(false);
+    expect(
+      shouldForwardPtyBeforeInputCommit("insertReplacementText", "hello", true),
+    ).toBe(false);
+    expect(shouldForwardPtyBeforeInputCommit("insertText", "h", true)).toBe(
+      false,
+    );
+    expect(shouldForwardPtyBeforeInputCommit("insertText", "hello", false)).toBe(
+      false,
+    );
+    expect(shouldForwardPtyBeforeInputCommit("insertFromPaste", "hello", true)).toBe(
+      false,
+    );
   });
 });

--- a/web/src/lib/pty-composition.ts
+++ b/web/src/lib/pty-composition.ts
@@ -2,7 +2,8 @@
  * Delays an IME/dead-key commit just long enough for xterm to emit onData.
  *
  * xterm is authoritative when it emits the commit. Browsers/layouts where it
- * does not emit onData still forward the compositionend text on the next turn.
+ * does not emit onData still forward the native beforeinput/composition commit
+ * on the next turn.
  */
 export function createPtyCompositionForwarder(send: (data: string) => void) {
   let pending: string | null = null;
@@ -20,19 +21,33 @@ export function createPtyCompositionForwarder(send: (data: string) => void) {
     }
   };
 
-  return {
-    onCompositionEnd(data: string | null) {
-      if (!data) return;
-      // Preserve rapid consecutive commits instead of discarding the first.
-      const previous = pending;
+  const scheduleCommit = (data: string | null | undefined) => {
+    if (!data) return;
+    // Preserve rapid consecutive commits instead of discarding the first.
+    const previous = pending;
+    clearPending();
+    if (previous) send(previous);
+    pending = data;
+    timer = setTimeout(() => {
+      const committed = pending;
       clearPending();
-      if (previous) send(previous);
-      pending = data;
-      timer = setTimeout(() => {
-        const committed = pending;
-        clearPending();
-        if (committed) send(committed);
-      }, 16);
+      if (committed) send(committed);
+    }, 16);
+  };
+
+  return {
+    onBeforeInput(
+      inputType: string | undefined,
+      data: string | null | undefined,
+      isMobileLike: boolean,
+    ) {
+      if (!shouldForwardPtyBeforeInputCommit(inputType, data, isMobileLike)) {
+        return;
+      }
+      scheduleCommit(data);
+    },
+    onCompositionEnd(data: string | null) {
+      scheduleCommit(data);
     },
     noteTerminalData(data: string) {
       if (!pending || data.startsWith("\x1b") || sawUnrelatedTerminalData) return;
@@ -51,4 +66,16 @@ export function createPtyCompositionForwarder(send: (data: string) => void) {
     },
     dispose: clearPending,
   };
+}
+
+export function shouldForwardPtyBeforeInputCommit(
+  inputType: string | undefined,
+  data: string | null | undefined,
+  isMobileLike: boolean,
+): boolean {
+  if (!data) return false;
+  if (inputType === "insertFromComposition") return true;
+  return (
+    isMobileLike && inputType === "insertText" && Array.from(data).length > 1
+  );
 }

--- a/web/src/lib/pty-composition.ts
+++ b/web/src/lib/pty-composition.ts
@@ -10,6 +10,8 @@ export function createPtyCompositionForwarder(send: (data: string) => void) {
   let timer: ReturnType<typeof setTimeout> | null = null;
   let matchedTerminalPrefix = "";
   let sawUnrelatedTerminalData = false;
+  let recentTerminalData = "";
+  let recentTerminalTimer: ReturnType<typeof setTimeout> | null = null;
 
   const clearPending = () => {
     pending = null;
@@ -21,8 +23,31 @@ export function createPtyCompositionForwarder(send: (data: string) => void) {
     }
   };
 
+  const clearRecentTerminalData = () => {
+    recentTerminalData = "";
+    if (recentTerminalTimer) {
+      clearTimeout(recentTerminalTimer);
+      recentTerminalTimer = null;
+    }
+  };
+
+  const rememberTerminalData = (data: string) => {
+    if (data.startsWith("\x1b")) return;
+    recentTerminalData += data;
+    if (recentTerminalData.length > 512) {
+      recentTerminalData = recentTerminalData.slice(-512);
+    }
+    if (recentTerminalTimer) clearTimeout(recentTerminalTimer);
+    recentTerminalTimer = setTimeout(clearRecentTerminalData, 32);
+  };
+
   const scheduleCommit = (data: string | null | undefined) => {
     if (!data) return;
+    if (recentTerminalData.endsWith(data)) {
+      clearPending();
+      clearRecentTerminalData();
+      return;
+    }
     // Preserve rapid consecutive commits instead of discarding the first.
     const previous = pending;
     clearPending();
@@ -50,6 +75,7 @@ export function createPtyCompositionForwarder(send: (data: string) => void) {
       scheduleCommit(data);
     },
     noteTerminalData(data: string) {
+      rememberTerminalData(data);
       if (!pending || data.startsWith("\x1b") || sawUnrelatedTerminalData) return;
 
       // xterm may split committed text across callbacks, but only a clean,
@@ -64,7 +90,10 @@ export function createPtyCompositionForwarder(send: (data: string) => void) {
         sawUnrelatedTerminalData = true;
       }
     },
-    dispose: clearPending,
+    dispose() {
+      clearPending();
+      clearRecentTerminalData();
+    },
   };
 }
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -869,6 +869,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent);
       const markReplacementInput = (ev: Event) => {
         const input = ev as InputEvent;
+        compositionForwarder.onBeforeInput(
+          input.inputType,
+          input.data,
+          isMobileLike,
+        );
         if (
           shouldTreatInputAsMobileReplacement(
             input.inputType,


### PR DESCRIPTION
Summary
On iPhone Safari, dashboard TUI dictation can commit final phrases through native `beforeinput` events without xterm reliably emitting matching `onData`, leaving the PTY input path to receive malformed or repeated fragments. This change routes final native composition/dictation commits through the existing delayed composition fallback and cancels that fallback whether xterm emits the same text before or after the native commit event, so each dictated phrase reaches the PTY once.

Changes
- `web/src/lib/pty-composition.ts`: Adds a native beforeinput commit predicate, remembers a short window of recent xterm data, and forwards accepted commits through the existing delayed/deduped composition path only when xterm has not already sent the same text.
- `web/src/pages/ChatPage.tsx`: Wires the xterm hidden textarea beforeinput listener into the composition forwarder while preserving mobile replacement tracking.
- `web/src/lib/pty-composition.test.ts`: Adds regression tests covering dictation fallback forwarding, duplicate suppression in both event orderings, stale recent-data expiry, interim/replacement rejection, and predicate boundaries.

How to Test
```bash
npm --workspace web test -- --run src/lib/pty-composition.test.ts
# ✅ 17/17 passed

npm --workspace web test -- --run src/pages/ChatPage.test.tsx src/lib/pty-mobile-input.test.ts src/lib/pty-composition.test.ts
# ✅ 34/34 passed

npm --workspace web run typecheck
# ✅ passed

npx eslint src/lib/pty-composition.ts src/lib/pty-composition.test.ts src/pages/ChatPage.tsx
# ✅ passed with existing ChatPage warnings only
```

Checklist
- [x] Tests pass — 34/34 targeted Vitest tests
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed (Linux / macOS / WSL2 / Windows / Termux)
- [x] profile-safe paths used — no hardcoded `~/.hermes`
- [x] `.env` not used for non-credential settings (behavioral settings → `config.yaml`)

Risk & Impact
Low. The change is limited to the dashboard browser input fallback and keeps xterm `onData` authoritative when it emits the committed text.

Type: Bug fix
Closes #108916
