### PR TITLE
fix(desktop): keep Bot Mode sidebar tabs reachable (#101535)

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/hide-only-strip-tabs.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/hide-only-strip-tabs.test.ts
@@ -104,14 +104,24 @@ describe('hide-only strip tabs', () => {
     expect(hideOnlyZoneTabs('g-main')).toEqual([])
   })
 
-  it('honors never on the sessions/Bots strip', () => {
+  it('keeps the sessions/Bots strip visible when a saved never choice would hide the mode switcher', () => {
     sessionsBotsTree()
     setTreeGroupTabStrip('g-side', 'never')
 
     const side = $layoutTree.get()
     const group = side && side.type === 'split' ? side.children[0] : side
 
-    expect(group && group.type === 'group' ? tabStripVisibleForGroup(group) : true).toBe(false)
+    expect(group && group.type === 'group' ? tabStripVisibleForGroup(group) : false).toBe(true)
+  })
+
+  it('keeps the remaining sessions tab visible when Bots is hidden so the show menu stays reachable', () => {
+    sessionsBotsTree()
+    setStripTabHidden('hermes-bots:pane', true)
+
+    const side = $layoutTree.get()
+    const group = side && side.type === 'split' ? side.children[0] : side
+
+    expect(group && group.type === 'group' ? tabStripVisibleForGroup(group) : false).toBe(true)
   })
 
   it('excludes hide-only tabs from every close verb', () => {

--- a/apps/desktop/src/components/pane-shell/tree/renderer/collapse-restore-affordance.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/collapse-restore-affordance.test.tsx
@@ -135,13 +135,15 @@ describe('Sessions/Bots strip — #91223', () => {
     expect(tabEl('hermes-bots:pane')).toBeTruthy()
   })
 
-  it('an explicit never hides the sessions/Bots strip', () => {
+  it('an explicit never still keeps the sessions/Bots mode switcher reachable', () => {
     setTreeGroupTabStrip('g-side', 'never')
-    expect(tabStripVisibleForGroup(zoneAt(0))).toBe(false)
+    expect(tabStripVisibleForGroup(zoneAt(0))).toBe(true)
 
     render(<LiveTreeGroup parentAxis="row" />)
 
-    expect(tablist()).toBeNull()
+    expect(tablist()).toBeTruthy()
+    expect(tabEl('sessions')).toBeTruthy()
+    expect(tabEl('hermes-bots:pane')).toBeTruthy()
   })
 })
 

--- a/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.test.ts
@@ -9,6 +9,7 @@ const tile = (): StripPane => ({ collapsePane: false, placement: 'main' })
 const workspace = (): StripPane => ({ collapsePane: false, placement: 'main', uncloseable: true })
 const toolPanel = (): StripPane => ({ collapsePane: true, placement: 'bottom' })
 const sideChrome = (): StripPane => ({ collapsePane: false, placement: 'right' })
+const hideOnlyChrome = (): StripPane => ({ collapsePane: false, hideOnly: true, placement: 'left' })
 
 describe('auto (no stored choice)', () => {
   it('gives a lone workspace no strip and a stack of two a strip', () => {
@@ -30,6 +31,14 @@ describe('the stored choice', () => {
     expect(resolveTabStripVisible({ mode: 'always', shown: [workspace()] })).toBe(true)
     expect(resolveTabStripVisible({ mode: 'never', shown: [workspace(), sideChrome()] })).toBe(false)
   })
+
+  it('does not hide a hide-only mode switcher under never', () => {
+    const sessions = hideOnlyChrome()
+    const bots = hideOnlyChrome()
+
+    expect(resolveTabStripVisible({ all: [sessions, bots], mode: 'never', shown: [sessions, bots] })).toBe(true)
+    expect(resolveTabStripVisible({ all: [sessions, bots], mode: 'never', shown: [sessions] })).toBe(true)
+  })
 })
 
 // THE invariant the old boolean could not hold. `never` used to sit above the
@@ -46,7 +55,7 @@ describe('no dead zone', () => {
 
   it('still hides a zone that cannot strand anything', () => {
     // The workspace is uncloseable, a stack is reachable by tab cycling, and
-    // hide-only chrome (sessions / Bots) keeps its panes + ⌘⌥T — the invariant
+    // ordinary side chrome has no recovery affordance to protect. The invariant
     // protects handles, it does not veto hiding as such.
     expect(resolveTabStripVisible({ mode: 'never', shown: [workspace()] })).toBe(false)
     expect(resolveTabStripVisible({ mode: 'never', shown: [toolPanel(), toolPanel()] })).toBe(false)

--- a/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.ts
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/strip-visibility.ts
@@ -19,6 +19,8 @@ import { paneChrome } from './track-model'
 export interface StripPane {
   /** A tool panel (terminal / logs) that collapses rather than closes. */
   collapsePane: boolean
+  /** Standing chrome tab (sessions / Bots) that hides instead of closing. */
+  hideOnly?: boolean
   /** Contribution placement — `'main'` marks a docked tile (session, page,
    *  preview) as opposed to standing side chrome. */
   placement?: string
@@ -27,6 +29,8 @@ export interface StripPane {
 }
 
 export interface StripZone {
+  /** All panes in the zone, including chrome-hidden ones. */
+  all?: readonly StripPane[]
   /** The ACTIVE pane declines to be tabbed (a full-page view). */
   headerVeto?: boolean
   /** The zone's standing choice; undefined = auto. */
@@ -67,6 +71,18 @@ function stranded(shown: readonly StripPane[]): boolean {
   return only.collapsePane || (!only.uncloseable && only.placement === 'main')
 }
 
+/** Sessions and Bot Mode are not interchangeable content tabs; together they
+ *  are the sidebar's mode switcher. If that hide-only chrome pair is in the
+ *  zone, the strip is the only visible affordance for switching modes and for
+ *  right-clicking the Show/Hide rows that recover a hidden sibling. A saved
+ *  `never` choice must not turn that switcher into an invisible preference. */
+function hideOnlyModeSwitcher(zone: StripZone): boolean {
+  const all = zone.all ?? zone.shown
+  const hideOnlyCount = all.filter(pane => pane.hideOnly).length
+
+  return hideOnlyCount > 1 && zone.shown.some(pane => pane.hideOnly)
+}
+
 export function resolveTabStripVisible(zone: StripZone): boolean {
   if (zone.shown.length === 0) {
     return false
@@ -80,6 +96,10 @@ export function resolveTabStripVisible(zone: StripZone): boolean {
   }
 
   if (stranded(zone.shown)) {
+    return true
+  }
+
+  if (hideOnlyModeSwitcher(zone)) {
     return true
   }
 
@@ -99,6 +119,8 @@ export function resolveTabStripVisible(zone: StripZone): boolean {
  * fold in the app-wide default.
  */
 export function tabStripVisibleForZone(zone: {
+  /** All panes in the zone, including chrome-hidden ones. */
+  all?: readonly string[]
   /** The zone's ACTIVE pane. */
   active: string
   isCollapsePane: (id: string) => boolean
@@ -108,17 +130,21 @@ export function tabStripVisibleForZone(zone: {
   /** Panes currently rendered as chips. */
   shown: readonly string[]
 }): boolean {
+  const toStripPane = (id: string): StripPane => {
+    const chrome = paneChrome(zone.paneFor(id))
+
+    return {
+      collapsePane: zone.isCollapsePane(id),
+      hideOnly: chrome.hideOnly,
+      placement: chrome.placement,
+      uncloseable: chrome.uncloseable
+    }
+  }
+
   return resolveTabStripVisible({
+    all: (zone.all ?? zone.shown).map(toStripPane),
     headerVeto: paneChrome(zone.paneFor(zone.active)).headerVeto,
     mode: effectiveTabStripMode(zone.mode),
-    shown: zone.shown.map(id => {
-      const chrome = paneChrome(zone.paneFor(id))
-
-      return {
-        collapsePane: zone.isCollapsePane(id),
-        placement: chrome.placement,
-        uncloseable: chrome.uncloseable
-      }
-    })
+    shown: zone.shown.map(toStripPane)
   })
 }

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -339,6 +339,7 @@ export function TreeGroup({
   // the keystroke and the screen always agree about which way "toggle" points.
   const stripVisible = tabStripVisibleForZone({
     active: activeId,
+    all: node.panes,
     isCollapsePane,
     mode: node.tabStrip,
     paneFor,

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -769,6 +769,7 @@ export function tabStripVisibleForGroup(group: GroupNode): boolean {
 
   return tabStripVisibleForZone({
     active: group.active,
+    all: group.panes,
     isCollapsePane,
     mode: group.tabStrip,
     paneFor: (id: string) => registered.find(c => c.id === id),


### PR DESCRIPTION
## What does this PR do?

The Desktop sidebar can store a pane-zone choice of `tabStrip: 'never'`. When the left sidebar contains the hide-only `SESSIONS` and `BOTS` chrome panes, that saved choice hid the only visible mode switcher. If `BOTS` was also hidden, auto mode saw only one shown pane and removed the remaining strip too, leaving no visible way to reach Bot Mode or reopen the hidden Bots tab.

This keeps the tab strip visible whenever a zone contains multiple hide-only chrome panes and at least one of them is shown. The resolver now receives both the shown panes and all panes in the zone, so it can preserve the Sessions/Bots switcher even when a sibling is chrome-hidden. Ordinary main/tool zones still honor explicit tab hiding when it does not strand the mode switcher.

## Related Issue

Fixes #101535

## Type of Change

- [x] 🐛 Bug fix
- [x] ✅ Tests

## Changes Made

- `strip-visibility.ts`: teach the shared tab-strip resolver about hide-only chrome panes and full-zone pane membership.
- `tree-group.tsx` / `store.ts`: pass the full group pane list to the resolver from both render and store-side callers.
- Regression tests for saved `never`, hidden-Bots recovery, the existing collapse affordance path, and ordinary tab-strip hiding controls.

## Verification

```bash
cd apps/desktop && npx vitest run \
  src/components/pane-shell/tree/hide-only-strip-tabs.test.ts \
  src/components/pane-shell/tree/renderer/collapse-restore-affordance.test.tsx \
  src/components/pane-shell/tree/renderer/strip-visibility.test.ts \
  src/components/pane-shell/tree/renderer/tab-strip-hide.test.tsx \
  src/components/pane-shell/tree/tabstrip-migration.test.ts
# 5 files, 38 tests passed

cd apps/desktop && npm run typecheck
# passed

cd apps/desktop && npx eslint \
  src/components/pane-shell/tree/renderer/strip-visibility.ts \
  src/components/pane-shell/tree/renderer/tree-group.tsx \
  src/components/pane-shell/tree/store.ts \
  src/components/pane-shell/tree/hide-only-strip-tabs.test.ts \
  src/components/pane-shell/tree/renderer/collapse-restore-affordance.test.tsx \
  src/components/pane-shell/tree/renderer/strip-visibility.test.ts
# passed

cd apps/desktop && npx prettier --check <changed files>
# passed

git diff --check
# passed
```

RED proof on upstream/main: the two new hide-only-strip regressions failed before the production fix because `tabStripVisibleForGroup()` returned `false` for the Sessions/Bots saved-`never` and hidden-Bots recovery states.

## Duplicate / competitor check

No open PRs found for `101535 in:title,body`, `"Bots tab"`, or `"Bot Mode" "sidebar" "tab"`. No open Tranquil-Flow branch/PR exists for `fix/101535*`.

Auto-published by Moonsong via Path B automated pipeline.
