### PR TITLE
fix(desktop): render skill detail markdown body with clickable links

### DIFF
--- a/apps/desktop/src/app/skills/index.tsx
+++ b/apps/desktop/src/app/skills/index.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router'
 
 import { ArchiveSkillConfirmDialog } from '@/app/learning/archive-skill-confirm-dialog'
 import { CodeEditor } from '@/components/chat/code-editor'
+import { MarkdownTextContent } from '@/components/assistant-ui/markdown-text'
 import { PageLoader } from '@/components/page-loader'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -1250,12 +1251,11 @@ function SkillDetail({
       {contentQuery.isLoading ? (
         <CountSkeleton />
       ) : parsed ? (
-        <pre
-          className="overflow-auto whitespace-pre-wrap wrap-break-word rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary) p-3 font-mono text-[0.68rem] leading-relaxed"
-          data-selectable-text="true"
-        >
-          {parsed.body.trim() || t.skills.noDescription}
-        </pre>
+        <MarkdownTextContent
+          isRunning={false}
+          containerClassName="rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary) p-3"
+          text={parsed.body.trim() || t.skills.noDescription}
+        />
       ) : null}
     </>
   )
@@ -1320,12 +1320,11 @@ function OfficialSkillDetail({
       {previewQuery.isLoading ? (
         <CountSkeleton />
       ) : parsed ? (
-        <pre
-          className="overflow-auto whitespace-pre-wrap wrap-break-word rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary) p-3 font-mono text-[0.68rem] leading-relaxed"
-          data-selectable-text="true"
-        >
-          {parsed.body.trim() || t.skills.noDescription}
-        </pre>
+        <MarkdownTextContent
+          isRunning={false}
+          containerClassName="rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary) p-3"
+          text={parsed.body.trim() || t.skills.noDescription}
+        />
       ) : null}
     </>
   )

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -29,7 +29,8 @@ import {
   Pencil,
   Plus,
 } from "lucide-react";
-import { api } from "@/lib/api";
+import { api } from "@/lib/api"
+import { Markdown } from "@/components/Markdown"
 import type {
   SkillInfo,
   ToolsetInfo,
@@ -1497,9 +1498,9 @@ function SkillDetailDialog({
                     <span className="font-mono">{preview.files.join("  ")}</span>
                   </div>
                 )}
-                <pre className="whitespace-pre-wrap break-words bg-background/50 border border-border p-3 text-xs font-mono text-text-secondary leading-relaxed">
-                  {(preview.skill_md || "").trim() || "(SKILL.md is empty)"}
-                </pre>
+                <div className="whitespace-pre-wrap break-words bg-background/50 border border-border p-3 text-xs leading-relaxed">
+                  <Markdown content={(preview.skill_md || "").trim() || "(SKILL.md is empty)"} />
+                </div>
               </div>
             ) : (
               <p className="text-sm text-muted-foreground text-center py-10">


### PR DESCRIPTION
## Summary

The skill detail pane (desktop Capabilities tab + dashboard preview dialog) was rendering the SKILL.md body inside a `<pre>` tag, making all links plain text and unclickable.

Route the body through the same `MarkdownTextContent` (desktop) and `Markdown` (dashboard) components that chat messages use, so links go through `openExternalLink` → `shell.openExternal` → system browser.

## Problem

Clicking links inside a skill detail pane did nothing — the body was rendered in a plain `<pre>` block with no anchor elements, so external URLs (e.g. Google Cloud Console setup links in the google-workspace skill) were dead text.

Chat messages already rendered links correctly via `MarkdownTextContent` / `Markdown` components, but the skill detail views did not use them.

## Changes

- `apps/desktop/src/app/skills/index.tsx`: replaced `<pre>` with `<MarkdownTextContent>` in both `SkillDetail` and `OfficialSkillDetail` components
- `web/src/pages/SkillsPage.tsx`: replaced `<pre>` with `<Markdown>` in the `SkillDetailDialog` preview

## Verification

- TypeScript compiles clean (`npx tsc --noEmit`)
- Both desktop and dashboard now render `[label](url)` markdown links as clickable anchors
- External https links open in the system browser via existing IPC channel

Fixes: SKILL.md links in the detail pane did nothing on click.