### PR TITLE
fix(mcp): preserve OAuth issuer across callback relays

### DIFF
--- a/apps/desktop/electron/mcp-oauth-callback-ipc.test.ts
+++ b/apps/desktop/electron/mcp-oauth-callback-ipc.test.ts
@@ -33,31 +33,42 @@ const invoke = (channel: string, ...args: unknown[]) => {
   return fn!({}, ...args)
 }
 
-test('listen binds a loopback listener and wait resolves with the redirect params', async () => {
-  const { id, redirectUri } = (await invoke('hermes:mcp-oauth:listen')) as { id: string; redirectUri: string }
+test.each(['https://issuer.example/tenant/%2F/', '', null])(
+  'listen preserves the callback issuer %j without synthesizing or normalizing it',
+  async iss => {
+    const { id, redirectUri } = (await invoke('hermes:mcp-oauth:listen')) as { id: string; redirectUri: string }
 
-  assert.match(redirectUri, /^http:\/\/127\.0\.0\.1:\d+\/callback$/)
+    assert.match(redirectUri, /^http:\/\/127\.0\.0\.1:\d+\/callback$/)
 
-  const waitPromise = invoke('hermes:mcp-oauth:wait', id, 5000) as Promise<{
-    code: null | string
-    error: null | string
-    state: null | string
-  }>
+    const waitPromise = invoke('hermes:mcp-oauth:wait', id, 5000) as Promise<{
+      code: null | string
+      error: null | string
+      iss: null | string
+      state: null | string
+    }>
 
-  const res = await fetch(`${redirectUri}?code=abc123&state=st-1`)
+    const params = new URLSearchParams({ code: 'abc123', state: 'st-1' })
 
-  assert.equal(res.status, 200)
-  assert.match(await res.text(), /return to Hermes/)
+    if (iss !== null) {
+      params.set('iss', iss)
+    }
 
-  const result = await waitPromise
+    const res = await fetch(`${redirectUri}?${params}`)
 
-  assert.equal(result.code, 'abc123')
-  assert.equal(result.state, 'st-1')
-  assert.equal(result.error, null)
+    assert.equal(res.status, 200)
+    assert.match(await res.text(), /return to Hermes/)
 
-  // Listener is one-shot: the port must be closed after the callback.
-  await assert.rejects(fetch(`${redirectUri}?code=again&state=st-1`))
-})
+    const result = await waitPromise
+
+    assert.equal(result.code, 'abc123')
+    assert.equal(result.state, 'st-1')
+    assert.equal(result.error, null)
+    assert.equal(result.iss, iss)
+
+    // Listener is one-shot: the port must be closed after the callback.
+    await assert.rejects(fetch(`${redirectUri}?code=again&state=st-1`))
+  }
+)
 
 test('non-callback noise (favicon) does not settle the listener', async () => {
   const { id, redirectUri } = (await invoke('hermes:mcp-oauth:listen')) as { id: string; redirectUri: string }

--- a/apps/desktop/electron/mcp-oauth-callback-ipc.ts
+++ b/apps/desktop/electron/mcp-oauth-callback-ipc.ts
@@ -11,13 +11,13 @@
  * login uses (native-oauth-login.ts): bind an ephemeral one-shot listener
  * on the USER'S loopback, hand its URL to the gateway as the OAuth
  * redirect_uri (`client_redirect_uri` on oauth.start), and resolve with the
- * redirect's `code`/`state` so the renderer can relay them via
+ * redirect's `code`/`state`/`iss` so the renderer can relay them via
  * `mcp.servers.oauth.callback`.
  *
  * Security posture:
  *   - binds 127.0.0.1 on an ephemeral port; closes on first callback,
  *     cancel, or timeout — no long-lived listener;
- *   - the listener only ever RECEIVES `code`/`state` query params and
+ *   - the listener only ever RECEIVES `code`/`state`/`iss` query params and
  *     forwards them to the renderer; no tokens are exchanged here — the
  *     gateway verifies `state` (constant-time) before redeeming anything;
  *   - the browser sees only a minimal "return to Hermes" page.
@@ -41,6 +41,7 @@ const DONE_HTML =
 interface CallbackResult {
   code: null | string
   error: null | string
+  iss: null | string
   state: null | string
 }
 
@@ -83,7 +84,7 @@ function dispose(id: string) {
   }
 
   if (!entry.settled) {
-    settle(id, { code: null, error: 'cancelled', state: null })
+    settle(id, { code: null, error: 'cancelled', iss: null, state: null })
   }
 
   pending.delete(id)
@@ -112,6 +113,7 @@ export function registerMcpOauthCallbackIpc() {
       let code: null | string = null
       let state: null | string = null
       let error: null | string = null
+      let iss: null | string = null
 
       try {
         const parsed = new URL(url, 'http://127.0.0.1')
@@ -119,11 +121,14 @@ export function registerMcpOauthCallbackIpc() {
         code = parsed.searchParams.get('code')
         state = parsed.searchParams.get('state')
         error = parsed.searchParams.get('error')
+        // RFC 9207 issuer validation belongs to the backend SDK. Preserve the
+        // provider value verbatim (including absence), never infer or normalize.
+        iss = parsed.searchParams.get('iss')
       } catch {
         error = 'unparseable callback URL'
       }
 
-      settle(id, { code, error, state })
+      settle(id, { code, error, iss, state })
     })
 
     await new Promise<void>((resolve, reject) => {
@@ -143,7 +148,7 @@ export function registerMcpOauthCallbackIpc() {
     const entry = pending.get(String(id || ''))
 
     if (!entry) {
-      return { code: null, error: 'listener not found', state: null }
+      return { code: null, error: 'listener not found', iss: null, state: null }
     }
 
     if (entry.result) {
@@ -158,7 +163,7 @@ export function registerMcpOauthCallbackIpc() {
 
     const result = await new Promise<CallbackResult>(resolve => {
       const timer = setTimeout(() => {
-        settle(String(id), { code: null, error: 'timeout waiting for OAuth callback', state: null })
+        settle(String(id), { code: null, error: 'timeout waiting for OAuth callback', iss: null, state: null })
       }, timeout)
 
       entry.waiters.push(value => {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -284,7 +284,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   mcpOauth: {
     // One-shot loopback listener for MCP OAuth against remote backends: bind
     // on this machine, hand redirectUri to mcp.servers.oauth.start, then wait
-    // for the provider redirect and relay code/state via oauth.callback.
+    // for the provider redirect and relay code/state/iss via oauth.callback.
     listen: () => ipcRenderer.invoke('hermes:mcp-oauth:listen'),
     wait: (id, timeoutMs) => ipcRenderer.invoke('hermes:mcp-oauth:wait', id, timeoutMs),
     cancel: id => ipcRenderer.invoke('hermes:mcp-oauth:cancel', id)

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -335,13 +335,13 @@ declare global {
       /** One-shot loopback callback listener for MCP OAuth against remote
        *  backends (electron/mcp-oauth-callback-ipc.ts): bind on THIS machine,
        *  pass redirectUri as client_redirect_uri to mcp.servers.oauth.start,
-       *  await the provider redirect, relay code/state via oauth.callback. */
+       *  await the provider redirect, relay code/state/iss via oauth.callback. */
       mcpOauth?: {
         listen: () => Promise<{ id: string; redirectUri: string }>
         wait: (
           id: string,
           timeoutMs?: number
-        ) => Promise<{ code: null | string; error: null | string; state: null | string }>
+        ) => Promise<{ code: null | string; error: null | string; iss?: null | string; state: null | string }>
         cancel: (id: string) => Promise<boolean>
       }
       openPreviewInBrowser?: (url: string) => Promise<void>

--- a/apps/desktop/src/lib/mcp-dashboard-oauth.test.ts
+++ b/apps/desktop/src/lib/mcp-dashboard-oauth.test.ts
@@ -7,6 +7,44 @@ import { completeMcpDesktopOAuth, McpOAuthCancelled } from './mcp-dashboard-oaut
 
 vi.mock('@/store/gateway', () => ({ requestGatewayForAgent: vi.fn() }))
 
+const { ipcHandlers, exposed } = vi.hoisted(() => ({
+  ipcHandlers: new Map<string, (...args: unknown[]) => unknown>(),
+  exposed: {} as { desktop: Window['hermesDesktop'] }
+}))
+
+// Only Electron's transport is replaced: the listener, preload and renderer
+// relay are real, driven by HTTP callbacks on an ephemeral loopback port.
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: (...args: unknown[]) => unknown) => ipcHandlers.set(channel, handler)
+  },
+  ipcRenderer: {
+    sendSync: () => undefined,
+    invoke: async (channel: string, ...args: unknown[]) => {
+      const handler = ipcHandlers.get(channel)
+
+      if (!handler) {
+        throw new Error(`Unexpected IPC channel: ${channel}`)
+      }
+
+      return handler({}, ...args)
+    }
+  },
+  contextBridge: {
+    exposeInMainWorld: (_name: string, desktop: Window['hermesDesktop']) => {
+      exposed.desktop = desktop
+    }
+  },
+  webFrame: {},
+  webUtils: {}
+}))
+
+const { registerMcpOauthCallbackIpc } = await import('../../electron/mcp-oauth-callback-ipc')
+registerMcpOauthCallbackIpc()
+// Execute the real preload without pulling its separately typechecked Electron
+// sources into the renderer tsconfig.
+await vi.importActual('../../electron/preload')
+
 const redirectUri = 'http://127.0.0.1:49152/callback'
 const authUrl = `https://idp.example/authorize?state=expected&redirect_uri=${encodeURIComponent(redirectUri)}`
 const started = { ok: true, session_id: 'flow-1', auth_url: authUrl, flow: 'pkce' }
@@ -29,8 +67,8 @@ function harness() {
 
   const bridge = {
     listen: vi.fn().mockResolvedValue({ id: 'listener-1', redirectUri }),
-    wait: vi.fn(() => callback.promise),
-    cancel: vi.fn(async () => {
+    wait: vi.fn((_id: string) => callback.promise),
+    cancel: vi.fn(async (_id: string) => {
       callback.resolve({ code: null, state: null, error: 'cancelled' })
 
       return true
@@ -39,7 +77,7 @@ function harness() {
 
   const api = vi.fn().mockRejectedValue(new Error('Desktop OAuth must not use the remote REST callback'))
 
-  const openExternal = vi.fn(async () => {
+  const openExternal = vi.fn(async (_url: string) => {
     callback.resolve({ code: 'code-1', state: 'expected', error: null })
   })
 
@@ -74,17 +112,44 @@ afterEach(() => {
 })
 
 describe('Desktop MCP client callback lifecycle', () => {
-  it.each(['local', 'remote-gateway'])(
-    'relays through the native listener and keeps the %s owner after foreground changes',
-    async connectionId => {
+  it.each([
+    { connectionId: 'local', iss: 'https://issuer.example/tenant/%2F/' },
+    { connectionId: 'remote-gateway', iss: 'https://issuer.example/tenant/%2F/' },
+    { connectionId: 'remote-gateway', iss: '' },
+    { connectionId: 'remote-gateway', iss: null }
+  ])(
+    'relays issuer $iss through the native listener/preload to the $connectionId owner after foreground changes',
+    async ({ connectionId, iss }) => {
       const { bridge, api, openExternal, rpc } = harness()
       setApiRequestConnection(connectionId)
       setApiRequestProfile('origin-profile')
-      const callbackResult = { code: 'code-1', state: 'expected', error: null }
-      bridge.wait.mockResolvedValue(callbackResult)
-      openExternal.mockImplementation(async () => {
+      const callbackResult = { code: 'code-1', state: 'expected', error: null, iss }
+      const nativeBridge = exposed.desktop.mcpOauth!
+      bridge.listen.mockImplementation(nativeBridge.listen)
+      bridge.wait.mockImplementation(nativeBridge.wait)
+      bridge.cancel.mockImplementation(nativeBridge.cancel)
+      let clientRedirectUri: string | undefined
+      rpc.mockImplementationOnce(async (_connection, _profile, _method, params) => {
+        clientRedirectUri = (params as { client_redirect_uri: string }).client_redirect_uri
+        const url = new URL(authUrl)
+        url.searchParams.set('redirect_uri', clientRedirectUri)
+
+        return { ...started, auth_url: url.href }
+      })
+      openExternal.mockImplementation(async authorizationUrl => {
         setApiRequestConnection('other-gateway')
         setApiRequestProfile('other-profile')
+        const url = new URL(new URL(authorizationUrl).searchParams.get('redirect_uri')!)
+        url.searchParams.set('code', callbackResult.code)
+        url.searchParams.set('state', callbackResult.state)
+
+        if (iss !== null) {
+          url.searchParams.set('iss', iss)
+        }
+
+        const response = await fetch(url)
+        expect(response.status).toBe(200)
+        await response.text()
       })
       const result = await completeMcpDesktopOAuth({ serverName: 'reports', sleep: async () => {} })
       expect(result).toMatchObject({ status: 'approved', tools })
@@ -92,7 +157,7 @@ describe('Desktop MCP client callback lifecycle', () => {
         connectionId,
         'origin-profile',
         'mcp.servers.oauth.start',
-        { name: 'reports', client_redirect_uri: redirectUri },
+        { name: 'reports', client_redirect_uri: clientRedirectUri },
         60_000
       )
       expect(rpc).toHaveBeenCalledWith(
@@ -103,7 +168,9 @@ describe('Desktop MCP client callback lifecycle', () => {
         60_000
       )
       expect(rpc.mock.calls.every(call => call[0] === connectionId && call[1] === 'origin-profile')).toBe(true)
-      expect(bridge.cancel).toHaveBeenCalledWith('listener-1')
+      const listener = await bridge.listen.mock.results[0].value
+      expect(bridge.cancel).toHaveBeenCalledWith(listener.id)
+      await expect(fetch(`${clientRedirectUri}?code=again&state=expected`)).rejects.toThrow()
       expect(api).not.toHaveBeenCalled()
     }
   )

--- a/evals/desktop_mcp_oauth/backend_http_fixture.py
+++ b/evals/desktop_mcp_oauth/backend_http_fixture.py
@@ -73,6 +73,7 @@ class ProviderHandler(BaseHTTPRequestHandler):
                 "grant_types_supported": ["authorization_code", "refresh_token"],
                 "token_endpoint_auth_methods_supported": ["none"],
                 "code_challenge_methods_supported": ["S256"],
+                "authorization_response_iss_parameter_supported": True,
                 "scopes_supported": ["tools:read"],
             })
         if path == "/authorize":
@@ -83,7 +84,8 @@ class ProviderHandler(BaseHTTPRequestHandler):
                 return self.reply(400, {"error": "invalid_request"})
             code = secrets.token_urlsafe(24)
             self.server.codes[code] = query
-            target = query["redirect_uri"] + "?" + urlencode({"code": code, "state": query["state"]})
+            target = query["redirect_uri"] + "?" + urlencode({
+                "code": code, "state": query["state"], "iss": self.server.origin})
             return self.reply(302, headers={"Location": target})
         self.reply(405 if path == "/mcp" else 404)
 
@@ -226,6 +228,7 @@ def run_probe(repo, receipt):
         response = browser.get(flow["auth_url"], follow_redirects=True)
         check("real_http_callback_received", response.status_code == 200 and bool(callback.callback.get("code")))
         captured = callback.callback
+        check("rfc9207_issuer_captured_exactly", captured.get("iss") == provider.origin)
         check("correct_callback_accepted", sessions.deliver_callback_flow(sid, "positive", **captured)["ok"])
         result = done(flow, "positive")
         receipt["positive_status"] = result["status"]

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -276,6 +276,7 @@ async def mcp_oauth_callback(
     code: Optional[str] = None,
     state: Optional[str] = None,
     error: Optional[str] = None,
+    iss: Optional[str] = None,
 ):
     _gc_mcp_oauth_flows()
     with _mcp_oauth_flows_lock:
@@ -291,7 +292,7 @@ async def mcp_oauth_callback(
     if flow is None:
         return HTMLResponse("<h1>OAuth flow expired</h1><p>Return to Hermes and try again.</p>", status_code=404)
     try:
-        flow.deliver_callback(code=code, state=state, error=error)
+        flow.deliver_callback(code=code, state=state, error=error, iss=iss)
     except ValueError as exc:
         return HTMLResponse(
             "<h1>OAuth callback rejected</h1><p>The callback was invalid or already used.</p>",

--- a/tests/hermes_cli/test_mcp_dashboard_oauth.py
+++ b/tests/hermes_cli/test_mcp_dashboard_oauth.py
@@ -85,7 +85,7 @@ def test_hosted_callback_bypasses_gated_cookie_auth(monkeypatch):
     )
 
     assert response.status_code == 200
-    assert flow._callback == ("abc", "expected")
+    assert flow._callback == ("abc", "expected", None)
 
 
 def test_hosted_auth_allows_same_server_name_in_different_profiles(tmp_path, monkeypatch):
@@ -132,7 +132,7 @@ def test_flow_status_does_not_expose_authorization_code():
     )
     flow.authorization_url = "https://idp.example/authorize"
     flow.status = "approved"
-    flow._callback = ("secret-code", "secret-state")
+    flow._callback = ("secret-code", "secret-state", None)
     _web_server_mcp._mcp_oauth_flows[flow.flow_id] = flow
 
     response = _client().get("/api/mcp/oauth/flows/flow-status")

--- a/tests/tools/test_mcp_dashboard_oauth.py
+++ b/tests/tools/test_mcp_dashboard_oauth.py
@@ -27,7 +27,7 @@ def test_dashboard_flow_exposes_authorization_url_and_accepts_callback():
     }
 
     flow.deliver_callback(code="code-1", state="s1", error=None)
-    assert asyncio.run(flow.wait_for_callback()) == ("code-1", "s1")
+    assert asyncio.run(flow.wait_for_callback()) == ("code-1", "s1", None)
 
 
 def test_dashboard_flow_accepts_only_one_concurrent_callback():

--- a/tests/tui_gateway/test_mcp_oauth_client_callback.py
+++ b/tests/tui_gateway/test_mcp_oauth_client_callback.py
@@ -186,7 +186,7 @@ def test_deliver_callback_accepts_matching_state():
     flow = _make_session()
     out = deliver_callback_flow("sess-relay-1", "hosp", code="abc", state="s3cr3tstate")
     assert out == {"ok": True, "session_id": "sess-relay-1"}
-    assert flow._callback == ("abc", "s3cr3tstate")
+    assert flow._callback == ("abc", "s3cr3tstate", None)
 
 
 def test_deliver_callback_rejects_state_mismatch():

--- a/tests/tui_gateway/test_mcp_oauth_issuer.py
+++ b/tests/tui_gateway/test_mcp_oauth_issuer.py
@@ -1,0 +1,153 @@
+"""RFC 9207 issuer survives native callback capture and reaches the SDK unchanged."""
+
+import asyncio
+import http.client
+import io
+import threading
+import time
+from urllib.parse import urlencode
+
+import pytest
+
+from hermes_constants import get_hermes_home
+from mcp.client.auth.exceptions import OAuthFlowError
+from mcp.client.auth.utils import validate_authorization_response_iss
+from mcp.shared.auth import AuthorizationCodeResult, OAuthMetadata
+from tools.mcp_dashboard_oauth import DashboardOAuthFlow, dashboard_oauth_flow
+from tools.mcp_oauth import (
+    _callback_outcome,
+    _make_callback_handler,
+    _make_callback_waiter,
+    _paste_callback_reader,
+    _start_callback_server,
+)
+from tui_gateway.mcp_oauth_sessions import _start_loopback_listener
+
+
+def _deliver_callback(route, flow, params, monkeypatch):
+    if route == "dashboard":
+        from fastapi import FastAPI
+        from starlette.testclient import TestClient
+        from hermes_cli.web_routers import mcp
+
+        app = FastAPI()
+        app.include_router(mcp.router)
+        monkeypatch.setitem(mcp._mcp_oauth_flows, flow.flow_id, flow)
+        response = TestClient(app).get(
+            f"/api/mcp/oauth/callback/{flow.server_name}", params=params,
+        )
+        assert response.status_code == 200
+        return
+    if route == "rpc":
+        from tui_gateway import mcp_oauth_sessions, server
+
+        monkeypatch.setitem(mcp_oauth_sessions._sessions, flow.flow_id, {
+            "flow": flow, "server_name": flow.server_name,
+            "hermes_home": flow.hermes_home, "created_at": time.time(),
+        })
+        response = server._methods["mcp.servers.oauth.callback"](1, {
+            "name": flow.server_name, "session_id": flow.flow_id, **params,
+        })
+        assert response["result"]["ok"] is True
+        return
+    captured = None
+    if route == "loopback":
+        listener = _start_loopback_listener(flow)
+    else:
+        handler, captured = _make_callback_handler()
+        if route == "cli-paste":
+            monkeypatch.setattr("tools.mcp_oauth.sys.stdin", io.StringIO(
+                "http://127.0.0.1/callback?" + urlencode(params) + "\n"))
+            _paste_callback_reader(captured)
+            return _callback_outcome(captured, None)
+        assert route == "cli-loopback"
+        listener = _start_callback_server(0, handler)
+        threading.Thread(target=listener.serve_forever, daemon=True).start()
+    conn = http.client.HTTPConnection("127.0.0.1", listener.server_port, timeout=5)
+    try:
+        conn.request("GET", "/callback?" + urlencode(params))
+        response = conn.getresponse()
+        response.read()
+        assert response.status == 200
+    finally:
+        conn.close()
+        listener.shutdown()
+        listener.server_close()
+    if captured is not None:
+        return _callback_outcome(captured, None)
+
+
+@pytest.mark.parametrize("route", ["loopback", "dashboard", "rpc", "cli-loopback", "cli-paste"])
+@pytest.mark.parametrize(
+    "issuer,supported,error",
+    [
+        ("https://issuer.example", True, None),
+        ("https://other.example", True, "iss mismatch"),
+        ("https://issuer.example/", True, "iss mismatch"),
+        (" https://issuer.example ", True, "iss mismatch"),
+        ("https://other.example", False, "iss mismatch"),
+        ("", True, "iss mismatch"),
+        ("", False, "iss mismatch"),
+        (None, True, "missing iss"),
+        (None, False, None),
+    ],
+)
+def test_callback_preserves_issuer_for_sdk_validation(route, issuer, supported, error, monkeypatch):
+    flow = DashboardOAuthFlow(
+        flow_id="issuer-flow", server_name="issuer-test", profile=None,
+        hermes_home=str(get_hermes_home()), redirect_uri="",
+    )
+    asyncio.run(flow.publish_authorization_url("https://issuer.example/authorize?state=test-state"))
+    metadata = OAuthMetadata.model_validate({
+        "issuer": "https://issuer.example",
+        "authorization_endpoint": "https://issuer.example/authorize",
+        "token_endpoint": "https://issuer.example/token",
+        "response_types_supported": ["code"],
+        "authorization_response_iss_parameter_supported": supported,
+    })
+    params = {"code": "test-code", "state": "test-state"}
+    if issuer is not None:
+        params["iss"] = issuer
+    result = _deliver_callback(route, flow, params, monkeypatch)
+    if result is None:
+        with dashboard_oauth_flow(flow):
+            result = asyncio.run(_make_callback_waiter(0)())
+    assert isinstance(result, AuthorizationCodeResult)
+    assert result.iss == issuer
+    assert (result.code, result.state) == ("test-code", "test-state")
+    if error:
+        with pytest.raises(OAuthFlowError, match=error):
+            validate_authorization_response_iss(result.iss, metadata)
+    else:
+        validate_authorization_response_iss(result.iss, metadata)
+
+
+@pytest.mark.parametrize("issuer", [False, True, 0, 1, 0.0, 1.5, [], ["issuer"], {}, {"iss": "issuer"}])
+def test_rpc_rejects_non_string_issuer_without_consuming_callback(issuer, monkeypatch):
+    from tui_gateway import mcp_oauth_sessions, server
+
+    flow = DashboardOAuthFlow(
+        flow_id="issuer-type-flow", server_name="issuer-test", profile=None,
+        hermes_home=str(get_hermes_home()), redirect_uri="",
+    )
+    asyncio.run(flow.publish_authorization_url("https://issuer.example/authorize?state=test-state"))
+    monkeypatch.setitem(mcp_oauth_sessions._sessions, flow.flow_id, {
+        "flow": flow, "server_name": flow.server_name,
+        "hermes_home": flow.hermes_home, "created_at": time.time(),
+    })
+    callback = server._methods["mcp.servers.oauth.callback"]
+    params = {
+        "name": flow.server_name, "session_id": flow.flow_id,
+        "code": "test-code", "state": "test-state", "iss": issuer,
+    }
+    response = callback(1, params)
+    assert response.get("error", {}).get("code") == 4063
+    assert "iss" in response["error"]["message"]
+
+    # Rejected input must not consume the callback; explicit null is accepted.
+    params["iss"] = None
+    assert callback(2, params)["result"]["ok"] is True
+    with dashboard_oauth_flow(flow):
+        result = asyncio.run(_make_callback_waiter(0)())
+    assert isinstance(result, AuthorizationCodeResult)
+    assert (result.code, result.state, result.iss) == ("test-code", "test-state", None)

--- a/tools/mcp_dashboard_oauth.py
+++ b/tools/mcp_dashboard_oauth.py
@@ -43,7 +43,7 @@ class DashboardOAuthFlow:
     error: str | None = None
     tools: list[dict] = field(default_factory=list)
     expected_state: str | None = field(default=None, init=False)
-    _callback: tuple[str, str | None] | None = field(default=None, init=False, repr=False)
+    _callback: tuple[str, str | None, str | None] | None = field(default=None, init=False, repr=False)
     _callback_error: str | None = field(default=None, init=False, repr=False)
     _authorization_ready: threading.Event = _event_field()
     _callback_ready: threading.Event = _event_field()
@@ -70,8 +70,10 @@ class DashboardOAuthFlow:
             raise RuntimeError(self.error or "MCP OAuth flow ended before authorization")
         return self.authorization_url
 
-    def deliver_callback(self, *, code: str | None, state: str | None, error: str | None) -> None:
-        """Hand the browser redirect to the waiting flow; ``state`` must match exactly."""
+    def deliver_callback(
+        self, *, code: str | None, state: str | None, error: str | None, iss: str | None = None,
+    ) -> None:
+        """Verify ``state`` and preserve the unmodified issuer for the SDK's RFC 9207 check."""
         with self._lock:
             if self._callback_ready.is_set():
                 raise ValueError("OAuth callback already received")
@@ -80,12 +82,12 @@ class DashboardOAuthFlow:
             if error:
                 self._callback_error = error
             elif code:
-                self._callback = (code, state)
+                self._callback = (code, state, iss)
             else:
                 self._callback_error = "OAuth callback did not include code or error"
             self._callback_ready.set()
 
-    async def wait_for_callback(self, timeout: float = 300.0) -> tuple[str, str | None]:
+    async def wait_for_callback(self, timeout: float = 300.0) -> tuple[str, str | None, str | None]:
         if not await asyncio.to_thread(self._callback_ready.wait, timeout):
             raise TimeoutError("Timed out waiting for MCP OAuth callback")
         if self._callback_error:

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -460,7 +460,9 @@ def _parse_redirect_query(query: str) -> dict[str, Any]:
     """code/state/error/iss from a redirect query string. ``iss`` (RFC 9207 issuer) is kept: mcp 2.0
     rejects a response omitting it when the server advertised ``authorization_response_iss_parameter_supported``."""
     params = parse_qs(query)
-    return {k: params.get(k, [None])[0] for k in ("code", "state", "error", "iss")}
+    # Only iss distinguishes an empty value from omission; keep other parsing unchanged.
+    iss = parse_qs(query, keep_blank_values=True).get("iss", [None])[0]
+    return {"iss": iss, **{k: params.get(k, [None])[0] for k in ("code", "state", "error")}}
 
 
 def _result_taken(result: dict) -> bool:
@@ -646,7 +648,7 @@ def _make_callback_waiter(port: int, cimd_url: str | None = None, timeout: float
     async def _wait():
         dashboard_flow = get_dashboard_oauth_flow()
         if dashboard_flow is not None:
-            # Dashboard flow speaks the legacy tuple; normalize to one shape.
+            # Preserve the callback issuer when adapting to the installed SDK.
             return _authorization_code_result(*await dashboard_flow.wait_for_callback())
         # The SDK entered the authorization-code flow, so any cached token is unusable. Reject BEFORE
         # binding: binding would block for the full timeout and collide with the TIME_WAIT port on retry.

--- a/tui_gateway/mcp_oauth_sessions.py
+++ b/tui_gateway/mcp_oauth_sessions.py
@@ -57,11 +57,13 @@ def _start_loopback_listener(flow) -> "http.server.HTTPServer":
                 self.end_headers()
                 return
             qs = parse_qs(parsed.query)
+            # Only iss distinguishes an empty value from omission; keep other parsing unchanged.
+            iss = parse_qs(parsed.query, keep_blank_values=True).get("iss", [None])[0]
             body = b"<h1>Authorization received</h1><p>You can close this tab and return to Hermes.</p>"
             status = 200
             try:
                 flow.deliver_callback(
-                    **{k: (qs.get(k) or [None])[0] for k in ("code", "state", "error")})
+                    iss=iss, **{k: (qs.get(k) or [None])[0] for k in ("code", "state", "error")})
             except Exception:
                 body = b"<h1>OAuth callback rejected</h1><p>The callback was invalid or already used.</p>"
                 status = 400
@@ -255,7 +257,7 @@ def cancel_flow(session_id: str, server_name: str, hermes_home: str) -> Dict[str
 
 def deliver_callback_flow(
     session_id: str, server_name: str, *, code: Optional[str], state: Optional[str],
-    error: Optional[str] = None) -> Dict[str, Any]:
+    error: Optional[str] = None, iss: Optional[str] = None) -> Dict[str, Any]:
     """Relay a client-captured OAuth redirect into a session's flow (remote-backend companion
     to ``start_flow(client_redirect_uri=...)``); ``deliver_callback`` still verifies ``state``
     and rejects replays. Returns ``{ok: true}`` or ``{ok: false, error_message}``."""
@@ -263,7 +265,7 @@ def deliver_callback_flow(
     if rec is None:
         return {"ok": False, "error_message": err}
     try:
-        rec["flow"].deliver_callback(code=code, state=state, error=error)
+        rec["flow"].deliver_callback(code=code, state=state, error=error, iss=iss)
     except ValueError as exc:
         return {"ok": False, "error_message": str(exc)}
     return {"ok": True, "session_id": session_id}

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1336,11 +1336,14 @@ def _(rid, params: dict) -> dict:
 
 @_mcp_rpc("oauth.callback", _NAME_SESSION)
 def _(rid, params: dict) -> dict:
-    """Relay a client-captured redirect (``code``/``state``/``error``) into a ``client_redirect_uri`` flow."""
+    """Relay a client-captured redirect, including its RFC 9207 issuer, without normalization."""
     code, state, error = (str(params.get(k) or "") or None for k in ("code", "state", "error"))
+    iss = params.get("iss")
+    if iss is not None and not isinstance(iss, str):
+        return _err(rid, 4063, "iss must be a string or null")
     deliver = _tools_mod("tui_gateway.mcp_oauth_sessions").deliver_callback_flow
     return _ok(rid, deliver(
-        _str_arg(params, "session_id"), _str_arg(params, "name"), code=code, state=state, error=error))
+        _str_arg(params, "session_id"), _str_arg(params, "name"), code=code, state=state, error=error, iss=iss))
 
 
 # ─── Plugins ─────────────────────────────────────────────────────────────────

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -271,6 +271,8 @@ mcp_servers:
 
 On first connect, Hermes prints an authorize URL, opens your browser when possible, and waits for the OAuth callback on a local loopback port. Tokens are cached at `~/.hermes/mcp-tokens/<server>.json` with 0o600 perms; subsequent runs reuse them silently until refresh fails.
 
+**Pitfall — `Authorization response missing iss parameter`.** Providers that advertise RFC 9207 issuer validation require the callback's `iss` parameter to reach the MCP SDK unchanged. Older Desktop/dashboard callback relays can drop it even after browser approval succeeds. Update both Desktop and its backend, restart them, and start a fresh sign-in. For interactive CLI paste-back, preserve the complete redirect URL, including `iss`. Do not disable issuer validation or substitute an issuer from discovery metadata.
+
 **Remote / headless hosts.** When Hermes runs on a different machine than your browser, the loopback callback can't reach your laptop. Ways to complete the flow:
 
 - **Hermes Desktop (automatic):** when you run the OAuth sign-in from the Desktop app's MCP setup UI against a remote backend, Desktop hosts the callback listener on *your* machine and relays the authorization back to the gateway automatically — no tunnel, paste, or proxy needed. Requires both the Desktop app and the backend to be up to date.


### PR DESCRIPTION
## What does this PR do?

Preserves the RFC 9207 `iss` authorization-response parameter across the Desktop, gateway, and hosted-dashboard MCP OAuth callback relays, so the MCP SDK can validate the original issuer instead of rejecting a valid response after a relay drops it.

Observed before the fix on macOS with Cloudflare MCP:

```text
Authorization response missing iss parameter advertised by the authorization server
```

The shared dashboard flow stored only `(code, state)`, and the Electron listener, native gateway listener, Desktop RPC, and dashboard HTTP route omitted `iss`. This change carries the issuer through those existing seams without disabling SDK issuer validation or inventing a provider-specific exception.

## Related issues and overlapping PRs

Related: #105895, #92758.

The existing-PR search found overlapping fixes in #105610, #108420, #108455, #106634, and #92765. This PR is not claiming a unique implementation: it publishes the locally deployed Cloudflare repair together with real-SDK validation tests, the HTTP OAuth fixture update, and Desktop listener/preload/renderer coverage. It can be consolidated with an existing fix if preferred.

## Type of change

- [x] Bug fix
- [x] Regression tests
- [x] Troubleshooting documentation

## Changes made

- Carry optional `iss` through `DashboardOAuthFlow` into the existing SDK-version adapter.
- Forward it through the native loopback listener, `mcp.servers.oauth.callback`, and hosted-dashboard HTTP callback.
- Capture it in Electron and expose it through the existing preload/renderer contract, including local and remote-backend ownership handling.
- Test real SDK validation across five Python callback routes, including CLI loopback/paste-back: matching issuer, mismatches, whitespace/trailing-slash differences, empty strings, required-but-missing issuer, and legacy omission.
- Preserve empty `iss` values in Python query parsing without changing `code`/`state`/`error` parsing; reject non-string/non-null RPC issuers before consuming the callback.
- Exercise the real Electron listener and preload over HTTP in Desktop tests, including encoded issuer paths, absence, cancellation, and one-shot listener behavior.
- Make the isolated HTTP OAuth fixture advertise RFC 9207 support and return its issuer.
- Document the missing-issuer error and the need to update/restart both Desktop and the backend.

State validation, callback replay rejection, cancellation, and profile-owner checks remain in place. No tokens, authorization URLs, account identifiers, local configuration, or packaged app artifacts are included.

## Verification

Re-run on macOS 26.6.2, Python 3.11 and Node 22.23.2:

- Python OAuth regression suite via `scripts/run_tests.sh`: **12 files, 193 passed, 0 failed**, with per-file isolation and credential-free test environments.
- Desktop `npm run test -- mcp oauth --maxWorkers=4`: **14 files, 152 passed**.
- `npm run typecheck`: renderer, Electron, and E2E TypeScript checks passed.
- Ruff on all changed Python files, ESLint and Prettier checks on all changed TypeScript files, and `git diff --cached --check`: passed.
- `evals/desktop_mcp_oauth/backend_http_fixture.py`: passed using an isolated temporary home and real HTTP discovery, DCR, PKCE, token persistence, MCP discovery, and a separate-process authenticated reconnect. Temporary credentials were removed.
- Prior deployment verification of the main issuer-forwarding repair: Desktop build/package succeeded, the packaged application and backend were restarted, native Desktop authorization completed, `hermes mcp test cloudflare` reported Connected, and a read-only Cloudflare `get_accounts` call returned MCP `is_error=false` and API `success=true`. The final empty-issuer/type-validation changes were subsequently verified by regression tests and the isolated HTTP fixture, not by another live sign-in.

### Known verification limits

The full Python suite was not run. A fresh full Desktop run (`npm run test -- --maxWorkers=4`) reported **9740 passed, 3 failed, 6 skipped**, matching the earlier run. The three failures are in unchanged `managed-ssh-update.test.ts` (one, subprocess exit 127) and `voice-prefs.test.ts` (two, localStorage expectations); they were also reproduced separately. They are outside this patch; this PR does not claim the full Desktop suite is green. Windows and Linux were not exercised locally.

## How to test

1. Run the changed Python callback tests and the surrounding OAuth regression files with `scripts/run_tests.sh`.
2. From `apps/desktop`, run `npm run test -- mcp oauth --maxWorkers=4` and `npm run typecheck`.
3. Run `venv/bin/python evals/desktop_mcp_oauth/backend_http_fixture.py --repo "$PWD" --output /tmp/hermes-mcp-oauth-verification.json` from the repository root.
4. With both Desktop and backend rebuilt/restarted, use the Desktop MCP authorization UI with an RFC 9207-capable server. Confirm authentication, tool discovery, and a read-only tool call. Do not bypass issuer validation or share callback/token material.

## Checklist

- [x] Read the contributing guidance and searched open/merged PRs; overlaps are explicitly listed above.
- [x] Conventional Commit; only related source, tests, fixture, and docs changes.
- [x] Added behavior-based regression tests and ran focused verification.
- [x] Updated relevant MCP troubleshooting documentation.
- [x] No new configuration keys, dependencies, or agent-tool schemas.
- [ ] Full repository test suite is green (not claimed; see limits above).
