### PR TITLE
fix(serve): treat ps keyword errors as inconclusive

### DIFF
--- a/hermes_cli/web_server_lifecycle.py
+++ b/hermes_cli/web_server_lifecycle.py
@@ -76,9 +76,11 @@ def _process_start_marker(pid: int) -> str:
     marker = result.stdout.strip()
     if result.returncode == 0 and marker:
         return f"ps:{marker}"
-    # Only known "missing pid" signals become ProcessLookupError; anything else stays OSError so the
-    # watchdog degrades to pid liveness instead of exiting on a healthy backend.
-    if (result.returncode == 1 and not marker) or "no such process" in result.stderr.lower():
+    # rc=1 with no output or diagnostic is the portable missing-pid signal. Diagnostics such as an
+    # unsupported output keyword remain OSError so the watchdog degrades to pid liveness.
+    if (
+        result.returncode == 1 and not marker and not result.stderr.strip()
+    ) or "no such process" in result.stderr.lower():
         raise ProcessLookupError(pid)
     raise OSError(f"ps could not inspect PID {pid}: {result.stderr.strip()}")
 

--- a/tests/hermes_cli/test_serve_parent_watchdog.py
+++ b/tests/hermes_cli/test_serve_parent_watchdog.py
@@ -208,12 +208,21 @@ def test_ps_marker_probe_classifies_missing_process_vs_other_ps_failures(monkeyp
 
     from hermes_cli import web_server_lifecycle
 
-    def fake_run(stderr):
-        return lambda *a, **k: subprocess.CompletedProcess(args=a, returncode=2, stdout="", stderr=stderr)
+    def fake_run(stderr, returncode=2):
+        return lambda *a, **k: subprocess.CompletedProcess(
+            args=a, returncode=returncode, stdout="", stderr=stderr
+        )
 
     monkeypatch.setattr(subprocess, "run", fake_run("ps: 4242: No such process"))
     with pytest.raises(ProcessLookupError):
         web_server_lifecycle._process_start_marker(4242)
+
+    monkeypatch.setattr(
+        subprocess, "run", fake_run("ps: lstart: keyword not found", returncode=1)
+    )
+    with pytest.raises(OSError) as excinfo:
+        web_server_lifecycle._process_start_marker(4242)
+    assert not isinstance(excinfo.value, ProcessLookupError)
 
     monkeypatch.setattr(subprocess, "run", fake_run("ps: temporary process table failure"))
     with pytest.raises(OSError) as excinfo:


### PR DESCRIPTION
## What does this PR do?

On macOS/BSD, an unsupported `ps -o lstart=` field can return status 1 with empty stdout and a diagnostic such as `ps: lstart: keyword not found`.

`_process_start_marker` treated every status-1 response with an empty marker as `ProcessLookupError`, regardless of stderr. The parent-death watchdog therefore interpreted this probe failure as a conclusively dead Desktop parent and could terminate a healthy backend.

This fix keeps the existing missing-PID behavior for silent status-1 responses, while preserving diagnostic failures as `OSError` unless stderr explicitly reports `No such process`. The watchdog can then fall back to PID liveness.

## Related Issue

No issue filed.

Related, not duplicate: #108602 changes shutdown behavior after orphan detection; this PR prevents false orphan detection before that path is reached.

## Type of Change

- 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server_lifecycle.py`: require stderr to be empty before treating status 1 with no marker as a missing process
- `tests/hermes_cli/test_serve_parent_watchdog.py`: added a regression case for status 1 with `lstart: keyword not found`

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_serve_parent_watchdog.py -q`
2. On Linux, 13 tests pass and the macOS-only regression test is skipped
3. The `tests-os` CI lane runs the regression test on `macos-latest`

## Checklist

### Code

- Contributing Guide read
- Conventional Commits followed
- No duplicate PRs found
- Only this fix in the PR
- 13 focused tests pass; 1 macOS-only test skipped on Linux
- Ruff checks pass
- Tested on: WSL2 Ubuntu

### Documentation & Housekeeping

- No docs changes needed — N/A
- No config key changes — N/A
- Security impact: N/A; no credential, permission, or trust-boundary changes
