### PR TITLE
fix(install): the installer reuses an installed 3.12/3.13 instead of downloading Python 3.11 (#10778)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -692,7 +692,9 @@ check_python() {
     # No 3.11, but any interpreter inside requires-python (>=3.11,<3.14) works: reuse it rather
     # than downloading 3.11 — the download is a hard failure on hosts that cannot reach GitHub
     # releases, and the user already has a supported Python (#10778).
-    if PYTHON_PATH="$("$UV_CMD" python find "$PYTHON_SUPPORTED_RANGE" 2>/dev/null)"; then
+    # --system: with the install's own venv activated (a re-run), `uv python find` would return
+    # venv/bin/python3, which setup_venv is about to delete out from under itself.
+    if PYTHON_PATH="$("$UV_CMD" python find --system "$PYTHON_SUPPORTED_RANGE" 2>/dev/null)"; then
         PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
         PYTHON_VERSION="$PYTHON_PATH"  # uv venv --python / UV_PYTHON pin onto this interpreter
         log_success "Python found: $PYTHON_FOUND_VERSION (supported; reusing instead of downloading 3.11)"
@@ -1746,8 +1748,12 @@ setup_venv() {
         rm -rf venv
     fi
 
-    # uv creates the venv and pins the Python version in one step
-    $UV_CMD venv venv --python "$PYTHON_VERSION"
+    # uv creates the venv and pins the Python version in one step. Fail loudly: `set -e` does not
+    # reach this line's callers on every path, and a missing venv used to be reported as ready.
+    if ! $UV_CMD venv venv --python "$PYTHON_VERSION" || [ ! -x "venv/bin/python" ]; then
+        log_error "Failed to create the virtual environment with Python $PYTHON_VERSION"
+        exit 1
+    fi
 
     # Neutralize any inherited UV_PYTHON (e.g. UV_PYTHON=3.14 left in the
     # user's shell env). uv honours UV_PYTHON over an existing venv for the

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -57,6 +57,7 @@ else
     INSTALL_DIR_EXPLICIT=false
 fi
 PYTHON_VERSION="3.11"
+PYTHON_SUPPORTED_RANGE=">=3.11,<3.14"  # pyproject requires-python; keep in sync
 NODE_VERSION="26"
 
 # FHS-style root install layout (set by resolve_install_layout when applicable):
@@ -685,6 +686,16 @@ check_python() {
     if PYTHON_PATH="$("$UV_CMD" python find "$PYTHON_VERSION" 2>/dev/null)"; then
         PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
         log_success "Python found: $PYTHON_FOUND_VERSION"
+        return 0
+    fi
+
+    # No 3.11, but any interpreter inside requires-python (>=3.11,<3.14) works: reuse it rather
+    # than downloading 3.11 — the download is a hard failure on hosts that cannot reach GitHub
+    # releases, and the user already has a supported Python (#10778).
+    if PYTHON_PATH="$("$UV_CMD" python find "$PYTHON_SUPPORTED_RANGE" 2>/dev/null)"; then
+        PYTHON_FOUND_VERSION="$("$PYTHON_PATH" --version 2>/dev/null)"
+        PYTHON_VERSION="$PYTHON_PATH"  # uv venv --python / UV_PYTHON pin onto this interpreter
+        log_success "Python found: $PYTHON_FOUND_VERSION (supported; reusing instead of downloading 3.11)"
         return 0
     fi
 
@@ -1749,7 +1760,7 @@ setup_venv() {
         export UV_PYTHON="$INSTALL_DIR/venv/bin/python"
     fi
 
-    log_success "Virtual environment ready (Python $PYTHON_VERSION)"
+    log_success "Virtual environment ready ($(./venv/bin/python --version 2>/dev/null || echo "Python $PYTHON_VERSION"))"
 }
 
 run_locked_uv_sync() {

--- a/tests/test_install_sh_reuse_supported_python.py
+++ b/tests/test_install_sh_reuse_supported_python.py
@@ -1,0 +1,50 @@
+"""install.sh reuses an already-installed supported Python instead of downloading 3.11 (#10778)."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _exe(path: Path, content: str) -> Path:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
+def _run_prerequisites(tmp_path: Path, *, uv_find_script: str) -> subprocess.CompletedProcess[str]:
+    """Run the real ``--stage prerequisites`` with a stub managed uv whose ``python find`` we script."""
+    home = tmp_path / "home"
+    hermes_home = home / ".hermes"
+    (hermes_home / "bin").mkdir(parents=True)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _exe(bin_dir / "python3.13", "#!/bin/sh\n[ \"$1\" = --version ] && echo 'Python 3.13.12'\nexit 0\n")
+    _exe(hermes_home / "bin" / "uv", "#!/bin/sh\n[ \"$1\" = --version ] && { echo 'uv 0.9.0'; exit 0; }\n"
+         "if [ \"$1\" = python ] && [ \"$2\" = find ]; then\n" + uv_find_script + "fi\n"
+         "if [ \"$1\" = python ] && [ \"$2\" = install ]; then echo 'DOWNLOAD ATTEMPTED' >&2; exit 1; fi\nexit 0\n")
+    for tool in ("git", "node", "npm", "curl", "rg", "g++", "c++"):
+        _exe(bin_dir / tool, "#!/bin/sh\ncase \"$1\" in --version|-v) echo 'v22.12.0 2.50.0';; esac\nexit 0\n")
+    env = os.environ.copy()
+    env.update({"HOME": str(home), "HERMES_HOME": str(hermes_home),
+                "PATH": f"{bin_dir}{os.pathsep}{env.get('PATH', os.defpath)}"})
+    bash = shutil.which("bash") or "/bin/bash"
+    return subprocess.run([bash, str(INSTALL_SH), "--stage", "prerequisites", "--non-interactive"],
+                          env=env, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False)
+
+
+@pytest.mark.linux_only
+def test_supported_newer_python_is_reused_instead_of_downloading_311(tmp_path: Path) -> None:
+    """3.11 absent, 3.13 present: the installer must take 3.13 and never call ``uv python install``."""
+    result = _run_prerequisites(tmp_path, uv_find_script=(
+        f"  [ \"$3\" = 3.11 ] && exit 2\n  [ \"$3\" = '>=3.11,<3.14' ] && {{ echo {tmp_path}/bin/python3.13; exit 0; }}\n  exit 2\n"))
+    assert "DOWNLOAD ATTEMPTED" not in result.stdout, result.stdout
+    assert "Python found: Python 3.13.12" in result.stdout, result.stdout

--- a/tests/test_install_sh_reuse_supported_python.py
+++ b/tests/test_install_sh_reuse_supported_python.py
@@ -45,6 +45,8 @@ def _run_prerequisites(tmp_path: Path, *, uv_find_script: str) -> subprocess.Com
 def test_supported_newer_python_is_reused_instead_of_downloading_311(tmp_path: Path) -> None:
     """3.11 absent, 3.13 present: the installer must take 3.13 and never call ``uv python install``."""
     result = _run_prerequisites(tmp_path, uv_find_script=(
-        f"  [ \"$3\" = 3.11 ] && exit 2\n  [ \"$3\" = '>=3.11,<3.14' ] && {{ echo {tmp_path}/bin/python3.13; exit 0; }}\n  exit 2\n"))
+        # The range probe must carry --system: with the install's own venv activated, a plain
+        # `uv python find` returns venv/bin/python3, which setup_venv then deletes.
+        f"  [ \"$3\" = 3.11 ] && exit 2\n  [ \"$3\" = --system ] && [ \"$4\" = '>=3.11,<3.14' ] && {{ echo {tmp_path}/bin/python3.13; exit 0; }}\n  exit 2\n"))
     assert "DOWNLOAD ATTEMPTED" not in result.stdout, result.stdout
     assert "Python found: Python 3.13.12" in result.stdout, result.stdout


### PR DESCRIPTION
`install.sh` no longer downloads CPython 3.11 when a Python inside `requires-python` (`>=3.11,<3.14`) is already installed; the venv is created on that interpreter.

- `scripts/install.sh::check_python` — after the 3.11 probe, `uv python find '>=3.11,<3.14'`; the found path becomes the `uv venv --python` / `UV_PYTHON` pin. Venv success line reports the real interpreter.
- 1 behavioural test: real `--stage prerequisites` with a stub managed `uv` (3.11 absent, 3.13 present) → no `uv python install`, `Python found: Python 3.13.12`.

**Root cause:** the script asked uv only for 3.11 and treated its absence as "install it" — a hard failure for hosts that cannot reach `github.com/astral-sh/python-build-standalone` (the reporter's macOS timeout) despite a supported 3.13 on the machine.

**Live repro:** test red on `origin/main` (`DOWNLOAD ATTEMPTED`), green here. `install.ps1` already had this fallback (`$PythonFallbackVersions`).

Same direction as #10824 (@gnanirahulnutakki), reduced to the shell path. Closes #10778.

**Review follow-up (aca88118):** the range probe now uses `uv python find --system` (with the install's own venv activated, the plain probe returned `venv/bin/python3`, which `setup_venv` then deleted), and venv creation failure is fatal instead of printing "ready". Live: activated 3.13 venv + hidden 3.11 → base rc=1/no venv, this branch rc=0 with a working venv.

## Infographic

![reuse-python](https://v3b.fal.media/files/b/0aaa2214/rC2R6uJsAygnBJywLa-UB_YAvOQR9i.png)

