### PR TITLE
fix(cli): multi-line paste while the agent runs is one message, not one steer per line (#10994)

### DIFF
--- a/hermes_cli/cli_tui_mixin.py
+++ b/hermes_cli/cli_tui_mixin.py
@@ -1351,14 +1351,9 @@ class CLITuiMixin:
         if self._tui_enter_overlay(event):
             return
         buf = event.app.current_buffer
-        # Paste without bracketed-paste (tmux strips it) and IME/voice dictation deliver each
-        # newline as its own Enter key event; the buffer collapse in _tui_on_text_changed only
-        # sees whole-chunk pastes. Text still arriving (<50 ms since the last change) means this
-        # Enter is a line break inside one message, not a submit — humans type >50 ms apart (#10994).
-        if time.monotonic() - getattr(self, "_tui_last_text_change", 0.0) < _RAPID_INPUT_ENTER_WINDOW_S:
-            buf.insert_text("\n")
-            return
         raw_text = buf.text
+        # Explicit `\` + Enter continuation runs first so its backslash is consumed identically
+        # whether the Enter was typed or arrived inside a paste.
         if (
             self._tui_multiline_shortcuts
             and buf.cursor_position == len(raw_text)
@@ -1367,6 +1362,13 @@ class CLITuiMixin:
             buf.text = continued
             buf.cursor_position = len(continued)
             event.app.invalidate()
+            return
+        # Paste without bracketed-paste (tmux strips it) and IME/voice dictation deliver each
+        # newline as its own Enter key event; the buffer collapse in _tui_on_text_changed only
+        # sees whole-chunk pastes. Text still arriving (<50 ms since the last change) means this
+        # Enter is a line break inside one message, not a submit (#10994).
+        if time.monotonic() - getattr(self, "_tui_last_text_change", 0.0) < _RAPID_INPUT_ENTER_WINDOW_S:
+            buf.insert_text("\n")
             return
         text = raw_text.strip()
         has_images = bool(self._attached_images)

--- a/hermes_cli/cli_tui_mixin.py
+++ b/hermes_cli/cli_tui_mixin.py
@@ -41,6 +41,8 @@ from typing import Optional
 # Rows below an overlay panel taken by spinner/tool-progress, status bar, input, separators and
 # prompt symbol (measured ~6 during live PTY approval prompts) — shared by every panel budget.
 _PANEL_RESERVED_BELOW = 6
+# Enter within this many seconds of the last buffer change is a pasted/dictated newline, not a submit.
+_RAPID_INPUT_ENTER_WINDOW_S = 0.05
 _TYPING_CHARS = string.digits + string.ascii_letters + "-_.:/ "
 
 _APPROVAL_CHOICE_LABELS = {
@@ -1349,6 +1351,13 @@ class CLITuiMixin:
         if self._tui_enter_overlay(event):
             return
         buf = event.app.current_buffer
+        # Paste without bracketed-paste (tmux strips it) and IME/voice dictation deliver each
+        # newline as its own Enter key event; the buffer collapse in _tui_on_text_changed only
+        # sees whole-chunk pastes. Text still arriving (<50 ms since the last change) means this
+        # Enter is a line break inside one message, not a submit — humans type >50 ms apart (#10994).
+        if time.monotonic() - getattr(self, "_tui_last_text_change", 0.0) < _RAPID_INPUT_ENTER_WINDOW_S:
+            buf.insert_text("\n")
+            return
         raw_text = buf.text
         if (
             self._tui_multiline_shortcuts
@@ -1676,6 +1685,7 @@ class CLITuiMixin:
         tick), or the newline count jumped by 4+ (terminals that feed characters individually
         but batch newlines; Alt+Enter adds 1 newline per event so never trips it).
         """
+        self._tui_last_text_change = time.monotonic()
         from cli import _strip_leaked_bracketed_paste_wrappers, _strip_leaked_terminal_responses_with_meta
         text = _strip_leaked_bracketed_paste_wrappers(buf.text)
         text, _had_mouse_reports = _strip_leaked_terminal_responses_with_meta(text)

--- a/tests/cli/test_tui_rapid_enter_paste.py
+++ b/tests/cli/test_tui_rapid_enter_paste.py
@@ -49,3 +49,16 @@ def test_enter_right_after_text_arrives_is_a_newline_not_a_steer():
     shell._tui_handle_enter(_event(buf))
     shell._tui_enter_while_busy.assert_called_once()
     assert shell._tui_enter_while_busy.call_args.args[0] == "line one\nline two"
+
+
+def test_fast_backslash_continuation_still_consumes_the_backslash():
+    """`\\` + Enter inside a paste (multiline shortcuts on) behaves like a typed one: the
+    backslash is removed and a newline inserted, never a literal backslash left in the text."""
+    shell = _shell()
+    shell._tui_multiline_shortcuts = True
+    buf = Buffer()
+    buf.on_text_changed += shell._tui_on_text_changed
+    buf.insert_text("alpha \\")
+    shell._tui_handle_enter(_event(buf))          # < 50 ms after the text change
+    assert buf.text == "alpha \n"
+    shell._tui_enter_while_busy.assert_not_called()

--- a/tests/cli/test_tui_rapid_enter_paste.py
+++ b/tests/cli/test_tui_rapid_enter_paste.py
@@ -1,0 +1,51 @@
+"""Enter arriving mid-paste (no bracketed paste; each newline is its own key event) must not
+submit / steer the partial line (#10994). Only the Enter-vs-recent-text-change timing is exercised;
+the real prompt_toolkit Buffer carries the text so the newline lands where the user's did."""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from prompt_toolkit.buffer import Buffer
+
+from hermes_cli.cli_tui_mixin import _RAPID_INPUT_ENTER_WINDOW_S
+
+
+def _shell():
+    from cli import HermesCLI
+    shell = object.__new__(HermesCLI)
+    shell._tui_enter_overlay = lambda event: False
+    shell._tui_multiline_shortcuts = False
+    shell._attached_images = []
+    shell._agent_running = True
+    shell._tui_enter_while_busy = MagicMock()
+    shell._tui_enter_inline_command = lambda *a, **k: False
+    shell._inline_pastes = lambda buf: None
+    shell._tui_paste_counter = 0
+    shell.config = {}
+    shell._tui_prev_text_len = shell._tui_prev_newline_count = 0
+    shell._tui_paste_just_collapsed = shell._skip_paste_collapse = False
+    return shell
+
+
+def _event(buf: Buffer):
+    return SimpleNamespace(app=SimpleNamespace(current_buffer=buf, invalidate=lambda: None, is_running=False))
+
+
+def test_enter_right_after_text_arrives_is_a_newline_not_a_steer():
+    """Line 1 of a paste followed by Enter within the window stays in the buffer; the same Enter
+    after a human-scale pause submits the accumulated multi-line message once."""
+    shell = _shell()
+    buf = Buffer()
+    buf.on_text_changed += shell._tui_on_text_changed
+    buf.insert_text("line one")
+    shell._tui_handle_enter(_event(buf))          # < 50 ms after the text change
+    assert buf.text == "line one\n"
+    shell._tui_enter_while_busy.assert_not_called()
+
+    buf.insert_text("line two")
+    time.sleep(_RAPID_INPUT_ENTER_WINDOW_S * 3)  # the paste has finished; a human presses Enter
+    shell._tui_handle_enter(_event(buf))
+    shell._tui_enter_while_busy.assert_called_once()
+    assert shell._tui_enter_while_busy.call_args.args[0] == "line one\nline two"


### PR DESCRIPTION
A multi-line paste (or IME / voice-dictation input) typed while the agent is running is delivered as one message; without bracketed paste (tmux strips it) each pasted newline used to arrive as its own Enter and became a separate steering message.

- `hermes_cli/cli_tui_mixin.py::_tui_handle_enter` — an Enter within 50 ms of the last buffer change (`_tui_on_text_changed` stamps it) inserts a newline instead of submitting; the existing whole-chunk paste collapse is untouched.
- 1 invariant test driving the real handler with a prompt_toolkit `Buffer`: Enter right after text → newline, no steer; Enter after a pause → one submit carrying both lines.

**Root cause:** `_tui_on_text_changed`'s paste heuristics only see whole-chunk pastes (many chars in one event or 4+ newlines at once). Per-keystroke delivery (tmux, Termux+SSH dictation) never trips them, so every line was routed through `_tui_enter_while_busy` → `agent.steer()`.

| PTY probe (`alpha\rbeta\rgamma`, then Enter after 500 ms) | result |
|---|---|
| `origin/main` | three separate `❯ … line` submissions, each an interrupt |
| this branch | one `❯ alpha line / beta line / gamma line` submission |

**Live repro:** real `hermes chat` under a pty, transcript above; test red on base with the same assertion.

Same mechanism as #10997 (@iRonin) and #19498 (@Ralojeil1), which targeted the removed classic-CLI `handle_enter`. Closes #10994.

**Review follow-up (989aaeae):** the `\` + Enter continuation now runs before the paste-timing guard, so a fast backslash continuation consumes the backslash exactly like a typed one (test added; red on the previous head).

## Infographic

![one-paste](https://v3b.fal.media/files/b/0aaa2258/0V7aKNYpCU340o37hl25k_TfmJJxBu.png)

