### PR TITLE
fix(search): accept a confirmed rg exit when the macOS process group is already gone

### DIFF
--- a/tests/tools/test_search_native_rg.py
+++ b/tests/tools/test_search_native_rg.py
@@ -112,3 +112,39 @@ def test_kill_switch_routes_search_back_to_the_shell(tree, ops_factory, monkeypa
     assert result.total_count == 4
     assert any(c.startswith("test -e") for c in calls)
     assert any("pipefail" in c and "rg" in c for c in calls)
+
+
+@pytest.mark.parametrize("child_exits", [True, False])
+def test_native_search_cleanup_permission_race(tree, ops_factory, monkeypatch, child_exits):
+    """An exited rg must not lose its results; a live child must not be reported stopped."""
+    import shlex
+    from tools.environments import local
+
+    real_cleanup = local._kill_process_group_posix
+    children = []
+
+    def denied_cleanup(proc):
+        children.append(proc)
+        if child_exits:
+            proc.wait(timeout=3)
+        raise PermissionError("process group disappeared during cleanup")
+
+    monkeypatch.setattr(local, "_kill_process_group_posix", denied_cleanup)
+    delay = 0.2 if child_exits else 30
+    command = "import time; print('needle', flush=True); time.sleep(%s)" % delay
+    ops = ops_factory(tree, [])
+    try:
+        if child_exits:
+            result = ops._run_rg_native([shlex.quote(sys.executable), "-c", shlex.quote(command)], 1, timeout=3)
+            assert result.exit_code == 0
+            assert result.stdout == "needle\n"
+        else:
+            with pytest.raises(PermissionError):
+                ops._run_rg_native([shlex.quote(sys.executable), "-c", shlex.quote(command)], 1, timeout=3)
+        assert children
+    finally:
+        for proc in children:
+            if proc.poll() is None:
+                real_cleanup(proc)
+            if proc.stdout is not None:
+                proc.stdout.close()

--- a/tools/file_operations_search.py
+++ b/tools/file_operations_search.py
@@ -371,7 +371,15 @@ class SearchMixin:
                 exit_code = 124
                 break
         if proc.poll() is None:
-            _kill_process_group_posix(proc)  # native lane is POSIX-only (gate above)
+            try:
+                _kill_process_group_posix(proc)  # native lane is POSIX-only (gate above)
+            except PermissionError as exc:
+                # macOS can reject a group signal while a short-lived rg exits.
+                # Accept only a confirmed exit; a child we cannot stop is still an error.
+                try:
+                    proc.wait(timeout=0.2)
+                except subprocess.TimeoutExpired:
+                    raise exc
         proc.wait()
         drainer.join()
         proc.stdout.close()


### PR DESCRIPTION
## Summary

On macOS, a short-lived `rg` can exit between ripgrep's own process-group cleanup and our `_kill_process_group_posix()` signal. The kernel then rejects the group signal with `PermissionError` even though nothing is wrong — the child we were about to reap is already gone. The native search lane raised that `PermissionError` and returned **zero results** instead of matches.

This PR catches the `PermissionError` and accepts it only after confirming the process actually exited within a short grace window (`proc.wait(timeout=0.2)`); if the child is somehow still alive, the original error is re-raised.

## Testing

- `scripts/run_tests.sh tests/tools/test_search_native_rg.py` → 5 passed, 0 failed with the fix; the existing race-window regression test fails on `main` without it (RED/GREEN proven locally).
- Branch is a clean cherry-pick of our fork's fix onto upstream `main` at `eec131b716`.
