### PR TITLE
Email attachments thread on the caller's reply_to (#10131)

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -702,9 +702,11 @@ class EmailAdapter(BasePlatformAdapter):
         logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
         return msg_id
 
-    def _send_with_files(self, to_addr: str, body: str, files: List[Tuple[Path, str]], *, lenient: bool) -> str:
-        """Send a reply with attachments; *lenient* logs-and-skips unattachable files instead of raising."""
-        msg, msg_id, _ = self._new_reply(to_addr, body)
+    def _send_with_files(self, to_addr: str, body: str, files: List[Tuple[Path, str]], *, lenient: bool,
+                         reply_to_msg_id: Optional[str] = None) -> str:
+        """Send a reply with attachments; *lenient* logs-and-skips unattachable files instead of raising.
+        An explicit *reply_to_msg_id* threads the mail like ``_send_email`` does (#10131)."""
+        msg, msg_id, _ = self._new_reply(to_addr, body, reply_to_msg_id)
         for path, name in files:
             try:
                 _attach_file(msg, path, name)
@@ -754,11 +756,14 @@ class EmailAdapter(BasePlatformAdapter):
     async def send_document(self, chat_id: str, file_path: str, caption: Optional[str] = None,
                             file_name: Optional[str] = None, reply_to: Optional[str] = None, **kwargs) -> SendResult:
         """Send a file as an email attachment."""
-        return await self._run_send(self._send_email_with_attachment, (chat_id, caption or "", file_path, file_name), "[Email] Send document failed: %s")
+        return await self._run_send(self._send_email_with_attachment, (chat_id, caption or "", file_path, file_name, reply_to),
+                                    "[Email] Send document failed: %s")
 
-    def _send_email_with_attachment(self, to_addr: str, body: str, file_path: str, file_name: Optional[str] = None) -> str:
+    def _send_email_with_attachment(self, to_addr: str, body: str, file_path: str, file_name: Optional[str] = None,
+                                    reply_to_msg_id: Optional[str] = None) -> str:
         """Send an email with a single file attachment via SMTP (raises if unattachable)."""
-        return self._send_with_files(to_addr, body, [(Path(file_path), file_name or Path(file_path).name)], lenient=False)
+        return self._send_with_files(to_addr, body, [(Path(file_path), file_name or Path(file_path).name)], lenient=False,
+                                     reply_to_msg_id=reply_to_msg_id)
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return basic info about the email chat."""

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -432,6 +432,27 @@ class TestSendMethods(unittest.TestCase):
             os.unlink(tmp_path)
 
 
+    def test_send_document_threads_on_explicit_reply_to(self):
+        """An explicit reply_to wins over the cached thread context for attachment sends (#10131)."""
+        import asyncio
+        import tempfile
+        adapter = self._make_adapter()
+        adapter._thread_context["user@test.com"] = {"subject": "Old", "message_id": "<cached@test.com>"}
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"doc")
+            tmp_path = f.name
+        try:
+            with patch("smtplib.SMTP") as mock_smtp:
+                mock_server = MagicMock()
+                mock_smtp.return_value = mock_server
+                result = asyncio.run(adapter.send_document("user@test.com", tmp_path, reply_to="<explicit@test.com>"))
+                self.assertTrue(result.success)
+                sent_msg = mock_server.send_message.call_args[0][0]
+                self.assertEqual(sent_msg["In-Reply-To"], "<explicit@test.com>")
+                self.assertEqual(sent_msg["References"], "<explicit@test.com>")
+        finally:
+            os.unlink(tmp_path)
+
     def test_get_chat_info(self):
         """get_chat_info should return email address as chat info."""
         import asyncio


### PR DESCRIPTION
`EmailAdapter.send_document(..., reply_to=...)` now threads the attachment mail on the caller's message id instead of silently ignoring it.

- `plugins/platforms/email/adapter.py`: `send_document` passes `reply_to` into `_send_email_with_attachment` → `_send_with_files` → `_new_reply`, the same path `_send_email` already used. Explicit target wins over the cached per-address thread context.
- 1 invariant test: with a cached context of `<cached@…>` and `reply_to="<explicit@…>"`, `In-Reply-To` and `References` are `<explicit@…>`.

| | before | after |
|---|---|---|
| `send_document(reply_to="<explicit@test.com>")` with cached `<cached@test.com>` | `In-Reply-To: <cached@test.com>` | `In-Reply-To: <explicit@test.com>` |
| `tests/gateway/test_email.py` + `tests/plugins/platforms/` | new test red | 40 + 200 green |

The other half of #10131 (`send_image` rejecting `metadata=`) was already fixed on main by the adapter parity pass (`192058fda497`).

Root cause: `_send_with_files` built the reply skeleton without a reply-target parameter.

Diagnosis by @NewTurn2017 (#10131); explicit-wins shape from #10321 by @LeonSGP43, which targeted the pre-plugin `gateway/platforms/email.py` path.

Fixes #10131

## Infographic
![email-reply-to](https://v3b.fal.media/files/b/0aaa22de/9MLf3oLKFgQT1XmIZOLxg_bvat5rI4.png)
