### PR TITLE
fix(agent): return clean-stop reasoning without costly retries

### DIFF
--- a/agent/turn_empty_response.py
+++ b/agent/turn_empty_response.py
@@ -189,6 +189,12 @@ def recover_empty_response(
         agent._emit_pending_fallback_notice()
         agent._clear_status_buffer()
         agent._drop_trailing_empty_response_scaffolding(messages)
+        while (
+            messages
+            and isinstance(messages[-1], dict)
+            and messages[-1].get("_thinking_prefill")
+        ):
+            messages.pop()
         final_msg = agent._build_assistant_message(assistant_message, finish_reason)
         final_msg["content"] = _reasoning_text
         append_message(messages, final_msg)

--- a/agent/turn_empty_response.py
+++ b/agent/turn_empty_response.py
@@ -1,10 +1,11 @@
 """Empty / thinking-only final-response recovery ladder for the conversation turn loop.
 
 Runs when the model returned no visible text after ``<think>`` blocks. Ladder order is
-load-bearing: partial-stream recovery → reuse prior turn content (housekeeping tools only)
-→ one post-tool-call nudge → thinking-only prefill continuation (×2) → empty-response
-retries (budgeted, deterministic-empty short-circuit) → fallback provider → terminal
-``(empty)`` sentinel. Nothing here imports ``agent.conversation_loop`` at module level.
+load-bearing: partial-stream recovery → clean-stop reasoning promotion → reuse prior turn
+content (housekeeping tools only) → one post-tool-call nudge → thinking-only prefill
+continuation (×2) → empty-response retries (budgeted, deterministic-empty short-circuit)
+→ fallback provider → terminal ``(empty)`` sentinel. Nothing here imports
+``agent.conversation_loop`` at module level.
 """
 
 from __future__ import annotations
@@ -174,6 +175,28 @@ def recover_empty_response(
         # A streamed fragment isn't a confirmed preview: gateway fallback delivery
         # sends the text plus the abnormal-turn explanation.
         agent._response_was_previewed = False
+        return _verdict("break")
+
+    # A clean stop says the provider considers generation complete. Some reasoning
+    # parsers misclassify the entire answer as reasoning when their closing delimiter
+    # is missing, so retrying would only re-bill the same input. Length-limited
+    # reasoning remains on the continuation path because it may be incomplete.
+    _reasoning_text = agent._extract_reasoning(assistant_message)
+    if finish_reason == "stop" and _reasoning_text:
+        _turn_exit_reason = "reasoning_response(clean_stop)"
+        agent._empty_content_retries = 0
+        agent._thinking_prefill_retries = 0
+        agent._emit_pending_fallback_notice()
+        agent._clear_status_buffer()
+        agent._drop_trailing_empty_response_scaffolding(messages)
+        final_msg = agent._build_assistant_message(assistant_message, finish_reason)
+        final_msg["content"] = _reasoning_text
+        append_message(messages, final_msg)
+        final_response = _reasoning_text
+        logger.info(
+            "Clean-stop reasoning-only response (%d chars) — using reasoning as final response",
+            len(_reasoning_text),
+        )
         return _verdict("break")
 
     # Prior turn had real content + ONLY housekeeping tools: model is done, reuse it.

--- a/agent/turn_empty_response.py
+++ b/agent/turn_empty_response.py
@@ -28,11 +28,12 @@ _INLINE_THINK_RE = re.compile(r'<think>|<thinking>|<reasoning>', re.IGNORECASE)
 class EmptyResponseVerdict:
     """Outcome of ``recover_empty_response``.
 
-    ``action``: ``"break"`` (turn is done — ``final_response`` is set), ``"continue"``
-    (re-enter the OUTER turn loop: a nudge/prefill row was appended, a retry wait
-    elapsed, or a fallback was activated and preflight must re-run), ``"return"``
-    (interrupted during a retry wait — return ``result``) or ``"fallthrough"``
-    (unreachable: every path exits; kept for the contract)."""
+    ``action``: ``"break"`` (turn is done — ``final_response`` is set), ``"promote"``
+    (reasoning became final text and must continue through the ordinary final-response
+    gates), ``"continue"`` (re-enter the OUTER turn loop: a nudge/prefill row was
+    appended, a retry wait elapsed, or a fallback was activated and preflight must
+    re-run), ``"return"`` (interrupted during a retry wait — return ``result``) or
+    ``"fallthrough"`` (unreachable: every path exits; kept for the contract)."""
 
     action: str
     result: Optional[Dict[str, Any]]
@@ -184,26 +185,12 @@ def recover_empty_response(
     _reasoning_text = agent._extract_reasoning(assistant_message)
     if finish_reason == "stop" and _reasoning_text:
         _turn_exit_reason = "reasoning_response(clean_stop)"
-        agent._empty_content_retries = 0
-        agent._thinking_prefill_retries = 0
-        agent._emit_pending_fallback_notice()
-        agent._clear_status_buffer()
-        agent._drop_trailing_empty_response_scaffolding(messages)
-        while (
-            messages
-            and isinstance(messages[-1], dict)
-            and messages[-1].get("_thinking_prefill")
-        ):
-            messages.pop()
-        final_msg = agent._build_assistant_message(assistant_message, finish_reason)
-        final_msg["content"] = _reasoning_text
-        append_message(messages, final_msg)
         final_response = _reasoning_text
         logger.info(
             "Clean-stop reasoning-only response (%d chars) — using reasoning as final response",
             len(_reasoning_text),
         )
-        return _verdict("break")
+        return _verdict("promote")
 
     # Prior turn had real content + ONLY housekeeping tools: model is done, reuse it.
     # With substantive tools it was mid-task narration and the empty reply is a choke;

--- a/agent/turn_final_response.py
+++ b/agent/turn_final_response.py
@@ -146,6 +146,8 @@ def finish_text_response(
             )
         codex_ack_continuations += 1
         interim_msg = agent._build_assistant_message(assistant_message, "incomplete")
+        if promoted_clean_stop:
+            interim_msg["content"] = agent._strip_think_blocks(final_response).strip()
         append_message(messages, interim_msg)
         agent._emit_interim_assistant_message(interim_msg)
         append_message(messages, {"role": "user", "content": _CODEX_ACK_CONTINUATION_NUDGE})

--- a/agent/turn_final_response.py
+++ b/agent/turn_final_response.py
@@ -73,6 +73,7 @@ def finish_text_response(
         )
 
     final_response = assistant_message.content or ""
+    promoted_clean_stop = False
     # Unmute: _mute_post_response from a housekeeping tool turn must not silence
     # empty-response warnings on the final response path.
     agent._mute_post_response = False
@@ -94,7 +95,9 @@ def finish_text_response(
             return _verdict("return", _ev.result)
         if _ev.action == "break":
             return _verdict("break")
-        return _verdict("continue")
+        if _ev.action != "promote":
+            return _verdict("continue")
+        promoted_clean_stop = True
 
     agent._empty_content_retries = 0
     agent._thinking_prefill_retries = 0
@@ -167,6 +170,8 @@ def finish_text_response(
     final_response = agent._strip_think_blocks(final_response).strip()
 
     final_msg = agent._build_assistant_message(assistant_message, finish_reason)
+    if promoted_clean_stop:
+        final_msg["content"] = final_response
 
     # Dropped tool-call recovery (copilot/Claude): finish_reason="tool_calls" with empty
     # tool_calls would end the turn unstarted; re-prompt (max 3 CONSECUTIVE stalls).
@@ -236,7 +241,8 @@ def finish_text_response(
             exc_info=True,
         )
 
-    _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
+    if not promoted_clean_stop:
+        _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
     if not agent.quiet_mode:
         agent._safe_print(f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)")
     return _verdict("break")

--- a/agent/turn_final_response.py
+++ b/agent/turn_final_response.py
@@ -74,6 +74,7 @@ def finish_text_response(
 
     final_response = assistant_message.content or ""
     promoted_clean_stop = False
+    promoted_content_for_storage = None
     # Unmute: _mute_post_response from a housekeeping tool turn must not silence
     # empty-response warnings on the final response path.
     agent._mute_post_response = False
@@ -98,6 +99,11 @@ def finish_text_response(
         if _ev.action != "promote":
             return _verdict("continue")
         promoted_clean_stop = True
+        from agent.redact import redact_sensitive_text
+
+        promoted_content_for_storage = redact_sensitive_text(
+            agent._strip_think_blocks(final_response).strip()
+        )
 
     agent._empty_content_retries = 0
     agent._thinking_prefill_retries = 0
@@ -147,7 +153,7 @@ def finish_text_response(
         codex_ack_continuations += 1
         interim_msg = agent._build_assistant_message(assistant_message, "incomplete")
         if promoted_clean_stop:
-            interim_msg["content"] = agent._strip_think_blocks(final_response).strip()
+            interim_msg["content"] = promoted_content_for_storage
         append_message(messages, interim_msg)
         agent._emit_interim_assistant_message(interim_msg)
         append_message(messages, {"role": "user", "content": _CODEX_ACK_CONTINUATION_NUDGE})
@@ -173,7 +179,7 @@ def finish_text_response(
 
     final_msg = agent._build_assistant_message(assistant_message, finish_reason)
     if promoted_clean_stop:
-        final_msg["content"] = final_response
+        final_msg["content"] = promoted_content_for_storage
 
     # Dropped tool-call recovery (copilot/Claude): finish_reason="tool_calls" with empty
     # tool_calls would end the turn unstarted; re-prompt (max 3 CONSECUTIVE stalls).

--- a/tests/run_agent/test_empty_terminal_reasoning_surface.py
+++ b/tests/run_agent/test_empty_terminal_reasoning_surface.py
@@ -79,6 +79,28 @@ def _truly_empty_response():
     )
 
 
+def _tool_call_response():
+    tool_call = SimpleNamespace(
+        id="call_1",
+        type="function",
+        function=SimpleNamespace(name="todo", arguments="{}"),
+    )
+    return SimpleNamespace(
+        choices=[SimpleNamespace(
+            message=SimpleNamespace(
+                content="",
+                reasoning=None,
+                reasoning_content=None,
+                reasoning_details=None,
+                tool_calls=[tool_call],
+            ),
+            finish_reason="tool_calls",
+        )],
+        usage=None,
+        model="test-model",
+    )
+
+
 def test_clean_stop_reasoning_is_promoted_without_retry(tmp_path, monkeypatch):
     agent = _build_agent(tmp_path, monkeypatch)
     calls = 0
@@ -123,6 +145,64 @@ def test_clean_stop_promotion_removes_prior_thinking_prefill(tmp_path, monkeypat
     assert not any(message.get("_thinking_prefill") for message in result["messages"])
     roles = [message["role"] for message in result["messages"]]
     assert all(left != right for left, right in zip(roles, roles[1:]))
+
+
+def test_clean_stop_promotion_preserves_completed_tool_exchange(tmp_path, monkeypatch):
+    agent = _build_agent(tmp_path, monkeypatch)
+    responses = [
+        _tool_call_response(),
+        _truly_empty_response(),
+        _reasoning_only_response(reasoning="The tool result is complete."),
+    ]
+    monkeypatch.setattr(
+        agent,
+        "_interruptible_api_call",
+        lambda api_kwargs: responses.pop(0),
+    )
+
+    def execute_tool(assistant_message, messages, effective_task_id, api_call_count=0):
+        messages.append({
+            "role": "tool",
+            "name": "todo",
+            "tool_call_id": "call_1",
+            "content": "tool result",
+        })
+
+    monkeypatch.setattr(agent, "_execute_tool_calls", execute_tool)
+
+    result = agent.run_conversation("run the tool")
+
+    assert result["final_response"] == "The tool result is complete."
+    assert not responses
+    assert any(message.get("tool_calls") for message in result["messages"])
+    assert any(message.get("role") == "tool" for message in result["messages"])
+    assert not any(
+        message.get("_empty_recovery_synthetic") for message in result["messages"]
+    )
+
+
+def test_clean_stop_promotion_runs_kanban_stop_gate(tmp_path, monkeypatch):
+    agent = _build_agent(tmp_path, monkeypatch)
+    responses = [
+        _reasoning_only_response(reasoning="I am done."),
+        _reasoning_only_response(reasoning="Lifecycle action completed."),
+    ]
+    monkeypatch.setattr(
+        agent,
+        "_interruptible_api_call",
+        lambda api_kwargs: responses.pop(0),
+    )
+    monkeypatch.setattr(
+        "agent.kanban_stop.build_kanban_stop_nudge",
+        lambda messages, attempts=0: "Call the terminal lifecycle tool." if attempts == 0 else None,
+    )
+
+    result = agent.run_conversation("finish the task")
+
+    assert result["final_response"] == "Lifecycle action completed."
+    assert result["turn_exit_reason"] == "reasoning_response(clean_stop)"
+    assert agent._kanban_stop_nudges == 1
+    assert not responses
 
 
 def test_exhausted_truly_empty_keeps_existing_behavior(tmp_path, monkeypatch):

--- a/tests/run_agent/test_empty_terminal_reasoning_surface.py
+++ b/tests/run_agent/test_empty_terminal_reasoning_surface.py
@@ -44,12 +44,13 @@ def _build_agent(tmp_path, monkeypatch):
     return agent
 
 
-def _reasoning_only_response(*, finish_reason="stop"):
+def _reasoning_only_response(*, finish_reason="stop", reasoning=None):
+    reasoning = reasoning or "The answer is 42 because of the calculation above."
     return SimpleNamespace(
         choices=[SimpleNamespace(
             message=SimpleNamespace(
                 content="",
-                reasoning="The answer is 42 because of the calculation above.",
+                reasoning=reasoning,
                 reasoning_content=None,
                 reasoning_details=None,
                 tool_calls=None,
@@ -97,6 +98,31 @@ def test_clean_stop_reasoning_is_promoted_without_retry(tmp_path, monkeypatch):
     assert calls == 1
     assert result["messages"][-1]["content"] == expected
     assert result["messages"][-1]["reasoning"] == expected
+
+
+def test_clean_stop_promotion_removes_prior_thinking_prefill(tmp_path, monkeypatch):
+    agent = _build_agent(tmp_path, monkeypatch)
+    responses = [
+        _reasoning_only_response(
+            finish_reason="tool_calls",
+            reasoning="Still working through the request.",
+        ),
+        _reasoning_only_response(reasoning="The completed answer."),
+    ]
+    monkeypatch.setattr(
+        agent,
+        "_interruptible_api_call",
+        lambda api_kwargs: responses.pop(0),
+    )
+
+    result = agent.run_conversation("what is the answer?")
+
+    assert result["final_response"] == "The completed answer."
+    assert result["turn_exit_reason"] == "reasoning_response(clean_stop)"
+    assert not responses
+    assert not any(message.get("_thinking_prefill") for message in result["messages"])
+    roles = [message["role"] for message in result["messages"]]
+    assert all(left != right for left, right in zip(roles, roles[1:]))
 
 
 def test_exhausted_truly_empty_keeps_existing_behavior(tmp_path, monkeypatch):

--- a/tests/run_agent/test_empty_terminal_reasoning_surface.py
+++ b/tests/run_agent/test_empty_terminal_reasoning_surface.py
@@ -1,16 +1,13 @@
-"""Tests for the empty-terminal reasoning surface.
+"""Tests for reasoning-only and truly empty final responses.
 
-When the empty-response ladder is fully exhausted (prefill continuation,
-empty-content retries, provider fallback) and the model produced structured
-reasoning but no visible text, the DELIVERED final_response is a clearly
-labeled reasoning excerpt instead of a bare "(empty)" — the reasoning often
-contains the actual answer. Idea credit: PR #48795 (@ligl0325).
+When a provider reports a clean stop with structured reasoning but no visible
+text, the reasoning is the completed response and must bypass the expensive
+empty-response recovery ladder. Idea credit: PR #48795 (@ligl0325).
 
 Invariants pinned here:
-- The persisted assistant message keeps the "(empty)" sentinel and the
-  ``_empty_terminal_sentinel`` marker (replay semantics unchanged).
-- Raw reasoning is NEVER promoted earlier in the ladder — a reasoning-only
-  response still goes through prefill continuation first.
+- Clean-stop reasoning is returned and persisted without another API call.
+- Length-limited reasoning still goes through continuation instead of being
+  promoted as a complete answer.
 - A truly empty exhaustion (no reasoning either) still returns "(empty)".
 """
 
@@ -47,7 +44,7 @@ def _build_agent(tmp_path, monkeypatch):
     return agent
 
 
-def _reasoning_only_response():
+def _reasoning_only_response(*, finish_reason="stop"):
     return SimpleNamespace(
         choices=[SimpleNamespace(
             message=SimpleNamespace(
@@ -57,7 +54,7 @@ def _reasoning_only_response():
                 reasoning_details=None,
                 tool_calls=None,
             ),
-            finish_reason="stop",
+            finish_reason=finish_reason,
         )],
         usage=None,
         model="test-model",
@@ -81,32 +78,25 @@ def _truly_empty_response():
     )
 
 
-def test_exhausted_reasoning_only_delivers_labeled_excerpt(tmp_path, monkeypatch):
-    """After the full ladder is exhausted on reasoning-only responses, the
-    delivered text is the labeled excerpt — not a bare '(empty)' — while the
-    transcript keeps its existing sentinel-scaffolding semantics."""
+def test_clean_stop_reasoning_is_promoted_without_retry(tmp_path, monkeypatch):
     agent = _build_agent(tmp_path, monkeypatch)
-    monkeypatch.setattr(
-        agent, "_interruptible_api_call",
-        lambda api_kwargs: _reasoning_only_response(),
-    )
+    calls = 0
+
+    def respond(api_kwargs):
+        nonlocal calls
+        calls += 1
+        return _reasoning_only_response()
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", respond)
 
     result = agent.run_conversation("what is the answer?")
 
-    final = result["final_response"]
-    assert "(empty)" != final
-    assert "only internal reasoning" in final
-    assert "The answer is 42" in final
-
-    # Persistence semantics unchanged: the delivered excerpt is
-    # delivery-only. The turn finalizer strips the "(empty)" terminal
-    # sentinel from the transcript tail (replay safety, existing design),
-    # and the labeled excerpt must never be persisted as assistant content.
-    assert not any(
-        m.get("role") == "assistant"
-        and "only internal reasoning" in (m.get("content") or "")
-        for m in result["messages"]
-    )
+    expected = "The answer is 42 because of the calculation above."
+    assert result["final_response"] == expected
+    assert result["turn_exit_reason"] == "reasoning_response(clean_stop)"
+    assert calls == 1
+    assert result["messages"][-1]["content"] == expected
+    assert result["messages"][-1]["reasoning"] == expected
 
 
 def test_exhausted_truly_empty_keeps_existing_behavior(tmp_path, monkeypatch):
@@ -128,13 +118,10 @@ def test_exhausted_truly_empty_keeps_existing_behavior(tmp_path, monkeypatch):
     assert "only internal reasoning" not in final
 
 
-def test_reasoning_never_promoted_before_ladder_exhaustion(tmp_path, monkeypatch):
-    """A reasoning-only response must first go through prefill continuation —
-    if the model then produces real text, THAT is the answer, and no labeled
-    reasoning excerpt appears."""
+def test_length_limited_reasoning_still_uses_continuation(tmp_path, monkeypatch):
     agent = _build_agent(tmp_path, monkeypatch)
     responses = [
-        _reasoning_only_response(),
+        _reasoning_only_response(finish_reason="length"),
         SimpleNamespace(
             choices=[SimpleNamespace(
                 message=SimpleNamespace(
@@ -158,4 +145,5 @@ def test_reasoning_never_promoted_before_ladder_exhaustion(tmp_path, monkeypatch
     result = agent.run_conversation("what is the answer?")
 
     assert result["final_response"] == "42."
-    assert "only internal reasoning" not in result["final_response"]
+    assert result["turn_exit_reason"] == "text_response(finish_reason=stop)"
+    assert not responses

--- a/tests/run_agent/test_empty_terminal_reasoning_surface.py
+++ b/tests/run_agent/test_empty_terminal_reasoning_surface.py
@@ -79,6 +79,23 @@ def _truly_empty_response():
     )
 
 
+def _text_response(content):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(
+            message=SimpleNamespace(
+                content=content,
+                reasoning=None,
+                reasoning_content=None,
+                reasoning_details=None,
+                tool_calls=None,
+            ),
+            finish_reason="stop",
+        )],
+        usage=None,
+        model="test-model",
+    )
+
+
 def _tool_call_response():
     tool_call = SimpleNamespace(
         id="call_1",
@@ -120,6 +137,33 @@ def test_clean_stop_reasoning_is_promoted_without_retry(tmp_path, monkeypatch):
     assert calls == 1
     assert result["messages"][-1]["content"] == expected
     assert result["messages"][-1]["reasoning"] == expected
+
+
+def test_clean_stop_promotion_survives_stall_guard_continuation(tmp_path, monkeypatch):
+    agent = _build_agent(tmp_path, monkeypatch)
+    agent.valid_tool_names = {"todo"}
+    promoted = "The tests pass. I will now run the linter."
+    responses = [
+        _reasoning_only_response(reasoning=promoted),
+        _text_response("The linter passes."),
+    ]
+    monkeypatch.setattr(
+        agent,
+        "_interruptible_api_call",
+        lambda api_kwargs: responses.pop(0),
+    )
+
+    result = agent.run_conversation("verify the change")
+
+    assert result["final_response"] == "The linter passes."
+    assert not responses
+    assistant_messages = [
+        message for message in result["messages"] if message["role"] == "assistant"
+    ]
+    assert assistant_messages[0]["content"] == promoted
+    assert assistant_messages[-1]["content"] == "The linter passes."
+    roles = [message["role"] for message in result["messages"]]
+    assert all(left != right for left, right in zip(roles, roles[1:]))
 
 
 def test_clean_stop_promotion_removes_prior_thinking_prefill(tmp_path, monkeypatch):

--- a/tests/run_agent/test_empty_terminal_reasoning_surface.py
+++ b/tests/run_agent/test_empty_terminal_reasoning_surface.py
@@ -121,28 +121,30 @@ def _tool_call_response():
 def test_clean_stop_reasoning_is_promoted_without_retry(tmp_path, monkeypatch):
     agent = _build_agent(tmp_path, monkeypatch)
     calls = 0
+    secret = "sk-" + "promoted-secret-value-123456"
+    expected = f"The answer is 42. Credential: {secret}"
 
     def respond(api_kwargs):
         nonlocal calls
         calls += 1
-        return _reasoning_only_response()
+        return _reasoning_only_response(reasoning=expected)
 
     monkeypatch.setattr(agent, "_interruptible_api_call", respond)
 
     result = agent.run_conversation("what is the answer?")
 
-    expected = "The answer is 42 because of the calculation above."
     assert result["final_response"] == expected
     assert result["turn_exit_reason"] == "reasoning_response(clean_stop)"
     assert calls == 1
-    assert result["messages"][-1]["content"] == expected
+    assert secret not in result["messages"][-1]["content"]
     assert result["messages"][-1]["reasoning"] == expected
 
 
 def test_clean_stop_promotion_survives_stall_guard_continuation(tmp_path, monkeypatch):
     agent = _build_agent(tmp_path, monkeypatch)
     agent.valid_tool_names = {"todo"}
-    promoted = "The tests pass. I will now run the linter."
+    secret = "sk-" + "interim-secret-value-123456"
+    promoted = f"The tests pass. Credential: {secret}. I will now run the linter."
     responses = [
         _reasoning_only_response(reasoning=promoted),
         _text_response("The linter passes."),
@@ -160,7 +162,8 @@ def test_clean_stop_promotion_survives_stall_guard_continuation(tmp_path, monkey
     assistant_messages = [
         message for message in result["messages"] if message["role"] == "assistant"
     ]
-    assert assistant_messages[0]["content"] == promoted
+    assert assistant_messages[0]["content"].startswith("The tests pass.")
+    assert secret not in assistant_messages[0]["content"]
     assert assistant_messages[-1]["content"] == "The linter passes."
     roles = [message["role"] for message in result["messages"]]
     assert all(left != right for left, right in zip(roles, roles[1:]))

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3451,7 +3451,7 @@ class TestRunConversation:
         assert result["api_calls"] == 2
 
     def test_reasoning_only_local_resumed_no_compression_triggered(self, agent):
-        """Reasoning-only responses no longer trigger compression — prefill then accepted."""
+        """Clean-stop reasoning is accepted without compression or retries."""
         self._setup_agent(agent)
         agent.base_url = "http://127.0.0.1:1234/v1"
         agent.compression_enabled = True
@@ -3465,9 +3465,8 @@ class TestRunConversation:
             {"role": "assistant", "content": "old answer"},
         ]
 
-        # 6 responses: original + 2 prefill + 3 retries after prefill exhaustion
         with (
-            patch.object(agent, "_interruptible_api_call", side_effect=[empty_resp] * 6),
+            patch.object(agent, "_interruptible_api_call", return_value=empty_resp),
             patch.object(agent, "_compress_context") as mock_compress,
             patch.object(agent, "_persist_session"),
             patch.object(agent, "_save_trajectory"),
@@ -3477,27 +3476,19 @@ class TestRunConversation:
 
         mock_compress.assert_not_called()  # no compression triggered
         assert result["completed"] is True
-        # The bare "(empty)" sentinel is never delivered for reasoning-only
-        # exhaustion: the labeled reasoning excerpt (which may contain the
-        # answer) replaces it at the terminal. See
-        # test_empty_terminal_reasoning_surface.py; #34452's explainer still
-        # covers the truly-empty case.
-        assert result["final_response"] != "(empty)"
-        assert "only internal reasoning" in result["final_response"]
-        assert "reasoning only" in result["final_response"]
-        assert result["turn_exit_reason"] == "empty_response_exhausted"
-        assert result["api_calls"] == 6  # 1 original + 2 prefill + 3 retries
+        assert result["final_response"] == "reasoning only"
+        assert result["turn_exit_reason"] == "reasoning_response(clean_stop)"
+        assert result["api_calls"] == 1
 
     def test_reasoning_only_response_prefill_then_empty(self, agent):
-        """Structured reasoning-only triggers prefill (2), then retries (3), then (empty)."""
+        """Structured clean-stop reasoning is promoted directly."""
         self._setup_agent(agent)
         empty_resp = _mock_response(
             content=None,
             finish_reason="stop",
             reasoning_content="structured reasoning answer",
         )
-        # 6 responses: 1 original + 2 prefill + 3 retries after prefill exhaustion
-        agent.client.chat.completions.create.side_effect = [empty_resp] * 6
+        agent.client.chat.completions.create.return_value = empty_resp
         with (
             patch.object(agent, "_persist_session"),
             patch.object(agent, "_save_trajectory"),
@@ -3505,13 +3496,9 @@ class TestRunConversation:
         ):
             result = agent.run_conversation("answer me")
         assert result["completed"] is True
-        # Reasoning-only exhaustion delivers the labeled reasoning excerpt
-        # instead of the bare "(empty)" sentinel (see
-        # test_empty_terminal_reasoning_surface.py).
-        assert result["final_response"] != "(empty)"
-        assert "only internal reasoning" in result["final_response"]
-        assert "structured reasoning answer" in result["final_response"]
-        assert result["api_calls"] == 6  # 1 original + 2 prefill + 3 retries
+        assert result["final_response"] == "structured reasoning answer"
+        assert result["turn_exit_reason"] == "reasoning_response(clean_stop)"
+        assert result["api_calls"] == 1
 
 
     def test_truly_empty_response_stops_after_repeated_empty(self, agent):

--- a/tests/run_agent/test_thinking_prefill_trailing_turn.py
+++ b/tests/run_agent/test_thinking_prefill_trailing_turn.py
@@ -1,11 +1,12 @@
 """Regression test for the thinking-only prefill reaching the wire.
 
-A thinking-only response (reasoning tokens, no visible text) makes the loop
-append an empty assistant turn and re-send so the model continues its own
-reasoning. On providers that don't echo reasoning back, the API copy has its
-reasoning fields stripped before ``_drop_thinking_only_and_merge_users`` runs,
-so the drop pass used to see a bare ``{"role": "assistant", "content": ""}``
-and let it through. Gemini rejects that with
+A non-clean-stop thinking-only response (reasoning tokens, no visible text)
+makes the loop append an empty assistant turn and re-send so the model continues
+its own reasoning. On providers that don't echo
+reasoning back, the API copy has its reasoning fields stripped before
+``_drop_thinking_only_and_merge_users`` runs, so the drop pass used to see a
+bare ``{"role": "assistant", "content": ""}`` and let it through. Gemini rejects
+that with
 
     400 INVALID_ARGUMENT: Requests ending with a model turn are not supported.
 
@@ -52,11 +53,11 @@ def loop_agent():
 
 
 def _thinking_only_response():
-    """Reasoning tokens, no visible text — what triggers the prefill retry."""
+    """Reasoning without a clean-stop signal triggers prefill retry."""
     from tests.run_agent.test_run_agent import _mock_response
     return _mock_response(
         content="",
-        finish_reason="stop",
+        finish_reason="tool_calls",
         reasoning="Let me work through the request step by step.",
     )
 


### PR DESCRIPTION
## What does this PR do?

Reasoning-only responses that finish with `stop` now return their completed reasoning immediately instead of walking the empty-response retry and fallback ladder. This prevents repeated billing of very large prompts and preserves the existing continuation behavior for every non-clean-stop response.

### Symptom

An OpenAI-compatible provider can return `content: null`, a complete answer in `reasoning`, and `finish_reason: stop`. Hermes treats that response as empty, retries the full prompt multiple times, and eventually returns only a truncated, misleading reasoning preview.

### Impact

Affected long-context requests can incur repeated full-input charges and large delays even though the first response already contains the answer. The reported 1,017,932-token request took 747 seconds for one prefill.

### Bug Cause

**Trigger:** `agent/turn_empty_response.py:recover_empty_response` when visible content is empty but structured reasoning is present on a clean stop.

**Causal chain:**
1. A provider parser places a completed answer in the reasoning field and returns `finish_reason="stop"` with no visible content.
2. `recover_empty_response()` routes every structured reasoning-only response into prefill continuation without considering the finish reason.
3. Hermes performs continuations, empty retries, and provider fallback before returning a truncated warning instead of the completed answer.

**Why it is wrong:** A clean stop marks generation as complete, so retrying the same large input cannot improve the already completed response and adds avoidable latency and cost.

**Working sibling / contrast:** A reasoning-only response with `finish_reason="length"` or another non-clean-stop signal is not known to be complete and correctly remains on the existing continuation path.

**Ruled out:** This is not a truly empty provider response because `_extract_reasoning()` returns the complete non-empty answer from the original response.

### Fix

Add a clean-stop reasoning rung immediately after partial-stream recovery. It resets empty-recovery state, preserves reasoning metadata, persists the promoted answer as assistant content, and exits without another provider call. Length-limited and reasoning-missing responses keep their existing paths.

## Related Issue

Closes #109205

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/turn_empty_response.py` - promote non-empty reasoning on a clean stop before retry recovery.
- `tests/run_agent/test_empty_terminal_reasoning_surface.py` - cover immediate promotion, persistence, and the length-limited boundary.
- `tests/run_agent/test_thinking_prefill_trailing_turn.py` - retain wire-level prefill coverage for non-clean-stop reasoning.

## How to Test

1. Run the focused reasoning-only response and adjacent recovery tests:

```bash
scripts/run_tests.sh tests/run_agent/test_empty_terminal_reasoning_surface.py tests/run_agent/test_thinking_prefill_trailing_turn.py tests/run_agent/test_thinking_only_sanitizer.py tests/run_agent/test_length_continuation_thinking_exhaustion.py
```

2. Confirm the clean-stop case makes one provider call and returns the full reasoning text.
3. Confirm the length-limited and non-clean-stop cases retain their continuation behavior.

Automated result: 36 tests passed on Windows 11.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

N/A
