### PR TITLE
fix(checkpoints): recover refs that block gc, report the size cap honestly

### DIFF
--- a/hermes_cli/checkpoints.py
+++ b/hermes_cli/checkpoints.py
@@ -55,6 +55,17 @@ def cmd_status(args: argparse.Namespace) -> int:
         _print_archives(sorted(legacy, key=lambda a: a.get("mtime", 0), reverse=True))
         print()
         print("Clear with: hermes checkpoints clear-legacy")
+
+    bad_refs = info.get("unresolvable_refs") or []
+    if bad_refs:
+        print()
+        print(f"⚠ {len(bad_refs)} ref(s) point at missing objects — `git gc` cannot reclaim")
+        print("  space while they exist, so the store stays over its size cap.")
+        for ref in bad_refs[:5]:
+            print(f"    {ref}")
+        if len(bad_refs) > 5:
+            print(f"    … and {len(bad_refs) - 5} more")
+        print("  Fix with: hermes checkpoints repair")
     return 0
 
 
@@ -116,6 +127,24 @@ def cmd_prune(args: argparse.Namespace) -> int:
     print(f"Errors:          {result['errors']}")
     print(f"Bytes reclaimed: {_fmt_bytes(result['bytes_freed'])}")
     return 0
+
+
+def cmd_repair(args: argparse.Namespace) -> int:
+    """Remove refs that point at missing objects (they block every `git gc`)."""
+    from tools.checkpoint_manager import repair_store
+
+    print("Repairing checkpoint store refs…")
+    result = repair_store()
+    print(f"Scanned:        {result['scanned']} ref(s)")
+    print(f"Shadow removed: {result['repaired']}")
+    print(f"Dropped:        {result['deleted']}  (refs whose object no longer exists)")
+    print(f"Errors:         {result['errors']}")
+    print()
+    if result["repaired"] or result["deleted"]:
+        print("Repaired. Run `hermes checkpoints prune` to reclaim the freed space.")
+    else:
+        print("No unresolvable refs — nothing to repair.")
+    return 0 if result["errors"] == 0 else 2
 
 
 def _confirm(prompt: str) -> bool:
@@ -207,6 +236,11 @@ def register_cli(parser: argparse.ArgumentParser) -> None:
     p_prune.add_argument("-f", "--force", action="store_true",
                          help="Skip the orphan-deletion confirmation prompt")
     p_prune.set_defaults(func=cmd_prune)
+
+    p_repair = subs.add_parser(
+        "repair",
+        help="Remove refs that point at missing objects (they block git gc and the size cap)")
+    p_repair.set_defaults(func=cmd_repair)
 
     for name, help_text, func in (
         ("clear", "Delete the entire checkpoint base (all /rollback history)", cmd_clear),

--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -319,7 +319,7 @@ _CLI_FAMILIES: dict[str, tuple[_CliSurface, str]] = {
         "diagnose, *link, *unlink, *claim, *comment, *complete, *edit, *block, *schedule, "
         "*unblock, *promote, *archive, stats, runs, heartbeat, assignments, context"),
     "bundles": (_reg("bundles", "bundles_command"), "list, show, *create, *delete, *reload"),
-    "checkpoints": (_reg("checkpoints"), "status, list, *prune, *clear, *clear-legacy"),
+    "checkpoints": (_reg("checkpoints"), "status, list, *prune, *repair, *clear, *clear-legacy"),
     "curator": (
         _reg("curator"),
         "status, *run, *pause, *resume, *pin, *unpin, *restore, list-archived, *archive, *prune, "

--- a/tests/hermes_cli/test_console_engine.py
+++ b/tests/hermes_cli/test_console_engine.py
@@ -174,6 +174,7 @@ EXPECTED_CONSOLE_COMMANDS = {
     ("checkpoints", "status"),
     ("checkpoints", "list"),
     ("checkpoints", "prune"),
+    ("checkpoints", "repair"),
     ("checkpoints", "clear"),
     ("checkpoints", "clear-legacy"),
     ("curator", "status"),

--- a/tests/tools/test_checkpoint_store_repair.py
+++ b/tests/tools/test_checkpoint_store_repair.py
@@ -1,0 +1,320 @@
+"""Tests for the checkpoint store's dangling-ref recovery and honest size-cap reporting.
+
+Background: a loose ref that shadows a valid packed-ref and points at a *missing* object
+(typically left behind by a ``git gc`` whose reachability snapshot predates a concurrent
+checkpoint's ``update-ref``) makes **every** later ``git gc`` fail with "does not point to
+a valid object!".  Object reclamation stops, the store grows past its size cap, and the old
+``_shrink_store_to_cap`` returned ``True`` regardless — so a 27 GB store over a 500 MB cap
+reported successful maintenance on every single write tool call (hot self-spin).
+
+Every test runs against real git in an isolated tmp store.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from tools.checkpoint_manager import (
+    CheckpointManager,
+    _cap_retry_cooling_down,
+    _candidate_refs,
+    _dir_size_bytes,
+    _gc_store,
+    _missing_tips,
+    _project_hash,
+    _ref_name,
+    _repair_unresolvable_refs,
+    _run_git,
+    _shrink_store_to_cap,
+    _store_lock,
+    _store_path,
+    repair_store,
+    store_status,
+)
+
+GIT_GC = ["gc", "--prune=now", "--quiet"]
+
+
+def _incompressible(size: int = 800_000) -> str:
+    """Random base64 payload: git's loose-object zlib cannot shrink it away, so sizes and
+    reclaiming behave like real data instead of collapsing to a few KB."""
+    return base64.b64encode(os.urandom(size // 2)).decode("ascii")
+
+
+@pytest.fixture()
+def env(tmp_path, monkeypatch) -> SimpleNamespace:
+    """A real, isolated checkpoint store with one project and one snapshot."""
+    base = tmp_path / "checkpoints"
+    work_dir = tmp_path / "project"
+    work_dir.mkdir()
+    (work_dir / "a.txt").write_text("hello\n", encoding="utf-8")
+    monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", base)
+    mgr = CheckpointManager(enabled=True, max_snapshots=50, max_total_size_mb=500)
+    assert mgr.ensure_checkpoint(str(work_dir), "first") is True
+    store = _store_path(base)
+    return SimpleNamespace(base=base, work_dir=work_dir, store=store, mgr=mgr,
+                           ref=_ref_name(_project_hash(str(work_dir))))
+
+
+def _seed_dangling_shadow(env: SimpleNamespace) -> tuple[str, str]:
+    """Leave ``env.ref`` as a loose ref pointing at a pruned object, shadowing a valid packed-ref.
+
+    Mirrors the production corruption: the ref is packed; a writer commits a new object and
+    moves the ref to it; a gc whose reachability snapshot predates that update prunes the
+    object.  Returns ``(valid_packed_tip, pruned_sha)``.
+    """
+    store, wd, ref = env.store, str(env.work_dir), env.ref
+    assert _run_git(["pack-refs", "--all"], store, wd)[0]
+    packed_tip = _run_git(["rev-parse", ref], store, wd)[1]
+    tree = _run_git(["rev-parse", f"{packed_tip}^{{tree}}"], store, wd)[1]
+    pruned = _run_git(["commit-tree", tree, "-p", packed_tip, "-m", "raced", "--no-gpg-sign"], store, wd)[1]
+    assert _run_git(["update-ref", ref, pruned], store, wd)[0]
+
+    stashed = env.base / "shadow.stash"
+    (store / ref).rename(stashed)          # gc's snapshot: the ref does not exist yet
+    assert _run_git(GIT_GC, store, wd)[0]
+    stashed.rename(store / ref)            # ... then the writer's update-ref lands
+    return packed_tip, pruned
+
+
+def _seed_dead_ref(env: SimpleNamespace, ref: str) -> None:
+    """A loose ref pointing at a well-formed sha that was never written."""
+    path = env.store / ref
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("d" * 40 + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# The pathology itself
+# ---------------------------------------------------------------------------
+
+class TestDanglingRefPathology:
+    def test_dangling_shadow_ref_makes_gc_fail(self, env):
+        _seed_dangling_shadow(env)
+        ok, _, err = _run_git(GIT_GC, env.store, str(env.work_dir))
+        assert ok is False, "baseline: a dangling loose ref must break git gc"
+        assert "does not point to a valid object" in err
+
+    def test_cleanup_paths_cannot_converge_on_a_dangling_ref(self, env):
+        """The old cleanup loop could not make progress, yet reported success."""
+        _, pruned = _seed_dangling_shadow(env)
+        assert _missing_tips(env.store, str(env.work_dir), [env.ref]) == [(env.ref, pruned)]
+        # Nothing droppable: the ref's tip does not resolve, so its commit count is 0.
+        ok, _, _ = _run_git(["rev-list", "--count", env.ref], env.store, str(env.work_dir))
+        assert ok is False
+
+    def test_store_status_surfaces_unresolvable_refs(self, env):
+        _seed_dangling_shadow(env)
+        info = store_status(env.base)
+        assert info["unresolvable_refs"] == [env.ref]
+
+
+# ---------------------------------------------------------------------------
+# Repair
+# ---------------------------------------------------------------------------
+
+class TestRepair:
+    def test_shadowed_ref_is_repaired_and_history_kept(self, env):
+        packed_tip, pruned = _seed_dangling_shadow(env)
+
+        result = repair_store(env.base)
+
+        assert result["repaired"] == 1 and result["deleted"] == 0 and result["errors"] == 0
+        assert not (env.store / env.ref).exists(), "the unresolvable loose shadow must be gone"
+        assert _run_git(["rev-parse", env.ref], env.store, str(env.work_dir))[1] == packed_tip, \
+            "the valid packed-ref value (real history) must take over"
+        assert _run_git(GIT_GC, env.store, str(env.work_dir))[0] is True, "gc must work again"
+        assert store_status(env.base)["unresolvable_refs"] == []
+
+    def test_ref_without_a_valid_twin_is_dropped(self, env):
+        dead = "refs/hermes/deadbeefcafe0001"
+        _seed_dead_ref(env, dead)
+
+        result = repair_store(env.base)
+
+        assert result["deleted"] == 1 and result["repaired"] == 0
+        assert not (env.store / dead).exists()
+        assert dead not in _candidate_refs(env.store)
+        assert _run_git(GIT_GC, env.store, str(env.work_dir))[0] is True
+
+    def test_packed_only_ref_is_removed_from_packed_refs(self, env):
+        """A dead ref that exists only in packed-refs must be dropped there too."""
+        packed_only = "refs/hermes/feedface00000001"
+        assert _run_git(["pack-refs", "--all"], env.store, str(env.work_dir))[0]
+        packed_file = env.store / "packed-refs"
+        packed_file.write_text(packed_file.read_text(encoding="utf-8") + f"{'e' * 40} {packed_only}\n",
+                              encoding="utf-8")
+
+        result = repair_store(env.base)
+
+        assert result["deleted"] == 1
+        assert packed_only not in packed_file.read_text(encoding="utf-8")
+        assert packed_only not in _candidate_refs(env.store)
+
+    def test_repair_is_a_noop_on_a_healthy_store(self, env):
+        result = repair_store(env.base)
+        assert result == {"scanned": result["scanned"], "repaired": 0, "deleted": 0, "errors": 0}
+        assert result["scanned"] >= 1
+
+    def test_repair_store_on_a_missing_base_is_inert(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", tmp_path / "nope")
+        assert repair_store() == {"scanned": 0, "repaired": 0, "deleted": 0, "errors": 0}
+
+
+# ---------------------------------------------------------------------------
+# gc-side recovery
+# ---------------------------------------------------------------------------
+
+class TestGcStore:
+    def test_gc_store_heals_a_dangling_ref_and_succeeds(self, env, caplog):
+        packed_tip, _ = _seed_dangling_shadow(env)
+
+        with caplog.at_level(logging.WARNING, logger="tools.checkpoint_manager"):
+            assert _gc_store(env.store, str(env.work_dir)) is True
+
+        assert any("gc failed" in rec.getMessage() for rec in caplog.records), \
+            "a gc failure must be visible below error level"
+        assert _run_git(GIT_GC, env.store, str(env.work_dir))[0] is True
+        assert _run_git(["rev-parse", env.ref], env.store, str(env.work_dir))[1] == packed_tip
+
+    def test_gc_store_skips_while_a_writer_holds_the_lock(self, env, monkeypatch):
+        monkeypatch.setattr("tools.checkpoint_manager._GC_LOCK_WAIT_S", 0.2)
+        with _store_lock(env.store, exclusive=False, blocking=True, timeout=0.0):
+            assert _gc_store(env.store, str(env.work_dir)) is False, \
+                "a checkpoint in flight means 'skip maintenance', never 'race it'"
+
+
+# ---------------------------------------------------------------------------
+# Honest size-cap reporting
+# ---------------------------------------------------------------------------
+
+class TestSizeCapReporting:
+    def test_shrink_reports_failure_instead_of_silent_success(self, env):
+        """The old code returned True while the store stayed over cap — the hot-loop bug."""
+        assert _shrink_store_to_cap(env.store, str(env.work_dir), 1) is False
+
+    def test_shrink_reports_success_when_already_under_cap(self, env):
+        cap = _dir_size_bytes(env.store) + 1
+        assert _shrink_store_to_cap(env.store, str(env.work_dir), cap) is True
+
+    def test_shrink_converges_by_dropping_and_reclaiming(self, tmp_path, monkeypatch):
+        base = tmp_path / "checkpoints"
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", base)
+        mgr = CheckpointManager(enabled=True, max_snapshots=50, max_total_size_mb=0)
+        payload = _incompressible()
+        for name in ("p1", "p2"):
+            wd = tmp_path / name
+            wd.mkdir()
+            for i in range(4):
+                (wd / "blob.bin").write_text(f"{name}-{i}:{payload}\n", encoding="utf-8")
+                mgr.new_turn()
+                assert mgr.ensure_checkpoint(str(wd), f"snap{i}") is True
+        store = _store_path(base)
+        size_before = _dir_size_bytes(store)
+        cap = size_before // 2
+
+        assert _shrink_store_to_cap(store, str(base), cap) is True
+        assert _dir_size_bytes(store) <= cap
+        assert _run_git(GIT_GC, store, str(base))[0] is True
+        for name in ("p1", "p2"):
+            ref = _ref_name(_project_hash(str(tmp_path / name)))
+            remaining = int(_run_git(["rev-list", "--count", ref], store, str(base))[1])
+            assert remaining >= 1, "a project must never be shrunk below one snapshot"
+
+    def test_failed_cap_pass_backs_off_instead_of_spinning(self, tmp_path, monkeypatch, caplog):
+        base = tmp_path / "checkpoints"
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", base)
+        wd = tmp_path / "project"
+        wd.mkdir()
+        (wd / "big.bin").write_text(_incompressible(4_000_000), encoding="utf-8")
+        mgr = CheckpointManager(enabled=True, max_snapshots=50, max_total_size_mb=1)
+        mgr.ensure_checkpoint(str(wd), "first")
+        store = _store_path(base)
+        assert _dir_size_bytes(store) > 1 * 1024 * 1024
+
+        mgr.new_turn()
+        (wd / "b.txt").write_text("change\n", encoding="utf-8")
+        with caplog.at_level(logging.INFO, logger="tools.checkpoint_manager"):
+            mgr.ensure_checkpoint(str(wd), "second")
+        assert _cap_retry_cooling_down(store) is True, "an unconvergeable store must arm the backoff"
+        assert any(r.levelno >= logging.WARNING and "still over its" in r.getMessage() for r in caplog.records)
+
+        caplog.clear()
+        mgr.new_turn()
+        (wd / "c.txt").write_text("change\n", encoding="utf-8")
+        with caplog.at_level(logging.INFO, logger="tools.checkpoint_manager"):
+            mgr.ensure_checkpoint(str(wd), "third")
+        assert not any("exceeded" in r.getMessage() for r in caplog.records), \
+            "the second pass must not re-run maintenance inside the backoff window"
+
+
+# ---------------------------------------------------------------------------
+# Write path
+# ---------------------------------------------------------------------------
+
+class TestWritePathSafety:
+    def test_tip_validation_rolls_the_ref_back_instead_of_leaving_it_dangling(self, env, monkeypatch):
+        before = _run_git(["rev-parse", env.ref], env.store, str(env.work_dir))[1]
+        (env.work_dir / "a.txt").write_text("changed\n", encoding="utf-8")
+        # Only the freshly committed tip is "missing" — a foreign gc pruned it in flight.
+        monkeypatch.setattr("tools.checkpoint_manager._object_present",
+                            lambda _store, _wd, sha: sha == before)
+
+        env.mgr.new_turn()
+        assert env.mgr.ensure_checkpoint(str(env.work_dir), "vanishing object") is False
+
+        after = _run_git(["rev-parse", env.ref], env.store, str(env.work_dir))
+        assert after[0] is True and after[1] == before, "the ref must not be left on a missing object"
+        assert _missing_tips(env.store, str(env.work_dir), [env.ref]) == []
+
+    def test_normal_checkpoint_still_moves_the_ref(self, env):
+        before = _run_git(["rev-parse", env.ref], env.store, str(env.work_dir))[1]
+        (env.work_dir / "a.txt").write_text("changed\n", encoding="utf-8")
+        env.mgr.new_turn()
+        assert env.mgr.ensure_checkpoint(str(env.work_dir), "second") is True
+        after = _run_git(["rev-parse", env.ref], env.store, str(env.work_dir))[1]
+        assert after != before
+        assert _run_git(["cat-file", "-e", after], env.store, str(env.work_dir))[0] is True
+        assert _run_git(GIT_GC, env.store, str(env.work_dir))[0] is True
+
+    def test_repair_helper_is_idempotent(self, env):
+        _seed_dangling_shadow(env)
+        first = _repair_unresolvable_refs(env.store, str(env.work_dir))
+        second = _repair_unresolvable_refs(env.store, str(env.work_dir))
+        assert first["repaired"] == 1
+        assert second["repaired"] == 0 and second["deleted"] == 0 and second["errors"] == 0
+
+
+class TestStoreLock:
+    def test_lock_wait_is_bounded_even_when_blocking(self, env):
+        """flock() without LOCK_NB blocks inside the syscall and ignores the deadline, which
+        would stall maintenance (or a checkpoint) forever; the wait must give up."""
+        with _store_lock(env.store, exclusive=False, blocking=True, timeout=0.0):
+            start = time.monotonic()
+            with _store_lock(env.store, exclusive=True, blocking=True, timeout=0.2) as gc_lock:
+                assert gc_lock is False, "an incompatible lock must not be granted"
+            assert time.monotonic() - start < 5.0, "the bounded wait must respect its deadline"
+
+    def test_exclusive_maintenance_lock_is_refused_while_a_writer_holds_it(self, env):
+        with _store_lock(env.store, exclusive=False, blocking=True, timeout=0.0) as writer:
+            assert writer is True
+            with _store_lock(env.store, exclusive=True, blocking=False) as gc_lock:
+                assert gc_lock is False
+        with _store_lock(env.store, exclusive=True, blocking=False) as free:
+            assert free is True
+
+    def test_lock_file_lives_at_the_store_root_and_is_inert(self, env):
+        with _store_lock(env.store, exclusive=True, blocking=False):
+            pass
+        assert (env.store / "maintenance.lock").exists()
+        ok, out, _ = _run_git(["count-objects", "-v"], env.store, str(env.work_dir))
+        assert ok is True and "count:" in out  # still a healthy git repo
+        env.mgr.new_turn()
+        (env.work_dir / "a.txt").write_text("after locking\n", encoding="utf-8")
+        assert env.mgr.ensure_checkpoint(str(env.work_dir), "post-lock") is True

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -10,6 +10,7 @@ repo with per-project ``refs/hermes/<hash16>``, ``indexes/<hash16>``, ``projects
 with GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE so nothing leaks into the user's project.
 """
 
+import contextlib
 import hashlib
 import itertools
 import json
@@ -23,6 +24,11 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Iterator, List, NamedTuple, Optional, Set, Tuple
+
+try:  # POSIX only: flock() serialises the shared object database across processes.
+    import fcntl
+except ImportError:  # pragma: no cover - Windows has no flock; locking degrades to no-op.
+    fcntl = None  # type: ignore[assignment]
 
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
@@ -61,6 +67,7 @@ DEFAULT_EXCLUDES = [
 _GIT_TIMEOUT: int = max(10, min(60, env_int("HERMES_CHECKPOINT_TIMEOUT", 30)))
 _MAX_FILES = 50_000  # skip huge directories to avoid slowdowns
 _COMMIT_HASH_RE = re.compile(r'^[0-9a-fA-F]{4,64}$')  # short or full SHA-1/SHA-256
+_SHA_RE = re.compile(r'^[0-9a-fA-F]{40,64}$')  # full SHA-1/SHA-256 (loose ref contents)
 _MB = 1024 * 1024
 # Inherited GIT_* vars that would redirect the shadow store's git calls.
 _GIT_LEAK_VARS = ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_NAMESPACE", "GIT_ALTERNATE_OBJECT_DIRECTORIES")
@@ -68,6 +75,20 @@ _GIT_LEAK_VARS = ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_NAMESPACE",
 _STORE_GIT_CONFIG = (("user.email", "hermes@local"), ("user.name", "Hermes Checkpoint"),
                      ("commit.gpgsign", "false"), ("tag.gpgSign", "false"), ("gc.auto", "0"))
 _PROJECT_MARKERS = {".git", "pyproject.toml", "package.json", "Cargo.toml", "go.mod", "Makefile", "pom.xml", ".hg", "Gemfile"}
+
+# --- shared-store maintenance coordination -------------------------------------------
+# One store is shared by every project AND every concurrent Hermes process, so object
+# creation and `git gc --prune=now` must be serialised between processes: a gc whose
+# reachability snapshot predates a checkpoint's `update-ref` deletes the commit that ref
+# just moved to, leaving a ref that points at nothing.  Such a ref makes *every* later gc
+# fail ("does not point to a valid object!"), which pins the store above its size cap
+# forever and turns each write tool call into another doomed maintenance pass.
+_STORE_LOCK_NAME = "maintenance.lock"
+_CAP_RETRY_MARKER_NAME = ".cap_maintenance_retry"
+_CAP_RETRY_COOLDOWN_S = 600  # backoff after a maintenance pass that could not converge
+_SHRINK_MAX_ROUNDS = 20  # bound on drop-oldest rounds against pathological loops
+_LOCK_WAIT_S = 5.0  # bounded wait for an in-flight maintenance pass (never unbounded)
+_GC_LOCK_WAIT_S = 5.0  # gc waits this long for writers to finish, then skips this round
 
 _SHORTSTAT_FIELDS = (("files_changed", r'(\d+) file'), ("insertions", r'(\d+) insertion'),
                      ("deletions", r'(\d+) deletion'))
@@ -305,6 +326,274 @@ def _delete_ref(store: Path, ref: str) -> bool:
     return ok
 
 
+# --- shared-store lock -----------------------------------------------------------------
+
+def _store_lock_path(store: Path) -> Path:
+    return store / _STORE_LOCK_NAME
+
+
+@contextlib.contextmanager
+def _store_lock(store: Path, *, exclusive: bool, blocking: bool = True, timeout: float = 0.0) -> Iterator[bool]:
+    """Interprocess lock over the shared store's object database.
+
+    Writers hold it SHARED across the whole object-creation -> ref-update window, so a
+    concurrent ``git gc --prune=now`` can never delete blobs/commits that are still in
+    flight (the race that leaves refs pointing at missing objects).  Maintenance takes it
+    EXCLUSIVE and non-blocking: when a writer or another maintenance pass is active the
+    pass is *skipped*, not queued — a concurrent gc is a safe maintenance skip (upstream
+    issue #65349).
+
+    Yields True when the lock is held, False when it could not be acquired: callers fail
+    open, because a checkpoint must never block the tool call that triggered it.  Platforms
+    without ``flock`` (Windows) behave as if the lock were always available.
+    """
+    if fcntl is None:  # pragma: no cover - Windows
+        yield True
+        return
+    try:
+        fd = os.open(_store_lock_path(store), os.O_CREAT | os.O_RDWR, 0o644)
+    except OSError as exc:
+        logger.debug("Checkpoint store lock unavailable for %s: %s", store, exc)
+        yield False
+        return
+    # LOCK_NB is always set: a blocking flock() would sit inside the syscall forever and
+    # ignore the deadline below — and a maintenance pass that holds the lock while wanting
+    # it again (different fd, same process) would deadlock instead of skipping.
+    flags = (fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH) | fcntl.LOCK_NB
+    deadline = time.monotonic() + max(0.0, timeout)
+    acquired = False
+    try:
+        while True:
+            try:
+                fcntl.flock(fd, flags)
+                acquired = True
+                break
+            except OSError:
+                if not blocking or time.monotonic() >= deadline:
+                    break
+                time.sleep(0.05)
+        yield acquired
+    finally:
+        if acquired:
+            with contextlib.suppress(OSError):
+                fcntl.flock(fd, fcntl.LOCK_UN)
+        with contextlib.suppress(OSError):
+            os.close(fd)
+
+
+def _object_present(store: Path, working_dir: str, sha: str) -> bool:
+    """Whether ``sha`` resolves to an object in the store."""
+    ok, _, _ = _run_git(["cat-file", "-e", sha], store, working_dir, allowed_returncodes={1, 128})
+    return ok
+
+
+# --- unresolvable-ref detection + repair -----------------------------------------------
+
+def _loose_ref_names(store: Path) -> List[str]:
+    """Every ref present as a loose *file* under ``refs/``, as ``refs/...`` names.
+
+    Reads the filesystem instead of ``git for-each-ref``: a ref whose tip object is
+    missing is exactly the ref ``for-each-ref`` may omit, and a ref git can never resolve
+    is a ref no cleanup path would otherwise see.
+    """
+    root = store / "refs"
+    names: List[str] = []
+    try:
+        for dirpath, dirnames, filenames in os.walk(root):
+            for name in filenames:
+                if name.endswith(".lock"):
+                    continue
+                full = Path(dirpath) / name
+                try:
+                    names.append(full.relative_to(store).as_posix())
+                except ValueError:
+                    continue
+    except OSError as exc:
+        logger.debug("Could not scan loose refs in %s: %s", store, exc)
+    return sorted(names)
+
+
+def _packed_refs_map(store: Path) -> Dict[str, str]:
+    """``{refname: sha}`` from ``packed-refs`` (comments and ``^`` tag lines skipped)."""
+    out: Dict[str, str] = {}
+    try:
+        text = (store / "packed-refs").read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return out
+    for line in text.splitlines():
+        if not line or line.startswith(("#", "^")):
+            continue
+        sha, _, ref = line.partition(" ")
+        if ref.strip():
+            out[ref.strip()] = sha.strip()
+    return out
+
+
+def _rewrite_packed_refs(store: Path, drop: Set[str]) -> bool:
+    """Rewrite ``packed-refs`` without ``drop`` (atomic replace, comments/tags preserved)."""
+    path = store / "packed-refs"
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return True  # nothing to rewrite
+    kept: List[str] = []
+    dropping_prev = False
+    for line in lines:
+        if not line.strip() or line.startswith("#"):
+            kept.append(line)
+            dropping_prev = False
+            continue
+        if line.startswith("^"):  # peeled tag target of the previous ref
+            if not dropping_prev:
+                kept.append(line)
+            continue
+        ref = line.partition(" ")[2].strip()
+        dropping_prev = ref in drop
+        if not dropping_prev:
+            kept.append(line)
+    try:
+        tmp = path.with_name(f"{path.name}.tmp{os.getpid()}")
+        tmp.write_text("\n".join(kept) + "\n", encoding="utf-8")
+        os.replace(tmp, path)
+        return True
+    except OSError as exc:
+        logger.warning("Could not rewrite %s: %s", path, exc)
+        return False
+
+
+def _remove_ref_everywhere(store: Path, ref: str) -> bool:
+    """Delete ``ref`` whether it lives in a loose file, ``packed-refs``, or both."""
+    _unlink_quiet(store / ref)
+    _unlink_quiet(store / "logs" / ref)
+    if ref in _packed_refs_map(store):
+        return _rewrite_packed_refs(store, {ref})
+    return not (store / ref).exists()
+
+
+def _candidate_refs(store: Path) -> List[str]:
+    """Refs under the hermes prefix that can be inspected (loose files + packed entries)."""
+    prefix = _REFS_PREFIX + "/"
+    names = set(_loose_ref_names(store)) | set(_packed_refs_map(store))
+    return sorted(r for r in names if r.startswith(prefix))
+
+
+def _objects_missing(store: Path, working_dir: str, shas: Set[str]) -> Set[str]:
+    """Subset of ``shas`` absent from the object database (one batched git call)."""
+    if not shas:
+        return set()
+    wd = _normalize_path(working_dir)
+    if not wd.is_dir():
+        return set()
+    try:
+        result = subprocess.run(["git", "cat-file", "--batch-check"],
+                                input="\n".join(sorted(shas)) + "\n", capture_output=True, text=True,
+                                timeout=_GIT_TIMEOUT, env=_git_env(store, str(wd)), cwd=str(wd),
+                                creationflags=windows_hide_flags())
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning("Checkpoint store: could not verify objects: %s", exc)
+        return set()
+    if result.returncode != 0:
+        logger.warning("Checkpoint store: 'git cat-file --batch-check' failed: %s", result.stderr.strip()[:200])
+        return set()
+    gone = {line.split()[0] for line in result.stdout.splitlines() if line.endswith("missing")}
+    return {sha for sha in shas if sha in gone}
+
+
+def _missing_tips(store: Path, working_dir: str, refs: List[str]) -> List[Tuple[str, str]]:
+    """``[(ref, sha)]`` for refs whose *stored* tip object is absent from the store.
+
+    The sha stored in the ref is checked directly (loose file wins over ``packed-refs``,
+    exactly like git), so a loose ref shadowing a valid packed-ref is caught either way,
+    and refs ``for-each-ref`` silently skips are still inspected.
+    """
+    packed = _packed_refs_map(store)
+    pairs: List[Tuple[str, str]] = []
+    for ref in refs:
+        loose = store / ref
+        if loose.is_file():
+            try:
+                value = loose.read_text(encoding="utf-8", errors="replace").strip()
+            except OSError:
+                continue
+            if not _SHA_RE.match(value):
+                continue  # symbolic or corrupt loose file: not a tip we can reason about
+            pairs.append((ref, value))
+        elif ref in packed:
+            pairs.append((ref, packed[ref]))
+    missing = _objects_missing(store, working_dir, {sha for _, sha in pairs})
+    return [(ref, sha) for ref, sha in pairs if sha in missing]
+
+
+def _apply_ref_repair(store: Path, working_dir: str, broken: List[Tuple[str, str]],
+                      result: Dict[str, int]) -> Dict[str, int]:
+    """Heal the ``[(ref, sha)]`` set produced by ``_missing_tips`` (caller holds the lock)."""
+    packed = _packed_refs_map(store)
+    for ref, sha in broken:
+        twin = packed.get(ref)
+        if twin and twin != sha and not _objects_missing(store, working_dir, {twin}):
+            # The loose file shadows a *valid* packed-ref: drop only the shadow, so the
+            # packed value (the real history) becomes effective again.
+            _unlink_quiet(store / ref)
+            logger.warning("Checkpoint store: removed unresolvable loose ref %s (%s) shadowing the "
+                           "valid packed-ref %s — history kept", ref, sha[:12], twin[:12])
+            result["repaired"] += 1
+            continue
+        if _remove_ref_everywhere(store, ref):
+            logger.warning("Checkpoint store: dropped ref %s — it points at the missing object %s",
+                           ref, sha[:12])
+            result["deleted"] += 1
+        else:
+            logger.warning("Checkpoint store: could not remove unresolvable ref %s (%s)", ref, sha[:12])
+            result["errors"] += 1
+    return result
+
+
+def _repair_unresolvable_refs(store: Path, working_dir: str, *, locked: bool = False) -> Dict[str, int]:
+    """Remove refs whose tip object no longer exists.
+
+    This is the corruption that makes every later ``git gc`` fail with "does not point to a
+    valid object!" and therefore pins the store above its size cap forever.  Ref removal is
+    lossless: a ref that resolves to nothing cannot be restored to, and a loose ref that
+    shadows a valid packed-ref only loses its shadow.  Returns
+    ``{"scanned", "repaired", "deleted", "errors"}``; never raises.
+    """
+    result = {"scanned": 0, "repaired": 0, "deleted": 0, "errors": 0}
+    try:
+        refs = _candidate_refs(store)
+        result["scanned"] = len(refs)
+        broken = _missing_tips(store, working_dir, refs)
+        if not broken:
+            return result
+        if locked:
+            return _apply_ref_repair(store, working_dir, broken, result)
+        with _store_lock(store, exclusive=True, blocking=True, timeout=_LOCK_WAIT_S) as held:
+            if not held:
+                logger.warning("Checkpoint store repair deferred: maintenance lock busy (%d unresolvable ref(s))",
+                               len(broken))
+                result["errors"] += 1
+                return result
+            return _apply_ref_repair(store, working_dir, broken, result)
+    except Exception as exc:  # never propagate into a checkpoint
+        logger.warning("Checkpoint store repair failed: %s", exc, exc_info=True)
+        result["errors"] += 1
+        return result
+
+
+def _rollback_ref(store: Path, working_dir: str, ref: str, previous: Optional[str], bad_sha: str) -> None:
+    """Undo an ``update-ref`` that moved ``ref`` onto a missing object.
+
+    Compare-and-swap on ``bad_sha``, so a concurrent writer's newer value is never
+    clobbered.
+    """
+    if previous and _object_present(store, working_dir, previous):
+        cmd = ["update-ref", ref, previous, bad_sha]
+    else:
+        cmd = ["update-ref", "-d", ref, bad_sha]
+    ok, _, _ = _run_git(cmd, store, working_dir, allowed_returncodes={128})
+    if not ok:
+        logger.warning("Checkpoint store: could not roll %s off the missing object %s", ref, bad_sha[:12])
+
+
 def _commit_tree_args(tree_sha: str, message: str, parent: Optional[str]) -> List[str]:
     return ["commit-tree", tree_sha, *(["-p", parent] if parent is not None else []), "-m", message, "--no-gpg-sign"]
 
@@ -325,21 +614,64 @@ def _rebuild_linear_chain(store: Path, working_dir: str, shas: List[str]) -> Opt
 
 
 def _rewrite_ref_to(store: Path, working_dir: str, ref: str, commits: List[str]) -> bool:
-    """Point ``ref`` at a freshly rebuilt linear chain of ``commits``; False if nothing was rewritten."""
+    """Point ``ref`` at a freshly rebuilt linear chain of ``commits``; False if nothing was rewritten.
+
+    The rebuild creates commit objects that only become reachable at the ``update-ref``, so
+    the whole sequence runs under the store's shared lock (see :func:`_store_lock`).
+    """
     if not commits:
         return False
-    tip = _rebuild_linear_chain(store, working_dir, commits)
-    if tip is None:
+    with _store_lock(store, exclusive=False, blocking=True, timeout=_LOCK_WAIT_S) as _locked:
+        tip = _rebuild_linear_chain(store, working_dir, commits)
+        if tip is None:
+            return False
+        ok, _, _ = _run_git(["update-ref", ref, tip], store, working_dir)
+        if ok and not _object_present(store, working_dir, tip):
+            # Only a foreign gc (another build, a hand-run `git gc`) can land here; the
+            # shared lock keeps our own maintenance out.  Never leave the ref on a
+            # missing object — that is the state that breaks every later gc.
+            _remove_ref_everywhere(store, ref)
+            logger.warning("Checkpoint store: rebuilt tip %s vanished before the ref update — ref %s "
+                           "dropped instead of left dangling", tip[:12], ref)
+            return False
+        return ok
+
+
+def _gc_store(store: Path, working_dir: str) -> bool:
+    """Reclaim objects unreachable from the (rewritten/deleted) refs.
+
+    Runs under the store's exclusive maintenance lock: checkpoint writers hold that lock
+    shared across their object-creation -> ref-update window, so ``--prune=now`` can never
+    delete an object a writer is about to reference.  Acquisition waits a bounded
+    ``_GC_LOCK_WAIT_S`` for writers to finish (a non-blocking attempt would starve
+    maintenance entirely under continuous concurrent writes, which is how a store grows
+    unbounded) and then skips the round rather than queueing behind it (a concurrent gc is
+    a safe maintenance skip).  A gc failure is visible at warning level and triggers an
+    unresolvable-ref repair + one retry.
+    Returns True when the store was maintained or the skip was deliberate.
+    """
+    with _store_lock(store, exclusive=True, blocking=True, timeout=_GC_LOCK_WAIT_S) as held:
+        if not held:
+            logger.info("Checkpoint store maintenance skipped: another process is writing to or "
+                        "maintaining %s", store)
+            return False
+        _run_git(["reflog", "expire", "--expire=now", "--all"], store, working_dir)
+        ok, _, err = _run_git(["gc", "--prune=now", "--quiet"], store, working_dir, timeout=_GIT_TIMEOUT * 3)
+        _repair_bare_repo_dirs(store)
+        if ok:
+            return True
+        logger.warning("Checkpoint store gc failed (rc!=0) — repairing unresolvable refs and retrying: %s",
+                       err or "no stderr")
+        healed = _repair_unresolvable_refs(store, working_dir, locked=True)
+        if healed["repaired"] or healed["deleted"]:
+            ok, _, err = _run_git(["gc", "--prune=now", "--quiet"], store, working_dir, timeout=_GIT_TIMEOUT * 3)
+            if ok:
+                logger.warning("Checkpoint store gc recovered after repairing %d unresolvable ref(s) "
+                               "(%d restored, %d dropped)", healed["repaired"] + healed["deleted"],
+                               healed["repaired"], healed["deleted"])
+                return True
+        logger.error("Checkpoint store left unmaintained: gc keeps failing (%s)", err or "rc!=0")
         return False
-    _run_git(["update-ref", ref, tip], store, working_dir)
-    return True
-
-
-def _gc_store(store: Path, working_dir: str) -> None:
-    """Reclaim objects unreachable from the (rewritten/deleted) refs."""
-    _run_git(["reflog", "expire", "--expire=now", "--all"], store, working_dir)
-    _run_git(["gc", "--prune=now", "--quiet"], store, working_dir, timeout=_GIT_TIMEOUT * 3)
-    _repair_bare_repo_dirs(store)
 
 
 def _drop_oldest_commit(store: Path, working_dir: str, ref: str) -> bool:
@@ -350,17 +682,60 @@ def _drop_oldest_commit(store: Path, working_dir: str, ref: str) -> bool:
 
 
 def _shrink_store_to_cap(store: Path, working_dir: str, cap_bytes: int) -> bool:
-    """Round-robin-drop the oldest commit per project ref until the store fits (bounded to 20
-    rounds against pathological loops).  False when there are no project refs."""
-    for _ in range(20):
+    """Drop the oldest commit per project ref, reclaiming between rounds, until the store fits.
+
+    Returns True only when the store is *observably* under ``cap_bytes`` afterwards.
+    Unconvergeable stores (nothing left to drop, gc unavailable) report False so callers
+    stop claiming success — the previous version returned True unconditionally, which let a
+    store 55x over its cap report healthy maintenance on every single tool call.
+    """
+    _repair_unresolvable_refs(store, working_dir)  # unresolvable refs fail every gc
+    for _ in range(_SHRINK_MAX_ROUNDS):
         if _dir_size_bytes(store) <= cap_bytes:
-            break
+            return True
         refs = _list_project_refs(store, working_dir)
-        if not refs:
-            return False
-        if not any([_drop_oldest_commit(store, working_dir, ref) for ref in refs]):
+        # Drop from every project (round-robin) before reclaiming: `git gc` is what makes
+        # the space observable, so without a pass the loop would shred history for nothing.
+        dropped = any([_drop_oldest_commit(store, working_dir, ref) for ref in refs]) if refs else False
+        if not _gc_store(store, working_dir):
             break
-    return True
+        if not dropped:
+            break
+    size = _dir_size_bytes(store)
+    if size <= cap_bytes:
+        return True
+    logger.warning("Checkpoint store did not converge under its %.2f MB cap (actual %.2f MB)",
+                   cap_bytes / _MB, size / _MB)
+    return False
+
+
+def _cap_retry_marker(store: Path) -> Path:
+    return store / _CAP_RETRY_MARKER_NAME
+
+
+def _cap_retry_cooling_down(store: Path) -> bool:
+    """True while a size-cap pass that could not converge is inside its backoff window.
+
+    Without this backoff the whole (expensive) sequence — size walk, repair, ref rewrites,
+    gc — ran on *every* write tool call, which is what turned one broken ref into 100+
+    doomed gc attempts a minute.
+    """
+    try:
+        stamp = float(_cap_retry_marker(store).read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return False
+    return 0 <= time.time() - stamp < _CAP_RETRY_COOLDOWN_S
+
+
+def _arm_cap_retry_marker(store: Path) -> None:
+    try:
+        _cap_retry_marker(store).write_text(str(time.time()), encoding="utf-8")
+    except OSError as exc:
+        logger.debug("Could not write checkpoint cap retry marker: %s", exc)
+
+
+def _clear_cap_retry_marker(store: Path) -> None:
+    _unlink_quiet(_cap_retry_marker(store))
 
 
 def _migrate_legacy_store(base: Path) -> Optional[Path]:
@@ -540,8 +915,10 @@ def _locate(working_dir: str, commit_hash: str,
 
 
 def _stage_all(p: _ProjectRefs) -> Tuple[bool, str, str]:
-    """``git add -A`` into the per-project index."""
-    return _run_git(["add", "-A"], p.store, p.abs_dir, timeout=_GIT_TIMEOUT * 2, index_file=p.index_file)
+    """``git add -A`` into the per-project index, under the store's shared lock so a
+    concurrent ``git gc`` cannot prune the freshly written blobs while they are unreferenced."""
+    with _store_lock(p.store, exclusive=False, blocking=True, timeout=_LOCK_WAIT_S):
+        return _run_git(["add", "-A"], p.store, p.abs_dir, timeout=_GIT_TIMEOUT * 2, index_file=p.index_file)
 
 
 def _diff_staged_tree(p: _ProjectRefs, *diff_args: List[str]) -> List[Tuple[bool, str, str]]:
@@ -823,9 +1200,27 @@ class CheckpointManager:
             logger.debug("Checkpoint skipped: >%d files in %s", _MAX_FILES, working_dir)
             return False
         ref_commit = _ref_tip(p.store, working_dir, p.ref)
-        _seed_project_index(p, ref_commit)
+        # The shared lock spans object creation -> ref update: a concurrent
+        # `git gc --prune=now` from another Hermes process must not delete the blobs or the
+        # commit we are about to reference (that race leaves a ref pointing at a missing
+        # object, which then fails every later gc).  Bounded and fail-open: a checkpoint
+        # must never stall the tool call that triggered it.
+        with _store_lock(p.store, exclusive=False, blocking=True, timeout=_LOCK_WAIT_S) as locked:
+            if not locked:
+                logger.warning("Checkpoint %s: store maintenance lock busy — snapshotting without "
+                               "gc exclusion", working_dir)
+            if not self._commit_snapshot(p, working_dir, reason, ref_commit):
+                return False
 
-        # Broad patterns come from the exclude file; oversize paths are dropped post-stage.
+        self._prune(p.store, working_dir, p.ref)
+        self._enforce_size_cap(p.store)
+        return True
+
+    def _commit_snapshot(self, p: _ProjectRefs, working_dir: str, reason: str,
+                         ref_commit: Optional[str]) -> bool:
+        """Stage, commit and move the ref.  Called with the store's shared lock held (when the
+        lock could be acquired); returns False on any failed step (never raises)."""
+        _seed_project_index(p, ref_commit)
         ok, _, err = _stage_all(p)
         if not ok:
             return _step_failed("git-add", err)
@@ -848,10 +1243,16 @@ class CheckpointManager:
         ok, _, err = _run_git(update_args, p.store, working_dir)
         if not ok:
             return _step_failed("update-ref", err)
+        if not _object_present(p.store, working_dir, new_sha):
+            # A foreign gc (another build, a hand-run `git gc`) pruned the object between
+            # commit-tree and update-ref.  Undo the ref move rather than leave a ref that
+            # points at nothing and blocks every future gc.
+            _rollback_ref(p.store, working_dir, p.ref, ref_commit, new_sha)
+            logger.warning("Checkpoint %s: object %s vanished before the ref update "
+                           "(concurrent gc?) — snapshot skipped", working_dir, new_sha[:12])
+            return False
 
         logger.debug("Checkpoint taken in %s: %s (%s)", working_dir, reason, new_sha[:8])
-        self._prune(p.store, working_dir, p.ref)
-        self._enforce_size_cap(p.store)
         return True
 
     def _exceeds_size_cap(self, path: Path) -> bool:
@@ -892,15 +1293,32 @@ class CheckpointManager:
             _gc_store(store, working_dir)
 
     def _enforce_size_cap(self, store: Path) -> None:
-        """Drop oldest checkpoints across ALL projects until under ``max_total_size_mb``."""
+        """Drop oldest checkpoints across ALL projects until under ``max_total_size_mb``.
+
+        Reports honestly: when the store cannot be brought under the cap the failure is a
+        warning (with the actionable next step) and the pass backs off, instead of silently
+        re-running — and silently succeeding — on every write tool call.
+        """
         cap_bytes = self.max_total_size_mb * _MB
-        size = _dir_size_bytes(store) if cap_bytes > 0 else 0
+        if cap_bytes <= 0:
+            return
+        if _cap_retry_cooling_down(store):
+            logger.debug("Checkpoint store over cap; maintenance in backoff for %ds", int(_CAP_RETRY_COOLDOWN_S))
+            return
+        size = _dir_size_bytes(store)
         if size <= cap_bytes:
+            _clear_cap_retry_marker(store)
             return
         logger.info("Checkpoint store exceeded %d MB (actual %d MB) — pruning oldest",
                     self.max_total_size_mb, size // _MB)
         if _shrink_store_to_cap(store, str(store.parent), cap_bytes):
-            _gc_store(store, str(store.parent))
+            _clear_cap_retry_marker(store)
+            return
+        _arm_cap_retry_marker(store)
+        logger.warning("Checkpoint store is still over its %d MB cap (actual %d MB) after maintenance; "
+                       "next attempt in %ds — run 'hermes checkpoints status' / 'hermes checkpoints repair' "
+                       "to diagnose", self.max_total_size_mb, _dir_size_bytes(store) // _MB,
+                       int(_CAP_RETRY_COOLDOWN_S))
 
 
 def _step_failed(step: str, err: str) -> bool:
@@ -1083,12 +1501,40 @@ def prune_checkpoints(retention_days: int = 7, delete_orphans: bool = True, chec
     if _store_has_head(store):
         _prune_v2_projects(store, cutoff, delete_orphans, orphan_allowlist, result)
         _gc_store(store, str(base))
-        if max_total_size_mb > 0:
-            _shrink_store_to_cap(store, str(base), max_total_size_mb * _MB)
-            _gc_store(store, str(base))
+        if max_total_size_mb > 0 and not _shrink_store_to_cap(store, str(base), max_total_size_mb * _MB):
+            # Reported, not swallowed: a store that could not be brought under the cap is a
+            # failure the operator has to see (it used to read as success every single time).
+            result["errors"] += 1
+            _arm_cap_retry_marker(store)
 
     result["bytes_freed"] = max(result["bytes_freed"], size_before - _dir_size_bytes(base))
     return result
+
+
+def repair_store(checkpoint_base: Optional[Path] = None) -> Dict[str, int]:
+    """Repair the shared store's refs: drop any ref whose tip object is missing.
+
+    Such a ref (typically a loose ref that shadows a valid packed-ref, left behind by a gc
+    that raced a checkpoint's ``update-ref``) makes every later ``git gc`` fail with
+    "does not point to a valid object!", so the store can never be reclaimed and stays over
+    its size cap.  Only refs that resolve to nothing are touched — a loose ref with a valid
+    packed twin only loses its shadow, so no reachable history is dropped.  Never raises.
+    Returns ``{"scanned", "repaired", "deleted", "errors"}``.
+    """
+    out = {"scanned": 0, "repaired": 0, "deleted": 0, "errors": 0}
+    # ``_store_path().parent`` == the active base on every revision (it resolves the
+    # profile-scoped base where that refactor exists) — an explicit override still wins.
+    base = checkpoint_base or _store_path().parent
+    store = _store_path(base)
+    if not _store_has_head(store):
+        return out
+    healed = _repair_unresolvable_refs(store, str(base))
+    out.update({k: healed.get(k, 0) for k in out})
+    if healed["repaired"] or healed["deleted"]:
+        # The repair only becomes observable space once the objects are reclaimed.
+        _gc_store(store, str(base))
+        _clear_cap_retry_marker(store)
+    return out
 
 
 def maybe_auto_prune_checkpoints(retention_days: int = 7, min_interval_hours: int = 24, delete_orphans: bool = True,
@@ -1130,13 +1576,16 @@ def maybe_auto_prune_checkpoints(retention_days: int = 7, min_interval_hours: in
 
 def store_status(checkpoint_base: Optional[Path] = None) -> Dict:
     """Summarise the shadow store: ``{"base", "store_size_bytes", "legacy_size_bytes",
-    "total_size_bytes", "project_count", "projects", "pre_v2_projects", "legacy_archives"}``.
-    ``pre_v2_projects`` are repos still on the pre-v2 layout, distinct from the migrated
-    ``legacy_archives``; an orphan-deletion preview must include both ``projects`` and
-    ``pre_v2_projects`` since ``prune_checkpoints`` sweeps both."""
+    "total_size_bytes", "project_count", "projects", "pre_v2_projects", "legacy_archives",
+    "unresolvable_refs"}``.  ``pre_v2_projects`` are repos still on the pre-v2 layout, distinct
+    from the migrated ``legacy_archives``; an orphan-deletion preview must include both
+    ``projects`` and ``pre_v2_projects`` since ``prune_checkpoints`` sweeps both.
+    ``unresolvable_refs`` are refs whose tip object is missing — they block every ``git gc``
+    until ``repair_store`` / ``hermes checkpoints repair`` removes them."""
     base = checkpoint_base or _resolve_checkpoint_base()
     out: Dict = {"base": str(base), "store_size_bytes": 0, "legacy_size_bytes": 0, "total_size_bytes": 0,
-                 "project_count": 0, "projects": [], "pre_v2_projects": [], "legacy_archives": []}
+                 "project_count": 0, "projects": [], "pre_v2_projects": [], "legacy_archives": [],
+                 "unresolvable_refs": []}
     if not base.exists():
         return out
 
@@ -1150,6 +1599,7 @@ def store_status(checkpoint_base: Optional[Path] = None) -> Dict:
                 "created_at": meta.get("created_at"), "last_touch": meta.get("last_touch"),
                 "commits": _ref_commit_count(store, str(base), _ref_name(meta.get("_hash") or "")),
             } for meta in _list_projects(store)]
+            out["unresolvable_refs"] = [ref for ref, _ in _missing_tips(store, str(base), _candidate_refs(store))]
     out["project_count"] = len(out["projects"])
     out["pre_v2_projects"] = [{"path": str(r["path"]), "workdir": r["workdir"], "exists": r["exists"]}
                               for r in _pre_v2_shadow_repos(base)]

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1004,6 +1004,7 @@ Inspect and manage the shadow git store at `~/.hermes/checkpoints/` — the stor
 | `status` (default) | Show total size, project count, and per-project breakdown. Bare `hermes checkpoints` is equivalent. |
 | `list` | Alias for `status`. |
 | `prune` | Force a cleanup sweep — delete orphan and stale projects, GC the store, enforce the size cap. Ignores the 24h idempotency marker. |
+| `repair` | Remove refs that point at missing objects. They make every `git gc` fail ("does not point to a valid object!"), which stops the store ever shrinking back under its size cap. Lossless: only refs that resolve to nothing are touched, and a ref whose valid packed twin exists keeps that twin. |
 | `clear` | Delete the entire checkpoint base. Irreversible; asks for confirmation unless `-f`. |
 | `clear-legacy` | Delete only the `legacy-<timestamp>/` archives produced by the v1→v2 migration. |
 
@@ -1023,6 +1024,7 @@ Inspect and manage the shadow git store at `~/.hermes/checkpoints/` — the stor
 hermes checkpoints                                  # status overview
 hermes checkpoints prune --retention-days 3         # aggressive cleanup
 hermes checkpoints prune --max-size-mb 200          # tighten size cap once
+hermes checkpoints repair                           # unblock git gc after a dangling ref
 hermes checkpoints clear-legacy -f                  # drop v1 archive dirs
 hermes checkpoints clear -f                         # wipe everything
 ```

--- a/website/docs/user-guide/checkpoints-and-rollback.md
+++ b/website/docs/user-guide/checkpoints-and-rollback.md
@@ -53,8 +53,15 @@ CLI for inspecting and managing the store outside a session:
 | `hermes checkpoints status` | Same as bare `checkpoints` |
 | `hermes checkpoints list` | Alias for `status` |
 | `hermes checkpoints prune` | Force a sweep: delete orphans/stale, GC, enforce size cap |
+| `hermes checkpoints repair` | Repair refs that point at missing objects (blocks GC and the size cap) |
 | `hermes checkpoints clear` | Nuke the entire checkpoint base (asks first) |
 | `hermes checkpoints clear-legacy` | Delete only the `legacy-*` archives from v1 migration |
+
+If `hermes checkpoints status` reports refs that point at missing objects, run
+`hermes checkpoints repair`. A ref left pointing at a pruned object makes **every**
+`git gc` fail, so the store can never be reclaimed and stays over its size cap. The repair
+is lossless: it only touches refs that resolve to nothing (a loose ref whose valid packed
+twin exists just loses its shadow), and normal checkpoints heal this state automatically.
 
 ## How Checkpoints Work
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/cli-commands.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/cli-commands.md
@@ -638,6 +638,7 @@ hermes checkpoints [COMMAND]
 | `status`（默认） | 显示总大小、项目数量和每个项目的详情。裸 `hermes checkpoints` 等同于此。 |
 | `list` | `status` 的别名。 |
 | `prune` | 强制执行清理——删除孤立和过期项目，GC 存储，强制执行大小上限。忽略 24 小时幂等性标记。 |
+| `repair` | 删除指向缺失对象的引用。这类引用会让每一次 `git gc` 失败（"does not point to a valid object!"），存储因此永远无法收缩回大小上限之下。无损：只处理解析不到任何对象的引用；若存在有效的 packed-ref 孪生条目则保留该条目。 |
 | `clear` | 删除整个 checkpoint 基础存储。不可逆；除非使用 `-f` 否则要求确认。 |
 | `clear-legacy` | 仅删除 v1→v2 迁移产生的 `legacy-<timestamp>/` 归档。 |
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/checkpoints-and-rollback.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/checkpoints-and-rollback.md
@@ -52,8 +52,14 @@ Agent 每个目录每轮**最多创建一个检查点**，因此长时间运行�
 | `hermes checkpoints status` | 与裸 `checkpoints` 相同 |
 | `hermes checkpoints list` | `status` 的别名 |
 | `hermes checkpoints prune` | 强制执行清理：删除孤立/过期条目、GC、强制大小上限 |
+| `hermes checkpoints repair` | 修复指向缺失对象的引用（它们会让 GC 与大小上限彻底失效） |
 | `hermes checkpoints clear` | 清除整个检查点库（会先询问确认） |
 | `hermes checkpoints clear-legacy` | 仅删除 v1 迁移留下的 `legacy-*` 归档 |
+
+如果 `hermes checkpoints status` 报告存在「指向缺失对象的引用」，请执行
+`hermes checkpoints repair`。这类引用会让**每一次** `git gc` 失败，导致存储永远无法回收、
+始终超出大小上限。修复是无损的：只处理解析不到任何对象的引用（若存在有效的 packed-ref
+孪生条目，仅删除遮蔽它的 loose 文件），且正常的检查点写入会自动完成修复。
 
 ## 检查点的工作原理
 


### PR DESCRIPTION
## What does this PR do?

Makes a checkpoint store whose ref points at a **missing object** recoverable, and stops the
size-cap path from reporting success while the store keeps growing.

A ref under `refs/hermes/<hash>` pointing at a pruned object makes **every** subsequent `git gc`
fail:

```
error: refs/hermes/01878b6113e1bdcd does not point to a valid object!
fatal: bad object refs/hermes/01878b6113e1bdcd
fatal: failed to run repack
```

Object reclamation then stops permanently, and because checkpoint maintenance runs synchronously
before every file-mutating tool call, each `write_file`/`patch`/`terminal` pays a doomed
maintenance pass. In the triggering incident: a 27 GB store (102,423 loose objects) under a
configured 500 MB cap, 108 gc failures in 60 s, `write_file` p90 ≈ 80 s.

Two independent defects combine:

1. **Nothing can heal such a ref.** `_list_project_refs()` uses `git for-each-ref`, which may omit
   an unresolvable ref; and even when the ref *is* listed, `_drop_oldest_commit()` sees
   `rev-list --count` == 0 and returns `False` — so the cleanup loop can never touch it.
2. **`_shrink_store_to_cap()` returns `True` unconditionally**, and `_gc_store()` ignores the gc
   exit status. A store 55× over its cap reports successful maintenance on every single tool call.

## How the dangling ref is created (a race, not a crash)

`git update-ref` refuses to point a ref at a missing object:

```
fatal: cannot update ref 'refs/hermes/<h>': trying to write ref 'refs/hermes/<h>'
       with nonexistent object <sha>
```

So the object existed when the ref landed and was pruned *afterwards*: a `git gc --prune=now` in
another process snapshotted reachability **before** the checkpoint's `update-ref`, deemed the
freshly created commit unreachable, and deleted it. Several Hermes processes share one store, so
the window is hit routinely.

Reproduced with a real multi-process soak (6 checkpoint writers + a gc hammer on one store, 25 s):

```
unfixed: gc hammer 187 attempts -> store corrupt
         error: Could not read 9ccdd7db84fd7efaf0086da0857707968b7f6b8f
         fatal: Failed to traverse parents of commit 162de8f4292f0d663fc392eaa4253a6e29650f03
fixed:   gc hammer 10 real passes + 2 deliberate skips -> 0 dangling refs, every ref resolvable, gc rc=0
```

## Related Issue

No existing issue covers this. Closest still-open reports, and what this PR does *not* duplicate:

- #83036 — failed/concurrent gc leaves tmp packs and corrupts the shared store. This is the
  dangling-ref half of the same maintenance-race family; it does **not** cover `tmp_pack_*` cleanup
  or store quarantine.
- #65349 — treat concurrent git gc as a safe maintenance skip. This PR's skip is in the same
  direction (a separate PR implements the rc=128 diagnostic demotion).
- #93314 — no atomic recovery path when directory replacement fails.
- #79334 — repeated synchronous ref-chain rewrites before GC.

The garbage-window approach (`gc --prune=2.hours.ago`) proposed in #61227 / #65354 lowers the
probability of the race; it does not heal a ref that is already dangling, and those PRs are
currently conflicting. This change removes the window instead (writers hold a lock over
object-creation → ref-update), and adds the missing recovery path.

## Changes Made

- `tools/checkpoint_manager.py`
  - **Interprocess store lock**: checkpoint writers hold `store/maintenance.lock` **shared** across
    the whole object-creation → ref-update window (including `git add`, whose blobs are
    unreferenced until the commit lands). Maintenance takes it **exclusive**, waits a bounded 5 s
    for writers to drain, then **skips that round** — never queues, never runs a competing gc.
    Platforms without `flock` (Windows) keep the previous behaviour.
  - **Tip verified after `update-ref`**: a vanished object compare-and-swaps the ref back instead
    of leaving it dangling.
  - **`_gc_store` returns status**, logs failures at warning level, and self-heals: repair of
    unresolvable refs plus one retry.
  - **`_repair_unresolvable_refs` / `repair_store`**: drop refs that resolve to nothing. Lossless —
    a loose ref shadowing a valid packed-ref only loses its shadow, so reachable history is never
    dropped.
  - **`_shrink_store_to_cap` reports honestly**: `True` only when the store is observably under cap,
    reclaiming between rounds; an unconvergeable store warns, is counted as a prune error, and
    backs off 600 s instead of re-running the whole pass on every tool call.
- `hermes_cli/checkpoints.py` — `hermes checkpoints repair`; `hermes checkpoints status` lists
  unresolvable refs and points at the fix.
- `tests/tools/test_checkpoint_store_repair.py` — new suite (real git, isolated tmp stores).
- Docs updated (`reference/cli-commands.md`, `user-guide/checkpoints-and-rollback.md`, + zh-Hans).

## How to Test

```bash
# 1. The repair path, end to end CLI (isolated HERMES_HOME)
hermes checkpoints status        # lists unresolvable refs, if any, with the fix command
hermes checkpoints repair        # drops refs that point at missing objects
hermes checkpoints status        # clean

# 2. New suite
python -m pytest tests/tools/test_checkpoint_store_repair.py -q      # 20 passed

# 3. Regression on the touched surfaces
python -m pytest tests/tools/test_checkpoint_manager.py \
  tests/tools/test_checkpoint_path_roundtrip.py \
  tests/hermes_cli/test_checkpoints_prune.py \
  tests/hermes_cli/test_console_engine.py -q                          # 91 passed, 2 skipped

# 4. Concurrency soak (the actual corruption): 6 writers + gc hammer, 25 s
#    unfixed -> "Failed to traverse parents of commit ..."; fixed -> 0 dangling refs
```

Verification on this branch, rebased onto `main` @ `1b1f5c4abe`:

- `pytest tests/tools/test_checkpoint_store_repair.py` — **20 passed**
- `pytest` (checkpoint manager / path-roundtrip / repair / prune / console-engine) — **91 passed, 2 skipped**
- `ruff check` on all changed Python files — passed
- `hermes checkpoints repair` / `status` exercised against an isolated `HERMES_HOME`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — see *Related Issue* above for why this is not a duplicate of #61227/#65354/#66108
- [x] My PR contains **only** changes related to this fix (9 files, all checkpoint-related)
- [x] I've run the checkpoint test suites and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6 (Apple Git 2.54), Python 3.13

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/reference/cli-commands.md`, `website/docs/user-guide/checkpoints-and-rollback.md`, + zh-Hans)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture — N/A
- [x] I've considered cross-platform impact: `flock` is POSIX-only; Windows degrades to the previous
      behaviour and relies on the reset-self-heal path. `msvcrt` locking was intentionally **not**
      added here to keep this change auditable.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (new CLI subcommand documented)

## Known trade-offs

- Writer lock wait is bounded at 5 s and fails **open** (warning, checkpoint still succeeds) rather
  than risking an unbounded stall inside the pre-edit path.
- Maintenance lock acquisition is also bounded at 5 s, so continuous writes cannot starve gc; a
  skipped round is logged at info/warning level.
