### PR TITLE
fix(redact): ordinary am_* identifiers are no longer masked in tool output (#10983, salvage #11124)

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -159,7 +159,10 @@ _PREFIX_PATTERNS = [
     r"pypi-[A-Za-z0-9_-]{10,}",         # PyPI API token
     r"dop_v1_[A-Za-z0-9]{10,}",         # DigitalOcean PAT
     r"doo_v1_[A-Za-z0-9]{10,}",         # DigitalOcean OAuth
-    r"am_[a-f0-9]{32,}",              # AgentMail API key (hex format, 32+ chars)
+    # AgentMail API key: ``am_`` / ``am_org_`` + an opaque alphanumeric body. The body has no ``_``/``-``,
+    # which is what separates it from ``am_example_identifier_123`` (#10983); public docs pin only the
+    # prefix, so the charset stays broad and the length floor does the discriminating.
+    r"am_(?:org_)?[A-Za-z0-9]{20,}",
     r"sk_[A-Za-z0-9_]{10,}",            # ElevenLabs TTS key (sk_ underscore, not sk- dash)
     r"tvly-[A-Za-z0-9]{10,}",           # Tavily search API key
     r"exa_[A-Za-z0-9]{10,}",            # Exa search API key

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -159,7 +159,7 @@ _PREFIX_PATTERNS = [
     r"pypi-[A-Za-z0-9_-]{10,}",         # PyPI API token
     r"dop_v1_[A-Za-z0-9]{10,}",         # DigitalOcean PAT
     r"doo_v1_[A-Za-z0-9]{10,}",         # DigitalOcean OAuth
-    r"am_[A-Za-z0-9_-]{10,}",           # AgentMail API key
+    r"am_[a-f0-9]{32,}",              # AgentMail API key (hex format, 32+ chars)
     r"sk_[A-Za-z0-9_]{10,}",            # ElevenLabs TTS key (sk_ underscore, not sk- dash)
     r"tvly-[A-Za-z0-9]{10,}",           # Tavily search API key
     r"exa_[A-Za-z0-9]{10,}",            # Exa search API key

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -63,8 +63,8 @@ class TestKnownPrefixes:
         """``am_`` is a common identifier prefix; only the documented hex key body is a secret (#10983)."""
         for benign in ["schema.am_example_identifier_123", "path/to/am_monthly_report.sql"]:
             assert redact_sensitive_text(benign) == benign
-        key = "am_" + "0123456789abcdef" * 2
-        assert "0123456789abcdef" not in redact_sensitive_text(f"AGENTMAIL_API_KEY is {key}")
+        for key in ("am_" + "0123456789abcdef" * 2, "am_" + "Ab9" * 8, "am_org_" + "Zq7k" * 6):
+            assert key[-12:] not in redact_sensitive_text(f"leaked {key} in output"), key
 
     def test_slack_token(self):
         token = "xoxb-" + "0" * 12 + "-" + "a" * 14

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -59,6 +59,13 @@ class TestKnownPrefixes:
         ]:
             assert redact_sensitive_text(benign) == benign
 
+    def test_agentmail_prefix_needs_a_key_shaped_hex_suffix(self):
+        """``am_`` is a common identifier prefix; only the documented hex key body is a secret (#10983)."""
+        for benign in ["schema.am_example_identifier_123", "path/to/am_monthly_report.sql"]:
+            assert redact_sensitive_text(benign) == benign
+        key = "am_" + "0123456789abcdef" * 2
+        assert "0123456789abcdef" not in redact_sensitive_text(f"AGENTMAIL_API_KEY is {key}")
+
     def test_slack_token(self):
         token = "xoxb-" + "0" * 12 + "-" + "a" * 14
         result = redact_sensitive_text(token)


### PR DESCRIPTION
Tool output containing identifiers like `schema.am_example_identifier` or `path/to/am_report.sql` is shown as-is; only key-shaped AgentMail secrets (`am_` + 32+ hex) are masked.

- `agent/redact.py` — `am_[A-Za-z0-9_-]{10,}` → `am_[a-f0-9]{32,}` (matches the documented AgentMail key body; @nightq, #11124).
- 1 invariant test: two benign identifiers survive, a hex key is still redacted.

**Root cause:** the prefix rule accepted any 10+ char identifier after `am_`, a very common prefix in schemas and file names.

**Live repro:** `redact_sensitive_text("schema.am_example_identifier_123")` → `schema.***` on `origin/main`, unchanged here.

Closes #10983.

**Review follow-up (da3884b2):** the hex-only grammar was unproven (AgentMail docs pin only the `am_` / `am_org_` prefix), so the rule is now `am_(?:org_)?[A-Za-z0-9]{20,}` — an opaque alphanumeric body with no `_`/`-`, which is what separates keys from `am_example_identifier_123`. Test covers hex, mixed-case and `am_org_` bodies.

## Infographic

![redaction](https://v3b.fal.media/files/b/0aaa21f4/iYVtJKYgUTKX0kBh0rhyu_6Oqs19q7.png)

