### PR TITLE
fix(background_review): surface the ignored reasoning_effort on same-model forks

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -789,6 +789,30 @@ def _same_model_parity_kwargs(agent: Any) -> Dict[str, Any]:
     return kwargs
 
 
+def _warn_ignored_reasoning_effort(agent: Any, task_cfg: Optional[Dict[str, Any]] = None) -> None:
+    """One-shot user-visible notice: ``auxiliary.background_review.reasoning_effort`` is IGNORED on
+    the same-model path (#104116). The fork inherits the parent's ``reasoning_config`` verbatim so
+    its request bytes keep the parent's prompt-cache prefix (#30532: a diverged ``thinking`` field
+    on the fork-birth request re-created a large share of the cache); the no-op used to be silent,
+    so a user who set the key saw no feedback at all. Gated on the parent so a nudge-per-turn
+    session warns once, not per fork."""
+    effort = str(_background_review_task_config(task_cfg).get("reasoning_effort") or "").strip()
+    if not effort or getattr(agent, "_warned_bg_review_reasoning_effort", False):
+        return
+    agent._warned_bg_review_reasoning_effort = True
+    message = (
+        f"⚠ auxiliary.background_review.reasoning_effort='{effort}' has no effect while the review "
+        "runs on the main model: the fork inherits the conversation's reasoning effort to keep the "
+        "parent's prompt-cache prefix (see memory docs, same-model review reasoning). Route the "
+        "review elsewhere via auxiliary.background_review.provider/model to use a different effort."
+    )
+    emit = getattr(agent, "_emit_warning", None)
+    if callable(emit):
+        with suppress(Exception):
+            emit(message)
+    logger.warning("%s", message)
+
+
 def _detach_fork_compression(review_agent: Any) -> None:
     """Detached in-memory compaction for a fork sharing the parent's session_id. Disabling
     compression (the old guard against compacting the parent's live session) removed the only
@@ -877,6 +901,11 @@ def build_cache_parity_fork(
     # OAuth-only providers, session-scoped creds and credential pools.
     _rt = _resolve_review_runtime(agent, task_cfg)
     _routed = bool(_rt.get("routed"))
+    # A configured effort is silently dropped on the same-model path (cache parity) — say so once,
+    # visible, instead of leaving the set-but-ignored key invisible (#104116). Routed forks are a
+    # separate, tracked issue (#94825) and are left alone.
+    if not _routed and write_origin == "background_review":
+        _warn_ignored_reasoning_effort(agent, task_cfg)
     review_agent = AIAgent(**_fork_init_kwargs(agent, _rt, _routed, max_iterations))
     review_agent._memory_write_origin = review_agent._memory_write_context = write_origin
     review_agent._memory_store = agent._memory_store

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -741,6 +741,10 @@ DEFAULT_CONFIG = {
         # enabled=false skips auto spawns (/refine still works). max_input_tokens caps the SUM of
         # replayed input tokens over the review loop (iterations capped at 16); the loop stops
         # before crossing it. <= 0 = unlimited.
+        # reasoning_effort is IGNORED while the review stays on the main model: the fork inherits the
+        # conversation's reasoning config verbatim so its request bytes keep the parent's warm
+        # prompt-cache prefix (#30532). Set provider/model below to route the review to another model
+        # if you want a different effort level; a one-time warning says so when the key is set.
         "background_review": {"enabled": True, **_aux(120), "max_input_tokens": 600000},
         # No reasoning_effort on MoA blocks by design — configured PER SLOT in the preset
         # (moa.presets.<name>.reference_models[].reasoning_effort / aggregator.reasoning_effort).

--- a/tests/run_agent/test_background_review_cache_parity.py
+++ b/tests/run_agent/test_background_review_cache_parity.py
@@ -424,3 +424,58 @@ def test_unrouted_review_fork_inherits_empty_tool_surface():
         assert added == set()
         assert fork.tools == []
         assert fork.valid_tool_names == set()
+
+
+def test_same_model_review_surfaces_ignored_reasoning_effort_once():
+    """#104116: ``auxiliary.background_review.reasoning_effort`` is dropped on the same-model path
+    (cache parity, #30532) — that no-op must be visible instead of silent, and must not fire per
+    fork (a nudge-per-turn session would spam)."""
+    import run_agent
+    from agent.background_review import build_cache_parity_fork
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+    warnings = []
+    agent._emit_warning = warnings.append
+    captured = {}
+    _Recorder = _make_recorder_class(captured)
+
+    with patch.object(run_agent, "AIAgent", _Recorder):
+        _fork, _rt, routed = build_cache_parity_fork(
+            agent, {"reasoning_effort": "low"}, max_iterations=5)
+        assert not routed
+        assert len(warnings) == 1, f"expected exactly one notice, got {warnings!r}"
+        assert "auxiliary.background_review.reasoning_effort='low'" in warnings[0], warnings[0]
+        # Cache-parity behaviour itself is unchanged: the fork still inherits the parent verbatim.
+        assert captured["init_kwargs"]["reasoning_config"] == agent.reasoning_config
+        # Second fork on the same parent: no repeat.
+        build_cache_parity_fork(agent, {"reasoning_effort": "low"}, max_iterations=5)
+        assert len(warnings) == 1, f"notice repeated per fork: {warnings!r}"
+
+
+def test_review_effort_notice_only_for_same_model_review_forks():
+    """No notice when the key is unset, when the fork is routed (#94825 owns that path), or for the
+    /btw ``side_question`` fork sharing ``build_cache_parity_fork``."""
+    import run_agent
+    import agent.background_review as bg_review
+    from agent.background_review import build_cache_parity_fork
+
+    _Recorder = _make_recorder_class()
+    routed_runtime = {
+        "provider": "openrouter", "model": "aux-cheap-model", "api_key": "test-key",
+        "base_url": None, "api_mode": None, "credential_pool": None, "request_overrides": {},
+        "max_tokens": None, "command": None, "args": [], "routed": True,
+    }
+
+    def _warns(task_cfg, **kwargs):
+        agent = _make_agent_stub(run_agent.AIAgent)
+        warnings = []
+        agent._emit_warning = warnings.append
+        with patch.object(run_agent, "AIAgent", _Recorder):
+            build_cache_parity_fork(agent, task_cfg, max_iterations=5, **kwargs)
+        return warnings
+
+    assert _warns({"reasoning_effort": ""}) == []
+    assert _warns({}) == []
+    assert _warns({"reasoning_effort": "low"}, write_origin="side_question") == []
+    with patch.object(bg_review, "_resolve_review_runtime", return_value=routed_runtime):
+        assert _warns({"reasoning_effort": "low"}) == []


### PR DESCRIPTION
# fix(background_review): make the ignored `reasoning_effort` visible on same-model review forks

## What Problem This Solves

`auxiliary.background_review.reasoning_effort` is silently ignored whenever the review runs on the main model — the default `auto` route as well as an explicit parent provider/model. The same-model fork inherits the parent's `reasoning_config` verbatim so its request bytes keep the parent's prompt-cache prefix (#30532: a diverged `thinking` field on the fork-birth request re-created a large share of the cache). That behaviour is deliberate and is NOT changed here. The gap (issue #104116): a user who sets the key gets no warning and no doc-level explanation on the same-model path, so the no-op is invisible.

This change surfaces the no-op without touching fork-birth bytes:

- `agent/background_review.py`: one-shot, parent-scoped warning when a same-model `background_review` fork spawns and `auxiliary.background_review.reasoning_effort` is actually set. Emitted through `_emit_warning` (CLI `_print_fn` / gateway `status_callback` — the same channel as the other degraded-path notices) plus `agent.log`. The once-flag lives on the parent agent, so a nudge-per-turn session warns once, not once per fork. Routed forks are left alone (their effort bug is tracked separately in #94825), and the `/btw` `side_question` fork — which shares `build_cache_parity_fork` — is excluded by write origin.
- `hermes_cli/config_defaults.py`: config-reference comment recording that the key is ignored on the same-model path, why (cache parity), and where to route the review instead.
- `tests/run_agent/test_background_review_cache_parity.py`: two tests — the notice fires exactly once per parent and names the configured value; no notice when the key is unset, when the fork is routed, or for the `side_question` fork; and the fork still inherits the parent's `reasoning_config` verbatim, i.e. cache-parity behaviour is unchanged.

The user-facing docs note for this behaviour already exists on `main` ("Same-model review reasoning" sections in the memory and configuration docs), so no doc edit is needed here.

## Evidence

Branch `fix/104116-descr`, commit `b4f78b0c0c467e2e8f05e3bb5171406541783d57` (3 files, +88 lines, local only).

- Post-fix: `HERMES_PYTHON=D:/code/hermes-agent/.venv/Scripts/python.exe bash scripts/run_tests.sh tests/run_agent/test_background_review_cache_parity.py` → `Summary: 1 files, 9 tests passed, 0 failed`.
- Pre-fix (same test file with the implementation hunks reverted, tests kept): `1 failed, 8 passed` — `test_same_model_review_surfaces_ignored_reasoning_effort_once` fails with `AssertionError: expected exactly one notice, got []`. The second test asserts absence cases only, so it passes by construction pre-fix and guards against over-warning, not against the missing warning.
- Cache-parity invariant asserted in-test: `captured["init_kwargs"]["reasoning_config"] == agent.reasoning_config` (fork-birth request bytes unchanged).

### Unverified boundaries

- Notice presentation was validated through the `_emit_warning` call path and the unit tests, not by driving the desktop UI. In surfaces where neither `_print_fn` nor `status_callback` is set and stdout is thread-silenced (background-review threads run under `thread_scoped_silence`), the visible line can be swallowed; the record still lands in `agent.log`, consistent with other background-review notices.
- The routed-fork effort bug (#94825) and any opt-in same-model effort decoupling (item 2 of #104116) are intentionally out of scope.

### Parent verification

```
$ HERMES_PYTHON=<venv>/python.exe bash scripts/run_tests.sh tests/run_agent/test_background_review_cache_parity.py
=== Summary: 1 files, 9 tests passed, 0 failed (100% complete) in 2.6s ===
```

Without the source change (`git stash` of `agent/background_review.py` alone), the new notice test fails: `1 failed, 8 passed`.
