### PR TITLE
fix(platforms): Slack/Feishu inbound message id reaches the session source (salvage #106688, #108776)

### DIFF
--- a/contributors/emails/harrison@succession.bio
+++ b/contributors/emails/harrison@succession.bio
@@ -1,0 +1,1 @@
+successionbio

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1897,7 +1897,7 @@ class BuzzAdapter(BasePlatformAdapter):
             message_type = MessageType.DOCUMENT
         source = self.build_source(
             chat_id=chat_id, chat_name=self._channel_names.get(chat_id, chat_id), chat_type=chat_type,
-            user_id=user_id, user_name=user_name, thread_id=thread_id,
+            user_id=user_id, user_name=user_name, thread_id=thread_id, message_id=message_id,
         )
         event = MessageEvent(
             text=text, message_type=message_type, source=source, raw_message=raw_message, message_id=message_id,

--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -365,7 +365,8 @@ class DingTalkAdapter(BasePlatformAdapter):
         if not text and not media_urls:
             return logger.debug("[%s] Empty message, skipping", self.name)
         source = self.build_source(chat_id=chat_id, chat_name=getattr(message, "conversation_title", None), chat_type="group" if is_group else "dm",
-                                   user_id=sender_id, user_name=sender_nick, user_id_alt=sender_staff_id if sender_staff_id else None)
+                                   user_id=sender_id, user_name=sender_nick, user_id_alt=sender_staff_id if sender_staff_id else None,
+                                   message_id=msg_id)
         create_at = getattr(message, "create_at", None)
         try:
             timestamp = datetime.fromtimestamp(int(create_at) / 1000, tz=timezone.utc) if create_at else datetime.now(tz=timezone.utc)

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -644,7 +644,8 @@ class EmailAdapter(BasePlatformAdapter):
         event = MessageEvent(
             text=text or "(empty email)", message_id=msg_data["message_id"],
             message_type=MessageType.DOCUMENT if "document" in kinds else MessageType.PHOTO if "image" in kinds else MessageType.TEXT,
-            source=self.build_source(chat_id=sender_addr, chat_name=name, chat_type="dm", user_id=sender_addr, user_name=name),
+            source=self.build_source(chat_id=sender_addr, chat_name=name, chat_type="dm", user_id=sender_addr, user_name=name,
+                                     message_id=msg_data["message_id"]),
             media_urls=[att["path"] for att in attachments], media_types=[att["media_type"] for att in attachments],
             reply_to_message_id=msg_data["in_reply_to"] or None)
         logger.info("[Email] New message from %s: %s", sender_addr, subject)

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2537,6 +2537,7 @@ class FeishuAdapter(BasePlatformAdapter):
             thread_id=thread_id,
             user_id_alt=sender_profile["user_id_alt"],
             is_bot=is_bot,
+            message_id=message_id,
         )
         normalized = MessageEvent(
             text=text, message_type=inbound_type, source=source, raw_message=data,

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -2589,6 +2589,7 @@ class FeishuAdapter(BasePlatformAdapter):
         existing.timestamp = event.timestamp
         if event.message_id:
             existing.message_id = event.message_id
+            existing.source.message_id = event.message_id
         self._schedule_media_batch_flush(key)
 
     def _schedule_media_batch_flush(self, key: str) -> None:
@@ -2847,6 +2848,7 @@ class FeishuAdapter(BasePlatformAdapter):
         existing.timestamp = event.timestamp
         if event.message_id:
             existing.message_id = event.message_id
+            existing.source.message_id = event.message_id
         self._pending_text_batch_counts[key] = next_count
         self._schedule_text_batch_flush(key)
 

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -920,7 +920,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
             # Email is the canonical id (allowlists use emails); the ``users/{id}``
             # resource name moves to user_id_alt.
             user_id=(sender_email or sender_name), user_name=sender.get("displayName") or sender_email or sender_name,
-            thread_id=session_thread_id, user_id_alt=(sender_name or None),
+            thread_id=session_thread_id, user_id_alt=(sender_name or None), message_id=msg.get("name") or None,
         )
         return MessageEvent(
             text=text, message_type=message_type, source=source, raw_message=msg, message_id=msg.get("name") or None,

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -582,7 +582,8 @@ class LineAdapter(BasePlatformAdapter):
         if chat_type == "dm" and self._client:  # best-effort typing indicator (DM only)
             asyncio.create_task(self._client.loading(chat_id))
         source_obj = self.build_source(
-            chat_id=chat_id, chat_type=chat_type, user_id=user_id, user_name=user_id, chat_name=chat_id)
+            chat_id=chat_id, chat_type=chat_type, user_id=user_id, user_name=user_id, chat_name=chat_id,
+            message_id=message_id)
         await self.handle_message(MessageEvent(
             text=text, message_type=_LINE_MESSAGE_TYPES.get(msg_type, MessageType.TEXT), source=source_obj,
             raw_message=event, message_id=message_id, media_urls=media_urls, media_types=media_types))

--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -256,7 +256,7 @@ class NtfyAdapter(BasePlatformAdapter):
         # NOT drive authorization, so user_id is fixed to the topic name.
         topic = event.get("topic") or self._topic
         source = self.build_source(
-            chat_id=topic, chat_name=topic, chat_type="dm", user_id=topic, user_name=topic)
+            chat_id=topic, chat_name=topic, chat_type="dm", user_id=topic, user_name=topic, message_id=msg_id)
         unix_ts, timestamp = event.get("time"), datetime.now(tz=timezone.utc)
         try:
             timestamp = datetime.fromtimestamp(int(unix_ts), tz=timezone.utc) if unix_ts else timestamp

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -759,7 +759,7 @@ class PhotonAdapter(BasePlatformAdapter):
 
         def _event(text: str, mtype: MessageType = MessageType.TEXT, **kwargs: Any) -> MessageEvent:
             source = self.build_source(chat_id=space_id, chat_name=space_id, chat_type=chat_type,
-                                       user_id=sender_id, user_name=sender_id or None)
+                                       user_id=sender_id, user_name=sender_id or None, message_id=message_id)
             return MessageEvent(text=text, message_type=mtype, source=source, message_id=message_id,
                                 raw_message=event, timestamp=timestamp, **kwargs)
         if ctype in {"read", "read_receipt"}:  # presence signal, not a user turn (receipts for our sends)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4360,6 +4360,7 @@ class SlackAdapter(BasePlatformAdapter):
             user_name=user_name,
             thread_id=thread_ts,
             scope_id=str(team_id) if team_id else None,
+            message_id=ts,
             # Workflow/app posts have user=None; flag them so the SLACK_ALLOW_BOTS bypass can
             # authorize them. Same predicate as the drop gate (api_human_users stay human).
             is_bot=self._event_declares_bot_sender(event))

--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -259,7 +259,8 @@ class SmsAdapter(BasePlatformAdapter):
             return _twiml_response()
         logger.info("[sms] inbound from %s -> %s: %s", redact_phone(from_number), redact_phone(to_number), text[:80])
         source = self.build_source(
-            chat_id=from_number, chat_name=from_number, chat_type="dm", user_id=from_number, user_name=from_number)
+            chat_id=from_number, chat_name=from_number, chat_type="dm", user_id=from_number, user_name=from_number,
+            message_id=message_sid)
         event = MessageEvent(
             text=text, message_type=MessageType.TEXT, source=source, raw_message=form, message_id=message_sid)
         # Non-blocking: Twilio expects a fast response

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -492,7 +492,8 @@ class TeamsAdapter(BasePlatformAdapter):
             chat_type=_CHAT_TYPES.get(getattr(conv, "conversation_type", None) or "", "dm"),
             user_id=str(user_id),
             user_name=getattr(from_account, "name", None) or "",
-            guild_id=getattr(conv, "tenant_id", None) or self._tenant_id)
+            guild_id=getattr(conv, "tenant_id", None) or self._tenant_id,
+            message_id=msg_id)
         media: list = [m for m in [await self._cache_attachment(a) for a in getattr(activity, "attachments", None) or []] if m]
         media_kinds = [kind for _, _, kind in media]  # media items are (path, media_type, kind)
         msg_type = next((t for kind, t in _MEDIA_KIND_PRECEDENCE if kind in media_kinds), MessageType.TEXT)

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -462,7 +462,8 @@ class WeComAdapter(WeComStreamMixin, WeComMediaMixin, ChatSendQueueMixin, BasePl
         if not text and not media_urls:
             logger.info("[%s] Empty WeCom message skipped: is_group=%s chat=%s msgtype=%r", self.name, is_group, chat_id, body.get("msgtype"))
             return
-        source = self.build_source(chat_id=chat_id, chat_type="group" if is_group else "dm", user_id=sender_id or None, user_name=sender_id or None)
+        source = self.build_source(chat_id=chat_id, chat_type="group" if is_group else "dm", user_id=sender_id or None, user_name=sender_id or None,
+                                   message_id=msg_id)
         event = MessageEvent(
             text=text, message_type=message_type, source=source, raw_message=payload, message_id=msg_id, media_urls=media_urls, media_types=media_types,
             reply_to_message_id=f"quote:{msg_id}" if has_reply_context else None, reply_to_text=reply_text if has_reply_context else None, timestamp=datetime.now(tz=timezone.utc),

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -827,7 +827,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 return None
             msg_type = self._classify_bridge_message(data)
             source = self.build_source(chat_id=data.get("chatId", ""), chat_name=data.get("chatName"), chat_type="group" if data.get("isGroup", False) else "dm",
-                                       user_id=data.get("senderId"), user_name=data.get("senderName"))
+                                       user_id=data.get("senderId"), user_name=data.get("senderName"),
+                                       message_id=data.get("messageId"))
             cached_urls, media_types = await self._collect_bridge_media(data, msg_type)
             body = data.get("body", "")
             if data.get("isGroup"):

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -952,6 +952,8 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(event.source.user_name, "张三")
         self.assertEqual(event.source.user_id_alt, "on_union")
         self.assertEqual(event.source.chat_name, "Feishu DM")
+        # Reply anchors / slash-command thread checks read source.message_id, not event.message_id.
+        self.assertEqual(event.source.message_id, "om_text")
 
 
     @patch.dict(

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -971,14 +971,18 @@ class TestAdapterBehavior(unittest.TestCase):
 
         adapter = FeishuAdapter(PlatformConfig())
         adapter.handle_message = AsyncMock()
-        source = SessionSource(
-            platform=adapter.platform,
-            chat_id="oc_chat",
-            chat_name="Feishu DM",
-            chat_type="dm",
-            user_id="ou_user",
-            user_name="张三",
-        )
+
+        def _source(message_id: str) -> SessionSource:
+            # Each inbound message carries its own source, pinned to that message's id.
+            return SessionSource(
+                platform=adapter.platform,
+                chat_id="oc_chat",
+                chat_name="Feishu DM",
+                chat_type="dm",
+                user_id="ou_user",
+                user_name="张三",
+                message_id=message_id,
+            )
 
         async def _sleep(_delay):
             return None
@@ -986,13 +990,13 @@ class TestAdapterBehavior(unittest.TestCase):
         async def _run() -> None:
             with patch("plugins.platforms.feishu.adapter.asyncio.sleep", side_effect=_sleep):
                 await adapter._dispatch_inbound_event(
-                    MessageEvent(text="A", message_type=MessageType.TEXT, source=source, message_id="om_1")
+                    MessageEvent(text="A", message_type=MessageType.TEXT, source=_source("om_1"), message_id="om_1")
                 )
                 await adapter._dispatch_inbound_event(
-                    MessageEvent(text="B", message_type=MessageType.TEXT, source=source, message_id="om_2")
+                    MessageEvent(text="B", message_type=MessageType.TEXT, source=_source("om_2"), message_id="om_2")
                 )
                 await adapter._dispatch_inbound_event(
-                    MessageEvent(text="C", message_type=MessageType.TEXT, source=source, message_id="om_3")
+                    MessageEvent(text="C", message_type=MessageType.TEXT, source=_source("om_3"), message_id="om_3")
                 )
                 pending = list(adapter._pending_text_batch_tasks.values())
                 self.assertEqual(len(pending), 1)
@@ -1005,6 +1009,10 @@ class TestAdapterBehavior(unittest.TestCase):
         second = adapter.handle_message.await_args_list[1].args[0]
         self.assertEqual(first.text, "A\nB")
         self.assertEqual(second.text, "C")
+        # Coalescing advances the event id to the latest message; the reply anchor
+        # (source.message_id) must move with it or replies/session tools disagree.
+        self.assertEqual(first.message_id, "om_2")
+        self.assertEqual(first.source.message_id, first.message_id)
 
     @patch.dict(os.environ, {}, clear=True)
     def test_media_batch_merges_rapid_photo_messages(self):

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3807,6 +3807,10 @@ class TestProgressMessageThread:
             "message_id must equal the event ts so _run_agent can use it as "
             "the fallback thread anchor for progress messages"
         )
+        assert source.message_id == "1234567890.000001", (
+            "source.message_id must carry the authenticated triggering Slack ts "
+            "into session-bound tools"
+        )
 
         # Verify that the Slack send() method correctly threads a message
         # when metadata contains thread_id equal to the original ts

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3334,6 +3334,9 @@ class TestAssistantThreadLifecycle:
             # connector's chat.startStream recipient fields.
             "scope_id": "T_OTHER",
             "user_id": "U_USER",
+            # Triggering ts: lets the reply_in_thread=false path tell this synthetic
+            # thread key (thread_id == own ts) from a real thread.
+            "message_id": "171.111",
         }
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Slack and Feishu (and 11 more adapters) now carry the triggering platform message id on `SessionSource.message_id`, so reply anchors, `/sethome`'s synthetic-thread check, the relay fallback and shutdown-notice anchoring stop seeing `None` on those platforms.

Salvages #106688 from @successionbio
Salvages #108776 from @addamsE

## Changes

- **Slack** (`plugins/platforms/slack/adapter.py`, @successionbio): `build_source(..., message_id=ts)` for the inbound message; the existing `TestProgressMessageThread` test gains one assertion on `source.message_id`.
- **Feishu** (`plugins/platforms/feishu/adapter.py`, @addamsE): `build_source(..., message_id=message_id)` in `_process_inbound_message`.
- Root cause: both adapters put the platform id on the `MessageEvent` but not on the `SessionSource`, while every `source.message_id` consumer (`gateway/run.py::_thread_metadata_for_source`, `gateway/platforms/base.py::_thread_metadata_for_source`, `gateway/slash_commands.py::_home_thread_from_source`, `gateway/relay/adapter.py::_event_ids`, `gateway/run_shutdown.py` notice anchor) reads the source. Telegram, Discord, Matrix and Mattermost already passed it.

## Improvements during salvage

- Feishu had no test: one assertion added to the existing `test_process_inbound_message_uses_event_sender_identity_only` (`source.message_id == "om_text"`), proven red on base.
- `chore:` mapping for `harrison@succession.bio -> successionbio` (`contributors/emails/`); @addamsE's commit is already on a `<id>+login@users.noreply` address.
- `test_agent_view_message_preserves_outer_team_and_turn_context` now expects `message_id` in the Slack per-turn thread metadata — a direct consequence of the fix (`_thread_metadata_for_target`'s Slack branch already stamps it whenever an anchor exists; it just never had one).
- **Sibling sweep** of every inbound `self.build_source(` in `plugins/platforms/*/adapter.py`:
  - Already passed `message_id`: discord (message + `gateway_platform_event`), telegram (both sites), matrix, mattermost, slack (event site, after this PR), feishu (`_process_inbound_message`, after this PR).
  - Widened in this PR (id variable already in scope one line away, one-line change each): buzz, dingtalk, email, google_chat, line, ntfy, photon, sms, teams, wecom, whatsapp.
  - Left alone (not an inbound user message, or no natural platform id): a2a (task_id is the event id, not a platform message), homeassistant (state-change synthesized id), irc (no message ids), raft (wake delivery), simplex (`MessageEvent` itself has no `message_id`), feishu `_dispatch_synthetic_event` (reaction/card synthetic), slack slash-command / reaction / view sites, discord slash-command sites.

## Validation

| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/gateway/test_{slack,feishu,buzz,dingtalk,email,google_chat,line,ntfy,photon,sms,teams,wecom,whatsapp,relay,slash}*.py` | 104 files, **1459 passed**, 0 failed, 24 skipped |
| Red-on-base: `test_slack.py::TestProgressMessageThread` with `origin/main` slack adapter swapped in | fails `source.message_id must carry the authenticated triggering Slack ts` → passes after restore |
| Red-on-base: `test_feishu.py::…uses_event_sender_identity_only` with `origin/main` feishu adapter swapped in | fails `None != 'om_text'` → passes after restore |
| `ruff check` touched files | clean |
| `scripts/check-windows-footguns.py --all` | 0 findings |
| `scripts/check_compat_pointers.py` | clean |
| `git diff --check`, behind-count vs `origin/main` | clean / 0 |

## Review follow-up

- **Feishu batching desync (`f19e050bb0d6`)**: `_enqueue_text_event` and `_enqueue_media_event` advance the coalesced `event.message_id` to the newest message but left `source.message_id` at the first one, so after a batch the reply anchor and the event id disagreed. Both now advance together at the two enqueue sites (2 lines).
- Test: extended `test_text_batch_flushes_when_message_count_limit_is_hit` to give each inbound event its own source and assert `first.message_id == first.source.message_id == "om_2"`. Red on the pre-fix adapter (`'om_1' != 'om_2'`), green after. `scripts/run_tests.sh` on the 5 `tests/gateway/test_feishu*.py` files: 105 passed, 0 failed.

## Infographic

![source-message-id](https://v3b.fal.media/files/b/0aaa22e5/96P_w8nCUXaNQTs3i-BV9_zrlhYU4a.png)

