### PR TITLE
mirror_to_session no longer reports success when the transcript write fails (#10130)

### DIFF
--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -115,14 +115,15 @@ def _find_session_id(platform: str, chat_id: str, thread_id: Optional[str] = Non
 
 
 def _append_to_sqlite(session_id: str, message: dict) -> None:
-    """Append a message to the SQLite session database."""
-    try:
-        from hermes_state_registry import acquire, release_or_close
+    """Append a message to the SQLite session database.
 
-        db = acquire()
-        try:
-            db.append_message(session_id=session_id, role=message.get("role", "assistant"), content=message.get("content"))
-        finally:
-            release_or_close(db)
-    except Exception as e:
-        logger.debug("Mirror SQLite write failed: %s", e)
+    Raises on failure: ``mirror_to_session`` reports ``False`` (and warns) only when the
+    exception reaches it — swallowing it here made every failed write look mirrored (#10130).
+    """
+    from hermes_state_registry import acquire, release_or_close
+
+    db = acquire()
+    try:
+        db.append_message(session_id=session_id, role=message.get("role", "assistant"), content=message.get("content"))
+    finally:
+        release_or_close(db)

--- a/tests/gateway/test_mirror.py
+++ b/tests/gateway/test_mirror.py
@@ -15,7 +15,7 @@ def _setup_sessions(tmp_path, sessions_data):
     sessions_dir = tmp_path / "sessions"
     sessions_dir.mkdir(parents=True, exist_ok=True)
     index_file = sessions_dir / "sessions.json"
-    index_file.write_text(json.dumps(sessions_data))
+    index_file.write_text(json.dumps(sessions_data), encoding="utf-8")
     return sessions_dir, index_file
 
 

--- a/tests/gateway/test_mirror.py
+++ b/tests/gateway/test_mirror.py
@@ -118,6 +118,29 @@ class TestMirrorToSession:
         assert result is False
 
 
+    def test_failed_sqlite_write_reports_false(self, tmp_path):
+        """A mirror whose transcript write raises must not report success (#10130)."""
+        sessions_dir, index_file = _setup_sessions(tmp_path, {
+            "dm": {
+                "session_id": "sess_dm",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+                "updated_at": "2026-01-01T00:00:00",
+            },
+        })
+        broken_db = MagicMock()
+        broken_db.find_session_by_origin.return_value = None  # resolve via sessions.json
+        broken_db.append_message.side_effect = OSError("disk full")
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file), \
+             patch("hermes_state_registry.acquire", return_value=broken_db), \
+             patch("hermes_state_registry.release_or_close"):
+            result = mirror_to_session("telegram", "123", "Hello!")
+
+        assert result is False
+        broken_db.append_message.assert_called_once()
+
+
 class TestAppendToSqlite:
     def test_connection_is_released_after_use(self, tmp_path):
         """Verify _append_to_sqlite returns the shared SessionDB reference."""


### PR DESCRIPTION
**A failed session-mirror write now returns `False` and logs a warning instead of `True`.**

- `gateway/mirror.py::_append_to_sqlite` swallowed its own exceptions at DEBUG level, so `mirror_to_session()` never saw a failure and returned `True` after a no-op write.
- The helper now lets the exception propagate; the existing handler in `mirror_to_session` warns and returns `False`.

| | before | after |
|---|---|---|
| `db.append_message` raises | `True`, debug log | `False`, WARNING |
| happy path | `True` | `True` |

**Root cause:** the inner try/except made the outer one unreachable.

**Live repro:** reporter's script (patched `acquire()` returning a DB whose `append_message` raises `OSError`) printed `True` on `origin/main`, `False` on this branch. Invariant test `test_failed_sqlite_write_reports_false` red on main, green here.

Fixes #10130 (reported by @NewTurn2017).

## Infographic
![mirror-write-failure](https://v3b.fal.media/files/b/0aaa221e/hFSCgb2-z4PEDJ_PbCYE1_bAWA9Vt8.png)
