### PR TITLE
fix(desktop): don't re-speak replies after hydrate rewrites durable ids

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx
@@ -129,4 +129,101 @@ describe('useAutoSpeakReplies — Edge TTS fallback chain (#93515)', () => {
     expect($voicePlayback.get().status).toBe('idle')
     expect(playSpeechText).toHaveBeenCalledTimes(1)
   })
+
+  // Tool-call completions append a bubble via `newAssistantFromCompletion()`
+  // with id `assistant-${Date.now()}` — NOT a live-tail id. Post-turn
+  // `hydrateFromStoredSession` then replaces the transcript with
+  // `toChatMessages()` ids like `${timestamp}-${index}-assistant` at the same
+  // assistant slot. Before the fix, `absorbSpokenReplyRewrite` only followed
+  // vanished `assistant-stream-*`/`inflight-assistant-*` ids, so this durable
+  // rewrite was missed, `pendingReply()` saw a "new" reply, and the same
+  // words got a second `playSpeechText` call — billed twice.
+  it('does not re-speak a tool-call reply once hydrate rewrites its durable id', async () => {
+    $autoSpeakReplies.set(true)
+
+    const $messages = atom<ChatMessage[]>([])
+
+    const pendingReply = () => {
+      const messages = $messages.get()
+      const last = messages.findLast(m => m.role === 'assistant' && !m.hidden)
+      const spoken = resolveSpokenReply(SESSION_ID, messages)
+
+      if (!last || last.id === spoken?.id) {
+        return null
+      }
+
+      return { id: last.id, pending: Boolean(last.pending), text: chatMessageText(last) }
+    }
+
+    const markSpoken = () => {
+      const messages = $messages.get()
+      const last = messages.findLast(m => m.role === 'assistant' && !m.hidden)
+
+      if (last) {
+        markAssistantIdSpoken(SESSION_ID, messages, last.id)
+      }
+    }
+
+    let settleFallback: (() => void) | null = null
+
+    vi.mocked(playSpeechText).mockImplementation(async () => {
+      setVoicePlaybackState({
+        audioElement: null,
+        messageId: 'assistant-12345',
+        sequence: 0,
+        source: 'read-aloud',
+        status: 'preparing'
+      })
+
+      await new Promise<void>(resolve => {
+        settleFallback = resolve
+      })
+
+      // hydrateFromStoredSession rewrites the same assistant slot to its
+      // durable toChatMessages() id — not a live-tail id.
+      $messages.set([assistantMessage('1770-3-assistant', 'hello there')])
+
+      setVoicePlaybackState({
+        audioElement: null,
+        messageId: '1770-3-assistant',
+        sequence: 0,
+        source: 'read-aloud',
+        status: 'idle'
+      })
+
+      return true
+    })
+
+    renderHook(
+      () =>
+        useAutoSpeakReplies({
+          conversationActive: false,
+          failureLabel: 'read-aloud failed',
+          markSpoken,
+          pendingReply,
+          sessionId: SESSION_ID
+        }),
+      {
+        wrapper: ({ children }) => (
+          <ComposerScopeProvider value={{ ...MAIN_COMPOSER_SCOPE, $messages }}>{children}</ComposerScopeProvider>
+        )
+      }
+    )
+
+    act(() => {
+      $messages.set([assistantMessage('assistant-12345', 'hello there')])
+    })
+
+    await waitFor(() => expect(playSpeechText).toHaveBeenCalledTimes(1))
+
+    await act(async () => {
+      settleFallback?.()
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect($voicePlayback.get().status).toBe('idle')
+    expect(playSpeechText).toHaveBeenCalledTimes(1)
+  })
 })

--- a/apps/desktop/src/lib/spoken-reply.test.ts
+++ b/apps/desktop/src/lib/spoken-reply.test.ts
@@ -53,11 +53,13 @@ describe('absorbSpokenReplyRewrite', () => {
     expect(absorbSpokenReplyRewrite(spoken, after)).toEqual(spoken)
   })
 
-  it('does not migrate a durable id that simply vanished', () => {
-    const spoken = { id: 'durable-old', ordinal: 0 }
-    const after = [assistant('durable-new')]
+  it('migrates a durable (non-live-tail) id rewritten at the same ordinal by hydrate', () => {
+    // e.g. a tool-call completion bubble `assistant-${Date.now()}` that
+    // post-turn hydrateFromStoredSession then rewrites to `${ts}-${idx}-assistant`.
+    const spoken = { id: 'assistant-12345', ordinal: 0 }
+    const after = [user('u1'), assistant('1770-3-assistant')]
 
-    expect(absorbSpokenReplyRewrite(spoken, after)).toEqual(spoken)
+    expect(absorbSpokenReplyRewrite(spoken, after)).toEqual({ id: '1770-3-assistant', ordinal: 0 })
   })
 
   it('keeps the anchor when the spoken id is still in the list', () => {

--- a/apps/desktop/src/lib/spoken-reply.ts
+++ b/apps/desktop/src/lib/spoken-reply.ts
@@ -56,8 +56,21 @@ function lastVisibleAssistant(messages: readonly SpokenReplyMessage[]): SpokenRe
   return messages.findLast(message => message.role === 'assistant' && !message.hidden)
 }
 
-/** If a spoken live-tail row vanished and the same assistant slot now has a
- *  durable id, migrate the anchor. Leave durable ids and later turns alone. */
+/**
+ * If the spoken row vanished — live-tail (`assistant-stream-*`,
+ * `inflight-assistant-*`) OR durable (e.g. a tool-call completion's
+ * `assistant-${Date.now()}` bubble later rewritten by
+ * `hydrateFromStoredSession`'s `toChatMessages()` ids) — follow it to the same
+ * slot. Any id can be rewritten underneath a held reply, not just the live
+ * ones: gate on ordinal, not on id shape.
+ *
+ * The last visible assistant bubble at ordinal <= spoken.ordinal is the same
+ * turn rewritten (or merged, if a bubble in between collapsed and its ordinal
+ * dropped) — migrate. Ordinal > spoken.ordinal means a genuinely new turn
+ * appended — keep the old anchor so that new reply still gets spoken. Never
+ * fingerprint by text: a later distinct turn is allowed to say the same words
+ * ("Done.") and must still be spoken.
+ */
 export function absorbSpokenReplyRewrite(
   spoken: SpokenReplyAnchor | null,
   messages: readonly SpokenReplyMessage[]
@@ -70,10 +83,6 @@ export function absorbSpokenReplyRewrite(
     return spoken
   }
 
-  if (!isLiveTailReplyId(spoken.id)) {
-    return spoken
-  }
-
   const last = lastVisibleAssistant(messages)
 
   if (!last) {
@@ -82,7 +91,7 @@ export function absorbSpokenReplyRewrite(
 
   const ordinal = assistantReplyOrdinal(messages, last.id)
 
-  if (ordinal !== spoken.ordinal) {
+  if (ordinal > spoken.ordinal) {
     return spoken
   }
 


### PR DESCRIPTION
## What does this PR do?

Desktop auto-speak (composer Speak replies) fires a second `playSpeechText` of the same completed turn: print → Preparing audio → Jenny → Preparing audio again. That second start is billed TTS. Confirmed on macOS Desktop with Edge TTS / Jenny, after a tool-using turn whose bubble id is rewritten by post-turn hydrate.

## Related Issue

No existing issue found (search: absorbSpokenReplyRewrite, Preparing audio twice, playSpeechText). Happy to file one if maintainers want it first.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/lib/spoken-reply.ts` — `absorbSpokenReplyRewrite` migrates any vanished spoken id when last visible assistant ordinal <= spoken.ordinal; only a strictly greater ordinal (new turn) is left unspoken. Dropped the `isLiveTailReplyId` gate on the migrate path.
- `apps/desktop/src/lib/spoken-reply.test.ts` — hydrate rewrite of durable id `assistant-12345` → `1770-3-assistant` at same ordinal must migrate; later-ordinal case still does not.
- `apps/desktop/src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx` — hook does not call `playSpeechText` a second time after that durable-id rewrite on idle.

## How to Test

1. From `apps/desktop`: `npx vitest run src/lib/spoken-reply.test.ts src/app/chat/composer/hooks/use-auto-speak-replies.test.tsx` (13 passed locally).
2. Manual: Desktop, Speak replies on. Send a turn that uses tools (or any turn whose renderer id is rewritten on hydrate). One Preparing audio chip, one read. A second Preparing of the same text is the bug.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (desktop vitest change; ran the scoped vitest files above)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26, Desktop 0.17.2, Edge TTS Jenny

### Documentation & Housekeeping

- [x] Docs N/A
- [x] Config keys N/A
- [x] CONTRIBUTING/AGENTS N/A
- [x] Cross-platform: renderer TypeScript only, no native/OS paths
- [x] Tool schemas N/A
