### PR TITLE
Explicit openrouter provider honors the config.yaml base_url mirror (#10622, salvage #10707)

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -491,7 +491,8 @@ def _openrouter_should_use_pool(requested_provider, model_cfg, explicit_api_key,
     """OpenRouter pool only for a plain openrouter/auto request with no custom endpoint or override."""
     cfg_base_url = str(model_cfg.get("base_url") or "").strip()
     env_base_urls = _getenv("OPENAI_BASE_URL", "").strip() or _getenv("OPENROUTER_BASE_URL", "").strip()
-    has_custom_endpoint = bool(explicit_base_url or env_base_urls or (cfg_base_url and _cfg_provider(model_cfg) in {"auto", "custom"}))
+    has_custom_endpoint = bool(explicit_base_url or env_base_urls
+                               or (cfg_base_url and _cfg_provider(model_cfg) in {"auto", "custom", "openrouter"}))
     return requested_provider in {"openrouter", "auto"} and not has_custom_endpoint and not bool(explicit_api_key or explicit_base_url)
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -491,8 +491,14 @@ def _openrouter_should_use_pool(requested_provider, model_cfg, explicit_api_key,
     """OpenRouter pool only for a plain openrouter/auto request with no custom endpoint or override."""
     cfg_base_url = str(model_cfg.get("base_url") or "").strip()
     env_base_urls = _getenv("OPENAI_BASE_URL", "").strip() or _getenv("OPENROUTER_BASE_URL", "").strip()
-    has_custom_endpoint = bool(explicit_base_url or env_base_urls
-                               or (cfg_base_url and _cfg_provider(model_cfg) in {"auto", "custom", "openrouter"}))
+    # A config base_url under provider: openrouter is a mirror only when it is NOT the canonical
+    # OpenRouter host — `hermes setup` persists https://openrouter.ai/api/v1 for plain installs,
+    # and treating that as custom would drop the auth.json pool (empty key).
+    cfg_is_mirror = bool(cfg_base_url) and (
+        _cfg_provider(model_cfg) in {"auto", "custom"}
+        or (_cfg_provider(model_cfg) == "openrouter" and not base_url_host_matches(cfg_base_url, "openrouter.ai"))
+    )
+    has_custom_endpoint = bool(explicit_base_url or env_base_urls or cfg_is_mirror)
     return requested_provider in {"openrouter", "auto"} and not has_custom_endpoint and not bool(explicit_api_key or explicit_base_url)
 
 

--- a/hermes_cli/runtime_provider_backends.py
+++ b/hermes_cli/runtime_provider_backends.py
@@ -131,6 +131,8 @@ def _resolve_openrouter_runtime(
     use_config_base_url = bool(cfg_base_url.strip()) and not explicit_base_url and (
         (requested_norm == "auto" and cfg_provider in ("", "auto"))
         or (requested_norm == "custom" and rp._config_base_url_trustworthy_for_bare_custom(cfg_base_url, cfg_provider))
+        # provider: openrouter + base_url in config.yaml is a deliberate mirror/proxy (#10622).
+        or (requested_norm == "openrouter" and cfg_provider == "openrouter")
     )
     base_url = ((explicit_base_url or "").strip() or env_custom_base_url or (cfg_base_url.strip() if use_config_base_url else "")
                 or env_openrouter_base_url or OPENROUTER_BASE_URL).rstrip("/")
@@ -138,11 +140,16 @@ def _resolve_openrouter_runtime(
     # prefer OPENROUTER_API_KEY (issue #289). When hitting a custom endpoint (e.g. Z.ai, local LLM), prefer
     # OPENAI_API_KEY so the OpenRouter key doesn't leak to an unrelated provider (issues #420, #560).
     is_openrouter_url = base_url_host_matches(base_url, "openrouter.ai")
-    # Explicitly-configured OpenRouter mirrors (OPENROUTER_BASE_URL + provider=openrouter) still
-    # count as OpenRouter for key selection.
+    # Explicitly-configured OpenRouter mirrors (OPENROUTER_BASE_URL, or a config.yaml base_url under
+    # provider: openrouter) still count as OpenRouter for key selection — otherwise the mirror's host
+    # fails the openrouter.ai match and the generic custom-endpoint branch never selects
+    # OPENROUTER_API_KEY for it (#10622).
     is_openrouter_context = is_openrouter_url or (
-        requested_norm == "openrouter" and (env_openrouter_base_url or base_url == env_openrouter_base_url)
-        and base_url == (env_openrouter_base_url or "").rstrip("/")
+        requested_norm == "openrouter" and (
+            (use_config_base_url and cfg_provider == "openrouter")
+            or ((env_openrouter_base_url or base_url == env_openrouter_base_url)
+                and base_url == (env_openrouter_base_url or "").rstrip("/"))
+        )
     )
     if is_openrouter_context:
         candidates = [explicit_api_key, rp._getenv("OPENROUTER_API_KEY"), rp._getenv("OPENAI_API_KEY")]

--- a/hermes_cli/runtime_provider_backends.py
+++ b/hermes_cli/runtime_provider_backends.py
@@ -146,7 +146,7 @@ def _resolve_openrouter_runtime(
     # OPENROUTER_API_KEY for it (#10622).
     is_openrouter_context = is_openrouter_url or (
         requested_norm == "openrouter" and (
-            (use_config_base_url and cfg_provider == "openrouter")
+            (use_config_base_url and cfg_provider == "openrouter" and base_url == cfg_base_url.strip().rstrip("/"))
             or ((env_openrouter_base_url or base_url == env_openrouter_base_url)
                 and base_url == (env_openrouter_base_url or "").rstrip("/"))
         )

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -932,6 +932,18 @@ def test_explicit_openrouter_config_mirror_bypasses_pool(monkeypatch):
     assert resolved["api_key"] == "router-key"
     assert resolved.get("credential_pool") is None
 
+    # The canonical URL that `hermes setup` persists is NOT a mirror: the pool must still serve it.
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "openrouter", "base_url": "https://openrouter.ai/api/v1"})
+    canonical = rp.resolve_runtime_provider(requested="openrouter")
+    assert canonical["api_key"] == "pool-key" and canonical.get("credential_pool") is not None
+
+    # An unrelated CUSTOM_BASE_URL outranks the mirror and must not receive the OpenRouter key.
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {"provider": "openrouter", "base_url": "https://openrouter-mirror.example.com/api/v1"})
+    monkeypatch.setattr(rp, "load_pool", lambda _provider: SimpleNamespace(has_credentials=lambda: False))
+    monkeypatch.setenv("CUSTOM_BASE_URL", "http://localhost:11434/v1")
+    custom = rp.resolve_runtime_provider(requested="openrouter")
+    assert custom["base_url"] == "http://localhost:11434/v1" and custom["api_key"] != "router-key"
+
 
 
 

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -868,6 +868,71 @@ def test_explicit_openrouter_skips_openai_base_url(monkeypatch):
     assert resolved["api_key"] == "or-test-key"
 
 
+def test_explicit_openrouter_honors_config_base_url_mirror(monkeypatch):
+    """requested='openrouter' + config provider='openrouter' + config base_url must
+    resolve to that mirror AND still select OPENROUTER_API_KEY for it — a
+    config-sourced mirror is an OpenRouter context for credential selection just
+    like the OPENROUTER_BASE_URL env path already is.  Regression test for #10622."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openrouter",
+            "base_url": "https://openrouter-mirror.example.com/api/v1",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda _provider: SimpleNamespace(has_credentials=lambda: False))
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "router-key")
+
+    resolved = rp.resolve_runtime_provider(requested="openrouter")
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["base_url"] == "https://openrouter-mirror.example.com/api/v1"
+    assert resolved["api_key"] == "router-key"
+
+
+def test_explicit_openrouter_config_mirror_bypasses_pool(monkeypatch):
+    """A config.yaml mirror under provider='openrouter' is a custom endpoint: the
+    OpenRouter credential pool must be skipped rather than silently routing the
+    request to openrouter.ai with a pooled key (#10622)."""
+    class _Entry:
+        access_token = "pool-key"
+        source = "manual"
+        base_url = "https://openrouter.ai/api/v1"
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "openrouter",
+            "base_url": "https://openrouter-mirror.example.com/api/v1",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda _provider: _Pool())
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "router-key")
+
+    resolved = rp.resolve_runtime_provider(requested="openrouter")
+
+    assert resolved["base_url"] == "https://openrouter-mirror.example.com/api/v1"
+    assert resolved["api_key"] == "router-key"
+    assert resolved.get("credential_pool") is None
+
+
 
 
 


### PR DESCRIPTION
`model.provider: openrouter` + `model.base_url: <mirror>` in config.yaml is now honored when the runtime provider is explicitly `openrouter`, and the mirror still receives `OPENROUTER_API_KEY` and bypasses the OpenRouter credential pool.

- `hermes_cli/runtime_provider_backends.py::_resolve_openrouter_runtime`: add the `requested == "openrouter" and cfg_provider == "openrouter"` branch to `use_config_base_url`, and count a config-sourced mirror as an OpenRouter context for key selection.
- `hermes_cli/runtime_provider.py::_openrouter_should_use_pool`: a config `base_url` under `provider: openrouter` is a custom endpoint, so the pool is skipped instead of silently routing to `openrouter.ai` with a pooled key.
- 2 regression tests (mirror URL + key; pool bypass).

| | before | after |
|---|---|---|
| Live probe (`resolve_runtime_provider(requested="openrouter")`, config mirror, `OPENROUTER_API_KEY` set) | `base_url=https://openrouter.ai/api/v1` | `base_url=https://openrouter-mirror.example.com/api/v1`, `api_key=router-key` |
| `provider: openrouter`, no `base_url` | default | default (unchanged) |
| `provider: custom` + `base_url`, requested `openrouter` | default | default (a custom config cannot hijack an explicit openrouter request) |
| `tests/hermes_cli/test_runtime_provider_resolution.py` | — | 67/67 |

Root cause: the branch existed for `auto` and `custom` but not for the direct `openrouter` case, so the persisted mirror was dropped.

Salvaged from #10707 by @jackjin1997 (clean cherry-pick, authorship preserved). Diagnosis by @NewTurn2017 in #10622.

Fixes #10622

**Review follow-up (cc16c49e):** the canonical `https://openrouter.ai/api/v1` that `hermes setup` persists under `provider: openrouter` is no longer treated as a mirror (it kept the auth.json pool on main; the first cut returned an empty key), and `OPENROUTER_API_KEY` is selected only when the config mirror is the endpoint actually chosen — an unrelated `CUSTOM_BASE_URL` no longer receives it. Both reproduced on the previous head with real config loaders, both covered in the regression test.

## Infographic
![openrouter-mirror](https://v3b.fal.media/files/b/0aaa22fe/mtsIElEk9kkHDgOOkRkAW_kIwcdKrv.png)