### PR TITLE
fix(gateway): resolve Docker MEDIA in named-profile scope

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -940,6 +940,78 @@ def _tenv(name: str, default: str = "") -> str:
     return terminal_env(name, default)
 
 
+def _is_named_profile_session_key(session_key: str) -> bool:
+    """Return whether *session_key* carries a non-default profile namespace."""
+    parts = str(session_key or "").split(":", 2)
+    return len(parts) >= 2 and parts[0] == "agent" and parts[1] not in {"", "main", "default"}
+
+
+def _profile_name_from_session_key(session_key: str) -> Optional[str]:
+    """Return a validated, live profile name from a routed session key."""
+    if not _is_named_profile_session_key(session_key):
+        return None
+    profile_name = str(session_key).split(":", 2)[1]
+    try:
+        from hermes_cli.profiles import (
+            get_profile_dir, normalize_profile_name, profile_exists, validate_profile_name,
+        )
+
+        profile = normalize_profile_name(profile_name)
+        validate_profile_name(profile)
+        if not profile_exists(profile):
+            return None
+        # Resolve through the canonical helper after validation so a malformed namespace can never
+        # become a filesystem path, even when the profile directory happens to exist.
+        get_profile_dir(profile)
+        return profile
+    except (ImportError, OSError, RuntimeError, TypeError, ValueError):
+        return None
+
+
+@contextlib.contextmanager
+def _docker_media_profile_scope(session_key: str):
+    """Bind the routed profile while Docker MEDIA paths and policies are resolved.
+
+    Deferred delivery runs after the turn's profile context has been reset.  A validated named
+    profile gets a context-local Hermes home and terminal policy; keyless and historical
+    ``agent:main`` callers deliberately retain ambient behavior.  Missing or unreadable named
+    profiles yield ``False`` so callers can fail closed instead of borrowing another profile.
+    """
+    if not _is_named_profile_session_key(session_key):
+        yield True
+        return
+
+    profile = _profile_name_from_session_key(session_key)
+    if profile is None:
+        yield False
+        return
+
+    try:
+        from hermes_cli.profiles import get_profile_dir
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from tools.terminal_scope import (
+            TerminalPolicyUnavailable, build_profile_terminal_scope,
+            reset_terminal_scope, set_terminal_scope,
+        )
+
+        profile_home = get_profile_dir(profile)
+        terminal_policy = build_profile_terminal_scope(profile_home)
+        home_token = set_hermes_home_override(profile_home)
+        terminal_token = set_terminal_scope(terminal_policy)
+    except (ImportError, OSError, RuntimeError, TypeError, ValueError):
+        yield False
+        return
+    except TerminalPolicyUnavailable:
+        yield False
+        return
+
+    try:
+        yield True
+    finally:
+        reset_terminal_scope(terminal_token)
+        reset_hermes_home_override(home_token)
+
+
 def _parse_docker_volume_mounts() -> List[Tuple[Path, Path]]:
     """Parse ``TERMINAL_DOCKER_VOLUMES`` (JSON list of ``host:container[:mode]``) into
     ``(host_path, container_path)``; named volumes / non-absolute hosts can't resolve here."""
@@ -1065,7 +1137,7 @@ def _warn_unresolved_docker_media(candidate: Path, session_key: str, reason: str
                    f", session_key={session_key}" if session_key else "")
 
 
-def _translate_docker_container_media_path(candidate: Path, session_key: str = "") -> Optional[Path]:
+def _translate_docker_container_media_path_in_scope(candidate: Path, session_key: str = "") -> Optional[Path]:
     """Container-absolute path -> host path via longest-prefix match over ``docker_volumes``, the
     auto-mounted cache dirs (``/root/.hermes/...``), persistent ``/workspace`` and ``/root``."""
     if not candidate.is_absolute():
@@ -1106,25 +1178,24 @@ def _translate_docker_container_media_path(candidate: Path, session_key: str = "
     return None
 
 
-def validate_media_delivery_path(path: str, session_key: str = "") -> Optional[str]:
-    """Safe absolute file path for native media delivery, else None. Default: any existing
-    regular file outside the credential / system denylist (symmetric with inbound). Strict
-    (``HERMES_MEDIA_DELIVERY_STRICT=1``, public bots where prompt injection must not exfiltrate
-    host secrets): MUST be under a Hermes cache, an operator root (``HERMES_MEDIA_ALLOW_DIRS``),
-    or freshly produced within the recency window. Symlinks are resolved before any check."""
-    candidate = _normalize_media_tag_path(path)
-    if not candidate:
-        return None
-    try:
-        expanded = Path(os.path.expanduser(candidate))
-    except (OSError, RuntimeError, ValueError):
-        # expanduser raises ValueError("embedded null byte") for a ~\x00 path.
-        return None
-    if not expanded.is_absolute():
-        return None
+def _translate_docker_container_media_path(candidate: Path, session_key: str = "") -> Optional[Path]:
+    """Translate a Docker MEDIA path under the profile named by *session_key*."""
+    with _docker_media_profile_scope(session_key) as profile_available:
+        if not profile_available:
+            _warn_unresolved_docker_media(candidate, session_key, "profile namespace unavailable")
+            return None
+        return _translate_docker_container_media_path_in_scope(candidate, session_key)
+
+
+def _validate_media_delivery_path_in_scope(expanded: Path, session_key: str) -> Optional[str]:
+    """Validate an expanded path while its routed profile scope is still installed."""
     # Docker agents emit MEDIA:/workspace/... — map container paths to host paths first.
-    resolved = _translate_docker_container_media_path(expanded, session_key=session_key)
+    resolved = _translate_docker_container_media_path_in_scope(expanded, session_key=session_key)
     if resolved is None:
+        # A named Docker namespace owns its container paths. Never reinterpret an unresolved
+        # /root, /workspace, or /output path through the ambient host filesystem.
+        if _is_named_profile_session_key(session_key) and _docker_env_active():
+            return None
         resolved = _resolve_path(expanded, strict=True)
     if resolved is None or not resolved.is_file():
         return None
@@ -1143,6 +1214,29 @@ def validate_media_delivery_path(path: str, session_key: str = "") -> Optional[s
             and _file_is_recently_produced(resolved, window)):
         return str(resolved)
     return None
+
+
+def validate_media_delivery_path(path: str, session_key: str = "") -> Optional[str]:
+    """Safe absolute file path for native media delivery, else None. Default: any existing
+    regular file outside the credential / system denylist (symmetric with inbound). Strict
+    (``HERMES_MEDIA_DELIVERY_STRICT=1``, public bots where prompt injection must not exfiltrate
+    host secrets): MUST be under a Hermes cache, an operator root (``HERMES_MEDIA_ALLOW_DIRS``),
+    or freshly produced within the recency window. Symlinks are resolved before any check."""
+    candidate = _normalize_media_tag_path(path)
+    if not candidate:
+        return None
+    try:
+        expanded = Path(os.path.expanduser(candidate))
+    except (OSError, RuntimeError, ValueError):
+        # expanduser raises ValueError("embedded null byte") for a ~\x00 path.
+        return None
+    if not expanded.is_absolute():
+        return None
+    with _docker_media_profile_scope(session_key) as profile_available:
+        if not profile_available:
+            _warn_unresolved_docker_media(expanded, session_key, "profile namespace unavailable")
+            return None
+        return _validate_media_delivery_path_in_scope(expanded, session_key)
 
 
 # Control chars + Unicode line separators (NEL, LS, PS) that log aggregators treat as breaks: a

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -261,7 +261,8 @@ class GatewayNotificationsMixin:
         return switched
 
     async def _deliver_media_from_response(
-        self, response: str, event: MessageEvent, adapter, thread_metadata: Optional[Dict[str, Any]] = None
+        self, response: str, event: MessageEvent, adapter,
+        thread_metadata: Optional[Dict[str, Any]] = None, session_key: Optional[str] = None,
     ) -> None:
         """Deliver explicit MEDIA: tags from an already-streamed response (text already delivered).
         EXPLICIT-ONLY, unlike the non-streaming path in ``gateway/platforms/base.py``: a bare local
@@ -278,7 +279,8 @@ class GatewayNotificationsMixin:
             force_document_attachments = "[[as_document]]" in response
             from gateway.platforms.base import BasePlatformAdapter, should_send_media_as_audio
             media_files, cleaned = adapter.extract_media(response)
-            media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+            media_files = BasePlatformAdapter.filter_media_delivery_paths(
+                media_files, session_key=session_key or "")
             # Strip image URLs (parity with the non-streaming chain); no extract_local_files here.
             # Do NOT deduplicate explicit MEDIA tags against prior turns here (#73771). This rescan is
             # already EXPLICIT-ONLY (see docstring): a MEDIA: directive in the final streamed reply is the
@@ -382,7 +384,7 @@ class GatewayNotificationsMixin:
             return
         await self._deliver_media_from_response(
             response, MessageEvent(text="", source=source, message_id=event_message_id), adapter,
-            thread_metadata=metadata,
+            thread_metadata=metadata, session_key=session_key,
         )
 
     async def _send_queued_final_text(

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2256,7 +2256,8 @@ class GatewayTurnMixin:
             images, media_files, text_content = [], [], ""
             if response:
                 media_files, response = adapter.extract_media(response)
-                media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+                media_files = BasePlatformAdapter.filter_media_delivery_paths(
+                    media_files, session_key=self._session_key_for_source(source))
                 images, text_content = adapter.extract_images(response)
             if text_content:
                 await adapter.send(chat_id=source.chat_id, content=header + text_content, metadata=_thread_metadata)

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1471,6 +1471,134 @@ class TestDockerProfileSandboxMediaTranslation:
             "/root/note.txt", session_key=self.SESSION_KEY
         ) == str(produced.resolve())
 
+    def test_named_profile_scope_restores_sandbox_and_volume_policy(self, tmp_path, monkeypatch):
+        """The session namespace must restore both profile-scoped Docker inputs."""
+        import json
+
+        import gateway.platforms.base as base
+        from hermes_cli.profiles import get_active_profile_name
+        from tools.environments.path_utils import sanitize_task_id_for_path
+        from tools.terminal_scope import get_terminal_scope, terminal_env
+
+        hermes_home = tmp_path / "hermes"
+        public_home = hermes_home / "profiles" / "public"
+        public_home.mkdir(parents=True)
+        public_output = public_home / "cache" / "output"
+        public_output.mkdir(parents=True)
+        (public_home / "config.yaml").write_text(json.dumps({
+            "terminal": {
+                "backend": "docker",
+                "docker_volumes": [f"{public_output}:/output"],
+            },
+        }), encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        self._enable_docker(monkeypatch)
+        monkeypatch.setenv("TERMINAL_DOCKER_VOLUMES", json.dumps(["C:/ambient:/output"]))
+
+        session_key = "agent:public:discord:thread:1:2"
+        expected_sandbox = (
+            public_home / "sandboxes" / "docker"
+            / sanitize_task_id_for_path("profile:public") / "home"
+        ).resolve()
+        expected_sandbox.mkdir(parents=True)
+        with base._docker_media_profile_scope(session_key) as profile_available:
+            assert profile_available is True
+            assert get_active_profile_name() == "public"
+            assert json.loads(terminal_env("TERMINAL_DOCKER_VOLUMES")) == [f"{public_output}:/output"]
+            assert base._docker_sandbox_dir_candidates(session_key)[0] == (
+                sanitize_task_id_for_path("profile:public")
+            )
+            assert base._docker_persistent_sandbox_roots(session_key, "home") == [expected_sandbox]
+        assert get_active_profile_name() == "default"
+        assert get_terminal_scope() is None
+
+    @pytest.mark.linux_only
+    def test_named_profile_home_and_output_mounts_ignore_ambient_default(self, tmp_path, monkeypatch):
+        """Deferred delivery must restore the producing profile before reading Docker state."""
+        import json
+
+        import gateway.platforms.base as base
+        from hermes_cli.profiles import get_active_profile_name, get_profile_dir
+        from tools.environments.path_utils import sanitize_task_id_for_path
+
+        hermes_home = tmp_path / "hermes"
+        public_home = hermes_home / "profiles" / "public"
+        public_home.mkdir(parents=True)
+        public_output = public_home / "cache" / "output"
+        public_output.mkdir(parents=True)
+        (public_home / "config.yaml").write_text(json.dumps({
+            "terminal": {
+                "backend": "docker",
+                "docker_volumes": [f"{public_output}:/output"],
+            },
+        }), encoding="utf-8")
+
+        default_home_file = hermes_home / "sandboxes" / "docker" / "default" / "home" / "named.txt"
+        default_home_file.parent.mkdir(parents=True)
+        default_home_file.write_text("ambient", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        public_home_file = (
+            get_profile_dir("public") / "sandboxes" / "docker"
+            / sanitize_task_id_for_path("profile:public") / "home" / "named.txt"
+        )
+        public_home_file.parent.mkdir(parents=True)
+        public_home_file.write_text("public", encoding="utf-8")
+
+        ambient_output = tmp_path / "ambient-output"
+        ambient_output.mkdir()
+        (ambient_output / "output.txt").write_text("ambient", encoding="utf-8")
+        (public_output / "output.txt").write_text("public", encoding="utf-8")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        self._enable_docker(monkeypatch)
+        monkeypatch.setenv("TERMINAL_DOCKER_VOLUMES", json.dumps([f"{ambient_output}:/output"]))
+
+        session_key = "agent:public:discord:thread:1:2"
+        assert get_profile_dir("public") == public_home
+        assert get_active_profile_name() == "default"
+        assert BasePlatformAdapter.validate_media_delivery_path(
+            "/root/named.txt", session_key=session_key
+        ) == str(public_home_file.resolve())
+        assert BasePlatformAdapter.validate_media_delivery_path(
+            "/output/output.txt", session_key=session_key
+        ) == str((public_output / "output.txt").resolve())
+
+    def test_named_profile_docker_path_fails_closed_without_translation(self, tmp_path, monkeypatch):
+        """A named Docker path must not fall back to an ambient host file."""
+        import gateway.platforms.base as base
+
+        hermes_home = tmp_path / "hermes"
+        (hermes_home / "profiles" / "secondary").mkdir(parents=True)
+        ambient = tmp_path / "ambient.png"
+        ambient.write_bytes(b"png")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        self._enable_docker(monkeypatch)
+        monkeypatch.setattr(base, "_docker_env_active", lambda: True)
+        monkeypatch.setattr(base, "_translate_docker_container_media_path", lambda *_a, **_k: None)
+        monkeypatch.setattr(base, "_resolve_path", lambda _path, **_kwargs: ambient)
+
+        assert BasePlatformAdapter.validate_media_delivery_path(
+            "C:/root/ambient.png", session_key="agent:secondary:telegram:dm:123"
+        ) is None
+
+    def test_keyless_and_main_docker_paths_keep_host_fallback(self, tmp_path, monkeypatch):
+        """Unscoped and historical ``agent:main`` callers retain compatibility."""
+        import gateway.platforms.base as base
+
+        ambient = tmp_path / "ambient.png"
+        ambient.write_bytes(b"png")
+        monkeypatch.setattr(base, "_docker_env_active", lambda: True)
+        monkeypatch.setattr(base, "_translate_docker_container_media_path", lambda *_a, **_k: None)
+        monkeypatch.setattr(base, "_resolve_path", lambda _path, **_kwargs: ambient)
+
+        assert BasePlatformAdapter.validate_media_delivery_path("C:/root/ambient.png") == str(ambient)
+        assert BasePlatformAdapter.validate_media_delivery_path(
+            "C:/root/ambient.png", session_key="agent:main:telegram:dm:123"
+        ) == str(ambient)
+
     def test_home_credential_surface_still_refused(self, monkeypatch):
         """The /root/.hermes exclusion survives profile scoping: translating
         the home mount must never expose the container's secret surface —

--- a/tests/gateway/test_stream_final_contract.py
+++ b/tests/gateway/test_stream_final_contract.py
@@ -19,6 +19,7 @@ Three invariants:
 
 import asyncio
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -222,6 +223,31 @@ class TestFinalAdoptionGuards:
 
 
 class TestQueuedLaneReconcile:
+    @pytest.mark.asyncio
+    async def test_queued_media_keeps_the_routed_session_key(self):
+        """Deferred post-stream media must retain named-profile identity."""
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner._deliver_media_from_response = AsyncMock()
+        runner._pop_post_delivery_callback = lambda *_args: None
+        source = SimpleNamespace(chat_id="D1", platform="discord")
+        session_key = "agent:public:discord:thread:1:2"
+
+        await GatewayRunner._deliver_queued_first_response(
+            runner,
+            "MEDIA: /output/result.pdf",
+            source=source,
+            adapter=SimpleNamespace(),
+            metadata={"thread_id": "2"},
+            text_already_delivered=True,
+            deliver_media=True,
+            session_key=session_key,
+        )
+
+        runner._deliver_media_from_response.assert_awaited_once()
+        assert runner._deliver_media_from_response.await_args.kwargs["session_key"] == session_key
+
     @pytest.mark.asyncio
     async def test_queued_first_response_edits_in_place(self):
         from gateway.run import GatewayRunner

--- a/tests/tools/test_terminal_scope_multiplex.py
+++ b/tests/tools/test_terminal_scope_multiplex.py
@@ -143,6 +143,22 @@ def test_profile_omitting_keys_gets_defaults_not_launch_values(tmp_path):
     assert json.loads(os.environ["TERMINAL_DOCKER_VOLUMES"])  # A unchanged
 
 
+def test_sandbox_dir_reads_routed_profile_policy(tmp_path):
+    """Sandbox storage must follow the scoped profile, not the launch environment."""
+    import gateway.run as gw
+    from tools.environments.base import get_sandbox_dir
+
+    custom = tmp_path / "profile-sandbox"
+    home = _profile(
+        tmp_path,
+        "bee",
+        json.dumps({"terminal": {"backend": "docker", "sandbox_dir": str(custom)}}),
+    )
+    with gw._profile_runtime_scope(home):
+        assert get_sandbox_dir() == custom
+        assert custom.is_dir()
+
+
 def test_malformed_profile_config_refuses_execution(tmp_path):
     """Unresolvable policy → refusal scope; terminal_tool refuses instead of
     running under the launch process's ambient policy (fail closed)."""

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -110,7 +110,14 @@ def touch_activity_if_due(state: dict, label: str) -> None:
 def get_sandbox_dir() -> Path:
     """Host-side root for all sandbox storage (Docker workspaces, Singularity
     overlays/SIF cache). ``TERMINAL_SANDBOX_DIR`` overrides ``{HERMES_HOME}/sandboxes``."""
-    custom = os.getenv("TERMINAL_SANDBOX_DIR")
+    try:
+        from tools.terminal_scope import terminal_env
+    except ImportError:
+        custom = os.getenv("TERMINAL_SANDBOX_DIR")
+    else:
+        # A multiplexed profile's terminal scope is authoritative; reading os.environ here would
+        # reintroduce the launch profile's sandbox root after the routed turn has been cleared.
+        custom = terminal_env("TERMINAL_SANDBOX_DIR", "")
     p = Path(custom) if custom else get_hermes_home() / "sandboxes"
     p.mkdir(parents=True, exist_ok=True)
     return p


### PR DESCRIPTION
## Summary

Fixes #109024.

This PR consolidates the two complementary contributions from #109041 and #109047 into one root-cause fix for multiplexed named-profile Docker `MEDIA:` delivery. Deferred delivery now resolves the producing profile's persistent Docker sandbox and terminal volume policy instead of the ambient/default profile, while unresolved named-profile Docker paths fail closed.

## Problem observed

- A routed turn in a named profile such as `agent:public:discord:thread:<id>:<id>` correctly runs in the `public` profile's persistent Docker container.
- Post-turn MEDIA delivery runs after the routed profile context has been cleared.
- `MEDIA: /root/<file>` and `MEDIA: /output/<file>` were therefore resolved with the default/ambient profile's sandbox and `TERMINAL_DOCKER_VOLUMES`.
- Existing files in the producing profile were dropped, and an unresolved container path could fall through to host-path resolution.

The issue report's direct reproduction showed the named profile's file present under its bind mount while the ambient resolver returned `None`. The same path resolved after entering the named profile context.

## Investigation and baseline

- Issue: https://github.com/NousResearch/hermes-agent/issues/109024
- Issue state at investigation: open, no comments or assignee.
- Baseline: `origin/main` at `f364c19775617acb6c16140b790cda9fb05e1906`.
- Relevant history: commit `15f7b7293cbe3b517b5f4560be2d0867478b6282` intentionally changed persistent Docker identity from per-session to profile-scoped (`default` / `profile:<name>`). The delivery resolver retained ambient profile reads, creating the mismatch.
- Production reproduction was also run against the clean baseline: under an intentionally default ambient home, a `public` profile sandbox file and explicit `/output` file both returned `None`.

Related work was read and compared by effective patch and ownership:

- #109028: closed and unmerged; a separate contributor's earlier named-profile implementation. It was not copied or cherry-picked.
- #109041: open PR from `JoaoMarcos44`, focused on failing closed instead of host fallback when named Docker translation fails.
- #109047: open PR from `JoaoMarcos44`, focused on restoring named-profile sandbox and volume resolution.

Additional related work checked during the duplicate sweep:

- #94509 (merged): fixed the earlier session-scoped Docker MEDIA drop from #93950; it predates the profile-scoped persistent-container contract.
- #94560 (merged): made persistent Docker containers shared per profile, which is the producer-side identity contract this fix now honors during delivery.
- #101242 (merged): established per-profile terminal backend/cwd/Docker policy under multiplexing; this issue is the remaining deferred-MEDIA boundary.
- #101187 (open): cross-profile bind-mount containment in Docker creation; related security boundary, but a different lifecycle and intentionally not combined here.
- #74066 (open): older task-id propagation for task-scoped/cron MEDIA delivery; it addresses a different task identity model, so this PR does not change cron's job-id contract.

This PR is the original unified implementation on a fresh branch from current `main`; the two existing branches were not modified.

## Root cause

The persistent Docker producer and the deferred MEDIA consumer used different identity sources:

1. `tools/terminal_tool.py:_resolve_container_task_id()` used the routed profile namespace and created `profile:<name>` for persistent Docker.
2. `gateway/platforms/base.py` delivery helpers used ambient state after the turn scope ended:
   - `_docker_sandbox_dir_candidates()` read `get_active_profile_name()` from the ambient home;
   - `_docker_persistent_sandbox_roots()` read the ambient sandbox root;
   - `_parse_docker_volume_mounts()` read the ambient terminal policy;
   - `validate_media_delivery_path()` treated a failed container translation as permission to try the host filesystem.
3. Two sibling delivery paths also discarded the identity before filtering media: queued post-stream delivery and `/bg` background-task delivery.

The result was not a Docker creation failure. It was a post-turn identity loss and an unsafe fallback at the shared validation chokepoint.

## Solution

- Parse the namespace from `agent:<profile>:...` session keys.
- Normalize and validate the profile name, require a live profile directory, and reject malformed or unavailable namespaces before any profile path is used.
- For a valid named profile, install a context-local `HERMES_HOME` override and the profile's complete terminal policy while Docker MEDIA paths are translated and validated. The context is always reset.
- Resolve the profile-scoped persistent sandbox and explicit Docker volume policy through that scope, including profile-specific `TERMINAL_SANDBOX_DIR`.
- Keep keyless and historical `agent:main` behavior ambient for compatibility.
- If a named profile cannot be restored or a named Docker translation is unresolved, do not reinterpret the container path against the ambient host filesystem.
- Carry the canonical session key through queued post-stream and background-task media filters.

This preserves the existing longest-prefix mount matching, legacy per-session sandbox fallback, credential-surface refusal, containment checks, and media policy checks. No configuration migration or process-global environment mutation was added.

## Impact and scope

Affected:

- Multiplexed named profiles using persistent Docker.
- Deferred/native MEDIA delivery for profile sandbox paths such as `/root`, `/workspace`, and explicit mounts such as `/output`.
- Queued post-stream and `/bg` media delivery paths that previously filtered without a session key.

Not affected:

- Keyless CLI delivery.
- Historical `agent:main` / default-profile behavior.
- Non-Docker media delivery.
- Existing legacy per-session Docker sandboxes, which remain fallback candidates.
- Docker execution and container creation logic.

Security and operational impact:

- Prevents a named profile's unresolved container path from being accepted as a file in the default profile or another ambient host location.
- Profile names are validated before filesystem resolution, preventing a session-key namespace from becoming an unvalidated path.
- Scope state is context-local and reset in `finally`; `os.environ` is not mutated.
- No credentials, tokens, `.env` contents, or secret-bearing logs were added.

## Tests and verification

All commands used the repository's canonical `scripts/run_tests.sh`; the checkout has no local `.venv`, so the existing pytest-capable `HERMES_PYTHON` fallback was supplied.

| Command | Result |
|---|---|
| `scripts/run_tests.sh tests/gateway/test_platform_base.py -k 'named_profile_scope_restores_sandbox_and_volume_policy or named_profile_home_and_output_mounts_ignore_ambient_default or named_profile_docker_path_fails_closed_without_translation or keyless_and_main_docker_paths_keep_host_fallback'` | 3 passed, 1 skipped on Windows; the real POSIX Docker translation test is marked `linux_only` and is for the Linux CI lane |
| `scripts/run_tests.sh tests/tools/test_terminal_scope_multiplex.py` | 12 passed |
| `scripts/run_tests.sh tests/gateway/test_stream_final_contract.py` | 9 passed |
| `scripts/run_tests.sh tests/gateway/test_multiplex_background_task_scope.py tests/gateway/test_background_command.py` | 11 passed |
| `ruff check gateway/platforms/base.py gateway/run_notifications.py gateway/run_turn.py tools/environments/base.py tests/gateway/test_platform_base.py tests/gateway/test_stream_final_contract.py tests/tools/test_terminal_scope_multiplex.py` | passed (`ruff` 0.15.17) |
| `python -m py_compile gateway/platforms/base.py gateway/run_notifications.py gateway/run_turn.py tools/environments/base.py tests/gateway/test_platform_base.py tests/gateway/test_stream_final_contract.py tests/tools/test_terminal_scope_multiplex.py` | passed |
| `git diff --check` | passed |

The regression tests were proven red on the old source using a source-only stash while preserving the test edits: 1 passed, 2 failed, 1 skipped. The failures were the named-profile scope restoration and fail-closed contracts; the corrected source passes the same focused command.

Clean-baseline comparison for the broad platform test on Windows:

- Clean `origin/main` (`f364c197...`): 90 passed, 15 failed, 2 skipped.
- This commit (`2b9f85c1f059a5bb4a44211aabd1197d66140c47`): 93 passed, 15 failed, 3 skipped.
- The same 15 baseline failures occur on both revisions and are existing POSIX Docker / POSIX `/root` assumptions exercised on the Windows host. They are not introduced by this change; the new Linux-specific integration test is explicitly skipped on Windows.

Limitations:

- Docker live E2E could not run because the Docker Desktop Linux engine was unavailable (`docker version` could not connect to its named pipe). WSL reported only the default `docker-desktop` distribution.
- `graphify update . --no-cluster` was attempted after the code edits but timed out after 420 seconds before producing `graphify-out/graph.json`; no graph receipt is claimed.
- Full CI results are not claimed here; they are pending the published PR and the Linux lane that executes the POSIX Docker regression.

## Files and documentation

- `gateway/platforms/base.py`: profile namespace validation, context-local profile restoration, scoped Docker translation/validation, fail-closed behavior.
- `tools/environments/base.py`: make `get_sandbox_dir()` honor the active terminal scope.
- `gateway/run_notifications.py`: preserve the session key for queued post-stream MEDIA filtering.
- `gateway/run_turn.py`: preserve the session key for background-task MEDIA filtering.
- `tests/gateway/test_platform_base.py`: named-profile sandbox/volume routing, fail-closed behavior, compatibility contracts, and Linux integration coverage.
- `tests/gateway/test_stream_final_contract.py`: queued-lane session-key propagation.
- `tests/tools/test_terminal_scope_multiplex.py`: profile-scoped sandbox directory policy.

Commit: `2b9f85c1f059a5bb4a44211aabd1197d66140c47`
Base: `3e09e5a15f43e7253abaf4760f0487fece39ff93`
Branch: `fix/109024-unified-profile-media`

Fixes #109024
