### PR TITLE
Fix desktop runtime plugin load by preventing DCE of installPluginSdk

### DIFF
--- a/apps/desktop/src/sdk/runtime.ts
+++ b/apps/desktop/src/sdk/runtime.ts
@@ -35,7 +35,13 @@ function pluginNamespaces() {
 type PluginGlobalKey = keyof ReturnType<typeof pluginNamespaces>
 
 export function installPluginSdk(): void {
-  Object.assign(globalThis, pluginNamespaces())
+  const namespaces = pluginNamespaces()
+  for (const [key, value] of Object.entries(namespaces)) {
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      get() { return value }
+    })
+  }
 }
 
 /** Build a shim ESM blob that re-exports a global namespace's live members.


### PR DESCRIPTION
Fixes #107336, fixes #107352, fixes #107721. Uses \Object.defineProperty\ to prevent vite/rolldown from dead-code eliminating the global SDK installation.