### PR TITLE
fix(acp): empty-string tool results and messages=[] reach ACP clients unchanged (#10845, #10844, salvage #10868)

### DIFF
--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -152,7 +152,8 @@ def make_step_cb(
             tool_name = result = function_args = None
             if isinstance(tool_info, dict):
                 tool_name = tool_info.get("name") or tool_info.get("function_name")
-                result = tool_info.get("result") or tool_info.get("output")
+                # Key presence, not truthiness: "", 0 and False are real results (#10845).
+                result = tool_info.get("result") if "result" in tool_info else tool_info.get("output")
                 function_args = tool_info.get("arguments") or tool_info.get("args")
             elif isinstance(tool_info, str):
                 tool_name = tool_info

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -878,7 +878,9 @@ class HermesACPAgent(SlashCommandsMixin, acp.Agent):
         streamed_message: bool,
     ) -> PromptResponse:
         """Persist, emit provenance/final text, drain queued prompts, report usage."""
-        if result.get("messages"):
+        # Key presence, not truthiness: ``messages=[]`` is a legitimate cleared transcript (#10844);
+        # only a result without the key leaves the history untouched.
+        if "messages" in result and isinstance(result["messages"], list):
             state.history = result["messages"]
             self.session_manager.save_session(session_id)
 

--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -128,6 +128,18 @@ class TestStepCallback:
 
 
 
+    @pytest.mark.parametrize("raw, expected", [("", ""), (0, "0"), (False, "False")])
+    def test_falsey_result_reaches_client_unchanged(self, mock_conn, event_loop_fixture, raw, expected):
+        """A present-but-falsey ``result`` is the tool's real output, not a missing key (#10845)."""
+        from collections import deque
+
+        cb = make_step_cb(mock_conn, "session-1", event_loop_fixture, {"terminal": deque(["tc-f"])}, {})
+        with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts, \
+             patch("acp_adapter.events.build_tool_complete") as mock_btc:
+            mock_rcts.return_value = MagicMock(spec=Future)
+            cb(1, [{"name": "terminal", "result": raw}])
+        mock_btc.assert_called_once_with("tc-f", "terminal", result=expected, function_args=None, snapshot=None)
+
     def test_result_passed_to_build_tool_complete(self, mock_conn, event_loop_fixture):
         """Tool result from prev_tools dict is forwarded to build_tool_complete."""
         from collections import deque

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -446,6 +446,24 @@ class TestPrompt:
 
         assert captured.get("child") == resp.session_id
 
+    @pytest.mark.asyncio
+    async def test_empty_messages_list_replaces_stale_history(self, agent, mock_manager):
+        """``run_conversation`` returning ``messages=[]`` clears the ACP transcript instead of
+        leaving the previous turn's history in place (#10844)."""
+        resp = await agent.new_session(cwd=".")
+        state = mock_manager.get_session(resp.session_id)
+        state.history = [{"role": "user", "content": "old"}]
+        state.agent.run_conversation = MagicMock(return_value={"final_response": "done", "messages": []})
+        state.agent.model = "test-model"
+        state.agent.provider = "openrouter"
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        await agent.prompt(prompt=[TextContentBlock(type="text", text="hi")], session_id=resp.session_id)
+
+        assert state.history == []
+
 
 
 


### PR DESCRIPTION
ACP clients now see a tool's real `""` / `0` / `False` result and a cleared transcript when the agent returns `messages=[]`, instead of `None` and stale history.

- `acp_adapter/events.py::make_step_cb` — `result` is read by key presence, falling back to `output` only when the key is absent (@Bartok9, #10868).
- `acp_adapter/server.py::_finish_turn` — history is replaced whenever the `messages` key is present (list), so `[]` clears it (same falsey-vs-absent class, #10844).
- 2 invariant tests (one parametrized over `""`/`0`/`False`, one for the `[]` history replacement).

| | before | after |
|---|---|---|
| `{"result": ""}` | `build_tool_complete(..., result=None)` | `result=""` |
| `run_conversation → {"messages": []}` | history kept | history `[]`, persisted |

**Live repro:** both contributor repros red on `origin/main`, green here (`tests/acp/test_events.py`, `tests/acp/test_server.py`).

Closes #10845, closes #10844.

## Infographic

![acp-fidelity](https://v3b.fal.media/files/b/0aaa21f4/qsox0vFGZJVB10XnXhNQ-_WC173zta.png)
