### PR TITLE
fix(desktop): hide Queue action while composer is idle

### DIFF
--- a/apps/desktop/src/app/chat/composer/controls.test.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.test.tsx
@@ -155,6 +155,13 @@ describe('ComposerControls shortcut tooltips', () => {
 
     await expectShortcutTooltip('Queue message', 'Ctrl+↵')
   })
+
+  it('hides Queue while idle even if the composer has a payload', () => {
+    renderControls({ busy: false, busyAction: 'queue', hasComposerPayload: true })
+
+    expect(screen.queryByLabelText('Queue message')).toBeNull()
+    expect(screen.getByLabelText('Send')).toBeTruthy()
+  })
 })
 
 describe('wake-word ear visibility', () => {

--- a/apps/desktop/src/app/chat/composer/controls.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.tsx
@@ -79,7 +79,7 @@ export function ComposerControls({
   // Steer is just send: a payload keeps the Send affordance mid-turn. Stop
   // only when the composer is empty and a turn is running.
   const showStop = busy && !hasComposerPayload
-  const showQueueButton = busyAction !== 'stop' && hasComposerPayload
+  const showQueueButton = busy && busyAction !== 'stop' && hasComposerPayload
   // The HUD is a Spotlight bar a few hundred pixels wide, so the four separate
   // voice toggles fold into one menu there and leave the row to the input. A
   // narrow tile hits the same wall from the other direction and folds for the


### PR DESCRIPTION
## Summary

- require an active turn before rendering the composer’s secondary Queue action
- keep the existing mid-turn Queue behavior unchanged
- add a regression test proving an idle composer with a payload shows Send without a dead Queue button

Fixes #109148

## Validation

- Red proof on unmodified `main`: the new idle-state regression failed because `Queue message` was rendered
- `npx vitest run --project ui src/app/chat/composer/controls.test.tsx` — 16 passed
- `npx eslint src/app/chat/composer/controls.tsx src/app/chat/composer/controls.test.tsx`
- `npx prettier --check src/app/chat/composer/controls.tsx src/app/chat/composer/controls.test.tsx`
- `npm run typecheck`
- `git diff --check`

## Scope

Two desktop composer files only; no queue semantics or submit handlers changed.