### PR TITLE
fix(desktop): Linux terminal panes stop printing the setlocale LC_CTYPE warning (salvage #107204)

### DIFF
--- a/apps/desktop/electron/terminal-ipc.ts
+++ b/apps/desktop/electron/terminal-ipc.ts
@@ -156,7 +156,10 @@ export function registerTerminalIpc({
     delete env.COLORFGBG
 
     env.COLORTERM = 'truecolor'
-    env.LC_CTYPE = env.LC_CTYPE || 'UTF-8'
+    // macOS accepts the bare charset name "UTF-8"; glibc does not, and bash
+    // warns: setlocale: LC_CTYPE: cannot change locale (UTF-8). Prefer LANG or C.UTF-8 on Linux.
+    env.LC_CTYPE =
+      env.LC_CTYPE || (process.platform === 'darwin' ? 'UTF-8' : env.LANG || 'C.UTF-8')
     env.TERM = 'xterm-256color'
     env.TERM_PROGRAM = 'Hermes'
     env.TERM_PROGRAM_VERSION = app.getVersion()

--- a/apps/desktop/electron/terminal-ipc.ts
+++ b/apps/desktop/electron/terminal-ipc.ts
@@ -31,6 +31,21 @@ export interface TerminalIpcApi {
   disposeAllTerminalSessions: () => void
 }
 
+// macOS accepts the bare charset name "UTF-8" as a locale; glibc does not, so
+// every Linux pane would print `bash: warning: setlocale: LC_CTYPE: cannot
+// change locale (UTF-8)`. Reuse the user's LANG there, else the glibc-guaranteed
+// C.UTF-8. Pure: the platform arrives as data so tests need not fake the host.
+export function terminalLcCtype(
+  env: { LANG?: string; LC_CTYPE?: string },
+  platform: NodeJS.Platform = process.platform
+): string {
+  if (env.LC_CTYPE) {
+    return env.LC_CTYPE
+  }
+
+  return platform === 'darwin' ? 'UTF-8' : env.LANG || 'C.UTF-8'
+}
+
 export function registerTerminalIpc({
   isWindows,
   findOnPath,
@@ -156,10 +171,7 @@ export function registerTerminalIpc({
     delete env.COLORFGBG
 
     env.COLORTERM = 'truecolor'
-    // macOS accepts the bare charset name "UTF-8"; glibc does not, and bash
-    // warns: setlocale: LC_CTYPE: cannot change locale (UTF-8). Prefer LANG or C.UTF-8 on Linux.
-    env.LC_CTYPE =
-      env.LC_CTYPE || (process.platform === 'darwin' ? 'UTF-8' : env.LANG || 'C.UTF-8')
+    env.LC_CTYPE = terminalLcCtype(env)
     env.TERM = 'xterm-256color'
     env.TERM_PROGRAM = 'Hermes'
     env.TERM_PROGRAM_VERSION = app.getVersion()

--- a/apps/desktop/electron/terminal-lc-ctype.test.ts
+++ b/apps/desktop/electron/terminal-lc-ctype.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict'
+
+import { test, vi } from 'vitest'
+
+// terminal-ipc.ts imports the Electron and native PTY modules at module scope;
+// neither loads under plain node, and this test only needs the pure locale helper.
+vi.mock('electron', () => ({ app: {}, ipcMain: {} }))
+vi.mock('node-pty', () => ({ default: {} }))
+
+import { terminalLcCtype } from './terminal-ipc'
+
+test('terminalLcCtype never hands glibc the bare "UTF-8" locale on Linux', () => {
+  assert.equal(terminalLcCtype({ LANG: 'en_US.UTF-8' }, 'linux'), 'en_US.UTF-8')
+  assert.equal(terminalLcCtype({}, 'linux'), 'C.UTF-8')
+  assert.equal(terminalLcCtype({ LANG: 'en_US.UTF-8', LC_CTYPE: 'de_DE.UTF-8' }, 'linux'), 'de_DE.UTF-8')
+  assert.equal(terminalLcCtype({ LANG: 'en_US.UTF-8' }, 'darwin'), 'UTF-8')
+})


### PR DESCRIPTION
Linux desktop terminal panes no longer print `bash: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8)` on every open.

Salvages #107204 from @daailouivan

`terminalShellEnv()` set `LC_CTYPE=UTF-8` whenever the parent env lacked one. macOS accepts the bare charset name as a locale; glibc does not, so bash in each embedded pane warned (four times for an interactive shell) before the prompt. User-visible on any Linux desktop launch where Electron's env does not already carry `LC_CTYPE` — i.e. the default.

## Changes

- `apps/desktop/electron/terminal-ipc.ts` — `LC_CTYPE` stays whatever the parent env set; otherwise `UTF-8` on darwin, `LANG || 'C.UTF-8'` elsewhere (contributor commit, picked as-is; applied clean on top of the post-`preserve terminal startup output` file).

**Improvements during salvage**

- Lifted the ternary into a pure `terminalLcCtype(env, platform = process.platform)` so the rule is testable without booting Electron or faking `process.platform` (platform arrives as data, per root AGENTS.md "Don't fake the host OS").
- `electron/terminal-lc-ctype.test.ts` — one vitest pinning the four arms: Linux reuses `LANG`, falls back to `C.UTF-8`, honours an explicit `LC_CTYPE`; darwin keeps `UTF-8`.

## Live check (this Linux box, glibc, `LANG=en_US.UTF-8`)

```
$ LC_CTYPE=UTF-8 bash -ic 'true'
bash: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
bash: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
bash: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory
bash: warning: setlocale: LC_CTYPE: cannot change locale (UTF-8): No such file or directory

$ LC_CTYPE=C.UTF-8 bash -ic 'true'
(no setlocale output)
```

(`bash -c` without `-i` is silent in both cases; interactive shells — what the pane spawns — are where the warning fires.)

## Validation

| Check | Result |
|---|---|
| `CI=true npx vitest run --project electron electron/terminal-lc-ctype.test.ts` | 1 passed |
| Red-on-base (`git show origin/main:…terminal-ipc.ts` cp-swapped in) | 1 failed — `terminalLcCtype is not a function`; restored → 1 passed |
| `npx tsc -p . --noEmit` (apps/desktop) | 0 errors |
| `npx tsc -p tsconfig.electron.json --noEmit` | 0 errors |
| `npx eslint` + `prettier --check` on both touched files | clean |
| `scripts/check-windows-footguns.py --all`, `scripts/check_compat_pointers.py`, `git diff --check` | clean |

## Infographic

![desktop-lc-ctype](https://v3b.fal.media/files/b/0aaa22db/7qeVOS5pnqiK0tIjqPq7l_tRRmxS2C.png)
