### PR TITLE
fix(auxiliary): auto-routed aux calls drop OpenRouter-format model overrides on the first cache miss too (#11289, salvage #11292)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5572,7 +5572,7 @@ def _get_cached_client(
                 client, default_model, _ = _client_cache[cache_key]
                 # Race loser was never exposed to a caller — safe to close now.
                 _close_cached_client(built_client, close_async=async_mode)
-    return client, model or default_model
+    return client, _compat_model(client, model, default_model)
 
 
 # Aliases for direct REST APIs not modeled in PROVIDER_REGISTRY, so ``auxiliary.<task>.provider:

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -219,6 +219,43 @@ class TestResolveVisionProviderClientModelNormalization:
         assert model == "glm-5v-turbo"  # zai has dedicated vision model in _PROVIDER_VISION_MODELS
 
 
+class TestAutoClientCacheModelCompatibility:
+    """Auto client cache should not keep OpenRouter-format model overrides on non-OR clients."""
+
+    def test_first_auto_cache_miss_drops_openrouter_model_for_named_custom_runtime(self, tmp_path):
+        from agent import auxiliary_client as ac
+
+        ac._client_cache.clear()
+        try:
+            fake_client = MagicMock()
+            fake_client.base_url = "https://aixj.vip/v1"
+            fake_client.api_key = "test-key"
+
+            runtime = {
+                "provider": "custom:aixj.vip",
+                "model": "gpt-5.4",
+                "base_url": "https://aixj.vip/v1",
+                "api_key": "***",
+                "api_mode": "codex_responses",
+            }
+
+            with patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(fake_client, "gpt-5.4"),
+            ) as mock_resolve:
+                client, model = ac._get_cached_client(
+                    "auto",
+                    "google/gemini-3-flash-preview",
+                    main_runtime=runtime,
+                )
+
+            assert client is fake_client
+            assert model == "gpt-5.4"
+            mock_resolve.assert_called_once()
+        finally:
+            ac._client_cache.clear()
+
+
 class TestVisionPathApiMode:
     """Vision path should propagate api_mode to _get_cached_client."""
 


### PR DESCRIPTION
Auxiliary calls routed via `provider: auto` no longer send an OpenRouter-format model slug to a non-OpenRouter client on the first (cache-miss) request.

- `agent/auxiliary_client.py::_get_cached_client` — the cache-miss return now goes through the same `_compat_model()` guard the cache-hit path already used.
- 1 invariant test: first auto-route to a named custom runtime with `google/gemini-3-flash-preview` configured resolves to the runtime's own model.

**Root cause:** the compat filter was applied only on cache hits, so behaviour depended on cache state (the reporter's compression 401 fired exactly once per fresh cache).

| | model handed to `https://aixj.vip/v1` client |
|---|---|
| before (cache miss) | `google/gemini-3-flash-preview` → 401 / "unknown model" |
| before (cache hit) | `gpt-5.4` |
| after (both) | `gpt-5.4` |

**Live repro:** real `_get_cached_client` in a subprocess against `origin/main` → miss returns `google/gemini-3-flash-preview`; on this branch → `gpt-5.4`.

Salvage of #11292 by @KeaneYan (cherry-picked, authorship preserved). Closes #11289.

## Infographic

![aux-cache-miss](https://v3b.fal.media/files/b/0aaa2202/aQ8UAKFa7pWZOJrzYYpQ5_vaZECc9d.png)
