### PR TITLE
Top-level `personalities:` config block is honoured on CLI, gateway and TUI (#9636)

### DIFF
--- a/hermes_cli/personality.py
+++ b/hermes_cli/personality.py
@@ -3,6 +3,8 @@
 * ``display.personality`` holds the selected NAME (empty = no overlay).
 * ``agent.system_prompt`` is the user-owned manual overlay; personality code never writes it.
 * ``agent.personalities`` holds user-defined/overridden personalities, overlaying built-ins by name.
+  The schema also exposes a top-level ``personalities:`` block (the original #643 shape); both are
+  honoured, ``agent.personalities`` winning on a name clash.
 """
 
 from __future__ import annotations
@@ -82,10 +84,12 @@ def normalize_personality_name(value: Any) -> str:
 
 
 def available_personalities(cfg: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-    """Built-ins overlaid by the user's ``agent.personalities`` (user wins)."""
+    """Built-ins overlaid by the user's personalities: root ``personalities`` then
+    ``agent.personalities`` (later wins). Root entries were silently ignored (#9636)."""
     merged: Dict[str, Any] = dict(BUILTIN_PERSONALITIES)
-    user = _get(cfg, "agent", "personalities", default={})
-    if isinstance(user, dict):
+    for user in (_get(cfg, "personalities", default={}), _get(cfg, "agent", "personalities", default={})):
+        if not isinstance(user, dict):
+            continue
         for name, definition in user.items():
             key = str(name).strip().lower()
             if key and key not in NEUTRAL_PERSONALITY_NAMES:

--- a/tests/hermes_cli/test_personality_single_owner.py
+++ b/tests/hermes_cli/test_personality_single_owner.py
@@ -135,11 +135,11 @@ def test_persist_personality_roundtrip(tmp_path):
     home.mkdir()
     with patch.dict(os.environ, {"HERMES_HOME": str(home)}):
         assert persist_personality("KAWAII ") is True
-        raw = yaml.safe_load((home / "config.yaml").read_text())
+        raw = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
         assert raw["display"]["personality"] == "kawaii"
 
         assert persist_personality("none") is True
-        raw = yaml.safe_load((home / "config.yaml").read_text())
+        raw = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
         assert raw["display"]["personality"] == ""
 
 
@@ -148,10 +148,10 @@ def test_persist_personality_never_touches_system_prompt(tmp_path):
     home.mkdir()
     (home / "config.yaml").write_text(
         yaml.safe_dump({"agent": {"system_prompt": "manual forever"}})
-    )
+    , encoding="utf-8")
     with patch.dict(os.environ, {"HERMES_HOME": str(home)}):
         assert persist_personality("kawaii") is True
-        raw = yaml.safe_load((home / "config.yaml").read_text())
+        raw = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
         assert raw["agent"]["system_prompt"] == "manual forever"
         assert raw["display"]["personality"] == "kawaii"
 
@@ -160,7 +160,7 @@ def test_persist_personality_never_touches_system_prompt(tmp_path):
 
 
 def _run_migration(home, cfg):
-    (home / "config.yaml").write_text(yaml.safe_dump(cfg, allow_unicode=True))
+    (home / "config.yaml").write_text(yaml.safe_dump(cfg, allow_unicode=True), encoding="utf-8")
     with patch.dict(os.environ, {"HERMES_HOME": str(home)}):
         from hermes_cli.config import migrate_config, read_raw_config
 

--- a/tests/hermes_cli/test_personality_single_owner.py
+++ b/tests/hermes_cli/test_personality_single_owner.py
@@ -50,6 +50,17 @@ def test_user_entries_overlay_builtins_by_name():
     assert merged["custom"] == "hi"
 
 
+def test_root_level_personalities_are_honoured_below_agent_block():
+    """config.yaml's top-level ``personalities:`` (the shape DEFAULT_CONFIG ships) must be
+    visible on every surface; ``agent.personalities`` wins on a clash (#9636)."""
+    cfg = {"personalities": {"robot": "root", "shared": "root"},
+           "agent": {"personalities": {"shared": "agent"}}}
+    merged = available_personalities(cfg)
+    assert merged["robot"] == "root"
+    assert merged["shared"] == "agent"
+    assert resolve_personality("robot", cfg)[0] == "robot"
+
+
 def test_neutral_names_normalize_to_empty():
     for raw in ("", "none", "None", " DEFAULT ", "neutral", None):
         assert normalize_personality_name(raw) == ""

--- a/website/docs/user-guide/features/personality.md
+++ b/website/docs/user-guide/features/personality.md
@@ -211,7 +211,7 @@ These are convenient overlays, but your global `SOUL.md` still gives Hermes its 
 
 ## Custom personalities in config
 
-Built-in personalities are always available on every surface (CLI, messaging platforms, TUI, and the desktop app). You can add your own — or override a built-in by reusing its name — in `~/.hermes/config.yaml` under `agent.personalities`.
+Built-in personalities are always available on every surface (CLI, messaging platforms, TUI, and the desktop app). You can add your own — or override a built-in by reusing its name — in `~/.hermes/config.yaml` under `agent.personalities` (a top-level `personalities:` block works too; `agent.personalities` wins if the same name appears in both).
 
 ```yaml
 agent:


### PR DESCRIPTION
**Custom personalities defined at the config root (the shape `DEFAULT_CONFIG` ships) now show up in `/personality` on every surface.**

- `hermes_cli/personality.py::available_personalities` (the single resolver used by CLI, gateway `/personality` and the TUI) read only `agent.personalities`; the schema also exposes and whitelists a root `personalities:` block, so users following the generated config saw "No personalities configured".
- Both blocks are merged, `agent.personalities` winning on a name clash. Docs updated.

**Live repro:** `available_personalities({"personalities": {"robot": ...}})` lacked `robot` on `origin/main`; test `test_root_level_personalities_are_honoured_below_agent_block` red on main.

Earlier attempt #9657 (@flobo3) patched the CLI loader only.

Fixes #9636 (reported by @NewTurn2017, confirmed by @LineckerN).

## Infographic
![root-level-personalities](https://v3b.fal.media/files/b/0aaa225d/8PP0FsZk5d4TK5W8_0yN8_o18UhQLt.png)
