### PR TITLE
Fix unauthenticated model list

### DIFF
--- a/hermes_cli/web_routers/models.py
+++ b/hermes_cli/web_routers/models.py
@@ -6,6 +6,7 @@ Extracted from ``hermes_cli.web_server``; helpers/state that tests monkeypatch o
 
 import asyncio
 import logging
+import os
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException
@@ -48,6 +49,18 @@ def _load_config_scoped(profile: Optional[str]) -> dict:
     with _profile_scope(profile):
         return load_config()
 
+def _resolve_model_cfg_api_key(model_cfg: dict) -> str:
+    """Inline ``api_key`` (a ``${VAR}`` template resolves from the environment), else
+    ``key_env``/``api_key_env``. Same resolution order as ``model_switch._entry_configured_key``,
+    needed here because custom-endpoint context-length probes (e.g. a LiteLLM proxy requiring
+    auth on /v1/models) 401 without it."""
+    key = str(model_cfg.get("api_key") or "").strip()
+    if key.startswith("${") and key.endswith("}"):
+        key = os.environ.get(key[2:-1], "").strip()
+    if not key:
+        key_env = str(model_cfg.get("key_env") or model_cfg.get("api_key_env") or "").strip()
+        key = os.environ.get(key_env, "").strip() if key_env else ""
+    return key
 
 @router.get("/api/model/info")
 def get_model_info(profile: Optional[str] = None):
@@ -59,6 +72,8 @@ def get_model_info(profile: Optional[str] = None):
         model_name, provider = _main_model_fields(model_cfg)
         base_url = model_cfg.get("base_url", "") if isinstance(model_cfg, dict) else ""
         config_ctx = model_cfg.get("context_length") if isinstance(model_cfg, dict) else None
+        api_key = _resolve_model_cfg_api_key(model_cfg) if isinstance(model_cfg, dict) else ""
+
 
         if not model_name:
             return dict(_EMPTY_MODEL_INFO, provider=provider)
@@ -66,8 +81,8 @@ def get_model_info(profile: Optional[str] = None):
         try:
             from agent.model_metadata import get_model_context_length
             # config_context_length=None: ignore the override — we want the auto value
-            auto_ctx = get_model_context_length(model=model_name, base_url=base_url, provider=provider,
-                                                config_context_length=None)
+            auto_ctx = get_model_context_length(model=model_name, base_url=base_url, api_key=api_key,
+                                                provider=provider, config_context_length=None)
         except Exception:
             auto_ctx = 0
 


### PR DESCRIPTION
fixed unathenticated /models request on profile swap

## What does this PR do?

`GET /api/model/info` auto-detects a model's context length via `get_model_context_length()`, which for a custom OpenAI-compatible endpoint probes `/v1/models/{model}` and `/v1/models` directly. The handler read `base_url` from the model config but never resolved `api_key`/`key_env`, so the probe always fired unauthenticated. Against an endpoint that requires auth on those routes (e.g. a self-hosted LiteLLM proxy in front of a local model fleet), every call to this endpoint — including the one the dashboard fires on every profile switch — produced a 401 on the remote server. The fix resolves the configured key the same way other call sites in this codebase already do (literal `api_key`, `${VAR}` template, then `key_env`/`api_key_env`) and passes it through to the probe.

## Related Issue

No existing issue — found and fixed directly while debugging repeated `401 Unauthorized` log spam from a LiteLLM proxy on profile switch.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_routers/models.py`: added `_resolve_model_cfg_api_key()`, mirroring the resolution order used by `model_switch._entry_configured_key`; `get_model_info()` now resolves this before calling `get_model_context_length()` and passes it as `api_key`.
- `tests/hermes_cli/test_web_server.py`: added `test_model_info_passes_resolved_api_key_to_context_probe`, asserting a `key_env`-configured custom endpoint's key reaches `get_model_context_length`.

## How to Test

1. Configure a custom endpoint with auth required on `/v1/models` (e.g. a LiteLLM proxy with a `master_key`), referenced via `model.key_env` in `config.yaml`.
2. Hit `GET /api/model/info` (or switch profiles in the dashboard, which triggers this call) — before the fix, the proxy logs a `401 Unauthorized` for `/v1/models/{model}` and `/v1/models`.
3. After the fix, the same request carries the resolved key and the proxy accepts it (no more 401 in its logs); `auto_context_length` in the response also becomes populated instead of falling back silently.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run**: this environment's venv has no `pytest` installed; I verified the two changed files compile (`py_compile`) and hand-verified `_resolve_model_cfg_api_key()`'s logic standalone against all four config shapes (literal key, `${VAR}` template, `key_env`, `api_key_env`). Please run the full suite before merge.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.5.0) — logic-level only, not run through the full CI suite

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A — docstring added on the new helper
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A — no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A — no architecture/workflow change
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A — pure config/env resolution, no platform-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A — response shape of `/api/model/info` unchanged

## Screenshots / Logs

Before (LiteLLM proxy log on profile switch):