### PR TITLE
feat(gateway): scoped GET /v1/runs listing for run discovery and approval-aware clients

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3821,6 +3821,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
     def _release_run_owner_if_forgotten(self, run_id: str) -> None:
         _api_runs._release_run_owner_if_forgotten(self, run_id)
 
+    _handle_list_runs = _run_route_delegate("_handle_list_runs")
     _handle_get_run = _run_route_delegate("_handle_get_run")
     _handle_run_events = _run_route_delegate("_handle_run_events")
     _handle_run_approval = _run_route_delegate("_handle_run_approval")

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -98,7 +98,8 @@ def _initialize_run_state(self, *, store_factory) -> None:
 
 def _http_routes(self) -> list[tuple[str, str, Any]]:
     return [
-        ("POST", "/v1/runs", self._handle_runs), ("GET", "/v1/runs/{run_id}", self._handle_get_run),
+        ("POST", "/v1/runs", self._handle_runs), ("GET", "/v1/runs", self._handle_list_runs),
+        ("GET", "/v1/runs/{run_id}", self._handle_get_run),
         ("GET", "/v1/runs/{run_id}/events", self._handle_run_events),
         ("POST", "/v1/runs/{run_id}/approval", self._handle_run_approval),
         ("POST", "/v1/runs/{run_id}/steer", self._handle_steer_run),
@@ -706,6 +707,51 @@ def _load_owned_run(self, request, *, _api_server, permission: Optional[str], ac
     if status is None:
         return run_id, None, agent, task, _run_not_found(_openai_error, run_id)
     return run_id, status, agent, task, None
+
+
+_RUN_LIST_FIELDS = (
+    "object", "run_id", "status", "created_at", "updated_at",
+    "session_id", "model", "last_event",
+)
+_RUN_LIST_APPROVAL_FIELDS = ("approval_id", "summary", "choices", "run_id")
+
+
+async def _handle_list_runs(self, request: "web.Request", *, _api_server) -> "web.Response":
+    """GET /v1/runs — pollable run statuses for the caller's scope, newest first.
+
+    Lets external UIs discover their own runs — including waiting_for_approval
+    ones — without knowing run ids up front (#87509, #99553). Same ownership
+    rule as GET /v1/runs/{run_id}: unstamped state is nobody's, not
+    everybody's. Approval payloads are trimmed to what a remote approver
+    needs. In-memory only; entries vanish when the gateway restarts.
+    """
+    auth_err = self._check_auth(request)
+    if auth_err:
+        return auth_err
+    entries = []
+    for run_id, status in list(self._run_statuses.items()):
+        if not isinstance(status, dict):
+            continue
+        if not self._request_owns_run(request, run_id):
+            continue
+        entry = {field: status[field] for field in _RUN_LIST_FIELDS if field in status}
+        approval = status.get("approval")
+        if isinstance(approval, dict):
+            trimmed = {
+                field: approval[field]
+                for field in _RUN_LIST_APPROVAL_FIELDS
+                if field in approval
+            }
+            if trimmed:
+                entry["approval"] = trimmed
+        entries.append(entry)
+    entries.sort(key=lambda entry: entry.get("updated_at") or 0.0, reverse=True)
+    try:
+        limit = int(request.query.get("limit", "50"))
+    except ValueError:
+        limit = 50
+    limit = max(1, min(limit, 200))
+    return web.json_response({"object": "list", "data": entries[:limit]})
 
 
 async def _handle_get_run(self, request: "web.Request", *, _api_server) -> "web.Response":

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -1,7 +1,8 @@
-"""Tests for /v1/runs endpoints: start, status, events, steer, and stop.
+"""Tests for /v1/runs endpoints: start, list, status, events, steer, and stop.
 
 Covers:
 - POST /v1/runs — start a run (202)
+- GET /v1/runs — list pollable run statuses for the caller's scope
 - GET /v1/runs/{run_id} — poll run status
 - GET /v1/runs/{run_id}/events — SSE event stream
 - POST /v1/runs/{run_id}/steer — inject guidance into a running agent
@@ -83,6 +84,7 @@ def _create_runs_app(adapter: APIServerAdapter) -> web.Application:
     app = web.Application(middlewares=mws)
     app["api_server_adapter"] = adapter
     app.router.add_post("/v1/runs", adapter._handle_runs)
+    app.router.add_get("/v1/runs", adapter._handle_list_runs)
     app.router.add_post(
         "/v1/room-members/invitations",
         adapter._handle_room_member_invitation,
@@ -2194,3 +2196,95 @@ class TestHostedRoomRuns:
                 )
             assert rejected.status == 403
             create.assert_not_called()
+
+# ---------------------------------------------------------------------------
+# GET /v1/runs — list pollable run statuses
+# ---------------------------------------------------------------------------
+
+
+class TestListRuns:
+    @pytest.mark.asyncio
+    async def test_list_returns_owned_runs_newest_first(self, adapter):
+        app = _create_runs_app(adapter)
+        _claim_run(adapter, "run_older")
+        adapter._set_run_status("run_older", "completed", session_id="s-older")
+        _claim_run(adapter, "run_newer")
+        adapter._set_run_status("run_newer", "running", session_id="s-newer")
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/runs")
+            assert resp.status == 200
+            data = await resp.json()
+        assert data["object"] == "list"
+        assert [entry["run_id"] for entry in data["data"]] == [
+            "run_newer",
+            "run_older",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_list_excludes_runs_owned_by_other_scopes(self, adapter):
+        """The list is scoped like GET /v1/runs/{id}: foreign runs are absent."""
+        app = _create_runs_app(adapter)
+        _claim_run(adapter, "run_mine")
+        adapter._set_run_status("run_mine", "running")
+        adapter._run_owners["run_theirs"] = "scope:someone-else"
+        adapter._set_run_status("run_theirs", "running")
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/runs")
+            assert resp.status == 200
+            data = await resp.json()
+        assert [entry["run_id"] for entry in data["data"]] == ["run_mine"]
+
+    @pytest.mark.asyncio
+    async def test_list_requires_auth(self, auth_adapter):
+        app = _create_runs_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/runs")
+        assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_list_trims_waiting_approval_payload(self, adapter):
+        app = _create_runs_app(adapter)
+        _claim_run(adapter, "run_waiting")
+        adapter._set_run_status(
+            "run_waiting",
+            "waiting_for_approval",
+            approval={
+                "run_id": "run_waiting",
+                "approval_id": "appr_1",
+                "summary": "rm -rf /tmp/scratch",
+                "choices": ["once", "session", "always", "deny"],
+                "internal_agent_ref": object(),
+                "callback": lambda: None,
+            },
+        )
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/runs")
+            assert resp.status == 200
+            data = await resp.json()
+        (entry,) = data["data"]
+        assert entry["status"] == "waiting_for_approval"
+        assert set(entry["approval"]) == {
+            "run_id",
+            "approval_id",
+            "summary",
+            "choices",
+        }
+
+    @pytest.mark.asyncio
+    async def test_list_honors_limit_query(self, adapter):
+        app = _create_runs_app(adapter)
+        for index in range(3):
+            run_id = f"run_{index}"
+            _claim_run(adapter, run_id)
+            adapter._set_run_status(run_id, "running")
+
+        async with TestClient(TestServer(app)) as cli:
+            default_resp = await cli.get("/v1/runs")
+            limited_resp = await cli.get("/v1/runs?limit=2")
+            invalid_resp = await cli.get("/v1/runs?limit=not-a-number")
+            assert len((await default_resp.json())["data"]) == 3
+            assert len((await limited_resp.json())["data"]) == 2
+            assert invalid_resp.status == 200

--- a/website/docs/developer-guide/programmatic-integration.md
+++ b/website/docs/developer-guide/programmatic-integration.md
@@ -108,6 +108,10 @@ Endpoints:
 POST /v1/chat/completions        OpenAI Chat Completions (streaming via SSE)
 POST /v1/responses               OpenAI Responses API (stateful)
 POST /v1/runs                    Start a run, returns run_id (202)
+GET  /v1/runs                    List pollable run statuses for the caller's
+                                 scope, newest first (?limit=N, default 50,
+                                 max 200); waiting_for_approval entries carry
+                                 a trimmed approval payload
 GET  /v1/runs/{id}               Run status
 GET  /v1/runs/{id}/events        SSE stream of lifecycle events
 POST /v1/runs/{id}/approval      Resolve a pending approval


### PR DESCRIPTION
## What does this PR do?

Adds `GET /v1/runs` — a scoped, read-only listing of pollable run statuses, newest first. It closes the discovery gap described in #109222: an API-server client can currently only poll a run it already knows about (`GET /v1/runs/{id}` needs an id it was told at creation), so approval-aware frontends have no way to notice one of *their* runs entered `waiting_for_approval` — the operational half of #87509 / #99553.

## Related Issue

Closes #109222

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server_runs.py`: `_handle_list_runs` + route registration. Returns `{"object": "list", "data": [...]}` sorted newest by `updated_at`, `?limit=` (default 50, capped 200). Entries carry pollable fields only; `waiting_for_approval` entries add a trimmed `approval` payload (`approval_id`, `summary`, `choices`, `run_id`) — enough to render a decision UI and call `POST /v1/runs/{id}/approval`.
- Scoping reuses the per-run rule (`_request_owns_run`): unstamped state stays nobody's (#93689); foreign-scope runs are absent, not redacted. In-memory only, same as the per-run status view.
- `gateway/platforms/api_server.py`: adapter delegate `_handle_list_runs`.
- `tests/gateway/test_api_server_runs.py`: `TestListRuns` — 5 cases (ownership scoping, newest-first, auth 401, approval payload trimming, `limit` handling incl. non-numeric fallback). **Red-on-base verified**: with the handler removed all 5 fail; restored, all 5 pass. Full file: 69 passed (aiohttp 3.14.3).
- `website/docs/developer-guide/programmatic-integration.md`: endpoint table entry.

## Notes

Runs the same on aiohttp < 3.14 once #109157 lands; on older aiohttp this handler hits the shared-import `web = None` issue that #109157 / #109014 already fix, so no separate change is carried here — keeps the diff single-purpose.
