### PR TITLE
fix(auxiliary): never cache an availability-probe stub from _get_cached_client

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5560,6 +5560,11 @@ def _get_cached_client(
         api_mode=api_mode, main_runtime=runtime, is_vision=is_vision, task=task,
     )
     if client is not None:
+        if isinstance(client, _AuxProbeClientStub):
+            # An availability probe must never leave its stub in the cache:
+            # the next runtime caller for the same tuple would receive it
+            # (same invariant _store_cached_client enforces).
+            return client, default_model
         with _client_cache_lock:
             if cache_key not in _client_cache:
                 # FIFO safety-belt eviction. Do NOT close evicted clients: another caller may be


### PR DESCRIPTION
_store_cached_client refuses _AuxProbeClientStub, but _get_cached_client
writes its freshly built client into _client_cache directly. A caller that
resolves a client inside aux_probe_mode() leaves the stub under the
(provider, base_url, api_key, model) tuple, and the next runtime caller for
the same tuple gets 'RuntimeError: _AuxProbeClientStub used as a real
client'. Observed on a local vLLM deployment: the kanban auto-decomposer
failed silently on every dispatcher tick for four days. Return the stub
without caching it, matching the documented invariant.
