### PR TITLE
fix(gateway): throttle restart drain notices

### DIFF
--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -91,6 +91,12 @@ class GatewayBusySessionMixin:
             return False
         if not session_id:
             return False
+        media_urls = getattr(event, "media_urls", None) or []
+        if media_urls:
+            from gateway.run import _build_media_placeholder
+
+            media_text = _build_media_placeholder(event)
+            event.text = "\n".join(part for part in (event.text, media_text) if part)
         event.session_id = session_id
         overflow.append(event)
         event._gateway_accepted = True

--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -33,6 +33,23 @@ logger = logging.getLogger("gateway.run")
 class GatewayBusySessionMixin:
     """Busy-session queueing, slot claims, slash dispatch tables, destructive-slash confirmation."""
 
+    _DRAIN_NOTICE_COOLDOWN_S = 30.0
+
+    def _should_send_drain_notice(self, source: SessionSource) -> bool:
+        """Rate-limit drain notices per routed chat without suppressing queueing."""
+        profile = str(getattr(source, "profile", None) or "main")
+        platform = source.platform.value if source.platform else "gateway"
+        chat_id = str(source.chat_id or "")
+        if not chat_id:
+            return True
+        key = (profile, platform, chat_id)
+        stamps = self.__dict__.setdefault("_drain_notice_ts", {})
+        now = time.monotonic()
+        if key in stamps and now - stamps[key] < self._DRAIN_NOTICE_COOLDOWN_S:
+            return False
+        stamps[key] = now
+        return True
+
     def _queue_during_drain_enabled(self, busy_input_mode: Optional[str] = None) -> bool:
         # "queue"/"steer" mean messages survive a restart (queued for the new process); "interrupt" drops.
         mode = busy_input_mode or self._busy_input_mode
@@ -410,7 +427,8 @@ class GatewayBusySessionMixin:
             message = f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
         else:
             message = f"⏳ Gateway is {self._status_action_gerund()} and is not accepting another turn right now."
-        await self._send_busy_reply(event, adapter, message)
+        if self._should_send_drain_notice(event.source):
+            await self._send_busy_reply(event, adapter, message)
 
     # Bare-word approval replies → (verb, args) for the synthesized slash command.
     _PLAINTEXT_APPROVAL_WORDS: Dict[str, tuple] = {

--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -55,6 +55,47 @@ class GatewayBusySessionMixin:
         mode = busy_input_mode or self._busy_input_mode
         return self._restart_requested and mode in {"queue", "steer"}
 
+    async def _hold_idle_event_for_restart(
+        self, session_key: str, event: "MessageEvent"
+    ) -> bool:
+        """Hold an already-running adapter event for shutdown recovery.
+
+        The adapter pending slot is drained when the current handler returns, so putting an
+        idle drain event there immediately respawns it under the same drain gate.  The overflow
+        FIFO is flushed during shutdown but is not consumed by the old adapter lifecycle.
+        """
+        overflow = self._session_state(session_key).conversation.queued_events
+        if len(overflow) >= self._BUSY_QUEUE_MAX_PENDING:
+            logger.warning(
+                "Dropping restart-drain message for session %s — pending queue at cap (%d).",
+                session_key, self._BUSY_QUEUE_MAX_PENDING,
+            )
+            return False
+        try:
+            session_store = getattr(self, "async_session_store", None)
+            if session_store is not None:
+                entry = await session_store.get_or_create_session(
+                    event.source, touch_activity=not bool(getattr(event, "internal", False))
+                )
+            else:
+                entry = await asyncio.to_thread(
+                    self.session_store.get_or_create_session, event.source
+                )
+            session_id = str(getattr(entry, "session_id", "") or "")
+        except Exception:
+            logger.warning(
+                "Could not resolve a durable session for restart-drain message %s",
+                session_key,
+                exc_info=True,
+            )
+            return False
+        if not session_id:
+            return False
+        event.session_id = session_id
+        overflow.append(event)
+        event._gateway_accepted = True
+        return True
+
     def _overflow_queue(self, session_key: str):
         """The session's FIFO overflow list, or None when no session state exists yet."""
         state = self._peek_session_state(session_key)

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -966,7 +966,7 @@ class GatewayInboundMixin:
                 self._effective_busy_input_mode(source)
             )
             if queue_during_drain:
-                self._queue_or_replace_pending_event(_quick_key, event)
+                queue_during_drain = await self._hold_idle_event_for_restart(_quick_key, event)
             if not self._should_send_drain_notice(source):
                 return True, None, command
             message = (

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -957,12 +957,24 @@ class GatewayInboundMixin:
             return f"Quick command error: {e}"
 
     async def _hm_dispatch_quick_and_plugin_commands(
-        self, event: "MessageEvent", source: SessionSource, command: Optional[str]
+        self, event: "MessageEvent", source: SessionSource, _quick_key: str, command: Optional[str]
     ) -> Tuple[bool, Optional[str], Optional[str]]:
         """Drain gate, user-defined quick commands (exec/alias) and plugin slash commands →
         ``(handled, result, command)``; an alias quick command rewrites ``command``."""
         if self._draining:
-            return True, f"⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now.", command
+            queue_during_drain = self._queue_during_drain_enabled(
+                self._effective_busy_input_mode(source)
+            )
+            if queue_during_drain:
+                self._queue_or_replace_pending_event(_quick_key, event)
+            if not self._should_send_drain_notice(source):
+                return True, None, command
+            message = (
+                f"⏳ Gateway {self._status_action_gerund()} — queued for the next turn after it comes back."
+                if queue_during_drain
+                else f"⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now."
+            )
+            return True, message, command
 
         # User-defined quick commands (bypass agent loop, no LLM call)
         qcmd = self._hm_quick_commands().get(command) if command else None
@@ -1148,7 +1160,9 @@ class GatewayInboundMixin:
         if not _handled:
             _handled, _result = await self._hm_dispatch_canonical_command(event, source, _quick_key, canonical)
         if not _handled:
-            _handled, _result, command = await self._hm_dispatch_quick_and_plugin_commands(event, source, command)
+            _handled, _result, command = await self._hm_dispatch_quick_and_plugin_commands(
+                event, source, _quick_key, command
+            )
         if not _handled:
             _result = self._hm_skill_slash_rewrite(event, source, _quick_key, command)
             _handled = _result is not None

--- a/gateway/shutdown_flush.py
+++ b/gateway/shutdown_flush.py
@@ -204,9 +204,24 @@ def recover_pending_to_db(session_db=None) -> int:
     ``session_db=None`` opens (and afterwards releases) the shared default ``state.db``.
     Returns the number of messages recovered.
     """
-    flush_files = sorted(_get_flush_dir().glob("*.json"))
+    flush_files = list(_get_flush_dir().glob("*.json"))
     if not flush_files:
         return 0
+    # UUID filenames are intentionally opaque.  Order queue payloads by their recorded
+    # arrival sequence instead; a slot payload has no seq and precedes its overflow tail.
+    def _replay_order(path: Path) -> tuple:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            return (
+                payload.get("ts", 0),
+                str(payload.get("session_key", "")),
+                payload.get("seq", -1),
+                path.name,
+            )
+        except Exception:
+            return (0, "", -1, path.name)
+
+    flush_files.sort(key=_replay_order)
     own_db = session_db is None
     if own_db:
         from hermes_state_registry import acquire

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -162,6 +162,7 @@ def make_restart_runner(
     runner.pairing_store = MagicMock()
     runner.session_store = MagicMock()
     runner.session_store._entries = {}
+    runner.session_store.get_or_create_session.return_value.session_id = "restart-session"
     runner.delivery_router = MagicMock()
 
     platform_adapter = adapter or RestartTestAdapter()

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -226,17 +226,36 @@ async def test_idle_restart_drain_holds_events_outside_adapter_lifecycle(
         return None
 
     adapter.set_message_handler(drain_handler)
-    events = [
+    text_events = [
         MessageEvent(
             text=text, message_type=MessageType.TEXT, source=source, message_id=f"m{index}"
         )
         for index, text in enumerate(("first", "second"), start=1)
     ]
+    media_events = [
+        MessageEvent(
+            text="",
+            message_type=MessageType.DOCUMENT,
+            source=source,
+            message_id="m3",
+            media_urls=["/tmp/report.pdf"],
+            media_types=["application/pdf"],
+        ),
+        MessageEvent(
+            text="caption",
+            message_type=MessageType.PHOTO,
+            source=source,
+            message_id="m4",
+            media_urls=["/tmp/photo.png", "/tmp/note.mp3", "/tmp/demo.mp4"],
+            media_types=["image/png", "audio/mpeg", "video/mp4"],
+        ),
+    ]
+    events = text_events + media_events
     for event in events:
         await adapter.handle_message(event)
         await adapter._session_tasks[session_key]
 
-    assert handled == ["m1", "m2"]
+    assert handled == ["m1", "m2", "m3", "m4"]
     assert adapter._pending_messages == {}
     assert session_key not in adapter._active_sessions
     assert runner._session_state(session_key).conversation.queued_events == events
@@ -244,12 +263,19 @@ async def test_idle_restart_drain_holds_events_outside_adapter_lifecycle(
     flush_dir = tmp_path / "pending_messages"
     flush_dir.mkdir()
     monkeypatch.setattr("gateway.shutdown_flush._get_flush_dir", lambda: flush_dir)
-    assert flush_overflow_to_file({session_key: events}) == 2
+    assert flush_overflow_to_file({session_key: events}) == 4
     recovered_db = MagicMock()
-    assert recover_pending_to_db(recovered_db) == 2
+    assert recover_pending_to_db(recovered_db) == 4
     assert [
         call.kwargs["content"] for call in recovered_db.append_message.call_args_list
-    ] == ["first", "second"]
+    ] == [
+        "first",
+        "second",
+        "[User sent a file: /tmp/report.pdf]",
+        "caption\n[User sent an image: /tmp/photo.png]\n"
+        "[User sent audio: /tmp/note.mp3]\n"
+        "[User sent a video: /tmp/demo.mp4]",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -160,6 +160,60 @@ async def test_request_restart_is_idempotent():
 
 
 @pytest.mark.asyncio
+async def test_idle_restart_drain_queues_every_message_but_throttles_notice():
+    runner, adapter = make_restart_runner()
+    runner._draining = True
+    runner._restart_requested = True
+    runner._busy_input_mode = "steer"
+    source = make_restart_source()
+    session_key = build_session_key(source)
+    first = MessageEvent(
+        text="first", message_type=MessageType.TEXT, source=source, message_id="m1"
+    )
+    second = MessageEvent(
+        text="second", message_type=MessageType.TEXT, source=source, message_id="m2"
+    )
+
+    first_result = await runner._hm_dispatch_quick_and_plugin_commands(
+        first, source, session_key, None
+    )
+    second_result = await runner._hm_dispatch_quick_and_plugin_commands(
+        second, source, session_key, None
+    )
+
+    assert first_result[0] is True and "queued" in first_result[1]
+    assert second_result == (True, None, None)
+    assert adapter._pending_messages[session_key] is first
+    assert runner._session_state(session_key).conversation.queued_events == [second]
+
+
+@pytest.mark.asyncio
+async def test_busy_and_idle_restart_drain_share_chat_notice_cooldown():
+    runner, adapter = make_restart_runner()
+    runner._draining = True
+    runner._restart_requested = True
+    runner._busy_input_mode = "queue"
+    source = make_restart_source()
+    session_key = build_session_key(source)
+    idle_event = MessageEvent(
+        text="idle", message_type=MessageType.TEXT, source=source, message_id="m1"
+    )
+    busy_event = MessageEvent(
+        text="busy", message_type=MessageType.TEXT, source=source, message_id="m2"
+    )
+
+    idle_result = await runner._hm_dispatch_quick_and_plugin_commands(
+        idle_event, source, session_key, None
+    )
+    await runner._send_busy_drain_notice(busy_event, session_key, "queue")
+
+    assert "queued" in idle_result[1]
+    assert adapter.sent == []
+    assert adapter._pending_messages[session_key] is idle_event
+    assert runner._session_state(session_key).conversation.queued_events == [busy_event]
+
+
+@pytest.mark.asyncio
 async def test_request_restart_defers_stop_until_active_turn_finishes():
     """Regression for #77184: requesting turn must not enter the drain set."""
     runner, _adapter = make_restart_runner()

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -14,6 +14,7 @@ from gateway.restart import (
     DEFAULT_GATEWAY_SIGNAL_INTERRUPT_GRACE_TIMEOUT,
 )
 from gateway.session import SessionEntry, build_session_key
+from gateway.shutdown_flush import flush_overflow_to_file, recover_pending_to_db
 from tests.gateway.restart_test_helpers import make_restart_runner, make_restart_source
 
 
@@ -179,8 +180,8 @@ async def test_idle_restart_drain_queues_every_message_but_throttles_notice():
 
     assert first_result[0] is True and "queued" in first_result[1]
     assert second_result == (True, None)
-    assert adapter._pending_messages[session_key] is first
-    assert runner._session_state(session_key).conversation.queued_events == [second]
+    assert adapter._pending_messages == {}
+    assert runner._session_state(session_key).conversation.queued_events == [first, second]
 
 
 @pytest.mark.asyncio
@@ -203,8 +204,52 @@ async def test_busy_and_idle_restart_drain_share_chat_notice_cooldown():
 
     assert "queued" in idle_result[1]
     assert adapter.sent == []
-    assert adapter._pending_messages[session_key] is idle_event
-    assert runner._session_state(session_key).conversation.queued_events == [busy_event]
+    assert adapter._pending_messages[session_key] is busy_event
+    assert runner._session_state(session_key).conversation.queued_events == [idle_event]
+
+
+@pytest.mark.asyncio
+async def test_idle_restart_drain_holds_events_outside_adapter_lifecycle(
+    tmp_path, monkeypatch
+):
+    runner, adapter = make_restart_runner()
+    runner._draining = True
+    runner._restart_requested = True
+    runner._busy_input_mode = "queue"
+    source = make_restart_source()
+    session_key = build_session_key(source)
+    handled = []
+
+    async def drain_handler(event):
+        handled.append(event.message_id)
+        await runner._hm_dispatch_idle_commands(event, event.source, session_key)
+        return None
+
+    adapter.set_message_handler(drain_handler)
+    events = [
+        MessageEvent(
+            text=text, message_type=MessageType.TEXT, source=source, message_id=f"m{index}"
+        )
+        for index, text in enumerate(("first", "second"), start=1)
+    ]
+    for event in events:
+        await adapter.handle_message(event)
+        await adapter._session_tasks[session_key]
+
+    assert handled == ["m1", "m2"]
+    assert adapter._pending_messages == {}
+    assert session_key not in adapter._active_sessions
+    assert runner._session_state(session_key).conversation.queued_events == events
+
+    flush_dir = tmp_path / "pending_messages"
+    flush_dir.mkdir()
+    monkeypatch.setattr("gateway.shutdown_flush._get_flush_dir", lambda: flush_dir)
+    assert flush_overflow_to_file({session_key: events}) == 2
+    recovered_db = MagicMock()
+    assert recover_pending_to_db(recovered_db) == 2
+    assert [
+        call.kwargs["content"] for call in recovered_db.append_message.call_args_list
+    ] == ["first", "second"]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -174,15 +174,11 @@ async def test_idle_restart_drain_queues_every_message_but_throttles_notice():
         text="second", message_type=MessageType.TEXT, source=source, message_id="m2"
     )
 
-    first_result = await runner._hm_dispatch_quick_and_plugin_commands(
-        first, source, session_key, None
-    )
-    second_result = await runner._hm_dispatch_quick_and_plugin_commands(
-        second, source, session_key, None
-    )
+    first_result = await runner._hm_dispatch_idle_commands(first, source, session_key)
+    second_result = await runner._hm_dispatch_idle_commands(second, source, session_key)
 
     assert first_result[0] is True and "queued" in first_result[1]
-    assert second_result == (True, None, None)
+    assert second_result == (True, None)
     assert adapter._pending_messages[session_key] is first
     assert runner._session_state(session_key).conversation.queued_events == [second]
 
@@ -202,9 +198,7 @@ async def test_busy_and_idle_restart_drain_share_chat_notice_cooldown():
         text="busy", message_type=MessageType.TEXT, source=source, message_id="m2"
     )
 
-    idle_result = await runner._hm_dispatch_quick_and_plugin_commands(
-        idle_event, source, session_key, None
-    )
+    idle_result = await runner._hm_dispatch_idle_commands(idle_event, source, session_key)
     await runner._send_busy_drain_notice(busy_event, session_key, "queue")
 
     assert "queued" in idle_result[1]


### PR DESCRIPTION
## Summary

- queue idle-session messages during restart drains when `busy_input_mode` is `queue` or `steer`
- rate-limit restart drain notices per profile/platform/chat across both idle and busy paths
- preserve every queued event even when a repeated notice is suppressed

## Root Cause

The idle drain gate returned before consulting the routed busy-input policy, so idle messages were dropped even when queueing was configured. Both idle and busy drain paths also emitted the same status notice for every inbound message without a shared cooldown.

## Testing

- `scripts/run_tests.sh tests/gateway/test_restart_drain.py` (18 passed)
- Regression selection failed 2/2 against the parent production code and passed 2/2 with this fix.

## Related Issue

Closes #109002