### PR TITLE
fix(auxiliary): recover when the cached Anthropic token was rotated by another process

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3499,7 +3499,9 @@ def _refresh_nous_credentials() -> bool:
 
 
 def _refresh_anthropic_credentials(failed_api_key: str = "") -> bool:
-    from agent.anthropic_credentials import read_claude_code_credentials, _refresh_oauth_token
+    from agent.anthropic_credentials import (
+        read_claude_code_credentials, _refresh_oauth_token, is_claude_code_token_valid,
+    )
     token = failed_api_key
     if not token:
         return False
@@ -3507,10 +3509,18 @@ def _refresh_anthropic_credentials(failed_api_key: str = "") -> bool:
     if pool.entry_id_for_api_key(token):
         return pool.try_refresh_matching(api_key_hint=token) is not None
     creds = read_claude_code_credentials()
-    # Never spend an ambient login's refresh rotation for another request's key.
-    if isinstance(creds, dict) and creds.get("accessToken") == token and creds.get("refreshToken"):
-        return bool(_refresh_oauth_token(creds))
-    return False
+    if not isinstance(creds, dict):
+        return False
+    if creds.get("accessToken") == token:
+        # Never spend an ambient login's refresh rotation for another request's key.
+        return bool(creds.get("refreshToken")) and bool(_refresh_oauth_token(creds))
+    # The failing client holds a token that is NOT the one on disk: another process (Claude
+    # Code, the CLI, another profile) already rotated the ambient login. A long-lived gateway
+    # keeps the superseded token in its cached client, so returning False here skipped the
+    # eviction and every auxiliary call 401ed forever — silently killing context compression.
+    # There is nothing to refresh, but the disk holds a usable token: report success so the
+    # caller evicts and rebuilds the client from disk.
+    return bool(creds.get("accessToken")) and is_claude_code_token_valid(creds)
 
 
 def _refresh_xai_oauth_credentials() -> bool:

--- a/tests/agent/test_anthropic_stale_gateway_token.py
+++ b/tests/agent/test_anthropic_stale_gateway_token.py
@@ -1,0 +1,56 @@
+"""A gateway holding a superseded on-disk token must recover, not 401 forever.
+
+Regression: context compression ran through ``auxiliary.compression`` on a long-lived
+gateway whose cached Anthropic client kept an access token that another process had
+since rotated. ``_refresh_anthropic_credentials`` returned False for any key that was
+not byte-identical to the on-disk one, so no eviction happened and every compression
+attempt aborted with ``summary_generation_aborted`` — silently, forever.
+"""
+import json
+import time
+
+import pytest
+
+from agent import anthropic_credentials as ac
+from agent import auxiliary_client as aux
+
+
+def _seed_disk_login(tmp_path, monkeypatch, *, expires_at_ms):
+    monkeypatch.setattr(ac.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(ac, "_first_env", lambda *names: "")
+    monkeypatch.setattr(ac, "_read_claude_code_credentials_from_keychain", lambda: None)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "auth.json").write_text(json.dumps({"credential_pool": {}}))
+    creds = tmp_path / ".claude" / ".credentials.json"
+    creds.parent.mkdir(exist_ok=True)
+    creds.write_text(json.dumps({"claudeAiOauth": {
+        "accessToken": "fresh-disk-token", "refreshToken": "disk-refresh",
+        "expiresAt": expires_at_ms,
+    }}))
+    return creds
+
+
+def _forbid_rotation(monkeypatch):
+    def forbidden(*args, **kwargs):
+        pytest.fail("Another process's refresh rotation was spent")
+    monkeypatch.setattr(ac, "_refresh_oauth_token", forbidden)
+
+
+def test_superseded_in_memory_token_recovers_from_disk(tmp_path, monkeypatch):
+    """Stale cached token + valid newer token on disk -> recoverable (evict & rebuild)."""
+    _seed_disk_login(tmp_path, monkeypatch, expires_at_ms=int(time.time() * 1000) + 3_600_000)
+    _forbid_rotation(monkeypatch)
+    assert aux._refresh_anthropic_credentials("stale-token-held-in-memory") is True
+
+
+def test_superseded_token_not_recoverable_when_disk_login_is_also_expired(tmp_path, monkeypatch):
+    """No usable credential anywhere -> report failure instead of an eviction loop."""
+    _seed_disk_login(tmp_path, monkeypatch, expires_at_ms=1)
+    _forbid_rotation(monkeypatch)
+    assert aux._refresh_anthropic_credentials("stale-token-held-in-memory") is False
+
+
+def test_no_failed_key_is_not_recoverable(tmp_path, monkeypatch):
+    _seed_disk_login(tmp_path, monkeypatch, expires_at_ms=int(time.time() * 1000) + 3_600_000)
+    _forbid_rotation(monkeypatch)
+    assert aux._refresh_anthropic_credentials("") is False


### PR DESCRIPTION
## Summary

On a 401 from an auxiliary provider, `_ladder_credential_rungs` calls
`_refresh_anthropic_credentials(failed_api_key=<the cached client's api_key>)`. For the
ambient Claude Code login that refresher returned `True` only when the failing key was
**byte-identical** to the one in `~/.claude/.credentials.json`.

A long-lived gateway is precisely the case where it is not. Another process — Claude Code
itself, `hermes` on the CLI, another profile — rotates the shared credentials file while the
gateway keeps the superseded access token inside its cached auxiliary client. The refresher
then returned `False`, so `_refresh_provider_credentials` never reached
`_evict_cached_clients("anthropic")`, and the dead token was replayed on every subsequent
auxiliary call. Nothing recovers it short of restarting the process.

**Context compression is the visible victim.** `auxiliary.compression` 401s on every attempt:

```
WARNING agent.context_compressor: Failed to generate context summary: Error code: 401 -
{'type': 'error', 'error': {'type': 'authentication_error',
 'message': 'OAuth access token has been revoked.'}}. Further summary attempts paused for 60 seconds.

INFO agent.conversation_compression: context compression attempt telemetry:
{"commit_status":"aborted","failure_class":"summary_generation_aborted","fallback_used":false,
 "current_estimated_tokens":335457,"effective_threshold":130000,
 "aux_model":"claude-haiku-4-5-20251001","aux_provider":"anthropic","trigger_source":"auto"}
```

Compression is enabled, the trigger fires, and it aborts — silently, in a 60s loop. Sessions
grow unbounded past `effective_threshold` (observed: 335k tokens / 684 messages against a
130k threshold) and the user only ever sees a generic `API call failed` on the messaging
gateway, two layers away from the actual cause. Observed three times on the same install
over four days; every time the token on disk was valid and only a gateway restart cleared it.

## Fix

When the failing key is not the one on disk **and** the disk login is still valid
(`is_claude_code_token_valid`), there is nothing to refresh but the credential *is*
recoverable: report success so the caller evicts the stale client and rebuilds it from disk.

The existing invariant is preserved — an ambient login's refresh rotation is still never
spent for another request's key. That path stays gated on
`creds["accessToken"] == token`, and `test_anthropic_owned_routing.py` still passes.

## Test Plan

New: `tests/agent/test_anthropic_stale_gateway_token.py` (3 cases, proven red on `main`):

- superseded in-memory token + valid newer disk login → recoverable
- superseded in-memory token + expired disk login → not recoverable (no eviction loop)
- no failed key → not recoverable

Each seeds an isolated `HERMES_HOME` and an empty credential pool, and fails the test outright
if `_refresh_oauth_token` is called, so a regression that starts spending a third party's
rotation is caught.

Ran the 74 `tests/agent/test_*{auxiliary,anthropic,credential}*` files before and after on the
same machine: **34 failures on `main` → 32 with the patch**, no new failure. The pre-existing
failures are local-environment noise (async/relay/pool fixtures), unrelated to this change.
