### PR TITLE
fix(desktop): resolve Windows packaging and stage-and-swap update conflicts (fixes #105629)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -188,6 +188,7 @@
     "wait-on": "9.0.10"
   },
   "build": {
+    "disableAsarIntegrity": true,
     "electronVersion": "40.10.2",
     "appId": "com.nousresearch.hermes",
     "productName": "Hermes",

--- a/hermes_cli/main_desktop.py
+++ b/hermes_cli/main_desktop.py
@@ -212,12 +212,17 @@ def _swap_staged_desktop_app(desktop_dir: Path, staging_dir: Path) -> Optional[P
             if stopped:
                 logger.info("stopped desktop processes before staged app promotion: %s", stopped)
             os.rename(live_root, previous)
-        try:
-            os.rename(staged_root, live_root)
-        except OSError:
-            if moved_aside:
-                os.rename(previous, live_root)  # restore; live app back as it was
-            raise
+        for attempt in range(3):
+            try:
+                os.rename(staged_root, live_root)
+                break
+            except OSError:
+                if attempt < 2:
+                    _time_mod.sleep(1)
+                else:
+                    if moved_aside:
+                        os.rename(previous, live_root)  # restore; live app back as it was
+                    raise
         if moved_aside:
             shutil.rmtree(previous, ignore_errors=True)
     except (OSError, ValueError) as exc:


### PR DESCRIPTION
- Disables \sarIntegrity\ checking in \electron-builder\ on Windows to prevent it from rewriting the PE and causing the subsequent \cedit\ step in the \fterPack\ hook to fail with \Unable to commit changes\.
- Adds a short retry loop (up to 3 attempts, 1s apart) to the stage-and-swap \os.rename\ operation to absorb transient file locks (e.g., from antivirus or search indexers scanning the freshly built executable) before giving up.
- Fixes #105629.