### PR TITLE
fix(gateway): no "still working" heartbeat after the restart notice (#10990, salvage #11127)

### DIFF
--- a/gateway/run_shutdown.py
+++ b/gateway/run_shutdown.py
@@ -1077,6 +1077,10 @@ class GatewayShutdownMixin:
         """
         if agent is None or (executor_task is not None and executor_task.done()):
             return False
+        # Drain/restart already told the chat the task will be interrupted; a "still working"
+        # heartbeat after that notice reads as a contradiction (#10990).
+        if getattr(self, "_draining", False) or getattr(self, "_restart_requested", False):
+            return False
         if session_key:
             _hb_state = self._peek_session_state(session_key)
             if (_hb_state.turn.agent if _hb_state else None) is not agent:

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -3854,6 +3854,12 @@ class GatewayTurnMixin:
                         logger.debug("Heartbeat edit failed: %s", _ee)
                         _notify_res = None
                 if not (_notify_res and getattr(_notify_res, "success", False)):
+                    # The edit above awaited; a drain/restart notice may have gone out meanwhile, and
+                    # a fresh "Working" bubble after it reads as a contradiction (#10990).
+                    if not self._should_emit_long_running_notification(
+                        session_key, agent_holder[0], _executor_task_holder[0]
+                    ):
+                        break
                     _notify_res = await _notify_adapter.send(
                         source.chat_id, _heartbeat_text,
                         metadata=_interim_metadata(_non_conversational_metadata(_status_thread_metadata, platform=source.platform)),

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -518,6 +518,43 @@ class TestLongRunningNotificationOwnership:
             "sess", original_agent, executor_task=None
         ) is False
 
+    @pytest.mark.asyncio
+    async def test_restart_during_heartbeat_edit_sends_no_fallback_bubble(self, monkeypatch):
+        """The guard is rechecked after the awaited edit: a restart that begins while the edit is
+        in flight must not be followed by a fresh "Working" send when that edit fails (#10990)."""
+        import asyncio
+        from types import SimpleNamespace
+        from gateway.run import GatewayRunner
+        from gateway.turn_context import TurnContext
+
+        monkeypatch.setenv("HERMES_AGENT_NOTIFY_INTERVAL", "0.01")
+        runner = object.__new__(GatewayRunner)
+        runner._running_agents = {}
+        runner._draining = runner._restart_requested = False
+        adapter = MagicMock()
+        first_send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="hb-1"))
+        adapter.send = first_send
+
+        async def _edit_then_restart(*a, **k):
+            runner._restart_requested = True  # restart notice goes out while the edit is awaited
+            return SimpleNamespace(success=False)
+
+        adapter.edit_message = AsyncMock(side_effect=_edit_then_restart)
+        runner._adapter_for_source = lambda source: adapter
+        runner._agent_activity_summary = staticmethod(lambda agent: None)
+        agent = MagicMock()
+        runner._running_agents["sess"] = agent
+        disp = MagicMock()
+        disp._display_surface_mode.return_value = "on"
+        disp.resolve_display_setting.return_value = False
+        ctx = TurnContext(source=SimpleNamespace(chat_id="c", platform="telegram"), session_key="sess")
+        ctx.agent_holder[0] = agent
+
+        await asyncio.wait_for(runner._run_agent_notify_long_running(disp, ctx, [None]), 5)
+
+        assert first_send.await_count == 1  # the original heartbeat only
+        adapter.edit_message.assert_awaited_once()
+
     @pytest.mark.parametrize("flag", ["_draining", "_restart_requested"])
     def test_notification_stops_once_shutdown_or_restart_begins(self, flag):
         """After the restart/shutdown notice a heartbeat would contradict it (#10990)."""

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -518,4 +518,17 @@ class TestLongRunningNotificationOwnership:
             "sess", original_agent, executor_task=None
         ) is False
 
+    @pytest.mark.parametrize("flag", ["_draining", "_restart_requested"])
+    def test_notification_stops_once_shutdown_or_restart_begins(self, flag):
+        """After the restart/shutdown notice a heartbeat would contradict it (#10990)."""
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner._running_agents = {}
+        agent = MagicMock()
+        runner._running_agents["sess"] = agent
+        assert runner._should_emit_long_running_notification("sess", agent, executor_task=None) is True
+        setattr(runner, flag, True)
+        assert runner._should_emit_long_running_notification("sess", agent, executor_task=None) is False
+
 


### PR DESCRIPTION
Once the gateway has told a chat "restarting — your task will be interrupted", it no longer follows up with `⏳ Working — N min` heartbeats from the old run.

- `gateway/run_shutdown.py::_should_emit_long_running_notification` — returns False when `_draining` or `_restart_requested` is set (@nightq, #11127, ported from the old `run.py` loop to the current ownership guard, which terminates the notifier instead of `continue`).
- 1 parametrized invariant test over both flags.

**Live repro:** guard returns True with `_draining=True` on `origin/main`; False here.

Closes #10990.

**Review follow-up (ec15bbe7):** the guard is rechecked after the awaited `edit_message`; a restart notice that lands during that await, followed by a failed edit, no longer produces a fallback "Working" bubble. Test drives the real notifier coroutine with that interleaving (2 sends on the previous head, 1 here).

## Infographic

![heartbeat](https://v3b.fal.media/files/b/0aaa21fb/arw_V-ofezWdL3KWWKOlc_9LpL4vln.png)

