### PR TITLE
fix(desktop): served profiles show running and route lifecycle to the multiplexer from a pooled local backend

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -803,6 +803,26 @@ test('resolveProfileApiRequest scopes complete safe families according to their 
   )
 })
 
+test('resolveProfileApiRequest keeps gateway lifecycle verbs on the primary with the profile scope', () => {
+  // A local sub-profile's gateway verbs must reach a backend that (a) receives
+  // `?profile=X` so the handler can answer "served by the multiplexer" (409 /
+  // restart the multiplexer) and (b) is the backend the gateway-restart status
+  // poll asks. A pooled `--profile X serve` gets neither: unscoped, it spawned a
+  // `-p X gateway restart` that exited 78 while the primary-routed poll read
+  // "no such action" as success.
+  for (const verb of ['restart', 'start', 'stop']) {
+    assert.deepEqual(
+      resolveProfileApiRequest('iris', `/api/gateway/${verb}`, { requestMethod: 'POST' }),
+      { backendProfile: null, requestPath: `/api/gateway/${verb}?profile=iris` }
+    )
+  }
+
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/actions/gateway-restart/status?lines=200', { requestMethod: 'GET' }),
+    { backendProfile: null, requestPath: '/api/actions/gateway-restart/status?lines=200&profile=iris' }
+  )
+})
+
 test('resolveProfileApiRequest routes action-status polls with the action-spawning routes', () => {
   // /api/actions/{name}/status must land on the SAME backend as the endpoints
   // that spawn actions (skills hub install/uninstall/update, mcp catalog

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -613,7 +613,15 @@ const LOCAL_PRIMARY_SCOPED_ROUTES = new Set([
   // Spawns a background action polled via /api/actions/{name}/status — must
   // live on the SAME backend as that poll family (below), or the poll asks a
   // backend that never registered the dynamic action name and 404s.
-  'POST /api/mcp/catalog/install'
+  'POST /api/mcp/catalog/install',
+  // Gateway lifecycle: the handlers take `?profile=` and already decide, per
+  // profile, whether X has its own gateway or is served by the default
+  // multiplexer (409 / restart the multiplexer). Spawning from the primary keeps
+  // the action on the backend the status poll asks AND outside the pooled
+  // backend's own shutdown, which SIGTERMs its gateway-restart child.
+  'POST /api/gateway/restart',
+  'POST /api/gateway/start',
+  'POST /api/gateway/stop'
 ])
 
 function localPrimaryRequestScope(opts: ProfileRouteOptions): boolean | null {

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1014,14 +1014,17 @@ def resolve_gateway_liveness(
             running=True, pid=runtime_pid, source="runtime_status", health_body=health_body
         )
     # (4) A named profile served by the live default multiplexer: no identity files of its own, but
-    # the multiplexer IS its gateway (mirrors `hermes -p X status` / `gateway list`).
-    if scoped:
-        served = guarded(multiplexer_liveness_for_profile, profile_dir)
-        if served is not None:
-            mux_pid, mux_runtime = served
-            return GatewayLiveness(
-                running=True, pid=mux_pid, source="multiplexer", health_body=health_body, runtime=mux_runtime
-            )
+    # the multiplexer IS its gateway (mirrors `hermes -p X status` / `gateway list`). Unscoped, the
+    # question is about the process's OWN home — which is a named profile inside a pooled
+    # `hermes --profile X serve` (the Desktop's per-profile backend answers its REST without
+    # `?profile=`), so it takes the same rung instead of reporting the served profile stopped.
+    own_home = profile_dir if scoped else _get_process_hermes_home()
+    served = guarded(multiplexer_liveness_for_profile, own_home)
+    if served is not None:
+        mux_pid, mux_runtime = served
+        return GatewayLiveness(
+            running=True, pid=mux_pid, source="multiplexer", health_body=health_body, runtime=mux_runtime
+        )
     return GatewayLiveness(
         running=False, pid=None, source="none", health_body=health_body, probe_error=probe_error
     )

--- a/hermes_cli/web_routers/messaging.py
+++ b/hermes_cli/web_routers/messaging.py
@@ -25,6 +25,7 @@ from gateway.status import (
     multiplexer_liveness_for_profile, profile_platforms_from_multiplexer, resolve_gateway_liveness)
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import OPTIONAL_ENV_VARS, get_env_path, redact_key
+from hermes_constants import get_process_hermes_home
 from hermes_cli.web_deps import LateState, late
 from hermes_cli.web_server_gateway import _restart_gateway_after
 from hermes_cli.web_server_messaging import (
@@ -277,12 +278,14 @@ def _platform_payloads(scoped_dir: Optional[Path], entries) -> list[dict[str, An
     HERMES_HOME contextvar; the gateway status readers do not, hence the explicit path)."""
     env_on_disk = load_env()
     runtime = read_runtime_status(path=scoped_dir / "gateway_state.json") if scoped_dir is not None else read_runtime_status()
-    if scoped_dir is not None and runtime is None:
+    if runtime is None:
         # A profile served by the multiplexer writes no record of its own; its adapters live in the
-        # multiplexer's record under ``<profile>:<platform>``.
-        served = multiplexer_liveness_for_profile(scoped_dir)
+        # multiplexer's record under ``<profile>:<platform>``. Unscoped, the profile is the process's
+        # own home (a pooled ``hermes --profile X serve``); the default home resolves to None here.
+        own_home = scoped_dir if scoped_dir is not None else get_process_hermes_home()
+        served = multiplexer_liveness_for_profile(own_home)
         if served is not None:
-            runtime = {**served[1], "platforms": profile_platforms_from_multiplexer(served[1], scoped_dir.name)}
+            runtime = {**served[1], "platforms": profile_platforms_from_multiplexer(served[1], own_home.name)}
     return [_messaging_platform_payload(entry, env_on_disk, runtime, scoped=scoped_dir is not None, profile_home=scoped_dir)
             for entry in entries]
 

--- a/hermes_cli/web_routers/status.py
+++ b/hermes_cli/web_routers/status.py
@@ -23,6 +23,7 @@ from gateway.status import (
     profile_platforms_from_multiplexer, resolve_gateway_liveness)
 from hermes_cli import __version__, __release_date__
 from hermes_cli.config import get_config_path, get_env_path
+from hermes_constants import get_process_hermes_home, profile_name_for_home
 from hermes_cli.web_models import CuratorPause, LearningNodeRef, LearningNodeEdit, DebugShareRequest
 from hermes_cli.web_routers._common import scoped_to_thread
 from pathlib import Path
@@ -252,11 +253,13 @@ async def _resolve_gateway_status(profile_dir: Optional[Path], health_url) -> Di
     runtime = local_runtime
     if runtime is None and remote_health_body and remote_health_body.get("gateway_state"):
         runtime = remote_health_body
-    if liveness.runtime is not None and profile_dir is not None:
+    if liveness.runtime is not None:
         # Served by the multiplexer: its record is this profile's runtime, with the profile's own
-        # adapters under ``<profile>:<platform>`` re-keyed to the standalone shape.
+        # adapters under ``<profile>:<platform>`` re-keyed to the standalone shape. Unscoped, the
+        # profile is the process's own home (a pooled ``hermes --profile X serve``).
+        served_name = profile_dir.name if profile_dir is not None else profile_name_for_home(get_process_hermes_home())
         runtime = {**liveness.runtime,
-                   "platforms": profile_platforms_from_multiplexer(liveness.runtime, profile_dir.name)}
+                   "platforms": profile_platforms_from_multiplexer(liveness.runtime, served_name or "")}
 
     gateway_state = None
     gateway_platforms: dict = {}

--- a/hermes_cli/web_server_gateway.py
+++ b/hermes_cli/web_server_gateway.py
@@ -425,15 +425,31 @@ def _spawn_hermes_action(
     return proc
 
 
+def _own_profile_selector(profile: Optional[str]) -> Optional[str]:
+    """The profile a lifecycle verb addresses: the explicit selector, else the process's own named
+    profile (a pooled Desktop ``hermes --profile X serve`` answers ``/api/gateway/*`` without
+    ``?profile=``; an unscoped verb there is about X, not about the default home)."""
+    requested = (profile or "").strip()
+    if requested:
+        return requested
+    from hermes_constants import get_process_hermes_home, profile_name_for_home
+    own = profile_name_for_home(get_process_hermes_home())
+    return own if own and own != "default" else None
+
+
 def _gateway_subcommand(profile: Optional[str], verb: str) -> List[str]:
     """``hermes [-p X] gateway <verb>`` argv for a dashboard lifecycle action. A profile served by the
     live default multiplexer has no gateway of its own: ``restart`` targets the multiplexer (the process
     that actually serves X — a ``-p X gateway restart`` child only exits 78 into the action log while the
-    UI reports "restarted"); ``start``/``stop`` are refused by the caller (``multiplexed_profile_refusal``)."""
+    UI reports "restarted"); ``start``/``stop`` are refused by the caller (``multiplexed_profile_refusal``).
+    The multiplexer is addressed as ``-p default`` explicitly: a bare ``gateway restart`` spawned from a
+    pooled ``--profile X serve`` would inherit X's ``HERMES_HOME`` and hit the same exit-78 refusal."""
     from hermes_cli.web_server_profiles import _profile_cli_args
+    profile = _own_profile_selector(profile)
     args = _profile_cli_args(profile)
-    if args and verb == "restart" and multiplexed_profile_refusal(args[-1], verb) is not None:
-        args = []
+    if profile and verb == "restart" and multiplexed_profile_refusal(profile, verb) is not None:
+        from hermes_constants import get_process_hermes_home, profile_name_for_home
+        args = [] if profile_name_for_home(get_process_hermes_home()) == "default" else ["-p", "default"]
     return args + ["gateway", verb]
 
 
@@ -447,7 +463,7 @@ def multiplexed_profile_refusal(profile: Optional[str], verb: str) -> Optional[s
     that has no gateway of its own (a ``--force``-started separate one is managed normally), else None.
     The spawned ``hermes -p X gateway <verb>`` would only print exit-78 / "no gateway running for this
     profile" into an action log nobody reads while the UI shows the verb as done."""
-    requested = (profile or "").strip()
+    requested = _own_profile_selector(profile) or ""
     if not requested or requested.lower() in {"current", "default"} or not _profile_is_multiplexed(requested):
         return None
     from hermes_cli.profiles import _check_gateway_running

--- a/tests/hermes_cli/test_gateway_multiplex_served_record.py
+++ b/tests/hermes_cli/test_gateway_multiplex_served_record.py
@@ -118,9 +118,13 @@ def test_dashboard_lifecycle_verbs_target_the_multiplexer(served_root, monkeypat
     """`gateway restart` for a served profile restarts the multiplexer (a `-p X` child only exits 78 into
     the action log); `start`/`stop` refuse; a profile with its own gateway is managed normally."""
     from hermes_cli import profiles as profiles_mod
-    from hermes_cli.web_server_gateway import _gateway_subcommand, multiplexed_profile_refusal
+    from hermes_cli.web_server_gateway import _gateway_subcommand, _profile_action_environment, multiplexed_profile_refusal
     monkeypatch.setattr(profiles_mod, "_check_gateway_running", lambda home: False)
-    assert _gateway_subcommand("coder", "restart") == ["gateway", "restart"]
+    # This process's own HERMES_HOME is coder's; the restart child must still run under the DEFAULT
+    # home (the multiplexer's) — a bare `gateway restart` here would inherit coder's home and exit 78.
+    restart = _gateway_subcommand("coder", "restart")
+    assert restart[-2:] == ["gateway", "restart"] and "coder" not in restart
+    assert _profile_action_environment(restart)["HERMES_HOME"] == str(served_root)
     assert multiplexed_profile_refusal("coder", "stop") and multiplexed_profile_refusal("coder", "start")
     assert _gateway_subcommand("other", "restart") == ["-p", "other", "gateway", "restart"]
     assert multiplexed_profile_refusal("other", "stop") is None

--- a/tests/hermes_cli/test_pooled_served_profile_backend_unscoped.py
+++ b/tests/hermes_cli/test_pooled_served_profile_backend_unscoped.py
@@ -1,0 +1,58 @@
+"""A pooled Desktop backend (``hermes --profile X serve``, HERMES_HOME=<root>/profiles/X) answers its
+REST without ``?profile=``. Those UNSCOPED reads/verbs are about X — a profile the live default
+multiplexer serves — and must agree with the scoped ``?profile=X`` answer and with ``hermes -p X status``:
+running-via-multiplexer, start/stop refused, restart addressed to the multiplexer's home.
+
+Live repro (Desktop over a multiplexed HOME): Command Center said "Messaging gateway stopped" for X,
+the Messaging page pinned every platform "gateway stopped", and Restart spawned a bare ``gateway
+restart`` under X's HERMES_HOME that exited 78 while the UI reported success.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+
+@pytest.fixture
+def pooled_served_process(tmp_path, monkeypatch):
+    """Process whose HERMES_HOME is a served named profile; the default home records a live multiplexer."""
+    root = tmp_path / "hermes"
+    (root / "profiles" / "alpha").mkdir(parents=True)
+    (root / "profiles" / "solo").mkdir(parents=True)
+    (root / "config.yaml").write_text("gateway: {multiplex_profiles: true}\n")
+    (root / "gateway.pid").write_text(json.dumps({"pid": os.getpid(), "hermes_home": str(root)}))
+    (root / "gateway_state.json").write_text(json.dumps({
+        "pid": os.getpid(), "hermes_home": str(root), "gateway_state": "running",
+        "served_profiles": ["default", "alpha"],
+        "platforms": {"api_server": {"state": "connected"}, "alpha:telegram": {"state": "connected"}}}))
+    monkeypatch.setenv("HERMES_HOME", str(root / "profiles" / "alpha"))
+    monkeypatch.delenv("GATEWAY_MULTIPLEX_PROFILES", raising=False)
+    import hermes_constants
+    monkeypatch.setattr(hermes_constants, "_default_hermes_root_memo", None)
+    from hermes_cli import profiles as profiles_mod
+    monkeypatch.setattr(profiles_mod, "_check_gateway_running", lambda home: False)
+    return root
+
+
+def test_unscoped_liveness_in_a_served_profile_process_matches_the_scoped_answer(pooled_served_process):
+    from gateway.status import profile_platforms_from_multiplexer, resolve_gateway_liveness
+    alpha = pooled_served_process / "profiles" / "alpha"
+    scoped = resolve_gateway_liveness(profile_dir=alpha, health_probe=None, use_cache=False)
+    unscoped = resolve_gateway_liveness(health_probe=None, use_cache=False)
+    assert (unscoped.running, unscoped.pid, unscoped.source) == (scoped.running, scoped.pid, "multiplexer")
+    assert profile_platforms_from_multiplexer(unscoped.runtime, "alpha") == {"telegram": {"state": "connected"}}
+
+
+def test_unscoped_lifecycle_verbs_in_a_served_profile_process_address_the_multiplexer(pooled_served_process):
+    from hermes_cli.web_server_gateway import _gateway_subcommand, _profile_action_environment, multiplexed_profile_refusal
+    assert multiplexed_profile_refusal(None, "stop") and multiplexed_profile_refusal(None, "start")
+    restart = _gateway_subcommand(None, "restart")
+    assert restart[-2:] == ["gateway", "restart"]
+    # The child must run under the DEFAULT home (the multiplexer's), not inherit alpha's HERMES_HOME.
+    assert _profile_action_environment(restart)["HERMES_HOME"] == str(pooled_served_process)
+    # A profile with no multiplexer relationship is still managed as its own gateway.
+    assert _gateway_subcommand("solo", "restart") == ["-p", "solo", "gateway", "restart"]
+    assert multiplexed_profile_refusal("solo", "stop") is None


### PR DESCRIPTION
## Summary

Discord report: "multiplexed profiles don't work in Desktop". Live-tested every profile-touching Desktop surface on `main` in both topologies (Electron-spawned local backends with a running `gateway.multiplex_profiles` multiplexer; remote `hermes serve` over URL+token). Remote is correct everywhere. **Local is broken on exactly the gateway surfaces**, for a served (non-default) profile:

| Surface, viewing served profile `alpha` | local (pooled backend) on main | remote on main |
|---|---|---|
| System page gateway indicator | "Messaging gateway stopped" (`/api/status` → `gateway_running:false`) | running |
| Messaging/channels page | every card "gateway stopped" | connected via multiplexer |
| Restart | spawns `gateway restart` under alpha's HOME → exit 78 in a log nobody reads, UI says restarted | multiplexer restarted |
| Start / Stop | 200 then child exit 78, no 409 | 409 |
| Profile picker, switch + turn under right profile (SOUL sentinel + state.db), Bot Mode, cron page / trigger / no double-fire, config edits, sessions list | works | works |

## Root cause

Electron routes a local sub-profile's REST to its pooled `hermes --profile alpha serve` **without `?profile=`** (`electron/connection-config.ts` `scopePath:false` for pool routes). Inside that process the unscoped branches had no multiplexer rung:

- `gateway/status.py` `resolve_gateway_liveness()` rung (4) "served by the live default multiplexer" ran only when `scoped`; unscoped under `HERMES_HOME=<root>/profiles/alpha` → no pid file, no health, no `gateway_state.json` → `running=False`.
- `web_routers/status.py` `_resolve_gateway_status(None, …)` and `web_routers/messaging.py` `_platform_payloads(None, …)`: served-profile projection gated on `profile_dir is not None`.
- `web_server_gateway.py` `multiplexed_profile_refusal(None, verb)` → `None`, so no 409; `_gateway_subcommand(None, 'restart')` → bare `gateway restart` inheriting alpha's HOME → the CLI's own exit-78 refusal.
- False green: `src/store/system-actions.ts` treats `exit_code == null` as success, and the `/api/actions/gateway-restart/status` poll is primary-routed while the spawn was pooled.

## Fix

- Unscoped liveness/status/messaging take the multiplexer rung for the **process's own home** (a pooled `--profile X serve` is X).
- Lifecycle verbs resolve `None` → own named profile: start/stop → 409; served restart spawns `-p default gateway restart` so the child runs under the multiplexer's HOME.
- Electron adds `POST /api/gateway/{restart,start,stop}` to `LOCAL_PRIMARY_SCOPED_ROUTES` (primary + `?profile=`): the action lives on the backend the status poll asks, and outside the pooled backend's shutdown SIGTERM (observed live: recycling alpha's pooled backend killed the multiplexer it had just restarted).

## Validation

| Check | Result |
|---|---|
| `tests/hermes_cli/test_pooled_served_profile_backend_unscoped.py` (2 invariants) | red on base, green |
| `test_gateway_multiplex_served_record.py::test_dashboard_lifecycle_verbs_target_the_multiplexer` | red on base, green |
| `electron/connection-config.test.ts` new case | red on base, green |
| `run_tests.sh tests/gateway tests/hermes_cli` (touched families) | 841 passed, 0 failed |
| `tsc -p tsconfig.electron.json`, eslint on touched files | clean |
| Live A (headless Electron over CDP, multiplexer up, pooled alpha backend) after fix | System page "Messaging gateway running" (green), messaging cards connected, stop/start → 409, restart rotated the multiplexer pid with `served_profiles` intact and the multiplexer survived Electron quit |
| Live B (remote serve + URL/token) after fix | unchanged, correct |

Screenshots (before → after, local topology, viewing alpha): System page `A_15_command_center_system_alpha.png` → `A_fixed_15_…png`, Messaging page `A_05_messaging_alpha.png` → `A_fixed_05_…png` (rig output under `/tmp/desktop-mux/`; image hosts were refusing uploads at PR time, will attach on request).

Not changed (design gap, reported separately): creating a profile from Desktop while the multiplexer runs gives no "restart the multiplexer to serve it" reminder in either topology; the CLI `profile create` prints it since #108928.
