### PR TITLE
fix(mcp): tool-level error payloads no longer trip the server circuit breaker (#11113, salvage #61555)

### DIFF
--- a/tests/tools/test_mcp_circuit_breaker.py
+++ b/tests/tools/test_mcp_circuit_breaker.py
@@ -323,6 +323,55 @@ def test_half_open_dead_session_recovers_after_reconnect(monkeypatch, tmp_path):
         _cleanup(mcp_tool, "srv")
 
 
+def test_tool_level_error_payload_closes_breaker(monkeypatch, tmp_path):
+    """A completed ``isError`` response proves the transport is up: it must reset a partially
+    tripped breaker and never open it, however many bad inputs arrive in a row (#11113).
+    Before: three bad URLs branded a healthy server "unreachable" for the whole cooldown."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from tools import mcp_tool
+    from tools.mcp_tool_handlers import _make_tool_handler
+
+    calls = {"n": 0}
+
+    async def _call_tool_semantic_error(*a, **kw):
+        calls["n"] += 1
+        result = MagicMock()
+        result.isError = True
+        block = MagicMock()
+        block.text = "net::ERR_NAME_NOT_RESOLVED"
+        result.content = [block]
+        result.structuredContent = None
+        return result
+
+    _install_stub_server(mcp_tool, "srv", _call_tool_semantic_error)
+    _mcp_loop._ensure_mcp_loop()
+    try:
+        mcp_tool._server_error_counts["srv"] = mcp_tool._CIRCUIT_BREAKER_THRESHOLD - 1
+        handler = _make_tool_handler("srv", "tool1", 10.0)
+        for _ in range(mcp_tool._CIRCUIT_BREAKER_THRESHOLD + 1):
+            parsed = json.loads(handler({}))
+            assert parsed.get("error") == "net::ERR_NAME_NOT_RESOLVED", parsed  # the real error, not "unreachable"
+        assert calls["n"] == mcp_tool._CIRCUIT_BREAKER_THRESHOLD + 1
+        assert mcp_tool._server_error_counts.get("srv", 0) == 0
+    finally:
+        _cleanup(mcp_tool, "srv")
+
+
+def test_recovery_retry_returns_tool_error_payload_as_is(monkeypatch, tmp_path):
+    """The recovery ladder's single retry follows the same rule: an error payload after a
+    successful reconnect is the tool's answer (breaker closed), not a reason to fall through."""
+    from tools import mcp_tool
+    from tools import mcp_tool_handlers as h
+
+    mcp_tool._server_error_counts["srv2"] = mcp_tool._CIRCUIT_BREAKER_THRESHOLD
+    try:
+        payload = json.dumps({"error": "403 MISSING_SCOPES"})
+        assert h._retry_once("srv2", lambda: payload, "call tool1", "session reconnect") == payload
+        assert mcp_tool._server_error_counts.get("srv2", 0) == 0
+    finally:
+        _cleanup(mcp_tool, "srv2")
+
+
 def test_circuit_breaker_cleared_on_reconnect(monkeypatch, tmp_path):
     """When the auth-recovery path successfully reconnects the server,
     the breaker should be cleared so subsequent calls aren't gated on a

--- a/tools/mcp_tool_handlers.py
+++ b/tools/mcp_tool_handlers.py
@@ -97,17 +97,11 @@ def _acquire_call_server(server_name: str, tool_timeout: float):
     return None, not_connected
 
 
-def _result_is_error(result) -> bool:
-    """True only for a JSON payload carrying an ``error`` key (non-JSON = success)."""
-    try:
-        return "error" in json.loads(result)
-    except (json.JSONDecodeError, TypeError):
-        return False
-
-
 def _record_call_outcome(server_name: str, result) -> Any:
-    """Breaker bookkeeping: an error payload from the tool itself still counts as a strike."""
-    (_core._bump_server_error if _result_is_error(result) else _core._reset_server_error)(server_name)
+    """A completed round-trip is the reachability proof: the breaker guards the TRANSPORT, so any
+    response — including a tool-level ``isError`` payload (bad URL, 4xx, validation) — closes it.
+    Counting those as strikes branded healthy servers "unreachable" after three bad inputs (#11113)."""
+    _core._reset_server_error(server_name)
     return result
 
 
@@ -132,17 +126,13 @@ def _lookup_reconnectable_server(server_name: str, require_loop: bool = False):
 
 
 def _retry_once(server_name: str, retry_call, op_description: str, what: str):
-    """Re-run ``retry_call`` after a recovery step. Returns the result (closing the breaker)
-    when it is not an error payload; None when the retry raised or errored (caller falls through)."""
+    """Re-run ``retry_call`` after a recovery step. Any completed response (error payload included)
+    closes the breaker and is returned as-is; None only when the retry raised (caller falls through)."""
     try:
-        result = retry_call()
+        return _record_call_outcome(server_name, retry_call())
     except Exception as retry_exc:
         logger.warning("MCP %s/%s retry after %s failed: %s", server_name, op_description, what, retry_exc)
         return None
-    if _result_is_error(result):
-        return None
-    _core._reset_server_error(server_name)
-    return result
 
 
 def _handle_auth_error_and_retry(server_name: str, exc: BaseException, retry_call, op_description: str):


### PR DESCRIPTION
Three bad URLs / 4xx responses / validation errors in a row no longer mark a healthy MCP server "unreachable" for the whole cooldown; the model gets the tool's real error text instead.

- `tools/mcp_tool_handlers.py::_record_call_outcome` — a completed RPC round-trip resets the breaker regardless of `isError`; only transport exceptions strike (@bradhallett, #61555, resolved onto the post-split handlers module).
- `_retry_once` (OAuth / session-expiry / stdio-respawn recovery paths) follows the same rule: an error payload after a successful reconnect is the answer, not a fall-through.
- `_result_is_error` deleted (no remaining callers). 2 invariant tests (handler path threshold+1 calls; recovery retry path).

**Root cause / policy note:** #10447's breaker deliberately counted tool `{"error": …}` payloads as strikes (its goal was any retry burn, not only dead transports). This PR narrows that policy to transport reachability: `isError` is the tool answering, which proves the transport, and the model gets the actionable error instead of a misleading "unreachable". Retry burn against a healthy server that keeps rejecting bad arguments is left to the loop detectors.

| | before | after |
|---|---|---|
| 5 × DNS-failing navigate | call 4+ → "unreachable after 3 consecutive failures" | every call → `net::ERR_NAME_NOT_RESOLVED`, count 0 |

**Live repro:** real `_make_tool_handler` against a stub server in a subprocess — output above, before/after.

Cluster: #61555 (base, credited), #74045 (@ppazosp), #75511 (@Doud-FR), #11128 (@nightq) address the same defect; this is the smallest complete form. Closes #11113.

## Infographic

![mcp-breaker](https://v3b.fal.media/files/b/0aaa21f4/NniOMTWMRk95HLGR-Fpgy_gq0eblR1.png)

