### PR TITLE
fix(computer-use): restore capture target after transport recovery

### DIFF
--- a/tests/tools/test_computer_use_capture_reconnect.py
+++ b/tests/tools/test_computer_use_capture_reconnect.py
@@ -1,0 +1,171 @@
+import base64
+import json
+from io import BytesIO
+from unittest.mock import Mock
+
+import pytest
+from PIL import Image
+
+from tools.computer_use.cua_backend import CuaDriverBackend
+
+
+@pytest.fixture
+def backend(monkeypatch):
+    backend = CuaDriverBackend()
+    backend._session._capabilities = {
+        "get_window_state": set(),
+        "click": {"accessibility.element_tokens"},
+    }
+    backend._session._tool_schemas = {"click": {"properties": {"element_token": {}}}}
+    monkeypatch.setattr(backend._session, "call_tool", Mock())
+    monkeypatch.setattr(backend._session, "_call_tool_via_cli", Mock())
+    return backend
+
+
+@pytest.fixture
+def dispatch(backend, monkeypatch):
+    import tools.computer_use_tool  # noqa: F401 -- registers the production handler
+    from tools.computer_use import tool
+    from tools.registry import registry
+
+    monkeypatch.setattr(tool, "_get_backend", lambda **kwargs: backend)
+
+    def call(**args):
+        result = registry.dispatch("computer_use", args)
+        assert isinstance(result, str)
+        return json.loads(result)
+
+    return call
+
+
+def _snapshot(token=None, *, image=False):
+    element = {"element_index": 0, "role": "button", "label": "Counter"}
+    if token:
+        element["element_token"] = token
+    images = []
+    if image:
+        buffer = BytesIO()
+        Image.new("RGB", (2, 2)).save(buffer, format="PNG")
+        images.append(base64.b64encode(buffer.getvalue()).decode("ascii"))
+    return {"data": "", "images": images, "structuredContent": {"elements": [element]}, "isError": False}
+
+
+@pytest.mark.parametrize("mode,read_tool", [
+    ("ax", "get_window_state"),
+    ("som", "get_window_state"),
+    ("vision", "get_window_state"),
+    ("vision", "screenshot"),
+])
+def test_capture_adopts_target_and_snapshot_after_transport_reset(backend, dispatch, mode, read_tool):
+    transport = backend._session.call_tool
+    transport.return_value = _snapshot("old:0")
+    assert backend.capture(mode="som", pid=101, window_id=202).elements
+    assert backend.click(element=0).ok
+    assert transport.call_args.args[1]["element_token"] == "old:0"
+
+    if read_tool == "screenshot":
+        backend._session._capabilities["screenshot"] = set()
+
+    def recovered_read(name, args):
+        assert name == read_tool
+        assert args["window_id"] == 456
+        backend._session._notify_transport_reset()
+        return _snapshot("fresh:0", image=mode == "vision")
+
+    transport.side_effect = recovered_read
+    capture = backend.capture(mode=mode, app="Counter", pid=123, window_id=456)
+    if mode == "vision":
+        assert capture.png_b64 and not capture.elements
+    else:
+        assert capture.elements[0].element_token == "fresh:0"
+
+    transport.side_effect = None
+    transport.return_value = {"data": "", "structuredContent": {"ok": True}, "isError": False}
+    assert dispatch(action="click", element=0, app="Counter")["ok"]
+    args = transport.call_args.args[1]
+    assert (args["pid"], args["window_id"]) == (123, 456)
+    assert args.get("element_token") == (None if mode == "vision" else "fresh:0")
+    assert backend.type_text("fresh target").ok
+    assert backend.key("return").ok
+    backend._session._call_tool_via_cli.assert_not_called()
+
+    backend._session._notify_transport_reset()
+    transport.reset_mock()
+    assert not backend.click(element=0).ok
+    assert not backend.type_text("must not land").ok
+    assert not backend.key("return").ok
+    transport.assert_not_called()
+
+    transport.return_value = _snapshot()
+    assert backend.capture(mode="som", pid=123, window_id=456).elements
+    assert backend.click(element=0).ok
+    assert "element_token" not in transport.call_args.args[1]
+
+
+@pytest.mark.parametrize("screenshot_available,use_cli", [(True, False), (True, True), (False, True)])
+def test_vision_fallback_preserves_target_after_imageless_reconnect(backend, screenshot_available, use_cli):
+    transport = backend._session.call_tool
+    if screenshot_available:
+        backend._session._capabilities["screenshot"] = set()
+    empty = {"data": "", "images": [], "structuredContent": {}, "isError": False}
+    reads = []
+
+    def recovered_read(name, args):
+        reads.append(name)
+        assert args["window_id"] == 456
+        if name == "get_window_state":
+            assert args["pid"] == 123
+        if len(reads) == 1:
+            backend._session._notify_transport_reset()
+        return empty if name == "screenshot" or use_cli else _snapshot(image=True)
+
+    def cli_read(name, args, timeout):
+        assert name == "get_window_state"
+        assert (args["pid"], args["window_id"]) == (123, 456)
+        return _snapshot(image=True)
+
+    transport.side_effect = recovered_read
+    fallback = backend._session._call_tool_via_cli
+    fallback.side_effect = cli_read
+    capture = backend.capture(mode="vision", pid=123, window_id=456)
+
+    assert capture.png_b64 and not capture.elements
+    assert reads == (["screenshot", "get_window_state"] if screenshot_available else ["get_window_state"])
+    assert fallback.call_count == int(use_cli)
+    transport.side_effect = None
+    transport.return_value = {"data": "", "structuredContent": {"ok": True}, "isError": False}
+    assert backend.click(x=1, y=1).ok
+    args = transport.call_args.args[1]
+    assert (args["pid"], args["window_id"]) == (123, 456)
+
+
+@pytest.mark.parametrize("mode", ["som", "vision"])
+@pytest.mark.parametrize("fallback_failure", ["error", "exception", "empty"])
+def test_failed_capture_fallback_keeps_input_disarmed(backend, dispatch, mode, fallback_failure):
+    transport = backend._session.call_tool
+    transport.return_value = _snapshot("old:0")
+    assert backend.capture(mode="som", pid=101, window_id=202).elements
+    assert backend.click(element=0).ok
+
+    empty = {"data": "", "images": [], "structuredContent": {}, "isError": False}
+    transport.return_value = empty
+    fallback = backend._session._call_tool_via_cli
+    fallback.return_value = empty
+    if fallback_failure == "error":
+        fallback.return_value = {**empty, "data": "window gone", "isError": True}
+    elif fallback_failure == "exception":
+        fallback.side_effect = RuntimeError("driver unavailable")
+
+    capture = backend.capture(mode=mode, pid=123, window_id=456)
+
+    assert not capture.elements and not capture.png_b64
+    fallback.assert_called_once()
+    name, args, _ = fallback.call_args.args
+    assert name == "get_window_state"
+    assert (args["pid"], args["window_id"]) == (123, 456)
+    transport.reset_mock()
+    assert not dispatch(action="click", element=0)["ok"]
+    assert not backend.click(x=10, y=10).ok
+    assert not backend.type_text("must not land").ok
+    assert not backend.key("return").ok
+    transport.assert_not_called()

--- a/tools/computer_use/cua_backend_capture.py
+++ b/tools/computer_use/cua_backend_capture.py
@@ -236,19 +236,20 @@ class _CaptureMixin:
         (tree DISCARDED here). Before discovery ran we still try ``screenshot`` first and fall back, so the path
         self-heals on any driver version."""
         png_b64, image_mime_type, window_title = None, None, ""
+        gws_args = self._gws_args()
         if self._session._has_tool("screenshot") or not self._session.capabilities_discovered:
             png_b64, image_mime_type = _image_from_tool_result(self._call_capture_tool("screenshot", {
-                "window_id": self._active_window_id, "format": "jpeg", "quality": 85, "session": self._session_id}))
+                "window_id": gws_args["window_id"], "format": "jpeg", "quality": 85, "session": self._session_id}))
         if not png_b64:
             # "Unknown tool: screenshot" or an empty image part -> get_window_state. The title is cheap
             # and useful; `elements` stays empty by contract.
-            gws_out = self._call_capture_tool("get_window_state", self._gws_args())
+            gws_out = self._call_capture_tool("get_window_state", gws_args)
             (png_b64, image_mime_type), (_, window_title) = _image_from_tool_result(gws_out), _tree_and_title(gws_out)
         if not png_b64:
             cli_out = self._cli_refetch(
-                "get_window_state", self._gws_args(), 30.0, "vision screenshot",
+                "get_window_state", gws_args, 30.0, "vision screenshot",
                 "cua-driver vision capture returned no image over MCP (window_id=%s); re-fetching via CLI transport",
-                self._active_window_id) or {}
+                gws_args["window_id"]) or {}
             if cli_out.get("images"):
                 png_b64, image_mime_type = cli_out["images"][0], "image/png"
         return png_b64, image_mime_type, [], window_title
@@ -271,9 +272,11 @@ class _CaptureMixin:
         sc_elements = (gws_out.get("structuredContent") or {}).get("elements")
         elements = (_parse_elements_from_structured(sc_elements) if isinstance(sc_elements, list) and sc_elements
                     else _parse_elements_from_tree(tree) if tree else [])
-        # Tokens are tied to this snapshot: overwrite the whole map (and clear it when the new capture carries none).
-        self._snapshot_tokens = {e.index: e.element_token for e in elements if e.element_token}
         return *_image_from_tool_result(gws_out), elements, window_title
+
+    def _adopt_capture_snapshot(self, target: Dict[str, Any], elements: List[UIElement]) -> None:
+        self._set_active_target(target)
+        self._snapshot_tokens = {e.index: e.element_token for e in elements if e.element_token}
 
     def capture(self, mode: str = "som", app: Optional[str] = None, pid: Optional[int] = None,
                 window_id: Optional[int] = None) -> CaptureResult:
@@ -292,12 +295,13 @@ class _CaptureMixin:
             return windows
         self._set_active_target(target := _select_capture_target(windows, app_requested=bool(app), exact_target=exact_target))
         app_name = target["app_name"]
-        # Record the resolved app so capture_after= follow-ups re-target the same app rather than falling back
-        # to the frontmost window.
-        if app or not self._last_app:
-            self._last_app = app_name or app or ""
         png_b64, image_mime_type, elements, window_title = (
             self._capture_vision() if mode == "vision" else self._capture_window_state())
+        if not png_b64 and not elements:
+            return self._failed_capture(mode, window_title)
+        self._adopt_capture_snapshot(target, elements)
+        if app or not self._last_app:
+            self._last_app = app_name or app or ""
         png_bytes_len, width, height = _png_metrics(png_b64, 0, 0) if png_b64 else (0, 0, 0)
         return CaptureResult(mode=mode, width=width, height=height, png_b64=png_b64, elements=elements, app=app_name,
                              window_title=window_title, png_bytes_len=png_bytes_len, image_mime_type=image_mime_type)


### PR DESCRIPTION
## Summary

A capture read can recover after a transport reset while leaving the backend's active target cleared. The screenshot succeeds, but the next input fails with `No active window`. Restore the exact target and snapshot tokens together only after a capture returns pixels or elements; failed captures remain disarmed.

Also preserve resolved PID/window arguments throughout vision screenshot → window-state → CLI fallbacks. Otherwise, an imageless read that reconnects clears the mutable target, and a subsequent fallback can receive null IDs before the original target is restored.

This complements #108222 without duplicating its reconnect implementation. It is independently mergeable onto main: test fixtures advertise the existing legacy token capability, so they do not require #104873.

## Validation

- Standalone branch: **257 passed** across 17 computer-use test files using `scripts/run_tests.sh tests/tools/test_computer_use*.py --file-retries 0 -j 6`.
- New capture regressions cover AX/SOM/vision recovery, token invalidation, failed fallback disarming, and imageless-reconnect fallbacks retaining exact IDs. The three latter cases failed before preserving the arguments.
- Combined with #104873, #108222, #106540 and the offered real-stdio crash tests: **320 passed, 1 macOS-only skip**.
- Live native Wayland / Hyprland / cua-driver 0.28.0: a fresh-process Hermes handler captured a disposable GTK fixture, clicked, changed its slider, recovered after its owned driver was terminated, captured again, and clicked successfully. Focus and visible workspaces stayed unchanged.
- Ruff on the new regression file and `git diff --check` pass. A full-repository attempt encountered missing optional dependencies (`acp`, `anthropic`) and was stopped; no full-suite pass claimed.

AI-assisted implementation and independent review; the stated tests were exercised locally. No installed-source changes.