### PR TITLE
fix(backup): skip regenerable cache/ trees and unix sockets in full backups (salvage #107009, #108569)

### DIFF
--- a/contributors/emails/mrwanstudio@gmail.com
+++ b/contributors/emails/mrwanstudio@gmail.com
@@ -1,0 +1,1 @@
+mrwanstudio

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -60,20 +60,28 @@ _EXCLUDED_DIRS = {
     ".cache", ".tox", ".nox", ".pytest_cache", ".mypy_cache", ".ruff_cache",
 }
 
-# Hermes-managed runtime downloads (GGUF models, llama.cpp runtimes, managed Node) and caches are
-# regenerable. Runtime trees routinely reach tens to hundreds of GB; live browser/tool caches may
-# also contain locked SQLite databases that cannot be snapshotted consistently. Match these names
-# ONLY at the root of HERMES_HOME and at ``profiles/<name>/`` — a deeper directory of the same name
-# (for example, a skill's ``models/`` or ``cache/``) is user data and must survive.
-_EXCLUDED_ROOT_DIRS = {"cache", "models", "runtimes", "node"}
+# Hermes-managed runtime downloads (GGUF models, llama.cpp runtimes, managed Node): re-downloaded
+# on demand and routinely tens to hundreds of GB. Matched ONLY at the root of HERMES_HOME and at
+# ``profiles/<name>/`` — a deeper dir of the same name (a skill's ``models/``) is user data.
+_EXCLUDED_ROOT_DIRS = {"models", "runtimes", "node"}
+
+# ``cache/`` at those same roots mixes regenerable state (model/plugin catalogs, stamps, browser
+# profiles with locked SQLite, tool-output spill) with durable artifacts nothing can rebuild: media
+# the gateway delivered to or received from the user (``gateway.platforms.base``'s media-delivery
+# subdirs) and the grounded-citations evidence ledger. Only these subdirs are archived.
+_KEPT_CACHE_SUBDIRS = {"images", "audio", "videos", "documents", "screenshots", "citations"}
 
 
 def _in_excluded_root_dir(rel_path: Path) -> bool:
     """True when *rel_path* is inside a regenerable tree at a profile-home root."""
     parts = rel_path.parts
-    return bool(parts) and (
-        parts[0] in _EXCLUDED_ROOT_DIRS
-        or (len(parts) >= 3 and parts[0] == "profiles" and parts[2] in _EXCLUDED_ROOT_DIRS))
+    if len(parts) >= 3 and parts[0] == "profiles":
+        parts = parts[2:]
+    if not parts:
+        return False
+    if parts[0] in _EXCLUDED_ROOT_DIRS:
+        return True
+    return parts[0] == "cache" and len(parts) >= 2 and parts[1] not in _KEPT_CACHE_SUBDIRS
 
 
 # SQLite sidecars are excluded because ``*.db`` is snapshotted via ``sqlite3.backup()``:

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -228,9 +228,21 @@ def _iter_external_files(base: Path) -> List[Path]:
     for dirpath, dirnames, filenames in os.walk(base, followlinks=False):
         dirnames[:] = [d for d in dirnames if d not in _EXCLUDED_DIRS]
         files.extend(fp for fp in (Path(dirpath) / f for f in filenames)
-                     if not (fp.is_symlink() or fp.name in _EXCLUDED_NAMES
+                     if not (_is_non_regular_path(fp) or fp.name in _EXCLUDED_NAMES
                              or fp.name.endswith(_EXCLUDED_SUFFIXES)))
     return files
+
+
+def _is_non_regular_path(path: Path) -> bool:
+    """True for symlinks, sockets, devices, and other non-regular filesystem entries.
+
+    A failed ``lstat`` is not treated as an exclusion: the archive writer must see the path and
+    report the read failure instead of silently claiming a complete backup.
+    """
+    try:
+        return not stat.S_ISREG(path.lstat().st_mode)
+    except OSError:
+        return False
 
 
 def _should_exclude(rel_path: Path) -> bool:
@@ -267,7 +279,7 @@ def _iter_backup_files(hermes_root: Path, out_path: Path, skipped_dirs: Optional
             fpath = hermes_root / rel
             # zipfile.write() follows file symlinks, so skip links before any archive write can
             # copy data from outside HERMES_HOME; never archive the output zip into itself.
-            if _should_exclude(rel) or fpath.is_symlink():
+            if _should_exclude(rel) or _is_non_regular_path(fpath):
                 continue
             with suppress(OSError, ValueError):
                 if fpath.resolve() == out_path.resolve():

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -60,14 +60,16 @@ _EXCLUDED_DIRS = {
     ".cache", ".tox", ".nox", ".pytest_cache", ".mypy_cache", ".ruff_cache",
 }
 
-# Hermes-managed runtime downloads (GGUF models, llama.cpp runtimes, managed Node): re-downloaded
-# on demand and routinely tens to hundreds of GB. Matched ONLY at the root of HERMES_HOME and at
-# ``profiles/<name>/`` — a deeper dir of the same name (a skill's ``models/``) is user data.
-_EXCLUDED_ROOT_DIRS = {"models", "runtimes", "node"}
+# Hermes-managed runtime downloads (GGUF models, llama.cpp runtimes, managed Node) and caches are
+# regenerable. Runtime trees routinely reach tens to hundreds of GB; live browser/tool caches may
+# also contain locked SQLite databases that cannot be snapshotted consistently. Match these names
+# ONLY at the root of HERMES_HOME and at ``profiles/<name>/`` — a deeper directory of the same name
+# (for example, a skill's ``models/`` or ``cache/``) is user data and must survive.
+_EXCLUDED_ROOT_DIRS = {"cache", "models", "runtimes", "node"}
 
 
 def _in_excluded_root_dir(rel_path: Path) -> bool:
-    """True when *rel_path* is, or sits inside, a managed runtime tree at a profile-home root."""
+    """True when *rel_path* is inside a regenerable tree at a profile-home root."""
     parts = rel_path.parts
     return bool(parts) and (
         parts[0] in _EXCLUDED_ROOT_DIRS

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -171,6 +171,13 @@ class TestShouldExclude:
         assert _should_exclude(Path("profiles/clean/models/big.gguf"))
         assert _should_exclude(Path("profiles/clean/runtimes/llamacpp/x.dll"))
 
+    def test_excludes_regenerable_cache_at_profile_roots(self):
+        """Live browser/tool caches are mutable and unsafe to snapshot."""
+        from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path("cache/chrome-debug/Default/Cookies"))
+        assert _should_exclude(Path("profiles/sage/cache/chrome-debug/cache.db"))
+        assert not _should_exclude(Path("skills/example/cache/notes.md"))
+
     def test_keeps_nested_dirs_named_like_runtime_trees(self):
         """A deeper directory that happens to be called models/ or node/ is
         user data (a skill's assets, project files) and must survive."""
@@ -231,6 +238,30 @@ class TestIterBackupFiles:
         assert rel_nested in selected
         assert str(Path("models/big.gguf")) not in selected
         assert not any(s.startswith("hermes-agent") for s in selected)
+
+    def test_prunes_profile_root_caches_but_keeps_nested_user_cache(self, tmp_path):
+        from hermes_cli.backup import _iter_backup_files
+
+        root = tmp_path / ".hermes"
+        root.mkdir()
+        root_cache = root / "cache" / "browser"
+        profile_cache = root / "profiles" / "sage" / "cache" / "browser"
+        nested_cache = root / "skills" / "example" / "cache"
+        for directory in (root_cache, profile_cache, nested_cache):
+            directory.mkdir(parents=True)
+            (directory / "state.db").write_bytes(b"cache contents")
+
+        skipped: set = set()
+        selected = {
+            str(rel)
+            for _, rel in _iter_backup_files(root, tmp_path / "out.zip", skipped)
+        }
+
+        assert str(Path("cache/browser/state.db")) not in selected
+        assert str(Path("profiles/sage/cache/browser/state.db")) not in selected
+        assert str(Path("skills/example/cache/state.db")) in selected
+        assert "cache" in skipped
+        assert str(Path("profiles/sage/cache")) in skipped
 
     def test_skipped_dirs_collected_for_summary(self, tmp_path):
         from hermes_cli.backup import _iter_backup_files

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -172,11 +172,15 @@ class TestShouldExclude:
         assert _should_exclude(Path("profiles/clean/models/big.gguf"))
         assert _should_exclude(Path("profiles/clean/runtimes/llamacpp/x.dll"))
 
-    def test_excludes_regenerable_cache_at_profile_roots(self):
-        """Live browser/tool caches are mutable and unsafe to snapshot."""
+    def test_excludes_regenerable_cache_but_keeps_durable_artifacts(self):
+        """Catalogs and live browser profiles are rebuilt on demand; delivered media and the
+        citation ledger are not, so they stay in the archive."""
         from hermes_cli.backup import _should_exclude
+        assert _should_exclude(Path("cache/model_catalog.json"))
         assert _should_exclude(Path("cache/chrome-debug/Default/Cookies"))
         assert _should_exclude(Path("profiles/sage/cache/chrome-debug/cache.db"))
+        assert not _should_exclude(Path("cache/images/x.png"))
+        assert not _should_exclude(Path("profiles/sage/cache/citations/ledger.json"))
         assert not _should_exclude(Path("skills/example/cache/notes.md"))
 
     def test_keeps_nested_dirs_named_like_runtime_trees(self):
@@ -240,29 +244,31 @@ class TestIterBackupFiles:
         assert str(Path("models/big.gguf")) not in selected
         assert not any(s.startswith("hermes-agent") for s in selected)
 
-    def test_prunes_profile_root_caches_but_keeps_nested_user_cache(self, tmp_path):
+    def test_prunes_regenerable_caches_but_keeps_durable_and_nested(self, tmp_path):
         from hermes_cli.backup import _iter_backup_files
 
         root = tmp_path / ".hermes"
         root.mkdir()
-        root_cache = root / "cache" / "browser"
-        profile_cache = root / "profiles" / "sage" / "cache" / "browser"
-        nested_cache = root / "skills" / "example" / "cache"
-        for directory in (root_cache, profile_cache, nested_cache):
-            directory.mkdir(parents=True)
-            (directory / "state.db").write_bytes(b"cache contents")
+        files = {
+            "cache/model_catalog.json": False,
+            "cache/chrome-debug/Default/Cookies": False,
+            "profiles/sage/cache/chrome-debug/cache.db": False,
+            "cache/images/x.png": True,
+            "cache/citations/ledger.json": True,
+            "profiles/sage/cache/images/y.png": True,
+            "skills/example/cache/state.db": True,
+        }
+        for rel in files:
+            (root / rel).parent.mkdir(parents=True, exist_ok=True)
+            (root / rel).write_bytes(b"x")
 
         skipped: set = set()
-        selected = {
-            str(rel)
-            for _, rel in _iter_backup_files(root, tmp_path / "out.zip", skipped)
-        }
+        selected = {str(rel) for _, rel in _iter_backup_files(root, tmp_path / "out.zip", skipped)}
 
-        assert str(Path("cache/browser/state.db")) not in selected
-        assert str(Path("profiles/sage/cache/browser/state.db")) not in selected
-        assert str(Path("skills/example/cache/state.db")) in selected
-        assert "cache" in skipped
-        assert str(Path("profiles/sage/cache")) in skipped
+        assert {rel for rel, keep in files.items() if keep} == {s.replace(os.sep, "/") for s in selected}
+        assert str(Path("cache/chrome-debug")) in skipped
+        assert str(Path("profiles/sage/cache/chrome-debug")) in skipped
+        assert "cache" not in skipped
 
     def test_skipped_dirs_collected_for_summary(self, tmp_path):
         from hermes_cli.backup import _iter_backup_files

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import socket
 import sqlite3
 import stat
 import zipfile
@@ -276,6 +277,20 @@ class TestIterBackupFiles:
         list(_iter_backup_files(root, tmp_path / "out.zip", skipped))
         assert "models" in skipped
         assert "hermes-agent" in skipped
+
+    @pytest.mark.linux_only
+    def test_skips_unix_sockets(self, tmp_path):
+        from hermes_cli.backup import _iter_backup_files
+
+        root = tmp_path / ".hermes"
+        root.mkdir()
+        socket_path = root / "gateway.sock"
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as gateway_socket:
+            gateway_socket.bind(str(socket_path))
+
+            selected = {str(rel) for _, rel in _iter_backup_files(root, tmp_path / "out.zip")}
+
+        assert "gateway.sock" not in selected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -279,14 +279,16 @@ class TestIterBackupFiles:
         assert "hermes-agent" in skipped
 
     @pytest.mark.linux_only
-    def test_skips_unix_sockets(self, tmp_path):
+    def test_skips_unix_sockets(self, tmp_path, monkeypatch):
         from hermes_cli.backup import _iter_backup_files
 
         root = tmp_path / ".hermes"
         root.mkdir()
-        socket_path = root / "gateway.sock"
+        # AF_UNIX paths are capped at ~108 bytes; pytest's tmp_path overflows that under the
+        # test runner's deep temp root, so bind by a relative name from inside ``root``.
+        monkeypatch.chdir(root)
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as gateway_socket:
-            gateway_socket.bind(str(socket_path))
+            gateway_socket.bind("gateway.sock")
 
             selected = {str(rel) for _, rel in _iter_backup_files(root, tmp_path / "out.zip")}
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -980,6 +980,8 @@ The backup uses SQLite's `backup()` API for safe copying, so it works correctly 
 
 - `*.db-wal`, `*.db-shm`, `*.db-journal` — SQLite's WAL / shared-memory / journal sidecars. The `*.db` file already got a consistent snapshot via `sqlite3.backup()`; shipping the live sidecars alongside it would let a restore see a half-committed state.
 - `checkpoints/` — per-session trajectory caches. Hash-keyed and regenerated per session; wouldn't port cleanly to another install anyway.
+- `cache/`, `models/`, `runtimes/`, `node/` at the root of `~/.hermes` (and of each `profiles/<name>/`) — regenerable downloads and tool caches, often tens of GB. Deeper directories with the same names (a skill's `cache/`) are kept.
+- Unix sockets, devices, and symlinks — a zip cannot hold them; before they were excluded, a stray `gateway.sock` made every full backup report `Backup incomplete`.
 - The `hermes-agent` code itself (this is a user-data backup, not a repo snapshot).
 
 ### Examples

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -980,7 +980,8 @@ The backup uses SQLite's `backup()` API for safe copying, so it works correctly 
 
 - `*.db-wal`, `*.db-shm`, `*.db-journal` — SQLite's WAL / shared-memory / journal sidecars. The `*.db` file already got a consistent snapshot via `sqlite3.backup()`; shipping the live sidecars alongside it would let a restore see a half-committed state.
 - `checkpoints/` — per-session trajectory caches. Hash-keyed and regenerated per session; wouldn't port cleanly to another install anyway.
-- `cache/`, `models/`, `runtimes/`, `node/` at the root of `~/.hermes` (and of each `profiles/<name>/`) — regenerable downloads and tool caches, often tens of GB. Deeper directories with the same names (a skill's `cache/`) are kept.
+- `models/`, `runtimes/`, `node/` at the root of `~/.hermes` (and of each `profiles/<name>/`) — regenerable runtime downloads, often tens of GB. Deeper directories with the same names (a skill's `models/`) are kept.
+- Regenerable entries of `cache/` at those same roots — model/plugin catalogs, stamps, browser profiles, tool-output spill. Durable artifacts stay in: `cache/images`, `cache/audio`, `cache/videos`, `cache/documents`, `cache/screenshots` (media delivered to or received from you) and `cache/citations` (the grounded-citations ledger). A deeper `cache/` (inside a skill) is kept whole.
 - Unix sockets, devices, and symlinks — a zip cannot hold them; before they were excluded, a stray `gateway.sock` made every full backup report `Backup incomplete`.
 - The `hermes-agent` code itself (this is a user-data backup, not a repo snapshot).
 


### PR DESCRIPTION
`hermes backup` no longer archives regenerable `cache/` entries (root and per-profile) — while keeping delivered media and the citation ledger — and no longer reports `Backup incomplete` when a Unix socket or device node sits under `HERMES_HOME`.

Salvages #107009 from @bradestes
Salvages #108569 from @mrwanstudio

## Changes

- `hermes_cli/backup.py` — `_in_excluded_root_dir()` now prunes regenerable `cache/<x>` subtrees at `~/.hermes/` and `profiles/<name>/` (model/plugin catalogs, stamps, browser-use scratch, terminal/exec spill, delegation live logs — regenerated on demand and routinely tens of GB) while keeping the durable subdirs listed in `_KEPT_CACHE_SUBDIRS`; a deeper `skills/x/cache/` is still user data and is kept whole. (#107009, narrowed — see *Review follow-up*)
- `hermes_cli/backup.py` — `_is_non_regular_path()` (`lstat` + `S_ISREG`) replaces the bare `is_symlink()` check in both the HERMES_HOME walker and the external memory-provider walker, so sockets, FIFOs and device nodes are skipped instead of failing `zf.write()` and flipping the run to `Backup incomplete`. A failed `lstat` still lets the path through so the archive writer reports the real error. (#108569)
- `website/docs/reference/cli-commands.md` — "What's excluded" lists the root-scoped `models/`/`runtimes/`/`node/` rule, the regenerable-`cache/` rule with the kept subdirs, and non-regular entries.

## Improvements during salvage

- The picked socket test bound an `AF_UNIX` socket at pytest's `tmp_path`, which overflows the ~108-byte `sun_path` limit under `scripts/run_tests.sh`'s temp root (`OSError: AF_UNIX path too long`). It now binds by a relative name from inside the temp `HERMES_HOME`.
- Contributor mapping for `mrwanstudio@gmail.com -> mrwanstudio` (`contributors/emails/`).

## Review follow-up

Review found that `cache` in `_EXCLUDED_ROOT_DIRS` dropped durable user artifacts: `cache/images` (`gateway/platforms/base.py` `IMAGE_CACHE_DIR` — generated/received images delivered to users, `computer_use` screenshots) and `cache/citations/ledger.json` (`skills/research/grounded-citations/scripts/sources.py` — the authoritative URL→id evidence ledger). Fix-forward commit `b69305fe`: `cache` leaves `_EXCLUDED_ROOT_DIRS`; instead `cache/<x>` at a profile root is pruned unless `x` is in `_KEPT_CACHE_SUBDIRS = {images, audio, videos, documents, screenshots, citations}` (the gateway's `_MEDIA_DELIVERY_CACHE_SUBDIRS` + the ledger). An allowlist of kept subdirs is smaller than a denylist of ~35 writers and fails safe when a new regenerable writer appears.

Classification of every `<home>/cache/*` writer (`grep -rn '"cache"' / 'get_hermes_dir("cache/'` over `hermes_cli tools agent gateway plugins tui_gateway skills`, tests excluded):

| `cache/…` | Writer | Class | Backup |
|---|---|---|---|
| `images/` | `gateway/platforms/base.py` IMAGE_CACHE_DIR, `tools/computer_use/tool.py` screenshots | durable — media delivered to/received from user | **kept** |
| `audio/`, `videos/`, `documents/`, `screenshots/` | `gateway/platforms/base.py` media-delivery dirs, `tts_tool.py`, `media_fetch.py`, `browser_tool*.py` | durable — same delivery class as images | **kept** |
| `citations/ledger.json` | `skills/research/grounded-citations/scripts/sources.py` | durable — authoritative evidence ledger | **kept** |
| `model_catalog.json`, `plugin-catalog.json`, `openrouter_curated_catalog.json`, `nous_recommended_cache.json`, `router_catalog.json`, `reasoning_caps.json`, `discord_capabilities.json`, `schema_columns.json`, model_metadata files | `hermes_cli/model_catalog.py`, `plugin_catalog.py`, `models.py`, `models_reasoning_caps.py`, `plugins/model-providers/router`, `tools/discord_tool.py`, `hermes_state_schema.py`, `agent/model_metadata.py` | regenerable — refetched | skipped |
| `banner_snapshot.json`, `tool_discovery_cache.json`, `plugin_toolset_keys.json`, `mcp_schema_cache`, `worktree_merge_verdicts.json`, `.uv_self_update_stamp`, `.browser_use_default_notice`, oauth heal mark | `banner.py`, `tools/registry.py`, `plugins.py`, `mcp_schema_cache.py`, `worktree_ops.py`, `managed_uv.py`, `browser_use_cli.py`, `auth_oauth_grants.py` | regenerable — derived/stamps | skipped |
| `security_advisories`, osv cache | `security_advisories.py`, `tools/osv_check.py` | regenerable — refetched feeds | skipped |
| `terminal/`, `terminal-output/`, `exec/`, `spillover/`, `delegation/`, `computer_use/` (element spill), `web/` | `environments/local.py`, `base_output.py`, `code_execution_tool.py`, `tool_result_storage.py`, `delegate_tool_results.py`, `delegation_live_log.py`, `computer_use/tool.py`, `web_result_cache.py`, `browser_tool_snapshot.py` | regenerable — tool-result spill, TTL-pruned | skipped |
| `vision/`, `video/` | `vision_tools*.py` | regenerable — temp transcodes | skipped |
| `browser-use/` (workspace, lightpanda), `chrome-debug/` | `browser_use_cli.py`, `browser_lightpanda.py` | regenerable — scratch + browser profile with locked SQLite | skipped |
| `wakewords/`, `piper-voices/` | `wake_word_engines.py`, `tts_tool_local.py` | regenerable — downloaded models | skipped |
| `pet-gen/`, `project_skill_scans/`, `blocked-scripts/` | `tui_gateway/server.py`, `agent/skill_utils.py`, `tools/approval_floors.py` | regenerable — staging, swept | skipped |
| `bws_cache*.json`, secret-source value caches | `agent/secret_sources/*` | regenerable and credential-bearing — must not enter an archive | skipped |

## Validation

| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/hermes_cli/test_backup.py` | 82 passed, 0 failed (head `b69305fe`) |
| Red-on-base for the socket half (`git show origin/main:hermes_cli/backup.py` swapped in) | `-k unix_sockets`: failed on base → pass on head |
| Red-on-previous-head for the narrowed cache rule (`cd3f00c7` `backup.py` swapped in) | `-k durable`: 2 failed → 2 pass on head |
| E2E real import, temp `HERMES_HOME` | seeded `cache/model_catalog.json`, `cache/chrome-debug/Default/Cookies`, `cache/.uv_self_update_stamp`, `cache/images/x.png`, `cache/citations/ledger.json`, `cache/audio/a.ogg`, `profiles/sage/cache/reasoning_caps.json`, `profiles/sage/cache/images/y.png`, `skills/example/cache/notes.md`, `config.yaml` → `_iter_backup_files` yields `SOUL.md config.yaml cache/audio/a.ogg cache/citations/ledger.json cache/images/x.png profiles/sage/cache/images/y.png skills/example/cache/notes.md`; pruned dirs `['cache/chrome-debug']` |
| E2E socket case (previous head) | live `gw.sock` under `HERMES_HOME`: base yields it (→ `Backup incomplete`), head skips it; `_write_full_zip_backup` zip matches |
| `ruff check` (touched .py) | All checks passed |
| `scripts/check-windows-footguns.py --all` | No Windows footguns found |
| `scripts/check_compat_pointers.py` | no in-tree dependency |
| `git diff --check` | clean |

## Infographic

![backup-excludes](https://files.catbox.moe/1ad56w.png)
