### PR TITLE
Package-manager uninstalls now require approval (#10199, salvage #64175)

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -19,6 +19,24 @@ from tools.approval_context import _normalize_approval_mode
 from tools.approval_smart import _smart_approve
 
 
+class TestPackageManagerUninstallApproval:
+    """Package-manager removal verbs remove software outside the project (#10199)."""
+
+    @pytest.mark.parametrize("command", [
+        "npm uninstall -g left-pad", "npm r left-pad", "pnpm un -g left-pad",
+        "yarn global remove left-pad", "pip3 uninstall left-pad", "brew rm left-pad",
+    ])
+    def test_uninstall_requires_approval(self, command):
+        dangerous, key, _ = detect_dangerous_command(command)
+        assert dangerous and key == "package manager uninstall"
+
+    @pytest.mark.parametrize("command", [
+        "npm update -g left-pad", "pnpm add left-pad", "yarn install", "pip install left-pad", "brew upgrade left-pad",
+    ])
+    def test_install_and_update_stay_unprompted(self, command):
+        assert detect_dangerous_command(command) == (False, None, None)
+
+
 class TestApprovalModeParsing:
     def test_normalization_table(self):
         # Unquoted YAML `off`/`on` arrive as booleans; unknown/empty fall back

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -25,6 +25,8 @@ class TestPackageManagerUninstallApproval:
     @pytest.mark.parametrize("command", [
         "npm uninstall -g left-pad", "npm r left-pad", "pnpm un -g left-pad",
         "yarn global remove left-pad", "pip3 uninstall left-pad", "brew rm left-pad",
+        "npm --prefix ./app uninstall left-pad", "pip --proxy http://p:1 uninstall -y requests",
+        "cd app && yarn --cwd ./app remove left-pad",
     ])
     def test_uninstall_requires_approval(self, command):
         dangerous, key, _ = detect_dangerous_command(command)
@@ -32,6 +34,7 @@ class TestPackageManagerUninstallApproval:
 
     @pytest.mark.parametrize("command", [
         "npm update -g left-pad", "pnpm add left-pad", "yarn install", "pip install left-pad", "brew upgrade left-pad",
+        'git commit -m "document npm uninstall usage"', 'echo "pip uninstall foo"',
     ])
     def test_install_and_update_stay_unprompted(self, command):
         assert detect_dangerous_command(command) == (False, None, None)

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -393,6 +393,15 @@ DANGEROUS_PATTERNS = [
     (r'\bsudo\b[^;|&\n]*?\s+(?:-s\b|--st[a-z]*\b|-a\b|--a[a-z]*\b)', "sudo with privilege flag (stdin/askpass/shell/list)"),
     # Combined short-flag form (-nS, -sa, -las).
     (r'\bsudo\b[^;|&\n]*?\s+-[a-z]*[sa][a-z]*\b', "sudo with combined-flag privilege escalation"),
+    # Package-manager uninstall commands can remove installed software outside
+    # the current project (notably `npm uninstall -g`). Treat their destructive
+    # subcommands like other state-removing operations while leaving installs
+    # and updates alone.
+    (r'\bnpm\s+(?:-[^\s]+\s+)*(?:uninstall|unlink|remove|rm|r|un)\b', "package manager uninstall"),
+    (r'\bpnpm\s+(?:-[^\s]+\s+)*(?:uninstall|remove|rm|un)\b', "package manager uninstall"),
+    (r'\byarn\s+(?:global\s+)?(?:uninstall|remove)\b', "package manager uninstall"),
+    (r'\bpip(?:3)?\s+(?:-[^\s]+\s+)*uninstall\b', "package manager uninstall"),
+    (r'\bbrew\s+(?:uninstall|remove|rm)\b', "package manager uninstall"),
 ]
 
 

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -82,6 +82,8 @@ _HARDLINE_SYSTEM_DIRS = (r'/home|/home/\*|/root|/root/\*|/etc|/etc/\*|/usr|/usr/
 # backslashes in replacement fields are unsupported on the 3.11 floor). _CMDPOS-anchored so `rm`
 # must be an actual command word — "rm -rf /" as DATA in `git commit -m "…rm -rf /…"` must not trip the floor.
 _RM_FLAG_PREFIX = _CMDPOS + r'rm\s+(-[^\s]*\s+)*'
+# Package-manager global options, each optionally taking ONE non-dash operand.
+_PKG_OPTS = r'(?:-[^\s]+(?:\s+[^-\s][^\s]*)?\s+)*'
 
 HARDLINE_PATTERNS = [
     # Root path: any root-anchored path whose components collapse to "/" in the shell ("/", "//",
@@ -397,11 +399,13 @@ DANGEROUS_PATTERNS = [
     # the current project (notably `npm uninstall -g`). Treat their destructive
     # subcommands like other state-removing operations while leaving installs
     # and updates alone.
-    (r'\bnpm\s+(?:-[^\s]+\s+)*(?:uninstall|unlink|remove|rm|r|un)\b', "package manager uninstall"),
-    (r'\bpnpm\s+(?:-[^\s]+\s+)*(?:uninstall|remove|rm|un)\b', "package manager uninstall"),
-    (r'\byarn\s+(?:global\s+)?(?:uninstall|remove)\b', "package manager uninstall"),
-    (r'\bpip(?:3)?\s+(?:-[^\s]+\s+)*uninstall\b', "package manager uninstall"),
-    (r'\bbrew\s+(?:uninstall|remove|rm)\b', "package manager uninstall"),
+    # _CMDPOS-anchored (quoted prose like `git commit -m "npm uninstall docs"` is data); the
+    # option group also swallows one operand (`--prefix DIR`, `--proxy URL`, `--cwd DIR`).
+    (_CMDPOS + r'npm\s+' + _PKG_OPTS + r'(?:uninstall|unlink|remove|rm|r|un)\b', "package manager uninstall"),
+    (_CMDPOS + r'pnpm\s+' + _PKG_OPTS + r'(?:uninstall|remove|rm|un)\b', "package manager uninstall"),
+    (_CMDPOS + r'yarn\s+' + _PKG_OPTS + r'(?:global\s+)?(?:uninstall|remove)\b', "package manager uninstall"),
+    (_CMDPOS + r'pip(?:3)?\s+' + _PKG_OPTS + r'uninstall\b', "package manager uninstall"),
+    (_CMDPOS + r'brew\s+' + _PKG_OPTS + r'(?:uninstall|remove|rm)\b', "package manager uninstall"),
 ]
 
 


### PR DESCRIPTION
`npm uninstall -g`, `pnpm remove`, `yarn remove`, `pip uninstall` and `brew uninstall` now go through the dangerous-command approval prompt; installs and updates stay unprompted.

- `tools/approval_detection.py::DANGEROUS_PATTERNS`: one `"package manager uninstall"` rule per manager (npm incl. the documented `unlink`/`remove`/`rm`/`r`/`un` aliases; pnpm; yarn incl. `global`; pip/pip3; brew incl. `remove`/`rm`).
- 2 invariant tests: six uninstall spellings are gated under one key; five install/update spellings are not.

| | before | after |
|---|---|---|
| `detect_dangerous_command("npm uninstall -g left-pad")` | `(False, None, None)` | `(True, "package manager uninstall", …)` |
| `npm update -g` / `pip install` / `brew upgrade` / `yarn install` | not flagged | not flagged |
| `tests/tools/test_approval.py` | 6 parametrized cases red | 129 green; `tests/tools/` 9141 green (4 host-env failures: optional `modal`/`parallel-web` not installed, identical on main) |

Root cause: the pattern list gated shell primitives (`rm -rf`, `git reset --hard`) but no package-manager removal verb, so the incident in #10199 ran without a prompt.

Hand-ported from #64175 by @konsisumer (the patterns moved from `tools/approval.py` to `tools/approval_detection.py` after it was opened; commit authored as konsisumer). Review feedback on that PR (npm `unlink`/`r`) is included.

Fixes #10199

**Review follow-up (5b177b55):** uninstall rules are now `_CMDPOS`-anchored like every other command-name rule (quoted prose such as `git commit -m "document npm uninstall usage"` no longer prompts) and each global option may take one operand, so `npm --prefix DIR uninstall x` / `pip --proxy URL uninstall x` / `yarn --cwd DIR remove x` are gated. 5 new cases red on the previous head.

## Infographic
![pkg-uninstall](https://v3b.fal.media/files/b/0aaa22d8/Sv138ZRA1dBkZJkj7Uq_o_tNOIRIu7.png)