### PR TITLE
fix(desktop): disable AsyncDns to prevent SIGTRAP crashes

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -504,6 +504,13 @@ let f12Blocked = false
 // Dev (`npm run dev`) and prod both load the esbuild output from dist/.
 const PRELOAD_PATH = path.join(APP_ROOT, 'dist', 'electron-preload.js')
 
+// Chromium's built-in async DNS resolver (c-ares) has a fatal parsing bug in
+// Electron 40.10.2 causing a SIGTRAP (ares_dns_rr_get_ttl on macOS,
+// string_view::substr out-of-range on Linux Wayland) during periods of heavy
+// event loop blocking / timeout retries. Fall back to the OS getaddrinfo
+// resolver to avoid the crash. Fixes #100573, #69247.
+app.commandLine.appendSwitch('disable-features', 'AsyncDns')
+
 // Remote displays (SSH X11 forwarding, VNC, RDP) make Chromium's GPU
 // compositor flicker — accelerated layers can't be presented cleanly over the
 // wire, so the window flashes during scroll/streaming/animation. Local


### PR DESCRIPTION
Fixes #100573
Fixes #69247

### Root Cause
Chromium's built-in async DNS resolver (`c-ares`) has a known parsing bug in Electron 40 (Chromium 128) that triggers a fatal `SIGTRAP` crash during periods of heavy event loop blocking (e.g. GIL contention) and DNS timeout retries.
- On macOS (#69247), this surfaces explicitly as `ares_dns_rr_get_ttl`.
- On Linux Wayland (#100573), it surfaces as an out-of-range `string_view::substr` during the same subsystem failure.

### Fix
Appended `app.commandLine.appendSwitch('disable-features', 'AsyncDns')` in the Electron main process before `app.ready`. This forces Chromium to bypass `c-ares` and fall back to the host OS's synchronous `getaddrinfo` resolver, which avoids the crash without degrading end-user DNS performance.
