### PR TITLE
fix(terminal): restore agent turns on Vertex-backed endpoints

### DIFF
--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -168,18 +168,13 @@ class TestCheckpointNotify:
 # =========================================================================
 
 class TestTerminalSchema:
-    def test_schema_advertises_unified_notify(self):
-        """`notify` is the single advertised notification arg: bool (notify on
-        exit) or list of strings (notify on pattern). The legacy
-        notify_on_complete/watch_patterns args stay handler-accepted but
-        unadvertised."""
+    def test_schema_advertises_boolean_notify_without_union(self):
+        """Strict providers can translate the exit notification declaration."""
         from tools.terminal_tool import TERMINAL_SCHEMA
         props = TERMINAL_SCHEMA["parameters"]["properties"]
-        assert "notify" in props
-        types = {alt["type"] for alt in props["notify"]["anyOf"]}
-        assert types == {"boolean", "array"}
+        assert props["notify"]["type"] == "boolean"
+        assert "anyOf" not in props["notify"]
         assert "notify_on_complete" not in props
-        assert "watch_patterns" not in props
 
     def test_handler_passes_notify(self):
         """_handle_terminal passes notify_on_complete to terminal_tool."""

--- a/tests/tools/test_watch_patterns.py
+++ b/tests/tools/test_watch_patterns.py
@@ -273,18 +273,16 @@ class TestCheckpointPersistence:
 # =========================================================================
 
 class TestTerminalToolSchema:
-    def test_schema_unified_notify_covers_patterns(self):
-        """Pattern-watching is advertised through `notify` (list form); the
-        legacy watch_patterns arg stays handler-accepted but unadvertised."""
+    def test_schema_advertises_patterns_as_a_separate_array(self):
+        """Pattern watching remains available without a union-typed property."""
         from tools.terminal_tool import TERMINAL_SCHEMA
         props = TERMINAL_SCHEMA["parameters"]["properties"]
-        assert "watch_patterns" not in props
-        array_alts = [alt for alt in props["notify"]["anyOf"] if alt["type"] == "array"]
-        assert array_alts and array_alts[0]["items"] == {"type": "string"}
+        assert props["watch_patterns"]["type"] == "array"
+        assert props["watch_patterns"]["items"] == {"type": "string"}
 
     def test_handler_passes_watch_patterns(self):
-        """_handle_terminal passes legacy watch_patterns through to
-        terminal_tool (background call — foreground+watch now errors)."""
+        """_handle_terminal passes watch_patterns through to terminal_tool
+        (background call — foreground+watch errors)."""
         from tools.terminal_tool import _handle_terminal
         with patch("tools.terminal_tool.terminal_tool") as mock_tt:
             mock_tt.return_value = json.dumps({"output": "ok", "exit_code": 0})

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -161,7 +161,7 @@ Do NOT use cat/head/tail (use read_file), grep/rg/find/ls (use search_files), se
 Environment state persists: activate a virtualenv or export variables once per session, not before every command.
 
 Foreground (default): returns INSTANTLY when the command finishes, even with a high timeout — set timeout generously for long builds.
-Background: set background=true (returns a session_id); add notify=true for bounded tasks, leave silent only for servers/daemons that never exit. After starting a server, verify readiness with a health check in a separate call (no blind sleep loops); manage with process(action="poll"/"wait").
+Background: set background=true (returns a session_id); add notify=true for bounded tasks, or watch_patterns=[...] for one-shot readiness signals on long-lived processes. Leave silent only for servers/daemons that never exit. After starting a server, verify readiness with a health check in a separate call (no blind sleep loops); manage with process(action="poll"/"wait").
 Working directory: use 'workdir' for per-command cwd; when a command changes the session cwd (cd, pushd), trust the result's "cwd" field instead of prefixing every command with 'cd'.
 PTY: pty=true + background=true for interactive CLIs (they hang without a terminal); drive them with process(action="write"/"submit"). Local backend only.
 """
@@ -1297,15 +1297,17 @@ TERMINAL_SCHEMA = {
                 "default": False
             },
             "notify": {
-                "description": "With background=true: notify=true fires exactly one notification when the process exits (the right choice for nearly every bounded task — builds, tests, deploys). notify=['pattern', ...] instead notifies when a line matches a pattern — ONLY for one-shot readiness signals on processes that never exit (e.g. ['Application startup complete']); rate-limited and auto-disabled if it over-fires. Omit for silent daemons.",
-                "anyOf": [
-                    {"type": "boolean"},
-                    {"type": "array", "items": {"type": "string"}}
-                ]
+                "type": "boolean",
+                "description": "With background=true: fire exactly one notification when the process exits. The right choice for nearly every bounded task (builds, tests, deploys). MUTUALLY EXCLUSIVE with watch_patterns.",
+                "default": False
+            },
+            "watch_patterns": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "With background=true: notify when a line matches any pattern. ONLY for one-shot readiness signals on processes that never exit (e.g. ['Application startup complete']); rate-limited and auto-disabled if it over-fires. MUTUALLY EXCLUSIVE with notify."
             }
-            # Legacy aliases (unadvertised, still accepted): notify_on_complete
-            # (bool) and watch_patterns (list). notify=true|[...] maps onto
-            # them in the dispatch wrapper; explicit notify wins on conflict.
+            # Legacy aliases remain accepted: notify_on_complete (bool), plus
+            # list-valued notify from transcripts created before the schema split.
         },
         "required": ["command"]
     }
@@ -1321,17 +1323,17 @@ def _handle_terminal(args, **kw):
             "command in 'command'. Use execute_code(code=...) for Python; "
             "for shell, retry as terminal(command=...)."
         )
-    # `notify` is the advertised interface (true → notify_on_complete,
-    # [...] → watch_patterns); the legacy args stay accepted, explicit
-    # `notify` wins. Background-only modifiers on a foreground call fail
-    # with the corrected call instead of being silently ignored.
+    # The advertised split is notify (bool) + watch_patterns (list). Legacy
+    # notify_on_complete and list-valued notify stay accepted for old
+    # transcripts; explicit notify wins. Background-only modifiers on a
+    # foreground call fail with the corrected call instead of being ignored.
     notify = args.get("notify")
     notify_on_complete = args.get("notify_on_complete", False)
     watch_patterns = args.get("watch_patterns")
     if not args.get("background", False):
         if notify or watch_patterns or notify_on_complete:
             return tool_error(
-                "notify only applies to background commands (foreground "
+                "notify and watch_patterns only apply to background commands (foreground "
                 "results return directly). Either drop notify, or run as "
                 "terminal(command=..., background=true, notify=...)."
             )


### PR DESCRIPTION
## What does this PR do?

Vertex-backed OpenAI-compatible endpoints reject every tool-bearing agent turn because the advertised `terminal.notify` property uses a multi-branch `anyOf`. This change exposes completion notifications as a boolean `notify` property and pattern notifications as a separate array-valued `watch_patterns` property while preserving legacy transcript handling in the dispatcher.

### Symptom

Requests that include the standard Hermes tool list fail with HTTP 400, identifying `terminal` function declaration `parameters.notify` as an incorrect schema type.

### Impact

Users of affected Vertex-backed OpenAI-compatible endpoints cannot complete agent turns while the terminal tool schema is present. The known impact is limited to strict endpoints that reject this union shape.

### Bug Cause

**Trigger:** `tools/terminal_tool.py:1299` / `TERMINAL_SCHEMA["parameters"]["properties"]["notify"]`

**Causal chain:**
1. Hermes advertises `notify` as `anyOf` boolean or array of strings.
2. Google's OpenAI-to-FunctionDeclaration translation cannot represent that multi-branch property and produces a declaration Vertex rejects.
3. Vertex rejects the complete request before the model can return an agent response.

**Why it is wrong:** A valid generic JSON Schema union is not portable to the stricter FunctionDeclaration schema accepted by this provider path.

**Working sibling / contrast:** Single-typed boolean and array properties are independently representable by the strict schema translator. The existing terminal dispatcher already accepts `watch_patterns` separately.

**Ruled out:** The issue's controlled A/B kept the endpoint, model, credentials, and full tool list unchanged; replacing only the union-shaped `notify` node with a boolean changed the response from HTTP 400 to HTTP 200.

### Fix

Declare `notify` as a boolean and advertise `watch_patterns` as a separate string array. Keep `notify_on_complete` and list-valued `notify` accepted internally so old transcripts and callers continue to work, and update the schema contract tests for both independent properties.

## Related Issue

Closes #109115

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/terminal_tool.py` - split the notification schema into two single-typed properties while preserving legacy dispatch compatibility.
- `tests/tools/test_notify_on_complete.py` - assert completion notification schema compatibility without a union.
- `tests/tools/test_watch_patterns.py` - assert pattern notifications remain advertised as a string array.

## How to Test

1. Inspect the terminal schema and confirm `notify` is boolean with no `anyOf`.
2. Confirm `watch_patterns` is an array whose items are strings.
3. Run `scripts/run_tests.sh tests/tools/test_notify_on_complete.py tests/tools/test_watch_patterns.py` (43 passed).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant tests and all 43 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior

## Screenshots / Logs

N/A
