### PR TITLE
fix(gateway): failure exit still stops cron, housekeeping and MCP (#12175, salvage #55031)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2140,7 +2140,7 @@ from gateway.run_voice import GatewayVoiceMixin
 from gateway.run_adapters import GatewayAdapterLifecycleMixin
 from gateway.run_topics import GatewayTopicThreadsMixin
 from gateway.run_turn import GatewayTurnMixin, is_context_overflow_failure_result
-from gateway.run_shutdown import GatewayShutdownMixin, _exit_with_failure_verdict, _resolve_gateway_exit_verdict
+from gateway.run_shutdown import GatewayShutdownMixin, _resolve_gateway_exit_verdict
 from gateway.run_busy import GatewayBusySessionMixin
 from gateway.run_config_loaders import GatewayConfigLoadersMixin
 from gateway.run_startup import GatewayStartupMixin
@@ -5214,8 +5214,6 @@ async def _start_gateway_shutdown_tail(
         stop_nous_auth_keepalive()
 
     _best_effort(_stop_keepalive)
-    if _exit_with_failure_verdict(runner):
-        return False
 
     # Never join(): an in-flight cron delivery is a coroutine on THIS loop; a sync join would drop it.
     # Stop cron scheduler + housekeeping cleanly. These MUST be awaited cooperatively, not join()ed. A cron
@@ -5238,6 +5236,8 @@ async def _start_gateway_shutdown_tail(
     with suppress(Exception):
         await _shutdown_mcp_servers_nonblocking()
 
+    # The failure verdict comes AFTER the cooperative teardown: returning early here leaked the
+    # cron ticker + housekeeping threads (and open MCP connections) for embedded callers (#12175).
     return _resolve_gateway_exit_verdict(runner, _signal_initiated_shutdown[0])
 
 

--- a/tests/gateway/test_startup_restart_race.py
+++ b/tests/gateway/test_startup_restart_race.py
@@ -322,3 +322,38 @@ async def test_start_gateway_classifies_startup_signal_exit(
 
     assert result is expected_success
     assert cron_started is False
+
+
+@pytest.mark.asyncio
+async def test_failure_exit_still_stops_cron_housekeeping_and_mcp(monkeypatch):
+    """``should_exit_with_failure`` used to return before the cooperative teardown, leaking the
+    cron ticker / housekeeping threads and open MCP connections for embedded callers (#12175)."""
+    import threading
+
+    stopped = []
+    cron_stop = threading.Event()
+    threads = [threading.Thread(target=cron_stop.wait, name=n, daemon=True) for n in ("cron", "housekeeping")]
+    for thread in threads:
+        thread.start()
+    watcher_stop = threading.Event()
+    watcher = threading.Thread(target=watcher_stop.wait, daemon=True)
+    watcher.start()
+
+    async def fake_mcp_shutdown():
+        stopped.append("mcp")
+
+    monkeypatch.setattr(gateway_run, "_shutdown_mcp_servers_nonblocking", fake_mcp_shutdown)
+    monkeypatch.setattr(gateway_run, "_stop_cron_provider", lambda provider: stopped.append("provider"))
+    monkeypatch.setattr("hermes_cli.nous_auth_keepalive.stop_nous_auth_keepalive", lambda: None)
+    runner = MagicMock(should_exit_with_failure=True, exit_reason="boom", exit_code=None)
+
+    result = await gateway_run._start_gateway_shutdown_tail(
+        runner, None, cron_stop, object(), threads[0], threads[1], watcher_stop, watcher, [False])
+
+    assert result is False
+    assert cron_stop.is_set() and watcher_stop.is_set()
+    assert stopped == ["provider", "mcp"]
+    for thread in threads + [watcher]:
+        thread.join(timeout=2)
+        assert not thread.is_alive()
+


### PR DESCRIPTION
When the gateway exits with `should_exit_with_failure`, the cron ticker, housekeeping thread, planned-stop watcher and MCP servers are now torn down before the verdict is returned; embedded/library callers no longer inherit leaked daemon threads.

Fixes #12175

## Changes
- `gateway/run.py::_start_gateway_shutdown_tail`: the early `return False` on the failure verdict is removed; `_resolve_gateway_exit_verdict()` (which already logs the failure reason and returns False) runs after the cooperative teardown. The startup-abort path already shut MCP down first and is unchanged. Dropped the now-unused `_exit_with_failure_verdict` import.

## Validation
| Runner state | Before | After |
|---|---|---|
| `should_exit_with_failure=True` after `wait_for_shutdown` | returns False; `cron_stop` never set, threads alive, MCP shutdown skipped | returns False; `cron_stop` + watcher stop set, `_stop_cron_provider` and MCP shutdown called, threads joined |

`scripts/run_tests.sh tests/gateway/test_startup_restart_race.py` → 6 passed; new test red on base.

## Credit
Cherry-picked from #55031 by @DavidMetcalfe (committed under their authorship), re-applied onto the extracted shutdown tail. #12184 bundled this with unrelated fixes that have since landed separately.

Root cause: the failure check sat above the cleanup block instead of below it.

## Infographic
![gateway-failure-exit-cleanup](https://v3b.fal.media/files/b/0aaa2330/blTtPObh35KKzYzzmNfpG_HBOZ6vIZ.png)
