### PR TITLE
fix(desktop): scope an entered project's live overlay to the sessions it owns

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -155,6 +155,7 @@ import { ProfileRail } from './profile-switcher'
 import { ProjectDialog } from './project-dialog'
 import { resolveLiveProjectFilter } from './project-filter'
 import {
+  enteredProjectOverlayRows,
   excludeProjectSessions,
   orderProjectsByIds,
   overlayLiveLanes,
@@ -163,7 +164,6 @@ import {
   ProjectBackRow,
   ProjectMenu,
   projectTreeCwd,
-  reconcileEnteredProjectSessions,
   sessionMatchesProjectFilter,
   sessionRecency as sessionTime,
   type SidebarProjectTree,
@@ -1029,8 +1029,8 @@ export function ChatSidebar({
   }, [overviewEnteredProject, enteredProjectTree, orderRepos, isHiddenFromProjects])
 
   const enteredProjectOverlaySessions = useMemo(
-    () => reconcileEnteredProjectSessions(agentSessions, overviewEnteredProject?.previewSessions),
-    [agentSessions, overviewEnteredProject?.previewSessions]
+    () => (overviewEnteredProject ? enteredProjectOverlayRows(agentSessions, overviewEnteredProject, projects) : []),
+    [agentSessions, overviewEnteredProject, projects]
   )
 
   // Overlay live `$sessions` onto the entered project so a just-created session

--- a/apps/desktop/src/app/chat/sidebar/projects/index.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/index.ts
@@ -11,6 +11,7 @@ export { ProjectBackRow, ProjectOverviewRow } from './overview-row'
 export { ProjectMenu } from './project-menu'
 export { SidebarWorkspaceGroup } from './workspace-group'
 export {
+  enteredProjectOverlayRows,
   excludeProjectSessions,
   liveSessionProjectId,
   overlayLiveLanes,

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -6,6 +6,7 @@ import type { ProjectInfo, SessionInfo } from '@/types/hermes'
 
 import {
   baseName,
+  enteredProjectOverlayRows,
   excludeProjectSessions,
   kanbanWorktreeDir,
   liveSessionProjectId,
@@ -1246,5 +1247,39 @@ describe('project filter row rule (#97762)', () => {
   it('a live id still narrows', () => {
     expect(sessionMatchesProjectFilter(appRow, ['p_app'], projects)).toBe(true)
     expect(sessionMatchesProjectFilter(homeRow, ['p_app'], projects)).toBe(false)
+  })
+})
+
+describe('enteredProjectOverlayRows', () => {
+  // A project nested INSIDE another project's folder (gpresearch/复盘 under
+  // gpresearch) shares a path prefix with its parent, but path-prefix is not
+  // membership: the entered view must not pull the child's rows into the
+  // parent's lanes.
+  const parent = makeProject('p_research', ['/work/gpresearch'])
+  const child = makeProject('p_review', ['/work/gpresearch/review'])
+  const node = projectNode({ id: 'p_research', path: '/work/gpresearch' })
+  const parentRow = makeCwdSession('/work/gpresearch', { id: 'parent-row' })
+  const childRow = makeCwdSession('/work/gpresearch/review', { id: 'child-row' })
+
+  it("keeps the parent's own rows and drops a NESTED project's rows", () => {
+    const rows = enteredProjectOverlayRows([parentRow, childRow], node, [parent, child])
+
+    expect(rows.map(session => session.id)).toEqual(['parent-row'])
+  })
+
+  it('still carries the overview preview rows belonging to the entered project', () => {
+    const preview = makeCwdSession('/work/gpresearch', { id: 'preview-row' })
+    const rows = enteredProjectOverlayRows([parentRow], { ...node, previewSessions: [preview] }, [parent, child])
+
+    expect(rows.map(session => session.id)).toEqual(['parent-row', 'preview-row'])
+  })
+
+  it('keeps detached rows for Home (the rows it owns)', () => {
+    const rows = enteredProjectOverlayRows([parentRow, makeCwdSession(null, { id: 'homeless' })], homeNode([]), [
+      parent,
+      child
+    ])
+
+    expect(rows.map(session => session.id)).toEqual(['homeless'])
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -789,6 +789,26 @@ export function reconcileEnteredProjectSessions(
   return missingPreviews.length ? [...live, ...missingPreviews] : live
 }
 
+/**
+ * The live rows an ENTERED project may overlay: only the rows that project
+ * OWNS — the same `sessionMatchesProjectFilter` rule every other surface uses —
+ * plus the overview's preview rows (so a row the drill-in hasn't loaded yet
+ * still renders). Never the unscoped live list: a NESTED project
+ * (`…/gpresearch/复盘` under `…/gpresearch`) shares its path prefix with its
+ * parent, and {@link overlayRepoLanes} places rows by path nesting, so an
+ * unscoped list injects the child's chats into the parent's lanes and the same
+ * row shows under BOTH projects. Path-prefix is not membership.
+ */
+export function enteredProjectOverlayRows(
+  live: SessionInfo[],
+  project: Pick<SidebarProjectTree, 'id' | 'previewSessions'>,
+  explicitProjects: ProjectInfo[]
+): SessionInfo[] {
+  const scoped = live.filter(session => sessionMatchesProjectFilter(session, [project.id], explicitProjects))
+
+  return reconcileEnteredProjectSessions(scoped, project.previewSessions)
+}
+
 interface PreviewOverlayOptions {
   removed?: ReadonlySet<string>
   /** The active sort key as an id order; recency when empty. */


### PR DESCRIPTION
## What does this PR do?

Fixes a sidebar bug where a session is listed under **multiple projects** whenever one project's folder is nested inside another project's folder.

Membership is already computed correctly everywhere else (backend `tui_gateway/project_tree.py`, frontend `liveSessionProjectId`, overview previews): **longest folder prefix = exactly one owner**. The *entered* project view was the exception — it fed the **whole** live session list into `overlayLiveLanes`, and `overlayRepoLanes` places a row by **path nesting** (`isPathUnder(repo.path, session.cwd)`). For a nested project the child's path *is* under the parent's path, so child-owned rows were injected into the parent's lanes and the same chat showed under both projects.

This PR scopes the overlay input to the rows the entered project actually owns, using the one shared membership rule (`sessionMatchesProjectFilter`). Path prefix is not membership.

## Related Issue

Fixes #109007

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding regression coverage for the nested-project case)

## Changes Made

- `apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts` — new `enteredProjectOverlayRows(live, project, explicitProjects)`: filters live rows by the project's membership (`sessionMatchesProjectFilter`) before merging in the overview previews. Documents why an unscoped list is wrong (nested projects share a path prefix).
- `apps/desktop/src/app/chat/sidebar/index.tsx` — `enteredProjectOverlaySessions` now uses `enteredProjectOverlayRows(...)` instead of `reconcileEnteredProjectSessions(agentSessions, …)`.
- `apps/desktop/src/app/chat/sidebar/projects/index.ts` — export the new helper from the barrel.
- `apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts` — 3 regression tests: nested project's rows are dropped, the entered project's preview rows still carry over, Home keeps its detached rows.

## How to Test

1. Create project *Research* with folder `…/gpresearch` and project *Review* with folder `…/gpresearch/复盘` (nested).
2. Have sessions with `cwd=…/gpresearch/复盘` and `cwd=…/gpresearch`.
3. Sidebar → Grouping: Projects → enter *Research*: it must list only its own sessions (before the fix the *Review* rows were injected there too).
4. Run `cd apps/desktop && npx vitest run --project ui src/app/chat/sidebar` → 32 files / 261 tests pass.

Numbers from the reporter's real workspace (68 sessions / 8 projects): foreign rows injected into an entered project **25 and 34 → 0** after the fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no PR addresses nested-project membership on the entered-project overlay
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` — N/A: this change is desktop-renderer-only (TypeScript); the Python suite does not touch it
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (Hermes desktop v0.21.1)

### Documentation & Housekeeping

- [x] Documentation — N/A (behaviour fix; the module docstring now spells out the rule)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered: the grouping rule is path-based and OS-agnostic; the new filter uses the existing cross-platform membership helper (Windows case-folding included) — no platform-specific behaviour added
