### PR TITLE
fix(cron): don't wait on the fire fence to renew a live fire claim

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -353,10 +353,16 @@ def _under_fire_fence(job_id: str, fn: Callable[[], Any]) -> Any:
 
 @contextlib.contextmanager
 def fire_claim_fence(job_id: str, *, expected_owner: str):
-    """Hold a per-job fence while an owner performs an external side effect."""
+    """Hold a per-job fence while an owner performs an external side effect.
+
+    Yields ``True`` while *expected_owner* still holds the claim, ``False`` when a
+    verified different owner holds it, and ``None`` when the fence could not be
+    acquired — ownership is *unverified*, not lost. Callers must fail closed on
+    ``None`` without recording an ownership loss.
+    """
     with _fire_job_lock(job_id) as acquired:
         if not acquired:
-            yield False
+            yield None
             return
         with _jobs_lock():
             job = next((item for item in load_jobs() if item.get("id") == job_id), None)
@@ -2599,12 +2605,20 @@ def claim_job_for_fire(
 
 
 def heartbeat_fire_claim(job_id: str, *, expected_owner: str) -> bool:
-    """Refresh an active ``fire_claim`` without extending another owner's lease: an execution may
-    outlive the TTL, and the owner check stops a stale runner from refreshing a recovered claim."""
+    """Refresh an active ``fire_claim`` without extending another owner's lease.
+
+    Uses ``_with_job`` (the global jobs-store lock) rather than ``_under_fire_fence``.
+    The per-job fire fence is held across long side effects (delivery, teardown) by
+    the worker thread; the heartbeat runs on a background thread and must not wait
+    on that fence. A fence-wait timeout here was reported as ownership loss on runs
+    that had already finished and delivered.
+
+    ``False`` is only a verified loss (claim gone, or a replacement owner holds it).
+    """
     def apply(jobs, _i, job):
         return _refresh_claim(jobs, job.get("fire_claim"), expected_owner)
 
-    return _under_fire_fence(job_id, lambda: _with_job(job_id, apply, False))
+    return _with_job(job_id, apply, False)
 
 
 # Completed one-shots are retained in jobs.json (final status stays inspectable) and pruned by

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -290,17 +290,23 @@ def _jobs_lock():
 
 
 @contextlib.contextmanager
-def _fire_job_lock(job_id: str):
+def _fire_job_lock(job_id: str, timeout: Optional[float] = None):
     """Serialize one job's owner mutations and external side effects. Unlike the global jobs lock
     this may be held across network delivery; scoped to one profile + job so unrelated jobs keep
-    progressing. Fails closed when cross-process locking is unavailable."""
+    progressing. Fails closed when cross-process locking is unavailable.
+
+    ``timeout`` defaults to ``_JOBS_LOCK_TIMEOUT_SECONDS``. Pass ``0`` for a non-blocking try
+    (heartbeat): wait neither on a live delivery nor on a takeover.
+    """
+    wait = _JOBS_LOCK_TIMEOUT_SECONDS if timeout is None else timeout
     cron_dir = _current_cron_store().cron_dir
     lock_key = f"{cron_dir.resolve()}::{job_id}"
     with _fire_fence_locks_guard:
         local_lock = _fire_fence_locks.setdefault(lock_key, threading.RLock())
 
-    if not local_lock.acquire(timeout=_JOBS_LOCK_TIMEOUT_SECONDS):
-        logger.error("Timed out waiting for local fire fence %s; failing closed", lock_key)
+    if not local_lock.acquire(timeout=wait):
+        log = logger.debug if wait == 0 else logger.error
+        log("Timed out waiting for local fire fence %s; failing closed", lock_key)
         yield False
         return
 
@@ -320,11 +326,12 @@ def _fire_job_lock(job_id: str):
         try:
             lock_fd = open(lock_path, "a+", encoding="utf-8")
             lock_fd.seek(0)
-            result = _acquire_flock(lock_fd, _JOBS_LOCK_TIMEOUT_SECONDS)
+            result = _acquire_flock(lock_fd, wait)
             if result is None:  # pragma: no cover - supported platforms provide one backend
                 logger.error("No cross-process lock backend for cron fire fence")
             elif not result:
-                logger.error("Timed out waiting for fire fence %s; failing closed", lock_path)
+                log = logger.debug if wait == 0 else logger.error
+                log("Timed out waiting for fire fence %s; failing closed", lock_path)
             acquired = bool(result)
         except (OSError, IOError) as exc:
             logger.error("Cron fire fence unavailable for %s: %s", job_id, exc)
@@ -2304,14 +2311,17 @@ def mark_job_run(
     status: Optional[str] = None,
     *,
     expected_fire_owner: Optional[str] = None,
-) -> bool:
+) -> Optional[bool]:
     """Mark a job as run: update last_run_at/last_status, bump completed, recompute next_run_at,
     and retire the record as a terminal completion when the repeat limit is reached.
 
     ``delivery_error`` is separate from the agent error: agent succeeded but delivery failed records
     ``last_status = "delivery_failed"`` (never "ok") while ``failure_streak`` is left alone. An
-    explicit ``status`` (e.g. "blocked_config") overrides the derived value. False when the fence
-    can't be taken, the job is missing, or ``expected_fire_owner`` no longer holds the fire claim.
+    explicit ``status`` (e.g. "blocked_config") overrides the derived value.
+
+    Returns ``True`` when the outcome was persisted, ``False`` when the job is missing or
+    ``expected_fire_owner`` no longer holds the claim (verified loss), and ``None`` when the
+    fire fence could not be acquired (indeterminate — not an owner mismatch).
     """
     def apply(jobs, _i, job):
         if expected_fire_owner is not None:
@@ -2334,7 +2344,11 @@ def mark_job_run(
             return False
         return found
 
-    return _under_fire_fence(job_id, locked)
+    with _fire_job_lock(job_id) as acquired:
+        if not acquired:
+            logger.debug("mark_job_run: fire fence busy for %s; outcome not persisted", job_id)
+            return None
+        return locked()
 
 
 def _write_oneshot_diagnostic(job: Dict[str, Any], text: str, what: str) -> bool:
@@ -2604,21 +2618,25 @@ def claim_job_for_fire(
     return _under_fire_fence(job_id, lambda: _with_job(job_id, apply, False))
 
 
-def heartbeat_fire_claim(job_id: str, *, expected_owner: str) -> bool:
+def heartbeat_fire_claim(job_id: str, *, expected_owner: str) -> Optional[bool]:
     """Refresh an active ``fire_claim`` without extending another owner's lease.
 
-    Uses ``_with_job`` (the global jobs-store lock) rather than ``_under_fire_fence``.
-    The per-job fire fence is held across long side effects (delivery, teardown) by
-    the worker thread; the heartbeat runs on a background thread and must not wait
-    on that fence. A fence-wait timeout here was reported as ownership loss on runs
-    that had already finished and delivered.
-
-    ``False`` is only a verified loss (claim gone, or a replacement owner holds it).
+    Tries the per-job fire fence without waiting (timeout 0): a live delivery or a
+    takeover holds that fence, and blocking on it for 30s was reported as ownership
+    loss on runs that had already finished and delivered. ``None`` means the fence
+    was busy — no write, ownership unverified. ``False`` is only a verified loss
+    (claim gone, or a replacement owner holds it). A successful refresh still holds
+    the fence so it cannot clobber a concurrent takeover.
     """
     def apply(jobs, _i, job):
         return _refresh_claim(jobs, job.get("fire_claim"), expected_owner)
 
-    return _with_job(job_id, apply, False)
+    with _fire_job_lock(job_id, timeout=0.0) as acquired:
+        if not acquired:
+            logger.debug(
+                "Job '%s': fire fence busy; fire_claim ownership unverified", job_id)
+            return None
+        return _with_job(job_id, apply, False)
 
 
 # Completed one-shots are retained in jobs.json (final status stays inspectable) and pruned by

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2381,7 +2381,7 @@ def _run_with_fire_claim_heartbeat(job: dict, run) -> bool:
         last_confirmed = time.monotonic()
         while not stop.wait(_RUN_CLAIM_HEARTBEAT_SECONDS):
             try:
-                if not heartbeat_fire_claim(job_id, expected_owner=owner):
+                if heartbeat_fire_claim(job_id, expected_owner=owner) is False:
                     lost_ownership.set()
                     logger.warning(
                         "Job '%s': fire claim ownership lost; interrupting stale run",
@@ -2499,7 +2499,7 @@ def _record_fire_ownership_lost(job_id: str, fire_owner: Optional[str], executio
     """Bookkeeping after fire-claim ownership loss. A transport-level cancel (dashboard drain) is
     not a real loss — we still own the claim, so record the interruption via the owner-fenced
     terminal write instead of leaving fire_claim/last_status stale; otherwise discard."""
-    if fire_owner is not None and heartbeat_fire_claim(job_id, expected_owner=fire_owner):
+    if fire_owner is not None and heartbeat_fire_claim(job_id, expected_owner=fire_owner) is True:
         mark_job_run(job_id, False, _OWNERSHIP_LOST_INTERRUPTED, expected_fire_owner=fire_owner)
         finish_execution(execution_id, success=False, error=_OWNERSHIP_LOST_INTERRUPTED)
     else:
@@ -2569,6 +2569,22 @@ class _FireClaimLostDuringSideEffect(Exception):
     """Raised inside a side-effect fence when the durable fire claim is no longer ours."""
 
 
+class _FireFenceBusyDuringSideEffect(Exception):
+    """Raised inside a side-effect fence when the fence itself could not be acquired.
+
+    Ownership is *unverified* here, not lost: another holder of this job's fence
+    (typically its in-flight save/delivery) kept us out. The side effect is still
+    skipped — never perform one on an unverified claim — but the run must not be
+    recorded as an ownership loss or shutdown interruption.
+    """
+
+
+_FIRE_FENCE_BUSY_FAILURE = (
+    "Fire fence busy: save/delivery skipped without performing side effects "
+    "(fire claim ownership could not be verified)."
+)
+
+
 class _FireOwnership:
     """Fire-claim ownership checks for one run (``owner`` is None when the job carries no claim)."""
 
@@ -2589,11 +2605,13 @@ class _FireOwnership:
         if self.owner is None:
             return False
         try:
-            if heartbeat_fire_claim(self.job["id"], expected_owner=self.owner):
-                return False
+            renewed = heartbeat_fire_claim(self.job["id"], expected_owner=self.owner)
         except Exception:
             logger.debug(
                 "Job '%s': fire_claim ownership validation failed", self.job["id"], exc_info=True)
+            return False
+        if renewed is not False:
+            # True, or any non-False (heartbeat does not wait on the fire fence).
             return False
         if self.fire_claim_lost is not None:
             self.fire_claim_lost.set()
@@ -2624,6 +2642,8 @@ def _save_compose_deliver(
     fence; a lost claim raises ``_FireClaimLostDuringSideEffect`` for the caller)."""
     job = d.job
     with fence.side_effect_fence() as owns_output:
+        if owns_output is None:
+            raise _FireFenceBusyDuringSideEffect
         if not owns_output:
             raise _FireClaimLostDuringSideEffect
         output_file = save_job_output(job["id"], output)
@@ -2667,6 +2687,8 @@ def _save_compose_deliver(
     )
     try:
         with fence.side_effect_fence() as owns_delivery:
+            if owns_delivery is None:
+                raise _FireFenceBusyDuringSideEffect
             if not owns_delivery:
                 raise _FireClaimLostDuringSideEffect
             d.delivery_attempted = True
@@ -2895,6 +2917,10 @@ def _run_one_job_body(
                 execution_token=execution_token)
         except _FireClaimLostDuringSideEffect:
             d.side_effect_ownership_lost = True
+        except _FireFenceBusyDuringSideEffect:
+            d.success = False
+            d.error = _FIRE_FENCE_BUSY_FAILURE
+            logger.warning("Job '%s': %s", job["id"], _FIRE_FENCE_BUSY_FAILURE)
         finally:
             delivery_attempted, delivery_error = d.delivery_attempted, d.delivery_error
             # Every path must tear down deferred agent(s) so they never leak subprocesses/clients.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2377,30 +2377,41 @@ def _run_with_fire_claim_heartbeat(job: dict, run) -> bool:
         _finish_unstarted("Fire claim ownership lost before execution started.")
         return True
 
+    if owns_fire_claim is None:
+        logger.warning(
+            "Job '%s': fire claim could not be confirmed before execution (fire fence busy)",
+            job_id)
+        _finish_unstarted("Fire claim ownership could not be validated before execution started.")
+        return True
+
     def _heartbeat_loop() -> None:
         last_confirmed = time.monotonic()
         while not stop.wait(_RUN_CLAIM_HEARTBEAT_SECONDS):
             try:
-                if heartbeat_fire_claim(job_id, expected_owner=owner) is False:
-                    lost_ownership.set()
-                    logger.warning(
-                        "Job '%s': fire claim ownership lost; interrupting stale run",
-                        job_id)
-                    return
-                last_confirmed = time.monotonic()
+                renewed = heartbeat_fire_claim(job_id, expected_owner=owner)
             except Exception:
                 logger.debug("Job '%s': fire_claim heartbeat failed", job_id, exc_info=True)
-                if (
-                    time.monotonic() - last_confirmed
-                    >= _FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS
-                ):
-                    lost_ownership.set()
-                    logger.warning(
-                        "Job '%s': fire_claim could not be renewed within %.1fs; "
-                        "interrupting uncertain run",
-                        job_id,
-                        _FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS)
-                    return
+                renewed = None
+            if renewed is True:
+                last_confirmed = time.monotonic()
+                continue
+            if renewed is False:
+                lost_ownership.set()
+                logger.warning(
+                    "Job '%s': fire claim ownership lost; interrupting stale run",
+                    job_id)
+                return
+            if (
+                time.monotonic() - last_confirmed
+                >= _FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS
+            ):
+                lost_ownership.set()
+                logger.warning(
+                    "Job '%s': fire_claim could not be renewed within %.1fs "
+                    "(fire fence busy); interrupting uncertain run",
+                    job_id,
+                    _FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS)
+                return
 
     heartbeat_thread = _start_heartbeat_thread(
         _heartbeat_loop, "cron-fire-claim-heartbeat",
@@ -2702,7 +2713,7 @@ def _save_compose_deliver(
                 for_failure=not d.success,
             )
     except Exception as de:
-        if isinstance(de, _FireClaimLostDuringSideEffect):
+        if isinstance(de, (_FireClaimLostDuringSideEffect, _FireFenceBusyDuringSideEffect)):
             raise
         d.delivery_error = str(de)
         logger.error("Delivery failed for job %s: %s", job["id"], de)
@@ -2743,11 +2754,23 @@ def _finish_completed_run(d: _RunDelivery, fire_owner: Optional[str], execution_
     if d.blocked_config:
         mark_kwargs["status"] = "blocked_config"
     marked = mark_job_run(job["id"], d.success, d.error, **mark_kwargs)
-    if fire_owner is not None and not marked:
+    if fire_owner is not None and marked is False:
         finish_execution(
             execution_id, success=False,
             error="Fire claim ownership lost before terminal completion.")
         return True
+    if marked is None:
+        from cron.jobs import update_job
+        try:
+            update_job(job["id"], {
+                "last_status": mark_kwargs.get("status") or (
+                    "error" if not d.success else "ok"),
+                "last_error": None if d.success else d.error,
+            })
+        except Exception:
+            logger.debug(
+                "Job '%s': could not persist last_status after fire-fence contention",
+                job["id"], exc_info=True)
     delivery_outcome = _classify_delivery_outcome(
         delivery_error=d.delivery_error,
         delivery_queued=job.get("last_delivery_queued"),

--- a/tests/cron/test_fire_claim_heartbeat_fence.py
+++ b/tests/cron/test_fire_claim_heartbeat_fence.py
@@ -1,0 +1,198 @@
+"""Fire-claim heartbeat must not treat a busy per-job fire fence as ownership loss.
+
+The fence is held across delivery (a Telegram send with retries can run 30–60s).
+The heartbeat runs on a background thread. Before this fix it acquired that same
+fence, timed out at 30s (_JOBS_LOCK_TIMEOUT_SECONDS), and returned False — which
+the heartbeat loop treated as a verified takeover and interrupted a run that had
+already finished and delivered.
+
+These tests fail on unpatched main: the first returns False (or blocks ~30s) while
+the fence is held; the second stamps a successful slow delivery as interrupted.
+"""
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def temp_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    yield tmp_path
+
+
+def test_heartbeat_succeeds_immediately_while_fire_fence_held(temp_home):
+    """Root cause: heartbeat must refresh the claim without waiting on the fire fence."""
+    from cron.jobs import (
+        claim_job_for_fire,
+        create_job,
+        fire_claim_fence,
+        get_job,
+        heartbeat_fire_claim,
+    )
+
+    job = create_job(prompt="x", schedule="every 5m", name="heartbeat-fence")
+    job_id = job["id"]
+    assert claim_job_for_fire(job_id) is True
+    claimed = get_job(job_id)
+    assert claimed is not None
+    owner = claimed["fire_claim"]["by"]
+
+    fence_entered = threading.Event()
+    release = threading.Event()
+    result = {}
+
+    def _hold():
+        with fire_claim_fence(job_id, expected_owner=owner) as owns:
+            assert owns is True
+            fence_entered.set()
+            release.wait(timeout=10)
+
+    holder = threading.Thread(target=_hold, daemon=True)
+    holder.start()
+    assert fence_entered.wait(timeout=5)
+
+    start = time.monotonic()
+    result["ok"] = heartbeat_fire_claim(job_id, expected_owner=owner)
+    result["waited"] = time.monotonic() - start
+    release.set()
+    holder.join(timeout=5)
+
+    assert result["ok"] is True, "heartbeat treated a busy fence as ownership loss"
+    assert result["waited"] < 2.0, f"heartbeat blocked on the fire fence ({result['waited']:.2f}s)"
+    assert heartbeat_fire_claim(job_id, expected_owner="other-owner") is False
+
+
+def _claimed_job(tmp_path, name):
+    import cron.jobs as jobs
+
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    with jobs.use_cron_store(profile_home):
+        job = jobs.create_job(prompt="x", schedule="every 5m", name=name)
+        assert jobs.claim_job_for_fire(job["id"]) is True
+        claimed = jobs.get_job(job["id"])
+    assert isinstance(claimed, dict)
+    return jobs, profile_home, claimed
+
+
+def _patch_run_scaffold(monkeypatch, scheduler, *, run_job):
+    monkeypatch.setattr(scheduler, "claim_dispatch", lambda *_a, **_kw: True)
+    monkeypatch.setattr(scheduler, "mark_execution_running", lambda *_a, **_kw: {})
+    monkeypatch.setattr(scheduler, "_launch_external_cron_worker", lambda *_a, **_kw: False)
+    monkeypatch.setattr(scheduler, "run_job", run_job)
+
+
+def test_slow_delivery_holding_fence_is_not_recorded_as_ownership_loss(tmp_path, monkeypatch):
+    """A delivery that outlives the fence wait must still be recorded successful."""
+    import cron.scheduler as scheduler
+
+    jobs, profile_home, claimed = _claimed_job(tmp_path, "slow-delivery")
+
+    monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 0.02)
+    monkeypatch.setattr(scheduler, "_FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS", 30.0)
+
+    delivered = threading.Event()
+    body_saw_loss: list[bool] = []
+
+    def _slow_delivery(*_args, **_kwargs):
+        delivered.set()
+        time.sleep(0.5)
+        return None
+
+    real_body = scheduler._run_one_job_body
+
+    def _observed_body(job, **kwargs):
+        result = real_body(job, **kwargs)
+        lost = kwargs.get("fire_claim_lost")
+        body_saw_loss.append(bool(lost is not None and lost.is_set()))
+        return result
+
+    _patch_run_scaffold(
+        monkeypatch, scheduler,
+        run_job=lambda *_a, **_kw: (True, "output", "response", None))
+    monkeypatch.setattr(scheduler, "_run_one_job_body", _observed_body)
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_a: "output.md")
+    monkeypatch.setattr(scheduler, "_deliver_result", _slow_delivery)
+    mark_run = MagicMock(return_value=True)
+    monkeypatch.setattr(scheduler, "mark_job_run", mark_run)
+    monkeypatch.setattr(scheduler, "finish_execution", MagicMock())
+
+    with jobs.use_cron_store(profile_home), \
+         patch("agent.secret_scope.set_secret_scope", return_value=None), \
+         patch("agent.secret_scope.build_profile_secret_scope", return_value=None), \
+         patch("agent.secret_scope.reset_secret_scope"):
+        assert scheduler.run_one_job(claimed) is True
+
+    assert delivered.is_set(), "delivery never ran"
+    assert body_saw_loss == [False], "a fire fence timeout was treated as ownership loss"
+    args, _kwargs = mark_run.call_args
+    assert args[1] is True, "the run was not recorded as successful"
+    assert args[2] is None, f"run was stamped with an error: {args[2]!r}"
+
+
+def test_fence_held_elsewhere_skips_side_effects_without_ownership_lost_stamp(
+    tmp_path, monkeypatch,
+):
+    """Side effect that cannot acquire the fence is skipped; not an ownership loss."""
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    with jobs.use_cron_store(profile_home):
+        job = jobs.create_job(prompt="x", schedule="every 5m", name="fence-busy")
+        assert jobs.claim_job_for_fire(job["id"]) is True
+        claimed = jobs.get_job(job["id"])
+        assert isinstance(claimed, dict)
+        owner = claimed["fire_claim"]["by"]
+
+        monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.05)
+        monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 60.0)
+
+        holder_ready = threading.Event()
+        release_holder = threading.Event()
+
+        def _hold_fence() -> None:
+            with jobs.use_cron_store(profile_home):
+                with jobs.fire_claim_fence(job["id"], expected_owner=owner) as owns:
+                    assert owns is True, "the holder must own the fence for this test"
+                    holder_ready.set()
+                    release_holder.wait(timeout=10)
+
+        holder = threading.Thread(target=_hold_fence, daemon=True, name="fence-holder")
+
+        def _start_holder_then_finish(*_a, **_kw):
+            holder.start()
+            assert holder_ready.wait(timeout=5)
+            return True, "output", "response", None
+
+        save_output = MagicMock(return_value="output.md")
+        deliver = MagicMock(return_value=None)
+        mark_run = MagicMock(return_value=True)
+        finish = MagicMock()
+        _patch_run_scaffold(monkeypatch, scheduler, run_job=_start_holder_then_finish)
+        monkeypatch.setattr(scheduler, "save_job_output", save_output)
+        monkeypatch.setattr(scheduler, "_deliver_result", deliver)
+        monkeypatch.setattr(scheduler, "mark_job_run", mark_run)
+        monkeypatch.setattr(scheduler, "finish_execution", finish)
+
+        try:
+            with patch("agent.secret_scope.set_secret_scope", return_value=None), \
+                 patch("agent.secret_scope.build_profile_secret_scope", return_value=None), \
+                 patch("agent.secret_scope.reset_secret_scope"):
+                assert scheduler.run_one_job(claimed) is True
+        finally:
+            release_holder.set()
+            holder.join(timeout=5)
+
+    save_output.assert_not_called()
+    deliver.assert_not_called()
+    finish.assert_called_once()
+    _args, fkwargs = finish.call_args
+    error_text = str(fkwargs.get("error") or "")
+    assert "fence" in error_text.lower(), f"honest cause not recorded: {error_text!r}"
+    interrupted = "Interrupted by shutdown" in error_text
+    assert not interrupted, f"busy fence stamped as shutdown interrupt: {error_text!r}"

--- a/tests/cron/test_fire_claim_heartbeat_fence.py
+++ b/tests/cron/test_fire_claim_heartbeat_fence.py
@@ -1,14 +1,10 @@
 """Fire-claim heartbeat must not treat a busy per-job fire fence as ownership loss.
 
-The fence is held across delivery (a Telegram send with retries can run 30–60s).
-The heartbeat runs on a background thread. Before this fix it acquired that same
-fence, timed out at 30s (_JOBS_LOCK_TIMEOUT_SECONDS), and returned False — which
-the heartbeat loop treated as a verified takeover and interrupted a run that had
-already finished and delivered.
-
-These tests fail on unpatched main: the first returns False (or blocks ~30s) while
-the fence is held; the second stamps a successful slow delivery as interrupted.
+The fence is held across delivery. Heartbeat tries it with timeout 0: busy returns
+None (no write) instead of blocking 30s and returning False. False remains verified
+takeover only.
 """
+import contextlib
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -22,8 +18,8 @@ def temp_home(tmp_path, monkeypatch):
     yield tmp_path
 
 
-def test_heartbeat_succeeds_immediately_while_fire_fence_held(temp_home):
-    """Root cause: heartbeat must refresh the claim without waiting on the fire fence."""
+def test_heartbeat_is_unverified_not_loss_while_fire_fence_held(temp_home):
+    """Busy fence → None immediately, no write; wrong owner still False after release."""
     from cron.jobs import (
         claim_job_for_fire,
         create_job,
@@ -38,10 +34,10 @@ def test_heartbeat_succeeds_immediately_while_fire_fence_held(temp_home):
     claimed = get_job(job_id)
     assert claimed is not None
     owner = claimed["fire_claim"]["by"]
+    original_at = claimed["fire_claim"]["at"]
 
     fence_entered = threading.Event()
     release = threading.Event()
-    result = {}
 
     def _hold():
         with fire_claim_fence(job_id, expected_owner=owner) as owns:
@@ -54,14 +50,58 @@ def test_heartbeat_succeeds_immediately_while_fire_fence_held(temp_home):
     assert fence_entered.wait(timeout=5)
 
     start = time.monotonic()
-    result["ok"] = heartbeat_fire_claim(job_id, expected_owner=owner)
-    result["waited"] = time.monotonic() - start
+    result = heartbeat_fire_claim(job_id, expected_owner=owner)
+    waited = time.monotonic() - start
+    still = get_job(job_id)
     release.set()
     holder.join(timeout=5)
 
-    assert result["ok"] is True, "heartbeat treated a busy fence as ownership loss"
-    assert result["waited"] < 2.0, f"heartbeat blocked on the fire fence ({result['waited']:.2f}s)"
+    assert result is None, "busy fence must be unverified, not ownership loss"
+    assert waited < 2.0, f"heartbeat blocked on the fire fence ({waited:.2f}s)"
+    assert still is not None and still["fire_claim"]["at"] == original_at
+    assert heartbeat_fire_claim(job_id, expected_owner=owner) is True
     assert heartbeat_fire_claim(job_id, expected_owner="other-owner") is False
+
+
+def test_heartbeat_does_not_restore_replaced_owner_while_fence_held(temp_home):
+    """Takeover persisted + fence held: heartbeat of the old owner must not rewrite the claim."""
+    from cron.jobs import (
+        claim_job_for_fire,
+        create_job,
+        fire_claim_fence,
+        get_job,
+        heartbeat_fire_claim,
+        load_jobs,
+        save_jobs,
+    )
+
+    job = create_job(prompt="x", schedule="every 5m", name="no-clobber")
+    job_id = job["id"]
+    assert claim_job_for_fire(job_id) is True
+    owner_a = get_job(job_id)["fire_claim"]["by"]
+    records = load_jobs()
+    records[0]["fire_claim"] = {"at": records[0]["fire_claim"]["at"], "by": "replacement-owner"}
+    save_jobs(records)
+
+    fence_entered = threading.Event()
+    release = threading.Event()
+
+    def _hold():
+        with fire_claim_fence(job_id, expected_owner="replacement-owner") as owns:
+            assert owns is True
+            fence_entered.set()
+            release.wait(timeout=10)
+
+    holder = threading.Thread(target=_hold, daemon=True)
+    holder.start()
+    assert fence_entered.wait(timeout=5)
+    result = heartbeat_fire_claim(job_id, expected_owner=owner_a)
+    persisted = get_job(job_id)["fire_claim"]["by"]
+    release.set()
+    holder.join(timeout=5)
+
+    assert result is None
+    assert persisted == "replacement-owner"
 
 
 def _claimed_job(tmp_path, name):
@@ -84,8 +124,14 @@ def _patch_run_scaffold(monkeypatch, scheduler, *, run_job):
     monkeypatch.setattr(scheduler, "run_job", run_job)
 
 
+def _enter_secrets(stack):
+    stack.enter_context(patch("agent.secret_scope.set_secret_scope", return_value=None))
+    stack.enter_context(patch("agent.secret_scope.build_profile_secret_scope", return_value=None))
+    stack.enter_context(patch("agent.secret_scope.reset_secret_scope"))
+
+
 def test_slow_delivery_holding_fence_is_not_recorded_as_ownership_loss(tmp_path, monkeypatch):
-    """A delivery that outlives the fence wait must still be recorded successful."""
+    """A delivery that outlives a heartbeat beat must still be recorded successful."""
     import cron.scheduler as scheduler
 
     jobs, profile_home, claimed = _claimed_job(tmp_path, "slow-delivery")
@@ -95,48 +141,39 @@ def test_slow_delivery_holding_fence_is_not_recorded_as_ownership_loss(tmp_path,
     monkeypatch.setattr(scheduler, "_FIRE_CLAIM_HEARTBEAT_GRACE_SECONDS", 30.0)
 
     delivered = threading.Event()
-    body_saw_loss: list[bool] = []
 
     def _slow_delivery(*_args, **_kwargs):
         delivered.set()
         time.sleep(0.5)
         return None
 
-    real_body = scheduler._run_one_job_body
-
-    def _observed_body(job, **kwargs):
-        result = real_body(job, **kwargs)
-        lost = kwargs.get("fire_claim_lost")
-        body_saw_loss.append(bool(lost is not None and lost.is_set()))
-        return result
-
     _patch_run_scaffold(
         monkeypatch, scheduler,
         run_job=lambda *_a, **_kw: (True, "output", "response", None))
-    monkeypatch.setattr(scheduler, "_run_one_job_body", _observed_body)
     monkeypatch.setattr(scheduler, "save_job_output", lambda *_a: "output.md")
     monkeypatch.setattr(scheduler, "_deliver_result", _slow_delivery)
-    mark_run = MagicMock(return_value=True)
-    monkeypatch.setattr(scheduler, "mark_job_run", mark_run)
-    monkeypatch.setattr(scheduler, "finish_execution", MagicMock())
 
-    with jobs.use_cron_store(profile_home), \
-         patch("agent.secret_scope.set_secret_scope", return_value=None), \
-         patch("agent.secret_scope.build_profile_secret_scope", return_value=None), \
-         patch("agent.secret_scope.reset_secret_scope"):
+    with jobs.use_cron_store(profile_home), contextlib.ExitStack() as stack:
+        _enter_secrets(stack)
         assert scheduler.run_one_job(claimed) is True
+        persisted = jobs.get_job(claimed["id"])
 
     assert delivered.is_set(), "delivery never ran"
-    assert body_saw_loss == [False], "a fire fence timeout was treated as ownership loss"
-    args, _kwargs = mark_run.call_args
-    assert args[1] is True, "the run was not recorded as successful"
-    assert args[2] is None, f"run was stamped with an error: {args[2]!r}"
+    assert persisted is not None
+    assert persisted.get("last_status") == "ok", (
+        f"slow delivery stamped {persisted.get('last_status')!r} "
+        f"error={persisted.get('last_error')!r}")
+    assert persisted.get("last_error") is None
 
 
 def test_fence_held_elsewhere_skips_side_effects_without_ownership_lost_stamp(
     tmp_path, monkeypatch,
 ):
-    """Side effect that cannot acquire the fence is skipped; not an ownership loss."""
+    """Side effect that cannot acquire the fence is skipped; not an ownership loss.
+
+    Uses real mark_job_run (not a True-stub) so fence-busy on the terminal write is
+    not misclassified as owner mismatch.
+    """
     import cron.jobs as jobs
     import cron.scheduler as scheduler
 
@@ -148,6 +185,7 @@ def test_fence_held_elsewhere_skips_side_effects_without_ownership_lost_stamp(
         claimed = jobs.get_job(job["id"])
         assert isinstance(claimed, dict)
         owner = claimed["fire_claim"]["by"]
+        original_claim = dict(claimed["fire_claim"])
 
         monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.05)
         monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 60.0)
@@ -171,28 +209,57 @@ def test_fence_held_elsewhere_skips_side_effects_without_ownership_lost_stamp(
 
         save_output = MagicMock(return_value="output.md")
         deliver = MagicMock(return_value=None)
-        mark_run = MagicMock(return_value=True)
-        finish = MagicMock()
         _patch_run_scaffold(monkeypatch, scheduler, run_job=_start_holder_then_finish)
         monkeypatch.setattr(scheduler, "save_job_output", save_output)
         monkeypatch.setattr(scheduler, "_deliver_result", deliver)
-        monkeypatch.setattr(scheduler, "mark_job_run", mark_run)
-        monkeypatch.setattr(scheduler, "finish_execution", finish)
 
         try:
-            with patch("agent.secret_scope.set_secret_scope", return_value=None), \
-                 patch("agent.secret_scope.build_profile_secret_scope", return_value=None), \
-                 patch("agent.secret_scope.reset_secret_scope"):
+            with contextlib.ExitStack() as stack:
+                _enter_secrets(stack)
                 assert scheduler.run_one_job(claimed) is True
         finally:
             release_holder.set()
             holder.join(timeout=5)
 
+        persisted = jobs.get_job(job["id"])
+
     save_output.assert_not_called()
     deliver.assert_not_called()
-    finish.assert_called_once()
-    _args, fkwargs = finish.call_args
-    error_text = str(fkwargs.get("error") or "")
-    assert "fence" in error_text.lower(), f"honest cause not recorded: {error_text!r}"
-    interrupted = "Interrupted by shutdown" in error_text
-    assert not interrupted, f"busy fence stamped as shutdown interrupt: {error_text!r}"
+    assert persisted is not None
+    assert persisted.get("last_status") == "error"
+    assert "fence" in str(persisted.get("last_error") or "").lower()
+    assert "ownership lost" not in str(persisted.get("last_error") or "").lower()
+    assert persisted.get("fire_claim", {}).get("by") == original_claim["by"]
+
+
+def test_delivery_fence_busy_after_output_is_not_recorded_success(tmp_path, monkeypatch):
+    """Output fence True, delivery fence None: re-raise busy; do not book success."""
+    import cron.scheduler as scheduler
+
+    jobs, profile_home, claimed = _claimed_job(tmp_path, "delivery-busy")
+    calls = {"n": 0}
+
+    @contextlib.contextmanager
+    def _seq_fence(job_id, *, expected_owner):
+        calls["n"] += 1
+        yield True if calls["n"] == 1 else None
+
+    monkeypatch.setattr(scheduler, "fire_claim_fence", _seq_fence)
+    monkeypatch.setattr(scheduler, "_RUN_CLAIM_HEARTBEAT_SECONDS", 60.0)
+    _patch_run_scaffold(
+        monkeypatch, scheduler,
+        run_job=lambda *_a, **_kw: (True, "output", "response", None))
+    monkeypatch.setattr(scheduler, "save_job_output", lambda *_a: "output.md")
+    deliver = MagicMock(return_value=None)
+    monkeypatch.setattr(scheduler, "_deliver_result", deliver)
+
+    with jobs.use_cron_store(profile_home), contextlib.ExitStack() as stack:
+        _enter_secrets(stack)
+        assert scheduler.run_one_job(claimed) is True
+        persisted = jobs.get_job(claimed["id"])
+
+    deliver.assert_not_called()
+    assert persisted is not None
+    assert persisted.get("last_status") == "error"
+    assert "fence" in str(persisted.get("last_error") or "").lower()
+    assert "ownership lost" not in str(persisted.get("last_error") or "").lower()


### PR DESCRIPTION
## Bug Description

A cron run that **finishes and delivers** is then recorded as failed: `Interrupted by shutdown before terminal completion` / `fire claim ownership lost; interrupting stale run`.

Production trace (2026-09-11, Telegram delivery):

1. `21:32:24` — agent turn ended (`Turn ended: reason=text_response`)
2. `21:33:17` — `Timed out waiting for local fire fence …; failing closed` then `fire claim ownership lost; interrupting stale run`
3. `21:33:22` — delivery succeeded (platform message id assigned)

Same signature on a second job the same day at `00:32:34`. The `executions` row is `failed` while the chat and journal contain the complete report.

Fixes #100401

## Root Cause

Two independent bugs, stacked:

1. **Heartbeat waits on the fire fence.** `_fire_job_lock` is documented as held across network delivery. `heartbeat_fire_claim` acquired that same fence from a background thread. A send longer than `_JOBS_LOCK_TIMEOUT_SECONDS` (30s) made the heartbeat return `False`.
2. **`False` is overloaded.** Fence-busy and verified takeover both returned `False`. The heartbeat loop treats `False` as instant ownership loss (exceptions get 180s grace; contention does not). `_FireOwnership.lost()` and `_record_fire_ownership_lost` used truthiness, so a busy fence was booked as a shutdown interrupt.

No existing test holds the fence on one thread and heartbeats from another — the tests only produce `False` via owner mismatch.

## Why this is not a duplicate

This bug has a swarm of open PRs. Closest:

| PR | Approach | Gap vs this |
|---|---|---|
| #108359 | Heartbeat skips the fence | Does not distinguish fence-busy on `fire_claim_fence`; side-effect path still stamps ownership loss |
| #109003 | Heartbeat stays on the fence, returns `None` when busy, grace window | Does not remove the collision; a delivery past the 180s grace still interrupts a live run. Production `_JOBS_LOCK_TIMEOUT_SECONDS` unchanged |
| #102627 | Large test matrix around `None` | Same architecture as #109003 (tolerate the collision) |
| #100418, #107844, #95432, … | Same family | Timeout constant only monkeypatched in tests, never changed in production — symptom, not cause |

This PR takes **#108359's root-cause change** (heartbeat uses the jobs-store lock only) **and #109003's call-site completeness** (`fire_claim_fence` yields `None`; save/deliver fail closed without an ownership-loss stamp). It does **not** widen the 30s fence wait: after this, the heartbeat no longer waits on it.

## Fix

- `heartbeat_fire_claim` → `_with_job` only (no `_under_fire_fence`)
- `fire_claim_fence` yields `None` when the fence cannot be acquired
- Heartbeat loop / `_record_fire_ownership_lost` / `_FireOwnership.lost()` use `is False` / `is True`
- `_save_compose_deliver` raises `_FireFenceBusyDuringSideEffect` on `None` and records that cause instead of a shutdown interrupt

Verified takeover (replacement owner) is unchanged: `heartbeat_fire_claim(..., expected_owner=original)` still returns `False`.

## How to Verify

1. `python -m pytest tests/cron/test_fire_claim_heartbeat_fence.py tests/cron/test_claim_job_for_fire.py tests/cron/test_script_claim_heartbeat.py tests/cron/test_shutdown_interrupt.py`
2. On unpatched main, `test_heartbeat_succeeds_immediately_while_fire_fence_held` either returns `False` or blocks ~30s.
3. After this patch it returns `True` in well under 2s while another thread holds `fire_claim_fence`.

## Test Plan

- [x] Regression: heartbeat succeeds immediately while the fire fence is held (fails on main)
- [x] E2E: slow delivery that outlives the fence wait is recorded successful
- [x] Sibling: fence held elsewhere skips side effects without a shutdown/ownership-loss stamp
- [x] Existing claim/heartbeat/shutdown tests still pass (62 in the files above)

## Risk Assessment

Low — heartbeat still serializes on the jobs-store lock (`_with_job` / `_jobs_lock`). A second process cannot steal the claim while the original owner is alive: `claim_job_for_fire` still goes through the fire fence, so a live delivery continues to block a duplicate fire. The only behavior change is that a slow delivery no longer looks like a dead owner.
