### PR TITLE
fix(telegram): honor explicit reactions env override

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6354,10 +6354,10 @@ class TelegramAdapter(BasePlatformAdapter):
     # -- Message reactions (processing lifecycle) --
 
     def _reactions_enabled(self) -> bool:
-        """Reactions enabled via ``extra.reactions`` (YAML, per profile) or TELEGRAM_REACTIONS."""
-        configured = self.config.extra.get("reactions")
-        if configured is None:
-            configured = _scoped_gate_env("TELEGRAM_REACTIONS", "false")
+        """Reactions enabled via TELEGRAM_REACTIONS or ``extra.reactions`` (YAML)."""
+        configured = _scoped_gate_env("TELEGRAM_REACTIONS")
+        if not configured:
+            configured = self.config.extra.get("reactions", False)
         return str(configured).lower() not in {"false", "0", "no"}
 
     async def _set_reaction(self, chat_id: str, message_id: str, emoji: Optional[str]) -> bool:

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -53,6 +53,23 @@ def test_reactions_enabled_when_set_true(monkeypatch):
     assert adapter._reactions_enabled() is True
 
 
+def test_reactions_explicit_env_overrides_stock_yaml_default(monkeypatch, tmp_path):
+    """An explicit env opt-in wins over the materialized YAML default."""
+    import yaml
+
+    (tmp_path / "config.yaml").write_text(yaml.dump({"telegram": {"reactions": False}}))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+
+    from gateway.config import load_gateway_config
+
+    adapter = _make_adapter()
+    adapter.config = load_gateway_config().platforms[Platform.TELEGRAM]
+
+    assert adapter.config.extra["reactions"] is False
+    assert adapter._reactions_enabled() is True
+
+
 # ── _set_reaction ────────────────────────────────────────────────────
 
 
@@ -152,5 +169,3 @@ def test_config_bridges_telegram_reactions(monkeypatch, tmp_path):
 
     import os
     assert os.getenv("TELEGRAM_REACTIONS") == "true"
-
-


### PR DESCRIPTION
## What does this PR do?

Restores the documented `TELEGRAM_REACTIONS` environment override when `config.yaml` contains the stock `telegram.reactions: false` value.

The adapter now reads the profile-scoped environment value first and falls back to the YAML-derived `extra.reactions` value only when the environment variable is unset. This matches the existing YAML-to-env bridge contract that explicit environment values win, while retaining multiplex profile isolation through `_scoped_gate_env()`.

## Related Issue

Fixes #109032

## Type of Change

- [x] 🐛 Bug fix
- [x] ✅ Tests

## Changes Made

- Honor an explicitly set `TELEGRAM_REACTIONS` value before the YAML-derived fallback.
- Add an integration-style regression test using a real temporary `config.yaml` with the stock false value and an explicit true environment override.
- Preserve default-disabled behavior and YAML-only enablement.

## Validation

- Red proof before the fix: new regression failed (1 failed, 7 passed).
- `scripts/run_tests.sh tests/gateway/test_telegram_reactions.py -q` — 8 passed.
- Ruff, Python compilation, and `git diff --check` passed.

## Checklist

- [x] Tested locally.
- [x] Added regression coverage.
- [x] Kept the change minimal and scoped to the reported regression.
