### PR TITLE
fix(mcp): upgrade default atlassian mcp endpoint to v2

### DIFF
--- a/apps/desktop/src/lib/mcp-directory.ts
+++ b/apps/desktop/src/lib/mcp-directory.ts
@@ -42,7 +42,7 @@ export const MCP_DIRECTORY: McpDirectoryEntry[] = [
     hosts: ['atlassian.net', 'atlassian.com', 'jira.com'],
     keywords: ['jira', 'confluence', 'atlassian', 'bitbucket'],
     name: 'atlassian',
-    url: 'https://mcp.atlassian.com/v1/sse'
+    url: 'https://mcp.atlassian.com/v2/mcp'
   },
   {
     description: 'Find, create, and update Linear issues and projects.',

--- a/optional-mcps/atlassian/manifest.yaml
+++ b/optional-mcps/atlassian/manifest.yaml
@@ -13,11 +13,8 @@ source: https://support.atlassian.com/rovo/docs/getting-started-with-the-atlassi
 # exchange, and refresh.
 transport:
   type: http
-  # /v1/sse was deprecated by Atlassian after June 30, 2026 (404s since the
-  # cutover — OAuth succeeded but every handshake failed; issue #91538).
-  # /v1/mcp/authv2 is the endpoint Atlassian's docs recommend for custom
-  # clients (Streamable HTTP, native OAuth 2.1 + DCR — verified live).
-  url: https://mcp.atlassian.com/v1/mcp/authv2
+  # Atlassian Rovo MCP v2 endpoint (Streamable HTTP, native OAuth 2.1 + DCR).
+  url: https://mcp.atlassian.com/v2/mcp
 
 auth:
   type: oauth

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -833,7 +833,7 @@ class TestBuildOAuthAuthNonInteractive:
         monkeypatch.setattr("tools.mcp_oauth.sys.stdin", mock_stdin)
 
         with pytest.raises(OAuthNonInteractiveError, match="non-interactive"):
-            build_oauth_auth("atlassian", "https://mcp.atlassian.com/v1/mcp")
+            build_oauth_auth("atlassian", "https://mcp.atlassian.com/v2/mcp")
 
 
 class TestNonInteractiveFailFastAtCallbackBoundary:


### PR DESCRIPTION
## What does this PR do?

    Upgrades the default Atlassian Rovo MCP configuration to use the v2 endpoint (`https://mcp.atlassian.com/v2/mcp`), replacing deprecated v1
  endpoints (`/v1/mcp`, `/v1/mcp/authv2`, `/v1/sse`) in accordance with Atlassian's upgrade guide:
    https://support.atlassian.com/atlassian-ai-gateway/docs/how-to-upgrade-from-atlassian-rovo-mcp-v1-to-atlassian-rovo-mcp-v2/

    ## Type of Change

    - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
    - [x] ♻️ Refactor (no behavior change)

    ## Changes Made

    - `optional-mcps/atlassian/manifest.yaml`: Updated transport URL from `https://mcp.atlassian.com/v1/mcp/authv2` to `https://mcp.atlassian.
  com/v2/mcp`.
    - `apps/desktop/src/lib/mcp-directory.ts`: Updated desktop fallback directory URL for `atlassian` to `https://mcp.atlassian.com/v2/mcp`.
    - `tests/tools/test_mcp_oauth.py`: Updated mock server URL to v2 endpoint.

    ## How to Test

    1. Run `pytest tests/hermes_cli/test_mcp_catalog.py tests/hermes_cli/test_mcp_config.py` (all tests pass).
    2. Validate catalog manifest parsing: `hermes mcp install atlassian`.

    ## Checklist

    ### Code

    - [x] I've read the Contributing Guide
    - [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
    - [x] I searched for existing PRs to make sure this isn't a duplicate
    - [x] My PR contains only changes related to this fix/feature
    - [x] I've run `pytest tests/ -q` and relevant tests pass
    - [x] I've tested on my platform: Linux (x86_64)