### PR TITLE
ACP sessions keep provider/base_url on the first persisted row (#9812, salvage #9883)

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -297,7 +297,7 @@ class SessionManager:
                     # Empty editor probes stay ephemeral; copied fork history persists.
                     return
                 db.create_session(session_id=state.session_id, source="acp", model=model_str,
-                                  model_config={"cwd": state.cwd})
+                                  model_config=session_meta)
             else:
                 try:
                     db.update_session_meta(state.session_id, json.dumps(session_meta), model_str)

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -249,6 +249,23 @@ class TestListAndCleanup:
 class TestPersistence:
     """Verify that sessions are persisted to SessionDB and can be restored."""
 
+    def test_first_persist_keeps_provider_snapshot(self, tmp_path):
+        """The FIRST row written for an ACP session carries provider/base_url/api_mode,
+        so a restart before any later save restores the same route (#9812)."""
+        agent = SimpleNamespace(
+            model="test-model", provider="anthropic",
+            base_url="https://anthropic.example/v1", api_mode="anthropic_messages",
+        )
+        db = SessionDB(tmp_path / "state.db")
+        manager = SessionManager(agent_factory=lambda: agent, db=db)
+        state = manager.create_session(cwd="/work")
+        state.history.append({"role": "user", "content": "hello"})
+        manager.save_session(state.session_id)
+
+        mc = json.loads(db.get_session(state.session_id)["model_config"])
+        assert mc == {"cwd": "/work", "provider": "anthropic",
+                      "base_url": "https://anthropic.example/v1", "api_mode": "anthropic_messages"}
+
 
 
 


### PR DESCRIPTION
**The first row written for an ACP session now carries `provider`, `base_url` and `api_mode`, so a restart before any later save restores the same route.**

- `acp_adapter/session.py::_persist` built `session_meta` with the snapshot but passed `{"cwd": ...}` to `create_session()`; the snapshot only landed on a later `update_session_meta`.
- One-line fix: pass `session_meta` on create too.

| | before | after |
|---|---|---|
| `model_config` after first save | `{"cwd": "/work"}` | `{"cwd", "provider", "base_url", "api_mode"}` |

**Live repro:** reporter's script on `origin/main` prints `{"cwd": "/work"}`; on this branch the full snapshot. Test `test_first_persist_keeps_provider_snapshot` red on main.

Cherry-pick of #9883 by @Ruzzgar (release.py hunk dropped, already mapped); #9977 is the same one-liner.

Fixes #9812 (reported by @NewTurn2017).

## Infographic
![acp-provider-snapshot-first-persist](https://v3b.fal.media/files/b/0aaa2248/1R7nOvpA3fyyKvBvcFdhZ_ZncBmNp8.png)
