### PR TITLE
fix(gateway): debounce the restart-drain refusal to one notice per chat per window

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3984,6 +3984,9 @@ class GatewayRunner(
     # Slow-tier respawns while work is queued; if 30 min of 5-min retries can't keep it up, fail loudly.
     _MAX_SLOW_WATCHER_RESPAWNS = 6
     _TELEGRAM_CAPABILITY_HINT_COOLDOWN_S = 300.0
+    # Drain-window refusal: one notice per (profile, chat) per window — a 30-min restart drain must
+    # not answer every message with the same line (#109002).
+    _DRAIN_NOTICE_COOLDOWN_S = 300.0
     _APPROVAL_TIMEOUT_SECONDS = 300  # 5 minutes
     _MAX_INTERRUPT_DEPTH = 3  # Cap recursive interrupt handling
     # Command-specific mid-run reject texts (busy_policy == "reject" with a busy_handler naming an

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -962,7 +962,11 @@ class GatewayInboundMixin:
         """Drain gate, user-defined quick commands (exec/alias) and plugin slash commands →
         ``(handled, result, command)``; an alias quick command rewrites ``command``."""
         if self._draining:
-            return True, f"⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now.", command
+            if self._should_send_drain_notice(source):
+                return True, f"⏳ Gateway is {self._status_action_gerund()} and is not accepting new work right now.", command
+            # Already told this chat inside the cooldown window; stay silent instead of repeating
+            # the identical refusal for every message sent during the drain (#109002).
+            return True, None, command
 
         # User-defined quick commands (bypass agent loop, no LLM call)
         qcmd = self._hm_quick_commands().get(command) if command else None

--- a/gateway/run_topics.py
+++ b/gateway/run_topics.py
@@ -123,6 +123,12 @@ class GatewayTopicThreadsMixin:
         """Rate-limit the BotFather Threads Settings screenshot (repeated /topic must not re-upload it)."""
         return self._telegram_cooldown_elapsed(source, "_telegram_capability_hint_ts", self._TELEGRAM_CAPABILITY_HINT_COOLDOWN_S)
 
+    def _should_send_drain_notice(self, source: SessionSource) -> bool:
+        """Rate-limit the drain-window refusal to one per (profile, chat) per cooldown window, not
+        one per message — during a long restart drain, repeated identical refusals read as a bot
+        stuck in a loop (#109002)."""
+        return self._telegram_cooldown_elapsed(source, "_drain_notice_ts", self._DRAIN_NOTICE_COOLDOWN_S)
+
     # ── Telegram topic mode: user-facing text ───────────────────────────────────────────────
 
     def _telegram_topic_root_lobby_message(self) -> str:

--- a/tests/gateway/test_drain_notice_cooldown_109002.py
+++ b/tests/gateway/test_drain_notice_cooldown_109002.py
@@ -1,0 +1,122 @@
+"""Tests for #109002: the drain-window refusal must be debounced per (profile, chat).
+
+During a restart drain, the idle-path ``_draining`` guard used to answer EVERY inbound
+message with the identical "not accepting new work" notice. A drain window can last
+~30 minutes (force-drain cap), so a user who kept typing saw the same line repeated
+and reasonably concluded the bot was stuck in a loop. The notice now goes through the
+existing per-(profile, chat) cooldown helper (same pattern as the Telegram lobby
+reminder): first message answered, messages inside the cooldown window stay silent.
+"""
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.event import MessageEvent, MessageType
+from gateway.session import SessionSource
+
+
+def _make_source(chat_id: str = "c1") -> SessionSource:
+    return SessionSource(
+        platform=Platform.WECOM,
+        user_id="u1",
+        chat_id=chat_id,
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(source: SessionSource) -> MessageEvent:
+    return MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="m1",
+    )
+
+
+def _make_runner() -> "GatewayRunner":
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._draining = True
+    runner._restart_requested = True  # → "restarting" in the notice text
+    return runner
+
+
+async def _dispatch(runner, source):
+    return await runner._hm_dispatch_quick_and_plugin_commands(
+        _make_event(source), source, None
+    )
+
+
+@pytest.mark.asyncio
+async def test_first_drain_message_gets_the_notice():
+    runner = _make_runner()
+    source = _make_source()
+
+    handled, result, command = await _dispatch(runner, source)
+
+    assert handled is True
+    assert result is not None and "not accepting new work" in result
+    assert command is None
+
+
+@pytest.mark.asyncio
+async def test_repeat_messages_inside_cooldown_window_stay_silent():
+    runner = _make_runner()
+    source = _make_source()
+
+    _handled, first, _cmd = await _dispatch(runner, source)
+    assert first is not None
+
+    # Burst (0.9 s apart in the report) and minutes-later follow-ups: all inside the window.
+    for _ in range(3):
+        handled, result, command = await _dispatch(runner, source)
+        assert handled is True
+        assert result is None  # already told this chat; swallow instead of repeating
+        assert command is None
+
+
+@pytest.mark.asyncio
+async def test_notice_returns_after_the_cooldown_window_elapses():
+    runner = _make_runner()
+    source = _make_source()
+
+    _handled, first, _cmd = await _dispatch(runner, source)
+    assert first is not None
+
+    # Age the stamp past the window (the drain itself can last ~30 min).
+    key = next(iter(runner._drain_notice_ts))
+    runner._drain_notice_ts[key] = time.monotonic() - runner._DRAIN_NOTICE_COOLDOWN_S - 1.0
+
+    handled, result, _cmd = await _dispatch(runner, source)
+    assert handled is True
+    assert result is not None and "not accepting new work" in result
+
+
+@pytest.mark.asyncio
+async def test_cooldown_is_per_chat():
+    runner = _make_runner()
+
+    _handled, first_a, _cmd = await _dispatch(runner, _make_source(chat_id="chat-a"))
+    _handled, first_b, _cmd = await _dispatch(runner, _make_source(chat_id="chat-b"))
+    assert first_a is not None
+    assert first_b is not None  # a different chat is not suppressed by chat-a's notice
+
+    _handled, second_a, _cmd = await _dispatch(runner, _make_source(chat_id="chat-a"))
+    assert second_a is None  # ...but chat-a itself stays silent inside the window
+
+
+@pytest.mark.asyncio
+async def test_no_drain_means_no_gate():
+    runner = _make_runner()
+    runner._draining = False
+    runner.config = {}  # no quick commands configured
+    source = _make_source()
+
+    handled, result, command = await _dispatch(runner, source)
+
+    assert handled is False  # falls through to normal idle processing
+    assert result is None


### PR DESCRIPTION
## What does this PR do?

During a restart drain, the idle-path `_draining` guard in `_hm_dispatch_quick_and_plugin_commands()` answered **every** inbound message with the identical "⏳ Gateway is restarting and is not accepting new work right now." notice. A drain window can stay open ~30 minutes (force-drain cap 1800 s), so a user who kept typing got one identical refusal per message and reasonably concluded the bot was stuck in a loop (#109002).

This PR routes that notice through the existing per-(profile, chat) debounce helper `_telegram_cooldown_elapsed()` — the same pattern already used for the Telegram lobby reminder ("rate-limit ... to one per cooldown window, not one per prompt typed"). The first message during a drain is still answered (it is the only signal the user gets that their message was not accepted); messages from the same chat inside the cooldown window (`_DRAIN_NOTICE_COOLDOWN_S = 300.0`, same value as the capability-hint cooldown) stay silent. The guard keeps `handled=True` in the silent case, so the message is still swallowed exactly as before — only the repeated reply is suppressed.

**Scope note:** the issue also proposes making the idle path consult `_queue_during_drain_enabled()` so `queue`/`steer` queue the message instead of dropping it. I looked into that and deliberately left it out: queue-then-restart only works for sessions that get auto-resumed, and only busy sessions get the `restart_interrupted`/`restart_timeout` `resume_pending` marker (`_mark_running_sessions_resume_pending()` walks `_running_agents` only). For an **idle** session a queued event survives the restart only as a replayed transcript row (`recover_pending_to_db()`) — no turn is ever scheduled for it, so the user's message would sit unanswered with a "queued" claim. That half of the fix needs a pickup mechanism for queued events on idle sessions (a design decision), so it seemed better to keep this PR to the clearly-safe half: the notice debounce.

## Related Issue

Fixes #109002

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` — add class constant `_DRAIN_NOTICE_COOLDOWN_S = 300.0` next to the existing cooldown constants.
- `gateway/run_topics.py` — add `_should_send_drain_notice()` next to the other `_should_send_*` cooldown wrappers; it calls the existing `_telegram_cooldown_elapsed()` with a `_drain_notice_ts` stamp dict (per-(profile, chat), fail-open when the chat has no id).
- `gateway/run_inbound.py` — the idle-path `_draining` guard now sends the notice only when `_should_send_drain_notice(source)` is True, otherwise returns `(True, None, command)` (handled + silent, mirroring the lobby-reminder pattern).
- `tests/gateway/test_drain_notice_cooldown_109002.py` — regression tests: first notice sent, repeats inside the window silent, notice returns after the window elapses, cooldown is per chat, and no drain ⇒ no gate.

## How to Test

1. `pytest tests/gateway/test_drain_notice_cooldown_109002.py -v` — Observed result: 5 passed.
2. `pytest tests/gateway/ -q` — Observed result: 8186 passed; the 23 failures on this machine reproduce identically on a clean `upstream/main` checkout (same 10-test set when run file-scoped on both trees — verified with a stash/baseline diff), i.e. pre-existing environment failures unrelated to this change.
3. Manual: set `runner._draining = True`, call `_hm_dispatch_quick_and_plugin_commands()` twice with the same source — first call returns the notice, second returns `None`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (gateway suite — the touched code lives entirely under `gateway/`; pre-existing local env failures documented above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure-Python control flow, no OS-specific behavior)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A
