### PR TITLE
feat(delegation): require host-declared subagent results before turn completion

### DIFF
--- a/agent/AGENTS.md
+++ b/agent/AGENTS.md
@@ -102,6 +102,14 @@ providers intentionally do not run during cron.
 
 ## Tests
 
+`SubagentLifecycleService.require()` is an opt-in prerequisite declared by a
+`pre_llm_call` policy. `required_delegation.py` owns its turn scope, result join and
+receipts. Keep declaration failures fail-closed across the ordinary fail-open hook
+boundary, append runtime result batches without rewriting a sent prefix, and gate
+both ordinary finalization and early returns. The parent retains its tools while
+required children run; an unconsumed result cannot become successful completion.
+`launch()` keeps its independent lifecycle semantics. See `subagent-lifecycle-api.md`.
+
 Loop/phase tests go in `tests/agent/`; patch the binding the phase actually reads (siblings often
 `from run_agent import X` inside the function — root "patch where production reads"). Assert
 message-shape invariants (alternation, byte-stable system prompt) rather than snapshotting prompt

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1502,6 +1502,14 @@ def _run_conversation_turn(
         max_compression_attempts=getattr(agent, "max_compression_attempts", 3),
         **{f.name: getattr(_ctx, f.name.lstrip("_")) for f in fields(_LoopState) if f.name in _CTX_FIELDS},
     )
+    from agent.required_delegation import required_delegation_launch_failure
+    launch_failure = required_delegation_launch_failure(agent)
+    if launch_failure:
+        s.final_response, s.failed, s._turn_exit_reason = launch_failure, True, "required_delegation_incomplete"
+        return finalize_turn(agent, **{
+            name: getattr(s, name)
+            for name in inspect.signature(finalize_turn).parameters if name != "agent"
+        })
     # Opt-in runtime: api_mode == codex_app_server hands the whole turn to the codex
     # app-server subprocess (see agent/transports/codex_app_server_session.py).
     if agent.api_mode == "codex_app_server":
@@ -1545,6 +1553,8 @@ def _run_conversation_turn(
                 return _ri.result
             if _ri.action == "continue":
                 continue
+            from agent.required_delegation import observe_required_delegation_results
+            observe_required_delegation_results(agent, s.api_messages)
             _v = _run_phase(
                 run_tool_round if s.assistant_message.tool_calls else finish_text_response, agent, s
             )

--- a/agent/required_delegation.py
+++ b/agent/required_delegation.py
@@ -1,0 +1,249 @@
+"""Turn-owned requirements over the existing subagent lifecycle service.
+
+Routing policies live in plugins. This module only enforces work a policy actually
+declared: launch it, let the parent continue, and join its results before completion.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+import json
+import time
+from typing import Any, Iterator
+import uuid
+
+from agent.message_metadata import append_message
+from agent.subagent_lifecycle import (
+    SubagentHandle, SubagentLaunchRequest, SubagentLifecycleError,
+    SubagentLifecycleService, SubagentResult, SubagentState,
+)
+
+
+@dataclass
+class _Requirement:
+    service: SubagentLifecycleService
+    request: SubagentLaunchRequest
+    handle: SubagentHandle | None = None
+    result: SubagentResult | None = None
+    error: str | None = None
+
+    def refresh(self) -> None:
+        if self.handle is not None:
+            self.result = self.service.result(self.handle)
+
+    def receipt(self, consumed: bool) -> dict[str, Any]:
+        handle, result = self.handle, self.result
+        return {
+            "subagent_id": handle.subagent_id if handle else None,
+            "correlation_id": getattr(self.request, "correlation_id", None),
+            "state": result.terminal_state.value if result else "LAUNCH_FAILED",
+            "provider": handle.provider if handle else None,
+            "model": handle.model if handle else None,
+            "result_hash": result.result_hash if result else None,
+            "result_consumed": consumed,
+            "error": self.error or (result.error_message if result else None),
+        }
+
+
+@dataclass
+class _RequiredTurn:
+    requirements: list[_Requirement] = field(default_factory=list)
+    accepting: bool = True
+    results_appended: bool = False
+    results_consumed: bool = False
+    receipt_messages: dict[str, str] = field(default_factory=dict)
+    error: str | None = None
+    interrupted: bool = False
+
+    def cancel_pending(self) -> None:
+        for requirement in self.requirements:
+            requirement.refresh()
+            if requirement.handle is not None and not requirement.result.ready:
+                requirement.service.cancel(requirement.handle, reason="owning required-delegation turn ended")
+                requirement.refresh()
+
+
+def _scope(agent: Any) -> _RequiredTurn | None:
+    scope = getattr(agent, "_required_delegation_turn", None)
+    return scope if isinstance(scope, _RequiredTurn) else None
+
+
+@contextmanager
+def required_delegation_turn(agent: Any) -> Iterator[None]:
+    previous = getattr(agent, "_required_delegation_turn", None)
+    scope = _RequiredTurn()
+    agent._required_delegation_turn = scope
+    try:
+        yield
+    finally:
+        try:
+            scope.cancel_pending()
+        finally:
+            agent._required_delegation_turn = previous
+
+
+def require_subagent(
+    agent: Any, service: SubagentLifecycleService, request: SubagentLaunchRequest,
+) -> SubagentHandle:
+    scope = _scope(agent)
+    if scope is None or not scope.accepting:
+        raise SubagentLifecycleError("Required delegation must be declared by a pre_llm_call hook in an active turn.")
+    requirement = _Requirement(service, request)
+    # Register before validation/launch: ordinary hooks log exceptions and continue.
+    # An accepted requirement must survive that fail-open hook boundary.
+    scope.requirements.append(requirement)
+    try:
+        if getattr(agent, "api_mode", None) == "codex_app_server":
+            raise SubagentLifecycleError("Required delegation needs the Hermes agent loop.")
+        if "delegate_task" not in getattr(agent, "valid_tool_names", ()):
+            raise SubagentLifecycleError("Required delegation needs the parent's delegation toolset enabled.")
+        requirement.handle = service.launch(request)
+        requirement.refresh()
+        return requirement.handle
+    except Exception as exc:
+        requirement.error = str(exc)[:2000]
+        raise
+
+
+def seal_required_delegations(agent: Any) -> str:
+    """Freeze this turn's declarations and supply context through the existing sidecar."""
+    scope = _scope(agent)
+    if scope is None:
+        return ""
+    scope.accepting = False
+    if not scope.requirements:
+        return ""
+    receipts = [r.receipt(False) for r in scope.requirements]
+    return (
+        "[Runtime-required delegation]\n"
+        "The host has already launched the following required work. Continue useful independent work, "
+        "gather context, or steer these subagents through delegate_task. Do not launch the same work again. "
+        "The runtime will collect their results before accepting your final answer.\n"
+        + json.dumps(receipts, ensure_ascii=False)
+    )
+
+
+def defer_required_delegation_text(agent: Any) -> bool:
+    """A candidate answer must not stream as completion before required results arrive."""
+    scope = _scope(agent)
+    return bool(scope and scope.requirements and not scope.results_appended)
+
+
+def required_delegation_launch_failure(agent: Any) -> str | None:
+    scope = _scope(agent)
+    if scope is not None:
+        scope.error = next((r.error for r in scope.requirements if r.error), None)
+        if scope.error:
+            return required_delegation_failure(agent)
+    return None
+
+
+def _wait_for_results(agent: Any, scope: _RequiredTurn) -> None:
+    for requirement in scope.requirements:
+        if requirement.error:
+            scope.error = requirement.error
+            break
+        while True:
+            requirement.refresh()
+            if requirement.result.ready:
+                break
+            if getattr(agent, "_interrupt_requested", False):
+                scope.interrupted = True
+                scope.error = "The parent turn was interrupted before required work completed."
+                break
+            budget = getattr(agent, "run_budget_seconds", None)
+            started = getattr(agent, "_run_budget_started_at", None)
+            if budget and started and time.time() - started >= budget:
+                scope.error = "The parent run budget expired before required work completed."
+                break
+            requirement.service.wait(requirement.handle, timeout_seconds=0.1)
+        if scope.error:
+            break
+        if requirement.result.terminal_state is not SubagentState.SUCCEEDED:
+            scope.error = requirement.result.error_message or requirement.result.terminal_state.value
+            break
+        if not (requirement.result.summary or "").strip():
+            scope.error = "A required subagent finished without a result."
+            break
+    if scope.error:
+        scope.cancel_pending()
+
+
+def collect_required_delegations(agent: Any, messages: list[dict]) -> tuple[bool, str | None]:
+    """Return (continue_with_results, failure), without asking a model to delegate/wait."""
+    scope = _scope(agent)
+    if scope is None or not scope.requirements:
+        return False, None
+    if scope.results_appended:
+        return False, required_delegation_failure(agent)
+    _wait_for_results(agent, scope)
+    if scope.error:
+        return False, required_delegation_failure(agent)
+
+    calls, results = [], []
+    for requirement in scope.requirements:
+        call_id = "call_required_" + uuid.uuid4().hex[:16]
+        args = {"goal": requirement.request.goal}
+        if requirement.request.context:
+            args["context"] = requirement.request.context
+        calls.append({"id": call_id, "type": "function", "function": {
+            "name": "delegate_task", "arguments": json.dumps(args, ensure_ascii=False),
+        }})
+        results.append({"role": "tool", "tool_call_id": call_id, "content": json.dumps({
+            **requirement.receipt(False), "summary": requirement.result.summary,
+            "origin": "runtime_required_delegation",
+        }, ensure_ascii=False)})
+    # Record actual host-issued work as a complete assistant/tool batch. Never
+    # rewrite a sent row or inject a synthetic user message into the running loop.
+    append_message(messages, {
+        "role": "assistant", "content": None, "tool_calls": calls,
+        "display_metadata": {"origin": "runtime_required_delegation"},
+    })
+    for result in results:
+        append_message(messages, result)
+        scope.receipt_messages[result["tool_call_id"]] = result["content"]
+    agent._session_messages = messages
+    scope.results_appended = True
+    return True, None
+
+
+def observe_required_delegation_results(agent: Any, api_messages: list[dict]) -> None:
+    """Count delivery only after a parent response to a request containing the receipts.
+
+    Compaction can remove an appended result before the next request. Conversely,
+    a parent may consume it in a tool-calling response and compact it later.
+    """
+    scope = _scope(agent)
+    if scope is None or not scope.results_appended or scope.results_consumed:
+        return
+    sent = {m.get("tool_call_id"): m.get("content") for m in api_messages if m.get("role") == "tool"}
+    scope.results_consumed = all(sent.get(key) == value for key, value in scope.receipt_messages.items())
+
+
+def required_delegation_failure(agent: Any) -> str | None:
+    scope = _scope(agent)
+    if scope is None or not scope.requirements or scope.results_consumed:
+        return None
+    detail = scope.error or "The parent turn ended before it could consume the required subagent results."
+    return "Required delegation is incomplete. " + detail
+
+
+def required_delegation_interrupted(agent: Any) -> bool:
+    scope = _scope(agent)
+    return bool(scope and scope.interrupted)
+
+
+def attach_required_delegation_outcome(agent: Any, result: dict[str, Any]) -> None:
+    """Also covers early returns that bypass ordinary turn finalization."""
+    scope = _scope(agent)
+    if scope is None or not scope.requirements:
+        return
+    failure = required_delegation_failure(agent)
+    if failure:
+        scope.cancel_pending()
+        result.update(completed=False, failed=True, final_response=failure, error=failure,
+                      failure_reason="required_delegation_incomplete", response_previewed=False)
+    if scope.interrupted:
+        result["interrupted"] = True
+    result["required_delegations"] = [r.receipt(scope.results_consumed) for r in scope.requirements]

--- a/agent/stream_delivery.py
+++ b/agent/stream_delivery.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List
 from agent.memory_manager import sanitize_context
 from agent.message_content import flatten_message_text
 from agent.redact import redact_sensitive_text
+from agent.required_delegation import defer_required_delegation_text
 
 # Same logger name as the origin module so log records / caplog filters are unchanged.
 logger = logging.getLogger("run_agent")
@@ -32,6 +33,8 @@ class StreamDeliveryMixin:
 
     def _deliver_to_stream_callbacks(self, text: str) -> bool:
         """Send ``text`` to the display + TTS delta callbacks; True if at least one accepted it."""
+        if defer_required_delegation_text(self):
+            return False
         results = [self._call_quietly(cb, text) for cb in (self.stream_delta_callback, self._stream_callback)]
         return any(results)
 
@@ -280,10 +283,14 @@ class StreamDeliveryMixin:
         self._enqueue_stream_hook("on_stream_start")
 
     def _emit_stream_end(self, *, final_text: str, finished: bool, error: str | None) -> None:
+        if defer_required_delegation_text(self):
+            final_text = ""
         self._enqueue_stream_hook("on_stream_end", final_text=final_text, finished=finished, error=error)
 
     def _fire_stream_delta(self, text: str) -> None:
         """Fire all registered stream delta callbacks (display + TTS)."""
+        if defer_required_delegation_text(self):
+            return
         # A superseded stream must not interleave its tokens alongside the retry that replaced it.
         if self._stream_writer_superseded():
             # See #65991.

--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -242,6 +242,17 @@ class SubagentLifecycleService:
     def __init__(self, parent_agent_resolver: Callable[[], Any]) -> None:
         self._parent_agent_resolver = parent_agent_resolver
 
+    def require(self, request: SubagentLaunchRequest) -> SubagentHandle:
+        """Launch work declared by a pre_llm_call policy and require its result this turn.
+
+        The parent keeps running with its normal tools. Before accepting a final
+        answer, Hermes joins required children and gives their results to the parent.
+        Failed launches remain unsatisfied even when the hook catches the exception.
+        """
+        from agent.required_delegation import require_subagent
+
+        return require_subagent(self._parent_agent_resolver(), self, request)
+
     def launch(self, request: SubagentLaunchRequest) -> SubagentHandle:
         parent = self._parent_agent_resolver()
         if parent is None:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -977,6 +977,10 @@ def build_turn_context(
         original_user_message=original_user_message, messages=messages,
         conversation_history=conversation_history,
     )
+    from agent.required_delegation import seal_required_delegations
+    plugin_user_context = "\n\n".join(
+        part for part in (plugin_user_context, seal_required_delegations(agent)) if part
+    )
     plugin_user_context = _merge_gateway_notes(
         agent, messages, current_turn_user_idx, plugin_user_context
     )

--- a/agent/turn_facade.py
+++ b/agent/turn_facade.py
@@ -47,6 +47,7 @@ class TurnFacadeMixin:
             set_conversation_context,
         )
         from agent.prompt_cache_scope import declared_conversation_scope_safe
+        from agent.required_delegation import attach_required_delegation_outcome, required_delegation_turn
         from agent.review_idle_queue import QUEUE as _review_queue
         from agent.subagent_lifecycle import bind_subagent_parent
         from agent.interrupt_scope import track_in_interrupt_scope
@@ -125,7 +126,8 @@ class TurnFacadeMixin:
 
             # Keep the ContextVar scope local (agent tokens may be observed from another thread).
             # A host that owns this thread (Hermes Console) may cancel the turn cross-thread.
-            with bind_subagent_parent(self), scoped_runtime_main({}), track_in_interrupt_scope(self):
+            with (bind_subagent_parent(self), scoped_runtime_main({}), track_in_interrupt_scope(self),
+                  required_delegation_turn(self)):
                 try:
                     if lease is not None:
                         lease.start()
@@ -138,6 +140,7 @@ class TurnFacadeMixin:
                         persist_user_platform_id=persist_user_platform_id, moa_config=moa_config,
                         turn_author=turn_author,
                     )
+                    attach_required_delegation_outcome(self, result)
                 finally:
                     # Post-loop relay/task finalization must not receive a late refresh interrupt;
                     # the interrupt clear itself waits for the thread join in the outer finally.

--- a/agent/turn_final_response.py
+++ b/agent/turn_final_response.py
@@ -73,6 +73,16 @@ def finish_text_response(
         )
 
     final_response = assistant_message.content or ""
+    from agent.required_delegation import collect_required_delegations
+    required_continue, required_failure = collect_required_delegations(agent, messages)
+    if required_continue:
+        final_response = None
+        return _verdict("continue")
+    if required_failure:
+        final_response = required_failure
+        _turn_exit_reason = "required_delegation_incomplete"
+        append_message(messages, {"role": "assistant", "content": final_response})
+        return _verdict("break")
     # Unmute: _mute_post_response from a housekeeping tool turn must not silence
     # empty-response warnings on the final response path.
     agent._mute_post_response = False

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -440,6 +440,14 @@ def finalize_turn(
 ):
     """Run the post-loop finalization and return the turn ``result`` dict."""
     from agent.conversation_loop import logger
+    from agent.required_delegation import (
+        attach_required_delegation_outcome, required_delegation_failure, required_delegation_interrupted,
+    )
+
+    interrupted = interrupted or required_delegation_interrupted(agent)
+    required_failure = required_delegation_failure(agent)
+    if required_failure:
+        final_response, failed, _turn_exit_reason = required_failure, True, "required_delegation_incomplete"
 
     final_response, _turn_exit_reason, preserved_verification_fallback = _resolve_budget_fallback(
         agent, final_response=final_response, api_call_count=api_call_count,
@@ -565,6 +573,7 @@ def finalize_turn(
         ).get("service_tier"),
         "session_id": agent.session_id,
     }
+    attach_required_delegation_outcome(agent, result)
     if agent._tool_guardrail_halt_decision is not None:
         result["guardrail"] = agent._tool_guardrail_halt_decision.to_metadata()
     # Persistence failures already set failed=True; also stamp `error` so the gateway

--- a/tests/agent/test_required_delegation.py
+++ b/tests/agent/test_required_delegation.py
@@ -1,0 +1,233 @@
+"""Required delegation through real plugin discovery, agent loops and an HTTP peer."""
+
+import http.server
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_turn(tmp_path, *, mode="required", max_iterations=8):
+    home = tmp_path / "profile"
+    home.mkdir()
+    plugin = home / "plugins" / "required-worker"
+    plugin.mkdir(parents=True)
+    (plugin / "plugin.yaml").write_text("name: required-worker\nversion: 1.0.0\n")
+    (plugin / "__init__.py").write_text(textwrap.dedent('''\
+        from agent.subagent_lifecycle import SubagentLaunchRequest
+
+        def register(ctx):
+            def route(user_message, parent_session_id, turn_id, **kwargs):
+                if parent_session_id or not str(user_message).startswith("@worker "):
+                    return
+                for index in range(ctx.get_config("worker_count", 1)):
+                    ctx.subagent_lifecycle.require(SubagentLaunchRequest(
+                        goal=str(user_message)[8:],
+                        model=ctx.get_config("worker_model"),
+                        correlation_id=f"required:{turn_id}:{index}",
+                        allowed_toolsets=("web",) if ctx.get_config("invalid", False) else None,
+                    ))
+            ctx.register_hook("pre_llm_call", route)
+    '''))
+    context = tmp_path / "context.txt"
+    context.write_text("PARENT_CONTEXT_COLLECTED")
+    requests, errors = [], []
+    context_collected = threading.Event()
+
+    class Provider(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_error(404)
+
+        def do_POST(self):
+            try:
+                request = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+                messages = request.get("messages", [])
+                if not messages:
+                    self.send_error(404)
+                    return
+                requests.append(request)
+                if request["model"] == "worker-model":
+                    if mode == "interrupted":
+                        (tmp_path / "cancel").touch()
+                        deadline = time.monotonic() + 20
+                        while not (tmp_path / "cancelled").exists() and time.monotonic() < deadline:
+                            time.sleep(0.01)
+                    if mode == "worker_failure":
+                        raw = json.dumps({"error": {
+                            "message": "Required worker fixture failure",
+                            "type": "invalid_request_error", "code": "invalid_request_error",
+                        }}).encode()
+                        self.send_response(400)
+                        self.send_header("Content-Type", "application/json")
+                        self.send_header("Content-Length", str(len(raw)))
+                        self.end_headers()
+                        self.wfile.write(raw)
+                        return
+                    if (max_iterations > 2 and mode not in {"no_tools", "interrupted"}
+                            and not context_collected.wait(timeout=20)):
+                        raise AssertionError("parent did not continue using its tools")
+                    message = {"role": "assistant", "content": "REQUIRED_WORKER_RESULT"}
+                else:
+                    tool_text = "\n".join(str(m.get("content", "")) for m in messages if m["role"] == "tool")
+                    if "REQUIRED_WORKER_RESULT" in tool_text:
+                        message = {"role": "assistant", "content": "RESULT_REVIEWED"}
+                    elif mode == "no_tools":
+                        message = {"role": "assistant", "content": "PREMATURE_DONE"}
+                    elif "PARENT_CONTEXT_COLLECTED" in tool_text:
+                        context_collected.set()
+                        message = {"role": "assistant", "content": "PREMATURE_DONE"}
+                    else:
+                        message = {"role": "assistant", "content": None, "tool_calls": [{
+                            "id": "call_context", "type": "function", "function": {
+                                "name": "read_file", "arguments": json.dumps({"path": str(context)}),
+                            },
+                        }]}
+                response = {
+                    "id": "chatcmpl-required", "object": "chat.completion", "created": 1,
+                    "model": request["model"], "choices": [{
+                        "index": 0, "message": message,
+                        "finish_reason": "tool_calls" if "tool_calls" in message else "stop",
+                    }], "usage": {"prompt_tokens": 20, "completion_tokens": 10, "total_tokens": 30},
+                }
+                content_type = "application/json"
+                if request.get("stream"):
+                    response["object"] = "chat.completion.chunk"
+                    response["choices"][0]["delta"] = response["choices"][0].pop("message")
+                    for index, tool in enumerate(message.get("tool_calls", [])):
+                        tool["index"] = index
+                    raw = ("data: " + json.dumps(response) + "\n\ndata: [DONE]\n\n").encode()
+                    content_type = "text/event-stream"
+                else:
+                    raw = json.dumps(response).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", content_type)
+                self.send_header("Content-Length", str(len(raw)))
+                self.end_headers()
+                self.wfile.write(raw)
+            except (BrokenPipeError, ConnectionResetError):
+                if mode != "interrupted":
+                    errors.append("unexpected disconnected model request")
+            except Exception as exc:
+                errors.append(repr(exc))
+                self.send_error(500)
+
+        def log_message(self, format, *args):
+            pass
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Provider)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+    url = f"http://127.0.0.1:{server.server_port}/v1"
+    (home / "config.yaml").write_text(
+        "memory:\n  memory_enabled: false\n  user_profile_enabled: false\n"
+        "agent:\n  skip_background_review: true\n"
+        "terminal:\n  env: local\n"
+        f"delegation:\n  provider: custom\n  base_url: {url}\n"
+        "  api_key: local-test-only\n  model: worker-model\n"
+        "plugins:\n  enabled: [required-worker]\n  entries:\n    required-worker:\n"
+        "      settings:\n        worker_model: worker-model\n"
+        f"        worker_count: {2 if mode == 'two_workers' else 1}\n"
+        f"        invalid: {'true' if mode == 'launch_failure' else 'false'}\n"
+    )
+    query = "ordinary task" if mode == "unmatched" else "@worker Implement the assigned change."
+    output = tmp_path / "result.json"
+    program = textwrap.dedent('''\
+        import json, sys, threading, time
+        from pathlib import Path
+        from run_agent import AIAgent
+        agent = AIAgent(
+            model="parent-model", provider="custom", base_url=sys.argv[1], api_key="local-test-only",
+            enabled_toolsets=["file"] if sys.argv[5] == "tool_unavailable" else ["file", "delegation"],
+            skip_context_files=True, skip_memory=True,
+            quiet_mode=True, save_trajectories=False, max_iterations=int(sys.argv[4]),
+            run_budget_seconds=30,
+        )
+        streamed = []
+        def cancel_on_request():
+            deadline = time.monotonic() + 20
+            while not Path("cancel").exists() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            if Path("cancel").exists():
+                agent.hard_interrupt("user cancelled required work")
+                Path("cancelled").touch()
+        if sys.argv[5] == "interrupted":
+            threading.Thread(target=cancel_on_request, daemon=True).start()
+        result = agent.run_conversation(sys.argv[2], stream_callback=streamed.append)
+        result["observed_stream"] = streamed
+        Path(sys.argv[3]).write_text(json.dumps(result, default=str))
+        agent.close()
+    ''')
+    env = {key: os.environ[key] for key in (
+        "PATH", "SYSTEMROOT", "WINDIR", "COMSPEC", "TEMP", "TMP", "LOCALAPPDATA", "APPDATA",
+    ) if key in os.environ}
+    env.update(HOME=str(tmp_path), USERPROFILE=str(tmp_path), HERMES_HOME=str(home),
+               HERMES_MANAGED_DIR=str(tmp_path / "managed"), TERMINAL_CWD=str(tmp_path),
+               OPENAI_BASE_URL=url, OPENAI_API_KEY="local-test-only", PYTHONPATH=str(REPO_ROOT),
+               PYTHONDONTWRITEBYTECODE="1", LANG="C.UTF-8")
+    try:
+        process = subprocess.run(
+            [sys.executable, "-c", program, url, query, str(output), str(max_iterations), mode],
+            cwd=tmp_path, env=env, stdin=subprocess.DEVNULL, capture_output=True, text=True,
+            encoding="utf-8", timeout=60,
+        )
+    finally:
+        context_collected.set()
+        server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=5)
+    assert process.returncode == 0, (process.stdout, process.stderr, requests, errors)
+    assert not errors, (errors, process.stderr)
+    errors_log = home / "logs" / "errors.log"
+    diagnostics = process.stderr + (errors_log.read_text() if errors_log.exists() else "")
+    return json.loads(output.read_text()), requests, diagnostics
+
+
+@pytest.mark.parametrize("mode", ["required", "no_tools", "two_workers", "unmatched"])
+def test_required_worker_runs_without_a_model_delegation_call(tmp_path, mode):
+    result, requests, stderr = _run_turn(tmp_path, mode=mode)
+    parents = [r for r in requests if r.get("model") == "parent-model"]
+    children = [r for r in requests if r.get("model") == "worker-model"]
+    assert result["completed"] and not result["failed"], (result, stderr)
+    if mode == "unmatched":
+        assert not children
+        assert "required_delegations" not in result
+        assert result["final_response"] == "PREMATURE_DONE"
+    else:
+        count = 2 if mode == "two_workers" else 1
+        assert len(children) == count, (result, stderr)
+        assert result["final_response"] == "RESULT_REVIEWED", (result, stderr)
+        assert [r["state"] for r in result["required_delegations"]] == ["SUCCEEDED"] * count
+        assert all(r["result_consumed"] for r in result["required_delegations"])
+        if mode != "no_tools":
+            assert any("PARENT_CONTEXT_COLLECTED" in str(r["messages"]) for r in parents)
+        assert "PREMATURE_DONE" not in str(result["messages"])
+        assert "PREMATURE_DONE" not in "".join(result["observed_stream"])
+    # Runtime receipts may append rows; neither schemas nor a sent prefix may change.
+    for previous, following in zip(parents, parents[1:]):
+        assert previous["tools"] == following["tools"]
+        assert previous["messages"] == following["messages"][:len(previous["messages"])]
+
+
+@pytest.mark.parametrize("mode,max_iterations", [
+    ("launch_failure", 8), ("tool_unavailable", 8), ("worker_failure", 8),
+    ("required", 2), ("interrupted", 8),
+])
+def test_missing_required_result_cannot_be_reported_as_success(tmp_path, mode, max_iterations):
+    result, requests, stderr = _run_turn(tmp_path, mode=mode, max_iterations=max_iterations)
+    assert result["failed"] and not result["completed"], (result, stderr)
+    assert result["failure_reason"] == "required_delegation_incomplete", (result, stderr)
+    assert result["required_delegations"], (result, stderr)
+    assert result["final_response"] != "PREMATURE_DONE", (result, stderr)
+    if mode in {"launch_failure", "tool_unavailable"}:
+        assert not requests
+    if mode == "interrupted":
+        assert result["interrupted"]

--- a/website/docs/developer-guide/subagent-lifecycle-api.md
+++ b/website/docs/developer-guide/subagent-lifecycle-api.md
@@ -59,3 +59,110 @@ parent-broadening toolsets are rejected, and per-tool blocks, working-directory
 overrides, and per-launch timeouts are explicitly rejected until Hermes can
 support them without weakening isolation. Use `allowed_toolsets` to narrow a
 child; Hermes's existing unsafe-tool block remains enforced.
+
+## Required work declared by a routing policy
+
+Use `ctx.subagent_lifecycle.require(request)` from a `pre_llm_call` hook when a
+user-selected policy makes a child result a prerequisite for completing the
+current turn. It takes the same `SubagentLaunchRequest` and returns the same
+handle as `launch`. The host starts the child directly; the parent model does
+not have to call `delegate_task`.
+
+The parent continues its normal agent loop with its existing tools, memory and
+skills. Hermes supplies the child's handle through the current user message's
+context sidecar, so the parent can collect additional information or steer the
+child. When the parent attempts a text-only answer, Hermes waits for the required
+children, records their results as a runtime-originated assistant/tool batch,
+and gives the parent another model call to consume them. A pre-result completion
+candidate is discarded; its text deltas and stream-end text are withheld from
+display, TTS and stream hooks. Tool activity remains visible.
+
+This is opt-in through the policy's call to `require`. Ordinary `launch` and
+model-issued delegation retain their existing behavior. No new model tool or
+tool-schema field is added. Sent message prefixes and the system prompt remain
+unchanged; result receipts are appended.
+
+### Example: explicitly selected worker
+
+An ordinary native plugin can bind a user-selected task without a gateway
+interceptor. Save these files in the active Hermes home's
+`plugins/required-worker/` directory:
+
+```yaml title="plugin.yaml"
+name: required-worker
+version: 1.0.0
+```
+
+```python title="__init__.py"
+from agent.subagent_lifecycle import SubagentLaunchRequest
+
+
+def register(ctx):
+    def route(user_message, parent_session_id, turn_id, **kwargs):
+        # This policy applies only to explicitly tagged, top-level requests.
+        # A child must not recursively reapply its parent's routing policy.
+        if parent_session_id or not isinstance(user_message, str):
+            return
+        if not user_message.startswith("@worker "):
+            return
+        ctx.subagent_lifecycle.require(SubagentLaunchRequest(
+            goal=user_message[len("@worker "):],
+            context="Return your findings, changes, validation and unresolved issues.",
+            model=ctx.get_config("worker_model"),
+            correlation_id=f"required:{turn_id}",
+        ))
+
+    ctx.register_hook("pre_llm_call", route)
+```
+
+Enable the plugin in `config.yaml` and select a model supported by the child's
+inherited provider. `worker_model` is a plugin-relative setting:
+
+```yaml
+plugins:
+  enabled: [required-worker]
+  entries:
+    required-worker:
+      settings:
+        worker_model: your-worker-model
+```
+
+For example, `@worker Review the proposed API migration` starts required work
+even if the main model never emits a delegation tool call. Supply relevant
+background in `context`, as with ordinary delegation; this API does not copy the
+parent's full conversation. Reuse the handle with the existing status and
+cancellation methods. The parent can use `delegate_task` steering for the active
+child. Multiple `require` calls declare independently running prerequisites.
+
+### Completion and failure contract
+
+- Requirements are declared before the first parent model request. Calling
+  `require` later, or outside an active Hermes turn, raises
+  `SubagentLifecycleError`. The parent's delegation toolset must be enabled;
+  a policy cannot widen the parent's capabilities or recursively bypass a leaf
+  child's delegation restriction.
+- A launch/validation failure is retained even if the hook catches its exception.
+  Hermes ends the turn as failed before executing the main model's task.
+- A successful requirement needs a terminal `SUCCEEDED` result with a nonempty
+  summary, followed by a parent response after that result entered its context.
+  Budget exhaustion before that response is incomplete, even if the child
+  succeeded. Domain correctness and acceptance still belong to the parent and
+  the task's validation process.
+- Child failure, interruption or an unconsumed result produces
+  `completed: false`, `failed: true` and
+  `failure_reason: "required_delegation_incomplete"`. Each requirement appears in
+  `required_delegations` with its child identity, state, result hash and
+  `result_consumed` flag. Provider/model fields describe the launch configuration;
+  they are not independent verification of a provider's internal execution.
+- Requirements belong to the current turn. Parent cancellation, budget exhaustion
+  or an exceptional exit requests cancellation of outstanding required children.
+  Cancellation remains cooperative: a request is not proof that a child has
+  stopped. Existing iteration/timeout controls still apply; the result wait also
+  honors the parent's configured run budget.
+
+The guarantee starts when a policy calls `require`. Natural-language task
+classification, a policy that fails before declaring its requirement, and
+cross-turn/restart recovery are separate concerns. This API manages native Hermes
+children; selecting a model is not an external CLI integration. It requires the
+Hermes agent loop, so whole-turn `codex_app_server` execution is rejected. Tasks
+without a declared requirement keep the normal Hermes behavior.


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `SubagentLifecycleService.require(request)` API for a routing policy that has already decided a task must be delegated. Hermes launches the child directly and requires its result before the parent can complete the turn, even when the parent model never calls `delegate_task`.

The concrete failure is an omitted action: a model can answer directly despite a delegation instruction, so there is no tool call for a tool guard to intercept. Existing `launch()` lets a plugin start work, but does not make receiving that work's result a prerequisite for parent completion. This change gives an explicit policy that missing completion contract.

Hermes remains the coordinating agent. It keeps its normal tools, memory and skills, can gather context while children run, and can steer them through the existing delegation controls. When it reaches a text-only completion candidate, the runtime joins required children, appends their results, and gives the parent another inference to incorporate and validate them.

## Related Issue

Refs #48217, particularly the reported omission of `delegate_task` despite explicit instructions. This provides enforcement after a policy declares the requirement; it does **not** claim to solve arbitrary natural-language task classification, so it should not auto-close that issue.

Related design work:
- #80113 proposes an all-turn dispatcher mode. This API binds selected work while keeping the parent's own loop active.
- #106268 and #103346 address worker profiles/routing and lifecycle capabilities. This PR reuses the lifecycle service on main and adds turn-completion semantics, without duplicating their profile or durable orchestration infrastructure.

## Type of Change

- [x] ✨ New feature (non-breaking, opt-in)

## Changes Made

- `agent/subagent_lifecycle.py`: expose `require(SubagentLaunchRequest)` using the existing request, handle, launch, status, wait and cancellation contracts.
- `agent/required_delegation.py`: own requirements for one turn. Register attempted requirements before validation/launch, so normal hook exception handling cannot silently turn a failed mandatory launch into ordinary execution.
- Turn facade/context/loop/finalization: start required work before parent inference, retain parent tools, join results before completion, and reject incomplete outcomes on early exits as well as normal finalization. A successful child alone is insufficient: the parent must receive a response to a request containing its result.
- Streaming: withhold pre-result candidate text from display, TTS and stream hooks; continue exposing tool activity.
- Documentation: add an installable native-plugin example using an explicit `@worker` selection, configuration, failure semantics and scope limits. Update the agent development guide.
- Tests: exercise real plugin discovery, configuration, child construction, parent/child loops and a local HTTP model fixture in isolated Hermes homes.

**Why the core change is small in scope:** routing remains in an ordinary plugin; runtime enforcement belongs to the owner of turn completion. No new model tool/schema field, classifier, dependency, global configuration key, queue or persistent store is introduced. Existing `launch()` and model-selected delegation retain their behavior. Context uses the existing per-turn sidecar and append-only assistant/tool result batches; previously sent messages and tool schemas stay unchanged.

**Contract boundaries:** required work must be declared during `pre_llm_call`, with the parent's delegation toolset enabled. Launch failure stops the turn before parent inference. Child failure, cancellation, budget exhaustion or unconsumed results yield `completed: false`, `failed: true` and `failure_reason: "required_delegation_incomplete"`, with per-child receipts. Outstanding children receive cooperative cancellation when the owning turn exits.

This API covers native Hermes children. It does not add a Codex CLI adapter, select task categories, establish cross-turn/restart requirements, or prove domain correctness. A policy that fails before calling `require` has not declared a requirement. Those boundaries are documented rather than hidden behind a promise that a model will always follow an instruction.

## How to Test

Use the documented `required-worker` plugin with a model supported by the inherited provider, then send `@worker Review the proposed API migration`. The child should start even if the parent does not choose the delegation tool; the parent should incorporate the child result before completion.

Validation below is for **`0d9cf0d290573904ad57ddb57e07e328af6aa233`**, compared with its unchanged parent **`044a77b3b6af4ce16138d42762f812a20b9f7a89`**.

**Behavioral coverage:** `tests/agent/test_required_delegation.py` passes all **9 cases on both macOS and Linux**, including real plugin discovery, parent/child loops, concurrent parent tool use, HTTP/SSE responses, launch failures, child failures, iteration exhaustion and interruption. The parent never selects `delegate_task`. Replaying this new file against the unchanged parent previously produced **8 failed, 1 passed**: the unmatched control passes, while `require()` is unavailable and the hook fails open. This is a counterexample for the new contract, not a failure of ordinary `launch()`'s existing contract.

**Full repository validation has now been executed. It is not fully green.** Dependencies were installed from `uv.lock` with the same extras as `.github/workflows/tests.yml`:

```sh
uv sync --locked --python 3.11 \
  --extra all --extra dev --extra anthropic --extra mistral --extra fal \
  --extra modal --extra daytona --extra hindsight --extra parallel-web

# macOS
TMP=/private/tmp scripts/run_tests.sh -j 10 -q
# Linux
scripts/run_tests.sh -j 8 -q
# Separately, on each platform
scripts/run_tests.sh tests/e2e/ -j 2 -q
```

| Run | Result |
| --- | --- |
| Full canonical suite, macOS 26.6.2 / Python 3.11.14, 4,013 files | **47,460 passed, 60 failed, 574 skipped** |
| Full canonical suite, Linux ARM64 / Python 3.11.14, 4,013 files | **47,390 passed, 27 failed, 481 skipped**, plus **8 setup errors and 5 file timeouts** |
| Separate e2e suite, macOS | **63 passed, 0 failed, 7 skipped** |
| Separate e2e suite, Linux | **63 passed, 0 failed, 7 skipped** |

Linux used a non-root Docker environment with uv 0.9.28 and the locked CI extras; this was not the upstream Ubuntu x86_64 runner. Both Python environments link SQLite 3.50.4. The canonical runner excludes `integration/`, `e2e/` and `docker/` by design; `e2e/` was run separately as above.

<details>
<summary>Failure triage and comparison with unchanged source</summary>

**Linux:** replayed all **18 files** that failed, errored or timed out, after installing Node.js 22.23.2/npm, OpenSSH, system Python at `/usr/bin/python3`, and checksum-verified ripgrep 15.1.0, and using `/home/tester/hermes-agent` instead of a top-level checkout. The missing-dependency errors and all file timeouts disappeared. No source or test assertions were changed.

| Same 18 files, same corrected environment | Passed | Failed | Skipped | Errors / timeouts |
| --- | ---: | ---: | ---: | --- |
| PR `0d9cf0d` | 655 | 12 | 14 | 0 / 0 |
| Unchanged parent `044a77b` | 655 | 12 | 14 | 0 / 0 |

The **12 failing node IDs are identical** on the PR and its parent. They are confined to these unchanged files:

- `tests/hermes_cli/test_doctor.py` — 1 missing Vercel diagnostic assertion.
- `tests/hermes_cli/test_gateway_service.py` — 1 systemd availability assertion in a container without systemd.
- `tests/hermes_cli/test_local_quickstart.py` — 2 assertions expecting HTTP 200 where hardware-dependent preflight returns 409.
- `tests/test_mcp_serve.py` — 2 event-bridge delivery assertions.
- `tests/tools/test_browser_open_timeout.py` — 2 session-cache cleanup assertions.
- `tests/tools/test_browser_real_profile.py` — 3 profile permission/browser availability assertions.
- `tests/tools/test_termux_api_detection.py` — 1 audio availability assertion affected by container detection.

**macOS:** replayed all **23 failing files** against the unchanged parent: **541 passed, 58 failed, 39 skipped**. Of the PR's 60 failures, 56 have identical failing node IDs on the parent. The four PR-only and two parent-only failures are varying cases in the same unmodified native-ripgrep process-cleanup path (`ProcessLookupError` after the subprocess exits). A further PR rerun of those two search files passed **29/29**. Other shared failures include paths containing spaces, unmarked platform assumptions, and existing runtime/assertion differences. The full runner also reported two pass-on-retry files (`test_code_kernel_remote.py` and `test_search_native_rg.py`); those are not presented as clean first-attempt passes.

The previously reported `test_delegate.py` `/tmp` versus `/private/tmp` assertion does **not** fail in the full macOS run with `TMP=/private/tmp`.

No PR-specific regression was identified in these runs. The remaining baseline/environment failures still prevent claiming that the complete suite passes; unrelated source changes or weakened assertions have not been added to this delegation PR.

</details>

Repository-wide `ruff check .`, `scripts/check-windows-footguns.py --all` (1,535 files), `scripts/check_compat_pointers.py` (2,091 compatibility pointers), and `git diff --check` pass.

Upstream [CI run 34689686621](https://github.com/NousResearch/hermes-agent/actions/runs/34689686621) currently requires maintainer approval (`action_required`); it has not created test jobs/check results. These local results do not replace required GitHub checks. Windows execution, Docker-image integration tests and live paid-provider acceptance are not claimed.

## Checklist

### Code

- [x] Read the Contributing Guide.
- [x] Conventional Commit title/message.
- [x] Searched existing open and merged PRs/issues; related work is discussed above.
- [x] Changes are limited to required-delegation semantics, documentation and tests.
- [ ] Full repository test suite passes — full runs completed on macOS and Linux; baseline/environment failures remain, with independent comparisons above.
- [x] Added behavioral tests through real imports and configuration.
- [x] Tested on macOS 26.6.2 and Linux ARM64.

### Documentation & Housekeeping

- [x] Updated lifecycle API documentation and docstrings.
- [x] Configuration example: plugin-relative settings only; no new core config keys.
- [x] Updated `agent/AGENTS.md` with the completion invariant.
- [x] Considered cross-platform behavior: stdlib threading/HTTP/subprocess and existing lifecycle cancellation; macOS and Linux exercised, Windows remains for CI.
- [x] Tool schema updates: N/A; the existing delegation schema is unchanged.
