### PR TITLE
feat(telegram): create a topic and start its first turn

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6556,6 +6556,8 @@ def register(ctx) -> None:
         install_hint="Run `hermes setup` to install Telegram support.", setup_fn=interactive_setup, apply_yaml_config_fn=_apply_yaml_config,
         allowed_users_env="TELEGRAM_ALLOWED_USERS", allow_all_env="TELEGRAM_ALLOW_ALL_USERS", cron_deliver_env_var="TELEGRAM_HOME_CHANNEL",
         standalone_sender_fn=_standalone_send, max_message_length=4096, emoji="✈️", allow_update_command=True)
+    from .topic_tool import register_topic_tool
+    register_topic_tool(ctx)
 
 
 # ---- BEGIN PLUGIN-COMPAT (revert-scheduled; see COMPAT_MANIFEST.md) ----

--- a/plugins/platforms/telegram/topic_tool.py
+++ b/plugins/platforms/telegram/topic_tool.py
@@ -1,0 +1,137 @@
+"""Telegram-scoped tool for creating a topic and starting its first agent turn."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+
+TELEGRAM_TOPIC_START_SCHEMA = {
+    "name": "telegram_topic_start",
+    "description": (
+        "Create a new topic in the current Telegram chat and start an agent turn "
+        "inside it. Use only when the user explicitly asks for a new topic."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "topic_name": {
+                "type": "string",
+                "description": "Name of the Telegram topic to create.",
+            },
+            "prompt": {
+                "type": "string",
+                "description": "Initial user-authorized prompt to run in the new topic.",
+            },
+        },
+        "required": ["topic_name", "prompt"],
+    },
+}
+
+
+def _error(message: str) -> str:
+    return json.dumps({"success": False, "error": message})
+
+
+def _run_on_gateway_loop(coro, loop):
+    if loop is None or loop.is_closed() or not loop.is_running():
+        coro.close()
+        raise RuntimeError("The live gateway event loop is not available")
+    future = asyncio.run_coroutine_threadsafe(coro, loop)
+    try:
+        return future.result(timeout=30)
+    except Exception:
+        future.cancel()
+        raise
+
+
+async def _create_topic_and_start(
+    adapter: Any,
+    *,
+    chat_id: str,
+    topic_name: str,
+    prompt: str,
+    user_id: str | None,
+    profile: str | None,
+) -> dict[str, Any]:
+    thread_id = await adapter.create_handoff_thread(chat_id, topic_name)
+    if not thread_id:
+        return {"success": False, "error": f"Failed to create Telegram topic {topic_name!r}"}
+
+    from gateway.config import Platform
+    from gateway.delivery import looks_like_telegram_private_chat_id
+    from gateway.session import SessionSource
+    from gateway.wake import deliver_wake
+
+    is_private = looks_like_telegram_private_chat_id(chat_id)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=str(chat_id),
+        chat_name=topic_name,
+        chat_type="dm" if is_private else "forum",
+        user_id=str(chat_id) if is_private else (user_id or "system:kickoff"),
+        thread_id=str(thread_id),
+        profile=profile,
+    )
+    await deliver_wake(adapter, text=prompt, source=source)
+    return {
+        "success": True,
+        "platform": "telegram",
+        "chat_id": str(chat_id),
+        "thread_id": str(thread_id),
+        "topic_name": topic_name,
+        "started": True,
+    }
+
+
+def telegram_topic_start(args: dict[str, Any], **_kwargs: Any) -> str:
+    topic_name = str(args.get("topic_name") or "").strip()
+    prompt = str(args.get("prompt") or "").strip()
+    if not topic_name or not prompt:
+        return _error("Both topic_name and prompt are required")
+
+    from gateway.config import Platform
+    from gateway.session_context import get_session_env
+
+    if get_session_env("HERMES_SESSION_PLATFORM", "").strip().lower() != "telegram":
+        return _error("telegram_topic_start is available only from a Telegram session")
+    chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "").strip()
+    if not chat_id:
+        return _error("The current Telegram chat could not be resolved")
+
+    try:
+        from gateway.run import _gateway_runner_ref
+
+        runner = _gateway_runner_ref()
+    except Exception:
+        runner = None
+    adapter = runner.adapters.get(Platform.TELEGRAM) if runner is not None else None
+    if adapter is None:
+        return _error("The live Telegram gateway adapter is not available")
+
+    try:
+        result = _run_on_gateway_loop(
+            _create_topic_and_start(
+                adapter,
+                chat_id=chat_id,
+                topic_name=topic_name,
+                prompt=prompt,
+                user_id=get_session_env("HERMES_SESSION_USER_ID", "").strip() or None,
+                profile=get_session_env("HERMES_SESSION_PROFILE", "").strip() or None,
+            ),
+            getattr(runner, "_gateway_loop", None),
+        )
+    except Exception as exc:
+        return _error(f"Create topic and start failed: {exc}")
+    return json.dumps(result)
+
+
+def register_topic_tool(ctx: Any) -> None:
+    ctx.register_tool(
+        name="telegram_topic_start",
+        toolset="telegram",
+        schema=TELEGRAM_TOPIC_START_SCHEMA,
+        handler=telegram_topic_start,
+        emoji="🧵",
+    )

--- a/tests/tools/test_send_message_topic_start.py
+++ b/tests/tools/test_send_message_topic_start.py
@@ -1,0 +1,103 @@
+"""Behavior tests for the Telegram topic kickoff tool."""
+
+import asyncio
+import json
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from gateway.config import Platform
+from plugins.platforms.telegram import topic_tool
+
+
+def test_topic_tool_is_registered_only_in_the_telegram_bundle():
+    ctx = SimpleNamespace(register_tool=MagicMock())
+
+    topic_tool.register_topic_tool(ctx)
+
+    ctx.register_tool.assert_called_once_with(
+        name="telegram_topic_start",
+        toolset="telegram",
+        schema=topic_tool.TELEGRAM_TOPIC_START_SCHEMA,
+        handler=topic_tool.telegram_topic_start,
+        emoji="🧵",
+    )
+    from toolsets import TOOLSETS
+
+    assert "telegram_topic_start" in TOOLSETS["hermes-telegram"]["tools"]
+    assert "telegram_topic_start" not in TOOLSETS["hermes-cli"]["tools"]
+
+
+def test_topic_start_creates_current_chat_topic_and_wakes_it(monkeypatch):
+    create_thread = AsyncMock(return_value="444")
+    adapter = SimpleNamespace(create_handoff_thread=create_thread)
+    loop = asyncio.new_event_loop()
+    loop_thread = threading.Thread(target=loop.run_forever)
+    loop_thread.start()
+    runner = SimpleNamespace(adapters={Platform.TELEGRAM: adapter}, _gateway_loop=loop)
+    wake = AsyncMock()
+    values = {
+        "HERMES_SESSION_PLATFORM": "telegram",
+        "HERMES_SESSION_CHAT_ID": "-100123",
+        "HERMES_SESSION_USER_ID": "42",
+        "HERMES_SESSION_PROFILE": "dev",
+    }
+
+    import gateway.run as gateway_run
+    import gateway.session_context as session_context
+
+    monkeypatch.setattr(gateway_run, "_gateway_runner_ref", lambda: runner)
+    monkeypatch.setattr(session_context, "get_session_env", lambda key, default="": values.get(key, default))
+
+    try:
+        with patch("gateway.wake.deliver_wake", wake):
+            result = json.loads(
+                topic_tool.telegram_topic_start(
+                    {"topic_name": "Research", "prompt": "Research the launch."}
+                )
+            )
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        loop_thread.join(timeout=5)
+        loop.close()
+
+    assert result == {
+        "success": True,
+        "platform": "telegram",
+        "chat_id": "-100123",
+        "thread_id": "444",
+        "topic_name": "Research",
+        "started": True,
+    }
+    create_thread.assert_awaited_once_with("-100123", "Research")
+    wake.assert_awaited_once()
+    source = wake.await_args.kwargs["source"]
+    assert wake.await_args.args == (adapter,)
+    assert wake.await_args.kwargs["text"] == "Research the launch."
+    assert source.platform == Platform.TELEGRAM
+    assert source.chat_id == "-100123"
+    assert source.chat_type == "forum"
+    assert source.thread_id == "444"
+    assert source.user_id == "42"
+    assert source.profile == "dev"
+
+
+def test_topic_start_refuses_non_telegram_session(monkeypatch):
+    import gateway.session_context as session_context
+
+    monkeypatch.setattr(
+        session_context,
+        "get_session_env",
+        lambda key, default="": "slack" if key == "HERMES_SESSION_PLATFORM" else default,
+    )
+
+    result = json.loads(
+        topic_tool.telegram_topic_start(
+            {"topic_name": "Research", "prompt": "Research the launch."}
+        )
+    )
+
+    assert result == {
+        "success": False,
+        "error": "telegram_topic_start is available only from a Telegram session",
+    }

--- a/toolsets.py
+++ b/toolsets.py
@@ -46,6 +46,7 @@ _FEISHU_TOOLS = [
     "feishu_doc_read", "feishu_drive_list_comments", "feishu_drive_list_comment_replies",
     "feishu_drive_reply_comment", "feishu_drive_add_comment",
 ]
+_TELEGRAM_TOOLS = ["telegram_topic_start"]
 _YUANBAO_TOOLS = ["yb_query_group_info", "yb_query_group_members", "yb_send_dm", "yb_search_sticker", "yb_send_sticker"]
 
 
@@ -199,7 +200,10 @@ TOOLSETS = {
     # Mirrors hermes-cli; `hermes tools` platform config filters it down and
     # _get_platform_tools() drops _DEFAULT_OFF_TOOLSETS unless user-enabled.
     "hermes-cron": _bundle("Default cron toolset - same core tools as hermes-cli; gated by `hermes tools`"),
-    "hermes-telegram": _bundle("Telegram bot toolset - full access for personal use (terminal has safety checks)"),
+    "hermes-telegram": _bundle(
+        "Telegram bot toolset - full access for personal use (terminal has safety checks)",
+        _TELEGRAM_TOOLS,
+    ),
     "hermes-discord": _bundle(
         "Discord bot toolset - full access (terminal has safety checks via dangerous "
         "command approval)",


### PR DESCRIPTION
## What does this PR do?

Adds a Telegram-scoped `telegram_topic_start` tool that creates a topic in the current Telegram chat and starts its first authorized agent turn there.

## Related Issue

Fixes #109208

## Type of Change

- [x] ✨ New feature

## Changes Made

- Register the tool through the Telegram platform plugin and expose it only in the Telegram bundle.
- Bind creation to the current Telegram chat rather than accepting arbitrary destinations.
- Create the topic through the live adapter and inject the initial prompt with the correct session source.
- Add focused registration, isolation, topic-creation, and wake-delivery coverage.

## How to Test

`scripts/run_tests.sh tests/tools/test_send_message_topic_start.py tests/test_toolsets.py tests/test_toolset_distributions.py -q`

Result: 39 passed.

Focused Ruff, diff, compatibility-pointer, and attribution checks also pass.

## Checklist

- [x] Read the contributing guide.
- [x] Searched current source and all open/closed issues and PRs.
- [x] Contains only the Telegram topic kickoff capability and tests.
- [x] Tested on macOS.
- [x] Documentation and config changes are N/A.
- [x] Cross-platform impact considered; the tool is Telegram-session gated.