### PR TITLE
fix(gateway): fail closed for routed Docker media

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1106,6 +1106,12 @@ def _translate_docker_container_media_path(candidate: Path, session_key: str = "
     return None
 
 
+def _is_named_profile_session_key(session_key: str) -> bool:
+    """Return whether a session key identifies a secondary profile namespace."""
+    parts = str(session_key or "").split(":", 2)
+    return len(parts) == 3 and parts[0] == "agent" and parts[1] not in {"", "main", "default"}
+
+
 def validate_media_delivery_path(path: str, session_key: str = "") -> Optional[str]:
     """Safe absolute file path for native media delivery, else None. Default: any existing
     regular file outside the credential / system denylist (symmetric with inbound). Strict
@@ -1124,7 +1130,9 @@ def validate_media_delivery_path(path: str, session_key: str = "") -> Optional[s
         return None
     # Docker agents emit MEDIA:/workspace/... — map container paths to host paths first.
     resolved = _translate_docker_container_media_path(expanded, session_key=session_key)
-    if resolved is None:
+    # A named Docker session must never fall back to the ambient host path: an unresolved
+    # container path belongs to that sandbox, not to whatever happens to exist on the host.
+    if resolved is None and not (_is_named_profile_session_key(session_key) and _docker_env_active()):
         resolved = _resolve_path(expanded, strict=True)
     if resolved is None or not resolved.is_file():
         return None

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -914,6 +914,61 @@ class TestDockerContainerMediaPathTranslation:
             "/workspace/out.png"
         ) == str(media.resolve())
 
+    def test_named_docker_session_does_not_fallback_to_ambient_host(self, tmp_path, monkeypatch):
+        """Reproduce the old fallback: an unresolved container path was host-resolved."""
+        ambient = tmp_path / "ambient.png"
+        ambient.write_bytes(b"png")
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        monkeypatch.setattr("gateway.platforms.base._docker_env_active", lambda: True)
+        monkeypatch.setattr("gateway.platforms.base._path_under_denied_prefix", lambda _path: False)
+        monkeypatch.setattr("gateway.platforms.base._media_delivery_allowed_roots", lambda: [tmp_path])
+        monkeypatch.setattr(
+            "gateway.platforms.base._translate_docker_container_media_path",
+            lambda *_args, **_kwargs: None,
+        )
+        monkeypatch.setattr(
+            "gateway.platforms.base._resolve_path",
+            lambda _path, **_kwargs: ambient,
+        )
+
+        assert BasePlatformAdapter.validate_media_delivery_path(
+            "C:/root/out.png", session_key="agent:secondary:telegram:dm:123"
+        ) is None
+
+    def test_keyless_docker_path_keeps_host_fallback(self, tmp_path, monkeypatch):
+        ambient = tmp_path / "ambient.png"
+        ambient.write_bytes(b"png")
+        monkeypatch.setattr("gateway.platforms.base._docker_env_active", lambda: True)
+        monkeypatch.setattr(
+            "gateway.platforms.base._translate_docker_container_media_path",
+            lambda *_args, **_kwargs: None,
+        )
+        monkeypatch.setattr(
+            "gateway.platforms.base._resolve_path",
+            lambda _path, **_kwargs: ambient,
+        )
+        monkeypatch.setattr("gateway.platforms.base._media_delivery_allowed_roots", lambda: [tmp_path])
+
+        assert BasePlatformAdapter.validate_media_delivery_path("C:/root/out.png") == str(ambient)
+
+    def test_main_profile_docker_path_keeps_host_fallback(self, tmp_path, monkeypatch):
+        ambient = tmp_path / "ambient.png"
+        ambient.write_bytes(b"png")
+        monkeypatch.setattr("gateway.platforms.base._docker_env_active", lambda: True)
+        monkeypatch.setattr(
+            "gateway.platforms.base._translate_docker_container_media_path",
+            lambda *_args, **_kwargs: None,
+        )
+        monkeypatch.setattr(
+            "gateway.platforms.base._resolve_path",
+            lambda _path, **_kwargs: ambient,
+        )
+        monkeypatch.setattr("gateway.platforms.base._media_delivery_allowed_roots", lambda: [tmp_path])
+
+        assert BasePlatformAdapter.validate_media_delivery_path(
+            "C:/root/out.png", session_key="agent:main:telegram:dm:123"
+        ) == str(ambient)
+
     def test_unmapped_container_path_fails(self, monkeypatch):
         monkeypatch.delenv("TERMINAL_DOCKER_VOLUMES", raising=False)
         monkeypatch.delenv("TERMINAL_ENV", raising=False)


### PR DESCRIPTION
## Summary

This is a complementary follow-up to the canonical implementation in #109028 for #109024. It hardens the Docker `MEDIA:` trust boundary without duplicating or replacing the routed-profile translation fix.

## Observed problem

After a multiplexed turn loses its profile runtime context, a Docker container path such as `/root/out.png` or `/output/result.png` can fail container-to-host translation. The existing validator then falls back to resolving the same absolute string against the gateway host filesystem. In a multiplexed named-profile session, that ambient fallback can select a file from the default profile or another host-visible location.

## Root cause

`validate_media_delivery_path()` used `None` from `_translate_docker_container_media_path()` as a generic signal and always attempted `_resolve_path(expanded, strict=True)`. That fallback is compatible with legacy/keyless and primary `agent:main` behavior, but it is unsafe for a secondary profile namespace whose container path has an authoritative session identity.

## Fix

- Recognize only the established `agent:<secondary-profile>:...` session-key shape as a named secondary namespace.
- When Docker is active and that namespace is present, fail closed if container translation returns no host path.
- Preserve host fallback for keyless calls and `agent:main:...` sessions.
- Keep the change at the existing validation chokepoint; no duplicated translation or profile-resolution implementation was introduced.

The check is O(1), performs no additional filesystem I/O, and does not change non-Docker behavior.

## Tests

Passed:

```text
python -m pytest tests/gateway/test_platform_base.py -k 'named_docker_session or keyless_docker_path or main_profile_docker_path' -q
Pytest: 3 passed

git diff --check
passed
```

The repository wrapper could not run in the isolated worktree because it has no `.venv`/`venv` containing pytest and no configured `HERMES_PYTHON`:

```text
scripts/run_tests.sh ...
error: no virtualenv with pytest found ...
```

## Scope and relationship to existing work

- References #109024.
- Complements PR #109028; does not copy its commits, alter its branch, or supersede its ownership.
- This PR intentionally does not change the profile restoration/volume translation implementation owned by #109028.
- The regression tests cover named secondary failure-closed behavior, keyless compatibility, and `agent:main` compatibility.

## Security impact

A failed translation for a named secondary Docker namespace can no longer be reinterpreted as an ambient host path by this validator. This prevents a cross-profile or wrong-root attachment caused by fallback resolution. Existing denylist and allowed-root checks remain unchanged.
