### PR TITLE
fix(compression): derive the hygiene turn-hold budget from the model context window

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4074,6 +4074,8 @@ class GatewayRunner(
         timeout_seconds: float
         total_ceiling_seconds: float
         max_turn_hold_seconds: float
+        turn_hold_configured: bool
+        turn_hold_tokens_per_second: float
         failure_cooldown_seconds: float
         config_context_length: Optional[int]
         provider: Optional[str]

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -66,6 +66,39 @@ def is_context_overflow_failure_result(agent_result: dict, history_len: int) -> 
     return any(p in err for p in _CONTEXT_OVERFLOW_ERROR_PHRASES) or ("400" in err and history_len > 50)
 
 
+# Floor for the window-derived hygiene turn-hold budget: the historical flat default, and the
+# shortest hold that still gives a live summary a chance to land within the same turn.
+_HYG_TURN_HOLD_FLOOR_SECONDS = 10.0
+
+
+def derive_hygiene_turn_hold_seconds(
+    context_length: Optional[int],
+    threshold_pct: float,
+    tokens_per_second: float,
+    floor_seconds: float,
+    ceiling_seconds: float,
+) -> float:
+    """Derive the hygiene turn-hold budget from the summary's expected ingest cost.
+
+    Hygiene summarises roughly ``threshold_pct x context_length`` tokens in ONE auxiliary call, so
+    how long an arriving user turn can afford to wait follows the model's context window and its
+    prefill rate rather than a flat constant (measured hygiene summaries of 205k-246k tokens took
+    45-98s on production gateways -- an order of magnitude beyond the historical 10s default).
+
+    ``tokens_per_second`` is the operator's throughput hint for the summary model (<= 0 keeps the
+    flat default). The result is clamped to ``[floor_seconds, ceiling_seconds]``; the ceiling must
+    stay under the transport idle timeout, so callers pass the resolved idle budget.
+    """
+    try:
+        tokens = float(context_length) * float(threshold_pct)
+        rate = float(tokens_per_second)
+    except (TypeError, ValueError):
+        return float(floor_seconds)
+    if tokens <= 0 or rate <= 0:
+        return float(floor_seconds)
+    return float(min(max(tokens / rate, floor_seconds), max(float(ceiling_seconds), float(floor_seconds))))
+
+
 class GatewayTurnMixin:
     """Agent-turn execution for GatewayRunner (see module docstring)."""
 
@@ -543,7 +576,12 @@ class GatewayTurnMixin:
         hs.total_ceiling_seconds = _knob("hygiene_total_ceiling_seconds", hs.total_ceiling_seconds, float)
         # The ceiling can never be tighter than one idle window, or the extension loop would be dead code.
         hs.total_ceiling_seconds = max(hs.total_ceiling_seconds, hs.timeout_seconds)
+        # An explicit knob always wins over the window-derived budget (see _hmwa_hygiene_plan).
+        hs.turn_hold_configured = _comp_cfg.get("hygiene_max_turn_hold_seconds") is not None
         hs.max_turn_hold_seconds = _knob("hygiene_max_turn_hold_seconds", hs.max_turn_hold_seconds, float)
+        hs.turn_hold_tokens_per_second = _knob(
+            "hygiene_max_turn_hold_tokens_per_second", hs.turn_hold_tokens_per_second, float, allow_zero=True,
+        )
         hs.failure_cooldown_seconds = _knob(
             "hygiene_failure_cooldown_seconds", hs.failure_cooldown_seconds, float, allow_zero=True,
         )
@@ -560,6 +598,7 @@ class GatewayTurnMixin:
             hard_msg_limit=5000, timeout_seconds=30.0, total_ceiling_seconds=600.0,
             max_turn_hold_seconds=10.0, failure_cooldown_seconds=300.0, config_context_length=None,
             provider=None, base_url=None, api_key=None, data={},
+            turn_hold_configured=False, turn_hold_tokens_per_second=0.0,
         )
         try:
             hs.data = _load_gateway_config()
@@ -618,6 +657,13 @@ class GatewayTurnMixin:
             hs.model, base_url=hs.base_url or "", api_key=hs.api_key or "",
             config_context_length=hs.config_context_length, provider=hs.provider or "",
         )
+        # The window implies how long summarising THIS transcript takes; a flat hold cannot outlast
+        # it. Derive the budget unless the operator pinned hygiene_max_turn_hold_seconds explicitly.
+        if hs.turn_hold_tokens_per_second > 0 and not hs.turn_hold_configured:
+            hs.max_turn_hold_seconds = derive_hygiene_turn_hold_seconds(
+                _hyg_context_length, hs.threshold_pct, hs.turn_hold_tokens_per_second,
+                _HYG_TURN_HOLD_FLOOR_SECONDS, hs.timeout_seconds,
+            )
         _compress_token_threshold = int(_hyg_context_length * hs.threshold_pct)
         _warn_token_threshold = int(_hyg_context_length * 0.95)
         _msg_count = len(history)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -587,6 +587,14 @@ DEFAULT_CONFIG = {
         # turn proceeds uncompressed; the detached worker keeps its watermark-fenced commit, so the
         # summary is adopted at the next safe boundary.
         "hygiene_max_turn_hold_seconds": 10,
+        # Prefill throughput hint (tokens/second) for the hygiene summary model. When > 0 AND
+        # hygiene_max_turn_hold_seconds is NOT set explicitly, the turn-hold budget is derived from
+        # the resolved context window instead of the flat default:
+        #   hold ~= (context_length x threshold) / hint, clamped to [10s, hygiene_timeout_seconds]
+        # Reference: hygiene summaries of 205k-246k tokens completed in 45-98s on production
+        # gateways (~2.5k-5.5k tokens/s), i.e. well beyond the flat default. 0 = keep today's
+        # behaviour (flat budget, no derivation).
+        "hygiene_max_turn_hold_tokens_per_second": 0,
         # Inactivity budget for in-agent compress_context (loop, /compress, preflight); same
         # progress-aware semantics as hygiene_timeout_seconds. 0 = disable the owned wrapper
         # (callers passing commit_fence, e.g. gateway hygiene, never use it).

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -1815,3 +1815,75 @@ async def test_hygiene_unwind_records_cooldown(monkeypatch, tmp_path):
         await asyncio.wait_for(asyncio.to_thread(cleanup_done.wait), timeout=2)
     finally:
         db.close()
+
+
+# ---------------------------------------------------------------------------
+# Window-derived turn-hold budget (#102138)
+# ---------------------------------------------------------------------------
+
+class TestHygieneTurnHoldDerivation:
+    """The hygiene turn-hold budget must follow the model's window, not a flat constant."""
+
+    @staticmethod
+    def _hs(**over):
+        felder = dict(
+            model="m", threshold_pct=0.85, compression_enabled=True, hard_msg_limit=5000,
+            timeout_seconds=30.0, total_ceiling_seconds=600.0, max_turn_hold_seconds=10.0,
+            turn_hold_configured=False, turn_hold_tokens_per_second=0.0,
+            failure_cooldown_seconds=300.0, config_context_length=None,
+            provider=None, base_url=None, api_key=None, data={},
+        )
+        felder.update(over)
+        return SimpleNamespace(**felder)
+
+    @staticmethod
+    def _derive(**over):
+        from gateway.run_turn import derive_hygiene_turn_hold_seconds
+        args = dict(
+            context_length=200_000, threshold_pct=0.85, tokens_per_second=2500.0,
+            floor_seconds=10.0, ceiling_seconds=30.0,
+        )
+        args.update(over)
+        return derive_hygiene_turn_hold_seconds(**args)
+
+    def test_hint_disabled_keeps_flat_default(self):
+        """Without a hint (the shipped default) the historical flat budget is untouched."""
+        assert self._derive(tokens_per_second=0.0) == 10.0
+        assert self._derive(tokens_per_second=-1.0) == 10.0
+
+    def test_large_window_saturates_at_the_idle_budget(self):
+        """1M window x 85% / 2500 tok/s ~ 340s clamps to the transport-safe ceiling."""
+        assert self._derive(context_length=1_000_000, ceiling_seconds=30.0) == 30.0
+
+    def test_small_window_lands_between_floor_and_ceiling(self):
+        """32k window ~ 10.9s: the window decides, not the constant."""
+        wert = self._derive(context_length=32_000)
+        assert 10.0 < wert < 30.0
+
+    def test_fast_model_stays_on_the_floor(self):
+        assert self._derive(context_length=4_000, tokens_per_second=100_000.0) == 10.0
+
+    def test_missing_or_zero_window_falls_back_to_floor(self):
+        assert self._derive(context_length=None) == 10.0
+        assert self._derive(context_length=0) == 10.0
+
+    def test_ceiling_never_below_floor(self):
+        """A pathological ceiling must not produce a zero-length hold."""
+        assert self._derive(context_length=1_000_000, ceiling_seconds=0.0) == 10.0
+
+    def test_config_reads_both_keys_and_flags_an_explicit_budget(self):
+        GatewayRunner = importlib.import_module("gateway.run").GatewayRunner
+        hs = self._hs()
+        GatewayRunner._hmwa_hygiene_read_config(hs, {"compression": {
+            "hygiene_max_turn_hold_seconds": 20,
+            "hygiene_max_turn_hold_tokens_per_second": 4000,
+        }})
+        assert hs.max_turn_hold_seconds == 20.0
+        assert hs.turn_hold_configured is True
+        assert hs.turn_hold_tokens_per_second == 4000.0
+
+        hs2 = self._hs()
+        GatewayRunner._hmwa_hygiene_read_config(hs2, {"compression": {"enabled": True}})
+        assert hs2.turn_hold_configured is False
+        assert hs2.turn_hold_tokens_per_second == 0.0
+        assert hs2.max_turn_hold_seconds == 10.0


### PR DESCRIPTION
### What this PR does

The gateway holds an arriving user turn for a flat `compression.hygiene_max_turn_hold_seconds` (10s by default) while the pre-agent session-hygiene summary runs. That budget does not scale with the work the summary actually has to do: hygiene summarises roughly `compression.threshold x context_length` tokens in ONE auxiliary call, so on a large-window model the hold expires long before the summary can land.

This PR derives the budget from the resolved context window instead, driven by an operator-supplied prefill throughput hint:

```
hold ~= (context_length x threshold) / hygiene_max_turn_hold_tokens_per_second
        clamped to [10s, hygiene_timeout_seconds]
```

Defaults are unchanged: the hint ships as `0` (no derivation, flat budget as today), and an explicitly configured `hygiene_max_turn_hold_seconds` always wins. The ceiling keeps the invariant documented next to the existing knob — the hold stays under the transport idle timeout.

### Evidence

- **#102138** (closed) — the maintainer fixed the commit-revocation race (`gateway/run_turn.py::_hyg_keep_admission`), which is also what my instance logged (`the watermark-fenced worker keeps its commit admission`). The latency mismatch named in the issue title was not addressed; the issue was closed on the race fix.
- **#102138, second-site measurement** (`strzhao`, pre-turn-hold build): four retained hygiene compressions of ~205k-246k tokens completed in **45s, 78s, 58s** (start -> commit, from the gateway.log lines quoted there) — roughly 2.5k-5.5k tokens/s of prefill, an order of magnitude beyond a 10s hold.
- **#102138** (`Schnee111`): cancel-and-respawn loop at ~270k tokens on a Discord gateway, with the 60s retry-after inert within milliseconds; their workaround was switching to a lower-latency summary model.
- **Own observation** (1M-window auxiliary compression model, ~872k tokens / 789 messages): the turn-hold is abandoned at exactly 10.0s on consecutive turns, and the transcript keeps growing.

### Verification status

- `python3 -m py_compile` on all four touched files: OK.
- 11 assertions over the derivation and the config precedence (floor, ceiling saturation, small window, invalid/zero window, pathological ceiling, explicit-knob precedence, unchanged defaults) pass against the patched tree.
- **Honest gap:** I could not run the repository's pytest suite in my deployment environment (no pytest available in the venv there). The new tests live in `tests/gateway/test_session_hygiene.py` and are written to be collected by CI.
- Default behaviour is intentionally bit-identical: no derivation unless the new key is set.

### Questions for maintainers

1. Is ~2,500 tok/s a reasonable shipped default for the hint, or would you rather keep it strictly opt-in with no suggested value (as done here)?
2. Should the derivation use the *actual* transcript size instead of `threshold x window`? `_hmwa_hygiene_plan` knows the real token count at that point, which would be a tighter estimate — I kept the window-only form because it needs no new plumbing into the settings path.
3. Is `hygiene_timeout_seconds` the right ceiling, or should the hold be allowed to run up to `hygiene_total_ceiling_seconds`?
4. For windows where the estimate far exceeds the ceiling: would you prefer to skip the inline hold entirely (proceed immediately, let the detached worker commit) rather than hold for the maximum? That is the #87013 direction, and I did not want to collide with it.

Refs #102138

---

*Drafted with assistance from an AI agent (Hermes, Nous Research) on behalf of the contributor @tilllt.*