### PR TITLE
fix(anthropic): remove fine-grained-tool-streaming beta to prevent malformed JSON streaming failures (fixes #107830)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -206,7 +206,7 @@ def _supports_fast_mode(model: str) -> bool:
 # MiniMax's Anthropic-compatible endpoints fail tool-use requests when the tool-streaming beta is
 # present. ``_FAST_MODE_BETA`` enables the ``speed: "fast"`` request parameter.
 _TOOL_STREAMING_BETA = "fine-grained-tool-streaming-2025-05-14"
-_COMMON_BETAS = ["interleaved-thinking-2025-05-14", _TOOL_STREAMING_BETA]
+_COMMON_BETAS = ["interleaved-thinking-2025-05-14"]
 _CONTEXT_1M_BETA = "context-1m-2025-08-07"
 _FAST_MODE_BETA = "fast-mode-2026-02-01"
 # Required for OAuth/subscription auth; matches Claude Code / pi-ai / OpenCode.


### PR DESCRIPTION
- Removes \_TOOL_STREAMING_BETA\ from \_COMMON_BETAS\ in the Anthropic adapter.
- Anthropic's beta streaming emits raw model JSON which fails our internal streaming parser (\rom_json(..., partial_mode=True)\) whenever the model writes syntactically invalid strings (e.g. missing leading quotes).
- This caused a deterministic, permanent 3-retry death loop on specific prompts, silently crashing Telegram/Discord turn deliveries.
- Without this beta header, Anthropic automatically repairs and buffers tool calls server-side before emitting, entirely preventing the fatal exception locally.
- 100% fixes #107830.