### PR TITLE
fix(memory/mem0): create the setup .env owner-only instead of umask-default

### DIFF
--- a/plugins/memory/mem0/_setup.py
+++ b/plugins/memory/mem0/_setup.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from hermes_constants import get_hermes_home  # noqa: F401 — patched by tests
+from utils import atomic_write_text
 
 from ._oss_providers import EMBEDDER_PROVIDERS, KNOWN_DIMS, LLM_PROVIDERS, SECTION_REGISTRIES, VECTOR_PROVIDERS, validate_oss_config
 
@@ -144,7 +145,11 @@ def _write_env(env_path: Path, env_writes: dict[str, str]) -> None:
     keys = [line.split("=", 1)[0].strip() if "=" in line and not line.startswith("#") else None for line in existing_lines]
     new_lines = [f"{k}={env_writes[k]}" if k in env_writes else line for k, line in zip(keys, existing_lines)]
     new_lines += [f"{k}={v}" for k, v in env_writes.items() if k not in keys]
-    env_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+    # This file holds provider API keys in plaintext, so a .env this wizard CREATES must be
+    # owner-only rather than umask-default (0644). An existing file keeps its mode: a profile
+    # .env is already seeded 0600 by `hermes profile create`, and silently loosening or
+    # tightening a file the operator manages is not this writer's call.
+    atomic_write_text(env_path, "\n".join(new_lines) + "\n", preserve_mode=True, create_mode=0o600)
 
 
 def _activate_provider(config: dict) -> None:

--- a/tests/plugins/memory/test_mem0_setup.py
+++ b/tests/plugins/memory/test_mem0_setup.py
@@ -184,6 +184,39 @@ class TestWriteEnv:
         assert "OPENAI_API_KEY=new" in content
 
 
+class TestWriteEnvPermissions:
+    """`.env` holds provider API keys in plaintext (and, once #79850 lands, the pgvector
+    password), so a file this wizard creates must not be umask-default world-readable."""
+
+    @staticmethod
+    def _mode(path):
+        import stat
+
+        return stat.S_IMODE(path.stat().st_mode)
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits; Windows uses ACLs")
+    def test_a_new_env_file_is_created_owner_only(self, tmp_path):
+        env_path = tmp_path / ".env"
+        _write_env(env_path, {"MEM0_API_KEY": "m0-secret"})
+        assert self._mode(env_path) == 0o600
+        assert "MEM0_API_KEY=m0-secret" in env_path.read_text(encoding="utf-8")
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX mode bits; Windows uses ACLs")
+    def test_an_existing_file_keeps_the_mode_the_operator_gave_it(self, tmp_path):
+        """`hermes profile create` already seeds .env 0600; a hand-managed file is the
+        operator's call either way, so this writer never re-modes what it did not create."""
+        import os
+
+        for existing_mode in (0o600, 0o644):
+            env_path = tmp_path / f"env-{existing_mode:o}"
+            env_path.write_text("EXISTING=1\n", encoding="utf-8")
+            os.chmod(env_path, existing_mode)
+            _write_env(env_path, {"MEM0_API_KEY": "m0-secret"})
+            assert self._mode(env_path) == existing_mode
+            content = env_path.read_text(encoding="utf-8")
+            assert "EXISTING=1" in content and "MEM0_API_KEY=m0-secret" in content
+
+
 class TestPromptApiKey:
 
     def test_existing_key_found_behind_bom(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

`hermes memory setup` writes provider API keys into `$HERMES_HOME/.env` with a plain
`Path.write_text`, so a `.env` the wizard **creates** lands at the umask default:

```
new .env                  : 0o644   contains MEM0_API_KEY
mem0.json via save_config : 0o600   <- the correct behaviour, same plugin
```

The rest of the codebase is already consistent — `Mem0MemoryProvider.save_config` uses
`atomic_json_write(..., mode=0o600)` (`mem0/__init__.py:159`), `hermes_cli/profiles.py:840` seeds a
profile `.env` at 0600, `profiles.py:927` / `doctor_config.py:155` chmod it back, and hindsight writes
its daemon env through `_secure_write_profile_env` (#41345 / #74236). `_write_env` was the outlier.

### The fix

`utils.atomic_write_text(..., preserve_mode=True, create_mode=0o600)` — the shared writer, already
used this way by `plugins/platforms/google_chat/oauth.py:201`:

- a file this wizard **creates** is owner-only;
- a file that **already exists** keeps the mode the operator gave it — `hermes profile create`
  already seeds 0600, and silently re-moding a hand-managed file is not this writer's call (an
  over-fix that forces 0600 unconditionally is covered by a sabotage test);
- and the temp-file-and-rename closes the partial-write window on a file the agent reads back for
  credentials.

### Why it matters more after #79850

That PR (open) correctly hardens `mem0.json` to 0600 and moves the PostgreSQL password out of it —
into `.env`, through this same `_write_env`:

```
+            env_writes["MEM0_PGVECTOR_PASSWORD"] = flags["oss_vector_password"]
```

It does not touch `_write_env`, so as written the password moves from one 0644 file to another while
that PR's own test asserts 0600 on the file it no longer holds. This PR touches only `_write_env`,
which #79850 leaves alone, so the two compose without conflict in either merge order.

## Related Issue

Fixes #109018

Same class as #41345 / #74236 (hindsight's embedded profile `.env`). #32244 applied 0600 to the
memory providers' `save_config` paths and was closed unmerged, but that behaviour is on `main` today
— this is the setup-wizard writer it never covered.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/mem0/_setup.py` — `_write_env` writes through `atomic_write_text` with
  `preserve_mode=True, create_mode=0o600`.
- `tests/plugins/memory/test_mem0_setup.py::TestWriteEnvPermissions` — one invariant test, run under
  an explicit umask 022 so it fails on the pre-fix code on any runner: a created `.env` is 0600 and
  carries the key, while an existing file at 0600 **and** at 0644 keeps its mode with content merged.
  Skips on Windows, where mode bits aren't the access control.

## How to Test

1. `scripts/run_tests.sh tests/plugins/memory/test_mem0_setup.py` → **23 passed**.
2. Reproduce on `main`: `_write_env(Path(fresh_home) / ".env", {"MEM0_API_KEY": "k"})` then
   `stat -f %Lp` the file → `644`. With this change → `600`; a pre-existing file is unchanged.
3. Merged onto current `main` locally: no conflicts; every `tests/plugins/memory/test_mem0*.py` file passes
   under `scripts/run_tests.sh` (76 passed).
4. `scripts/check-windows-footguns.py --all` → clean (1537 files).

Sabotage-checked:

| Sabotage | Result |
| --- | --- |
| Back to `Path.write_text` (the bug) | the test fails on the created file's mode |
| `preserve_mode` dropped — force 0600 onto an existing file (the over-fix) | the test fails on the 0644 file's mode |

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate — `mem0.json permissions 0600`,
      `"_write_env" mem0 chmod` and `memory setup world-readable credentials` return #79850 (hardens
      `mem0.json`, not `.env`), #25085 (key written *into* mem0.json at all), #41345 / #74236
      (hindsight's `.env`) and the closed-unmerged #32244 (`save_config` paths). None covers this writer.
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the affected files with `scripts/run_tests.sh` rather than the full tree
- [x] I've added tests for my changes — one invariant test with the existing-file control folded in
- [x] I've tested on my platform: macOS 27.0 (Darwin 27.0.0), Apple Silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the comment at the write site states why a created file is
      tightened and an existing one is not
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — POSIX mode bits only; the tests skip on Windows, where
      `atomic_write_text` behaves as before

