### PR TITLE
fix(tui): render vault save-login prompt in dashboard

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -92,6 +92,25 @@ describe('createGatewayEventHandler', () => {
     expect(getTurnState().tools).toEqual([])
   })
 
+  it('opens and expires only the matching vault save-login request', () => {
+    const onEvent = createGatewayEventHandler(buildCtx([]))
+
+    onEvent({
+      payload: { origin: 'https://example.test', request_id: 'save-1', site: 'Example' },
+      type: 'vault.save_login.request'
+    } as any)
+
+    expect(getOverlayState().vaultSaveLogin).toEqual({
+      origin: 'https://example.test',
+      requestId: 'save-1',
+      site: 'Example'
+    })
+    onEvent({ payload: { request_id: 'stale' }, type: 'vault.save_login.expire' } as any)
+    expect(getOverlayState().vaultSaveLogin?.requestId).toBe('save-1')
+    onEvent({ payload: { request_id: 'save-1' }, type: 'vault.save_login.expire' } as any)
+    expect(getOverlayState().vaultSaveLogin).toBeNull()
+  })
+
   it('archives incomplete todos into transcript flow at end of turn so they scroll up', () => {
     const appended: Msg[] = []
 

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -107,8 +107,18 @@ describe('createGatewayEventHandler', () => {
     })
     onEvent({ payload: { request_id: 'stale' }, type: 'vault.save_login.expire' } as any)
     expect(getOverlayState().vaultSaveLogin?.requestId).toBe('save-1')
+    expect(getUiState().status).toBe('save login for Example')
     onEvent({ payload: { request_id: 'save-1' }, type: 'vault.save_login.expire' } as any)
     expect(getOverlayState().vaultSaveLogin).toBeNull()
+    expect(getUiState().status).toBe('ready')
+
+    onEvent({
+      payload: { origin: 'https://example.test', request_id: 'save-2', site: 'Example' },
+      type: 'vault.save_login.request'
+    } as any)
+    patchUiState({ busy: true })
+    onEvent({ payload: { request_id: 'save-2' }, type: 'vault.save_login.expire' } as any)
+    expect(getUiState().status).toBe('running…')
   })
 
   it('archives incomplete todos into transcript flow at end of turn so they scroll up', () => {

--- a/ui-tui/src/__tests__/useInputHandlers.test.ts
+++ b/ui-tui/src/__tests__/useInputHandlers.test.ts
@@ -183,4 +183,20 @@ describe('dismissSensitivePrompt', () => {
     expect(rpc).toHaveBeenCalledWith('secret.respond', { request_id: 'secret-1', value: '' })
     await pending
   })
+
+  it('declines a save-login prompt without putting credentials in the transcript', async () => {
+    resetOverlayState()
+    patchOverlayState({
+      vaultSaveLogin: { origin: 'https://example.test', requestId: 'save-1', site: 'Example' }
+    })
+    const rpc = vi.fn().mockResolvedValue(null)
+    const sys = vi.fn()
+
+    const pending = dismissSensitivePrompt(getOverlayState(), rpc, sys)
+
+    expect(getOverlayState().vaultSaveLogin).toBeNull()
+    expect(sys).toHaveBeenCalledWith('login was not saved')
+    expect(rpc).toHaveBeenCalledWith('vault.save_login.respond', { login: '', request_id: 'save-1' })
+    await pending
+  })
 })

--- a/ui-tui/src/__tests__/useInputHandlers.test.ts
+++ b/ui-tui/src/__tests__/useInputHandlers.test.ts
@@ -10,6 +10,7 @@ import {
   shouldDetachEditedHistoryInput,
   shouldFallThroughForScroll
 } from '../app/useInputHandlers.js'
+import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
 
 const baseKey = {
   downArrow: false,
@@ -186,6 +187,8 @@ describe('dismissSensitivePrompt', () => {
 
   it('declines a save-login prompt without putting credentials in the transcript', async () => {
     resetOverlayState()
+    resetUiState()
+    patchUiState({ status: 'save login for Example' })
     patchOverlayState({
       vaultSaveLogin: { origin: 'https://example.test', requestId: 'save-1', site: 'Example' }
     })
@@ -195,6 +198,7 @@ describe('dismissSensitivePrompt', () => {
     const pending = dismissSensitivePrompt(getOverlayState(), rpc, sys)
 
     expect(getOverlayState().vaultSaveLogin).toBeNull()
+    expect(getUiState().status).toBe('ready')
     expect(sys).toHaveBeenCalledWith('login was not saved')
     expect(rpc).toHaveBeenCalledWith('vault.save_login.respond', { login: '', request_id: 'save-1' })
     await pending

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -1338,6 +1338,26 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         return
 
+      case 'vault.save_login.request':
+        patchOverlayState({
+          vaultSaveLogin: {
+            origin: String(ev.payload.origin ?? ''),
+            requestId: ev.payload.request_id,
+            site: String(ev.payload.site ?? '')
+          }
+        })
+        setStatus(`save login for ${ev.payload.site || ev.payload.origin}`)
+        ringPromptBell()
+
+        return
+
+      case 'vault.save_login.expire':
+        patchOverlayState(prev =>
+          prev.vaultSaveLogin?.requestId === ev.payload.request_id ? { ...prev, vaultSaveLogin: null } : prev
+        )
+
+        return
+
       case 'background.complete':
         dropBgTask(ev.payload.task_id)
         sys(`[bg ${ev.payload.task_id}] ${ev.payload.text}`)

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -1352,9 +1352,10 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         return
 
       case 'vault.save_login.expire':
-        patchOverlayState(prev =>
-          prev.vaultSaveLogin?.requestId === ev.payload.request_id ? { ...prev, vaultSaveLogin: null } : prev
-        )
+        if (getOverlayState().vaultSaveLogin?.requestId === ev.payload.request_id) {
+          patchOverlayState({ vaultSaveLogin: null })
+          setStatus(statusFromBusy())
+        }
 
         return
 

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -30,6 +30,7 @@ import type {
   SlashCatalog,
   SudoReq,
   Usage,
+  VaultSaveLoginReq,
   VaultUnlockReq
 } from '../types.js'
 
@@ -298,6 +299,7 @@ export interface OverlayState {
   petPicker: boolean
   pluginsHub: boolean
   secret: null | SecretReq
+  vaultSaveLogin: null | VaultSaveLoginReq
   vaultUnlock: null | VaultUnlockReq
   sessions: boolean
   skillsHub: boolean
@@ -569,6 +571,7 @@ export interface AppLayoutActions {
   answerClarifyQuestion: (qid: string, answer: string) => void
   answerSecret: (value: string) => void
   answerSudo: (pw: string) => void
+  answerVaultSaveLogin: (login: { identifier: string; password: string }) => void
   answerVaultUnlock: (password: string) => void
   clearSelection: () => void
   activateLiveSession: (id: string) => void
@@ -644,6 +647,7 @@ export interface AppOverlaysProps {
   onResumeSelect: (sessionId: string) => void
   onSecretSubmit: (value: string) => void
   onSudoSubmit: (pw: string) => void
+  onVaultSaveLoginSubmit: (login: { identifier: string; password: string }) => void
   onVaultUnlockSubmit: (password: string) => void
   pagerPageSize: number
 }

--- a/ui-tui/src/app/overlayStore.ts
+++ b/ui-tui/src/app/overlayStore.ts
@@ -18,6 +18,7 @@ const buildOverlayState = (): OverlayState => ({
   petPicker: false,
   pluginsHub: false,
   secret: null,
+  vaultSaveLogin: null,
   vaultUnlock: null,
   sessions: false,
   skillsHub: false,
@@ -45,6 +46,7 @@ export const $isBlocked = computed(
     skillsHub,
     subscription,
     sudo,
+    vaultSaveLogin,
     vaultUnlock,
     widget
   }) =>
@@ -64,6 +66,7 @@ export const $isBlocked = computed(
       skillsHub ||
       subscription ||
       sudo ||
+      vaultSaveLogin ||
       vaultUnlock ||
       widget
     )

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -29,7 +29,7 @@ import {
 import { $isBlocked, $overlayState, patchOverlayState } from './overlayStore.js'
 import { turnController } from './turnController.js'
 import { patchTurnState } from './turnStore.js'
-import { getUiState } from './uiStore.js'
+import { getUiState, patchUiState } from './uiStore.js'
 
 const isCtrl = (key: { ctrl: boolean }, ch: string, target: string) => key.ctrl && ch.toLowerCase() === target
 const DASHBOARD_NEW_SESSION_MESSAGE = 'starting a fresh dashboard chat...'
@@ -178,6 +178,7 @@ export function dismissSensitivePrompt(
     const requestId = overlay.vaultSaveLogin.requestId
 
     patchOverlayState({ vaultSaveLogin: null })
+    patchUiState({ status: getUiState().busy ? 'running…' : 'ready' })
     sys('login was not saved')
 
     return rpc<SecretRespondResponse>('vault.save_login.respond', { login: '', request_id: requestId })

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -143,7 +143,7 @@ export function applyVoiceRecordResponse(
 }
 
 export function dismissSensitivePrompt(
-  overlay: Pick<OverlayState, 'secret' | 'sudo' | 'vaultUnlock'>,
+  overlay: Pick<OverlayState, 'secret' | 'sudo' | 'vaultSaveLogin' | 'vaultUnlock'>,
   rpc: GatewayRpc,
   sys: (text: string) => void
 ) {
@@ -172,6 +172,15 @@ export function dismissSensitivePrompt(
     sys(`${overlay.vaultUnlock.displayName} stays locked`)
 
     return rpc<SecretRespondResponse>('vault.unlock.respond', { password: '', request_id: requestId })
+  }
+
+  if (overlay.vaultSaveLogin) {
+    const requestId = overlay.vaultSaveLogin.requestId
+
+    patchOverlayState({ vaultSaveLogin: null })
+    sys('login was not saved')
+
+    return rpc<SecretRespondResponse>('vault.save_login.respond', { login: '', request_id: requestId })
   }
 }
 
@@ -233,7 +242,7 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
         .then(r => r && (patchOverlayState({ approval: null }), patchTurnState({ outcome: 'denied' })))
     }
 
-    if (overlay.sudo || overlay.secret || overlay.vaultUnlock) {
+    if (overlay.sudo || overlay.secret || overlay.vaultSaveLogin || overlay.vaultUnlock) {
       return dismissSensitivePrompt(overlay, gateway.rpc, actions.sys)
     }
 
@@ -490,7 +499,10 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
         return
       }
 
-      if (isCtrl(key, ch, 'c') || (key.escape && (overlay.secret || overlay.sudo || overlay.vaultUnlock))) {
+      if (
+        isCtrl(key, ch, 'c') ||
+        (key.escape && (overlay.secret || overlay.sudo || overlay.vaultSaveLogin || overlay.vaultUnlock))
+      ) {
         cancelOverlayFromCtrlC()
       } else if (key.escape && overlay.sessions) {
         patchOverlayState({ sessions: false })

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -1090,6 +1090,26 @@ export function useMainApp(gw: GatewayClient) {
     [overlay.vaultUnlock, respondWith]
   )
 
+  const answerVaultSaveLogin = useCallback(
+    (login: { identifier: string; password: string }) => {
+      if (!overlay.vaultSaveLogin) {
+        return
+      }
+
+      const requestId = overlay.vaultSaveLogin.requestId
+
+      return respondWith(
+        'vault.save_login.respond',
+        { login: JSON.stringify(login), request_id: requestId },
+        () => {
+          patchOverlayState({ vaultSaveLogin: null })
+          patchUiState({ status: 'running…' })
+        }
+      )
+    },
+    [overlay.vaultSaveLogin, respondWith]
+  )
+
   const onModelSelect = useCallback((value: string) => {
     patchOverlayState({ modelPicker: false })
     slashRef.current(`/model ${value}`)
@@ -1200,6 +1220,7 @@ export function useMainApp(gw: GatewayClient) {
       answerClarifyQuestion,
       answerSecret,
       answerSudo,
+      answerVaultSaveLogin,
       answerVaultUnlock,
       clearSelection,
       newLiveSession: () => session.newLiveSession(),
@@ -1224,6 +1245,7 @@ export function useMainApp(gw: GatewayClient) {
       answerClarifyQuestion,
       answerSecret,
       answerSudo,
+      answerVaultSaveLogin,
       answerVaultUnlock,
       clearSelection,
       closeLiveSession,

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -577,6 +577,7 @@ export const AppLayout = memo(function AppLayout({
                 onClarifyQuestionAnswer={actions.answerClarifyQuestion}
                 onSecretSubmit={actions.answerSecret}
                 onSudoSubmit={actions.answerSudo}
+                onVaultSaveLoginSubmit={actions.answerVaultSaveLogin}
                 onVaultUnlockSubmit={actions.answerVaultUnlock}
               />
             </PerfPane>

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -19,6 +19,7 @@ import { PluginsHub } from './pluginsHub.js'
 import { ApprovalPrompt, ClarifyPrompt, ConfirmPrompt } from './prompts.js'
 import { SkillsHub } from './skillsHub.js'
 import { SubscriptionOverlay } from './subscriptionOverlay.js'
+import { VaultSaveLoginPrompt } from './vaultSaveLoginPrompt.js'
 import { WidgetGrid, type WidgetGridWidget } from './widgetGrid.js'
 
 const COMPLETION_WINDOW = 16
@@ -62,6 +63,7 @@ export function PromptZone({
   onClarifyQuestionAnswer,
   onSecretSubmit,
   onSudoSubmit,
+  onVaultSaveLoginSubmit,
   onVaultUnlockSubmit
 }: Pick<
   AppOverlaysProps,
@@ -71,6 +73,7 @@ export function PromptZone({
   | 'onClarifyQuestionAnswer'
   | 'onSecretSubmit'
   | 'onSudoSubmit'
+  | 'onVaultSaveLoginSubmit'
   | 'onVaultUnlockSubmit'
 >) {
   const overlay = useStore($overlayState)
@@ -165,6 +168,20 @@ export function PromptZone({
           label={overlay.secret.prompt}
           onSubmit={onSecretSubmit}
           sub={`for ${overlay.secret.envVar}`}
+          t={theme}
+        />
+      </PromptCell>
+    )
+  }
+
+  if (overlay.vaultSaveLogin) {
+    return (
+      <PromptCell cols={cols} id="vault-save-login">
+        <VaultSaveLoginPrompt
+          cols={cols}
+          onSubmit={onVaultSaveLoginSubmit}
+          origin={overlay.vaultSaveLogin.origin}
+          site={overlay.vaultSaveLogin.site}
           t={theme}
         />
       </PromptCell>

--- a/ui-tui/src/components/vaultSaveLoginPrompt.tsx
+++ b/ui-tui/src/components/vaultSaveLoginPrompt.tsx
@@ -1,0 +1,72 @@
+import { Box, Text, useInput } from '@hermes/ink'
+import { useState } from 'react'
+
+import type { Theme } from '../theme.js'
+
+import { TextInput } from './textInput.js'
+
+interface VaultSaveLoginPromptProps {
+  cols?: number
+  onSubmit: (login: { identifier: string; password: string }) => void
+  origin: string
+  site: string
+  t: Theme
+}
+
+/**
+ * Collect a new login entirely inside the prompt surface. Values live only in
+ * this mounted component and are handed directly to vault.save_login.respond;
+ * neither field is copied into the composer or transcript.
+ */
+export function VaultSaveLoginPrompt({ cols = 80, onSubmit, origin, site, t }: VaultSaveLoginPromptProps) {
+  const [field, setField] = useState<'identifier' | 'password'>('identifier')
+  const [identifier, setIdentifier] = useState('')
+  const [password, setPassword] = useState('')
+
+  useInput((_ch, key) => {
+    if (key.tab || key.upArrow || key.downArrow) {
+      setField(current => (current === 'identifier' ? 'password' : 'identifier'))
+    }
+  })
+
+  const submit = () => {
+    if (identifier && password) {
+      onSubmit({ identifier, password })
+    }
+  }
+
+  const inputColumns = Math.max(20, cols - 24)
+
+  return (
+    <Box flexDirection="column">
+      <Text bold color={t.color.warn}>
+        🔐 Save login for {site || origin}
+      </Text>
+      <Text color={t.color.muted}> bound to {origin}</Text>
+      <Box>
+        <Text color={t.color.label}> Email or username </Text>
+        <TextInput
+          color={t.color.text}
+          columns={inputColumns}
+          focus={field === 'identifier'}
+          onChange={setIdentifier}
+          onSubmit={() => setField('password')}
+          value={identifier}
+        />
+      </Box>
+      <Box>
+        <Text color={t.color.label}> Password          </Text>
+        <TextInput
+          color={t.color.text}
+          columns={inputColumns}
+          focus={field === 'password'}
+          mask="*"
+          onChange={setPassword}
+          onSubmit={submit}
+          value={password}
+        />
+      </Box>
+      <Text color={t.color.muted}> Tab/↑↓ switch · Enter saves and signs in · Esc does not save</Text>
+    </Box>
+  )
+}

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -770,12 +770,17 @@ export type GatewayEvent =
   | {
       payload: { request_id: string }
       session_id?: string
-      type: 'secret.expire' | 'sudo.expire' | 'vault.unlock.expire'
+      type: 'secret.expire' | 'sudo.expire' | 'vault.save_login.expire' | 'vault.unlock.expire'
     }
   | {
       payload: { backend: string; display_name: string; request_id: string }
       session_id?: string
       type: 'vault.unlock.request'
+    }
+  | {
+      payload: { origin: string; request_id: string; site: string }
+      session_id?: string
+      type: 'vault.save_login.request'
     }
   | { payload: { task_id: string; text: string }; session_id?: string; type: 'background.complete' }
   | { payload: { question?: string; task_id: string; text: string }; session_id?: string; type: 'btw.complete' }

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -250,6 +250,13 @@ export interface VaultUnlockReq {
   requestId: string
 }
 
+/** New login for the current page — identifier visible, password masked. */
+export interface VaultSaveLoginReq {
+  origin: string
+  requestId: string
+  site: string
+}
+
 export interface PanelData {
   sections: PanelSection[]
   title: string


### PR DESCRIPTION
## Summary

Render `vault.save_login.request` in the Ink TUI used by both `hermes --tui` and the dashboard chat. The prompt shows the requesting site and bound origin, keeps the identifier in the prompt surface, masks the password, blocks the composer, and responds directly to the gateway without adding either value to the transcript or model context.

The renderer now also handles matching `vault.save_login.expire` events and declines immediately on Esc/Ctrl+C, so abandoned requests do not wait for the backend's 180-second timeout.

## Root cause

`tui_gateway/agent_callbacks.py` already emitted `vault.save_login.request` and accepted `vault.save_login.respond`, but `ui-tui/src/app/createGatewayEventHandler.ts` had handlers only for the password-manager unlock prompt. The request therefore never entered overlay state and no Ink component could answer it.

## Changes

- Add typed request/expire events and a flow-scoped, composer-blocking overlay state.
- Add an origin-bound two-field prompt with a plain identifier and masked password.
- Serialize the login object into the JSON string expected by `save_login_cb` before sending `vault.save_login.respond`.
- Clear sensitive component/overlay state on successful response, cancellation, timeout, and ordinary flow reset.
- Cover matching request expiration and cancellation RPC behavior with regression tests.

## Why this PR vs existing PR #109113

PR #109113 sends `login` as a JavaScript object. The gateway stores that value unchanged in `_answers`, while `save_login_cb` calls `json.loads(raw)` and catches only `ValueError`; receiving an object raises `TypeError`, so the save-login flow still fails after the prompt is submitted. This PR sends `JSON.stringify({identifier, password})`, matching the existing Desktop wire contract and the Python callback's parser. It also renders the exact bound `origin`, rather than only the display site, so the user can verify where the credential will be stored.

## Related Issue

Closes #109101

## Validation

- `npm test -- src/__tests__/createGatewayEventHandler.test.ts src/__tests__/useInputHandlers.test.ts`: 132 passed.
- `npm run typecheck`: passed.
- `npm run lint`: passed with 0 errors and 2 pre-existing hook warnings.
- Full `npm test`: 1,738 passed, 8 skipped, 21 failed across pre-existing Windows/platform and Ink mock suites; neither modified regression-test file failed.
