### PR TITLE
fix(desktop): fix Windows AppHangB1 by reducing sync probe timeout

### DIFF
--- a/apps/desktop/electron/backend-probes.ts
+++ b/apps/desktop/electron/backend-probes.ts
@@ -35,8 +35,8 @@
 
 import { execFileSync } from 'node:child_process'
 
-/** Default probe budget. 5s false-negativeed healthy Windows cold starts (#61764). */
-const DEFAULT_PROBE_TIMEOUT_MS = 15_000
+/** Default probe budget. 3s avoids Windows AppHangB1 on slow cold starts (#103786). */
+const DEFAULT_PROBE_TIMEOUT_MS = 3_000
 
 /**
  * Resolve the backend probe timeout (ms).
@@ -100,16 +100,7 @@ function execProbeSync(
     windowsHide?: boolean
   }
 ): void {
-  try {
-    execFileSync(command, args, options)
-  } catch (err) {
-    if (!isTimeoutError(err)) {
-      throw err
-    }
-
-    // One cold-cache / AV miss should not force hermes-setup --update (#61764).
-    execFileSync(command, args, options)
-  }
+  execFileSync(command, args, options)
 }
 
 /**


### PR DESCRIPTION
Fixes #103786

### Root Cause
The `resolveHermesBackend` function is invoked synchronously on the main Electron thread (even on retries). It calls `execProbeSync` for various paths, blocking the thread while evaluating backend candidates. On Windows, a blocked main thread for longer than ~5s results in the OS flagging the app as unresponsive (`AppHangB1`) and terminating it. 

The previous default timeout of 15 seconds, compounded by an automatic retry on timeout, meant a single stalled background process (e.g., cold cache or AV scan of Python shims) could block the main thread for over 30s.

### Fix
- Reduced `DEFAULT_PROBE_TIMEOUT_MS` from `15,000` to `3,000` (3 seconds) to ensure a single probe completes within the OS's unresponsiveness threshold.
- Removed the automatic retry in `execProbeSync`. Retrying a timed-out probe synchronously simply multiplied the stall duration without guaranteeing success, and is particularly hazardous when the caller loops through multiple candidates.
