### PR TITLE
fix(agent): `cd backend && ls` loads backend/AGENTS.md subdirectory hints (#11032, salvage #11037)

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -52,6 +52,10 @@ def _first_hint_file(directory: Path):
     return None
 
 
+_NAV_COMMANDS = frozenset({"cd", "pushd"})
+_SHELL_OPERATORS = frozenset({"&&", "||", "|", ";", "&"})
+
+
 class SubdirectoryHintTracker:
     """Track which directories the agent visits and load hints on first access.
 
@@ -116,6 +120,14 @@ class SubdirectoryHintTracker:
             tokens = shlex.split(cmd)
         except ValueError:
             tokens = cmd.split()
+        # `cd backend && ls`: a bare directory name has no `/` or `.`, so the generic filter below drops
+        # it; the token after a navigation command is a path by construction (#11032). `cd -` / bare `cd`
+        # are skipped (nothing under the working dir to load).
+        for idx, token in enumerate(tokens):
+            if token in _NAV_COMMANDS:
+                target = next((t for t in tokens[idx + 1:] if not t.startswith("-")), None)
+                if target and target not in _SHELL_OPERATORS:
+                    self._add_path_candidate(target.rstrip(";"), candidates)
         for token in tokens:
             if token.startswith(("-", "http://", "https://", "git@")) or ("/" not in token and "." not in token):
                 continue

--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -53,7 +53,28 @@ def _first_hint_file(directory: Path):
 
 
 _NAV_COMMANDS = frozenset({"cd", "pushd"})
-_SHELL_OPERATORS = frozenset({"&&", "||", "|", ";", "&"})
+_SHELL_OPERATORS = frozenset({"&&", "||", "|", ";", "&", ";;", "|&", "(", ")"})
+
+
+def _nav_targets(cmd: str) -> list:
+    """Operands of `cd` / `pushd` that begin a shell segment. `cd -` and bare `cd` yield nothing."""
+    lexer = shlex.shlex(cmd, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    try:
+        tokens = list(lexer)
+    except ValueError:
+        return []
+    targets, segment_start = [], True
+    for idx, token in enumerate(tokens):
+        if token in _SHELL_OPERATORS:
+            segment_start = True
+            continue
+        if segment_start and token in _NAV_COMMANDS:
+            operand = next((t for t in tokens[idx + 1:] if t in _SHELL_OPERATORS or not t.startswith("-")), None)
+            if operand and operand not in _SHELL_OPERATORS:
+                targets.append(operand)
+        segment_start = False
+    return targets
 
 
 class SubdirectoryHintTracker:
@@ -121,13 +142,11 @@ class SubdirectoryHintTracker:
         except ValueError:
             tokens = cmd.split()
         # `cd backend && ls`: a bare directory name has no `/` or `.`, so the generic filter below drops
-        # it; the token after a navigation command is a path by construction (#11032). `cd -` / bare `cd`
-        # are skipped (nothing under the working dir to load).
-        for idx, token in enumerate(tokens):
-            if token in _NAV_COMMANDS:
-                target = next((t for t in tokens[idx + 1:] if not t.startswith("-")), None)
-                if target and target not in _SHELL_OPERATORS:
-                    self._add_path_candidate(target.rstrip(";"), candidates)
+        # it; the operand of a navigation command is a path by construction (#11032). Only a `cd` at the
+        # START of a shell segment counts (`echo cd backend` is prose); punctuation-aware tokenizing keeps
+        # a quoted `'backend;'` literal while splitting bare `backend;ls` at the operator.
+        for target in _nav_targets(cmd):
+            self._add_path_candidate(target, candidates)
         for token in tokens:
             if token.startswith(("-", "http://", "https://", "git@")) or ("/" not in token and "." not in token):
                 continue

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -72,6 +72,13 @@ class TestSubdirectoryHintTracker:
 
 
 
+    @pytest.mark.parametrize("command", ["cd backend && ls", "pushd backend", "echo start; cd backend; ls"])
+    def test_bare_directory_after_navigation_command_is_a_path(self, project, command):
+        """`cd backend` has no `/` or `.` yet names a subdirectory; its AGENTS.md must load (#11032)."""
+        tracker = SubdirectoryHintTracker(working_dir=str(project))
+        result = tracker.check_tool_call("terminal", {"command": command})
+        assert result is not None and "Backend-specific instructions" in result
+
     def test_relative_path(self, project):
         """Relative paths resolved against working_dir."""
         tracker = SubdirectoryHintTracker(working_dir=str(project))

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -72,12 +72,19 @@ class TestSubdirectoryHintTracker:
 
 
 
-    @pytest.mark.parametrize("command", ["cd backend && ls", "pushd backend", "echo start; cd backend; ls"])
+    @pytest.mark.parametrize("command", ["cd backend && ls", "pushd backend", "echo start; cd backend; ls", "cd backend;ls"])
     def test_bare_directory_after_navigation_command_is_a_path(self, project, command):
         """`cd backend` has no `/` or `.` yet names a subdirectory; its AGENTS.md must load (#11032)."""
         tracker = SubdirectoryHintTracker(working_dir=str(project))
         result = tracker.check_tool_call("terminal", {"command": command})
         assert result is not None and "Backend-specific instructions" in result
+
+    @pytest.mark.parametrize("command", ["echo cd backend", "printf '%s %s' cd backend", "cd 'backend;'"])
+    def test_cd_as_an_argument_or_a_quoted_other_name_is_not_navigation(self, project, command):
+        """Only a `cd` that starts a shell segment navigates, and a quoted `'backend;'` is a
+        different directory than `backend` — neither may inject backend/AGENTS.md."""
+        tracker = SubdirectoryHintTracker(working_dir=str(project))
+        assert tracker.check_tool_call("terminal", {"command": command}) is None
 
     def test_relative_path(self, project):
         """Relative paths resolved against working_dir."""


### PR DESCRIPTION
A bare directory name after `cd` / `pushd` is now treated as a path candidate, so `AGENTS.md` / `CLAUDE.md` / `.cursorrules` in the entered subdirectory are injected.

- `agent/subdirectory_hints.py::_extract_paths_from_command` — the token following a navigation command is resolved against `working_dir` before the generic `/`-or-`.` filter runs (@tmchow, #11037; resolved onto the current compacted module, trailing `;` handled).
- 1 parametrized invariant test: `cd backend && ls`, `pushd backend`, `echo start; cd backend; ls`.

**Root cause:** the token filter dropped anything without `/` or `.`, which is every relative directory name.

**Live repro:** `check_tool_call("terminal", {"command": "cd backend && ls"})` → `None` on `origin/main`; returns the backend hint here.

Closes #11032. #11046 (@vominh1919) was the earlier duplicate, already closed in favour of #11037.

**Review follow-up (58893333):** navigation targets come from a `cd`/`pushd` that STARTS a shell segment (`echo cd backend` no longer injects), tokenized with `punctuation_chars` so `cd 'backend;'` keeps its literal name while `cd backend;ls` splits at the operator. Negative cases added.

## Infographic

![subdir-hints](https://v3b.fal.media/files/b/0aaa21f4/c6mIsbS7gmeMvSlSBU3ZY_aJX4AStc.png)

