### PR TITLE
fix(kanban): harden Codex worktree delivery

### DIFF
--- a/agent/transports/codex_app_server.py
+++ b/agent/transports/codex_app_server.py
@@ -15,11 +15,107 @@ import re
 import subprocess
 import threading
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Optional
 
+from hermes_cli._subprocess_compat import harden_git_argv, noninteractive_git_env
 from tools.environments.local import hermes_subprocess_env
 
 MIN_CODEX_VERSION = (0, 125, 0)
+_GIT_COMMON_DIR_TIMEOUT_SECONDS = 5
+
+
+def _kanban_writable_roots(env: dict[str, str]) -> list[str]:
+    """Return the narrow extra roots a managed Kanban Codex worker needs.
+
+    A linked worktree stores its administrative files in the repository's
+    shared ``.git`` directory, outside the worktree itself.  Codex's
+    ``workspace-write`` sandbox therefore needs that directory explicitly,
+    but only after Git resolves it from the worker workspace.  The probe is
+    deliberately bounded and failure-tolerant: the normal workspace and board
+    roots still retain their existing behavior, while a failed probe cannot
+    turn into an unbounded subprocess retry loop.
+    """
+    raw_roots = [
+        os.path.dirname(env["HERMES_KANBAN_DB"]) if env.get("HERMES_KANBAN_DB") else "",
+        env.get("HERMES_KANBAN_WORKSPACES_ROOT", ""),
+        env.get("HERMES_KANBAN_WORKSPACE", ""),
+        env.get("HERMES_KANBAN_ROOT", ""),
+    ]
+    workspace = env.get("HERMES_KANBAN_WORKSPACE") or os.getcwd()
+    workspace_path: Optional[Path]
+    try:
+        workspace_path = Path(workspace).expanduser().resolve(strict=True)
+        if not workspace_path.is_dir():
+            workspace_path = None
+    except OSError:
+        workspace_path = None
+    if workspace_path is not None:
+        try:
+            git_args = [
+                "-C", str(workspace_path), "rev-parse", "--path-format=absolute",
+                "--show-toplevel", "--git-common-dir",
+            ]
+            probe_env = noninteractive_git_env()
+            # The assigned workspace, rather than ambient process state, is the authority for this
+            # admission check.  In particular, an inherited GIT_DIR can make Git resolve an unrelated
+            # repository and grant its administrative directory to the sandbox.
+            for key in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE"):
+                probe_env.pop(key, None)
+            result = subprocess.run(
+                ["git", *harden_git_argv(git_args)],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=_GIT_COMMON_DIR_TIMEOUT_SECONDS,
+                check=False,
+                stdin=subprocess.DEVNULL,
+                env=probe_env,
+            )
+        except (OSError, subprocess.SubprocessError):
+            result = None
+    else:
+        result = None
+    if result is not None and result.returncode == 0:
+        fields = (result.stdout or "").splitlines()
+        if (
+            len(fields) == 2
+            and all(field.strip() == field and field for field in fields)
+            and all(Path(field).is_absolute() for field in fields)
+        ):
+            repo_root, common_dir = (Path(field).expanduser() for field in fields)
+            try:
+                repo_root = repo_root.resolve(strict=True)
+                common_dir = common_dir.resolve(strict=True)
+                # A regular checkout has <repo>/.git; a linked worktree is below that same
+                # repository root.  Require both the Git-reported root and the administrative
+                # directory to agree with that relationship and the on-disk Git layout.
+                common_root = common_dir.parent if common_dir.name == ".git" else None
+                if (
+                    common_root is not None
+                    and workspace_path.is_relative_to(common_root)
+                    and workspace_path.is_relative_to(repo_root)
+                    and common_dir.is_dir()
+                    and all((common_dir / marker).exists() for marker in ("HEAD", "config", "objects", "refs"))
+                ):
+                    raw_roots.append(str(common_dir))
+            except (OSError, ValueError):
+                pass
+
+    roots: list[str] = []
+    seen: set[str] = set()
+    for raw in raw_roots:
+        if not raw:
+            continue
+        try:
+            resolved = str(Path(raw).expanduser().resolve(strict=False))
+        except OSError:
+            continue
+        if resolved not in seen:
+            seen.add(resolved)
+            roots.append(resolved)
+    return roots
 
 
 @dataclass
@@ -70,22 +166,25 @@ class CodexAppServerClient:
         # Native shell children remain unowned. Only Hermes' managed MCP tool
         # endpoint acts for this worker; grant it scope via its existing per-server
         # environment, never by granting the whole executor process ownership.
-        owned_task = os.environ.get("HERMES_KANBAN_TASK") and is_dispatcher_owned_worker_context()
+        # ``hermes_subprocess_env`` intentionally removes Hermes control-plane
+        # variables. Keep the original worker identity for this one admission
+        # decision, while still passing only the explicit MCP scope below.
+        kanban_env = dict(os.environ)
+        kanban_env.update(spawn_env)
+        owned_task = kanban_env.get("HERMES_KANBAN_TASK") and is_dispatcher_owned_worker_context()
         if owned_task:
             for key in (*KANBAN_ENV_KEYS, "HERMES_KANBAN_DB", "HERMES_KANBAN_BOARD"):
-                if key in os.environ:
-                    cmd += ["-c", f"mcp_servers.hermes-mcp.env.{key}={json.dumps(os.environ[key])}"]
+                if key in kanban_env:
+                    cmd += ["-c", f"mcp_servers.hermes-mcp.env.{key}={json.dumps(kanban_env[key])}"]
             cmd += ["-c", f'mcp_servers.hermes-mcp.env.{DELEGATED_CHILD_ENV_MARKER}=""']
         spawn_env = delegated_child_subprocess_env(spawn_env)
         # Kanban workers must write handoff/status to the board DB outside the
         # workspace: keep the sandbox on, add the Kanban root as writable.
         if owned_task:
-            kanban_db = spawn_env.get("HERMES_KANBAN_DB")
-            default_root = os.path.join(spawn_env.get("HERMES_HOME", os.path.expanduser("~/.hermes")), "kanban")
-            kanban_root = os.path.dirname(kanban_db) if kanban_db else spawn_env.get("HERMES_KANBAN_ROOT", default_root)
+            writable_roots = _kanban_writable_roots(kanban_env)
             cmd += [
                 "-c", 'sandbox_mode="workspace-write"',
-                "-c", f'sandbox_workspace_write.writable_roots=["{kanban_root}"]',
+                "-c", f"sandbox_workspace_write.writable_roots={json.dumps(writable_roots)}",
                 "-c", "sandbox_workspace_write.network_access=false",
             ]
         # Codex emits tracing to stderr; default WARN keeps it quiet for users.

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -1684,7 +1684,17 @@ def run_kanban_goal_loop(
             last_response = run_turn(prompt) or ""
         except Exception as exc:
             _log(f"kanban goal loop: run_turn failed ({exc}); stopping")
-            return _result("stopped", f"run_turn error: {type(exc).__name__}")
+            reason = (
+                "Kanban goal worker turn failed before it could complete the task: "
+                f"{type(exc).__name__}: {_truncate(str(exc), 400)}"
+            )
+            # This crosses the durable Kanban/user-facing boundary.  Keep the actionable
+            # exception type/context, but never persist or display secret-shaped details.
+            from agent.redact import redact_sensitive_text
+
+            reason = redact_sensitive_text(reason, force=True, redact_url_credentials=True)
+            _block(reason)
+            return _result("blocked_turn_error", reason)
         turns_used += 1
 
 

--- a/tests/agent/transports/test_codex_app_server_runtime.py
+++ b/tests/agent/transports/test_codex_app_server_runtime.py
@@ -245,6 +245,9 @@ class TestSpawnEnvIsolation:
         monkeypatch.setattr(subprocess, "Popen", FakePopen)
         monkeypatch.setenv("HOME", "/users/alice")
         monkeypatch.setenv("HERMES_HOME", "/users/alice/.hermes/profiles/backend-worker")
+        monkeypatch.setattr(subprocess, "run", lambda cmd, **kwargs: subprocess.CompletedProcess(
+            cmd, 1, stdout="", stderr="not a repo"
+        ))
         monkeypatch.setenv("HERMES_KANBAN_TASK", "t_smoke")
         monkeypatch.setenv(
             "HERMES_KANBAN_DB",
@@ -257,12 +260,143 @@ class TestSpawnEnvIsolation:
         cmd = captured["cmd"]
         assert cmd[:2] == ["codex", "app-server"]
         assert 'sandbox_mode="workspace-write"' in cmd
-        assert (
-            'sandbox_workspace_write.writable_roots=["/users/alice/.hermes/kanban/boards/smoke"]'
-            in cmd
-        )
+        roots_arg = next(part for part in cmd if part.startswith("sandbox_workspace_write.writable_roots="))
+        assert "/users/alice/.hermes/kanban/boards/smoke" in roots_arg
         assert "sandbox_workspace_write.network_access=false" in cmd
         assert all("danger" not in part for part in cmd)
+
+    def test_worktree_worker_adds_resolved_git_common_dir(self, monkeypatch, tmp_path):
+        """A linked worktree gets only its resolved shared Git directory too."""
+        import subprocess
+        from agent.transports import codex_app_server as cas
+
+        workspace = tmp_path / "repo" / ".worktrees" / "task"
+        workspace.mkdir(parents=True)
+        common_dir = tmp_path / "repo" / ".git"
+        common_dir.mkdir(parents=True)
+        (common_dir / "HEAD").write_text("ref: refs/heads/main\n")
+        (common_dir / "config").write_text("[core]\n")
+        (common_dir / "objects").mkdir()
+        (common_dir / "refs").mkdir()
+        captured = {}
+
+        class FakePopen:
+            def __init__(self, cmd, *args, **kwargs):
+                captured["cmd"] = list(cmd)
+                self.stdin = self.stdout = self.stderr = None
+                self.pid = 1
+                self.returncode = None
+
+            def poll(self):
+                return None
+
+            def terminate(self):
+                pass
+
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                pass
+
+        def fake_run(cmd, **kwargs):
+            assert kwargs["timeout"] == 5
+            assert cmd[-2:] == ["--show-toplevel", "--git-common-dir"]
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=f"{workspace.parent.parent}\n{common_dir}\n", stderr=""
+            )
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_worktree")
+        monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace))
+        monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "board" / "kanban.db"))
+
+        client = cas.CodexAppServerClient(codex_bin="codex")
+        client._closed = True
+
+        roots_arg = next(
+            part for part in captured["cmd"]
+            if part.startswith("sandbox_workspace_write.writable_roots=")
+        )
+        assert str(common_dir) in roots_arg
+        assert 'sandbox_mode="workspace-write"' in captured["cmd"]
+        assert "sandbox_workspace_write.network_access=false" in captured["cmd"]
+        assert all("danger-full-access" not in part for part in captured["cmd"])
+
+    def test_git_common_dir_probe_rejects_unrelated_output(self, monkeypatch, tmp_path):
+        """Git output cannot widen the sandbox to an unrelated or malformed directory."""
+        import subprocess
+        from agent.transports import codex_app_server as cas
+
+        workspace = tmp_path / "repo" / ".worktrees" / "task"
+        workspace.mkdir(parents=True)
+        outside = tmp_path / "outside" / ".git"
+        outside.mkdir(parents=True)
+        captured = {}
+
+        class FakePopen:
+            def __init__(self, cmd, *args, **kwargs):
+                captured["cmd"] = list(cmd)
+                self.stdin = self.stdout = self.stderr = None
+                self.pid = 1
+                self.returncode = None
+
+            def poll(self): return None
+            def terminate(self): pass
+            def wait(self, timeout=None): return 0
+            def kill(self): pass
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        monkeypatch.setattr(subprocess, "run", lambda cmd, **kwargs: subprocess.CompletedProcess(
+            cmd, 0, stdout=f"{workspace}\n{outside}\n", stderr=""
+        ))
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_outside")
+        monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(workspace))
+        monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "board" / "kanban.db"))
+        monkeypatch.setenv("GIT_DIR", str(outside))
+
+        cas.CodexAppServerClient(codex_bin="codex")._closed = True
+
+        roots_arg = next(
+            part for part in captured["cmd"]
+            if part.startswith("sandbox_workspace_write.writable_roots=")
+        )
+        assert str(outside) not in roots_arg
+
+    def test_git_common_dir_probe_is_bounded_when_git_hangs(self, monkeypatch):
+        """A broken Git installation cannot create an unbounded nested retry."""
+        import subprocess
+        from agent.transports import codex_app_server as cas
+
+        class FakePopen:
+            def __init__(self, cmd, *args, **kwargs):
+                self.stdin = self.stdout = self.stderr = None
+                self.pid = 1
+                self.returncode = None
+
+            def poll(self):
+                return None
+
+            def terminate(self):
+                pass
+
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                pass
+
+        def hanging_git(cmd, **kwargs):
+            raise subprocess.TimeoutExpired(cmd, kwargs["timeout"])
+
+        monkeypatch.setattr(subprocess, "Popen", FakePopen)
+        monkeypatch.setattr(subprocess, "run", hanging_git)
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_timeout")
+        monkeypatch.setenv("HERMES_KANBAN_DB", "/tmp/kanban/board.db")
+
+        client = cas.CodexAppServerClient(codex_bin="codex")
+        client._closed = True
 
 
 class TestSpawnEnvSecretStripping:
@@ -339,4 +473,3 @@ class TestSpawnEnvSecretStripping:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-codex-needs-this")
         env = self._capture_spawn_env(monkeypatch)
         assert env.get("OPENAI_API_KEY") == "sk-codex-needs-this"
-

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -129,6 +129,31 @@ def test_loop_stops_when_worker_already_completed(monkeypatch):
     assert turns == []  # no extra turns
 
 
+def test_loop_blocks_when_nested_worker_turn_fails(monkeypatch):
+    """A failed runtime/Git turn must terminate the card, not leave it retrying."""
+    _patch_judge(monkeypatch, ["continue"])
+    blocked = []
+    secret = "ghp_" + "S" * 40
+
+    res = goals.run_kanban_goal_loop(
+        task_id="t_nested_failure",
+        goal_text="deliver the change",
+        run_turn=lambda _prompt: (_ for _ in ()).throw(RuntimeError(f"git delivery timed out ({secret})")),
+        task_status_fn=lambda: "running",
+        block_fn=blocked.append,
+        max_turns=10,
+        first_response="not finished",
+    )
+
+    assert res["outcome"] == "blocked_turn_error"
+    assert len(blocked) == 1
+    assert secret not in blocked[0]
+    assert "Kanban goal worker turn failed" in blocked[0]
+    assert "RuntimeError" in blocked[0]
+    assert "git delivery timed out" in blocked[0]
+    assert secret not in res["reason"]
+
+
 
 
 


### PR DESCRIPTION
## Summary
- Make managed Codex app-server Kanban workers writable for their resolved linked-worktree Git common directory while retaining workspace-write and network-disabled sandboxing.
- Bound Git probing and fail closed on ambient Git overrides or invalid/outside common directories.
- Convert failed goal-mode turns into one clear, force-redacted Kanban block instead of retrying nested Codex work.
- Add regression coverage for writable-root resolution, bounded probes, redaction, and blocking behavior.

## Verification
- `scripts/run_tests.sh tests/agent/transports/test_codex_app_server_runtime.py tests/hermes_cli/test_kanban_goal_mode.py` — 32 passed.
- `scripts/run_tests.sh tests/agent/transports/test_codex_app_server_session.py tests/plugins/test_kanban_model_override.py tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py` — 58 passed.
- `python -m py_compile agent/transports/codex_app_server.py hermes_cli/goals.py` — passed.
- `git diff --check` — passed.
- Independent Codex review — passed; no concrete findings.

Review-only PR. Do not merge, deploy, or modify production systems.