### PR TITLE
fix(gateway): keep aiohttp web import alive when RequestKey is unavailable

### DIFF
--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -13,9 +13,16 @@ from typing import Any, Callable, Dict, List, Optional
 
 try:
     from aiohttp import web
-    from aiohttp.web_request import RequestKey
-except ImportError:
+except ImportError:  # pragma: no cover
     web = None  # type: ignore[assignment]
+try:
+    from aiohttp.web_request import RequestKey
+except ImportError:  # pragma: no cover
+    # aiohttp < 3.14 does not export RequestKey. Import it separately so its
+    # absence does not clobber the already-imported ``web`` module: sharing
+    # one try/except turned ``web`` into None on older aiohttp, making every
+    # non-streaming ``POST /v1/runs`` reply crash with ``AttributeError:
+    # 'NoneType' object has no attribute 'json_response'``.
     RequestKey = None  # type: ignore[assignment,misc]
 
 from gateway.platforms.api_server_room_grants import _json_error, _room_grant_error_response


### PR DESCRIPTION
Fixes #109013

## What

Split the shared `try/except ImportError` in `gateway/platforms/api_server_runs.py` so that a missing `aiohttp.web_request.RequestKey` (aiohttp < 3.14) no longer resets the already-imported `aiohttp.web` module to `None`.

## Why

On aiohttp < 3.14 every JSON admission reply — e.g. non-streaming `POST /v1/runs` — crashed with `AttributeError: 'NoneType' object has no attribute 'json_response'` and surfaced as HTTP 500 to clients. Full traceback and reproduction are in #109013. `RequestKey` already has `None`-guards at its use site, so its fallback behavior is unchanged.

## Testing

- Verified on a live 0.21.1 deployment (aiohttp 3.13.3) that previously returned 500: after this change `POST /v1/runs` returns the expected `{"run_id": ..., "status": "started", ...}` admission, `GET /v1/runs/{id}/events` SSE streaming is unchanged, and non-streaming `POST /v1/responses` returns a completed response.
- Platform: Ubuntu 24.04, Python 3.11 venv.
