### PR TITLE
fix(tools): resolve symlinks in binary-document write guard (#108715)

### DIFF
--- a/tests/tools/test_binary_document_write_guard.py
+++ b/tests/tools/test_binary_document_write_guard.py
@@ -72,6 +72,25 @@ class TestCheckBinaryDocumentWrite:
     def test_plain_text_allowed(self, tmp_path: Path):
         assert _check_binary_document_write(str(tmp_path / "notes.txt")) is None
 
+    def test_symlink_to_docx_rejected(self, tmp_path: Path):
+        """A text-suffixed symlink pointing to a .docx must be rejected."""
+        target = tmp_path / "document.docx"
+        _make_minimal_docx(target)
+        alias = tmp_path / "alias.txt"
+        alias.symlink_to(target)
+        err = _check_binary_document_write(str(alias))
+        assert err is not None
+        assert "symlink" in err.lower()
+        assert ".docx" in err.lower()
+
+    def test_symlink_to_plain_text_allowed(self, tmp_path: Path):
+        """A symlink to a .txt file should pass the guard."""
+        target = tmp_path / "real.txt"
+        target.write_text("hello")
+        alias = tmp_path / "alias.txt"
+        alias.symlink_to(target)
+        assert _check_binary_document_write(str(alias)) is None
+
 
 class TestWriteFileToolGuard:
     def test_write_file_rejects_existing_docx(self, tmp_path: Path):

--- a/tools/file_tools_write_guards.py
+++ b/tools/file_tools_write_guards.py
@@ -388,6 +388,24 @@ def _check_binary_document_write(filepath: str, task_id: str = "default") -> str
             "bytes). Use the docx/xlsx/powerpoint skills or a library like "
             "python-docx/openpyxl/python-pptx via the terminal to create or edit "
             "this document.")
+    # Guard against symlinks: a text-suffixed alias pointing to a binary document
+    # bypasses the extension check above.  Check the *original* path for a symlink,
+    # then inspect the resolved target's extension.
+    try:
+        original = Path(filepath).expanduser()
+        if original.is_symlink():
+            target = str(original.resolve())
+            if has_opaque_document_extension(target):
+                ext = target[target.rfind("."):].lower()
+                return (
+                    f"Refusing to write plain text to '{filepath}' — symlink target "
+                    f"'{target}' is a binary document ({ext}). A text write cannot "
+                    "produce a valid document container and would corrupt the file. "
+                    "Use the docx/xlsx/powerpoint skills or a library like "
+                    "python-docx/openpyxl/python-pptx via the terminal to create or "
+                    "edit this document.")
+    except OSError:
+        pass
     if is_pdf_path(filepath):
         try:
             resolved = Path(_resolve_path_for_task(filepath, task_id))


### PR DESCRIPTION
## Bug

`_check_binary_document_write` checks the supplied filename suffix. A text-suffixed symlink (`alias.txt -> document.docx`) bypasses the guard because the extension check sees `.txt`, not `.docx`. The write proceeds and modifies the `.docx` target through the alias.

## Fix

Check the original path for a symlink before the extension test. If it is a symlink, resolve the real target and re-check its extension against the opaque document list.

## Regression tests

- `test_symlink_to_docx_rejected` — a `.txt` symlink pointing to a `.docx` is rejected with a "symlink" message
- `test_symlink_to_plain_text_allowed` — a symlink to a `.txt` file passes the guard (control)

Fixes #108715