### PR TITLE
fix(skills): non-ASCII skill names register as slash commands (#12351, salvage #12522)

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -20,7 +20,10 @@ _skill_commands_home: Optional[str] = None
 # Guards the (map, platform-tag, home-tag) triple so publication and the
 # freshness lookup always see a consistent snapshot. Scanning stays outside.
 _publish_lock = threading.Lock()
-_SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
+# ``\w`` keeps Unicode letters (CJK, Cyrillic) so a ``name: 小说拆条`` skill registers ``/小说拆条``
+# instead of slugging to "" and being dropped (#12351); Telegram's ``[a-z0-9_]`` menu limit is
+# applied by hermes_cli/commands_platforms.py, not here.
+_SKILL_INVALID_CHARS = re.compile(r"[^\w-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
 
 # Skill-scaffolding markers. A /skill (or /bundle) turn is expanded into a

--- a/contributors/emails/jiancheng@gmail.com
+++ b/contributors/emails/jiancheng@gmail.com
@@ -1,0 +1,2 @@
+zjc-enigma
+# PR #12522 salvage

--- a/hermes_cli/commands_platforms.py
+++ b/hermes_cli/commands_platforms.py
@@ -32,9 +32,14 @@ def _requires_argument(args_hint: str) -> bool:
 
 
 def _sanitize_telegram_name(raw: str) -> str:
-    """Telegram allows only ``[a-z0-9_]``: lowercase, hyphens -> ``_``, strip the rest,
-    collapse/strip ``_``."""
-    name = _TG_INVALID_CHARS.sub("", raw.lower().replace("-", "_"))
+    """Telegram allows only ``[a-z0-9_]``: lowercase, hyphens -> ``_``, collapse/strip ``_``.
+    A name that would lose letters (``中文helper`` -> ``helper``) is omitted (``""``): the menu
+    entry could not resolve back to the registered ``/中文helper`` and would answer
+    "Unknown command"."""
+    lowered = raw.lower().replace("-", "_")
+    name = _TG_INVALID_CHARS.sub("", lowered)
+    if any(ch.isalnum() for ch in _TG_INVALID_CHARS.findall(lowered)):
+        return ""
     return _TG_MULTI_UNDERSCORE.sub("_", name).strip("_")
 
 

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -517,6 +517,20 @@ class TestScanSkillCommands:
         # partial one growing from 0.
         assert observed_sizes == [skill_count] * skill_count
 
+    def test_non_ascii_name_registers_command(self, tmp_path):
+        """A CJK skill name slugs to itself (punctuation still stripped) instead of "" and being
+        silently dropped (#12351); ``resolve_skill_command_key`` round-trips it."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = tmp_path / "novel-clipper"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: 小说+拆条\ndescription: Split novels into clips.\n---\n\nBody.\n", encoding="utf-8"
+            )
+            result = scan_skill_commands()
+            assert "/小说拆条" in result
+            assert result["/小说拆条"]["name"] == "小说+拆条"
+            assert resolve_skill_command_key("小说拆条") == "/小说拆条"
+
 
 class TestResolveSkillCommandKey:
     """Telegram bot-command names disallow hyphens, so the menu registers

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -34,7 +34,7 @@ description: Description for {name}.
 
 {body}
 """
-    (skill_dir / "SKILL.md").write_text(content)
+    (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
     return skill_dir
 
 
@@ -267,7 +267,7 @@ class TestScanSkillCommands:
 
         profile_b = tmp_path / "profiles" / "b"
         _make_skill(profile_b / "skills", "b-only", body="Body of b-only.")
-        (profile_b / "config.yaml").write_text("{}\n")
+        (profile_b / "config.yaml").write_text("{}\n", encoding="utf-8")
 
         with (
             patch.object(sc_mod, "_skill_commands", {}),
@@ -717,7 +717,7 @@ class TestBuildSkillInvocationMessage:
             skill_dir = _make_skill(tmp_path, "test-skill")
             references = skill_dir / "references"
             references.mkdir()
-            (references / "api.md").write_text("reference")
+            (references / "api.md").write_text("reference", encoding="utf-8")
             scan_skill_commands()
             msg = build_skill_invocation_message("/test-skill", "do stuff")
 
@@ -744,7 +744,7 @@ class TestSkillDirectoryHeader:
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             skill_dir = _make_skill(tmp_path, "scripted-skill")
             (skill_dir / "scripts").mkdir()
-            (skill_dir / "scripts" / "run.js").write_text("console.log('hi')")
+            (skill_dir / "scripts" / "run.js").write_text("console.log('hi')", encoding="utf-8")
             scan_skill_commands()
             msg = build_skill_invocation_message("/scripted-skill")
 

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -303,7 +303,7 @@ class TestGatewayConfigGate:
         """When the config gate is falsy, the command should not appear in help."""
         # Write a config with the gate off (default)
         config_file = tmp_path / "config.yaml"
-        config_file.write_text("display:\n  tool_progress_command: false\n")
+        config_file.write_text("display:\n  tool_progress_command: false\n", encoding="utf-8")
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
         lines = gateway_help_lines()
@@ -313,7 +313,7 @@ class TestGatewayConfigGate:
 
     def test_config_gate_included_in_slack_when_on(self, tmp_path, monkeypatch):
         config_file = tmp_path / "config.yaml"
-        config_file.write_text("display:\n  tool_progress_command: true\n")
+        config_file.write_text("display:\n  tool_progress_command: true\n", encoding="utf-8")
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
         mapping = slack_subcommand_map()
@@ -518,6 +518,13 @@ class TestSanitizeTelegramName:
         assert _sanitize_telegram_name("-leading") == "leading"
         assert _sanitize_telegram_name("trailing-") == "trailing"
         assert _sanitize_telegram_name("-both-") == "both"
+
+    def test_names_that_would_lose_letters_are_omitted(self):
+        """``/中文helper`` is registered under its Unicode slug; advertising ``/helper`` would
+        answer "Unknown command", so mixed-script names are left out of the menu (#12351)."""
+        assert _sanitize_telegram_name("中文helper") == ""
+        assert _sanitize_telegram_name("小说拆条") == ""
+        assert _sanitize_telegram_name("plan+review") == "planreview"  # punctuation-only loss keeps the entry
 
 
 # ---------------------------------------------------------------------------
@@ -1007,7 +1014,7 @@ class TestDiscordSkillCommandsByCategory:
                 name = f"skill-{c:02d}-{s:02d}"
                 skill_subdir = tmp_path / "skills" / cat / name
                 skill_subdir.mkdir(parents=True, exist_ok=True)
-                (skill_subdir / "SKILL.md").write_text("---\nname: x\n---\n")
+                (skill_subdir / "SKILL.md").write_text("---\nname: x\n---\n", encoding="utf-8")
                 fake_cmds[f"/{name}"] = {
                     "name": name,
                     "description": f"Category {cat} skill {s}",
@@ -1054,10 +1061,10 @@ class TestDiscordSkillCommandsByCategory:
         external_dir = tmp_path / "external-skills"
 
         (local_skills_dir / "creative" / "local-skill").mkdir(parents=True)
-        (local_skills_dir / "creative" / "local-skill" / "SKILL.md").write_text("")
+        (local_skills_dir / "creative" / "local-skill" / "SKILL.md").write_text("", encoding="utf-8")
 
         (external_dir / "mlops" / "external-skill").mkdir(parents=True)
-        (external_dir / "mlops" / "external-skill" / "SKILL.md").write_text("")
+        (external_dir / "mlops" / "external-skill" / "SKILL.md").write_text("", encoding="utf-8")
 
         fake_cmds = {
             "/local-skill": {


### PR DESCRIPTION
A skill with `name: 小说拆条` now registers `/小说拆条` (and resolves back through `resolve_skill_command_key`) instead of slugging to an empty string and being silently dropped.

Fixes #12351

## Changes
- `agent/skill_commands.py`: `_SKILL_INVALID_CHARS` becomes `[^\w-]`, keeping Unicode letters while still stripping `+`, `/` and other punctuation. Telegram's `[a-z0-9_]` menu restriction is enforced downstream in `hermes_cli/commands_platforms.py::_sanitize_telegram_name` (a CJK-only name is omitted from the Telegram menu but the command still works when typed); Discord's `/skill` autocomplete lists it.

## Validation
E2E with a temp skills dir (one CJK skill, one ASCII skill):

| | Before | After |
|---|---|---|
| `scan_skill_commands()` keys | `['/plain-skill']` | `['/plain-skill', '/小说拆条']` |
| `resolve_skill_command_key("小说拆条")` | `None` | `/小说拆条` |
| Telegram menu | unaffected | ASCII skill listed, CJK skill omitted (BotFather rule), no error |
| Discord `/skill` categories | ASCII only | both |

`scripts/run_tests.sh tests/agent/test_skill_commands.py tests/hermes_cli/test_commands.py tests/hermes_cli/test_discord_skill_clamp_warning.py` → 93 passed.

## Credit
Cherry-picked from #12522 by @zjc-enigma; five contributor tests collapsed into one, conflict onto the extracted `slugify_skill_name` ours. #12366 (dir-name fallback) and #12739 (warn only) were partials.

Root cause: the slug regex was ASCII-only, written for Telegram's constraint at the wrong layer.

## Infographic
![skill-slug-unicode](https://v3b.fal.media/files/b/0aaa2315/8ude9CqSdak2eYL5FlHNi_vHQncv1T.png)
