### PR TITLE
feat(search): add opt-in reasoning trace recall

### DIFF
--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -125,26 +125,33 @@ def _like_params(term: str, *, include_reasoning: bool = False) -> List[str]:
 
 
 def _reasoning_snippet_sql(terms: List[str]) -> Tuple[str, List[str]]:
-    """Bounded snippet from the first query term that matches a reasoning field."""
+    """Bounded snippet from the first query term and searchable field that match."""
     cases: List[str] = []
     params: List[str] = []
     for term in terms:
         pattern = f"%{_escape_like(term)}%"
-        for column in ("m.reasoning", "m.reasoning_content"):
+        for column in ("m.content", "m.tool_name", "m.tool_calls"):
             cases.append(
                 f"WHEN COALESCE({column}, '') LIKE ? ESCAPE '\\' "
                 f"THEN substr({column}, max(1, instr(lower({column}), lower(?)) - 40), 120)"
             )
             params.extend((pattern, term))
+        for column in ("m.reasoning", "m.reasoning_content"):
+            cases.append(
+                f"WHEN m.role = 'assistant' AND COALESCE({column}, '') LIKE ? ESCAPE '\\' "
+                f"THEN substr({column}, max(1, instr(lower({column}), lower(?)) - 40), 120)"
+            )
+            params.extend((pattern, term))
         cases.append(
-            "WHEN NOT json_valid(COALESCE(m.reasoning_details, '')) "
+            "WHEN m.role = 'assistant' AND NOT json_valid(COALESCE(m.reasoning_details, '')) "
             "AND COALESCE(m.reasoning_details, '') LIKE ? ESCAPE '\\' "
             "THEN substr(m.reasoning_details, "
             "max(1, instr(lower(m.reasoning_details), lower(?)) - 40), 120)"
         )
         params.extend((pattern, term))
         cases.append(
-            f"WHEN EXISTS (SELECT 1 FROM json_tree({_REASONING_DETAILS_JSON_SQL}) AS rd "
+            f"WHEN m.role = 'assistant' AND EXISTS "
+            f"(SELECT 1 FROM json_tree({_REASONING_DETAILS_JSON_SQL}) AS rd "
             "             WHERE rd.type = 'text' AND CAST(rd.value AS TEXT) LIKE ? ESCAPE '\\') "
             f"THEN (SELECT substr(CAST(rd.value AS TEXT), "
             "                         max(1, instr(lower(CAST(rd.value AS TEXT)), lower(?)) - 40), 120) "
@@ -152,10 +159,9 @@ def _reasoning_snippet_sql(terms: List[str]) -> Tuple[str, List[str]]:
             "      WHERE rd.type = 'text' AND CAST(rd.value AS TEXT) LIKE ? ESCAPE '\\' LIMIT 1)"
         )
         params.extend((pattern, term, pattern))
-    params.append(terms[0])
     return (
         f"CASE {' '.join(cases)} "
-        "ELSE substr(m.content, max(1, instr(m.content, ?) - 40), 120) END AS snippet",
+        "ELSE '' END AS snippet",
         params,
     )
 

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -45,8 +45,23 @@ _QUOTED_PHRASE_RE = re.compile(r'"[^"]*"')
 # Column list shared by every search route (snippet + metadata, never content).
 _SEARCH_SELECT_TAIL = "m.timestamp, m.tool_name, s.source, s.model, s.started_at AS session_started"
 _LIKE_SNIPPET_SQL = "substr(m.content, max(1, instr(m.content, ?) - 40), 120) AS snippet"
+_REASONING_TEXT_SQL = (
+    "COALESCE(m.reasoning, '') || ' ' || COALESCE(m.reasoning_content, '') || ' ' || "
+    "COALESCE(m.reasoning_details, '')"
+)
+_LIKE_REASONING_SNIPPET_SQL = (
+    f"CASE WHEN {_REASONING_TEXT_SQL} LIKE ? ESCAPE '\\' "
+    f"THEN substr({_REASONING_TEXT_SQL}, max(1, instr(lower({_REASONING_TEXT_SQL}), lower(?)) - 40), 120) "
+    "ELSE substr(m.content, max(1, instr(m.content, ?) - 40), 120) END AS snippet"
+)
 _LIKE_ANY_COLUMN_SQL = (
     "(m.content LIKE ? ESCAPE '\\' OR m.tool_name LIKE ? ESCAPE '\\' OR m.tool_calls LIKE ? ESCAPE '\\')"
+)
+_LIKE_ANY_COLUMN_WITH_REASONING_SQL = (
+    "(COALESCE(m.content, '') LIKE ? ESCAPE '\\' OR "
+    "COALESCE(m.tool_name, '') LIKE ? ESCAPE '\\' OR "
+    "COALESCE(m.tool_calls, '') LIKE ? ESCAPE '\\' OR "
+    f"(m.role = 'assistant' AND {_REASONING_TEXT_SQL} LIKE ? ESCAPE '\\'))"
 )
 _LIKE_COALESCED_COLUMN_SQL = (
     "(COALESCE(m.content, '') LIKE ? ESCAPE '\\' OR "
@@ -101,9 +116,9 @@ def _quote_fts_tokens(raw_query: str) -> str:
     )
 
 
-def _like_params(term: str) -> List[str]:
-    """One ``%term%`` bind per column of ``_LIKE_ANY_COLUMN_SQL``."""
-    return [f"%{_escape_like(term)}%"] * 3
+def _like_params(term: str, *, include_reasoning: bool = False) -> List[str]:
+    """One ``%term%`` bind per column in the selected canonical LIKE scope."""
+    return [f"%{_escape_like(term)}%"] * (4 if include_reasoning else 3)
 
 
 def _flatten_text(decoded: Any) -> str:
@@ -909,13 +924,23 @@ class SessionSearchMixin:
                 fail_open, exc)
             return None
 
-    def _like_rows(self, where: List[str], params: list, *, order_by: str, limit_sql: str) -> List[Dict[str, Any]]:
+    def _like_rows(self, where: List[str], params: list, *, order_by: str, limit_sql: str,
+                   include_reasoning: bool = False) -> List[Dict[str, Any]]:
         """Canonical-table LIKE scan; ``params[0]`` is the snippet anchor term."""
-        sql = _search_select_sql(_LIKE_SNIPPET_SQL, "messages m", where, order_by, limit_sql)
-        return [dict(row) for row in self._read_all(sql, params)]
+        if include_reasoning:
+            term = params[0]
+            snippet_params = [f"%{_escape_like(term)}%", term, term]
+            snippet_sql = _LIKE_REASONING_SNIPPET_SQL
+        else:
+            snippet_params = [params[0]]
+            snippet_sql = _LIKE_SNIPPET_SQL
+        sql = _search_select_sql(snippet_sql, "messages m", where, order_by, limit_sql)
+        return [dict(row) for row in self._read_all(sql, [*snippet_params, *params[1:]])]
 
     @staticmethod
-    def _compile_like_boolean_query(query: str) -> Tuple[str, List[Any], Optional[str]]:
+    def _compile_like_boolean_query(
+        query: str, *, include_reasoning: bool = False,
+    ) -> Tuple[str, List[Any], Optional[str]]:
         """Compile the supported FTS boolean subset into LIKE predicates: terms within an OR
         group are ANDed (FTS5's implicit conjunction) and ``NOT`` negates the next term."""
         groups: List[List[Tuple[str, bool]]] = [[]]
@@ -940,29 +965,34 @@ class SessionSearchMixin:
         compiled_groups: List[str] = []
         params: List[Any] = []
         snippet_term: Optional[str] = None
+        column_sql = _LIKE_ANY_COLUMN_WITH_REASONING_SQL if include_reasoning else _LIKE_COALESCED_COLUMN_SQL
         for group in groups:
             if not group or not any(not negated for _, negated in group):
                 continue
             clauses: List[str] = []
             for term, negated in group:
-                clauses.append(f"NOT {_LIKE_COALESCED_COLUMN_SQL}" if negated else _LIKE_COALESCED_COLUMN_SQL)
-                params.extend(_like_params(term))
+                clauses.append(f"NOT {column_sql}" if negated else column_sql)
+                params.extend(_like_params(term, include_reasoning=include_reasoning))
                 if snippet_term is None and not negated:
                     snippet_term = term
             compiled_groups.append(f"({' AND '.join(clauses)})")
         return " OR ".join(compiled_groups), params, snippet_term
 
     def _search_messages_like_fallback(
-        self, query: str, *, limit: int, offset: int, sort: Optional[str], **filters) -> List[Dict[str, Any]]:
+        self, query: str, *, limit: int, offset: int, sort: Optional[str], include_reasoning: bool = False,
+        **filters,
+    ) -> List[Dict[str, Any]]:
         """Search canonical messages while derived FTS state is stale."""
-        predicate, params, snippet_term = self._compile_like_boolean_query(query)
+        predicate, params, snippet_term = self._compile_like_boolean_query(
+            query, include_reasoning=include_reasoning)
         if not predicate or snippet_term is None:
             return []
         where = [f"({predicate})"]
         _search_filter_clauses(where, params, **filters)
         order = "ASC" if isinstance(sort, str) and sort.strip().lower() == "oldest" else "DESC"
         return self._like_rows(where, [snippet_term, *params, limit, offset],
-                               order_by=f"ORDER BY m.timestamp {order}, m.id {order}", limit_sql="LIMIT ? OFFSET ?")
+                               order_by=f"ORDER BY m.timestamp {order}, m.id {order}", limit_sql="LIMIT ? OFFSET ?",
+                               include_reasoning=include_reasoning)
 
     def _refresh_fts_stale_state(self) -> None:
         """Observe fail-open initiated by another process sharing state.db."""
@@ -1010,7 +1040,7 @@ class SessionSearchMixin:
     def search_messages(
         self, query: str, source_filter: List[str] = None, exclude_sources: List[str] = None,
         role_filter: List[str] = None, limit: int = 20, offset: int = 0, sort: str = None,
-        include_inactive: bool = False, fields: Optional[Collection[str]] = None,
+        include_inactive: bool = False, fields: Optional[Collection[str]] = None, include_reasoning: bool = False,
     ) -> List[Dict[str, Any]]:
         """:meth:`_search_messages_impl` plus one log line per slow search with the routing
         path taken. Threshold HERMES_SEARCH_SLOW_MS (default 1000; 0 logs every call)."""
@@ -1019,7 +1049,8 @@ class SessionSearchMixin:
         try:
             rows = self._search_messages_impl(
                 query, source_filter=source_filter, exclude_sources=exclude_sources, role_filter=role_filter,
-                limit=limit, offset=offset, sort=sort, include_inactive=include_inactive, fields=fields)
+                limit=limit, offset=offset, sort=sort, include_inactive=include_inactive, fields=fields,
+                include_reasoning=include_reasoning)
             return rows
         finally:
             elapsed_ms = (time.time() - started) * 1000.0
@@ -1031,7 +1062,7 @@ class SessionSearchMixin:
     def _search_messages_impl(
         self, query: str, source_filter: List[str] = None, exclude_sources: List[str] = None,
         role_filter: List[str] = None, limit: int = 20, offset: int = 0, sort: str = None,
-        include_inactive: bool = False, fields: Optional[Collection[str]] = None,
+        include_inactive: bool = False, fields: Optional[Collection[str]] = None, include_reasoning: bool = False,
     ) -> List[Dict[str, Any]]:
         """FTS5 search across session messages (keywords, ``"phrases"``, AND/OR/NOT, ``prefix*``).
         Returns snippet + session metadata + 1-message context per hit; ``fields`` selects a
@@ -1046,6 +1077,12 @@ class SessionSearchMixin:
             return []
         filters = dict(include_inactive=include_inactive, source_filter=source_filter,
                        exclude_sources=exclude_sources, role_filter=role_filter)
+        # Reasoning is deliberately absent from every derived index. The explicit opt-in
+        # searches canonical rows so existing databases work without a rebuild or index growth.
+        if include_reasoning:
+            matches = self._search_messages_like_fallback(
+                query, limit=limit, offset=offset, sort=sort, include_reasoning=True, **filters)
+            return self._finalize_search_matches(matches, result_fields=result_fields)
         # New oversized tool results index only a bounded prefix; an explicit tool-role search is the
         # opt-in full-body path and scans canonical rows via LIKE.
         if role_filter and "tool" in role_filter:

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -45,23 +45,26 @@ _QUOTED_PHRASE_RE = re.compile(r'"[^"]*"')
 # Column list shared by every search route (snippet + metadata, never content).
 _SEARCH_SELECT_TAIL = "m.timestamp, m.tool_name, s.source, s.model, s.started_at AS session_started"
 _LIKE_SNIPPET_SQL = "substr(m.content, max(1, instr(m.content, ?) - 40), 120) AS snippet"
-_REASONING_TEXT_SQL = (
-    "COALESCE(m.reasoning, '') || ' ' || COALESCE(m.reasoning_content, '') || ' ' || "
-    "COALESCE(m.reasoning_details, '')"
-)
-_LIKE_REASONING_SNIPPET_SQL = (
-    f"CASE WHEN {_REASONING_TEXT_SQL} LIKE ? ESCAPE '\\' "
-    f"THEN substr({_REASONING_TEXT_SQL}, max(1, instr(lower({_REASONING_TEXT_SQL}), lower(?)) - 40), 120) "
-    "ELSE substr(m.content, max(1, instr(m.content, ?) - 40), 120) END AS snippet"
-)
 _LIKE_ANY_COLUMN_SQL = (
     "(m.content LIKE ? ESCAPE '\\' OR m.tool_name LIKE ? ESCAPE '\\' OR m.tool_calls LIKE ? ESCAPE '\\')"
+)
+_REASONING_DETAILS_JSON_SQL = (
+    "CASE WHEN json_valid(COALESCE(m.reasoning_details, '')) "
+    "THEN m.reasoning_details ELSE '[]' END"
+)
+_LIKE_REASONING_SQL = (
+    "(COALESCE(m.reasoning, '') LIKE ? ESCAPE '\\' OR "
+    "COALESCE(m.reasoning_content, '') LIKE ? ESCAPE '\\' OR "
+    "(NOT json_valid(COALESCE(m.reasoning_details, '')) AND "
+    " COALESCE(m.reasoning_details, '') LIKE ? ESCAPE '\\') OR "
+    f"EXISTS (SELECT 1 FROM json_tree({_REASONING_DETAILS_JSON_SQL}) AS rd "
+    "        WHERE rd.type = 'text' AND CAST(rd.value AS TEXT) LIKE ? ESCAPE '\\'))"
 )
 _LIKE_ANY_COLUMN_WITH_REASONING_SQL = (
     "(COALESCE(m.content, '') LIKE ? ESCAPE '\\' OR "
     "COALESCE(m.tool_name, '') LIKE ? ESCAPE '\\' OR "
     "COALESCE(m.tool_calls, '') LIKE ? ESCAPE '\\' OR "
-    f"(m.role = 'assistant' AND {_REASONING_TEXT_SQL} LIKE ? ESCAPE '\\'))"
+    f"(m.role = 'assistant' AND {_LIKE_REASONING_SQL}))"
 )
 _LIKE_COALESCED_COLUMN_SQL = (
     "(COALESCE(m.content, '') LIKE ? ESCAPE '\\' OR "
@@ -118,7 +121,43 @@ def _quote_fts_tokens(raw_query: str) -> str:
 
 def _like_params(term: str, *, include_reasoning: bool = False) -> List[str]:
     """One ``%term%`` bind per column in the selected canonical LIKE scope."""
-    return [f"%{_escape_like(term)}%"] * (4 if include_reasoning else 3)
+    return [f"%{_escape_like(term)}%"] * (7 if include_reasoning else 3)
+
+
+def _reasoning_snippet_sql(terms: List[str]) -> Tuple[str, List[str]]:
+    """Bounded snippet from the first query term that matches a reasoning field."""
+    cases: List[str] = []
+    params: List[str] = []
+    for term in terms:
+        pattern = f"%{_escape_like(term)}%"
+        for column in ("m.reasoning", "m.reasoning_content"):
+            cases.append(
+                f"WHEN COALESCE({column}, '') LIKE ? ESCAPE '\\' "
+                f"THEN substr({column}, max(1, instr(lower({column}), lower(?)) - 40), 120)"
+            )
+            params.extend((pattern, term))
+        cases.append(
+            "WHEN NOT json_valid(COALESCE(m.reasoning_details, '')) "
+            "AND COALESCE(m.reasoning_details, '') LIKE ? ESCAPE '\\' "
+            "THEN substr(m.reasoning_details, "
+            "max(1, instr(lower(m.reasoning_details), lower(?)) - 40), 120)"
+        )
+        params.extend((pattern, term))
+        cases.append(
+            f"WHEN EXISTS (SELECT 1 FROM json_tree({_REASONING_DETAILS_JSON_SQL}) AS rd "
+            "             WHERE rd.type = 'text' AND CAST(rd.value AS TEXT) LIKE ? ESCAPE '\\') "
+            f"THEN (SELECT substr(CAST(rd.value AS TEXT), "
+            "                         max(1, instr(lower(CAST(rd.value AS TEXT)), lower(?)) - 40), 120) "
+            f"      FROM json_tree({_REASONING_DETAILS_JSON_SQL}) AS rd "
+            "      WHERE rd.type = 'text' AND CAST(rd.value AS TEXT) LIKE ? ESCAPE '\\' LIMIT 1)"
+        )
+        params.extend((pattern, term, pattern))
+    params.append(terms[0])
+    return (
+        f"CASE {' '.join(cases)} "
+        "ELSE substr(m.content, max(1, instr(m.content, ?) - 40), 120) END AS snippet",
+        params,
+    )
 
 
 def _flatten_text(decoded: Any) -> str:
@@ -925,22 +964,22 @@ class SessionSearchMixin:
             return None
 
     def _like_rows(self, where: List[str], params: list, *, order_by: str, limit_sql: str,
-                   include_reasoning: bool = False) -> List[Dict[str, Any]]:
+                   include_reasoning: bool = False, snippet_terms: Optional[List[str]] = None) -> List[Dict[str, Any]]:
         """Canonical-table LIKE scan; ``params[0]`` is the snippet anchor term."""
         if include_reasoning:
-            term = params[0]
-            snippet_params = [f"%{_escape_like(term)}%", term, term]
-            snippet_sql = _LIKE_REASONING_SNIPPET_SQL
+            snippet_sql, snippet_params = _reasoning_snippet_sql(snippet_terms or [params[0]])
+            query_params = params if snippet_terms else params[1:]
         else:
             snippet_params = [params[0]]
             snippet_sql = _LIKE_SNIPPET_SQL
+            query_params = params[1:]
         sql = _search_select_sql(snippet_sql, "messages m", where, order_by, limit_sql)
-        return [dict(row) for row in self._read_all(sql, [*snippet_params, *params[1:]])]
+        return [dict(row) for row in self._read_all(sql, [*snippet_params, *query_params])]
 
     @staticmethod
     def _compile_like_boolean_query(
         query: str, *, include_reasoning: bool = False,
-    ) -> Tuple[str, List[Any], Optional[str]]:
+    ) -> Tuple[str, List[Any], List[str]]:
         """Compile the supported FTS boolean subset into LIKE predicates: terms within an OR
         group are ANDed (FTS5's implicit conjunction) and ``NOT`` negates the next term."""
         groups: List[List[Tuple[str, bool]]] = [[]]
@@ -964,7 +1003,7 @@ class SessionSearchMixin:
 
         compiled_groups: List[str] = []
         params: List[Any] = []
-        snippet_term: Optional[str] = None
+        snippet_terms: List[str] = []
         column_sql = _LIKE_ANY_COLUMN_WITH_REASONING_SQL if include_reasoning else _LIKE_COALESCED_COLUMN_SQL
         for group in groups:
             if not group or not any(not negated for _, negated in group):
@@ -973,26 +1012,28 @@ class SessionSearchMixin:
             for term, negated in group:
                 clauses.append(f"NOT {column_sql}" if negated else column_sql)
                 params.extend(_like_params(term, include_reasoning=include_reasoning))
-                if snippet_term is None and not negated:
-                    snippet_term = term
+                if not negated:
+                    snippet_terms.append(term)
             compiled_groups.append(f"({' AND '.join(clauses)})")
-        return " OR ".join(compiled_groups), params, snippet_term
+        return " OR ".join(compiled_groups), params, snippet_terms
 
     def _search_messages_like_fallback(
         self, query: str, *, limit: int, offset: int, sort: Optional[str], include_reasoning: bool = False,
         **filters,
     ) -> List[Dict[str, Any]]:
         """Search canonical messages while derived FTS state is stale."""
-        predicate, params, snippet_term = self._compile_like_boolean_query(
+        predicate, params, snippet_terms = self._compile_like_boolean_query(
             query, include_reasoning=include_reasoning)
-        if not predicate or snippet_term is None:
+        if not predicate or not snippet_terms:
             return []
         where = [f"({predicate})"]
         _search_filter_clauses(where, params, **filters)
         order = "ASC" if isinstance(sort, str) and sort.strip().lower() == "oldest" else "DESC"
-        return self._like_rows(where, [snippet_term, *params, limit, offset],
+        return self._like_rows(where, [*params, limit, offset] if include_reasoning
+                               else [snippet_terms[0], *params, limit, offset],
                                order_by=f"ORDER BY m.timestamp {order}, m.id {order}", limit_sql="LIMIT ? OFFSET ?",
-                               include_reasoning=include_reasoning)
+                               include_reasoning=include_reasoning,
+                               snippet_terms=snippet_terms if include_reasoning else None)
 
     def _refresh_fts_stale_state(self) -> None:
         """Observe fail-open initiated by another process sharing state.db."""

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -81,6 +81,7 @@ class TestSchema:
         assert "window" in params
         # Shared
         assert "role_filter" in params
+        assert params["include_reasoning"]["default"] is False
         # Mode is inferred from which args are set — no explicit mode param
         assert "mode" not in params
 
@@ -98,7 +99,7 @@ class TestSchema:
             "sort",
             "profile",
         ]
-        assert parameters == [*historical_prefix, "detail"]
+        assert parameters == [*historical_prefix, "detail", "include_reasoning"]
 
 
 class TestFormatTimestamp:
@@ -207,6 +208,29 @@ class TestBrowseShape:
 # =========================================================================
 
 class TestDiscoveryShape:
+    @pytest.mark.parametrize(
+        ("reasoning_field", "reasoning_value", "needle"),
+        [
+            ("reasoning", "reasoning-only-alpha", "reasoning-only-alpha"),
+            ("reasoning_content", "reasoning-only-beta", "reasoning-only-beta"),
+            ("reasoning_details", [{"type": "reasoning.summary", "summary": "reasoning-only-gamma"}],
+             "reasoning-only-gamma"),
+        ],
+    )
+    def test_reasoning_search_is_opt_in_and_anchors_the_snippet(
+        self, db, reasoning_field, reasoning_value, needle
+    ):
+        db.create_session("reasoning_session", source="cli")
+        message_id = db.append_message(
+            "reasoning_session", role="assistant", content="", **{reasoning_field: reasoning_value}
+        )
+
+        assert json.loads(session_search(query=needle, db=db))["results"] == []
+
+        result = json.loads(session_search(query=needle, include_reasoning=True, db=db))
+        assert result["results"][0]["match_message_id"] == message_id
+        assert needle in result["results"][0]["snippet"]
+
     def test_discovery_field_plan_preserves_full_default_result(self, db, monkeypatch):
         _seed_modpack_sessions(db)
         original = db.search_messages

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -246,6 +246,21 @@ class TestDiscoveryShape:
         assert result["results"][0]["match_message_id"] == message_id
         assert "reasoning-only-beta" in result["results"][0]["snippet"]
 
+    def test_reasoning_search_anchors_snippet_to_later_content_alternative(self, db):
+        db.create_session("reasoning_content_or_session", source="cli")
+        message_id = db.append_message(
+            "reasoning_content_or_session",
+            role="assistant",
+            content=f"{'x' * 200}later-content-match",
+        )
+
+        result = json.loads(session_search(
+            query="absent OR later-content-match", include_reasoning=True, db=db
+        ))
+
+        assert result["results"][0]["match_message_id"] == message_id
+        assert "later-content-match" in result["results"][0]["snippet"]
+
     def test_discovery_field_plan_preserves_full_default_result(self, db, monkeypatch):
         _seed_modpack_sessions(db)
         original = db.search_messages

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -215,6 +215,8 @@ class TestDiscoveryShape:
             ("reasoning_content", "reasoning-only-beta", "reasoning-only-beta"),
             ("reasoning_details", [{"type": "reasoning.summary", "summary": "reasoning-only-gamma"}],
              "reasoning-only-gamma"),
+            ("reasoning_details", [{"type": "reasoning.summary", "summary": "仅推理可见标记"}],
+             "仅推理可见标记"),
         ],
     )
     def test_reasoning_search_is_opt_in_and_anchors_the_snippet(
@@ -230,6 +232,19 @@ class TestDiscoveryShape:
         result = json.loads(session_search(query=needle, include_reasoning=True, db=db))
         assert result["results"][0]["match_message_id"] == message_id
         assert needle in result["results"][0]["snippet"]
+
+    def test_reasoning_search_anchors_snippet_to_matching_or_alternative(self, db):
+        db.create_session("reasoning_or_session", source="cli")
+        message_id = db.append_message(
+            "reasoning_or_session", role="assistant", content="", reasoning="reasoning-only-beta"
+        )
+
+        result = json.loads(session_search(
+            query="missing OR reasoning-only-beta", include_reasoning=True, db=db
+        ))
+
+        assert result["results"][0]["match_message_id"] == message_id
+        assert "reasoning-only-beta" in result["results"][0]["snippet"]
 
     def test_discovery_field_plan_preserves_full_default_result(self, db, monkeypatch):
         _seed_modpack_sessions(db)

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -259,14 +259,16 @@ def _hydrate_hit(db, lineage_root: str, match_info: Dict[str, Any], result_detai
 
 
 def _discover(db, query: str, role_filter: Optional[List[str]], limit: int, sort: Optional[str],
-              detail: str, current_session_id: str = None, link_profile: str = None) -> str:
+              detail: str, current_session_id: str = None, link_profile: str = None,
+              include_reasoning: bool = False) -> str:
     """Discovery shape: FTS5 plus adaptive or full result hydration."""
     current_lineage_root = _resolve_lineage(db, current_session_id) if current_session_id else None
     title_result = _title_match_result(db, query, current_lineage_root)
     raw_results, err = _loud(lambda: db.search_messages(
         query=query, role_filter=role_filter or ["user", "assistant"],
         exclude_sources=list(_HIDDEN_SESSION_SOURCES), limit=_DISCOVER_SCAN_LIMIT, offset=0, sort=sort,
-        fields=_DISCOVER_SEARCH_FIELDS), "FTS5 search failed: %s", "Search failed")
+        fields=_DISCOVER_SEARCH_FIELDS, include_reasoning=include_reasoning),
+        "session search failed: %s", "Search failed")
     if err:
         return err
     # Demote cron rows below interactive ones BEFORE dedup so a high-volume cron corpus
@@ -470,7 +472,7 @@ def _scroll(db, session_id: str, around_message_id: int, window: int = 5,
 
 
 def _dispatch(query, role_filter, limit, db, current_session_id, session_id,
-              around_message_id, window, sort, profile, detail, owned_dbs) -> str:
+              around_message_id, window, sort, profile, detail, include_reasoning, owned_dbs) -> str:
     """Mode dispatch (see module docstring); scroll wins when an anchor is set.
     Profile DBs opened here are appended to *owned_dbs* for the caller to close."""
     # A raw `@session:<profile>/<id>` link as session_id: ids never contain "/", so
@@ -502,12 +504,13 @@ def _dispatch(query, role_filter, limit, db, current_session_id, session_id,
         db=db, query=query.strip(), limit=limit, sort=sort_norm if sort_norm in ("newest", "oldest") else None,
         role_filter=([r.strip() for r in role_filter.split(",") if r.strip()] or None) if isinstance(role_filter, str) else None,
         detail="full" if isinstance(detail, str) and detail.strip().lower() == "full" else "adaptive",
-        current_session_id=current_session_id, link_profile=profile)
+        current_session_id=current_session_id, link_profile=profile, include_reasoning=include_reasoning is True)
 
 
 def session_search(query: str = "", role_filter: str = None, limit: int = 3, db=None,
                    current_session_id: str = None, session_id: str = None, around_message_id: int = None,
-                   window: int = 5, sort: str = None, profile: str = None, detail: str = "adaptive") -> str:
+                   window: int = 5, sort: str = None, profile: str = None, detail: str = "adaptive",
+                   include_reasoning: bool = False) -> str:
     """Run session search, closing DBs opened here. Positional order is frozen for old callers."""
     from hermes_state import format_session_db_unavailable
     from hermes_state_registry import acquire, release_or_close
@@ -519,7 +522,7 @@ def session_search(query: str = "", role_filter: str = None, limit: int = 3, db=
         owned_dbs.append(db)
     try:
         return _dispatch(query, role_filter, limit, db, current_session_id, session_id,
-                         around_message_id, window, sort, profile, detail, owned_dbs)
+                         around_message_id, window, sort, profile, detail, include_reasoning, owned_dbs)
     finally:
         for owned_db in reversed(owned_dbs):
             _quiet(lambda: release_or_close(owned_db), None, "Failed to close session_search SessionDB")
@@ -625,6 +628,14 @@ SESSION_SEARCH_SCHEMA = {
                     "behaviour) or 'tool' to search tool output only."
                 ),
             },
+            "include_reasoning": {
+                "type": "boolean",
+                "description": (
+                    "Discovery shape only. Opt in to searching persisted assistant reasoning "
+                    "alongside normal message content. Defaults to false."
+                ),
+                "default": False,
+            },
             "profile": {
                 "type": "string",
                 "description": (
@@ -649,6 +660,7 @@ registry.register(
     handler=lambda args, **kw: session_search(
         query=args.get("query") or "", limit=args.get("limit", 3), window=args.get("window", 5),
         detail=args.get("detail", "adaptive"), db=kw.get("db"), current_session_id=kw.get("current_session_id"),
-        **{k: args.get(k) for k in ("role_filter", "session_id", "around_message_id", "sort", "profile")}),
+        **{k: args.get(k) for k in (
+            "role_filter", "session_id", "around_message_id", "sort", "profile", "include_reasoning")}),
     check_fn=check_session_search_requirements,
     emoji="🔍")


### PR DESCRIPTION
## Summary

- add an explicit `include_reasoning` discovery scope to `session_search`
- search canonical assistant `reasoning`, `reasoning_content`, and `reasoning_details` fields without changing the FTS index shape
- anchor snippets in matched reasoning text while preserving the existing default search behavior

## Testing

- `scripts/run_tests.sh tests/tools/test_session_search.py` (56 passed)
- `scripts/run_tests.sh tests/test_hermes_state.py` (272 passed, 2 skipped)

## Related Issue

Closes #109092
