### PR TITLE
fix(billing): Anthropic OAuth subscription usage no longer priced as metered API cost

### DIFF
--- a/agent/aux_accounting.py
+++ b/agent/aux_accounting.py
@@ -16,7 +16,7 @@ from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
-# (session_db, session_id) for the active agent turn, or None outside one.
+# (session_db, session_id, api_key) for the active agent turn, or None outside one.
 _accounting: ContextVar[Optional[tuple]] = ContextVar("aux_accounting_context", default=None)
 
 # MoA advisor/aggregator usage is already folded into conversation_loop's
@@ -24,14 +24,14 @@ _accounting: ContextVar[Optional[tuple]] = ContextVar("aux_accounting_context", 
 _EXCLUDED_TASKS = frozenset({"moa_reference", "moa_aggregator"})
 
 
-def set_accounting_context(session_db: Any, session_id: Optional[str]):
+def set_accounting_context(session_db: Any, session_id: Optional[str], api_key: Optional[str] = None):
     """Publish the active session's accounting handles; returns the token for ``reset_accounting_context``.
 
     ``None`` handles (no DB / no session id) clear the context.
     """
     if session_db is None or not session_id:
         return _accounting.set(None)
-    return _accounting.set((session_db, session_id))
+    return _accounting.set((session_db, session_id, api_key))
 
 
 def reset_accounting_context(token) -> None:
@@ -59,7 +59,7 @@ def record_aux_usage(
         ctx = _accounting.get()
         if ctx is None:
             return
-        session_db, session_id = ctx
+        session_db, session_id, api_key = ctx
         raw_usage = getattr(response, "usage", None)
         if raw_usage is None:
             return
@@ -76,7 +76,7 @@ def record_aux_usage(
         model = str(getattr(response, "model", "") or "") or "unknown"
         estimated_cost = None
         try:
-            cost = estimate_usage_cost(model, usage, provider=provider, base_url=base_url)
+            cost = estimate_usage_cost(model, usage, provider=provider, base_url=base_url, api_key=api_key)
             if cost.amount_usd is not None:
                 estimated_cost = float(cost.amount_usd)
         except Exception:

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -26,16 +26,20 @@ def _fmt_est_cost(est_cost: float) -> str:
 
 
 def _estimate_cost(session_or_model: Dict[str, Any] | str, input_tokens: int = 0, output_tokens: int = 0, *, cache_read_tokens: int = 0,
-                   cache_write_tokens: int = 0, provider: Optional[str] = None, base_url: Optional[str] = None) -> tuple[float, str]:
+                    cache_write_tokens: int = 0, provider: Optional[str] = None, base_url: Optional[str] = None,
+                    billing_mode: Optional[str] = None) -> tuple[float, str]:
     """Estimate the USD cost for a session row or a model/token tuple."""
     if isinstance(session_or_model, dict):
         s = session_or_model
         model = s.get("model") or ""
         usage = CanonicalUsage(**{k: s.get(k) or 0 for k in _TOKEN_KEYS})
         provider, base_url = s.get("billing_provider"), s.get("billing_base_url")
+        billing_mode = billing_mode or s.get("billing_mode")
     else:
         model = session_or_model or ""
         usage = CanonicalUsage(input_tokens, output_tokens, cache_read_tokens, cache_write_tokens)
+    if billing_mode == "subscription_included":
+        return 0.0, "included"
     result = estimate_usage_cost(model, usage, provider=provider, base_url=base_url)
     return float(result.amount_usd or 0.0), result.status
 
@@ -324,7 +328,7 @@ class InsightsEngine:
                                           "api_calls": 0, "tool_calls": 0, "cost": 0.0, "actual_cost": 0.0})
 
         def _accumulate(model, provider, base_url, session_id, counts: Dict[str, int], *,
-                        stored_cost=None, actual_cost=None, cost_status=None):
+                        stored_cost=None, actual_cost=None, cost_status=None, billing_mode=None):
             model = model or "unknown"
             d: Dict[str, Any] = model_data[_short_model(model)]
             d["sessions"].add(session_id)
@@ -334,7 +338,8 @@ class InsightsEngine:
             d["api_calls"] += counts["api_call_count"]
             if stored_cost is None:
                 estimate, status = _estimate_cost(model, counts["input_tokens"], counts["output_tokens"], cache_read_tokens=counts["cache_read_tokens"],
-                                                  cache_write_tokens=counts["cache_write_tokens"], provider=provider or None, base_url=base_url)
+                                                   cache_write_tokens=counts["cache_write_tokens"], provider=provider or None, base_url=base_url,
+                                                   billing_mode=billing_mode)
             else:
                 estimate, status = float(stored_cost or 0.0), cost_status or "unknown"
             d["cost"] += estimate
@@ -351,7 +356,7 @@ class InsightsEngine:
             totals["actual_cost_usd"] += r["actual_cost_usd"] or 0.0
             _accumulate(r["model"], r["billing_provider"], r.get("billing_base_url"), r["session_id"], counts,
                         stored_cost=r["estimated_cost_usd"] if r.get("cost_status") or r.get("cost_source") else None,
-                        actual_cost=r["actual_cost_usd"], cost_status=r.get("cost_status"))
+                        actual_cost=r["actual_cost_usd"], cost_status=r.get("cost_status"), billing_mode=r.get("billing_mode"))
         # Reconcile against the aggregate row: covers legacy sessions,
         # interrupted migrations, and absolute cumulative updates without
         # double-counting already-attributed route deltas.
@@ -363,7 +368,7 @@ class InsightsEngine:
             residual_actual = max(0.0, float(s.get("actual_cost_usd") or 0.0) - totals["actual_cost_usd"])
             if any(residual.values()) or residual_cost or residual_actual:
                 _accumulate(s.get("model"), s.get("billing_provider"), s.get("billing_base_url"), s["id"], residual,
-                            stored_cost=residual_cost, actual_cost=residual_actual, cost_status=s.get("cost_status"))
+                            stored_cost=residual_cost, actual_cost=residual_actual, cost_status=s.get("cost_status"), billing_mode=s.get("billing_mode"))
         for s in sessions:
             if s.get("tool_call_count"):
                 model_data[_short_model(s.get("model"))]["tool_calls"] += s["tool_call_count"]

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -374,7 +374,7 @@ def auto_title_session(
         set_conversation_context(conversation_id)
         # Same for the accounting context, so the title call's token usage is recorded against this session
         # (task='title_generation', #23270).
-        set_accounting_context(session_db, session_id)
+        set_accounting_context(session_db, session_id, (main_runtime or {}).get("api_key"))
         title, source = generate_title(
             user_message, failure_callback=failure_callback, main_runtime=main_runtime, runtime_validator=runtime_validator,
         ), "llm"

--- a/agent/turn_facade.py
+++ b/agent/turn_facade.py
@@ -120,7 +120,7 @@ class TurnFacadeMixin:
             # usage into session_model_usage (task dimension) — the fix for aux spend being invisible in
             # analytics (issue #23270).
             acct_token = set_accounting_context(
-                getattr(self, "_session_db", None), getattr(self, "session_id", None)
+                getattr(self, "_session_db", None), getattr(self, "session_id", None), getattr(self, "api_key", None)
             )
 
             # Keep the ContextVar scope local (agent tokens may be observed from another thread).

--- a/agent/turn_response_intake.py
+++ b/agent/turn_response_intake.py
@@ -61,6 +61,12 @@ def _fire_post_api_request_hook(
     try:
         from hermes_cli.lifecycle import has_hook, invoke_hook as _invoke_hook
         if has_hook("post_api_request"):
+            from agent.usage_pricing import resolve_billing_route
+
+            billing_mode = resolve_billing_route(
+                agent.model, provider=agent.provider, base_url=agent.base_url,
+                api_key=getattr(agent, "api_key", None),
+            ).billing_mode
             _invoke_hook(
                 "post_api_request",
                 task_id=effective_task_id,
@@ -72,6 +78,7 @@ def _fire_post_api_request_hook(
                 provider=agent.provider,
                 base_url=agent.base_url,
                 api_mode=agent.api_mode,
+                billing_mode=billing_mode,
                 api_call_count=api_call_count,
                 api_duration=api_duration,
                 started_at=api_start_time,

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -322,7 +322,8 @@ _GOOGLE_PROVIDER_NAMES = {"google", "gemini", "vertex", "google-gemini", "google
 
 
 def resolve_billing_route(
-    model_name: str, provider: Optional[str] = None, base_url: Optional[str] = None
+    model_name: str, provider: Optional[str] = None, base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
 ) -> BillingRoute:
     provider_name = (provider or "").strip().lower()
     base = (base_url or "").strip().lower()
@@ -343,6 +344,11 @@ def resolve_billing_route(
 
     if provider_name == "openai-codex":
         return BillingRoute(provider="openai-codex", model=model, base_url=url, billing_mode="subscription_included")
+    if provider_name == "anthropic" and (not base or host("api.anthropic.com")):
+        from agent.anthropic_credentials import _is_oauth_token
+
+        if _is_oauth_token(api_key or ""):
+            return BillingRoute(provider="anthropic", model=bare, base_url=url, billing_mode="subscription_included")
     if provider_name == "openrouter" or host("openrouter.ai"):
         return BillingRoute(provider="openrouter", model=model, base_url=url, billing_mode="official_models_api")
     if provider_name == "nous" or host("inference-api.nousresearch.com"):
@@ -443,7 +449,7 @@ def get_pricing_entry(
     model_name: str, provider: Optional[str] = None, base_url: Optional[str] = None,
     api_key: Optional[str] = None,
 ) -> Optional[PricingEntry]:
-    route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
+    route = resolve_billing_route(model_name, provider=provider, base_url=base_url, api_key=api_key)
     if route.billing_mode == "subscription_included":
         return _INCLUDED_ENTRY
     if route.provider == "openrouter":
@@ -553,7 +559,7 @@ def estimate_usage_cost(
     model_name: str, usage: CanonicalUsage, *, provider: Optional[str] = None,
     base_url: Optional[str] = None, api_key: Optional[str] = None,
 ) -> CostResult:
-    route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
+    route = resolve_billing_route(model_name, provider=provider, base_url=base_url, api_key=api_key)
     if route.billing_mode == "subscription_included":
         return CostResult(
             amount_usd=_ZERO, status="included", source="none", label="included",

--- a/hermes_cli/model_cost_guard.py
+++ b/hermes_cli/model_cost_guard.py
@@ -60,11 +60,11 @@ def _can_trust_model_info_pricing(
 
 
 def _can_trust_pricing_lookup(
-    model_name: str, *, provider: Optional[str], base_url: Optional[str]) -> bool:
+    model_name: str, *, provider: Optional[str], base_url: Optional[str], api_key: Optional[str]) -> bool:
     try:
         from agent.usage_pricing import resolve_billing_route
 
-        route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
+        route = resolve_billing_route(model_name, provider=provider, base_url=base_url, api_key=api_key)
     except Exception:
         return False
     return route.billing_mode != "unknown"
@@ -97,7 +97,9 @@ def expensive_model_warning(
         except Exception:
             pass
 
-    if _unpriced() and _can_trust_pricing_lookup(model, provider=provider, base_url=base_url):
+    if _unpriced() and _can_trust_pricing_lookup(
+        model, provider=provider, base_url=base_url, api_key=api_key,
+    ):
         try:
             from agent.usage_pricing import get_pricing_entry
 

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -477,13 +477,15 @@ def _serialize_assistant_message(message: Any) -> dict[str, Any]:
 
 
 def _canonical_usage_and_cost(canonical: Any, *, provider: str, model: str,
-                              base_url: str) -> tuple[dict[str, int], dict[str, float]]:
+                              base_url: str, billing_mode: str = "") -> tuple[dict[str, int], dict[str, float]]:
     """Translate canonical Hermes usage into Langfuse usage and cost maps."""
     usage_details: Dict[str, int] = {
         key: tokens for key, attr, _ in _USAGE_FIELDS
         if (tokens := getattr(canonical, attr)) or key in ("input", "output")
     }
     cost_details: Dict[str, float] = {}
+    if billing_mode == "subscription_included":
+        return usage_details, cost_details
     try:
         from agent.usage_pricing import estimate_usage_cost, resolve_billing_route
 
@@ -527,7 +529,7 @@ def _canonical_usage_and_cost(canonical: Any, *, provider: str, model: str,
 
 
 def _usage_and_cost(response: Any, *, provider: str, model: str, base_url: str, api_mode: str = "",
-                    usage: Optional[dict] = None) -> tuple[dict[str, int], dict[str, float]]:
+                    usage: Optional[dict] = None, billing_mode: str = "") -> tuple[dict[str, int], dict[str, float]]:
     """Langfuse usage/cost maps from ``response.usage`` (post_llm_call) or, when ``usage``
     is given (post_api_request), from that pre-built CanonicalUsage summary dict."""
     raw_usage = getattr(response, "usage", None)
@@ -541,7 +543,9 @@ def _usage_and_cost(response: Any, *, provider: str, model: str, base_url: str, 
             request_count=usage.get("request_count", 1),
             **{attr: usage.get(attr, 0) for attr in ("input_tokens", "cache_read_tokens", "cache_write_tokens", "reasoning_tokens")},
         )
-        return _canonical_usage_and_cost(canonical, provider=provider, model=model, base_url=base_url)
+        return _canonical_usage_and_cost(
+            canonical, provider=provider, model=model, base_url=base_url, billing_mode=billing_mode,
+        )
     except Exception as exc:  # pragma: no cover - fail-open
         if usage is None:
             _debug(f"usage normalization failed: {exc}")
@@ -808,7 +812,7 @@ def on_pre_llm_request(*, task_id: str = "", session_id: str = "", platform: str
 
 
 def on_post_llm_call(*, task_id: str = "", session_id: str = "", provider: str = "", base_url: str = "",
-                     api_mode: str = "", model: str = "", api_call_count: int = 0, assistant_message: Any = None,
+                     api_mode: str = "", billing_mode: str = "", model: str = "", api_call_count: int = 0, assistant_message: Any = None,
                      response: Any = None, api_duration: float = 0.0, finish_reason: str = "", usage: Any = None,
                      assistant_content_chars: int = 0, assistant_tool_call_count: int = 0,
                      assistant_response: Any = None, turn_id: str = "", api_request_id: str = "",
@@ -843,10 +847,17 @@ def on_post_llm_call(*, task_id: str = "", session_id: str = "", provider: str =
 
     # post_api_request's ``response`` is a sanitized dict with no ``.usage``;
     # gate on the attribute so the usage-dict fallback is actually reached.
+    pricing_kwargs = {"billing_mode": billing_mode} if billing_mode else {}
     if getattr(response, "usage", None) is not None:
-        usage_details, cost_details = _usage_and_cost(response, provider=provider, api_mode=api_mode, model=model, base_url=base_url)
+        usage_details, cost_details = _usage_and_cost(
+            response, provider=provider, api_mode=api_mode, model=model, base_url=base_url,
+            **pricing_kwargs,
+        )
     elif isinstance(usage, dict) and usage:
-        usage_details, cost_details = _usage_and_cost(None, provider=provider, model=model, base_url=base_url, usage=usage)
+        usage_details, cost_details = _usage_and_cost(
+            None, provider=provider, model=model, base_url=base_url, usage=usage,
+            **pricing_kwargs,
+        )
     else:
         usage_details, cost_details = {}, {}
 

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -186,6 +186,18 @@ class TestEstimateCost:
         expected = (1000 * 3.0 + 500 * 15.0 + 2000 * 0.30 + 400 * 3.75) / 1_000_000
         assert cost == pytest.approx(expected, abs=0.0001)
 
+    def test_subscription_included_session_uses_persisted_billing_mode(self):
+        cost, status = _estimate_cost({
+            "model": "anthropic/claude-sonnet-4-20250514",
+            "input_tokens": 1_000_000,
+            "output_tokens": 100_000,
+            "billing_provider": "anthropic",
+            "billing_mode": "subscription_included",
+        })
+
+        assert cost == 0.0
+        assert status == "included"
+
 
 # =========================================================================
 # Format helpers
@@ -708,6 +720,22 @@ class TestEdgeCases:
         assert "included" in text.lower()
         assert "subscription" in text.lower()
 
+    def test_subscription_included_anthropic_oauth_session_has_no_estimated_cost(self, db):
+        db.create_session(session_id="oauth1", source="cli", model="anthropic/claude-sonnet-4-20250514")
+        db.update_token_counts(
+            "oauth1", input_tokens=1_000_000, output_tokens=100_000, model="anthropic/claude-sonnet-4-20250514",
+            billing_provider="anthropic", billing_base_url=None,
+            estimated_cost_usd=0.0, actual_cost_usd=0.0,
+            cost_status="included", cost_source="none", billing_mode="subscription_included", api_call_count=1,
+        )
+
+        report = InsightsEngine(db).generate(days=30)
+
+        assert report["overview"]["estimated_cost"] == pytest.approx(0.0)
+        model = next(m for m in report["models"] if m["model"] == "claude-sonnet-4-20250514")
+        assert model["cost"] == pytest.approx(0.0)
+        assert model["cost_status"] == "included"
+
     def test_sub_cent_aggregate_estimated_cost_not_zero(self, db):
         """A sub-cent aggregate must not render 'Estimated: ~$0.00' (#79220).
 
@@ -772,5 +800,4 @@ class TestEdgeCases:
         # The session has no cost data, so it falls in the "unknown" bucket.
         assert "💰 Cost" in text
         assert "Unknown" in text
-
 

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -308,6 +308,43 @@ def test_bedrock_claude_cached_session_estimates_cost_not_unknown():
     assert result.amount_usd is not None
 
 
+def test_anthropic_oauth_usage_is_subscription_included():
+    token = "sk-ant-oat01-test-oauth-token"
+    route = resolve_billing_route("claude-sonnet-5", provider="anthropic", api_key=token)
+    result = estimate_usage_cost(
+        "claude-sonnet-5", CanonicalUsage(input_tokens=100, output_tokens=100),
+        provider="anthropic", api_key=token,
+    )
+
+    assert route.billing_mode == "subscription_included"
+    assert result.status == "included"
+    assert result.amount_usd == Decimal("0")
+    assert result.label == "included"
+    assert "subscription" in result.notes[0]
+
+
+def test_anthropic_console_api_key_remains_metered():
+    token = "sk-ant-api03-test-console-key"
+    route = resolve_billing_route("claude-sonnet-5", provider="anthropic", api_key=token)
+    result = estimate_usage_cost(
+        "claude-sonnet-5", CanonicalUsage(input_tokens=100, output_tokens=100),
+        provider="anthropic", api_key=token,
+    )
+
+    assert route.billing_mode == "official_docs_snapshot"
+    assert result.status == "estimated"
+    assert result.amount_usd is not None and result.amount_usd > Decimal("0")
+
+
+def test_anthropic_oauth_token_on_third_party_endpoint_remains_metered():
+    route = resolve_billing_route(
+        "claude-sonnet-5", provider="anthropic", base_url="https://proxy.example/v1",
+        api_key="sk-ant-oat01-test-oauth-token",
+    )
+
+    assert route.billing_mode == "official_docs_snapshot"
+
+
 
 
 


### PR DESCRIPTION
resolve_billing_route() classified every anthropic-provider call through the official_docs_snapshot pricing table, even when the credential is a Claude subscription OAuth bearer token (no per-token invoice exists for that route, same as openai-codex's ChatGPT subscription tokens). A live account showed ~$812 estimated_cost_usd accrued against an OAuth session that was actually billed nothing beyond the flat subscription (found via a token-efficiency research chain, delegation logs deleg_8a0ee222 -> deleg_908707f9 -> deleg_3ae2a500).

Fix: `resolve_billing_route()` now accepts `api_key` and routes anthropic + `_is_oauth_token(api_key)` + (no base_url or api.anthropic.com host) to `subscription_included`, mirroring the existing openai-codex branch. A third-party proxy base_url is explicitly excluded so a borrowed OAuth token relayed through a paid third party still gets metered.

Propagates `api_key` through every `resolve_billing_route`/`get_pricing_entry`/`estimate_usage_cost` caller that has a credential available: `model_cost_guard`'s expensive-model warning, `turn_response_intake`'s post_api_request hook (now also passes the resolved `billing_mode` to hooks), `aux_accounting`'s accounting context (`title_generator`, `turn_facade`), and the Langfuse plugin's cost export (skips synthesizing a cost when `billing_mode` is `subscription_included`, matching its existing openai-codex handling).

**Tests:** 3 new cases in `test_usage_pricing.py` — OAuth token -> included, console API key -> still metered, OAuth token behind a third-party base_url -> still metered (regression guard for the proxy carve-out).

**Verified:** `scripts/run_tests.sh` on every file importing `usage_pricing`, `anthropic_credentials`, `turn_usage`, `aux_accounting`, `title_generator`, `turn_facade`, `turn_response_intake`, or the langfuse plugin — 639 passed, 1 pre-existing failure (`test_model_options_preserves_canonical_custom_row_after_agent_init`, reproduced identically on clean `origin/main`, unrelated to this change).