### PR TITLE
fix(hindsight): flush final partial retain after memory sync drain

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1123,6 +1123,37 @@ class HindsightMemoryProvider(MemoryProvider):
 
     # -- session lifecycle -------------------------------------------------------
 
+    def _enqueue_shutdown_retain(self) -> None:
+        """Queue the partial final batch after MemoryManager has drained sync work."""
+        batch_size = getattr(self, "_retain_every_n_turns", 0)
+        if (
+            not self._session_turns
+            or (batch_size > 0 and self._turn_counter % batch_size == 0)
+            or self._shutting_down.is_set()
+        ):
+            return
+        document_id, update_mode = self._resolve_retain_target(self._document_id)
+        turns_snapshot = list(self._session_turns)
+        if update_mode == "append":
+            turns_snapshot = turns_snapshot[self._last_retained_turn_count:]
+        if not turns_snapshot:
+            return
+        job = self._make_turn_retain_job(
+            turns_snapshot,
+            document_id=document_id,
+            update_mode=update_mode,
+            label="flush-on-shutdown",
+            track_ops=False,
+        )
+
+        def _flush() -> None:
+            try:
+                job()
+            except Exception as exc:
+                logger.warning("Hindsight flush-on-shutdown failed: %s", exc, exc_info=True)
+
+        self._enqueue_retain(_flush)
+
     def on_session_switch(self, new_session_id: str, *, parent_session_id: str = "",
                           reset: bool = False, **kwargs) -> None:
         """Rotate per-session state (/resume, /branch, /reset, /new, compression) so
@@ -1193,8 +1224,11 @@ class HindsightMemoryProvider(MemoryProvider):
             self._client.close()
 
     def shutdown(self) -> None:
-        logger.debug("Hindsight shutdown: stopping writer + waiting for background threads")
-        # Stop accepting retain jobs first so late sync_turn() calls are dropped.
+        logger.debug("Hindsight shutdown: flushing buffered turns + waiting for background threads")
+        # MemoryManager drains its sync worker before provider shutdown, so every
+        # accepted turn is now visible here. Queue the partial final batch before
+        # closing admission; the writer drains it before the sentinel.
+        self._enqueue_shutdown_retain()
         self._shutting_down.set()
         # The writer finishes in-flight work then exits on the sentinel; the
         # bounded join keeps shutdown predictable even if the daemon is wedged.

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1098,6 +1098,79 @@ class TestShutdownRace:
         assert client.aretain_batch.call_count == 2
         assert provider._retain_queue.empty()
 
+    def test_shutdown_flushes_turn_buffered_by_memory_manager(self, tmp_path, monkeypatch):
+        """A partial batch queued by MemoryManager must survive process shutdown."""
+        from agent.memory_manager import MemoryManager
+        from plugins.memory import load_memory_provider
+
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps({
+            "mode": "cloud",
+            "apiKey": "test-key",
+            "api_url": "http://localhost:9999",
+            "bank_id": "test-bank",
+            "budget": "mid",
+            "memory_mode": "hybrid",
+            "retain_every_n_turns": 3,
+            "retain_async": False,
+        }))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+
+        provider = load_memory_provider("hindsight", register_skills=False)
+        assert isinstance(provider, HindsightMemoryProvider)
+        provider.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
+        provider._client = _make_mock_client()
+        monkeypatch.setattr(
+            provider, "_resolve_retain_target", lambda fallback: (fallback, None)
+        )
+        client = provider._client
+        manager = MemoryManager()
+        manager.add_provider(provider)
+
+        manager.sync_all("last user turn", "last assistant turn", session_id="test-session")
+        manager.shutdown_all()
+
+        client.aretain_batch.assert_called_once()
+        content = json.loads(client.aretain_batch.call_args.kwargs["items"][0]["content"])
+        assert "last user turn" in json.dumps(content)
+        assert "last assistant turn" in json.dumps(content)
+
+    @pytest.mark.parametrize(("update_mode", "expected_final_turns"), [("append", 1), (None, 4)])
+    def test_shutdown_flush_uses_append_delta_but_full_legacy_snapshot(
+        self, provider_with_config, monkeypatch, update_mode, expected_final_turns
+    ):
+        """Final append writes only the tail; legacy overwrite rewrites the full document."""
+        from agent.memory_manager import MemoryManager
+
+        provider = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        monkeypatch.setattr(
+            provider,
+            "_resolve_retain_target",
+            lambda fallback: ("test-session" if update_mode == "append" else fallback, update_mode),
+        )
+        client = provider._client
+        manager = MemoryManager()
+        manager.add_provider(provider)
+
+        for turn in range(1, 5):
+            manager.sync_all(
+                f"turn {turn} user", f"turn {turn} assistant", session_id="test-session"
+            )
+        manager.shutdown_all()
+
+        assert client.aretain_batch.call_count == 2
+        final_content = json.loads(
+            client.aretain_batch.call_args_list[-1].kwargs["items"][0]["content"]
+        )
+        assert len(final_content) == expected_final_turns
+        assert "turn 4 user" in json.dumps(final_content)
+        if update_mode == "append":
+            assert "turn 1 user" not in json.dumps(final_content)
+        else:
+            assert "turn 1 user" in json.dumps(final_content)
+
 
 # ---------------------------------------------------------------------------
 # on_session_switch — flush + prefetch reset behavior


### PR DESCRIPTION
## What does this PR do?

Fixes loss of the final partial Hindsight retain batch during process shutdown when `retain_every_n_turns > 1`.

`MemoryManager.shutdown_all()` already closes manager admission and drains accepted serialized `sync_turn` work before calling provider shutdown. The Hindsight provider now uses that provider-owned lifecycle point to enqueue any remaining partial batch before it closes retain admission and sends the writer sentinel.

This is intentionally narrower than #94252: it addresses only the post-manager-drain terminal-batch loss from #36216. It does not include broader session-switch locking, retry/watermark, prefetch, or configuration changes.

AI assistance disclosure: the implementation and tests were prepared with Hermes Agent under the contributor's direction. Validation commands and results are summarized below.

## Related Issue

Fixes #36216

Related work and credit:
- #94252 by @rutgerblom — broader Hindsight lifecycle hardening
- #80503 by @stepanov1975 — earlier broader implementation of the same terminal-suffix failure mode
- #55046 and #41911 — related lifecycle work

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/hindsight/__init__.py`
  - enqueue the final partial batch from `shutdown()` after `MemoryManager` has drained accepted sync work;
  - append only the unretained suffix on append-capable servers;
  - preserve full-snapshot replacement semantics for legacy servers;
  - skip empty exact-boundary flushes and preserve the existing bounded writer shutdown.
- `tests/plugins/memory/test_hindsight_provider.py`
  - add a real provider-discovery → `MemoryManager` → provider-shutdown regression;
  - add one parameterized behavior-contract test covering modern append suffixes and legacy full snapshots.

## How to Test

1. On unmodified `origin/main`, run:
   `scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py -k shutdown_flushes_turn_buffered_by_memory_manager`
   It fails because `aretain_batch` is called 0 times.
2. On this branch, run:
   `scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py tests/run_agent/test_memory_sync_interrupted.py tests/agent/test_memory_session_switch.py`
   Result: **97 passed, 0 failed**.
3. Full-suite attempt:
   `scripts/run_tests.sh`
   Result: exit 1 with **11 failures across 9 files**, plus `tests/test_hermes_state.py` exceeding the per-file timeout. None of the failing files overlaps this two-file diff.
4. Exact-base comparison at this branch's parent `3e09e5a15f`:
   - Canonically rerunning the nine reported failing files (except `test_hermes_state.py`) produced the identical result on branch and base: **228 passed, 7 failed**.
   - The remaining deterministic `test_hermes_state.py::TestFTS5Search::test_search_projection_skips_context_enrichment_queries` failure was reproduced directly on the exact base.
   - Three timing-sensitive failures from the full run passed on focused rerun on the branch.

The PR remains a draft and the all-tests-pass checkbox remains unchecked; this does **not** claim a green full suite. The focused Hindsight/lifecycle suite is green, and every persistent full-suite failure was reproduced on the exact base commit.

Additional checks:

```bash
/home/alex/.hermes/hermes-agent/venv/bin/ruff check \
  plugins/memory/hindsight/__init__.py \
  tests/plugins/memory/test_hindsight_provider.py
```

Result: passed.

Narrow isolated type check (not a repository-wide mypy claim):

```bash
/home/alex/.hermes/hermes-agent/venv/bin/python -m mypy \
  --config-file=/dev/null \
  --follow-imports=skip \
  --ignore-missing-imports \
  --disable-error-code=func-returns-value \
  plugins/memory/hindsight/__init__.py \
  tests/plugins/memory/test_hindsight_provider.py
```

Result: passed.

- `python scripts/check-windows-footguns.py --all`: passed (1,537 files scanned)
- `python scripts/check_compat_pointers.py`: passed
- `git diff --check origin/main...HEAD`: passed
- independent concurrency/lifecycle review: no critical or important findings

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full canonical runner has unrelated failures reproduced on the exact base; details above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04.4 LTS, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; this corrects an internal lifecycle bug without changing configuration or documented interfaces
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no OS-specific APIs or timing assumptions added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Canonical RED evidence on `origin/main`:

```text
FAILED ...test_shutdown_flushes_turn_buffered_by_memory_manager
AssertionError: Expected 'aretain_batch' to have been called once. Called 0 times.
```

Focused GREEN evidence on this branch:

```text
=== Summary: 3 files, 97 tests passed, 0 failed (100% complete)
```

Exact-base persistent-failure comparison:

```text
branch: 9 files, 228 tests passed, 7 failed
base:   9 files, 228 tests passed, 7 failed
base:   test_search_projection_skips_context_enrichment_queries failed identically
```
