### PR TITLE
fix(dashboard,website): opaque mobile header/drawer, wrapping cron badges, readable light-mode pills (salvage #107189, #107409, #107970)

### DIFF
--- a/contributors/emails/marynych.ivan@icloud.com
+++ b/contributors/emails/marynych.ivan@icloud.com
@@ -1,0 +1,1 @@
+loqimean

--- a/contributors/emails/maximusttt@gmail.com
+++ b/contributors/emails/maximusttt@gmail.com
@@ -1,0 +1,1 @@
+lawcheck

--- a/contributors/emails/zohuyhieuzo03@gmail.com
+++ b/contributors/emails/zohuyhieuzo03@gmail.com
@@ -1,0 +1,1 @@
+zohuyhieuzo03

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -532,7 +532,8 @@ export default function App() {
           "bg-background-base",
         )}
         style={{
-          background: "var(--component-header-background)",
+          background:
+            "var(--component-header-background, var(--background-base))",
           borderImage: "var(--component-header-border-image)",
           clipPath: "var(--component-header-clip-path)",
         }}
@@ -591,7 +592,8 @@ export default function App() {
               collapsed && "lg:w-14",
             )}
             style={{
-              background: "var(--component-sidebar-background)",
+              background:
+                "var(--component-sidebar-background, var(--background-base))",
               clipPath: "var(--component-sidebar-clip-path)",
               borderImage: "var(--component-sidebar-border-image)",
             }}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1764,7 +1764,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             "border-l border-current/20 text-midground",
             "bg-background-base/95",
             "transition-transform duration-200 ease-out",
-            "[background:var(--component-sidebar-background)]",
+            "[background:var(--component-sidebar-background,var(--background-base))]",
             "[clip-path:var(--component-sidebar-clip-path)]",
             "[border-image:var(--component-sidebar-border-image)]",
             mobilePanelOpen

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -1107,8 +1107,8 @@ export default function CronPage() {
             <Card key={jobKey}>
               <CardContent className="flex items-start gap-4 py-4">
                 <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 mb-1">
-                    <span className="font-medium text-sm truncate">
+                  <div className="flex flex-wrap items-center gap-2 mb-1">
+                    <span className="font-medium text-sm truncate min-w-0">
                       {title}
                     </span>
                     <Badge tone={STATUS_TONE[state] ?? "secondary"}>

--- a/website/src/components/UserStoriesCollage/styles.module.css
+++ b/website/src/components/UserStoriesCollage/styles.module.css
@@ -68,7 +68,10 @@
 }
 .filterActive {
   background: var(--ifm-color-emphasis-900);
-  color: var(--ifm-background-color);
+  /* emphasis-0 keeps labels readable on the near-black pill; --ifm-background-color
+     is only set under [data-theme='dark'] in custom.css, so Infima's light theme
+     resolves it to transparent and the default-active pills look like empty blobs (#91491). */
+  color: var(--ifm-color-emphasis-0);
   border-color: var(--ifm-color-emphasis-900);
 }
 [data-theme='dark'] .filterActive {

--- a/website/src/components/UserStoriesCollage/styles.module.css
+++ b/website/src/components/UserStoriesCollage/styles.module.css
@@ -72,6 +72,10 @@
   color: var(--ifm-color-emphasis-0);
   border-color: var(--ifm-color-emphasis-900);
 }
+/* .filterBtn:hover outranks .filterActive and would paint emphasis-1000 text on the emphasis-900 pill. */
+.filterActive:hover {
+  color: var(--ifm-color-emphasis-0);
+}
 [data-theme='dark'] .filterActive {
   background: #e2e8f0;
   color: #0f172a;

--- a/website/src/components/UserStoriesCollage/styles.module.css
+++ b/website/src/components/UserStoriesCollage/styles.module.css
@@ -68,9 +68,7 @@
 }
 .filterActive {
   background: var(--ifm-color-emphasis-900);
-  /* emphasis-0 keeps labels readable on the near-black pill; --ifm-background-color
-     is only set under [data-theme='dark'] in custom.css, so Infima's light theme
-     resolves it to transparent and the default-active pills look like empty blobs (#91491). */
+  /* --ifm-background-color is only set for the dark theme, so it resolves to transparent in light mode (#91491). */
   color: var(--ifm-color-emphasis-0);
   border-color: var(--ifm-color-emphasis-900);
 }

--- a/website/src/pages/skills/styles.module.css
+++ b/website/src/pages/skills/styles.module.css
@@ -1036,5 +1036,6 @@
 
 .pickBtn:hover {
   background: var(--ifm-color-primary);
-  color: var(--ifm-background-color, #0b0b0e);
+  /* Same transparent --ifm-background-color failure mode as #91491. */
+  color: var(--ifm-color-emphasis-0, #f7f8fa);
 }

--- a/website/src/pages/skills/styles.module.css
+++ b/website/src/pages/skills/styles.module.css
@@ -1036,6 +1036,6 @@
 
 .pickBtn:hover {
   background: var(--ifm-color-primary);
-  /* Same transparent --ifm-background-color failure mode as #91491. */
+  /* --ifm-background-color is transparent in light mode (#91491). */
   color: var(--ifm-color-emphasis-0, #f7f8fa);
 }


### PR DESCRIPTION
The dashboard's mobile header and nav drawer stay opaque under skins that don't define the `--component-*-background` vars, cron cards keep their title readable when badges overflow at narrow widths, and the website's active filter pills / skill-picker hover are readable in light mode.

Salvages #107189 from @lawcheck
Salvages #107409 from @loqimean
Salvages #107970 from @zohuyhieuzo03

Fixes #91491.

All three are user-visible CSS/className regressions (community-reported), each fixed at the line where it manifests; cherry-picked onto current `main` with authorship preserved.

## Changes

- **`web/src/App.tsx`** (@loqimean) — header and sidebar inline `background` become `var(--component-header-background, var(--background-base))` / `var(--component-sidebar-background, var(--background-base))`. The `bg-background-base` utility was being overridden by an inline `background: var(--undefined)` that resolves to transparent, so on mobile the drawer rendered see-through over page content.
- **`web/src/pages/CronPage.tsx`** (@lawcheck) — cron card title row gets `flex-wrap`, and the truncating title span gets `min-w-0` so badges wrap to a second row instead of squeezing the title to zero width.
- **`website/src/components/UserStoriesCollage/styles.module.css`**, **`website/src/pages/skills/styles.module.css`** (@zohuyhieuzo03) — active pill text and `.pickBtn:hover` text use `--ifm-color-emphasis-0` instead of `--ifm-background-color`, which `custom.css` only sets for `[data-theme='dark']` and therefore resolves to transparent in light mode (#91491).

### Improvements during salvage

- Widened the sidebar fallback to the sibling site in `web/src/pages/ChatPage.tsx` (`#chat-side-panel` uses the same `--component-sidebar-background` var via a Tailwind arbitrary property) — same bug class, same fix.
- Trimmed the two salvaged CSS comments to one WHY line each.
- Contributor email mappings (`contributors/emails/`) for all three authors, each login confirmed via `gh api users/<login>`.

## Validation

| Check | Result |
|---|---|
| `cd web && npm ci --ignore-scripts && npx tsc -p . --noEmit` | 0 errors |
| `cd web && npm run build` | ✓ built in 3.9s |
| Live repro (built dist served, headless Chromium 390×844 mobile emulation, drawer open) | base: sidebar `background-color: rgba(0, 0, 0, 0)` (transparent); this branch: `rgb(4, 28, 28)` (opaque `--background-base`) |
| `website/**` | CSS only — no typecheck; `--ifm-color-emphasis-0` confirmed defined by Infima in both themes |
| `scripts/check-windows-footguns.py --all`, `check_compat_pointers.py`, `audit_pr_attribution.py --fix`, `git diff --check` | all clean |
| Tests | no Python or vitest surface touched (className/CSS-only) |

### Mobile drawer, 390px — before / after

| base (`origin/main`) | this PR |
|---|---|
| ![before](https://files.catbox.moe/z2kowp.png) | ![after](https://files.catbox.moe/capqc8.png) |

## Review follow-up

`0d1554e` — **fix(website): active filter pill stays readable on hover.** The generic `.filterBtn:hover` rule outranked `.filterActive` and set the label to `emphasis-1000` (near-black) on the `emphasis-900` pill, so hovering the selected filter in light mode was black-on-charcoal — the #91491 contrast fix was incomplete. Added a `.filterActive:hover { color: var(--ifm-color-emphasis-0); }` rule. Dark mode needs no change: `[data-theme='dark'] .filterActive` ties `.filterBtn:hover` on specificity and wins by source order.

Probe: standalone HTML with Infima's light defaults (`emphasis-0 #fff`, `emphasis-900 #1c1e21`, `emphasis-1000 #000`) + the module's filter rules, headless Chromium with `:hover` forced via CDP, computed `color on background-color` of `.filterBtn.filterActive`:

| theme | base of this PR (`b4bbb1a`) | after `0d1554e` |
|---|---|---|
| light | `rgb(60, 60, 60)` on `rgb(28, 30, 33)` — unreadable | `rgb(255, 255, 255)` on `rgb(28, 30, 33)` |
| dark | `rgb(15, 23, 42)` on `rgb(226, 232, 240)` | unchanged |

## Infographic
![ui-css-polish](https://v3b.fal.media/files/b/0aaa231b/ylFVvM_BQU0xGNfCc71Ap_fdEoZ47d.png)

