### PR TITLE
fix(discord): clear stale disconnect acknowledgment after voice recovery

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3379,7 +3379,9 @@ class DiscordAdapter(DiscordMediaMixin, BasePlatformAdapter):
                 await existing.move_to(channel)
                 self._reset_voice_timeout(guild_id)
                 return True
-            vc = await channel.connect()
+            from .voice_connection import DiscordVoiceClient
+
+            vc = await channel.connect(cls=DiscordVoiceClient)
             self._voice_clients[guild_id] = vc
             self._reset_voice_timeout(guild_id)
             if text_channel_id is not None:

--- a/plugins/platforms/discord/voice_connection.py
+++ b/plugins/platforms/discord/voice_connection.py
@@ -1,0 +1,24 @@
+"""Temporary discord.py connection-state compatibility for room moves.
+
+Import only from the live join path: Discord is an optional dependency.
+Remove when native discord.py passes the reconnect/move and disconnect tests
+in tests/test_discord_voice_connection.py without this correction.
+"""
+from discord import VoiceClient
+from discord.voice_state import VoiceConnectionState
+
+
+class _VoiceConnectionState(VoiceConnectionState):
+    async def _connect(self, *args, **kwargs):
+        await super()._connect(*args, **kwargs)
+        if self.is_connected():
+            # discord.py 2.7.1 leaves an expected disconnect acknowledgment set
+            # after automatic recovery. A later move's 4014 then looks like a
+            # kick (upstream PRs 9683/9772). Only retire it after a new connection;
+            # leave failed connects and genuine current disconnects untouched.
+            self._disconnected.clear()
+
+
+class DiscordVoiceClient(VoiceClient):
+    def create_connection_state(self):
+        return _VoiceConnectionState(self)

--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -191,6 +191,11 @@ def _ensure_discord_mock() -> None:
 
     from types import SimpleNamespace
 
+    # Lifecycle tests use fake transports. Real dependency composition is tested
+    # separately in tests/test_discord_voice_connection.py.
+    sys.modules["plugins.platforms.discord.voice_connection"] = SimpleNamespace(
+        DiscordVoiceClient=type("FakeVoiceClient", (), {})
+    )
     discord_mod = MagicMock()
     discord_mod.Intents.default.return_value = MagicMock()
     discord_mod.Client = MagicMock

--- a/tests/gateway/test_discord_race_polish.py
+++ b/tests/gateway/test_discord_race_polish.py
@@ -58,7 +58,7 @@ async def test_concurrent_joins_do_not_double_connect():
     channel = MagicMock()
     channel.id = 111
     channel.guild.id = 42
-    channel.connect = lambda: slow_connect(channel)
+    channel.connect = lambda **_: slow_connect(channel)
 
     from plugins.platforms.discord import adapter as discord_mod
     with patch.object(discord_mod, "VoiceReceiver",

--- a/tests/test_discord_voice_connection.py
+++ b/tests/test_discord_voice_connection.py
@@ -1,0 +1,154 @@
+"""Exercise discord.py's real connection lifecycle, without Discord traffic."""
+import asyncio
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+import pytest_asyncio
+
+# Gateway unit tests install a Discord stub. Run this dependency suite on its
+# own to exercise the real package rather than treating that stub as evidence.
+if "discord" in sys.modules and not hasattr(sys.modules["discord"], "__file__"):
+    pytest.skip("gateway discord stub is loaded; run this file in its own process",
+                allow_module_level=True)
+pytest.importorskip("discord.voice_state")
+from discord import ConnectionClosed
+from plugins.platforms.discord.voice_connection import DiscordVoiceClient, _VoiceConnectionState
+from discord.voice_state import ConnectionFlowState as Flow
+
+
+@pytest_asyncio.fixture
+async def state():
+    client = SimpleNamespace(_connection=SimpleNamespace(
+        loop=asyncio.get_running_loop(), _remove_voice_client=Mock()))
+    guild = SimpleNamespace(id=1, change_voice_state=AsyncMock())
+    channel = SimpleNamespace(id=10, guild=guild, _get_voice_client_key=lambda: (1, "guild_id"))
+    vc = DiscordVoiceClient(client, channel)
+    connection = vc._connection
+    assert isinstance(connection, _VoiceConnectionState)
+    connection._runner = asyncio.current_task()  # no background network poller
+    try:
+        yield connection
+    finally:
+        connection._socket_reader.stop()
+        connection._socket_reader.join(timeout=1)
+        assert not connection._socket_reader.is_alive()
+
+
+async def connect_without_network(state, monkeypatch):
+    async def voice_connect(**kwargs):
+        state.state = Flow.got_voice_server_update
+        await state.voice_state_update({'channel_id': '10', 'session_id': 'test'})
+    monkeypatch.setattr(state, '_voice_connect', voice_connect)
+    state.ip = '127.0.0.1'
+    ws = SimpleNamespace(secret_key=b'x' * 32, close=AsyncMock())
+    monkeypatch.setattr(state, '_connect_websocket', AsyncMock(return_value=ws))
+    await state._connect(True, 1, False, False, False)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('code', [4014, 4022])
+async def test_move_after_expected_disconnect_and_successful_reconnect(state, monkeypatch, code):
+    state._expecting_disconnect = True
+    await state.voice_state_update({'channel_id': None})
+    assert state._disconnected.is_set()
+    await connect_without_network(state, monkeypatch)
+    state.ws.poll_event = AsyncMock(side_effect=ConnectionClosed(SimpleNamespace(close_code=code), code=code, shard_id=None))
+    recovery = AsyncMock(return_value=False)
+    disconnect = AsyncMock()
+    monkeypatch.setattr(state, '_potential_reconnect', recovery)
+    monkeypatch.setattr(state, 'disconnect', disconnect)
+    await state._poll_voice_ws(True)
+    recovery.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_first_connection_and_keyword_connect(state, monkeypatch):
+    await connect_without_network(state, monkeypatch)
+    assert state.is_connected()
+    assert not state._disconnected.is_set()
+    state._disconnected.set()
+    await state._connect(reconnect=True, timeout=1, self_deaf=False,
+                         self_mute=False, resume=True)
+    assert state.is_connected()
+    assert not state._disconnected.is_set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('error', [RuntimeError, asyncio.CancelledError])
+async def test_failed_or_cancelled_connect_preserves_acknowledgment(state, monkeypatch, error):
+    state._disconnected.set()
+    monkeypatch.setattr(state, '_inner_connect', AsyncMock(side_effect=error()))
+    with pytest.raises(error):
+        await state._connect(True, 1, False, False, False)
+    assert state._disconnected.is_set()
+    assert not state.is_connected()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_before_connect_returns_is_not_cleared(state, monkeypatch):
+    async def inner(**kwargs):
+        # Represents a newer disconnect between handshake and wait_for return.
+        await state.voice_state_update({'channel_id': None})
+        state._expecting_disconnect = True
+        await state.voice_state_update({'channel_id': None})
+    monkeypatch.setattr(state, '_inner_connect', inner)
+    await state._connect(True, 1, False, False, False)
+    assert state._disconnected.is_set()
+    assert not state.is_connected()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('null_first', [True, False])
+async def test_real_kick_terminates_in_both_event_orders(state, monkeypatch, null_first):
+    await connect_without_network(state, monkeypatch)
+    ws = state.ws
+    closed = ConnectionClosed(Mock(close_code=4014), code=4014, shard_id=None)
+    kick_tasks = []
+    if null_first:
+        await state.voice_state_update({'channel_id': None})
+        # Discord acknowledges the native disconnect request.
+        await state.voice_state_update({'channel_id': None})
+        ws.poll_event = AsyncMock(side_effect=closed)
+    else:
+        async def poll():
+            asyncio.get_running_loop().call_soon(
+                lambda: kick_tasks.append(asyncio.create_task(
+                    state.voice_state_update({'channel_id': None}))))
+            raise closed
+        ws.poll_event = poll
+    await asyncio.wait_for(state._poll_voice_ws(True), timeout=1)
+    await asyncio.gather(*kick_tasks)
+    assert not state.is_connected()
+
+
+@pytest.mark.asyncio
+async def test_manual_leave_waits_for_acknowledgment(state, monkeypatch):
+    await connect_without_network(state, monkeypatch)
+    state._runner = None
+    leave = asyncio.create_task(state.disconnect(wait=True))
+    await asyncio.sleep(0)
+    assert not leave.done()
+    await state.voice_state_update({'channel_id': None})
+    await asyncio.wait_for(leave, timeout=1)
+    assert not state.is_connected()
+    assert state._disconnected.is_set()
+
+
+@pytest.mark.asyncio
+async def test_shared_join_selects_real_client_factory(monkeypatch):
+    from plugins.platforms.discord import adapter
+    monkeypatch.setattr(adapter, 'DISCORD_AVAILABLE', True)
+    class Selected(Exception):
+        pass
+    async def connect(*, cls):
+        assert cls is DiscordVoiceClient
+        raise Selected
+    channel = SimpleNamespace(guild=SimpleNamespace(id=1), connect=connect)
+    owner = object.__new__(adapter.DiscordAdapter)
+    owner._client = Mock()
+    owner._voice_locks = {}
+    owner._voice_clients = {}
+    with pytest.raises(Selected):
+        await owner.join_voice_channel(channel)


### PR DESCRIPTION
## Summary
Prevent a bot from disappearing when moved between voice channels after discord.py has automatically recovered its voice connection.

In discord.py 2.7.1, an expected null-channel voice-state acknowledgment sets `VoiceConnectionState._disconnected`. A subsequent successful automatic `_connect` leaves that event set. When a later room move closes the voice WebSocket with 4014 (also relevant to 4022), the native poller can mistake the old acknowledgment for a current disconnect and terminate instead of taking `_potential_reconnect`.

## Fix
- Select a small `VoiceClient` subclass through the existing `channel.connect(cls=...)` seam.
- Await native `_connect`, then clear the old acknowledgment only if the state is still connected.
- Keep native reconnect ownership, genuine kick handling, manual leave, exceptions and cancellation unchanged. No new retries, timers or configuration.
- Import lazily so Discord remains optional.

This is a temporary compatibility workaround, not a replacement connection state machine. It depends on discord.py's private `_connect` / `_disconnected` contract. Remove it once the dependency passes the included lifecycle regression tests without the correction.

Related dependency history: Rapptz/discord.py#9683 introduced the acknowledgment event; Rapptz/discord.py#9772 added the close-code event check. Hermes #87300 addresses gateway resume/restoration and #101377 addresses receive/key rotation; this is specifically stale acknowledgment state after native voice recovery followed by a move.

## Verification
- Real installed discord.py 2.7.1: `python -m pytest tests/test_discord_voice_connection.py -q` — **10 passed**, run in its own process. Covers recovery then move (4014/4022), initial/resumed connects, failure/cancellation, disconnect before connect returns, kicks in both event orders, manual leave acknowledgment and actual client selection.
- Gateway concurrent-join regression: **1 passed**. The accompanying mixer module skipped in this environment; two mocked-task coroutine warnings were emitted. No claim of a full-suite pass.
- `git diff --check` passed.
- The equivalent fix was live-tested in a downstream integration: native automatic recovery followed by a same-connection room move remained connected and accepted a fresh voice request in the destination. This validates movement/routing, not the separate missing-speech/audibility issue. This clean-upstream port was tested offline and was not separately deployed.

The dependency suite skips when the gateway tests have installed their Discord stub; run it separately with the real optional voice dependency installed to exercise the actual native lifecycle.
