### PR TITLE
fix(bot-mode): reject truncated agent messages

### DIFF
--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -185,6 +185,41 @@ def test_empty_and_oversized_message_rejected(tmp_path):
     )
 
 
+def test_truncated_message_tail_rejected_before_delivery(tmp_path, monkeypatch):
+    calls = _capture_spawn(monkeypatch)
+    home = _managed_home(tmp_path)
+    agent = _FakeAgent(home, title="Bot Chat")
+
+    result = json.loads(
+        bot_mode_dm.message_agent_tool(
+            target="researcher",
+            message="Please inspect the failing request...[truncated]",
+            agent=agent,
+        )
+    )
+
+    assert "error" in result
+    assert "truncated" in result["error"].lower()
+    assert calls == []
+
+
+def test_truncation_marker_quotation_inside_message_is_delivered(tmp_path, monkeypatch):
+    calls = _capture_spawn(monkeypatch)
+    home = _managed_home(tmp_path)
+    agent = _FakeAgent(home, title="Bot Chat")
+
+    result = json.loads(
+        bot_mode_dm.message_agent_tool(
+            target="researcher",
+            message="The bad sample ended with ...[truncated], but this explanation is complete.",
+            agent=agent,
+        )
+    )
+
+    assert result["status"] == "sent"
+    assert len(calls) == 1
+
+
 def test_unregistered_peer_rejected(tmp_path):
     home = _managed_home(tmp_path, peers=("spark",))
     agent = _FakeAgent(home, title="Bot Chat")

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -50,6 +50,9 @@ _LIVE_WAIT_SECONDS = 300
 _PEER_TARGET_RE = re.compile(r"^([a-z0-9][a-z0-9_-]{0,63})/([a-zA-Z0-9][a-zA-Z0-9_-]{0,63})$")
 # Same shape as ``tools.bot_relay._HANDLE_RE`` (kept local: see import note above).
 _LOCAL_TARGET_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$")
+# A marker at the very end is evidence that the authored body was already cut. Matching
+# only the anchored bracketed token keeps discussions or quoted examples deliverable.
+_TRUNCATED_MESSAGE_TAIL_RE = re.compile(r"\[truncated\]$", re.IGNORECASE)
 
 
 def _default_home() -> str:
@@ -208,6 +211,8 @@ def message_agent_tool(target: str = "", message: str = "", task_id: Optional[st
     if len(body) > MESSAGE_MAX_CHARS:
         return _err(f"message too long ({len(body)} chars > {MESSAGE_MAX_CHARS}). "
                     "Send the essentials; share large content as a file path instead.")
+    if _TRUNCATED_MESSAGE_TAIL_RE.search(body):
+        return _err("message appears truncated and was not delivered. Regenerate the complete message and retry.")
 
     raw_target = str(target or "").strip().lstrip("@")
     if not raw_target:


### PR DESCRIPTION
## What does this PR do?

Prevents `message_agent` from reporting a successful send when the authored body already ends in the literal bracketed truncation marker. The sender now fails closed before target resolution or delivery and asks for a complete regenerated message.

The check is deliberately end-anchored: discussion or quoted examples containing `...[truncated]` in the middle of an otherwise complete message still deliver normally. This is a canary for an already-cut body, not a claim to repair or identify the unreproduced authoring mechanism, and it does not change the separate file-write guard.

Fixes #109069.

## Changes

- add a narrow end-of-body truncation-marker guard in `tools/bot_mode_dm.py`
- add two invariant tests covering refusal before dispatch and the mid-body quotation case

## Verification

- focused RED on current main: truncated-tail case dispatched successfully before the fix
- focused GREEN: 2 passed
- remaining file coverage excluding five pre-existing host/shell/mode failures: 42 passed, 1 skipped
- `ruff check tools/bot_mode_dm.py tests/tools/test_bot_mode_dm.py`: passed
- `git diff --check`: passed
- repository preflight: PASS (2 files, +40/-0, no merge commits, current main)

The full test file still has five unrelated local Windows environment failures: unavailable Git Bash/WSL shell, native path slash comparison, stdin Unicode console translation, and POSIX permission-mode assertions. The new focused tests pass independently.