### PR TITLE
fix(gateway): resolve Docker MEDIA in routed profile

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -940,10 +940,35 @@ def _tenv(name: str, default: str = "") -> str:
     return terminal_env(name, default)
 
 
-def _parse_docker_volume_mounts() -> List[Tuple[Path, Path]]:
+def _profile_name_from_session_key(session_key: str) -> Optional[str]:
+    """Return the profile namespace carried by a gateway session key."""
+    parts = session_key.split(":", 2)
+    if len(parts) < 2 or parts[0] != "agent" or not parts[1]:
+        return None
+    try:
+        from hermes_cli.profiles import get_profile_dir, normalize_profile_name
+        profile = normalize_profile_name(parts[1])
+        if profile != "default":
+            get_profile_dir(profile)
+        return profile
+    except (ValueError, FileNotFoundError):
+        return None
+
+
+def _parse_docker_volume_mounts(profile_name: Optional[str] = None) -> List[Tuple[Path, Path]]:
     """Parse ``TERMINAL_DOCKER_VOLUMES`` (JSON list of ``host:container[:mode]``) into
     ``(host_path, container_path)``; named volumes / non-absolute hosts can't resolve here."""
-    raw = _tenv("TERMINAL_DOCKER_VOLUMES", "").strip()
+    if profile_name is None:
+        raw = _tenv("TERMINAL_DOCKER_VOLUMES", "").strip()
+    else:
+        try:
+            from hermes_cli.profiles import get_profile_dir
+            from tools.terminal_scope import build_profile_terminal_scope
+            raw = build_profile_terminal_scope(get_profile_dir(profile_name)).get(
+                "TERMINAL_DOCKER_VOLUMES", ""
+            ).strip()
+        except (ImportError, OSError, ValueError):
+            raw = ""
     try:
         import json as _json
         parsed = _json.loads(raw) if raw else []
@@ -983,7 +1008,7 @@ def _docker_sandbox_dir_candidates(session_key: str = "") -> List[str]:
         return ["default"]
     try:
         from hermes_cli.profiles import get_active_profile_name
-        profile = get_active_profile_name() or "default"
+        profile = _profile_name_from_session_key(session_key) or get_active_profile_name() or "default"
     except Exception:
         profile = "default"
     candidates: List[str] = []
@@ -1017,7 +1042,12 @@ def _docker_persistent_sandbox_roots(session_key: str, leaf: str) -> List[Path]:
         return []
     try:
         from tools.environments.base import get_sandbox_dir
-        base = get_sandbox_dir() / "docker"
+        profile = _profile_name_from_session_key(session_key)
+        if profile and profile != "default":
+            from hermes_cli.profiles import get_profile_dir
+            base = get_profile_dir(profile) / "sandboxes" / "docker"
+        else:
+            base = get_sandbox_dir() / "docker"
         return [cand for name in _docker_sandbox_dir_candidates(session_key)
                 if (cand := (base / name / leaf).resolve(strict=False)).is_dir()]
     except Exception:
@@ -1075,7 +1105,8 @@ def _translate_docker_container_media_path(candidate: Path, session_key: str = "
     with contextlib.suppress(Exception):
         from tools.terminal_tool import _ensure_terminal_env_bridged
         _ensure_terminal_env_bridged()
-    mounts = [*_parse_docker_volume_mounts(), *_cache_dir_container_mounts()]
+    profile = _profile_name_from_session_key(session_key)
+    mounts = [*_parse_docker_volume_mounts(profile), *_cache_dir_container_mounts()]
     mounted = {c.as_posix() for _, c in mounts}
     # Synthetic /workspace mounts: profile-scoped layout first, then legacy per-session.
     if "/workspace" not in mounted:
@@ -1125,6 +1156,13 @@ def validate_media_delivery_path(path: str, session_key: str = "") -> Optional[s
     # Docker agents emit MEDIA:/workspace/... — map container paths to host paths first.
     resolved = _translate_docker_container_media_path(expanded, session_key=session_key)
     if resolved is None:
+        # A routed named profile must not reinterpret a container path through the
+        # ambient gateway host when its profile-scoped mounts are unavailable.
+        profile = _profile_name_from_session_key(session_key)
+        if (profile and profile != "default" and _docker_env_active()
+                and any(expanded == root or expanded.is_relative_to(root)
+                        for root in (Path("/root"), Path("/workspace"), Path("/output")))):
+            return None
         resolved = _resolve_path(expanded, strict=True)
     if resolved is None or not resolved.is_file():
         return None

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1471,6 +1471,23 @@ class TestDockerProfileSandboxMediaTranslation:
             "/root/note.txt", session_key=self.SESSION_KEY
         ) == str(produced.resolve())
 
+    def test_named_profile_home_mount_ignores_ambient_default(self, tmp_path, monkeypatch):
+        """A multiplexed named session resolves against its own profile sandbox."""
+        hermes_home = tmp_path / ".hermes"
+        profile_home = hermes_home / "profiles" / "public"
+        profile_home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        self._enable_docker(monkeypatch)
+
+        produced = profile_home / "sandboxes" / "docker" / "profile_public" / "home" / "named.txt"
+        produced.parent.mkdir(parents=True)
+        produced.write_text("named")
+
+        assert BasePlatformAdapter.validate_media_delivery_path(
+            "/root/named.txt", session_key="agent:public:discord:thread:1:2"
+        ) == str(produced.resolve())
+
     def test_home_credential_surface_still_refused(self, monkeypatch):
         """The /root/.hermes exclusion survives profile scoping: translating
         the home mount must never expose the container's secret surface —


### PR DESCRIPTION
## Summary

Fixes #109024.

Multiplexed gateway delivery can process a Docker `MEDIA:` directive after the routed profile context has been cleared. The resolver previously consulted ambient/default profile state, so valid files from a named profile's persistent Docker sandbox or explicit `/output` mount were dropped.

## Investigation

Issue #109024 is open and has no assignee or comments. The report is a named-profile follow-up to #94441/#94437.

The directly related PR #109028 is closed and unmerged. This PR is an independent implementation and does not reuse its commit or claim its authorship.

Graphify and source inspection identified the delivery path in `gateway/platforms/base.py`:

- `_docker_sandbox_dir_candidates()` used ambient `get_active_profile_name()`.
- `_docker_persistent_sandbox_roots()` used ambient `get_sandbox_dir()`.
- `_parse_docker_volume_mounts()` used ambient terminal policy.
- Delivery happens after the routed turn scope is reset.

The authoritative profile namespace is already present in session keys such as `agent:public:discord:thread:<id>:<id>`.

## Root cause

The Docker execution path correctly creates the persistent container using `profile:<name>`, but deferred media delivery discarded that profile identity and searched the default profile's filesystem and terminal policy.

This affected both:

- `/root/<file>` and `/workspace/<file>` in the named profile sandbox;
- explicitly configured `/output` mounts from the named profile.

## Implementation

- Parse and validate the profile namespace from the session key.
- Resolve named profile sandbox roots through `get_profile_dir()`.
- Prefer the profile-scoped persistent Docker sandbox while retaining legacy session-sandbox fallback.
- Rebuild `TERMINAL_DOCKER_VOLUMES` from the producing profile's terminal policy.
- Fail closed for named-profile Docker `/root`, `/workspace`, and `/output` paths when profile mounts cannot be resolved, preventing accidental ambient-host/default-profile resolution.
- Preserve keyless/default and legacy behavior.

The algorithm remains bounded by the configured mount count and sandbox candidate count; no process-global cache or ambient environment mutation was added.

## Tests and verification

Passed:

```text
python -m py_compile gateway/platforms/base.py tests/gateway/test_platform_base.py
```

The focused test command was attempted with the canonical runner:

```text
scripts/run_tests.sh tests/gateway/test_platform_base.py -k 'DockerProfileSandboxMediaTranslation'
```

It is currently blocked before test collection by pre-existing unresolved merge markers in unrelated working-tree files, notably `agent/redact.py:430` (`<<<<<<< HEAD`). The unrelated files were not modified by this PR.

The regression test added is:

- `TestDockerProfileSandboxMediaTranslation.test_named_profile_home_mount_ignores_ambient_default`

It creates a separate `public` profile sandbox while ambient state points at the default home and verifies `/root/named.txt` resolves to the public profile's existing host file.

## Scope

Changed files:

- `gateway/platforms/base.py`
- `tests/gateway/test_platform_base.py`

No cron, profile-management, Docker execution, or unrelated refactoring changes are included.

## Security considerations

A named profile must never inherit the default profile's Docker mount policy or reinterpret an unresolved container path through the ambient host. The resolver continues strict real-path and containment validation, and unresolved named-profile synthetic paths now fail closed.
