### PR TITLE
CLI prints 'preparing <tool>…' once per tool per batch (#10478)

### DIFF
--- a/hermes_cli/cli_stream_mixin.py
+++ b/hermes_cli/cli_stream_mixin.py
@@ -519,6 +519,8 @@ class CLIStreamMixin:
         self._reasoning_buf = ""
         self._reasoning_preview_buf = ""
         self._deferred_content = ""
+        # A batch cancelled/errored before any tool.started would otherwise mute the next turn's line.
+        self.__dict__.pop("_tool_gen_announced", None)
         self._stream_table_buf = []
         self._in_stream_table = False
         self._stream_box_live = False

--- a/hermes_cli/cli_stream_mixin.py
+++ b/hermes_cli/cli_stream_mixin.py
@@ -621,12 +621,20 @@ class CLIStreamMixin:
 
     def _on_tool_gen_start(self, tool_name: str) -> None:
         """Model began generating tool-call arguments: close open boxes once, then print a status
-        line so a large payload (e.g. 45 KB write_file) doesn't look like a frozen screen."""
+        line so a large payload (e.g. 45 KB write_file) doesn't look like a frozen screen.
+
+        Fires once per tool CALL, so a batch of parallel calls to the same tool printed the same
+        line N times (#10478); repeats within one generation batch are coalesced. The set is
+        cleared when a tool actually starts (``tool.started``), i.e. on the next batch."""
         from cli import _cprint
-        if getattr(self, "_stream_box_opened", False):
+        if getattr(self, '_stream_box_opened', False):
             self._flush_stream()
             self._stream_box_opened = False
         self._close_reasoning_box()
+        announced = self.__dict__.setdefault("_tool_gen_announced", set())
+        if tool_name in announced:
+            return
+        announced.add(tool_name)
         from agent.display import get_tool_emoji
         _cprint(f"  ┊ {get_tool_emoji(tool_name, default='⚡')} preparing {tool_name}…")
 
@@ -666,6 +674,7 @@ class CLIStreamMixin:
         # Feed the pet: tools mean "running"; a failed tool latches the turn to end on a sulk.
         if event_type == "tool.started":
             self._pet_reasoning = False
+            self.__dict__.pop("_tool_gen_announced", None)
         elif event_type == "tool.completed" and kwargs.get("is_error"):
             self._pet_turn_error = True
         elif event_type and event_type.startswith("reasoning"):

--- a/tests/cli/test_tool_gen_start_dedupe.py
+++ b/tests/cli/test_tool_gen_start_dedupe.py
@@ -1,0 +1,25 @@
+"""A batch of parallel tool calls announces "preparing <tool>…" once per tool, not once per call (#10478)."""
+
+from unittest.mock import patch
+
+from tests.cli.test_tool_progress_scrollback import _make_cli
+import tests.cli.test_tool_progress_scrollback as _scrollback
+
+
+def _announce(cli, names):
+    printed = []
+    with patch.object(_scrollback._cli_mod, "_cprint", lambda line: printed.append(line)):
+        for n in names:
+            cli._on_tool_gen_start(n)
+    return printed
+
+
+def test_repeated_tool_in_one_batch_prints_once():
+    cli = _make_cli(tool_progress="off")
+    printed = _announce(cli, ["terminal", "terminal", "terminal", "read_file"])
+    assert sum("preparing terminal" in p for p in printed) == 1
+    assert sum("preparing read_file" in p for p in printed) == 1
+    # A tool actually starting closes the batch; the next generation announces again.
+    with patch.object(_scrollback._cli_mod, "_cprint", lambda line: None):
+        cli._on_tool_progress("tool.started", "terminal", "ls", {"command": "ls"})
+    assert sum("preparing terminal" in p for p in _announce(cli, ["terminal"])) == 1

--- a/tests/cli/test_tool_gen_start_dedupe.py
+++ b/tests/cli/test_tool_gen_start_dedupe.py
@@ -23,3 +23,6 @@ def test_repeated_tool_in_one_batch_prints_once():
     with patch.object(_scrollback._cli_mod, "_cprint", lambda line: None):
         cli._on_tool_progress("tool.started", "terminal", "ls", {"command": "ls"})
     assert sum("preparing terminal" in p for p in _announce(cli, ["terminal"])) == 1
+    # A batch that never reached tool.started (cancel/error) must not mute the next invocation.
+    cli._reset_stream_state()
+    assert sum("preparing terminal" in p for p in _announce(cli, ["terminal"])) == 1


### PR DESCRIPTION
The CLI prints `┊ 💻 preparing terminal…` once per tool per generation batch instead of once per tool call, so three parallel `terminal` calls no longer produce three identical lines.

- `hermes_cli/cli_stream_mixin.py::_on_tool_gen_start`: coalesce repeats of the same tool name; the set is cleared on `tool.started` (the next batch announces again).
- The line itself is kept: it is the only feedback while a large argument payload (e.g. a 45 KB `write_file`) streams, before the spinner exists. #10598 removed it globally.
- 1 invariant test through the real `HermesCLI` display path.

| | before | after |
|---|---|---|
| Live A/B: in-process OpenAI-compatible SSE mock streaming 3 parallel `terminal` calls into a real `HermesCLI` (`display.streaming: true`) | 3 × `preparing terminal…` | 1 × `preparing terminal…` |
| `tests/cli/` | new test red (`3 == 1`) | 137 files / 1428 green |

Root cause: the tool-gen callback fires per tool call and the display printed unconditionally.

Reporter @jordanhubbard (#10478).

Fixes #10478

**Review follow-up (30f5929c):** `_tool_gen_announced` is also cleared in `_reset_stream_state`, so a batch cancelled or errored before any `tool.started` no longer mutes the next invocation's line. Red on the previous head, green now.

## Infographic
![preparing-dedupe](https://v3b.fal.media/files/b/0aaa230b/eqbJSV5AWaAfdWMJG5rkn_wVBOUjTg.png)