### PR TITLE
fix(gateway): serialize rich sent index updates

### DIFF
--- a/gateway/rich_sent_store.py
+++ b/gateway/rich_sent_store.py
@@ -13,11 +13,25 @@ from __future__ import annotations
 
 import json
 import os
+import threading
 import time
+import uuid
+from contextlib import contextmanager, suppress
 from typing import Optional
 
 _MAX_ENTRIES = 1000
 _MAX_TEXT_CHARS = 2000
+_STORE_LOCK = threading.RLock()
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows only
+    fcntl = None
+
+try:
+    import msvcrt
+except ImportError:  # pragma: no cover - POSIX only
+    msvcrt = None
 
 
 def _store_path() -> str:
@@ -29,9 +43,35 @@ def _load(path: str) -> dict:
     try:
         with open(path, "r", encoding="utf-8") as fh:
             data = json.load(fh)
-    except (FileNotFoundError, ValueError):
+    except (OSError, ValueError):
         return {}
     return data if isinstance(data, dict) else {}
+
+
+@contextmanager
+def _locked_store(path: str):
+    """Serialize index read-modify-write cycles across gateway processes."""
+    with _STORE_LOCK:
+        lock_path = f"{path}.lock"
+        os.makedirs(os.path.dirname(lock_path), exist_ok=True)
+        if msvcrt and (not os.path.exists(lock_path) or os.path.getsize(lock_path) == 0):
+            with open(lock_path, "w", encoding="utf-8") as fh:
+                fh.write(" ")
+        with open(lock_path, "a+", encoding="utf-8") as fh:
+            if fcntl:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            elif msvcrt:
+                fh.seek(0)
+                msvcrt.locking(fh.fileno(), msvcrt.LK_LOCK, 1)
+            try:
+                yield
+            finally:
+                with suppress(OSError):
+                    if fcntl:
+                        fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+                    elif msvcrt:
+                        fh.seek(0)
+                        msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
 
 
 def _update(chat_id, message_id, fields: dict) -> None:
@@ -39,18 +79,19 @@ def _update(chat_id, message_id, fields: dict) -> None:
     path = _store_path()
     try:
         os.makedirs(os.path.dirname(path), exist_ok=True)
-        data = _load(path)
-        key = f"{chat_id}:{message_id}"
-        entry = data.get(key)
-        entry = entry if isinstance(entry, dict) else {}
-        data[key] = {**entry, **fields, "ts": int(time.time())}
-        if len(data) > _MAX_ENTRIES:  # trim oldest by timestamp
-            for k, _ in sorted(data.items(), key=lambda kv: kv[1].get("ts", 0))[: len(data) - _MAX_ENTRIES]:
-                data.pop(k, None)
-        tmp = f"{path}.tmp.{os.getpid()}"
-        with open(tmp, "w", encoding="utf-8") as fh:
-            json.dump(data, fh, ensure_ascii=False)
-        os.replace(tmp, path)  # atomic; tolerates concurrent writers racing
+        with _locked_store(path):
+            data = _load(path)
+            key = f"{chat_id}:{message_id}"
+            entry = data.get(key)
+            entry = entry if isinstance(entry, dict) else {}
+            data[key] = {**entry, **fields, "ts": int(time.time())}
+            if len(data) > _MAX_ENTRIES:  # trim oldest by timestamp
+                for k, _ in sorted(data.items(), key=lambda kv: kv[1].get("ts", 0))[: len(data) - _MAX_ENTRIES]:
+                    data.pop(k, None)
+            tmp = f"{path}.tmp.{os.getpid()}.{uuid.uuid4().hex}"
+            with open(tmp, "w", encoding="utf-8") as fh:
+                json.dump(data, fh, ensure_ascii=False)
+            os.replace(tmp, path)
     except Exception:
         return
 

--- a/tests/gateway/test_rich_sent_store.py
+++ b/tests/gateway/test_rich_sent_store.py
@@ -1,0 +1,48 @@
+import threading
+
+from gateway import rich_sent_store
+
+
+def test_lookup_degrades_when_index_path_is_unreadable(tmp_path, monkeypatch):
+    path = tmp_path / "rich_sent_index.json"
+    path.mkdir()
+    monkeypatch.setattr(rich_sent_store, "_store_path", lambda: str(path))
+
+    assert rich_sent_store.lookup("chat", "message") is None
+    assert rich_sent_store.lookup_media("chat", "message") == []
+
+
+def test_concurrent_records_preserve_both_entries(tmp_path, monkeypatch):
+    path = tmp_path / "rich_sent_index.json"
+    monkeypatch.setattr(rich_sent_store, "_store_path", lambda: str(path))
+    original_load = rich_sent_store._load
+    first_loaded = threading.Event()
+    release_first = threading.Event()
+    load_count = 0
+    count_lock = threading.Lock()
+
+    def delayed_first_load(store_path):
+        nonlocal load_count
+        data = original_load(store_path)
+        with count_lock:
+            load_count += 1
+            first = load_count == 1
+        if first:
+            first_loaded.set()
+            assert release_first.wait(timeout=5)
+        return data
+
+    monkeypatch.setattr(rich_sent_store, "_load", delayed_first_load)
+    first = threading.Thread(target=rich_sent_store.record, args=("chat", "first", "one"))
+    second = threading.Thread(target=rich_sent_store.record, args=("chat", "second", "two"))
+    first.start()
+    assert first_loaded.wait(timeout=5)
+    second.start()
+    release_first.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert rich_sent_store.lookup("chat", "first") == "one"
+    assert rich_sent_store.lookup("chat", "second") == "two"


### PR DESCRIPTION
## Summary
- Serialize rich-message index read-modify-write cycles across threads and processes.
- Use a unique temporary file per write.
- Treat unreadable index files as cache misses so reply handling remains best-effort.

## Tests
- `python3 -m pytest --confcutdir=tests/gateway tests/gateway/test_rich_sent_store.py -q` (2 passed)
- `python3 -m ruff check gateway/rich_sent_store.py tests/gateway/test_rich_sent_store.py`
- `python3 -m compileall -q gateway/rich_sent_store.py tests/gateway/test_rich_sent_store.py`

The existing Telegram integration test cannot collect in this sparse checkout because its external `plugins` package is absent.