### PR TITLE
fix(retry): key Z.AI coding-plan overload policy on the GLM-5 family prefix

### DIFF
--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -86,13 +86,24 @@ def _error_text(error: Any) -> str:
 
 
 def is_zai_coding_overload_error(*, base_url: str | None, model: str | None, error: Any) -> bool:
-    """True only for the narrow Z.AI Coding Plan overload shape (429 + code
-    1305 / "temporarily overloaded"), so ordinary quota 429s still fail fast."""
+    """Return True for Z.AI Coding Plan transient overload 429s.
+
+    The coding-plan endpoint reports overload as HTTP 429 with body code 1305
+    and message "The service may be temporarily overloaded...". Treat only
+    that narrow shape specially so ordinary quota/billing 429s still fail fast
+    through the existing classifier.
+
+    Matches the GLM-5 family by prefix (glm-5.2, glm-5.3, ...) so a new
+    coding-plan model release does not silently drop the overload policy.
+    """
+    base = (base_url or "").lower()
+    model_name = (model or "").lower()
+    status = getattr(error, "status_code", None)
     text = _error_text(error)
     return (
-        getattr(error, "status_code", None) == 429
-        and "api.z.ai/api/coding/paas/v4" in (base_url or "").lower()
-        and "glm-5.2" in (model or "").lower()
+        status == 429
+        and "api.z.ai/api/coding/paas/v4" in base
+        and ("glm-5." in model_name or "glm-5-" in model_name)
         and ("1305" in text or "temporarily overloaded" in text)
     )
 

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -169,6 +169,37 @@ def test_zai_overload_ceiling_makes_long_tier_reachable(monkeypatch):
     assert long_waits == [30.0, 60.0, 90.0, 120.0]
 
 
+def test_zai_overload_policy_covers_glm5_family():
+    """The overload schedule keys on the GLM-5 family prefix, not one pinned
+    slug: a new coding-plan release (glm-5.3 and later) must keep reaching the
+    long-backoff tier while ordinary quota 429s still fail fast."""
+    err = _zai_overload_error()
+    # Attempt 4 sits in the long-backoff tier (short tier covers the first
+    # attempts; proven by test_zai_overload_ceiling_makes_long_tier_reachable).
+    for model in ("glm-5.2", "glm-5.3-flash", "GLM-5.6"):
+        _wait, policy = adaptive_rate_limit_backoff(
+            4,
+            base_url="https://api.z.ai/api/coding/paas/v4",
+            model=model,
+            error=err,
+            default_wait=1.0,
+        )
+        assert policy == "zai_coding_overload_long", model
+    # A quota/billing 429 without the overload body is NOT the overload shape.
+    quota = SimpleNamespace(
+        status_code=429,
+        body={"error": {"code": "1113", "message": "free quota exceeded"}},
+    )
+    _wait, policy = adaptive_rate_limit_backoff(
+        4,
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        model="glm-5.3-flash",
+        error=quota,
+        default_wait=1.0,
+    )
+    assert policy != "zai_coding_overload_long"
+
+
 # ---------------------------------------------------------------------------
 # parse_retry_after_seconds — shared Retry-After parser
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The Z.AI Coding Plan endpoint reports transient overload as HTTP 429 with body code `1305` / "temporarily overloaded". The detector in `is_zai_coding_overload_error()` pinned the model check to `glm-5.2`, so a newer coding-plan release (we hit this on `glm-5.3-flash`) silently lost the extended 30/60/90/120s backoff schedule and fell back to the short-retry path while the platform was actually overloaded — hammering the same overloaded window.

This PR keys the family by prefix (`glm-5.` / `glm-5-`) so future slugs keep the policy, while ordinary quota/billing 429s still fail fast through the existing classifier (unchanged).

## Testing

- New invariant test `test_zai_overload_policy_covers_glm5_family`:
  - family coverage: `glm-5.2`, `glm-5.3-flash`, `GLM-5.6` all reach the `zai_coding_overload_long` tier (RED on `main` — `glm-5.3-flash` got the short tier),
  - negative contract: a quota/billing 429 (non-overload body) does **not** take the overload schedule.
- Full file: `scripts/run_tests.sh tests/test_retry_utils.py` → 12 passed, 0 failed.
