### PR TITLE
fix(mcp-oauth): preserve cached callback URI paths

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -20,6 +20,9 @@ from tools.mcp_oauth import (
     _make_callback_handler,
     _make_redirect_handler,
     _paste_callback_reader,
+    _cached_redirect,
+    _configure_callback_port,
+    _resolve_redirect_uri,
 )
 
 
@@ -209,6 +212,51 @@ class TestHermesTokenStorage:
             assert asyncio.run(storage.get_tokens()) is None
         assert any("Corrupt" in r.message for r in caplog.records)
         assert secret not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Cached redirect registration
+# ---------------------------------------------------------------------------
+
+class TestCachedRedirect:
+    def test_preserves_dashboard_callback_path_when_restoring_loopback_registration(
+        self, tmp_path, monkeypatch
+    ):
+        """A cached DCR registration owns the complete redirect URI, not only its port.
+
+        Notion registers Hermes' dashboard callback path; reducing it to the
+        generic ``/callback`` path makes every reauthorization mismatch.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("notion")
+        storage._client_info_path().parent.mkdir(parents=True, exist_ok=True)
+        storage._client_info_path().write_text(json.dumps({
+            "client_id": "cached-client",
+            "redirect_uris": [
+                "http://127.0.0.1:54997/api/mcp/oauth/callback/notion"
+            ],
+        }))
+
+        assert _cached_redirect(storage) == (
+            "http://127.0.0.1:54997/api/mcp/oauth/callback/notion", 54997
+        )
+
+    def test_restored_loopback_registration_is_used_verbatim(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("notion")
+        storage._client_info_path().parent.mkdir(parents=True, exist_ok=True)
+        registered = "http://127.0.0.1:54997/api/mcp/oauth/callback/notion"
+        storage._client_info_path().write_text(json.dumps({
+            "client_id": "cached-client",
+            "redirect_uris": [registered],
+        }))
+
+        cfg = {}
+        assert _configure_callback_port(cfg, storage) == 54997
+        assert cfg["redirect_uri"] == registered
+        assert _resolve_redirect_uri(cfg, 54997) == registered
 
 
 # ---------------------------------------------------------------------------

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -152,9 +152,12 @@ def _cached_client_info(storage: "HermesTokenStorage | None") -> dict | None:
 
 
 def _cached_redirect(storage: "HermesTokenStorage | None") -> "tuple[str | None, int | None]":
-    """``(https proxy URI, loopback callback port)`` from the cached client registration (None when
-    absent): a DCR ``client_id`` is bound to its registered redirect URI, so a new random port under
-    it gets ``redirect_uri does not match any registered URIs``."""
+    """``(registered non-generic URI, loopback callback port)`` from the cached
+    client registration. A DCR ``client_id`` is bound to the complete redirect
+    URI, not merely its port: dashboard callbacks such as
+    ``/api/mcp/oauth/callback/notion`` must be replayed verbatim. Legacy
+    loopback registrations using the generic ``/callback`` path retain the port
+    return so their existing listener behavior is unchanged."""
     uri = port = None
     for raw in (_cached_client_info(storage) or {}).get("redirect_uris") or []:
         try:
@@ -163,9 +166,15 @@ def _cached_redirect(storage: "HermesTokenStorage | None") -> "tuple[str | None,
             continue
         if uri is None and parsed.scheme == "https" and parsed.netloc:
             uri = str(raw)
-        is_loopback_callback = parsed.scheme == "http" and parsed.path == "/callback" and parsed.hostname in {"127.0.0.1", "localhost"}
-        if port is None and is_loopback_callback and parsed.port is not None:
+        is_loopback = parsed.scheme == "http" and parsed.hostname in {"127.0.0.1", "localhost"}
+        if not is_loopback or parsed.port is None:
+            continue
+        if port is None:
             port = int(parsed.port)
+        if parsed.path != "/callback" and uri is None:
+            # The registered path is part of the OAuth client contract. Keep
+            # it instead of silently deriving the generic /callback path.
+            uri = str(raw)
     return uri, port
 
 
@@ -794,14 +803,14 @@ def token_request_user_agent(cfg: dict) -> str | None:
 
 
 def _configure_callback_port(cfg: dict, storage: "HermesTokenStorage | None" = None) -> int:
-    """Resolve the callback port into ``cfg['_resolved_port']`` (0 = non-loopback URI). Precedence:
-    dashboard flow / cached https redirect URI → CIMD pinned port (sets ``cfg['_cimd_url']``) →
-    ``oauth.redirect_port`` → cached registration port → fresh ephemeral port (the only parked one).
-    Also sets the legacy ``_oauth_port``.
+    """Resolve the callback endpoint from the complete OAuth registration. Precedence:
+    dashboard flow / cached redirect URI → CIMD pinned port (sets ``cfg['_cimd_url']``) →
+    ``oauth.redirect_port`` → cached registration port → fresh ephemeral port.
+    Cached loopback registrations preserve both their path and port; ``0`` means
+    a non-loopback URI. Also sets the legacy ``_oauth_port``.
 
-    NOTE: also sets the legacy module-level ``_oauth_port`` so existing calls to ``_wait_for_callback`` keep
-    working. The legacy global is the root cause of issue #5344 (port collision on concurrent OAuth flows);
-    replacing it with a ContextVar is out of scope for this consolidation PR.
+    NOTE: the legacy module-level value remains for compatibility with existing
+    callers; per-flow closures are the real concurrency mechanism.
     """
     global _oauth_port
     dashboard_flow = get_dashboard_oauth_flow()
@@ -812,6 +821,16 @@ def _configure_callback_port(cfg: dict, storage: "HermesTokenStorage | None" = N
     cached_uri, cached_port = _cached_redirect(storage)
     if cached_uri and not cfg.get("redirect_uri"):
         cfg["redirect_uri"] = cached_uri
+        parsed_cached_uri = urlparse(cached_uri)
+        if (parsed_cached_uri.scheme == "http"
+                and parsed_cached_uri.hostname in {"127.0.0.1", "localhost"}
+                and cached_port is not None):
+            # A cached loopback URI still needs Hermes' local listener. Keep
+            # both the registered path and its registered port; treating it as
+            # a remote URI would bind an unrelated ephemeral port.
+            cfg["_resolved_port"] = cached_port
+            _oauth_port = cached_port
+            return cached_port
         cfg["_resolved_port"] = 0
         return 0
     cimd = _maybe_use_cimd(cfg, storage)


### PR DESCRIPTION
## Summary

Preserve the complete cached loopback OAuth callback registration, including its path and port, instead of discarding non-generic paths and generating a fresh `/callback` URI.

This fixes the repeated Notion OAuth mismatch when the registered callback is:

`http://127.0.0.1:54997/api/mcp/oauth/callback/notion`

## Verification

- `scripts/run_tests.sh tests/tools/test_mcp_oauth.py -k CachedRedirect`
- focused OAuth/CIMD/dashboard tests
- `compileall`
- `git diff --check`

The resolver now returns the registered URI unchanged.
