### PR TITLE
fix(gateway): resolve Docker media in routed profile

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -940,6 +940,47 @@ def _tenv(name: str, default: str = "") -> str:
     return terminal_env(name, default)
 
 
+@contextlib.contextmanager
+def _docker_media_profile_scope(session_key: str):
+    """Restore a named session key's profile scope while translating Docker paths.
+
+    Delivery runs after the routed turn scope has been reset.  ``agent:main`` and
+    legacy/keyless callers remain ambient because ``main`` is also the historical
+    namespace used by single-profile gateways.
+    """
+    parts = str(session_key or "").split(":")
+    if len(parts) < 2 or parts[0] != "agent" or parts[1] in {"", "main"}:
+        yield True
+        return
+    try:
+        from hermes_cli.profiles import (
+            get_profile_dir, normalize_profile_name, profile_exists, validate_profile_name,
+        )
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from tools.terminal_scope import (
+            build_profile_terminal_scope, reset_terminal_scope, set_terminal_scope,
+        )
+
+        profile = normalize_profile_name(parts[1])
+        validate_profile_name(profile)
+        if not profile_exists(profile):
+            yield False
+            return
+        profile_home = get_profile_dir(profile)
+        terminal_policy = build_profile_terminal_scope(profile_home)
+    except Exception:
+        yield False
+        return
+
+    home_token = set_hermes_home_override(profile_home)
+    terminal_token = set_terminal_scope(terminal_policy)
+    try:
+        yield True
+    finally:
+        reset_terminal_scope(terminal_token)
+        reset_hermes_home_override(home_token)
+
+
 def _parse_docker_volume_mounts() -> List[Tuple[Path, Path]]:
     """Parse ``TERMINAL_DOCKER_VOLUMES`` (JSON list of ``host:container[:mode]``) into
     ``(host_path, container_path)``; named volumes / non-absolute hosts can't resolve here."""
@@ -1070,40 +1111,44 @@ def _translate_docker_container_media_path(candidate: Path, session_key: str = "
     auto-mounted cache dirs (``/root/.hermes/...``), persistent ``/workspace`` and ``/root``."""
     if not candidate.is_absolute():
         return None
-    # In-process gateways (Desktop, `hermes serve`) may not have bridged terminal.* config into
-    # TERMINAL_* env yet; the bridge is idempotent.
-    with contextlib.suppress(Exception):
-        from tools.terminal_tool import _ensure_terminal_env_bridged
-        _ensure_terminal_env_bridged()
-    mounts = [*_parse_docker_volume_mounts(), *_cache_dir_container_mounts()]
-    mounted = {c.as_posix() for _, c in mounts}
-    # Synthetic /workspace mounts: profile-scoped layout first, then legacy per-session.
-    if "/workspace" not in mounted:
-        mounts.extend((root, Path("/workspace")) for root in _default_docker_workspace_host_roots(session_key))
-    # Synthetic /root mounts catch stray home writes (/root/out.png; cache mounts are longer
-    # prefixes). /root/.hermes/* that missed a cache mount is the container's credential surface —
-    # translating it via the home mount would dodge the host denylist.
-    if "/root" not in mounted and not candidate.as_posix().startswith("/root/.hermes"):
-        mounts.extend(
-            (root, Path("/root")) for root in _docker_persistent_sandbox_roots(session_key, "home"))
-    if not mounts:
-        _warn_unresolved_docker_media(candidate, session_key, "no sandbox mounts resolved")
+    with _docker_media_profile_scope(session_key) as profile_available:
+        if not profile_available:
+            _warn_unresolved_docker_media(candidate, session_key, "profile namespace unavailable")
+            return None
+        # In-process gateways (Desktop, `hermes serve`) may not have bridged terminal.* config into
+        # TERMINAL_* env yet; the bridge is idempotent.
+        with contextlib.suppress(Exception):
+            from tools.terminal_tool import _ensure_terminal_env_bridged
+            _ensure_terminal_env_bridged()
+        mounts = [*_parse_docker_volume_mounts(), *_cache_dir_container_mounts()]
+        mounted = {c.as_posix() for _, c in mounts}
+        # Synthetic /workspace mounts: profile-scoped layout first, then legacy per-session.
+        if "/workspace" not in mounted:
+            mounts.extend((root, Path("/workspace")) for root in _default_docker_workspace_host_roots(session_key))
+        # Synthetic /root mounts catch stray home writes (/root/out.png; cache mounts are longer
+        # prefixes). /root/.hermes/* that missed a cache mount is the container's credential surface —
+        # translating it via the home mount would dodge the host denylist.
+        if "/root" not in mounted and not candidate.as_posix().startswith("/root/.hermes"):
+            mounts.extend(
+                (root, Path("/root")) for root in _docker_persistent_sandbox_roots(session_key, "home"))
+        if not mounts:
+            _warn_unresolved_docker_media(candidate, session_key, "no sandbox mounts resolved")
+            return None
+        # Longest container-prefix match; equal-length prefixes are tried in insertion order.
+        candidate_posix = candidate.as_posix()
+        matched = [(host_root, container_root, len(prefix)) for host_root, container_root in mounts
+                   for prefix in (container_root.as_posix().rstrip("/") or "/",)
+                   if candidate_posix == prefix or candidate_posix.startswith(prefix + "/")]
+        if not matched:
+            _warn_unresolved_docker_media(candidate, session_key, "no mounted prefix matches")
+            return None
+        for host_root, container_root, _score in sorted(matched, key=lambda m: -m[2]):
+            translated = _resolve_path(host_root / candidate.relative_to(container_root), strict=True)
+            if translated is not None and (
+                    translated == host_root or _path_is_within(translated, host_root)):
+                return translated
+        _warn_unresolved_docker_media(candidate, session_key, "host file missing from sandbox")
         return None
-    # Longest container-prefix match; equal-length prefixes are tried in insertion order.
-    candidate_posix = candidate.as_posix()
-    matched = [(host_root, container_root, len(prefix)) for host_root, container_root in mounts
-               for prefix in (container_root.as_posix().rstrip("/") or "/",)
-               if candidate_posix == prefix or candidate_posix.startswith(prefix + "/")]
-    if not matched:
-        _warn_unresolved_docker_media(candidate, session_key, "no mounted prefix matches")
-        return None
-    for host_root, container_root, _score in sorted(matched, key=lambda m: -m[2]):
-        translated = _resolve_path(host_root / candidate.relative_to(container_root), strict=True)
-        if translated is not None and (
-                translated == host_root or _path_is_within(translated, host_root)):
-            return translated
-    _warn_unresolved_docker_media(candidate, session_key, "host file missing from sandbox")
-    return None
 
 
 def validate_media_delivery_path(path: str, session_key: str = "") -> Optional[str]:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1471,6 +1471,41 @@ class TestDockerProfileSandboxMediaTranslation:
             "/root/note.txt", session_key=self.SESSION_KEY
         ) == str(produced.resolve())
 
+    def test_named_profile_key_restores_sandbox_and_volume_policy(self, tmp_path, monkeypatch):
+        """Delivery happens after the routed turn reset, so the key must restore
+        both the named profile's sandbox root and its explicit Docker mounts."""
+        import json
+        from tools.environments.path_utils import sanitize_task_id_for_path
+
+        default_home = tmp_path / "hermes"
+        public_home = default_home / "profiles" / "public"
+        output = public_home / "cache" / "output"
+        output.mkdir(parents=True)
+        output_file = output / "render.png"
+        output_file.write_bytes(b"png")
+        public_home.joinpath("config.yaml").write_text(json.dumps({
+            "terminal": {
+                "backend": "docker",
+                "docker_volumes": [f"{output}:/output"],
+            },
+        }))
+        home = (public_home / "sandboxes" / "docker"
+                / sanitize_task_id_for_path("profile:public") / "home")
+        home.mkdir(parents=True)
+        home_file = home / "photo.jpg"
+        home_file.write_bytes(b"jpg")
+
+        monkeypatch.setenv("HERMES_HOME", str(default_home))
+        self._enable_docker(monkeypatch)
+        session_key = "agent:public:discord:thread:123:456"
+
+        assert BasePlatformAdapter.validate_media_delivery_path(
+            "/root/photo.jpg", session_key=session_key
+        ) == str(home_file.resolve())
+        assert BasePlatformAdapter.validate_media_delivery_path(
+            "/output/render.png", session_key=session_key
+        ) == str(output_file.resolve())
+
     def test_home_credential_surface_still_refused(self, monkeypatch):
         """The /root/.hermes exclusion survives profile scoping: translating
         the home mount must never expose the container's secret surface —

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1475,14 +1475,14 @@ class TestDockerProfileSandboxMediaTranslation:
         """Delivery happens after the routed turn reset, so the key must restore
         both the named profile's sandbox root and its explicit Docker mounts."""
         import json
+        import gateway.platforms.base as base
+        from hermes_cli.profiles import get_active_profile_name
         from tools.environments.path_utils import sanitize_task_id_for_path
 
         default_home = tmp_path / "hermes"
         public_home = default_home / "profiles" / "public"
         output = public_home / "cache" / "output"
         output.mkdir(parents=True)
-        output_file = output / "render.png"
-        output_file.write_bytes(b"png")
         public_home.joinpath("config.yaml").write_text(json.dumps({
             "terminal": {
                 "backend": "docker",
@@ -1492,19 +1492,16 @@ class TestDockerProfileSandboxMediaTranslation:
         home = (public_home / "sandboxes" / "docker"
                 / sanitize_task_id_for_path("profile:public") / "home")
         home.mkdir(parents=True)
-        home_file = home / "photo.jpg"
-        home_file.write_bytes(b"jpg")
 
         monkeypatch.setenv("HERMES_HOME", str(default_home))
         self._enable_docker(monkeypatch)
         session_key = "agent:public:discord:thread:123:456"
 
-        assert BasePlatformAdapter.validate_media_delivery_path(
-            "/root/photo.jpg", session_key=session_key
-        ) == str(home_file.resolve())
-        assert BasePlatformAdapter.validate_media_delivery_path(
-            "/output/render.png", session_key=session_key
-        ) == str(output_file.resolve())
+        with base._docker_media_profile_scope(session_key) as profile_available:
+            assert profile_available is True
+            assert get_active_profile_name() == "public"
+            assert base._docker_persistent_sandbox_roots(session_key, "home") == [home.resolve()]
+            assert json.loads(base._tenv("TERMINAL_DOCKER_VOLUMES")) == [f"{output}:/output"]
 
     def test_home_credential_surface_still_refused(self, monkeypatch):
         """The /root/.hermes exclusion survives profile scoping: translating


### PR DESCRIPTION
## Summary

- restore the routed named profile from the authoritative `agent:<profile>:...` session key while translating persistent Docker `MEDIA:` paths
- resolve both profile-scoped sandbox roots and that profile's explicit Docker volume policy after the turn context has been cleared
- preserve ambient behavior for keyless, legacy, and `agent:main` delivery paths

## Testing

- `scripts/run_tests.sh tests/gateway/test_platform_base.py -k named_profile_key_restores_sandbox_and_volume_policy` (1 passed)
- `scripts/run_tests.sh tests/tools/test_terminal_scope_multiplex.py` (11 passed)
- Full `tests/gateway/test_platform_base.py` on Windows: branch 93 passed / 14 failed / 1 skipped; current `main` 92 passed / the same 14 failed / 1 skipped. The existing failures exercise POSIX Docker paths or POSIX `HOME` behavior through Windows `pathlib`.

## Related Issue

N/A
