### PR TITLE
fix(memory): exact whole-entry match beats substring match in replace/remove/batch

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -184,6 +184,28 @@ class TestMemoryStoreRemove:
         assert store.remove("memory", "  ")["success"] is False
 
 
+class TestExactWholeEntryMatchPriority:
+    """A short entry whose full text is contained inside a longer sibling entry
+    must stay addressable: old_text that equals an entry wins outright, and
+    substring matches only apply when no entry equals old_text. Without this,
+    remove('test') against entries ['test', '...tests pass...'] reported
+    ambiguity and the entry could never be addressed."""
+
+    def test_remove_exact_entry_beats_substring_collision(self, store):
+        store.add("memory", "test")
+        store.add("memory", "echo-reply tests pass via local twins and are false positives")
+        result = store.remove("memory", "test")
+        assert result["success"] is True
+        assert store.memory_entries == ["echo-reply tests pass via local twins and are false positives"]
+
+    def test_batch_remove_exact_entry_beats_substring_collision(self, store):
+        store.add("memory", "test")
+        store.add("memory", "echo-reply tests pass via local twins and are false positives")
+        result = store.apply_batch("memory", [{"action": "remove", "old_text": "test"}])
+        assert result["success"] is True
+        assert store.memory_entries == ["echo-reply tests pass via local twins and are false positives"]
+
+
 class TestMemoryConsolidationGracefulDegrade:
     """Fix #3 for #42405: a failed at-capacity consolidation must never loop the
     turn to budget exhaustion — after a per-turn cap of failures, memory ops

--- a/tools/memory_tool_store.py
+++ b/tools/memory_tool_store.py
@@ -55,9 +55,14 @@ def _read_failed_error(path: Path) -> Dict[str, Any]:
 
 
 def _find_unique_match(entries: List[str], old_text: str) -> Tuple[Optional[int], bool]:
-    """``(index, ambiguous)`` for entries containing *old_text*. Exact-duplicate
+    """``(index, ambiguous)`` for entries matching *old_text*. A whole-entry
+    EXACT match (``old_text == entry``) takes absolute priority — substring
+    matches are only considered when no entry equals *old_text*, so a short
+    entry stays addressable even when its full text is contained inside a
+    longer sibling entry (remove('test') vs '...tests pass...'). Exact-duplicate
     matches are safe (first wins); distinct matches → ``(None, True)``."""
-    matches = [i for i, e in enumerate(entries) if old_text in e]
+    exact = [i for i, e in enumerate(entries) if e == old_text]
+    matches = exact if exact else [i for i, e in enumerate(entries) if old_text in e]
     if len({entries[i] for i in matches}) > 1:
         return None, True
     return (matches[0] if matches else None), False


### PR DESCRIPTION
# fix(memory): exact whole-entry match beats substring match in replace/remove/batch

## Summary

`memory` tool `replace`/`remove`/`batch` matched `old_text` by pure substring scan. A short entry whose full text is contained inside a longer sibling entry became **unaddressable**: every `old_text` candidate collided with multiple entries, so the operation always failed with `Multiple entries matched`, and `apply_batch` aborted the whole all-or-nothing operation.

Real-world case: removing the entry `test` while an entry containing `echo-reply tests pass via local twins...` existed — `remove(old_text="test")` matched both, reported ambiguity, and the short entry could never be deleted or replaced.

## Root cause

`_find_unique_match()` in `tools/memory_tool_store.py`:

```python
matches = [i for i, e in enumerate(entries) if old_text in e]
if len({entries[i] for i in matches}) > 1:
    return None, True  # ambiguous
```

When `old_text == entries[j]` exactly AND `old_text in entries[k]` (longer sibling), both indices match with distinct contents → always `(None, True)`. There is no `old_text` value that can target the exact entry: full text collides, and any shorter substring collides too.

## The fix

Whole-entry EXACT match (`old_text == entry`) takes absolute priority; substring matching remains the fallback for partial `old_text` values (unchanged behavior):

```python
exact = [i for i, e in enumerate(entries) if e == old_text]
matches = exact if exact else [i for i, e in enumerate(entries) if old_text in e]
```

Both call sites share the matcher — `_edit()` (single `replace`/`remove`) and `_apply_batch_op()` (batch) — so the whole bug class is fixed at one seam. Exact-duplicate entries matching `old_text` remain safe (first wins, existing behavior).

## Reproduction (red on current main)

```python
store.add("memory", "test")
store.add("memory", "echo-reply tests pass via local twins and are false positives")
store.remove("memory", "test")
# main: success=False — "Multiple entries matched 'test'"
# this PR: success=True — removes the exact entry, sibling untouched
```

Two invariant tests added (`TestExactWholeEntryMatchPriority`) covering the single-op and batch paths, proven red on base and green after the fix.

## Verification

- `scripts/run_tests.sh tests/tools/test_memory_tool.py` — 53/53 (51 existing + 2 new)
- 8 sibling memory suites green via the canonical runner (learning mutations, inline executor args, background review scope, skip-memory-store, disabled-surface, import fallback, schema)
- Full `tests/tools/` directory green
- Substring partial matching unchanged (`replace("3.11", ...)` style still works)

## Notes

- No behavior contract broken: ambiguity errors still fire for genuinely ambiguous partial `old_text`; exact-duplicate handling unchanged.
- The system prompt's `old_text` guidance ("a short unique substring") remains accurate — exact full-entry values now also work.