### PR TITLE
fix(telegram): let an explicit TELEGRAM_REACTIONS beat the materialized YAML default

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6354,10 +6354,19 @@ class TelegramAdapter(BasePlatformAdapter):
     # -- Message reactions (processing lifecycle) --
 
     def _reactions_enabled(self) -> bool:
-        """Reactions enabled via ``extra.reactions`` (YAML, per profile) or TELEGRAM_REACTIONS."""
-        configured = self.config.extra.get("reactions")
+        """Reactions enabled via TELEGRAM_REACTIONS or ``extra.reactions`` (YAML, per profile).
+
+        An explicitly set env var wins over YAML — the same rule ``yaml_env_setter`` documents for
+        the YAML→env bridge — so the stock ``reactions: false`` every install materializes cannot
+        silently kill a documented ``TELEGRAM_REACTIONS=true`` (#109032). Under multiplex a scoped
+        miss returns the default instead of another profile's process-env value (#72348), so only
+        a scoped/env hit counts as explicit; otherwise the profile's own YAML decides.
+        """
+        configured = _scoped_gate_env("TELEGRAM_REACTIONS", "")
+        if not configured:
+            configured = self.config.extra.get("reactions")
         if configured is None:
-            configured = _scoped_gate_env("TELEGRAM_REACTIONS", "false")
+            return False
         return str(configured).lower() not in {"false", "0", "no"}
 
     async def _set_reaction(self, chat_id: str, message_id: str, emoji: Optional[str]) -> bool:

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -53,6 +53,75 @@ def test_reactions_enabled_when_set_true(monkeypatch):
     assert adapter._reactions_enabled() is True
 
 
+def test_explicit_env_wins_over_materialized_yaml_default(monkeypatch):
+    """TELEGRAM_REACTIONS=true must beat the stock ``reactions: false`` in config.yaml (#109032).
+
+    Fresh installs materialize the whole default config tree, so ``_apply_yaml_config`` seeds
+    ``extra["reactions"] = False`` even when the user never chose a value; the reader must still
+    honour the explicitly set env var, like ``yaml_env_setter`` documents for the bridge.
+    """
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    adapter = _make_adapter()
+    adapter.config.extra["reactions"] = False
+    assert adapter._reactions_enabled() is True
+
+
+def test_bridged_yaml_false_without_explicit_env_still_disables(monkeypatch):
+    """With no explicit env the YAML→env bridge writes 'false'; reactions stay off."""
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "false")
+    adapter = _make_adapter()
+    adapter.config.extra["reactions"] = False
+    assert adapter._reactions_enabled() is False
+
+
+def test_yaml_true_enables_when_env_unset(monkeypatch):
+    """An explicit ``reactions: true`` in config.yaml enables reactions without any env var."""
+    monkeypatch.delenv("TELEGRAM_REACTIONS", raising=False)
+    adapter = _make_adapter()
+    adapter.config.extra["reactions"] = True
+    assert adapter._reactions_enabled() is True
+
+
+def test_explicit_env_false_wins_over_yaml_true(monkeypatch):
+    """An explicit TELEGRAM_REACTIONS=false also wins over a YAML ``reactions: true``."""
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "false")
+    adapter = _make_adapter()
+    adapter.config.extra["reactions"] = True
+    assert adapter._reactions_enabled() is False
+
+
+def test_scoped_miss_does_not_leak_default_profile_env(monkeypatch):
+    """Under multiplex a scoped miss must not read another profile's process-env value (#72348)."""
+    from agent.secret_scope import reset_secret_scope, set_multiplex_active, set_secret_scope
+
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")  # default profile's bridged value
+    adapter = _make_adapter()
+    adapter.config.extra["reactions"] = False  # this profile's own YAML
+    set_multiplex_active(True)
+    token = set_secret_scope({"TELEGRAM_BOT_TOKEN": "222:b2"})
+    try:
+        assert adapter._reactions_enabled() is False
+    finally:
+        reset_secret_scope(token)
+        set_multiplex_active(False)
+
+
+def test_scoped_env_hit_wins_over_own_yaml(monkeypatch):
+    """A secondary profile's own scoped TELEGRAM_REACTIONS=true beats its YAML ``reactions: false``."""
+    from agent.secret_scope import reset_secret_scope, set_multiplex_active, set_secret_scope
+
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "false")  # default profile's value
+    adapter = _make_adapter()
+    adapter.config.extra["reactions"] = False
+    set_multiplex_active(True)
+    token = set_secret_scope({"TELEGRAM_BOT_TOKEN": "222:b2", "TELEGRAM_REACTIONS": "true"})
+    try:
+        assert adapter._reactions_enabled() is True
+    finally:
+        reset_secret_scope(token)
+        set_multiplex_active(False)
+
+
 # ── _set_reaction ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What does this PR do?

Since 545e74d0ea, `TelegramAdapter._reactions_enabled()` consults `config.extra.get("reactions")` **before** the `TELEGRAM_REACTIONS` env var, while `_apply_yaml_config`'s `_bridge_lower` seeds `extra["reactions"]` whenever the YAML key is present — including the stock `reactions: false` that every fresh install materializes from `DEFAULT_CONFIG`. Net effect: the documented `TELEGRAM_REACTIONS=true` switch became a silent no-op after the 0.21.2 update, and 👀/👍/👎 reactions stop with no log line.

This contradicts the writer side of the same bridge: `yaml_env_setter` (in `gateway/platforms/_shared.py`) documents *"writes `os.environ[name]` only when the var is unset (**explicit env wins over YAML**)"*. The reader now honours the same rule: read the scoped env first, fall back to the profile's own YAML. Multiplex isolation is unchanged — `_platform_gate_env` returns the default on a scoped miss instead of falling through to another profile's process-env value (#72348), so only a scoped/env hit counts as explicit.

## Related Issue

Fixes #109032

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/telegram/adapter.py`: `_reactions_enabled()` now reads `_scoped_gate_env("TELEGRAM_REACTIONS", "")` first (explicit env wins, per-profile scoped) and falls back to `extra["reactions"]` (the profile's own YAML); docstring states the precedence rule and both issue refs.
- `tests/gateway/test_telegram_reactions.py`: six regression tests — explicit env beats materialized YAML false, bridged YAML false still disables, YAML true enables with env unset, explicit env false beats YAML true, scoped miss does not leak the default profile's env (#72348 isolation), scoped hit beats the profile's own YAML.

## How to Test

1. `python -m pytest tests/gateway/test_telegram_reactions.py -q` — Observed result: **13 passed** (7 pre-existing + 6 new). On unmodified `main`, the three precedence tests fail (`extra.reactions=false` shadows `TELEGRAM_REACTIONS=true`), proving the regression coverage.
2. `python -m pytest tests/gateway/test_telegram_*.py -q` — Observed result: 666 passed, 2 skipped, 1 failed (`test_telegram_thread_fallback.py::test_send_image_upload_fallback_blocks_connect_time_rebind`, `httpx.ConnectError`). That test fails identically on unmodified `main` (verified on a clean checkout) — an environment/network flake unrelated to this change.
3. `python -m pytest tests/gateway/test_multiplex_yaml_env_bridge_isolation.py tests/gateway/test_adapter_settings_profile_parity.py tests/plugins/platforms/photon/test_multiplex_profile_scope.py -q` — Observed result: **23 passed** (multiplex isolation and per-profile parity are preserved).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (full telegram + multiplex scopes above; one unrelated network flake fails identically on clean main)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 (Darwin 25.6.0, Apple Silicon), Python 3.11.16

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (no platform-specific code touched)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
