### PR TITLE
fix(plugins): guard unreadable paths in disk-cleanup post_tool_call hook (#108970)

### DIFF
--- a/plugins/disk-cleanup/__init__.py
+++ b/plugins/disk-cleanup/__init__.py
@@ -64,7 +64,12 @@ def _on_post_tool_call(tool_name: str = "", args: Optional[Dict[str, Any]] = Non
             p = Path(path_str).expanduser()
         except Exception:
             continue
-        category = dg.guess_category(p) if p.exists() else None
+        try:
+            exists = p.exists()
+        except OSError:
+            # PermissionError / unreadable parent directory — nothing to track.
+            continue
+        category = dg.guess_category(p) if exists else None
         if category is not None and dg.track(str(p), category, silent=True) and category == "test":
             with _lock:
                 _recent_test_tracks.setdefault(task_id or session_id or "default", set()).add(str(p))

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -326,6 +326,26 @@ class TestPostToolCallHook:
         tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
         assert not tracked_file.exists() or tracked_file.read_text().strip() == "[]"
 
+    def test_unreadable_path_never_aborts_the_hook(self, _isolate_env):
+        """PermissionError from an unreadable parent must not crash the hook."""
+        import os
+        if os.geteuid() == 0:
+            pytest.skip("chmod 000 is ineffective as root")
+        pi = _load_plugin_init()
+        locked_dir = _isolate_env / "locked"
+        locked_dir.mkdir()
+        locked_dir.chmod(0o000)
+        try:
+            # Must not raise — the hook contract is "best-effort, never raises".
+            pi._on_post_tool_call(
+                tool_name="terminal",
+                args={"command": f"cat {locked_dir / 'test_secret.log'}"},
+                result="",
+                task_id="t5", session_id="s5",
+            )
+        finally:
+            locked_dir.chmod(0o755)
+
 
 class TestOnSessionEndHook:
     def test_runs_quick_when_test_files_tracked(self, _isolate_env):


### PR DESCRIPTION
## Bug

`_on_post_tool_call` in `plugins/disk-cleanup/__init__.py` calls `Path.exists()` which only swallows `ENOENT`/`ENOTDIR`/`EBADF`/`ELOOP`. A `PermissionError` from an unreadable parent directory (e.g. a `docker exec` command referencing `/root/.local/share/...`) propagates and aborts the entire post_tool_call hook.

The hook contract is "best-effort, never raises" — this violates it.

## Fix

Wrap the `p.exists()` probe in an `OSError` guard so the hook continues silently on unreadable paths.

## Regression test

`test_unreadable_path_never_aborts_the_hook` drives the hook with a path under a `chmod 000` directory (skipped when running as root) and asserts the call does not raise.

Fixes #108970