### PR TITLE
fix(desktop): throttle the global agent-roster refresh

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -356,6 +356,7 @@ import {
 import { missingRendererAssets } from './renderer-bundle'
 import { loadRendererLoadErrorPage } from './renderer-load-error-page'
 import { attachRendererConsoleCapture, formatRendererBoundaryReport } from './renderer-log'
+import { createRosterRefreshThrottle } from './roster-refresh-throttle'
 import { fetchRosterSourceData } from './roster-source-fetch'
 import {
   classifyStoredSecret,
@@ -15811,28 +15812,50 @@ async function enumerateRegistryAgentSources(registry = readDesktopConnectionsRe
   )
 }
 
-ipcMain.handle('hermes:agents:roster', async () => {
-  const registry = readDesktopConnectionsRegistry()
-  const enumerations = await enumerateRegistryAgentSources(registry)
+// One throttle for the roster IPC below: the roster is a single global
+// snapshot, so its window/backoff state is global too. A clean pass resets it;
+// a refused/unreachable source doubles the wait up to a minute.
+const rosterRefreshThrottle = createRosterRefreshThrottle()
 
-  return {
-    agents: buildAgentRoster(enumerations, { primaryConnectionId: registry.primary }),
-    // The active gateway owns the renderer's profiles.list — union agents
-    // that report THIS connection are the same identities, not extra rows.
-    // Expose the primary id so the plugin merger can annotate them in place
-    // instead of appending duplicates (remote-only desktops doubled every
-    // bot otherwise; see #88344).
-    primaryConnectionId: registry.primary,
-    sources: enumerations.map(({ connection, error, installId, profiles }) => ({
-      connectionId: connection.id,
-      label: connection.label,
-      kind: connection.kind,
-      reachable: profiles !== null,
-      ...(installId ? { installId } : {}),
-      ...(error ? { error } : {})
-    }))
-  }
-})
+ipcMain.handle('hermes:agents:roster', () =>
+  // Bounded/coalesced refresh (#104227): several surfaces fetch this roster —
+  // the sidebar on mount/focus/registry change, the skills pane, and every
+  // profile-routed SDK call — and each pass enumerates EVERY registered
+  // source; for a not-yet-pooled source that dials or spawns a backend. When
+  // the pool cap refuses the spawn (after the coordinator's 30s slot wait) the
+  // roster stays "incomplete", so the sidebar store's 5s retry window keeps
+  // asking and every fetch re-attempts the refused spawn: refresh → refused
+  // spawn → refresh. The throttle collapses concurrent callers onto one
+  // enumeration and makes a pass that came back with a real source error wait
+  // longer before the next.
+  rosterRefreshThrottle.run(
+    async () => {
+      const registry = readDesktopConnectionsRegistry()
+      const enumerations = await enumerateRegistryAgentSources(registry)
+
+      return {
+        agents: buildAgentRoster(enumerations, { primaryConnectionId: registry.primary }),
+        // The active gateway owns the renderer's profiles.list — union agents
+        // that report THIS connection are the same identities, not extra rows.
+        // Expose the primary id so the plugin merger can annotate them in place
+        // instead of appending duplicates (remote-only desktops doubled every
+        // bot otherwise; see #88344).
+        primaryConnectionId: registry.primary,
+        sources: enumerations.map(({ connection, error, installId, profiles }) => ({
+          connectionId: connection.id,
+          label: connection.label,
+          kind: connection.kind,
+          reachable: profiles !== null,
+          ...(installId ? { installId } : {}),
+          ...(error ? { error } : {})
+        }))
+      }
+    },
+    // `connect-on-demand` is a deliberate skip (an un-dialed SSH source), not a
+    // failure — only a real dial/spawn refusal backs the refresh off.
+    payload => payload.sources.some(source => Boolean(source.error) && source.error !== 'connect-on-demand')
+  )
+)
 
 // Registry-scoped fresh WS URL: the (connectionId, profile) analogue of
 // hermes:gateway:ws-url. Same single-use-ticket discipline for OAuth sources.

--- a/apps/desktop/electron/roster-refresh-throttle.test.ts
+++ b/apps/desktop/electron/roster-refresh-throttle.test.ts
@@ -1,0 +1,198 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { createRosterRefreshThrottle } from './roster-refresh-throttle'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const mainSource = fs.readFileSync(path.join(here, 'main.ts'), 'utf8').replace(/\r\n/g, '\n')
+
+/** Deterministic clock: the throttle's cooldown/backoff windows are measured,
+ *  never waited on, so no test sleeps. */
+function fakeClock(start = 1_700_000_000_000) {
+  let now = start
+
+  return {
+    now: () => now,
+    advance: (ms: number) => {
+      now += ms
+    }
+  }
+}
+
+describe('roster refresh throttle (#104227)', () => {
+  it('coalesces concurrent refreshes onto ONE enumeration', async () => {
+    const clock = fakeClock()
+    const throttle = createRosterRefreshThrottle({ now: clock.now })
+    let resolveEnumeration: ((value: string) => void) | undefined
+
+    const enumerate = vi.fn(
+      () =>
+        new Promise<string>(resolve => {
+          resolveEnumeration = resolve
+        })
+    )
+
+    // Boot: the sidebar mount, the skills pane, and an SDK profile-routed
+    // call can all ask for the roster before the first answer lands.
+    const first = throttle.run(enumerate)
+    const second = throttle.run(enumerate)
+    const third = throttle.run(enumerate)
+
+    expect(enumerate).toHaveBeenCalledTimes(1)
+    expect(throttle.inFlight).toBe(true)
+
+    resolveEnumeration?.('roster-1')
+
+    expect(await Promise.all([first, second, third])).toEqual(['roster-1', 'roster-1', 'roster-1'])
+    expect(enumerate).toHaveBeenCalledTimes(1)
+    expect(throttle.inFlight).toBe(false)
+  })
+
+  it('serves the last snapshot inside the cooldown, then re-enumerates once it elapses', async () => {
+    const clock = fakeClock()
+    const throttle = createRosterRefreshThrottle({ now: clock.now, cooldownMs: 5_000 })
+    let calls = 0
+    const enumerate = async () => `roster-${++calls}`
+
+    expect(await throttle.run(enumerate)).toBe('roster-1')
+
+    // The sidebar's next mount/focus lands inside the retry window: no new
+    // enumeration, the fresh snapshot is handed back instead.
+    clock.advance(1_000)
+    expect(await throttle.run(enumerate)).toBe('roster-1')
+    expect(calls).toBe(1)
+
+    clock.advance(5_000)
+    expect(await throttle.run(enumerate)).toBe('roster-2')
+    expect(calls).toBe(2)
+  })
+
+  it('a failed refresh backs off exponentially instead of re-hammering the pool', async () => {
+    const clock = fakeClock()
+    const throttle = createRosterRefreshThrottle({ now: clock.now, cooldownMs: 5_000, maxCooldownMs: 60_000 })
+    let calls = 0
+
+    const failing = () => {
+      calls += 1
+
+      return Promise.reject(new Error('pool cap: spawn refused'))
+    }
+
+    // Cold failure: nothing to serve, so the poll still retries at its own
+    // cadence (fail open, never latched)...
+    await expect(throttle.run(failing)).rejects.toThrow('pool cap: spawn refused')
+    await expect(throttle.run(failing)).rejects.toThrow('pool cap: spawn refused')
+    expect(calls).toBe(2)
+
+    // ...but the cooldown doubles on every failure: 5s -> 10s -> 20s...
+    expect(throttle.cooldownMs).toBe(20_000)
+
+    // A warm snapshot is now held for the whole backoff window — the pool-cap
+    // storm waits politely instead of respawning on every fetch.
+    const healthy = async () => {
+      calls += 1
+
+      return 'recovered'
+    }
+
+    expect(await throttle.run(healthy)).toBe('recovered')
+    expect(calls).toBe(3)
+    expect(throttle.cooldownMs).toBe(5_000)
+  })
+
+  it('backoff window holds the warm snapshot for callers that arrive early', async () => {
+    const clock = fakeClock()
+    const throttle = createRosterRefreshThrottle({ now: clock.now, cooldownMs: 5_000, maxCooldownMs: 60_000 })
+    let calls = 0
+    let fail = false
+
+    const enumerate = () => {
+      calls += 1
+
+      return fail ? Promise.reject(new Error('spawn refused')) : Promise.resolve(`roster-${calls}`)
+    }
+
+    expect(await throttle.run(enumerate)).toBe('roster-1')
+
+    clock.advance(5_000)
+    fail = true
+    await expect(throttle.run(enumerate)).rejects.toThrow('spawn refused')
+    expect(calls).toBe(2)
+    expect(throttle.cooldownMs).toBe(10_000)
+
+    // Inside the doubled window: the stale-but-good snapshot is served and the
+    // backend that just refused a spawn is left alone.
+    clock.advance(6_000)
+    expect(await throttle.run(enumerate)).toBe('roster-1')
+    expect(calls).toBe(2)
+
+    clock.advance(4_500)
+    fail = false
+    expect(await throttle.run(enumerate)).toBe('roster-3')
+    expect(calls).toBe(3)
+  })
+
+  it('a degraded (source-error) refresh backs off, and the next clean one resets the cooldown', async () => {
+    const clock = fakeClock()
+    const throttle = createRosterRefreshThrottle({ now: clock.now, cooldownMs: 5_000, maxCooldownMs: 60_000 })
+    const degraded = (payload: { sources: { error?: string }[] }) => Boolean(payload?.sources?.some(source => source.error))
+    let calls = 0
+
+    const enumerate = async (): Promise<{ sources: Array<{ connectionId?: string; error?: string }> }> => {
+      calls += 1
+
+      return calls === 2
+        ? { sources: [{ error: 'profile backend start timed out while waiting for a free slot.' }] }
+        : { sources: [{ connectionId: 'local' }] }
+    }
+
+    expect(await throttle.run(enumerate, degraded)).toEqual({ sources: [{ connectionId: 'local' }] })
+    expect(throttle.cooldownMs).toBe(5_000)
+
+    // The enumeration RESOLVED, but a source came back refused: the pool cap
+    // was hit, so the next refresh must wait longer, not immediately retry.
+    clock.advance(5_000)
+    await throttle.run(enumerate, degraded)
+    expect(throttle.cooldownMs).toBe(10_000)
+    expect(calls).toBe(2)
+
+    clock.advance(5_000)
+    await throttle.run(enumerate, degraded)
+    expect(calls).toBe(2) // still inside the backed-off window: served stale
+    expect(throttle.cooldownMs).toBe(10_000)
+
+    clock.advance(5_000)
+    await throttle.run(enumerate, degraded)
+    expect(calls).toBe(3)
+    expect(throttle.cooldownMs).toBe(5_000) // clean refresh resets the backoff
+  })
+
+  it('propagates a synchronous throw to the caller without wedging the seam', async () => {
+    const clock = fakeClock()
+    const throttle = createRosterRefreshThrottle({ now: clock.now })
+
+    await expect(
+      throttle.run(() => {
+        throw new Error('registry unreadable')
+      })
+    ).rejects.toThrow('registry unreadable')
+
+    expect(throttle.inFlight).toBe(false)
+    expect(await throttle.run(async () => 'ok')).toBe('ok')
+  })
+})
+
+describe('main.ts wiring for #104227', () => {
+  it('routes the union roster IPC through the bounded refresh throttle', () => {
+    const handlerStart = mainSource.indexOf("ipcMain.handle('hermes:agents:roster',")
+    expect(handlerStart).toBeGreaterThan(-1)
+    const body = mainSource.slice(handlerStart, handlerStart + 2_600)
+
+    expect(body).toContain('rosterRefreshThrottle.run(')
+    expect(body).toContain('enumerateRegistryAgentSources(')
+    expect(body).toContain('connect-on-demand')
+  })
+})

--- a/apps/desktop/electron/roster-refresh-throttle.ts
+++ b/apps/desktop/electron/roster-refresh-throttle.ts
@@ -1,0 +1,149 @@
+/**
+ * roster-refresh-throttle.ts
+ *
+ * Bounded, coalesced refresh for the desktop-wide agent roster — the one
+ * choke point every roster read routes through (`hermes:agents:roster` →
+ * enumerateRegistryAgentSources, per #104227).
+ *
+ * Why this exists: several renderer surfaces fetch this roster — the sidebar
+ * on mount/focus/registry change (fleet-roster.ts), the skills pane, and every
+ * profile-routed SDK call. Each fetch enumerates EVERY registered connection,
+ * and for a source that is not yet in the backend pool that enumeration dials
+ * or spawns a backend. When the profile pool cap is reached the coordinator
+ * refuses the spawn after its 30s slot wait; the refused source keeps the
+ * roster "incomplete", so the sidebar store re-asks on its 5s retry window and
+ * the next fetch re-attempts the refused spawn. That is the reported storm:
+ * refresh → refused spawn → refresh, cascading across sources and hammering
+ * the model API while wedging the pool.
+ *
+ * Three bounds, all applied at that one seam:
+ *  - single-flight: concurrent refreshes (boot fan-out, several panes) share
+ *    ONE enumeration, so N callers cannot become N spawns;
+ *  - cooldown: a refresh that arrives inside the current window is served the
+ *    last snapshot instead of starting a new enumeration — the periodic poll
+ *    keeps its data, the backends are left alone;
+ *  - backoff: a refresh whose enumeration threw, or which came back DEGRADED
+ *    (a source reported a real refusal/dial error — the pool-cap case, where
+ *    the enumeration itself still resolves), doubles the cooldown up to a
+ *    ceiling. The first clean refresh resets it.
+ *
+ * Fail open, never latched: with no snapshot to serve, a caller still runs
+ * (the renderer must be able to recover), and a later success clears every
+ * failure. Dependency-free (clock injected) so the windows are asserted
+ * directly, same pattern as backend-dial-claim.ts / pool-eviction.ts.
+ */
+
+/** Floor between two enumerations. Matches the sidebar store's 5s retry
+ *  window for an incomplete roster (fleet-roster.ts), so a healthy fleet
+ *  refreshes exactly as often as it always did — only the duplicate and
+ *  post-failure refreshes collapse away. */
+export const ROSTER_REFRESH_COOLDOWN_MS = 5_000
+
+/** Ceiling the failure backoff doubles up to — one refresh a minute while the
+ *  pool is capped or a source is refusing to come up. */
+export const ROSTER_REFRESH_MAX_COOLDOWN_MS = 60_000
+
+export interface RosterRefreshThrottleOptions {
+  /** Floor between two enumerations, in milliseconds. */
+  cooldownMs?: number
+  /** Ceiling for the failure backoff, in milliseconds. */
+  maxCooldownMs?: number
+  /** Injectable clock (tests). */
+  now?: () => number
+}
+
+/** Did an enumeration that RESOLVED still report a failed source? A predicate
+ *  rather than a fixed shape because only the caller knows which source errors
+ *  are failures and which are deliberate skips. */
+export type RosterRefreshDegraded<T> = (value: T) => boolean
+
+export interface RosterRefreshThrottle {
+  /** The cooldown currently enforced — grows on failure, resets on success. */
+  readonly cooldownMs: number
+  /** Whether an enumeration is in flight (test/diagnostic seam). */
+  readonly inFlight: boolean
+  /**
+   * Run one refresh through the throttle. Concurrent callers share the
+   * in-flight enumeration; a caller inside the cooldown is handed the last
+   * snapshot without enumerating. Rejections propagate to every waiter.
+   */
+  run<T>(producer: () => Promise<T> | T, degraded?: RosterRefreshDegraded<T>): Promise<T>
+}
+
+export function createRosterRefreshThrottle(options: RosterRefreshThrottleOptions = {}): RosterRefreshThrottle {
+  const baseCooldownMs = options.cooldownMs ?? ROSTER_REFRESH_COOLDOWN_MS
+  const maxCooldownMs = Math.max(baseCooldownMs, options.maxCooldownMs ?? ROSTER_REFRESH_MAX_COOLDOWN_MS)
+  const now = options.now ?? Date.now
+
+  let inflight: Promise<unknown> | null = null
+  let snapshot: { value: unknown } | null = null
+  let nextAllowedAt = 0
+  let cooldownMs = baseCooldownMs
+  let failures = 0
+
+  function backOff() {
+    failures += 1
+    cooldownMs = Math.min(maxCooldownMs, baseCooldownMs * 2 ** failures)
+  }
+
+  return {
+    get cooldownMs() {
+      return cooldownMs
+    },
+
+    get inFlight() {
+      return inflight !== null
+    },
+
+    run<T>(producer: () => Promise<T> | T, degraded?: RosterRefreshDegraded<T>): Promise<T> {
+      if (inflight) {
+        return inflight as Promise<T>
+      }
+
+      // A warm snapshot inside the window is cheaper AND kinder than another
+      // enumeration; with nothing to serve, the caller runs (fail open).
+      if (snapshot && now() < nextAllowedAt) {
+        return Promise.resolve(snapshot.value as T)
+      }
+
+      let pending: Promise<T>
+
+      try {
+        pending = Promise.resolve(producer())
+      } catch (error) {
+        pending = Promise.reject(error)
+      }
+
+      inflight = pending
+
+      const release = () => {
+        if (inflight === pending) {
+          inflight = null
+        }
+      }
+
+      const onResolved = (value: T) => {
+        if (degraded?.(value)) {
+          backOff()
+        } else {
+          failures = 0
+          cooldownMs = baseCooldownMs
+        }
+
+        snapshot = { value }
+        nextAllowedAt = now() + cooldownMs
+        release()
+      }
+
+      const onRejected = () => {
+        backOff()
+        nextAllowedAt = now() + cooldownMs
+        release()
+      }
+
+      void pending.then(onResolved, onRejected)
+
+      return pending
+    }
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Several renderer surfaces fetch the desktop-wide agent roster over `hermes:agents:roster` — the sidebar (mount / window focus / registry change), the skills pane, and every profile-routed SDK call. Each fetch runs `enumerateRegistryAgentSources`, which enumerates **every** registered connection; for a source that is not yet in the backend pool, that enumeration dials or spawns a backend. When the profile pool cap is reached, the coordinator refuses the spawn after its 30s slot wait — but the refused source keeps the roster "incomplete", so `fleet-roster.ts` keeps re-asking on its 5s retry window and the next fetch re-attempts the refused spawn: refresh → refused spawn → refresh, cascading across sources while the pool is wedged (#104227).

This PR routes that one IPC handler through a small bounded-refresh seam (`electron/roster-refresh-throttle.ts`):

- **single-flight** — concurrent fetches (boot fan-out, several surfaces) share ONE enumeration, so N callers cannot become N spawns;
- **cooldown (5s)** — a caller inside the window is served the last snapshot instead of starting a new enumeration. 5s matches the sidebar's incomplete-retry window, so a healthy fleet fetches exactly as often as it always did — only duplicate and post-failure fetches collapse away;
- **backoff (5s → … → 60s)** — a pass that threw, or that resolved *degraded* (a source reported a real refusal/dial error — the pool-cap case, where the enumeration itself still resolves), doubles the cooldown up to one minute. The first clean pass resets it;
- `connect-on-demand` stays a deliberate skip (an un-dialed SSH source), never treated as a failure.

Fail-open by design: with no snapshot to serve, a caller still runs (the renderer must always be able to recover), and a later success clears the failure state — nothing is latched.

## Scope (Partial)

This is a **Partial** implementation for #104227: only the refresh-throttling slice. The other two asks from the issue — idle-agent auto-suspend and the manual online/offline toggle — are **not included**, and the issue should stay open for them.

## Evidence

Verified locally on this branch's commit (`c5dd23d4edb`), Windows 11, node v26.4.0, vitest 4.1.10:

- `npx vitest run --project electron electron/roster-refresh-throttle.test.ts` → **7/7 pass**. Coverage: three concurrent callers coalesce onto one enumeration; the snapshot is served inside the cooldown (no extra call until the window elapses); exponential backoff on a thrown pass (5s → 10s → 20s …) reset by the first clean pass; the warm snapshot is held through the backoff window; the degraded predicate (resolved pass carrying a real source error) backs off and resets on the next clean pass; a synchronous throw propagates without wedging the seam; plus a wiring test that pins the IPC handler to the throttle.
- Pre/post on the wiring: on the base tree the roster test file is **6/7** — the wiring assertion fails because `main.ts` does not route through the throttle; on this commit it is **7/7**.
- `npx tsc --build tsconfig.electron.json` → clean.
- `npx eslint electron/main.ts electron/roster-refresh-throttle.ts electron/roster-refresh-throttle.test.ts` → 0 problems.
- Full `--project electron` suite (309 files / 2224 tests): **2174 passed**; the remaining failures are pre-existing Windows-environment failures (ssh / git / chmod / real-child-process suites). Verified identical failure file set before vs after by stashing `main.ts` and re-running — the only delta is this PR's wiring test flipping to pass. Two load-sensitive suites (`pool-spawn-coordinator`'s "100 real child processes…" and `git-review-ops`) additionally flake under the parallel full run and pass standalone.

Behavior numbers: pre-change, every roster fetch re-enumerates and a refused spawn is re-attempted on the sidebar's next fetch (≈5s retry window while any source is refused). Post-change, N concurrent callers collapse to 1 enumeration, and a refused pass backs off 5s → 10s → 20s → … → 60s until the first clean pass.

Not verified: an end-to-end desktop boot against a genuinely capped profile pool (no Electron boot / live repro on the verifying machine).

### Parent verification

```
$ cd apps/desktop && npx vitest run --project electron electron/roster-refresh-throttle.test.ts
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

Against the base tree (wiring reverted) the same file is `6/7` — the wiring assertion is what the change turns green.
