### PR TITLE
fix(gateway): service repair no longer claims success it can't deliver (#12866, #12863; salvage #68493, #12989)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3234,9 +3234,12 @@ def systemd_install(
         else:
             print(f"Service already installed at: {unit_path}")
             print("Use --force to reinstall")
+        # Same post-install guarantee as a fresh install: a repaired user unit must survive logout too.
         configured_user = _read_systemd_user_from_unit(unit_path) if system else None
         if configured_user:
             _ensure_system_service_linger(configured_user)
+        elif not system:
+            _ensure_linger_enabled()
         return
 
     unit_path.parent.mkdir(parents=True, exist_ok=True)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4033,6 +4033,7 @@ def refresh_launchd_plist_if_needed() -> bool:
             "launchd reload of %s failed — service not registered after %ds of retries; see %s",
             target, int(_reload_budget), _launchd_reload_log_path(),
         )
+        return False
     print("↻ Updated gateway launchd service definition to match the current Hermes install")
     return True
 
@@ -4043,8 +4044,17 @@ def launchd_install(force: bool = False):
     if plist_path.exists() and not force:
         if not launchd_plist_is_current():
             print(f"↻ Repairing outdated launchd service at: {plist_path}")
-            refresh_launchd_plist_if_needed()
-            print("✓ Service definition updated")
+            if refresh_launchd_plist_if_needed():
+                print("✓ Service definition updated")
+            else:
+                # The plist was rewritten but launchd never registered it (or the write was refused):
+                # a success line here would hide an unloaded service with no KeepAlive.
+                from hermes_constants import display_hermes_home
+                print(
+                    "⚠ Service definition could not be reloaded with launchd. "
+                    "Run 'hermes gateway install --force' or check "
+                    f"{display_hermes_home()}/logs/launchd-reload.log for details."
+                )
             return
         print(f"Service already installed at: {plist_path}")
         print("Use --force to reinstall")

--- a/tests/hermes_cli/test_gateway_linger.py
+++ b/tests/hermes_cli/test_gateway_linger.py
@@ -215,3 +215,25 @@ def test_existing_system_install_repairs_linger_for_configured_user(monkeypatch,
     gateway.systemd_install(system=True, run_as_user="alice")
 
     assert helper_calls == ["alice"]
+
+
+@pytest.mark.parametrize("system", [False, True])
+def test_systemd_install_repair_path_keeps_linger_guarantee(monkeypatch, tmp_path, system):
+    """Repairing a stale unit used to return before the linger step, so an upgraded headless
+    user service died at logout (#12863). System scope never touches user linger."""
+    unit_path = tmp_path / "hermes-gateway.service"
+    unit_path.write_text("old unit\n", encoding="utf-8")
+    monkeypatch.setattr(gateway, "get_systemd_unit_path", lambda system=False: unit_path)
+    monkeypatch.setattr(gateway, "systemd_unit_is_current", lambda system=False: False)
+    monkeypatch.setattr(gateway, "has_legacy_hermes_units", lambda: False)
+    monkeypatch.setattr(gateway, "_require_root_for_system_service", lambda _action: None)
+    monkeypatch.setattr(gateway, "_sync_hermes_home_from_systemd_unit", lambda system=False: None)
+    monkeypatch.setattr(gateway, "_read_systemd_user_from_unit", lambda path: None)
+    monkeypatch.setattr(gateway, "refresh_systemd_unit_if_needed", lambda system=False: None)
+    monkeypatch.setattr(gateway, "_run_systemctl", lambda *args, **kwargs: None)
+    helper_calls = []
+    monkeypatch.setattr(gateway, "_ensure_linger_enabled", lambda: helper_calls.append(True))
+
+    gateway.systemd_install(force=False, system=system)
+
+    assert helper_calls == ([] if system else [True])

--- a/tests/hermes_cli/test_launchd_refresh_reporting.py
+++ b/tests/hermes_cli/test_launchd_refresh_reporting.py
@@ -1,0 +1,46 @@
+"""launchd plist refresh must not report success when launchd never registered the service (#12866)."""
+import subprocess
+from unittest.mock import MagicMock
+
+from hermes_cli import gateway as gw
+
+
+def _stale_plist(tmp_path, monkeypatch, *, registered: bool):
+    plist_path = tmp_path / "com.hermes.plist"
+    plist_path.write_text("<old/>", encoding="utf-8")
+    monkeypatch.setattr(gw, "get_launchd_plist_path", lambda: plist_path)
+    monkeypatch.setattr(gw, "launchd_plist_is_current", lambda: False)
+    monkeypatch.setattr(gw, "generate_launchd_plist", lambda: "<new/>")
+    monkeypatch.setattr(gw, "_refuse_temp_home_service_write", lambda *a: False)
+    monkeypatch.setattr(gw, "get_launchd_label", lambda: "com.hermes.agent")
+    monkeypatch.setattr(gw, "_launchd_domain", lambda: "gui/501")
+    monkeypatch.setattr(gw, "_append_launchd_reload_log", lambda msg: None)
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: None)
+    monkeypatch.setattr(gw, "_retry_launchctl_bootstrap_until_registered", lambda *a, **k: registered)
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: MagicMock(returncode=0))
+
+
+def test_refresh_reports_registration_outcome(tmp_path, monkeypatch, capsys):
+    _stale_plist(tmp_path, monkeypatch, registered=False)
+    assert gw.refresh_launchd_plist_if_needed() is False
+    assert "Updated" not in capsys.readouterr().out
+
+    _stale_plist(tmp_path, monkeypatch, registered=True)
+    assert gw.refresh_launchd_plist_if_needed() is True
+    assert "Updated" in capsys.readouterr().out
+
+
+def test_install_repair_warns_instead_of_claiming_success(tmp_path, monkeypatch, capsys):
+    plist_path = tmp_path / "com.hermes.plist"
+    plist_path.write_text("<old/>", encoding="utf-8")
+    monkeypatch.setattr(gw, "get_launchd_plist_path", lambda: plist_path)
+    monkeypatch.setattr(gw, "launchd_plist_is_current", lambda: False)
+    monkeypatch.setattr(gw, "refresh_launchd_plist_if_needed", lambda: False)
+    monkeypatch.setattr("hermes_constants.display_hermes_home", lambda: "~/.hermes-work")
+
+    gw.launchd_install(force=False)
+
+    out = capsys.readouterr().out
+    assert "Service definition updated" not in out
+    assert "could not be reloaded" in out
+    assert "~/.hermes-work/logs/launchd-reload.log" in out


### PR DESCRIPTION
`hermes gateway install` on an outdated unit now tells the truth on macOS and finishes the job on Linux.

Fixes #12866
Fixes #12863

## Changes
- **launchd (#12866):** `refresh_launchd_plist_if_needed()` returns `False` when the bootstrap retry loop exhausts without registering the service; `launchd_install()` prints a warning with the reload log path (profile-aware via `display_hermes_home()`) instead of `✓ Service definition updated`. `launchd_start()` has its own recovery path and is untouched.
- **systemd (#12863):** the stale-unit repair branch now runs the same post-install guarantee as a fresh install: `_ensure_linger_enabled()` for user scope, `_ensure_system_service_linger()` for a `User=` system unit. Previously it `return`ed before either, so a repaired headless gateway died at logout.

## Validation
| Probe (origin/main → this branch) | Before | After |
|---|---|---|
| refresh with `_retry_launchctl_bootstrap_until_registered` → False | returns `True`, prints "Updated" | returns `False`, no success line |
| `launchd_install()` repair with failed refresh | `✓ Service definition updated` | `⚠ Service definition could not be reloaded … launchd-reload.log` |
| `systemd_install(force=False, system=False)` on stale unit | `_ensure_linger_enabled` never called | called once; `system=True` still never calls it |

`scripts/run_tests.sh tests/hermes_cli/test_gateway_linger.py tests/hermes_cli/test_launchd_refresh_reporting.py tests/hermes_cli/test_gateway_service.py` → 131 passed. Both new tests red on base.

## Credit
Cherry-picked from #68493 by @ygd58 (launchd) and #12989 by @season179 (systemd); contributor tests trimmed to one invariant each, conflict resolution onto current `hermes_cli/gateway.py` ours. Earlier attempts: #12882, #63762, #61387.

Root cause: both repair paths were written as "rewrite the file and print", not "rewrite, apply, report".

## Infographic
![gateway-service-repair](https://v3b.fal.media/files/b/0aaa22f9/EAUkk8Vit6OFy6NEfgPbh_gyEyOxWm.png)
