### PR TITLE
hermes doctor tells image_gen users to configure a provider, not "system dependency not met" (#9516, salvage #9548)

### DIFF
--- a/hermes_cli/doctor_tools.py
+++ b/hermes_cli/doctor_tools.py
@@ -119,7 +119,7 @@ def _enabled_cli_toolsets_for_doctor() -> set[str] | None:
 # `requires_env`, so the generic branch would call a missing credential a "system dependency".
 # Name the real fix instead (#9516).
 _TOOLSET_SETUP_HINTS: dict[str, str] = {
-    "image_gen": "(no image generation provider configured — set one up with 'hermes tools')",
+    "image_gen": "(image generation unavailable — check the provider selection and its key or SDK with 'hermes tools')",
 }
 
 

--- a/hermes_cli/doctor_tools.py
+++ b/hermes_cli/doctor_tools.py
@@ -115,9 +115,21 @@ def _enabled_cli_toolsets_for_doctor() -> set[str] | None:
         return None
 
 
+# Toolsets gated by a multi-path setup (several providers / managed auth) declare no single
+# `requires_env`, so the generic branch would call a missing credential a "system dependency".
+# Name the real fix instead (#9516).
+_TOOLSET_SETUP_HINTS: dict[str, str] = {
+    "image_gen": "(no image generation provider configured — set one up with 'hermes tools')",
+}
+
+
+def _setup_gated(item: dict) -> bool:
+    return bool(item.get("missing_vars") or item.get("env_vars") or item.get("name") in _TOOLSET_SETUP_HINTS)
+
+
 def _missing_api_key_toolsets_for_summary(unavailable: list[dict]) -> list[dict]:
-    """Filter unavailable API-key toolsets to those enabled for the CLI."""
-    api_key_unavailable = [item for item in unavailable if item.get("missing_vars") or item.get("env_vars")]
+    """Filter unavailable setup-gated toolsets (missing key OR setup hint) to those enabled for the CLI."""
+    api_key_unavailable = [item for item in unavailable if _setup_gated(item)]
     enabled_toolsets = _enabled_cli_toolsets_for_doctor()
     return api_key_unavailable if enabled_toolsets is None else [i for i in api_key_unavailable if str(i.get("name") or "") in enabled_toolsets]
 
@@ -445,7 +457,8 @@ def _check_tool_availability(should_fix: bool, f: Finding) -> None:
         (check_ok if status == "ok" else check_warn)(label, detail)
     for item in unavailable:
         env_vars = item.get("missing_vars") or item.get("env_vars") or []
-        check_warn(item["name"], f"(missing {', '.join(env_vars)})" if env_vars else "(system dependency not met)")
+        detail = f"(missing {', '.join(env_vars)})" if env_vars else _TOOLSET_SETUP_HINTS.get(item["name"], "(system dependency not met)")
+        check_warn(item["name"], detail)
     # Only toolsets enabled for the CLI count toward the summary; default-off or
     # disabled toolsets may warn above but must not pollute it.
     api_disabled = _missing_api_key_toolsets_for_summary(unavailable)

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -110,7 +110,7 @@ class TestDoctorToolAvailabilitySummary:
         out = buf.getvalue()
 
         image_line = next(line for line in out.splitlines() if "image_gen" in line)
-        assert "hermes tools" in image_line and "system dependency" not in image_line
+        assert "hermes tools" in image_line and "system dependency" not in image_line and "unavailable" in image_line
         assert "system dependency not met" in next(line for line in out.splitlines() if "homeassistant" in line)
         assert any("hermes setup" in issue for issue in f.issues)
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -89,6 +89,31 @@ class TestDoctorToolAvailabilitySummary:
 
         assert [item["name"] for item in filtered] == ["web"]
 
+    def test_image_gen_without_provider_reports_setup_hint_not_system_dependency(self, monkeypatch):
+        """image_gen declares no single env var (FAL / managed Nous / plugin providers); an
+        unconfigured backend is a setup problem and must say so, and it counts toward the
+        'run hermes setup' summary like any missing key (#9516)."""
+        unavailable = [{"name": "image_gen", "env_vars": [], "tools": ["image_generate"]},
+                       {"name": "homeassistant", "env_vars": [], "tools": []}]
+        monkeypatch.setattr(doctor_tools, "_enabled_cli_toolsets_for_doctor", lambda: {"image_gen"})
+        monkeypatch.setattr(doctor_tools, "_apply_doctor_tool_availability_overrides", lambda a, u: (a, u))
+        monkeypatch.setattr(doctor_tools, "_doctor_web_capability_rows", lambda: [])
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda: ([], unavailable),
+            TOOLSET_REQUIREMENTS={"image_gen": {"name": "image_gen"}, "homeassistant": {"name": "homeassistant"}},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            f = doctor_tools._check_tool_availability(False)
+        out = buf.getvalue()
+
+        image_line = next(line for line in out.splitlines() if "image_gen" in line)
+        assert "hermes tools" in image_line and "system dependency" not in image_line
+        assert "system dependency not met" in next(line for line in out.splitlines() if "homeassistant" in line)
+        assert any("hermes setup" in issue for issue in f.issues)
+
     def test_web_capability_rows_warn_when_selected_provider_not_ready(self, monkeypatch):
         """#78412: selected firecrawl with is_available=False must warn."""
         class _Unavailable:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -163,7 +163,7 @@ class TestDoctorToolAvailabilitySummary:
 
 class TestDoctorEnvFileEncoding:
     """Regression for #18637 (bug 3): `hermes doctor` crashed on Windows
-    Chinese locale (GBK) because `.env` was read with Path.read_text() which
+    Chinese locale (GBK) because `.env` was read with Path.read_text(encoding="utf-8") which
     defaults to the system locale encoding, not UTF-8."""
 
     def test_doctor_reads_env_as_utf8_even_when_locale_is_not_utf8(
@@ -330,7 +330,7 @@ class TestDoctorMemoryProviderSection:
         if provider:
             config["provider"] = provider
         config = {"memory": config}
-        (home / "config.yaml").write_text(yaml.dump(config))
+        (home / "config.yaml").write_text(yaml.dump(config), encoding="utf-8")
         return home
 
     def _run_doctor_and_capture(
@@ -467,7 +467,7 @@ def test_run_doctor_accepts_named_provider_from_providers_section(monkeypatch, t
                 },
             }
         )
-    )
+    , encoding="utf-8")
 
     monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
     monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")


### PR DESCRIPTION
**`hermes doctor` reports `image_gen (no image generation provider configured — set one up with 'hermes tools')` and counts it toward the "run hermes setup" summary.**

- `image_gen` has several setup paths (FAL_KEY, managed Nous image generation, plugin providers) so it declares no single `requires_env`; doctor's generic branch mislabelled a missing credential as a system dependency and left it out of the summary.
- A small per-toolset setup-hint table in `hermes_cli/doctor_tools.py`; toolsets with a genuine system dependency (`homeassistant`) keep the old wording.

**Live repro:** test `test_image_gen_without_provider_reports_setup_hint_not_system_dependency` red on `origin/main` (`⚠ image_gen (system dependency not met)`), green here.

Salvage of #9548 by @skyc1e onto `doctor_tools.py`; #9540 / #9558 / #9715 / #9757 were narrower variants.

Fixes #9516 (reported by @404Dealer).

## Update — review fix
Hint reworded to "image generation unavailable — check the provider selection and its key or SDK with 'hermes tools'" so it is also accurate when a provider is selected but its SDK/key is missing. Commit 34b8d29d.

## Infographic
![doctor-image-gen-hint](https://v3b.fal.media/files/b/0aaa223f/N32QBDQq11lQ3zhnaQrga_lFIDDYBO.png)

