### PR TITLE
fix(cron): agent pre-run scripts run in the job's configured workdir (salvage #106644)

### DIFF
--- a/contributors/emails/ycy1990@gmail.com
+++ b/contributors/emails/ycy1990@gmail.com
@@ -1,0 +1,1 @@
+metricano

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1969,7 +1969,12 @@ def _prepare_job_prompt(
     prerun_script = None
     script_path = job.get("script")
     if script_path:
-        prerun_script = _run_job_script_with_claim_heartbeat(job, script_path, cancel_event=cancel_event)
+        prerun_script = _run_job_script_with_claim_heartbeat(
+            job,
+            script_path,
+            workdir=_resolve_job_workdir(job, job_id),
+            cancel_event=cancel_event,
+        )
         _ran_ok, _script_output = prerun_script
         if _ran_ok and not _parse_wake_gate(_script_output):
             logger.info("Job '%s' (ID: %s): wakeAgent=false, skipping agent run", job_name, job_id)

--- a/cron/scheduler_prompt.py
+++ b/cron/scheduler_prompt.py
@@ -222,7 +222,9 @@ def _build_job_prompt(
     script_path = job.get("script")
     if script_path:
         success, script_output = (
-            prerun_script if prerun_script is not None else _script._run_job_script(script_path))
+            prerun_script if prerun_script is not None
+            else _script._run_job_script(
+                script_path, workdir=_sched._resolve_job_workdir(job, str(job.get("id") or ""))))
         if success and not script_output:
             return None  # no output → nothing to report, skip the AI call
         heading, intro = (

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -351,3 +351,25 @@ class TestRunJobTerminalCwd:
 
         assert success is True
         assert observed["script_workdir"] == str(workdir)
+
+
+def test_build_job_prompt_inline_script_receives_configured_workdir(monkeypatch, tmp_path):
+    """Callers that skip the wake-gate (no cached ``prerun_script``) run the script inline from
+    ``_build_job_prompt``; that path must honour the job's workdir too."""
+    from cron import scheduler_prompt, scheduler_script
+
+    workdir = tmp_path / "project"
+    workdir.mkdir()
+    observed: dict = {}
+
+    def run_script(script_path, workdir=None, cancel_event=None):
+        observed["script_workdir"] = workdir
+        return True, "collected data"
+
+    monkeypatch.setattr(scheduler_script, "_run_job_script", run_script)
+    prompt = scheduler_prompt._build_job_prompt(
+        {"id": "inline", "name": "inline", "prompt": "Review.", "script": "collect.py",
+         "workdir": str(workdir)})
+
+    assert observed["script_workdir"] == str(workdir)
+    assert "collected data" in prompt

--- a/tests/cron/test_cron_workdir.py
+++ b/tests/cron/test_cron_workdir.py
@@ -320,3 +320,34 @@ class TestRunJobTerminalCwd:
         assert observed["terminal_cwd_during_run"] == baseline
         assert os.environ["TERMINAL_CWD"] == baseline
         assert get_session_cwd(observed["task_id"]) is None
+
+    def test_agent_prerun_script_receives_configured_workdir(
+        self, monkeypatch, tmp_path
+    ):
+        import cron.scheduler as sched
+
+        workdir = tmp_path / "project"
+        workdir.mkdir()
+        observed: dict = {}
+        self._install_stubs(monkeypatch, observed)
+
+        def run_script(job, script_path, workdir=None, cancel_event=None):
+            observed["script_workdir"] = workdir
+            return True, '{"wakeAgent": false}'
+
+        monkeypatch.setattr(
+            sched, "_run_job_script_with_claim_heartbeat", run_script
+        )
+        success, *_ = sched.run_job(
+            {
+                "id": "agent-script-workdir",
+                "name": "agent-script-workdir",
+                "prompt": "Review the project.",
+                "script": "collect.py",
+                "workdir": str(workdir),
+                "schedule_display": "manual",
+            }
+        )
+
+        assert success is True
+        assert observed["script_workdir"] == str(workdir)


### PR DESCRIPTION
A cron job's configured `workdir` is now honoured by its agent pre-run script (`script` field) on every code path — previously only the `no_agent` short-circuit passed it, so agent jobs ran their data-collection script from the scripts-dir parent and relative reads against the project failed silently.

Salvages #106644 from @metricano

## Changes

- `cron/scheduler.py::_prepare_job_prompt` (contributor commit, cherry-picked): the wake-gate call `_run_job_script_with_claim_heartbeat(job, script_path, ...)` now passes `workdir=_resolve_job_workdir(job, job_id)`, the same resolver `_run_no_agent_job` already used.
- `tests/cron/test_cron_workdir.py::test_agent_prerun_script_receives_configured_workdir` (contributor test, kept as-is).

### Improvements during salvage

- **Widened to the sibling site.** `cron/scheduler_prompt.py::_build_job_prompt` runs the script inline via `_script._run_job_script(script_path)` when no cached `prerun_script` is supplied — the same bug class, so it now routes through `_resolve_job_workdir` too. Full caller sweep of `_run_job_script` / `_run_job_script_with_claim_heartbeat`: `_run_no_agent_job` and `cron/monitor.py` already passed `workdir`; wake-gate fixed by the picked commit; the inline prompt path was the last one. One invariant test added for it.
- `contributors/emails/ycy1990@gmail.com -> metricano` mapping (real personal email, needs a mapping file for `check-attribution`).

Root cause in one sentence: the workdir plumbing (#69396) was added to `_run_job_script` and wired at the `no_agent` site, but the two agent-path callers kept the pre-plumbing positional call.

## Validation

| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/cron/test_cron_workdir.py tests/cron/test_cron_script.py tests/cron/test_script_claim_heartbeat.py tests/cron/test_scheduler.py tests/cron/test_notepad.py tests/cron/test_cron_context_from.py tests/cron/test_cron_prompt_injection_skill.py tests/cron/test_scheduler_mcp_init.py tests/cron/test_cron_no_agent.py` | 9 files, 251 passed, 0 failed, 1 skipped |
| Red-on-base (swap `origin/main:cron/scheduler.py` + `cron/scheduler_prompt.py` in, run `test_cron_workdir.py`) | both new tests FAIL on base (2 failed / 16 passed); swap back → 18 passed |
| E2E real-subprocess probe (worktree at `sys.path[0]`, temp `HERMES_HOME`, real `pwd.py` script) | inline path with workdir → cwd is the project dir; without workdir → not the project dir; heartbeat helper + resolver → project dir; vanished workdir → `None` + warning, no crash |
| `ruff check --fix` on touched files | All checks passed |
| `scripts/check-windows-footguns.py --all` | No Windows footguns found |
| `scripts/check_compat_pointers.py` | no in-tree dependency on plugin-compat pointers |
| `git diff --check` | clean |

## Infographic
![cron-prerun-workdir](https://v3b.fal.media/files/b/0aaa22e0/UcSgBE-AHyfOYsF98xf_r_VWtOLWVa.png)
