### PR TITLE
fix(tui): Web Dashboard recognizes custom providers during bootstrap (fixes #107918)

### DIFF
--- a/hermes_cli/free_tier_bootstrap.py
+++ b/hermes_cli/free_tier_bootstrap.py
@@ -126,6 +126,12 @@ def run_bootstrap(*, announce: bool = True) -> SetupRecord:
             error = str(exc)
             logger.info("Nous free tier not set up at boot: %s", exc)
     free_tier = bool(state) and anon_auth.is_guest_state(state) and anon_auth.guest_enabled()
+
+    if not other and not free_tier:
+        from hermes_cli.main import _has_any_provider_configured
+        if _has_any_provider_configured(strict_profile_scope=False):
+            other = True
+
     record = SetupRecord(
         provider_configured=other or free_tier or (bool(state) and not anon_auth.is_guest_state(state)),
         inference_provider=_resolve_inference(),


### PR DESCRIPTION
- Fixes a regression in \ree_tier_bootstrap.py\ where custom providers (which lack an auth mechanism in PROVIDER_REGISTRY) caused the web TUI to incorrectly demand setup.
- If both the standard provider check and the free_tier check return False, we now explicitly fall back to \_has_any_provider_configured(strict_profile_scope=False)\ to check for unlisted custom providers.
- Fully fixes #107918.