### PR TITLE
CLI banner no longer center-pads hero art, keeping braille skins intact (#9879, salvage #9880)

### DIFF
--- a/contributors/emails/guy@wyrdrune.com
+++ b/contributors/emails/guy@wyrdrune.com
@@ -1,0 +1,1 @@
+ggascoigne

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -964,7 +964,7 @@ def build_welcome_banner(
             right_lines.append(_format_update_notice(behind))
     _quiet(_update_line)  # Never break the banner over an update check
     layout_table = Table.grid(padding=(0, 2))
-    layout_table.add_column("left", justify="center")
+    layout_table.add_column("left", justify="left")
     layout_table.add_column("right", justify="left")
     layout_table.add_row("\n".join(left_lines), "\n".join(right_lines))
     version_label = format_banner_version_label()

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -109,3 +109,29 @@ def test_empty_model_shows_the_free_tier_route_when_it_carries_inference(tmp_pat
 
     assert "welcome" in render(True) and "no model configured" not in render(True)
     assert "no model configured" in render(False)
+
+
+def test_build_welcome_banner_does_not_center_pad_hero_art():
+    """A braille hero relies on its own U+2800 padding for symmetry; Rich centering inserts
+    ASCII spaces around the left column and distorts the silhouette (#9879). The hero line
+    must start flush at the column start."""
+    import io
+    from types import SimpleNamespace
+    from tools import mcp_tool_discovery as _mcp_discovery
+
+    skin = SimpleNamespace(banner_hero="[green]\u2800X[/]", banner_logo="")
+    buf = io.StringIO()
+    with (
+        patch.object(model_tools, "check_tool_availability", return_value=([], [])),
+        patch.object(banner, "get_available_skills", return_value={}),
+        patch.object(banner, "get_update_result", return_value=None),
+        patch.object(banner, "get_latest_release_tag", return_value=None),
+        patch.object(_mcp_discovery, "get_mcp_status", return_value=[]),
+        patch.object(banner, "_active_skin", return_value=skin),
+    ):
+        console = Console(file=buf, force_terminal=False, color_system=None, width=80)
+        banner.build_welcome_banner(console=console, model="m", cwd="/tmp", tools=[],
+                                    get_toolset_for_tool=lambda _: None)
+
+    hero_line = next(line for line in buf.getvalue().splitlines() if "\u2800X" in line)
+    assert hero_line.startswith("\u2502  \u2800X"), repr(hero_line)


### PR DESCRIPTION
**Skin hero art in the welcome banner is left-aligned, so braille-padded heroes render with their own symmetry instead of Rich-inserted spaces.**

- `hermes_cli/banner.py::build_welcome_banner`: left column `justify="center"` → `justify="left"`.
- Braille heroes rely on U+2800 blanks for shape; centering added ASCII spaces around the art and distorted it in some terminals.

**Live repro:** test `test_build_welcome_banner_does_not_center_pad_hero_art` (hero `⠀X` must start flush at the column) red on `origin/main`, green here.

Cherry-pick of #9880 by @ggascoigne (conflicts were pure drift; the test is re-authored against current banner internals). #9886 / #9904 were duplicates.

Fixes #9879.

## Infographic
![banner-hero-left-align](https://v3b.fal.media/files/b/0aaa2239/Y9yFtPenEKRnRp-kPgTCg_P5f0ti8u.png)
