### PR TITLE
fix(sessions): /branch and API fork keep the original session open when creating the branch fails (#11030, salvage #11048)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2980,11 +2980,12 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         if await asyncio.to_thread(db.get_session, fork_id):
             return _error_response(f"Session already exists: {fork_id}", 409, code="session_exists")
 
-        # CLI /branch semantics: end the original as branched, create a child with the transcript.
-        await asyncio.to_thread(db.end_session, source_id, "branched")
+        # CLI /branch semantics: create the child, then end the original as branched (child first, so
+        # a failed create never leaves the source ended with no fork, #11030).
         await asyncio.to_thread(
             db.create_session, fork_id, "api_server", model=source.get("model"),
             system_prompt=source.get("system_prompt"), parent_session_id=source_id)
+        await asyncio.to_thread(db.end_session, source_id, "branched")
         messages = await asyncio.to_thread(db.get_messages, source_id)
         await asyncio.to_thread(db.replace_messages, fork_id, messages)
         title = body.get("title")

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2982,9 +2982,13 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
 
         # CLI /branch semantics: create the child, then end the original as branched (child first, so
         # a failed create never leaves the source ended with no fork, #11030).
+        # ``_branched_from`` is the durable branch marker (same as CLI /branch): with the child created
+        # first, the timestamp fallback in _BRANCH_CHILD_SQL (child.started_at >= parent.ended_at) no
+        # longer holds, and an unmarked child would vanish from default session listings.
         await asyncio.to_thread(
             db.create_session, fork_id, "api_server", model=source.get("model"),
-            system_prompt=source.get("system_prompt"), parent_session_id=source_id)
+            system_prompt=source.get("system_prompt"), parent_session_id=source_id,
+            model_config={"_branched_from": source_id})
         await asyncio.to_thread(db.end_session, source_id, "branched")
         messages = await asyncio.to_thread(db.get_messages, source_id)
         await asyncio.to_thread(db.replace_messages, fork_id, messages)

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1377,7 +1377,8 @@ class CLICommandsMixin:
         branch_title = branch_name or self._session_db.get_next_title_in_lineage(
             self._session_db.get_session_title(self.session_id) or "branch")
         parent_session_id = self.session_id
-        _end_current_session(self, "branched")
+        # Create the child BEFORE ending the parent: a failed create_session must leave the session the
+        # user is still on open, not ended with end_reason="branched" and no branch (#11030).
         # The stable ``_branched_from`` marker keeps the branch visible in /resume + /sessions
         # even after the parent is re-ended with a different end_reason.
         try:
@@ -1388,6 +1389,7 @@ class CLICommandsMixin:
                               "_branched_from": parent_session_id})
         except Exception as e:
             return _cp(f"  Failed to create branch session: {e}")
+        _end_current_session(self, "branched")
         # Best-effort chunked copy (a failed copy still yields a usable branch); the api_content
         # sidecar lets the branch's first turn replay the parent's exact wire bytes (warm cache).
         with suppress(Exception):

--- a/tests/cli/test_branch_command.py
+++ b/tests/cli/test_branch_command.py
@@ -77,6 +77,20 @@ class TestBranchCommandCLI:
         new_session = session_db.get_session(cli_instance.session_id)
         assert new_session is not None
 
+    def test_failed_branch_creation_leaves_original_session_open(self, cli_instance, session_db):
+        """Branching is child-first: when create_session fails the user stays on the original
+        session, so it must not be marked ended as "branched" (#11030)."""
+        from unittest.mock import patch
+        from cli import HermesCLI
+
+        original = cli_instance.session_id
+        with patch.object(session_db, "create_session", side_effect=RuntimeError("boom")):
+            HermesCLI._handle_branch_command(cli_instance, "/branch")
+
+        assert cli_instance.session_id == original
+        row = session_db.get_session(original)
+        assert row["end_reason"] is None and row["ended_at"] is None
+
     def test_branch_copies_history(self, cli_instance, session_db):
         """Branching should copy all messages to the new session."""
         from cli import HermesCLI

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -117,6 +117,25 @@ async def test_session_messages_default_to_latest_bounded_page(adapter, session_
 
 
 @pytest.mark.asyncio
+async def test_forked_session_stays_listable_and_parent_survives_failed_fork(adapter, session_db):
+    """A fork is created before the parent is ended (#11030) and carries the explicit branch
+    marker, so it still shows in the default listing (the timestamp fallback no longer holds)."""
+    session_db.create_session("parent", "api_server")
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post("/api/sessions/parent/fork", json={"id": "child"})
+        assert resp.status == 201
+        listed = await (await cli.get("/api/sessions")).json()
+        ids = {row["id"] for row in listed["data"]}
+        assert {"parent", "child"} <= ids, ids
+
+        session_db.create_session("solo", "api_server")
+        with patch.object(session_db, "create_session", side_effect=RuntimeError("boom")):
+            resp = await cli.post("/api/sessions/solo/fork", json={"id": "never"})
+        assert resp.status >= 500
+    assert session_db.get_session("solo")["end_reason"] is None
+
+@pytest.mark.asyncio
 async def test_run_agent_binds_api_session_context_for_tool_env(adapter, monkeypatch):
     """API-server request sessions should reach tools and terminal subprocess env."""
     monkeypatch.setenv("HERMES_SESSION_ID", "stale-session")


### PR DESCRIPTION
A failed `create_session()` during `/branch` (or `POST /api/sessions/{id}/fork`) leaves the user on a still-open session instead of one already marked `end_reason=branched` with no branch behind it.

- `hermes_cli/cli_commands_mixin.py::_handle_branch_command` and `gateway/platforms/api_server.py::_handle_fork_session` — create the child first, end the parent second (@vominh1919, #11048; ported from the pre-split `cli.py` handler and widened to the API sibling).
- 1 invariant test: `create_session` raising leaves the original row with `end_reason`/`ended_at` unset.

**Live repro:** on `origin/main` the original session shows `end_reason='branched'` after the failure; unchanged here.

Closes #11030.

**Review follow-up (d844e6c3):** API forks now persist `model_config._branched_from` (as CLI `/branch` does); with child-first creation the `started_at >= ended_at` timestamp fallback in `_BRANCH_CHILD_SQL` no longer held and the fork vanished from default `GET /api/sessions`. Test covers listing + failed-fork parent survival (red on the previous head and on base for the respective halves).

## Infographic

![branch](https://v3b.fal.media/files/b/0aaa2201/vTFnSR2v3amAbetDEuG0t_GmfF83Jx.png)

