### PR TITLE
fix(auxiliary): surface vision-provider fallback and honor the explicit Anthropic aux model

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2849,7 +2849,7 @@ def _try_azure_foundry(
     return client, final_model
 
 
-def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optional[str]]:
+def _try_anthropic(explicit_api_key: str = None, model: str = None) -> Tuple[Optional[Any], Optional[str]]:
     try:
         from agent.anthropic_adapter import build_anthropic_client
         from agent.anthropic_credentials import resolve_anthropic_token
@@ -2879,7 +2879,10 @@ def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optiona
                     base_url = cfg_base_url
     from agent.anthropic_credentials import _is_oauth_token
     is_oauth = _is_oauth_token(token)
-    model = _get_aux_model_for_provider("anthropic") or "claude-haiku-4-5-20251001"
+    # An explicit model (auxiliary.<task>.model / caller kwarg) wins over the curated
+    # default; previously the caller's model was dropped here and the client silently
+    # bound default_aux_model, which happens to equal what most users configure (#109111).
+    model = model or _get_aux_model_for_provider("anthropic") or "claude-haiku-4-5-20251001"
     if _aux_probe_active():
         # Probe: token + adapter import resolved; skip real client construction.
         return _AuxProbeClientStub(api_key="", base_url=base_url), model
@@ -4799,7 +4802,7 @@ def _resolve_api_key_branch(req: _ResolveRequest, pconfig: Any, resolve_creds: C
     """PROVIDER_REGISTRY ``api_key`` providers (Anthropic via its own resolver), honouring explicit overrides."""
     provider = req.provider
     if provider == "anthropic":
-        client, default_model = _try_anthropic(explicit_api_key=req.explicit_api_key)
+        client, default_model = _try_anthropic(explicit_api_key=req.explicit_api_key, model=req.model)
         return _route_or_warn(req, client, default_model,
                               "resolve_provider_client: anthropic requested but no Anthropic credentials found")
     creds = resolve_creds(provider)
@@ -5081,7 +5084,7 @@ _STRICT_VISION_BACKENDS: Dict[str, Callable[[Optional[str]], Tuple[Optional[Any]
     "openrouter": lambda model: _try_openrouter(model=model),
     "nous": lambda model: resolve_provider_client("nous", model, is_vision=True),
     "openai-codex": lambda model: resolve_provider_client("openai-codex", model, is_vision=True),
-    "anthropic": lambda model: _try_anthropic(),
+    "anthropic": lambda model: _try_anthropic(model=model),
     "deepinfra": _deepinfra_strict_vision_backend,
     "custom": lambda model: _try_custom_endpoint(),
 }
@@ -6687,6 +6690,7 @@ def _resolve_call_client(
     api_key: Optional[str], resolved_provider: str, resolved_model: Optional[str],
     resolved_base_url: Optional[str], resolved_api_key: Optional[str],
     resolved_api_mode: Optional[str], main_runtime: Optional[Dict[str, Any]], async_mode: bool,
+    route_info: Optional[Dict[str, str]] = None,
 ) -> _ResolvedAuxRoute:
     """Resolve the client for one aux call: vision chain, or cached text client with the
     explicit-provider fallback_chain / auto-chain rescue; RuntimeError when nothing is configured."""
@@ -6703,6 +6707,13 @@ def _resolve_call_client(
             effective_provider, client, final_model = resolve_vision_provider_client(
                 provider="auto", model=resolved_model, async_mode=async_mode,
                 main_runtime=main_runtime)
+            if client is not None and route_info is not None:
+                # Surface the silent detour: an explicitly configured auxiliary.vision.provider
+                # was unavailable and auto routing served the call instead (#109111).
+                route_info["fallback_notice"] = (
+                    f"Configured vision provider '{resolved_provider}' is unavailable "
+                    f"(no credentials or backend offline); analysis ran on the auto "
+                    f"vision backend '{effective_provider or 'auto'}' instead.")
         if client is not None:
             resolved_provider = effective_provider or resolved_provider
     else:
@@ -6773,6 +6784,7 @@ def _prepare_aux_request(
         resolved_provider=resolved_provider, resolved_model=resolved_model,
         resolved_base_url=resolved_base_url, resolved_api_key=resolved_api_key,
         resolved_api_mode=resolved_api_mode, main_runtime=main_runtime, async_mode=async_mode,
+        route_info=route_info,
     )
     effective_timeout = _effective_aux_timeout(task, timeout)
     request_provider = effective_provider or resolved_provider

--- a/tests/agent/test_auxiliary_vision_provider_notice_109111.py
+++ b/tests/agent/test_auxiliary_vision_provider_notice_109111.py
@@ -1,0 +1,150 @@
+"""Regression tests for issue #109111.
+
+Before the fix:
+  - ``_try_anthropic()`` ignored the caller's model entirely — the aux client bound the
+    curated ``default_aux_model`` for the Anthropic profile, which happens to equal
+    ``claude-haiku-4-5-20251001`` (what most users configure), so the swap was invisible.
+    ``_STRICT_VISION_BACKENDS["anthropic"]`` and ``_resolve_api_key_branch`` both dropped
+    the ``model`` argument on the floor.
+  - When an explicitly configured ``auxiliary.vision.provider`` failed to resolve (e.g.
+    pointed at an unauthenticated backend), ``_resolve_call_client`` silently fell back to
+    the auto vision chain, which happily served the call on the main model. A negative
+    test (sabotage the provider, repeat the analysis) changed nothing and the detour was
+    only visible in debug logs, never to the user.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import agent.auxiliary_client as aux
+from tools.vision_tools import _with_route_notice
+
+
+# ---------------------------------------------------------------------------
+# 1. _try_anthropic honors an explicit model
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def anthropic_env(monkeypatch):
+    """Hermetic Anthropic aux resolution: no pool, standalone token, fake SDK client."""
+    monkeypatch.setattr(aux, "_select_pool_entry", lambda provider: (False, None))
+    monkeypatch.setattr(
+        "agent.anthropic_credentials.resolve_anthropic_token", lambda: "sk-test-token")
+    monkeypatch.setattr("agent.anthropic_adapter.build_anthropic_client",
+                        lambda token, base_url: object())
+    monkeypatch.setattr(aux, "_get_aux_model_for_provider",
+                        lambda provider_id, **kw: "claude-haiku-4-5-20251001")
+
+
+def test_try_anthropic_explicit_model_wins(anthropic_env):
+    _, model = aux._try_anthropic(model="claude-sonnet-4-5-20261001")
+    assert model == "claude-sonnet-4-5-20261001"
+
+
+def test_try_anthropic_defaults_to_curated_aux_model(anthropic_env):
+    _, model = aux._try_anthropic()
+    assert model == "claude-haiku-4-5-20251001"
+
+
+def test_strict_vision_backend_forwards_model(anthropic_env, monkeypatch):
+    captured = {}
+
+    def fake_try_anthropic(explicit_api_key=None, model=None):
+        captured["model"] = model
+        return None, None
+
+    monkeypatch.setattr(aux, "_try_anthropic", fake_try_anthropic)
+    aux._resolve_strict_vision_backend("anthropic", "claude-sonnet-4-5-20261001")
+    assert captured["model"] == "claude-sonnet-4-5-20261001"
+
+
+# ---------------------------------------------------------------------------
+# 2. Vision provider fallback surfaces a notice via route_info
+# ---------------------------------------------------------------------------
+
+def _fake_vision_resolver(unavailable_provider, fallback_provider, fallback_client):
+    def resolve(provider=None, model=None, *, base_url=None, api_key=None,
+                async_mode=False, main_runtime=None):
+        if provider == unavailable_provider:
+            return unavailable_provider, None, None
+        return fallback_provider, fallback_client, "fallback-model"
+    return resolve
+
+
+def test_vision_fallback_records_notice_in_route_info(monkeypatch):
+    sentinel_client = object()
+    monkeypatch.setattr(
+        aux, "resolve_vision_provider_client",
+        _fake_vision_resolver("openrouter", "anthropic", sentinel_client))
+
+    route_info: dict = {}
+    route = aux._resolve_call_client(
+        "vision", provider=None, model=None, base_url=None, api_key=None,
+        resolved_provider="openrouter", resolved_model=None,
+        resolved_base_url=None, resolved_api_key=None, resolved_api_mode=None,
+        main_runtime=None, async_mode=False, route_info=route_info)
+
+    assert route.client is sentinel_client
+    assert "openrouter" in route_info.get("fallback_notice", "")
+    assert "anthropic" in route_info.get("fallback_notice", "")
+
+
+def test_vision_no_fallback_leaves_route_info_clean(monkeypatch):
+    sentinel_client = object()
+    monkeypatch.setattr(
+        aux, "resolve_vision_provider_client",
+        _fake_vision_resolver("__never__", "anthropic", sentinel_client))
+
+    route_info: dict = {}
+    aux._resolve_call_client(
+        "vision", provider=None, model=None, base_url=None, api_key=None,
+        resolved_provider="anthropic", resolved_model="claude-haiku-4-5-20251001",
+        resolved_base_url=None, resolved_api_key=None, resolved_api_mode=None,
+        main_runtime=None, async_mode=False, route_info=route_info)
+
+    assert "fallback_notice" not in route_info
+
+
+def test_prepare_aux_request_forwards_route_info(monkeypatch, tmp_path):
+    """``route_info`` flows from ``async_call_llm``/``call_llm`` down to the resolver."""
+    captured = {}
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text("")
+
+    def fake_resolve_call_client(task, **kw):
+        captured.update(kw)
+        return aux._ResolvedAuxRoute(object(), "m", "anthropic", "anthropic")
+
+    monkeypatch.setattr(aux, "_resolve_call_client", fake_resolve_call_client)
+
+    route_info: dict = {}
+    aux._prepare_aux_request(
+        "vision", provider=None, model=None, base_url=None, api_key=None,
+        main_runtime={}, messages=[{"role": "user", "content": "hi"}],
+        temperature=None, max_tokens=None, tools=None, timeout=None,
+        extra_body=None, reasoning_config=None, extra_headers=None,
+        api_mode=None, route_info=route_info, async_mode=True)
+
+    assert captured.get("route_info") is route_info
+
+
+# ---------------------------------------------------------------------------
+# 3. The notice reaches the tool result
+# ---------------------------------------------------------------------------
+
+def test_with_route_notice_prefixes_analysis():
+    debug_call_data: dict = {}
+    out = _with_route_notice(
+        "the analysis", {"fallback_notice": "Configured vision provider 'openrouter' is unavailable"},
+        debug_call_data)
+    assert out.startswith("[Configured vision provider 'openrouter' is unavailable]")
+    assert out.endswith("the analysis")
+    assert "openrouter" in debug_call_data["vision_fallback_notice"]
+
+
+def test_with_route_notice_passthrough_without_notice():
+    debug_call_data: dict = {}
+    out = _with_route_notice("the analysis", {}, debug_call_data)
+    assert out == "the analysis"
+    assert "vision_fallback_notice" not in debug_call_data

--- a/tests/agent/test_auxiliary_vision_provider_notice_109111.py
+++ b/tests/agent/test_auxiliary_vision_provider_notice_109111.py
@@ -143,6 +143,22 @@ def test_with_route_notice_prefixes_analysis():
     assert "openrouter" in debug_call_data["vision_fallback_notice"]
 
 
+def test_with_route_notice_stays_single_line_beside_scale_note():
+    """When both notices apply, the result must read
+    ``[scale_note] [fallback_notice] <analysis>`` on one line, matching the existing
+    ``[{scale_note}] {analysis}`` prefix style in ``_run_analysis``."""
+    debug_call_data: dict = {}
+    out = _with_route_notice(
+        "the analysis", {"fallback_notice": "Configured vision provider 'openrouter' is unavailable"},
+        debug_call_data)
+    assert "\n" not in out
+    scale_note = "image auto-resized to fit the provider limit"
+    combined = f"[{scale_note}] {out}" if scale_note else out
+    assert combined == (
+        "[image auto-resized to fit the provider limit] "
+        "[Configured vision provider 'openrouter' is unavailable] the analysis")
+
+
 def test_with_route_notice_passthrough_without_notice():
     debug_call_data: dict = {}
     out = _with_route_notice("the analysis", {}, debug_call_data)

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -625,10 +625,13 @@ async def _vision_analyze_native(
 
 
 def _aux_call_kwargs(messages: list, model: Optional[str], default_timeout: float, *,
-                     min_timeout: Optional[float] = None) -> dict:
+                     min_timeout: Optional[float] = None,
+                     route_info: Optional[Dict[str, str]] = None) -> dict:
     """``async_call_llm`` kwargs with ``auxiliary.vision.timeout`` / ``.temperature`` from config.
     Local vision models (llama.cpp, ollama) can take well over 30s, hence generous defaults
-    (temperature 0.1); ``min_timeout`` lets video enforce a floor."""
+    (temperature 0.1); ``min_timeout`` lets video enforce a floor. ``route_info`` (optional,
+    mutated in place) receives the fallback notice when an explicitly configured
+    ``auxiliary.vision.provider`` was unavailable and the auto chain served the call."""
     timeout, temperature = default_timeout, 0.1
     try:
         _vision_cfg = _cfg_auxiliary("vision", default={}) or {}
@@ -639,7 +642,20 @@ def _aux_call_kwargs(messages: list, model: Optional[str], default_timeout: floa
     except Exception:
         pass
     return {"task": "vision", "messages": messages, "temperature": temperature, "timeout": timeout,
-            **({"model": model} if model else {})}
+            **({"model": model} if model else {}),
+            **({"route_info": route_info} if route_info is not None else {})}
+
+
+def _with_route_notice(analysis: str, route_info: Dict[str, str], debug_call_data: dict) -> str:
+    """Prefix the in-band fallback notice when an explicitly configured vision provider
+    was unavailable and the auto chain served the call; without it the detour is silent
+    and a sabotaged ``auxiliary.vision.provider`` negative test changes nothing (#109111)."""
+    notice = (route_info or {}).get("fallback_notice")
+    if not notice:
+        return analysis
+    debug_call_data["vision_fallback_notice"] = notice
+    logger.warning("%s", notice)
+    return f"[{notice}]\n{analysis}"
 
 
 def _media_messages(user_prompt: str, part_type: str, data_url: str) -> list:
@@ -778,7 +794,8 @@ async def vision_analyze_tool(
         debug_call_data["image_size_bytes"] = prepared.size_bytes
         messages = _media_messages(prompt, "image_url", image_data_url)
         logger.info("Processing image with vision model...")
-        call_kwargs = _aux_call_kwargs(messages, model, 120.0)
+        route_info: Dict[str, str] = {}
+        call_kwargs = _aux_call_kwargs(messages, model, 120.0, route_info=route_info)
         _load_auxiliary_client()
         try:
             response = await async_call_llm(**call_kwargs)
@@ -793,7 +810,8 @@ async def vision_analyze_tool(
             response = await async_call_llm(**call_kwargs)
         analysis = await _call_vision_llm(
             call_kwargs, "Vision LLM returned empty content, retrying once", response)
-        return analysis, _build_scale_note(_scale_info or None, prepared.crop_offset or None)
+        return _with_route_notice(analysis, route_info, debug_call_data), \
+            _build_scale_note(_scale_info or None, prepared.crop_offset or None)
     return await _run_analysis("image", image_url, user_prompt, model, stage)
 
 
@@ -998,9 +1016,10 @@ async def video_analyze_tool(
                 f"Compress or trim the video and retry.")
         debug_call_data["video_size_bytes"] = video_size_bytes
         messages = _media_messages(prompt, "video_url", video_data_url)
-        call_kwargs = _aux_call_kwargs(messages, model, 180.0, min_timeout=180.0)
+        route_info: Dict[str, str] = {}
+        call_kwargs = _aux_call_kwargs(messages, model, 180.0, min_timeout=180.0, route_info=route_info)
         analysis = await _call_vision_llm(call_kwargs, "Empty video response, retrying once")
-        return analysis, None
+        return _with_route_notice(analysis, route_info, debug_call_data), None
     return await _run_analysis("video", video_url, user_prompt, model, stage)
 
 

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -655,7 +655,9 @@ def _with_route_notice(analysis: str, route_info: Dict[str, str], debug_call_dat
         return analysis
     debug_call_data["vision_fallback_notice"] = notice
     logger.warning("%s", notice)
-    return f"[{notice}]\n{analysis}"
+    # Single space, matching the ``[{scale_note}] {analysis}`` prefix style so the
+    # both-notice result reads ``[scale_note] [fallback_notice] <analysis>`` on one line.
+    return f"[{notice}] {analysis}"
 
 
 def _media_messages(user_prompt: str, part_type: str, data_url: str) -> list:


### PR DESCRIPTION
## What does this PR do?

Two silent-ignore bugs in the auxiliary vision routing reported by #109111:

1. **Configured vision provider detour was invisible.** When an explicitly configured `auxiliary.vision.provider` failed to resolve (e.g. pointed at a backend with no credentials), `_resolve_call_client` fell through to the auto vision chain, which happily served the call on the main chat model. The detour existed only in debug logs, so the issue's negative test (point the provider at an unauthenticated OpenRouter, repeat the analysis) succeeded exactly as before — the setting appeared to not be read at all. The fallback itself is intended resilience and is kept; it now records a `fallback_notice` in `route_info`, which `vision_analyze` / `video_analyze` prefix onto the tool result so the user sees which backend actually ran.

2. **`_try_anthropic()` dropped the caller's model.** It always bound the curated `default_aux_model` for the Anthropic profile (`claude-haiku-4-5-20251001` — exactly what most users configure, which camouflaged the swap). It now accepts an explicit `model`, forwarded from `_resolve_api_key_branch` and the `_STRICT_VISION_BACKENDS` entry like every sibling provider, so the client and the "Auxiliary client: Anthropic native (…)" log line reflect the configured model.

Note: the issue's suggested `anthropic: lambda model: _try_anthropic(model=model)` alone would have raised `TypeError` (`_try_anthropic` had no `model` parameter) — that strict-dict entry is unreachable for `resolve_vision_provider_client` (anthropic is not in `_VISION_AUTO_PROVIDER_ORDER`); the real model-drop happens in `_resolve_api_key_branch`, fixed here too.

## Related Issue

Fixes #109111

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` — `_try_anthropic()` takes `model` (explicit wins over the curated default); `_resolve_api_key_branch` forwards `req.model`; `_STRICT_VISION_BACKENDS["anthropic"]` forwards `model` like its siblings; `_resolve_call_client` accepts `route_info` and records a `fallback_notice` when an explicit vision provider is unavailable and the auto chain serves the call; `_prepare_aux_request` passes `route_info` through.
- `tools/vision_tools.py` — `_aux_call_kwargs` accepts `route_info`; new `_with_route_notice()` prefixes the notice onto the image/video analysis and records it in the debug call data; both `vision_analyze` and `video_analyze` stages pass a `route_info` dict.
- `tests/agent/test_auxiliary_vision_provider_notice_109111.py` — 8 regression tests: explicit model honored / curated default preserved / strict-backend forwarding, fallback notice recorded only on actual fallback, `route_info` threading, and notice surfacing in the tool result.

## How to Test

1. `pytest tests/agent/test_auxiliary_vision_provider_notice_109111.py -q` — 8 passed.
2. `pytest tests/agent/test_vision_routing_31179.py tests/agent/test_vision_resolved_args.py tests/tools/test_vision_tools.py tests/tools/test_vision_native_fast_path.py tests/tools/test_vision_scale_disclosure.py tests/agent/test_auxiliary_anthropic_pool_fallback_regression.py tests/agent/test_auxiliary_client_anthropic_custom.py tests/agent/test_auxiliary_named_custom_providers.py -q` — failure set identical to unmodified `upstream/main` under the same invocation (verified via stash baseline comparison; no new failures).
3. Issue negative test (reproduced on a scratch HERMES_HOME with `auxiliary.vision.provider: openrouter` and no OpenRouter credential, explicit provider resolve forced unavailable): the analysis still succeeds via the auto backend, and the tool result now begins with `[Configured vision provider 'openrouter' is unavailable (no credentials or backend offline); analysis ran on the auto vision backend 'anthropic' instead.]` — Observed result: notice present, effective provider named.
4. `ruff check agent/auxiliary_client.py tools/vision_tools.py tests/agent/test_auxiliary_vision_provider_notice_109111.py` — all checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

End-to-end verification of the issue's negative test after the fix (scratch HERMES_HOME, `model: anthropic/claude-opus-5`, `auxiliary.vision.provider: openrouter` without credentials):

```
STEP1 _explicit_aux_vision_override = True
STEP2 decide_image_input_mode = text
STEP3 _should_use_native_vision_fast_path = False
STEP4 client resolved = True | effective provider = anthropic
STEP5 fallback_notice present = True
NOTICE: Configured vision provider 'openrouter' is unavailable (no credentials or backend offline); analysis ran on the auto vision backend 'anthropic' instead.
STEP7 explicit anthropic model honored = claude-sonnet-4-5-20261001
```