### PR TITLE
MemoryManager no longer keeps a provider whose schema load failed (#9948, salvage #9997)

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -331,16 +331,22 @@ class MemoryManager:
 
     def add_provider(self, provider: MemoryProvider) -> None:
         """Register a provider; builtin always accepted, only ONE external allowed."""
+        if provider.name != "builtin" and self._has_external:
+            existing = next((p.name for p in self._providers if p.name != "builtin"), "unknown")
+            logger.warning(
+                "Rejected memory provider '%s' — external provider '%s' is "
+                "already registered. Only one external memory provider is "
+                "allowed at a time. Configure which one via memory.provider "
+                "in config.yaml.", provider.name, existing,
+            )
+            return
+
+        # Load schemas BEFORE mutating any manager state: a provider whose schema
+        # load raises must leave `_providers` / `_has_external` untouched, otherwise
+        # it blocks every later external provider in this process (#9948).
+        schemas = list(provider.get_tool_schemas())
+
         if provider.name != "builtin":
-            if self._has_external:
-                existing = next((p.name for p in self._providers if p.name != "builtin"), "unknown")
-                logger.warning(
-                    "Rejected memory provider '%s' — external provider '%s' is "
-                    "already registered. Only one external memory provider is "
-                    "allowed at a time. Configure which one via memory.provider "
-                    "in config.yaml.", provider.name, existing,
-                )
-                return
             self._has_external = True
             self._external_prefetch_spill_config = get_spill_config()
 
@@ -353,7 +359,7 @@ class MemoryManager:
         # registries. See #40466.
         from toolsets import _HERMES_CORE_TOOLS
 
-        for raw_schema in provider.get_tool_schemas():
+        for raw_schema in schemas:
             schema = normalize_tool_schema(raw_schema)
             if schema is None:
                 continue
@@ -372,7 +378,7 @@ class MemoryManager:
             else:
                 self._tool_to_provider[tool_name] = provider
 
-        logger.info("Memory provider '%s' registered (%d tools)", provider.name, len(provider.get_tool_schemas()))
+        logger.info("Memory provider '%s' registered (%d tools)", provider.name, len(schemas))
 
     @property
     def providers(self) -> List[MemoryProvider]:

--- a/contributors/emails/zhou.he3@xydigit.com
+++ b/contributors/emails/zhou.he3@xydigit.com
@@ -1,0 +1,1 @@
+zhouhe-xydt

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -174,6 +174,21 @@ class TestMemoryManager:
         assert mgr.get_provider("test1") is p
         assert mgr.get_provider("nonexistent") is None
 
+    def test_failed_schema_load_leaves_manager_unregistered(self):
+        """A provider whose get_tool_schemas() raises must not poison the single-external slot (#9948)."""
+        class BrokenProvider(FakeMemoryProvider):
+            def get_tool_schemas(self):
+                raise RuntimeError("boom")
+
+        mgr = MemoryManager()
+        with pytest.raises(RuntimeError):
+            mgr.add_provider(BrokenProvider("broken"))
+        assert mgr.providers == []
+
+        ok = FakeMemoryProvider("ok")
+        mgr.add_provider(ok)
+        assert mgr.get_provider("ok") is ok
+
     def test_on_turn_start_passes_each_provider_only_the_kwargs_it_accepts(self):
         """A provider with the two-positional ``on_turn_start`` still runs; one declaring the author kwargs gets them."""
         class AuthorAwareProvider(FakeMemoryProvider):

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -226,7 +226,7 @@ class TestMemoryManager:
         assert "external memory prefetch output truncated" in result
         spill_files = list((tmp_path / "session-1").glob("*.txt"))
         assert len(spill_files) == 1
-        assert spill_files[0].read_text() == provider._prefetch_result + "\n"
+        assert spill_files[0].read_text(encoding="utf-8") == provider._prefetch_result + "\n"
 
     def test_builtin_prefetch_is_not_spilled(self, tmp_path, monkeypatch):
         self._set_spill_config(monkeypatch, tmp_path, max_chars=10)
@@ -439,10 +439,10 @@ class TestUserInstalledProviderDiscovery:
             "    def sync_turn(self, *a, **kw): pass\n"
             "    def get_tool_schemas(self): return []\n"
             "    def handle_tool_call(self, *a, **kw): return '{}'\n"
-        )
+        , encoding="utf-8")
         (plugin_dir / "plugin.yaml").write_text(
             f"name: {name}\ndescription: Test user provider\n"
-        )
+        , encoding="utf-8")
         return plugin_dir
 
 
@@ -475,7 +475,7 @@ class TestUserInstalledProviderDiscovery:
             "    def sync_turn(self, *a, **kw): pass\n"
             "    def get_tool_schemas(self): return []\n"
             "    def handle_tool_call(self, *a, **kw): return '{}'\n"
-        )
+        , encoding="utf-8")
         monkeypatch.setattr(
             "plugins.memory._get_user_plugins_dir",
             lambda: tmp_path / "plugins",
@@ -600,7 +600,7 @@ class TestEntryPointMemoryProviderDiscovery:
             skill_md.write_text(
                 "---\nname: maintenance\ndescription: Memory maintenance\n---\n\n"
                 "Packaged provider maintenance body.\n"
-            )
+            , encoding="utf-8")
             register_skill = (
                 "    ctx.register_skill(\n"
                 "        'maintenance',\n"


### PR DESCRIPTION
**A memory provider whose `get_tool_schemas()` raises is no longer left half-registered, so the next external provider can still be added.**

- `agent/memory_manager.py::add_provider` set `_has_external = True` and appended the provider before loading schemas; a failure left the single-external slot poisoned for the process.
- Schemas are materialized first; state changes only after that succeeds. Exception propagation is unchanged.

| | before | after |
|---|---|---|
| broken provider added | `providers == ["broken"]`, `_has_external == True` | `providers == []` |
| a second provider added afterwards | rejected as "already registered" | registered |

**Live repro:** reporter's script on `origin/main` prints `['broken'] True` then rejects `ok`; on this branch `ok` registers. Test `test_failed_schema_load_leaves_manager_unregistered` red on main.

Salvage of #9997 by @zhouhe-xydt (hand-port; the function gained the reserved-core-tool filter since April). Same fix was independently proposed in #9958, #13224, #26613, #26660, #21418, #10051.

Fixes #9948 (reported by @NewTurn2017).

## Infographic
![memory-provider-half-registration](https://v3b.fal.media/files/b/0aaa2223/IRa2rIvc0ovXZEY4xt844_FBTUNmrv.png)
