### PR TITLE
feat(skills): add hermes-session-retitle optional skill

### DIFF
--- a/optional-skills/productivity/hermes-session-retitle/SKILL.md
+++ b/optional-skills/productivity/hermes-session-retitle/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: hermes-session-retitle
+description: Bulk-rename Hermes session titles to a consistent format.
+version: 1.0.0
+author: caesarjue
+license: MIT
+platforms: [macos]
+metadata:
+  hermes:
+    tags: [hermes, sessions, title, state-db, batch-ops]
+    related_skills: [hermes-state-db-maintenance, hermes-agent]
+---
+
+# Hermes Session Retitle
+
+Normalize Hermes session titles in `state.db` to one consistent, scannable
+format — either as a one-shot cleanup of the whole history or as an incremental
+pass over newly created sessions. This skill manages **titles only**: it never
+touches message content, and every rename goes through the `hermes sessions
+rename` CLI rather than writing to the database directly.
+
+The default format is a convention the original author uses — treat it as a
+recommended starting point and adapt it to any format the user prefers. What
+makes a format *work* is a stable machine-checkable prefix (used for the
+normalized / not-normalized test) and a fixed number of `|`-separated parts.
+
+## When to Use
+
+- User says "rename session titles", "重命名会话标题", "clean up my session list",
+  or complains the session sidebar is a wall of inconsistent auto-generated names.
+- After a burst of sessions (batch jobs, parallel agents, cron reruns) left
+  titles like `AI早报 · Sep 12 09:42` or `None`.
+- Periodically, when the user wants newly created sessions to keep a format the
+  rest of the history already follows.
+
+## Prerequisites
+
+- `hermes` CLI on PATH — the rename path is `hermes sessions rename <session_id> "<new title>"`.
+- `sqlite3` available for read-only inspection (`terminal` is fine for this).
+- The database lives at `~/.hermes/state.db` (profile-aware:
+  `~/.hermes/profiles/<name>/state.db`). All reads open it read-only
+  (`file:...?mode=ro`); no mode that can write is ever used.
+
+## Quick Reference
+
+Recommended default format (customize per user):
+
+```
+📅 MMDD | <emoji> <type> | <topic>
+```
+
+- `MMDD` comes from the session id's first 8 digits (`20260911_...` → `0911`).
+- `<type>` is a small closed set; one emoji per type. Example taxonomy:
+
+  | Type | Emoji |
+  |---|---|
+  | development | 💻 |
+  | fix / repair | 🔧 |
+  | research | 🔍 |
+  | content / writing | ✍️ |
+  | ops | ⚙️ |
+  | finance | 💰 |
+  | life | 🏠 |
+  | other | 📦 |
+
+- `<topic>` keeps the user's own anchor words; prefer their language, strip
+  dates and boilerplate.
+- Cron sessions: keep the task name and the `HH:MM` from the run — same task
+  reruns on one day must stay distinguishable for the UNIQUE index.
+- Working in the DB:
+
+  | Object | Detail |
+  |---|---|
+  | `sessions` primary key | `id` (NOT `session_id`) |
+  | session creation time | `started_at` (REAL, unix seconds) |
+  | `messages` join key | `session_id` |
+  | normalized test | `title LIKE '📅%'` (or your chosen prefix) |
+
+- Helper script: `scripts/retitle.py list` prints every unnormalized session
+  with a first-message excerpt; `scripts/retitle.py apply plan.json` prechecks,
+  backs up, renames, and verifies (see `## Procedure`).
+
+## Procedure
+
+1. **Inventory** — run `scripts/retitle.py list` (or query `state.db`
+   read-only). For each candidate also pull the first user message; skip the
+   machine-generated banners (`[IMPORTANT`, `[CONTEXT COMPACTION`, …) to reach
+   the real anchor text. Sessions with zero messages are never named.
+2. **Name** — classify each session into a type; keep the user's own words for
+   the topic. For mixed-topic sessions, sample a few mid-history messages
+   before deciding. When the user's existing title already states the topic,
+   keep its wording.
+3. **Precheck & back up** — build the plan as JSON (`[{"id": ..., "title": ...}]`).
+   `scripts/retitle.py apply` rejects the plan if (a) two proposed titles are
+   identical, or (b) one collides with a title already in the database —
+   `title` carries a UNIQUE index, so either case would hard-fail mid-batch.
+   The old titles are captured before any rename.
+4. **Apply** — `scripts/retitle.py apply plan.json` runs `hermes sessions
+   rename` per entry (~0.3s each) and reads every row back afterwards.
+5. **Verify & report** — the script prints renamed / failed / verified counts.
+   Finish with a full-DB ratio (`SUM(title LIKE '📅%') / COUNT(*)`) and report
+   the result plus the backup location. The backup JSON is the undo record.
+
+## Pitfalls
+
+- **Column names**: `sessions.id` (not `session_id`); `sessions.started_at`
+  (not `created_at`). A wrong column name returns an empty set silently on
+  some sqlite3 invocations — verify with a count before trusting an empty list.
+- **UNIQUE title index**: duplicates abort a batch partway. Disambiguate with
+  time suffixes for cron reruns; always run the precheck.
+- **`title_source` is not a freshness signal**: sessions processed by a
+  previous pass also read `user`. Detect stale titles with the format prefix
+  instead.
+- **Skip zero-message sessions** (e.g. abandoned "Bot Chat" shells) — they
+  exist to hold a chat id, not to be read; naming them adds noise.
+- **Don't skip categories on your own initiative**: users who ask to
+  "normalize everything" mean cron sessions and hand-named sessions too. Only
+  empty sessions are a rule-based skip.
+- **Idempotence**: a title already matching the format is left alone. The
+  prefix test makes reruns safe.
+
+## Verification
+
+- Every renamed row read back byte-identical (the script does this and reports
+  `unverified` on any mismatch).
+- Full-DB ratio: `SELECT COUNT(*), SUM(title LIKE '📅%') FROM sessions;` — the
+  remaining unnormalized count should equal exactly the intentional skips
+  (empty sessions).
+- Backup file present with one `{id, old, new}` record per change.

--- a/optional-skills/productivity/hermes-session-retitle/scripts/retitle.py
+++ b/optional-skills/productivity/hermes-session-retitle/scripts/retitle.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Hermes session title normalizer.
+
+Two modes:
+  list   — print unnormalized sessions (title NULL or not matching the format
+           prefix) with a first-user-message excerpt for naming context.
+  apply  — take a JSON plan ([{"id": ..., "title": ...}, ...]), precheck for
+           conflicts, back up the old titles, rename via the hermes CLI, and
+           verify by reading back.
+
+Both modes open state.db read-only. Nothing here writes to the database
+directly — renames go through `hermes sessions rename`, the sanctioned path.
+
+Usage:
+  retitle.py list  [--db PATH] [--prefix '📅']
+  retitle.py apply [--db PATH] plan.json [--dry-run]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_DB = Path.home() / ".hermes" / "state.db"
+DEFAULT_PREFIX = "\U0001F4C5"  # 📅
+
+# Machine-generated first messages to skip when hunting for a naming anchor.
+SKIP_PREFIXES = ("[IMPORTANT", "[CONTEXT COMPACTION", "[Note: model", "[PRIOR CONTEXT")
+
+
+def strip_skip_prefixes(text: str) -> str:
+    """Drop machine-generated lead-ins so the real user message is visible."""
+    out = text.strip()
+    for _ in range(4):  # a few stacked banners happen
+        for p in SKIP_PREFIXES:
+            if out.startswith(p):
+                nl = out.find("\n")
+                out = out[nl + 1:].strip() if nl != -1 else ""
+                break
+        else:
+            return out
+    return out
+
+
+def is_normalized(title: str | None, prefix: str = DEFAULT_PREFIX) -> bool:
+    """A title counts as normalized when it starts with the format prefix."""
+    return bool(title) and title.startswith(prefix)
+
+
+def build_title(date_mmdd: str, emoji: str, kind: str, topic: str) -> str:
+    """Compose the target title: '<prefix> MMDD | <emoji> <type> | <topic>'."""
+    return f"{DEFAULT_PREFIX} {date_mmdd} | {emoji} {kind} | {topic}"
+
+
+def parse_title(title: str) -> dict | None:
+    """Parse a normalized title back into its parts (None if it doesn't match)."""
+    m = re.match(rf"{re.escape(DEFAULT_PREFIX)}\s+(\d{{4}})\s*\|\s*(\S+)\s+(\S+)\s*\|\s*(.+)$", title)
+    if not m:
+        return None
+    return {"date": m.group(1), "emoji": m.group(2), "type": m.group(3), "topic": m.group(4).strip()}
+
+
+def precheck_plan(plan: list[dict], existing: set[str]) -> list[str]:
+    """Return conflict descriptions; empty list means the plan is safe.
+
+    Checks both internal duplication and collisions with titles already in the
+    database (title carries a UNIQUE index, so a collision would hard-fail).
+    """
+    problems: list[str] = []
+    seen: set[str] = set()
+    for item in plan:
+        t = item.get("title", "")
+        if t in seen:
+            problems.append(f"internal duplicate: {t}")
+        seen.add(t)
+        if t in existing:
+            problems.append(f"collides with existing title: {t}")
+    return problems
+
+
+def open_ro(db: Path) -> sqlite3.Connection:
+    return sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    con = open_ro(Path(args.db))
+    con.row_factory = sqlite3.Row
+    rows = con.execute(
+        "SELECT id, title, message_count FROM sessions "
+        "WHERE title IS NULL OR title NOT LIKE ? ORDER BY started_at",
+        (args.prefix + "%",),
+    ).fetchall()
+    if not rows:
+        print("All sessions normalized.")
+        return 0
+    for row in rows:
+        first = con.execute(
+            "SELECT content FROM messages WHERE session_id = ? AND role = 'user' "
+            "AND content IS NOT NULL ORDER BY timestamp LIMIT 1",
+            (row["id"],),
+        ).fetchone()
+        anchor = strip_skip_prefixes(first["content"])[:80].replace(chr(10), " ") if first else ""
+        print(f"{row['id']} | {row['message_count']:>4} msgs | {row['title']} | {anchor}")
+    print(f"\n{len(rows)} unnormalized session(s).")
+    return 0
+
+
+def cmd_apply(args: argparse.Namespace) -> int:
+    plan = json.loads(Path(args.plan).read_text())
+    con = open_ro(Path(args.db))
+    existing = {r[0] for r in con.execute("SELECT title FROM sessions WHERE title IS NOT NULL")}
+
+    problems = precheck_plan(plan, existing)
+    if problems:
+        print("Plan rejected:")
+        for p in problems:
+            print("  -", p)
+        return 1
+
+    backup = []
+    for item in plan:
+        old = con.execute("SELECT title FROM sessions WHERE id = ?", (item["id"],)).fetchone()
+        backup.append({"id": item["id"], "old": old[0] if old else None, "new": item["title"]})
+    if args.dry_run:
+        print(json.dumps(backup, ensure_ascii=False, indent=2))
+        return 0
+
+    failed = []
+    for item in plan:
+        proc = subprocess.run(
+            ["hermes", "sessions", "rename", item["id"], item["title"]],
+            capture_output=True, text=True,
+        )
+        if proc.returncode != 0:
+            failed.append((item["id"], (proc.stderr or proc.stdout).strip()[:120]))
+
+    verified, unverified = 0, []
+    for item in plan:
+        row = con.execute("SELECT title FROM sessions WHERE id = ?", (item["id"],)).fetchone()
+        if row and row[0] == item["title"]:
+            verified += 1
+        else:
+            unverified.append(item["id"])
+
+    print(json.dumps({"renamed": len(plan) - len(failed), "failed": failed,
+                      "verified": verified, "unverified": unverified,
+                      "backup": backup}, ensure_ascii=False, indent=2))
+    return 0 if not failed and not unverified else 1
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--db", default=str(DEFAULT_DB))
+    ap.add_argument("--prefix", default=DEFAULT_PREFIX)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("list")
+    p_apply = sub.add_parser("apply")
+    p_apply.add_argument("plan")
+    p_apply.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+    return cmd_list(args) if args.cmd == "list" else cmd_apply(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/skills/test_hermes_session_retitle_skill.py
+++ b/tests/skills/test_hermes_session_retitle_skill.py
@@ -1,0 +1,107 @@
+"""
+Tests for the hermes-session-retitle skill.
+
+Validates:
+  - SKILL.md frontmatter conforms to the ≤60-char description standard
+  - Frontmatter credits the human contributor and has required fields
+  - scripts/retitle.py loads and its pure helpers behave as documented
+    (normalization test, title round-trip, conflict precheck)
+"""
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+SKILL_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "productivity"
+    / "hermes-session-retitle"
+)
+
+
+@pytest.fixture(scope="module")
+def skill_source() -> str:
+    return (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def frontmatter(skill_source) -> dict:
+    m = re.search(r"^---\n(.*?)\n---", skill_source, re.DOTALL)
+    assert m, "SKILL.md missing YAML frontmatter"
+    return yaml.safe_load(m.group(1))
+
+
+@pytest.fixture(scope="module")
+def retitle():
+    spec = importlib.util.spec_from_file_location(
+        "retitle_skill_script", SKILL_DIR / "scripts" / "retitle.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_skill_dir_exists() -> None:
+    assert SKILL_DIR.is_dir(), f"missing skill dir: {SKILL_DIR}"
+
+
+def test_description_under_60_chars(frontmatter) -> None:
+    desc = frontmatter["description"]
+    assert len(desc) <= 60, f"description is {len(desc)} chars (limit ≤60): {desc!r}"
+
+
+def test_has_required_frontmatter_fields(frontmatter) -> None:
+    for field in ("name", "description", "version", "license"):
+        assert field in frontmatter, f"missing required field: {field}"
+
+
+def test_credits_contributor(frontmatter) -> None:
+    assert "caesarjue" in str(frontmatter.get("author", "")), (
+        "author must credit the human contributor first"
+    )
+
+
+def test_script_exists() -> None:
+    assert (SKILL_DIR / "scripts" / "retitle.py").is_file()
+
+
+def test_is_normalized_matches_prefix_only(retitle) -> None:
+    assert retitle.is_normalized("📅 0911 | 🔧 修复 | x")
+    assert not retitle.is_normalized("修复 dsh desktop")
+    assert not retitle.is_normalized("")
+    assert not retitle.is_normalized(None)
+
+
+def test_build_and_parse_title_round_trip(retitle) -> None:
+    title = retitle.build_title("0911", "🔧", "修复", "排查 DSH")
+    assert title.startswith("📅 0911 | 🔧 修复 | ")
+    parts = retitle.parse_title(title)
+    assert parts == {"date": "0911", "emoji": "🔧", "type": "修复", "topic": "排查 DSH"}
+    assert retitle.parse_title("not a normalized title") is None
+
+
+def test_strip_skip_prefixes_reaches_user_text(retitle) -> None:
+    raw = "[IMPORTANT: Background process x completed]\nReal user request here"
+    assert retitle.strip_skip_prefixes(raw) == "Real user request here"
+    assert retitle.strip_skip_prefixes("plain message") == "plain message"
+
+
+def test_precheck_rejects_duplicates_and_collisions(retitle) -> None:
+    plan = [
+        {"id": "a", "title": "📅 0911 | 🔧 修复 | one"},
+        {"id": "b", "title": "📅 0911 | 🔧 修复 | one"},  # internal duplicate
+        {"id": "c", "title": "📅 0912 | ✍️ 内容 | two"},
+    ]
+    problems = retitle.precheck_plan(plan, existing={"📅 0912 | ✍️ 内容 | two"})
+    assert any("internal duplicate" in p for p in problems)
+    assert any("collides with existing" in p for p in problems)
+
+
+def test_precheck_accepts_clean_plan(retitle) -> None:
+    plan = [{"id": "a", "title": "📅 0911 | 🔧 修复 | one"}]
+    assert retitle.precheck_plan(plan, existing={"📅 0910 | ✍️ 内容 | zero"}) == []


### PR DESCRIPTION
## What does this PR do?

Adds a new optional skill, `hermes-session-retitle`, that normalizes session titles in `state.db` to a consistent, scannable format — as a one-shot cleanup of a whole history or an incremental pass over newly created sessions.

Motivation: the session sidebar degrades into a wall of inconsistent auto-generated names (mixed languages, cron-style `AI早报 · Sep 12 09:42`, `None`). This skill makes the cleanup repeatable and safe.

Two surfaces:

- **`scripts/retitle.py`** — `list` (unnormalized sessions + first-user-message excerpts) and `apply` (conflict precheck → old-title backup → rename via the sanctioned `hermes sessions rename` CLI → read-back verification). Stdlib only; every DB read opens `file:...?mode=ro`.
- **SKILL.md** — a recommended `📅 MMDD | <emoji> <type> | <topic>` convention (framed as customizable, not hard-required), the `sessions.id` / `started_at` column traps, the UNIQUE-title-index collision rule, idempotence via the format prefix, and the empty-session skip rule.

## Type of Change

- [x] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-skills/productivity/hermes-session-retitle/SKILL.md` — the skill.
- `optional-skills/productivity/hermes-session-retitle/scripts/retitle.py` — list/apply helper (pure helpers + CLI).
- `tests/skills/test_hermes_session_retitle_skill.py` — frontmatter standards + pure-helper tests.

## How to Test

1. `python3 optional-skills/productivity/hermes-session-retitle/scripts/retitle.py list` — prints unnormalized sessions from a real `state.db` (verified against a 307-session database).
2. `pytest tests/skills/test_hermes_session_retitle_skill.py -q` — 10 tests, all passing (verified on macOS 26.6).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [ ] Commit messages follow Conventional Commits — API-created commits read "Add hermes-session-retitle skill: …"; suggested squash title: `feat(skills): add hermes-session-retitle optional skill`
- [x] I searched existing PRs — no duplicate
- [x] PR contains only changes related to this skill
- [ ] Full `pytest tests/ -q` not run locally (dev-dependency environment not set up on this machine); the new test file passes 10/10 locally — CI will confirm the full sweep
- [x] Tests added for the new skill
- [x] Tested on: macOS 26.6

### Documentation & Housekeeping

- [x] Documentation updated — SKILL.md is the documentation; N/A otherwise
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — `platforms: [macos]` declared; the script itself is stdlib-only and portable

### Notes

- `hermes-session-retitle` manages **titles only** — every rename goes through the `hermes sessions rename` CLI; the skill never writes to `state.db` directly.
- The default title format comes from the author's own usage; the skill presents it as a starting convention the user can adapt (the machine-checkable prefix is the part that matters for idempotence).
