### PR TITLE
fix(guardrails): settle loop-cap spawn estimates on call outcome

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -302,6 +302,10 @@ class ToolCallGuardrailController:
         self._persisted_result_paths: dict[str, str] = {}
         self._turn_web_search_count = 0
         self._turn_subagent_count = 0
+        # Loop-cap estimates are provisionally counted in before_call and settled
+        # in after_call: a delegate_task batch the tool REJECTS spawns nothing, so
+        # its estimate must roll back instead of poisoning the turn's budget.
+        self._pending_loop_cap_estimates: dict[ToolCallSignature, int] = {}
 
     @property
     def halt_decision(self) -> ToolGuardrailDecision | None:
@@ -346,6 +350,12 @@ class ToolCallGuardrailController:
         if failed is None:
             failed, _ = classify_tool_failure(tool_name, result)
         warnings = self.config.warnings_enabled
+
+        # Settle the loop-cap estimate from before_call: a failed call spawned
+        # nothing, so its optimistic spawn estimate must return to the budget.
+        # (web_search has no batch semantics — its estimate of 1 is kept as-is
+        # whenever the search itself ran, success or failure alike.)
+        self._settle_loop_cap_estimate(tool_name, signature, failed=failed)
 
         if failed:
             # An identical failing call is only a REPLAY if nothing landed in between;
@@ -465,7 +475,13 @@ class ToolCallGuardrailController:
         self, tool_name: str, args: Mapping[str, Any], signature: ToolCallSignature,
     ) -> ToolGuardrailDecision | None:
         """Block once a per-turn cap is reached (BEFORE the call, so the (cap+1)-th is refused), else advance
-        the counter and return None. delegate_task control actions spawn nothing and keep working after the cap."""
+        the counter and return None. delegate_task control actions spawn nothing and keep working after the cap.
+
+        Spawn counting is estimate-then-settle: before_call counts the batch optimistically so the
+        (cap+1)-th valid batch is still refused in time, and after_call rolls the estimate back when
+        the tool rejected the batch or the call failed (a rejected batch spawns nothing). Estimates
+        unsettled by after_call (call crashed, legacy callers) stay counted — fail-closed.
+        """
         spec = _LOOP_CAPS.get(tool_name)
         if spec is None:
             return None
@@ -474,8 +490,42 @@ class ToolCallGuardrailController:
         increment = 1 if tool_name == "web_search" else (_subagent_spawn_count(args) if cap else 0)
         if increment and cap and count >= cap:
             return self._decide("block", code, tool_name, count, signature, cap=cap)
+        if increment and cap and tool_name == "delegate_task" and count + increment > cap:
+            # A batch larger than the whole remaining turn budget can never run;
+            # refuse it upfront (with a truthful count) instead of letting the tool
+            # reject it and still burn the estimate.
+            return self._decide("block", code, tool_name, count, signature, cap=cap)
         setattr(self, count_attr, count + increment)
+        if increment:
+            self._pending_loop_cap_estimates[signature] = (
+                self._pending_loop_cap_estimates.get(signature, 0) + increment
+            )
         return None
+
+    def _settle_loop_cap_estimate(self, tool_name: str, signature: ToolCallSignature, *, failed: bool) -> None:
+        """Settle the before_call estimate once the call's outcome is known.
+
+        Only delegate_task has batch semantics: a FAILED delegate_task spawned nothing
+        (validation error, crash, timeout before spawn), so its whole estimate rolls
+        back. A successful call spawned what it asked for — the estimate stands.
+        web_search counts searches that RAN (the cap is against runaway searching,
+        not failed searching), so its estimate of 1 is kept even on failure.
+        Estimates with no matching pending entry (blocked pre-call, legacy callers
+        that skip after_call) are left untouched — fail-closed.
+        """
+        spec = _LOOP_CAPS.get(tool_name)
+        if spec is None:
+            return
+        pending = self._pending_loop_cap_estimates.pop(signature, None)
+        if pending is None:
+            return
+        if tool_name == "delegate_task" and failed:
+            _, count_attr, _ = spec
+            count = getattr(self, count_attr)
+            setattr(self, count_attr, max(0, count - pending))
+            return
+        # Success (or web_search failure): estimate confirmed as spawned/run.
+        return
 
 
 def toolguard_synthetic_result(decision: ToolGuardrailDecision) -> str:

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -282,6 +282,70 @@ def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
     assert decision.should_halt is True
 
 
+def test_subagent_cap_counts_only_calls_that_actually_spawned():
+    # A rejected batch (oversized, malformed, no goal, ...) spawns NOTHING, so it
+    # must not consume the per-turn subagent budget. Pinning the regression: a
+    # poisoned counter blocked every later valid single-task call for the turn.
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=False,
+            loop_caps=LoopCapConfig(max_subagents=5),
+        )
+    )
+    # A batch WITHIN the turn budget is allowed by the guardrail, but the tool
+    # can still reject it for its own reasons (validation, pool limits) — the
+    # failed result must roll the estimate back.
+    mid = {"tasks": [{"goal": f"g{i} " + "x" * 40} for i in range(3)]}
+    assert controller.before_call("delegate_task", mid).action == "allow"
+    rejected = json.dumps({"error": "Task 1 goal is too short."})
+    assert controller.after_call("delegate_task", mid, rejected, failed=True).action == "allow"
+    assert controller._turn_subagent_count == 0  # estimate rolled back
+
+    # The turn's budget is intact: a valid single-task call still spawns.
+    ok = {"goal": "do the thing", "context": "ctx"}
+    assert controller.before_call("delegate_task", ok).action == "allow"
+    spawned = json.dumps({"status": "completed", "subagent_id": "sa-1"})
+    assert controller.after_call("delegate_task", ok, spawned, failed=False).action == "allow"
+    assert controller._turn_subagent_count == 1
+
+
+def test_subagent_cap_still_blocks_runaway_valid_spawning():
+    # The rollback must not weaken the cap: enough SUCCESSFUL spawns still block.
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=False,
+            loop_caps=LoopCapConfig(max_subagents=2),
+        )
+    )
+    ok = json.dumps({"status": "completed", "subagent_id": "sa-1"})
+    for i in range(2):
+        args = {"goal": f"task {i} " + "x" * 40}
+        assert controller.before_call("delegate_task", args).action == "allow"
+        assert controller.after_call("delegate_task", args, ok, failed=False).action == "allow"
+    blocked = controller.before_call("delegate_task", {"goal": "one more " + "x" * 40})
+    assert blocked.action == "block"
+    assert blocked.code == "loop_subagent_cap"
+    assert "2" in blocked.message  # truthful count: 2 actually spawned
+
+
+def test_subagent_cap_pending_estimate_blocks_oversized_batch_upfront():
+    # A single batch larger than the whole turn budget is refused BEFORE any
+    # counter moves — with a truthful message naming the batch size.
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=False,
+            loop_caps=LoopCapConfig(max_subagents=5),
+        )
+    )
+    big = {"tasks": [{"goal": f"g{i} " + "x" * 40} for i in range(6)]}
+    decision = controller.before_call("delegate_task", big)
+    assert decision.action == "block"
+    assert decision.code == "loop_subagent_cap"
+    assert controller._turn_subagent_count == 0  # blocked call consumed nothing
+    # And the turn is not poisoned: a valid call still goes through.
+    assert controller.before_call("delegate_task", {"goal": "ok " + "x" * 40}).action == "allow"
+
+
 
 
 


### PR DESCRIPTION
## Problem

A `delegate_task` batch the tool **rejects** (oversized vs `max_concurrent_children`, validation error, crash) spawns nothing — but `ToolCallGuardrailController._check_loop_cap` counted `len(tasks)` optimistically in `before_call`, and `after_call` never rolled it back. One rejected call poisoned the turn's entire subagent budget: every later *valid* single-task call died with `loop_subagent_cap` and a factually wrong message ("this turn has already spawned 151 subagents" when zero spawned).

Observed live: a corrupted 151-task batch was rejected by the tool, and the turn's delegation was locked out for good.

## Fix

Estimate-then-settle:

- `before_call` keeps the optimistic count (so the (cap+1)-th **valid** batch is still refused in time) and records the estimate per `ToolCallSignature`.
- `after_call` settles: a **failed** `delegate_task` spawns nothing → its estimate rolls back. A successful call spawned what it asked for → estimate stands.
- A batch larger than the entire remaining turn budget is refused **upfront** with the same truthful message instead of burning the estimate on a guaranteed rejection.
- `web_search` estimates are kept on failure — its cap counts searches that *ran* (the runaway-search concern), not failed ones.
- Estimates never settled by `after_call` (call crashed mid-flight, legacy callers) stay counted — **fail-closed**.

The rollback also makes the existing block message truthful: `count` now reflects actually-spawned work.

## Testing

- Red-first: `test_subagent_cap_counts_only_calls_that_actually_spawned` (rejected batch → budget intact → later valid call still spawns) and `test_subagent_cap_pending_estimate_blocks_oversized_batch_upfront` failed on `origin/main`, pass after.
- `test_subagent_cap_still_blocks_runaway_valid_spawning` pins that the rollback does not weaken the cap (N successful spawns still block, message carries the truthful count).
- Mutation-proofed: no-op settle (`return` injected at settle top) reverts the rollback test to red; restored → green.
- Gates: `bash scripts/run_tests.sh tests/agent/test_tool_guardrails.py tests/tools/test_delegate_control_actions.py tests/agent/test_stall_guards.py tests/run_agent/test_length_continuation_thinking_exhaustion.py` → **109/109 passed**.