### PR TITLE
fix: restore Desktop lifecycle notifications

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -435,6 +435,7 @@ describe('useComposerSubmit busy-turn routing', () => {
     await waitFor(() =>
       expect(onSubmit).toHaveBeenCalledWith('ordinary question', {
         attachments: [],
+        desktopWork: { origin: 'desktop_user', root_id: expect.any(String) },
         composerScope: 'stored-session'
       })
     )

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -85,7 +85,8 @@ export function useComposerSubmit({
 
   // Shared send primitive: fire onSubmit, and if the gateway rejects (accepted
   // === false) or throws, re-load + re-stash the draft so the words survive.
-  const dispatchSubmit = (text: string, attachments?: ComposerAttachment[], displayKind?: 'hidden') => {
+  const dispatchSubmit = (text: string, attachments?: ComposerAttachment[], displayKind?: 'hidden', human = false) => {
+    const provenance = human ? { desktopWork: { origin: 'desktop_user' as const, root_id: crypto.randomUUID() } } : {}
     const submittedScope = activeQueueSessionKeyRef.current
     const submittedAttachments = attachments ?? []
 
@@ -104,8 +105,8 @@ export function useComposerSubmit({
 
     void Promise.resolve(
       attachments
-        ? onSubmit(text, { attachments, composerScope: submittedScope, ...(displayKind ? { displayKind } : {}) })
-        : onSubmit(text, { composerScope: submittedScope, ...(displayKind ? { displayKind } : {}) })
+        ? onSubmit(text, { ...provenance, attachments, composerScope: submittedScope, ...(displayKind ? { displayKind } : {}) })
+        : onSubmit(text, { ...provenance, composerScope: submittedScope, ...(displayKind ? { displayKind } : {}) })
     )
       .then(accepted => void (accepted === false ? rejected() : clearSessionDraft(submittedScope)))
       .catch(rejected)
@@ -288,7 +289,7 @@ export function useComposerSubmit({
       resetBrowseState(sessionId)
       clearDraft()
       scope.attachments.clear()
-      dispatchSubmit(text, submittedAttachments)
+      dispatchSubmit(text, submittedAttachments, undefined, true)
     }
 
     focusInput()

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1958,10 +1958,10 @@ describe('usePromptActions submit / queue drain semantics', () => {
       />
     )
 
-    expect(await handle!.submitText('continue remotely')).toBe(true)
+    expect(await handle!.submitText('continue remotely', { desktopWork: { origin: 'desktop_user', root_id: '11111111-1111-4111-8111-111111111111' } })).toBe(true)
     expect(ambientRequest).toHaveBeenCalledWith(
       'prompt.submit',
-      { session_id: 'runtime-remote', text: 'continue remotely' },
+      { session_id: 'runtime-remote', text: 'continue remotely', desktop_work: { origin: 'desktop_user', root_id: '11111111-1111-4111-8111-111111111111' } },
       1_800_000
     )
     expect(requestGatewayForAgent).not.toHaveBeenCalled()

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -757,6 +757,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         const submitParams = (targetId: string) => ({
           session_id: targetId,
           text,
+          ...(options?.desktopWork && options.displayKind !== 'hidden' && { desktop_work: options.desktopWork }),
           ...(interrupted && { interrupted }),
           // Off-screen widget intent: the gateway types the persisted user
           // row display_kind=hidden so no client renders it as a bubble.

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -701,6 +701,8 @@ export function visibleUserIndexAtOrdinal(messages: readonly ChatMessage[], targ
 }
 
 export interface SubmitTextOptions {
+  /** Minted only by a human composer submission, never by shared send APIs. */
+  desktopWork?: { origin: 'desktop_user'; root_id: string }
   attachments?: ComposerAttachment[]
   /** The composer scope key that was actually loaded when this text was
    *  submitted (see use-composer-draft's activeQueueSessionKeyRef). Compared

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -122,6 +122,105 @@ def test_connect_preserves_wal_and_applies_macos_durability_barriers(
         conn.close()
 
 
+def test_persistence_failure_does_not_strand_desktop_root(monkeypatch):
+    from tui_gateway.desktop_work import DesktopWork, current_work, finish
+
+    work = DesktopWork("root", "sid", "stored", "default", "Title")
+    seen = []
+    publish = lambda *args: seen.append(args[2]["kind"])
+    work.begin_turn()
+    work.emit(publish, "started")
+    monkeypatch.setattr(
+        ad, "_prune_durable_records",
+        lambda: (_ for _ in ()).throw(RuntimeError("disk full")),
+    )
+
+    token = current_work.set(work)
+    try:
+        with pytest.raises(RuntimeError, match="disk full"):
+            ad.dispatch_async_delegation(
+                goal="g", context=None, toolsets=None, role="leaf", model="m",
+                session_key="", runner=lambda: {"status": "completed"},
+            )
+    finally:
+        current_work.reset(token)
+
+    finish(work, publish, {"completed": True})
+    assert seen == ["started", "completed"]
+    assert work.pending == set()
+    assert ad.active_count() == 0
+
+
+def test_failed_delivery_ack_does_not_consume_desktop_root(monkeypatch):
+    from tui_gateway.desktop_work import DesktopWork, current_work
+
+    work = DesktopWork("root", "sid", "stored", "default", "Title")
+    work.retain_async("batch")
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "batch",
+        "_desktop_work": work,
+    }
+    monkeypatch.setattr(ad, "complete_completion_delivery", lambda *args: False)
+
+    token = current_work.set(work)
+    try:
+        ad.complete_event_delivery(event, "stale-claim")
+    finally:
+        current_work.reset(token)
+
+    assert work.pending == {"batch"}
+
+
+def test_released_delivery_is_requeued_in_same_process(monkeypatch):
+    from tui_gateway.desktop_work import DesktopWork
+
+    work = DesktopWork("root", "sid", "stored", "default", "Title")
+    work.retain_async("batch")
+    event = {"type": "async_delegation", "delegation_id": "batch", "_desktop_work": work}
+    target = queue.Queue()
+    monkeypatch.setattr(ad, "defer_completion_delivery", lambda *args: True)
+    monkeypatch.setattr(process_registry, "completion_queue", target)
+
+    assert ad.retry_event_delivery(event, "claim", defer=True) is True
+    assert target.get_nowait() is event
+    assert work.pending == {"batch"}
+    assert work.closed is False
+
+
+@pytest.mark.parametrize("failure_stage", ["persist", "enqueue"])
+def test_completion_publication_failure_closes_desktop_root(monkeypatch, failure_stage):
+    from tui_gateway.desktop_work import DesktopWork, finish
+
+    work = DesktopWork("root", "sid", "stored", "default", "Title")
+    seen = []
+    publish = lambda *args: seen.append(args[2]["kind"])
+    work.begin_turn()
+    work.emit(publish, "started")
+    work.retain_async("batch")
+    finish(work, publish, {"completed": True})
+    ad._records["batch"] = {
+        "delegation_id": "batch", "status": "running", "dispatched_at": time.time(),
+        "session_key": "stored", "_desktop_work": work,
+    }
+
+    if failure_stage == "persist":
+        monkeypatch.setattr(ad, "_persist_completion",
+                            lambda *args: (_ for _ in ()).throw(RuntimeError("disk")))
+    else:
+        class FailedQueue(queue.Queue):
+            def put(self, event):
+                raise RuntimeError("queue")
+        monkeypatch.setattr(process_registry, "completion_queue", FailedQueue())
+
+    ad._finalize("batch", {"summary": "done"}, "completed")
+
+    assert ad._records["batch"]["status"] == "failed"
+    assert work.pending == set()
+    assert work.closed is True
+    assert seen[-1] == "interrupted"
+
+
 def test_dispatch_returns_immediately_without_blocking():
     gate = threading.Event()
 

--- a/tests/tui_gateway/test_desktop_work.py
+++ b/tests/tui_gateway/test_desktop_work.py
@@ -1,0 +1,135 @@
+from uuid import uuid4
+
+from tui_gateway.desktop_work import admit, finish
+
+
+def test_terminal_requires_classified_provider_failure():
+    session = {'source': 'desktop', 'session_key': 'stored'}
+    proof = {'origin': 'desktop_user', 'root_id': str(uuid4())}
+    seen = []
+    work = admit('sid', session, proof)
+    finish(work, lambda *args: seen.append(args[2]), {'error': 'local runtime crashed', 'failed': True})
+    assert seen[-1]['kind'] == 'interrupted'
+    seen.clear()
+    work = admit('sid', session, {**proof, 'root_id': str(uuid4())})
+    finish(work, lambda *args: seen.append(args[2]), {'error': 'quota', 'failed': True, 'failure_reason': 'billing'})
+    assert seen[-1]['kind'] == 'provider_failed'
+
+
+def test_title_is_read_from_canonical_db_at_outcome(tmp_path, monkeypatch):
+    from hermes_state import SessionDB
+    from tui_gateway import server
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("stored", source="desktop")
+    db.set_session_title("stored", "First title")
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    session = {
+        'source': 'desktop', 'session_key': 'stored',
+        'pending_title': 'Stale pending title', 'title': 'Stale cached title',
+    }
+    work = admit('sid', session, {'origin': 'desktop_user', 'root_id': str(uuid4())})
+    seen = []
+    work.emit(lambda *args: seen.append(args[2]), 'started')
+    db.set_session_title("stored", "Renamed title")
+    finish(work, lambda *args: seen.append(args[2]), {'completed': True})
+    assert [e['title'] for e in seen] == ['First title', 'Renamed title']
+    db.close()
+
+
+def test_notification_dispatch_exception_requeues_delivery(monkeypatch):
+    import threading
+
+    from tools import async_delegation
+    from tui_gateway import server
+
+    event = {'type': 'completion', 'session_id': 'child'}
+    session = {'running': True, 'history_lock': threading.RLock()}
+    completed = []
+    retried = []
+
+    def fail_submit(*args, **kwargs):
+        raise RuntimeError('dispatcher failed')
+
+    monkeypatch.setattr(server, '_emit', lambda *args: None)
+    monkeypatch.setattr(server, '_run_prompt_submit', fail_submit)
+    monkeypatch.setattr(async_delegation, 'claim_event_delivery', lambda *args: 'claim')
+    monkeypatch.setattr(async_delegation, 'complete_event_delivery', lambda *args: completed.append(args))
+    monkeypatch.setattr(async_delegation, 'retry_event_delivery',
+                        lambda *args, **kwargs: retried.append((args, kwargs)))
+
+    failure = server._notif_submit('rid', 'sid', session, 'text', 'dispatch failed')
+    monkeypatch.setattr(server, '_notif_submit', lambda *args, **kwargs: failure)
+    server._notif_dispatch_event('sid', session, event, 'text')
+
+    assert completed == []
+    assert retried == [((event, 'claim'), {})]
+
+
+def test_notification_refused_admission_requeues_delivery(monkeypatch):
+    import threading
+
+    from tools import async_delegation
+    from tui_gateway import server
+
+    event = {'type': 'async_delegation', 'delegation_id': 'batch'}
+    session = {'running': True, 'history_lock': threading.RLock()}
+    completed = []
+    retried = []
+    sleeps = []
+
+    monkeypatch.setattr(server, '_notif_submit', lambda *args, **kwargs: False)
+    monkeypatch.setattr(async_delegation, 'claim_event_delivery', lambda *args: 'claim')
+    monkeypatch.setattr(async_delegation, 'complete_event_delivery', lambda *args: completed.append(args))
+    monkeypatch.setattr(async_delegation, 'retry_event_delivery',
+                        lambda *args, **kwargs: retried.append((args, kwargs)))
+    monkeypatch.setattr(server.time, 'sleep', lambda seconds: sleeps.append(seconds))
+
+    server._notif_dispatch_event('sid', session, event, 'text')
+
+    assert completed == []
+    assert retried == [((event, 'claim'), {'defer': True})]
+    assert sleeps == [0.25]
+
+
+def test_async_requires_consumption_and_settled_continuation():
+    work = admit('sid', {'source': 'desktop', 'session_key': 'stored'},
+                 {'origin': 'desktop_user', 'root_id': str(uuid4())})
+    seen = []
+    publish = lambda *args: seen.append(args[2]['kind'])
+    work.begin_turn()
+    work.emit(publish, 'started')
+    work.retain_async('batch')
+    finish(work, publish, {'completed': True})
+    assert seen == ['started', 'waiting']
+    work.begin_turn()
+    # Fast continuation can finish before the poller commits delivery.
+    finish(work, publish, {'completed': True})
+    assert 'completed' not in seen
+    work.consume_async('batch')
+    work.consume_async('batch')
+    assert seen == ['started', 'waiting', 'completed']
+
+
+def test_missing_or_synthetic_provenance_is_not_human():
+    session = {'source': 'desktop', 'session_key': 'stored'}
+    proof = {'origin': 'desktop_user', 'root_id': str(uuid4())}
+    for invalid in (None, {}, {'root_id': str(uuid4())}, {**proof, 'origin': 'tool'}, {**proof, 'root_id': 'bad'}):
+        assert admit('sid', session, invalid) is None
+    assert admit('sid', session, proof, 'hidden') is None
+    for extra in ({'hidden': True}, {'source': 'tool'}, {'parent_session_id': 'parent'}):
+        assert admit('sid', {**session, **extra}, proof) is None
+
+
+def test_publish_failure_cannot_interrupt_agent_lifecycle():
+    from tui_gateway.desktop_work import DesktopWork
+
+    work = DesktopWork("root", "sid", "stored", "default", "Title")
+    work.begin_turn()
+
+    def fail_publish(*args):
+        raise RuntimeError("observer unavailable")
+
+    work.emit(fail_publish, "started")
+    finish(work, fail_publish, {"completed": True})
+
+    assert work.closed is True

--- a/tests/tui_gateway/test_failed_turn_retention.py
+++ b/tests/tui_gateway/test_failed_turn_retention.py
@@ -95,6 +95,171 @@ def _events(captured, name):
     return [payload for event, _sid, payload in captured if event == name]
 
 
+@pytest.mark.parametrize("result,kind", [
+    ({"final_response": "done", "messages": [], "completed": True}, "completed"),
+    ({"error": "provider unavailable", "failed": True, "failure_reason": "rate_limit"}, "provider_failed"),
+    ({"interrupted": True}, "interrupted"),
+    ({"failed": True, "error": "unclassified local error"}, "interrupted"),
+])
+def test_desktop_human_work_terminal(emits, turn_env, result, kind):
+    agent = types.SimpleNamespace(
+        session_id="session-key", run_conversation=lambda *a, **k: result,
+        clear_interrupt=lambda: None)
+    session = _session(agent=agent, source="desktop", profile="default", running=True)
+    server._run_prompt_submit(
+        "rid", "sid", session, "human text",
+        desktop_work={"origin": "desktop_user", "root_id": "11111111-1111-4111-8111-111111111111"})
+    work = _events(emits, "desktop.work")
+    assert [e["kind"] for e in work] == ["started", kind]
+    assert all(e["schema_version"] == 1 and e["origin"] == "desktop_user" for e in work)
+    assert all(e["root_id"] == "11111111-1111-4111-8111-111111111111" for e in work)
+    assert all(e["stored_session_id"] == "session-key" and e["title"] == "Chat senza titolo" for e in work)
+    assert len({e["event_id"] for e in work}) == len(work)
+
+
+def test_goal_continuation_keeps_one_desktop_root_until_terminal(
+    emits, turn_env, monkeypatch
+):
+    calls = []
+
+    def run_conversation(*args, **kwargs):
+        calls.append((args, kwargs))
+        return {"final_response": "done", "messages": [], "completed": True}
+
+    followups = iter(["continue the goal", None])
+    monkeypatch.setattr(
+        server, "_goal_followup_after_turn", lambda *args, **kwargs: next(followups))
+    agent = types.SimpleNamespace(
+        session_id="session-key", run_conversation=run_conversation,
+        clear_interrupt=lambda: None)
+    session = _session(agent=agent, source="desktop", profile="default", running=True)
+
+    server._run_prompt_submit(
+        "rid", "sid", session, "human text",
+        desktop_work={
+            "origin": "desktop_user",
+            "root_id": "11111111-1111-4111-8111-111111111111",
+        })
+
+    work = _events(emits, "desktop.work")
+    assert len(calls) == 2
+    assert [event["kind"] for event in work] == ["started", "waiting", "completed"]
+    assert {event["root_id"] for event in work} == {
+        "11111111-1111-4111-8111-111111111111"}
+
+
+def test_ready_dispatch_preserves_explicit_human_admission(emits, turn_env, monkeypatch):
+    agent = types.SimpleNamespace(session_id="session-key", clear_interrupt=lambda: None,
+        run_conversation=lambda *a, **k: {"completed": True, "messages": [], "final_response": "ok"})
+    session = _session(agent=agent, source="desktop", running=True)
+    monkeypatch.setattr(server, "_wait_agent_for_prompt", lambda *a: None)
+    proof = {"origin": "desktop_user", "root_id": "11111111-1111-4111-8111-111111111111"}
+    server._run_after_agent_ready(
+        "rid", "sid", session, "human", None, None, desktop_work=proof)
+    assert [p["kind"] for p in _events(emits, "desktop.work")] == ["started", "completed"]
+
+
+@pytest.mark.parametrize("wait_result,cancelled", [
+    ({"error": {"message": "agent initialization failed"}}, False),
+    (None, True),
+])
+def test_desktop_human_work_closes_before_agent_ready(
+    emits, turn_env, monkeypatch, wait_result, cancelled
+):
+    session = _session(
+        source="desktop", running=True, _turn_cancel_requested=cancelled)
+    monkeypatch.setattr(server, "_wait_agent_for_prompt", lambda *a: wait_result)
+    proof = {"origin": "desktop_user", "root_id": "11111111-1111-4111-8111-111111111111"}
+
+    server._run_after_agent_ready(
+        "rid", "sid", session, "human", None, None, desktop_work=proof)
+
+    assert [p["kind"] for p in _events(emits, "desktop.work")] == ["started", "interrupted"]
+
+
+def test_desktop_human_work_closes_when_turn_thread_cannot_start(emits, turn_env, monkeypatch):
+    agent = types.SimpleNamespace(session_id="session-key", clear_interrupt=lambda: None)
+    session = _session(agent=agent, source="desktop", running=True)
+    proof = {"origin": "desktop_user", "root_id": "11111111-1111-4111-8111-111111111111"}
+
+    def race_after_admission(*args):
+        session["_closing"] = True
+        return [], agent
+
+    monkeypatch.setattr(server, "_admit_prompt_turn", race_after_admission)
+    accepted = server._run_prompt_submit(
+        "rid", "sid", session, "human", desktop_work=proof)
+
+    assert accepted is False
+    assert [p["kind"] for p in _events(emits, "desktop.work")] == ["started", "interrupted"]
+
+
+def test_deferred_desktop_work_closes_when_admission_is_lost(emits, monkeypatch):
+    agent = types.SimpleNamespace(session_id="session-key", clear_interrupt=lambda: None)
+    session = _session(agent=agent, source="desktop", running=True)
+    proof = {"origin": "desktop_user", "root_id": "11111111-1111-4111-8111-111111111111"}
+    monkeypatch.setattr(server, "_wait_agent_for_prompt", lambda *args: None)
+    monkeypatch.setattr(server, "_admit_prompt_turn", lambda *args: None)
+
+    server._run_after_agent_ready(
+        "rid", "sid", session, "human", None, None, desktop_work=proof)
+
+    assert [p["kind"] for p in _events(emits, "desktop.work")] == ["started", "interrupted"]
+
+
+def test_human_approval_is_correlated_to_running_work(emits, turn_env):
+    def invoke(*a, **k):
+        server._emit_approval_request("sid", {"request_id": "approval-1", "command": "sensitive"})
+        server._emit_approval_request("sid", {"request_id": "approval-1", "command": "sensitive"})
+        return {"completed": True, "messages": [], "final_response": "ok"}
+    agent = types.SimpleNamespace(session_id="session-key", clear_interrupt=lambda: None, run_conversation=invoke)
+    session = _session(agent=agent, source="desktop", running=True)
+    server._run_prompt_submit("rid", "sid", session, "human", desktop_work={
+        "origin": "desktop_user", "root_id": "11111111-1111-4111-8111-111111111111"})
+    work = _events(emits, "desktop.work")
+    assert [p["kind"] for p in work] == ["started", "approval", "completed"]
+    assert work[1]["request_id"] == "approval-1"
+    server._emit_approval_request("sid", {"request_id": "after-turn"})
+    assert len(_events(emits, "desktop.work")) == 3
+
+
+def test_async_continuation_finishes_original_work(emits, turn_env):
+    from tui_gateway.desktop_work import admit
+    agent = types.SimpleNamespace(session_id="session-key", clear_interrupt=lambda: None,
+        run_conversation=lambda *a, **k: {"completed": True, "messages": [], "final_response": "ok"})
+    session = _session(agent=agent, source="desktop", running=True)
+    work = admit("sid", session, {"origin": "desktop_user", "root_id": "11111111-1111-4111-8111-111111111111"})
+    work.emit(server._emit, "started")
+    work.retain_async("batch")
+    server._run_prompt_submit("rid", "sid", session, "results", display_kind="async_delegation_complete",
+                              continued_desktop_work=work)
+    assert "completed" not in [p["kind"] for p in _events(emits, "desktop.work")]
+    work.consume_async("batch")
+    assert [p["kind"] for p in _events(emits, "desktop.work")] == ["started", "waiting", "completed"]
+
+
+@pytest.mark.parametrize("provider_error", [True, False])
+@pytest.mark.parametrize("next_admission", [True, False])
+def test_escaped_exception_has_terminal_work_classification(emits, turn_env, monkeypatch, provider_error, next_admission):
+    import httpx
+    from openai import AuthenticationError
+    error = (AuthenticationError("auth failed", response=httpx.Response(401,
+        request=httpx.Request("POST", "https://example.invalid")), body=None)
+        if provider_error else RuntimeError("local dispatcher failed"))
+    if next_admission:
+        # A new turn can replace the retained snapshot after running is released.
+        monkeypatch.setattr(server, "_emit_settled_session_info",
+            lambda sid, session, agent: session.update(inflight_turn=None))
+    def invoke(*a, **k):
+        raise error
+    agent = types.SimpleNamespace(session_id="session-key", clear_interrupt=lambda: None, run_conversation=invoke)
+    session = _session(agent=agent, source="desktop", running=True)
+    server._run_prompt_submit("rid", "sid", session, "human", desktop_work={
+        "origin": "desktop_user", "root_id": "11111111-1111-4111-8111-111111111111"})
+    assert [p["kind"] for p in _events(emits, "desktop.work")] == [
+        "started", "provider_failed" if provider_error else "interrupted"]
+
+
 # ── Unit: retention helpers ───────────────────────────────────────────
 
 

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -414,17 +414,69 @@ def complete_completion_delivery(delegation_id: str, claim_id: str) -> bool:
              AND delivery_claim=?""", (now, now, delegation_id, claim_id))
 
 
-def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
-    _event_delivery(complete_completion_delivery, evt, claim_id)
+def complete_event_delivery(evt: Dict[str, Any], claim_id: str) -> bool:
+    acknowledged = _event_delivery(complete_completion_delivery, evt, claim_id)
+    if acknowledged:
+        consume_desktop_completion(evt)
+    return acknowledged
+
+
+def _current_desktop_work():
+    # Lazy surface dependency: CLI/gateway dispatches carry no Desktop identity.
+    from tui_gateway import desktop_work
+    context = getattr(desktop_work, "current_work", None)
+    return context.get() if context is not None else None
+
+
+def consume_desktop_completion(evt: Dict[str, Any]) -> None:
+    """Release only under the original root's active consumption context.
+
+    An unrelated user turn (or restart replay without the object) cannot adopt
+    this completion. Unsupported drains deliberately leave the root waiting.
+    DesktopWork owns idempotence and defers terminal emission while a turn runs.
+    """
+    work = evt.get("_desktop_work")
+    if work is not None and _current_desktop_work() is work:
+        work.consume_async(str(evt.get("delegation_id") or ""))
+
+
+def abandon_desktop_completion(evt: Dict[str, Any]) -> None:
+    """Terminate only the exact live root whose completion became undeliverable."""
+    work = evt.get("_desktop_work")
+    if work is not None:
+        work.abandon_async(str(evt.get("delegation_id") or ""))
 
 
 def release_event_delivery(evt: Dict[str, Any], claim_id: str) -> None:
     _event_delivery(release_completion_delivery, evt, claim_id)
 
 
-def _event_delivery(fn, evt: Dict[str, Any], claim_id: str) -> None:
+def retry_event_delivery(evt: Dict[str, Any], claim_id: str, *, defer: bool = False) -> bool:
+    """Release a durable claim and put the event back on the live queue."""
+    release = defer_completion_delivery if defer else release_completion_delivery
+    if not _event_delivery(release, evt, claim_id):
+        abandon_desktop_completion(evt)
+        return False
+    if not defer and evt.get("type") == "async_delegation":
+        durable = get_durable_delegation(str(evt.get("delegation_id") or ""))
+        if durable is not None and durable.get("delivery_state") == "dropped":
+            abandon_desktop_completion(evt)
+            return False
+    try:
+        from tools.process_registry import process_registry
+        process_registry.completion_queue.put(evt)
+        return True
+    except Exception:
+        logger.error("Async delegation %s: failed to requeue completion event",
+                     evt.get("delegation_id"), exc_info=True)
+        abandon_desktop_completion(evt)
+        return False
+
+
+def _event_delivery(fn, evt: Dict[str, Any], claim_id: str) -> bool:
     if claim_id and evt.get("type") == "async_delegation":
-        fn(str(evt.get("delegation_id") or ""), claim_id)
+        return bool(fn(str(evt.get("delegation_id") or ""), claim_id))
+    return evt.get("type") != "async_delegation"
 
 
 def get_durable_delegation(delegation_id: str) -> Optional[Dict[str, Any]]:
@@ -570,12 +622,22 @@ def _dispatch(
             return {"status": "rejected", "error": capacity_error}
         _records[delegation_id] = record
         live_units = sum(1 for r in _records.values() if r.get("status") in _LIVE_STATES)
-    _persist_dispatch(record)
+    work = _current_desktop_work()
+    try:
+        _persist_dispatch(record)
+    except Exception:
+        with _records_lock:
+            _records.pop(delegation_id, None)
+        with _DB_LOCK, _transaction() as conn:
+            conn.execute("DELETE FROM async_delegations WHERE delegation_id=?", (delegation_id,))
+        raise
     # Units of one call share a slot, so live units can exceed slots: size the pool by units or a
     # unit queues behind a full pool and the stale monitor kills it before its child ever starts.
-    executor = _get_executor(max(max_async_children, live_units))
 
     def _worker() -> None:
+        from tui_gateway.desktop_work import current_work
+        # Profile context follows the worker; human notification authority does not.
+        work_token = current_work.set(None)
         result: Dict[str, Any] = {}
         status = "error"
         with _records_lock:
@@ -590,14 +652,21 @@ def _dispatch(
             logger.exception(f"Async delegation{label} %s crashed", delegation_id)
             result = crash_result(f"{type(exc).__name__}: {exc}", round(time.time() - dispatched_at, 2))
         finally:
+            current_work.reset(work_token)
             _finalize(delegation_id, result, status)
 
     try:
+        executor = _get_executor(max(max_async_children, live_units))
+        if work is not None:
+            work.retain_async(delegation_id)
+            record["_desktop_work"] = work
         # Propagate the dispatching profile so the detached child resolves get_hermes_home() correctly.
         executor.submit(propagate_context_to_thread(_worker))
     except Exception as exc:  # pragma: no cover — pool submit failure is rare
         with _records_lock:
             _records.pop(delegation_id, None)
+        if work is not None:
+            work.consume_async(delegation_id)
         with _DB_LOCK, _transaction() as conn:
             conn.execute("DELETE FROM async_delegations WHERE delegation_id=?", (delegation_id,))
         return {"status": "rejected", "error": f"Failed to schedule async delegation{label}: {exc}"}
@@ -685,14 +754,14 @@ def _finalize(delegation_id: str, result: Any, status: str) -> None:
         record["interrupt_fn"] = None  # drop the closure; child is done
         record["progress_fn"] = None  # stop stale-monitor sampling
         snapshot = dict(record)
-    _push_completion_event(snapshot, result(snapshot) if callable(result) else result, status)
+    published = _push_completion_event(snapshot, result(snapshot) if callable(result) else result, status)
     with _records_lock:
         if delegation_id in _records:
-            _records[delegation_id]["status"] = status
+            _records[delegation_id]["status"] = status if published else "failed"
         _prune_completed_locked()
 
 
-def _push_completion_event(record: Dict[str, Any], result: Dict[str, Any], status: str) -> None:
+def _push_completion_event(record: Dict[str, Any], result: Dict[str, Any], status: str) -> bool:
     """Push a type='async_delegation' event onto the shared completion queue. Batch records
     (``is_batch``) carry the per-task ``results`` list (plus live transcript paths, the
     full-fidelity record of each child's run) instead of a single summary. Best-effort: failure
@@ -704,7 +773,10 @@ def _push_completion_event(record: Dict[str, Any], result: Dict[str, Any], statu
     except Exception as exc:  # pragma: no cover
         logger.error(f"Async delegation{label} %s finished but process_registry import failed; "
                      "result lost: %s", record.get("delegation_id"), exc)
-        return
+        work = record.get("_desktop_work")
+        if work is not None:
+            work.abandon_async(str(record.get("delegation_id") or ""))
+        return False
     dispatched_at = record.get("dispatched_at") or time.time()
     completed_at = record.get("completed_at") or time.time()
     if is_batch:
@@ -731,12 +803,24 @@ def _push_completion_event(record: Dict[str, Any], result: Dict[str, Any], statu
         **({} if is_batch else {"exit_reason": result.get("exit_reason")}),
         **{k: record[k] for k in _ROUTING_KEYS if record.get(k)},
         **{k: result[k] for k in _STALL_META_KEYS if k in result}}
-    _persist_completion(evt, result)
+    # In-memory identity only: never JSON, task text, or display metadata.
+    if record.get("_desktop_work") is not None:
+        evt["_desktop_work"] = record["_desktop_work"]
+    try:
+        _persist_completion({k: v for k, v in evt.items() if k != "_desktop_work"}, result)
+    except Exception:
+        logger.error("Async delegation%s %s: failed to persist completion event",
+                     label, record.get("delegation_id"), exc_info=True)
+        abandon_desktop_completion(evt)
+        return False
     try:
         process_registry.completion_queue.put(evt)
     except Exception as exc:  # pragma: no cover
         logger.error(f"Async delegation{label} %s: failed to enqueue completion event; "
                      "result lost: %s", record.get("delegation_id"), exc)
+        abandon_desktop_completion(evt)
+        return False
+    return True
 
 
 def push_task_failure_notice(delegation_id: str, entry: Dict[str, Any], *, n_tasks: int) -> None:

--- a/tui_gateway/desktop_work.py
+++ b/tui_gateway/desktop_work.py
@@ -1,0 +1,162 @@
+"""Read-only Desktop work events. Identity is explicit, never inferred from a session.
+
+Unsupported continuations have no admission proof and cannot inherit a newer turn.
+This metadata never enters messages, prompts, model kwargs or persistent history.
+"""
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from uuid import UUID, NAMESPACE_URL, uuid5
+from pathlib import Path
+import logging
+from threading import RLock
+
+logger = logging.getLogger(__name__)
+
+
+current_work = ContextVar("desktop_work", default=None)
+
+
+@dataclass
+class DesktopWork:
+    root_id: str
+    sid: str
+    stored_session_id: str
+    profile: str
+    title: str
+    emitted: set = field(default_factory=set)
+    session: dict | None = field(default=None, repr=False)
+
+    pending: set = field(default_factory=set)
+    active_turns: int = 0
+    closed: bool = False
+    _candidate: tuple | None = field(default=None, repr=False)
+    _publish: object | None = field(default=None, repr=False)
+    _lock: object = field(default_factory=RLock, repr=False)
+
+    def begin_turn(self):
+        with self._lock:
+            self.active_turns += 1
+            self._candidate = None
+
+    def retain_async(self, delegation_id):
+        with self._lock:
+            self.pending.add(delegation_id)
+
+    def consume_async(self, delegation_id):
+        with self._lock:
+            self.pending.discard(delegation_id)
+            if not self.pending and not self.active_turns and self._candidate:
+                publish, kind = self._candidate
+                self.emit(publish, kind)
+
+    def abandon_async(self, delegation_id):
+        """Close a root whose child result cannot be delivered in this process."""
+        with self._lock:
+            self.pending.discard(delegation_id)
+            if self._publish is not None:
+                self._emit_locked(self._publish, "interrupted")
+
+    def end_turn(self, publish, kind):
+        with self._lock:
+            self.active_turns = max(0, self.active_turns - 1)
+            self._candidate = (publish, kind)
+            if kind == "completed" and (self.pending or self.active_turns):
+                self.emit(publish, "waiting")
+            else:
+                self.emit(publish, kind)
+
+    def emit(self, publish, kind, request_id=None):
+        with self._lock:
+            self._publish = publish
+            self._emit_locked(publish, kind, request_id)
+
+    def _emit_locked(self, publish, kind, request_id=None):
+        key = (kind, request_id)
+        if self.closed or key in self.emitted:
+            return
+        if kind in {"completed", "provider_failed", "interrupted"}:
+            self.closed = True
+        self.emitted.add(key)
+        payload = {
+            "schema_version": 1,
+            "event_id": str(uuid5(NAMESPACE_URL, f"desktop.work:{self.profile}:{self.root_id}:{kind}:{request_id or ''}")),
+            "root_id": self.root_id, "stored_session_id": self.stored_session_id,
+            "profile": self.profile, "origin": "desktop_user", "kind": kind,
+            "title": read_title(self.session) if self.session is not None else self.title,
+        }
+        if request_id is not None:
+            payload["request_id"] = request_id
+        try:
+            publish("desktop.work", self.sid, payload)
+        except Exception:
+            logger.warning("Desktop work observer failed", exc_info=True)
+
+
+def read_title(session):
+    from tui_gateway import server
+    title = None
+    try:
+        with server._session_db(session) as db:
+            title = db.get_session_title(session.get("session_key")) if db else None
+    except Exception:
+        logger.debug("Desktop work title unavailable", exc_info=True)
+    if not title:
+        title = session.get("pending_title") or session.get("title")
+    return " ".join(str(title or "Chat senza titolo").split())[:160] or "Chat senza titolo"
+
+
+def admit(sid, session, proof, display_kind=None):
+    if (not isinstance(proof, dict) or proof.get("origin") != "desktop_user"
+            or session.get("source") != "desktop" or display_kind is not None
+            or session.get("hidden") or session.get("parent_session_id") or session.get("lazy")):
+        return None
+    root = proof.get("root_id")
+    if not isinstance(root, str):
+        return None
+    try:
+        if str(UUID(root)) != root:
+            return None
+    except ValueError:
+        return None
+    stored = session.get("session_key")
+    if not isinstance(stored, str) or not stored:
+        return None
+    from tui_gateway import server
+    profile = (server._response_profile_name(Path(session["profile_home"]).name)
+               if session.get("profile_home") else server._current_profile_name())
+    return DesktopWork(root, sid, stored, profile, read_title(session), session=session)
+
+
+def interrupt_before_turn(sid, session, proof, display_kind, publish):
+    """Close an accepted human root that cannot reach the agent turn."""
+    work = admit(sid, session, proof, display_kind)
+    if work is None:
+        return
+    work.begin_turn()
+    work.emit(publish, "started")
+    finish(work, publish, {"interrupted": True})
+
+
+def finish(work, publish, result, *, uncertain=False, terminal_surface=None):
+    if work is None:
+        return
+    result = result if isinstance(result, dict) else {}
+    if terminal_surface is not None:
+        kind = "provider_failed" if terminal_surface.get("code") not in {None, "unknown"} and terminal_surface.get("layer") in {
+            "provider", "auth", "billing", "streaming", "endpoint"
+        } else "interrupted"
+    elif result.get("interrupted"):
+        kind = "interrupted"
+    elif result.get("error") or result.get("failed"):
+        # Unknown dispatcher/tool errors must never masquerade as provider quota.
+        from agent.error_surface import build_error_surface_from_result
+        surface = (build_error_surface_from_result(result)
+                   if result.get("failure_reason") or result.get("billing_block") else None)
+        kind = "provider_failed" if surface and surface.get("layer") in {
+            "provider", "auth", "billing", "streaming", "endpoint"
+        } else "interrupted"
+    elif uncertain or result.get("completed") is not True:
+        kind = "waiting"
+    else:
+        kind = "completed"
+    work.end_turn(publish, kind)

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -471,7 +471,10 @@ def _persist_session_row_for_submit(rid, session):
     return error
 
 
-def _run_after_agent_ready(rid, sid, session, text, display_kind, hosted_terminal_callback, turn_author=None):
+def _run_after_agent_ready(
+    rid, sid, session, text, display_kind, hosted_terminal_callback,
+    turn_author=None, desktop_work=None,
+):
     """Turn thread body: patient wait for a deferred build (a slow build must not eat the
     accepted in-flight message), then run."""
     # The wait delivers the prompt when the still-running build completes, honors a cancel promptly, notices
@@ -488,6 +491,8 @@ def _run_after_agent_ready(rid, sid, session, text, display_kind, hosted_termina
             session["running"] = False
             session["last_active"] = time.time()
         _emit("session.info", sid, _session_info(session.get("agent"), session))
+        from tui_gateway.desktop_work import interrupt_before_turn
+        interrupt_before_turn(sid, session, desktop_work, display_kind, _emit)
         return
     with session["history_lock"]:
         if session.get("_turn_cancel_requested") or not session.get("running"):
@@ -498,9 +503,16 @@ def _run_after_agent_ready(rid, sid, session, text, display_kind, hosted_termina
                 "Turn cancelled before the agent was ready"
                 if session.get("_turn_cancel_requested")
                 else "Session no longer running before the agent was ready")})
+            from tui_gateway.desktop_work import interrupt_before_turn
+            interrupt_before_turn(sid, session, desktop_work, display_kind, _emit)
             return
+    from tui_gateway.desktop_work import admit
+    admitted_work = admit(sid, session, desktop_work, display_kind)
+    if admitted_work is not None:
+        admitted_work.begin_turn()
     _run_prompt_submit(
         rid, sid, session, text, display_kind=display_kind,
+        desktop_work=desktop_work, admitted_desktop_work=admitted_work,
         terminal_callback=hosted_terminal_callback, turn_author=turn_author)
 
 
@@ -654,7 +666,8 @@ def _(rid, params: dict) -> dict:
         _start_agent_build(sid, session)
     run_thread = threading.Thread(
         target=lambda: _run_after_agent_ready(
-            rid, sid, session, text, display_kind, hosted_terminal_callback, turn_author),
+            rid, sid, session, text, display_kind, hosted_terminal_callback,
+            turn_author, None if internal_hosted_submit else params.get("desktop_work")),
         daemon=True)
     # Handle lets session.interrupt tell a live turn from a stuck `running` flag.
     session["_run_thread"] = run_thread

--- a/tui_gateway/prompt_turn.py
+++ b/tui_gateway/prompt_turn.py
@@ -353,24 +353,29 @@ def _after_complete_turn(sid: str, session: dict, st: _TurnRun, raw: Any) -> Non
 
 
 def _dispatch_followup_turn(rid, sid: str, session: dict, prompt: Any, what: str, *,
-                            on_done=None, on_error=None) -> None:
+                            on_done=None, on_error=None, continued_desktop_work=None) -> None:
     """Chain one follow-up turn (caller set ``running``); on failure run ``on_error``, log,
     release ``running``."""
     try:
         _emit("message.start", sid)
-        _run_prompt_submit(rid, sid, session, prompt)
+        _run_prompt_submit(
+            rid, sid, session, prompt, continued_desktop_work=continued_desktop_work)
         if on_done is not None:
             on_done()
     except Exception as exc:
         if on_error is not None:
             on_error()
+        if continued_desktop_work is not None:
+            from tui_gateway.desktop_work import finish
+            finish(continued_desktop_work, _emit, {"interrupted": True})
         _hook_failure(what, exc)
         with session["history_lock"]:
             session["running"] = False
 
 
 def _run_post_turn_followups(
-    rid, sid: str, session: dict, result: Any, goal_followup: str | None) -> None:
+    rid, sid: str, session: dict, result: Any, goal_followup: str | None,
+    desktop_work=None) -> None:
     """Chain whatever should run after ``running`` was released.  Order: a mid-turn user
     prompt wins over every auto follow-up (drain it, skip the rest); a leftover /steer is
     requeued first so it isn't dropped; then goal continuation, then completion
@@ -380,13 +385,23 @@ def _run_post_turn_followups(
         with session["history_lock"]:
             _enqueue_prompt(session, steer, session.get("transport"))
     if _drain_queued_prompt(rid, sid, session):
+        if desktop_work is not None:
+            from tui_gateway.desktop_work import finish
+            finish(desktop_work, _emit, {"interrupted": True})
         return
     if goal_followup:
         with session["history_lock"]:
-            if session.get("running"):
-                return  # user already sent something — their turn wins
-            session["running"] = True
-        _dispatch_followup_turn(rid, sid, session, goal_followup, "goal continuation dispatch")
+            user_turn_won = bool(session.get("running"))
+            if not user_turn_won:
+                session["running"] = True
+        if user_turn_won:
+            if desktop_work is not None:
+                from tui_gateway.desktop_work import finish
+                finish(desktop_work, _emit, {"interrupted": True})
+            return  # user already sent something — their turn wins
+        _dispatch_followup_turn(
+            rid, sid, session, goal_followup, "goal continuation dispatch",
+            continued_desktop_work=desktop_work)
     # Safety net for completion events that arrived mid-turn.  Ownership is positive-proof
     # and compression-chain aware (same fail-closed gate as the poller): session B must
     # not consume session A's event.  Unclaimable events are requeued for the poller.
@@ -792,12 +807,29 @@ def _run_prompt_submit(
     rid, sid: str, session: dict, text: Any, *, display_kind: str | None = None,
     display_metadata: dict | None = None, image_paths: list[str] | None = None,
     queued_prompt_generation: int | None = None,
+    desktop_work: dict | None = None,
+    continued_desktop_work=None,
+    admitted_desktop_work=None,
     terminal_callback: Callable[[dict[str, Any]], None] | None = None,
     turn_author: dict | None = None) -> bool:
+    from tui_gateway.desktop_work import admit, finish, current_work
+    work = admitted_desktop_work
+    if (work is None and continued_desktop_work is not None
+            and continued_desktop_work.sid == sid and continued_desktop_work.session is session
+            and not continued_desktop_work.closed):
+        work = continued_desktop_work
     admitted = _admit_prompt_turn(sid, session, text, image_paths, queued_prompt_generation)
     if admitted is None:
+        if work is not None and not work.closed:
+            work.emit(_emit, "started")
+            finish(work, _emit, {"interrupted": True})
         return False
     images, agent = admitted
+    if work is None:
+        work = admit(sid, session, desktop_work, display_kind)
+
+    if work is not None and work is not admitted_desktop_work:
+        work.begin_turn()
     # The ONE INFO record proving a prompt was accepted by THIS process; ties ui sid,
     # session_key and the agent's live session_id together.  No prompt content is logged.
     _turn_started_monotonic = time.monotonic()
@@ -815,10 +847,13 @@ def _run_prompt_submit(
     _emit("message.start", sid)
 
     def run():
+        if work is not None:
+            work.emit(_emit, "started")
         # RPC-dispatcher ContextVars do not follow onto this thread: rebind the transport
         # before any tool can commission a child (delegate_task captures it as authority).
         transport_token = bind_transport(session.get("transport"))
         runtime_session_token = _current_runtime_session_record.set(session)
+        work_token = current_work.set(work)
         st = _TurnRun(
             session["agent"], session.pop("one_turn_model_restore", None), terminal_callback,
             receipt_committed=terminal_callback is None)
@@ -850,7 +885,12 @@ def _run_prompt_submit(
         except Exception as e:
             _recover_turn_exception(sid, session, st, e)
         finally:
+            # Snapshot this turn's classification before releasing admission. A
+            # newer user turn may replace inflight_turn as soon as running=False.
+            terminal_surface = ((session.get("inflight_turn") or {}).get("error_surface")
+                                if st.error_retained else None)
             _finish_turn(sid, session, st)
+            current_work.reset(work_token)
             _current_runtime_session_record.reset(runtime_session_token)
             reset_transport(transport_token)
             # A stale interim closure must not fire during a later turn.
@@ -882,7 +922,9 @@ def _run_prompt_submit(
                     session.pop("_hosted_room_task", None)
             session.pop("_auto_continue_scheduled", None)
             _emit_settled_session_info(sid, session, st.agent)
-        _run_post_turn_followups(rid, sid, session, st.result, goal_followup)
+            finish(work, _emit, st.result, uncertain=bool(goal_followup or st.error_retained),
+                   terminal_surface=terminal_surface)
+        _run_post_turn_followups(rid, sid, session, st.result, goal_followup, work)
     run_thread = threading.Thread(target=run, daemon=True)
     # The handle is resolved BEFORE _sessions_lock: a profile session opens its own SessionDB through the
     # state registry, and _sessions_lock gates every create/close/prompt on this backend.
@@ -899,6 +941,9 @@ def _run_prompt_submit(
     if not can_start:
         with session["history_lock"]:
             session["running"] = False
+        if work is not None:
+            work.emit(_emit, "started")
+            finish(work, _emit, {"interrupted": True})
     return can_start
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -686,6 +686,11 @@ def _emit_approval_request(sid: str, data: dict | None) -> None:
     Reuse the shared gateway See #48456, #50767.
     """
     _emit("approval.request", sid, _approval_request_payload(data))
+    from tui_gateway.desktop_work import current_work
+    work = current_work.get()
+    request_id = (data or {}).get("request_id")
+    if work is not None and work.sid == sid and isinstance(request_id, str) and request_id:
+        work.emit(_emit, "approval", request_id)
 
 
 def _status_update(sid: str, kind: str, text: str | None = None):

--- a/tui_gateway/session_notifications.py
+++ b/tui_gateway/session_notifications.py
@@ -138,15 +138,21 @@ def _notif_log_failure(what: str, exc: BaseException) -> None:
     print(f"[tui_gateway] {what}: {type(exc).__name__}: {exc}", file=sys.stderr)
 
 
-def _notif_submit(rid: str, sid: str, session: dict, text: str, what: str, **kwargs) -> None:
-    """message.start + _run_prompt_submit for a claimed (running=True) turn; releases on failure."""
+_NOTIF_DISPATCH_FAILED = object()
+
+
+def _notif_submit(rid: str, sid: str, session: dict, text: str, what: str, **kwargs):
+    """Return admission for a claimed turn; release running on dispatch failure."""
     try:
         _emit("message.start", sid)
-        _run_prompt_submit(rid, sid, session, text, **kwargs)
+        accepted = _run_prompt_submit(rid, sid, session, text, **kwargs)
+        if accepted is False:
+            _notif_release_turn(session)
+        return accepted
     except Exception as exc:
         _notif_log_failure(what, exc)
         _notif_release_turn(session)
-        raise
+        return _NOTIF_DISPATCH_FAILED
 
 
 def _notif_loop_status(sid: str, text: str) -> None:
@@ -383,17 +389,40 @@ def _notif_poll_kanban(sid: str, session: dict) -> None:
 
 def _notif_dispatch_event(sid: str, session: dict, evt: dict, text: str) -> None:
     """Run the claimed (running=True) agent turn for one notification event."""
-    from tools.async_delegation import claim_event_delivery, complete_event_delivery, release_event_delivery
+    from tools.async_delegation import claim_event_delivery, complete_event_delivery, retry_event_delivery
     if (claim := claim_event_delivery(evt, "tui-poller")) is None:
+        _notif_release_turn(session)
         return
     kwargs = ({"display_kind": "async_delegation_complete", "display_metadata": _async_delegation_display_metadata(evt)}
               if evt.get("type") == "async_delegation" else {})
+    from tui_gateway.desktop_work import current_work
+    work = evt.get("_desktop_work") if evt.get("type") == "async_delegation" else None
+    if work is not None and (work.sid != sid or work.session is not session or work.closed):
+        work = None
+    if work is not None:
+        kwargs["continued_desktop_work"] = work
     try:
-        _notif_submit(f"__notif__{int(time.time() * 1000)}", sid, session, text, "notification poller dispatch failed", **kwargs)
+        accepted = _notif_submit(
+            f"__notif__{int(time.time() * 1000)}", sid, session, text,
+            "notification poller dispatch failed", **kwargs)
+        if accepted is _NOTIF_DISPATCH_FAILED:
+            retry_event_delivery(evt, claim)
+            time.sleep(0.25)
+            return
+        if accepted is not True:
+            retry_event_delivery(evt, claim, defer=True)
+            time.sleep(0.25)
+            return
+        token = current_work.set(work)
+        try:
+            if not complete_event_delivery(evt, claim):
+                retry_event_delivery(evt, claim)
+        finally:
+            current_work.reset(token)
     except Exception:
-        release_event_delivery(evt, claim)
+        retry_event_delivery(evt, claim)
+        time.sleep(0.25)
         return
-    complete_event_delivery(evt, claim)
 
 
 def _notif_handle_event(sid, session, evt, emitted, registry, fmt, deferred, completions=None, *, owned=False) -> bool:
@@ -450,7 +479,7 @@ def _notif_handle_event(sid, session, evt, emitted, registry, fmt, deferred, com
 
 def _notif_dispatch_completions(sid, session, notifications, registry, deferred):
     from tools.process_registry_notifications import ProcessNotificationBatch
-    from tools.async_delegation import claim_event_delivery, complete_event_delivery, release_event_delivery
+    from tools.async_delegation import claim_event_delivery, complete_event_delivery, retry_event_delivery
 
     if not notifications:
         return
@@ -467,14 +496,26 @@ def _notif_dispatch_completions(sid, session, notifications, registry, deferred)
         _notif_release_turn(session)
     try:
         if text is not None:
-            _notif_submit(f"__notif__{int(time.time() * 1000)}", sid, session, text,
-                          "completion batch dispatch failed")
+            accepted = _notif_submit(f"__notif__{int(time.time() * 1000)}", sid, session, text,
+                                     "completion batch dispatch failed")
+            if accepted is _NOTIF_DISPATCH_FAILED:
+                for event, _text, claim in claimed:
+                    retry_event_delivery(event, claim)
+                time.sleep(0.25)
+                return
+            if accepted is not True:
+                for event, _text, claim in claimed:
+                    retry_event_delivery(event, claim, defer=True)
+                time.sleep(0.25)
+                return
     except Exception:
         for event, _text, claim in claimed:
-            release_event_delivery(event, claim)
+            retry_event_delivery(event, claim)
+        time.sleep(0.25)
         return
     for event, _text, claim in claimed:
-        complete_event_delivery(event, claim)
+        if not complete_event_delivery(event, claim):
+            retry_event_delivery(event, claim)
 
 
 def _notif_handle_ready(sid, session, events, emitted, registry, fmt, deferred, *, owned=False):


### PR DESCRIPTION
## Summary
- restore Desktop-origin lifecycle events consumed by passive notification plugins
- preserve exact root/session/profile identity across normal turns, async delegation, failures, and goal continuations
- make durable completion claims retryable without stranding live Desktop roots

## Verification
- 100 focused Python tests passed (1 platform-specific skip)
- 164 focused Desktop Vitest tests passed
- Desktop TypeScript typecheck passed
- ESLint on changed Desktop files passed with no errors
- independent fail-closed review passed after rebase onto current main
- added-line secret scan and diff checks were clean

The notifier remains a passive observer: no model calls, prompt/history mutation, or automatic restart behavior.