### PR TITLE
fix(agent): make sanitize_context idempotent on overlapping tags (#108964)

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -175,9 +175,16 @@ _INTERNAL_NOTE_RE = re.compile(
 
 
 def sanitize_context(text: str) -> str:
-    """Strip fence tags, injected context blocks, and system notes from provider output."""
-    for pattern in (_INTERNAL_CONTEXT_RE, _INTERNAL_NOTE_RE, _FENCE_TAG_RE):
-        text = pattern.sub('', text)
+    """Strip fence tags, injected context blocks, and system notes from provider output.
+
+    Runs in a loop until stable: overlapping tags can splice into valid new tags
+    after a single pass, so ``re.sub`` alone is not idempotent on adversarial input.
+    """
+    prev = None
+    while prev != text:
+        prev = text
+        for pattern in (_INTERNAL_CONTEXT_RE, _INTERNAL_NOTE_RE, _FENCE_TAG_RE):
+            text = pattern.sub('', text)
     return text
 
 

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -919,6 +919,17 @@ class TestMemoryContextFencing:
         assert "</memory-context>" not in result.lower()
         assert "datamore" in result
 
+    def test_sanitize_context_idempotent_on_overlapping_tags(self):
+        """Overlapping tags must not produce a live fence after sanitization."""
+        from agent.memory_manager import sanitize_context
+        # Inner deletion splices prefix+suffix into a valid new tag.
+        payload = "</memory-</memory-context>context>"
+        result = sanitize_context(payload)
+        assert "</memory-context>" not in result.lower()
+        assert "<memory-context>" not in result.lower()
+        # Must be idempotent.
+        assert sanitize_context(result) == result
+
 
 class TestFlattenMessageContent:
     """Multimodal message content (list of typed parts) must flatten to a


### PR DESCRIPTION
## Bug

`sanitize_context()` in `agent/memory_manager.py` applies `re.sub` once per pattern. `re.sub` never rescans the text it produces, so deleting an inner match can splice the surviving prefix and suffix into a brand-new valid fence tag:

```
</memory-</memory-context>context>
         ^^^^^^^^^^^^^^^^^^  inner match deleted
</memory-                  context>   ->   </memory-context>
```

The sanitizer *emits* the thing it exists to remove.

## Fix

Loop `re.sub` until stable (no more changes). This makes `sanitize_context` idempotent on adversarial overlapping payloads.

## Regression test

`test_sanitize_context_idempotent_on_overlapping_tags` verifies the overlapping payload `</memory-</memory-context>context>` produces no live fence tag, and that the result is idempotent.

Fixes #108964