### PR TITLE
Feishu inbound post text is no longer markdown-escaped (#9816, salvage #9991)

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -385,7 +385,10 @@ def _render_text_element(element: Dict[str, Any]) -> str:
     style_dict = style if isinstance(style, dict) else None
     if _is_style_enabled(style_dict, "code"):
         return _wrap_inline_code(text)
-    rendered = _escape_markdown_text(text)
+    # Post text elements carry raw text plus separate style flags; the style wrappers below
+    # re-create the markdown. Escaping the text here put `\*\*bold\*\*` / `\`code\`` into the
+    # model's context and those backslashes came straight back out in replies (#9816).
+    rendered = text
     if not rendered:
         return ""
     for key, prefix, suffix in _TEXT_STYLE_WRAPPERS:  # order matters for nesting

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2154,6 +2154,22 @@ class TestFeishuPostMentionParsing(unittest.TestCase):
         self.assertEqual(result.text_content, "@Alice hello")
 
 
+class TestFeishuPostTextIsNotMarkdownEscaped(unittest.TestCase):
+    def test_text_elements_keep_markdown_characters_and_style_wrappers(self):
+        """Inbound post text reaches the model verbatim (no backslash escapes) while the
+        structured style flags still render as markdown (#9816)."""
+        from plugins.platforms.feishu.adapter import parse_feishu_post_payload
+
+        payload = {"zh_cn": {"content": [[
+            {"tag": "text", "text": "run `print('hi')` for **emphasis** [x](y)"},
+            {"tag": "text", "text": "strong", "style": {"bold": True}},
+        ]]}}
+        text = parse_feishu_post_payload(payload).text_content
+        self.assertIn("run `print('hi')` for **emphasis** [x](y)", text)
+        self.assertIn("**strong**", text)
+        self.assertNotIn("\\", text)
+
+
 class TestFeishuNormalizeWithMentions(unittest.TestCase):
     def test_text_message_renders_mention_by_name(self):
         from plugins.platforms.feishu.adapter import normalize_feishu_message, _FeishuBotIdentity


### PR DESCRIPTION
**A Feishu user's `` `code` `` / `**bold**` reaches the model verbatim, so replies stop carrying `\*\*` backslashes that Feishu renders literally.**

- `plugins/platforms/feishu/adapter.py::_render_text_element` ran every inbound post text element through `_escape_markdown_text`; the escapes landed in the model's context and came back out in replies. The outbound path never escaped.
- Post elements carry raw text plus style flags; the wrappers already rebuild the markdown, so the text is passed through. Mention/emoji labels keep their escaping.

**Live repro:** test `test_text_elements_keep_markdown_characters_and_style_wrappers` red on `origin/main` (backslashes present), green here.

Salvage of #9991 by @nightq onto the plugin adapter; #43486 was a global no-op variant.

Fixes #9816 (reported by @TshyGO, root-caused by @TshyGO's follow-up).

## Infographic
![feishu-inbound-markdown-escape](https://v3b.fal.media/files/b/0aaa2281/rw2WgpFy-6QgIk_9pmc3r_kokuEYxR.png)
