### PR TITLE
fix(gateway): run the unclean-exit database integrity scan off the startup path

### DIFF
--- a/gateway/lifecycle_ledger.py
+++ b/gateway/lifecycle_ledger.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import sqlite3
+import threading
 import time
 from contextlib import closing
 from datetime import datetime, timezone
@@ -202,14 +203,19 @@ def _report_unclean_exit(evidence: Dict[str, Any], home: Optional[Path]) -> None
     )
 
 
-def record_startup(home: Optional[Path] = None) -> Optional[Dict[str, Any]]:
-    """Boot entry point: report any unclean previous exit (evidence dict, also persisted
-    to ``gateway-exit-diag.log`` and logged at WARNING) then claim the sentinel.  Never raises."""
+def record_startup(
+    home: Optional[Path] = None, *, background_integrity_check: bool = False,
+) -> Optional[Dict[str, Any]]:
+    """Claim this life and report an unclean predecessor. Never raises.
+
+    Gateway startup runs the potentially lengthy database scan on a daemon thread:
+    diagnostics must not delay platform startup or hold shutdown open. The worker
+    only writes the exit diagnostic, never the lifecycle sentinel.
+    """
+    home = home if home is not None else _process_hermes_home()
     evidence: Optional[Dict[str, Any]] = None
     try:
         evidence = detect_unclean_exit(home)
-        if evidence is not None:
-            _report_unclean_exit(evidence, home)
     except Exception:
         logger.debug("Unclean-exit detection failed", exc_info=True)
     try:
@@ -224,6 +230,21 @@ def record_startup(home: Optional[Path] = None) -> Optional[Dict[str, Any]]:
         _write_sentinel(claim, home)
     except Exception:
         logger.debug("Failed to claim lifecycle sentinel", exc_info=True)
+    if evidence is not None:
+        def report() -> None:
+            try:
+                _report_unclean_exit(evidence, home)
+            except Exception:
+                logger.debug("Unclean-exit reporting failed", exc_info=True)
+
+        try:
+            if background_integrity_check:
+                logger.warning("Previous gateway exit was unclean; checking state.db in the background")
+                threading.Thread(target=report, name="gateway-integrity-check", daemon=True).start()
+            else:
+                report()
+        except Exception:
+            logger.debug("Could not start unclean-exit report", exc_info=True)
     return evidence
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5331,7 +5331,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         # Report if the previous life died uncleanly (SIGKILL / OOM / VM death), then claim the
         # sentinel for this life. After the PID-file claim so a --replace loser can't clobber it.
         from gateway.lifecycle_ledger import record_startup
-        record_startup()
+        record_startup(background_integrity_check=True)
 
     def _start_keepalive() -> None:
         from hermes_cli.nous_auth_keepalive import start_nous_auth_keepalive

--- a/tests/gateway/test_lifecycle_ledger.py
+++ b/tests/gateway/test_lifecycle_ledger.py
@@ -214,3 +214,39 @@ def test_prior_exit_label_survives_corrupt_sentinel(tmp_path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("garbage", encoding="utf-8")
     assert read_prior_exit_label(tmp_path) == "unknown"
+
+
+def test_background_integrity_check_does_not_block_startup_or_rewrite_exit(tmp_path, monkeypatch):
+    import threading
+    import gateway.lifecycle_ledger as ledger
+
+    started, release, finished = threading.Event(), threading.Event(), threading.Event()
+    _write_sentinel(tmp_path, {"phase": "running", "pid": _DEAD_PID,
+                               "start_time": 1000.0, "started_at": "2026-07-11T04:30:00+00:00"})
+    original_report = ledger._report_unclean_exit
+
+    def slow_check(home=None):
+        started.set()
+        assert release.wait(5)
+        return "ok"
+
+    def report(evidence, home):
+        try:
+            original_report(evidence, home)
+        finally:
+            finished.set()
+
+    monkeypatch.setattr(ledger, "check_state_db_integrity", slow_check)
+    monkeypatch.setattr(ledger, "_report_unclean_exit", report)
+    try:
+        evidence = record_startup(home=tmp_path, background_integrity_check=True)
+        assert evidence["prior_pid"] == _DEAD_PID
+        assert started.wait(2)
+        assert not finished.is_set()
+        assert _read_sentinel(tmp_path)["pid"] == os.getpid()
+        mark_exited(home=tmp_path)
+    finally:
+        release.set()
+    assert finished.wait(2)
+    assert _read_sentinel(tmp_path)["phase"] == "exited"
+    assert _exit_diag_records(tmp_path)[0]["state_db_integrity"] == "ok"


### PR DESCRIPTION
## Summary

`record_startup()` reports an unclean previous exit and then runs the database integrity check **inline on the startup path**. On a large `state.db` that scan is slow — so a gateway that just crashed (the exact case where you need the fastest restart) also boots slowest, and a crash loop pairs the slow scan with every retry.

This PR moves the integrity scan onto a daemon thread:

- `record_startup()` still claims the sentinel and reports the predecessor synchronously (fast, unchanged behavior).
- The scan runs in the background; its result still reaches `gateway-exit-diag.log` when it completes.
- The daemon thread cannot delay platform startup or hold shutdown open.
- Adds a regression test pinning the non-blocking contract (`background_integrity_check=True` returns before the scan completes, and the diagnostics still record the outcome).

## Testing

- `scripts/run_tests.sh tests/gateway/test_lifecycle_ledger.py` → 9 passed, 1 skipped (green with the fix; the new non-blocking test fails on `main` without it — RED/GREEN proven locally).
- Proven against upstream `main` at `eec131b716` via a clean cherry-pick from our fork's patch stack.
