### PR TITLE
fix(buzz): probe relay liveness before WS reconnect + reconcile fleet_restart_pending against live fleet evidence

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1227,7 +1227,9 @@ def _apply_pulled_update(
 
     # Gateways still serve pre-pull modules until the restart phase; an interrupt before a
     # completed restart leaves this marker so the next update catches up even when git is
-    # current. Distinct from ``.update-incomplete`` (venv/install repair).
+    # current. Distinct from ``.update-incomplete`` (venv/install repair). Written even when
+    # post_pull_sha is None (interrupt-recovery net) — the writer logs loudly so an
+    # unverifiable (expected_sha="") obligation is visible and ages out via the ceiling.
     # See #95294.
     _write_fleet_restart_pending_marker(expected_sha=post_pull_sha or "")
     # Stale .pyc would ImportError on gateway restart when new source references new names.

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -25,6 +25,14 @@ logger = logging.getLogger("hermes_cli.update_cmd")
 # The existing ``.update-incomplete`` / ``.lazy-refresh-incomplete`` markers gate dependency/venv repair;
 # this one is the fleet-restart obligation after a git pull that advanced HEAD (#95294).
 _FLEET_RESTART_PENDING_NAME = "fleet_restart_pending"
+# Lease-with-verification bounds (see _reconcile_fleet_restart_pending): an external restart
+# (launchd KeepAlive, desktop respawn, reboot) can discharge the obligation before any
+# ``hermes update`` runs; only positive evidence clears, ambiguity keeps warning (#XRE marker-fix).
+_FLEET_RESTART_PENDING_IDLE_GRACE_SECONDS = 600.0      # trust "no live gateways" only after this
+# Age ceiling applies ONLY to unverifiable evidence: expected_sha="" legacy markers and
+# unknown/unresolvable probe verdicts. Provably stale rows (code_sha present && != expected)
+# NEVER age out — the cure for those is a gateway restart, not time. See _fleet_restart_verdict.
+_FLEET_RESTART_PENDING_MAX_AGE_SECONDS = 7 * 86400.0   # backstop for unverifiable markers
 
 _FRESH_RESTART_SUPERVISORS = frozenset({"systemd", "launchd", "service", "s6"})
 
@@ -46,7 +54,17 @@ def _fleet_restart_pending_marker_path() -> Path:
 
 
 def _write_fleet_restart_pending_marker(*, expected_sha: str = "") -> None:
-    """Drop the pull→restart obligation breadcrumb. Never raises."""
+    """Drop the pull→restart obligation breadcrumb. Never raises.
+
+    Written even when *expected_sha* is empty (sha resolution can be flaky exactly on the
+    interrupted runs this marker exists for) — but with a LOUD log, so an unverifiable
+    obligation is visible: it can only be discharged by the age ceiling. See update_cmd.py's
+    write site. Marker format (additive-only; readers tolerate missing fields):
+      started=<unix ts>      write time
+      pid=<int>              updater pid — WRITE-LOCK while alive (see _marker_writer_alive)
+      writer_start=<epoch>   writer's process creation time (pid+start pairing, recycle-safe)
+      expected_sha=<40hex>   the obligation in force; empty = unverifiable (age-ceiling only)
+    """
     from hermes_cli.update_cmd import _m
     path = _fleet_restart_pending_marker_path()
     if _m()._pytest_owns_live_checkout(path.parent):
@@ -54,11 +72,27 @@ def _write_fleet_restart_pending_marker(*, expected_sha: str = "") -> None:
         return
     try:
         lines = [f"started={_time.time()}", f"pid={os.getpid()}"]
+        with suppress(Exception):
+            from gateway.status import get_process_start_time
+            writer_start = get_process_start_time(os.getpid())
+            if writer_start is not None:
+                lines.append(f"writer_start={writer_start}")
         if expected_sha:
             lines.append(f"expected_sha={expected_sha}")
-        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        else:
+            logger.warning(
+                "fleet_restart_pending written WITHOUT expected_sha: unverifiable obligation, "
+                "dischargeable only by the %d-day age ceiling", _FLEET_RESTART_PENDING_MAX_AGE_SECONDS // 86400,
+            )
+        # Atomic replace: a kill mid-write must never leave a truncated marker that parses
+        # as {} and silently degrades to the age-ceiling path.
+        tmp = path.with_name(path.name + ".tmp")
+        tmp.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        os.replace(tmp, path)
     except OSError as exc:
         logger.debug("Could not write fleet-restart-pending marker: %s", exc)
+        with suppress(OSError):
+            path.with_name(path.name + ".tmp").unlink()
 
 
 def _clear_fleet_restart_pending_marker() -> None:
@@ -172,6 +206,9 @@ def _live_fleet_covers_receipt(expected_sha: str | None) -> bool:
         if not owed:
             return False
         fleet = collect_fleet_versions()
+        # None = sweep incomplete: evidence unavailable, cannot cover the receipt (fail-closed).
+        if fleet is None:
+            return False
         if not fleet or any(
             row.get("state") != "current" or row.get("code_sha") != expected_sha
             for row in fleet
@@ -183,15 +220,147 @@ def _live_fleet_covers_receipt(expected_sha: str | None) -> bool:
         return False
 
 
+def _read_fleet_restart_pending_marker() -> dict[str, str]:
+    """Parse the marker's key=value lines; {} when absent/unreadable. Never raises."""
+    try:
+        text = _fleet_restart_pending_marker_path().read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    fields: dict[str, str] = {}
+    for line in text.splitlines():
+        key, _, value = line.partition("=")
+        if key and value:
+            fields[key.strip()] = value.strip()
+    return fields
+
+
+def _marker_writer_alive(fields: dict[str, str]) -> bool:
+    """True while the updater PID that wrote the marker exists (an update may be in flight).
+
+    Liveness is a WRITE-LOCK, never an expiry rule: a dead writer means the update that owed
+    the restart was interrupted — the pending condition is real until live evidence discharges it.
+    Identity is pid + writer_start pairing (gateway.status.get_process_start_time precedent):
+    a recycled PID whose creation time differs from the recorded one is NOT the writer.
+    """
+    try:
+        pid = int(fields.get("pid", ""))
+    except ValueError:
+        return False
+    if pid <= 0:
+        return False
+    if pid == os.getpid():
+        return True  # our own process wrote it — treat as in-flight
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists, owned by another user
+    except OSError:
+        return False
+    recorded_start = fields.get("writer_start", "")
+    if not recorded_start:
+        return True  # legacy marker without the pairing field: pid-only check (additive format)
+    try:
+        from gateway.status import get_process_start_time
+        live_start = get_process_start_time(pid)
+    except Exception:
+        return True  # start time unreadable: keep the conservative write-lock
+    if live_start is None:
+        return True
+    try:
+        return abs(float(live_start) - float(recorded_start)) < 1.0
+    except ValueError:
+        return True  # malformed field: conservative write-lock
+
+
+def _marker_age_seconds(fields: dict[str, str]) -> float:
+    try:
+        return max(0.0, _time.time() - float(fields.get("started", "")))
+    except ValueError:
+        return 0.0
+
+
+def _fleet_restart_verdict(expected_sha: str) -> str:
+    """Live-fleet verdict vs the marker's own obligation: 'match' | 'stale' | 'idle' | 'unknown'.
+
+    Compares against the MARKER's expected_sha (not checkout HEAD): a later pull rewrites the
+    marker, so marker.expected_sha is always the obligation currently in force.
+
+    'stale' is reserved for PROVABLY stale rows: code_sha PRESENT and != expected_sha.
+    Rows with state "unknown" or a missing/unresolvable code_sha are UNVERIFIABLE evidence
+    (gateway predates the identity stamp, or its state file could not be parsed) — they yield
+    verdict "unknown", which routes to the age ceiling instead of pinning the marker forever.
+    A None probe result (incomplete sweep) is also "unknown": never fail open on partial data.
+    """
+    if not expected_sha:
+        return "unknown"
+    try:
+        from hermes_cli.update_receipt import collect_fleet_versions
+        rows = collect_fleet_versions()
+    except Exception:
+        return "unknown"
+    if rows is None:
+        return "unknown"  # sweep incomplete — evidence unavailable (fail-closed, A1)
+    # Malformed/non-dict rows are unverifiable evidence: drop them, and if nothing
+    # trustworthy remains, fail closed (never crash the reconcile path — R4).
+    rows = [row for row in rows if isinstance(row, dict)]
+    live = [row for row in rows if row.get("state") != "down"]
+    if not live:
+        return "idle"
+    stale = any(
+        isinstance(row.get("code_sha"), str) and row.get("code_sha") and row["code_sha"] != expected_sha
+        for row in live
+    )
+    if stale:
+        return "stale"
+    return "match" if all(row.get("code_sha") == expected_sha for row in live) else "unknown"
+
+
+def _reconcile_fleet_restart_pending() -> bool:
+    """Verify-then-clear an obligation an external restart may already have discharged.
+
+    Fail-closed: only positive evidence clears (every live gateway stamps the marker's
+    expected_sha, or no gateways are live past the grace window, or an unverifiable marker
+    hits the age ceiling). Ambiguity keeps the marker and the warning.
+
+    CONTRACT: this function MAY CLEAR the marker as a side effect. It is called from
+    ``_pending_fleet_restart_needed`` (a predicate in name only), which is invoked from the
+    CLI-startup warning and the update catch-up gate — both WANT the reconciliation. Any
+    future caller that needs a pure query must not use this path.
+    """
+    fields = _read_fleet_restart_pending_marker()
+    if _marker_writer_alive(fields):
+        return True  # update in flight — don't race it
+    expected = fields.get("expected_sha", "")
+    verdict = _fleet_restart_verdict(expected)
+    if verdict == "match":
+        _clear_fleet_restart_pending_marker()
+        # Warning-level: auto-discharge must be visible in errors.log (audit trail, wizred R3).
+        logger.warning("fleet_restart_pending CLEARED: all live gateways stamp the marker's expected_sha")
+        return False
+    if verdict == "idle" and _marker_age_seconds(fields) > _FLEET_RESTART_PENDING_IDLE_GRACE_SECONDS:
+        _clear_fleet_restart_pending_marker()
+        logger.warning("fleet_restart_pending CLEARED: no live gateways to restart (past grace window)")
+        return False
+    if verdict == "unknown" and _marker_age_seconds(fields) > _FLEET_RESTART_PENDING_MAX_AGE_SECONDS:
+        _clear_fleet_restart_pending_marker()
+        logger.warning("fleet_restart_pending CLEARED: unverifiable marker hit the %d-day age ceiling",
+                       _FLEET_RESTART_PENDING_MAX_AGE_SECONDS // 86400)
+        return False
+    return True  # stale / ambiguous / within grace — keep warning
+
+
 def _pending_fleet_restart_needed() -> bool:
     """Reconcile old restart obligations against current, identity-matched gateways."""
     from hermes_cli.update_cmd import _current_checkout_sha
 
-    # The marker has no runtime inventory and may belong to a newer, killed update
-    # than latest.json. An older receipt cannot discharge that unknown obligation.
+    # The marker's payload (started/pid/expected_sha) is reconciled against LIVE fleet state
+    # before it may warn: an external restart that already brought every gateway onto the
+    # marker's expected_sha discharges the obligation (lease-with-verification, fail-closed).
     with suppress(OSError):
         if _fleet_restart_pending_marker_path().is_file():
-            return True
+            return _reconcile_fleet_restart_pending()
     if not _receipt_reports_stale_runtime():
         return False
     return not _live_fleet_covers_receipt(_current_checkout_sha())

--- a/hermes_cli/update_receipt.py
+++ b/hermes_cli/update_receipt.py
@@ -278,12 +278,16 @@ def _fleet_row(
 _NOT_EXPECTED_STATES = {"stopped", "startup_failed"}
 
 
-def collect_fleet_versions(*, pre_restart_pids: Optional[list[int]] = None) -> list[dict[str, Any]]:
+def collect_fleet_versions(*, pre_restart_pids: Optional[list[int]] = None) -> Optional[list[dict[str, Any]]]:
     """Snapshot every profile's gateway code identity vs. the current tree.
 
     Rollout safety: ``down`` requires membership in ``pre_restart_pids`` — a stale state file from a
     long-dead gateway (machine reboot, manual kill weeks ago) must NOT fail every future update.
     Without a pre-restart snapshot (``None``/empty) dead PIDs are skipped (historical behavior).
+
+    Returns ``None`` when the sweep is INCOMPLETE (a profile probe raised, or setup failed):
+    callers must treat ``None`` as "evidence unavailable", never as "no gateways found".
+    A clean sweep returns ``[]`` (completed, nothing found) or the row list.
 
     ``stale``   — gateway stamped a code_sha that differs from the updated checkout's HEAD (it is still
     serving pre-update modules). ``unknown`` — gateway predates the code-identity stamp (started before this
@@ -296,41 +300,56 @@ def collect_fleet_versions(*, pre_restart_pids: Optional[list[int]] = None) -> l
     _pre_restart = {int(p) for p in (pre_restart_pids or []) if isinstance(p, int)}
     results: list[dict[str, Any]] = []
     expected_sha = _code_identity(refresh=True).get("sha")
+    aborted = False
     try:
         from gateway.status import read_runtime_status, runtime_status_pid_is_live
 
         for profile, home in _profile_homes():
-            sock = _socket_identity(home)
-            if sock is not None:
-                pid, identity = sock
-                row = _fleet_row(profile, pid, identity.get("code_sha"), identity.get("code_version"), expected_sha)
-                results.append({**row, "source": "socket"})
-                continue
-            record = read_runtime_status(home / "gateway_state.json")
-            if not record:
-                continue
+            # Per-profile isolation: one broken profile must not abort the sweep into a
+            # silent partial result that callers could mistake for a complete snapshot.
             try:
-                pid = int(record.get("pid"))
-            except (TypeError, ValueError):
-                continue
-            if runtime_status_pid_is_live(record):
-                results.append(
-                    _fleet_row(profile, pid, record.get("code_sha"), record.get("code_version"), expected_sha)
-                )
-                continue
-            # Dead PID (or a live PID recycled by an unrelated process during the update's own
-            # churn): a DOWN row only when this exact pid was alive at update start AND the record
-            # still claims a running state — "the restart phase stopped it and nothing came back."
-            # Everything else (clean stop, startup failure, long-dead stale record) keeps the no-row
-            # behavior so the rollout can't false-positive. ``_pre_restart`` is a bare PID set, not
-            # (pid, start_time) pairs, so a recycled PID from gateway A landing in B's stale record
-            # could still mislabel B as down — inherent to the snapshot's data model.
-            # See #93258.
-            gw_state = record.get("gateway_state")
-            if pid in _pre_restart and isinstance(gw_state, str) and gw_state and gw_state not in _NOT_EXPECTED_STATES:
-                results.append(_fleet_row(profile, pid, None, record.get("code_version"), None, state="down"))
+                sock = _socket_identity(home)
+                if sock is not None:
+                    pid, identity = sock
+                    row = _fleet_row(profile, pid, identity.get("code_sha"), identity.get("code_version"), expected_sha)
+                    results.append({**row, "source": "socket"})
+                    continue
+                record = read_runtime_status(home / "gateway_state.json")
+                if not record:
+                    continue
+                try:
+                    pid = int(record.get("pid"))
+                except (TypeError, ValueError):
+                    continue
+                if runtime_status_pid_is_live(record):
+                    results.append(
+                        _fleet_row(profile, pid, record.get("code_sha"), record.get("code_version"), expected_sha)
+                    )
+                    continue
+                # Dead PID (or a live PID recycled by an unrelated process during the update's own
+                # churn): a DOWN row only when this exact pid was alive at update start AND the record
+                # still claims a running state — "the restart phase stopped it and nothing came back."
+                # Everything else (clean stop, startup failure, long-dead stale record) keeps the no-row
+                # behavior so the rollout can't false-positive. ``_pre_restart`` is a bare PID set, not
+                # (pid, start_time) pairs, so a recycled PID from gateway A landing in B's stale record
+                # could still mislabel B as down — inherent to the snapshot's data model.
+                # See #93258.
+                gw_state = record.get("gateway_state")
+                if pid in _pre_restart and isinstance(gw_state, str) and gw_state and gw_state not in _NOT_EXPECTED_STATES:
+                    results.append(_fleet_row(profile, pid, None, record.get("code_version"), None, state="down"))
+            except Exception as exc:
+                # A failed profile read means the sweep is INCOMPLETE. Return None (not the
+                # partial rows) so fail-closed callers never treat a broken probe as a clean
+                # empty/full snapshot. See the lease-with-verification contract in
+                # hermes_cli/update_cmd_fleet.py.
+                aborted = True
+                logger.debug("Fleet version probe failed for profile %s: %s", profile, exc)
     except Exception as exc:
+        # Setup-level failure (imports, enumeration): the sweep never ran.
+        aborted = True
         logger.debug("Fleet version probe failed: %s", exc)
+    if aborted:
+        return None
     return results
 
 

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -271,6 +271,11 @@ _WS_AUTH_TIMEOUT = 20.0
 # close the transport never surfaces (observed as a CLOSE_WAIT socket with the loop parked on recv, #98097)
 # leaves the gateway "connected" while inbound stops; this timeout forces the normal reconnect path instead.
 _WS_READ_IDLE_TIMEOUT = 300.0
+# Idle reads on a healthy-but-quiet relay are normal (no chat traffic ⇒ no app frames), so before the read
+# watchdog declares the connection silent it probes liveness with an explicit control ping and waits for the
+# pong (herc flap, 2026-09-10: relay answers pings fine — killing healthy connections every 300s opened a
+# message-loss window every cycle). The probe must stay well inside the transport's ping_timeout (20s).
+_WS_IDLE_PROBE_TIMEOUT = 10.0
 _WS_MAX_MESSAGE_BYTES = 2_000_000
 _WS_MEMBERSHIP_KIND = 44100  # Buzz channel-membership event — live DM discovery
 _WS_MEMBERSHIP_SUB_ID = "hermes-buzz-membership"
@@ -1263,7 +1268,7 @@ class BuzzAdapter(BasePlatformAdapter):
                 backoff = min(backoff * 2, 30.0)
 
     async def _ws_read_loop(self, websocket, subscriptions: Dict[str, Optional[str]]) -> None:
-        """Read frames until the relay closes; an idle read raises ConnectionError to reconnect."""
+        """Read frames until the relay closes; a read that stays idle past the liveness probe reconnects."""
         frame_iter = websocket.__aiter__()
         while True:
             try:
@@ -1271,7 +1276,18 @@ class BuzzAdapter(BasePlatformAdapter):
             except StopAsyncIteration:
                 return
             except asyncio.TimeoutError:
-                raise ConnectionError(f"no WebSocket frame for {_WS_READ_IDLE_TIMEOUT:.0f}s; assuming the connection went silent") from None
+                # 300s without an app frame is normal for a quiet relay; distinguish "quiet" from
+                # "dead" before reconnecting — a failed probe (or a closed transport raising here)
+                # still takes the reconnect path, so the #98097 CLOSE_WAIT cover holds.
+                try:
+                    pong = await websocket.ping()
+                    await asyncio.wait_for(pong, timeout=_WS_IDLE_PROBE_TIMEOUT)
+                    continue
+                except Exception:
+                    raise ConnectionError(
+                        f"no WebSocket frame for {_WS_READ_IDLE_TIMEOUT:.0f}s and idle liveness ping "
+                        f"got no pong within {_WS_IDLE_PROBE_TIMEOUT:.0f}s; assuming the connection went silent"
+                    ) from None
             try:
                 message = json.loads(raw)
             except (ValueError, TypeError):

--- a/tests/gateway/test_buzz_websocket.py
+++ b/tests/gateway/test_buzz_websocket.py
@@ -116,9 +116,10 @@ class _ScriptedWebSocket(_FakeWebSocket):
     a clean close.
     """
 
-    def __init__(self, anext_behavior):
+    def __init__(self, anext_behavior, pong_ok=False):
         super().__init__()
         self._anext_behavior = anext_behavior
+        self.pong_ok = pong_ok
         self.exited = False
 
     async def __aenter__(self):
@@ -133,6 +134,19 @@ class _ScriptedWebSocket(_FakeWebSocket):
     async def __anext__(self):
         return await self._anext_behavior()
 
+    async def ping(self, data=None):
+        """NIP-42 relays answer RFC 6455 control pings via the transport; script both outcomes.
+
+        Mirrors the real Connection.ping() contract: returns promptly with an
+        awaitable; the awaitable resolves with the latency on pong, or never
+        when the relay is dead.
+        """
+        if self.pong_ok:
+            fut = asyncio.get_running_loop().create_future()
+            fut.set_result(0.0)
+            return fut
+        return asyncio.get_running_loop().create_future()  # never resolves: the pong never comes
+
 
 @pytest.mark.asyncio
 async def test_websocket_loop_reconnects_when_read_goes_silent(monkeypatch, caplog):
@@ -146,6 +160,7 @@ async def test_websocket_loop_reconnects_when_read_goes_silent(monkeypatch, capl
 
     adapter = _make_adapter()
     monkeypatch.setattr(_buzz_mod, "_WS_READ_IDLE_TIMEOUT", 0.05)
+    monkeypatch.setattr(_buzz_mod, "_WS_IDLE_PROBE_TIMEOUT", 0.05)  # dead relay: probe must fail fast too
     caplog.set_level(logging.WARNING)
 
     sockets = []
@@ -177,6 +192,100 @@ async def test_websocket_loop_reconnects_when_read_goes_silent(monkeypatch, capl
     assert len(sockets) >= 2, "idle read watchdog did not force a reconnect"
     assert sockets[0].exited, "the silent connection was not closed before reconnecting"
     assert any("went silent" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_websocket_loop_reconnects_when_idle_ping_gets_no_pong(monkeypatch, caplog):
+    """Idle read + failed liveness probe must reconnect (the repaired #98097 cover).
+
+    A truly dead relay yields no app frames AND no pong, so the watchdog must
+    still take the reconnect path after probing — the probe narrows the
+    #98097 cover, it does not remove it.
+    """
+    import logging
+
+    adapter = _make_adapter()
+    monkeypatch.setattr(_buzz_mod, "_WS_READ_IDLE_TIMEOUT", 0.05)
+    monkeypatch.setattr(_buzz_mod, "_WS_IDLE_PROBE_TIMEOUT", 0.05)
+    caplog.set_level(logging.WARNING)
+
+    sockets = []
+
+    async def dead_anext():
+        await asyncio.Event().wait()  # never yields, never raises
+
+    def fake_connect(*args, **kwargs):
+        ws = _ScriptedWebSocket(dead_anext, pong_ok=False)
+        sockets.append(ws)
+        return ws
+
+    import websockets as _ws_mod
+
+    monkeypatch.setattr(_ws_mod, "connect", fake_connect)
+
+    task = asyncio.create_task(adapter._websocket_loop())
+    try:
+        deadline = time.monotonic() + 5.0
+        while len(sockets) < 2 and time.monotonic() < deadline:
+            await asyncio.sleep(0.02)
+    finally:
+        task.cancel()
+        try:
+            await asyncio.wait_for(task, 5.0)
+        except (asyncio.CancelledError, asyncio.TimeoutError):
+            pass
+
+    assert len(sockets) >= 2, "idle watchdog with a dead relay (no pong) did not force a reconnect"
+    assert sockets[0].exited, "the dead connection was not closed before reconnecting"
+    assert any("went silent" in record.message for record in caplog.records)
+    assert any("no pong" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_websocket_loop_survives_idle_when_relay_answers_ping(monkeypatch):
+    """A healthy-but-quiet relay (no app frames, pongs fine) must NOT be reconnected.
+
+    The herc flap (2026-09-10): the relay answered transport pings the whole
+    time, yet the 300s idle guard killed the healthy connection every 5
+    minutes. The liveness probe must distinguish this case and keep reading.
+    """
+    adapter = _make_adapter()
+    monkeypatch.setattr(_buzz_mod, "_WS_READ_IDLE_TIMEOUT", 0.05)
+
+    sockets = []
+    probes = []
+
+    async def quiet_anext():
+        await asyncio.Event().wait()  # relay is healthy but sends nothing
+
+    def fake_connect(*args, **kwargs):
+        ws = _ScriptedWebSocket(quiet_anext, pong_ok=True)
+        sockets.append(ws)
+        return ws
+
+    import websockets as _ws_mod
+
+    orig_ping = _ScriptedWebSocket.ping
+
+    async def counting_ping(self, data=None):
+        probes.append(time.monotonic())
+        return await orig_ping(self, data)
+
+    monkeypatch.setattr(_ScriptedWebSocket, "ping", counting_ping)
+    monkeypatch.setattr(_ws_mod, "connect", fake_connect)
+
+    task = asyncio.create_task(adapter._websocket_loop())
+    try:
+        await asyncio.sleep(0.4)  # several idle cycles' worth of time
+    finally:
+        task.cancel()
+        try:
+            await asyncio.wait_for(task, 5.0)
+        except (asyncio.CancelledError, asyncio.TimeoutError):
+            pass
+
+    assert len(sockets) == 1, "healthy-but-quiet relay was reconnected"
+    assert len(probes) >= 2, "liveness probe was not repeated on successive idle reads"
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -17,6 +17,8 @@ No live gateway, no network. Git and restart are mocked.
 from __future__ import annotations
 
 import json
+import os
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -26,6 +28,7 @@ import hermes_cli.main_web_build as main_web_build
 import hermes_cli.main_install_repair as main_install_repair
 from hermes_cli import update_cmd
 import hermes_cli.update_cmd_fleet as update_cmd_fleet
+from hermes_cli import update_receipt
 import hermes_cli.update_cmd_deps as update_cmd_deps
 from hermes_cli.update_receipt import COMMAND_BOUNDARY_STOP_REASON
 from hermes_constants import get_hermes_home
@@ -609,3 +612,322 @@ def test_startup_warn_silent_when_nothing_pending(capsys):
     captured = capsys.readouterr()
     assert captured.err == ""
     assert captured.out == ""
+
+
+# ---------------------------------------------------------------------------
+# Lease-with-verification: a stranded marker must yield to live fleet evidence.
+# Markers are written DIRECTLY (bypassing the writer) so their pid is dead — the
+# "update in flight" state; the writer-alive guard is exercised separately.
+# ---------------------------------------------------------------------------
+
+_DEAD_PID = 999_999_998
+
+
+def _stranded_marker(expected_sha: str, *, age_seconds: float = 0.0) -> None:
+    path = update_cmd._fleet_restart_pending_marker_path()
+    started = time.time() - age_seconds
+    path.write_text(
+        f"started={started}\npid={_DEAD_PID}\nexpected_sha={expected_sha}\n", encoding="utf-8"
+    )
+
+
+def test_marker_with_live_fleet_at_expected_sha_discharges(monkeypatch):
+    _stranded_marker("a" * 40)
+    monkeypatch.setattr(
+        update_receipt, "collect_fleet_versions",
+        lambda: [{"profile": "neo", "pid": 5, "state": "current", "code_sha": "a" * 40}],
+    )
+    try:
+        assert update_cmd_fleet._pending_fleet_restart_needed() is False
+        assert not update_cmd._fleet_restart_pending_marker_path().exists()
+    finally:
+        update_cmd._clear_fleet_restart_pending_marker()
+
+
+def test_dead_pid_marker_with_current_fleet_discharges(monkeypatch):
+    _stranded_marker("b" * 40, age_seconds=26 * 86400)  # the 26-day neo shape
+    monkeypatch.setattr(
+        update_receipt, "collect_fleet_versions",
+        lambda: [
+            {"profile": "herc", "pid": 6, "state": "current", "code_sha": "b" * 40},
+            {"profile": "nvx", "pid": 7, "state": "current", "code_sha": "b" * 40},
+        ],
+    )
+    try:
+        assert update_cmd_fleet._pending_fleet_restart_needed() is False
+    finally:
+        update_cmd._clear_fleet_restart_pending_marker()
+
+
+def test_marker_with_stale_fleet_still_pends(monkeypatch):
+    _stranded_marker("c" * 40)
+    monkeypatch.setattr(
+        update_receipt, "collect_fleet_versions",
+        lambda: [{"profile": "neo", "pid": 8, "state": "stale", "code_sha": "old"}],
+    )
+    try:
+        assert update_cmd_fleet._pending_fleet_restart_needed() is True
+        assert update_cmd._fleet_restart_pending_marker_path().is_file()  # fail-closed: kept
+    finally:
+        update_cmd._clear_fleet_restart_pending_marker()
+
+
+def test_marker_with_unprobeable_fleet_pends(monkeypatch):
+    _stranded_marker("d" * 40)
+    monkeypatch.setattr(update_receipt, "collect_fleet_versions", lambda: [])
+    try:
+        assert update_cmd_fleet._pending_fleet_restart_needed() is True  # no evidence ≠ discharge
+        assert update_cmd._fleet_restart_pending_marker_path().is_file()
+    finally:
+        update_cmd._clear_fleet_restart_pending_marker()
+
+
+def test_marker_writer_alive_keeps_pending():
+    marker = update_cmd._fleet_restart_pending_marker_path()
+    marker.write_text(
+        f"started={time.time()}\npid={os.getpid()}\nexpected_sha={'e' * 40}\n", encoding="utf-8"
+    )
+    try:
+        assert update_cmd_fleet._pending_fleet_restart_needed() is True  # update in flight: don't race
+        assert marker.is_file()
+    finally:
+        update_cmd._clear_fleet_restart_pending_marker()
+
+
+def test_marker_without_expected_sha_discharges_only_via_age_ceiling(monkeypatch):
+    path = update_cmd._fleet_restart_pending_marker_path()
+    path.write_text(f"started={time.time()}\npid={_DEAD_PID}\n", encoding="utf-8")
+    monkeypatch.setattr(update_receipt, "collect_fleet_versions", lambda: [])
+    try:
+        # young unverifiable marker: keep warning
+        assert update_cmd_fleet._pending_fleet_restart_needed() is True
+        assert path.is_file()
+        # past the 30-day ceiling: clear
+        path.write_text(
+            f"started={time.time() - 31 * 86400}\npid={_DEAD_PID}\n", encoding="utf-8"
+        )
+        assert update_cmd_fleet._pending_fleet_restart_needed() is False
+        assert not path.exists()
+    finally:
+        if path.exists():
+            update_cmd._clear_fleet_restart_pending_marker()
+
+
+def test_catchup_is_noop_when_fleet_already_current(monkeypatch):
+    _stranded_marker("f" * 40)
+    monkeypatch.setattr(
+        update_receipt, "collect_fleet_versions",
+        lambda: [{"profile": "neo", "pid": 9, "state": "current", "code_sha": "f" * 40}],
+    )
+    called = {"ran": False}
+
+    def _must_not_run():
+        called["ran"] = True
+        return True
+
+    monkeypatch.setattr(update_cmd, "_run_pending_fleet_restart", _must_not_run)
+    monkeypatch.setattr(update_cmd_fleet, "_run_pending_fleet_restart", _must_not_run)
+    update_cmd_fleet._apply_pending_fleet_restart_catchup()
+    assert called["ran"] is False
+    assert not update_cmd._fleet_restart_pending_marker_path().exists()
+
+
+def test_startup_warn_silent_when_fleet_current_despite_marker(monkeypatch, capsys):
+    _stranded_marker("1" * 40)
+    monkeypatch.setattr(
+        update_receipt, "collect_fleet_versions",
+        lambda: [{"profile": "xbook", "pid": 10, "state": "current", "code_sha": "1" * 40}],
+    )
+    try:
+        update_cmd._warn_pending_fleet_restart_on_startup()
+        captured = capsys.readouterr()
+        assert "did not restart running gateways" not in captured.err
+        assert not update_cmd._fleet_restart_pending_marker_path().exists()
+    finally:
+        if update_cmd._fleet_restart_pending_marker_path().exists():
+            update_cmd._clear_fleet_restart_pending_marker()
+
+
+# ---------------------------------------------------------------------------
+# Pre-commit bundle (FUP-20260910-11): A1 partial-probe fail-open, M1 stale-vs-
+# unknown forever-pin, atomic write, pid+writer_start pairing, 7d ceiling.
+# ---------------------------------------------------------------------------
+
+def _fleet_rows(*specs):
+    """Build fleet rows: (state, code_sha) tuples -> row dicts."""
+    return [
+        {"profile": f"p{i}", "pid": 100 + i, "state": state, "code_sha": sha}
+        for i, (state, sha) in enumerate(specs)
+    ]
+
+
+def test_probe_abort_midloop_never_clears_marker(monkeypatch, capsys):
+    """T1 (A1 fault-injection, MANDATORY): a sweep that raises on profile k of N returns
+    None; verdict is unknown; the marker is NOT cleared AND the warning persists."""
+    _stranded_marker("a" * 40)
+    calls = {"n": 0}
+
+    def _aborting_probe():
+        # A1 fault-injection at the collect contract layer: an aborted sweep returns
+        # None (per-profile isolation catches the raise inside collect_fleet_versions
+        # and converts it to None) — NEVER partial rows, even when the rows gathered
+        # before the abort all match expected_sha. First call exercises the None
+        # contract; later calls raise outright to prove the except path too.
+        calls["n"] += 1
+        if calls["n"] > 1:
+            raise RuntimeError("profile k exploded mid-sweep")
+        return None  # aborted sweep — even though rows seen before the abort matched
+
+    monkeypatch.setattr(update_receipt, "collect_fleet_versions", _aborting_probe)
+    try:
+        # Not cleared...
+        assert update_cmd_fleet._pending_fleet_restart_needed() is True
+        assert update_cmd._fleet_restart_pending_marker_path().is_file()
+        # ...and still warning (fail-closed = not cleared AND still warning).
+        update_cmd._warn_pending_fleet_restart_on_startup()
+        assert "did not restart running gateways" in capsys.readouterr().err
+    finally:
+        update_cmd._clear_fleet_restart_pending_marker()
+
+def test_probe_error_does_not_start_grace_clock(monkeypatch):
+    """T2 (neo's caution): consecutive probe errors past the idle-grace window do NOT
+    clear — errors route to the age ceiling only, never the grace path."""
+    _stranded_marker("b" * 40, age_seconds=3600)  # 1h old: way past the 600s grace
+    monkeypatch.setattr(
+        update_receipt, "collect_fleet_versions",
+        lambda: None,  # aborted sweep (None), not a clean empty sweep
+    )
+    try:
+        assert update_cmd_fleet._pending_fleet_restart_needed() is True
+        assert update_cmd._fleet_restart_pending_marker_path().is_file()
+    finally:
+        update_cmd._clear_fleet_restart_pending_marker()
+
+
+def test_unknown_sha_gateway_clears_at_age_ceiling_not_forever(monkeypatch):
+    """T3 (M1): a legacy pre-stamp gateway (state=unknown / code_sha=None) yields verdict
+    unknown, which routes to the age ceiling — the marker does NOT pin forever."""
+    _stranded_marker("c" * 40, age_seconds=1 * 3600)
+    monkeypatch.setattr(
+        update_receipt, "collect_fleet_versions",
+        lambda: [{"profile": "legacy", "pid": 11, "state": "unknown", "code_sha": None}],
+    )
+    path = update_cmd._fleet_restart_pending_marker_path()
+    try:
+        # young unverifiable: keep warning (fail-closed)
+        assert update_cmd_fleet._pending_fleet_restart_needed() is True
+        assert path.is_file()
+        # past the 7d ceiling: clear (not forever)
+        path.write_text(
+            f"started={time.time() - 8 * 86400}\npid={_DEAD_PID}\nexpected_sha={'c' * 40}\n",
+            encoding="utf-8",
+        )
+        assert update_cmd_fleet._pending_fleet_restart_needed() is False
+        assert not path.exists()
+    finally:
+        if path.exists():
+            update_cmd._clear_fleet_restart_pending_marker()
+
+
+def test_stale_with_present_sha_keeps_pending_indefinitely(monkeypatch):
+    """T4 (M1 inverse): a PROVABLY stale row (code_sha present && != expected) holds the
+    marker past ANY age — the cure is a restart, not time."""
+    _stranded_marker("d" * 40, age_seconds=100 * 86400)
+    monkeypatch.setattr(
+        update_receipt, "collect_fleet_versions",
+        lambda: [{"profile": "neo", "pid": 12, "state": "stale", "code_sha": "olds" + "h" * 36}],
+    )
+    try:
+        assert update_cmd_fleet._pending_fleet_restart_needed() is True
+        assert update_cmd._fleet_restart_pending_marker_path().is_file()
+    finally:
+        update_cmd._clear_fleet_restart_pending_marker()
+
+
+def test_recycled_writer_pid_does_not_block_reconcile(monkeypatch):
+    """T5 (Change 5): a live pid whose process start time DIFFERS from the recorded
+    writer_start is a recycled PID, not the writer — reconciliation proceeds."""
+    marker = update_cmd._fleet_restart_pending_marker_path()
+    marker.write_text(
+        f"started={time.time()}\npid={os.getpid()}\nwriter_start=1234567890.0\n"
+        f"expected_sha={'e' * 40}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        update_cmd_fleet, "_fleet_restart_verdict", lambda expected: "match"
+    )
+    try:
+        assert update_cmd_fleet._marker_writer_alive(
+            {"pid": str(os.getpid()), "writer_start": "1234567890.0"}
+        ) is True  # our OWN pid still counts as in-flight regardless of pairing
+        # A different live pid with a mismatched start time does not count as the writer.
+        def _other_process_start(pid):
+            return 9999999999.0 if pid == 987654 else None
+        from gateway import status as gw_status
+        monkeypatch.setattr(gw_status, "get_process_start_time", _other_process_start)
+        monkeypatch.setattr(update_cmd_fleet.os, "kill", lambda pid, sig: None)  # pid "exists"
+        assert update_cmd_fleet._marker_writer_alive(
+            {"pid": "987654", "writer_start": "1234567890.0"}
+        ) is False
+    finally:
+        update_cmd._clear_fleet_restart_pending_marker()
+
+
+def test_writer_alive_with_matching_start_time_blocks(monkeypatch):
+    """T6 (Change 5 inverse): a live pid with a MATCHING start time is the writer —
+    write-lock holds, reconciliation is suppressed."""
+    live_start = 1700000000.0
+    from gateway import status as gw_status
+    monkeypatch.setattr(gw_status, "get_process_start_time", lambda pid: live_start)
+    monkeypatch.setattr(update_cmd_fleet.os, "kill", lambda pid, sig: None)
+    assert update_cmd_fleet._marker_writer_alive(
+        {"pid": "987654", "writer_start": str(live_start)}
+    ) is True
+
+
+def test_truncated_marker_write_is_atomic(monkeypatch):
+    """T7 (M3): the writer uses temp+os.replace — no torn-marker parse window; the tmp
+    file never survives a successful write."""
+    update_cmd._write_fleet_restart_pending_marker(expected_sha="7" * 40)
+    path = update_cmd._fleet_restart_pending_marker_path()
+    try:
+        assert path.is_file()
+        assert not path.with_name(path.name + ".tmp").exists()
+        fields = update_cmd_fleet._read_fleet_restart_pending_marker()
+        assert fields.get("expected_sha") == "7" * 40
+        assert fields.get("writer_start")  # pairing field present on fresh writes
+    finally:
+        update_cmd._clear_fleet_restart_pending_marker()
+
+
+def test_unverifiable_write_is_loud_not_refused(monkeypatch, caplog):
+    """Change 4 (wizred variant): expected_sha="" markers are still written (interrupt-
+    recovery net) with a LOUD warning — never silently, never refused."""
+    import logging
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.update_cmd"):
+        update_cmd._write_fleet_restart_pending_marker(expected_sha="")
+    path = update_cmd._fleet_restart_pending_marker_path()
+    try:
+        assert path.is_file()
+        assert any("WITHOUT expected_sha" in rec.message for rec in caplog.records)
+    finally:
+        update_cmd._clear_fleet_restart_pending_marker()
+
+
+def test_error_vs_idle_distinction(monkeypatch):
+    """T8 (item 3 merged with A1): an aborted sweep with zero good rows -> verdict
+    'unknown', NOT 'idle' — the grace window must not run on a broken probe."""
+    monkeypatch.setattr(update_receipt, "collect_fleet_versions", lambda: None)
+    assert update_cmd_fleet._fleet_restart_verdict("8" * 40) == "unknown"
+
+
+def test_reconcile_contract_may_clear_marker():
+    """T9 (M2 guard): the reconcile path is documented as a may-clear operation reached
+    through the _pending_fleet_restart_needed predicate — pin the wiring so a future
+    refactor cannot silently drop the side effect."""
+    import inspect
+    reconcile_doc = update_cmd_fleet._reconcile_fleet_restart_pending.__doc__ or ""
+    assert "MAY CLEAR" in reconcile_doc
+    # The predicate routes through the reconciler (the side-effecting path).
+    src = inspect.getsource(update_cmd_fleet._pending_fleet_restart_needed)
+    assert "_reconcile_fleet_restart_pending()" in src

--- a/tests/hermes_cli/test_update_obligation_identity.py
+++ b/tests/hermes_cli/test_update_obligation_identity.py
@@ -83,4 +83,32 @@ def test_every_owed_identity_requires_current_evidence(monkeypatch, bad):
         })
     monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: "new")
     monkeypatch.setattr(update_receipt, "collect_fleet_versions", lambda: rows)
-    assert update_cmd_fleet._pending_fleet_restart_needed()
+    if bad == "marker":
+        # REVERSED (lease-with-verification): a stranded marker whose expected_sha matches a
+        # fully-current live fleet is DISCHARGED by that evidence — live truth outranks the
+        # breadcrumb. The old assertion (marker beats live evidence) pinned the 26-day warning bug.
+        try:
+            assert not update_cmd_fleet._pending_fleet_restart_needed()
+        finally:
+            update_cmd_fleet._clear_fleet_restart_pending_marker()
+    else:
+        assert update_cmd_fleet._pending_fleet_restart_needed()
+
+
+def test_unverifiable_row_routes_to_age_ceiling_not_forever_pin(monkeypatch):
+    """M1 (wizred): a row with state='unknown'/code_sha=None is UNVERIFIABLE evidence, not
+    provably stale — it must yield verdict 'unknown' (age-ceiling route), never a forever
+    'stale' pin. Contrast: a present-and-different code_sha stays provably stale."""
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: "new")
+    # Unverifiable row: no sha to compare.
+    monkeypatch.setattr(
+        update_receipt, "collect_fleet_versions",
+        lambda: [{"profile": "beta", "state": "unknown", "code_sha": None}],
+    )
+    assert update_cmd_fleet._fleet_restart_verdict("new") == "unknown"
+    # Inverse: present-and-different sha is PROVABLY stale (restart is the cure, not time).
+    monkeypatch.setattr(
+        update_receipt, "collect_fleet_versions",
+        lambda: [{"profile": "beta", "state": "stale", "code_sha": "old"}],
+    )
+    assert update_cmd_fleet._fleet_restart_verdict("new") == "stale"


### PR DESCRIPTION
Two independent fixes (separable if reviewers prefer):

## 1. fix(buzz): probe relay liveness before reconnecting on WS read idle
On WS read-idle the buzz platform reconnected even when the relay connection was already dead/unhealthy, causing reconnect flapping. Probe relay liveness first and only reconnect when warranted.

## 2. fix(update): reconcile fleet_restart_pending marker against live fleet evidence
Lease-with-verification: an external restart (launchd KeepAlive, desktop respawn, reboot) can discharge the post-pull restart obligation before any `hermes update` runs, leaving the marker stranded and the startup warning permanent. Reconcile the marker's payload against a live fleet sweep and clear it only on positive evidence (fail-closed):

- marker gains pid + writer_start pairing and atomic write; writer liveness is a write-lock, never an expiry rule
- 'stale' verdict reserved for provably stale rows (code_sha present and != expected); unverifiable rows route to a 7-day age ceiling instead of pinning the marker forever
- `collect_fleet_versions` returns `None` on an incomplete sweep so callers fail closed instead of mistaking a broken probe for a clean snapshot
- per-profile probe isolation

## Testing
- `scripts/run_tests.sh tests/hermes_cli/test_update_fleet_restart_pending.py tests/hermes_cli/test_update_obligation_identity.py` — 50 passed, 0 failed
- New invariant tests cover: marker discharged by live fleet at expected_sha, stranded marker kept on ambiguity, age-ceiling path, writer-liveness write-lock, fail-closed `None` sweep