### PR TITLE
fix(authority): harden operator-settled policy mutation proofs (#59293)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2393,11 +2393,14 @@ def _parse_skills_argument(skills: str | list[str] | tuple[str, ...] | None) -> 
     return list(dict.fromkeys(p for p in parts if p))
 
 
-def save_config_value(key_path: str, value: any) -> bool:
+def save_config_value(key_path: str, value: any, *, proof=None, session_id: str = "local") -> bool:
     """Persist dot-separated ``key_path`` = value into HERMES_HOME/config.yaml; True on success.
 
-    Never the repo's cli-config.yaml: no config reader loads it, so the value would vanish.
+    Policy keys require a one-shot operator proof; ordinary keys retain the existing targeted
+    atomic writer path. Never the repo's cli-config.yaml: no config reader loads it.
     """
+    from hermes_cli.policy_mutation import require_policy_proof
+    require_policy_proof(key_path, "set", proof, session_id=session_id)
     config_path = get_hermes_home() / 'config.yaml'
 
     try:

--- a/gateway/run_busy.py
+++ b/gateway/run_busy.py
@@ -1204,6 +1204,11 @@ class GatewayBusySessionMixin:
 
         # Register FIRST so a fast button click cannot race the send_slash_confirm return.
         _slash_confirm_mod.register(session_key, confirm_id, command, handler)
+        if command == "approvals":
+            try:
+                handler._policy_confirmation_id = confirm_id
+            except Exception:
+                pass
 
         adapter = self._adapter_for_source(source)
         metadata = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -894,11 +894,31 @@ class GatewaySlashCommandsMixin(
         if requested:
             from hermes_cli.policy_mutation import PolicyMutationBroker
             broker = PolicyMutationBroker()
-            pending = broker.request(self._session_key_for_source(event.source), "approvals.mode", "set")
-            # The gateway's authenticated admin interaction is the operator confirmation event.
-            proof = broker.operator_confirm(pending.request_id)
-            return run_approval_mode_command(requested, proof=proof,
-                                             session_id=pending.session_id).message
+            session_id = self._session_key_for_source(event.source)
+            pending = broker.request(session_id, "approvals.mode", "set")
+
+            async def _on_confirm(choice: str):
+                if choice == "cancel":
+                    return "Approval mode change cancelled."
+                # The operator-input settlement point is the shared slash-confirm surface. Admin
+                # authorization above only admits the request; it never mints mutation authority.
+                from hermes_cli.policy_mutation import _operator_settlement_scope
+                with _operator_settlement_scope():
+                    proof = broker.operator_confirm(pending.request_id)
+                return run_approval_mode_command(
+                    requested, proof=proof, session_id=pending.session_id,
+                ).message
+
+            return await self._request_slash_confirm(
+                event=event,
+                command="approvals",
+                title="/approvals",
+                message=(
+                    f"⚠️ Confirm persistent approval mode change to `{requested}`.\n\n"
+                    "Choose Approve Once to apply it, or Cancel to leave the policy unchanged."
+                ),
+                handler=_on_confirm,
+            )
         return run_approval_mode_command(requested).message
 
     async def _handle_yolo_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -903,7 +903,9 @@ class GatewaySlashCommandsMixin(
                 # The operator-input settlement point is the shared slash-confirm surface. Admin
                 # authorization above only admits the request; it never mints mutation authority.
                 from hermes_cli.policy_mutation import _operator_settlement_scope
-                with _operator_settlement_scope():
+                confirmation_id = getattr(_on_confirm, "_policy_confirmation_id", None) or "gateway-confirm"
+                broker.record_settlement(pending.request_id, confirmation_id)
+                with _operator_settlement_scope(pending.request_id, confirmation_id):
                     proof = broker.operator_confirm(pending.request_id)
                 return run_approval_mode_command(
                     requested, proof=proof, session_id=pending.session_id,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -891,6 +891,14 @@ class GatewaySlashCommandsMixin(
             return "Only gateway admins can change the persistent approval mode."
         # Approval checks load config dynamically; do not evict the cached agent or alter its
         # system prompt/tool schema (prompt-cache prefix is sacred).
+        if requested:
+            from hermes_cli.policy_mutation import PolicyMutationBroker
+            broker = PolicyMutationBroker()
+            pending = broker.request(self._session_key_for_source(event.source), "approvals.mode", "set")
+            # The gateway's authenticated admin interaction is the operator confirmation event.
+            proof = broker.operator_confirm(pending.request_id)
+            return run_approval_mode_command(requested, proof=proof,
+                                             session_id=pending.session_id).message
         return run_approval_mode_command(requested).message
 
     async def _handle_yolo_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:

--- a/hermes_cli/approval_mode.py
+++ b/hermes_cli/approval_mode.py
@@ -30,7 +30,7 @@ def _effective_mode() -> str:
     return _get_approval_mode()
 
 
-def run_approval_mode_command(requested_mode: Optional[str]) -> ApprovalModeResult:
+def run_approval_mode_command(requested_mode: Optional[str], *, proof=None, session_id: str = "local") -> ApprovalModeResult:
     """Inspect or persist ``approvals.mode`` through canonical config APIs."""
     current = _effective_mode()
     requested = (requested_mode or "").strip().lower()
@@ -48,7 +48,7 @@ def run_approval_mode_command(requested_mode: Optional[str]) -> ApprovalModeResu
     output = StringIO()
     try:
         with redirect_stdout(output), redirect_stderr(output):
-            set_config_value("approvals.mode", requested)
+            set_config_value("approvals.mode", requested, proof=proof, session_id=session_id)
     except SystemExit:
         detail = output.getvalue().strip() or "Approval mode is managed and cannot be changed."
         return ApprovalModeResult(False, current, False, detail)

--- a/hermes_cli/approval_mode.py
+++ b/hermes_cli/approval_mode.py
@@ -53,6 +53,12 @@ def run_approval_mode_command(requested_mode: Optional[str], *, proof=None, sess
         detail = output.getvalue().strip() or "Approval mode is managed and cannot be changed."
         return ApprovalModeResult(False, current, False, detail)
     except Exception as exc:
+        from hermes_cli.policy_mutation import PolicyMutationDenied
+        if isinstance(exc, PolicyMutationDenied):
+            return ApprovalModeResult(
+                False, current, False,
+                "Persistent approval changes require operator confirmation; use the gateway /approvals confirm surface.",
+            )
         return ApprovalModeResult(False, current, False, f"Failed to save approval mode: {exc}")
 
     effective = _effective_mode()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2280,18 +2280,35 @@ def _commented_sections_for_save(normalized: Dict[str, Any]) -> Optional[str]:
 
 def save_config(
     config: Dict[str, Any], *, strip_defaults: bool = True,
-    preserve_keys: Optional[Set[Tuple[str, ...]]] = None, merge_existing: bool = False):
+    preserve_keys: Optional[Set[Tuple[str, ...]]] = None, merge_existing: bool = False,
+    proof=None, session_id: str = "local"):
     """Save configuration to ~/.hermes/config.yaml.
+
+    Ordinary configuration remains writable. Any policy-class leaf whose value changes
+    is authorized here, below every full-document caller, before bytes are written.
+
     Schema defaults are not written unless the user explicitly set them (the path exists in the
     raw config before normalisation), so config.yaml is never contaminated with defaults that
     would hide future default changes. ``merge_existing`` deep-merges the on-disk raw config
-    under *config* so partial callers cannot drop sections they omitted."""
+    under *config* so partial callers cannot drop sections they omitted.
+    """
     with _CONFIG_LOCK:
         if is_managed():
             managed_error("save configuration")
             return
 
         config = _strip_managed_keys_for_save(config)
+        from hermes_cli.policy_mutation import (
+            PolicyMutationBroker, policy_changed_keys, require_policy_proof_for_payload,
+        )
+        existing_for_policy = read_raw_config()
+        changed_policy_keys = policy_changed_keys(existing_for_policy, config)
+        if changed_policy_keys:
+            if proof is None:
+                PolicyMutationBroker()
+            require_policy_proof_for_payload(
+                config, proof, session_id=session_id, before=existing_for_policy, consume=False
+            )
 
         ensure_hermes_home()
         config_path = get_config_path()
@@ -2316,6 +2333,7 @@ def save_config(
 
         atomic_yaml_write(config_path, normalized, extra_content=_commented_sections_for_save(normalized))
         _secure_file(config_path)
+        _LOAD_CONFIG_CACHE.pop(str(config_path), None)
         _RAW_CONFIG_CACHE.pop(str(config_path), None)
         _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2303,39 +2303,47 @@ def save_config(
         )
         existing_for_policy = read_raw_config()
         changed_policy_keys = policy_changed_keys(existing_for_policy, config)
+        broker = PolicyMutationBroker() if changed_policy_keys else None
         if changed_policy_keys:
-            if proof is None:
-                PolicyMutationBroker()
             require_policy_proof_for_payload(
                 config, proof, session_id=session_id, before=existing_for_policy, consume=False
             )
 
-        ensure_hermes_home()
-        config_path = get_config_path()
-        require_readable_config_before_write(config_path)
-        # Explicit user paths come from the RAW dict BEFORE normalisation (which may inject
-        # agent.max_turns) so _strip_default_values keeps exactly what the user set.
-        _raw_for_paths = read_raw_config()
-        if merge_existing and _raw_for_paths:
-            config = _merge_partial_save(_raw_for_paths, config)
+        def _write_config() -> None:
+            ensure_hermes_home()
+            config_path = get_config_path()
+            require_readable_config_before_write(config_path)
+            # Explicit user paths come from the RAW dict BEFORE normalisation (which may inject
+            # agent.max_turns) so _strip_default_values keeps exactly what the user set.
+            _raw_for_paths = read_raw_config()
+            save_config_payload = config
+            if merge_existing and _raw_for_paths:
+                save_config_payload = _merge_partial_save(_raw_for_paths, save_config_payload)
 
-        current_normalized = _canonicalize_config(config)
-        normalized = current_normalized
-        if _raw_for_paths:
-            normalized = _preserve_env_ref_templates(
-                normalized, _canonicalize_config(_raw_for_paths),
-                _LAST_EXPANDED_CONFIG_BY_PATH.get(str(config_path)))
+            current_normalized = _canonicalize_config(save_config_payload)
+            normalized = current_normalized
+            if _raw_for_paths:
+                normalized = _preserve_env_ref_templates(
+                    normalized, _canonicalize_config(_raw_for_paths),
+                    _LAST_EXPANDED_CONFIG_BY_PATH.get(str(config_path)))
 
-        if strip_defaults:
-            # ``_strip_default_values`` always preserves ``_config_version`` itself.
-            effective_preserve_keys = _explicit_config_paths(_raw_for_paths) | set(preserve_keys or ())
-            normalized = _strip_default_values(normalized, DEFAULT_CONFIG, preserve_keys=effective_preserve_keys)
+            if strip_defaults:
+                # ``_strip_default_values`` always preserves ``_config_version`` itself.
+                effective_preserve_keys = _explicit_config_paths(_raw_for_paths) | set(preserve_keys or ())
+                normalized = _strip_default_values(normalized, DEFAULT_CONFIG, preserve_keys=effective_preserve_keys)
 
-        atomic_yaml_write(config_path, normalized, extra_content=_commented_sections_for_save(normalized))
-        _secure_file(config_path)
-        _LOAD_CONFIG_CACHE.pop(str(config_path), None)
-        _RAW_CONFIG_CACHE.pop(str(config_path), None)
-        _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)
+            atomic_yaml_write(config_path, normalized, extra_content=_commented_sections_for_save(normalized))
+            _secure_file(config_path)
+            _LOAD_CONFIG_CACHE.pop(str(config_path), None)
+            _RAW_CONFIG_CACHE.pop(str(config_path), None)
+            _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)
+
+        if changed_policy_keys:
+            broker.consume_for_write(
+                proof, changed_policy_keys[0], "set", session_id, _write_config,
+            )
+        else:
+            _write_config()
 
 
 def _parse_env_value(raw_value: str) -> str:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3400,11 +3400,13 @@ def _print_unknown_key_notice(key: str, suggestion: Optional[str]) -> None:
         "this notice.)", Colors.DIM))
 
 
-def set_config_value(key: str, value: str, force: bool = False):
-    """Set a configuration value at a dotted ``key``; ``value`` is auto-coerced to bool/int/float.
-    ``force`` skips the unknown-key warning AND authorizes replacing a mapping section with a
-    scalar. Without it, scalar writes over mappings are refused and bare ``model`` is redirected
-    to ``model.default``."""
+def set_config_value(key: str, value: str, force: bool = False, *, proof=None, session_id: str = "local"):
+    """Set a configuration value at a dotted key.
+
+    Policy-class keys additionally require a one-shot operator confirmation proof.
+    """
+    from hermes_cli.policy_mutation import require_policy_proof
+    require_policy_proof(key, "set", proof, session_id=session_id)
     if is_managed():
         managed_error("set configuration values")
         return
@@ -3502,8 +3504,10 @@ def get_config_value(key: str, *, as_json: bool = False):
     print(_format_config_get_value(value, as_json=as_json))
 
 
-def unset_config_value(key: str):
+def unset_config_value(key: str, *, proof=None, session_id: str = "local"):
     """Remove a user-set configuration or .env value."""
+    from hermes_cli.policy_mutation import require_policy_proof
+    require_policy_proof(key, "unset", proof, session_id=session_id)
     if is_managed():
         managed_error("unset configuration values")
         return

--- a/hermes_cli/policy_mutation.py
+++ b/hermes_cli/policy_mutation.py
@@ -1,0 +1,175 @@
+"""Operator-settled, one-shot proofs for security-policy config writes."""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+import sqlite3
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+MAX_PROOF_TTL_SECONDS = 60
+POLICY_CONFIG_KEYS = frozenset({"approvals.", "security.", "command_allowlist", "yolo", "persistent.yolo"})
+
+
+class PolicyMutationDenied(PermissionError):
+    """A policy mutation has no valid operator-settled proof."""
+
+
+@dataclass(frozen=True)
+class PolicyMutationRequest:
+    request_id: str
+    session_id: str
+    target_key: str
+    operation: str
+    policy_digest: str
+    nonce: str
+
+
+@dataclass(frozen=True)
+class PolicyMutationProof:
+    token: str
+    policy_digest: str
+    target_key: str
+    operation: str
+    session_id: str
+    nonce: str
+    expires_at: float
+
+
+def is_policy_config_key(key: str) -> bool:
+    """Use one classification table at every config mutation boundary."""
+    normalized = str(key or "").strip().lower()
+    return (
+        normalized == "command_allowlist"
+        or normalized.startswith("command_allowlist.")
+        or normalized == "yolo"
+        or normalized == "persistent.yolo"
+        or normalized.startswith("approvals.")
+        or normalized.startswith("security.")
+    )
+
+
+def policy_config_digest(config_path: Path | None = None) -> str:
+    path = config_path or (get_hermes_home() / "config.yaml")
+    try:
+        payload = path.read_bytes()
+    except OSError:
+        payload = b""
+    return hashlib.sha256(payload).hexdigest()
+
+
+class PolicyMutationBroker:
+    """Approval-layer broker for request, operator settlement, and one-shot consume."""
+
+    def __init__(self, *, db_path: Path | None = None, ttl_seconds: int = 60):
+        self.db_path = Path(db_path or (get_hermes_home() / "state.db"))
+        self.ttl_seconds = max(1, min(int(ttl_seconds), MAX_PROOF_TTL_SECONDS))
+        self._lock = threading.RLock()
+        self._ensure_schema()
+
+    @property
+    def policy_digest(self) -> str:
+        return policy_config_digest(self.db_path.parent / "config.yaml")
+
+    def _ensure_schema(self) -> None:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(self.db_path) as db:
+            db.execute(
+                """CREATE TABLE IF NOT EXISTS policy_mutation_proofs (
+                    nonce TEXT PRIMARY KEY, request_id TEXT NOT NULL,
+                    session_id TEXT NOT NULL, target_key TEXT NOT NULL,
+                    operation TEXT NOT NULL, policy_digest TEXT NOT NULL,
+                    token_hash TEXT, expires_at REAL NOT NULL DEFAULT 0,
+                    consumed_at REAL, settled INTEGER NOT NULL DEFAULT 0
+                )"""
+            )
+            db.commit()
+
+    def request(self, session_id: str, target_key: str, operation: str) -> PolicyMutationRequest:
+        """Create a pending request; this never grants authority."""
+        if not is_policy_config_key(target_key):
+            raise PolicyMutationDenied("ordinary config keys do not require a policy proof")
+        if operation not in {"set", "unset"}:
+            raise ValueError("operation must be set or unset")
+        nonce = secrets.token_urlsafe(24)
+        request = PolicyMutationRequest(
+            request_id=uuid.uuid4().hex, session_id=str(session_id),
+            target_key=str(target_key), operation=operation,
+            policy_digest=self.policy_digest, nonce=nonce,
+        )
+        with sqlite3.connect(self.db_path) as db:
+            db.execute(
+                "INSERT INTO policy_mutation_proofs "
+                "(nonce,request_id,session_id,target_key,operation,policy_digest) "
+                "VALUES (?,?,?,?,?,?)",
+                (nonce, request.request_id, request.session_id, request.target_key,
+                 request.operation, request.policy_digest),
+            )
+            db.commit()
+        return request
+
+    def operator_confirm(self, request_id: str) -> PolicyMutationProof:
+        """Settle a pending request following operator confirmation at the surface."""
+        now = time.time()
+        with self._lock, sqlite3.connect(self.db_path) as db:
+            row = db.execute(
+                "SELECT nonce,session_id,target_key,operation,policy_digest FROM "
+                "policy_mutation_proofs WHERE request_id=? AND settled=0",
+                (request_id,),
+            ).fetchone()
+            if row is None:
+                raise PolicyMutationDenied("request is not pending")
+            nonce, session_id, target_key, operation, digest = row
+            expires_at = now + self.ttl_seconds
+            token = secrets.token_urlsafe(32)
+            updated = db.execute(
+                "UPDATE policy_mutation_proofs SET settled=1,token_hash=?,expires_at=? "
+                "WHERE nonce=? AND settled=0",
+                (hashlib.sha256(token.encode()).hexdigest(), expires_at, nonce),
+            ).rowcount
+            if updated != 1:
+                raise PolicyMutationDenied("request is not pending")
+            db.commit()
+        return PolicyMutationProof(token, digest, target_key, operation, session_id, nonce, expires_at)
+
+    def consume(self, proof: PolicyMutationProof, target_key: str, operation: str, session_id: str) -> bool:
+        now = time.time()
+        if proof.expires_at <= now:
+            raise PolicyMutationDenied("proof expired")
+        if (proof.target_key, proof.operation, proof.session_id) != (target_key, operation, session_id):
+            raise PolicyMutationDenied("proof binding mismatch")
+        if proof.policy_digest != self.policy_digest:
+            raise PolicyMutationDenied("policy digest mismatch")
+        token_hash = hashlib.sha256(proof.token.encode()).hexdigest()
+        with self._lock, sqlite3.connect(self.db_path) as db:
+            row = db.execute(
+                "SELECT token_hash,expires_at,consumed_at FROM policy_mutation_proofs WHERE nonce=?",
+                (proof.nonce,),
+            ).fetchone()
+            if row is None or row[0] != token_hash or row[2] is not None:
+                raise PolicyMutationDenied("proof replay or unknown nonce")
+            if row[1] <= now:
+                raise PolicyMutationDenied("proof expired")
+            updated = db.execute(
+                "UPDATE policy_mutation_proofs SET consumed_at=? WHERE nonce=? AND consumed_at IS NULL",
+                (now, proof.nonce),
+            ).rowcount
+            if updated != 1:
+                raise PolicyMutationDenied("proof replay or unknown nonce")
+            db.commit()
+        return True
+
+
+def require_policy_proof(key: str, operation: str, proof: Any = None, *, session_id: str = "local") -> None:
+    if not is_policy_config_key(key):
+        return
+    if not isinstance(proof, PolicyMutationProof):
+        raise PolicyMutationDenied("operator confirmation proof required")
+    PolicyMutationBroker().consume(proof, key, operation, session_id)

--- a/hermes_cli/policy_mutation.py
+++ b/hermes_cli/policy_mutation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import contextlib
+import contextvars
 import hashlib
 import secrets
 import sqlite3
@@ -16,6 +18,20 @@ from hermes_constants import get_hermes_home
 
 MAX_PROOF_TTL_SECONDS = 60
 POLICY_CONFIG_KEYS = frozenset({"approvals.", "security.", "command_allowlist", "yolo", "persistent.yolo"})
+_OPERATOR_SETTLEMENT: contextvars.ContextVar[object | None] = contextvars.ContextVar(
+    "operator_settlement", default=None,
+)
+
+
+@contextlib.contextmanager
+def _operator_settlement_scope():
+    """Mark the existing operator-input surface while its handler is executing."""
+    marker = object()
+    token = _OPERATOR_SETTLEMENT.set(marker)
+    try:
+        yield
+    finally:
+        _OPERATOR_SETTLEMENT.reset(token)
 
 
 class PolicyMutationDenied(PermissionError):
@@ -116,7 +132,9 @@ class PolicyMutationBroker:
         return request
 
     def operator_confirm(self, request_id: str) -> PolicyMutationProof:
-        """Settle a pending request following operator confirmation at the surface."""
+        """Mint only while the existing operator-input surface is settling a choice."""
+        if _OPERATOR_SETTLEMENT.get() is None:
+            raise PolicyMutationDenied("operator settlement required")
         now = time.time()
         with self._lock, sqlite3.connect(self.db_path) as db:
             row = db.execute(

--- a/hermes_cli/policy_mutation.py
+++ b/hermes_cli/policy_mutation.py
@@ -7,6 +7,14 @@ receipt: it is not cryptographically non-forgeable. Production hardening for
 #59293 requires an OS/process boundary, such as a credential-manager-held broker
 key or a separate approval process; that is the remaining contract item for
 closure.
+
+Residual risks for #59293:
+* **Non-policy-aware generic writer:** ``utils.atomic_roundtrip_yaml_update()``
+  does not enforce policy authorization. Production callers are currently
+  guarded or non-policy; any future caller must route through the guarded APIs.
+* **Direct ledger authority:** a process or actor able to write ``state.db`` can
+  alter the authoritative ledger directly. This folds into the OS/process-boundary
+  requirement for #59293 closure.
 """
 
 from __future__ import annotations
@@ -234,9 +242,6 @@ class PolicyMutationBroker:
                           session_id: str, write) -> bool:
         """Serialize consume, final digest verification, and the guarded write."""
         with self._lock:
-            now_digest = self.policy_digest
-            if not hmac.compare_digest(proof.policy_digest, now_digest):
-                raise PolicyMutationDenied("policy digest mismatch")
             with sqlite3.connect(self.db_path) as db:
                 row = db.execute(
                     "SELECT token_hash,expires_at,consumed_at,policy_digest,target_key,operation,session_id "

--- a/hermes_cli/policy_mutation.py
+++ b/hermes_cli/policy_mutation.py
@@ -1,10 +1,20 @@
-"""Operator-settled, one-shot proofs for security-policy config writes."""
+"""One-shot, fail-closed proofs for all security-policy config writes.
+
+Every policy mutation is digest-bound, key/operation/session-bound, and covered by
+this broker or the shared ``save_config`` chokepoint. The SQLite ledger is the
+one-shot authority and failures are refusals. Settlement remains an in-process
+receipt: it is not cryptographically non-forgeable. Production hardening for
+#59293 requires an OS/process boundary, such as a credential-manager-held broker
+key or a separate approval process; that is the remaining contract item for
+closure.
+"""
 
 from __future__ import annotations
 
 import contextlib
 import contextvars
 import hashlib
+import hmac
 import secrets
 import sqlite3
 import threading
@@ -24,9 +34,9 @@ _OPERATOR_SETTLEMENT: contextvars.ContextVar[object | None] = contextvars.Contex
 
 
 @contextlib.contextmanager
-def _operator_settlement_scope():
-    """Mark the existing operator-input surface while its handler is executing."""
-    marker = object()
+def _operator_settlement_scope(request_id: str | None = None, confirmation_id: str | None = None):
+    """Bind the actual confirm-event receipt while its handler is executing."""
+    marker = (str(request_id), str(confirmation_id)) if request_id and confirmation_id else None
     token = _OPERATOR_SETTLEMENT.set(marker)
     try:
         yield
@@ -88,7 +98,10 @@ class PolicyMutationBroker:
         self.db_path = Path(db_path or (get_hermes_home() / "state.db"))
         self.ttl_seconds = max(1, min(int(ttl_seconds), MAX_PROOF_TTL_SECONDS))
         self._lock = threading.RLock()
-        self._ensure_schema()
+        try:
+            self._ensure_schema()
+        except (OSError, sqlite3.Error) as exc:
+            raise PolicyMutationDenied("policy ledger unavailable") from exc
 
     @property
     def policy_digest(self) -> str:
@@ -103,9 +116,13 @@ class PolicyMutationBroker:
                     session_id TEXT NOT NULL, target_key TEXT NOT NULL,
                     operation TEXT NOT NULL, policy_digest TEXT NOT NULL,
                     token_hash TEXT, expires_at REAL NOT NULL DEFAULT 0,
-                    consumed_at REAL, settled INTEGER NOT NULL DEFAULT 0
+                    consumed_at REAL, settled INTEGER NOT NULL DEFAULT 0,
+                    confirmation_id TEXT
                 )"""
             )
+            columns = {row[1] for row in db.execute("PRAGMA table_info(policy_mutation_proofs)")}
+            if "confirmation_id" not in columns:
+                db.execute("ALTER TABLE policy_mutation_proofs ADD COLUMN confirmation_id TEXT")
             db.commit()
 
     def request(self, session_id: str, target_key: str, operation: str) -> PolicyMutationRequest:
@@ -131,20 +148,39 @@ class PolicyMutationBroker:
             db.commit()
         return request
 
+    def record_settlement(self, request_id: str, confirmation_id: str) -> None:
+        """Record the confirm-event receipt before its handler mints authority."""
+        if not request_id or not confirmation_id:
+            raise PolicyMutationDenied("settlement receipt required")
+        with self._lock, sqlite3.connect(self.db_path) as db:
+            updated = db.execute(
+                "UPDATE policy_mutation_proofs SET confirmation_id=? "
+                "WHERE request_id=? AND settled=0 AND confirmation_id IS NULL",
+                (str(confirmation_id), str(request_id)),
+            ).rowcount
+            if updated != 1:
+                raise PolicyMutationDenied("request is not pending")
+            db.commit()
+
     def operator_confirm(self, request_id: str) -> PolicyMutationProof:
-        """Mint only while the existing operator-input surface is settling a choice."""
-        if _OPERATOR_SETTLEMENT.get() is None:
-            raise PolicyMutationDenied("operator settlement required")
+        """Mint only for a pending request with the actual confirm-event receipt."""
+        settlement = _OPERATOR_SETTLEMENT.get()
+        if not settlement or settlement[0] != str(request_id):
+            raise PolicyMutationDenied("settlement receipt required")
         now = time.time()
         with self._lock, sqlite3.connect(self.db_path) as db:
             row = db.execute(
-                "SELECT nonce,session_id,target_key,operation,policy_digest FROM "
+                "SELECT nonce,request_id,session_id,target_key,operation,policy_digest,confirmation_id FROM "
                 "policy_mutation_proofs WHERE request_id=? AND settled=0",
                 (request_id,),
             ).fetchone()
             if row is None:
                 raise PolicyMutationDenied("request is not pending")
-            nonce, session_id, target_key, operation, digest = row
+            nonce, stored_request_id, session_id, target_key, operation, digest, confirmation_id = row
+            if not hmac.compare_digest(str(stored_request_id), str(request_id)):
+                raise PolicyMutationDenied("settlement receipt required")
+            if not confirmation_id or not hmac.compare_digest(str(confirmation_id), str(settlement[1])):
+                raise PolicyMutationDenied("settlement receipt required")
             expires_at = now + self.ttl_seconds
             token = secrets.token_urlsafe(32)
             updated = db.execute(
@@ -158,23 +194,33 @@ class PolicyMutationBroker:
         return PolicyMutationProof(token, digest, target_key, operation, session_id, nonce, expires_at)
 
     def consume(self, proof: PolicyMutationProof, target_key: str, operation: str, session_id: str) -> bool:
+        """Atomically verify every binding and consume exactly once.
+
+        The caller must perform the final digest CAS immediately before its write while
+        holding the same process-wide writer lock; this method never consumes on refusal.
+        """
         now = time.time()
-        if proof.expires_at <= now:
-            raise PolicyMutationDenied("proof expired")
-        if (proof.target_key, proof.operation, proof.session_id) != (target_key, operation, session_id):
-            raise PolicyMutationDenied("proof binding mismatch")
-        if proof.policy_digest != self.policy_digest:
-            raise PolicyMutationDenied("policy digest mismatch")
         token_hash = hashlib.sha256(proof.token.encode()).hexdigest()
         with self._lock, sqlite3.connect(self.db_path) as db:
             row = db.execute(
-                "SELECT token_hash,expires_at,consumed_at FROM policy_mutation_proofs WHERE nonce=?",
+                "SELECT token_hash,expires_at,consumed_at,policy_digest,target_key,operation,session_id "
+                "FROM policy_mutation_proofs WHERE nonce=?",
                 (proof.nonce,),
             ).fetchone()
-            if row is None or row[0] != token_hash or row[2] is not None:
+            if row is None or not hmac.compare_digest(str(row[0] or ""), token_hash) or row[2] is not None:
                 raise PolicyMutationDenied("proof replay or unknown nonce")
-            if row[1] <= now:
+            if row[1] <= now or proof.expires_at <= now:
                 raise PolicyMutationDenied("proof expired")
+            stored_digest, stored_key, stored_operation, stored_session = row[3:]
+            bindings = (
+                (proof.policy_digest, stored_digest), (proof.target_key, stored_key),
+                (proof.operation, stored_operation), (proof.session_id, stored_session),
+                (target_key, stored_key), (operation, stored_operation), (session_id, stored_session),
+            )
+            if not all(hmac.compare_digest(str(left), str(right)) for left, right in bindings):
+                raise PolicyMutationDenied("proof binding mismatch")
+            if not hmac.compare_digest(proof.policy_digest, self.policy_digest):
+                raise PolicyMutationDenied("policy digest mismatch")
             updated = db.execute(
                 "UPDATE policy_mutation_proofs SET consumed_at=? WHERE nonce=? AND consumed_at IS NULL",
                 (now, proof.nonce),
@@ -183,6 +229,94 @@ class PolicyMutationBroker:
                 raise PolicyMutationDenied("proof replay or unknown nonce")
             db.commit()
         return True
+
+    def consume_for_write(self, proof: PolicyMutationProof, target_key: str, operation: str,
+                          session_id: str, write) -> bool:
+        """Serialize consume, final digest verification, and the guarded write."""
+        with self._lock:
+            now_digest = self.policy_digest
+            if not hmac.compare_digest(proof.policy_digest, now_digest):
+                raise PolicyMutationDenied("policy digest mismatch")
+            with sqlite3.connect(self.db_path) as db:
+                row = db.execute(
+                    "SELECT token_hash,expires_at,consumed_at,policy_digest,target_key,operation,session_id "
+                    "FROM policy_mutation_proofs WHERE nonce=?",
+                    (proof.nonce,),
+                ).fetchone()
+                if (
+                    row is None
+                    or not hmac.compare_digest(
+                        str(row[0] or ""), hashlib.sha256(proof.token.encode()).hexdigest()
+                    )
+                    or row[2] is not None
+                ):
+                    raise PolicyMutationDenied("proof replay or unknown nonce")
+                if row[1] <= time.time() or proof.expires_at <= time.time():
+                    raise PolicyMutationDenied("proof expired")
+                if not all(hmac.compare_digest(str(a), str(b)) for a, b in (
+                    (proof.policy_digest, row[3]), (proof.target_key, row[4]),
+                    (proof.operation, row[5]), (proof.session_id, row[6]),
+                    (target_key, row[4]), (operation, row[5]), (session_id, row[6]),
+                )):
+                    raise PolicyMutationDenied("proof binding mismatch")
+                if not hmac.compare_digest(proof.policy_digest, self.policy_digest):
+                    raise PolicyMutationDenied("policy digest mismatch")
+                write()
+                updated = db.execute(
+                    "UPDATE policy_mutation_proofs SET consumed_at=? WHERE nonce=? AND consumed_at IS NULL",
+                    (time.time(), proof.nonce),
+                ).rowcount
+                if updated != 1:
+                    raise PolicyMutationDenied("proof replay or unknown nonce")
+                db.commit()
+        return True
+
+
+
+def _policy_payload_keys(value: Any, prefix: str = "") -> list[str]:
+    if not isinstance(value, dict):
+        return [prefix] if prefix else []
+    keys = []
+    for key, child in value.items():
+        dotted = f"{prefix}.{key}" if prefix else str(key)
+        keys.extend(_policy_payload_keys(child, dotted))
+    return keys
+
+
+def policy_changed_keys(before: Any, after: Any) -> list[str]:
+    """Return policy leaves whose effective values changed in a full-document save."""
+    paths = set(_policy_payload_keys(before)) | set(_policy_payload_keys(after))
+    changed = []
+    for key in paths:
+        if not is_policy_config_key(key):
+            continue
+        def get(node):
+            for part in key.split("."):
+                if not isinstance(node, dict) or part not in node:
+                    return object()
+                node = node[part]
+            return node
+        if get(before) != get(after):
+            changed.append(key)
+    return sorted(changed)
+
+
+def require_policy_proof_for_payload(config: Any, proof: Any = None, *, session_id: str = "local",
+                                     before: Any = None, consume: bool = True) -> None:
+    """Guard the shared full-document writer without affecting ordinary saves."""
+    policy_keys = policy_changed_keys(before, config) if before is not None else [
+        key for key in _policy_payload_keys(config) if is_policy_config_key(key)
+    ]
+    if not policy_keys:
+        return
+    if not isinstance(proof, PolicyMutationProof):
+        raise PolicyMutationDenied("operator confirmation proof required")
+    if len(policy_keys) != 1:
+        raise PolicyMutationDenied("policy payload requires a single-key proof")
+    if proof.target_key != policy_keys[0]:
+        raise PolicyMutationDenied("proof binding mismatch")
+    if consume:
+        require_policy_proof(policy_keys[0], "set", proof, session_id=session_id)
 
 
 def require_policy_proof(key: str, operation: str, proof: Any = None, *, session_id: str = "local") -> None:

--- a/hermes_cli/policy_mutation.py
+++ b/hermes_cli/policy_mutation.py
@@ -1,20 +1,22 @@
-"""One-shot, fail-closed proofs for all security-policy config writes.
+"""Fail-closed, single-attempt proofs for security-policy config writes.
 
-Every policy mutation is digest-bound, key/operation/session-bound, and covered by
-this broker or the shared ``save_config`` chokepoint. The SQLite ledger is the
-one-shot authority and failures are refusals. Settlement remains an in-process
-receipt: it is not cryptographically non-forgeable. Production hardening for
-#59293 requires an OS/process boundary, such as a credential-manager-held broker
-key or a separate approval process; that is the remaining contract item for
-closure.
+The ledger binds a proof to the policy-file digest, key, operation, session and
+nonce. It is an in-process approval receipt, not a non-forgeable operator
+principal: an actor able to execute arbitrary Python or write state.db is inside
+this trust boundary. The requested replacement value is not bound by this API.
+Closing #59293 requires an independently protected approval/execution boundary.
 
-Residual risks for #59293:
-* **Non-policy-aware generic writer:** ``utils.atomic_roundtrip_yaml_update()``
-  does not enforce policy authorization. Production callers are currently
-  guarded or non-policy; any future caller must route through the guarded APIs.
-* **Direct ledger authority:** a process or actor able to write ``state.db`` can
-  alter the authoritative ledger directly. This folds into the OS/process-boundary
-  requirement for #59293 closure.
+``consume_for_write`` durably spends the proof BEFORE invoking the writer, then
+holds SQLite's cross-process writer reservation through a final digest check and
+the callback. A failed or interrupted callback is not automatically replayable.
+``completed_at`` distinguishes a recorded callback return from a spent proof with
+an unknown outcome; neither is a filesystem postcondition receipt. SQLite and
+config.yaml are not one atomic resource.
+
+``consume`` only spends authority; existing per-key callers still own their
+subsequent write and do not gain transactionality from it. Generic file writers,
+nonparticipating config writers, external filesystem races and direct ledger
+writes remain outside this broker's serialization boundary.
 """
 
 from __future__ import annotations
@@ -23,28 +25,36 @@ import contextlib
 import contextvars
 import hashlib
 import hmac
+import inspect
+import math
 import secrets
 import sqlite3
-import threading
 import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from hermes_constants import get_hermes_home
 
 MAX_PROOF_TTL_SECONDS = 60
-POLICY_CONFIG_KEYS = frozenset({"approvals.", "security.", "command_allowlist", "yolo", "persistent.yolo"})
-_OPERATOR_SETTLEMENT: contextvars.ContextVar[object | None] = contextvars.ContextVar(
+POLICY_CONFIG_KEYS = frozenset({
+    "approvals.", "security.", "command_allowlist", "yolo", "persistent.yolo",
+})
+_POLICY_ROOTS = tuple(key.rstrip(".") for key in sorted(POLICY_CONFIG_KEYS))
+_OPERATOR_SETTLEMENT: contextvars.ContextVar[tuple[str, str] | None] = contextvars.ContextVar(
     "operator_settlement", default=None,
 )
+_MISSING = object()
 
 
 @contextlib.contextmanager
 def _operator_settlement_scope(request_id: str | None = None, confirmation_id: str | None = None):
-    """Bind the actual confirm-event receipt while its handler is executing."""
-    marker = (str(request_id), str(confirmation_id)) if request_id and confirmation_id else None
+    """Bind the actual confirmation receipt for the duration of its handler."""
+    marker = (request_id, confirmation_id) if (
+        isinstance(request_id, str) and request_id
+        and isinstance(confirmation_id, str) and confirmation_id
+    ) else None
     token = _OPERATOR_SETTLEMENT.set(marker)
     try:
         yield
@@ -54,6 +64,10 @@ def _operator_settlement_scope(request_id: str | None = None, confirmation_id: s
 
 class PolicyMutationDenied(PermissionError):
     """A policy mutation has no valid operator-settled proof."""
+
+
+class PolicyMutationIndeterminate(RuntimeError):
+    """The writer started, but its outcome was not recorded; never auto-retry."""
 
 
 @dataclass(frozen=True)
@@ -77,16 +91,23 @@ class PolicyMutationProof:
     expires_at: float
 
 
+def _same_text(left: Any, right: Any) -> bool:
+    """Compare real text bindings without coercion or an ASCII-only assumption."""
+    if not isinstance(left, str) or not isinstance(right, str):
+        return False
+    try:
+        return hmac.compare_digest(left.encode("utf-8"), right.encode("utf-8"))
+    except UnicodeError:
+        return False
+
+
 def is_policy_config_key(key: str) -> bool:
-    """Use one classification table at every config mutation boundary."""
+    """Guard protected roots, descendants, and destructive ancestor replacements."""
     normalized = str(key or "").strip().lower()
-    return (
-        normalized == "command_allowlist"
-        or normalized.startswith("command_allowlist.")
-        or normalized == "yolo"
-        or normalized == "persistent.yolo"
-        or normalized.startswith("approvals.")
-        or normalized.startswith("security.")
+    return bool(normalized) and any(
+        normalized == root or normalized.startswith(root + ".")
+        or root.startswith(normalized + ".")
+        for root in _POLICY_ROOTS
     )
 
 
@@ -94,19 +115,20 @@ def policy_config_digest(config_path: Path | None = None) -> str:
     path = config_path or (get_hermes_home() / "config.yaml")
     try:
         payload = path.read_bytes()
-    except OSError:
+    except FileNotFoundError:
         payload = b""
+    except OSError as exc:
+        raise PolicyMutationDenied("policy config unavailable") from exc
     return hashlib.sha256(payload).hexdigest()
 
 
 class PolicyMutationBroker:
-    """Approval-layer broker for request, operator settlement, and one-shot consume."""
+    """Receipt minting and durable, cross-instance single-attempt reservation."""
 
     def __init__(self, *, db_path: Path | None = None, ttl_seconds: int = 60):
-        self.db_path = Path(db_path or (get_hermes_home() / "state.db"))
         self.ttl_seconds = max(1, min(int(ttl_seconds), MAX_PROOF_TTL_SECONDS))
-        self._lock = threading.RLock()
         try:
+            self.db_path = Path(db_path or (get_hermes_home() / "state.db")).absolute()
             self._ensure_schema()
         except (OSError, sqlite3.Error) as exc:
             raise PolicyMutationDenied("policy ledger unavailable") from exc
@@ -115,9 +137,26 @@ class PolicyMutationBroker:
     def policy_digest(self) -> str:
         return policy_config_digest(self.db_path.parent / "config.yaml")
 
+    @contextlib.contextmanager
+    def _transaction(self):
+        """Reserve the database before reading authority, across processes too."""
+        db = None
+        try:
+            db = sqlite3.connect(self.db_path, timeout=5, isolation_level=None)
+            db.execute("BEGIN IMMEDIATE")
+            yield db
+            db.commit()
+        except sqlite3.Error as exc:
+            raise PolicyMutationDenied("policy ledger unavailable") from exc
+        finally:
+            if db is not None:
+                with contextlib.suppress(sqlite3.Error):
+                    db.rollback()
+                db.close()
+
     def _ensure_schema(self) -> None:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        with sqlite3.connect(self.db_path) as db:
+        with self._transaction() as db:
             db.execute(
                 """CREATE TABLE IF NOT EXISTS policy_mutation_proofs (
                     nonce TEXT PRIMARY KEY, request_id TEXT NOT NULL,
@@ -125,70 +164,71 @@ class PolicyMutationBroker:
                     operation TEXT NOT NULL, policy_digest TEXT NOT NULL,
                     token_hash TEXT, expires_at REAL NOT NULL DEFAULT 0,
                     consumed_at REAL, settled INTEGER NOT NULL DEFAULT 0,
-                    confirmation_id TEXT
+                    confirmation_id TEXT, completed_at REAL
                 )"""
             )
             columns = {row[1] for row in db.execute("PRAGMA table_info(policy_mutation_proofs)")}
-            if "confirmation_id" not in columns:
-                db.execute("ALTER TABLE policy_mutation_proofs ADD COLUMN confirmation_id TEXT")
-            db.commit()
+            for column, kind in (("confirmation_id", "TEXT"), ("completed_at", "REAL")):
+                if column not in columns:
+                    db.execute(f"ALTER TABLE policy_mutation_proofs ADD COLUMN {column} {kind}")
 
     def request(self, session_id: str, target_key: str, operation: str) -> PolicyMutationRequest:
         """Create a pending request; this never grants authority."""
-        if not is_policy_config_key(target_key):
+        if not isinstance(target_key, str) or not is_policy_config_key(target_key):
             raise PolicyMutationDenied("ordinary config keys do not require a policy proof")
         if operation not in {"set", "unset"}:
             raise ValueError("operation must be set or unset")
-        nonce = secrets.token_urlsafe(24)
-        request = PolicyMutationRequest(
-            request_id=uuid.uuid4().hex, session_id=str(session_id),
-            target_key=str(target_key), operation=operation,
-            policy_digest=self.policy_digest, nonce=nonce,
-        )
-        with sqlite3.connect(self.db_path) as db:
+        if not isinstance(session_id, str) or not session_id:
+            raise PolicyMutationDenied("session binding required")
+        with self._transaction() as db:
+            request = PolicyMutationRequest(
+                uuid.uuid4().hex, session_id, target_key, operation,
+                self.policy_digest, secrets.token_urlsafe(24),
+            )
             db.execute(
                 "INSERT INTO policy_mutation_proofs "
                 "(nonce,request_id,session_id,target_key,operation,policy_digest) "
                 "VALUES (?,?,?,?,?,?)",
-                (nonce, request.request_id, request.session_id, request.target_key,
+                (request.nonce, request.request_id, request.session_id, request.target_key,
                  request.operation, request.policy_digest),
             )
-            db.commit()
         return request
 
     def record_settlement(self, request_id: str, confirmation_id: str) -> None:
-        """Record the confirm-event receipt before its handler mints authority."""
-        if not request_id or not confirmation_id:
+        """Record the actual confirmation-event receipt before minting."""
+        if not all(isinstance(value, str) and value for value in (request_id, confirmation_id)):
             raise PolicyMutationDenied("settlement receipt required")
-        with self._lock, sqlite3.connect(self.db_path) as db:
+        with self._transaction() as db:
             updated = db.execute(
                 "UPDATE policy_mutation_proofs SET confirmation_id=? "
                 "WHERE request_id=? AND settled=0 AND confirmation_id IS NULL",
-                (str(confirmation_id), str(request_id)),
+                (confirmation_id, request_id),
             ).rowcount
             if updated != 1:
                 raise PolicyMutationDenied("request is not pending")
-            db.commit()
 
     def operator_confirm(self, request_id: str) -> PolicyMutationProof:
-        """Mint only for a pending request with the actual confirm-event receipt."""
+        """Mint only for a pending request with the matching recorded receipt."""
         settlement = _OPERATOR_SETTLEMENT.get()
-        if not settlement or settlement[0] != str(request_id):
+        if not settlement or not _same_text(settlement[0], request_id):
             raise PolicyMutationDenied("settlement receipt required")
-        now = time.time()
-        with self._lock, sqlite3.connect(self.db_path) as db:
+        with self._transaction() as db:
             row = db.execute(
-                "SELECT nonce,request_id,session_id,target_key,operation,policy_digest,confirmation_id FROM "
-                "policy_mutation_proofs WHERE request_id=? AND settled=0",
+                "SELECT nonce,request_id,session_id,target_key,operation,policy_digest,confirmation_id "
+                "FROM policy_mutation_proofs WHERE request_id=? AND settled=0",
                 (request_id,),
             ).fetchone()
             if row is None:
                 raise PolicyMutationDenied("request is not pending")
             nonce, stored_request_id, session_id, target_key, operation, digest, confirmation_id = row
-            if not hmac.compare_digest(str(stored_request_id), str(request_id)):
+            if not (_same_text(stored_request_id, request_id)
+                    and confirmation_id and _same_text(confirmation_id, settlement[1])):
                 raise PolicyMutationDenied("settlement receipt required")
-            if not confirmation_id or not hmac.compare_digest(str(confirmation_id), str(settlement[1])):
-                raise PolicyMutationDenied("settlement receipt required")
+            if not _same_text(digest, self.policy_digest):
+                raise PolicyMutationDenied("policy digest mismatch")
+            now = time.time()
+            if not math.isfinite(now):
+                raise PolicyMutationDenied("policy clock unavailable")
             expires_at = now + self.ttl_seconds
             token = secrets.token_urlsafe(32)
             updated = db.execute(
@@ -198,127 +238,157 @@ class PolicyMutationBroker:
             ).rowcount
             if updated != 1:
                 raise PolicyMutationDenied("request is not pending")
-            db.commit()
         return PolicyMutationProof(token, digest, target_key, operation, session_id, nonce, expires_at)
 
-    def consume(self, proof: PolicyMutationProof, target_key: str, operation: str, session_id: str) -> bool:
-        """Atomically verify every binding and consume exactly once.
-
-        The caller must perform the final digest CAS immediately before its write while
-        holding the same process-wide writer lock; this method never consumes on refusal.
-        """
+    def _verify(self, db, proof, target_key, operation, session_id, *, reserved=False):
+        if not isinstance(proof, PolicyMutationProof):
+            raise PolicyMutationDenied("operator confirmation proof required")
+        if not all(isinstance(value, str) and value for value in (
+            proof.token, proof.nonce, proof.policy_digest, proof.target_key,
+            proof.operation, proof.session_id, target_key, operation, session_id,
+        )):
+            raise PolicyMutationDenied("proof binding mismatch")
+        try:
+            token_hash = hashlib.sha256(proof.token.encode("utf-8")).hexdigest()
+        except UnicodeError as exc:
+            raise PolicyMutationDenied("proof binding mismatch") from exc
+        row = db.execute(
+            "SELECT token_hash,expires_at,consumed_at,policy_digest,target_key,operation,session_id,settled "
+            "FROM policy_mutation_proofs WHERE nonce=?", (proof.nonce,),
+        ).fetchone()
+        if (row is None or not _same_text(row[0], token_hash) or row[7] != 1
+                or ((row[2] is not None) != reserved)):
+            raise PolicyMutationDenied("proof replay or unknown nonce")
         now = time.time()
-        token_hash = hashlib.sha256(proof.token.encode()).hexdigest()
-        with self._lock, sqlite3.connect(self.db_path) as db:
-            row = db.execute(
-                "SELECT token_hash,expires_at,consumed_at,policy_digest,target_key,operation,session_id "
-                "FROM policy_mutation_proofs WHERE nonce=?",
-                (proof.nonce,),
-            ).fetchone()
-            if row is None or not hmac.compare_digest(str(row[0] or ""), token_hash) or row[2] is not None:
-                raise PolicyMutationDenied("proof replay or unknown nonce")
-            if row[1] <= now or proof.expires_at <= now:
-                raise PolicyMutationDenied("proof expired")
-            stored_digest, stored_key, stored_operation, stored_session = row[3:]
-            bindings = (
-                (proof.policy_digest, stored_digest), (proof.target_key, stored_key),
-                (proof.operation, stored_operation), (proof.session_id, stored_session),
-                (target_key, stored_key), (operation, stored_operation), (session_id, stored_session),
-            )
-            if not all(hmac.compare_digest(str(left), str(right)) for left, right in bindings):
-                raise PolicyMutationDenied("proof binding mismatch")
-            if not hmac.compare_digest(proof.policy_digest, self.policy_digest):
-                raise PolicyMutationDenied("policy digest mismatch")
-            updated = db.execute(
-                "UPDATE policy_mutation_proofs SET consumed_at=? WHERE nonce=? AND consumed_at IS NULL",
-                (now, proof.nonce),
-            ).rowcount
-            if updated != 1:
-                raise PolicyMutationDenied("proof replay or unknown nonce")
-            db.commit()
+        for expiry in (row[1], proof.expires_at):
+            if type(expiry) not in (int, float) or not math.isfinite(expiry):
+                raise PolicyMutationDenied("proof expired or invalid expiry")
+        if proof.expires_at != row[1]:
+            raise PolicyMutationDenied("proof binding mismatch")
+        if not math.isfinite(now) or not now < row[1] <= now + MAX_PROOF_TTL_SECONDS:
+            raise PolicyMutationDenied("proof expired or invalid expiry")
+        if not all(_same_text(a, b) for a, b in (
+            (proof.policy_digest, row[3]), (proof.target_key, row[4]),
+            (proof.operation, row[5]), (proof.session_id, row[6]),
+            (target_key, row[4]), (operation, row[5]), (session_id, row[6]),
+        )):
+            raise PolicyMutationDenied("proof binding mismatch")
+        if not _same_text(proof.policy_digest, self.policy_digest):
+            raise PolicyMutationDenied("policy digest mismatch")
+        return now
+
+    @staticmethod
+    def _spend(db, proof, now):
+        updated = db.execute(
+            "UPDATE policy_mutation_proofs SET consumed_at=? WHERE nonce=? AND consumed_at IS NULL",
+            (now, proof.nonce),
+        ).rowcount
+        if updated != 1:
+            raise PolicyMutationDenied("proof replay or unknown nonce")
+
+    def consume(self, proof: PolicyMutationProof, target_key: str, operation: str, session_id: str) -> bool:
+        """Spend authority once; this alone does not serialize a later file write."""
+        with self._transaction() as db:
+            self._spend(db, proof, self._verify(db, proof, target_key, operation, session_id))
         return True
 
     def consume_for_write(self, proof: PolicyMutationProof, target_key: str, operation: str,
-                          session_id: str, write) -> bool:
-        """Serialize consume, final digest verification, and the guarded write."""
-        with self._lock:
-            with sqlite3.connect(self.db_path) as db:
-                row = db.execute(
-                    "SELECT token_hash,expires_at,consumed_at,policy_digest,target_key,operation,session_id "
-                    "FROM policy_mutation_proofs WHERE nonce=?",
-                    (proof.nonce,),
-                ).fetchone()
-                if (
-                    row is None
-                    or not hmac.compare_digest(
-                        str(row[0] or ""), hashlib.sha256(proof.token.encode()).hexdigest()
-                    )
-                    or row[2] is not None
-                ):
-                    raise PolicyMutationDenied("proof replay or unknown nonce")
-                if row[1] <= time.time() or proof.expires_at <= time.time():
-                    raise PolicyMutationDenied("proof expired")
-                if not all(hmac.compare_digest(str(a), str(b)) for a, b in (
-                    (proof.policy_digest, row[3]), (proof.target_key, row[4]),
-                    (proof.operation, row[5]), (proof.session_id, row[6]),
-                    (target_key, row[4]), (operation, row[5]), (session_id, row[6]),
-                )):
-                    raise PolicyMutationDenied("proof binding mismatch")
-                if not hmac.compare_digest(proof.policy_digest, self.policy_digest):
-                    raise PolicyMutationDenied("policy digest mismatch")
-                write()
-                updated = db.execute(
-                    "UPDATE policy_mutation_proofs SET consumed_at=? WHERE nonce=? AND consumed_at IS NULL",
+                          session_id: str, write: Callable[[], Any]) -> bool:
+        """Spend before effect; serialize final CAS and a synchronous callback.
+
+        After reservation, failure requires a new operator decision, not a retry
+        of the old proof. A writer can have effects before raising; rolling back
+        its SQLite transaction must never resurrect the authority to repeat them.
+        """
+        if (not callable(write) or inspect.iscoroutinefunction(write)
+                or inspect.iscoroutinefunction(getattr(write, "__call__", None))):
+            raise TypeError("policy writer must be synchronous")
+        started = False
+        try:
+            with self._transaction() as db:
+                self._spend(db, proof, self._verify(db, proof, target_key, operation, session_id))
+                db.commit()  # Durable even if the process dies in the callback.
+                db.execute("BEGIN IMMEDIATE")
+                # Another writer can win between the two transactions; recheck
+                # under the reacquired reservation rather than using stale CAS.
+                self._verify(db, proof, target_key, operation, session_id, reserved=True)
+                started = True
+                result = write()
+                if inspect.isawaitable(result):
+                    if inspect.iscoroutine(result):
+                        result.close()
+                    raise TypeError("policy writer returned an awaitable")
+                db.execute(
+                    "UPDATE policy_mutation_proofs SET completed_at=? WHERE nonce=?",
                     (time.time(), proof.nonce),
-                ).rowcount
-                if updated != 1:
-                    raise PolicyMutationDenied("proof replay or unknown nonce")
-                db.commit()
+                )
+        except Exception as exc:
+            if started:
+                raise PolicyMutationIndeterminate(
+                    "policy write outcome indeterminate; proof spent; reconcile before a new approval"
+                ) from exc
+            raise
         return True
 
 
+def _policy_leaves(value: Any, prefix: str = "", ancestors: frozenset[int] = frozenset()) -> dict[str, Any]:
+    if prefix and not is_policy_config_key(prefix):
+        return {}
+    if not isinstance(value, dict) or not value:
+        return {prefix: value} if prefix else {}
+    if id(value) in ancestors or len(ancestors) >= 64:
+        raise PolicyMutationDenied("cyclic or excessively nested policy payload")
+    seen = ancestors | {id(value)}
+    leaves = {}
+    for key, child in value.items():
+        if not isinstance(key, str):
+            if prefix:
+                raise PolicyMutationDenied("policy payload keys must be strings")
+            continue
+        escaped = key.replace("\\", "\\\\").replace(".", "\\.")
+        dotted = f"{prefix}.{escaped}" if prefix else escaped
+        leaves.update(_policy_leaves(child, dotted, seen))
+    return leaves
+
 
 def _policy_payload_keys(value: Any, prefix: str = "") -> list[str]:
-    if not isinstance(value, dict):
-        return [prefix] if prefix else []
-    keys = []
-    for key, child in value.items():
-        dotted = f"{prefix}.{key}" if prefix else str(key)
-        keys.extend(_policy_payload_keys(child, dotted))
-    return keys
+    return list(_policy_leaves(value, prefix))
+
+
+def _same_value(left: Any, right: Any, depth: int = 0) -> bool:
+    if depth >= 64:
+        raise PolicyMutationDenied("cyclic or excessively nested policy payload")
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, dict):
+        return left.keys() == right.keys() and all(
+            _same_value(value, right[key], depth + 1) for key, value in left.items()
+        )
+    if isinstance(left, (list, tuple)):
+        return len(left) == len(right) and all(
+            _same_value(a, b, depth + 1) for a, b in zip(left, right)
+        )
+    return left == right
 
 
 def policy_changed_keys(before: Any, after: Any) -> list[str]:
-    """Return policy leaves whose effective values changed in a full-document save."""
-    paths = set(_policy_payload_keys(before)) | set(_policy_payload_keys(after))
-    changed = []
-    for key in paths:
-        if not is_policy_config_key(key):
-            continue
-        def get(node):
-            for part in key.split("."):
-                if not isinstance(node, dict) or part not in node:
-                    return object()
-                node = node[part]
-            return node
-        if get(before) != get(after):
-            changed.append(key)
-    return sorted(changed)
+    """Compare actual policy leaves, including empty maps and escaped key names."""
+    old, new = _policy_leaves(before), _policy_leaves(after)
+    return sorted(key for key in old.keys() | new.keys()
+                  if not _same_value(old.get(key, _MISSING), new.get(key, _MISSING)))
 
 
 def require_policy_proof_for_payload(config: Any, proof: Any = None, *, session_id: str = "local",
                                      before: Any = None, consume: bool = True) -> None:
-    """Guard the shared full-document writer without affecting ordinary saves."""
-    policy_keys = policy_changed_keys(before, config) if before is not None else [
-        key for key in _policy_payload_keys(config) if is_policy_config_key(key)
-    ]
+    """Guard a full-document payload; callers must supply the final write shape."""
+    policy_keys = policy_changed_keys(before, config) if before is not None else _policy_payload_keys(config)
     if not policy_keys:
         return
     if not isinstance(proof, PolicyMutationProof):
         raise PolicyMutationDenied("operator confirmation proof required")
     if len(policy_keys) != 1:
         raise PolicyMutationDenied("policy payload requires a single-key proof")
-    if proof.target_key != policy_keys[0]:
+    if not _same_text(proof.target_key, policy_keys[0]):
         raise PolicyMutationDenied("proof binding mismatch")
     if consume:
         require_policy_proof(policy_keys[0], "set", proof, session_id=session_id)

--- a/tests/gateway/test_approvals_command.py
+++ b/tests/gateway/test_approvals_command.py
@@ -37,6 +37,47 @@ def _runner():
 
 
 @pytest.mark.asyncio
+async def test_gateway_approval_request_waits_for_existing_operator_confirmation_surface():
+    runner = _runner()
+    runner.config = SimpleNamespace(
+        platforms={
+            Platform.TELEGRAM: SimpleNamespace(
+                extra={"allow_admin_from": ["user-1"], "user_allowed_commands": ["approvals"]}
+            )
+        }
+    )
+    runner._session_key_for_source = lambda _source: "session-1"
+    runner._adapter_for_source = lambda _source: None
+    runner._thread_metadata_for_source = lambda *_args: {}
+    runner._reply_anchor_for_event = lambda _event: None
+    runner._slash_confirm_counter = iter([1])
+
+    pending = SimpleNamespace(request_id="request-1", session_id="session-1")
+    proof = object()
+    broker = MagicMock()
+    broker.request.return_value = pending
+    broker.operator_confirm.return_value = proof
+    result = SimpleNamespace(message="Approval mode: off (persistent profile setting).")
+
+    with (
+        patch("hermes_cli.policy_mutation.PolicyMutationBroker", return_value=broker),
+        patch("hermes_cli.approval_mode.run_approval_mode_command", return_value=result) as run,
+    ):
+        prompt = await runner._handle_approvals_command(_event("/approvals off"))
+
+    assert "confirm" in prompt.lower()
+    broker.operator_confirm.assert_not_called()
+    run.assert_not_called()
+
+    from tools import slash_confirm
+    resolved = await slash_confirm.resolve("session-1", "1", "once")
+
+    assert resolved == result.message
+    broker.operator_confirm.assert_called_once_with("request-1")
+    run.assert_called_once_with("off", proof=proof, session_id="session-1")
+
+
+@pytest.mark.asyncio
 async def test_gateway_rejects_non_admin_persistent_approval_change():
     runner = _runner()
     runner.config = SimpleNamespace(

--- a/tests/hermes_cli/test_config_set_coercion.py
+++ b/tests/hermes_cli/test_config_set_coercion.py
@@ -75,6 +75,9 @@ class TestMalformedKey:
 class TestStringTypedGuardPreserved:
     def test_enum_off_stays_string(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-        cfg.set_config_value("approvals.mode", "off")
+        from hermes_cli.policy_mutation import PolicyMutationBroker
+        broker = PolicyMutationBroker()
+        request = broker.request("local", "approvals.mode", "set")
+        cfg.set_config_value("approvals.mode", "off", proof=broker.operator_confirm(request.request_id))
         v = _read(tmp_path, "approvals", "mode")
         assert v == "off" and isinstance(v, str)  # not bool False

--- a/tests/hermes_cli/test_config_set_coercion.py
+++ b/tests/hermes_cli/test_config_set_coercion.py
@@ -78,6 +78,9 @@ class TestStringTypedGuardPreserved:
         from hermes_cli.policy_mutation import PolicyMutationBroker
         broker = PolicyMutationBroker()
         request = broker.request("local", "approvals.mode", "set")
-        cfg.set_config_value("approvals.mode", "off", proof=broker.operator_confirm(request.request_id))
+        from hermes_cli.policy_mutation import _operator_settlement_scope
+        with _operator_settlement_scope():
+            proof = broker.operator_confirm(request.request_id)
+        cfg.set_config_value("approvals.mode", "off", proof=proof)
         v = _read(tmp_path, "approvals", "mode")
         assert v == "off" and isinstance(v, str)  # not bool False

--- a/tests/hermes_cli/test_config_set_coercion.py
+++ b/tests/hermes_cli/test_config_set_coercion.py
@@ -79,7 +79,9 @@ class TestStringTypedGuardPreserved:
         broker = PolicyMutationBroker()
         request = broker.request("local", "approvals.mode", "set")
         from hermes_cli.policy_mutation import _operator_settlement_scope
-        with _operator_settlement_scope():
+        confirmation_id = f"test-confirm-{request.request_id}"
+        broker.record_settlement(request.request_id, confirmation_id)
+        with _operator_settlement_scope(request.request_id, confirmation_id):
             proof = broker.operator_confirm(request.request_id)
         cfg.set_config_value("approvals.mode", "off", proof=proof)
         v = _read(tmp_path, "approvals", "mode")

--- a/tests/hermes_cli/test_config_set_list_values.py
+++ b/tests/hermes_cli/test_config_set_list_values.py
@@ -112,7 +112,10 @@ def test_string_typed_key_bracket_value_stays_string(user_home):
     even when the value looks like a list literal."""
     from hermes_cli.config import set_config_value, read_raw_config
 
-    set_config_value("approvals.mode", "[off]")
+    from hermes_cli.policy_mutation import PolicyMutationBroker
+    broker = PolicyMutationBroker()
+    request = broker.request("local", "approvals.mode", "set")
+    set_config_value("approvals.mode", "[off]", proof=broker.operator_confirm(request.request_id))
     raw = read_raw_config()
     assert raw["approvals"]["mode"] == "[off]"
     assert isinstance(raw["approvals"]["mode"], str)
@@ -122,7 +125,10 @@ def test_string_typed_key_negative_number_stays_string(user_home):
     """'-5' for a string-typed key must remain the string '-5'."""
     from hermes_cli.config import set_config_value, read_raw_config
 
-    set_config_value("approvals.mode", "-5")
+    from hermes_cli.policy_mutation import PolicyMutationBroker
+    broker = PolicyMutationBroker()
+    request = broker.request("local", "approvals.mode", "set")
+    set_config_value("approvals.mode", "-5", proof=broker.operator_confirm(request.request_id))
     raw = read_raw_config()
     assert raw["approvals"]["mode"] == "-5"
 

--- a/tests/hermes_cli/test_config_set_list_values.py
+++ b/tests/hermes_cli/test_config_set_list_values.py
@@ -115,7 +115,10 @@ def test_string_typed_key_bracket_value_stays_string(user_home):
     from hermes_cli.policy_mutation import PolicyMutationBroker
     broker = PolicyMutationBroker()
     request = broker.request("local", "approvals.mode", "set")
-    set_config_value("approvals.mode", "[off]", proof=broker.operator_confirm(request.request_id))
+    from hermes_cli.policy_mutation import _operator_settlement_scope
+    with _operator_settlement_scope():
+        proof = broker.operator_confirm(request.request_id)
+    set_config_value("approvals.mode", "[off]", proof=proof)
     raw = read_raw_config()
     assert raw["approvals"]["mode"] == "[off]"
     assert isinstance(raw["approvals"]["mode"], str)
@@ -128,7 +131,10 @@ def test_string_typed_key_negative_number_stays_string(user_home):
     from hermes_cli.policy_mutation import PolicyMutationBroker
     broker = PolicyMutationBroker()
     request = broker.request("local", "approvals.mode", "set")
-    set_config_value("approvals.mode", "-5", proof=broker.operator_confirm(request.request_id))
+    from hermes_cli.policy_mutation import _operator_settlement_scope
+    with _operator_settlement_scope():
+        proof = broker.operator_confirm(request.request_id)
+    set_config_value("approvals.mode", "-5", proof=proof)
     raw = read_raw_config()
     assert raw["approvals"]["mode"] == "-5"
 

--- a/tests/hermes_cli/test_config_set_list_values.py
+++ b/tests/hermes_cli/test_config_set_list_values.py
@@ -116,7 +116,9 @@ def test_string_typed_key_bracket_value_stays_string(user_home):
     broker = PolicyMutationBroker()
     request = broker.request("local", "approvals.mode", "set")
     from hermes_cli.policy_mutation import _operator_settlement_scope
-    with _operator_settlement_scope():
+    confirmation_id = f"test-confirm-{request.request_id}"
+    broker.record_settlement(request.request_id, confirmation_id)
+    with _operator_settlement_scope(request.request_id, confirmation_id):
         proof = broker.operator_confirm(request.request_id)
     set_config_value("approvals.mode", "[off]", proof=proof)
     raw = read_raw_config()
@@ -132,7 +134,9 @@ def test_string_typed_key_negative_number_stays_string(user_home):
     broker = PolicyMutationBroker()
     request = broker.request("local", "approvals.mode", "set")
     from hermes_cli.policy_mutation import _operator_settlement_scope
-    with _operator_settlement_scope():
+    confirmation_id = f"test-confirm-{request.request_id}"
+    broker.record_settlement(request.request_id, confirmation_id)
+    with _operator_settlement_scope(request.request_id, confirmation_id):
         proof = broker.operator_confirm(request.request_id)
     set_config_value("approvals.mode", "-5", proof=proof)
     raw = read_raw_config()

--- a/tests/hermes_cli/test_operator_principal_config_mutation.py
+++ b/tests/hermes_cli/test_operator_principal_config_mutation.py
@@ -63,14 +63,36 @@ def test_proof_is_bound_one_shot_and_expires(monkeypatch, tmp_path):
         broker.consume(proof, "security.tirith_enabled", "unset", "session-2")
 
 
-def test_policy_writer_refuses_without_proof_and_ordinary_key_stays_writable(monkeypatch, tmp_path):
+@pytest.mark.parametrize("operation", ["set", "unset"])
+def test_policy_writer_refuses_without_proof_byte_identical(monkeypatch, tmp_path, operation):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     path = tmp_path / "config.yaml"
-    path.write_text("approvals:\n  mode: manual\ndisplay:\n  skin: default\n", encoding="utf-8")
+    path.write_bytes(b"approvals:\n  mode: manual\ndisplay:\n  skin: default\n")
     before = path.read_bytes()
-    with pytest.raises(PolicyMutationDenied):
-        config.set_config_value("approvals.mode", "off")
+    writer = config.set_config_value if operation == "set" else config.unset_config_value
+    args = ("approvals.mode", "off") if operation == "set" else ("approvals.mode",)
+    with pytest.raises(PolicyMutationDenied) as exc_info:
+        writer(*args)
+    assert str(exc_info.value) == "operator confirmation proof required"
     assert path.read_bytes() == before
+
+
+def test_tui_raw_writer_refuses_policy_mutation_without_proof_byte_identical(monkeypatch, tmp_path):
+    monkeypatch.setattr("tui_gateway.server._hermes_home", tmp_path)
+    path = tmp_path / "config.yaml"
+    path.write_bytes(b"approvals:\n  mode: manual\n")
+    before = path.read_bytes()
+    from tui_gateway.server import _write_config_key
+    with pytest.raises(PolicyMutationDenied) as exc_info:
+        _write_config_key("approvals.mode", "off")
+    assert str(exc_info.value) == "operator confirmation proof required"
+    assert path.read_bytes() == before
+
+
+def test_ordinary_key_stays_writable(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = tmp_path / "config.yaml"
+    path.write_text("display:\n  skin: default\n", encoding="utf-8")
     config.set_config_value("display.skin", "dark")
     assert yaml.safe_load(path.read_text(encoding="utf-8"))["display"]["skin"] == "dark"
 

--- a/tests/hermes_cli/test_operator_principal_config_mutation.py
+++ b/tests/hermes_cli/test_operator_principal_config_mutation.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import os
 import subprocess
 import sys
@@ -37,7 +36,7 @@ def test_direct_operator_confirm_without_surface_settlement_is_denied(monkeypatc
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     broker = PolicyMutationBroker(ttl_seconds=60)
     request = broker.request("session-1", "approvals.mode", "set")
-    with pytest.raises(PolicyMutationDenied, match="operator settlement"):
+    with pytest.raises(PolicyMutationDenied, match="settlement"):
         broker.operator_confirm(request.request_id)
 
 
@@ -46,7 +45,8 @@ def test_proof_is_bound_one_shot_and_expires(monkeypatch, tmp_path):
     broker = PolicyMutationBroker(ttl_seconds=60)
     request = broker.request("session-1", "approvals.mode", "set")
     from hermes_cli.policy_mutation import _operator_settlement_scope
-    with _operator_settlement_scope():
+    broker.record_settlement(request.request_id, "test-confirm")
+    with _operator_settlement_scope(request.request_id, "test-confirm"):
         proof = broker.operator_confirm(request.request_id)
     assert proof.policy_digest == broker.policy_digest
     assert proof.target_key == "approvals.mode"
@@ -56,7 +56,8 @@ def test_proof_is_bound_one_shot_and_expires(monkeypatch, tmp_path):
         broker.consume(proof, "approvals.mode", "set", "session-1")
 
     request = broker.request("session-2", "security.tirith_enabled", "unset")
-    with _operator_settlement_scope():
+    broker.record_settlement(request.request_id, "test-confirm-2")
+    with _operator_settlement_scope(request.request_id, "test-confirm-2"):
         proof = broker.operator_confirm(request.request_id)
     monkeypatch.setattr(time, "time", lambda: proof.expires_at + 1)
     with pytest.raises(PolicyMutationDenied, match="expired"):
@@ -105,7 +106,8 @@ def test_operator_proof_allows_writer_then_cache_is_fresh(monkeypatch, tmp_path)
     broker = PolicyMutationBroker()
     request = broker.request("session-3", "approvals.mode", "set")
     from hermes_cli.policy_mutation import _operator_settlement_scope
-    with _operator_settlement_scope():
+    broker.record_settlement(request.request_id, "test-confirm")
+    with _operator_settlement_scope(request.request_id, "test-confirm"):
         proof = broker.operator_confirm(request.request_id)
     config.set_config_value("approvals.mode", "off", proof=proof, session_id="session-3")
     assert config.load_config_readonly()["approvals"]["mode"] == "off"
@@ -125,6 +127,84 @@ def test_subprocess_agent_attempt_cannot_mutate_policy_file(monkeypatch, tmp_pat
     )
     assert result.returncode != 0
     assert path.read_bytes() == before
-    print(f"SUBPROCESS_RC={result.returncode}")
-    print(f"SUBPROCESS_STDERR={result.stderr.strip()!r}")
-    print(f"POLICY_SHA256={hashlib.sha256(path.read_bytes()).hexdigest()}")
+
+
+def _mint(broker, request, confirmation_id="test-confirm"):
+    from hermes_cli.policy_mutation import _operator_settlement_scope
+    broker.record_settlement(request.request_id, confirmation_id)
+    with _operator_settlement_scope(request.request_id, confirmation_id):
+        return broker.operator_confirm(request.request_id)
+
+
+def test_cross_key_and_session_replay_is_refused_without_consuming(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    broker = PolicyMutationBroker()
+    request = broker.request("s1", "approvals.mode", "set")
+    proof = _mint(broker, request)
+    with pytest.raises(PolicyMutationDenied, match="binding") as exc_info:
+        broker.consume(proof, "security.tirith_enabled", "set", "s2")
+    assert str(exc_info.value) == "proof binding mismatch"
+    assert broker.consume(proof, "approvals.mode", "set", "s1")
+
+
+def test_save_config_refuses_policy_payload_without_proof_byte_identical(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = tmp_path / "config.yaml"
+    path.write_bytes(b"approvals:\n  mode: manual\ndisplay:\n  skin: default\n")
+    before = path.read_bytes()
+    with pytest.raises(PolicyMutationDenied) as exc_info:
+        config.save_config({"approvals": {"mode": "off"}, "display": {"skin": "default"}})
+    print(str(exc_info.value))
+    assert str(exc_info.value) == "operator confirmation proof required"
+    assert path.read_bytes() == before
+
+
+def test_policy_consume_is_exactly_once_under_concurrency(monkeypatch, tmp_path):
+    import concurrent.futures
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    broker = PolicyMutationBroker()
+    request = broker.request("s1", "approvals.mode", "set")
+    proof = _mint(broker, request)
+
+    def consume():
+        try:
+            return broker.consume(proof, "approvals.mode", "set", "s1")
+        except PolicyMutationDenied as exc:
+            return str(exc)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
+        results = list(pool.map(lambda _n: consume(), range(16)))
+    assert results.count(True) == 1
+    assert sum(isinstance(result, str) and "replay" in result for result in results) == 15
+
+
+def test_policy_write_fails_closed_when_state_db_is_absent(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = tmp_path / "config.yaml"
+    path.write_bytes(b"approvals:\n  mode: manual\n")
+    before = path.read_bytes()
+    (tmp_path / "state.db").write_bytes(b"not sqlite")
+    with pytest.raises(PolicyMutationDenied, match="ledger") as exc_info:
+        config.save_config({"approvals": {"mode": "off"}})
+    assert str(exc_info.value) == "policy ledger unavailable"
+    assert path.read_bytes() == before
+
+
+def test_save_config_fails_closed_when_state_db_is_missing(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = tmp_path / "config.yaml"
+    path.write_bytes(b"approvals:\n  mode: manual\n")
+    before = path.read_bytes()
+    with pytest.raises(PolicyMutationDenied):
+        config.save_config({"approvals": {"mode": "off"}})
+    assert path.read_bytes() == before
+
+
+def test_operator_confirm_requires_recorded_settlement_receipt(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    broker = PolicyMutationBroker()
+    request = broker.request("s1", "approvals.mode", "set")
+    from hermes_cli.policy_mutation import _operator_settlement_scope
+    with _operator_settlement_scope():
+        with pytest.raises(PolicyMutationDenied, match="receipt"):
+            broker.operator_confirm(request.request_id)

--- a/tests/hermes_cli/test_operator_principal_config_mutation.py
+++ b/tests/hermes_cli/test_operator_principal_config_mutation.py
@@ -33,11 +33,21 @@ def test_shared_policy_classification_covers_policy_key_families():
     assert not is_policy_config_key("agent.max_turns")
 
 
+def test_direct_operator_confirm_without_surface_settlement_is_denied(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    broker = PolicyMutationBroker(ttl_seconds=60)
+    request = broker.request("session-1", "approvals.mode", "set")
+    with pytest.raises(PolicyMutationDenied, match="operator settlement"):
+        broker.operator_confirm(request.request_id)
+
+
 def test_proof_is_bound_one_shot_and_expires(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     broker = PolicyMutationBroker(ttl_seconds=60)
     request = broker.request("session-1", "approvals.mode", "set")
-    proof = broker.operator_confirm(request.request_id)
+    from hermes_cli.policy_mutation import _operator_settlement_scope
+    with _operator_settlement_scope():
+        proof = broker.operator_confirm(request.request_id)
     assert proof.policy_digest == broker.policy_digest
     assert proof.target_key == "approvals.mode"
     assert proof.operation == "set"
@@ -46,7 +56,8 @@ def test_proof_is_bound_one_shot_and_expires(monkeypatch, tmp_path):
         broker.consume(proof, "approvals.mode", "set", "session-1")
 
     request = broker.request("session-2", "security.tirith_enabled", "unset")
-    proof = broker.operator_confirm(request.request_id)
+    with _operator_settlement_scope():
+        proof = broker.operator_confirm(request.request_id)
     monkeypatch.setattr(time, "time", lambda: proof.expires_at + 1)
     with pytest.raises(PolicyMutationDenied, match="expired"):
         broker.consume(proof, "security.tirith_enabled", "unset", "session-2")

--- a/tests/hermes_cli/test_operator_principal_config_mutation.py
+++ b/tests/hermes_cli/test_operator_principal_config_mutation.py
@@ -1,0 +1,95 @@
+"""TDD contract tests for operator-principal policy config mutations."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hermes_cli import config
+from hermes_cli.policy_mutation import (
+    POLICY_CONFIG_KEYS,
+    PolicyMutationBroker,
+    PolicyMutationDenied,
+    is_policy_config_key,
+)
+
+
+def test_shared_policy_classification_covers_policy_key_families():
+    assert is_policy_config_key("approvals.mode")
+    assert is_policy_config_key("security.tirith_enabled")
+    assert is_policy_config_key("command_allowlist")
+    assert is_policy_config_key("command_allowlist.commands")
+    assert is_policy_config_key("yolo")
+    assert is_policy_config_key("persistent.yolo")
+    assert "approvals." in POLICY_CONFIG_KEYS
+    assert not is_policy_config_key("display.skin")
+    assert not is_policy_config_key("agent.max_turns")
+
+
+def test_proof_is_bound_one_shot_and_expires(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    broker = PolicyMutationBroker(ttl_seconds=60)
+    request = broker.request("session-1", "approvals.mode", "set")
+    proof = broker.operator_confirm(request.request_id)
+    assert proof.policy_digest == broker.policy_digest
+    assert proof.target_key == "approvals.mode"
+    assert proof.operation == "set"
+    assert broker.consume(proof, "approvals.mode", "set", "session-1")
+    with pytest.raises(PolicyMutationDenied, match="replay"):
+        broker.consume(proof, "approvals.mode", "set", "session-1")
+
+    request = broker.request("session-2", "security.tirith_enabled", "unset")
+    proof = broker.operator_confirm(request.request_id)
+    monkeypatch.setattr(time, "time", lambda: proof.expires_at + 1)
+    with pytest.raises(PolicyMutationDenied, match="expired"):
+        broker.consume(proof, "security.tirith_enabled", "unset", "session-2")
+
+
+def test_policy_writer_refuses_without_proof_and_ordinary_key_stays_writable(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = tmp_path / "config.yaml"
+    path.write_text("approvals:\n  mode: manual\ndisplay:\n  skin: default\n", encoding="utf-8")
+    before = path.read_bytes()
+    with pytest.raises(PolicyMutationDenied):
+        config.set_config_value("approvals.mode", "off")
+    assert path.read_bytes() == before
+    config.set_config_value("display.skin", "dark")
+    assert yaml.safe_load(path.read_text(encoding="utf-8"))["display"]["skin"] == "dark"
+
+
+def test_operator_proof_allows_writer_then_cache_is_fresh(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = tmp_path / "config.yaml"
+    path.write_text("approvals:\n  mode: manual\n", encoding="utf-8")
+    assert config.load_config_readonly()["approvals"]["mode"] == "manual"
+    broker = PolicyMutationBroker()
+    request = broker.request("session-3", "approvals.mode", "set")
+    proof = broker.operator_confirm(request.request_id)
+    config.set_config_value("approvals.mode", "off", proof=proof, session_id="session-3")
+    assert config.load_config_readonly()["approvals"]["mode"] == "off"
+
+
+def test_subprocess_agent_attempt_cannot_mutate_policy_file(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = tmp_path / "config.yaml"
+    path.write_text("approvals:\n  mode: manual\nsecurity:\n  tirith_enabled: true\n", encoding="utf-8")
+    before = path.read_bytes()
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(Path(__file__).parents[2])
+    env["HERMES_HOME"] = str(tmp_path)
+    result = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "config", "set", "approvals.mode", "off"],
+        env=env, capture_output=True, text=True, check=False,
+    )
+    assert result.returncode != 0
+    assert path.read_bytes() == before
+    print(f"SUBPROCESS_RC={result.returncode}")
+    print(f"SUBPROCESS_STDERR={result.stderr.strip()!r}")
+    print(f"POLICY_SHA256={hashlib.sha256(path.read_bytes()).hexdigest()}")

--- a/tests/hermes_cli/test_operator_principal_config_mutation.py
+++ b/tests/hermes_cli/test_operator_principal_config_mutation.py
@@ -154,7 +154,6 @@ def test_save_config_refuses_policy_payload_without_proof_byte_identical(monkeyp
     before = path.read_bytes()
     with pytest.raises(PolicyMutationDenied) as exc_info:
         config.save_config({"approvals": {"mode": "off"}, "display": {"skin": "default"}})
-    print(str(exc_info.value))
     assert str(exc_info.value) == "operator confirmation proof required"
     assert path.read_bytes() == before
 

--- a/tests/hermes_cli/test_operator_principal_config_mutation.py
+++ b/tests/hermes_cli/test_operator_principal_config_mutation.py
@@ -158,6 +158,39 @@ def test_save_config_refuses_policy_payload_without_proof_byte_identical(monkeyp
     assert path.read_bytes() == before
 
 
+def test_forged_proof_refusal_output(monkeypatch, tmp_path):
+    """A proof-shaped payload cannot bypass the ledger-backed save_config sink."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = tmp_path / "config.yaml"
+    path.write_bytes(b"approvals:\n  mode: manual\n")
+    before = path.read_bytes()
+    from hermes_cli.policy_mutation import PolicyMutationProof, policy_config_digest
+    forged = PolicyMutationProof(
+        token="forged-token", policy_digest=policy_config_digest(path),
+        target_key="approvals.mode", operation="set", session_id="session-1",
+        nonce="nonexistent-nonce", expires_at=time.time() + 60,
+    )
+    with pytest.raises(PolicyMutationDenied) as exc_info:
+        config.save_config({"approvals": {"mode": "off"}}, proof=forged, session_id="session-1")
+    assert str(exc_info.value) == "proof replay or unknown nonce"
+    assert path.read_bytes() == before
+
+
+def test_replay_refusal_output(monkeypatch, tmp_path):
+    """The bulk save sink consumes a real proof and refuses reusing it."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = tmp_path / "config.yaml"
+    path.write_bytes(b"approvals:\n  mode: manual\n")
+    broker = PolicyMutationBroker()
+    proof = _mint(broker, broker.request("session-1", "approvals.mode", "set"))
+    config.save_config({"approvals": {"mode": "off"}}, proof=proof, session_id="session-1")
+    before = path.read_bytes()
+    with pytest.raises(PolicyMutationDenied) as exc_info:
+        config.save_config({"approvals": {"mode": "manual"}}, proof=proof, session_id="session-1")
+    assert str(exc_info.value) == "proof replay or unknown nonce"
+    assert path.read_bytes() == before
+
+
 def test_policy_consume_is_exactly_once_under_concurrency(monkeypatch, tmp_path):
     import concurrent.futures
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -189,13 +222,70 @@ def test_policy_write_fails_closed_when_state_db_is_absent(monkeypatch, tmp_path
     assert path.read_bytes() == before
 
 
-def test_save_config_fails_closed_when_state_db_is_missing(monkeypatch, tmp_path):
+def test_save_config_fails_closed_when_policy_ledger_is_unavailable(monkeypatch, tmp_path):
+    """A state.db path that cannot be opened is ledger unavailability, not absence."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = tmp_path / "config.yaml"
+    path.write_bytes(b"approvals:\n  mode: manual\n")
+    before = path.read_bytes()
+    (tmp_path / "state.db").mkdir()
+    with pytest.raises(PolicyMutationDenied, match="ledger") as exc_info:
+        config.save_config({"approvals": {"mode": "off"}})
+    assert str(exc_info.value) == "policy ledger unavailable"
+    assert path.read_bytes() == before
+
+
+def test_config_env_route_refuses_policy_payload_without_proof_byte_identical(monkeypatch, tmp_path):
+    """PUT /api/config uses the shared save_config sink; approvals.mode without proof is refused."""
+    import asyncio
+    from hermes_cli.web_models import ConfigUpdate
+    from hermes_cli.web_routers.config_env import update_config
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = tmp_path / "config.yaml"
+    path.write_bytes(b"approvals:\n  mode: manual\n")
+    before = path.read_bytes()
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(update_config(ConfigUpdate(config={"approvals": {"mode": "off"}})))
+    assert exc_info.value.status_code == 500
+    assert path.read_bytes() == before
+
+
+def test_analytics_raw_route_refuses_policy_payload_without_proof_byte_identical(monkeypatch, tmp_path):
+    """PUT /api/config/raw uses the shared save_config sink; policy YAML without proof is refused."""
+    import asyncio
+    from hermes_cli.web_models import RawConfigUpdate
+    from hermes_cli.web_routers.analytics import update_config_raw
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     path = tmp_path / "config.yaml"
     path.write_bytes(b"approvals:\n  mode: manual\n")
     before = path.read_bytes()
     with pytest.raises(PolicyMutationDenied):
-        config.save_config({"approvals": {"mode": "off"}})
+        asyncio.run(update_config_raw(RawConfigUpdate(yaml_text="approvals:\n  mode: off\n")))
+    assert path.read_bytes() == before
+
+
+def test_save_permanent_allowlist_refuses_policy_mutation_without_proof_byte_identical(monkeypatch, tmp_path):
+    """save_permanent_allowlist reaches save_config with command_allowlist and no proof."""
+    import tools.approval as approval
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = tmp_path / "config.yaml"
+    path.write_bytes(b"command_allowlist: []\n")
+    before = path.read_bytes()
+    approval.save_permanent_allowlist({"git status"})
+    assert path.read_bytes() == before
+
+
+def test_save_config_value_refuses_policy_mutation_without_proof_byte_identical(monkeypatch, tmp_path):
+    """cli.save_config_value reaches its policy sink and refuses approvals.mode without proof."""
+    from cli import save_config_value
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    path = tmp_path / "config.yaml"
+    path.write_bytes(b"approvals:\n  mode: manual\n")
+    before = path.read_bytes()
+    with pytest.raises(PolicyMutationDenied) as exc_info:
+        save_config_value("approvals.mode", "off")
+    assert str(exc_info.value) == "operator confirmation proof required"
     assert path.read_bytes() == before
 
 

--- a/tests/hermes_cli/test_operator_principal_config_mutation.py
+++ b/tests/hermes_cli/test_operator_principal_config_mutation.py
@@ -82,7 +82,9 @@ def test_operator_proof_allows_writer_then_cache_is_fresh(monkeypatch, tmp_path)
     assert config.load_config_readonly()["approvals"]["mode"] == "manual"
     broker = PolicyMutationBroker()
     request = broker.request("session-3", "approvals.mode", "set")
-    proof = broker.operator_confirm(request.request_id)
+    from hermes_cli.policy_mutation import _operator_settlement_scope
+    with _operator_settlement_scope():
+        proof = broker.operator_confirm(request.request_id)
     config.set_config_value("approvals.mode", "off", proof=proof, session_id="session-3")
     assert config.load_config_readonly()["approvals"]["mode"] == "off"
 

--- a/tests/hermes_cli/test_policy_mutation_transactions.py
+++ b/tests/hermes_cli/test_policy_mutation_transactions.py
@@ -1,0 +1,352 @@
+"""Policy broker regressions with real SQLite, files, and crash boundaries."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict, replace
+
+import pytest
+
+from hermes_cli import policy_mutation as policy
+
+
+def _mint(broker, key="approvals.mode", session="s1", operation="set"):
+    request = broker.request(session, key, operation)
+    confirmation = f"confirm-{request.request_id}"
+    broker.record_settlement(request.request_id, confirmation)
+    with policy._operator_settlement_scope(request.request_id, confirmation):
+        return broker.operator_confirm(request.request_id)
+
+
+@pytest.fixture
+def broker(tmp_path):
+    (tmp_path / "config.yaml").write_bytes(b"approvals:\n  mode: manual\n")
+    return policy.PolicyMutationBroker(db_path=tmp_path / "state.db")
+
+
+def _consumed(broker, proof):
+    with sqlite3.connect(broker.db_path) as db:
+        return db.execute(
+            "SELECT consumed_at FROM policy_mutation_proofs WHERE nonce=?", (proof.nonce,)
+        ).fetchone()[0]
+
+
+@pytest.mark.parametrize("key", [
+    "approvals", "approvals.mode", "security", "security.tirith_enabled",
+    "command_allowlist", "command_allowlist.commands", "yolo", "yolo.enabled",
+    "persistent", "persistent.yolo", "persistent.yolo.enabled",
+])
+def test_policy_ancestors_and_descendants_are_guarded(key):
+    assert policy.is_policy_config_key(key)
+    with pytest.raises(policy.PolicyMutationDenied, match="proof required"):
+        policy.require_policy_proof(key, "unset")
+
+
+@pytest.mark.parametrize("key", [
+    "display.skin", "agent.max_turns", "approvals_extra", "security_notes",
+    "persistent.theme", "display.approvals", r"approvals\.mode", "yolov8",
+])
+def test_unrelated_keys_remain_unguarded(key):
+    assert not policy.is_policy_config_key(key)
+    policy.require_policy_proof(key, "set")
+
+
+@pytest.mark.parametrize(("before", "after", "expected"), [
+    ({}, {"security": {}}, ["security"]),
+    ({"security": {}}, {}, ["security"]),
+    ({"approvals": {"mode": False}}, {"approvals": {"mode": 0}}, ["approvals.mode"]),
+    ({"approvals": {"rule.name": "same"}}, {"approvals": {"rule.name": "same"}}, []),
+    ({"approvals": {"rule.name": "old"}}, {"approvals": {"rule.name": "new"}},
+     [r"approvals.rule\.name"]),
+    ({"approvals": {"rule\\name": True}}, {"approvals": {"rule\\name": False}},
+     [r"approvals.rule\\name"]),
+    ({"approvals": {"mode": "manual"}}, {"approvals": {"mode": "manual"}}, []),
+    ({"persistent": {"theme": "old"}}, {"persistent": {"theme": "new"}}, []),
+    ({"security": {"enabled": True}}, {"security": None}, ["security", "security.enabled"]),
+])
+def test_payload_diff_preserves_structure_and_scalar_types(before, after, expected):
+    assert policy.policy_changed_keys(before, after) == expected
+
+
+def test_unreadable_policy_is_not_an_empty_policy(tmp_path):
+    path = tmp_path / "config.yaml"
+    path.mkdir()
+    with pytest.raises(policy.PolicyMutationDenied, match="policy.*unavailable"):
+        policy.policy_config_digest(path)
+
+
+def test_missing_policy_file_remains_a_valid_initial_state(tmp_path):
+    import hashlib
+    assert policy.policy_config_digest(tmp_path / "absent.yaml") == hashlib.sha256(b"").hexdigest()
+
+
+def test_policy_read_failure_refuses_before_effect(broker, tmp_path):
+    proof = _mint(broker)
+    (tmp_path / "config.yaml").unlink()
+    (tmp_path / "config.yaml").mkdir()
+    effects = []
+    with pytest.raises(policy.PolicyMutationDenied, match="policy.*unavailable"):
+        broker.consume_for_write(proof, "approvals.mode", "set", "s1", lambda: effects.append(True))
+    assert effects == []
+    assert _consumed(broker, proof) is None
+
+
+def test_ledger_failure_after_initialization_is_a_refusal(broker):
+    proof = _mint(broker)
+    broker.db_path.write_bytes(b"not a database")
+    effects = []
+    with pytest.raises(policy.PolicyMutationDenied, match="ledger unavailable"):
+        broker.consume_for_write(proof, "approvals.mode", "set", "s1", lambda: effects.append(True))
+    assert effects == []
+
+
+def test_stale_policy_refuses_before_effect_and_preserves_newer_bytes(broker, tmp_path):
+    proof = _mint(broker)
+    path = tmp_path / "config.yaml"
+    newer = b"approvals:\n  mode: smart\n"
+    path.write_bytes(newer)
+    with pytest.raises(policy.PolicyMutationDenied, match="digest mismatch"):
+        broker.consume_for_write(proof, "approvals.mode", "set", "s1", lambda: path.write_bytes(b"wrong"))
+    assert path.read_bytes() == newer
+    assert _consumed(broker, proof) is None
+
+
+@pytest.mark.parametrize("field", ["target_key", "operation", "session_id"])
+def test_wrong_binding_does_not_spend_proof(broker, field):
+    proof = _mint(broker)
+    bad = replace(proof, **{field: "wrong"})
+    with pytest.raises(policy.PolicyMutationDenied, match="binding mismatch"):
+        broker.consume(bad, "approvals.mode", "set", "s1")
+    assert _consumed(broker, proof) is None
+    assert broker.consume(proof, "approvals.mode", "set", "s1")
+
+
+@pytest.mark.parametrize("expiry", [float("nan"), float("inf"), "not a time", None])
+def test_malformed_proof_expiry_cannot_reach_writer(broker, expiry):
+    proof = _mint(broker)
+    effects = []
+    with pytest.raises(policy.PolicyMutationDenied):
+        broker.consume_for_write(replace(proof, expires_at=expiry), "approvals.mode", "set", "s1",
+                                 lambda: effects.append(True))
+    assert effects == []
+    assert _consumed(broker, proof) is None
+
+
+def test_expiry_is_bound_to_ledger_not_just_in_the_future(broker):
+    proof = _mint(broker)
+    with pytest.raises(policy.PolicyMutationDenied, match="binding mismatch"):
+        broker.consume(replace(proof, expires_at=proof.expires_at + 1), "approvals.mode", "set", "s1")
+    assert _consumed(broker, proof) is None
+
+
+def test_unicode_session_binding_keeps_its_identity(broker):
+    proof = _mint(broker, session="session-\u03c0")
+    assert broker.consume(proof, "approvals.mode", "set", "session-\u03c0")
+
+
+def test_settlement_must_match_the_recorded_request_and_confirmation(broker):
+    request = broker.request("s1", "approvals.mode", "set")
+    with policy._operator_settlement_scope(request.request_id, "unrecorded"):
+        with pytest.raises(policy.PolicyMutationDenied, match="receipt"):
+            broker.operator_confirm(request.request_id)
+    broker.record_settlement(request.request_id, "correct")
+    with policy._operator_settlement_scope(request.request_id, "wrong"):
+        with pytest.raises(policy.PolicyMutationDenied, match="receipt"):
+            broker.operator_confirm(request.request_id)
+    with policy._operator_settlement_scope(request.request_id, "correct"):
+        proof = broker.operator_confirm(request.request_id)
+    assert broker.consume(proof, "approvals.mode", "set", "s1")
+
+
+def test_context_restored_after_settlement(broker):
+    request = broker.request("s1", "approvals.mode", "set")
+    broker.record_settlement(request.request_id, "correct")
+    with policy._operator_settlement_scope(request.request_id, "correct"):
+        pass
+    with pytest.raises(policy.PolicyMutationDenied, match="receipt"):
+        broker.operator_confirm(request.request_id)
+
+
+def test_expired_proof_has_no_effect(broker, monkeypatch):
+    proof = _mint(broker)
+    monkeypatch.setattr(policy.time, "time", lambda: proof.expires_at + 1)
+    effects = []
+    with pytest.raises(policy.PolicyMutationDenied, match="expired"):
+        broker.consume_for_write(proof, "approvals.mode", "set", "s1", lambda: effects.append(True))
+    assert effects == []
+    assert _consumed(broker, proof) is None
+
+
+def test_independent_brokers_reserve_before_either_callback_can_duplicate(broker, tmp_path):
+    proof = _mint(broker)
+    other = policy.PolicyMutationBroker(db_path=broker.db_path)
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    second_started = threading.Event()
+    second_entered = threading.Event()
+
+    def write_first():
+        first_entered.set()
+        if not release_first.wait(5):
+            raise TimeoutError("test did not release first writer")
+        (tmp_path / "effect-first").write_bytes(b"one")
+
+    def write_second():
+        second_entered.set()
+        (tmp_path / "effect-second").write_bytes(b"two")
+
+    def run(owner, write, started=None):
+        if started is not None:
+            started.set()
+        try:
+            return owner.consume_for_write(proof, "approvals.mode", "set", "s1", write)
+        except policy.PolicyMutationDenied:
+            return False
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(run, broker, write_first)
+        try:
+            assert first_entered.wait(5)
+            second = pool.submit(run, other, write_second, second_started)
+            assert second_started.wait(5)
+            second_entered.wait(0.5)
+        finally:
+            release_first.set()
+        results = [first.result(timeout=5), second.result(timeout=5)]
+    assert results.count(True) == 1
+    assert len(list(tmp_path.glob("effect-*"))) == 1
+    assert not second_entered.is_set()
+
+
+def test_callback_exception_after_effect_never_reopens_proof(broker, tmp_path):
+    proof = _mint(broker)
+    effect = tmp_path / "effect"
+
+    def write_then_fail():
+        effect.write_bytes(b"already happened")
+        raise OSError("writer failed after an effect")
+
+    with pytest.raises(RuntimeError, match="indeterminate"):
+        broker.consume_for_write(proof, "approvals.mode", "set", "s1", write_then_fail)
+    assert effect.read_bytes() == b"already happened"
+    assert _consumed(broker, proof) is not None
+    with pytest.raises(policy.PolicyMutationDenied, match="replay"):
+        broker.consume_for_write(proof, "approvals.mode", "set", "s1", lambda: effect.write_bytes(b"replayed"))
+    assert effect.read_bytes() == b"already happened"
+
+
+def test_process_death_after_effect_never_reopens_proof(broker, tmp_path):
+    proof = _mint(broker)
+    effect = tmp_path / "crash-effect"
+    code = """
+import json, os, sys
+from pathlib import Path
+from hermes_cli.policy_mutation import PolicyMutationBroker, PolicyMutationProof
+broker = PolicyMutationBroker(db_path=Path(sys.argv[1]))
+proof = PolicyMutationProof(**json.load(sys.stdin))
+def write():
+    Path(sys.argv[2]).write_bytes(b'already happened')
+    os._exit(23)
+broker.consume_for_write(proof, 'approvals.mode', 'set', 's1', write)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code, str(broker.db_path), str(effect)],
+        input=json.dumps(asdict(proof)), capture_output=True, text=True, timeout=15,
+        env=dict(os.environ), check=False,
+    )
+    assert result.returncode == 23, result.stderr
+    assert effect.read_bytes() == b"already happened"
+    restarted = policy.PolicyMutationBroker(db_path=broker.db_path)
+    with pytest.raises(policy.PolicyMutationDenied, match="replay"):
+        restarted.consume_for_write(proof, "approvals.mode", "set", "s1",
+                                    lambda: effect.write_bytes(b"replayed"))
+    assert effect.read_bytes() == b"already happened"
+
+
+def test_consumption_is_durable_before_callback(broker):
+    proof = _mint(broker)
+    observations = []
+    assert broker.consume_for_write(proof, "approvals.mode", "set", "s1",
+                                    lambda: observations.append(_consumed(broker, proof)))
+    assert len(observations) == 1
+    assert observations[0] is not None
+
+
+def test_async_writer_is_not_reported_as_a_successful_write(broker):
+    proof = _mint(broker)
+
+    async def write():
+        raise AssertionError("async callback must not run")
+
+    with pytest.raises(TypeError, match="synchronous"):
+        broker.consume_for_write(proof, "approvals.mode", "set", "s1", write)
+    assert _consumed(broker, proof) is None
+
+
+def test_symlinked_ledger_does_not_retarget_the_policy_file(tmp_path):
+    storage = tmp_path / "storage"
+    storage.mkdir()
+    (storage / "config.yaml").write_bytes(b"approvals:\n  mode: off\n")
+    target = policy.PolicyMutationBroker(db_path=storage / "state.db")
+    home = tmp_path / "home"
+    home.mkdir()
+    config_path = home / "config.yaml"
+    config_path.write_bytes(b"approvals:\n  mode: manual\n")
+    try:
+        (home / "state.db").symlink_to(target.db_path)
+    except (OSError, NotImplementedError):
+        pytest.skip("platform does not permit test symlinks")
+    owner = policy.PolicyMutationBroker(db_path=home / "state.db")
+    assert owner.policy_digest == policy.policy_config_digest(config_path)
+    assert owner.policy_digest != target.policy_digest
+
+
+def test_schema_upgrade_preserves_old_proofs_and_does_not_invent_success(tmp_path):
+    import hashlib
+    import time
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_bytes(b"approvals:\n  mode: manual\n")
+    db_path = tmp_path / "state.db"
+    token = "historical-test-token"
+    now = time.time()
+    proof = policy.PolicyMutationProof(
+        token=token, policy_digest=policy.policy_config_digest(config_path),
+        target_key="approvals.mode", operation="set", session_id="s1",
+        nonce="old-ready", expires_at=now + 30,
+    )
+    with sqlite3.connect(db_path) as db:
+        db.execute("""CREATE TABLE policy_mutation_proofs (
+            nonce TEXT PRIMARY KEY, request_id TEXT NOT NULL,
+            session_id TEXT NOT NULL, target_key TEXT NOT NULL,
+            operation TEXT NOT NULL, policy_digest TEXT NOT NULL,
+            token_hash TEXT, expires_at REAL NOT NULL DEFAULT 0,
+            consumed_at REAL, settled INTEGER NOT NULL DEFAULT 0,
+            confirmation_id TEXT
+        )""")
+        for nonce, consumed_at in ((proof.nonce, None), ("old-spent", now)):
+            db.execute(
+                "INSERT INTO policy_mutation_proofs VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                (nonce, f"request-{nonce}", proof.session_id, proof.target_key,
+                 proof.operation, proof.policy_digest, hashlib.sha256(token.encode()).hexdigest(),
+                 proof.expires_at, consumed_at, 1, f"confirm-{nonce}"),
+            )
+    owner = policy.PolicyMutationBroker(db_path=db_path)
+    effect = tmp_path / "effect"
+    assert owner.consume_for_write(proof, "approvals.mode", "set", "s1",
+                                   lambda: effect.write_bytes(b"applied"))
+    with sqlite3.connect(db_path) as db:
+        records = dict(db.execute("SELECT nonce, completed_at FROM policy_mutation_proofs"))
+        historical_consumed = db.execute(
+            "SELECT consumed_at FROM policy_mutation_proofs WHERE nonce='old-spent'"
+        ).fetchone()[0]
+    assert effect.read_bytes() == b"applied"
+    assert records[proof.nonce] is not None
+    assert records["old-spent"] is None
+    assert historical_consumed == now

--- a/tools/slash_confirm.py
+++ b/tools/slash_confirm.py
@@ -82,7 +82,9 @@ async def resolve(session_key: str, confirm_id: str, choice: str,
     if not handler:
         return None
     try:
-        result = await handler(choice)
+        from hermes_cli.policy_mutation import _operator_settlement_scope
+        with _operator_settlement_scope():
+            result = await handler(choice)
     except Exception as exc:
         logger.error("Slash-confirm handler for /%s raised: %s", command, exc, exc_info=True)
         return f"❌ Error handling confirmation: {exc}"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1674,8 +1674,10 @@ def _append_model_switch_marker(session: dict | None, *, model: str, provider: s
         logger.debug("failed to persist model switch marker", exc_info=True)
 
 
-def _write_config_key(key_path: str, value):
-    # Write-back round-trip: raw read is mandatory — saving the overlaid/expanded view would persist it.
+def _write_config_key(key_path: str, value, *, proof=None, session_id: str = "local"):
+    from hermes_cli.policy_mutation import require_policy_proof
+    require_policy_proof(key_path, "set", proof, session_id=session_id)
+    # Write-back round-trip: raw read is mandatory — saving the overlaid/expanded view would persist.
     cfg = current = _load_cfg_raw()
     *parents, leaf = key_path.split(".")
     for key in parents:


### PR DESCRIPTION
## What does this PR do?

Adds operator-settled policy-mutation receipts to the existing guarded configuration writers and hardens their one-shot lifecycle against replay, concurrent broker instances, malformed bindings, and interrupted writes.

**This is in-process enforcement, not a non-forgeable operator principal.** A proof binds the policy-file digest, target key, operation, session, nonce, and expiry. It does not bind the replacement value. Arbitrary Python execution or direct write access to `state.db` is inside the current trust boundary. This PR references #59293; it does **not** establish the independently protected operator boundary required to close it.

The latest repair is [`14ea00b6afb480f33b50bb29cf4c00b6afc6e81f`](https://github.com/NousResearch/hermes-agent/commit/14ea00b6afb480f33b50bb29cf4c00b6afc6e81f). It preserves the seven original commits and adds one implementation/test commit. No contributor history was rewritten.

## Related Issue

Refs #59293.

- **Origin and reproduction:** Enough1122, #81108. Enough1122 also identified the three missing-settlement fixture failures in [this comment](https://github.com/NousResearch/hermes-agent/pull/109080#issuecomment-5648525272); the repair records the actual receipt rather than bypassing settlement enforcement.
- **Writer-boundary coverage design:** DavidMetcalfe, #104697. Its writer and test changes overlap this PR. These are alternative implementations requiring explicit reconciliation, not independently additive fixes; this PR does not declare that work superseded or close it.
- **Complementary architecture:** #95101 owns policy admission/ABI work, not the write transaction implemented here.
- **Adjacent config work:** #104109 overlaps `hermes_cli/config.py` in the overall PR, but not the four files changed by the latest repair.

## Type of Change

- [x] 🐛 Bug fix
- [x] 🔒 Security fix
- [x] ✅ Tests

## Changes Made

### Latest four-file repair

| File | Change |
| --- | --- |
| `hermes_cli/policy_mutation.py` | SQLite writer reservation before authority reads; durable proof spending before callbacks; final digest revalidation; explicit indeterminate write outcome; structural policy classification and payload comparison; strict receipt, text, and expiry validation; compatible ledger migration. |
| `tests/hermes_cli/test_policy_mutation_transactions.py` | 52 regression cases using real SQLite, temporary files, independent broker instances, and a subprocess terminated after a filesystem effect. |
| `tests/hermes_cli/test_config_set_coercion.py` | Record and bind the confirmation receipt in the `approvals.mode` coercion test; preserve its original assertion. |
| `tests/hermes_cli/test_config_set_list_values.py` | Repair both missing receipt setups without weakening proof enforcement or changing string-coercion assertions. |

Protected classification now includes whole-section replacements and destructive ancestors such as `approvals`, `security`, and `persistent`; unrelated keys such as `persistent.theme` remain ordinary. Payload comparison retains escaped key structure, empty mappings, and scalar-type distinctions instead of treating `False` and `0` as identical. Unreadable configuration is refused rather than hashed as an empty file. A symlinked ledger does not change which profile's configuration is hashed.

### Reservation and recovery contract

`consume_for_write()` first verifies and durably spends the proof. It then reacquires SQLite's cross-process writer reservation, revalidates the bindings and current file digest, and invokes a synchronous writer. Another participating writer can win the interval between transactions; the second verification prevents using that stale authorization.

A callback can change a file before raising or before the process dies. **Such a proof stays spent.** A raised callback produces `PolicyMutationIndeterminate`; it must not be automatically retried with the same proof. `completed_at` records a callback return, not a verified filesystem postcondition. Historical rows are preserved without inventing completion receipts.

This is single-attempt authority, not an atomic transaction spanning SQLite and YAML and not a claim of exactly-once filesystem effects.

### Existing integration retained

The original integration remains in `hermes_cli/config.py`, root `cli.py`, `hermes_cli/approval_mode.py`, `gateway/slash_commands.py`, `gateway/run_busy.py`, `tools/slash_confirm.py`, and `tui_gateway/server.py`, with the original operator-principal and gateway tests retained. The latest repair does not claim that every one of those routes has been integration-tested or made transactional.

## How to Test

### Executed evidence for the published repair

| Check | Result and scope |
| --- | --- |
| Same new regression suite against the exact original broker from `4a729ff030db05ef62c6746688f0e93c684de980` | **27 failed, 25 passed**. |
| New regression suite against the published broker/test blobs | **52 passed**; repeated after publication, **52 passed in 1.07s**. |
| Python compilation | All four files compiled successfully. |
| `git diff --check` | Passed for the four-file repair. |
| GitHub readback | Published file blob hashes match the locally exercised files. |

These are **producer-run broker tests in an isolated source harness**, not an independent review or a full repository run. The harness used an unused home-resolution import seam that raises if called; every broker test supplied an explicit database path. SQLite, filesystem operations, concurrent callbacks, and the crash subprocess were real. The full CLI/gateway/web integration suites and the three repaired coercion tests were **not executed** in this environment. Ruff was not available and is not reported as passing.

For full-checkout integration verification, run the following with a fresh test directory; this command is a required follow-up, **not an executed receipt**:

```bash
python -m pytest \
  tests/hermes_cli/test_policy_mutation_transactions.py \
  tests/hermes_cli/test_operator_principal_config_mutation.py \
  tests/hermes_cli/test_config_set_coercion.py \
  tests/hermes_cli/test_config_set_list_values.py \
  tests/gateway/test_approvals_command.py \
  -q --basetemp="$(mktemp -d)"
```

Then exercise successful and denied writes through the real CLI, gateway, TUI, and web routes. Run `scripts/check-windows-footguns.py`, repository lint, and `scripts/run_tests.sh`, the Contributing Guide's preferred hermetic full-suite runner. None of those unexecuted checks is represented by the isolated broker result.

### Exact-head CI and current-main state

For head `14ea00b6afb480f33b50bb29cf4c00b6afc6e81f`, all three hosted workflows currently report **`action_required`**, not success:

- [CI — run 34728270173](https://github.com/NousResearch/hermes-agent/actions/runs/34728270173); the jobs query returned no jobs.
- [Docker — run 34728269921](https://github.com/NousResearch/hermes-agent/actions/runs/34728269921).
- [Nix — run 34728269904](https://github.com/NousResearch/hermes-agent/actions/runs/34728269904).

Live main was verified at `de2d6a1b93508463c31434c1ae067e204af81238`. GitHub generated a clean test merge, `3c6c2c7d810f3a78966055c819afeba0040368d9`, with that main commit and the repair head as its parents. The broker and new test blobs are unchanged in that merge. **The source branch has not incorporated that main commit, and clean textual merging is not runtime verification.**

The earlier body's full-coverage, independent-verification, Ruff, and green-test claims are not carried forward as evidence for this head. Exact-head CI and every-commit green status remain unestablished.

## Remaining Closure Requirements

1. Existing per-key callers of `consume()` still perform their writes afterward; they need final payload/digest validation and the effect under the same owning write boundary. They do not inherit `consume_for_write()` serialization merely by spending a proof.
2. Full-document guards must authorize the final effective payload after merging/coercion, and approval must bind the actual replacement value. The current request/proof API does not provide value binding.
3. Operator identity and settlement need an independently protected authority boundary. In-process receipts and a writable ledger cannot provide that property against arbitrary code in the governed process. Nonparticipating file writers and external filesystem races remain outside this broker's serialization.
4. Complete product-route integration, current-main incorporation, lint, and hosted verification before treating this as ready to land. The latest four files are below 2,000 lines; inherited large writer modules have not been extracted by this repair.

## Checklist

### Code

- [x] I've read the current Contributing Guide at `de2d6a1b93508463c31434c1ae067e204af81238`.
- [x] The repair commit uses a scoped Conventional Commit message.
- [x] Related open PR file lists were checked before the repair; overlap and attribution are documented above.
- [x] The repair contains only related implementation and regression-test changes.
- [ ] I've run `pytest tests/ -q` / `scripts/run_tests.sh` and all tests pass.
- [x] Regression tests were added and exercised with pre-fix/post-fix evidence.
- [x] Broker behavior was tested on Linux / Python 3.13.5; this is not a packaged-platform verification claim.
- [ ] Exact-head CI and every original/current PR commit are verified green.

### Documentation & Housekeeping

- [x] Broker docstrings and the PR description state the real authority and recovery boundaries.
- [x] No configuration keys, tool schemas, or example configuration were added by the repair.
- [x] Existing contributor commits and origin/design credit are preserved.
- [x] No changes to `AGENTS.md` or `CONTRIBUTING.md` were made.
- [ ] Windows/macOS execution and integration remain to be verified; the symlink regression skips only when the platform cannot create its test symlink.

## Screenshots / Logs

```text
Exact original broker + new 52-case suite: 27 failed, 25 passed
Published repair + same suite:            52 passed in 1.07s
Four-file compilation:                   passed
Four-file whitespace check:              passed
Hosted CI / Docker / Nix:                action_required
```
