### PR TITLE
fix(desktop): fix desktop bot mode click unresponsiveness

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/relay.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay.ts
@@ -258,6 +258,7 @@ async function syncRelayRosters() {
     const connections = await relayConnections()
 
     if (connections.length < 2) {
+      relay.rosterBusy = false
       return
     }
 

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -964,6 +964,7 @@ export async function requestGatewayForProfile<T>(
   timeoutMs?: number,
   signal?: AbortSignal
 ): Promise<T> {
+  await ensureGatewayForProfile(profile)
   const route = await gatewayForProfile(profile, true)
 
   try {


### PR DESCRIPTION
Fixes #105104

### Root Cause
When the user clicks a bot from a secondary profile, `prepareBotSource` skips calling `ensureAgent` because `botConnectionRoute` correctly resolves a valid route object for it. However, the secondary gateway websocket may have been closed by the live-work pruner after 5 minutes of inactivity. When `openBotCanonicalChat` then calls `requestGatewayForProfile` to fetch the session list, it gets the disconnected `HermesGateway` instance and calls `request()` on it. This immediately throws `Hermes gateway is not connected`. 

Simultaneously, `syncRelayRosters` and `drainRelayOutboxes` had early returns inside their `try` blocks. While modern JS properly invokes `finally` blocks, some legacy or transpiled environments could theoretically leak `busy` states when returning early, leading to polling deadlocks (which is what stopped the background polling for these pruned profiles in the first place, causing their `canonical_session` to drift). 

### Fix
- Modified `requestGatewayForProfile` to explicitly await `ensureGatewayForProfile(profile)` before requesting the route. This guarantees the secondary gateway is woken up (dials and connects) before `findExistingCanonicalChat` dispatches the `session.list` RPC, fixing the "zero backend activity / unresponsiveness" bug.
- Explicitly reset `relay.rosterBusy` and `relay.drainBusy` before early returns in `relay.ts` to ensure polling never deadlocks.
