### PR TITLE
Top-level platform keys like platforms.webhook.port reach the adapter (#10206, #20501)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -383,12 +383,22 @@ class PlatformConfig:
             result["channel_overrides"] = {cid: ov.to_dict() for cid, ov in self.channel_overrides.items()}
         return result
 
+    # Keys consumed by typed fields; everything else at the top of a platform block is adapter
+    # config and belongs in ``extra`` (see from_dict).
+    _TYPED_KEYS = frozenset({
+        "enabled", "token", "api_key", "home_channel", "reply_to_mode", "channel_overrides", "extra",
+        "gateway_restart_notification", "typing_indicator", "typing_status_text",
+    })
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "PlatformConfig":
         data = _coerce_dict(data)
         home = data.get("home_channel")
-        # The typing/restart-notification keys may be top-level or bridged into ``extra``; top-level wins.
-        extra = _coerce_dict(data.get("extra", {}))
+        # Adapters read their settings from ``extra`` (``config.extra.get("port")``), but users
+        # write them where the docs and ``hermes config set platforms.webhook.port`` put them:
+        # directly under the platform block. Promote every non-typed top-level key so neither
+        # spelling is silently dropped (#10206); an explicit ``extra:`` value wins on a clash.
+        extra = {**{k: v for k, v in data.items() if k not in cls._TYPED_KEYS}, **_coerce_dict(data.get("extra", {}))}
 
         def toplevel_or_extra(key: str) -> Any:
             value = data.get(key)

--- a/gateway/config_loader.py
+++ b/gateway/config_loader.py
@@ -125,8 +125,8 @@ def merge_platform_sections(yaml_cfg: dict, gateway_cfg: Any, gw_data: dict) -> 
     ``gateway.platforms.*`` → top-level ``platforms.*`` → ``gateway.<platform>`` subsections (nested
     first so top-level config keeps precedence, matching the gateway.streaming fallback). An
     ``enabled`` key in any block sets the ``_enabled_explicit`` marker consumed by the env pass.
-    Finally api_server's port/key/host/cors_origins/model_name are bridged into ``extra`` so
-    ``gateway.api_server.port: 8642`` reaches the adapter (mirrors the env path).
+    Top-level adapter keys (``gateway.api_server.port: 8642``) reach ``extra`` in
+    ``PlatformConfig.from_dict``.
     """
     platforms_data = _dict_slot(gw_data, "platforms")
 
@@ -150,13 +150,6 @@ def merge_platform_sections(yaml_cfg: dict, gateway_cfg: Any, gw_data: dict) -> 
     merge(nested_gateway.get("platforms"))
     merge(yaml_cfg.get("platforms"))
     merge({k: v for k, v in nested_gateway.items() if k != "platforms" and isinstance(v, dict) and _is_platform_name(k)})
-
-    api_plat = platforms_data.get("api_server")
-    if isinstance(api_plat, dict):
-        api_extra = _dict_slot(api_plat, "extra")
-        for key in ("port", "key", "host", "cors_origins", "model_name"):
-            if key in api_plat and key not in api_extra:
-                api_extra[key] = api_plat.pop(key)
     return platforms_data
 
 
@@ -212,15 +205,6 @@ _SHARED_KEYS: tuple = (
     *_plain("gateway_restart_notification", "typing_indicator", "typing_status_text"),
 )
 
-# Top-level port/host/secret bridged into ``extra`` for adapters that read them from config.extra
-# (PlatformConfig.from_dict only reads the ``extra:`` sub-key, so ``platforms.webhook.port`` would be lost).
-_PORT_BRIDGE_KEYS: dict = {
-    Platform.WEBHOOK: ("port", "host", "secret"),
-    Platform.MSGRAPH_WEBHOOK: ("port", "host", "secret"),
-    Platform.API_SERVER: ("port", "host"),
-}
-
-
 def _bridged_keys(plat: Platform, platform_cfg: dict, gw_data: dict) -> dict:
     bridged: dict = {}
     for key, only, transform in _SHARED_KEYS:
@@ -230,9 +214,6 @@ def _bridged_keys(plat: Platform, platform_cfg: dict, gw_data: dict) -> dict:
             bridged[key] = _dm_behavior_choice(platform_cfg[key], gw_data.get("unauthorized_dm_behavior", "pair"))
         else:
             bridged[key] = transform(platform_cfg[key]) if transform else platform_cfg[key]
-    for key in _PORT_BRIDGE_KEYS.get(plat, ()):
-        if key in platform_cfg and key not in platform_cfg.get("extra", {}):
-            bridged[key] = platform_cfg[key]
     return bridged
 
 

--- a/gateway/config_loader.py
+++ b/gateway/config_loader.py
@@ -13,7 +13,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from gateway.config import Platform, _dict_slot, _normalize_choice
+from gateway.config import Platform, PlatformConfig, _coerce_dict, _dict_slot, _normalize_choice
 
 # Logger name parity with the origin module: records stay under "gateway.config".
 logger = logging.getLogger("gateway.config")
@@ -205,8 +205,15 @@ _SHARED_KEYS: tuple = (
     *_plain("gateway_restart_notification", "typing_indicator", "typing_status_text"),
 )
 
-def _bridged_keys(plat: Platform, platform_cfg: dict, gw_data: dict) -> dict:
+def _bridged_keys(plat: Platform, platform_cfg: dict, gw_data: dict, *, root_block: bool = False) -> dict:
+    """Shared-key bridge; a ROOT-level ``<platform>:`` block (which ``merge_platform_sections``
+    never copies into ``platforms_data``) also gets its adapter keys promoted into ``extra``, with
+    the same typed-key exclusion and explicit-``extra`` precedence as ``PlatformConfig.from_dict``."""
     bridged: dict = {}
+    if root_block:
+        typed = PlatformConfig._TYPED_KEYS | {"channel_overrides"}
+        bridged.update({k: v for k, v in platform_cfg.items() if k not in typed})
+        bridged.update(_coerce_dict(platform_cfg.get("extra", {})))
     for key, only, transform in _SHARED_KEYS:
         if key not in platform_cfg or (only is not None and plat not in only):
             continue
@@ -243,7 +250,7 @@ def bridge_platform_shared_keys(
         platform_cfg, cfg_toplevel = platform_section(yaml_cfg, plat.value, gateway_platforms)
         if not isinstance(platform_cfg, dict):
             continue
-        bridged = _bridged_keys(plat, platform_cfg, gw_data)
+        bridged = _bridged_keys(plat, platform_cfg, gw_data, root_block=cfg_toplevel)
         has_channel_overrides = "channel_overrides" in platform_cfg
         if has_channel_overrides and isinstance(platform_cfg.get("channel_overrides"), dict):
             plat_data = _dict_slot(platforms_data, plat.value)

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1055,6 +1055,21 @@ class TestWebhookPortBridging:
         assert wh.extra.get("host") == "0.0.0.0"
 
 
+    def test_root_level_platform_block_adapter_keys_reach_extra(self, tmp_path, monkeypatch):
+        """A ROOT-level ``webhook:`` block (not under ``platforms:``) is a supported spelling; its
+        adapter keys must reach ``extra`` like the nested form, with nested ``extra:`` winning."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "webhook:\n  enabled: true\n  port: 9100\n  host: 127.0.0.2\n  secret: fixture\n"
+            "  extra:\n    port: 9999\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("WEBHOOK_PORT", raising=False)
+        wh = load_gateway_config().platforms[Platform.WEBHOOK]
+        assert (wh.extra.get("port"), wh.extra.get("host"), wh.extra.get("secret")) == (9999, "127.0.0.2", "fixture")
+
     def test_msgraph_webhook_port_host_secret_bridged_from_toplevel(self, tmp_path, monkeypatch):
         """msgraph_webhook top-level port/host/secret must be bridged into extra,
         with an explicit extra: value still winning over the top-level one."""

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -46,6 +46,18 @@ class TestHomeChannelRoundtrip:
 
 
 class TestPlatformConfigRoundtrip:
+    def test_toplevel_adapter_keys_promoted_into_extra(self):
+        """Adapter settings written directly under the platform block (the documented
+        ``platforms.webhook.port`` shape) reach ``extra``; an explicit ``extra:`` value wins and
+        typed fields never leak into ``extra`` (#10206)."""
+        pc = PlatformConfig.from_dict({
+            "enabled": True, "reply_to_mode": "all", "typing_indicator": False,
+            "port": 9100, "routes": {"gh": {"prompt": "x"}}, "extra": {"port": 9999},
+        })
+        assert pc.extra == {"port": 9999, "routes": {"gh": {"prompt": "x"}}}
+        assert pc.reply_to_mode == "all" and pc.typing_indicator is False
+        assert PlatformConfig.from_dict(pc.to_dict()).extra == pc.extra
+
     def test_to_dict_from_dict(self):
         pc = PlatformConfig(
             enabled=True,

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -72,7 +72,7 @@ Expected response:
 
 ## Configuring Routes {#configuring-routes}
 
-Routes define how different webhook sources are handled. Each route is a named entry under `platforms.webhook.extra.routes` in your `config.yaml`.
+Routes define how different webhook sources are handled. Each route is a named entry under `platforms.webhook.extra.routes` in your `config.yaml`. Adapter settings (`port`, `host`, `secret`, `routes`) may also be written directly under `platforms.webhook:` — both spellings reach the adapter; a value nested under `extra:` wins if the same key appears in both places.
 
 ### Route properties
 


### PR DESCRIPTION
Every adapter setting written directly under a platform block (`platforms.webhook.port`, `routes`, `secret`, api_server `key`/`cors_origins`, …) now reaches `PlatformConfig.extra`, so both the documented `extra:` nesting and the natural top-level spelling work.

- `gateway/config.py::PlatformConfig.from_dict`: promote every non-typed top-level key into `extra`; an explicit `extra:` value wins on a clash; typed fields (`enabled`, `token`, `reply_to_mode`, `typing_indicator`, …) never leak into `extra` on a `to_dict`/`from_dict` roundtrip.
- Removed the two partial bridges this replaces: `_PORT_BRIDGE_KEYS` (webhook/msgraph/api_server port/host/secret) and the api_server-only `port/key/host/cors_origins/model_name` block in `gateway/config_loader.py` — both had to be extended per key.
- Docs: webhooks guide notes both spellings and the `extra:` precedence.
- 1 invariant test on `from_dict` (promotion + explicit-wins + roundtrip); the existing loader tests for webhook/msgraph/api_server port bridging still pass and now exercise the new path.

| | before | after |
|---|---|---|
| `platforms.webhook: {port: 9100, routes: {...}}` | `extra={'port': 9100}` (routes dropped) | `extra={'port': 9100, 'routes': {...}}` |
| `platforms.api_server: {key: abc, cors_origins: ...}` | key/cors bridged by special-case | same result, no special-case |
| `extra: {port: 9999}` + top-level `port: 9100` | 9999 | 9999 |
| `tests/gateway/` | new test red; 4 loader tests red without the old bridge | 829 files / 8241 green |

Root cause: `from_dict` read a fixed set of fields and discarded the rest.

Same direction as #10208 / #10211 / #10453 (@rainow's #10206 diagnosis) and #20506 (@Beandon13, #20501), all of which target the pre-`config_loader` layout.

Fixes #10206
Fixes #20501

**Review follow-up (708ea078):** a ROOT-level `webhook:` block (the pre-`platforms:` spelling, still supported) is never copied into `platforms_data`, so removing `_PORT_BRIDGE_KEYS` regressed it (port fell back to 8644). `_bridged_keys` now promotes every non-typed key of a root block with the same typed-key exclusion and explicit-`extra` precedence. Root webhook / msgraph / nested forms all verified with `load_gateway_config` on a real temp `HERMES_HOME`.

## Infographic
![platform-extra](https://v3b.fal.media/files/b/0aaa22e9/5eWGexYvL57yNrbLANQ0V_kmkJeo3C.png)