### PR TITLE
fix(reasoning): Daybreak Blue keeps max effort and deepseek-flash gets reasoning controls (salvage #107535, #107768)

### DIFF
--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -35,6 +35,9 @@ CODEX_LEGACY_EFFORTS: tuple[str, ...] = ("none", "low", "medium", "high", "xhigh
 # wire level; callers normalize those requests to ``low`` at the transport boundary.
 CODEX_ASTRA_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
 ASTRA_MODEL_IDS: frozenset[str] = frozenset({"gpt-6-astra", "gpt-6-astra-900k"})
+DAYBREAK_MODEL_IDS: frozenset[str] = frozenset(
+    {"gpt-daybreak-blue-latest", "gpt-daybreak-blue-latest-900k"}
+)
 
 #: xAI Responses — Grok 4.6+ accepts xhigh; older Grok tops out at high.
 XAI_GROK46_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "xhigh")
@@ -93,7 +96,12 @@ def codex_supported_efforts(model: Optional[str]) -> tuple[str, ...]:
     """Supported effort set for an OpenAI/Codex Responses model."""
     if is_astra_model(model):
         return CODEX_ASTRA_EFFORTS
-    return CODEX_GPT56_EFFORTS if "gpt-5.6" in (model or "").lower() else CODEX_LEGACY_EFFORTS
+    bare = (model or "").strip().lower().rsplit("/", 1)[-1]
+    return (
+        CODEX_GPT56_EFFORTS
+        if "gpt-5.6" in bare or bare in DAYBREAK_MODEL_IDS
+        else CODEX_LEGACY_EFFORTS
+    )
 
 
 def kimi_supported_efforts(model: Optional[str]) -> tuple[str, ...]:

--- a/contributors/emails/ada.a0uew@56.pt
+++ b/contributors/emails/ada.a0uew@56.pt
@@ -1,0 +1,1 @@
+Arguably1341

--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -25,9 +25,15 @@ def _flat_model_name(model: str | None) -> str:
     return (model or "").strip().rsplit("/", 1)[-1].lower()
 
 
+# Version-less DeepSeek ids that still carry the thinking/effort knobs on this wire: the retired
+# ``deepseek-reasoner`` alias and the canonical ``deepseek-flash`` (2026-09 Flash refresh), for
+# which the Go relay honours the same top-level ``reasoning_effort``/``thinking`` contract.
+_THINKING_CAPABLE_IDS: frozenset[str] = frozenset({"deepseek-reasoner", "deepseek-flash"})
+
+
 def _is_deepseek_thinking_model(model: str | None) -> bool:
     m = _flat_model_name(model)
-    return (m.startswith("deepseek-v") and not m.startswith("deepseek-v3")) or m == "deepseek-reasoner"
+    return (m.startswith("deepseek-v") and not m.startswith("deepseek-v3")) or m in _THINKING_CAPABLE_IDS
 
 
 def _is_glm_5_2_model(model: str | None) -> bool:

--- a/tests/agent/test_reasoning_effort_module.py
+++ b/tests/agent/test_reasoning_effort_module.py
@@ -160,6 +160,19 @@ class TestCodexVocabulary:
         assert clamp_effort("ultra", CODEX_LEGACY_EFFORTS) == "xhigh"
         assert clamp_effort("minimal", CODEX_LEGACY_EFFORTS) == "low"
 
+    @pytest.mark.parametrize(
+        "model",
+        ["gpt-daybreak-blue-latest", "gpt-daybreak-blue-latest-900k"],
+    )
+    def test_daybreak_alias_uses_gpt56_max_support(self, model):
+        """Daybreak Blue is a GPT-5.6 Sol alias, so its base and 900k picker
+        slugs must preserve Sol's max reasoning level."""
+        from agent.reasoning_effort import codex_supported_efforts
+
+        supported = codex_supported_efforts(model)
+        assert clamp_effort("max", supported) == "max"
+        assert clamp_effort("ultra", supported) == "max"
+
 
 class TestRequestedEffort:
     def test_extracts_effort(self):

--- a/tests/plugins/model_providers/test_opencode_go_profile.py
+++ b/tests/plugins/model_providers/test_opencode_go_profile.py
@@ -182,6 +182,36 @@ class TestOpenCodeGoDeepSeekThinking:
             assert extra_body == {}
             assert top_level == {"reasoning_effort": "max"}
 
+    @pytest.mark.parametrize("model", ["deepseek-flash", "deepseek/deepseek-flash"])
+    def test_version_less_canonical_id_gets_the_controls(self, opencode_go_profile, model):
+        """The canonical version-less Flash id must reach the wire like the versioned ids:
+        the asked effort, and an explicit thinking-off when reasoning is disabled."""
+        _, top_level = opencode_go_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model=model,
+        )
+        assert top_level == {"reasoning_effort": "high"}
+        extra_body, top_level = opencode_go_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model=model,
+        )
+        assert extra_body == {"thinking": {"type": "disabled"}}
+        assert top_level == {}
+
+    def test_version_less_flash_effort_reaches_the_wire(self, opencode_go_profile):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+
+        kwargs = ChatCompletionsTransport().build_kwargs(
+            model="deepseek-flash",
+            messages=[{"role": "user", "content": "ping"}],
+            tools=None,
+            provider_profile=opencode_go_profile,
+            reasoning_config={"enabled": True, "effort": "max"},
+            base_url="https://opencode.ai/zen/go/v1",
+        )
+        assert "extra_body" not in kwargs
+        assert kwargs["reasoning_effort"] == "max"
+
 
 class TestOpenCodeGoGLM52Reasoning:
     """GLM-5.2 uses its native high/max reasoning_effort knob on OpenCode Go."""


### PR DESCRIPTION
Two reasoning-effort aliases now reach the wire as the user configured them: `gpt-daybreak-blue-latest` (and its `-900k` picker slug) keeps `max` on the Codex Responses route instead of being clamped to `xhigh`, and the version-less canonical `deepseek-flash` id gets its `reasoning_effort` / `thinking` controls on the OpenCode Go relay instead of silently dropping them.

Salvages #107535 from @Arguably1341
Salvages #107768 from @secsson

## Changes

- `plugins/model-providers/opencode-zen/__init__.py::_is_deepseek_thinking_model` — matches the version-less `deepseek-flash` id via a `_THINKING_CAPABLE_IDS` set (mirrors the direct `deepseek` provider profile, which already carries the same set for the same 2026-09 Flash refresh). Root cause: the check only recognised `deepseek-v<N>` and `deepseek-reasoner`, so the canonical id fell through and every effort/thinking setting was omitted.
- `agent/reasoning_effort.py::codex_supported_efforts` — `DAYBREAK_MODEL_IDS` routes `gpt-daybreak-blue-latest(-900k)` to `CODEX_GPT56_EFFORTS`. Root cause: the vocabulary picker substring-matched `gpt-5.6` only, so the verified Sol alias (already 900k-eligible in `agent/model_metadata.py`) was treated as legacy and `max` was clamped away.
- `contributors/emails/` — mapping for @Arguably1341's commit email (real, non-noreply address).

### Salvage notes

- Both picks applied clean onto `origin/main`; authorship preserved.
- Follow-up check: no existing shared "is 5.6-Sol alias" helper in `agent/model_metadata.py` / `agent/auxiliary_client.py` (the latter hardcodes the bare string inline for the compaction threshold), so the contributor's constant stays as the single home in `reasoning_effort.py` next to `ASTRA_MODEL_IDS`.
- Tests kept as shipped: 1 parametrized invariant for Daybreak (max survives clamp for both slugs); 2 for deepseek-flash (profile emits effort and explicit thinking-off; effort reaches the Chat Completions request kwargs). Each covers a distinct invariant.

## Validation

| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/agent/test_reasoning_effort_module.py tests/plugins/model_providers/test_opencode_go_profile.py` | 61 passed, 0 failed |
| Red-on-base (swap both source files to `origin/main`, tests unchanged) | 5 failed (2 Daybreak params + 3 deepseek-flash), 56 passed → back to 61 passed after restore |
| Real-import probe (worktree at `sys.path[0]`, temp `HERMES_HOME`) | `clamp_effort("max", codex_supported_efforts(m))` → `max` for `gpt-daybreak-blue-latest`, `openai/gpt-daybreak-blue-latest-900k`, `gpt-5.6-sol`; `xhigh` for `gpt-5.5`. `_is_deepseek_thinking_model` → True for `deepseek-flash`, `deepseek/deepseek-flash`; False for `deepseek-v3.2`, `deepseek-chat` |
| `ruff check` (4 touched files) | All checks passed |
| `scripts/check-windows-footguns.py --all` | No footguns (1537 files) |
| `scripts/check_compat_pointers.py` | no in-tree dependency |
| `scripts/audit_pr_attribution.py --fix` | all contributor emails mapped |
| `git diff --check` | clean |

## Infographic

![reasoning-aliases](https://v3b.fal.media/files/b/0aaa22d9/wWOHRpRn5OUReyYN5WoIe_37seaduI.png)
