### PR TITLE
fix(delegate): validator-accepted wrapped prose survives upstream failed flag

### DIFF
--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -3,8 +3,8 @@
 import os
 import sys
 
-__version__ = "0.21.2"
-__release_date__ = "2026.9.11"
+__version__ = "0.21.3"
+__release_date__ = "2026.9.12"
 
 
 def _ensure_utf8():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "hermes-agent"
-version = "0.21.2"
+version = "0.21.3"
 description = "The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"
 readme = "README.md"
 # Upper bound is load-bearing, not cosmetic. uv resolves the project's

--- a/tests/tools/test_delegate_output_schema.py
+++ b/tests/tools/test_delegate_output_schema.py
@@ -77,6 +77,64 @@ class TestValidateOutput:
         assert errors
 
 
+class TestForgivingSchema:
+    """v0.21.3: ``{}`` (or any non-constraining schema) wraps prose into a
+    JSON object instead of failing. Closes the "活干了但汇报被吞" bug where
+    a child agent reported in markdown prose (a valid response to the work)
+    but the empty schema's strict JSON parse ate it and the parent saw
+    ``status="failed"`` with ``Final answer does not satisfy the declared
+    output_schema (after 1 retry)``.
+    """
+
+    def test_empty_schema_is_forgiving(self):
+        from tools.delegation_output_schema import is_forgiving_schema
+        assert is_forgiving_schema({}) is True
+        assert is_forgiving_schema({"title": "anything"}) is True
+        assert is_forgiving_schema({"description": "x", "$schema": "https://x"}) is True
+
+    def test_constraining_keys_make_schema_strict(self):
+        from tools.delegation_output_schema import is_forgiving_schema
+        # Any of these keys makes the schema impose real constraints — keep strict.
+        for k in ("type", "properties", "required", "items", "allOf",
+                  "anyOf", "oneOf", "additionalProperties", "minProperties"):
+            assert is_forgiving_schema({k: []}) is False, f"{k!r} should be strict"
+        # Even a bare "type":"object" is constraining — caller wants an object.
+        assert is_forgiving_schema({"type": "object"}) is False
+
+    def test_prose_passes_forgiving_schema(self):
+        ok, errs = validate_output(
+            "I did the work. Here is the report:\n- step 1\n- step 2",
+            {},
+        )
+        assert ok is True
+        assert any("non_json_wrapped" in e for e in errs)
+
+    def test_fenced_prose_passes_forgiving_schema(self):
+        ok, errs = validate_output(
+            "```\n## Summary\nDid it.\n```",
+            {},
+        )
+        assert ok is True
+        assert any("non_json_wrapped" in e for e in errs)
+
+    def test_constraining_schema_still_rejects_prose(self):
+        # Regression: the lenient path must NOT swallow strict-schema failures.
+        ok, errs = validate_output(
+            "not json, sorry",
+            {"type": "object", "required": ["city"]},
+        )
+        assert ok is False
+        assert errs
+        assert not any("non_json_wrapped" in e for e in errs)
+
+    def test_json_object_passes_forgiving_schema(self):
+        # Sanity: forgiving schema still validates a proper JSON object cleanly
+        # (no spurious "non_json_wrapped" warning).
+        ok, errs = validate_output('{"city": "Berlin"}', {})
+        assert ok is True
+        assert errs == []
+
+
 class TestCoerceOutputSchema:
     def test_valid_schema_passes(self):
         schema, err = coerce_output_schema(ADDRESS_SCHEMA)
@@ -308,6 +366,69 @@ class TestRunSingleChildSchemaValidation:
         entry = _run(child)
         assert entry["status"] == "completed"
         assert "error" not in entry
+
+    # ----- v0.21.3: forgiving-schema prose acceptance -----
+
+    def test_forgiving_schema_with_prose_first_try_completed_with_warnings(self):
+        """Empty schema {} + prose answer (the live-site bug):
+        no retry turn, summary preserved verbatim, status="completed_with_warnings".
+        """
+        PROSE = "I did the work. Here is the report:\n- step 1\n- step 2"
+        child = _StubChild([PROSE])
+        child._delegate_output_schema = {}
+        entry = _run(child)
+        assert entry["status"] == "completed_with_warnings"
+        assert entry["summary"] == PROSE
+        assert entry["schema_valid"] is True
+        assert any("non_json_wrapped" in w for w in entry["schema_warnings"])
+        assert entry["answer_was_wrapped"] is True
+        # Critical: no retry was sent — the work is already done.
+        assert len(child.calls) == 1
+
+    def test_forgiving_schema_skips_retry_turn_altogether(self):
+        """Forgiving schema + prose: validator wraps on the first try and skips
+        the bounded retry turn — re-prompting the child to "give JSON" wastes
+        a turn on work that is already done. The child's only call is the
+        original one (calls == 1)."""
+        PROSE = "Same prose on retry."
+        child = _StubChild([PROSE, PROSE])  # 2 responses queued, only 1 used
+        child._delegate_output_schema = {}
+        entry = _run(child)
+        assert entry["status"] == "completed_with_warnings"
+        assert entry["summary"] == PROSE
+        assert entry["answer_was_wrapped"] is True
+        # Critical efficiency win: no retry was sent — the work was already done.
+        assert len(child.calls) == 1
+        # schema_retries is NOT emitted (retries == 0 is falsy).
+        assert "schema_retries" not in entry
+
+    def test_forgiving_schema_with_json_object_still_completed(self):
+        """Sanity: forgiving schema + proper JSON object → status="completed"
+        (no spurious warning, no wrapped flag)."""
+        child = _StubChild(['{"answer": 42}'])
+        child._delegate_output_schema = {}
+        entry = _run(child)
+        assert entry["status"] == "completed"
+        assert entry["schema_valid"] is True
+        assert "schema_warnings" not in entry
+        assert "answer_was_wrapped" not in entry
+        assert len(child.calls) == 1
+
+    def test_constraining_schema_with_prose_still_failed(self):
+        """Regression: strict-schema + prose answer keeps the v0.21.2 contract
+        of status="failed" with a schema violation error message. The lenient
+        path must NOT swallow strict-schema failures (otherwise orchestrators
+        would silently accept empty verdicts)."""
+        child = _StubChild(["not json", "still not json"])
+        child._delegate_output_schema = ADDRESS_SCHEMA
+        entry = _run(child)
+        assert entry["status"] == "failed"
+        assert entry["schema_valid"] is False
+        assert entry["schema_errors"]
+        assert "output_schema" in entry.get("error", "")
+        assert entry["summary"] == "still not json"
+        assert "schema_warnings" not in entry
+        assert "answer_was_wrapped" not in entry
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_delegate_output_schema.py
+++ b/tests/tools/test_delegate_output_schema.py
@@ -532,3 +532,102 @@ class TestDelegateTaskDispatch:
         assert "OUTPUT CONTRACT" in (captured.get("context") or "")
         results = payload.get("results") or []
         assert results and results[0].get("schema_valid") is True
+
+
+# ---------------------------------------------------------------------------
+# _build_result_entry: schema-wrapped prose must NOT be eaten by an upstream
+# child-loop failure flag. Regression for "活干了但汇报被吞" #2 — when the
+# child produced a real prose answer that the forgiving-schema validator
+# already wrapped, the validator's acceptance wins over a downstream
+# `result["failed"]=True` (e.g. provider rate-limit fired mid-turn, transport
+# glitch on the last write). status must be `completed_with_warnings`, not
+# `failed`.
+# ---------------------------------------------------------------------------
+
+
+class _FailingButProseChild(_StubChild):
+    """Child whose run_conversation returns the prose answer AND marks the
+    result as failed (mimics a provider error racing the child's last turn).
+    """
+
+    def __init__(self, prose, *, error="provider rate_limit", reason="rate_limit"):
+        super().__init__([prose])
+        self._prose = prose
+        self._error = error
+        self._reason = reason
+
+    def run_conversation(self, user_message=None, task_id=None, **_kwargs):
+        self.calls.append(user_message)
+        return {
+            "final_response": self._prose,
+            "completed": True,
+            "failed": True,
+            "error": self._error,
+            "failure_reason": self._reason,
+            "api_calls": 1,
+            "messages": [],
+        }
+
+
+class TestWrappedProseSurvivesUpstreamFailure:
+    """v0.21.3+followup: the `completed_with_warnings` branch in
+    _build_result_entry must take precedence over `result["failed"]=True` —
+    without this, the very rate-limit case the original bug fix was meant to
+    handle still loses the answer when the failure flag races the response.
+    """
+
+    PROSE = (
+        "## 任务完成\n\n"
+        "- 找到 3 个相关 issue\n"
+        "- 复现步骤见 step 2\n\n"
+        "**结论**: 需要在 xcode 中升级 SDK 版本"
+    )
+
+    def test_forgiving_schema_prose_with_failed_flag_is_completed_with_warnings(self):
+        """Empty schema + prose answer + result['failed']=True:
+        validator wraps the prose (answer_was_wrapped=True), so status must
+        be `completed_with_warnings` and the summary must survive verbatim."""
+        child = _FailingButProseChild(self.PROSE)
+        child._delegate_output_schema = {}
+        entry = _run(child)
+        assert entry["status"] == "completed_with_warnings", (
+            f"wrapped prose must not be eaten by upstream failed flag; got {entry['status']!r} "
+            f"with error={entry.get('error')!r}"
+        )
+        # the prose is preserved — no truncation, no "(empty)" sentinel
+        assert entry["summary"] == self.PROSE
+        # validator did its job; upstream error is a separate signal, not the verdict
+        assert entry.get("schema_valid") is True
+        assert entry.get("answer_was_wrapped") is True
+        # the structured upstream failure is still surfaced for observability
+        # (caller may render a ⚠ icon or page the operator), but it MUST NOT
+        # override status when the work has been wrapped into the contract.
+        assert entry.get("failure_reason") == "rate_limit"
+        # no retry was warranted — the first prose was already accepted
+        assert entry.get("schema_retries", 0) == 0
+        # the literal error string from the strict-schema branch must NOT fire
+        assert "Final answer does not satisfy the declared output_schema" not in (
+            entry.get("error") or ""
+        )
+
+    def test_constraining_schema_still_fails_with_failed_flag(self):
+        """Belt: a constraining schema + non-JSON answer + result['failed']=True
+        must still report `failed` (we only promote wrapped-prose; the strict
+        path is untouched)."""
+        child = _FailingButProseChild("not json at all")
+        child._delegate_output_schema = ADDRESS_SCHEMA
+        entry = _run(child)
+        assert entry["status"] == "failed"
+        # The literal contract-violation text wins because the schema is strict
+        # (the upstream error is still recorded for context, not as the verdict)
+        assert "output_schema" in (entry.get("error") or "")
+
+    def test_forgiving_schema_prose_without_failed_flag(self):
+        """Sanity: the original completed_with_warnings path still works
+        when there is no upstream failure flag."""
+        child = _StubChild([self.PROSE])
+        child._delegate_output_schema = {}
+        entry = _run(child)
+        assert entry["status"] == "completed_with_warnings"
+        assert entry["summary"] == self.PROSE
+        assert "failure_reason" not in entry

--- a/tools/delegate_tool_child_run.py
+++ b/tools/delegate_tool_child_run.py
@@ -389,18 +389,45 @@ class _SchemaOutcome:
     valid: Optional[bool]
     errors: List[str]
     retries: int
+    # Non-fatal validator notes the caller MAY surface to users without
+    # flipping status to "failed" (e.g. "non_json_wrapped" when a forgiving
+    # schema accepted a prose answer). Empty for strict happy-path validation.
+    warnings: List[str] = field(default_factory=list)
+    # True when the child's final text was not a JSON object and the validator
+    # wrapped it. Lets the result-entry builder label the status accurately
+    # (completed_with_warnings vs completed).
+    answer_was_wrapped: bool = False
 
 def _validate_child_output_schema(
     child: Any, result: Dict[str, Any], task_index: int, child_task_id: str, relay_child_text: Any
 ) -> _SchemaOutcome:
     """Validate the final answer against the attached output_schema with ONE bounded retry. Schema-less children (no
-    dict on ``child._delegate_output_schema``) take no branch here so their result entry stays byte-identical."""
+    dict on ``child._delegate_output_schema``) take no branch here so their result entry stays byte-identical.
+
+    Forgiving schemas (``{}`` or non-constraining keys only) wrap prose answers into
+    a JSON object instead of triggering a retry — the contract is "produce *a* JSON
+    object", and re-prompting the child for JSON would waste a turn on work that is
+    already done.
+    """
     _output_schema = getattr(child, "_delegate_output_schema", None)
     if not isinstance(_output_schema, dict):
         return _SchemaOutcome(_output_schema, None, [], 0)
-    from tools.delegation_output_schema import build_retry_message, validate_output
+    from tools.delegation_output_schema import (
+        build_retry_message,
+        is_forgiving_schema,
+        validate_output,
+    )
     _first_text = result.get("final_response") or ""
     _schema_valid, _schema_errors = validate_output(_first_text, _output_schema)
+    _answer_was_wrapped = bool(_schema_errors) and any(
+        e.startswith("non_json_wrapped") for e in _schema_errors
+    )
+    # Forgiving-schema + prose: accept immediately, no retry, no failure.
+    if _answer_was_wrapped:
+        return _SchemaOutcome(
+            _output_schema, True, [], 0,
+            warnings=_schema_errors, answer_was_wrapped=True,
+        )
     if _schema_valid or not _first_text.strip() or result.get("interrupted", False):
         return _SchemaOutcome(_output_schema, _schema_valid, _schema_errors, 0)
 
@@ -425,6 +452,15 @@ def _validate_child_output_schema(
         if isinstance(_retry_messages, list) and isinstance(result.get("messages"), list):
             result["messages"] = result["messages"] + _retry_messages
         _schema_valid, _schema_errors = validate_output(_retry_text, _output_schema)
+        # Forgiving-schema + retry-prose: same path, wrap the retry answer.
+        _retry_wrapped = bool(_schema_errors) and any(
+            e.startswith("non_json_wrapped") for e in _schema_errors
+        )
+        if _retry_wrapped:
+            return _SchemaOutcome(
+                _output_schema, True, [], 1,
+                warnings=_schema_errors, answer_was_wrapped=True,
+            )
     return _SchemaOutcome(_output_schema, _schema_valid, _schema_errors, 1)
 
 def _build_tool_trace(messages: Any) -> list[Dict[str, Any]]:
@@ -480,8 +516,24 @@ def _build_result_entry(
         # failure = budget exhaustion. A declared schema still violated after the bounded retry makes the summary
         # unusable under the contract, so status must not say completed (orchestrators reading only status/icon would
         # accept an empty verdict).
+        #
+        # CONTRACT (v0.21.3, see tools/delegation_output_schema.is_forgiving_schema):
+        #   * ``completed``              — schema-valid OR no schema requested.
+        #   * ``completed_with_warnings``— forgiving schema + prose answer that the validator wrapped. The work is
+        #                                  done and the summary is preserved; the status just signals "the answer was
+        #                                  not a JSON object as the contract asked" so callers can render a ⚠ icon.
+        #   * ``failed``                 — constraining schema violated after the bounded retry, OR child genuinely
+        #                                  failed (no summary / structured error).
+        #   * ``interrupted``            — cooperative interrupt.
         exit_reason = "completed" if result.get("completed", False) else "max_iterations"
-        status = "completed" if schema.valid is not False and usable_summary else "failed"
+        if schema.answer_was_wrapped and usable_summary:
+            # Forgiving-schema prose: the work is done, the validator wrapped the
+            # answer to honor the contract, and the summary is preserved. Status
+            # "completed_with_warnings" lets UIs render a ⚠ icon without rejecting
+            # the partial output (closes the "活干了但汇报被吞" bug).
+            status = "completed_with_warnings"
+        else:
+            status = "completed" if schema.valid is not False and usable_summary else "failed"
 
     _cost = getattr(child, "session_estimated_cost_usd", 0.0)
     _cost_status = getattr(child, "session_cost_status", None)
@@ -533,6 +585,13 @@ def _build_result_entry(
             entry["schema_retries"] = schema.retries
         if not schema.valid and schema.errors:
             entry["schema_errors"] = schema.errors
+        if schema.warnings:
+            # Non-fatal validator notes (e.g. "non_json_wrapped" — the answer was
+            # prose that a forgiving schema accepted via wrap). Distinct from
+            # schema_errors so consumers can distinguish "rejected" from "wrapped".
+            entry["schema_warnings"] = list(schema.warnings)
+        if schema.answer_was_wrapped:
+            entry["answer_was_wrapped"] = True
 
     # A steer queued after the final assistant turn had no tool batch to land
     # in; name it so the parent sees it was MISSED rather than silently absorbed.

--- a/tools/delegate_tool_child_run.py
+++ b/tools/delegate_tool_child_run.py
@@ -505,8 +505,22 @@ def _build_result_entry(
     # "(empty)" is run_agent's give-up sentinel after repeated empty LLM
     # responses (usually a transport bug) — a failure, not a success.
     usable_summary = bool(summary) and summary.strip() != "(empty)"
+    # Branch order matters (every branch is exclusive):
+    #   1. Explicit cooperative interrupt — a deliberate user signal that wins
+    #      over every other heuristic, including the schema-wrap promotion.
+    #   2. Forgiving-schema + prose answer — the validator already accepted the
+    #      work via wrap, so a downstream `result["failed"]=True` (provider
+    #      rate-limit, transport glitch racing the last turn) MUST NOT flip
+    #      status to "failed" and hide the real work in `summary`. This is
+    #      the v0.21.3 "活干了但汇报被吞" fix in its strict form.
+    #   3. Genuine child-loop failure (no usable summary / structured error
+    #      not explained by #2) — status="failed", exit_reason="error".
+    #   4. Schema-valid answer or no schema → "completed".
+    #   5. Constraining schema violated after bounded retry → "failed".
     if result.get("interrupted", False):
         status, exit_reason = "interrupted", "interrupted"
+    elif schema.answer_was_wrapped and usable_summary:
+        status, exit_reason = "completed_with_warnings", "completed"
     elif result.get("failed") or result.get("error"):
         # The loop returns the error text as final_response, which would otherwise read as "completed". Never report a
         # provider rejection as "max_iterations" — that is only truthful for real budget exhaustion.
@@ -522,18 +536,13 @@ def _build_result_entry(
         #   * ``completed_with_warnings``— forgiving schema + prose answer that the validator wrapped. The work is
         #                                  done and the summary is preserved; the status just signals "the answer was
         #                                  not a JSON object as the contract asked" so callers can render a ⚠ icon.
+        #                                  (resolved ABOVE this branch so an upstream child-loop failed/error flag
+        #                                  cannot override it.)
         #   * ``failed``                 — constraining schema violated after the bounded retry, OR child genuinely
         #                                  failed (no summary / structured error).
         #   * ``interrupted``            — cooperative interrupt.
         exit_reason = "completed" if result.get("completed", False) else "max_iterations"
-        if schema.answer_was_wrapped and usable_summary:
-            # Forgiving-schema prose: the work is done, the validator wrapped the
-            # answer to honor the contract, and the summary is preserved. Status
-            # "completed_with_warnings" lets UIs render a ⚠ icon without rejecting
-            # the partial output (closes the "活干了但汇报被吞" bug).
-            status = "completed_with_warnings"
-        else:
-            status = "completed" if schema.valid is not False and usable_summary else "failed"
+        status = "completed" if schema.valid is not False and usable_summary else "failed"
 
     _cost = getattr(child, "session_estimated_cost_usd", 0.0)
     _cost_status = getattr(child, "session_cost_status", None)
@@ -573,6 +582,16 @@ def _build_result_entry(
             entry["error"] = result.get("error", "Subagent did not produce a response.")
         # Classified reason from the child loop (e.g. "rate_limit", "billing")
         # lets the parent tell a quota wall from a task error without parsing prose.
+        _failure_reason = result.get("failure_reason")
+        if isinstance(_failure_reason, str) and _failure_reason:
+            entry["failure_reason"] = _failure_reason
+    elif status == "completed_with_warnings" and (result.get("failed") or result.get("error")):
+        # Validator already accepted the work via wrap, so status stays
+        # `completed_with_warnings` — but the upstream transport / provider
+        # error is a real signal the parent should see (rate-limit, billing,
+        # mid-turn timeout that still left prose). Surface as a non-verdict
+        # field so dashboards can warn without flipping status back to failed.
+        entry["_upstream_error"] = result.get("error") or "child loop reported failure"
         _failure_reason = result.get("failure_reason")
         if isinstance(_failure_reason, str) and _failure_reason:
             entry["failure_reason"] = _failure_reason

--- a/tools/delegation_output_schema.py
+++ b/tools/delegation_output_schema.py
@@ -16,6 +16,28 @@ from typing import Any, Dict, List, Optional, Tuple
 logger = logging.getLogger(__name__)
 
 
+def is_forgiving_schema(schema: Dict[str, Any]) -> bool:
+    """True when the schema is essentially unconstrained — accepts ANY JSON object.
+
+    An empty ``{}`` (or a schema that only sets non-restricting keys like ``title`` /
+    ``description`` / ``$schema``) lets any JSON object through. For these, the
+    contract is "produce a JSON object", not "produce *this* shape". When the child
+    returns prose instead of JSON, we wrap the prose rather than reject the whole
+    answer — the work is real, and a contract violation should not silently eat
+    the partial output (see delegate_task bug: "活干了但汇报被吞").
+    """
+    if not isinstance(schema, dict) or not schema:
+        return True
+    # Anything that imposes a constraint is NOT forgiving — must validate strictly.
+    _CONSTRAINING = {"type", "properties", "required", "patternProperties",
+                     "additionalProperties", "items", "prefixItems", "minProperties",
+                     "maxProperties", "minItems", "maxItems", "uniqueItems",
+                     "allOf", "anyOf", "oneOf", "not", "if", "then", "else",
+                     "dependentSchemas", "dependentRequired", "contains",
+                     "propertyNames", "unevaluatedProperties", "unevaluatedItems"}
+    return not any(k in schema for k in _CONSTRAINING)
+
+
 def coerce_output_schema(raw: Any) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
     """``(schema, None)`` when usable, ``(None, error)`` when not; ``None`` input
     passes through as ``(None, None)`` (no schema requested)."""
@@ -76,14 +98,24 @@ def extract_json_candidate(text: str) -> str:
     return raw
 
 
-def validate_output(text: str, schema: Dict[str, Any]) -> Tuple[bool, List[str]]:
-    """``(True, [])`` or ``(False, errors)`` with strings suitable for the retry turn."""
+def validate_output(text: str, schema: Dict[str, Any]) -> tuple[bool, List[str]]:
+    """``(True, [])`` or ``(False, errors)`` with strings suitable for the retry turn.
+
+    Forgiving schemas (empty ``{}`` or non-constraining keys only) wrap prose
+    into ``{"final_response": <text>}`` and accept it — the contract is
+    "produce *a* JSON object", so the partial output is preserved instead of
+    being eaten by a strict parse error.
+    """
     candidate = extract_json_candidate(text or "")
     if not candidate.strip():
         return False, ["Response was empty — expected a JSON object matching the schema."]
     try:
         parsed = json.loads(candidate)
     except (ValueError, TypeError) as exc:
+        if is_forgiving_schema(schema):
+            # Forgiving schema + prose: the work is real, wrap it. Caller decides
+            # whether to surface this as a warning; the validator MUST NOT eat it.
+            return True, [f"non_json_wrapped: {exc}"]
         return False, [f"Response is not valid JSON: {exc}"]
     try:
         from jsonschema.validators import validator_for  # type: ignore[import-untyped]


### PR DESCRIPTION
## 症状

v0.21.3 引入了宽容 schema (`{}`) + prose 答案的 `completed_with_warnings` 路径,本意是让 validator 把 prose 包进 wrapper、保留 summary、不吞用户的工作。但这个分支在 `_build_result_entry` 里被排在了 `result["failed"]`/`result["error"]` 之后——而 `result["failed"]=True` 恰好是 provider rate-limit / transport 中段报错时 child 标志位会有的状态。结果:**宽容 schema {}+prose 已经被 validator 接受,work 已经做完了**,但因为 `result["failed"]=True` 短路,status 被翻成 `failed`,partial output 被吞进 `summary`,UI 上看到的是一个 "失败" 而真实答案藏在 error 字符串里。"活干了但汇报被吞" bug 的严格形式。

## 根因

`tools/delegate_tool_child_run.py::_build_result_entry` 的分支顺序问题:宽容 schema wrap 命中这一支 (`schema.answer_was_wrapped and usable_summary`) 是"工作已交付"的强信号,排在 result-level failed 之后意味着任何下游 false-positive 失败标志都能把它压掉。

## 修法

重排 `_build_result_entry` 分支,显式独占(每支独立):

1. 显式 cooperative interrupt (`result.interrupted=True`)——最高优先,胜过 schema-wrap promotion。
2. **宽容 schema + prose 已被 wrap** —— validator 已经接受 work,`result["failed"]=True` (rate-limit/transport/账单错误 race last turn) 不能再翻 status;status 保持 `completed_with_warnings`,prose 完整保留。
3. 真正的 child-loop 失败 (无 usable summary / 非 #2 的结构化错误) —— status=`failed`, exit_reason=`error`。
4. Schema-valid 答案或无 schema —— `completed`。
5. 约束 schema 在 bounded retry 后仍违反 —— `failed`。

新增 `_upstream_error` / `failure_reason` 字段:status 保持 `completed_with_warnings` 时,把上游 transport / provider 错误作为**非裁定字段**单独挂在 entry 上,让 dashboard 可告警但不让 status 回翻。`failure_reason` 原样透传。

`tools/delegate_tool_child_run.py`:净增 +27 / -8 (分支重排 + `_upstream_error` 路径 + 顶部 5 步分支顺序注释)。
`tests/tools/test_delegate_output_schema.py`:新增 `TestWrappedProseSurvivesUpstreamFailure`,3 个用例 (wrapped-prose + failed flag → completed_with_warnings;constraining schema + failed → 仍 failed;sanity 没 failed flag → 仍 completed_with_warnings)。

## 测试

- `tests/tools/test_delegate_output_schema.py`:**40/40 全绿** (含 3 个新增)。
- `tests/tools/test_delegate*.py` 全部 20 档:**269/270 全绿**。唯一失败 `test_child_dedicated_db_follows_parents_db_path` 是 macOS `/private/var` vs `/var` 路径归一化问题,在基线 `5b6fa483c6` 同样失败,与本修复无关。
- `tests/tools/test_approval.py` 唯一失败 `test_nonrecursive_verification_artifact_cleanup_is_not_dangerous` 同样在基线失败,与本修复无关。

## 依赖

基于上游 commit `5b6fa483c6` — "fix(delegate): forgiving-schema prose acceptance + completed_with_warnings (v0.21.3)"。本 PR 是该修复的严格形式,把 v0.21.3 试图保护的 race-condition 路径真正兜住。

## 文件

- `tools/delegate_tool_child_run.py`
- `tests/tools/test_delegate_output_schema.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
