### PR TITLE
fix(agent): remove tool_choice on iteration-limit summary to avoid xAI 400

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2075,6 +2075,8 @@ def _codex_summary_attempt(agent, api_messages: list, api_request_id: str):
     def _attempt(retry_count: int) -> str:
         codex_kwargs = agent._build_api_kwargs(api_messages)
         codex_kwargs.pop("tools", None)
+        codex_kwargs.pop("tool_choice", None)
+        codex_kwargs.pop("parallel_tool_calls", None)
         return _summary_text(agent, agent._run_codex_stream(codex_kwargs))
     return _attempt
 
@@ -2146,7 +2148,7 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
 
     except Exception as e:
         logger.warning("Failed to get summary response: %s", e)
-        final_response = f"I reached the maximum iterations ({agent.max_iterations}) but couldn't summarize. Error: {str(e)}"
+        raise RuntimeError(f"Max iterations reached and failed to summarize: {str(e)}") from e
     finally:
         from agent import relay_llm
         relay_llm.complete_logical_call(summary_api_request_id, outcome=summary_call_outcome)


### PR DESCRIPTION
Fixes #94139

### Root Cause
When the agent reaches the maximum iteration limit, it makes a final API request to get a summary of the session. The `_build_api_kwargs` helper includes the tools list, `tool_choice: "auto"`, and `parallel_tool_calls` based on the agent's state.

In `_codex_summary_attempt`, `codex_kwargs.pop("tools", None)` successfully removed the tools array to prevent the model from generating further tool calls. However, it left `tool_choice: "auto"` and `parallel_tool_calls` in the payload. Strict providers like xAI reject requests that contain a `tool_choice` directive but no `tools` array with a 400 Bad Request (`'A tool_choice was set on the request but no tools were specified.'`), causing the summary to fail. 

Furthermore, when the summary failed, the agent silently swallowed the error, logged a warning, and appended a synthetic failure string while exiting cleanly with status code `0`, causing downstream tools to treat the truncation as a success.

### Fix
- Modified `_codex_summary_attempt` to explicitly `pop("tool_choice", None)` and `pop("parallel_tool_calls", None)` alongside `tools`.
- Modified the `except Exception` block in `handle_max_iterations` to raise a `RuntimeError` rather than silently swallowing the failure. This ensures the agent exits with a non-zero exit code when summary generation fails, accurately reflecting the failed state to callers.
