### PR TITLE
fix(tui): fast status reports normal for an explicit-normal tier pin (salvage #108581)

### DIFF
--- a/tests/tui_gateway/test_empty_fast_status.py
+++ b/tests/tui_gateway/test_empty_fast_status.py
@@ -1,21 +1,29 @@
+"""``config.set fast status`` reports "normal" for an explicit-normal pin.
+
+A session pinned to normal carries ``""`` (not ``None``) in ``create_service_tier_override``
+and, once built, in ``agent.service_tier`` — the status branch echoed that ``""`` back.
+"""
+
 from types import SimpleNamespace
+from unittest.mock import patch
+
 import pytest
-from tui_gateway import methods_config_set as config
+
+import tui_gateway.server as server
 
 
-@pytest.mark.parametrize('tier,expected', [('', 'normal'), (None, 'normal'), ('priority', 'fast'), ('normal', 'normal'), ('auto', 'auto'), ('cold', 'cold')])
-@pytest.mark.parametrize('built', [True, False])
-def test_fast_status_preserves_tier_semantics_without_mutation(monkeypatch, tier, expected, built):
-    session = {'agent': SimpleNamespace(service_tier=tier)} if built else {'create_service_tier_override': tier}
-    replies = []
-    monkeypatch.setattr(config, '_load_service_tier', lambda: tier, raising=False)
-    monkeypatch.setattr(config, '_kv', lambda rid, key, value: replies.append((rid, key, value)))
-    def forbidden(*args, **kwargs):
-        pytest.fail('Status query must not write configuration')
-    monkeypatch.setattr(config, '_write_config_key', forbidden, raising=False)
-    config._set_fast(1, {'session_id': 'test'}, 'fast', 'status', session)
-    assert replies == [(1, 'fast', expected)]
+@pytest.mark.parametrize("tier,expected", [("", "normal"), (None, "normal"), ("priority", "fast")])
+@pytest.mark.parametrize("built", [True, False])
+def test_fast_status_reports_tier_without_writing_config(tier, expected, built):
+    session = ({"agent": SimpleNamespace(service_tier=tier)} if built
+               else {"create_service_tier_override": tier})
+    with patch.dict(server._sessions, {"s-fast": session}, clear=False), \
+            patch.object(server, "_load_service_tier", return_value=tier), \
+            patch.object(server, "_write_config_key") as write_key:
+        res = server._methods["config.set"]("rid", {"session_id": "s-fast", "key": "fast", "value": "status"})
+    assert res["result"]["value"] == expected
+    write_key.assert_not_called()
     if built:
-        assert session['agent'].service_tier == tier
+        assert session["agent"].service_tier == tier
     else:
-        assert session['create_service_tier_override'] == tier
+        assert session["create_service_tier_override"] == tier

--- a/tests/tui_gateway/test_empty_fast_status.py
+++ b/tests/tui_gateway/test_empty_fast_status.py
@@ -1,0 +1,21 @@
+from types import SimpleNamespace
+import pytest
+from tui_gateway import methods_config_set as config
+
+
+@pytest.mark.parametrize('tier,expected', [('', 'normal'), (None, 'normal'), ('priority', 'fast'), ('normal', 'normal'), ('auto', 'auto'), ('cold', 'cold')])
+@pytest.mark.parametrize('built', [True, False])
+def test_fast_status_preserves_tier_semantics_without_mutation(monkeypatch, tier, expected, built):
+    session = {'agent': SimpleNamespace(service_tier=tier)} if built else {'create_service_tier_override': tier}
+    replies = []
+    monkeypatch.setattr(config, '_load_service_tier', lambda: tier, raising=False)
+    monkeypatch.setattr(config, '_kv', lambda rid, key, value: replies.append((rid, key, value)))
+    def forbidden(*args, **kwargs):
+        pytest.fail('Status query must not write configuration')
+    monkeypatch.setattr(config, '_write_config_key', forbidden, raising=False)
+    config._set_fast(1, {'session_id': 'test'}, 'fast', 'status', session)
+    assert replies == [(1, 'fast', expected)]
+    if built:
+        assert session['agent'].service_tier == tier
+    else:
+        assert session['create_service_tier_override'] == tier

--- a/tui_gateway/methods_config_set.py
+++ b/tui_gateway/methods_config_set.py
@@ -168,7 +168,7 @@ def _set_fast(rid, params, key, value, session):
     else:
         current_tier = _load_service_tier()
     if raw == "status":
-        return _kv(rid, key, {"priority": "fast", None: "normal"}.get(current_tier, current_tier))
+        return _kv(rid, key, {"priority": "fast", None: "normal", "": "normal"}.get(current_tier, current_tier))
     nv = _FAST_WORDS.get(raw, ("normal" if current_tier == "priority" else "fast") if raw in {"", "toggle"} else None)
     if nv is None:
         return _err(rid, 4002, f"unknown fast mode: {value}")


### PR DESCRIPTION
`config.set key=fast value=status` now reports `normal` for a session explicitly pinned to the normal tier, instead of echoing back an empty string.

Salvages #108581 from @Poxel2

## Changes

- `tui_gateway/methods_config_set.py::_set_fast` — the status branch mapped `priority → fast` and `None → normal`, but an explicit-normal pin is stored as `""` (`create_service_tier_override`, and `agent.service_tier` once `_make_agent` builds from that pin), so `fast status` returned `""`. Adds `"": "normal"` to the mapping. Code-path-reachable: any session where the user toggled fast off and then asked for status.
- `tests/tui_gateway/test_empty_fast_status.py` — regression test through the real `config.set` handler.

### Improvements during salvage

- Contributor commit re-authored from a placeholder local identity (`pox-local@example.invalid`) to `Poxel2 <28976520+Poxel2@users.noreply.github.com>` (misconfigured local git, not malice).
- Trimmed the test from 12 parametrized cases to the 6 that carry the invariant (`"" → normal`, `None → normal`, `priority → fast` × built agent / pre-build pin), driven through `server._methods["config.set"]` so it exercises the bound handler; keeps the "status never writes config" guard and the "status does not mutate the tier" assertions.

## Validation

| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/tui_gateway/test_empty_fast_status.py` | 6 passed |
| `scripts/run_tests.sh` + `test_fast_session_scope.py`, `test_config_set_display_toggles.py`, `test_config_set_voice_chat_mode.py` | 4 files, 19 passed, 0 failed |
| Red-on-base (swap `origin/main:tui_gateway/methods_config_set.py` in) | 1 failed (`""` case), back to green after restore |
| `ruff check --fix` touched files | All checks passed |
| `scripts/check-windows-footguns.py --all` / `check_compat_pointers.py` / `git diff --check` | clean |

## Infographic

![fast-status-normal](https://v3b.fal.media/files/b/0aaa22d6/ZrNbMF1RxoP13rkkZ4GWC_yKCeRe5y.png)
