### PR TITLE
skip_context_files also disables subdirectory hint injection, fixing cron output leaks (#9441)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2108,7 +2108,8 @@ def _snapshot_primary_runtime(agent):
 
 def _init_usage_state(agent):
     from agent.runtime_cwd import scope_terminal_cwd
-    agent._subdirectory_hints = SubdirectoryHintTracker(working_dir=scope_terminal_cwd() or None)
+    agent._subdirectory_hints = SubdirectoryHintTracker(
+        working_dir=scope_terminal_cwd() or None, enabled=not agent.skip_context_files)
     _set_defaults(agent, _USAGE_STATE)
 
 

--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -59,7 +59,11 @@ class SubdirectoryHintTracker:
     and append the returned text to the tool result.
     """
 
-    def __init__(self, working_dir: Optional[str] = None):
+    def __init__(self, working_dir: Optional[str] = None, *, enabled: bool = True):
+        # ``enabled=False`` mirrors ``skip_context_files``: a session that opted out of
+        # AGENTS.md/CLAUDE.md injection at startup must not get the same files spliced into
+        # tool results later — cron jobs relaying exact stdout leaked them to chat (#9441).
+        self.enabled = enabled
         self.working_dir = Path(working_dir or os.getcwd()).resolve()
         # The working dir is pre-marked loaded (startup context handles it).
         self._loaded_dirs: Set[Path] = {self.working_dir}
@@ -73,6 +77,8 @@ class SubdirectoryHintTracker:
 
     def check_tool_call(self, tool_name: str, tool_args: Dict[str, Any]) -> Optional[str]:
         """Return formatted hint text for newly visited directories, or None."""
+        if not self.enabled:
+            return None
         all_hints = [h for d in self._extract_directories(tool_name, tool_args) if (h := self._load_hints_for_directory(d))]
         return "\n\n" + "\n\n".join(all_hints) if all_hints else None
 

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -56,6 +56,12 @@ class TestSubdirectoryHintTracker:
         assert result is not None
         assert "Frontend rules" in result
 
+    def test_disabled_tracker_never_injects_hints(self, project):
+        """A session that skips context files (cron without a workdir) must not have the same
+        files spliced into tool results, where they leak into exact-output deliveries (#9441)."""
+        tracker = SubdirectoryHintTracker(working_dir=str(project), enabled=False)
+        assert tracker.check_tool_call("read_file", {"path": str(project / "frontend" / "index.ts")}) is None
+
     def test_no_duplicate_loading(self, project):
         """Same directory should not be loaded twice."""
         tracker = SubdirectoryHintTracker(working_dir=str(project))

--- a/tests/agent/test_subdirectory_hints.py
+++ b/tests/agent/test_subdirectory_hints.py
@@ -14,30 +14,30 @@ from agent.subdirectory_hints import SubdirectoryHintTracker
 def project(tmp_path):
     """Create a mock project tree with hint files in subdirectories."""
     # Root — already loaded at startup
-    (tmp_path / "AGENTS.md").write_text("Root project instructions")
+    (tmp_path / "AGENTS.md").write_text("Root project instructions", encoding="utf-8")
 
     # backend/ — has its own AGENTS.md
     backend = tmp_path / "backend"
     backend.mkdir()
-    (backend / "AGENTS.md").write_text("Backend-specific instructions:\n- Use FastAPI\n- Always add type hints")
+    (backend / "AGENTS.md").write_text("Backend-specific instructions:\n- Use FastAPI\n- Always add type hints", encoding="utf-8")
 
     # backend/src/ — no hints
     (backend / "src").mkdir()
-    (backend / "src" / "main.py").write_text("print('hello')")
+    (backend / "src" / "main.py").write_text("print('hello')", encoding="utf-8")
 
     # frontend/ — has CLAUDE.md
     frontend = tmp_path / "frontend"
     frontend.mkdir()
-    (frontend / "CLAUDE.md").write_text("Frontend rules:\n- Use TypeScript\n- No any types")
+    (frontend / "CLAUDE.md").write_text("Frontend rules:\n- Use TypeScript\n- No any types", encoding="utf-8")
 
     # docs/ — no hints
     (tmp_path / "docs").mkdir()
-    (tmp_path / "docs" / "README.md").write_text("Documentation")
+    (tmp_path / "docs" / "README.md").write_text("Documentation", encoding="utf-8")
 
     # deep/nested/path/ — has .cursorrules
     deep = tmp_path / "deep" / "nested" / "path"
     deep.mkdir(parents=True)
-    (deep / ".cursorrules").write_text("Cursor rules for nested path")
+    (deep / ".cursorrules").write_text("Cursor rules for nested path", encoding="utf-8")
 
     return tmp_path
 
@@ -110,7 +110,7 @@ class TestSubdirectoryHintTracker:
         sub = tmp_path / "bigdir"
         sub.mkdir()
         body = "HEAD-MARKER " + ("x" * (sh._MAX_HINT_CHARS + 5_000)) + " TAIL-MARKER"
-        (sub / "AGENTS.md").write_text(body)
+        (sub / "AGENTS.md").write_text(body, encoding="utf-8")
 
         tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
         with caplog.at_level(logging.WARNING, logger="agent.prompt_builder"):
@@ -126,7 +126,7 @@ class TestSubdirectoryHintTracker:
         sub = tmp_path / "gateway"
         sub.mkdir()
         body = "# Gateway rules\n" + ("- rule\n" * 1500)   # ~12k chars: over the OLD 8k cap, under the new one
-        (sub / "AGENTS.md").write_text(body)
+        (sub / "AGENTS.md").write_text(body, encoding="utf-8")
         tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
         result = tracker.check_tool_call("read_file", {"path": str(sub / "run.py")})
         assert result is not None and "truncated" not in result.lower()
@@ -143,7 +143,7 @@ class TestSubdirectoryHintTracker:
     def test_timeout_skips_slow_hint_files(self, project, monkeypatch, caplog):
         """Slow hint reads time out instead of blocking the turn."""
         backend = project / "backend"
-        (backend / "AGENTS.md").write_text("Backend-specific instructions")
+        (backend / "AGENTS.md").write_text("Backend-specific instructions", encoding="utf-8")
         import sys
 
         from agent import subdirectory_hints as sh_mod
@@ -244,7 +244,7 @@ class TestContentDeduplication:
         """Two directories whose AGENTS.md is the same file yield one injection."""
         real = tmp_path / "real"
         real.mkdir()
-        (real / "AGENTS.md").write_text("Shared workspace instructions")
+        (real / "AGENTS.md").write_text("Shared workspace instructions", encoding="utf-8")
 
         mirror = tmp_path / "mirror"
         mirror.mkdir()
@@ -264,8 +264,8 @@ class TestContentDeduplication:
         b = tmp_path / "b"
         a.mkdir()
         b.mkdir()
-        (a / "AGENTS.md").write_text("Same content")
-        (b / "AGENTS.md").write_text("Same content")
+        (a / "AGENTS.md").write_text("Same content", encoding="utf-8")
+        (b / "AGENTS.md").write_text("Same content", encoding="utf-8")
 
         tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
         assert tracker.check_tool_call("read_file", {"path": str(a / "f.py")}) is not None
@@ -277,8 +277,8 @@ class TestContentDeduplication:
         b = tmp_path / "b"
         a.mkdir()
         b.mkdir()
-        (a / "AGENTS.md").write_text("Alpha rules")
-        (b / "AGENTS.md").write_text("Beta rules")
+        (a / "AGENTS.md").write_text("Alpha rules", encoding="utf-8")
+        (b / "AGENTS.md").write_text("Beta rules", encoding="utf-8")
 
         tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
         first = tracker.check_tool_call("read_file", {"path": str(a / "f.py")})
@@ -289,10 +289,10 @@ class TestContentDeduplication:
 
     def test_working_dir_content_seeded(self, tmp_path):
         """A copy of the CWD's own context file is not re-injected."""
-        (tmp_path / "AGENTS.md").write_text("Root instructions")
+        (tmp_path / "AGENTS.md").write_text("Root instructions", encoding="utf-8")
         elsewhere = tmp_path / "elsewhere"
         elsewhere.mkdir()
-        (elsewhere / "AGENTS.md").write_text("Root instructions")
+        (elsewhere / "AGENTS.md").write_text("Root instructions", encoding="utf-8")
 
         tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
         assert tracker.check_tool_call("read_file", {"path": str(elsewhere / "f.py")}) is None
@@ -308,7 +308,7 @@ class TestExcludedDirectories:
     def test_excluded_directory_skipped(self, tmp_path, excluded):
         target = tmp_path / excluded / "snapshot"
         target.mkdir(parents=True)
-        (target / "AGENTS.md").write_text("Stale archived instructions")
+        (target / "AGENTS.md").write_text("Stale archived instructions", encoding="utf-8")
 
         tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
         assert tracker.check_tool_call("read_file", {"path": str(target / "f.py")}) is None
@@ -317,7 +317,7 @@ class TestExcludedDirectories:
         """A hint nested under an excluded ancestor is still skipped."""
         deep = tmp_path / "backups" / "2026" / "proj"
         deep.mkdir(parents=True)
-        (deep / "AGENTS.md").write_text("Archived")
+        (deep / "AGENTS.md").write_text("Archived", encoding="utf-8")
 
         tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
         assert tracker.check_tool_call("read_file", {"path": str(deep / "f.py")}) is None
@@ -328,7 +328,7 @@ class TestExcludedDirectories:
         root.mkdir(parents=True)
         sub = root / "pkg"
         sub.mkdir()
-        (sub / "AGENTS.md").write_text("Package rules")
+        (sub / "AGENTS.md").write_text("Package rules", encoding="utf-8")
 
         tracker = SubdirectoryHintTracker(working_dir=str(root))
         result = tracker.check_tool_call("read_file", {"path": str(sub / "f.py")})
@@ -337,7 +337,7 @@ class TestExcludedDirectories:
     def test_normal_directory_unaffected(self, tmp_path):
         normal = tmp_path / "backend"
         normal.mkdir()
-        (normal / "AGENTS.md").write_text("Backend rules")
+        (normal / "AGENTS.md").write_text("Backend rules", encoding="utf-8")
 
         tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
         result = tracker.check_tool_call("read_file", {"path": str(normal / "f.py")})
@@ -347,8 +347,8 @@ class TestExcludedDirectories:
         """AGENTS.override.md takes priority over AGENTS.md per directory."""
         sub = tmp_path / "backend"
         sub.mkdir()
-        (sub / "AGENTS.md").write_text("Committed backend rules")
-        (sub / "AGENTS.override.md").write_text("Personal backend override")
+        (sub / "AGENTS.md").write_text("Committed backend rules", encoding="utf-8")
+        (sub / "AGENTS.override.md").write_text("Personal backend override", encoding="utf-8")
 
         tracker = SubdirectoryHintTracker(working_dir=str(tmp_path))
         result = tracker.check_tool_call("read_file", {"path": str(sub / "f.py")})


### PR DESCRIPTION
**Cron jobs (and any session with `skip_context_files=True`) no longer get `AGENTS.md`/`CLAUDE.md` spliced onto tool results, so exact-stdout deliveries stay clean.**

- `skip_context_files` kept context files out of the system prompt, but `SubdirectoryHintTracker` was always on; the first tool call touching a directory with such a file appended `[Subdirectory context discovered: ...]` plus the file body to the tool result, which leaked into Telegram/Discord deliveries.
- The tracker takes `enabled=`; agent init wires it to `not skip_context_files`. One flag, both injection paths. Interactive sessions and cron jobs with a workdir are unchanged.

**Live repro (E2E, real `AIAgent`, temp `HERMES_HOME`, `TERMINAL_CWD` with a `sub/AGENTS.md`):**

| `skip_context_files` | `origin/main` | this branch |
|---|---|---|
| True | hint injected | no hint |
| False | hint injected | hint injected |

Test `test_disabled_tracker_never_injects_hints` red on main. Direction from #9434 (@zhitiao), which gated on `platform == "cron"`; gating on the existing flag covers the same case without a platform special-case.

Fixes #9441.

## Infographic
![cron-subdirectory-hints](https://v3b.fal.media/files/b/0aaa225a/xiKewQ4a9U96iEYITgHpQ_D5vcbV2L.png)
