### PR TITLE
fix(cron): anti-wipe guard + `hermes cron restore --confirm`

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1415,6 +1415,13 @@ def _refuse_unexplained_shrink(
     """
     if replace:
         return
+    # Same stamp fast-path the shrink-merge honors (#80703): a matching load
+    # stamp means disk provably hasn't changed since our last read, so there is
+    # nothing on disk to reconcile — return without peeking (a save inside a
+    # healthy load->save critical section must not re-read jobs.json).
+    stamp = getattr(_jobs_lock_state, "load_stamp", None)
+    if stamp is not None and _jobs_file_stamp(_current_cron_store().jobs_file) == stamp:
+        return
     try:
         disk_jobs = _peek_jobs_unlocked()
     except Exception:
@@ -1444,9 +1451,6 @@ def _save_jobs_unlocked(
     """Save all jobs; caller must hold _jobs_lock(). ``removed_ids`` = intentional deletes;
     ``replace=True`` skips the shrink-merge guard (wholesale rewrite for tests/disaster
     recovery)."""
-    # Structural guard against silent store wipes — runs BEFORE shrink-merge so TOCTOU
-    # deletes are caught explicitly rather than silently merged.
-    _refuse_unexplained_shrink(jobs, removed_ids, replace)
     jobs_file = _current_cron_store().jobs_file
     ensure_dirs()
     # Owner snapshot BEFORE replace so a root writer can hand the file back to the gateway user.
@@ -1472,6 +1476,13 @@ def _save_jobs_unlocked(
                 _unlink_quiet(tmp_path)
                 tmp_path = None
                 continue
+            # Structural anti-wipe, AFTER recovery's last word: a disk job still
+            # missing from the (post-merge) payload and not in removed_ids means
+            # the bounded merge could not account for it (e.g. a job landing on
+            # the final attempt). Refuse rather than silently drop it (#99022).
+            # Runs on the merged payload so concurrent creates the shrink-merge
+            # recovered are NOT vetoed (#80624). replace=True opts out (D3 path).
+            _refuse_unexplained_shrink(jobs, removed_ids, replace)
             atomic_replace(tmp_path, jobs_file)
             tmp_path = None
             _secure_file(jobs_file)

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1391,6 +1391,52 @@ def _stage_jobs_payload(jobs_file: Path, jobs: List[Dict[str, Any]]) -> str:
 _SAVE_JOBS_MERGE_ATTEMPTS = 5
 
 
+def _refuse_unexplained_shrink(
+    jobs: List[Dict[str, Any]], removed_ids: Optional[Collection[str]],
+    replace: bool = False,
+) -> None:
+    """Structural guard against silent store wipes (wipe incident 2026-09-08).
+
+    The shrink-merge path (see ``_merge_unexpected_disk_jobs``) preserves on-disk
+    jobs that are absent from the in-memory payload; it cannot, however, tell
+    INTENTIONAL DELETE from UNINTENDED WIPE apart — both look the same at the
+    shrink-merge boundary. This guard makes the distinction explicit: a save
+    that shrinks the on-disk job count must account for EVERY missing ID via
+    ``removed_ids``. Any unexplained shrink refuses loudly (ValueError) rather
+    than silently overwriting the persistent store. ``replace=True`` opts out
+    of the guard by design (disaster recovery path; documented at save_jobs).
+
+    Defense in depth with the existing shrink-merge: that path catches
+    concurrent creates that landed during the save window (TOCTOU on the create
+    side); this guard catches concurrent DELETES that landed during the save
+    window (TOCTOU on the delete side). Both bugs are now impossible by
+    construction — a save either succeeds with all IDs accounted for, or fails
+    loudly with the offending IDs named in the exception.
+    """
+    if replace:
+        return
+    try:
+        disk_jobs = _peek_jobs_unlocked()
+    except Exception:
+        return  # _peek failures are non-fatal elsewhere; don't block saves on them.
+    if disk_jobs is None:
+        return  # corrupt disk; let the auto-repair branch handle it.
+    disk_ids = {str(d.get("id")) for d in disk_jobs if isinstance(d, dict) and d.get("id")}
+    payload_ids = {str(j.get("id")) for j in jobs if isinstance(j, dict) and j.get("id")}
+    accounted_removals = {str(r) for r in (removed_ids or ()) if r}
+    unexplained = disk_ids - payload_ids - accounted_removals
+    if unexplained:
+        raise ValueError(
+            f"save_jobs refusing unexplained shrink of cron store: "
+            f"{len(unexplained)} job(s) present on disk but missing from save "
+            f"payload AND not in removed_ids: {sorted(unexplained)}. "
+            f"Use replace=True for disaster recovery (silent replacement)."
+        )
+
+
+_SAVE_JOBS_MERGE_ATTEMPTS = 5
+
+
 def _save_jobs_unlocked(
     jobs: List[Dict[str, Any]], *, removed_ids: Optional[Collection[str]] = None,
     replace: bool = False,
@@ -1398,6 +1444,9 @@ def _save_jobs_unlocked(
     """Save all jobs; caller must hold _jobs_lock(). ``removed_ids`` = intentional deletes;
     ``replace=True`` skips the shrink-merge guard (wholesale rewrite for tests/disaster
     recovery)."""
+    # Structural guard against silent store wipes — runs BEFORE shrink-merge so TOCTOU
+    # deletes are caught explicitly rather than silently merged.
+    _refuse_unexplained_shrink(jobs, removed_ids, replace)
     jobs_file = _current_cron_store().jobs_file
     ensure_dirs()
     # Owner snapshot BEFORE replace so a root writer can hand the file back to the gateway user.

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -771,10 +771,64 @@ _CRON_SUBCOMMANDS = {
     "pause": lambda a: _job_action("pause", a.job_id, "Paused"),
     "resume": lambda a: cron_resume(a),
     "run": lambda a: _job_action("run", a.job_id, "Triggered"),
-    "remove": lambda a: _job_action("remove", a.job_id, "Removed")}
+    "remove": lambda a: _job_action("remove", a.job_id, "Removed"),
+    "restore": lambda a: cron_restore(a)}
 _CRON_SUBCOMMANDS["history"] = _CRON_SUBCOMMANDS["runs"]
 _CRON_SUBCOMMANDS["add"] = _CRON_SUBCOMMANDS["create"]
 _CRON_SUBCOMMANDS["rm"] = _CRON_SUBCOMMANDS["delete"] = _CRON_SUBCOMMANDS["remove"]
+_CRON_SUBCOMMANDS["replace-jobs"] = _CRON_SUBCOMMANDS["restore"]
+
+
+def cron_restore(args) -> int:
+    """Disaster-recovery: wholesale-replace jobs.json via save_jobs(replace=True).
+
+    The ONLY sanctioned path to full silent store replacement. Refuses to run without
+    the explicit ``--confirm`` flag (a bare ``hermes cron restore`` is a no-op), and
+    validates the backup before touching the live store. ``--dry-run`` validates and
+    reports without writing. Escapes the D2 shrink-guard on purpose (replace=True);
+    that is exactly what makes this a high-stakes command worth the confirmation gate.
+    """
+    from cron.jobs import load_jobs, save_jobs
+
+    src = Path(getattr(args, "file", "")).expanduser()
+    confirm = bool(getattr(args, "confirm", False))
+    dry_run = bool(getattr(args, "dry_run", False))
+
+    if not src.is_file():
+        print(color(f"Backup file not found: {src}", Colors.RED))
+        return 1
+
+    # Validate the backup shape before anything destructive.
+    try:
+        data = json.loads(src.read_text(encoding="utf-8"))
+        jobs = data.get("jobs") if isinstance(data, dict) else data
+        if not isinstance(jobs, list):
+            raise ValueError("expected {'jobs': [...]} or a bare list")
+        for j in jobs:
+            if not isinstance(j, dict) or not j.get("id"):
+                raise ValueError("every job record must be a dict with an 'id'")
+    except Exception as exc:
+        print(color(f"Invalid backup file {src}: {exc}", Colors.RED))
+        return 1
+
+    current = load_jobs()
+    print(f"Current jobs.json: {len(current)} job(s)")
+    print(f"Backup {src}: {len(jobs)} job(s)")
+    if dry_run:
+        print("--dry-run: validated; live store NOT modified.")
+        return 0
+
+    if not confirm:
+        print(color(
+            "Refusing: `hermes cron restore` wholesale-replaces your entire jobs.json "
+            "from the backup (silent replace, skips the anti-wipe guard).",
+            Colors.YELLOW))
+        print(color("Pass --confirm to acknowledge and proceed.", Colors.RED))
+        return 1
+
+    save_jobs(jobs, replace=True)
+    print(color(f"Restored {len(jobs)} job(s) from {src}.", Colors.GREEN))
+    return 0
 
 
 def cron_command(args):

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -183,6 +183,20 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
 
     cron_subparsers.add_parser("doctor", help="Check scheduled jobs for common health issues")
 
+    # restore — disaster-recovery wholesale store replacement. Uses save_jobs(replace=True),
+    # which opts out of the shrink-merge-guard (see cron/jobs.save_jobs). MUST require the
+    # explicit --confirm flag; a bare `hermes cron restore` is a no-op. No silent blast radius.
+    cron_restore = cron_subparsers.add_parser(
+        "restore", aliases=["replace-jobs"],
+        help="Wholesale-replace jobs.json from a backup file (disaster recovery; requires --confirm)")
+    cron_restore.add_argument(
+        "file", help="Path to a jobs.json backup produced by `hermes cron export` or a snapshot copy")
+    _flag(cron_restore, "--confirm",
+        help="REQUIRED: acknowledge that the current jobs.json will be replaced by the backup")
+    cron_restore.add_argument(
+        "--dry-run", dest="dry_run", action="store_true",
+        help="Validate the backup file and show what would be replaced, without writing")
+
     cron_tick = cron_subparsers.add_parser("tick", help="Run due jobs once and exit")
     add_accept_hooks_flag(cron_tick)
     add_accept_hooks_flag(cron_parser)


### PR DESCRIPTION
D2: _refuse_unexplained_shrink structural guard against silent jobs.json wipes (reconciled with #80624 shrink-merge — refuses genuine post-merge residual, concurrent creates preserved). D3: `hermes cron restore [--confirm] [--dry-run]` (+ alias replace-jobs) — validate-then-write, bare restore = no-op. Shrink-merge tests 9/9 recovered, cron 124/124.