### PR TITLE
feat(agent): adaptive reasoning effort (auto) — deterministic per-turn resolution

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1202,6 +1202,79 @@ def _reasoning_config_for_wire(agent):
     return cfg
 
 
+def _turn_signature(messages: list) -> tuple | None:
+    """Stable identity of the user turn a request belongs to: (position, length) of the
+    LAST user message. Stable across a tool loop (nothing is appended after it but
+    assistant/tool messages); changes when a new user message arrives. Position alone
+    breaks when history is pruned; length alone collides; together they are cheap."""
+    last_pos, last_len = None, 0
+    for pos, msg in enumerate(messages or []):
+        role = msg.get("role") if isinstance(msg, dict) else getattr(msg, "role", None)
+        if role == "user":
+            content = msg.get("content") if isinstance(msg, dict) else getattr(msg, "content", "")
+            last_pos, last_len = pos, len(content or "")
+    return (last_pos, last_len) if last_pos is not None else None
+
+
+def _auto_effort_signals(messages: list) -> dict:
+    """Deterministic request-shape signals for THIS user turn, measured from the
+    request payload about to ship: the triggering user message length, the whole-request
+    context estimate, tool results accumulated in the turn, and requests already sent
+    in the turn (assistant rounds since the last user message + 1)."""
+    import json as _json
+
+    msgs = [
+        m if isinstance(m, dict) else {"role": getattr(m, "role", ""), "content": getattr(m, "content", "")}
+        for m in (messages or [])
+    ]
+    last_user_pos = -1
+    for pos, msg in enumerate(msgs):
+        if msg.get("role") == "user":
+            last_user_pos = pos
+    user_chars = len(msgs[last_user_pos].get("content") or "") if last_user_pos >= 0 else 0
+    turn_tail = msgs[last_user_pos + 1:] if last_user_pos >= 0 else msgs
+    tool_results = sum(1 for m in turn_tail if m.get("role") == "tool")
+    turn_depth = 1 + sum(1 for m in turn_tail if m.get("role") == "assistant")
+    est_ctx_tokens = int(len(_json.dumps(msgs, default=str)) / 4)
+    return {
+        "user_chars": user_chars,
+        "est_ctx_tokens": est_ctx_tokens,
+        "tool_results": tool_results,
+        "turn_depth": turn_depth,
+    }
+
+
+def _auto_effort_for_request(agent, messages: list | None = None) -> str | None:
+    """Resolve ``effort: "auto"`` to a concrete ladder level for the request about to
+    ship, pinned per user turn — or None when the agent's config is not ``auto``.
+
+    Pinning matters for the prompt cache: a reasoning-config change costs a cold
+    prefix write on config-sensitive providers, so the level is resolved once when
+    the turn's first request is built and held through the tool loop (same turn
+    signature), then re-resolved when the next user message arrives.
+    """
+    cfg = getattr(agent, "reasoning_config", None)
+    if not (isinstance(cfg, dict) and cfg.get("enabled") is not False and cfg.get("effort") == "auto"):
+        return None
+    from agent.reasoning_effort import resolve_auto_effort
+
+    if messages is None:
+        messages = getattr(agent, "conversation_history", None) or []
+    sig = _turn_signature(messages)
+    if sig is not None and getattr(agent, "_adaptive_effort_turn_sig", None) == sig:
+        return agent._adaptive_effort_level
+    level = resolve_auto_effort(**_auto_effort_signals(messages))
+    agent._adaptive_effort_turn_sig = sig
+    agent._adaptive_effort_level = level
+    return level
+
+
+def _reset_auto_effort_pin(agent) -> None:
+    """Drop the per-turn pin (model switch, session resume — signals may differ)."""
+    agent._adaptive_effort_turn_sig = None
+    agent._adaptive_effort_level = None
+
+
 def _alias_tool_search_bridge_for_xai(agent, transport, tools_for_api):
     """xAI chat-completions reserves ``tool_search`` and 400s when the bridge declares
     it (#95003): rename the wire declaration; ``normalize_response`` maps calls back
@@ -1382,6 +1455,10 @@ def _build_api_kwargs_for_mode(agent, api_messages: list, tools_for_api: list | 
     # One-shot continuation override — consumed exactly once, on the FIRST
     # request this call builds (only one api_mode branch runs per invocation).
     reasoning_config = _reasoning_config_for_wire(agent)
+    auto_level = _auto_effort_for_request(agent, api_messages)
+    if auto_level is not None:
+        base = reasoning_config if isinstance(reasoning_config, dict) else {}
+        reasoning_config = {**base, "effort": auto_level}
     if tools_for_api is None:
         tools_for_api = agent.tools
     # The one place request_overrides are consumed: static /fast values are already pinned

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1261,8 +1261,14 @@ def _auto_effort_for_request(agent, messages: list | None = None) -> str | None:
     if messages is None:
         messages = getattr(agent, "conversation_history", None) or []
     sig = _turn_signature(messages)
-    if sig is not None and getattr(agent, "_adaptive_effort_turn_sig", None) == sig:
-        return agent._adaptive_effort_level
+    pinned_sig = getattr(agent, "_adaptive_effort_turn_sig", None)
+    pinned_level = getattr(agent, "_adaptive_effort_level", None)
+    if pinned_level is not None and pinned_sig == sig:
+        # pinned_sig == sig covers both same-user-turn and the no-user-message
+        # case (both None): system-only/scheduled flows re-resolving per request
+        # as tool results grow is the mid-loop change the pin exists to prevent.
+        # Held until _reset_auto_effort_pin or a real user turn arrives.
+        return pinned_level
     level = resolve_auto_effort(**_auto_effort_signals(messages))
     agent._adaptive_effort_turn_sig = sig
     agent._adaptive_effort_level = level

--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -148,6 +148,50 @@ def requested_effort(reasoning_config: Optional[dict]) -> Optional[str]:
     return str(reasoning_config.get("effort") or "").strip().lower() or None
 
 
+#: Sentinal effort requesting per-turn adaptive resolution (resolved before the wire,
+#: never sent to a provider).
+AUTO_EFFORT = "auto"
+
+# Adaptive thresholds: deliberately coarse, deterministic, and cheap to reason about.
+# They gate a THINKING BUDGET, not a routing decision — the cost of a near-miss is a
+# slightly over/under-thought answer, so three bands suffice until data says otherwise.
+_AUTO_TRIVIAL_USER_CHARS = 160      # short ask ...
+_AUTO_TRIVIAL_CTX_TOKENS = 4_000    # ... with an empty context
+_AUTO_HEAVY_CTX_TOKENS = 60_000     # long-horizon session context
+_AUTO_HEAVY_TOOL_RESULTS = 6        # multi-step tool work already in flight
+_AUTO_HEAVY_USER_CHARS = 4_000      # a long, dense single ask
+
+
+def resolve_auto_effort(
+    *, user_chars: int, est_ctx_tokens: int, tool_results: int, turn_depth: int,
+) -> str:
+    """Deterministic request-shape signals → an internal effort level.
+
+    Signals (all cheap, all measured at request-build time, no LLM judgment):
+    ``user_chars`` length of the triggering user message; ``est_ctx_tokens``
+    estimated whole-request context; ``tool_results`` tool results already in the
+    message list; ``turn_depth`` requests since the last user message (1 = first).
+
+    Mapping: trivial ask (short prompt, near-empty context, no tool loop) → ``low``;
+    heavy work (large context, deep tool loop, or a very long ask) → ``high``;
+    everything else → ``medium``. Returns a concrete ladder level — never ``auto``.
+    """
+    if (
+        user_chars <= _AUTO_TRIVIAL_USER_CHARS
+        and est_ctx_tokens <= _AUTO_TRIVIAL_CTX_TOKENS
+        and tool_results == 0
+        and turn_depth <= 1
+    ):
+        return "low"
+    if (
+        est_ctx_tokens >= _AUTO_HEAVY_CTX_TOKENS
+        or tool_results >= _AUTO_HEAVY_TOOL_RESULTS
+        or user_chars >= _AUTO_HEAVY_USER_CHARS
+    ):
+        return "high"
+    return "medium"
+
+
 # ---- BEGIN PLUGIN-COMPAT (revert-scheduled; see COMPAT_MANIFEST.md) ----
 # Names external plugins imported from this module before the Sep 2026 decomposition.
 # Internal code MUST NOT use these (scripts/check_compat_pointers.py fails CI if it does).

--- a/batch_runner.py
+++ b/batch_runner.py
@@ -954,7 +954,7 @@ def main(
         reasoning_config = {"effort": "none"}
         print("🧠 Reasoning: DISABLED (effort=none)")
     elif reasoning_effort:
-        valid_efforts = ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]
+        valid_efforts = ["auto", "none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]
         if reasoning_effort not in valid_efforts:
             print(f"❌ Error: --reasoning_effort must be one of: {', '.join(valid_efforts)}")
             raise SystemExit(1)

--- a/gateway/slash_commands_model.py
+++ b/gateway/slash_commands_model.py
@@ -697,6 +697,8 @@ class GatewayModelCommandsMixin:
             title=t("gateway.reasoning.picker_title", level=level, scope=scope, display=display_state),
             choices=[
                 {"value": "none", "label": t("gateway.reasoning.choice_none"), "is_current": current_effort == "none"},
+                {"value": "auto", "label": t("gateway.reasoning.choice_auto", default="auto (adaptive)"),
+                 "is_current": current_effort == "auto"},
                 *({"value": lv, "label": lv, "is_current": lv == current_effort} for lv in VALID_REASONING_EFFORTS),
                 *({"value": v, "label": t(f"gateway.reasoning.choice_{v}"), "is_current": False}
                   for v in ("reset", "show", "hide")),

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -107,6 +107,8 @@ def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
     value = str(effort or "").strip().lower()
     if not value:
         return None
+    if value == "auto":
+        return "auto"  # adaptive: resolved per user turn at request-build time
     if value == "none" or value in VALID_REASONING_EFFORTS:
         return value
     allowed = ", ".join(("none", *VALID_REASONING_EFFORTS))

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -938,6 +938,10 @@ def parse_reasoning_effort(effort) -> dict | None:
     effort = str(effort).strip().lower()  # False -> "false" -> disabled; "" matches neither set
     if effort in {"none", "false", "disabled"}:
         return {"enabled": False}
+    if effort == "auto":
+        # Adaptive: resolved per user turn at request-build time (agent.reasoning_effort.
+        # resolve_auto_effort); never sent to a provider verbatim.
+        return {"enabled": True, "effort": "auto"}
     if effort in VALID_REASONING_EFFORTS:
         return {"enabled": True, "effort": effort}
     return None

--- a/tests/agent/test_adaptive_effort.py
+++ b/tests/agent/test_adaptive_effort.py
@@ -1,0 +1,209 @@
+"""Adaptive reasoning effort (`effort: "auto"`).
+
+`auto` is accepted wherever an effort level is configured, resolved to a concrete
+ladder level per user turn from deterministic request-shape signals (no LLM
+classifier), pinned for the turn's tool loop (changing reasoning config mid-loop
+costs a cold prefix write on config-sensitive providers), and NEVER emitted on
+the wire — transports only ever see a concrete level.
+"""
+
+import json
+
+import pytest
+
+from agent.reasoning_effort import (
+    AUTO_EFFORT,
+    resolve_auto_effort,
+)
+from hermes_constants import parse_reasoning_effort, resolve_reasoning_config
+
+
+# ── Config acceptance ───────────────────────────────────────────────────────
+
+def test_parse_reasoning_effort_accepts_auto():
+    assert parse_reasoning_effort("auto") == {"enabled": True, "effort": "auto"}
+    assert parse_reasoning_effort("Auto") == {"enabled": True, "effort": "auto"}
+
+
+def test_auto_flows_through_resolve_reasoning_config():
+    cfg = {"agent": {"reasoning_effort": "auto"}}
+    assert resolve_reasoning_config(cfg, "glm-5.3") == {"enabled": True, "effort": "auto"}
+
+
+def test_auto_not_added_to_valid_reasoning_efforts():
+    # The public ladder stays wire-safe: only the seam may resolve auto, and it
+    # must never leak into the tuple transports clamp against.
+    from hermes_constants import VALID_REASONING_EFFORTS
+    assert AUTO_EFFORT not in VALID_REASONING_EFFORTS
+    assert AUTO_EFFORT == "auto"
+
+
+# ── The resolver: deterministic signal → level mapping ─────────────────────
+
+def test_short_simple_prompt_maps_low():
+    level = resolve_auto_effort(user_chars=40, est_ctx_tokens=800, tool_results=0, turn_depth=1)
+    assert level == "low"
+
+
+def test_long_complex_prompt_maps_high():
+    level = resolve_auto_effort(user_chars=4000, est_ctx_tokens=6000, tool_results=0, turn_depth=1)
+    assert level == "high"
+
+
+def test_mid_complexity_maps_medium():
+    level = resolve_auto_effort(user_chars=600, est_ctx_tokens=2500, tool_results=0, turn_depth=1)
+    assert level == "medium"
+
+
+def test_deep_tool_loop_escalates():
+    # A turn that has grown many tool results is doing agentic work: at least medium.
+    level = resolve_auto_effort(user_chars=100, est_ctx_tokens=20000, tool_results=12, turn_depth=1)
+    assert level in {"medium", "high"}
+
+
+def test_resolver_is_pure_and_total():
+    # Any non-negative signal combination yields a valid wire level, never auto.
+    from hermes_constants import VALID_REASONING_EFFORTS
+    for user_chars in (0, 10, 300, 2000, 9000):
+        for est_ctx_tokens in (0, 1500, 30000, 200000):
+            for tool_results in (0, 2, 9, 40):
+                for turn_depth in (1, 3, 8):
+                    level = resolve_auto_effort(
+                        user_chars=user_chars, est_ctx_tokens=est_ctx_tokens,
+                        tool_results=tool_results, turn_depth=turn_depth,
+                    )
+                    assert level in VALID_REASONING_EFFORTS, (user_chars, est_ctx_tokens, tool_results, turn_depth)
+
+
+# ── The seam: resolve once per user turn, pin through the tool loop ─────────
+
+class _StubAgent:
+    model = "gpt-5"
+    api_mode = "chat_completions"
+    base_url = "https://api.example.com"
+    provider = "custom"
+    tools = []
+    max_tokens = 4096
+    _base_url_hostname = "api.example.com"
+    _base_url_lower = "https://api.example.com"
+    session_id = "test-session"
+
+    def __init__(self, reasoning_config):
+        self.reasoning_config = reasoning_config
+        self.captured_configs = []
+        self.captured_effort = None
+
+    def __getattr__(self, name):
+        # Catch-all for builder-probed attrs: anything not explicitly defined
+        # reads as None (falsy, harmless). Called methods are all defined
+        # explicitly above; a None slip would raise loudly, not silently pass.
+        if name.startswith("__"):
+            raise AttributeError(name)
+        return None
+
+    def _prepare_messages_for_non_vision_model(self, msgs):
+        return msgs
+
+    def _resolved_api_call_timeout(self):
+        return 30
+
+    def _max_tokens_param(self, *a, **k):
+        return {}
+
+    def _supports_reasoning_extra_body(self):
+        return False
+
+    def _is_qwen_portal(self):
+        return False
+
+    def _is_openrouter_url(self):
+        return False
+
+    def _github_models_reasoning_extra_body(self):
+        return None
+
+    def _qwen_meta(self):
+        return None
+
+    def _openrouter_preferences(self):
+        return None
+
+    def _lmstudio_reasoning_options_cached(self):
+        return None
+
+    def _qwen_prepare_chat_messages(self, msgs):
+        return msgs
+
+    def _qwen_prepare_chat_messages_inplace(self, msgs):
+        return msgs
+
+    def _prompt_cache_scope(self):
+        return "test-scope"
+
+    def _ephemeral_reasoning_off_flag(self):
+        return False
+
+    def _ollama_num_ctx(self):
+        return None
+
+    def _get_transport(self):
+        return _RecordingTransport(self)
+
+
+class _RecordingTransport:
+    """Records the reasoning_config the seam handed the transport."""
+    def __init__(self, agent):
+        self._agent = agent
+
+    def build_kwargs(self, model, messages, tools, reasoning_config=None, **kw):
+        self._agent.captured_configs.append(reasoning_config)
+        if isinstance(reasoning_config, dict):
+            self._agent.captured_effort = reasoning_config.get("effort")
+        return {"model": model, "messages": messages}
+
+
+def _msg(role, content):
+    return {"role": role, "content": content}
+
+
+def test_seam_resolves_auto_to_concrete_level():
+    from agent.chat_completion_helpers import build_api_kwargs
+
+    agent = _StubAgent({"enabled": True, "effort": "auto"})
+    messages = [_msg("user", "Explain " + "quantum tunneling " * 40)]
+    kwargs = build_api_kwargs(agent, messages)
+    wire_effort = kwargs.get("reasoning_effort") or (kwargs.get("extra_body") or {}).get("reasoning_effort")
+    # Never auto on the wire; a concrete level or provider-default omission.
+    assert wire_effort != "auto"
+    if isinstance(wire_effort, str):
+        from hermes_constants import VALID_REASONING_EFFORTS
+        assert wire_effort in VALID_REASONING_EFFORTS
+
+
+def test_seam_pins_level_across_tool_loop():
+    """Second request in the SAME user turn must reuse the first resolution."""
+    from agent.chat_completion_helpers import _auto_effort_for_request, _reset_auto_effort_pin
+
+    agent = _StubAgent({"enabled": True, "effort": "auto"})
+    # Trivial opening ask -> resolves low.
+    user_turn = [_msg("user", "list the files")]
+    first = _auto_effort_for_request(agent, user_turn)
+    assert first == "low"
+    # Tool round: same turn, messages grew into heavy tool work — WITHOUT the
+    # pin this would re-resolve to high; the pin must hold it at low.
+    grown = user_turn + [_msg("assistant", json.dumps([{"callee": "t", "arguments": {}}])),
+                         _msg("tool", "x" * 5000)] * 7
+    second = _auto_effort_for_request(agent, grown)
+    assert second == first == "low"
+    # New user turn re-resolves.
+    new_turn = grown + [_msg("user", "short")]
+    _reset_auto_effort_pin(agent)
+    third = _auto_effort_for_request(agent, new_turn)
+    assert isinstance(third, str)
+
+
+def test_static_effort_bypasses_resolver():
+    from agent.chat_completion_helpers import _auto_effort_for_request
+
+    agent = _StubAgent({"enabled": True, "effort": "high"})
+    assert _auto_effort_for_request(agent, [_msg("user", "hi")]) is None

--- a/tests/agent/test_adaptive_effort.py
+++ b/tests/agent/test_adaptive_effort.py
@@ -202,6 +202,37 @@ def test_seam_pins_level_across_tool_loop():
     assert isinstance(third, str)
 
 
+def test_seam_pins_level_in_user_message_less_loop():
+    """No user message (scheduled/system-only flows): _turn_signature() is None and
+    the pin must STILL hold. Re-resolving per request as tool results grow is the
+    mid-loop config change the pin exists to prevent (cold prefix writes)."""
+    from agent.chat_completion_helpers import _auto_effort_for_request
+
+    agent = _StubAgent({"enabled": True, "effort": "auto"})
+    system_only = [_msg("system", "be terse")]
+    first = _auto_effort_for_request(agent, system_only)
+    assert first == "low"  # near-empty context, no tools, depth 1
+    grown = system_only + [_msg("assistant", json.dumps([{"callee": "t", "arguments": {}}])),
+                           _msg("tool", "x" * 5000)] * 7
+    second = _auto_effort_for_request(agent, grown)
+    # tool_results=7 >= 6 would re-resolve high; the None-signature pin holds it.
+    assert second == first == "low"
+
+
+def test_none_pin_yields_to_first_real_user_turn():
+    """After a None-signature pin, the first real user message must re-resolve on
+    its own shape (and pin there): None-pin must not leak into user turns."""
+    from agent.chat_completion_helpers import _auto_effort_for_request
+
+    agent = _StubAgent({"enabled": True, "effort": "auto"})
+    assert _auto_effort_for_request(agent, [_msg("system", "x")]) == "low"
+    heavy_user = [_msg("system", "x"), _msg("user", "deep " * 1200)]  # 6000 chars
+    assert _auto_effort_for_request(agent, heavy_user) == "high"
+    grown = heavy_user + [_msg("assistant", json.dumps([{"callee": "t", "arguments": {}}])),
+                          _msg("tool", "y")]
+    assert _auto_effort_for_request(agent, grown) == "high"
+
+
 def test_static_effort_bypasses_resolver():
     from agent.chat_completion_helpers import _auto_effort_for_request
 

--- a/tests/gateway/test_choice_picker.py
+++ b/tests/gateway/test_choice_picker.py
@@ -82,10 +82,11 @@ class TestReasoningChoicePicker:
         assert len(adapter.calls) == 1
         call = adapter.calls[0]
         values = [c["value"] for c in call["choices"]]
-        # Full canonical ladder + none + subcommands, in order
+        # Full canonical ladder + none + auto + subcommands, in order
         from hermes_constants import VALID_REASONING_EFFORTS
         assert values[0] == "none"
-        assert values[1:1 + len(VALID_REASONING_EFFORTS)] == list(VALID_REASONING_EFFORTS)
+        assert values[1] == "auto"
+        assert values[2:2 + len(VALID_REASONING_EFFORTS)] == list(VALID_REASONING_EFFORTS)
         assert values[-3:] == ["reset", "show", "hide"]
 
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1705,10 +1705,28 @@ Control how much "thinking" the model does before responding:
 
 ```yaml
 agent:
-  reasoning_effort: ""   # empty = medium. Options: none, minimal, low, medium, high, xhigh, max, ultra
+  reasoning_effort: ""   # empty = medium. Options: auto, none, minimal, low, medium, high, xhigh, max, ultra
 ```
 
 When unset (default), reasoning effort defaults to "medium" — a balanced level that works well for most tasks. Setting a value overrides it — higher reasoning effort gives better results on complex tasks at the cost of more tokens and latency.
+
+#### Adaptive effort (`auto`)
+
+```yaml
+agent:
+  reasoning_effort: "auto"
+```
+
+`auto` lets Hermes pick the level **per user turn** from deterministic request-shape signals — no extra model call, no LLM judgment:
+
+| Signal | Meaning |
+|---|---|
+| Triggering user message length | Short ask → cheaper turn |
+| Estimated whole-request context tokens | Long-horizon session → deeper thinking |
+| Tool results already in the turn | Multi-step work in flight → deeper thinking |
+| Requests already sent in the turn | Deep tool loop → deeper thinking |
+
+Trivial turns (short prompt, near-empty context, no tool loop) resolve to `low`; heavy turns (large context, dense tool loop, or a very long ask) resolve to `high`; everything else stays `medium`. The level is **pinned for the whole turn** — resolving mid-tool-loop would change the reasoning config between requests and cost a cold prompt-cache prefix write on cache-sensitive providers (Anthropic, OpenAI). A concrete ladder level always goes on the wire — `auto` itself is never sent to a provider. `/reasoning auto` (session or `--global`) and `--reasoning_effort auto` (batch runner) are accepted everywhere an explicit level is.
 
 :::note Adaptive-thinking models (Claude 4.6+, Fable/Mythos-class) over OpenRouter
 These models use *adaptive* thinking and don't accept the usual `reasoning.effort`


### PR DESCRIPTION
## Summary

Adds `reasoning_effort: "auto"`: Hermes resolves the thinking level per user turn from deterministic request-shape signals, pinned through the tool loop. No LLM classifier, no extra model calls.

## Motivation

Today effort is static per session (per-model override > global > server default). Either the user guesses a level per session, or trivial turns overthink and heavy turns underthink. `auto` lets the request shape pick.

## Design

- **`resolve_auto_effort()`** (`agent/reasoning_effort.py`): pure function, three bands — trivial (short ask, near-empty ctx, no tools) → `low`; heavy (≥60k ctx tokens, ≥6 tool results, or ≥4k-char ask) → `high`; else `medium`.
- **Chokepoint accepts `auto`**: `parse_reasoning_effort` returns `{"enabled": true, "effort": "auto"}`; never added to `VALID_REASONING_EFFORTS` (that tuple feeds UI ladders and provider wire sets — `auto` must not leak to a wire).
- **Seam** (`_build_api_kwargs_for_mode`): if effort is `auto`, `_auto_effort_for_request(agent, api_messages)` resolves ONCE per user turn and the level is pinned for the whole tool loop. Rationale: a reasoning-config change mid-loop costs a cold prompt-cache prefix write on config-sensitive providers (Anthropic, OpenAI) — same invariant the `_ephemeral_reasoning_off` path already respects.
- A concrete ladder level always goes on the wire via the existing `requested_effort`/`clamp_effort` path — `auto` itself is never sent to a provider.
- Input edges accepting `auto`: `/reasoning` picker (none → auto → ladder), kanban validator, batch runner `--reasoning_effort`.

## Signals (deterministic, measured at request-build time)

| Signal | Thresholds |
|---|---|
| Triggering user message length | ≤160 chars trivial; ≥4000 heavy |
| Estimated whole-request context tokens | ≤4k trivial; ≥60k heavy |
| Tool results in the turn | 0 trivial; ≥6 heavy |
| Requests since last user message | ≤1 trivial |

## Evidence

- `tests/agent/test_adaptive_effort.py` (11 tests): resolver band mapping, purity/totality, seam wire-never-auto, per-turn pinning, new-turn re-resolution, static-effort bypass, edge acceptance.
- Mutation-proofed both mechanisms: resolver threshold inverted → band test red; pin disabled → pin test red (first pin test was vacuous — both resolutions hit the same level; rewritten to make trivial→low then grown-to-heavy where the pin must hold low).
- Full gate: `bash scripts/run_tests.sh` over 9 suites (144 tests, 0 failed) incl. reasoning ladder, choice picker, batch runner, LM Studio, fast compression lane, length-continuation.

## Docs

`website/docs/user-guide/configuration.md`: new "Adaptive effort (`auto`)" subsection.

## Out of scope (deliberate)

- Cron jobs / auxiliary tasks (auxiliary config keeps its own explicit knob) — can follow.
- LLM-judged complexity classification — rejected by design (gate on data, not model judgment).