### PR TITLE
fix(cron): refuse a run whose named MCP server resolves to zero tools

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1585,6 +1585,74 @@ def _init_cron_mcp_tools(job_id: str) -> None:
         logger.warning("Job '%s': MCP initialization failed (non-fatal): %s", job_id, _mcp_exc)
 
 
+def _verify_cron_mcp_toolsets(job: dict, job_id: str, job_name: str, cfg: dict) -> Optional[tuple]:
+    """Refuse a run whose per-job ``enabled_toolsets`` names an MCP server that resolves to zero
+    tools, routing it through the blocked_config path (#109050).
+
+    MCP registrations are keyed ``(owner_scope, name)`` under a profile multiplexer, so a server
+    named by the job can pass validate_toolset via its registry alias yet contribute no tools in
+    this run's scope (teardown/re-registration window, or another profile owning the only live
+    connection). The agent would run tool-less and improvise around the missing capability while
+    the scheduler records success — no incident, ``failure_streak`` stays 0. Runs AFTER
+    ``_init_cron_mcp_tools`` (the pre-dispatch preflight cannot see the registry, which fills only
+    after discovery) and blocks before any LLM call, mirroring ``_preflight_or_block``'s shape.
+    Only servers the job explicitly names are checked; ones layered in by the global MCP merge
+    are not the job's intent statement.
+    """
+    try:
+        if not _cron_preflight_enabled(cfg):
+            return None
+        per_job = job.get("enabled_toolsets") or []
+        if not per_job:
+            return None
+        from tools.registry import registry
+        from toolsets import resolve_toolset
+        named_servers = []
+        for name in per_job:
+            target = registry.get_toolset_alias_target(str(name))
+            if target and target.startswith("mcp-"):
+                named_servers.append(str(name))
+        if not named_servers:
+            return None
+        empty = sorted(name for name in named_servers if not resolve_toolset(name))
+        if not empty:
+            return None
+    except Exception:
+        # Fail open: the verifier must never take down a runnable job (mirrors _preflight_or_block).
+        logger.debug("Job '%s': MCP toolset verification errored — failing open", job_id, exc_info=True)
+        return None
+
+    logger.warning(
+        "Job '%s' (ID: %s): BLOCKED — per-job enabled_toolsets names MCP server(s) resolving to "
+        "zero tools: %s (no LLM call was made)", job_name, job_id, ", ".join(empty))
+    reason = (
+        "MCP server(s) named in enabled_toolsets resolve to zero tools in this run's scope: "
+        + ", ".join(f"'{name}'" for name in empty)
+        + ". The connection is not visible here (per-profile ledger: teardown/re-registration "
+        "window, or another profile owns the only live connection), so the agent would run "
+        "tool-less while the run is still recorded as success (#109050). Check the server with "
+        "`hermes mcp` or restart the gateway to re-register it."
+    )
+    # Alert-once without sharing the preflight bit: a job already parked in blocked_config
+    # re-blocks silently (dedup on last_status); the next healthy run clears that state for free.
+    marker = (
+        BLOCKED_CONFIG_SILENT_MARKER if job.get("last_status") == "blocked_config"
+        else BLOCKED_CONFIG_MARKER)
+    blocked_doc = (
+        f"# Cron Job: {job_name}\n\n"
+        f"**Job ID:** {job_id}\n"
+        f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n"
+        f"**Status:** BLOCKED (configuration)\n\n"
+        "Pre-dispatch validation found an MCP toolset problem and "
+        "the agent was NOT run (no tokens spent).\n\n"
+        f"**Reason:** {reason}\n\n"
+        "The job will stay blocked (without re-alerting) until the "
+        "MCP server is reachable again; the next healthy run clears this "
+        "state. Set `cron.preflight: false` in config.yaml to disable this validation."
+    )
+    return False, blocked_doc, "", f"{marker} {reason}"
+
+
 def _open_cron_session_db(job: dict):
     """Open the SQLite session store under its own timeout (HERMES_CRON_TIMEOUT only watches
     run_conversation). A wedged sqlite3.connect returns None (no session store) instead of
@@ -2146,6 +2214,11 @@ def _resolve_cron_agent_setup(job: dict, job_id: str, job_name: str, jc) -> _Cro
     setup.credential_pool = _load_credential_pool(setup.runtime, job_id)
     # MCP servers must be registered before AIAgent is constructed.
     _init_cron_mcp_tools(job_id)
+    # #109050: a per-job enabled_toolsets entry can name an MCP server whose per-profile
+    # connection resolves to zero tools in this scope — the agent would run tool-less while the
+    # run records success. Verified after discovery (the registry fills only here) and refused
+    # into the blocked_config path; the opt-out shares cron.preflight with the pre-dispatch gate.
+    setup.blocked = _verify_cron_mcp_toolsets(job, job_id, job_name, _cfg)
     return setup
 
 

--- a/tests/cron/test_cron_mcp_toolset_guard_109050.py
+++ b/tests/cron/test_cron_mcp_toolset_guard_109050.py
@@ -1,0 +1,165 @@
+"""Regression tests for #109050: a per-job ``enabled_toolsets`` entry naming an MCP server that
+resolves to zero tools must refuse the run through the blocked_config path instead of letting the
+agent run tool-less while the scheduler records success.
+
+Covers the guard added in ``cron.scheduler._verify_cron_mcp_toolsets`` (wired at the end of
+``_resolve_cron_agent_setup``, after MCP discovery): fail-closed on a named server with zero
+tools, silent re-block via ``last_status`` dedup, opt-out via ``cron.preflight``, fail-open on
+verifier errors, and the unknown-name / no-per-job-list exclusions.
+"""
+
+from __future__ import annotations
+
+import cron.scheduler as scheduler
+
+
+def _job(**overrides):
+    job = {
+        "id": "job-1",
+        "name": "notion sync",
+        "prompt": "sync notes",
+        "enabled_toolsets": ["file", "terminal", "notion"],
+    }
+    job.update(overrides)
+    return job
+
+
+def _alias_mcp_server(monkeypatch, mapping):
+    from tools.registry import registry
+
+    monkeypatch.setattr(
+        registry, "get_toolset_alias_target", lambda alias: mapping.get(alias)
+    )
+
+
+def _resolve_tools(monkeypatch, mapping):
+    import toolsets
+
+    monkeypatch.setattr(
+        toolsets, "resolve_toolset", lambda name, *a, **k: list(mapping.get(name, []))
+    )
+
+
+def test_named_mcp_server_with_zero_tools_blocks(monkeypatch):
+    _alias_mcp_server(monkeypatch, {"notion": "mcp-notion"})
+    _resolve_tools(
+        monkeypatch, {"file": ["read_file"], "terminal": ["terminal"], "notion": []}
+    )
+
+    result = scheduler._verify_cron_mcp_toolsets(_job(), "job-1", "notion sync", {})
+
+    assert result is not None
+    success, blocked_doc, final_response, error = result
+    assert success is False
+    assert final_response == ""
+    assert error.startswith("[blocked_config] ")
+    assert "'notion'" in error
+    assert "BLOCKED (configuration)" in blocked_doc
+    assert "'notion'" in blocked_doc
+
+
+def test_named_mcp_server_with_tools_passes(monkeypatch):
+    _alias_mcp_server(monkeypatch, {"notion": "mcp-notion"})
+    _resolve_tools(
+        monkeypatch, {"notion": ["mcp__notion__search", "mcp__notion__create"]}
+    )
+
+    assert (
+        scheduler._verify_cron_mcp_toolsets(_job(), "job-1", "notion sync", {}) is None
+    )
+
+
+def test_unknown_name_without_alias_is_not_guarded(monkeypatch):
+    # A typo'd or unknown toolset stays the -t/quiet-warning domain (#94151): only names whose
+    # registry alias targets an mcp-* toolset are MCP servers.
+    _alias_mcp_server(monkeypatch, {})
+    _resolve_tools(monkeypatch, {})
+
+    assert (
+        scheduler._verify_cron_mcp_toolsets(_job(), "job-1", "notion sync", {}) is None
+    )
+
+
+def test_no_per_job_toolsets_skips_check(monkeypatch):
+    # Servers layered in by the global MCP merge are not the job's intent statement.
+    _alias_mcp_server(monkeypatch, {"notion": "mcp-notion"})
+    _resolve_tools(monkeypatch, {"notion": []})
+
+    job = _job(enabled_toolsets=None)
+    assert scheduler._verify_cron_mcp_toolsets(job, "job-1", "notion sync", {}) is None
+
+
+def test_verifier_errors_fail_open(monkeypatch):
+    from tools.registry import registry
+
+    def _boom(alias):
+        raise RuntimeError("registry unavailable")
+
+    monkeypatch.setattr(registry, "get_toolset_alias_target", _boom)
+
+    assert (
+        scheduler._verify_cron_mcp_toolsets(_job(), "job-1", "notion sync", {}) is None
+    )
+
+
+def test_reblock_after_blocked_config_is_silent(monkeypatch):
+    _alias_mcp_server(monkeypatch, {"notion": "mcp-notion"})
+    _resolve_tools(monkeypatch, {"notion": []})
+
+    result = scheduler._verify_cron_mcp_toolsets(
+        _job(last_status="blocked_config"), "job-1", "notion sync", {}
+    )
+
+    assert result is not None
+    assert result[3].startswith("[blocked_config:silent] ")
+
+
+def test_preflight_opt_out_disables_guard(monkeypatch):
+    _alias_mcp_server(monkeypatch, {"notion": "mcp-notion"})
+    _resolve_tools(monkeypatch, {"notion": []})
+
+    cfg = {"cron": {"preflight": False}}
+    assert (
+        scheduler._verify_cron_mcp_toolsets(_job(), "job-1", "notion sync", cfg) is None
+    )
+
+
+def test_setup_wiring_blocks_run_after_mcp_discovery(monkeypatch):
+    # End of _resolve_cron_agent_setup: after _init_cron_mcp_tools runs, a named MCP server with
+    # zero tools must surface as setup.blocked so run_job refuses the dispatch (no LLM call).
+    _alias_mcp_server(monkeypatch, {"notion": "mcp-notion"})
+    _resolve_tools(monkeypatch, {"file": ["read_file"], "notion": []})
+
+    init_calls: list[str] = []
+    monkeypatch.setattr(scheduler, "_load_prefill_messages", lambda cfg, job_id: None)
+    monkeypatch.setattr(scheduler, "_guard_job_credential_exfil", lambda job: None)
+    monkeypatch.setattr(
+        scheduler, "_preflight_or_block", lambda job, job_id, job_name, cfg: None
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_resolve_job_runtime",
+        lambda job, job_id, jc: ({"provider": "test"}, "m"),
+    )
+    monkeypatch.setattr(
+        scheduler, "_resolve_job_reasoning_config", lambda job, cfg, model: None
+    )
+    monkeypatch.setattr(scheduler, "get_fallback_chain", lambda cfg: [])
+    monkeypatch.setattr(
+        scheduler, "_load_credential_pool", lambda runtime, job_id: None
+    )
+    monkeypatch.setattr(
+        scheduler, "_init_cron_mcp_tools", lambda job_id: init_calls.append(job_id)
+    )
+
+    jc = scheduler._CronJobConfig(
+        cfg={}, model="m", model_cfg={}, cron_default_provider=""
+    )
+    setup = scheduler._resolve_cron_agent_setup(_job(), "job-1", "notion sync", jc)
+
+    assert init_calls == [
+        "job-1"
+    ]  # verification happens after MCP discovery, not before
+    assert setup.blocked is not None
+    assert setup.blocked[0] is False
+    assert "'notion'" in setup.blocked[3]


### PR DESCRIPTION
## What does this PR do?

Under `gateway.multiplex_profiles`, MCP registrations are keyed `(owner_scope, name)`, so a per-job `enabled_toolsets` entry can pass `validate_toolset` via its registry alias yet resolve to **zero tools** in the run's scope — the teardown/re-registration window, or another profile owning the only live connection without adoption. The agent then runs tool-less and improvises around the missing capability (in the issue's run: 39 "MCP tools are not available" statements, `which notion` hunts, `curl` against the service's web UI), while the scheduler records **success** — no incident, `failure_streak: 0`, `hermes cron doctor` green.

This PR refuses that dispatch through the existing `blocked_config` path: a visible incident, the alert-once dedup, and a real `last_status` instead of a false green.

The check lives at the end of `_resolve_cron_agent_setup`, right after `_init_cron_mcp_tools`. It cannot live in `_preflight_job_config` because the pre-dispatch preflight runs *before* MCP discovery — the registry it would inspect is still empty at that point (the "run the preflight after MCP discovery" half already noted in #27948).

## Related Issue

Fixes #109050

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py` — new `_verify_cron_mcp_toolsets(job, job_id, job_name, cfg)`: for each per-job `enabled_toolsets` name whose registry alias targets an `mcp-*` toolset, resolve it; if it contributes zero tools, return the `_preflight_or_block`-shaped failure tuple (`BLOCKED_CONFIG_MARKER` + reason) so `run_job`'s existing short-circuit records `blocked_config` before any LLM call.
- `cron/scheduler.py` — wire it in `_resolve_cron_agent_setup` after `_init_cron_mcp_tools` via the existing `setup.blocked` field (no `run_job` changes).
- `tests/cron/test_cron_mcp_toolset_guard_109050.py` — 8 regression tests.

Design boundaries:

- **Only servers the job explicitly names** are checked; ones layered in by `_merge_mcp_into_per_job_toolsets` are not the job's intent statement, so a globally-enabled-but-currently-invisible server does not block jobs that never asked for it.
- **Fail-open** on verifier errors (registry lookup raising must never take down a runnable job — mirrors `_preflight_or_block`).
- **Alert-once without sharing the preflight bit**: a job already parked in `blocked_config` re-blocks with the `[blocked_config:silent]` marker (dedup on `last_status`), and the next healthy run clears that state for free — no new persisted state.
- Opt-out shares the existing `cron.preflight: false` switch.
- Unknown/typo'd toolset names stay in the quiet-warning domain (#94151); only registry-alias → `mcp-*` names are MCP servers.

## How to Test

1. `pytest tests/cron/test_cron_mcp_toolset_guard_109050.py -v`
   Observed result: 8 passed (fail-closed block with `[blocked_config]` + `'notion'` in reason; healthy server passes; unknown name without alias not guarded; no per-job list skips; verifier error fails open; re-block after `blocked_config` is silent; `cron.preflight: false` opts out; end-to-end `setup.blocked` wiring after MCP discovery).
2. `pytest tests/cron/ -q`
   Observed result: 1250 passed, 4 skipped, 1 failed — the single failure (`test_file_permissions.py::test_ensure_hermes_home_sets_0700`) reproduces identically on a clean `upstream/main` checkout of this branch's base (environment-local, pre-existing, unrelated to this change).
3. `ruff check cron/scheduler.py tests/cron/test_cron_mcp_toolset_guard_109050.py`
   Observed result: All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#53422 changes `_merge_mcp_into_per_job_toolsets` semantics — globally-enabled servers auto-added *into* a per-job allowlist; this PR handles the opposite face: a *named* server resolving to zero tools — orthogonal mechanisms, both files touched but different functions)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (full `tests/cron/` suite; the one failure shown above is pre-existing on the base commit)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior surfaces through the existing blocked_config delivery format)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (reuses the existing `cron.preflight` key)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — not a skill.

## Screenshots / Logs

Regression test run:

```
tests/cron/test_cron_mcp_toolset_guard_109050.py::test_named_mcp_server_with_zero_tools_blocks PASSED
tests/cron/test_cron_mcp_toolset_guard_109050.py::test_named_mcp_server_with_tools_passes PASSED
tests/cron/test_cron_mcp_toolset_guard_109050.py::test_unknown_name_without_alias_is_not_guarded PASSED
tests/cron/test_cron_mcp_toolset_guard_109050.py::test_no_per_job_toolsets_skips_check PASSED
tests/cron/test_cron_mcp_toolset_guard_109050.py::test_verifier_errors_fail_open PASSED
tests/cron/test_cron_mcp_toolset_guard_109050.py::test_reblock_after_blocked_config_is_silent PASSED
tests/cron/test_cron_mcp_toolset_guard_109050.py::test_preflight_opt_out_disables_guard PASSED
tests/cron/test_cron_mcp_toolset_guard_109050.py::test_setup_wiring_blocks_run_after_mcp_discovery PASSED

8 passed in 0.21s
```
