### PR TITLE
fix(checkpoints): canonicalize the home-directory guard against macOS /tmp aliasing

### DIFF
--- a/tests/tools/test_checkpoint_home_guard.py
+++ b/tests/tools/test_checkpoint_home_guard.py
@@ -1,0 +1,42 @@
+import pytest
+
+from tools import checkpoint_manager as checkpoints
+
+
+def test_ensure_checkpoint_refuses_home_through_symlink_alias(tmp_path, monkeypatch):
+    """HOME itself is never a snapshot root — even when it resolves through a
+    symlink alias (macOS /tmp -> /private/tmp) that makes the raw home string
+    differ from its canonical form, which let the old string guard pass and
+    snapshot the whole home directory."""
+    real_home = tmp_path / "realhome"
+    real_home.mkdir()
+    alias = tmp_path / "home-alias"
+    alias.symlink_to(real_home)
+    monkeypatch.setattr(checkpoints.Path, "home", staticmethod(lambda: alias))
+
+    def _fake_take(self, working_dir, reason):
+        return True  # would snapshot HOME — the bug this guard prevents
+
+    monkeypatch.setattr(checkpoints.CheckpointManager, "_take", _fake_take)
+    manager = checkpoints.CheckpointManager(enabled=True)
+    manager._git_available = True
+    assert manager.ensure_checkpoint(str(alias), reason="test") is False
+
+
+def test_ensure_checkpoint_refuses_filesystem_root():
+    manager = checkpoints.CheckpointManager(enabled=True)
+    manager._git_available = True
+    assert manager.ensure_checkpoint("/", reason="test") is False
+
+
+def test_ensure_checkpoint_allows_normal_project_dir(tmp_path, monkeypatch):
+    work = tmp_path / "project"
+    work.mkdir()
+
+    def _fake_take(self, working_dir, reason):
+        return True
+
+    monkeypatch.setattr(checkpoints.CheckpointManager, "_take", _fake_take)
+    manager = checkpoints.CheckpointManager(enabled=True)
+    manager._git_available = True
+    assert manager.ensure_checkpoint(str(work), reason="test") is True

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -640,7 +640,12 @@ class CheckpointManager:
         if not self._git_available:
             return False
         abs_dir = str(_normalize_path(working_dir))
-        if abs_dir in {"/", str(Path.home())}:  # never snapshot root/home
+
+        # Skip root, home, and other overly broad directories.  Compare
+        # canonical paths so macOS' /tmp -> /private/tmp alias cannot bypass
+        # the home-directory safety guard when HOME is under /tmp.
+        canonical_home = str(_normalize_path(str(Path.home())))
+        if abs_dir in {"/", canonical_home}:
             logger.debug("Checkpoint skipped: directory too broad (%s)", abs_dir)
             return False
         if abs_dir in self._checkpointed_dirs:


### PR DESCRIPTION
## Summary

`ensure_checkpoint()` skips overly broad directories by comparing the normalized working dir against `Path.home()`. On macOS, `/tmp` is a symlink to `/private/tmp`, so a process with HOME under /tmp resolves to `/private/tmp/...` while the raw `Path.home()` string stays `/tmp/...`. The guard never matches, and the manager happily snapshots the **entire home directory** into the checkpoint store.

This PR compares canonical paths on both sides so the alias cannot bypass the safety guard.

## Testing

- New invariant tests in `tests/tools/test_checkpoint_home_guard.py`:
  - `ensure_checkpoint` must refuse HOME itself when it resolves through a symlink alias (RED on `main`: the stale-string guard lets the snapshot through; GREEN with the fix).
  - Refuses `/`; a normal project directory stays eligible.
- Existing checkpoint suites still pass: `tests/tools/test_checkpoint_home_guard.py test_checkpoint_path_roundtrip.py test_checkpoint_manager.py` → 58 passed, 2 skipped.
