### PR TITLE
Double Ctrl+C on exit no longer prints a browser-cleanup traceback (#10764, salvage #10765)

### DIFF
--- a/tests/tools/test_browser_cleanup.py
+++ b/tests/tools/test_browser_cleanup.py
@@ -128,7 +128,7 @@ class TestInactivityJanitorMultiplex:
         monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
         p1 = tmp_path / "profiles" / "p1"
         p1.mkdir(parents=True)
-        (p1 / ".env").write_text("CAMOFOX_URL=http://127.0.0.1:1\n")
+        (p1 / ".env").write_text("CAMOFOX_URL=http://127.0.0.1:1\n", encoding="utf-8")
 
         # Profile p1's turn opens the session; the janitor later runs unscoped.
         home_tok = set_hermes_home_override(str(p1))

--- a/tests/tools/test_browser_cleanup.py
+++ b/tests/tools/test_browser_cleanup.py
@@ -187,3 +187,19 @@ class TestInactivityJanitorMultiplex:
         assert "t1" not in self.bt._active_sessions
         assert "t1" not in self.bt._session_last_activity
         assert "t1" not in self.bt._cleanup_failures
+
+
+class TestAtexitStopSwallowsInterrupt:
+    def test_second_ctrl_c_during_join_does_not_propagate(self, monkeypatch):
+        """A second Ctrl+C while the atexit hook waits on the janitor must not escape as a
+        traceback (#10764): the thread is a daemon, the interpreter is already exiting."""
+        from tools import browser_tool
+
+        class _InterruptedJoin:
+            def join(self, timeout=None):
+                raise KeyboardInterrupt
+
+        monkeypatch.setattr(browser_tool, "_cleanup_thread", _InterruptedJoin())
+        monkeypatch.setattr(browser_tool, "_cleanup_running", True)
+        bt_lifecycle._stop_browser_cleanup_thread()  # must not raise
+        assert browser_tool._cleanup_running is False

--- a/tools/browser_tool_lifecycle.py
+++ b/tools/browser_tool_lifecycle.py
@@ -424,7 +424,12 @@ def _stop_browser_cleanup_thread():
     """Stop the background cleanup thread."""
     _bt._cleanup_running = False
     if _bt._cleanup_thread is not None:
-        _bt._cleanup_thread.join(timeout=5)
+        # A second Ctrl+C during the timed join lands here as KeyboardInterrupt; the janitor is a
+        # daemon thread, so letting it propagate only prints "Exception ignored in atexit callback".
+        try:
+            _bt._cleanup_thread.join(timeout=5)
+        except (SystemExit, KeyboardInterrupt):
+            pass
 
 
 def _update_session_activity(task_id: str):


### PR DESCRIPTION
Pressing Ctrl+C a second time while Hermes exits no longer prints an `Exception ignored in atexit callback` traceback.

- `tools/browser_tool_lifecycle.py::_stop_browser_cleanup_thread` swallows `KeyboardInterrupt`/`SystemExit` around the 5 s janitor join — the same guard `tools/terminal_tool.py::_stop_cleanup_thread` already has. The janitor is a daemon thread and the interpreter is exiting, so nothing is lost.
- One invariant test: a join that raises `KeyboardInterrupt` does not escape the atexit hook.
- `chore(tests)`: `encoding="utf-8"` on a pre-existing `write_text` in the same test file (windows-footgun ratchet).

| | before | after |
|---|---|---|
| Live repro (`atexit` join + SIGINT at 0.5 s, real `tools.browser_tool`) | `KeyboardInterrupt` traceback printed after `^C` | clean exit, no output |
| `tests/tools/test_browser_cleanup.py` | new test aborts pytest with KeyboardInterrupt | 7/7 green |

Root cause: atexit callbacks run on the main thread with no outer handler, so an interrupt during `Thread.join(timeout=5)` surfaced as an ignored-exception traceback.

Salvaged from #10765 by @LehaoLin (authorship preserved via commit author); the function moved from `browser_tool.py` to `browser_tool_lifecycle.py` since that PR was opened. #11149 catches only `Exception` and does not address the reported cause.

Fixes #10764

## Infographic
![browser-atexit](https://v3b.fal.media/files/b/0aaa22c4/-Tglbl5gqyFkJNNxVGG8P_oBTSDnYD.png)
