### PR TITLE
fix(title): ignore reply-context openers

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -81,6 +81,10 @@ _CONTROL_WRAPPERS = tuple(
 # Hermes' own machine-authored openers: a compaction handoff or resumed session must not be titled after them.
 _MACHINE_PREFIXES = (
     "[CONTEXT COMPACTION", LEGACY_SUMMARY_PREFIX, "[Runtime note:", "[System note:", "[SYSTEM]",
+    # Gateway reply-context decoration. It is useful in the transcript but is
+    # not the user's request; cover both `[Replying to: ...]` and
+    # `[Replying to your previous message: ...]` from gateway/run_inbound.py.
+    "[Replying to",
     # tui_gateway.server._MODEL_SWITCH_MARKER_PREFIX (keep in sync); persisted as role="user" because
     # strict providers reject a non-first system message.
     # Model-switch marker from tui_gateway.server._append_model_switch_marker. It is persisted with

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -7,10 +7,23 @@ from unittest.mock import MagicMock, patch
 from agent.title_generator import (
     generate_title,
     auto_title_session,
+    is_titleable_user_message,
     maybe_auto_title,
     _title_language,
 )
 from hermes_state import SessionDB
+
+
+class TestDerivedTitle:
+    @pytest.mark.parametrize(
+        "wrapper",
+        [
+            '[Replying to: "Cronjob Response: media-inbox-mirror"]',
+            '[Replying to your previous message: "Cronjob Response: media-inbox-mirror"]',
+        ],
+    )
+    def test_reply_context_wrapper_is_not_titleable(self, wrapper):
+        assert is_titleable_user_message(f"{wrapper}\n\nReparieren") is False
 
 
 class TestGenerateTitle:


### PR DESCRIPTION
## Summary

- Treat gateway reply-context prefixes as machine-authored openers for session titling.
- Cover both `[Replying to: ...]` and `[Replying to your previous message: ...]` emitted by `gateway/run_inbound.py`.

## Verification

- `pytest tests/agent/test_title_generator.py`: 38 passed
- Sabotage run with the pre-fix source: non-zero with both new parameterized cases failing
- `git diff --check`: passed

## Risk

- Limited to the titleability guard; transcript content and reply context passed to the model are unchanged.
