### PR TITLE
Skills index builds again after 54 days frozen; K-Dense + OpenScience science skills tapped (salvage #60559)

### DIFF
--- a/.github/workflows/skills-index.yml
+++ b/.github/workflows/skills-index.yml
@@ -20,7 +20,10 @@ jobs:
     # Only run on the upstream repository, not on forks
     if: github.repository == 'NousResearch/hermes-agent'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Critical path (Sep 2026): clawhub walk ~14 min ∥ github taps ~8 min, then skills.sh
+    # resolve ~6 min, then a bounded 8 min owner enrichment. 15 min cancelled every
+    # scheduled run for two months and left the live index frozen.
+    timeout-minutes: 50
     environment: trusted-automation
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/scripts/build_skills_index.py
+++ b/scripts/build_skills_index.py
@@ -41,6 +41,7 @@ import httpx
 
 OUTPUT_PATH = os.path.join(REPO_ROOT, "website", "static", "api", "skills-index.json")
 INDEX_VERSION = 1
+CLAWHUB_ENRICH_BUDGET_SECONDS = 480
 
 
 def _meta_to_dict(meta: SkillMeta) -> dict:
@@ -316,7 +317,10 @@ def main():
         print(f"  Enriching {len(clawhub_metas)} ClawHub skills with owner handles...",
               flush=True)
         enrich_start = time.time()
-        enriched = sources["clawhub"].enrich_owners(clawhub_metas, max_workers=30)
+        # Best-effort: ~2s per detail call means the full catalog would take >1h;
+        # the un-enriched remainder ships without an owner link (see enrich_owners).
+        enriched = sources["clawhub"].enrich_owners(
+            clawhub_metas, max_workers=30, budget_seconds=CLAWHUB_ENRICH_BUDGET_SECONDS)
         # Write enriched owner back into the index dicts.
         meta_by_id = {m.identifier: m for m in clawhub_metas}
         for s in clawhub_skills:

--- a/tests/scripts/test_build_skills_index_health.py
+++ b/tests/scripts/test_build_skills_index_health.py
@@ -39,7 +39,7 @@ class _FakeSource:
     def search(self, query, limit=10):
         return [_meta(f"{self._src}-{i}", self._src) for i in range(self._n)]
 
-    def enrich_owners(self, skills, max_workers=30):
+    def enrich_owners(self, skills, max_workers=30, budget_seconds=None):
         # No-op: fake source doesn't need owner enrichment.
         return 0
 

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -103,6 +103,44 @@ class TestSkillsShGroupings:
         assert len(skills) == 1
         assert skills[0].extra["category"] == "Decision Optimization"
 
+    def test_list_skills_bucket_stamps_category_when_no_sidecar(self):
+        # A tap-level bucket labels every skill when the repo ships no skills.sh.json
+        # grouping — how several repos share one hub category (e.g. science).
+        src = GitHubSource(auth=MagicMock())
+        meta = SkillMeta(
+            name="rdkit", description="d", source="github",
+            identifier="K-Dense-AI/scientific-agent-skills/skills/rdkit", trust_level="community",
+        )
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = [{"type": "dir", "name": "rdkit"}]
+        with patch("tools.skills_hub_github._cached_metas", return_value=None), \
+             patch("tools.skills_hub_github._cache_metas"), \
+             patch.object(src, "_get_skillsh_groupings", return_value=None), \
+             patch.object(src, "inspect", return_value=meta), \
+             patch.object(src, "_github_get", return_value=resp):
+            skills = src._list_skills_in_repo("K-Dense-AI/scientific-agent-skills", "skills/", "science")
+
+        assert len(skills) == 1
+        assert skills[0].extra["category"] == "science"
+
+    def test_list_skills_sidecar_grouping_wins_over_bucket(self):
+        src = GitHubSource(auth=MagicMock())
+        meta = SkillMeta(
+            name="cuopt-developer", description="d", source="github",
+            identifier="NVIDIA/skills/skills/cuopt-developer", trust_level="trusted",
+        )
+        resp = MagicMock(status_code=200)
+        resp.json.return_value = [{"type": "dir", "name": "cuopt-developer"}]
+        with patch("tools.skills_hub_github._cached_metas", return_value=None), \
+             patch("tools.skills_hub_github._cache_metas"), \
+             patch.object(src, "_get_skillsh_groupings",
+                          return_value={"cuopt-developer": "Decision Optimization"}), \
+             patch.object(src, "inspect", return_value=meta), \
+             patch.object(src, "_github_get", return_value=resp):
+            skills = src._list_skills_in_repo("NVIDIA/skills", "skills/", "science")
+
+        assert skills[0].extra["category"] == "Decision Optimization"
+
 # ---------------------------------------------------------------------------
 # GitHubSource.trust_level_for
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_skills_hub_clawhub.py
+++ b/tests/tools/test_skills_hub_clawhub.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import time
 import unittest
 from unittest.mock import patch
 
@@ -680,6 +681,26 @@ class TestFetchOwnerHandleRetry(unittest.TestCase):
         # 3 skills × 2 attempts each = 6 total HTTP calls (no abort)
         self.assertEqual(call_count["n"], 6)
         mock_sleep.assert_called()
+
+    @patch("tools.skills_hub_clawhub.httpx.get")
+    def test_enrich_owners_budget_stops_early_and_keeps_partial_results(self, mock_get):
+        """An exhausted budget ends enrichment early (the un-enriched rest ships without an
+        owner) instead of walking every remaining skill — the unbounded walk over 78k skills
+        at ~2s each is what timed out the CI index build for two months."""
+        def slow_owner(url, *args, **kwargs):
+            time.sleep(0.05)
+            return _MockResponse(status_code=200,
+                                 json_data={"skill": {"slug": "s"}, "owner": {"handle": "eve"}})
+        mock_get.side_effect = slow_owner
+        skills = [SkillMeta(name=f"s{i}", description="", source="clawhub",
+                            identifier=f"s{i}", trust_level="community") for i in range(200)]
+
+        enriched = self.src.enrich_owners(skills, max_workers=1, budget_seconds=0.3)
+
+        self.assertGreaterEqual(enriched, 1)
+        self.assertLess(enriched, 200)
+        self.assertEqual(enriched, sum(1 for s in skills if s.extra.get("owner") == "eve"))
+        self.assertLess(mock_get.call_count, 200)
 
 
 if __name__ == "__main__":

--- a/tools/skills_hub_clawhub.py
+++ b/tools/skills_hub_clawhub.py
@@ -390,10 +390,15 @@ class ClawHubSource(GuardedFetchMixin, SkillSource):
             time.sleep(delay)
         return None
 
-    def enrich_owners(self, skills: List[SkillMeta], max_workers: int = 30) -> int:
+    def enrich_owners(self, skills: List[SkillMeta], max_workers: int = 30,
+                      budget_seconds: Optional[float] = None) -> int:
         """Batch-fetch owner handles for ClawHub skills missing ``extra["owner"]``
-        (in-place; returns the number enriched). For the offline index builder:
-        the full 50k catalog takes ~5–10 min at 30 workers.
+        (in-place; returns the number enriched).
+
+        ``budget_seconds`` makes this best-effort: the detail API answers in ~2s, so the
+        full catalog (78k+ skills) needs well over an hour at 30 workers — unbounded, it
+        was the phase that pushed the index build past its CI timeout for two months.
+        Skills left un-enriched simply ship without a "View source" owner link.
 
         Safety rails: aborts after 50 consecutive failures (systemic outage),
         per-request 429 backoff, progress log every 1000 skills.
@@ -403,6 +408,7 @@ class ClawHubSource(GuardedFetchMixin, SkillSource):
             return 0
         enriched = consecutive_failures = processed = 0
         max_consecutive_failures = 50
+        deadline = time.monotonic() + budget_seconds if budget_seconds is not None else None
 
         from concurrent.futures import ThreadPoolExecutor, as_completed
         with ThreadPoolExecutor(max_workers=max_workers) as pool:
@@ -410,6 +416,13 @@ class ClawHubSource(GuardedFetchMixin, SkillSource):
             for future in as_completed(futures):
                 meta = futures[future]
                 processed += 1
+                if deadline is not None and time.monotonic() > deadline:
+                    logger.warning("ClawHub owner enrichment: budget of %.0fs exhausted after %d/%d "
+                                   "(%d enriched) — shipping the rest without owner handles.",
+                                   budget_seconds, processed, len(needs_enrichment), enriched)
+                    for f in futures:
+                        f.cancel()
+                    break
                 try:
                     handle = future.result()
                 except Exception:

--- a/tools/skills_hub_github.py
+++ b/tools/skills_hub_github.py
@@ -179,6 +179,25 @@ class GitHubSource(SkillSource):
         # + governance card; `trusted` via tools/skills_guard.py::TRUSTED_REPOS.
         {"repo": "NVIDIA/skills", "path": "skills/"},
         {"repo": "garrytan/gstack", "path": ""},
+        # --- Science bucket ---
+        # Two scientific-skill repos share one hub category via the tap-level "bucket" key so
+        # their skills surface together. Both stay `community` trust on purpose (NOT in
+        # tools/skills_guard.py::TRUSTED_REPOS): the guard scans every skill and INSTALL_POLICY
+        # auto-installs only "safe" ones. Skills wrap third-party tools with their OWN licenses
+        # (some GPL; KEGG is commercial for non-academic use) — surfaced per skill, not vetted here.
+        # K-Dense-AI/scientific-agent-skills: flat skills/<name>/, MIT.
+        {"repo": "K-Dense-AI/scientific-agent-skills", "path": "skills/", "bucket": "science"},
+        # synthetic-sciences/openscience: Apache-2.0, nested backend/cli/skills/<category>/<name>/.
+        # _list_skills_in_repo walks ONE level under a tap path, so each category is its own tap
+        # (same one-entry-per-inner-path pattern as openai/skills above).
+        *(
+            {"repo": "synthetic-sciences/openscience", "path": f"backend/cli/skills/{_cat}/", "bucket": "science"}
+            for _cat in (
+                "biology", "chemistry", "cloud-compute", "coding", "data-engineering", "databases",
+                "document-parsing", "llm-tools", "ml-inference", "ml-training", "other", "physics",
+                "quantum", "research", "scholar-evaluation", "visualization", "writing",
+            )
+        ),
     ]
 
     SOURCE_ID = "github"
@@ -210,7 +229,7 @@ class GitHubSource(SkillSource):
         query_lower = query.lower()
         for tap in self.taps:
             try:
-                for skill in self._list_skills_in_repo(tap["repo"], tap.get("path", "")):
+                for skill in self._list_skills_in_repo(tap["repo"], tap.get("path", ""), tap.get("bucket")):
                     if _matches_query(query_lower, skill.name, skill.description, skill.tags):
                         results.append(skill)
             except Exception as e:
@@ -316,9 +335,11 @@ class GitHubSource(SkillSource):
 
     # -- Internal helpers --
 
-    def _list_skills_in_repo(self, repo: str, path: str) -> List[SkillMeta]:
-        """List skill directories in a GitHub repo path, using cached index."""
-        cache_key = f"{repo}_{path}".replace("/", "_").replace(" ", "_")
+    def _list_skills_in_repo(self, repo: str, path: str, bucket: Optional[str] = None) -> List[SkillMeta]:
+        """List skill directories in a GitHub repo path, using cached index. ``bucket`` labels every
+        skill from a tap whose repo ships no ``skills.sh.json`` grouping, so several repos can share one
+        hub category (e.g. "science"); a sidecar grouping still wins when present."""
+        cache_key = f"{repo}_{path}_{bucket or ''}".replace("/", "_").replace(" ", "_")
         cached = _cached_metas(cache_key)
         if cached is not None:
             return cached
@@ -337,7 +358,7 @@ class GitHubSource(SkillSource):
             dir_name = entry["name"]
             meta = self.inspect(f"{repo}/{prefix}/{dir_name}" if prefix else f"{repo}/{dir_name}")
             if meta:
-                category = groupings and (groupings.get(meta.name) or groupings.get(dir_name))
+                category = (groupings and (groupings.get(meta.name) or groupings.get(dir_name))) or bucket
                 if category:
                     meta.extra["category"] = category
                 skills.append(meta)

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -747,6 +747,7 @@ Default taps (browsable without any setup):
 - [huggingface/skills](https://github.com/huggingface/skills)
 - [NVIDIA/skills](https://github.com/NVIDIA/skills) — NVIDIA-verified skills (signed `skill.oms.sig` + governance `skill-card.md`)
 - [garrytan/gstack](https://github.com/garrytan/gstack)
+- [K-Dense-AI/scientific-agent-skills](https://github.com/K-Dense-AI/scientific-agent-skills) and [synthetic-sciences/openscience](https://github.com/synthetic-sciences/openscience) — ~480 scientific research skills (bioinformatics, chemistry, physics, ML training, scholarly tooling), grouped under one `science` category. Community trust: every install is security-scanned. Many wrap third-party tools with their own licenses (some GPL; KEGG requires a commercial license for non-academic use) — check each skill's prerequisites.
 
 - Example:
 


### PR DESCRIPTION
The scheduled Skills Hub index build completes again (it had silently failed every run for 54 days), and ~480 scientific research skills from K-Dense and OpenScience become searchable/installable through it under one `science` category, with nothing vendored.

Salvages #60559 (retitled: the diff always tapped both repos) and supersedes #13191 (@RUFFY-369's optional-skill index over the same K-Dense library; the tap makes every skill directly installable instead of a pointer file).

## Why the index was dead
Every `skills-index.yml` run since 2026-07-20 was cancelled at the 15-minute job timeout. The live `skills-index.json` has been stamped `2026-07-20` since, the watchdog has appended to #66616 four times a day, and every `hermes skills search` fell through to live GitHub API calls (~500 `inspect` requests per cold search, against a 60/hr unauthenticated budget).

Root cause: `ClawHubSource.enrich_owners()` walks every ClawHub skill's detail endpoint (~2 s each) to get an owner handle for the "View source" link. The catalog grew from ~50k to 78k skills; at 30 workers that phase alone runs well over an hour and nothing bounded it.

## Changes
- `tools/skills_hub_clawhub.py::enrich_owners` — new `budget_seconds`; on expiry it stops and ships the remainder without an owner handle (the link is a nicety, the index is not). One invariant test.
- `scripts/build_skills_index.py` — passes an 8-minute enrichment budget.
- `.github/workflows/skills-index.yml` — build job `timeout-minutes` 15 → 50 (measured critical path below, ~21 min headroom).
- `tools/skills_hub_github.py` — optional tap-level `bucket` key: stamps `extra["category"]` when a tapped repo ships no `skills.sh.json`; a sidecar grouping still wins. Taps `K-Dense-AI/scientific-agent-skills` (165, MIT) + 17 `synthetic-sciences/openscience` category paths (312, Apache-2.0) under `bucket: "science"`. Both stay `community` trust (not in `TRUSTED_REPOS`) so the guard scans every install. Two invariant tests, proven red with the bucket line neutralized.
- `website/docs/user-guide/features/skills.md` — default taps list.

## Validation
| Check | Result |
|---|---|
| Full `build_skills_index.py` on this branch (real network, App-equivalent PAT) | exit 0, **28.8 min wall**, 100,244 skills |
| Phase timings | github taps 458 s ∥ clawhub walk 880 s → skills.sh resolve 359 s → enrichment stopped at budget 486 s (5,597/78,167 owners) |
| Same build on `origin/main` | killed by me at 54 min, still in enrichment (matches 54 days of CI cancels) |
| Produced index: `category=science` | 477 skills (K-Dense 165 + OpenScience 312) |
| Client E2E: index in a temp `HERMES_HOME`, `httpx.get` patched to raise | `unified_search("rdkit")` returns both science repos with `category=science`; live `github` source not selected (0 API calls) |
| A/B: neutralize `or bucket` in `_list_skills_in_repo` | bucket test goes red |
| `tests/tools/test_skills_hub.py`, `test_skills_hub_clawhub.py`, `tests/scripts/test_build_skills_index_health.py` | green |

After merge: `gh workflow run skills-index.yml --ref main`, then confirm the freshness watchdog goes `ok` and close #66616.

## Infographic
![Skills index back online](https://v3b.fal.media/files/b/0aaa232c/u1RNOurj2RhOrFKVJZ4Vq_qtTdyuWE.png)
