### PR TITLE
fix(config): HERMES_MANAGED=false no longer counts as a managed install (#12864, salvage #12880)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -243,6 +243,9 @@ _NIX_STORE = Path("/nix/store")
 # Homebrew is no longer a supported distribution: these markers fall through to git/unknown
 # detection instead of blocking config writes.
 _IGNORED_MANAGED_VALUES = frozenset({"brew", "homebrew"})
+# Explicit opt-out (``HERMES_MANAGED=false``): without this a bool-shaped value became a package
+# manager literally named "false" and is_managed() blocked `hermes update` (#12864).
+_MANAGED_FALSE_VALUES = frozenset({"false", "0", "no", "off"})
 
 
 def get_managed_system() -> Optional[str]:
@@ -256,7 +259,7 @@ def get_managed_system() -> Optional[str]:
             marker = managed_marker.read_text(encoding="utf-8", errors="replace").strip().lower()
         except OSError:
             marker = ""
-    if marker is None or marker in _IGNORED_MANAGED_VALUES:
+    if marker is None or marker in _IGNORED_MANAGED_VALUES or marker in _MANAGED_FALSE_VALUES:
         return None
     if marker == "" or marker in _MANAGED_TRUE_VALUES:
         return _LEGACY_MANAGED_SYSTEM

--- a/tests/hermes_cli/test_managed_installs.py
+++ b/tests/hermes_cli/test_managed_installs.py
@@ -1,7 +1,9 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from hermes_cli.config import recommended_update_command
+import pytest
+
+from hermes_cli.config import get_managed_system, is_managed, recommended_update_command
 from hermes_cli.main import cmd_update
 from tools.skills_hub_official import OptionalSkillSource
 
@@ -16,6 +18,17 @@ def test_recommended_update_command_defaults_to_hermes_update(monkeypatch):
     # detect_install_method().
     with patch("hermes_cli.config.get_managed_update_command", return_value=None), \
          patch("hermes_cli.config.detect_install_method", return_value="git"):
+        assert recommended_update_command() == "hermes update"
+
+
+@pytest.mark.parametrize("false_value", ["false", "0", "no", "off", "FALSE"])
+def test_get_managed_system_false_values(monkeypatch, false_value):
+    """An explicit opt-out is not a package manager named "false" (#12864)."""
+    monkeypatch.setenv("HERMES_MANAGED", false_value)
+
+    assert get_managed_system() is None
+    assert not is_managed()
+    with patch("hermes_cli.config.detect_install_method", return_value="git"):
         assert recommended_update_command() == "hermes update"
 
 


### PR DESCRIPTION
`HERMES_MANAGED=false` (and `0`, `no`, `off`, any case) now means "not managed" instead of "managed by a package manager named `false`", so `hermes update` runs again after an explicit opt-out.

Fixes #12864

## Changes
- `hermes_cli/config.py::get_managed_system`: a `_MANAGED_FALSE_VALUES` set short-circuits to `None` alongside the existing ignored (`brew`) markers. True values, named managers and the `.managed` marker file behave as before.

## Validation
| `HERMES_MANAGED` | Before | After |
|---|---|---|
| `false` / `0` / `no` / `off` / `FALSE` | `get_managed_system() == "false"`, `is_managed() is True` | `None` / `False` |
| `true` / `nix` | `nixos` / `nix` | unchanged |

`scripts/run_tests.sh tests/hermes_cli/test_managed_installs.py tests/hermes_cli/test_config.py` → 130 passed; the parametrized test is red on base.

## Credit
Cherry-picked from #12880 by @zhouhe-xydt; conflict onto the current `_IGNORED_MANAGED_VALUES` shape ours. #52892 was the same fix rebased and is superseded.

Root cause: the env var was parsed as "any non-empty string is a manager name" with only a truthy allow-list, never a falsy one.

## Infographic
![managed-false-optout](https://v3b.fal.media/files/b/0aaa22e8/YzAdlk-gGWqtW4O4HxVvk_JybAJVVo.png)
