### PR TITLE
fix(desktop): clear PrimaryProfilePin on current backend exit/error/rejection (#108417)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -13123,6 +13123,8 @@ async function runHermesStart() {
         return
       }
 
+      primaryProfilePin.clear()
+
       rememberLog(`Hermes backend failed to start: ${error.message}`)
       updateBootProgress(
         {
@@ -13148,6 +13150,8 @@ async function runHermesStart() {
 
         return
       }
+
+      primaryProfilePin.clear()
 
       rememberLog(`Hermes backend exited (${signal || code})`)
       sendBackendExit({ code, signal })
@@ -13235,6 +13239,7 @@ async function runHermesStart() {
       throw error
     }
 
+    primaryProfilePin.clear()
     const failedProcess = backendConnectionState.invalidate()
     stopBackendChild(failedProcess)
 


### PR DESCRIPTION
��Closes #108417

This ensures the `PrimaryProfilePin` is properly cleared whenever the backend connection state is cleared for the current process (on unexpected `exit`, `error`, or startup rejection). This prevents the routing profile from surviving a crashed backend and diverging from the newly read `--profile` on respawn.
