### PR TITLE
feat(search): make assistant reasoning traces retrievable via an opt-in scope

### DIFF
--- a/agent/inline_tool_executors.py
+++ b/agent/inline_tool_executors.py
@@ -106,6 +106,7 @@ def _session_search(agent, args: dict, ctx: InlineToolContext) -> Any:
             ("session_id", "session_id"), ("around_message_id", "around_message_id"),
             ("window", "window", 5), ("sort", "sort"), ("profile", "profile"),
             ("detail", "detail", "adaptive"),
+            ("include_reasoning", "include_reasoning", False),
         ),
         db=session_db, current_session_id=agent.session_id,
     )

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -53,6 +53,19 @@ _LIKE_COALESCED_COLUMN_SQL = (
     "COALESCE(m.tool_name, '') LIKE ? ESCAPE '\\' OR "
     "COALESCE(m.tool_calls, '') LIKE ? ESCAPE '\\')"
 )
+# Reasoning traces are stored on the row but absent from every FTS index, so an explicit
+# search for them answers from canonical rows (same class as the role='tool' fallback route).
+_LIKE_REASONING_COLUMN_SQL = (
+    "(COALESCE(m.reasoning, '') LIKE ? ESCAPE '\\' "
+    "OR COALESCE(m.reasoning_content, '') LIKE ? ESCAPE '\\')"
+)
+# Reasoning-first snippet: anchor inside the reasoning text when the term is there, so a hit
+# whose match lives only in a thought shows that thought rather than an unrelated reply head.
+_LIKE_REASONING_SNIPPET_SQL = (
+    "substr(COALESCE(NULLIF(m.reasoning, ''), NULLIF(m.reasoning_content, ''), m.content, ''), "
+    "max(1, instr(COALESCE(NULLIF(m.reasoning, ''), NULLIF(m.reasoning_content, ''), m.content, ''), ?) - 40), "
+    "120) AS snippet"
+)
 # ``sort`` -> ORDER BY for the FTS routes; unknown values are rank-only (user input passes through).
 _FTS_ORDER_BY = {"newest": "ORDER BY m.timestamp DESC, rank", "oldest": "ORDER BY m.timestamp ASC, rank"}
 # Indexed neighbor seeks avoid scanning whole sessions for a sparse set of hits.
@@ -909,13 +922,18 @@ class SessionSearchMixin:
                 fail_open, exc)
             return None
 
-    def _like_rows(self, where: List[str], params: list, *, order_by: str, limit_sql: str) -> List[Dict[str, Any]]:
+    def _like_rows(
+        self, where: List[str], params: list, *, order_by: str, limit_sql: str,
+        snippet_sql: str = _LIKE_SNIPPET_SQL, snippet_params: int = 1,
+    ) -> List[Dict[str, Any]]:
         """Canonical-table LIKE scan; ``params[0]`` is the snippet anchor term."""
-        sql = _search_select_sql(_LIKE_SNIPPET_SQL, "messages m", where, order_by, limit_sql)
+        sql = _search_select_sql(snippet_sql, "messages m", where, order_by, limit_sql)
         return [dict(row) for row in self._read_all(sql, params)]
 
     @staticmethod
-    def _compile_like_boolean_query(query: str) -> Tuple[str, List[Any], Optional[str]]:
+    def _compile_like_boolean_query(
+        query: str, column_sql: str = _LIKE_COALESCED_COLUMN_SQL, params_per_term: int = 3,
+    ) -> Tuple[str, List[Any], Optional[str]]:
         """Compile the supported FTS boolean subset into LIKE predicates: terms within an OR
         group are ANDed (FTS5's implicit conjunction) and ``NOT`` negates the next term."""
         groups: List[List[Tuple[str, bool]]] = [[]]
@@ -945,24 +963,40 @@ class SessionSearchMixin:
                 continue
             clauses: List[str] = []
             for term, negated in group:
-                clauses.append(f"NOT {_LIKE_COALESCED_COLUMN_SQL}" if negated else _LIKE_COALESCED_COLUMN_SQL)
-                params.extend(_like_params(term))
+                clauses.append(f"NOT {column_sql}" if negated else column_sql)
+                params.extend(_like_params(term)[:params_per_term])
                 if snippet_term is None and not negated:
                     snippet_term = term
             compiled_groups.append(f"({' AND '.join(clauses)})")
         return " OR ".join(compiled_groups), params, snippet_term
 
     def _search_messages_like_fallback(
-        self, query: str, *, limit: int, offset: int, sort: Optional[str], **filters) -> List[Dict[str, Any]]:
+        self, query: str, *, limit: int, offset: int, sort: Optional[str],
+        include_reasoning: bool = False, **filters,
+    ) -> List[Dict[str, Any]]:
         """Search canonical messages while derived FTS state is stale."""
-        predicate, params, snippet_term = self._compile_like_boolean_query(query)
+        if include_reasoning:
+            predicate, params, snippet_term = self._compile_like_boolean_query(
+                query, _LIKE_REASONING_COLUMN_SQL, 2
+            )
+        else:
+            predicate, params, snippet_term = self._compile_like_boolean_query(query)
         if not predicate or snippet_term is None:
             return []
         where = [f"({predicate})"]
+        if include_reasoning:
+            where.append(
+                "TRIM(COALESCE(m.reasoning, '') || COALESCE(m.reasoning_content, '')) <> ''"
+            )
         _search_filter_clauses(where, params, **filters)
         order = "ASC" if isinstance(sort, str) and sort.strip().lower() == "oldest" else "DESC"
-        return self._like_rows(where, [snippet_term, *params, limit, offset],
-                               order_by=f"ORDER BY m.timestamp {order}, m.id {order}", limit_sql="LIMIT ? OFFSET ?")
+        snippet_params = 1
+        return self._like_rows(
+            where, [snippet_term] * snippet_params + [*params, limit, offset],
+            order_by=f"ORDER BY m.timestamp {order}, m.id {order}", limit_sql="LIMIT ? OFFSET ?",
+            snippet_sql=_LIKE_REASONING_SNIPPET_SQL if include_reasoning else _LIKE_SNIPPET_SQL,
+            snippet_params=snippet_params,
+        )
 
     def _refresh_fts_stale_state(self) -> None:
         """Observe fail-open initiated by another process sharing state.db."""
@@ -1011,6 +1045,7 @@ class SessionSearchMixin:
         self, query: str, source_filter: List[str] = None, exclude_sources: List[str] = None,
         role_filter: List[str] = None, limit: int = 20, offset: int = 0, sort: str = None,
         include_inactive: bool = False, fields: Optional[Collection[str]] = None,
+        include_reasoning: bool = False,
     ) -> List[Dict[str, Any]]:
         """:meth:`_search_messages_impl` plus one log line per slow search with the routing
         path taken. Threshold HERMES_SEARCH_SLOW_MS (default 1000; 0 logs every call)."""
@@ -1019,7 +1054,8 @@ class SessionSearchMixin:
         try:
             rows = self._search_messages_impl(
                 query, source_filter=source_filter, exclude_sources=exclude_sources, role_filter=role_filter,
-                limit=limit, offset=offset, sort=sort, include_inactive=include_inactive, fields=fields)
+                limit=limit, offset=offset, sort=sort, include_inactive=include_inactive, fields=fields,
+                include_reasoning=include_reasoning)
             return rows
         finally:
             elapsed_ms = (time.time() - started) * 1000.0
@@ -1032,6 +1068,7 @@ class SessionSearchMixin:
         self, query: str, source_filter: List[str] = None, exclude_sources: List[str] = None,
         role_filter: List[str] = None, limit: int = 20, offset: int = 0, sort: str = None,
         include_inactive: bool = False, fields: Optional[Collection[str]] = None,
+        include_reasoning: bool = False,
     ) -> List[Dict[str, Any]]:
         """FTS5 search across session messages (keywords, ``"phrases"``, AND/OR/NOT, ``prefix*``).
         Returns snippet + session metadata + 1-message context per hit; ``fields`` selects a
@@ -1050,6 +1087,11 @@ class SessionSearchMixin:
         # opt-in full-body path and scans canonical rows via LIKE.
         if role_filter and "tool" in role_filter:
             matches = self._search_messages_like_fallback(query, limit=limit, offset=offset, sort=sort, **filters)
+            return self._finalize_search_matches(matches, result_fields=result_fields)
+        if include_reasoning:
+            matches = self._search_messages_like_fallback(
+                query, limit=limit, offset=offset, sort=sort, include_reasoning=True, **filters
+            )
             return self._finalize_search_matches(matches, result_fields=result_fields)
         self._refresh_fts_stale_state()
         if self._fts_stale:

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -1048,7 +1048,8 @@ class SessionSearchMixin:
         include_reasoning: bool = False,
     ) -> List[Dict[str, Any]]:
         """:meth:`_search_messages_impl` plus one log line per slow search with the routing
-        path taken. Threshold HERMES_SEARCH_SLOW_MS (default 1000; 0 logs every call)."""
+        path taken. ``include_reasoning`` searches only the canonical reasoning columns.
+        Threshold HERMES_SEARCH_SLOW_MS (default 1000; 0 logs every call)."""
         started = time.time()
         rows = None
         try:
@@ -1074,7 +1075,8 @@ class SessionSearchMixin:
         Returns snippet + session metadata + 1-message context per hit; ``fields`` selects a
         projection. ``sort``: None = BM25 rank; "newest"/"oldest" = timestamp then rank (the
         CJK LIKE fallback ignores it). Rewound rows (``active=0, compacted=0``) are excluded
-        by default; compaction-archived rows ARE included; ``include_inactive`` = every row."""
+        by default; compaction-archived rows ARE included; ``include_inactive`` = every row.
+        ``include_reasoning`` opts into an unranked canonical-row scan of reasoning traces."""
         result_fields = self._search_message_fields(fields)
         if not query or not query.strip():
             return []

--- a/tests/hermes_state/test_reasoning_search_scope.py
+++ b/tests/hermes_state/test_reasoning_search_scope.py
@@ -1,0 +1,106 @@
+import json
+
+import pytest
+
+from hermes_state import SessionDB
+from tools.session_search_tool import SESSION_SEARCH_SCHEMA, session_search
+
+
+@pytest.fixture
+def db(tmp_path):
+    session_db = SessionDB(tmp_path / "state.db")
+    session_db.create_session("session", source="cli")
+    return session_db
+
+
+def test_reasoning_scope_finds_thought_only_token(db):
+    reasoning_id = db.append_message(
+        "session",
+        role="assistant",
+        content="Visible answer without the search term.",
+        reasoning="reasoning-only-token appears in this thought",
+    )
+    reasoning_content_id = db.append_message(
+        "session",
+        role="assistant",
+        content="Another visible answer without the search term.",
+        reasoning_content="reasoning-only-token appears in this alternate trace",
+    )
+
+    assert db.search_messages("reasoning-only-token") == []
+    assert {
+        row["id"]
+        for row in db.search_messages(
+            "reasoning-only-token", include_reasoning=True
+        )
+    } == {reasoning_id, reasoning_content_id}
+
+
+def test_reasoning_scope_snippet_anchors_on_reasoning(db):
+    db.append_message(
+        "session",
+        role="assistant",
+        content="Unrelated visible reply head.",
+        reasoning="A distinctive reasoning fragment contains snippet-anchor-token here.",
+    )
+
+    matches = db.search_messages("snippet-anchor-token", include_reasoning=True)
+
+    assert len(matches) == 1
+    assert "distinctive reasoning fragment" in matches[0]["snippet"]
+    assert "Unrelated visible reply head" not in matches[0]["snippet"]
+
+
+def test_reasoning_scope_composes_with_role_filter_and_visibility(db):
+    visible_id = db.append_message(
+        "session",
+        role="assistant",
+        content="Visible reply.",
+        reasoning="scope-filter-token in visible reasoning",
+    )
+    db.append_message(
+        "session",
+        role="assistant",
+        content="Hidden scaffold.",
+        reasoning="scope-filter-token in hidden reasoning",
+        display_kind="hidden",
+    )
+
+    assistant_matches = db.search_messages(
+        "scope-filter-token",
+        role_filter=["assistant"],
+        include_reasoning=True,
+    )
+    user_matches = db.search_messages(
+        "scope-filter-token",
+        role_filter=["user"],
+        include_reasoning=True,
+    )
+
+    assert [row["id"] for row in assistant_matches] == [visible_id]
+    assert user_matches == []
+
+
+def test_session_search_tool_forwards_include_reasoning(db):
+    message_id = db.append_message(
+        "session",
+        role="assistant",
+        content="Visible tool result without the search term.",
+        reasoning="tool-reasoning-only-token appears only in this thought",
+    )
+
+    default_result = json.loads(
+        session_search(query="tool-reasoning-only-token", db=db)
+    )
+    reasoning_result = json.loads(
+        session_search(
+            query="tool-reasoning-only-token", db=db, include_reasoning=True
+        )
+    )
+
+    assert "include_reasoning" in SESSION_SEARCH_SCHEMA["parameters"]["properties"]
+    assert default_result["results"] == []
+    assert reasoning_result["success"] is True
+    assert [row["match_message_id"] for row in reasoning_result["results"]] == [
+        message_id
+    ]

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -84,7 +84,7 @@ class TestSchema:
         # Mode is inferred from which args are set — no explicit mode param
         assert "mode" not in params
 
-    def test_detail_parameter_is_appended_for_positional_compatibility(self):
+    def test_new_parameters_are_appended_for_positional_compatibility(self):
         parameters = list(inspect.signature(session_search).parameters)
         historical_prefix = [
             "query",
@@ -98,7 +98,7 @@ class TestSchema:
             "sort",
             "profile",
         ]
-        assert parameters == [*historical_prefix, "detail"]
+        assert parameters == [*historical_prefix, "detail", "include_reasoning"]
 
 
 class TestFormatTimestamp:

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -513,7 +513,10 @@ def session_search(query: str = "", role_filter: str = None, limit: int = 3, db=
                    current_session_id: str = None, session_id: str = None, around_message_id: int = None,
                    window: int = 5, sort: str = None, profile: str = None, detail: str = "adaptive",
                    include_reasoning: bool = False) -> str:
-    """Run session search, closing DBs opened here. Positional order is frozen for old callers."""
+    """Run session search, optionally over reasoning traces, and close DBs opened here.
+
+    Positional order is frozen for old callers.
+    """
     from hermes_state import format_session_db_unavailable
     from hermes_state_registry import acquire, release_or_close
     owned_dbs: List[Any] = []
@@ -550,6 +553,8 @@ SESSION_SEARCH_SCHEMA = {
         "`session_id` alone = read a whole session — how you resolve an "
         "`@session:<profile>/<id>` link (split on '/' into profile + id); no "
         "args = browse recent sessions. Results are actual DB messages, no LLM. "
+        "Hits returned with `include_reasoning` come from what the assistant reasoned, "
+        "not from what it said. "
         "Searches conversation history ONLY — when the user gave a direct "
         "source (URL, file, contact, live system), inspect that first; never "
         "conclude 'not found' from history alone. Use for questions about past "

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -259,14 +259,16 @@ def _hydrate_hit(db, lineage_root: str, match_info: Dict[str, Any], result_detai
 
 
 def _discover(db, query: str, role_filter: Optional[List[str]], limit: int, sort: Optional[str],
-              detail: str, current_session_id: str = None, link_profile: str = None) -> str:
+              detail: str, current_session_id: str = None, link_profile: str = None,
+              include_reasoning: bool = False) -> str:
     """Discovery shape: FTS5 plus adaptive or full result hydration."""
     current_lineage_root = _resolve_lineage(db, current_session_id) if current_session_id else None
     title_result = _title_match_result(db, query, current_lineage_root)
     raw_results, err = _loud(lambda: db.search_messages(
         query=query, role_filter=role_filter or ["user", "assistant"],
         exclude_sources=list(_HIDDEN_SESSION_SOURCES), limit=_DISCOVER_SCAN_LIMIT, offset=0, sort=sort,
-        fields=_DISCOVER_SEARCH_FIELDS), "FTS5 search failed: %s", "Search failed")
+        fields=_DISCOVER_SEARCH_FIELDS, include_reasoning=include_reasoning),
+        "FTS5 search failed: %s", "Search failed")
     if err:
         return err
     # Demote cron rows below interactive ones BEFORE dedup so a high-volume cron corpus
@@ -470,7 +472,8 @@ def _scroll(db, session_id: str, around_message_id: int, window: int = 5,
 
 
 def _dispatch(query, role_filter, limit, db, current_session_id, session_id,
-              around_message_id, window, sort, profile, detail, owned_dbs) -> str:
+              around_message_id, window, sort, profile, detail, owned_dbs,
+              include_reasoning=False) -> str:
     """Mode dispatch (see module docstring); scroll wins when an anchor is set.
     Profile DBs opened here are appended to *owned_dbs* for the caller to close."""
     # A raw `@session:<profile>/<id>` link as session_id: ids never contain "/", so
@@ -502,12 +505,14 @@ def _dispatch(query, role_filter, limit, db, current_session_id, session_id,
         db=db, query=query.strip(), limit=limit, sort=sort_norm if sort_norm in ("newest", "oldest") else None,
         role_filter=([r.strip() for r in role_filter.split(",") if r.strip()] or None) if isinstance(role_filter, str) else None,
         detail="full" if isinstance(detail, str) and detail.strip().lower() == "full" else "adaptive",
-        current_session_id=current_session_id, link_profile=profile)
+        current_session_id=current_session_id, link_profile=profile,
+        include_reasoning=include_reasoning)
 
 
 def session_search(query: str = "", role_filter: str = None, limit: int = 3, db=None,
                    current_session_id: str = None, session_id: str = None, around_message_id: int = None,
-                   window: int = 5, sort: str = None, profile: str = None, detail: str = "adaptive") -> str:
+                   window: int = 5, sort: str = None, profile: str = None, detail: str = "adaptive",
+                   include_reasoning: bool = False) -> str:
     """Run session search, closing DBs opened here. Positional order is frozen for old callers."""
     from hermes_state import format_session_db_unavailable
     from hermes_state_registry import acquire, release_or_close
@@ -519,7 +524,8 @@ def session_search(query: str = "", role_filter: str = None, limit: int = 3, db=
         owned_dbs.append(db)
     try:
         return _dispatch(query, role_filter, limit, db, current_session_id, session_id,
-                         around_message_id, window, sort, profile, detail, owned_dbs)
+                         around_message_id, window, sort, profile, detail, owned_dbs,
+                         include_reasoning)
     finally:
         for owned_db in reversed(owned_dbs):
             _quiet(lambda: release_or_close(owned_db), None, "Failed to close session_search SessionDB")
@@ -625,6 +631,16 @@ SESSION_SEARCH_SCHEMA = {
                     "behaviour) or 'tool' to search tool output only."
                 ),
             },
+            "include_reasoning": {
+                "type": "boolean",
+                "description": (
+                    "Search the assistant's reasoning traces instead of message text. "
+                    "Reasoning is stored on the row but is not in the FTS index, so this "
+                    "answers from canonical rows via a scan (slower, no ranking) and exists "
+                    "for facts the assistant worked out but never wrote into a reply. "
+                    "Default false."
+                ),
+            },
             "profile": {
                 "type": "string",
                 "description": (
@@ -649,6 +665,7 @@ registry.register(
     handler=lambda args, **kw: session_search(
         query=args.get("query") or "", limit=args.get("limit", 3), window=args.get("window", 5),
         detail=args.get("detail", "adaptive"), db=kw.get("db"), current_session_id=kw.get("current_session_id"),
+        include_reasoning=args.get("include_reasoning", False),
         **{k: args.get(k) for k in ("role_filter", "session_id", "around_message_id", "sort", "profile")}),
     check_fn=check_session_search_requirements,
     emoji="🔍")


### PR DESCRIPTION
## What does this PR do?

Makes the assistant's reasoning traces retrievable from `session_search` through an opt-in `include_reasoning` scope.

Hermes persists reasoning on every row (`messages.reasoning`, `messages.reasoning_content`), but no search route can reach it: `messages_fts` indexes only `content` / `tool_name` / `tool_calls`, the trigram source view projects `id, role, content, tool_name`, and the LIKE fallback matches those same three columns. A fact that only ever appeared in a reasoning trace is stored and unreachable.

Measured on a real 289,433-row `state.db`:

| Metric | Value |
|---|---|
| Rows carrying reasoning | 61,043 (21.1%) |
| Reasoning text | 95.1M chars vs 307.4M chars of indexed content (+30.9%) |
| Assistant rows with empty `content` and non-empty `reasoning` | 22,454 |

Those 22,454 turns have no `content` to match at all. In a needle-in-the-middle measurement on a small local model, a fact planted mid-context reached the final answer in 0/7 runs but was present in the reasoning trace in 2/7 — reasoning is sometimes where a fact actually survived.

The scope answers from canonical rows through the existing LIKE fallback path — the same mechanism the repo already uses for rows the indexes exclude (`role_filter=['tool']`) — with the snippet anchored in the reasoning text so a hit shows the thought rather than an unrelated reply head.

Explicitly not in this PR: indexing reasoning into `messages_fts` (index-shape change + version bump + reindex + ~31% index growth). That is a separate decision and this change does not depend on it — happy to follow up if maintainers prefer the indexed route.

Default behavior is unchanged: without the flag, no search route matches reasoning text.

## Related Issue

Fixes #109092

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state_search.py` — `_LIKE_REASONING_COLUMN_SQL` + reasoning-anchored `_LIKE_REASONING_SNIPPET_SQL`; `_compile_like_boolean_query`/`_like_rows` take a column/snippet SQL so the LIKE route can be pointed at other columns; `include_reasoning` threaded through `search_messages` → `_search_messages_impl` → `_search_messages_like_fallback` (appended last, positional order unchanged).
- `tools/session_search_tool.py` — `include_reasoning` parameter, schema entry, description note, `_dispatch`/`_discover` passthrough, registry handler.
- `agent/inline_tool_executors.py` — argument passthrough.
- `tests/hermes_state/test_reasoning_search_scope.py` — four invariant tests.
- `tests/tools/test_session_search.py` — the positional-compatibility assertion now covers the new trailing parameter.

## How to Test

1. `scripts/run_tests.sh tests/hermes_state/test_reasoning_search_scope.py`
2. `scripts/run_tests.sh tests/hermes_state/ tests/test_fts_tool_write_bounds.py tests/tools/test_session_search.py`
3. Manually: a session where an assistant turn reasoned about a token but never wrote it into the reply — `session_search(query=<token>)` misses it, `session_search(query=<token>, include_reasoning=True)` returns the turn with a snippet taken from the reasoning text.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `scripts/run_tests.sh` (neighbour suites; full suite not run — see the log section)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (tool description, schema, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` — N/A (no new config key)
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact (pure SQL paths, no new platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior

## Screenshots / Logs

Red on the base commit (implementation reverted, tests kept) — the tests exist for a reason:

```
FAILED tests/hermes_state/test_reasoning_search_scope.py::test_reasoning_scope_finds_thought_only_token
FAILED tests/hermes_state/test_reasoning_search_scope.py::test_reasoning_scope_snippet_anchors_on_reasoning
FAILED tests/hermes_state/test_reasoning_search_scope.py::test_reasoning_scope_composes_with_role_filter_and_visibility
FAILED tests/hermes_state/test_reasoning_search_scope.py::test_session_search_tool_forwards_include_reasoning
=== 1 file with test failures (4 tests failed) ===
```

Green on the branch:

```
=== Summary: 1 files, 4 tests passed, 0 failed (100% complete) in 8.0s ===
```

Neighbour suites on the branch (`tests/hermes_state/`, `tests/test_fts_tool_write_bounds.py`, `tests/tools/test_session_search.py`):

```
=== Summary: 43 files, 370 tests passed, 9 failed, 28 skipped (100% complete) in 57.2s (24 workers) ===
=== 3 files with test failures (9 tests failed) ===
  tests\hermes_state\test_state_db_file_identity.py  (3 tests failed)
  tests\hermes_state\test_shared_session_db_registry.py  (5 tests failed)
  tests\hermes_state\test_state_db_corrupt_quarantine.py  (1 test failed)
```

Those 9 are pre-existing on Windows and unrelated: the same three files at the base commit (no changes from this PR) fail identically —

```
=== Summary: 3 files, 35 tests passed, 9 failed, 2 skipped (100% complete) in 30.7s ===
=== 3 files with test failures (9 tests failed) ===
```

They are filesystem-permission failures (`PermissionError: [WinError 5]` replacing a DB file in the pytest temp root, file-identity and shared-registry assertions), not search-route behaviour. `ruff check` on the changed files is clean.
