### PR TITLE
fix(hooks): Ctrl+C during a shell hook reaps the hook process tree (salvage #108625)

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -317,10 +317,14 @@ def _spawn(spec: ShellHookSpec, stdin_json: str) -> Dict[str, Any]:
         return failed(next((msg for cls, msg in _POPEN_ERRORS if isinstance(exc, cls)), str(exc)))
     try:
         stdout, stderr = proc.communicate(input=stdin_json, timeout=spec.timeout)
-    except Exception as exc:
+    except BaseException as exc:
+        # BaseException, not Exception: Ctrl+C raises KeyboardInterrupt here, and the hook leads its own
+        # process group (above), so the terminal's SIGINT never reaches it — it would keep running.
         kill_process_tree(proc)  # the whole tree — forked helpers holding the pipes would stall the drain
         with suppress(Exception):
             proc.communicate(timeout=1)
+        if not isinstance(exc, Exception):  # KeyboardInterrupt / SystemExit: reap the hook, then propagate
+            raise
         if not isinstance(exc, subprocess.TimeoutExpired):  # pragma: no cover — defensive
             return failed(str(exc))
         result.update(timed_out=True, elapsed_seconds=round(time.monotonic() - t0, 3))

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -318,12 +318,11 @@ def _spawn(spec: ShellHookSpec, stdin_json: str) -> Dict[str, Any]:
     try:
         stdout, stderr = proc.communicate(input=stdin_json, timeout=spec.timeout)
     except BaseException as exc:
-        # BaseException, not Exception: Ctrl+C raises KeyboardInterrupt here, and the hook leads its own
-        # process group (above), so the terminal's SIGINT never reaches it — it would keep running.
+        # BaseException: the hook leads its own process group, so Ctrl+C's SIGINT never reaches it — only we can.
         kill_process_tree(proc)  # the whole tree — forked helpers holding the pipes would stall the drain
         with suppress(Exception):
             proc.communicate(timeout=1)
-        if not isinstance(exc, Exception):  # KeyboardInterrupt / SystemExit: reap the hook, then propagate
+        if not isinstance(exc, Exception):
             raise
         if not isinstance(exc, subprocess.TimeoutExpired):  # pragma: no cover — defensive
             return failed(str(exc))

--- a/tests/agent/test_shell_hooks_tree_kill.py
+++ b/tests/agent/test_shell_hooks_tree_kill.py
@@ -164,7 +164,7 @@ def test_interrupt_kills_hook_and_propagates(tmp_path):
     """
     marker = tmp_path / "hook.pid"
     script = tmp_path / "hook.sh"
-    script.write_text(f"#!/bin/bash\necho $$ > {marker}\nsleep 300\n")
+    script.write_text(f'#!/bin/bash\necho $$ > "{marker}"\nsleep 300\n')
     script.chmod(0o755)
 
     def interrupt_once_running():

--- a/tests/agent/test_shell_hooks_tree_kill.py
+++ b/tests/agent/test_shell_hooks_tree_kill.py
@@ -13,8 +13,10 @@ semantics cannot be mocked.
 """
 
 import os
+import signal
 import sys
 import textwrap
+import threading
 import time
 
 import pytest
@@ -152,6 +154,42 @@ def test_fast_path_contract_unchanged(tmp_path):
     assert "errline" in r["stderr"]
     assert r["error"] is None
     assert r["timed_out"] is False
+
+
+def test_interrupt_kills_hook_and_propagates(tmp_path):
+    """Ctrl+C during a hook must reap the hook, then let KeyboardInterrupt through.
+
+    The hook leads its own process group, so the terminal's SIGINT never
+    reaches it: only ``_spawn``'s own cleanup can stop it.
+    """
+    marker = tmp_path / "hook.pid"
+    script = tmp_path / "hook.sh"
+    script.write_text(f"#!/bin/bash\necho $$ > {marker}\nsleep 300\n")
+    script.chmod(0o755)
+
+    def interrupt_once_running():
+        """Interrupt only once the hook is up, so the signal lands inside _spawn."""
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            if marker.exists() and marker.read_text().strip():
+                os.kill(os.getpid(), signal.SIGINT)
+                return
+            time.sleep(0.05)
+
+    interrupter = threading.Thread(target=interrupt_once_running, daemon=True)
+    interrupter.start()
+    with pytest.raises(KeyboardInterrupt):
+        _spawn(_spec(str(script), timeout=300), "{}")
+    interrupter.join(timeout=5)
+
+    hook_pid = _read_marker(marker)
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline and _pid_alive(hook_pid):
+        time.sleep(0.05)
+    alive = _pid_alive(hook_pid)
+    if alive:  # cleanup so a failure doesn't leak a 300s sleeper
+        os.kill(hook_pid, 9)
+    assert not alive, f"hook {hook_pid} survived the interrupt"
 
 
 def test_missing_command_still_fails_open():


### PR DESCRIPTION
Pressing Ctrl+C while a shell hook is running now kills the hook and everything it forked, instead of leaving them running in the background.

Salvages #108625 from @yotamleo
Fixes #108624

## Changes

- `agent/shell_hooks.py::_spawn` — the `proc.communicate` cleanup now catches `BaseException` instead of `Exception`. `KeyboardInterrupt` is a `BaseException`, so Ctrl+C used to skip `kill_process_tree` entirely; and because the hook leads its own process group on POSIX (`process_group=0`, from #84901), the terminal's SIGINT never reached it either. The hook (plus its descendants) kept running. After the tree kill and drain, anything that is not an `Exception` subclass is re-raised unchanged, so `KeyboardInterrupt`/`SystemExit` still reach the caller. Timeout and error paths are untouched.
- `tests/agent/test_shell_hooks_tree_kill.py::test_interrupt_kills_hook_and_propagates` — one real-subprocess regression test: SIGINTs the test process once the hook is confirmed running, asserts `KeyboardInterrupt` propagates and the hook pid is gone. Uses the file's existing POSIX `skipif` marker.

### Improvements during salvage
- Folded the two inline comments on the new branch into one WHY line (own process group ⇒ SIGINT never reaches the hook); the `isinstance` re-raise no longer restates itself.

Root cause: `except Exception` does not catch `KeyboardInterrupt`, and the hook's own process group shields it from the terminal's SIGINT.

## Validation

| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/agent/test_shell_hooks_tree_kill.py` ×5 | 6 passed, 0 failed on every run (no flake) |
| `scripts/run_tests.sh tests/agent/test_shell_hooks*.py` | 3 files, 64 passed |
| Red-on-base (`origin/main:agent/shell_hooks.py` swapped in) | `test_interrupt_kills_hook_and_propagates` FAILED, other 5 passed; green again after restore |
| `ruff check` (touched files) | All checks passed |
| `scripts/check-windows-footguns.py --all` | No Windows footguns found |
| `scripts/check_compat_pointers.py`, `scripts/check_subprocess_stdin.py` | clean |
| `git diff --check` | clean |

## Infographic
![shell-hook-interrupt-reaps-tree](https://v3b.fal.media/files/b/0aaa22d2/5NhOPPXZ1LdEpRB5lvKyR_bW7gbv9K.png)
