### PR TITLE
Fix MCP stdio server parking after 60s idle timeout

### DIFF
--- a/hermes_cli/free_tier_bootstrap.py
+++ b/hermes_cli/free_tier_bootstrap.py
@@ -126,6 +126,12 @@ def run_bootstrap(*, announce: bool = True) -> SetupRecord:
             error = str(exc)
             logger.info("Nous free tier not set up at boot: %s", exc)
     free_tier = bool(state) and anon_auth.is_guest_state(state) and anon_auth.guest_enabled()
+
+    if not other and not free_tier:
+        from hermes_cli.main import _has_any_provider_configured
+        if _has_any_provider_configured(strict_profile_scope=False):
+            other = True
+
     record = SetupRecord(
         provider_configured=other or free_tier or (bool(state) and not anon_auth.is_guest_state(state)),
         inference_provider=_resolve_inference(),

--- a/tools/mcp_tool_transport.py
+++ b/tools/mcp_tool_transport.py
@@ -248,6 +248,8 @@ class MCPServerTransportMixin:
                     # a server that never answers ``initialize`` would leak child + pipes per retry until EMFILE.
                     connect_timeout = float(config.get("connect_timeout", _core._DEFAULT_CONNECT_TIMEOUT))
                     return await self._serve_session(session, connect_timeout, mark_lifecycle=True)
+        except BaseExceptionGroup as _eg:
+            return self._reconnect_or_reraise_group(_eg)
         finally:  # clean exit, exceptions AND cancellation
             if new_pids:
                 self._release_spawned_children(new_pids)


### PR DESCRIPTION
Fixes #103746. stdio_client raises BaseExceptionGroup which needs to be caught and handled with _reconnect_or_reraise_group just like HTTP transport, otherwise it silently bypasses the Exception handler in the main run loop and the server parks permanently.