### PR TITLE
fix(cron): separate fire-fence contention from fire-claim ownership loss

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -344,7 +344,10 @@ def _fire_job_lock(job_id: str):
 
 
 def _under_fire_fence(job_id: str, fn: Callable[[], Any]) -> Any:
-    """Run ``fn()`` holding the job's fire fence; False (fail closed) when it can't be acquired."""
+    """Run ``fn()`` holding the job's fire fence; False (fail closed) when it can't be acquired.
+
+    ``False`` here means only that the fence was unavailable — it never means a claim was verified
+    lost — so callers that must tell the two apart use ``_fire_job_lock`` directly."""
     with _fire_job_lock(job_id) as acquired:
         if not acquired:
             return False
@@ -353,10 +356,15 @@ def _under_fire_fence(job_id: str, fn: Callable[[], Any]) -> Any:
 
 @contextlib.contextmanager
 def fire_claim_fence(job_id: str, *, expected_owner: str):
-    """Hold a per-job fence while an owner performs an external side effect."""
+    """Hold a per-job fence while an owner performs an external side effect.
+
+    Yields ``True`` while *expected_owner* still holds the claim, ``False`` when a verified
+    different owner holds it, and ``None`` when the fence could not be acquired at all — another
+    holder of this job's fence kept us out, so ownership is *unverified*, not lost. Callers must
+    fail closed on ``None`` without recording an ownership loss."""
     with _fire_job_lock(job_id) as acquired:
         if not acquired:
-            yield False
+            yield None
             return
         with _jobs_lock():
             job = next((item for item in load_jobs() if item.get("id") == job_id), None)
@@ -2598,13 +2606,23 @@ def claim_job_for_fire(
     return _under_fire_fence(job_id, lambda: _with_job(job_id, apply, False))
 
 
-def heartbeat_fire_claim(job_id: str, *, expected_owner: str) -> bool:
+def heartbeat_fire_claim(job_id: str, *, expected_owner: str) -> Optional[bool]:
     """Refresh an active ``fire_claim`` without extending another owner's lease: an execution may
-    outlive the TTL, and the owner check stops a stale runner from refreshing a recovered claim."""
+    outlive the TTL, and the owner check stops a stale runner from refreshing a recovered claim.
+
+    ``None`` means the fire fence could not be acquired, so ownership is *unverified*: the fence is
+    held across external side effects, and a slow save/delivery holds it for as long as the side
+    effect takes, past the fence wait. ``False`` means a verified loss — the claim is gone or a
+    replacement owner holds it — and is the only value callers may fail closed on."""
     def apply(jobs, _i, job):
         return _refresh_claim(jobs, job.get("fire_claim"), expected_owner)
 
-    return _under_fire_fence(job_id, lambda: _with_job(job_id, apply, False))
+    with _fire_job_lock(job_id) as acquired:
+        if not acquired:
+            logger.debug(
+                "Job '%s': fire fence busy; fire_claim ownership unverified", job_id)
+            return None
+        return _with_job(job_id, apply, False)
 
 
 # Completed one-shots are retained in jobs.json (final status stays inspectable) and pruned by

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2377,30 +2377,50 @@ def _run_with_fire_claim_heartbeat(job: dict, run) -> bool:
         _finish_unstarted("Fire claim ownership lost before execution started.")
         return True
 
+    if owns_fire_claim is None:
+        # Fence busy: ownership could not be confirmed. Running on an unverified claim is exactly
+        # what the claim exists to prevent, so fail closed before any side effect.
+        logger.warning(
+            "Job '%s': fire claim could not be confirmed before execution (fire fence busy)",
+            job_id)
+        _finish_unstarted("Fire claim ownership could not be validated before execution started.")
+        return True
+
     def _heartbeat_loop() -> None:
         last_confirmed = time.monotonic()
         while not stop.wait(_RUN_CLAIM_HEARTBEAT_SECONDS):
             try:
-                if not heartbeat_fire_claim(job_id, expected_owner=owner):
-                    lost_ownership.set()
-                    logger.warning(
-                        "Job '%s': fire claim ownership lost; interrupting stale run",
-                        job_id)
-                    return
-                last_confirmed = time.monotonic()
+                renewed = heartbeat_fire_claim(job_id, expected_owner=owner)
             except Exception:
                 logger.debug("Job '%s': fire_claim heartbeat failed", job_id, exc_info=True)
-                if (
-                    time.monotonic() - last_confirmed
-                    >= _FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS
-                ):
-                    lost_ownership.set()
-                    logger.warning(
-                        "Job '%s': fire_claim could not be renewed within %.1fs; "
-                        "interrupting uncertain run",
-                        job_id,
-                        _FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS)
-                    return
+                renewed = None
+            if renewed is True:
+                last_confirmed = time.monotonic()
+                continue
+            if renewed is False:
+                # Verified loss: a replacement owner holds the claim, so stop this run now.
+                lost_ownership.set()
+                logger.warning(
+                    "Job '%s': fire claim ownership lost; interrupting stale run",
+                    job_id)
+                return
+            # None: the fence was busy, not lost. The run's own save/delivery holds this job's
+            # fence for as long as the side effect takes (a slow delivery outlives the fence wait),
+            # which says nothing about the claim — renew as soon as the fence frees up, and give up
+            # only once the grace window since the last confirmation has run out.
+            if (
+                time.monotonic() - last_confirmed
+                >= _FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS
+            ):
+                lost_ownership.set()
+                logger.warning(
+                    "Job '%s': fire_claim could not be renewed within %.1fs "
+                    "(fire fence busy); interrupting uncertain run",
+                    job_id,
+                    _FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS)
+                return
+            logger.debug(
+                "Job '%s': fire fence busy; fire_claim ownership unverified", job_id)
 
     heartbeat_thread = _start_heartbeat_thread(
         _heartbeat_loop, "cron-fire-claim-heartbeat",
@@ -2499,7 +2519,8 @@ def _record_fire_ownership_lost(job_id: str, fire_owner: Optional[str], executio
     """Bookkeeping after fire-claim ownership loss. A transport-level cancel (dashboard drain) is
     not a real loss — we still own the claim, so record the interruption via the owner-fenced
     terminal write instead of leaving fire_claim/last_status stale; otherwise discard."""
-    if fire_owner is not None and heartbeat_fire_claim(job_id, expected_owner=fire_owner):
+    if fire_owner is not None and heartbeat_fire_claim(
+            job_id, expected_owner=fire_owner) is True:
         mark_job_run(job_id, False, _OWNERSHIP_LOST_INTERRUPTED, expected_fire_owner=fire_owner)
         finish_execution(execution_id, success=False, error=_OWNERSHIP_LOST_INTERRUPTED)
     else:
@@ -2569,6 +2590,20 @@ class _FireClaimLostDuringSideEffect(Exception):
     """Raised inside a side-effect fence when the durable fire claim is no longer ours."""
 
 
+class _FireFenceBusyDuringSideEffect(Exception):
+    """Raised inside a side-effect fence when the fence itself could not be acquired.
+
+    Ownership is *unverified* here, not lost: another holder of this job's fence (typically its
+    in-flight save/delivery) kept us out. The side effect is still skipped — never perform one on
+    an unverified claim — but the run must not be recorded as an ownership loss or interruption."""
+
+
+_FIRE_FENCE_BUSY_FAILURE = (
+    "Fire fence busy: save/delivery skipped without performing side effects "
+    "(fire claim ownership could not be verified)."
+)
+
+
 class _FireOwnership:
     """Fire-claim ownership checks for one run (``owner`` is None when the job carries no claim)."""
 
@@ -2589,11 +2624,17 @@ class _FireOwnership:
         if self.owner is None:
             return False
         try:
-            if heartbeat_fire_claim(self.job["id"], expected_owner=self.owner):
-                return False
+            renewed = heartbeat_fire_claim(self.job["id"], expected_owner=self.owner)
         except Exception:
             logger.debug(
                 "Job '%s': fire_claim ownership validation failed", self.job["id"], exc_info=True)
+            return False
+        if renewed is None:
+            # Fence busy: unverified, not lost. The heartbeat's grace window bounds a stuck fence.
+            logger.debug(
+                "Job '%s': fire fence busy; fire_claim ownership unverified", self.job["id"])
+            return False
+        if renewed:
             return False
         if self.fire_claim_lost is not None:
             self.fire_claim_lost.set()
@@ -2624,6 +2665,8 @@ def _save_compose_deliver(
     fence; a lost claim raises ``_FireClaimLostDuringSideEffect`` for the caller)."""
     job = d.job
     with fence.side_effect_fence() as owns_output:
+        if owns_output is None:
+            raise _FireFenceBusyDuringSideEffect
         if not owns_output:
             raise _FireClaimLostDuringSideEffect
         output_file = save_job_output(job["id"], output)
@@ -2667,6 +2710,8 @@ def _save_compose_deliver(
     )
     try:
         with fence.side_effect_fence() as owns_delivery:
+            if owns_delivery is None:
+                raise _FireFenceBusyDuringSideEffect
             if not owns_delivery:
                 raise _FireClaimLostDuringSideEffect
             d.delivery_attempted = True
@@ -2895,6 +2940,12 @@ def _run_one_job_body(
                 execution_token=execution_token)
         except _FireClaimLostDuringSideEffect:
             d.side_effect_ownership_lost = True
+        except _FireFenceBusyDuringSideEffect:
+            # No side effect ran and ownership was never verified: record the contention itself as
+            # the run's failure cause instead of an ownership loss or a shutdown interruption.
+            d.success = False
+            d.error = _FIRE_FENCE_BUSY_FAILURE
+            logger.warning("Job '%s': %s", job["id"], _FIRE_FENCE_BUSY_FAILURE)
         finally:
             delivery_attempted, delivery_error = d.delivery_attempted, d.delivery_error
             # Every path must tear down deferred agent(s) so they never leak subprocesses/clients.

--- a/tests/cron/test_fire_fence_contention.py
+++ b/tests/cron/test_fire_fence_contention.py
@@ -1,0 +1,158 @@
+"""The per-job fire fence is a serialization primitive, not an ownership signal.
+
+A fence acquire timeout means a same-job holder (typically the in-flight save/delivery) kept
+us out — ownership is *unverified*, not lost. Treating it as loss stamps a successfully
+delivered run with "Interrupted by shutdown before terminal completion." and, on the sibling
+path, discards a run whose side effects were never attempted.
+
+Reproduction of the 2026-09-12 shape: a Telegram send held the side-effect fence for 33s while
+the fire-claim heartbeat waited 30s (``_JOBS_LOCK_TIMEOUT_SECONDS``) for the same fence, timed
+out, and reported ownership loss on a run that had delivered (message_id=43288).
+"""
+
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+
+def _claimed_job(tmp_path, name):
+    import cron.jobs as jobs
+
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    with jobs.use_cron_store(profile_home):
+        job = jobs.create_job(prompt="x", schedule="every 5m", name=name)
+        assert jobs.claim_job_for_fire(job["id"]) is True
+        claimed = jobs.get_job(job["id"])
+    assert isinstance(claimed, dict)
+    return jobs, profile_home, claimed
+
+
+def _patch_run_scaffold(monkeypatch, scheduler, *, run_job):
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda *_a, **_kw: True)
+    monkeypatch.setattr(scheduler, "mark_execution_running", lambda *_a, **_kw: {})
+    monkeypatch.setattr(scheduler, "run_job", run_job)
+
+
+def test_fence_contention_during_slow_delivery_is_not_ownership_loss(tmp_path, monkeypatch):
+    """A delivery that outlives the fence wait must not be recorded as an ownership loss."""
+    import cron.scheduler as scheduler
+
+    jobs, profile_home, claimed = _claimed_job(tmp_path, "slow-delivery")
+
+    # Compressed stand-ins for the production constants: the delivery outlives the fence wait
+    # several times over, while the grace window (the real 180s) stays comfortably open.
+    monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.02)
+    monkeypatch.setattr(scheduler, "_FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS", 30.0)
+
+    delivered = threading.Event()
+    body_saw_loss: list[bool] = []
+
+    def _slow_delivery(*_args, **_kwargs):
+        delivered.set()
+        time.sleep(0.5)
+        return None
+
+    real_body = scheduler._run_one_job_body
+
+    def _observed_body(job, **kwargs):
+        result = real_body(job, **kwargs)
+        lost = kwargs.get("fire_claim_lost")
+        body_saw_loss.append(bool(lost is not None and lost.is_set()))
+        return result
+
+    _patch_run_scaffold(
+        monkeypatch, scheduler,
+        run_job=lambda *_a, **_kw: (True, "output", "response", None))
+    monkeypatch.setattr(scheduler, "_run_one_job_body", _observed_body)
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_a: "output.md")
+    monkeypatch.setattr(scheduler, "_deliver_result", _slow_delivery)
+    mark_run = MagicMock(return_value=True)
+    monkeypatch.setattr(scheduler, "mark_job_run", mark_run)
+    monkeypatch.setattr(scheduler, "finish_execution", MagicMock())
+
+    with jobs.use_cron_store(profile_home), \
+         patch("agent.secret_scope.set_secret_scope", return_value=None), \
+         patch("agent.secret_scope.build_profile_secret_scope", return_value=None), \
+         patch("agent.secret_scope.reset_secret_scope"):
+        assert scheduler.run_one_job(claimed) is True
+
+    assert delivered.is_set(), "delivery never ran"
+    assert body_saw_loss == [False], "a fire fence timeout was treated as ownership loss"
+    args, _kwargs = mark_run.call_args
+    assert args[1] is True, "the run was not recorded as successful"
+    assert args[2] is None, f"run was stamped with an error: {args[2]!r}"
+
+
+def test_fence_held_elsewhere_skips_side_effects_without_ownership_lost_stamp(
+    tmp_path, monkeypatch,
+):
+    """A side effect that cannot acquire the fence is skipped and reported as such.
+
+    Ownership is unverified there, so the run must not be recorded as a lost/interrupted run
+    (the fail-closed policy for the side effect itself is unchanged: nothing is written or sent).
+    """
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    with jobs.use_cron_store(profile_home):
+        job = jobs.create_job(prompt="x", schedule="every 5m", name="fence-busy")
+        assert jobs.claim_job_for_fire(job["id"]) is True
+        claimed = jobs.get_job(job["id"])
+        assert isinstance(claimed, dict)
+        owner = claimed["fire_claim"]["by"]
+
+        monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.05)
+        monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 60.0)
+
+        holder_ready = threading.Event()
+        release_holder = threading.Event()
+
+        def _hold_fence() -> None:
+            # ContextVars do not cross a bare thread boundary: re-enter the profile store so the
+            # holder resolves the same cron store as the run under test.
+            with jobs.use_cron_store(profile_home):
+                with jobs.fire_claim_fence(job["id"], expected_owner=owner) as owns:
+                    assert owns is True, "the holder must own the fence for this test"
+                    holder_ready.set()
+                    release_holder.wait(timeout=10)
+
+        holder = threading.Thread(target=_hold_fence, daemon=True, name="fence-holder")
+
+        def _start_holder_then_finish(*_a, **_kw):
+            # The run starts with the fence free (initial claim validation succeeds); the holder
+            # takes it once the run is under way, like a concurrent delivery.
+            holder.start()
+            assert holder_ready.wait(timeout=5)
+            return True, "output", "response", None
+
+        save_output = MagicMock(return_value="output.md")
+        deliver = MagicMock(return_value=None)
+        mark_run = MagicMock(return_value=True)
+        finish = MagicMock()
+        _patch_run_scaffold(monkeypatch, scheduler, run_job=_start_holder_then_finish)
+        monkeypatch.setattr(scheduler, "save_job_output", save_output)
+        monkeypatch.setattr(scheduler, "_deliver_result", deliver)
+        monkeypatch.setattr(scheduler, "mark_job_run", mark_run)
+        monkeypatch.setattr(scheduler, "finish_execution", finish)
+
+        try:
+            with patch("agent.secret_scope.set_secret_scope", return_value=None), \
+                 patch("agent.secret_scope.build_profile_secret_scope", return_value=None), \
+                 patch("agent.secret_scope.reset_secret_scope"):
+                assert scheduler.run_one_job(claimed) is True
+        finally:
+            release_holder.set()
+            holder.join(timeout=5)
+
+    save_output.assert_not_called()
+    deliver.assert_not_called()
+    finish.assert_called_once()
+    _args, fkwargs = finish.call_args
+    error_text = str(fkwargs.get("error") or "")
+    assert "fence" in error_text.lower(), f"honest cause not recorded: {error_text!r}"
+    assert "ownership lost" not in error_text.lower(), error_text
+    assert "interrupted" not in error_text.lower(), error_text


### PR DESCRIPTION
Fixes #100401 (canonical; also reported as #108341, #108862, #106737, #105861).

## Problem

A cron job whose delivery leg holds its per-job fire fence past `_JOBS_LOCK_TIMEOUT_SECONDS` (30s) gets
its own fire-claim heartbeat timed out into `heartbeat_fire_claim() -> False`, which the heartbeat loop
reads as *ownership lost*. A run that delivered is then booked failed.

Real incident on a self-hosted gateway (2026-09-12) — a `no_agent` script job delivering to Telegram:

```
03:30:56,856 INFO    cron.scheduler: Cron job 'e7d0e5ec5197' handed to restart-safe worker execution=33fd39d1cd0f4b4965345dab08825
03:32:26,832 ERROR   cron.jobs: Timed out waiting for local fire fence <cron_dir>::e7d0e5ec5197; failing closed
03:32:26,832 WARNING __main__: Job 'e7d0e5ec5197': fire claim ownership lost; interrupting stale run
03:32:29,410 INFO    cron.scheduler: Job 'e7d0e5ec5197': delivered to telegram:515754425 message_id=43288
```

The same worker delivered the notification 2.6s after the "ownership lost" line — nothing had shut down.
`jobs.json` still recorded `last_status=error`, `last_error="Interrupted by shutdown before terminal
completion."`, and the executions ledger recorded the same. That write only happens on the branch that
first re-verifies the claim still belongs to us, i.e. the claim was never taken by anyone else.

## Root cause

`_fire_job_lock()` (`cron/jobs.py`) serializes a job's owner mutations *and its external side effects*:
the run thread holds the fence across `save_job_output()` and `_deliver_result()`. The heartbeat runs on
a different thread, so the fence's thread-local reentrancy does not apply and the `RLock` is genuinely
contended for as long as delivery takes. On timeout the fence yields `False`, and
`heartbeat_fire_claim()` (`cron/jobs.py:2601`) collapsed that into the *same* `False` it returns when the
CAS proves another owner holds the claim, so the heartbeat loop (`cron/scheduler.py:2380`) could not tell
"could not determine ownership" from "definitely lost it".

That conflation reaches four consumers, not one:

| consumer | on fence timeout today | should be |
|---|---|---|
| `_run_with_fire_claim_heartbeat` | sets `lost_ownership`, interrupts the run | unverified: renew later, bounded by the existing grace |
| pre-run validation | "ownership lost before execution started" | unverified: fail closed without claiming loss |
| `_FireOwnership.lost()` | skips a legitimate delivery | unverified: do not skip on contention |
| `fire_claim_fence()` → `_save_compose_deliver` | raises claim-lost, stamps "Interrupted by shutdown..." | skip the side effect, record fence contention as the cause |

## Approach

The fence is a serialization primitive, not an ownership signal, so both primitives now report the two
states separately — `None` = fence not acquired, ownership unverified; `False` = verified loss (claim
gone or a replacement owner holds it):

- `heartbeat_fire_claim()` and `fire_claim_fence()` return/yield `None` when the fence is unavailable.
- The heartbeat loop renews on `True`, still fails closed immediately on `False`, and lets `None` be
  renewed inside the existing `_FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS` window instead of interrupting on the
  first contended tick.
- Pre-run validation treats `None` as "not confirmed" and fails closed before any side effect.
- A side effect that cannot acquire its fence is still **skipped** — never act on an unverified claim —
  but the run records `"Fire fence busy: save/delivery skipped without performing side effects (fire claim
  ownership could not be verified)."` instead of the ownership-lost/shutdown stamp.
- `_record_fire_ownership_lost()` writes the interrupted stamp only for a *verified* still-owned claim.

## Tests

`tests/cron/test_fire_fence_contention.py` — both tests fail on `main`:

- `test_fence_contention_during_slow_delivery_is_not_ownership_loss`: a delivery that outlives the
  (compressed) fence wait while the real heartbeat timer ticks. On `main`: `Timed out waiting for local
  fire fence` → `fire claim ownership lost; interrupting stale run`, and the run body is handed a
  set lost-ownership event. After the fix: the delivery runs and the run is recorded successful.
- `test_fence_held_elsewhere_skips_side_effects_without_ownership_lost_stamp`: a second thread holds the
  real fence. On `main`: side effects skipped, ledger closed with `"Fire claim ownership lost; stale
  result was discarded."` After the fix: nothing is written or sent, and the ledger carries the
  fence-contention cause.

`scripts/run_tests.sh tests/cron/` → 105 files, 1248 passed, 0 failed, 1 skipped (windows_only lane).

## Overlap with existing PRs — please read before triaging

This issue has ~12 open fix PRs. The heartbeat half of this patch overlaps #100418 / #100965 / #107844
and should lose to whichever of those the maintainers prefer — I am happy to be closed in favour of one
of them, or to rebase this down to only the parts below.

What none of the existing PRs cover (I checked every open fix's diff: none touches
`_FireClaimLostDuringSideEffect` or the `fire_claim_fence()` fence-busy path): the side-effect path.
Applying the converged heartbeat shape (heartbeat refreshes its CAS under `_jobs_lock()` only, no fire
fence) on top of this branch and running the new tests gives `1 passed, 1 failed` — the second test still
fails with `'Interrupted by shutdown before terminal completion.'`. So a heartbeat-only fix still books a
run whose fence is held elsewhere as an ownership loss / shutdown. That half is in this PR with its test,
and it is the follow-up the reporters on #100401 asked for ("_OWNERSHIP_LOST_INTERRUPTED ... is written
from _record_fire_ownership_lost ... the current message is not [honest]").

## Risk

- `heartbeat_fire_claim()`'s return type widens to `Optional[bool]`; all call sites are in-tree (3 in
  `cron/scheduler.py`, plus tests) and are updated here. A caller treating `None` as falsy reads
  unverified as lost — the pre-existing behaviour — so nothing gets weaker by omission.
- Fail-closed policy is unchanged for verified loss and for side effects: an unverified fence never
  performs a side effect. What changes is the bookkeeping, plus not interrupting on the first contended
  heartbeat tick.
- Residual bound, not addressed here: a single side effect holding the fence past
  `_FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS` (180s) still ends in an uncertain-loss interrupt, and the claim's
  own 300s TTL can still expire during a very long delivery (#88507 tracks that separately).

Verified in production on the reporting host: this commit is applied to the live checkout and the
regression tests pass there against the running cron store.
