### PR TITLE
fix(computer_use): attach window_id/snapshot_id for element clicks (#108355)

### DIFF
--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -359,6 +359,11 @@ class CuaDriverBackend(_CaptureMixin, _InputMixin, ComputerUseBackend):
         token = self._snapshot_tokens.get(idx) if isinstance(idx, int) else None
         if token and self._session.supports_capability("accessibility.element_tokens", tool=name):
             args["element_token"] = token
+        elif "element_index" in args:
+            if getattr(self, "_last_snapshot_id", None):
+                args.setdefault("snapshot_id", self._last_snapshot_id)
+            elif getattr(self, "_active_window_id", None) is not None:
+                args.setdefault("window_id", self._active_window_id)
         if inject_session:  # setdefault preserves any explicit session a caller already supplied
             args.setdefault("session", self._session_id)
         try:

--- a/tools/computer_use/cua_backend_capture.py
+++ b/tools/computer_use/cua_backend_capture.py
@@ -273,6 +273,7 @@ class _CaptureMixin:
                     else _parse_elements_from_tree(tree) if tree else [])
         # Tokens are tied to this snapshot: overwrite the whole map (and clear it when the new capture carries none).
         self._snapshot_tokens = {e.index: e.element_token for e in elements if e.element_token}
+        self._last_snapshot_id = gws_out.get("snapshot_id")
         return *_image_from_tool_result(gws_out), elements, window_title
 
     def capture(self, mode: str = "som", app: Optional[str] = None, pid: Optional[int] = None,


### PR DESCRIPTION
��Closes #108355

This fixes the structural refusal for `click(element_index=N)` on newer `cua-driver` versions by properly attaching the `window_id` and `snapshot_id` when `element_token` is missing. This restores functional AX-addressed clicks on macOS and avoids falling back to unverifiable CGEvent pixel synthesis.
