### PR TITLE
fix(kanban): reduce notify wake load (#108913)

### DIFF
--- a/gateway/kanban_watchers_common.py
+++ b/gateway/kanban_watchers_common.py
@@ -88,13 +88,13 @@ def _resolve_auto_decompose_settings(load_config: Callable[[], Any]) -> "tuple[b
 
 
 def _gc_retention_days() -> int:
-    """``kanban.done_sub_retention_days`` (default 30; 0 disables), re-read per sweep; fails safe to 30."""
+    """``kanban.done_sub_retention_days`` (default 7; 0 disables), re-read per sweep; fails safe to 7."""
     try:
         from hermes_cli.config import load_config
 
-        return int(((load_config() or {}).get("kanban") or {}).get("done_sub_retention_days", 30))
+        return int(((load_config() or {}).get("kanban") or {}).get("done_sub_retention_days", 7))
     except Exception:
-        return 30
+        return 7
 
 
 def _kanban_dispatch_allowed() -> bool:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -376,7 +376,7 @@ class GatewaySlashCommandsMixin(
         return output or t("gateway.kanban.no_output")
 
     async def _kanban_auto_subscribe(self, event: MessageEvent, task_id: str, requested_board) -> bool:
-        """Subscribe the event's chat to *task_id* notifications (notify+wake). False when the
+        """Subscribe the event's chat to *task_id* notifications. False when the
         source has no platform/chat to route back to."""
         source = event.source
 
@@ -405,8 +405,9 @@ class GatewaySlashCommandsMixin(
                     # the same session key only when the alt id survives the round-trip.
                     user_id_alt=_field("user_id_alt"),
                     notifier_profile=_field("profile") or getattr(self, "_kanban_notifier_profile", None) or self._active_profile_name(),
-                    # Subscribing from chat: deliver the passive message and wake the destination agent.
-                    delivery_mode="notify+wake", delivery_metadata=delivery_metadata)
+                    # Leave delivery_mode unset so normal chat subscriptions are passive notify,
+                    # while stateless api_server keeps its add_notify_sub() wake default.
+                    delivery_metadata=delivery_metadata)
             finally:
                 conn.close()
         await asyncio.to_thread(_sub)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1768,8 +1768,8 @@ DEFAULT_CONFIG = {
         "reconcile_orphans": True,
         # Notify subscriptions survive `done` (completion is reversible) and are removed on archive.
         # On boards that never archive, the notifier GC purges subscriptions for tasks done with no
-        # activity for this many days so stale rows aren't scanned forever. 0 = off.
-        "done_sub_retention_days": 30,
+        # activity for this many days so stale rows don't keep notifying/waking indefinitely. 0 = off.
+        "done_sub_retention_days": 7,
     },
     # Bot Mode cross-connection relay (tools/bot_relay.py): envelopes queued by message_agent for
     # agents on other connections wait in an on-disk outbox until the Desktop drains them.

--- a/hermes_cli/kanban_db_notify.py
+++ b/hermes_cli/kanban_db_notify.py
@@ -256,7 +256,7 @@ def remove_notify_sub(
     return cur.rowcount > 0
 
 
-def purge_stale_done_notify_subs(conn: sqlite3.Connection, *, max_age_days: int = 30) -> int:
+def purge_stale_done_notify_subs(conn: sqlite3.Connection, *, max_age_days: int = 7) -> int:
     """Delete notify subs whose task sat in ``done``/``blocked`` untouched for
     longer than ``max_age_days`` (``<= 0`` disables); returns rows deleted.
 
@@ -277,7 +277,7 @@ def purge_stale_done_notify_subs(conn: sqlite3.Connection, *, max_age_days: int 
     try:
         days = int(max_age_days)
     except (TypeError, ValueError):
-        days = 30
+        days = 7
     if days <= 0:
         return 0
     cutoff = int(time.time()) - days * 86400

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -1,5 +1,6 @@
 import asyncio
 import sqlite3
+import time
 from pathlib import Path
 
 
@@ -80,6 +81,47 @@ def _unseen_terminal_events(tid):
             kinds=["completed", "blocked", "gave_up", "crashed", "timed_out"],
         )
         return events
+    finally:
+        conn.close()
+
+
+def test_notifier_gc_purges_week_old_done_subscription_by_default(tmp_path, monkeypatch):
+    """Default notifier GC bounds never-archived done-task subscriptions.
+
+    Done remains reversible for short review/controller flows, but a task that
+    has been quiet in ``done`` for over a week is treated as settled by the
+    notifier and its subscription is purged before it can wake or notify a stale
+    origin session.
+    """
+    db_path = tmp_path / "done-sub-gc-default.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    old = int(time.time()) - 8 * 86400
+    conn = kbc.connect()
+    try:
+        tid = kb.create_task(conn, title="stale done", assignee="worker")
+        kbn.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb.complete_task(conn, tid, summary="done a while ago")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET created_at = ?, completed_at = ? WHERE id = ?",
+                (old, old, tid),
+            )
+            conn.execute(
+                "UPDATE task_events SET created_at = ? WHERE task_id = ?",
+                (old, tid),
+            )
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+
+    assert adapter.sent == []
+    conn = kbc.connect()
+    try:
+        assert kbn.list_notify_subs(conn, tid) == []
     finally:
         conn.close()
 

--- a/tests/gateway/test_kanban_route_anchor_capture.py
+++ b/tests/gateway/test_kanban_route_anchor_capture.py
@@ -42,5 +42,6 @@ def test_slash_subscription_keeps_the_routed_source_owner(tmp_path, monkeypatch)
     with kbc.connect() as conn:
         sub = kbn.list_notify_subs(conn, task)[0]
     assert sub["notifier_profile"] == source.profile
+    assert sub["delivery_mode"] == "notify"
     assert all(sub["delivery_metadata"][key] == getattr(source, key)
                for key in ("scope_id", "parent_chat_id"))

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -714,6 +714,7 @@ async def test_gateway_create_autosubscribes_on_explicit_board(kanban_home):
     assert len(subs) == 1
     assert subs[0]["chat_id"] == "chat1"
     assert subs[0]["thread_id"] == "20197"
+    assert subs[0]["delivery_mode"] == "notify"
     assert subs[0]["delivery_metadata"] == {
         "chat_type": "dm",
         "direct_messages_topic_id": "20197",
@@ -788,6 +789,7 @@ async def test_gateway_autosubscribe_roundtrips_user_id_alt_for_session_key(
     row = subs[0]
     assert row["user_id"] == "open-id"
     assert row["user_id_alt"] == "union-id"
+    assert row["delivery_mode"] == "notify"
 
     original = SessionSource(
         platform=Platform.TELEGRAM,
@@ -1109,19 +1111,22 @@ def test_gc_honors_configured_retention_days(kanban_home):
         tid = _make_done_task_with_sub(kb, conn, title="ten days old", chat_id="c-10d")
         _backdate_task(kb, conn, tid, days=10)
 
-        # Under the shipped default (>= 30d) a 10-day-old done task is fresh.
-        assert kbn.purge_stale_done_notify_subs(conn, max_age_days=default_days) == 0
-        assert len(kbn.list_notify_subs(conn, tid)) == 1
-
-        # A tighter user-configured retention purges the same row.
-        assert kbn.purge_stale_done_notify_subs(conn, max_age_days=7) == 1
+        # Under the shipped default a 10-day-old done task is settled and is
+        # swept before it can keep notifying/waking a stale origin session.
+        assert kbn.purge_stale_done_notify_subs(conn, max_age_days=default_days) == 1
         assert kbn.list_notify_subs(conn, tid) == []
 
-        # Zero (and below) disables the sweep entirely.
-        tid2 = _make_done_task_with_sub(kb, conn, title="ancient", chat_id="c-anc")
-        _backdate_task(kb, conn, tid2, days=3650)
-        assert kbn.purge_stale_done_notify_subs(conn, max_age_days=0) == 0
+        # Users can still choose a longer reversible-done window explicitly.
+        tid2 = _make_done_task_with_sub(kb, conn, title="ten days old long", chat_id="c-10d-long")
+        _backdate_task(kb, conn, tid2, days=10)
+        assert kbn.purge_stale_done_notify_subs(conn, max_age_days=30) == 0
         assert len(kbn.list_notify_subs(conn, tid2)) == 1
+
+        # Zero (and below) disables the sweep entirely.
+        tid3 = _make_done_task_with_sub(kb, conn, title="ancient", chat_id="c-anc")
+        _backdate_task(kb, conn, tid3, days=3650)
+        assert kbn.purge_stale_done_notify_subs(conn, max_age_days=0) == 0
+        assert len(kbn.list_notify_subs(conn, tid3)) == 1
     finally:
         conn.close()
 

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -934,7 +934,13 @@ def _sub_index(subs):
 def test_create_subscribes_gateway_session(monkeypatch, worker_env):
     """A gateway session (platform + chat_id set) gets auto-subscribed
     to its own kanban_create result, and the response surfaces the
-    ``subscribed`` flag so the orchestrator can react."""
+    ``subscribed`` flag so the orchestrator can react.
+
+    Auto-subscribe is passive by default: it should notify the originating
+    chat without waking a full agent turn for routine completion notices.
+    Operators who need wake behaviour can still opt in with an explicit
+    ``kanban_notify-subscribe --delivery-mode notify+wake``.
+    """
     from tools import kanban_tools as kt
     monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
     monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat-42")
@@ -961,7 +967,7 @@ def test_create_subscribes_gateway_session(monkeypatch, worker_env):
     assert s["user_id"] == "user-9"
     assert s["user_id_alt"] == "alt-user-9"
     assert s["chat_type"] == "forum"
-    assert s["delivery_mode"] == "notify+wake"
+    assert s["delivery_mode"] == "notify"
 
 
 def test_create_subscribes_tui_session_via_session_key(monkeypatch, worker_env):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -905,7 +905,6 @@ def _resolve_notify_target() -> Optional[dict[str, Any]]:
         user_id=env("HERMES_SESSION_USER_ID", "") or None,
         user_id_alt=env("HERMES_SESSION_USER_ID_ALT", "") or None,
         notifier_profile=notifier_profile,
-        delivery_mode="notify+wake" if platform != "tui" else None,
         delivery_metadata=delivery_metadata or None)
 
 


### PR DESCRIPTION
## Summary

Fixes #108913.

This reduces kanban notification inference load in two places:

- auto-subscribed kanban task origins now default to passive `notify` instead of `notify+wake`, including both tool-created tasks (`kanban_create`) and gateway slash-created tasks (`/kanban create`)
- stale subscriptions for tasks that sit in `done`/`blocked` with no activity are purged after the configured retention window, with the shipped default lowered from 30 days to 7 days

`api_server` remains wake-capable by default because it has no adapter send path, and explicit `notify+wake` subscriptions still wake as before.

## Review revision

During Path B review I found the builder had fixed the tool auto-subscribe path but missed the sibling gateway `/kanban create` auto-subscribe path. I revised `gateway/slash_commands.py` so it also leaves `delivery_mode` unset and added regression assertions for slash-created subscriptions.

## Verification

- `scripts/run_tests.sh tests/tools/test_kanban_tools.py::test_create_subscribes_gateway_session tests/hermes_cli/test_kanban_notify.py::test_gateway_create_autosubscribes_on_explicit_board tests/hermes_cli/test_kanban_notify.py::test_gateway_autosubscribe_roundtrips_user_id_alt_for_session_key tests/gateway/test_kanban_route_anchor_capture.py::test_slash_subscription_keeps_the_routed_source_owner tests/gateway/test_kanban_notifier.py::test_notifier_gc_purges_week_old_done_subscription_by_default -q --tb=short` — 6 passed, 0 failed
- `scripts/run_tests.sh tests/tools/test_kanban_tools.py tests/gateway/test_kanban_notifier.py tests/gateway/test_kanban_notifier_apiserver_wake.py tests/hermes_cli/test_kanban_notify.py tests/hermes_cli/test_kanban_db.py tests/gateway/test_kanban_route_anchor_capture.py -q --tb=short` — 114 passed, 0 failed, 1 skipped (windows-only on macOS)
- `git diff --check` — passed
- branch rebased onto current `upstream/main`; `git rev-list --left-right --count upstream/main...HEAD` = `0 1`

## Duplicate / competitor check

No open same-author PRs were found for #108913 or branch pattern `fix/108913*`. Topic searches for the distinctive kanban notify subscription / `notify+wake` / `done_sub_retention_days` area returned no competing open PRs.

Auto-published by Moonsong via Path B automated pipeline.
