### PR TITLE
feat(desktop): model picker search/filter polish and sticky collapsible headers

### DIFF
--- a/apps/desktop/src/app/chat/composer/queue-panel.tsx
+++ b/apps/desktop/src/app/chat/composer/queue-panel.tsx
@@ -49,6 +49,7 @@ export function QueuePanel({
 
   return (
     <StatusSection
+      stickyHeader
       accessory={
         parked ? (
           <Tip label={c.queueResumeTip}>

--- a/apps/desktop/src/app/chat/composer/status-stack/session-control-goal.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/session-control-goal.tsx
@@ -326,12 +326,11 @@ export const SessionControlGoalSection = memo(function SessionControlGoalSection
               }
               icon={<Codicon className={iconClass} name="target" size="0.8rem" />}
               label={headerLabel}
+              stickyHeader
             >
               <div className="space-y-1.5 px-1 py-1">
-                {/* Full goal title */}
-                <div className="text-xs font-normal leading-relaxed text-foreground/92 break-words">{goal.title}</div>
-
-                {/* Optional reasons */}
+                {/* Pinned status: why waiting/paused/blocked stays visible —
+                  it is state chrome, not scrollable content. */}
                 {!detailsOpen && goal.wait_barrier && (
                   <div className="text-[0.7rem] italic text-muted-foreground/80">
                     {goal.wait_barrier.reason
@@ -346,103 +345,108 @@ export const SessionControlGoalSection = memo(function SessionControlGoalSection
                   <div className="text-[0.7rem] italic text-muted-foreground/80">{goal.last_reason}</div>
                 )}
 
-                {/* View details button */}
-                {hasDetails && (
-                  <div>
-                    <Button
-                      className="text-[0.7rem] text-muted-foreground/75 hover:text-foreground/90"
-                      onClick={() => setDetailsOpen(true)}
-                      size="micro"
-                      type="button"
-                      variant="text"
-                    >
-                      {ctrl.viewDetails}
-                    </Button>
-                  </div>
-                )}
+                {/* Scrollable body: long titles and criteria lists scroll in
+                  their own container — header above and the criteria footer
+                  below stay put, so collapse/add are always reachable. */}
+                <div className="max-h-[30vh] space-y-1.5 overflow-y-auto overscroll-contain pr-0.5">
+                  {/* Full goal title */}
+                  <div className="text-xs font-normal leading-relaxed text-foreground/92 break-words">{goal.title}</div>
 
-                {/* Criteria subsection */}
-                <div className="mt-2 border-t border-(--ui-stroke-tertiary)/40 pt-1.5">
-                  <div className="flex items-center justify-between pb-1 text-[0.68rem] font-medium text-muted-foreground/75">
-                    <div className="flex items-center gap-1.5">
-                      <span aria-hidden="true" className={`inline-flex ${iconClass}`} data-slot="criteria-state-marker">
-                        <Codicon name="target" size="0.68rem" />
-                      </span>
-                      <span>{ctrl.criteriaHeader(goal.subgoals.length)}</span>
-                    </div>
-                    <div className="flex items-center gap-1">
+                  {/* View details button */}
+                  {hasDetails && (
+                    <div>
                       <Button
-                        className="text-[0.68rem] text-muted-foreground/75 hover:text-foreground/90"
-                        disabled={isBusy}
-                        onClick={openAddCriterion}
+                        className="text-[0.7rem] text-muted-foreground/75 hover:text-foreground/90"
+                        onClick={() => setDetailsOpen(true)}
                         size="micro"
                         type="button"
                         variant="text"
                       >
-                        {ctrl.addCriterion}
+                        {ctrl.viewDetails}
                       </Button>
-                      {goal.subgoals.length > 0 && (
-                        <Button
-                          className="text-[0.68rem] text-muted-foreground/60 hover:text-destructive"
-                          disabled={isBusy}
-                          onClick={confirmClearCriteria}
-                          size="micro"
-                          type="button"
-                          variant="text"
-                        >
-                          {ctrl.clearCriteria}
-                        </Button>
-                      )}
                     </div>
-                  </div>
-
-                  {goal.subgoals.length > 0 ? (
-                    <div className="space-y-1">
-                      {goal.subgoals.map((subgoal, idx) => {
-                        const index = idx + 1
-
-                        return (
-                          <div
-                            className="group/criterion flex items-start justify-between gap-1.5 rounded px-1 py-0.5 text-xs text-foreground/85 hover:bg-(--ui-control-active-background)/40"
-                            key={`${index}-${subgoal}`}
-                          >
-                            <div className="flex min-w-0 flex-1 items-start gap-1.5 leading-relaxed">
-                              <span className="shrink-0 text-muted-foreground/60 tabular-nums">{index}.</span>
-                              <span className="break-words">{subgoal}</span>
-                            </div>
-                            <div className="flex shrink-0 items-center gap-0.5 opacity-80 group-hover/criterion:opacity-100">
-                              <Tip label={ctrl.copyCriterion(index)}>
-                                <Button
-                                  aria-label={ctrl.copyCriterion(index)}
-                                  className="size-6 rounded text-muted-foreground/60 hover:text-foreground/90"
-                                  onClick={() => void copyCriterionText(subgoal)}
-                                  size="icon-xs"
-                                  type="button"
-                                  variant="ghost"
-                                >
-                                  <Codicon name="copy" size="0.7rem" />
-                                </Button>
-                              </Tip>
-                              <Tip label={ctrl.removeCriterion(index)}>
-                                <Button
-                                  aria-label={ctrl.removeCriterion(index)}
-                                  className="size-6 rounded text-muted-foreground/60 hover:text-destructive"
-                                  disabled={isBusy}
-                                  onClick={() => confirmRemoveCriterion(index)}
-                                  size="icon-xs"
-                                  type="button"
-                                  variant="ghost"
-                                >
-                                  <Codicon name="close" size="0.7rem" />
-                                </Button>
-                              </Tip>
-                            </div>
-                          </div>
-                        )
-                      })}
-                    </div>
-                  ) : null}
+                  )}
                 </div>
+                {/* Pinned footer: count + add/clear stay visible under the scroll body. */}
+                <div className="flex items-center justify-between border-t border-(--ui-stroke-tertiary)/40 pt-1 text-[0.68rem] font-medium text-muted-foreground/75">
+                  <div className="flex items-center gap-1.5">
+                    <span aria-hidden="true" className={`inline-flex ${iconClass}`} data-slot="criteria-state-marker">
+                      <Codicon name="target" size="0.68rem" />
+                    </span>
+                    <span>{ctrl.criteriaHeader(goal.subgoals.length)}</span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      className="text-[0.68rem] text-muted-foreground/75 hover:text-foreground/90"
+                      disabled={isBusy}
+                      onClick={openAddCriterion}
+                      size="micro"
+                      type="button"
+                      variant="text"
+                    >
+                      {ctrl.addCriterion}
+                    </Button>
+                    {goal.subgoals.length > 0 && (
+                      <Button
+                        className="text-[0.68rem] text-muted-foreground/60 hover:text-destructive"
+                        disabled={isBusy}
+                        onClick={confirmClearCriteria}
+                        size="micro"
+                        type="button"
+                        variant="text"
+                      >
+                        {ctrl.clearCriteria}
+                      </Button>
+                    )}
+                  </div>
+                </div>
+
+                {goal.subgoals.length > 0 ? (
+                  <div className="space-y-1">
+                    {goal.subgoals.map((subgoal, idx) => {
+                      const index = idx + 1
+
+                      return (
+                        <div
+                          className="group/criterion flex items-start justify-between gap-1.5 rounded px-1 py-0.5 text-xs text-foreground/85 hover:bg-(--ui-control-active-background)/40"
+                          key={`${index}-${subgoal}`}
+                        >
+                          <div className="flex min-w-0 flex-1 items-start gap-1.5 leading-relaxed">
+                            <span className="shrink-0 text-muted-foreground/60 tabular-nums">{index}.</span>
+                            <span className="break-words">{subgoal}</span>
+                          </div>
+                          <div className="flex shrink-0 items-center gap-0.5 opacity-80 group-hover/criterion:opacity-100">
+                            <Tip label={ctrl.copyCriterion(index)}>
+                              <Button
+                                aria-label={ctrl.copyCriterion(index)}
+                                className="size-6 rounded text-muted-foreground/60 hover:text-foreground/90"
+                                onClick={() => void copyCriterionText(subgoal)}
+                                size="icon-xs"
+                                type="button"
+                                variant="ghost"
+                              >
+                                <Codicon name="copy" size="0.7rem" />
+                              </Button>
+                            </Tip>
+                            <Tip label={ctrl.removeCriterion(index)}>
+                              <Button
+                                aria-label={ctrl.removeCriterion(index)}
+                                className="size-6 rounded text-muted-foreground/60 hover:text-destructive"
+                                disabled={isBusy}
+                                onClick={() => confirmRemoveCriterion(index)}
+                                size="icon-xs"
+                                type="button"
+                                variant="ghost"
+                              >
+                                <Codicon name="close" size="0.7rem" />
+                              </Button>
+                            </Tip>
+                          </div>
+                        </div>
+                      )
+                    })}
+                  </div>
+                ) : null}
               </div>
             </StatusSection>
           </div>

--- a/apps/desktop/src/app/chat/composer/status-stack/session-control-heartbeat.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/session-control-heartbeat.tsx
@@ -147,6 +147,7 @@ export const SessionControlHeartbeatSection = memo(function SessionControlHeartb
         <ContextMenuTrigger asChild>
           <div data-slot="session-control-heartbeat">
             <StatusSection
+              stickyHeader
               accessory={
                 <DropdownMenu onOpenChange={setMenuOpen} open={menuOpen}>
                   <Tip label={ctrl.heartbeatActions}>

--- a/apps/desktop/src/app/chat/composer/status-stack/session-control-loop.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/session-control-loop.tsx
@@ -154,6 +154,7 @@ export const SessionControlLoopSection = memo(function SessionControlLoopSection
         <ContextMenuTrigger asChild>
           <div data-slot="session-control-loop">
             <StatusSection
+              stickyHeader
               accessory={
                 <DropdownMenu onOpenChange={setMenuOpen} open={menuOpen}>
                   <Tip label={ctrl.loopActions}>

--- a/apps/desktop/src/app/chat/composer/status-stack/subagent-section.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/subagent-section.tsx
@@ -64,6 +64,7 @@ export function SubagentSection({ sessionId }: SubagentSectionProps) {
   return (
     <div className="composer-no-drag min-w-0" data-slot="composer-subagents">
       <StatusSection
+        stickyHeader
         collapsedIndicator={
           <GlyphSpinner
             ariaLabel={live.some(item => item.status === 'running') ? t.agents.running : t.agents.queued}

--- a/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.test.tsx
@@ -60,12 +60,12 @@ afterEach(() => {
 
 // A minimal controller — these tests are about the CATALOG's own behaviour
 // (what it lists, what it offers), not about what any host does with a pick.
-function renderMenu() {
+function renderMenu(current: ModelMenuController['current'] = { effort: '', fast: false, model: '', provider: '' }) {
   const select = vi.fn()
 
   const controller: ModelMenuController = {
     applyPreset: vi.fn(),
-    current: { effort: '', fast: false, model: '', provider: '' },
+    current,
     presetFor: () => ({}),
     select,
     setOptions: vi.fn()
@@ -118,7 +118,9 @@ describe('the catalog owns model curation', () => {
       // row label span carries it (plus the effort meta suffix).
       expect(
         screen.getByText((_, element) =>
-          Boolean(element?.classList.contains('truncate') && (element?.textContent ?? '').startsWith('Gemini 3.1 pro'))
+          Boolean(
+            element?.hasAttribute?.('data-row-label') && (element?.textContent ?? '').startsWith('Gemini 3.1 pro')
+          )
         )
       ).toBeDefined()
     })
@@ -131,6 +133,165 @@ describe('the catalog owns model curation', () => {
     fireEvent.click(screen.getByText('Edit models…'))
 
     expect($modelVisibilityOpen.get()).toBe(true)
+  })
+
+  it('focuses the search field on open so typing filters immediately', async () => {
+    renderMenu()
+    await screen.findByText(/Gemini 3\.1 Pro/i)
+
+    await vi.waitFor(() => {
+      expect(document.activeElement?.getAttribute('placeholder')).toBe('Search models')
+    })
+  })
+})
+
+describe('multi-upstream rows stay distinguishable', () => {
+  const LOCAL_MODELS = ['cmd/deepseek/deepseek-v4-flash', 'cbai/deepseek-v4-flash', 'auto/best-coding']
+
+  function renderLocal(total = 5973, current?: ModelMenuController['current']) {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [{ models: LOCAL_MODELS, name: 'Local', slug: 'local', total_models: total }]
+    })
+    renderMenu(current)
+  }
+
+  it('shows the upstream in the id line, no pills', async () => {
+    renderLocal()
+    await screen.findByText('Best Coding')
+
+    // No qualifier pills — the id line carries the upstream verbatim.
+    expect(screen.getByText('cmd/deepseek/deepseek-v4-flash')).toBeDefined()
+    expect(screen.getByText('cbai/deepseek-v4-flash')).toBeDefined()
+    expect(screen.queryByText('cmd/deepseek')).toBeNull()
+  })
+
+  it('meters the effort as text next to the name', async () => {
+    renderLocal()
+    await screen.findByText('Best Coding')
+    // Native tooltip carries the exact id — truncated rows reveal on hover.
+    const row = screen.getByTitle('cmd/deepseek/deepseek-v4-flash')
+
+    expect(row).toBeDefined()
+    // Medium effort renders as a text suffix on the row.
+    expect(row.textContent).toContain('Med')
+  })
+
+  it('lists families A–Z by default', async () => {
+    renderLocal()
+    await screen.findByText('Best Coding')
+    const names = [...document.querySelectorAll('[data-row-label]')].map(el => el.textContent)
+
+    // Tie on "Deepseek V4 Flash" breaks by id: cbai before cmd.
+    expect(names).toEqual(['Best Coding', 'Deepseek V4 Flash', 'Deepseek V4 Flash'])
+  })
+
+  it('badges the provider header with shown-of-total counts', async () => {
+    renderLocal()
+    await screen.findByText('3 of 5,973')
+  })
+
+  it('still pins the active model first while searching', async () => {
+    renderLocal(5973, { effort: '', fast: false, model: 'cmd/deepseek/deepseek-v4-flash', provider: 'local' })
+    await screen.findByText('Best Coding')
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search models' }), { target: { value: 'flash' } })
+
+    await vi.waitFor(() => {
+      const rows = [...document.querySelectorAll('[data-row-label]')]
+
+      // Alphabetically cbai would lead — the active cmd pick stays on top.
+      expect(rows.map(el => el.textContent)).toEqual(['Deepseek V4 Flash', 'Deepseek V4 Flash'])
+      expect(rows[0].closest('span[title]')?.getAttribute('title')).toContain('cmd/deepseek/deepseek-v4-flash')
+    })
+  })
+
+  it('pins the active model first, rest stays A–Z', async () => {
+    renderLocal(5973, { effort: '', fast: false, model: 'cbai/deepseek-v4-flash', provider: 'local' })
+    await screen.findByText('Best Coding')
+    const names = [...document.querySelectorAll('[data-row-label]')]
+
+    expect(names.map(el => el.textContent)).toEqual(['Deepseek V4 Flash', 'Best Coding', 'Deepseek V4 Flash'])
+    expect(names[0].closest('span[title]')?.getAttribute('title')).toContain('cbai/deepseek-v4-flash')
+  })
+
+  it('glides a clipped label on hover and snaps back on leave', async () => {
+    renderLocal()
+    await screen.findByText('Best Coding')
+    const marquee = document.querySelector('[data-marquee="name:cmd/deepseek/deepseek-v4-flash"]') as HTMLElement
+    const inner = marquee.firstElementChild as HTMLElement
+
+    // jsdom reports zero sizes — stage a 200px overflow.
+    Object.defineProperty(inner, 'scrollWidth', { configurable: true, value: 300 })
+    Object.defineProperty(marquee, 'clientWidth', { configurable: true, value: 100 })
+
+    // Hover bubbles to the row, which scrolls every clipped line together.
+    fireEvent.mouseOver(marquee)
+    await vi.waitFor(() => {
+      expect(inner.style.transform).toContain('translateX(-200px)')
+    })
+
+    fireEvent.mouseOut(marquee)
+    expect(inner.style.transform).toBe('')
+  })
+
+  it('leaves fitting labels put on hover', async () => {
+    renderLocal()
+    await screen.findByText('Best Coding')
+    const marquee = document.querySelector('[data-marquee="name:auto/best-coding"]') as HTMLElement
+    const inner = marquee.firstElementChild as HTMLElement
+
+    fireEvent.mouseOver(marquee)
+    expect(inner.style.transform).toBe('')
+  })
+
+  it('renders the variant tag instead of dropping it', async () => {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [{ models: ['deepseek/deepseek-v4-pro-thinking'], name: 'Local', slug: 'local' }]
+    })
+    renderMenu()
+    await screen.findByText('Deepseek V4 Pro')
+    expect(screen.getByText('Thinking')).toBeDefined()
+  })
+})
+
+describe('token search', () => {
+  it('matches unordered tokens across id and upstream', async () => {
+    getGlobalModelOptions.mockResolvedValue({
+      providers: [
+        { models: ['opencode/deepseek-v4-flash', 'cmd/deepseek/deepseek-v4-flash'], name: 'Mixed', slug: 'mixed' }
+      ]
+    })
+    renderMenu()
+    await screen.findAllByText('Deepseek V4 Flash')
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search models' }), {
+      target: { value: 'deepseek v4 flash opencode' }
+    })
+
+    await vi.waitFor(() => {
+      const names = [...document.querySelectorAll('[data-row-label]')].map(el => el.textContent)
+
+      expect(names).toEqual(['Deepseek V4 Flash'])
+    })
+    // The survivor is the opencode route.
+    expect(screen.getByTitle('opencode/deepseek-v4-flash')).toBeDefined()
+  })
+})
+
+describe('search render cap', () => {
+  const MANY = Array.from({ length: 250 }, (_, i) => `zz-model-${String(i).padStart(3, '0')}`)
+
+  it('renders the first 100 matches with a narrowing note', async () => {
+    getGlobalModelOptions.mockResolvedValue({ providers: [{ models: MANY, name: 'Many', slug: 'many' }] })
+    renderMenu()
+    await screen.findByText('Zz Model 000')
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search models' }), { target: { value: 'zz-model' } })
+
+    await vi.waitFor(() => {
+      expect(screen.getByText(/keep typing to narrow/i)).toBeDefined()
+    })
+    expect(document.querySelectorAll('[data-row-label]').length).toBe(100)
   })
 })
 

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -1,6 +1,6 @@
 import { useStore } from '@nanostores/react'
 import { useQuery } from '@tanstack/react-query'
-import { createContext, type ReactNode, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { createContext, type ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 
 import { Codicon } from '@/components/ui/codicon'
 import { DisclosureCaret } from '@/components/ui/disclosure-caret'
@@ -17,14 +17,16 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { HighlightMatches } from '@/components/ui/highlight-matches'
 import { usePointerQuiet } from '@/components/ui/keyboard-first'
+import { HoverScroll } from '@/components/ui/marquee'
 import { Skeleton } from '@/components/ui/skeleton'
 import type { HermesGateway } from '@/hermes'
 import { getLocalModelsStatus } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { catalogProviderMatches, modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
-import { displayModelName, modelDisplayParts } from '@/lib/model-status-label'
+import { compareModelIds, displayModelName, modelDisplayParts } from '@/lib/model-status-label'
 import { DEFAULT_REASONING_EFFORT, reasoningEffortLabel } from '@/lib/reasoning-effort'
-import { foldIncludes, normalize } from '@/lib/text'
+import { foldIncludes, normalize, searchFold } from '@/lib/text'
+import { useDebouncedValue } from '@/lib/use-debounced-value'
 import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
 import { $localModelsEnabled } from '@/store/local-models-flag'
@@ -43,6 +45,56 @@ import { $defaultReasoningEffort } from '@/store/session'
 import type { LocalModelLoadProgress, ModelOptionProvider, ModelOptionsResponse } from '@/types/hermes'
 
 import { type FastControl, ModelEditSubmenu, resolveFastControl } from './model-edit-submenu'
+
+/** One model row's text lines. Hovering anywhere on them scrolls every
+ *  clipped line together; the meter, chips and toggles stay pinned. */
+function ModelRowLines({
+  idKey,
+  idNode,
+  meter,
+  nameNode,
+  tagNode,
+  title
+}: {
+  idKey: string
+  idNode: ReactNode
+  meter: ReactNode
+  nameNode: ReactNode
+  tagNode: ReactNode
+  title: string
+}) {
+  const [go, setGo] = useState(false)
+
+  return (
+    <span
+      className="block min-w-0 flex-1 overflow-hidden"
+      onMouseOut={event => {
+        if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          return
+        }
+
+        setGo(false)
+      }}
+      onMouseOver={() => setGo(true)}
+      title={title}
+    >
+      <span className="flex min-w-0 items-center gap-1.5">
+        <HoverScroll className="min-w-0 flex-1" go={go} marqueeKey={`name:${idKey}`}>
+          {nameNode}
+        </HoverScroll>
+        {tagNode}
+        {meter}
+      </span>
+      <HoverScroll
+        className="font-mono text-[0.65rem] font-normal text-(--ui-text-tertiary)"
+        go={go}
+        marqueeKey={`id:${idKey}`}
+      >
+        {idNode}
+      </HoverScroll>
+    </span>
+  )
+}
 
 // Lets the host dropdown (model-pill, a kanban field trigger, …) hand the panel
 // a way to dismiss itself so clicking a model row commits + closes, while the
@@ -109,7 +161,41 @@ interface ModelCatalogMenuProps {
 interface ProviderGroup {
   families: ModelFamily[]
   provider: ModelOptionProvider
+  /** Matches before the render cap (search mode); families.length otherwise. */
+  total: number
 }
+
+const SearchInput = ({ onDebouncedChange, onKeyAction, placeholder }: {
+  onDebouncedChange: (value: string) => void
+  onKeyAction: (key: string) => void
+  placeholder: string
+}) => {
+  const [value, setValue] = useState('')
+  const debounced = useDebouncedValue(value, 150)
+  const ref = useRef(onDebouncedChange)
+  ref.current = onDebouncedChange
+  useEffect(() => { ref.current(debounced) }, [debounced])
+
+  return (
+    <DropdownMenuSearch
+      aria-label={placeholder}
+      onKeyDown={event => {
+        if (event.key === 'ArrowDown' || event.key === 'ArrowUp' || event.key === 'Enter') {
+          event.preventDefault()
+          event.stopPropagation()
+          onKeyAction(event.key)
+        }
+      }}
+      onValueChange={setValue}
+      placeholder={placeholder}
+      value={value}
+    />
+  )
+}
+
+/** Render cap per provider in search mode — filtering 6k ids is cheap, mounting
+ *  6k submenu rows is not. The trailing note says how much is hidden. */
+const SEARCH_RENDER_CAP = 100
 
 /**
  * THE model catalog menu: searchable, provider-grouped, `-fast` families
@@ -254,6 +340,39 @@ export function ModelCatalogMenu({
 
   const q = normalize(search)
 
+  // Token terms for filtering + highlighting (match the token-AND filter in
+  // groupModels). Single-word queries keep the raw string so separator
+  // folding still highlights one contiguous range.
+  const searchTerms = useMemo(() => {
+    const tokens = searchFold(q).split(/\s+/).filter(Boolean)
+
+    return tokens.length > 1 && /\s/.test(search) ? tokens : search
+  }, [q, search])
+
+  // Per-catalog search index: collapsed families + folded haystacks, built once
+  // per catalog so keystrokes only scan cheap substrings instead of re-folding
+  // every id per keystroke.
+  const catalogIndex = useMemo(() => {
+    const families = new Map<string, ModelFamily[]>()
+    const haystacks = new Map<string, string>()
+
+    for (const provider of pickerProviders) {
+      const collapsed = collapseModelFamilies(provider.models ?? [])
+      families.set(provider.slug, collapsed)
+
+      for (const family of collapsed) {
+        haystacks.set(
+          `${provider.slug}::${family.id}`,
+          searchFold(
+            `${family.id} ${family.fastId ?? ''} ${provider.name} ${provider.slug} ${displayModelName(family.id)}`
+          )
+        )
+      }
+    }
+
+    return { families, haystacks }
+  }, [pickerProviders])
+
   // In-flight downloads render inside the Local provider group when it
   // exists, else as their own trailing 'Local' group (first download —
   // nothing staged yet, so the catalog has no local provider row).
@@ -269,8 +388,15 @@ export function ModelCatalogMenu({
   )
 
   const groups = useMemo(
-    () => groupModels(pickerProviders, search, { model: current.model, provider: current.provider }, shownKeys),
-    [pickerProviders, search, current.model, current.provider, shownKeys]
+    () =>
+      groupModels(
+        pickerProviders,
+        catalogIndex,
+        search,
+        { model: current.model, provider: current.provider },
+        shownKeys
+      ),
+    [pickerProviders, catalogIndex, search, current.model, current.provider, shownKeys]
   )
 
   // Presets are searchable rows like everything else — an unfiltered preset
@@ -337,6 +463,7 @@ export function ModelCatalogMenu({
   )
 
   const [kbOverride, setKbOverride] = useState<null | number>(null)
+
   // A parked cursor is not a cursor in use: until the mouse actually moves,
   // hover can't take rows out from under the keyboard.
   const pointerQuiet = usePointerQuiet()
@@ -403,27 +530,19 @@ export function ModelCatalogMenu({
 
   return (
     <>
-      <DropdownMenuSearch
-        aria-label={copy.search}
-        onKeyDown={event => {
-          // Claim arrows and Enter from Radix so DOM focus stays in the input
-          // and Enter commits the highlighted row without a DownArrow first.
-          if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-            event.preventDefault()
-            event.stopPropagation()
-            stepKb(event.key === 'ArrowDown' ? 1 : -1)
-          } else if (event.key === 'Enter') {
-            event.preventDefault()
-            event.stopPropagation()
-            commitKbRow()
-          }
-        }}
-        onValueChange={value => {
+      <SearchInput
+        onDebouncedChange={value => {
           setSearch(value)
           setKbOverride(null)
         }}
+        onKeyAction={key => {
+          if (key === 'ArrowDown' || key === 'ArrowUp') {
+            stepKb(key === 'ArrowDown' ? 1 : -1)
+          } else if (key === 'Enter') {
+            commitKbRow()
+          }
+        }}
         placeholder={copy.search}
-        value={search}
       />
 
       <DropdownMenuSeparator className="mx-0" />
@@ -471,6 +590,12 @@ export function ModelCatalogMenu({
                   <span className="truncate">
                     <HighlightMatches foldSeparators query={search} text={group.provider.name} />
                   </span>
+                  {typeof group.provider.total_models === 'number' &&
+                  group.provider.total_models > group.families.length ? (
+                    <span className="shrink-0 font-normal normal-case tracking-normal">
+                      {group.families.length} of {group.provider.total_models.toLocaleString()}
+                    </span>
+                  ) : null}
                   <DisclosureCaret
                     className="shrink-0 text-(--ui-text-tertiary) opacity-0 transition group-hover/label:opacity-100"
                     open={!collapsed}
@@ -488,7 +613,7 @@ export function ModelCatalogMenu({
                         : null
 
                     const isCurrent = activeId !== null
-                    const name = modelDisplayParts(family.id).name
+                    const { name, tag } = modelDisplayParts(family.id)
                     const caps = group.provider.capabilities?.[family.id]
 
                     // Managed local model loading into memory right now:
@@ -541,10 +666,26 @@ export function ModelCatalogMenu({
                           }}
                           {...kbRowProps(`${group.provider.slug}:${family.id}`)}
                         >
-                          <span className="min-w-0 flex-1 truncate">
-                            <HighlightMatches foldSeparators query={search} text={name} />
-                            {meta ? <span className="text-(--ui-text-tertiary)"> {meta}</span> : null}
-                          </span>
+                          <ModelRowLines
+                            idKey={family.id}
+                            idNode={<HighlightMatches query={searchTerms} text={family.id} />}
+                            meter={
+                              meta ? <span className="text-(--ui-text-tertiary)"> {meta}</span> : null
+                            }
+                            nameNode={
+                              <span data-row-label>
+                                <HighlightMatches foldSeparators query={searchTerms} text={name} />
+                              </span>
+                            }
+                            tagNode={
+                              tag ? (
+                                <span className="shrink-0 rounded bg-(--ui-bg-tertiary) px-1 text-[0.625rem] font-medium text-(--ui-text-secondary)">
+                                  {tag}
+                                </span>
+                              ) : null
+                            }
+                            title={family.id}
+                          />
                           {loadProgress ? (
                             <span
                               className="ml-auto flex shrink-0 items-center gap-1.5"
@@ -590,6 +731,11 @@ export function ModelCatalogMenu({
                       </DropdownMenuSub>
                     )
                   })}
+                {search && group.total > group.families.length ? (
+                  <div className="px-2.5 py-1 text-[0.65rem] text-(--ui-text-tertiary)">
+                    Showing {group.families.length} of {group.total.toLocaleString()} — keep typing to narrow
+                  </div>
+                ) : null}
                 {!collapsed &&
                   slug === LOCAL_PROVIDER_SLUG &&
                   shownDownloads.map(job => (
@@ -627,7 +773,7 @@ export function ModelCatalogMenu({
                 }}
                 {...kbRowProps(`moa:${preset}`)}
               >
-                <span className="min-w-0 flex-1 truncate">
+                <span className="min-w-0 flex-1 truncate" data-row-label>
                   MoA: <HighlightMatches foldSeparators query={search} text={preset} />
                 </span>
                 {isCurrentMoa ? <Codicon className="ml-auto text-foreground" name="check" size="0.75rem" /> : null}
@@ -700,54 +846,78 @@ function DownloadingModelRow({ jobId, target }: { jobId: string; target: string 
 // Collapsed we show the user's chosen models (or the curated default); typing
 // spans every available model so anything is reachable past the cut. A search
 // is itself a narrowing action, so we do NOT cap per-provider matches.
+/** Family order inside a provider group: A–Z by display name, id as the
+ *  tiebreak (shared with the visibility dialog). */
+function compareFamilies(a: ModelFamily, b: ModelFamily): number {
+  return compareModelIds(a.id, b.id)
+}
+
 function groupModels(
   providers: ModelOptionProvider[],
+  index: { families: Map<string, ModelFamily[]>; haystacks: Map<string, string> },
   search: string,
   current: { model: string; provider: string },
   visible: Set<string> | null
 ): ProviderGroup[] {
   const q = normalize(search)
+  const foldedQuery = searchFold(q)
+  // Token-AND: `deepseek v4 flash opencode` finds `opencode/deepseek-v4-flash`
+  // regardless of token order. Computed once — keystrokes only scan.
+  const queryTokens = foldedQuery.split(/\s+/).filter(Boolean)
   const groups: ProviderGroup[] = []
 
   for (const provider of providers) {
-    const allFamilies = collapseModelFamilies(provider.models ?? [])
+    const allFamilies = index.families.get(provider.slug) ?? []
 
     if (allFamilies.length === 0) {
       continue
     }
 
-    const matches = (family: ModelFamily) =>
-      foldIncludes(
-        `${family.id} ${family.fastId ?? ''} ${provider.name} ${provider.slug} ${displayModelName(family.id)}`,
-        q
-      )
+    const matches = (family: ModelFamily) => {
+      const haystack = index.haystacks.get(`${provider.slug}::${family.id}`) ?? ''
 
-    let shown: Set<string>
-
-    if (q) {
-      // Search spans every family, regardless of visibility.
-      shown = new Set(allFamilies.filter(matches).map(family => family.id))
-    } else if (visible) {
-      // User has customized which models show — honor their selection exactly.
-      shown = new Set(
-        allFamilies.filter(family => visible.has(modelVisibilityKey(provider.slug, family.id))).map(family => family.id)
-      )
-    } else {
-      shown = new Set(allFamilies.slice(0, DEFAULT_VISIBLE_PER_PROVIDER).map(family => family.id))
+      return queryTokens.every(token => haystack.includes(token))
     }
 
-    // Always include the active model — but keep every row in the provider's
-    // stable curated order, so selecting a model can't shuffle the list. While
-    // SEARCHING the pin is skipped: a query means "show me matches".
+    // Rows read A–Z by display name (ties by id, so duplicate names from
+    // different upstreams order deterministically). The slices below therefore
+    // keep the first N alphabetically, not an arbitrary curated head.
+    const ordered = [...allFamilies].sort(compareFamilies)
+
+    // The active model pins first whenever it is listed — browsing and
+    // searching alike. A non-matching active model stays out (a query means
+    // "show me matches", never "plus my current pick").
     const activeId =
-      !q && catalogProviderMatches(provider, current.provider) && current.model
+      catalogProviderMatches(provider, current.provider) && current.model
         ? allFamilies.find(family => family.id === current.model || family.fastId === current.model)?.id
         : undefined
 
-    const families = allFamilies.filter(family => shown.has(family.id) || family.id === activeId)
+    const pinActiveFirst = (a: ModelFamily, b: ModelFamily) =>
+      a.id === activeId ? -1 : b.id === activeId ? 1 : compareFamilies(a, b)
+
+    let families: ModelFamily[]
+    let total: number
+
+    if (q) {
+      // Search spans every family, regardless of visibility — capped for
+      // render (see SEARCH_RENDER_CAP); the group carries the true total.
+      const matched = ordered.filter(matches).sort(pinActiveFirst)
+      families = matched.slice(0, SEARCH_RENDER_CAP)
+      total = matched.length
+    } else {
+      // A customized shortlist is honored exactly, else the first 50 A–Z.
+      const shown = new Set(
+        visible
+          ? ordered.filter(family => visible.has(modelVisibilityKey(provider.slug, family.id))).map(family => family.id)
+          : ordered.slice(0, DEFAULT_VISIBLE_PER_PROVIDER).map(family => family.id)
+      )
+
+      families = ordered.filter(family => shown.has(family.id) || family.id === activeId).sort(pinActiveFirst)
+      total = families.length
+    }
 
     if (families.length > 0) {
-      groups.push({ families, provider })
+      groups.push({ families, provider, total })
     }
   }
 

--- a/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.test.tsx
@@ -128,4 +128,12 @@ describe('ModelEditSubmenu reports edits without performing them', () => {
 
     expect(onSelectModel).toHaveBeenCalledWith('m1-fast')
   })
+
+  it('heads the controls with the edited model identity', () => {
+    renderSubmenu({ fastControl: { kind: 'none' }, onSetOptions: vi.fn(), reasoning: true })
+
+    // Pretty name plus exact id — duplicate names across upstreams stay distinct.
+    expect(screen.getByText('M1')).toBeDefined()
+    expect(screen.getByText('m1')).toBeDefined()
+  })
 })

--- a/apps/desktop/src/app/shell/model-edit-submenu.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Switch } from '@/components/ui/switch'
 import { useI18n } from '@/i18n'
+import { displayModelName } from '@/lib/model-status-label'
 import { isThinkingEnabled, REASONING_EFFORTS, resolveReasoningEffort } from '@/lib/reasoning-effort'
 
 // Hermes' real reasoning levels live in lib/reasoning-effort; `none` is owned
@@ -107,6 +108,7 @@ function ModelEditSubmenuBody({
   effort,
   fastControl,
   isActive,
+  model,
   onSelectModel,
   onSetOptions,
   reasoning
@@ -144,6 +146,15 @@ function ModelEditSubmenuBody({
     <div className="px-2.5 py-3 text-xs text-(--ui-text-tertiary)">{copy.noOptions}</div>
   ) : (
     <>
+      {/* Which model these controls edit — duplicate names across upstreams
+        are otherwise indistinguishable here. */}
+      <DropdownMenuLabel className="px-2 pb-1 pt-2">
+        <span className="block truncate text-xs font-semibold text-foreground">{displayModelName(model)}</span>
+        <span className="block font-mono text-[0.65rem] font-normal break-all whitespace-normal text-(--ui-text-tertiary)">
+          {model}
+        </span>
+      </DropdownMenuLabel>
+      <DropdownMenuSeparator className="mx-0" />
       <DropdownMenuLabel className={dropdownMenuSectionLabel}>{copy.options}</DropdownMenuLabel>
       {showThinkingToggle ? (
         <DropdownMenuItem className={dropdownMenuRow} onSelect={event => event.preventDefault()}>

--- a/apps/desktop/src/app/shell/model-menu-panel.test.tsx
+++ b/apps/desktop/src/app/shell/model-menu-panel.test.tsx
@@ -172,7 +172,9 @@ describe('ModelMenuPanel search', () => {
   // Highlighted labels are split across <mark> nodes, so single-text-node
   // queries miss them — match on the row span's composed textContent.
   const rowWithText = (content: ReturnType<typeof renderPanel>['content'], pattern: RegExp) =>
-    content.queryByText((_, element) => element?.tagName === 'SPAN' && pattern.test(element.textContent ?? ''))
+    content.queryByText(
+      (_, element) => element?.hasAttribute?.('data-row-label') === true && pattern.test(element.textContent ?? '')
+    )
 
   it('hides the non-matching current model while a query is active', async () => {
     $currentProvider.set('deepseek')
@@ -185,9 +187,9 @@ describe('ModelMenuPanel search', () => {
     fireEvent.change(input, { target: { value: 'gemini' } })
 
     await vi.waitFor(() => {
-      expect(rowWithText(content, /Gemini 3\.1 Pro/i)).not.toBeNull()
+      expect(rowWithText(content, /Deepseek V4 Pro/i)).toBeNull()
     })
-    expect(rowWithText(content, /Deepseek V4 Pro/i)).toBeNull()
+    expect(rowWithText(content, /Gemini 3\.1 Pro/i)).not.toBeNull()
   })
 
   it('Enter in the search field commits the first match', async () => {
@@ -199,15 +201,16 @@ describe('ModelMenuPanel search', () => {
     fireEvent.change(input, { target: { value: 'gemini' } })
 
     await vi.waitFor(() => {
-      expect(rowWithText(content, /Gemini 3\.1 Pro/i)).not.toBeNull()
+      expect(rowWithText(content, /Deepseek V4 Pro/i)).toBeNull()
     })
 
     fireEvent.keyDown(input, { key: 'Enter' })
 
-    // First matching family of the first (alphabetical) matching provider.
+    // First matching family of the first (alphabetical) matching provider;
+    // families read A–Z, so 2.5 Flash leads 3.1 Pro.
     await vi.waitFor(() => {
       expect(onSelectModel).toHaveBeenCalledWith({
-        model: 'gemini-3.1-pro',
+        model: 'gemini-2.5-flash',
         provider: 'google',
         sessionId: 'runtime-1'
       })
@@ -235,7 +238,7 @@ describe('ModelMenuPanel search', () => {
     fireEvent.change(input, { target: { value: 'gemini' } })
 
     await vi.waitFor(() => {
-      expect(rowWithText(content, /Gemini 3\.1 Pro/i)).not.toBeNull()
+      expect(rowWithText(content, /Deepseek V4 Pro/i)).toBeNull()
     })
 
     // First match auto-selected; ↓ steps to the second match.
@@ -244,7 +247,7 @@ describe('ModelMenuPanel search', () => {
 
     await vi.waitFor(() => {
       expect(onSelectModel).toHaveBeenCalledWith({
-        model: 'gemini-2.5-flash',
+        model: 'gemini-2.5-pro',
         provider: 'google',
         sessionId: 'runtime-1'
       })
@@ -273,9 +276,9 @@ describe('ModelMenuPanel search', () => {
     fireEvent.change(input, { target: { value: 'beast' } })
 
     await vi.waitFor(() => {
-      expect(rowWithText(content, /MoA: BeastMode/)).not.toBeNull()
+      expect(rowWithText(content, /MoA: default/)).toBeNull()
     })
-    expect(rowWithText(content, /MoA: default/)).toBeNull()
+    expect(rowWithText(content, /MoA: BeastMode/)).not.toBeNull()
 
     // The surviving preset IS the first row, so Enter commits it.
     fireEvent.keyDown(input, { key: 'Enter' })
@@ -353,7 +356,9 @@ describe('ModelMenuPanel provider collapse', () => {
     await vi.waitFor(() => {
       expect(
         content.queryByText(
-          (_, element) => element?.tagName === 'SPAN' && (element.textContent ?? '').startsWith('Deepseek V4 Pro')
+          (_, element) =>
+            element?.hasAttribute?.('data-row-label') === true &&
+            (element.textContent ?? '').startsWith('Deepseek V4 Pro')
         )
       ).not.toBeNull()
     })

--- a/apps/desktop/src/components/chat/status-section.tsx
+++ b/apps/desktop/src/components/chat/status-section.tsx
@@ -15,6 +15,10 @@ interface StatusSectionProps {
   /** Optional glyph between the caret and the label (e.g. a `Codicon`). */
   icon?: ReactNode
   label: ReactNode
+  /** Pin the header while the section body scrolls (long goal/subagent
+   *  sections) so collapse stays reachable mid-scroll. Paints the composer
+   *  fill — only set inside the composer dock card. */
+  stickyHeader?: boolean
 }
 
 /**
@@ -30,13 +34,20 @@ export function StatusSection({
   defaultCollapsed = true,
   icon,
   label,
-  preview
+  preview,
+  stickyHeader = false
 }: StatusSectionProps) {
   const [collapsed, setCollapsed] = useState(defaultCollapsed)
 
   return (
     <div>
-      <div className="flex items-center gap-1 pr-1">
+      <div
+        className={
+          stickyHeader
+            ? 'sticky top-0 z-10 flex items-center gap-1 bg-(--composer-fill) pr-1'
+            : 'flex items-center gap-1 pr-1'
+        }
+      >
         <button
           aria-expanded={!collapsed}
           className="flex min-w-0 flex-1 items-center gap-1.5 px-2 py-1 text-left text-xs font-normal text-muted-foreground/92 transition-colors hover:text-foreground/90"

--- a/apps/desktop/src/components/model-visibility-dialog.test.tsx
+++ b/apps/desktop/src/components/model-visibility-dialog.test.tsx
@@ -1,0 +1,122 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $visibleModels } from '@/store/model-visibility'
+import { $collapsedProviders } from '@/store/provider-collapse'
+
+import { ModelVisibilityDialog } from './model-visibility-dialog'
+
+// Radix calls these on open; jsdom doesn't implement them.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+
+const requestModelOptions = vi.fn()
+
+vi.mock('@/lib/model-options', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/lib/model-options')>()),
+  requestModelOptions: (...args: unknown[]) => requestModelOptions(...args)
+}))
+
+const LOCAL_MODELS = ['cmd/deepseek/deepseek-v4-flash', 'cbai/deepseek-v4-flash', 'auto/best-coding']
+
+beforeEach(() => {
+  $visibleModels.set(null)
+  $collapsedProviders.set([])
+  requestModelOptions.mockResolvedValue({
+    providers: [{ models: LOCAL_MODELS, name: 'Local', slug: 'local' }]
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+function renderDialog() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+  render(
+    <QueryClientProvider client={client}>
+      <ModelVisibilityDialog onOpenChange={() => {}} onOpenProviders={() => {}} open />
+    </QueryClientProvider>
+  )
+}
+
+describe('ModelVisibilityDialog', () => {
+  it('shows the upstream in the id line, no pills', async () => {
+    renderDialog()
+    await screen.findByText('Best Coding')
+
+    const names = [...document.querySelectorAll('[data-row-label]')].map(el => el.textContent)
+
+    expect(names).toEqual(['Best Coding', 'Deepseek V4 Flash', 'Deepseek V4 Flash'])
+    // No qualifier pills — the id line carries the upstream verbatim.
+    expect(screen.getByText('cmd/deepseek/deepseek-v4-flash')).toBeDefined()
+    expect(screen.getByText('cbai/deepseek-v4-flash')).toBeDefined()
+    expect(screen.queryByText('cmd/deepseek')).toBeNull()
+  })
+
+  it('filters by upstream prefix', async () => {
+    renderDialog()
+    await screen.findByText('Best Coding')
+
+    fireEvent.change(screen.getByPlaceholderText('Search models'), { target: { value: 'cbai' } })
+
+    // Highlighting splits the id across nodes — assert on row labels instead.
+    await vi.waitFor(() => {
+      const names = [...document.querySelectorAll('[data-row-label]')].map(el => el.textContent)
+
+      expect(names).toEqual(['Deepseek V4 Flash'])
+    })
+    expect(screen.getByText('cbai', { selector: 'mark' })).toBeDefined()
+  })
+
+  it('freezes order while toggling — no reshuffle under the pointer', async () => {
+    renderDialog()
+    await screen.findByText('Best Coding')
+
+    const before = [...document.querySelectorAll('[data-row-label]')].map(el => el.textContent)
+    const switches = screen.getAllByRole('switch')
+
+    // Disable the first (enabled) row.
+    fireEvent.click(switches[0])
+
+    await vi.waitFor(() => {
+      expect(switches[0].getAttribute('aria-checked')).toBe('false')
+    })
+    expect([...document.querySelectorAll('[data-row-label]')].map(el => el.textContent)).toEqual(before)
+  })
+
+  it('matches unordered tokens across id and upstream', async () => {
+    renderDialog()
+    await screen.findByText('Best Coding')
+
+    fireEvent.change(screen.getByPlaceholderText('Search models'), { target: { value: 'flash cmd' } })
+
+    await vi.waitFor(() => {
+      const names = [...document.querySelectorAll('[data-row-label]')].map(el => el.textContent)
+
+      expect(names).toEqual(['Deepseek V4 Flash'])
+    })
+    expect(screen.getAllByText('flash', { selector: 'mark' }).length).toBeGreaterThan(0)
+  })
+
+  it('caps the initial list with a show-all expander', async () => {
+    const MANY = Array.from({ length: 250 }, (_, i) => `zz-model-${String(i).padStart(3, '0')}`)
+    requestModelOptions.mockResolvedValue({ providers: [{ models: MANY, name: 'Many', slug: 'many' }] })
+    renderDialog()
+    await screen.findByText('Zz Model 000')
+
+    expect(document.querySelectorAll('[data-row-label]').length).toBe(200)
+
+    fireEvent.click(screen.getByText(/Show all 250/))
+
+    await vi.waitFor(() => {
+      expect(document.querySelectorAll('[data-row-label]').length).toBe(250)
+    })
+  })
+})

--- a/apps/desktop/src/components/model-visibility-dialog.tsx
+++ b/apps/desktop/src/components/model-visibility-dialog.tsx
@@ -1,6 +1,6 @@
 import { useStore } from '@nanostores/react'
 import { useQuery } from '@tanstack/react-query'
-import { useMemo, useState } from 'react'
+import { memo, useMemo, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -8,13 +8,15 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { DisclosureCaret } from '@/components/ui/disclosure-caret'
 import { GlyphSpinner } from '@/components/ui/glyph-spinner'
 import { HighlightMatches } from '@/components/ui/highlight-matches'
+import { HoverScroll } from '@/components/ui/marquee'
 import { Switch } from '@/components/ui/switch'
 import type { HermesGateway } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { Search } from '@/lib/icons'
 import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
-import { displayModelName, modelDisplayParts } from '@/lib/model-status-label'
-import { foldIncludes, normalize } from '@/lib/text'
+import { compareModelIds, displayModelName, modelDisplayParts } from '@/lib/model-status-label'
+import { normalize, searchFold } from '@/lib/text'
+import { useDebouncedValue } from '@/lib/use-debounced-value'
 import {
   $visibleModels,
   collapseModelFamilies,
@@ -26,6 +28,79 @@ import {
 } from '@/store/model-visibility'
 import { $collapsedProviders, toggleCollapsedProvider } from '@/store/provider-collapse'
 import type { ModelOptionProvider, ModelOptionsResponse } from '@/types/hermes'
+
+/** Render cap per provider — filtering thousands of ids is cheap, mounting
+ *  thousands of toggle rows is not. The expander below lifts it per provider. */
+const DIALOG_RENDER_CAP = 200
+
+/** One toggle row, memoized so a switch flips one row instead of re-rendering
+ *  hundreds (the per-row toggle closure is intentionally excluded from the
+ *  compare — it reads fresh stores itself). No pills: the id line below
+ *  already carries the upstream verbatim. */
+const VisibilityRow = memo(
+  function VisibilityRow({
+    checked,
+    familyId,
+    onToggle,
+    provider,
+    search,
+    terms
+  }: {
+    checked: boolean
+    familyId: string
+    onToggle: () => void
+    provider: ModelOptionProvider
+    search: string
+    terms: string | string[]
+  }) {
+    const [go, setGo] = useState(false)
+    const { name } = modelDisplayParts(familyId)
+    const caps = provider.capabilities?.[familyId]
+
+    const details = [familyId, caps?.fast ? 'fast' : null, caps && !caps.reasoning ? 'no reasoning' : null]
+      .filter(Boolean)
+      .join(' · ')
+
+    return (
+      <label className="flex cursor-pointer items-center gap-2 px-3 py-1 text-xs hover:bg-(--ui-control-active-background)">
+        <span
+          className="block min-w-0 flex-1 overflow-hidden"
+          onMouseOut={event => {
+            if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+              return
+            }
+
+            setGo(false)
+          }}
+          onMouseOver={() => setGo(true)}
+          title={details}
+        >
+          <span className="flex min-w-0 items-center gap-1.5">
+            <HoverScroll className="min-w-0 flex-1" go={go} marqueeKey={`name:${familyId}`}>
+              <span data-row-label>
+                <HighlightMatches query={terms} text={name} />
+              </span>
+            </HoverScroll>
+          </span>
+          <HoverScroll
+            className="font-mono text-[0.65rem] font-normal text-(--ui-text-tertiary)"
+            go={go}
+            marqueeKey={`id:${familyId}`}
+          >
+            <HighlightMatches query={terms} text={familyId} />
+          </HoverScroll>
+        </span>
+        <Switch checked={checked} onCheckedChange={onToggle} size="xs" />
+      </label>
+    )
+  },
+  (prev, next) =>
+    prev.checked === next.checked &&
+    prev.familyId === next.familyId &&
+    prev.provider === next.provider &&
+    prev.search === next.search &&
+    prev.terms === next.terms
+)
 
 interface ModelVisibilityDialogProps {
   gw?: HermesGateway
@@ -48,9 +123,20 @@ export function ModelVisibilityDialog({
 }: ModelVisibilityDialogProps) {
   const { t } = useI18n()
   const copy = t.modelVisibility
-  const [search, setSearch] = useState('')
+  const [searchInput, setSearchInput] = useState('')
+  // Filtering runs on the settled query; the input itself stays instant.
+  const search = useDebouncedValue(searchInput, 150)
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
   const stored = useStore($visibleModels)
   const collapsedProviders = useStore($collapsedProviders)
+
+  // Order snapshot per open: toggling a switch must not reshuffle the list
+  // under the pointer — enablement ranks freeze when the modal opens.
+  const rankRef = useRef<Set<string> | null>(null)
+
+  if (!open) {
+    rankRef.current = null
+  }
 
   const modelOptions = useQuery({
     queryKey: modelOptionsQueryKey(profile, sessionId, ownerConnectionId),
@@ -65,6 +151,12 @@ export function ModelVisibilityDialog({
 
   const visible = effectiveVisibleKeys(stored, providers)
 
+  if (open && rankRef.current === null) {
+    rankRef.current = new Set(visible)
+  }
+
+  const rank = rankRef.current ?? visible
+
   const toggle = (provider: ModelOptionProvider, model: string) => {
     setVisibleModels(toggleModelVisibility($visibleModels.get(), providers, provider.slug, model))
   }
@@ -75,8 +167,31 @@ export function ModelVisibilityDialog({
 
   const q = normalize(search)
 
+  // Token-AND index (`deepseek v4 flash opencode` finds
+  // `opencode/deepseek-v4-flash` regardless of order), folded once per
+  // catalog so keystrokes only scan cheap substrings. Highlighting reuses the
+  // tokens only for multi-token queries — single-token queries keep the raw
+  // string so separator folding highlights one contiguous range.
+  const queryTokens = useMemo(() => searchFold(q).split(/\s+/).filter(Boolean), [q])
+  const highlightQuery = queryTokens.length > 1 && /\s/.test(search) ? queryTokens : search
+
+  const haystacks = useMemo(() => {
+    const map = new Map<string, string>()
+
+    for (const provider of providers) {
+      for (const model of provider.models ?? []) {
+        map.set(
+          `${provider.slug}::${model}`,
+          searchFold(`${model} ${provider.name} ${provider.slug} ${displayModelName(model)}`)
+        )
+      }
+    }
+
+    return map
+  }, [providers])
+
   const matches = (provider: ModelOptionProvider, model: string) =>
-    !q || foldIncludes(`${model} ${provider.name} ${provider.slug} ${displayModelName(model)}`, q)
+    queryTokens.every(token => (haystacks.get(`${provider.slug}::${model}`) ?? '').includes(token))
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
@@ -90,10 +205,10 @@ export function ModelVisibilityDialog({
           <input
             autoFocus
             className="h-5 w-full bg-transparent text-xs text-foreground placeholder:text-(--ui-text-tertiary) focus:outline-none"
-            onChange={event => setSearch(event.target.value)}
+            onChange={event => setSearchInput(event.target.value)}
             placeholder={copy.search}
             type="text"
-            value={search}
+            value={searchInput}
           />
         </div>
 
@@ -104,13 +219,23 @@ export function ModelVisibilityDialog({
             </div>
           ) : (
             providers.map(provider => {
-              const models = collapseModelFamilies(provider.models ?? []).filter(family => matches(provider, family.id))
+              const allFamilies = collapseModelFamilies(provider.models ?? [])
+              // A–Z, same order as the model menu; the raw id stays searchable
+              // so an upstream prefix (`cmd/…`) filters even when the pretty
+              // name hides it.
+              // Enabled first, then A–Z — ranked by the open-time snapshot so
+              // toggling never reshuffles.
+              const enabledRank = (id: string) => (rank.has(modelVisibilityKey(provider.slug, id)) ? 0 : 1)
+
+              const models = allFamilies
+                .filter(family => matches(provider, family.id))
+                .sort((a, b) => enabledRank(a.id) - enabledRank(b.id) || compareModelIds(a.id, b.id))
 
               if (models.length === 0) {
                 return null
               }
 
-              const allFamilies = collapseModelFamilies(provider.models ?? [])
+              const shown = expanded.has(provider.slug) ? models : models.slice(0, DIALOG_RENDER_CAP)
 
               const onCount = allFamilies.filter(family =>
                 visible.has(modelVisibilityKey(provider.slug, family.id))
@@ -131,6 +256,9 @@ export function ModelVisibilityDialog({
                       <span className="min-w-0 truncate">
                         <HighlightMatches foldSeparators query={search} text={provider.name} />
                       </span>
+                      <span className="shrink-0 font-normal normal-case tracking-normal">
+                        {onCount}/{allFamilies.length}
+                      </span>
                       <DisclosureCaret
                         className="shrink-0 opacity-0 transition group-hover/label:opacity-100"
                         open={!collapsed}
@@ -143,27 +271,33 @@ export function ModelVisibilityDialog({
                     />
                   </div>
                   {!collapsed &&
-                    models.map(family => {
-                      const { name, tag } = modelDisplayParts(family.id)
-                      const key = modelVisibilityKey(provider.slug, family.id)
+                    shown.map(family => (
+                      <VisibilityRow
+                        checked={visible.has(modelVisibilityKey(provider.slug, family.id))}
+                        familyId={family.id}
+                        key={modelVisibilityKey(provider.slug, family.id)}
+                        onToggle={() => toggle(provider, family.id)}
+                        provider={provider}
+                        search={search}
+                        terms={highlightQuery}
+                      />
+                    ))}
+                  {!collapsed && shown.length < models.length ? (
+                    <button
+                      className="w-full px-3 py-1 text-left text-[0.65rem] text-(--ui-text-tertiary) hover:text-foreground"
+                      onClick={() =>
+                        setExpanded(prev => {
+                          const next = new Set(prev)
+                          next.add(provider.slug)
 
-                      return (
-                        <label
-                          className="flex cursor-pointer items-center gap-2 px-3 py-1 text-xs hover:bg-(--ui-control-active-background)"
-                          key={key}
-                        >
-                          <span className="min-w-0 flex-1 truncate">
-                            <HighlightMatches foldSeparators query={search} text={name} />
-                            {tag ? <span className="text-(--ui-text-tertiary)"> {tag}</span> : null}
-                          </span>
-                          <Switch
-                            checked={visible.has(key)}
-                            onCheckedChange={() => toggle(provider, family.id)}
-                            size="xs"
-                          />
-                        </label>
-                      )
-                    })}
+                          return next
+                        })
+                      }
+                      type="button"
+                    >
+                      Show all {models.length.toLocaleString()} — {models.length - shown.length} more
+                    </button>
+                  ) : null}
                 </div>
               )
             })

--- a/apps/desktop/src/components/ui/dropdown-menu.tsx
+++ b/apps/desktop/src/components/ui/dropdown-menu.tsx
@@ -42,6 +42,16 @@ function DropdownMenuSearch({
 }: Omit<React.ComponentProps<'input'>, 'type'> & {
   onValueChange?: (value: string) => void
 }) {
+  const inputRef = React.useRef<HTMLInputElement>(null)
+
+  // Radix focuses the first menuitem on open, beating the input's autoFocus —
+  // reclaim focus a frame later so typing filters immediately, no click needed.
+  React.useEffect(() => {
+    const frame = requestAnimationFrame(() => inputRef.current?.focus({ preventScroll: true }))
+
+    return () => cancelAnimationFrame(frame)
+  }, [])
+
   return (
     <div className="px-2.5 py-1.5" data-slot="dropdown-menu-search">
       <input
@@ -61,6 +71,7 @@ function DropdownMenuSearch({
 
           onKeyDown?.(event)
         }}
+        ref={inputRef}
         // Search fields here filter ids, slugs, and model names — dictionary
         // squiggles under them are noise (matching the composer/settings
         // inputs, which already disable spellcheck).

--- a/apps/desktop/src/components/ui/marquee.tsx
+++ b/apps/desktop/src/components/ui/marquee.tsx
@@ -1,0 +1,68 @@
+import { type ReactNode, useEffect, useRef, useState } from 'react'
+
+import { cn } from '@/lib/utils'
+
+/** Marquee line: glides its tail into view while `go` holds, snaps back
+ *  after. Stays put when nothing overflows or reduced motion is preferred.
+ *  The owner passes one shared `go` so a whole row scrolls together. */
+export function HoverScroll({
+  children,
+  className,
+  go,
+  marqueeKey
+}: {
+  children: ReactNode
+  className?: string
+  go: boolean
+  /** Test hook; never rendered. */
+  marqueeKey?: string
+}) {
+  const outer = useRef<HTMLSpanElement>(null)
+  const inner = useRef<HTMLSpanElement>(null)
+  const [distance, setDistance] = useState(0)
+
+  useEffect(() => {
+    if (!go) {
+      setDistance(0)
+
+      return
+    }
+
+    const box = outer.current
+    const content = inner.current
+
+    if (!box || !content) {
+      return
+    }
+
+    if (typeof window.matchMedia === 'function' && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      return
+    }
+
+    const overflow = content.scrollWidth - box.clientWidth
+
+    if (overflow > 8) {
+      setDistance(overflow)
+    }
+  }, [go, children])
+
+  return (
+    <span
+      className={cn('block overflow-hidden', distance > 0 ? null : 'truncate', className)}
+      data-marquee={marqueeKey ?? true}
+      ref={outer}
+    >
+      <span
+        className="inline-block whitespace-nowrap will-change-transform"
+        ref={inner}
+        style={
+          distance > 0
+            ? { transform: `translateX(${-distance}px)`, transition: `transform ${Math.max(1, distance / 32)}s linear` }
+            : undefined
+        }
+      >
+        {children}
+      </span>
+    </span>
+  )
+}

--- a/apps/desktop/src/lib/model-status-label.test.ts
+++ b/apps/desktop/src/lib/model-status-label.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  compareModelIds,
   currentPickerSelection,
   displayModelName,
   formatModelStatusLabel,
@@ -85,6 +86,18 @@ describe('model-status-label', () => {
 
     it('falls back to the store while options are still loading', () => {
       expect(currentPickerSelection(store, undefined)).toEqual(store)
+    })
+  })
+
+  describe('compareModelIds', () => {
+    it('orders A–Z by display name, id breaking ties', () => {
+      const ids = ['cmd/deepseek/deepseek-v4-flash', 'auto/best-coding', 'cbai/deepseek-v4-flash']
+
+      expect([...ids].sort(compareModelIds)).toEqual([
+        'auto/best-coding',
+        'cbai/deepseek-v4-flash',
+        'cmd/deepseek/deepseek-v4-flash'
+      ])
     })
   })
 })

--- a/apps/desktop/src/lib/model-status-label.ts
+++ b/apps/desktop/src/lib/model-status-label.ts
@@ -109,6 +109,14 @@ export function displayModelName(model: string): string {
   return modelDisplayParts(model).name
 }
 
+/** Row order inside a provider group: A–Z by display name, id as the tiebreak
+ *  so equal names from different upstreams stay deterministic. */
+export function compareModelIds(a: string, b: string): number {
+  const byName = displayModelName(a).localeCompare(displayModelName(b), undefined, { sensitivity: 'base' })
+
+  return byName !== 0 ? byName : a.toLowerCase() < b.toLowerCase() ? -1 : 1
+}
+
 /** Status bar trigger label — model name plus the live session state (effort/fast).
  *  `defaultEffort` is the profile's configured level, used when the surface has
  *  no explicit effort so the label never advertises a default the agent won't use. */

--- a/apps/desktop/src/lib/text.ts
+++ b/apps/desktop/src/lib/text.ts
@@ -43,3 +43,18 @@ export function searchFold(v: unknown): string {
 export function foldIncludes(text: unknown, query: unknown): boolean {
   return searchFold(text).includes(searchFold(query))
 }
+
+/** Token-AND matcher: every whitespace-separated query token must occur in the
+ *  haystack, in any order — `deepseek v4 flash opencode` finds
+ *  `opencode/deepseek-v4-flash`. Single-token queries behave like foldIncludes. */
+export function foldIncludesAllTokens(text: unknown, query: unknown): boolean {
+  const tokens = searchFold(query).split(/\s+/).filter(Boolean)
+
+  if (tokens.length === 0) {
+    return true
+  }
+
+  const haystack = searchFold(text)
+
+  return tokens.every(token => haystack.includes(token))
+}

--- a/apps/desktop/src/lib/use-debounced-value.test.ts
+++ b/apps/desktop/src/lib/use-debounced-value.test.ts
@@ -1,0 +1,34 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useDebouncedValue } from './use-debounced-value'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useDebouncedValue', () => {
+  it('holds the old value until the pause elapses, then settles once', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebouncedValue(value, 50), {
+      initialProps: { value: 'a' }
+    })
+
+    rerender({ value: 'ab' })
+    rerender({ value: 'abc' })
+    expect(result.current).toBe('a')
+
+    act(() => {
+      vi.advanceTimersByTime(49)
+    })
+    expect(result.current).toBe('a')
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(result.current).toBe('abc')
+  })
+})

--- a/apps/desktop/src/lib/use-debounced-value.ts
+++ b/apps/desktop/src/lib/use-debounced-value.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react'
+
+/** Delays value propagation until it settles ~`delayMs` after the last change:
+ *  the input stays instant while expensive filtering (thousands of catalog
+ *  rows) runs at most once per pause instead of per keystroke. */
+export function useDebouncedValue<T>(value: T, delayMs = 50): T {
+  const [settled, setSettled] = useState(value)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setSettled(value), delayMs)
+
+    return () => clearTimeout(timer)
+  }, [value, delayMs])
+
+  return settled
+}


### PR DESCRIPTION
## What does this PR do?

Model picker search/filter/models polish only — typing stays instant on a ~6k-model catalog, and results read A–Z with the active model pinned.

- **Typing lag:** the query lived in `ModelCatalogMenu` state, so every keystroke re-rendered the whole menu before the character painted. The raw input now lives in a small `SearchInput` child that owns its state and hands the parent the value after a 150 ms debounce. Filtering runs once per pause.
- **Focus:** Radix focuses the first menu item on open, beating the input's `autoFocus` — the search field reclaims focus a frame later so typing filters immediately, no click needed.
- **Filter cost:** token-AND matching over a prebuilt, pre-folded haystack index (built once per catalog) instead of re-folding every id per keystroke; multi-word queries match in any order.
- **Ordering:** families read A–Z (`compareModelIds`), active model pinned first — including while searching (a non-matching active pick stays out). Search results capped per provider (100) with a "N of M — keep typing to narrow" note; provider headers show shown-of-total counts.
- **Rows:** name + upstream id line with hover marquee scrolling clipped lines together; Edit Models dialog sorts enabled-first then A–Z with search highlight.
- **Collapsibles:** shared `StatusSection` `stickyHeader` — goal, subagent, loop, heartbeat and queue sections keep their headers (and the goal panel its criteria footer) pinned while the body scrolls.

## Related Issue

N/A.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/shell/model-catalog-menu.tsx` — `SearchInput` child (debounced), haystack index, A–Z ordering + active pin + render cap, hover-scroll rows with shown-of-total counts.
- `apps/desktop/src/components/ui/dropdown-menu.tsx` — search field reclaims focus on open.
- `apps/desktop/src/lib/use-debounced-value.ts` — debounce hook (+ tests).
- `apps/desktop/src/lib/text.ts`, `apps/desktop/src/lib/model-status-label.ts` — token helpers, `compareModelIds` (+ tests).
- `apps/desktop/src/components/ui/marquee.tsx` — shared hover-scroll.
- `apps/desktop/src/app/shell/model-edit-submenu.tsx`, `apps/desktop/src/components/model-visibility-dialog.tsx` — sort/highlight polish (+ tests).
- `apps/desktop/src/components/chat/status-section.tsx` + goal/subagent/loop/heartbeat/queue sections — `stickyHeader`.
- `apps/desktop/src/app/shell/model-catalog-menu.test.tsx`, `model-menu-panel.test.tsx` — search/filter/collapse coverage.

## How to Test

1. Open the model picker and type — characters appear immediately, results update ~150 ms after you stop; no per-keystroke stutter, no click needed to focus.
2. Type `deepseek v4 flash opencode` — token-AND finds `opencode/deepseek-v4-flash` regardless of order; only 100 rows mount with a narrowing note.
3. Search with an active model set — the matching active model stays on top; clear the query and families read A–Z.
4. Open the composer status stack with a goal / subagent run active — section headers stay pinned while the body scrolls.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, desktop/TypeScript only
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64) — `tsc --noEmit` clean, affected `vitest` files green

### Documentation & Housekeeping

- [x] Docs — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (no new platform APIs)
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

N/A — search/filter/models behavior only.
