### PR TITLE
fix(plugins): `hermes plugins validate` no longer crashes on manifests declaring requires_hermes (salvage #107553, #108842)

### DIFF
--- a/contributors/emails/jinli.yl@alibaba-inc.com
+++ b/contributors/emails/jinli.yl@alibaba-inc.com
@@ -1,0 +1,1 @@
+jinliyl

--- a/contributors/emails/teddychenfeiyang@gmail.com
+++ b/contributors/emails/teddychenfeiyang@gmail.com
@@ -1,0 +1,1 @@
+teddychenfeiyang-png

--- a/hermes_cli/plugin_validate.py
+++ b/hermes_cli/plugin_validate.py
@@ -74,11 +74,11 @@ class ValidationReport:
 def _requires_hermes_spec_valid(spec: str) -> bool:
     """Strictly validate a ``requires_hermes`` spec.
 
-    Unlike :func:`hermes_cli.plugins._version_satisfies` (permissive at load
+    Unlike :func:`hermes_cli.plugins_manifest.version_satisfies` (permissive at load
     time), validation REJECTS clauses whose version segment doesn't parse —
     a typo'd spec should fail admission, not silently gate nothing.
     """
-    from hermes_cli.plugins import _VERSION_COMPARATOR_RE, _version_tuple
+    from hermes_cli.plugins_manifest import _VERSION_COMPARATOR_RE, _version_tuple
 
     for clause in spec.split(","):
         clause = clause.strip()

--- a/tests/hermes_cli/test_plugin_validate.py
+++ b/tests/hermes_cli/test_plugin_validate.py
@@ -33,6 +33,16 @@ BASE_MANIFEST = {
 }
 
 
+def test_requires_hermes_spec_is_validated(tmp_path):
+    manifest = dict(BASE_MANIFEST, requires_hermes=">=0.21")
+    d = _make_plugin(tmp_path, manifest=manifest)
+
+    report = validate_plugin_dir(d)
+
+    assert report.ok, report.failures
+    assert ("requires_hermes", True, "spec '>=0.21' parses") in report.checks
+
+
 class TestCapabilityProbe:
     def test_undeclared_tool_registration_fails_with_diff(self, tmp_path):
         init = (

--- a/tests/hermes_cli/test_plugin_validate.py
+++ b/tests/hermes_cli/test_plugin_validate.py
@@ -122,3 +122,18 @@ class TestCapabilityProbe:
         )
         report = validate_plugin_dir(d)
         assert report.ok, report.failures
+
+
+class TestRequiresHermesSpec:
+    """A typo'd ``requires_hermes`` clause must fail admission, not silently gate nothing."""
+
+    def test_typoed_clause_fails_admission(self, tmp_path):
+        d = _make_plugin(
+            tmp_path, manifest={**BASE_MANIFEST, "requires_hermes": ">=0.21.1,<0.x"}
+        )
+        report = validate_plugin_dir(d)
+        assert not report.ok
+        assert any(
+            "requires_hermes" in f and "does not parse" in f for f in report.failures
+        ), report.failures
+


### PR DESCRIPTION
`hermes plugins validate` no longer crashes with `ImportError` on any manifest that declares `requires_hermes`.

Salvages #107553 from @jinliyl (earliest) and #108842 from @teddychenfeiyang-png (negative test).

**Root cause:** `hermes_cli/plugin_validate.py::_requires_hermes_spec_valid` late-imported `_VERSION_COMPARATOR_RE` / `_version_tuple` from `hermes_cli.plugins`, but the Sep-2026 decomposition moved them to `hermes_cli.plugins_manifest`. Plugins without the field validated fine, so nothing caught it.

## Changes
- `hermes_cli/plugin_validate.py`: import the two spec helpers from `hermes_cli.plugins_manifest`; docstring cross-reference updated to `plugins_manifest.version_satisfies` (@jinliyl).
- `tests/hermes_cli/test_plugin_validate.py`: `test_requires_hermes_spec_is_validated` — a valid spec passes admission and lands in `report.checks` (@jinliyl); `TestRequiresHermesSpec::test_typoed_clause_fails_admission` — `>=0.21.1,<0.x` fails admission with a `does not parse` failure (@teddychenfeiyang-png).
- `contributors/emails/`: mappings for both authors' commit emails.

## Salvage notes
- Both PRs fixed the same import identically; #107553 was filed first and is the base. From #108842 only the negative test is carried — its duplicate positive test and source hunk were dropped in the conflict resolution, and its commit message body was reworded to say so (author preserved).
- Two tests total (one positive, one negative), both red on `origin/main`.

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/hermes_cli/test_plugin_validate.py` | 10 passed, 0 failed |
| Red-on-base (swap `hermes_cli/plugin_validate.py` to `origin/main`) | both new tests fail: `ImportError: cannot import name '_VERSION_COMPARATOR_RE' from 'hermes_cli.plugins'`; pass after restore |
| E2E real-import probe (temp `HERMES_HOME`, `validate_plugin_dir` on a temp plugin) | `>=0.21.1` → `ok=True`, check `("requires_hermes", True, "spec '>=0.21.1' parses")`; `>=0.21.1,<0.x` → `ok=False`, `does not parse` failure |
| `ruff check` (touched files) | All checks passed |
| `scripts/check-windows-footguns.py --all` | No Windows footguns found |
| `scripts/check_compat_pointers.py` | no in-tree dependency on plugin-compat pointers |
| `git diff --check` | clean |

## Infographic
![plugin-validate-requires-hermes](https://v3b.fal.media/files/b/0aaa22d2/AVMzYyINmjWn-_gm1e-tO_X6XNC15T.png)
