### PR TITLE
feat(memory): refuse near-duplicate entries on add

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1262,6 +1262,8 @@ def _init_memory(agent, _agent_cfg, skip_memory, platform):
                     user_char_limit=mem_config.get("user_char_limit", 1375),
                     memory_enabled=agent._memory_enabled,
                     user_profile_enabled=agent._user_profile_enabled,
+                    near_duplicate_detection=is_truthy_value(
+                        mem_config.get("near_duplicate_detection"), default=True),
                 )
                 agent._memory_store.load_from_disk()
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1213,6 +1213,10 @@ DEFAULT_CONFIG = {
         "write_approval": False,
         "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
+        # Refuse an add whose content only rewords an entry already in that store
+        # (case/punctuation-normalized equality, or near-total containment). False =
+        # exact-equality gate only.
+        "near_duplicate_detection": True,
         # Periodic built-in memory review; 0 when an external provider auto-extracts.
         "nudge_interval": 10,
         # External memory provider plugin (empty = built-in only); only ONE at a time: "openviking",

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -144,6 +144,84 @@ class TestMemoryStoreAdd:
         assert "Blocked" in result["error"]
 
 
+class TestMemoryStoreNearDuplicate:
+    """Write-time near-duplicate detection (#103920 slice 1): a reworded restatement of
+    an entry already in that store is not written; a genuinely different fact still is."""
+
+    def test_reworded_entry_is_not_stored(self, store):
+        assert store.add("memory", "User prefers Python 3.12")["success"] is True
+        result = store.add("memory", "  user prefers python3.12!  ")
+        assert result["success"] is True  # terminal no-op, not a turn-failing error
+        assert store.memory_entries == ["User prefers Python 3.12"]
+        assert "rewrites an existing entry" in result["message"]
+
+    def test_single_token_difference_is_not_a_duplicate(self, store):
+        """Negative control: differing by one distinguishing token is a different fact.
+        A global similarity ratio flagged these, which is why the gate is containment-only."""
+        assert store.add("memory", "server A runs nginx")["success"] is True
+        assert store.add("memory", "server B runs nginx")["success"] is True
+        assert len(store.memory_entries) == 2
+
+    def test_containment_variant_is_not_stored(self, store):
+        store.add("memory", "Always run the test suite with run_tests.sh before committing")
+        store.add("memory", "Run the test suite with run_tests.sh before committing")
+        assert len(store.memory_entries) == 1
+
+    def test_chinese_reword_is_not_stored(self, store):
+        store.add("memory", "用户使用中文交流")
+        store.add("memory", "用户使用中文交流。")
+        assert store.memory_entries == ["用户使用中文交流"]
+
+    def test_distinct_facts_still_stored(self, store):
+        """Negative control: unrelated facts — and two that share a shape but not a
+        fact — must all get through."""
+        for entry in ("Deploys ship from the release branch", "The user's name is Finn",
+                      "Uses uv for Python packaging", "Uses pnpm for JS packaging",
+                      "用户偏好深色主题"):
+            result = store.add("memory", entry)
+            assert result["success"] is True, (entry, result)
+        assert len(store.memory_entries) == 5
+
+    def test_flag_off_falls_back_to_exact_gate_only(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        s = MemoryStore(memory_char_limit=500, user_char_limit=300, near_duplicate_detection=False)
+        s.load_from_disk()
+        s.add("memory", "User prefers Python 3.12")
+        assert s.add("memory", "user prefers python3.12!")["success"] is True
+        assert len(s.memory_entries) == 2
+
+    def test_batch_near_duplicate_add_is_noop_not_failure(self, store):
+        store.add("memory", "Deploys ship from the release branch")
+        result = json.loads(memory_tool(
+            target="memory",
+            operations=[
+                {"action": "add", "content": "deploys ship from the Release Branch."},
+                {"action": "add", "content": "Uses uv for Python packaging"},
+            ],
+            store=store,
+        ))
+        assert result["success"] is True
+        assert len(store.memory_entries) == 2
+        assert "Uses uv for Python packaging" in store.memory_entries
+
+    def test_replace_is_not_gated(self, store):
+        """Scope: new writes only. replace stays the deliberate merge/edit path."""
+        store.add("memory", "Alpha fact")
+        store.add("memory", "Beta fact")
+        assert store.replace("memory", "Alpha", "beta fact")["success"] is True
+        assert store.memory_entries == ["beta fact", "Beta fact"]
+
+    def test_load_does_not_drop_near_duplicates(self, tmp_path, monkeypatch):
+        """External near-dups stay on disk — load must not silently discard content the
+        tool never wrote."""
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        (tmp_path / "MEMORY.md").write_text(
+            "User prefers Python 3.12\n§\nuser prefers python3.12!", encoding="utf-8")
+        s = MemoryStore()
+        s.load_from_disk()
+        assert len(s.memory_entries) == 2
+
+
 class TestMemoryStoreReplace:
     def test_replace_entry(self, store):
         store.add("memory", "Python 3.11 project")

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -54,7 +54,9 @@ def load_on_disk_store() -> "MemoryStore":
         mem_cfg = get_builtin_memory_config(config)
         memory_enabled, user_profile_enabled = get_builtin_memory_store_flags(config)
         store = MemoryStore(int(mem_cfg.get("memory_char_limit", 2200)), int(mem_cfg.get("user_char_limit", 1375)),
-                            memory_enabled=memory_enabled, user_profile_enabled=user_profile_enabled)
+                            memory_enabled=memory_enabled, user_profile_enabled=user_profile_enabled,
+                            near_duplicate_detection=is_truthy_value(
+                                mem_cfg.get("near_duplicate_detection"), default=True))
     except Exception:
         store = MemoryStore()  # config optional — fall back to defaults rather than break /memory
     store.load_from_disk()

--- a/tools/memory_tool_store.py
+++ b/tools/memory_tool_store.py
@@ -63,6 +63,50 @@ def _find_unique_match(entries: List[str], old_text: str) -> Tuple[Optional[int]
     return (matches[0] if matches else None), False
 
 
+# Near-duplicate detection on the WRITE path (issue #103920, slice 1). The only
+# mechanical gate was exact equality, so the same fact arrives reworded ("User
+# prefers Python 3.12" / "user prefers python3.12!", "Note: deploys ship from the
+# release branch" / "Deploys ship from the release branch") and long-lived stores
+# clone entries across sessions. Two conservative signals only — normalized equality,
+# and near-total containment (the shorter entry is most of the longer one).
+#
+# Ceiling: a reworded restatement that neither equals nor contains the other (a
+# typo'd variant, synonyms) still gets through. A global character-similarity ratio
+# was tried and rejected — it flags entries distinguished by one token
+# ("server A runs nginx" / "server B runs nginx"), which is a real different fact.
+# Upgrade path: token-level ratio with a distinguishing-token carve-out, if a
+# mis-wording class shows up in practice. The negative control in
+# tests/tools/test_memory_tool.py::TestMemoryStoreNearDuplicate pins both directions.
+_NEAR_DUP_CONTAINMENT = 0.85  # shorter normalized text must cover this much of the longer
+
+
+def _normalize_for_dedup(text: str) -> str:
+    """Lowercase, alphanumerics only — case, punctuation, and whitespace fold away.
+    CJK characters count as alphanumeric, so Chinese entries normalize too."""
+    return "".join(c for c in text.lower() if c.isalnum())
+
+
+def _near_duplicate_reason(candidate: str, entries: List[str]) -> Optional[str]:
+    """The existing entry *candidate* near-duplicates, or None if it is genuinely new.
+
+    O(len(entries)) containment checks on normalized text — entries are char-budget
+    bounded and this runs only on writes, so no index is kept.
+    """
+    norm = _normalize_for_dedup(candidate)
+    if not norm:
+        return None
+    for entry in entries:
+        other = _normalize_for_dedup(entry)
+        if not other:
+            continue
+        if norm == other:
+            return entry
+        short, long_ = (norm, other) if len(norm) <= len(other) else (other, norm)
+        if short in long_ and len(short) / len(long_) >= _NEAR_DUP_CONTAINMENT:
+            return entry
+    return None
+
+
 class MemoryStore:
     """Bounded curated memory with file persistence; one instance per AIAgent.
     ``_system_prompt_snapshot`` is frozen at load time (prefix-cache stable);
@@ -75,11 +119,15 @@ class MemoryStore:
     _MAX_CONSOLIDATION_FAILURES_PER_TURN = 3
 
     def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375, *,
-                 memory_enabled: bool = True, user_profile_enabled: bool = True):
+                 memory_enabled: bool = True, user_profile_enabled: bool = True,
+                 near_duplicate_detection: bool = True):
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
         self.memory_char_limit, self.user_char_limit = memory_char_limit, user_char_limit
         self.memory_enabled, self.user_profile_enabled = memory_enabled, user_profile_enabled
+        # memory.near_duplicate_detection (config): refuse a write that only rewords an
+        # existing entry. Off = exact-equality gate only, the pre-#103920 behaviour.
+        self.near_duplicate_detection = near_duplicate_detection
         self._system_prompt_snapshot: Dict[str, str] = {"memory": "", "user": ""}
         self._consolidation_failures = 0  # per turn; reset by reset_consolidation_failures()
 
@@ -91,6 +139,13 @@ class MemoryStore:
     def reset_consolidation_failures(self) -> None:
         """Call at turn start."""
         self._consolidation_failures = 0
+
+    def _near_duplicate(self, entries: List[str], content: str) -> Optional[str]:
+        """Existing entry *content* only rewrites, or None. No-op when disabled via
+        ``memory.near_duplicate_detection``."""
+        if not self.near_duplicate_detection:
+            return None
+        return _near_duplicate_reason(content, entries)
 
     def _consolidation_failure(self, response: Dict[str, Any]) -> Dict[str, Any]:
         """Count a consolidation failure: under the per-turn cap return ``response``
@@ -222,6 +277,13 @@ class MemoryStore:
         def _add(entries, limit):
             if content in entries:
                 return self._success_response(target, "Entry already exists (no duplicate added).")
+            if (existing := self._near_duplicate(entries, content)) is not None:
+                # Success, not an error: the store already holds this fact, and a terminal
+                # no-op must not fail the batch/turn (same shape as the exact-dup gate).
+                shown = existing[:60] + ("…" if len(existing) > 60 else "")
+                return self._success_response(target, (
+                    f"Entry not added: it rewrites an existing entry (\"{shown}\"). "
+                    f"No duplicate stored — use 'replace' with old_text to update that entry instead."))
             if len(ENTRY_DELIMITER.join(entries + [content])) > limit:
                 return self._failure_with_entries(target, (
                     f"Memory at {self._char_count(target):,}/{limit:,} chars. Adding this entry "
@@ -273,13 +335,13 @@ class MemoryStore:
             return replaced, "Entry replaced."
         return self._mutate(target, _apply)
 
-    @staticmethod
-    def _apply_batch_op(working: List[str], act: str, content: str, old_text: str, pos: str) -> Optional[str]:
+    def _apply_batch_op(self, working: List[str], act: str, content: str, old_text: str, pos: str) -> Optional[str]:
         """Apply one batch op to *working* in place; return an error message or None."""
         if act == "add":
             if not content:
                 return f"{pos}: content is required."
-            if content not in working:  # idempotent -- skip duplicate, don't fail the batch
+            # Idempotent -- skip duplicate, don't fail the batch (exact or near-duplicate).
+            if content not in working and self._near_duplicate(working, content) is None:
                 working.append(content)
             return None
         if act not in ("replace", "remove"):

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -176,7 +176,16 @@ located at ~/code/api. I discovered it uses Go version 1.22 and...
 
 ## Duplicate Prevention
 
-The memory system automatically rejects exact duplicate entries. If you try to add content that already exists, it returns success with a "no duplicate added" message.
+The memory system rejects two kinds of duplicate on `add`:
+
+- **Exact duplicates** — the entry already exists verbatim. Returns success with a "no duplicate added" message.
+- **Near-duplicates** — the entry only rewords an existing one (case, punctuation, or whitespace differ, or the shorter entry is nearly all of the longer one). Returns success with an "it rewrites an existing entry" message naming the entry it matched. Nothing is stored.
+
+Both are a terminal no-op rather than an error: the store already holds the fact, so the turn doesn't fail and the agent isn't invited to retry. To update a near-duplicate instead, use `replace` with `old_text` — that path is deliberately not gated.
+
+Set `memory.near_duplicate_detection: false` to keep only the exact-equality gate (the pre-#103920 behaviour), e.g. when a store intentionally keeps deliberately reworded variants.
+
+Near-duplicate detection only applies to **new writes**. Loading a file never drops entries, so reworded variants that arrived by an edit outside the tool stay on disk until the agent consolidates them.
 
 ## Security Scanning
 
@@ -238,6 +247,7 @@ memory:
   memory_char_limit: 2200   # ~800 tokens
   user_char_limit: 1375     # ~500 tokens
   write_approval: false     # false = write freely (default) | true = require approval
+  near_duplicate_detection: true   # false = reject exact duplicates only (pre-#103920)
 ```
 
 Setting **both** `memory_enabled` and `user_profile_enabled` to `false` turns the


### PR DESCRIPTION
# feat(memory): refuse near-duplicate entries on add (issue #103920, slice 1)

Partial #103920 — this PR lands the **write-time near-duplicate detection** half only.
The issue's other half (**per-target write policy**) is deliberately out of scope here.

## What Problem This Solves

Today the only mechanical gate on the memory write path is exact string equality
(`content in entries`). The same fact therefore re-enters a long-lived store whenever it
arrives reworded — `User prefers Python 3.12` / `user prefers python3.12!`,
`Deploys ship from the release branch` / `Note: deploys ship from the release branch` —
and stores quietly clone entries across sessions until the char budget is spent on
duplicates. The model is asked to consolidate, but consolidation is a model judgement;
this adds the mechanical guard.

## What This PR Does

- **`MemoryStore.add` and the batch `add` op** now skip a candidate that
  (a) normalizes equal to an existing entry (lowercase, alphanumerics only — case,
  punctuation and whitespace fold away; CJK counts as alphanumeric), or
  (b) is contained in an existing entry covering **≥85%** of the longer normalized text.
  Two conservative signals only: substring containment plus a size floor, **not** a global
  character-similarity ratio. A ratio flags entries distinguished by one token
  (`server A runs nginx` / `server B runs nginx`), which is a real different fact — the
  negative control below pins that direction.
- A skip is a **terminal success no-op**, the same shape as the existing exact-dup gate:
  the message names the entry it matched and points at `replace`. It does not fail the
  batch or the turn (nothing worse than a wrong retry loop).
- New config `memory.near_duplicate_detection` (**default `true`**); `false` restores the
  pre-#103920 exact-equality-only behaviour. Wired through `agent_init` and
  `load_on_disk_store`, so the CLI/gateway/Desktop stores enforce the same setting.
- **Scope discipline:** `replace` is the deliberate merge/edit path and stays ungated;
  `load_from_disk` never drops entries, so a reworded variant that arrived via an editor
  or another tool stays on disk (no silent data loss on startup).
- Docs updated: `website/docs/user-guide/features/memory.md` (`Duplicate Prevention`
  section and the config block) previously claimed exact duplicates only.

## Evidence

Test file: `tests/tools/test_memory_tool.py`.

- `cd D:/code/wt-103920 && HERMES_PYTHON=D:/code/hermes-agent/.venv/Scripts/python.exe bash scripts/run_tests.sh tests/tools/test_memory_tool.py`
  → **60 tests passed, 0 failed** (5.4s). Pre-change baseline in the same file: 49 `def test_`
  at `origin/main` → 58 now (**+9 new, in `TestMemoryStoreNearDuplicate`**; pytest collects 60
  including parametrisation).
- Adjacent suites that construct/reload the store, same command, 4 files:
  `tests/tools/test_memory_tool.py tests/agent/test_background_review_memory_scope.py tests/agent/test_builtin_memory_disabled_surface.py tests/hermes_cli/test_set_config_value.py`
  → **176 tests passed, 0 failed** (7.9s). No regressions in the existing memory / background-review / config paths.
- Negative control (both directions), in `TestMemoryStoreNearDuplicate`:
  - `test_single_token_difference_is_not_a_duplicate` — `server A runs nginx` then
    `server B runs nginx` ⇒ **both stored**.
  - `test_distinct_facts_still_stored` — five genuinely different facts (incl. two that share
    a shape: `Uses uv for Python packaging` / `Uses pnpm for JS packaging`) ⇒ **all five stored**.
  - Positive side: case/punctuation reword, containment variant, and a Chinese reword
    (`用户使用中文交流` / `用户使用中文交流。`) are each not stored; flag-off path
    (`near_duplicate_detection=False`) stores both; batch near-dup is a no-op that doesn't
    fail the batch; `replace` is not gated; load keeps externally-added near-dups.
- Flag semantics verified directly: `is_truthy_value(False, default=True) is False`
  (explicit `false` turns the gate off; unset/key-missing keeps it on).

## Not Verified / Known Boundaries

- **Slice 2 not done:** per-target write policy is untouched — this PR is `add`-gate only.
- Algorithm ceiling (documented in code): a reworded restatement that neither equals nor
  *contains* the other (a typo'd variant, true synonyms like "prefers" vs "likes") still gets
  through. Embedding similarity was not attempted (no new dependency); upgrade path is a
  token-level ratio with a distinguishing-token carve-out if a mis-wording class shows up.
- The 0.85 containment threshold is a judgment call pinned by tests, not derived from real
  store telemetry.
- Config propagation to `agent_init` / `load_on_disk_store` is verified by unit tests +
  reading; no live end-to-end agent run against a real store was performed.

### Parent verification

```
$ HERMES_PYTHON=<venv>/python.exe bash scripts/run_tests.sh tests/tools/test_memory_tool.py
=== Summary: 1 files, 60 tests passed, 0 failed (100% complete) in 4.7s ===
```
