### PR TITLE
matrix: support channel_prompts + channel_skill_bindings (parity with discord/telegram)

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2066,6 +2066,20 @@ class MatrixAdapter(BasePlatformAdapter):
                 reply_to_author_name = await self._get_display_name(room_id, reply_to_author_id)
         return body, reply_to, reply_to_text, reply_to_author_id, reply_to_author_name
 
+    def _resolve_channel_skills(
+        self, channel_id: str, parent_id: str | None = None) -> list[str] | None:
+        """Auto-skill binding(s) for a room/thread from ``channel_skill_bindings``
+        (``{id: "<room id>", skills: [...]}``; ``skill: "<name>"`` also accepted). Exact
+        *channel_id* first, then *parent_id* (threads inherit the parent room's binding)."""
+        from gateway.platforms.base import resolve_channel_skills
+        return resolve_channel_skills(self.config.extra, channel_id, parent_id)
+
+    def _resolve_channel_prompt(self, channel_id: str, parent_id: str | None = None) -> str | None:
+        """Per-room ephemeral prompt from ``channel_prompts``: exact *channel_id* first, then
+        *parent_id* (threads inherit the parent room's prompt). Blank prompts count as absent."""
+        from gateway.platforms.base import resolve_channel_prompt
+        return resolve_channel_prompt(self.config.extra, channel_id, parent_id)
+
     async def _build_inbound_event(
         self, room_id: str, sender: str, event_id: str, body: str, source_content: dict, relates_to: dict,
         **extra) -> Optional[MessageEvent]:
@@ -2084,12 +2098,18 @@ class MatrixAdapter(BasePlatformAdapter):
             extra["message_type"] = MessageType.COMMAND if body.startswith("/") else MessageType.TEXT
         elif _is_bare_media_filename(media_msgtype, body):
             body = ""  # transport filename, not user text
+        # Per-room persona: exact thread/event id first, parent room as fallback (threads inherit),
+        # mirroring Discord/Telegram. Both fields are ephemeral (never persisted to transcript).
+        parent_id = room_id if _thread_id and _thread_id != room_id else None
+        channel_prompt = self._resolve_channel_prompt(_thread_id or room_id, parent_id)
+        channel_skills = self._resolve_channel_skills(_thread_id or room_id, parent_id)
         return MessageEvent(
             text=body, source=source, raw_message=source_content, message_id=event_id,
             reply_to_message_id=reply_to, reply_to_text=reply_to_text, reply_to_author_id=reply_to_author_id,
             reply_to_author_name=reply_to_author_name,
             # Top-level sender fields mirror source.* — downstream prompt code reads them.
-            user_id=sender, user_name=display_name, **extra)
+            user_id=sender, user_name=display_name,
+            auto_skill=channel_skills, channel_prompt=channel_prompt, **extra)
 
     async def _handle_text_message(
         self, room_id: str, sender: str, event_id: str, event_ts: float, source_content: dict,
@@ -3065,6 +3085,12 @@ def _apply_yaml_config(yaml_cfg: dict, matrix_cfg: dict) -> dict | None:
     if "max_message_length" in matrix_cfg:
         seeded["max_message_length"] = matrix_cfg["max_message_length"]
         _set_env("MATRIX_MAX_MESSAGE_LENGTH", str(matrix_cfg["max_message_length"]))
+    # Per-room persona plumbing (parity with discord/telegram): ``channel_prompts`` already
+    # reaches ``extra`` via the core shared-key loop; ``channel_skill_bindings`` is restricted to
+    # discord+slack there, so seed it here (extra-only — no env bridge, multiplex-safe).
+    bindings = matrix_cfg.get("channel_skill_bindings")
+    if isinstance(bindings, list) and bindings:
+        seeded["channel_skill_bindings"] = bindings
     return seeded or None
 
 

--- a/tests/gateway/test_matrix_channel_prompts.py
+++ b/tests/gateway/test_matrix_channel_prompts.py
@@ -1,0 +1,119 @@
+"""Matrix per-room prompts + skill bindings (channel_prompts / channel_skill_bindings).
+
+Parity with discord/telegram: ``_build_inbound_event`` resolves an ephemeral
+``channel_prompt`` and ``auto_skill`` for (thread_id, room_id) and passes both
+into the MessageEvent. Empty config => neither field (no behavior change).
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _make_adapter(extra=None):
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+    config = PlatformConfig(
+        enabled=True,
+        token="syt_test_token",
+        extra={
+            "homeserver": "https://matrix.example.org",
+            "user_id": "@bot:example.org",
+            "require_mention": False,
+            **(extra or {}),
+        },
+    )
+    adapter = MatrixAdapter(config)
+    adapter._is_dm_room = AsyncMock(return_value=False)
+    adapter._resolve_room_identity = AsyncMock(
+        return_value=MagicMock(display_name="Project Room", room_topic=None, server_name="example.org"))
+    adapter._get_display_name = AsyncMock(return_value="Alice")
+    adapter._background_read_receipt = MagicMock()
+    return adapter
+
+
+async def _build(adapter, room_id="!room:example.org", event_id="$evt1",
+                 body="hello", relates_to=None):
+    return await adapter._build_inbound_event(
+        room_id, "@alice:example.org", event_id, body,
+        {"body": body}, relates_to or {})
+
+
+FITNESS = "!l4ov9AshdbJPMzyydE:example.org"
+CFO = "!0DtNoREf7ZeiroFObR:example.org"
+_EXTRA = {
+    "channel_prompts": {
+        FITNESS: "You are Greg the coach. DB-first, evidence over vibes.",
+        CFO: "You are Greg the CFO. Terse, numbers, deltas never balances.",
+    },
+    "channel_skill_bindings": [
+        {"id": FITNESS, "skills": ["fitness-coach"]},
+        {"id": CFO, "skill": "finance"},
+    ],
+}
+
+
+class TestMatrixChannelResolutionEmpty:
+    @pytest.mark.asyncio
+    async def test_no_config_gets_neither_field(self):
+        event = await _build(_make_adapter())
+        assert event is not None
+        assert event.channel_prompt is None
+        assert event.auto_skill is None
+
+    @pytest.mark.asyncio
+    async def test_empty_containers_get_neither_field(self):
+        adapter = _make_adapter({"channel_prompts": {}, "channel_skill_bindings": []})
+        event = await _build(adapter)
+        assert event is not None
+        assert event.channel_prompt is None
+        assert event.auto_skill is None
+
+    @pytest.mark.asyncio
+    async def test_blank_prompt_counts_as_absent(self):
+        adapter = _make_adapter({"channel_prompts": {"!room:example.org": "   "}})
+        event = await _build(adapter)
+        assert event is not None
+        assert event.channel_prompt is None
+
+
+class TestMatrixChannelResolutionConfigured:
+    @pytest.mark.asyncio
+    async def test_room_prompt_and_skill(self):
+        event = await _build(_make_adapter(_EXTRA), room_id=FITNESS)
+        assert event is not None
+        assert event.channel_prompt == "You are Greg the coach. DB-first, evidence over vibes."
+        assert event.auto_skill == ["fitness-coach"]
+
+    @pytest.mark.asyncio
+    async def test_second_room_resolves_own_pair(self):
+        event = await _build(_make_adapter(_EXTRA), room_id=CFO)
+        assert event is not None
+        assert event.channel_prompt == "You are Greg the CFO. Terse, numbers, deltas never balances."
+        assert event.auto_skill == ["finance"]
+
+    @pytest.mark.asyncio
+    async def test_thread_inherits_parent_room(self):
+        event = await _build(
+            _make_adapter(_EXTRA), room_id=FITNESS, event_id="$reply1",
+            relates_to={"rel_type": "m.thread", "event_id": "$threadroot1"})
+        assert event is not None
+        assert event.channel_prompt == "You are Greg the coach. DB-first, evidence over vibes."
+        assert event.auto_skill == ["fitness-coach"]
+
+    @pytest.mark.asyncio
+    async def test_exact_thread_entry_wins_over_parent(self):
+        extra = dict(_EXTRA, channel_prompts={
+            **_EXTRA["channel_prompts"], "$threadroot1": "Thread-specific prompt."})
+        event = await _build(
+            _make_adapter(extra), room_id=FITNESS, event_id="$reply1",
+            relates_to={"rel_type": "m.thread", "event_id": "$threadroot1"})
+        assert event is not None
+        assert event.channel_prompt == "Thread-specific prompt."
+
+    @pytest.mark.asyncio
+    async def test_unbound_room_gets_neither(self):
+        event = await _build(_make_adapter(_EXTRA), room_id="!other:example.org")
+        assert event is not None
+        assert event.channel_prompt is None
+        assert event.auto_skill is None

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -550,6 +550,59 @@ See also: [admin/user slash command split](../../reference/slash-commands.md#per
 To find a Room ID: in Element, go to the room → **Settings** → **Advanced** → the **Internal room ID** is shown there (starts with `!`).
 :::
 
+## Per-room prompts (`channel_prompts`)
+
+Per-room ephemeral system prompts that are injected on every turn in the matching Matrix room or thread without being persisted to transcript history.
+
+```yaml
+matrix:
+  channel_prompts:
+    "!fitnessroom:matrix.example.org": |
+      You are Greg the coach. DB-first, evidence over vibes.
+    "!cfodebrief:matrix.example.org": |
+      You are Greg the CFO. Terse, numbers, deltas never balances.
+```
+
+Behavior:
+- Exact thread/event ID matches win.
+- If a message arrives inside a thread and that thread has no explicit entry, Hermes falls back to the parent room ID.
+- Prompts are applied ephemerally at runtime, so changing them affects future turns immediately without rewriting past session history.
+
+Use the room's **internal ID** (`!abc...:server`), not its alias (`#room:server`).
+
+## Per-room skill bindings (`channel_skill_bindings`)
+
+Auto-load a skill whenever a new session starts in a specific room. Unlike per-room prompts (which are injected on every turn), skill bindings inject the skill content as a user message at **session start** — it becomes part of the conversation history and does not need to be reloaded on subsequent turns.
+
+This is ideal for rooms with a dedicated purpose (a fitness-coaching room, a finance-debrief room, etc.) where you don't want the model's own skill selector to decide whether to load on every short reply.
+
+```yaml
+matrix:
+  channel_skill_bindings:
+    # Fitness room — always runs in "fitness-coach" mode
+    - id: "!fitnessroom:matrix.example.org"
+      skills:
+        - fitness-coach
+    # CFO debrief room — preload multiple skills in order
+    - id: "!cfodebrief:matrix.example.org"
+      skills:
+        - finance
+        - writing-plans
+    # Short form: single skill as a string (must be an installed skill name)
+    - id: "!supportroom:matrix.example.org"
+      skill: hubspot-on-demand
+```
+
+:::warning Skill names must exist
+If the bound skill isn't installed, the gateway logs `[Gateway] Auto-skill '<name>' not found` and the turn proceeds without it. Verify names with `hermes skills list`.
+:::
+```
+
+Notes:
+- The binding matches by room ID. For threaded messages in a bound room, the thread inherits the parent room's binding.
+- The skill is loaded only at session start (new session). If you change the binding, run `/new` for it to take effect.
+- Combine with `channel_prompts` for per-room tone/constraints on top of the skill's instructions.
+
 ## Commands in Matrix
 
 Hermes supports the same gateway commands in Matrix that it supports on other


### PR DESCRIPTION
## What

Matrix was the only major platform missing the per-channel persona framework: `gateway/platforms/base.py` already ships `resolve_channel_prompt()` / `resolve_channel_skills()` plus the ephemeral `MessageEvent.channel_prompt` / `auto_skill` fields, and Discord + Telegram already use them. This PR wires Matrix up, adapter-only + docs + tests:

- `plugins/platforms/matrix/adapter.py`: new `_resolve_channel_prompt` / `_resolve_channel_skills` helper pair (mirroring Discord's); `_build_inbound_event` resolves both for (thread_id, room_id) — exact thread/event id first, parent room fallback so threads inherit — and passes `channel_prompt=` + `auto_skill=` into the MessageEvent.
- Same file, `_apply_yaml_config` hook: seeds `channel_skill_bindings` into `PlatformConfig.extra` (`channel_prompts` already flows via the core shared-key loop; the loop restricts skill bindings to discord+slack, so the Matrix plugin seeds it itself — extra-only, no env bridge, multiplex-safe).
- `website/docs/user-guide/messaging/matrix.md`: `matrix.channel_prompts` + `matrix.channel_skill_bindings` sections mirroring the Discord/Slack wording, adapted to Matrix room IDs (`!abc:server`) and thread semantics, with a 2-room example and a warning that bound skill names must be installed (`hermes skills list`; unknown names log `Auto-skill '<name>' not found` and fail open).

## Why

Per-room personas (coach room, CFO room, …) previously required global prompts or manual skill invocation on Matrix. Discord/Telegram/Slack already support this; Matrix lagged.

## Config example

```yaml
platforms:
  matrix:
    channel_prompts:
      "!fitnessroom:server": |
        You are Greg the coach. DB-first, evidence over vibes.
    channel_skill_bindings:
      - id: "!fitnessroom:server"
        skills: [fitness-coach]
```

No core/gateway/E2EE/crypto changes. No other platform touched. Empty config is a verified no-op.

## Test evidence

- New `tests/gateway/test_matrix_channel_prompts.py` (8 tests): empty/missing/blank config yields neither field; room prompt+skill resolution; second-room isolation; thread inherits parent; exact thread entry wins; unbound room clean.
- Full existing `tests/gateway/test_matrix.py` still passes (112 tests on the local tree; 120 total incl. new file on the rebased branch).
- Live trial on a real homeserver: configured 2 rooms, sent 1 probe message each. Fitness room bot replied "Greg the coach — fitness-coach skill loaded." Gateway log shows `inbound message` → `response ready` → `sent event` for both rooms. Also caught live that a bound-but-uninstalled skill name logs `Auto-skill 'finance' not found` (fail-open, documented).

## Platforms tested

Linux (Arch) gateway + local Tuwunel homeserver, E2EE rooms, `hermes send` + live gateway turns.