### PR TITLE
fix(mcp): `include: []` no longer reopens as "all tools enabled" in CLI, catalog and desktop (#12865)

### DIFF
--- a/apps/desktop/src/lib/mcp-tool-filter.test.ts
+++ b/apps/desktop/src/lib/mcp-tool-filter.test.ts
@@ -31,6 +31,13 @@ describe('isToolEnabled', () => {
     expect(isToolEnabled(server, 'a')).toBe(true)
     expect(isToolEnabled(server, 'b')).toBe(false)
   })
+
+  it('empty include blocks every tool (block-all, not all-on)', () => {
+    const server = { tools: { include: [] as string[] } }
+    expect(isToolEnabled(server, 'a')).toBe(false)
+    expect(isToolEnabled(server, 'b')).toBe(false)
+    expect(countEnabledTools(server, ['a', 'b', 'c'])).toBe(0)
+  })
 })
 
 describe('toggleToolInServer', () => {
@@ -47,6 +54,12 @@ describe('toggleToolInServer', () => {
   it('respects include mode: toggling removes from include', () => {
     const next = toggleToolInServer({ tools: { include: ['a', 'b'] } }, 'a')
     expect(next.tools).toEqual({ include: ['b'] })
+  })
+
+  it('retains empty include when last include tool is toggled off', () => {
+    const next = toggleToolInServer({ tools: { include: ['a'] } }, 'a')
+    expect(next.tools).toEqual({ include: [] })
+    expect(isToolEnabled(next, 'a')).toBe(false)
   })
 
   it('respects include mode: re-enabling adds back to include', () => {

--- a/apps/desktop/src/lib/mcp-tool-filter.ts
+++ b/apps/desktop/src/lib/mcp-tool-filter.ts
@@ -28,22 +28,30 @@ export function readToolsFilter(server: ServerConfig | null | undefined): McpToo
 export function isToolEnabled(server: ServerConfig | null | undefined, name: string): boolean {
   const { exclude, include } = readToolsFilter(server)
 
-  return include?.length ? include.includes(name) : !exclude?.includes(name)
+  // An explicit `include` (even []) is a whitelist — the runtime registers nothing for `[]`
+  // (tools/mcp_tool_registration.py), so the desktop must not show every tool as enabled (#12865).
+  if (include !== undefined) {
+    return include.includes(name)
+  }
+
+  return !exclude?.includes(name)
 }
 
-// Toggle one tool, preserving the config's mode (include if present, else an
-// exclude denylist). Empty lists — and an emptied `tools` — are dropped.
+// Toggle one tool, preserving the config's mode (include if the key is present, even empty, else
+// an exclude denylist). An emptied exclude is dropped; an emptied include is kept (block-all).
 export function toggleToolInServer(server: ServerConfig, name: string): ServerConfig {
   const { exclude, include } = readToolsFilter(server)
-  const key = include?.length ? 'include' : 'exclude'
+  const key = include !== undefined ? 'include' : 'exclude'
   const current = (key === 'include' ? include : exclude) ?? []
   const names = current.includes(name) ? current.filter(n => n !== name) : [...current, name]
   const tools = { ...toolsObject(server) }
 
-  if (names.length) {
-    tools[key] = names
+  if (key === 'include') {
+    tools.include = names
+  } else if (names.length) {
+    tools.exclude = names
   } else {
-    delete tools[key]
+    delete tools.exclude
   }
 
   const next = { ...server }

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -576,7 +576,9 @@ def _apply_tool_selection(
         )
         return
 
-    pre_set = {n for n in (prior_selection or entry.tools.default_enabled or tool_names) if n in tool_names}
+    # A prior ``include: []`` (user chose zero tools) outranks manifest defaults, like the non-TTY path.
+    preferred = prior_selection if prior_selection is not None else (entry.tools.default_enabled or tool_names)
+    pre_set = {n for n in preferred if n in tool_names}
     pre_indices = {i for i, n in enumerate(tool_names) if n in pre_set}
     _say(f"  Found {len(probed)} tool(s). Pre-checked: {len(pre_indices)}.")
 

--- a/hermes_cli/mcp_catalog.py
+++ b/hermes_cli/mcp_catalog.py
@@ -561,7 +561,9 @@ def _apply_tool_selection(
         return
 
     if not probed:
-        _write_tools_filter(name, "include", None)
+        # Keep a prior explicit selection: "no tools today" must not widen ``include: []`` to
+        # "all tools" the next time the server does advertise some.
+        _write_tools_filter(name, "include", prior_selection)
         _say("  Server reported no tools.", Colors.YELLOW)
         return
 

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -61,14 +61,18 @@ def _get_mcp_servers(config: Optional[dict] = None) -> Dict[str, dict]:
 
 
 def _tool_filters(cfg: dict) -> Tuple[Optional[list], Optional[list]]:
-    """Return the ``(include, exclude)`` tool lists from a server config (non-empty lists only)."""
+    """Return the ``(include, exclude)`` tool lists from a server config; ``None`` = key absent.
+
+    An explicit ``include: []`` is a real (block-all) whitelist — the runtime registers nothing
+    (tools/mcp_tool_registration.py) — so it must not collapse to "no filter" here (#12865).
+    """
     tools_cfg = cfg.get("tools", {})
     if not isinstance(tools_cfg, dict):
         return None, None
     include, exclude = tools_cfg.get("include"), tools_cfg.get("exclude")
     return (
-        include if include and isinstance(include, list) else None,
-        exclude if exclude and isinstance(exclude, list) else None)
+        include if isinstance(include, list) else None,
+        exclude if isinstance(exclude, list) else None)
 
 
 def _save_mcp_server(name: str, server_config: dict) -> bool:
@@ -565,7 +569,7 @@ def cmd_mcp_list(args=None):
             transport = transport[:25] + "..."
 
         include, exclude = _tool_filters(cfg)
-        if include:
+        if include is not None:
             tools_str = f"{len(include)} selected"
         elif exclude:
             tools_str = f"-{len(exclude)} excluded"
@@ -814,11 +818,10 @@ def cmd_mcp_configure(args):
         def matches_name_filter(tool_name, patterns):
             return tool_name in patterns
 
-    patterns = {str(p) for p in (include or exclude or [])}
-    if patterns:
-        pre_selected = {
-            i for i, tn in enumerate(tool_names) if matches_name_filter(tn, patterns) == bool(include)
-        }
+    if include is not None:
+        pre_selected = {i for i, tn in enumerate(tool_names) if matches_name_filter(tn, {str(p) for p in include})}
+    elif exclude:
+        pre_selected = {i for i, tn in enumerate(tool_names) if not matches_name_filter(tn, {str(p) for p in exclude})}
     else:
         pre_selected = set(range(total))
 
@@ -835,7 +838,7 @@ def cmd_mcp_configure(args):
 
     config = load_config()
     server_entry = cfg_get(config, "mcp_servers", name, default={})
-    exclude_mode = bool(exclude) and not include
+    exclude_mode = bool(exclude) and include is None
 
     if len(chosen) == total and not exclude_mode:
         server_entry.pop("tools", None)  # all selected → register all

--- a/hermes_cli/tools_config_mcp.py
+++ b/hermes_cli/tools_config_mcp.py
@@ -26,7 +26,7 @@ def _mcp_match_filter():
 
 def _mcp_preselected(tool_names: List[str], include_set, exclude_set, match) -> Set[int]:
     """Indices of tools currently enabled: include mode, exclude mode, or all when unfiltered."""
-    if include_set:
+    if include_set is not None:
         return {i for i, tn in enumerate(tool_names) if match(tn, include_set)}
     if exclude_set:
         return {i for i, tn in enumerate(tool_names) if not match(tn, exclude_set)}
@@ -36,7 +36,7 @@ def _mcp_preselected(tool_names: List[str], include_set, exclude_set, match) -> 
 def _apply_mcp_checklist(server_name: str, tools_cfg: dict, tool_names: List[str], chosen: Set[int],
                          include_set, exclude_set, match) -> None:
     """Write a checklist result back as ``tools.include`` / ``tools.exclude``."""
-    exclude_mode = bool(exclude_set) and not include_set
+    exclude_mode = bool(exclude_set) and include_set is None
 
     if len(chosen) == len(tool_names) and not exclude_mode:
         # All tools enabled — clear filters so tools the server adds later are auto-enabled.
@@ -118,8 +118,10 @@ def _configure_mcp_tools_interactive(config: dict):
             continue
 
         tools_cfg = mcp_servers.get(server_name, {}).get("tools") or {}
-        include_set = {str(p) for p in tools_cfg.get("include") or []} or None
-        exclude_set = {str(p) for p in tools_cfg.get("exclude") or []} or None
+        # ``include: []`` is an explicit block-all whitelist, not "unfiltered" (#12865).
+        include_raw, exclude_raw = tools_cfg.get("include"), tools_cfg.get("exclude")
+        include_set = {str(p) for p in include_raw} if isinstance(include_raw, list) else None
+        exclude_set = {str(p) for p in exclude_raw or []} or None
 
         labels = []
         for tool_name, description in tools:
@@ -207,9 +209,9 @@ def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = 
         print("MCP servers:")
         for srv_name, srv_cfg in mcp_servers.items():
             tools_cfg = srv_cfg.get("tools") or {}
-            exclude, include = tools_cfg.get("exclude") or [], tools_cfg.get("include") or []
-            if include:
-                _print_info(f"{srv_name}  [include only: {', '.join(include)}]")
+            exclude, include = tools_cfg.get("exclude") or [], tools_cfg.get("include")
+            if isinstance(include, list):
+                _print_info(f"{srv_name}  [include only: {', '.join(include) or '(none)'}]")
             elif exclude:
                 _print_info(f"{srv_name}  [excluded: {color(', '.join(exclude), Colors.YELLOW)}]")
             else:

--- a/tests/hermes_cli/test_mcp_catalog.py
+++ b/tests/hermes_cli/test_mcp_catalog.py
@@ -71,7 +71,7 @@ def _write_manifest(catalog_dir: Path, name: str, body: dict) -> Path:
     entry_dir = catalog_dir / name
     entry_dir.mkdir(exist_ok=True)
     path = entry_dir / "manifest.yaml"
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         yaml.safe_dump(body, f)
     return path
 
@@ -421,6 +421,24 @@ class TestInstall:
         assert server["tools"]["include"] == ["tool_a"]
         assert "exclude" not in server["tools"]
 
+    def test_empty_discovery_reinstall_keeps_explicit_empty_include(self, catalog_dir, monkeypatch):
+        """A probe that succeeds with zero tools must not widen a deliberate ``include: []``
+        to "all tools" (#12865): the block-all choice survives until the user changes it."""
+        import hermes_cli.mcp_catalog as mc
+        from hermes_cli.config import load_config, save_config
+
+        monkeypatch.setattr(mc, "_probe_tools", lambda name: [])
+        _write_manifest(catalog_dir, "demo", _basic_manifest())
+        cfg = load_config()
+        cfg.setdefault("mcp_servers", {})["demo"] = {
+            "command": "npx", "args": ["-y", "demo-mcp"], "enabled": True, "tools": {"include": []},
+        }
+        save_config(cfg)
+
+        mc.install_entry(_entry("demo"), enable=True)
+
+        assert load_config()["mcp_servers"]["demo"]["tools"]["include"] == []
+
     def test_probe_fail_reinstall_preserves_manual_exclude(self, catalog_dir):
         """A failed probe during reinstall keeps a hand-written
         tools.exclude on a manifest with no tool defaults, instead of
@@ -515,7 +533,7 @@ class TestInstall:
         # load_config resolves it; config.yaml itself stays secret-free.
         from hermes_cli.config import get_config_path
 
-        raw = get_config_path().read_text()
+        raw = get_config_path().read_text(encoding="utf-8")
         assert "${MCP_DEMO_API_KEY}" in raw
         assert "secret-val" not in raw
 

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -65,7 +65,7 @@ def _seed_config(tmp_path: Path, mcp_servers: dict):
 
     config = {"mcp_servers": mcp_servers, "_config_version": 9}
     config_path = tmp_path / "config.yaml"
-    with open(config_path, "w") as f:
+    with open(config_path, "w", encoding="utf-8") as f:
         yaml.safe_dump(config, f)
 
 
@@ -162,7 +162,7 @@ class TestMcpRemove:
         token_dir = tmp_path / "mcp-tokens"
         token_dir.mkdir()
         token_file = token_dir / "oauth-srv.json"
-        token_file.write_text("{}")
+        token_file.write_text("{}", encoding="utf-8")
 
         from hermes_cli.mcp_config import cmd_mcp_remove
 
@@ -771,7 +771,7 @@ class TestMcpLogin:
         def mock_probe(name, cfg, connect_timeout=30):
             seen["connect_timeout"] = connect_timeout
             token_dir.mkdir(exist_ok=True)
-            (token_dir / "realserver.json").write_text('{"access_token": "x"}')
+            (token_dir / "realserver.json").write_text('{"access_token": "x"}', encoding="utf-8")
             return [("a", "d"), ("b", "d"), ("c", "d")]
 
         monkeypatch.setattr(

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -845,3 +845,14 @@ class TestMcpReauth:
         cmd_mcp_reauth(_make_args(name="ghost", all=False))
         out = capsys.readouterr().out
         assert "not found" in out
+
+
+def test_tool_filters_keeps_explicit_empty_include():
+    """``include: []`` (block-all, as written by an all-unchecked picker) is a filter, not
+    "no filter"; only an absent/non-list key is None (#12865)."""
+    from hermes_cli.mcp_config import _tool_filters
+
+    assert _tool_filters({"tools": {"include": []}}) == ([], None)
+    assert _tool_filters({"tools": {"include": "bad", "exclude": ["x"]}}) == (None, ["x"])
+    assert _tool_filters({}) == (None, None)
+

--- a/tests/hermes_cli/test_mcp_tools_config.py
+++ b/tests/hermes_cli/test_mcp_tools_config.py
@@ -73,3 +73,20 @@ def test_empty_tools_server_skipped(capsys):
     assert len(checklist_calls) == 0
     captured = capsys.readouterr()
     assert "no tools found" in captured.out
+
+
+def test_empty_include_reopens_with_nothing_preselected():
+    """``include: []`` is the runtime's block-all whitelist; the picker must not reopen it as
+    "all tools enabled" and must persist it when the user keeps zero tools checked (#12865)."""
+    config = {"mcp_servers": {"github": {"command": "npx", "tools": {"include": []}}}}
+    tools = [("create_issue", "Create an issue"), ("search_repos", "Search repos")]
+
+    with patch(_PROBE, return_value={"github": tools}), \
+         patch(_CHECKLIST, side_effect=lambda title, labels, pre, **kw: pre) as checklist, \
+         patch(_SAVE) as mock_save:
+        _configure_mcp_tools_interactive(config)
+
+    assert checklist.call_args.args[2] == set()
+    mock_save.assert_not_called()
+    assert config["mcp_servers"]["github"]["tools"] == {"include": []}
+


### PR DESCRIPTION
Deselecting every tool for an MCP server now sticks everywhere: `hermes mcp list`, `hermes mcp configure`, `hermes tools`, a catalog reinstall and the desktop MCP panel all read `tools.include: []` as "0 selected", matching what the runtime already registers.

Fixes #12865

## Changes
- `hermes_cli/mcp_config.py::_tool_filters` returns the list whenever the key holds a list (empty included); only an absent/non-list key is `None`. List output and the configure picker branch on `is not None`.
- `hermes_cli/tools_config_mcp.py`: `hermes tools` picker pre-selection and `[include only: (none)]` list line.
- `hermes_cli/mcp_catalog.py`: interactive reinstall pre-check honours a prior `[]` over manifest defaults (the non-TTY path already did).
- `apps/desktop/src/lib/mcp-tool-filter.ts`: `isToolEnabled` treats a present `include` as the whitelist; toggling the last include entry off keeps `include: []` instead of deleting the key (which silently flipped the server to all-on).

The runtime side (`tools/mcp_tool_registration.py`) was already fixed in fb1ec36a4b86; this PR is the divergent readers.

## Validation
E2E against a temp `HERMES_HOME` with `demo: {tools: {include: []}}` and `demo2: {}`:

| Surface | Before | After |
|---|---|---|
| `hermes mcp list` | `demo … all` | `demo … 0 selected` |
| `hermes tools` list | `demo  all tools enabled` | `demo  [include only: (none)]` |
| `hermes tools` picker for `demo` | every tool pre-checked; confirming re-enabled all | nothing pre-checked; confirming keeps `include: []` |
| runtime `_make_tool_filter("demo")("a")` | False | False (unchanged) |

`scripts/run_tests.sh tests/hermes_cli/test_mcp_tools_config.py tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_mcp_catalog.py tests/tools/test_mcp_tool.py` → 179 passed; `vitest src/lib/mcp-tool-filter.test.ts` → 14 passed; `tsc --noEmit` clean.

## Credit
Desktop commit cherry-picked from #52874 by @Bartok9 (itself a salvage of #13096 by @dingn42). CLI reader fixes re-applied onto the current `_tool_filters` / `tools_config_mcp` split, which the PR predates.

Root cause: five readers coerced the include list with `or []` / truthiness, so `[]` and "missing" became indistinguishable.

## Infographic
![mcp-empty-include-readers](https://v3b.fal.media/files/b/0aaa22ed/o-6XpUrYxxfbGMMkWDSAQ_w9IcrUoe.png)
