### PR TITLE
/model provider:model resolves like provider/model on non-aggregator providers (#9748)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1135,19 +1135,36 @@ def _route_alias_fallback(st: _Switch, key: str) -> Optional[ModelSwitchResult]:
 
 
 def _convert_vendor_colon_slug(st: _Switch) -> None:
-    """Step c: on an aggregator, ``vendor:model`` -> ``vendor/model``. Only without a slash: with
-    one, the colon is a variant tag (:free, :extended, :fast) that must be preserved."""
+    """Step c: ``vendor:model`` -> ``vendor/model``. Only without a slash: with one, the colon is
+    a variant tag (:free, :extended, :fast) that must be preserved.
+
+    On an aggregator every ``left:right`` is a slug. Elsewhere the colon is converted only when
+    ``left`` names a provider Hermes knows, so ``/model alibaba:qwen3.6-plus`` routes like
+    ``alibaba/qwen3.6-plus`` (#9748) while Ollama-style tags (``qwen3.5:4b``) stay intact."""
     raw_input = st.raw_input
     colon_pos = raw_input.find(":")
     cur_norm = str(st.current_provider).strip().lower()
-    if (
-        colon_pos > 0 and "/" not in raw_input and is_aggregator(st.current_provider)
-        and not cur_norm.startswith("custom") and cur_norm != "ollama"):
-        left = raw_input[:colon_pos].strip().lower()
-        right = raw_input[colon_pos + 1:].strip()
-        if left and right:
-            st.new_model = f"{left}/{right}"
-            logger.debug("Converted vendor:model '%s' to aggregator slug '%s'", raw_input, st.new_model)
+    if colon_pos <= 0 or "/" in raw_input or cur_norm.startswith("custom") or cur_norm == "ollama":
+        return
+    left = raw_input[:colon_pos].strip().lower()
+    right = raw_input[colon_pos + 1:].strip()
+    if not left or not right:
+        return
+    if not is_aggregator(st.current_provider) and not _names_known_provider(left, st):
+        return
+    st.new_model = f"{left}/{right}"
+    logger.debug("Converted vendor:model '%s' to slug '%s'", raw_input, st.new_model)
+
+
+def _names_known_provider(name: str, st: _Switch) -> bool:
+    """Whether ``name`` is a built-in provider id/alias or a provider the user configured."""
+    from hermes_cli.providers import get_provider
+    if resolve_provider_full(name, st.user_providers, st.custom_providers) is not None:
+        return True
+    try:
+        return get_provider(name, allow_network=False) is not None
+    except Exception:
+        return False
 
 
 def _route_configured_provider(st: _Switch) -> Optional[ModelSwitchResult] | bool:

--- a/tests/hermes_cli/test_model_switch_variant_tags.py
+++ b/tests/hermes_cli/test_model_switch_variant_tags.py
@@ -55,3 +55,18 @@ class TestVariantTagPreservation:
         assert result == "nvidia/nemotron-3-super-120b-a12b"
 
 
+
+
+class TestColonFormOffAggregators:
+    """``provider:model`` must resolve exactly like ``provider/model`` on a non-aggregator
+    current provider (#9748); an Ollama-style tag whose left side is not a provider is untouched."""
+
+    def test_known_provider_colon_matches_slash_form(self):
+        with patch("hermes_cli.model_switch.resolve_provider_full", return_value=None):
+            colon = _run_switch("Alibaba:qwen3.6-plus", current_provider="alibaba")
+            slash = _run_switch("Alibaba/qwen3.6-plus", current_provider="alibaba")
+        assert colon == slash
+
+    def test_non_provider_left_side_keeps_colon(self):
+        with patch("hermes_cli.model_switch.resolve_provider_full", return_value=None):
+            assert _run_switch("qwen3.5:4b", current_provider="alibaba") == "qwen3.5:4b"


### PR DESCRIPTION
**`/model Alibaba:qwen3.6-plus` now routes exactly like `/model Alibaba/qwen3.6-plus` while on a direct provider.**

- `hermes_cli/model_switch.py::_convert_vendor_colon_slug` only converted `vendor:model` on aggregators; on `alibaba` the colon form went into the catalog lookup as an unknown id.
- Off aggregators the colon is converted when the left side names a provider Hermes knows (built-in id/alias or configured `providers:` entry). Ollama-style tags (`qwen3.5:4b`) have no provider on the left and stay intact; aggregators are unchanged.

| input on `alibaba` | before | after |
|---|---|---|
| `Alibaba:qwen3.6-plus` | model `Alibaba:qwen3.6-plus`, "not found" warning | model `qwen3.6-plus` |
| `Alibaba/qwen3.6-plus` | model `qwen3.6-plus` | same |
| `qwen3.5:4b` | untouched | untouched |

**Live repro:** `switch_model(...)` probe on `origin/main` vs branch (table above); test `test_known_provider_colon_matches_slash_form` red on main.

Fixes #9748 (reported by @maryjeck).

## Infographic
![model-switch-provider-colon](https://v3b.fal.media/files/b/0aaa224a/Pn6LpngY8LXZPI6CEdcPK_5bIvqN5k.png)
