### PR TITLE
feat(plugin-catalog): Snyk ships as a standalone plugin with its skill (supersedes #73860)

### DIFF
--- a/plugin-catalog/snyk.yaml
+++ b/plugin-catalog/snyk.yaml
@@ -1,0 +1,16 @@
+name: snyk
+repo: https://github.com/NousResearch/hermes-plugin-snyk
+sha: 2a41a07f81e45125bf82a19af1b13396ace4b81f
+description: 'Scan code (SAST), dependencies, container images, IaC and SBOMs with Snyk through its
+  first-party MCP server (pinned snyk@1.1306.0 over npx stdio, CLI analytics disabled), with the
+  snyk-security-scan workflow skill bundled. Portable Agent Plugins v1 package (mcp.json + skills/);
+  needs Node.js/npm on PATH and a free Snyk account (browser login via the snyk_auth tool).'
+maintainer: NousResearch
+tier: official
+docs_url: https://github.com/NousResearch/hermes-plugin-snyk
+platforms: []
+capabilities:
+  provides_tools: []
+  provides_hooks: []
+  provides_middleware: []
+  requires_env: []

--- a/website/docs/user-guide/features/plugin-catalog.md
+++ b/website/docs/user-guide/features/plugin-catalog.md
@@ -93,6 +93,16 @@ hermes plugins install touchdesigner
 hermes plugins enable td
 ```
 
+Portable packages can also carry a stdio MCP server. The `snyk` entry pins the
+Snyk CLI (`npx -y snyk@<version> mcp`) and bundles the `snyk-security-scan`
+skill, so one install gives Hermes code, dependency, container and IaC scanning
+plus the workflow for using it; the catalog name and manifest name match:
+
+```bash
+hermes plugins install snyk
+hermes plugins enable snyk
+```
+
 ### Updating a catalog install
 
 `hermes plugins update <name>` never runs `git pull` for catalog installs —


### PR DESCRIPTION
## Summary
`hermes plugins install snyk` now gives Hermes Snyk's code/dependency/container/IaC/SBOM scanners **and** the skill that tells the agent how to use them, from a standalone Nous-owned plugin repo — no `optional-mcps` entry, no core changes.

Supersedes #73860, which added the same server as an MCP-catalog manifest. Per the contribution rubric third-party products ship outside the core tree, and the plugin form lets the MCP server travel with its playbook (the pruning rationale, absolute-path rule, `snyk_trust` policy and `snyk_send_feedback` telemetry stance from that PR now live in the skill where the model actually reads them).

## Changes
- `plugin-catalog/snyk.yaml` — `official` entry, pinned to `2a41a07f` of [NousResearch/hermes-plugin-snyk](https://github.com/NousResearch/hermes-plugin-snyk).
- `website/docs/user-guide/features/plugin-catalog.md` — one paragraph beside the touchdesigner example (portable package carrying a **stdio** server).

The plugin repo (Agent Plugins v1, same shape as `hermes-plugin-touchdesigner`):
- `mcp.json` — server `sn`: `npx -y snyk@1.1306.0 mcp -t stdio --profile full --DISABLE_ANALYTICS`, `SNYK_DISABLE_ANALYTICS=1`. Same pin as #73860 (published 2026-07-09; `@latest` avoided). Key is `sn` because `snyk` puts `mcp__agent_plugin_snyk_8cb0f11d__snyk__snyk_package_health_check` at exactly 64 chars; `sn` tops out at 62.
- `skills/snyk-security-scan/SKILL.md` — when to use which scanner, the auth → trust → scan → fix loop, pitfalls; `references/tools.md` is generated from a live `tools/list` of the pinned server (all 13 tools, every argument).
- No credentials at install; `snyk_auth` runs Snyk's browser login on demand.

## Validation
| | Result |
|---|---|
| Live stdio handshake, pinned version | `Snyk MCP Server 1.1306.0`, 13 tools |
| Real `PluginManager().discover_and_load()` against temp `HERMES_HOME` (enabled) | plugin loaded, skill `agent-plugin-snyk-8cb0f11d:snyk-security-scan` registered, 1 portable server |
| Same, `plugins.enabled: []` | 0 servers, plugin `enabled=False` |
| `tools.mcp_tool_discovery.discover_mcp_tools()` from the installed copy | **17 tools registered, connected, max name 62 chars**; `snyk_version` handler → `1.1306.0` |
| CLI E2E, temp `HERMES_HOME`, live-cache seeded from this catalog | `plugins search snyk` lists it → `install snyk` clones + checks out `2a41a07f` (`.install-metadata.json` pinned) → `enable snyk` → `list` shows `catalog:official@2a41a07f` |
| `tests/hermes_cli/test_plugin_catalog.py`, `test_plugins_cmd_catalog.py`, `test_catalog_json.py` | **12 passed, 0 failed** |
| `website/scripts/extract-plugins.py` | emits the `snyk` entry with the pinned SHA |

Pin maturity: the plugin repo was created today, so the catalog's "≥ 2 weeks old" rule is not met by the wrapper commit itself; the thing it launches (`snyk@1.1306.0`) is 9 weeks old. Same situation as the `touchdesigner` entry, which pinned a same-day commit.

## Infographic

![Snyk plugin for Hermes Agent](https://v3b.fal.media/files/b/0aaa2152/EaaA0PGwGPVKhf22vZIQ__2MmkI4aN.png)
