### PR TITLE
fix(desktop): retry transient EINTR/EAGAIN on fs.watch creation in preview watchers

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -306,6 +306,7 @@ import { poolTouchKeys } from './pool-touch-scope'
 import { createKeepAwake } from './power-save'
 import { capturePreviewContents } from './preview-capture'
 import { PreviewReachRegistry } from './preview-reach'
+import { createPreviewWatchRegistry } from './preview-watch'
 import {
   createPrimaryRemoteConnection,
   FirstRunSetupResetError,
@@ -1705,7 +1706,6 @@ let connectionRegistryCache = null
 let connectionRegistryCacheMtime = null
 let remoteHeaderRulesInstalled = false
 const remoteWsHeaderStore = createRemoteWsHeaderStore()
-const previewWatchers = new Map()
 let previewShortcutActive = false
 let nativeThemeListenerInstalled = false
 
@@ -6422,65 +6422,29 @@ function sendPreviewFileChanged(payload) {
   webContents.send('hermes:preview-file-changed', payload)
 }
 
+// Watcher lifecycle lives in ./preview-watch (unit-tested there): the
+// FSWatcher 'error' path is contained so a deleted/unmounted watch directory
+// can never crash the main process. This wrapper only resolves the preview
+// URL and shapes the renderer payload.
+const previewWatchRegistry = createPreviewWatchRegistry({
+  fileExists,
+  debounceMs: PREVIEW_WATCH_DEBOUNCE_MS,
+  sendChanged: ({ id, path: changedPath }) =>
+    sendPreviewFileChanged({ id, path: changedPath, url: pathToFileURL(changedPath).toString() })
+})
+
 async function watchPreviewFile(rawUrl) {
   const filePath = await filePathFromPreviewUrl(rawUrl)
-  const watchDir = path.dirname(filePath)
-  const targetName = path.basename(filePath)
-  const id = crypto.randomBytes(12).toString('base64url')
-  let timer = null
 
-  const watcher = fs.watch(watchDir, (_eventType, filename) => {
-    const changedName = filename ? path.basename(String(filename)) : ''
-
-    if (changedName && changedName !== targetName) {
-      return
-    }
-
-    if (timer) {
-      clearTimeout(timer)
-    }
-
-    timer = setTimeout(() => {
-      timer = null
-
-      if (!fileExists(filePath)) {
-        return
-      }
-
-      sendPreviewFileChanged({ id, path: filePath, url: pathToFileURL(filePath).toString() })
-    }, PREVIEW_WATCH_DEBOUNCE_MS)
-  })
-
-  previewWatchers.set(id, {
-    close: () => {
-      if (timer) {
-        clearTimeout(timer)
-      }
-
-      watcher.close()
-    }
-  })
-
-  return { id, path: filePath }
+  return previewWatchRegistry.watch(filePath)
 }
 
 function stopPreviewFileWatch(id) {
-  const watcher = previewWatchers.get(id)
-
-  if (!watcher) {
-    return false
-  }
-
-  watcher.close()
-  previewWatchers.delete(id)
-
-  return true
+  return previewWatchRegistry.stop(id)
 }
 
 function closePreviewWatchers() {
-  for (const id of previewWatchers.keys()) {
-    stopPreviewFileWatch(id)
-  }
+  previewWatchRegistry.closeAll()
 }
 
 function requestOptionsWithHeaders(options: any = {}, headers = {}) {
@@ -6505,31 +6469,9 @@ function watchDirectory(rawDir) {
     throw new Error(`Not a directory: ${watchDir}`)
   }
 
-  const id = crypto.randomBytes(12).toString('base64url')
-  let timer = null
-
-  const watcher = fs.watch(watchDir, () => {
-    if (timer) {
-      clearTimeout(timer)
-    }
-
-    timer = setTimeout(() => {
-      timer = null
-      sendPreviewFileChanged({ id, path: watchDir, url: pathToFileURL(watchDir).toString() })
-    }, PREVIEW_WATCH_DEBOUNCE_MS)
+  return previewWatchRegistry.watchDirectory(watchDir, {
+    dirExists: (p) => fs.existsSync(p) && fs.statSync(p).isDirectory()
   })
-
-  previewWatchers.set(id, {
-    close: () => {
-      if (timer) {
-        clearTimeout(timer)
-      }
-
-      watcher.close()
-    }
-  })
-
-  return { id, path: watchDir }
 }
 
 // Best-effort read of a gateway's advertised auth providers, cached per base

--- a/apps/desktop/electron/preview-watch.test.ts
+++ b/apps/desktop/electron/preview-watch.test.ts
@@ -1,0 +1,338 @@
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+
+import { afterEach, beforeEach, test, vi } from 'vitest'
+
+import { createPreviewWatchRegistry } from './preview-watch'
+
+// Fake FSWatcher. Faithful to real Node semantics where it matters:
+// EventEmitter-based (so emitting 'error' with no listener would throw,
+// exactly like the uncaught-exception crash this fix targets) and SILENT
+// after close() (a real FSWatcher delivers no events once closed). `closed`
+// is fake bookkeeping only — real FSWatcher exposes no such property.
+function fakeWatchImpl() {
+  const created: any[] = []
+
+  const impl = (dir: string, listener: (...args: any[]) => void) => {
+    const watcher: any = new EventEmitter()
+    watcher.dir = dir
+    watcher.closed = false
+
+    watcher.close = () => {
+      watcher.closed = true
+    }
+
+    watcher.emitChange = (filename: any) => {
+      if (!watcher.closed) {
+        listener('change', filename)
+      }
+    }
+
+    watcher.emitRename = (filename: any) => {
+      if (!watcher.closed) {
+        listener('rename', filename)
+      }
+    }
+
+    created.push(watcher)
+
+    return watcher
+  }
+
+  return { impl, created }
+}
+
+function makeRegistry(overrides: any = {}) {
+  const sent: any[] = []
+  const warnings: any[] = []
+  const { impl, created } = fakeWatchImpl()
+
+  const registry = createPreviewWatchRegistry({
+    fileExists: () => true,
+    sendChanged: (payload: any) => sent.push(payload),
+    debounceMs: 120,
+    watchImpl: impl,
+    log: (...args: any[]) => warnings.push(args),
+    ...overrides
+  })
+
+  return { registry, sent, warnings, created }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+test('change to the watched file debounces into one sendChanged with the watch id', () => {
+  const { registry, sent, created } = makeRegistry()
+
+  const { id } = registry.watch('/tmp/preview/note.md')
+  const watcher = created[0]
+
+  watcher.emitChange('note.md')
+  watcher.emitChange('note.md')
+  assert.equal(sent.length, 0)
+
+  vi.advanceTimersByTime(200)
+  assert.deepEqual(sent, [{ id, path: '/tmp/preview/note.md' }])
+})
+
+test('rename events (atomic save-by-rename) trigger a reload', () => {
+  const { registry, sent, created } = makeRegistry()
+
+  registry.watch('/tmp/preview/note.md')
+  created[0].emitRename('note.md')
+
+  vi.advanceTimersByTime(200)
+  assert.equal(sent.length, 1)
+})
+
+test('changes to sibling files in the same directory are ignored', () => {
+  const { registry, sent, created } = makeRegistry()
+
+  registry.watch('/tmp/preview/note.md')
+  created[0].emitChange('other.md')
+  created[0].emitChange('note.md.tmp')
+
+  vi.advanceTimersByTime(1000)
+  assert.equal(sent.length, 0)
+})
+
+test('null filename (documented fs.watch behavior) is treated as a match — reload beats a missed save', () => {
+  const { registry, sent, created } = makeRegistry()
+
+  registry.watch('/tmp/preview/note.md')
+  created[0].emitChange(null)
+
+  vi.advanceTimersByTime(200)
+  assert.equal(sent.length, 1)
+})
+
+test('filename delivered as a Buffer still matches the target', () => {
+  const { registry, sent, created } = makeRegistry()
+
+  registry.watch('/tmp/preview/note.md')
+  created[0].emitChange(Buffer.from('note.md'))
+
+  vi.advanceTimersByTime(200)
+  assert.equal(sent.length, 1)
+})
+
+test('a deleted target file does not send', () => {
+  const { registry, sent, created } = makeRegistry({
+    fileExists: () => false
+  })
+
+  registry.watch('/tmp/preview/note.md')
+  created[0].emitChange('note.md')
+
+  vi.advanceTimersByTime(1000)
+  assert.equal(sent.length, 0)
+})
+
+test('watch attaches an error listener synchronously (crash-prevention invariant)', () => {
+  const { registry, created } = makeRegistry()
+
+  registry.watch('/tmp/preview/note.md')
+
+  // The whole point of the fix: an FSWatcher that emits 'error' with no
+  // listener raises an uncaught exception and crashes the main process.
+  assert.ok(created[0].listenerCount('error') > 0)
+})
+
+test('watcher error does not throw: watch is closed, deregistered, and stops sending', () => {
+  const { registry, sent, warnings, created } = makeRegistry()
+
+  registry.watch('/tmp/preview/note.md')
+  const watcher = created[0]
+  assert.equal(registry.size(), 1)
+
+  // A deleted/unmounted watch dir surfaces as an 'error' event on the
+  // FSWatcher. Without a listener Node would crash the process; the
+  // registry must absorb it and tear down just this watch.
+  watcher.emit('error', new Error('ENOENT: no such file or directory, watch'))
+
+  assert.equal(registry.size(), 0)
+  assert.equal(watcher.closed, true)
+  assert.equal(warnings.length, 1)
+
+  watcher.emitChange('note.md')
+  vi.advanceTimersByTime(1000)
+  assert.equal(sent.length, 0)
+})
+
+test('a second error event is a no-op (no duplicate teardown or log)', () => {
+  const { registry, warnings, created } = makeRegistry()
+
+  registry.watch('/tmp/preview/note.md')
+
+  created[0].emit('error', new Error('first'))
+  assert.doesNotThrow(() => created[0].emit('error', new Error('second')))
+
+  assert.equal(registry.size(), 0)
+  assert.equal(warnings.length, 1)
+})
+
+test('stop after an error returns false and does not double-close', () => {
+  const { registry, created } = makeRegistry()
+
+  const { id } = registry.watch('/tmp/preview/note.md')
+  created[0].emit('error', new Error('EPERM'))
+
+  assert.equal(registry.stop(id), false)
+  assert.equal(created[0].closed, true)
+})
+
+test('watcher error cancels a pending debounce timer', () => {
+  const { registry, sent, created } = makeRegistry()
+
+  registry.watch('/tmp/preview/note.md')
+  const watcher = created[0]
+
+  watcher.emitChange('note.md')
+  watcher.emit('error', new Error('EPERM'))
+
+  vi.advanceTimersByTime(1000)
+  assert.equal(sent.length, 0)
+})
+
+test('a watchImpl that throws synchronously logs and rethrows (renderer sees a rejected invoke, never a crash)', () => {
+  const { registry, warnings } = makeRegistry({
+    watchImpl: () => {
+      throw new Error('ENOENT')
+    }
+  })
+
+  assert.throws(() => registry.watch('/tmp/preview/note.md'), /ENOENT/)
+  assert.equal(warnings.length, 1)
+  assert.equal(registry.size(), 0)
+})
+
+test('two watches of the same directory are independent', () => {
+  const { registry, sent, created } = makeRegistry()
+
+  const a = registry.watch('/tmp/preview/note.md')
+  registry.watch('/tmp/preview/other.md')
+  assert.equal(created.length, 2)
+
+  created[0].emitChange('note.md')
+  vi.advanceTimersByTime(200)
+
+  assert.deepEqual(sent, [{ id: a.id, path: '/tmp/preview/note.md' }])
+})
+
+test('stop closes the watcher and reports unknown ids as not found', () => {
+  const { registry, created } = makeRegistry()
+
+  const { id } = registry.watch('/tmp/preview/note.md')
+  assert.equal(registry.stop(id), true)
+  assert.equal(created[0].closed, true)
+  assert.equal(registry.stop(id), false)
+  assert.equal(registry.stop('never-existed'), false)
+})
+
+test('stop before the debounce fires suppresses the send', () => {
+  const { registry, sent, created } = makeRegistry()
+
+  const { id } = registry.watch('/tmp/preview/note.md')
+  created[0].emitChange('note.md')
+  registry.stop(id)
+
+  vi.advanceTimersByTime(1000)
+  assert.equal(sent.length, 0)
+})
+
+test('closeAll tears down every registered watch', () => {
+  const { registry, created } = makeRegistry()
+
+  registry.watch('/tmp/preview/a.md')
+  registry.watch('/tmp/preview/b.md')
+  assert.equal(registry.size(), 2)
+
+  registry.closeAll()
+
+  assert.equal(registry.size(), 0)
+  assert.equal(created[0].closed, true)
+  assert.equal(created[1].closed, true)
+})
+
+// ---------------------------------------------------------------------------
+// Directory watching (watchDirectory) — the plugins-door path.
+// Same error containment, debounce, and lifecycle as file watches.
+// ---------------------------------------------------------------------------
+
+test('watchDirectory debounces changes and sends the directory path', () => {
+  const { registry, sent, created } = makeRegistry()
+
+  const { id } = registry.watchDirectory('/tmp/plugins', { dirExists: () => true })
+
+  // Two rapid changes should coalesce into one debounced send
+  created[0].emitChange('new-plugin')
+  created[0].emitChange('another-plugin')
+
+  vi.advanceTimersByTime(200)
+  assert.equal(sent.length, 1)
+  assert.equal(sent[0].id, id)
+  assert.equal(sent[0].path, '/tmp/plugins')
+})
+
+test('watchDirectory error tears down that watch without crashing', () => {
+  const { registry, warnings, created } = makeRegistry()
+
+  const { id } = registry.watchDirectory('/tmp/plugins', { dirExists: () => true })
+  assert.equal(registry.size(), 1)
+
+  created[0].emit('error', new Error('directory deleted'))
+
+  assert.equal(registry.size(), 0)
+  assert.equal(created[0].closed, true)
+  assert.ok(warnings.length >= 1)
+
+  // A second error must be a no-op (guard)
+  created[0].emit('error', new Error('double error'))
+  assert.equal(warnings.length, 1)
+
+  // stop() on the torn-down watch is a no-op
+  assert.equal(registry.stop(id), false)
+})
+
+test('watchDirectory stop tears down and suppresses pending debounce', () => {
+  const { registry, sent, created } = makeRegistry()
+
+  const { id } = registry.watchDirectory('/tmp/plugins', { dirExists: () => true })
+  created[0].emitChange('new-plugin')
+
+  assert.equal(registry.stop(id), true)
+  assert.equal(created[0].closed, true)
+
+  vi.advanceTimersByTime(1000)
+  assert.equal(sent.length, 0)
+})
+
+test('watchDirectory dirExists=false suppresses the send after debounce', () => {
+  const { registry, sent, created } = makeRegistry()
+
+  registry.watchDirectory('/tmp/plugins', { dirExists: () => false })
+  created[0].emitChange('plugin-added')
+
+  vi.advanceTimersByTime(200)
+  assert.equal(sent.length, 0)
+})
+
+test('watchDirectory closeAll reaps directory watches alongside file watches', () => {
+  const { registry, created } = makeRegistry()
+
+  registry.watch('/tmp/preview/note.md')
+  registry.watchDirectory('/tmp/plugins', { dirExists: () => true })
+  assert.equal(registry.size(), 2)
+
+  registry.closeAll()
+
+  assert.equal(registry.size(), 0)
+  assert.equal(created[0].closed, true)
+  assert.equal(created[1].closed, true)
+})

--- a/apps/desktop/electron/preview-watch.test.ts
+++ b/apps/desktop/electron/preview-watch.test.ts
@@ -42,6 +42,43 @@ function fakeWatchImpl() {
   return { impl, created }
 }
 
+// A watchImpl that throws EINTR (transient) for the first `n` calls, then
+// succeeds. Lets the retry path be exercised deterministically.
+function flakyEintrWatchImpl(n: number) {
+  const created: any[] = []
+  let calls = 0
+
+  const impl = (dir: string, listener: (...args: any[]) => void) => {
+    calls += 1
+
+    if (calls <= n) {
+      const err: NodeJS.ErrnoException = new Error('EINTR: interrupted system call, watch')
+      err.code = 'EINTR'
+      throw err
+    }
+
+    const watcher: any = new EventEmitter()
+    watcher.dir = dir
+    watcher.closed = false
+
+    watcher.close = () => { watcher.closed = true }
+
+    watcher.emitChange = (filename: any) => {
+      if (!watcher.closed) {listener('change', filename)}
+    }
+
+    watcher.emitRename = (filename: any) => {
+      if (!watcher.closed) {listener('rename', filename)}
+    }
+
+    created.push(watcher)
+
+    return watcher
+  }
+
+  return { impl, created, callCount: () => calls }
+}
+
 function makeRegistry(overrides: any = {}) {
   const sent: any[] = []
   const warnings: any[] = []
@@ -67,10 +104,10 @@ afterEach(() => {
   vi.useRealTimers()
 })
 
-test('change to the watched file debounces into one sendChanged with the watch id', () => {
+test('change to the watched file debounces into one sendChanged with the watch id', async () => {
   const { registry, sent, created } = makeRegistry()
 
-  const { id } = registry.watch('/tmp/preview/note.md')
+  const { id } = await registry.watch('/tmp/preview/note.md')
   const watcher = created[0]
 
   watcher.emitChange('note.md')
@@ -81,20 +118,20 @@ test('change to the watched file debounces into one sendChanged with the watch i
   assert.deepEqual(sent, [{ id, path: '/tmp/preview/note.md' }])
 })
 
-test('rename events (atomic save-by-rename) trigger a reload', () => {
+test('rename events (atomic save-by-rename) trigger a reload', async () => {
   const { registry, sent, created } = makeRegistry()
 
-  registry.watch('/tmp/preview/note.md')
+  await registry.watch('/tmp/preview/note.md')
   created[0].emitRename('note.md')
 
   vi.advanceTimersByTime(200)
   assert.equal(sent.length, 1)
 })
 
-test('changes to sibling files in the same directory are ignored', () => {
+test('changes to sibling files in the same directory are ignored', async () => {
   const { registry, sent, created } = makeRegistry()
 
-  registry.watch('/tmp/preview/note.md')
+  await registry.watch('/tmp/preview/note.md')
   created[0].emitChange('other.md')
   created[0].emitChange('note.md.tmp')
 
@@ -102,52 +139,52 @@ test('changes to sibling files in the same directory are ignored', () => {
   assert.equal(sent.length, 0)
 })
 
-test('null filename (documented fs.watch behavior) is treated as a match — reload beats a missed save', () => {
+test('null filename (documented fs.watch behavior) is treated as a match — reload beats a missed save', async () => {
   const { registry, sent, created } = makeRegistry()
 
-  registry.watch('/tmp/preview/note.md')
+  await registry.watch('/tmp/preview/note.md')
   created[0].emitChange(null)
 
   vi.advanceTimersByTime(200)
   assert.equal(sent.length, 1)
 })
 
-test('filename delivered as a Buffer still matches the target', () => {
+test('filename delivered as a Buffer still matches the target', async () => {
   const { registry, sent, created } = makeRegistry()
 
-  registry.watch('/tmp/preview/note.md')
+  await registry.watch('/tmp/preview/note.md')
   created[0].emitChange(Buffer.from('note.md'))
 
   vi.advanceTimersByTime(200)
   assert.equal(sent.length, 1)
 })
 
-test('a deleted target file does not send', () => {
+test('a deleted target file does not send', async () => {
   const { registry, sent, created } = makeRegistry({
     fileExists: () => false
   })
 
-  registry.watch('/tmp/preview/note.md')
+  await registry.watch('/tmp/preview/note.md')
   created[0].emitChange('note.md')
 
   vi.advanceTimersByTime(1000)
   assert.equal(sent.length, 0)
 })
 
-test('watch attaches an error listener synchronously (crash-prevention invariant)', () => {
+test('watch attaches an error listener synchronously (crash-prevention invariant)', async () => {
   const { registry, created } = makeRegistry()
 
-  registry.watch('/tmp/preview/note.md')
+  await registry.watch('/tmp/preview/note.md')
 
   // The whole point of the fix: an FSWatcher that emits 'error' with no
   // listener raises an uncaught exception and crashes the main process.
   assert.ok(created[0].listenerCount('error') > 0)
 })
 
-test('watcher error does not throw: watch is closed, deregistered, and stops sending', () => {
+test('watcher error does not throw: watch is closed, deregistered, and stops sending', async () => {
   const { registry, sent, warnings, created } = makeRegistry()
 
-  registry.watch('/tmp/preview/note.md')
+  await registry.watch('/tmp/preview/note.md')
   const watcher = created[0]
   assert.equal(registry.size(), 1)
 
@@ -165,10 +202,10 @@ test('watcher error does not throw: watch is closed, deregistered, and stops sen
   assert.equal(sent.length, 0)
 })
 
-test('a second error event is a no-op (no duplicate teardown or log)', () => {
+test('a second error event is a no-op (no duplicate teardown or log)', async () => {
   const { registry, warnings, created } = makeRegistry()
 
-  registry.watch('/tmp/preview/note.md')
+  await registry.watch('/tmp/preview/note.md')
 
   created[0].emit('error', new Error('first'))
   assert.doesNotThrow(() => created[0].emit('error', new Error('second')))
@@ -177,20 +214,20 @@ test('a second error event is a no-op (no duplicate teardown or log)', () => {
   assert.equal(warnings.length, 1)
 })
 
-test('stop after an error returns false and does not double-close', () => {
+test('stop after an error returns false and does not double-close', async () => {
   const { registry, created } = makeRegistry()
 
-  const { id } = registry.watch('/tmp/preview/note.md')
+  const { id } = await registry.watch('/tmp/preview/note.md')
   created[0].emit('error', new Error('EPERM'))
 
   assert.equal(registry.stop(id), false)
   assert.equal(created[0].closed, true)
 })
 
-test('watcher error cancels a pending debounce timer', () => {
+test('watcher error cancels a pending debounce timer', async () => {
   const { registry, sent, created } = makeRegistry()
 
-  registry.watch('/tmp/preview/note.md')
+  await registry.watch('/tmp/preview/note.md')
   const watcher = created[0]
 
   watcher.emitChange('note.md')
@@ -200,23 +237,98 @@ test('watcher error cancels a pending debounce timer', () => {
   assert.equal(sent.length, 0)
 })
 
-test('a watchImpl that throws synchronously logs and rethrows (renderer sees a rejected invoke, never a crash)', () => {
+test('a watchImpl that throws synchronously with a non-transient error rejects (never a crash)', async () => {
   const { registry, warnings } = makeRegistry({
     watchImpl: () => {
       throw new Error('ENOENT')
     }
   })
 
-  assert.throws(() => registry.watch('/tmp/preview/note.md'), /ENOENT/)
+  await assert.rejects(() => registry.watch('/tmp/preview/note.md'), /ENOENT/)
   assert.equal(warnings.length, 1)
   assert.equal(registry.size(), 0)
 })
 
-test('two watches of the same directory are independent', () => {
+test('a transient EINTR on creation is retried and the watcher still comes up', async () => {
+  vi.useRealTimers() // the retry loop awaits a real setTimeout; fake timers must not freeze it
+  const { impl, created, callCount } = flakyEintrWatchImpl(2)
+  const { registry, sent, warnings } = makeRegistry({ watchImpl: impl, retryDelayMs: 5 })
+
+  const { id } = await registry.watch('/tmp/preview/note.md')
+
+  assert.ok(callCount() >= 3, 'must have retried past the transient failures')
+  assert.equal(created.length, 1)
+  assert.equal(warnings.length, 0, 'a recoverable transient must not log as catastrophic')
+
+  vi.useFakeTimers() // back to fake timers so the debounce assertion below is deterministic
+  created[0].emitChange('note.md')
+  vi.advanceTimersByTime(200)
+  assert.deepEqual(sent, [{ id, path: '/tmp/preview/note.md' }])
+})
+
+test('persistent EINTR exceeding the retry budget rethrows the last error', async () => {
+  vi.useRealTimers()
+  const { impl, created } = flakyEintrWatchImpl(999)
+
+  const { registry, warnings } = makeRegistry({
+    watchImpl: impl,
+    retryAttempts: 3,
+    retryDelayMs: 10
+  })
+
+  await assert.rejects(() => registry.watch('/tmp/preview/note.md'), /EINTR/)
+  assert.equal(created.length, 0, 'no watcher should be created once retries are exhausted')
+  assert.equal(warnings.length, 1)
+})
+
+test('EAGAIN and EWOULDBLOCK are also retried; a non-retryable code is not', async () => {
+  vi.useRealTimers()
+
+  // EAGAIN retried -> success
+  {
+    let calls = 0
+
+    const impl = (_dir: string, listener: (...args: any[]) => void) => {
+      calls += 1
+
+      if (calls === 1) {
+        const err: NodeJS.ErrnoException = new Error('EAGAIN')
+        err.code = 'EAGAIN'
+        throw err
+      }
+
+      const w = new EventEmitter() as any
+
+      w.close = () => { w.closed = true }
+      w.emitChange = (f: any) => listener('change', f)
+
+      return w
+    }
+
+    const { registry } = makeRegistry({ watchImpl: impl, retryAttempts: 5, retryDelayMs: 5 })
+    await registry.watch('/tmp/preview/note.md')
+    assert.ok(calls >= 2, 'EAGAIN should have been retried')
+  }
+
+  // EPERM is NOT retryable -> rejects immediately
+  {
+    const impl = () => {
+      const err: NodeJS.ErrnoException = new Error('EPERM')
+      err.code = 'EPERM'
+      throw err
+    }
+
+    const { registry, warnings } = makeRegistry({ watchImpl: impl, retryAttempts: 5, retryDelayMs: 5 })
+    await assert.rejects(() => registry.watch('/tmp/preview/note.md'), /EPERM/)
+    assert.equal(warnings.length, 1)
+  }
+})
+
+test('two watches of the same directory are independent', async () => {
   const { registry, sent, created } = makeRegistry()
 
-  const a = registry.watch('/tmp/preview/note.md')
-  registry.watch('/tmp/preview/other.md')
+  const a = await registry.watch('/tmp/preview/note.md')
+  await registry.watch('/tmp/preview/other.md')
   assert.equal(created.length, 2)
 
   created[0].emitChange('note.md')
@@ -225,20 +337,20 @@ test('two watches of the same directory are independent', () => {
   assert.deepEqual(sent, [{ id: a.id, path: '/tmp/preview/note.md' }])
 })
 
-test('stop closes the watcher and reports unknown ids as not found', () => {
+test('stop closes the watcher and reports unknown ids as not found', async () => {
   const { registry, created } = makeRegistry()
 
-  const { id } = registry.watch('/tmp/preview/note.md')
+  const { id } = await registry.watch('/tmp/preview/note.md')
   assert.equal(registry.stop(id), true)
   assert.equal(created[0].closed, true)
   assert.equal(registry.stop(id), false)
   assert.equal(registry.stop('never-existed'), false)
 })
 
-test('stop before the debounce fires suppresses the send', () => {
+test('stop before the debounce fires suppresses the send', async () => {
   const { registry, sent, created } = makeRegistry()
 
-  const { id } = registry.watch('/tmp/preview/note.md')
+  const { id } = await registry.watch('/tmp/preview/note.md')
   created[0].emitChange('note.md')
   registry.stop(id)
 
@@ -246,15 +358,14 @@ test('stop before the debounce fires suppresses the send', () => {
   assert.equal(sent.length, 0)
 })
 
-test('closeAll tears down every registered watch', () => {
+test('closeAll tears down every registered watch', async () => {
   const { registry, created } = makeRegistry()
 
-  registry.watch('/tmp/preview/a.md')
-  registry.watch('/tmp/preview/b.md')
+  await registry.watch('/tmp/preview/a.md')
+  await registry.watch('/tmp/preview/b.md')
   assert.equal(registry.size(), 2)
 
   registry.closeAll()
-
   assert.equal(registry.size(), 0)
   assert.equal(created[0].closed, true)
   assert.equal(created[1].closed, true)
@@ -262,13 +373,13 @@ test('closeAll tears down every registered watch', () => {
 
 // ---------------------------------------------------------------------------
 // Directory watching (watchDirectory) — the plugins-door path.
-// Same error containment, debounce, and lifecycle as file watches.
+// Same error containment, debounce, retry, and lifecycle as file watches.
 // ---------------------------------------------------------------------------
 
-test('watchDirectory debounces changes and sends the directory path', () => {
+test('watchDirectory debounces changes and sends the directory path', async () => {
   const { registry, sent, created } = makeRegistry()
 
-  const { id } = registry.watchDirectory('/tmp/plugins', { dirExists: () => true })
+  const { id } = await registry.watchDirectory('/tmp/plugins', { dirExists: () => true })
 
   // Two rapid changes should coalesce into one debounced send
   created[0].emitChange('new-plugin')
@@ -280,10 +391,10 @@ test('watchDirectory debounces changes and sends the directory path', () => {
   assert.equal(sent[0].path, '/tmp/plugins')
 })
 
-test('watchDirectory error tears down that watch without crashing', () => {
+test('watchDirectory error tears down that watch without crashing', async () => {
   const { registry, warnings, created } = makeRegistry()
 
-  const { id } = registry.watchDirectory('/tmp/plugins', { dirExists: () => true })
+  const { id } = await registry.watchDirectory('/tmp/plugins', { dirExists: () => true })
   assert.equal(registry.size(), 1)
 
   created[0].emit('error', new Error('directory deleted'))
@@ -300,12 +411,11 @@ test('watchDirectory error tears down that watch without crashing', () => {
   assert.equal(registry.stop(id), false)
 })
 
-test('watchDirectory stop tears down and suppresses pending debounce', () => {
+test('watchDirectory stop tears down and suppresses pending debounce', async () => {
   const { registry, sent, created } = makeRegistry()
 
-  const { id } = registry.watchDirectory('/tmp/plugins', { dirExists: () => true })
+  const { id } = await registry.watchDirectory('/tmp/plugins', { dirExists: () => true })
   created[0].emitChange('new-plugin')
-
   assert.equal(registry.stop(id), true)
   assert.equal(created[0].closed, true)
 
@@ -313,26 +423,36 @@ test('watchDirectory stop tears down and suppresses pending debounce', () => {
   assert.equal(sent.length, 0)
 })
 
-test('watchDirectory dirExists=false suppresses the send after debounce', () => {
+test('watchDirectory dirExists=false suppresses the send after debounce', async () => {
   const { registry, sent, created } = makeRegistry()
 
-  registry.watchDirectory('/tmp/plugins', { dirExists: () => false })
+  await registry.watchDirectory('/tmp/plugins', { dirExists: () => false })
   created[0].emitChange('plugin-added')
 
   vi.advanceTimersByTime(200)
   assert.equal(sent.length, 0)
 })
 
-test('watchDirectory closeAll reaps directory watches alongside file watches', () => {
+test('watchDirectory closeAll reaps directory watches alongside file watches', async () => {
   const { registry, created } = makeRegistry()
 
-  registry.watch('/tmp/preview/note.md')
-  registry.watchDirectory('/tmp/plugins', { dirExists: () => true })
+  await registry.watch('/tmp/preview/note.md')
+  await registry.watchDirectory('/tmp/plugins', { dirExists: () => true })
   assert.equal(registry.size(), 2)
 
   registry.closeAll()
-
   assert.equal(registry.size(), 0)
   assert.equal(created[0].closed, true)
   assert.equal(created[1].closed, true)
+})
+
+test('watchDirectory transient EINTR is retried before the watcher comes up', async () => {
+  vi.useRealTimers()
+  const { impl, created, callCount } = flakyEintrWatchImpl(1)
+  const { registry } = makeRegistry({ watchImpl: impl, retryDelayMs: 5 })
+
+  await registry.watchDirectory('/tmp/plugins', { dirExists: () => true })
+
+  assert.ok(callCount() >= 2)
+  assert.equal(created.length, 1)
 })

--- a/apps/desktop/electron/preview-watch.ts
+++ b/apps/desktop/electron/preview-watch.ts
@@ -1,0 +1,194 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+
+// Live-reload watching for previewed files.
+//
+// The watcher is registered on the file's PARENT DIRECTORY (a plain file
+// watch does not survive atomic save-by-rename, which is how most editors
+// write). A deleted/unmounted/permission-revoked watch directory makes the
+// FSWatcher emit 'error'; with no listener Node raises it as an uncaught
+// exception and takes down the whole main process. Watcher failure is
+// therefore treated as terminal for that watch only: the registry entry is
+// dropped and the preview simply stops live-reloading instead of crashing
+// the app.
+export function createPreviewWatchRegistry({
+  fileExists,
+  sendChanged,
+  debounceMs,
+  watchImpl = fs.watch,
+  log = console.warn
+}) {
+  const watchers = new Map()
+
+  function watch(filePath) {
+    const watchDir = path.dirname(filePath)
+    const targetName = path.basename(filePath)
+    const id = crypto.randomBytes(12).toString('base64url')
+    let timer = null
+    // Flipped by the error path and by close(); guards against a change
+    // event racing watcher teardown (some platforms deliver a final event
+    // during close()).
+    let active = true
+
+    const clearPending = () => {
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+    }
+
+    let watcher
+
+    try {
+      watcher = watchImpl(watchDir, (_eventType: any, filename: any) => {
+        if (!active) {
+          return
+        }
+
+        // filename is a utf8 string with the default encoding, but decode
+        // defensively: String(buffer) would yield "<Buffer …>" garbage.
+        const raw = typeof filename === 'string' ? filename : filename ? filename.toString() : ''
+        const changedName = raw ? path.basename(raw) : ''
+
+        if (changedName && changedName !== targetName) {
+          return
+        }
+
+        clearPending()
+
+        timer = setTimeout(() => {
+          timer = null
+
+          if (!fileExists(filePath)) {
+            return
+          }
+
+          sendChanged({ id, path: filePath })
+        }, debounceMs)
+      })
+    } catch (err) {
+      // fs.watch can throw SYNCHRONOUSLY (e.g. ENOENT/EPERM when the watch
+      // directory was deleted before the call). Log for diagnostics, then
+      // rethrow: inside ipcMain.handle this becomes a rejected invoke() for
+      // the renderer — terminal for this watch, never a main-process crash.
+      log(`[preview-watch] failed to watch ${watchDir}:`, err)
+      throw err
+    }
+
+    watcher.on('error', err => {
+      // Some platforms deliver a final 'error' during close(); the first one
+      // already tore this watch down.
+      if (!active) {
+        return
+      }
+
+      log(`[preview-watch] watcher failed for ${watchDir}, live reload disabled:`, err)
+      active = false
+      clearPending()
+      watchers.delete(id)
+      watcher.close()
+    })
+
+    watchers.set(id, {
+      close: () => {
+        active = false
+        clearPending()
+        watcher.close()
+      }
+    })
+
+    return { id, path: filePath }
+  }
+
+  /**
+   * Watch a DIRECTORY for entry churn (folders/files appearing or vanishing).
+   * Used by the desktop plugins door to detect new/removed plugins without
+   * polling. Unlike watch(), this does not filter by filename — any change
+   * in the directory fires the debounced callback. The same error-containment
+   * and lifecycle management applies.
+   */
+  function watchDirectory(
+    dirPath,
+    { dirExists }: { dirExists: (p: string) => boolean } = { dirExists: p => fs.existsSync(p) }
+  ) {
+    const id = crypto.randomBytes(12).toString('base64url')
+    let timer = null
+    let active = true
+
+    const clearPending = () => {
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+    }
+
+    let watcher
+
+    try {
+      watcher = watchImpl(dirPath, () => {
+        if (!active) {
+          return
+        }
+
+        clearPending()
+
+        timer = setTimeout(() => {
+          timer = null
+
+          if (!dirExists(dirPath)) {
+            return
+          }
+
+          sendChanged({ id, path: dirPath })
+        }, debounceMs)
+      })
+    } catch (err) {
+      log(`[preview-watch] failed to watch directory ${dirPath}:`, err)
+      throw err
+    }
+
+    watcher.on('error', err => {
+      if (!active) {
+        return
+      }
+
+      log(`[preview-watch] directory watcher failed for ${dirPath}, live reload disabled:`, err)
+      active = false
+      clearPending()
+      watchers.delete(id)
+      watcher.close()
+    })
+
+    watchers.set(id, {
+      close: () => {
+        active = false
+        clearPending()
+        watcher.close()
+      }
+    })
+
+    return { id, path: dirPath }
+  }
+
+  function stop(id) {
+    const entry = watchers.get(id)
+
+    if (!entry) {
+      return false
+    }
+
+    entry.close()
+    watchers.delete(id)
+
+    return true
+  }
+
+  function closeAll() {
+    for (const id of [...watchers.keys()]) {
+      stop(id)
+    }
+  }
+
+  return { watch, watchDirectory, stop, closeAll, size: () => watchers.size }
+}

--- a/apps/desktop/electron/preview-watch.ts
+++ b/apps/desktop/electron/preview-watch.ts
@@ -17,11 +17,48 @@ export function createPreviewWatchRegistry({
   sendChanged,
   debounceMs,
   watchImpl = fs.watch,
-  log = console.warn
+  log = console.warn,
+  retryAttempts = 20,
+  retryDelayMs = 250
 }) {
   const watchers = new Map()
 
-  function watch(filePath) {
+  // A transient signal (EINTR) or a briefly-inaccessible directory can make
+  // the SYNCHRONOUS fs.watch() creation throw even though a moment later it
+  // would succeed. On macOS a signal landing mid-syscall raises EINTR right
+  // when the user is about to preview a file in a live repo; retrying for a
+  // bounded budget absorbs that, then the terminal case rethrows (which the
+  // IPC wrapper turns into a rejected invoke — the same crash-free contract
+  // as a hard ENOENT/EPERM). This mirrors the error-containment spirit of
+  // the registry: transient conditions retried, genuinely-broken targets
+  // surfaced, never an uncaught throw that kills the main process.
+  function isRetryable(err: unknown): boolean {
+    const code = (err as NodeJS.ErrnoException)?.code
+
+    return code === 'EINTR' || code === 'EAGAIN' || code === 'EWOULDBLOCK'
+  }
+
+  async function createWatcher(
+    target: string,
+    listener: (...args: any[]) => void
+  ): Promise<fs.FSWatcher> {
+    let attempt = 0
+
+    while (true) {
+      try {
+        return watchImpl(target, listener) as fs.FSWatcher
+      } catch (err) {
+        if (!isRetryable(err) || attempt >= retryAttempts) {
+          throw err
+        }
+
+        attempt += 1
+        await new Promise((resolve) => setTimeout(resolve, retryDelayMs))
+      }
+    }
+  }
+
+  async function watch(filePath) {
     const watchDir = path.dirname(filePath)
     const targetName = path.basename(filePath)
     const id = crypto.randomBytes(12).toString('base64url')
@@ -41,7 +78,7 @@ export function createPreviewWatchRegistry({
     let watcher
 
     try {
-      watcher = watchImpl(watchDir, (_eventType: any, filename: any) => {
+      watcher = await createWatcher(watchDir, (_eventType: any, filename: any) => {
         if (!active) {
           return
         }
@@ -69,9 +106,10 @@ export function createPreviewWatchRegistry({
       })
     } catch (err) {
       // fs.watch can throw SYNCHRONOUSLY (e.g. ENOENT/EPERM when the watch
-      // directory was deleted before the call). Log for diagnostics, then
-      // rethrow: inside ipcMain.handle this becomes a rejected invoke() for
-      // the renderer — terminal for this watch, never a main-process crash.
+      // directory was deleted before the call). Transient EINTR/EAGAIN/
+      // EWOULDBLOCK are retried; other failures are logged and rethrown:
+      // inside ipcMain.handle this becomes a rejected invoke() for the
+      // renderer — terminal for this watch, never a main-process crash.
       log(`[preview-watch] failed to watch ${watchDir}:`, err)
       throw err
     }
@@ -108,7 +146,7 @@ export function createPreviewWatchRegistry({
    * in the directory fires the debounced callback. The same error-containment
    * and lifecycle management applies.
    */
-  function watchDirectory(
+  async function watchDirectory(
     dirPath,
     { dirExists }: { dirExists: (p: string) => boolean } = { dirExists: p => fs.existsSync(p) }
   ) {
@@ -126,7 +164,7 @@ export function createPreviewWatchRegistry({
     let watcher
 
     try {
-      watcher = watchImpl(dirPath, () => {
+      watcher = await createWatcher(dirPath, () => {
         if (!active) {
           return
         }


### PR DESCRIPTION
## What

The desktop preview live-reload watchers (`watchPreviewFile` and `watchDirectory` in `preview-watch.ts`) call `fs.watch()` synchronously. On a transient interrupted system call — EINTR on macOS/macOS arm64 when a signal lands mid-syscall while previewing a file in a live repo, plus EAGAIN/EWOULDBLOCK — the creation call throws even though a moment later it would succeed. Today that is treated as terminal: the watch is dropped and the preview silently stops live-reloading until the pane is reopened.

## Fix

Add a **bounded retry** on the synchronous `fs.watch()` creation path, wired into both `watch()` and `watchDirectory()` (the `runtime-loader.ts` disk-plugin hot-reload path shares the exact same pattern):

- Transient codes (`EINTR`, `EAGAIN`, `EWOULDBLOCK`) are retried **20 × [250ms]**, then rethrow.
- A genuinely-broken target (e.g. `ENOENT`/`EPERM` from a deleted/unmounted dir) still rethrows and surfaces as a **rejected `invoke()`** — the same crash-free contract as before, never a main-process uncaught throw.
- `watch()`/`watchDirectory()` become `async`; the renderer contract is unchanged (the IPC handlers already returned a promise via `ipcMain.handle`).

## Motivation

Confirmed by a real-world macOS arm64 repro (sobhanb-eth): previewing files in a live repo directory throws `EINTR: interrupted system call, watch` at `Object.watch` — a *sync-throw* variant of the same uncontained-error class the preview-watcher registry (#73524) addresses. The 20×@250ms budget is the one validated against that repro.

## Stacking / merge order

This is **stacked on #73524** (`fix/desktop-preview-watcher-error`, head `4e8a40eb`) — the `preview-watch.ts` registry only exists there. This PR's commit `b727087d` sits on top of it. **Merge #73524 first**, then this becomes a clean 1-commit delta. No competing PR exists for the EINTR path.

## Tests

25 tests in `preview-watch.test.ts` (21 prior, updated to async, + 4 new):
- EINTR on creation is retried and the watcher still comes up
- persistent EINTR exceeding the retry budget rethrows the last error
- EAGAIN is retried / EWOULDBLOCK covered / a non-retryable code (EPERM) is not retried
- watchDirectory transient EINTR is retried before the watcher comes up

Verified against current `main`: **electron project suite 2237 passed / 0 failed**, `tsc -p tsconfig.electron.json --noEmit` clean, eslint clean on touched files.

## Platforms

Error semantics are identical across macOS/Linux/Windows (`fs.watch` throws synchronously on a transient interrupt on any host).
