### PR TITLE
fix(identity): spawn ledger is written owner-only (0600) regardless of umask (salvage #108019)

### DIFF
--- a/hermes_cli/process_identity.py
+++ b/hermes_cli/process_identity.py
@@ -20,6 +20,8 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Optional
 
+from utils import atomic_json_write
+
 logger = logging.getLogger(__name__)
 
 SPAWN_ENV_VAR = "HERMES_SPAWN"
@@ -265,9 +267,7 @@ def _append_entry(entry: LedgerEntry) -> bool:
         pruned.append(asdict(entry))
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
-            tmp = path.with_suffix(path.suffix + f".tmp{os.getpid()}")
-            tmp.write_text(json.dumps(pruned, indent=2), encoding="utf-8")
-            os.replace(tmp, path)
+            atomic_json_write(path, pruned, mode=0o600)
             return True
         except OSError:
             logger.debug("spawn ledger write failed", exc_info=True)

--- a/tests/hermes_cli/test_process_identity.py
+++ b/tests/hermes_cli/test_process_identity.py
@@ -134,16 +134,20 @@ def test_register_self_writes_and_prunes_dead(tmp_path):
     assert me["create_time"] == pytest.approx(50.0, abs=0.01)
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits are platform-specific")
 def test_register_self_writes_ledger_with_0600(tmp_path):
     ledger = tmp_path / "spawn-ledger.json"
     fake = _fake_psutil({999: 50.0})
-    with patch.dict(sys.modules, {"psutil": fake}), \
-         patch.object(pi, "_ledger_path", return_value=ledger), \
-         patch.object(pi.os, "getpid", return_value=999):
-        assert pi.register_self("serve", project_root=Path("/x/install")) is True
+    old_umask = os.umask(0o022)  # permissive umask: the mode must come from the writer, not the env
+    try:
+        with patch.dict(sys.modules, {"psutil": fake}), \
+             patch.object(pi, "_ledger_path", return_value=ledger), \
+             patch.object(pi.os, "getpid", return_value=999):
+            assert pi.register_self("serve", project_root=Path("/x/install")) is True
+    finally:
+        os.umask(old_umask)
 
-    mode = stat.S_IMODE(os.stat(ledger).st_mode)
-    assert mode == 0o600
+    assert stat.S_IMODE(os.stat(ledger).st_mode) == 0o600
 
 
 def test_register_self_inherits_spawn_tag_lineage(tmp_path):

--- a/tests/hermes_cli/test_process_identity.py
+++ b/tests/hermes_cli/test_process_identity.py
@@ -15,6 +15,8 @@ Runs on any host: psutil interactions go through a fake module.
 from __future__ import annotations
 
 import json
+import os
+import stat
 import sys
 import types
 from pathlib import Path
@@ -130,6 +132,18 @@ def test_register_self_writes_and_prunes_dead(tmp_path):
     me = next(e for e in entries if e["pid"] == 999)
     assert me["purpose"] == "serve"
     assert me["create_time"] == pytest.approx(50.0, abs=0.01)
+
+
+def test_register_self_writes_ledger_with_0600(tmp_path):
+    ledger = tmp_path / "spawn-ledger.json"
+    fake = _fake_psutil({999: 50.0})
+    with patch.dict(sys.modules, {"psutil": fake}), \
+         patch.object(pi, "_ledger_path", return_value=ledger), \
+         patch.object(pi.os, "getpid", return_value=999):
+        assert pi.register_self("serve", project_root=Path("/x/install")) is True
+
+    mode = stat.S_IMODE(os.stat(ledger).st_mode)
+    assert mode == 0o600
 
 
 def test_register_self_inherits_spawn_tag_lineage(tmp_path):


### PR DESCRIPTION
The spawn ledger (`spawn-ledger.json`, the process-lineage record every `hermes` launch appends to) is now written owner-only (0600) regardless of the user's umask, instead of inheriting whatever `write_text` + `os.replace` produced (typically 0644).

Salvages #108019 from @codeshipsingh

## Changes

- `hermes_cli/process_identity.py::_append_entry` — replace the hand-rolled tmp-file + `os.replace` with `utils.atomic_json_write(path, pruned, mode=0o600)`. `_atomic_write` fchmods the temp fd before the replace, so the ledger never transits through a broader mode and a pre-existing 0644 ledger is narrowed on the next write.
- `tests/hermes_cli/test_process_identity.py` — one invariant test: `register_self` leaves the ledger at `0o600`.

### Improvements during salvage

- The test now runs under an explicit permissive `umask(0o022)` so it fails whenever the mode comes from the environment rather than the writer (on a `0002`-umask host the original assertion could only pass by accident), and is gated off Windows with the same `skipif(os.name == "nt")` form the sibling POSIX mode-bit tests in `tests/hermes_cli/` use (st_mode is synthesized there).
- Contributor commit re-authored from a placeholder local git identity (`nerd@hermes.local`) to `codeshipsingh <58661393+codeshipsingh@users.noreply.github.com>` (misconfigured local git, not malice); no mapping file needed.

## Validation

| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/hermes_cli/test_process_identity.py` | 23 passed, 0 failed |
| Red-on-base (`origin/main:hermes_cli/process_identity.py` swapped in) | `test_register_self_writes_ledger_with_0600` FAILED; passes with the fix |
| E2E real import, temp `HERMES_HOME`, umask 0022 | fresh ledger 0600; pre-existing 0644 ledger narrowed to 0600 on rewrite |
| `ruff check` (both touched files) | All checks passed |
| `scripts/check-windows-footguns.py --all` | No Windows footguns found |
| `scripts/check_compat_pointers.py` | no in-tree dependency on compat pointers |
| `git diff --check` | clean |

## Infographic

![spawn-ledger-0600](https://v3b.fal.media/files/b/0aaa22d6/9HuMTGSV8R1h-UGpXku-l_6347aPAp.png)
