### PR TITLE
feat(agent): add self_help_guidance config to drop the Hermes docs-pointer block

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1329,9 +1329,12 @@ def _apply_agent_section(agent, _agent_cfg):
 
     # Default-on boolean gates: anti-stall guards (notice-only), universal guidance toggles
     # (ALL models, unlike enforcement), the local toolchain probe, Bot Mode protocol section.
+    # self_help_guidance gates the "You run on Hermes Agent ..." docs-pointer block;
+    # embedded / white-labeled deployments turn it off to strip the runtime's vendor
+    # identity and public docs URL from the prompt without losing the other blocks.
     for _key in (
         "stall_guards", "task_completion_guidance", "parallel_tool_call_guidance",
-        "environment_probe", "bot_mode_protocol",
+        "environment_probe", "bot_mode_protocol", "self_help_guidance",
     ):
         setattr(agent, f"_{_key}", bool(_agent_section.get(_key, True)))
     # Warm the probe (~0.5s of subprocesses) off-thread so the first prompt build finds it cached.

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -618,13 +618,19 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # The skill_view() pointer dangles without skill tools OR without the
     # hermes-agent skill installed, so the variant is chosen after the skills
     # index is built; this slot holds its position.
-    _help_guidance_slot = len(stable_parts)
-    stable_parts.append(HERMES_AGENT_HELP_GUIDANCE_NO_SKILLS)
+    # Gated by config.yaml ``agent.self_help_guidance`` (default True):
+    # embedded / white-labeled deployments turn it off to strip the runtime's
+    # vendor identity and public docs URL from the prompt.
+    _help_guidance_slot = None
+    if getattr(agent, "_self_help_guidance", True):
+        _help_guidance_slot = len(stable_parts)
+        stable_parts.append(HERMES_AGENT_HELP_GUIDANCE_NO_SKILLS)
     stable_parts.extend(_guidance_parts(agent))
     skills_prompt = _skills_prompt(agent)
     # Skill-pointer variant requires BOTH skill_view AND the hermes-agent skill
     # in the rendered index (pure string check — inherits the index's stability).
-    if "skill_view" in (agent.valid_tool_names or set()) and "- hermes-agent:" in skills_prompt:
+    # _help_guidance_slot is None when self-help guidance is disabled.
+    if _help_guidance_slot is not None and "skill_view" in (agent.valid_tool_names or set()) and "- hermes-agent:" in skills_prompt:
         stable_parts[_help_guidance_slot] = HERMES_AGENT_HELP_GUIDANCE
     stable_parts.extend(_alibaba_identity_part(agent))
     # Coding posture: the operating brief stays in the stable prefix. The

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1172,6 +1172,13 @@ agent:
   # Default 3.
   # max_verify_nudges: 3
 
+  # Self-help docs-pointer in the system prompt ("You run on Hermes Agent ...").
+  # Points the model at the public docs and the hermes-agent skill for
+  # questions about Hermes itself. Set false for embedded / white-labeled
+  # deployments where the runtime's vendor identity and docs URL should not
+  # reach end users. Default true.
+  # self_help_guidance: true
+
   # Enable verbose logging
   verbose: false
   

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -1,5 +1,6 @@
 """Tests for agent/system_prompt.py — context-file cwd wiring."""
 
+from contextlib import ExitStack
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -450,6 +451,58 @@ def test_coding_prompt_orders_shared_context_before_workspace(monkeypatch):
 
     assert prompt == expected
     assert agent._cached_system_prompt_static == "\n\n".join(expected.split("\n\n")[:4])
+
+
+def test_self_help_guidance_toggle(monkeypatch):
+    """config.yaml ``agent.self_help_guidance: False`` drops the "You run on
+    Hermes Agent" docs-pointer block without touching any other guidance.
+
+    Embedded / white-labeled deployments use this to strip the runtime's
+    vendor identity and public docs URL from the prompt. Default (attribute
+    absent) must keep today's behavior.
+    """
+    import agent.system_prompt as system_prompt
+
+    monkeypatch.setattr(system_prompt, "DEFAULT_AGENT_IDENTITY", "IDENTITY")
+    monkeypatch.setattr(system_prompt, "HERMES_AGENT_HELP_GUIDANCE", "HELP-SKILL-VARIANT")
+    monkeypatch.setattr(system_prompt, "HERMES_AGENT_HELP_GUIDANCE_NO_SKILLS", "HELP-NO-SKILL-VARIANT")
+    monkeypatch.setattr(system_prompt, "STEER_CHANNEL_NOTE", "STEER")
+    monkeypatch.setattr(system_prompt, "get_hermes_home", lambda: Path("/hermes"))
+
+    common = (
+        patch("run_agent.load_soul_md", return_value=""),
+        patch("run_agent.build_environment_hints", return_value=""),
+        patch("run_agent.build_context_files_prompt", return_value="CONTEXT_FILES"),
+        patch(
+            "agent.coding_context.coding_system_prompt_parts",
+            return_value=(["CODING_STABLE"], ["WORKSPACE"], ["Operator instructions:\nOPERATOR"]),
+        ),
+        patch("agent.file_safety._resolve_active_profile_name", return_value="default"),
+        patch("hermes_time.now", return_value=datetime(2026, 1, 2)),
+    )
+
+    # Default: the no-skills variant is present and holds its slot.
+    agent = _make_agent()
+    with ExitStack() as stack:
+        for cm in common:
+            stack.enter_context(cm)
+        prompt = build_system_prompt(agent, system_message="SYSTEM_MESSAGE")
+    assert "HELP-NO-SKILL-VARIANT" in prompt
+    assert agent._cached_system_prompt_static.split("\n\n")[1] == "HELP-NO-SKILL-VARIANT"
+
+    # Disabled: the block is gone, identity still first, and the static
+    # cache split loses exactly one part (order of the rest preserved).
+    agent = _make_agent(_self_help_guidance=False)
+    with ExitStack() as stack:
+        for cm in common:
+            stack.enter_context(cm)
+        prompt = build_system_prompt(agent, system_message="SYSTEM_MESSAGE")
+    assert "HELP-NO-SKILL-VARIANT" not in prompt
+    assert "HELP-SKILL-VARIANT" not in prompt
+    # The static/dynamic cache split stays consistent without the slot.
+    static = agent._cached_system_prompt_static
+    assert static and prompt.startswith(static)
+    assert "HELP-NO-SKILL-VARIANT" not in static and "HELP-SKILL-VARIANT" not in static
 
 
 class TestTelegramRichMessagesHint:


### PR DESCRIPTION
## What does this PR do?

Adds a config toggle, `agent.self_help_guidance` (default `true`), that removes the unconditional **"You run on Hermes Agent (by Nous Research)"** docs-pointer block from the system prompt when set to `false`.

The block makes sense for standalone CLI users, but it is injected unconditionally today, which hurts embedded / white-labeled deployments (products that run Hermes as their built-in assistant under a different name):

- It identifies the runtime vendor to end users, who may see it echoed in answers ("What are you?" → "I run on Hermes Agent by Nous Research").
- It directs the model to treat the public docs site as the *authoritative reference* for configuration/troubleshooting — in an embedded product, configuration lives server-side and end users cannot act on that URL, so the model gets steered toward misleading answers.

The implementation follows the existing `task_completion_guidance` / `parallel_tool_call_guidance` toggle pattern exactly: `agent_init` reads the key into `agent._self_help_guidance`, and `system_prompt` gates the slot on it. When disabled, the later skill-pointer variant swap (`stable_parts[_help_guidance_slot] = HERMES_AGENT_HELP_GUIDANCE`) is skipped too, since the slot no longer exists. No other guidance block (identity, task-completion, parallel-tool-call, execution discipline) is affected, and the default keeps today's behavior byte-for-byte.

## Related Issue

No existing issue found (searched open/closed issues and PRs for "self_help", "help guidance", "white-label", "identity block"). Happy to split an issue out if maintainers prefer.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/agent_init.py`: read `agent.self_help_guidance` (default `true`) into `agent._self_help_guidance`, alongside the sibling guidance toggles.
- `agent/system_prompt.py`: gate the help-guidance slot (`HERMES_AGENT_HELP_GUIDANCE_NO_SKILLS` append + the `HERMES_AGENT_HELP_GUIDANCE` variant swap) on `getattr(agent, "_self_help_guidance", True)`.
- `cli-config.yaml.example`: document the new key in the `agent:` section.
- `tests/agent/test_system_prompt.py`: `test_self_help_guidance_toggle` — default keeps the block (and its slot in the static cache split); `false` drops the block, keeps identity first, and keeps the static/dynamic cache split consistent.

## How to Test

1. `pytest tests/agent/test_system_prompt.py tests/agent/test_phantom_tool_references.py -q` — all pass (62 pre-existing + 1 new). Locally the full suite has collection errors in 7 unrelated files that need optional dev deps (`acp`, `a2a`, MCP-OAuth) not installed in this environment; CI will run the authoritative full suite.
2. Set `self_help_guidance: false` under `agent:` in `config.yaml`, start a session, and inspect the system prompt: the "You run on Hermes Agent" block is gone.
3. Remove the key (or set `true`): behavior is unchanged from before this PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(agent): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
      <!-- Affected areas pass; 7 unrelated files can't be collected locally for lack of optional dev deps (acp/a2a/mcp-oauth) — CI covers the full suite. -->
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `cli-config.yaml.example` documents the new key
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — done
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure prompt-assembly change, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (default) — block present in system prompt:

```
... You run on Hermes Agent (by Nous Research). When the user needs help with
Hermes itself — configuring, setting up, using, extending, or troubleshooting
it — ... the documentation at https://hermes-agent.nousresearch.com/docs is the
authoritative reference ...
```

After `self_help_guidance: false` — block absent; all other guidance blocks unchanged:

```
(verified via tests/agent/test_system_prompt.py::test_self_help_guidance_toggle)
```
