### PR TITLE
fix(model-metadata): output-cap errors no longer cached as the context window (salvage #106769)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1122,14 +1122,8 @@ def get_next_probe_tier(current_length: int) -> Optional[int]:
 def parse_context_limit_from_error(error_msg: str) -> Optional[int]:
     """Context limit quoted in a provider error ("maximum context length is 32768 tokens"), if any.
 
-    2026-09-08 bugfix: a message that talks only about an OUTPUT limit/cap and never mentions
-    "context" (e.g. Switchyard's "max_tokens cannot exceed the configured model output limit of
-    16384") was matched by the generic "limit ... of N" pattern below and wrongly cached as the
-    CONTEXT window (switchyard/fallback's real context is >117K; 16384 is its output cap). Bail
-    out here so ``parse_available_output_tokens_from_error``/``is_output_cap_error`` — which run
-    first in the overflow-recovery path — get the chance to classify it as an output-cap error
-    instead. Genuine context-length messages (OpenAI/OpenRouter style) always say "context", so
-    this does not affect them."""
+    A message about only an OUTPUT cap ("... model output limit of 16384") never says "context";
+    bail out so the generic "limit ... of N" pattern can't cache the output cap as the window."""
     error_lower = error_msg.lower()
     if ("output limit" in error_lower or "output tokens" in error_lower or "output token" in error_lower) and "context" not in error_lower:
         return None

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1120,8 +1120,19 @@ def get_next_probe_tier(current_length: int) -> Optional[int]:
 
 
 def parse_context_limit_from_error(error_msg: str) -> Optional[int]:
-    """Context limit quoted in a provider error ("maximum context length is 32768 tokens"), if any."""
+    """Context limit quoted in a provider error ("maximum context length is 32768 tokens"), if any.
+
+    2026-09-08 bugfix: a message that talks only about an OUTPUT limit/cap and never mentions
+    "context" (e.g. Switchyard's "max_tokens cannot exceed the configured model output limit of
+    16384") was matched by the generic "limit ... of N" pattern below and wrongly cached as the
+    CONTEXT window (switchyard/fallback's real context is >117K; 16384 is its output cap). Bail
+    out here so ``parse_available_output_tokens_from_error``/``is_output_cap_error`` — which run
+    first in the overflow-recovery path — get the chance to classify it as an output-cap error
+    instead. Genuine context-length messages (OpenAI/OpenRouter style) always say "context", so
+    this does not affect them."""
     error_lower = error_msg.lower()
+    if ("output limit" in error_lower or "output tokens" in error_lower or "output token" in error_lower) and "context" not in error_lower:
+        return None
     patterns = (
         r'max_model_len\s*(?:is\s*)?[:=(]?\s*(\d{4,})',  # vLLM: "max_model_len 32768", "=32768", ": 32768", "(32768)", "is 32768"
         r'maximum model length\s*(?:is\s*)?[:=(]?\s*(\d{4,})',  # vLLM alt: "maximum model length 131072", "... is 131072"
@@ -1163,6 +1174,8 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
         r'range of max_tokens should be\s*\[\s*\d+\s*,\s*(\d+)\s*\]',
         r'available_tokens[:\s]+(\d+)',
         r'available\s+tokens[:\s]+(\d+)',
+        # Switchyard: "max_tokens cannot exceed the configured model output limit of 16384".
+        r'output limit (?:of|is)\s*(\d+)',
         r'=\s*(\d+)\s*$',
     ):
         match = re.search(pattern, error_lower)
@@ -1206,6 +1219,7 @@ _OUTPUT_CAP_SIGNALS = (
     ("range of max_tokens should be",), ("available_tokens",), ("available tokens",),
     ("in the output", "maximum context length"), ("requested", "output tokens"),
     ("should be",), ("less than or equal",), ("must be",), ("exceeds model", "maximum output tokens"),
+    ("output limit",),
 )
 _INPUT_OVERFLOW_SIGNALS = (
     "prompt is too long", "prompt too long", "input is too long", "input token",
@@ -1220,6 +1234,7 @@ _PARSEABLE_OUTPUT_CAP_SIGNALS = (
     ("in the output", "maximum context length"),
     ("maximum context length", "requested", "output tokens"),
     ("range of max_tokens should be",), ("exceeds model", "maximum output tokens"),
+    ("output limit",),
 )
 
 

--- a/contributors/emails/francesco@carucci.org
+++ b/contributors/emails/francesco@carucci.org
@@ -1,0 +1,1 @@
+fcarucci

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1495,6 +1495,24 @@ class TestParseContextLimitFromError:
         )
         assert get_context_length_from_provider_error(msg, 131072) == 32768
 
+    def test_output_cap_message_is_not_a_context_limit(self):
+        """An output-cap error must never be cached as the context window (salvage #106769):
+        the generic "limit ... of N" pattern matched Switchyard's message and clamped a
+        >117K-context model to 16K on every later request."""
+        from agent.model_metadata import (
+            is_output_cap_error,
+            parse_available_output_tokens_from_error,
+        )
+
+        msg = "max_tokens cannot exceed the configured model output limit of 16384"
+        assert parse_context_limit_from_error(msg) is None
+        assert parse_available_output_tokens_from_error(msg) == 16384
+        assert is_output_cap_error(msg)
+        # Genuine context messages still parse.
+        assert parse_context_limit_from_error(
+            "This model's maximum context length is 32768 tokens"
+        ) == 32768
+
 
 
 


### PR DESCRIPTION
A provider's output-cap error ("max_tokens cannot exceed the configured model output limit of 16384") is no longer cached as the model's context window, so a >117K-context model stops being clamped to 16K on every later request.

Salvages #106769 from @fcarucci

**Root cause:** `parse_context_limit_from_error` has a generic `limit ... of N` fallback that matched the output-cap phrasing, and the recovered "context length" was persisted to the context cache. Class: user-reported (Switchyard `switchyard/fallback`).

## Changes
- `agent/model_metadata.py::parse_context_limit_from_error` — return `None` when the message mentions an output limit/tokens and never says "context" (genuine context-length messages always do).
- `agent/model_metadata.py::parse_available_output_tokens_from_error` — new `output limit (of|is) N` pattern so the message yields `16384` as the available output budget.
- `_OUTPUT_CAP_SIGNALS` / `_PARSEABLE_OUTPUT_CAP_SIGNALS` — `("output limit",)` so `is_output_cap_error` classifies it as an output-cap error instead of an overflow.
- `contributors/emails/francesco@carucci.org` → `fcarucci` (contributor's own mapping commit, picked as-is).

## Improvements during salvage
- Trimmed the dated 8-line bugfix narrative in the docstring to a 2-line WHY.
- One invariant test (`TestParseContextLimitFromError::test_output_cap_message_is_not_a_context_limit`): the Switchyard message → `parse_context_limit_from_error` is `None`, `parse_available_output_tokens_from_error` is `16384`, `is_output_cap_error` is `True`; `"maximum context length is 32768 tokens"` still parses to `32768`.

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/agent/test_model_metadata.py tests/test_ctx_halving_fix.py` | 140 passed, 0 failed |
| Red-on-base (swap `agent/model_metadata.py` to `origin/main`) | new test fails `assert 16384 is None`; passes with the fix |
| Real-import E2E (worktree at `sys.path[0]`, temp `HERMES_HOME`) | negative: `None / None / True / 16384`; positive: `32768`, `max_model_len 32768` → `32768` |
| `ruff check --fix` touched files | All checks passed |
| `scripts/check-windows-footguns.py --all` | no footguns |
| `scripts/check_compat_pointers.py` | clean |
| `git diff --check` | clean |

## Infographic
![output-limit-parse](https://v3b.fal.media/files/b/0aaa22d1/zB_ZFFO6cqsTfXwA0TTkW_IuXURQi3.png)
