### PR TITLE
fix(tools): bind env_type by keyword in sandbox partials to prevent TypeError (fixes #105414)

### DIFF
--- a/tools/terminal_tool_backends.py
+++ b/tools/terminal_tool_backends.py
@@ -168,9 +168,9 @@ def _build_sandbox_env(env_type, *, image, cwd, timeout, cc, task_id, **_):
     return cls()(**kwargs)
 
 
-_build_singularity_env = functools.partial(_build_sandbox_env, "singularity")
-_build_daytona_env = functools.partial(_build_sandbox_env, "daytona")
-_build_vercel_env = functools.partial(_build_sandbox_env, "vercel_sandbox")
+_build_singularity_env = functools.partial(_build_sandbox_env, env_type="singularity")
+_build_daytona_env = functools.partial(_build_sandbox_env, env_type="daytona")
+_build_vercel_env = functools.partial(_build_sandbox_env, env_type="vercel_sandbox")
 
 
 def _build_ssh_env(*, cwd, timeout, ssh_config, probe_only=False, **_):


### PR DESCRIPTION
- Binds \env_type\ by keyword instead of position in \unctools.partial\ builders for Singularity, Daytona, and Vercel sandboxes.
- Prevents \TypeError: _build_sandbox_env() got multiple values for argument 'env_type'\ when the caller also supplies \env_type\ as a keyword argument.
- Fixes #105414.