### PR TITLE
fix(memory): refuse to stage a review batch the budget can never fit

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -296,6 +296,19 @@ def _digest_history(messages_snapshot: List[Dict], tail: int = 24) -> List[Dict]
 
 # Review prompts. AIAgent exposes them as class attributes (``_MEMORY_REVIEW_PROMPT`` etc.) so
 # per-agent overrides work; the text lives here.
+
+# Memory is a BOUNDED store and a batch is validated on its FINAL total, so the fork must plan
+# its write against the budget instead of discovering the wall: an over-budget batch is refused
+# outright (tools/memory_tool.py — it could otherwise only sit in the approval queue failing on
+# every approve). Shared by the memory-only and combined prompts.
+_MEMORY_BUDGET_BLOCK = (
+    "Memory is a BOUNDED store (the tool reports usage/limit and the live entries). Plan the write "
+    "against that budget: a batch is validated on its FINAL total, so every addition must be paid "
+    "for by removes or merges in the same batch. An over-budget batch is refused, not queued — and "
+    "when a durable fact has no room and nothing can be merged, its home is the skill that governs "
+    "the task, not memory.\n\n"
+)
+
 _MEMORY_REVIEW_PROMPT = (
     "Review the conversation above and consider saving to memory if appropriate.\n\n"
     "Focus on:\n"
@@ -303,6 +316,7 @@ _MEMORY_REVIEW_PROMPT = (
     "personal details worth remembering?\n"
     "2. Has the user expressed expectations about how you should behave, their work style, or ways "
     "they want you to operate?\n\n"
+    + _MEMORY_BUDGET_BLOCK +
     "If something stands out, save it using the memory tool. If nothing is worth saving, just say "
     "'Nothing to save.' and stop."
 )
@@ -455,7 +469,7 @@ _COMBINED_REVIEW_PROMPT = (
     "Review the conversation above and update two things:\n\n"
     "**Memory**: who the user is. Did the user reveal persona, desires, preferences, personal "
     "details, or expectations about how you should behave? Save facts about the user and durable "
-    "preferences with the memory tool.\n\n"
+    "preferences with the memory tool.\n\n" + _MEMORY_BUDGET_BLOCK +
     "**Skills**: how to do this class of task. Be ACTIVE — most sessions produce at least one "
     "skill update. A pass that does nothing is a missed learning opportunity, not a neutral "
     "outcome.\n\n"

--- a/tests/agent/test_background_review_memory_scope.py
+++ b/tests/agent/test_background_review_memory_scope.py
@@ -197,3 +197,22 @@ class TestConsolidationProposalSurfaces:
         ]
         actions = bg.summarize_background_review_actions(review_messages, [])
         assert any("staged for your approval" in a for a in actions)
+
+
+class TestMemoryReviewBudgetGuidance:
+    """The staging gate refuses an over-budget proposal instead of queueing it — so the fork has
+    to hear about the budget BEFORE it writes: the shared budget rule must be wired into every
+    prompt that grants the memory tool, or the review rediscovers the wall on every pass."""
+
+    def test_budget_rule_present_in_both_memory_prompts(self):
+        assert bg._MEMORY_BUDGET_BLOCK.strip()
+        assert bg._MEMORY_BUDGET_BLOCK in bg._MEMORY_REVIEW_PROMPT
+        assert bg._MEMORY_BUDGET_BLOCK in bg._COMBINED_REVIEW_PROMPT
+
+    def test_spawned_memory_review_prompt_carries_the_rule(self):
+        # Module-level prompt (no per-agent override on this stub), so this is the wire-up an
+        # automatic review actually sends.
+        for review_memory, review_skills in ((True, False), (True, True)):
+            _target, prompt = bg.spawn_background_review_thread(
+                SimpleNamespace(), [], review_memory=review_memory, review_skills=review_skills, task_cfg={})
+            assert bg._MEMORY_BUDGET_BLOCK in prompt

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -819,6 +819,58 @@ class TestBackgroundReviewDeleteGate:
         # Atomic: the batch is only a proposal — its add must not land either.
         assert "fork consolidation" not in store._entries_for("memory")
 
+    def test_over_budget_batch_refused_not_queued(self, store, tmp_path, monkeypatch):
+        """A batch the budget can never fit must not be staged: a pending write is a decision the
+        user can ACCEPT (approve replays the payload verbatim -- there is no editing step), so
+        queueing one that fails on every approve leaves an item the queue can never drain."""
+        from tools.write_approval import MEMORY, list_pending
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        assert store.add("memory", "filler " * 70)["success"] is True  # ~489/500 chars used
+
+        token = set_current_write_origin("background_review")
+        try:
+            refused = json.loads(memory_tool(operations=[
+                {"action": "remove", "old_text": "filler"},
+                {"action": "add", "content": "x" * 600},
+            ], store=store))
+            staged = json.loads(memory_tool(operations=[
+                {"action": "remove", "old_text": "filler"},
+                {"action": "add", "content": "merged, shorter entry"},
+            ], store=store))
+        finally:
+            reset_current_write_origin(token)
+
+        assert refused["success"] is False
+        assert "over the limit" in refused["error"]
+        # The fork gets what it needs to reissue a leaner batch instead of a bare denial.
+        assert refused["current_entries"] and refused["usage"]
+        assert not refused.get("staged")
+        # Same consolidation, content that fits the budget: still staged. The refusal is about the
+        # budget, not a blanket denial of proposals.
+        assert staged["staged"] is True and staged["proposal_staged"] is True
+        assert [r["id"] for r in list_pending(MEMORY)] == [staged["pending_id"]]
+        # Fail-closed on both sides: nothing queued for the refused batch, nothing applied.
+        assert store._entries_for("memory") == ["filler " * 69 + "filler"]
+
+    def test_over_budget_single_replace_refused_not_queued(self, store, tmp_path, monkeypatch):
+        """Single-op path shares the staging budget check: a lone over-budget replace is refused
+        rather than queued as an unapprovable proposal."""
+        from tools.write_approval import MEMORY, pending_count
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        assert store.add("memory", "filler " * 70)["success"] is True
+
+        token = set_current_write_origin("background_review")
+        try:
+            result = json.loads(memory_tool(
+                action="replace", old_text="filler", content="y" * 600, store=store))
+        finally:
+            reset_current_write_origin(token)
+
+        assert result["success"] is False
+        assert "over the limit" in result["error"]
+        assert pending_count(MEMORY) == 0
+        assert store._entries_for("memory") == ["filler " * 69 + "filler"]
+
     def test_add_still_allowed_in_background_review(self, store):
         token = set_current_write_origin("background_review")
         try:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -129,13 +129,20 @@ def _validate_single_op(store, action, target, content, old_text) -> Optional[st
 _BG_DELETE_ACTIONS = ("replace", "remove")
 
 
-def _background_delete_gate(action, operations, target="memory", content=None, old_text=None) -> Optional[str]:
+def _background_delete_gate(action, operations, target="memory", content=None, old_text=None,
+                            store=None) -> Optional[str]:
     """Fail-closed operation gate for unattended background-review forks (#105921): ``add``
     stays available (it is all any review prompt asks for), while ``replace``/``remove`` —
     single or inside a batch — are never applied unattended. The op is staged in the pending
     store instead of merely denied: the fork's own review summary is never published back, so
     a plain denial would drop the consolidation request with no surfacing path at all. A
-    staging failure fails closed to a plain denial."""
+    staging failure fails closed to a plain denial.
+
+    Staging also requires the write to be one the user can ACCEPT: ``/memory approve`` replays
+    the payload verbatim (there is no editing step), so a batch the budget can never fit would
+    sit in the queue failing on every approve — and a failed approve does not consume it. Such
+    a batch is refused here, with the live entries and usage the fork needs to reissue a leaner
+    one, instead of being queued."""
     from tools.skill_provenance import is_unattended_review
 
     if not is_unattended_review():
@@ -144,6 +151,19 @@ def _background_delete_gate(action, operations, target="memory", content=None, o
         isinstance(op, dict) and op.get("action") in _BG_DELETE_ACTIONS for op in (operations or []))
     if not hit:
         return None
+    ops = operations if operations is not None else [{"action": action, "content": content, "old_text": old_text}]
+    if store is not None:
+        # The payload shape decides the replay path, so the preview must match it: a batch replays
+        # through apply_batch, a lone op through replace/remove.
+        over_budget = (store.preview_batch(target, ops) if operations is not None
+                       else store.preview_single(target, action, content, old_text))
+        if over_budget:
+            return tool_error(
+                f"{over_budget} This proposal was NOT staged for approval: the pending queue only holds "
+                "writes that can be accepted. Reissue ONE batch that fits the limit on its final state "
+                "(merge or shorten entries in the same batch), or — if the durable fact is a procedure — "
+                "put it in the skill that governs the task instead of memory.",
+                success=False, current_entries=store._entries_for(target), usage=store._usage(target))
     payload = ({"action": "batch", "target": target, "operations": operations}
                if operations is not None else
                {"action": action, "target": target, "content": content, "old_text": old_text})
@@ -187,7 +207,7 @@ def memory_tool(action: str = None, target: str = "memory", content: str = None,
     if operations:
         if not isinstance(operations, list):
             return tool_error("operations must be a list of {action, content?, old_text?} objects.", success=False)
-        denied = _background_delete_gate(action, operations, target)
+        denied = _background_delete_gate(action, operations, target, store=store)
         if denied is not None:
             return denied
         # Approval gate: stages (background/gateway) or prompts inline (CLI); off by default.
@@ -198,7 +218,7 @@ def memory_tool(action: str = None, target: str = "memory", content: str = None,
     if action not in _STORE_ACTIONS:
         return tool_error(f"Unknown action '{action}'. Use: add, replace, remove", success=False)
     invalid = (_validate_single_op(store, action, target, content, old_text)
-               or _background_delete_gate(action, None, target, content, old_text)
+               or _background_delete_gate(action, None, target, content, old_text, store=store)
                or _apply_write_gate(action, target, content, old_text))
     if invalid is not None:
         return invalid

--- a/tools/memory_tool_store.py
+++ b/tools/memory_tool_store.py
@@ -296,6 +296,72 @@ class MemoryStore:
         working[idx:idx + 1] = [content] if act == "replace" else []
         return None
 
+    @staticmethod
+    def _scan_batch(operations: List[Dict[str, Any]]) -> Optional[str]:
+        """Scan every add/replace content in a batch; one poisoned op rejects the whole batch."""
+        for i, op in enumerate(operations):
+            scan_error = op.get("action") in {"add", "replace"} and op.get("content") and _scan_memory_content(op["content"])
+            if scan_error:
+                return f"Operation {i + 1}: {scan_error}"
+        return None
+
+    def plan_batch(self, entries: List[str], limit: int, operations: List[Dict[str, Any]],
+                   target: str = "memory") -> Tuple[Optional[List[str]], str]:
+        """Validate a batch against *entries* without touching disk or failure counters:
+        ``(new_entries, message)`` when it would apply, ``(None, failure)`` when it would not.
+        Single source of the batch rules — ``apply_batch`` persists the plan, ``preview_batch``
+        only reads it."""
+        working = list(entries)  # only committed if the whole batch validates
+        for i, op in enumerate(operations):
+            act = op.get("action") or ""
+            msg = self._apply_batch_op(working, act, (op.get("content") or op.get("new_text") or "").strip(),
+                                       (op.get("old_text") or "").strip(), f"Operation {i + 1} ({act or 'unknown'})")
+            if msg:
+                return None, msg + " No operations were applied (batch is all-or-nothing)."
+        if entries and not working:
+            # #103419: a consolidation batch that removes the last entry would
+            # commit an empty file as a normal successful write. Refuse; single
+            # remove() is the deliberate-wipe path.
+            label = self._path_for(target).name
+            return None, (
+                f"Refusing to empty {label}: this batch would remove every entry from a "
+                f"previously non-empty store. Nothing was applied (batch is all-or-nothing). "
+                f"Keep at least one entry — merge overlapping entries into a shorter one instead "
+                f"of removing the last one (see current_entries below). To delete the final entry "
+                f"deliberately, use single remove() calls.")
+        new_total = len(ENTRY_DELIMITER.join(working))  # budget check against the FINAL state only
+        if new_total > limit:
+            return None, (
+                f"After applying all {len(operations)} operations, memory would be at "
+                f"{new_total:,}/{limit:,} chars -- over the limit. Remove or shorten more "
+                f"entries in the same batch (see current_entries below), then retry.")
+        return working, f"Applied {len(operations)} operation(s)."
+
+    def preview_batch(self, target: str, operations: List[Dict[str, Any]]) -> Optional[str]:
+        """Dry run of ``apply_batch`` against the LIVE entries: the failure message that call
+        would return, or None when the batch would apply. Never writes and never counts a
+        consolidation failure. Staging needs it because a pending write must be one the user can
+        ACCEPT — ``/memory approve`` replays the payload verbatim (no editing), so a batch that
+        cannot fit the budget would sit in the queue failing on every approve."""
+        if not operations:
+            return "operations list is empty."
+        ops = [op or {} for op in operations]
+        if scan_error := self._scan_batch(ops):
+            return scan_error
+        working, message = self.plan_batch(self._entries_for(target), self._char_limit(target), ops, target)
+        return None if working is not None else message
+
+    def preview_single(self, target: str, action: str, content: Optional[str] = None,
+                       old_text: Optional[str] = None) -> Optional[str]:
+        """Dry run of the SINGLE-op replay path (``/memory approve`` -> ``replace``/``remove``, not
+        ``apply_batch``): its failure message, or None. A lone ``remove`` only ever shrinks and
+        emptying the store is its deliberate-wipe path (#103419 is batch-only), so it is always
+        applicable; a lone ``replace`` goes through the same match + budget rules as the batch
+        form, which is why it delegates instead of restating them."""
+        if action != "replace":
+            return None
+        return self.preview_batch(target, [{"action": "replace", "content": content, "old_text": old_text}])
+
     def apply_batch(self, target: str, operations: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Apply add/replace/remove ops atomically against the FINAL budget, so one call
         can free space and add entries. All-or-nothing: any malformed / unmatched op or
@@ -303,38 +369,14 @@ class MemoryStore:
         if not operations:
             return _error("operations list is empty.")
         ops = [op or {} for op in operations]
-        # Scan every add/replace content BEFORE touching disk -- one poisoned op rejects the batch.
-        for i, op in enumerate(ops):
-            scan_error = op.get("action") in {"add", "replace"} and op.get("content") and _scan_memory_content(op["content"])
-            if scan_error:
-                return _error(f"Operation {i + 1}: {scan_error}")
+        if scan_error := self._scan_batch(ops):
+            return _error(scan_error)
 
         def _apply(entries, limit):
-            working = list(entries)  # only committed if the whole batch validates
-            for i, op in enumerate(ops):
-                act = op.get("action")
-                msg = self._apply_batch_op(working, act, (op.get("content") or op.get("new_text") or "").strip(),
-                                           (op.get("old_text") or "").strip(), f"Operation {i + 1} ({act or 'unknown'})")
-                if msg:
-                    return self._failure_with_entries(target, msg + " No operations were applied (batch is all-or-nothing).")
-            if entries and not working:
-                # #103419: a consolidation batch that removes the last entry would
-                # commit an empty file as a normal successful write. Refuse; single
-                # remove() is the deliberate-wipe path.
-                label = self._path_for(target).name
-                return self._failure_with_entries(target, (
-                    f"Refusing to empty {label}: this batch would remove every entry from a "
-                    f"previously non-empty store. Nothing was applied (batch is all-or-nothing). "
-                    f"Keep at least one entry — merge overlapping entries into a shorter one instead "
-                    f"of removing the last one (see current_entries below). To delete the final entry "
-                    f"deliberately, use single remove() calls."))
-            new_total = len(ENTRY_DELIMITER.join(working))  # budget check against the FINAL state only
-            if new_total > limit:
-                return self._failure_with_entries(target, (
-                    f"After applying all {len(operations)} operations, memory would be at "
-                    f"{new_total:,}/{limit:,} chars -- over the limit. Remove or shorten more "
-                    f"entries in the same batch (see current_entries below), then retry."))
-            return working, f"Applied {len(operations)} operation(s)."
+            working, message = self.plan_batch(entries, limit, ops, target)
+            if working is None:
+                return self._failure_with_entries(target, message)
+            return working, message
         return self._mutate(target, _apply)
 
     def format_for_system_prompt(self, target: str) -> Optional[str]:


### PR DESCRIPTION
## What

An unattended background-review fork can stage a consolidation batch (`/memory pending`) that the memory budget can never accept. Nothing validated the batch before queueing it, so `/memory approve` replays the payload verbatim (there is no editing step), fails on the budget — and because a failed approve does not consume the item, it stays in the queue failing on every retry.

Repro on current `main`, with the real 3-op payload a review fork staged against a 2192/2200 store:

```
fork write  : success=True staged=True pending=e154738a
/memory approve -> success=False
  After applying all 3 operations, memory would be at 2,299/2,200 chars -- over the limit.
  Remove or shorten more entries in the same batch (see current_entries below), then retry.
queue after failed approve: 1 item(s) — never consumed
```

Where it manifests: `tools/memory_tool.py::_background_delete_gate` stages the write without ever consulting the store, while `MemoryStore.apply_batch` (`tools/memory_tool_store.py`) is the only place the budget is enforced — at replay time, far too late for the fork (whose summary is not published back) and for the user (who can only approve or discard).

## Fix

The whole class, on both staging shapes (batch payload, and a lone `replace`):

- **`MemoryStore.plan_batch()`** — the batch rules (scan, per-op apply, the #103419 keep-one-entry rule, the final-total budget) extracted so they can be evaluated with no write and no failure counter. `apply_batch` now persists the plan, `preview_batch()` only reads it. No rule is restated in two places.
- **`MemoryStore.preview_single()`** — the lone-op replay path runs through `replace`/`remove`, not `apply_batch`, and a lone `remove` may empty the store (#103419 is batch-only), so it delegates the match + budget rules instead of duplicating them.
- **`_background_delete_gate()`** — refuses an unapprovable proposal instead of queueing it, returning the message the live path already gives plus `current_entries`/`usage`, so the fork can reissue a batch that fits.
- **`_MEMORY_REVIEW_PROMPT` / `_COMBINED_REVIEW_PROMPT`** — state the budget up front (shared `_MEMORY_BUDGET_BLOCK`), so a review plans a consolidation that fits instead of rediscovering the wall every pass.

After:

```
fork write  : success=False  (same "2,299/2,200 chars" reason + current_entries/usage)
queue: 0 item(s) — nothing dead to approve
memory kept unchanged: 2,192 chars
```

Staging still keeps its #105921 purpose — the user keeps the authority to accept or discard a `replace`/`remove` — but the queue now only holds writes that can actually be accepted.

## Tests

`scripts/run_tests.sh`, all green:
- `tests/tools/test_memory_tool.py` — invariant pair: an over-budget batch is refused and the queue stays empty (while the same consolidation with content that fits is still staged), and the lone `replace` path shares the check.
- `tests/agent/test_background_review_memory_scope.py` — the budget rule stays wired into both prompts that grant the memory tool, including through `spawn_background_review_thread`.
- plus `tests/tools/test_write_approval.py`, `tests/agent/test_builtin_memory_disabled_surface.py`, `tests/agent/test_background_review_memory_scope.py`, `tests/run_agent/test_background_review*.py`, `tests/test_journal_mode_config.py`.
