### PR TITLE
fix(memory): reject invalid proposals before staging

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -877,7 +877,7 @@ class TestBackgroundReviewDeleteGate:
         store.add("memory", "first entry")
         store.add("memory", "second entry")
         path = store._path_for("memory")
-        path.write_text(path.read_text(encoding="utf-8").replace("\n§\n", "\n§ \n"), encoding="utf-8")
+        path.write_text(path.read_text(encoding="utf-8").replace("\n§\n", "\n§\n "), encoding="utf-8")
         before = path.read_text(encoding="utf-8")
 
         token = set_current_write_origin("background_review")

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -861,6 +861,36 @@ class TestBackgroundReviewDeleteGate:
         assert wa.pending_count(wa.MEMORY) == 0
         assert store.memory_entries == ["seed"]
 
+    @pytest.mark.parametrize("proposal", [
+        {"action": "replace", "old_text": "first", "content": "first revised"},
+        {"operations": [
+            {"action": "replace", "old_text": "first", "content": "first revised"},
+            {"action": "remove", "old_text": "second"},
+        ]},
+    ])
+    def test_drifted_proposals_are_rejected_without_staging_or_backup(
+        self, store, tmp_path, monkeypatch, proposal
+    ):
+        from tools.write_approval import MEMORY, pending_count
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        store.add("memory", "first entry")
+        store.add("memory", "second entry")
+        path = store._path_for("memory")
+        path.write_text(path.read_text(encoding="utf-8").replace("\n§\n", "\n§ \n"), encoding="utf-8")
+        before = path.read_text(encoding="utf-8")
+
+        token = set_current_write_origin("background_review")
+        try:
+            result = json.loads(memory_tool(store=store, **proposal))
+        finally:
+            reset_current_write_origin(token)
+
+        assert result["success"] is False
+        assert pending_count(MEMORY) == 0
+        assert path.read_text(encoding="utf-8") == before
+        assert not list(path.parent.glob("MEMORY.md.bak.*"))
+
     def test_add_still_allowed_in_background_review(self, store):
         token = set_current_write_origin("background_review")
         try:

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -819,6 +819,48 @@ class TestBackgroundReviewDeleteGate:
         # Atomic: the batch is only a proposal — its add must not land either.
         assert "fork consolidation" not in store._entries_for("memory")
 
+    @pytest.mark.parametrize("proposal", [
+        {"action": "replace", "old_text": "missing anchor", "content": "replacement"},
+        {"action": "replace", "old_text": "seed", "content": "x" * 501},
+        {"operations": [
+            {"action": "add", "content": "must not commit"},
+            {"action": "replace", "old_text": "missing batch anchor", "content": "replacement"},
+        ]},
+    ])
+    def test_invalid_proposals_are_rejected_before_background_staging(
+        self, store, tmp_path, monkeypatch, proposal
+    ):
+        from tools.write_approval import MEMORY, pending_count
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        store.add("memory", "seed")
+        token = set_current_write_origin("background_review")
+        try:
+            result = json.loads(memory_tool(store=store, **proposal))
+        finally:
+            reset_current_write_origin(token)
+
+        assert result["success"] is False
+        assert pending_count(MEMORY) == 0
+        assert store.memory_entries == ["seed"]
+
+    def test_invalid_proposal_is_rejected_before_write_approval_staging(
+        self, store, tmp_path, monkeypatch
+    ):
+        from tools import write_approval as wa
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(
+            wa, "evaluate_gate", lambda *args, **kwargs: wa.GateDecision(stage=True, message="stage"))
+        store.add("memory", "seed")
+
+        result = json.loads(memory_tool(
+            action="replace", old_text="missing anchor", content="replacement", store=store))
+
+        assert result["success"] is False
+        assert wa.pending_count(wa.MEMORY) == 0
+        assert store.memory_entries == ["seed"]
+
     def test_add_still_allowed_in_background_review(self, store):
         token = set_current_write_origin("background_review")
         try:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -61,7 +61,18 @@ def load_on_disk_store() -> "MemoryStore":
     return store
 
 
-def _gate_or_stage(summary: str, detail: str, payload: Dict[str, Any]) -> Optional[str]:
+def _preflight_stage(store: "MemoryStore", payload: Dict[str, Any]) -> Optional[str]:
+    """Return a JSON error when a proposal cannot apply to current on-disk memory."""
+    action = payload.get("action")
+    result = store.preflight(
+        payload.get("target", "memory"), action=action,
+        content=payload.get("content") or "", old_text=payload.get("old_text") or "",
+        operations=payload.get("operations") if action == "batch" else None)
+    return None if result.get("success") else json.dumps(result, ensure_ascii=False)
+
+
+def _gate_or_stage(summary: str, detail: str, payload: Dict[str, Any],
+                   store: "MemoryStore") -> Optional[str]:
     """JSON tool-result string when the write must NOT proceed (blocked or staged
     for approval), None to proceed. Fails open if the gate module can't load."""
     try:
@@ -73,6 +84,8 @@ def _gate_or_stage(summary: str, detail: str, payload: Dict[str, Any]) -> Option
         return None
     if decision.blocked:
         return tool_error(decision.message, success=False)
+    if invalid := _preflight_stage(store, payload):
+        return invalid
     record = wa.stage_write(wa.MEMORY, payload, summary=f"{summary}: {detail[:120]}", origin=wa.current_origin())
     return json.dumps({"success": True, "staged": True, "pending_id": record["id"], "message": decision.message},
                       ensure_ascii=False)
@@ -97,15 +110,16 @@ def _batch_op_line(op: Dict[str, Any]) -> str:
 
 
 def _apply_write_gate(action: str, target: str, content: Optional[str], old_text: Optional[str],
+                      store: "MemoryStore",
                       operations: Optional[List[Dict[str, Any]]] = None) -> Optional[str]:
     """Gate one mutating op, or (``operations`` set) a whole batch as a single unit."""
     label = "user profile" if target == "user" else "memory"
     if operations is not None:
         return _gate_or_stage(f"apply {len(operations)} op(s) to {label}",
                               "\n".join(_batch_op_line(op) for op in operations),
-                              {"action": "batch", "target": target, "operations": operations})
+                              {"action": "batch", "target": target, "operations": operations}, store)
     return _gate_or_stage(*_STORE_ACTIONS[action][1](label, content, old_text),
-                          {"action": action, "target": target, "content": content, "old_text": old_text})
+                          {"action": action, "target": target, "content": content, "old_text": old_text}, store)
 
 
 def _validate_single_op(store, action, target, content, old_text) -> Optional[str]:
@@ -129,7 +143,8 @@ def _validate_single_op(store, action, target, content, old_text) -> Optional[st
 _BG_DELETE_ACTIONS = ("replace", "remove")
 
 
-def _background_delete_gate(action, operations, target="memory", content=None, old_text=None) -> Optional[str]:
+def _background_delete_gate(action, operations, store, target="memory", content=None,
+                            old_text=None) -> Optional[str]:
     """Fail-closed operation gate for unattended background-review forks (#105921): ``add``
     stays available (it is all any review prompt asks for), while ``replace``/``remove`` —
     single or inside a batch — are never applied unattended. The op is staged in the pending
@@ -149,6 +164,8 @@ def _background_delete_gate(action, operations, target="memory", content=None, o
                {"action": action, "target": target, "content": content, "old_text": old_text})
     detail = ("; ".join(_batch_op_line(op) for op in operations) if operations is not None
               else _batch_op_line({"action": action, "content": content, "old_text": old_text}))
+    if invalid := _preflight_stage(store, payload):
+        return invalid
     try:
         from tools import write_approval as wa
         record = wa.stage_write(
@@ -187,19 +204,19 @@ def memory_tool(action: str = None, target: str = "memory", content: str = None,
     if operations:
         if not isinstance(operations, list):
             return tool_error("operations must be a list of {action, content?, old_text?} objects.", success=False)
-        denied = _background_delete_gate(action, operations, target)
+        denied = _background_delete_gate(action, operations, store, target)
         if denied is not None:
             return denied
         # Approval gate: stages (background/gateway) or prompts inline (CLI); off by default.
-        gate_result = _apply_write_gate("batch", target, None, None, operations)
+        gate_result = _apply_write_gate("batch", target, None, None, store, operations)
         if gate_result is not None:
             return gate_result
         return json.dumps(store.apply_batch(target, operations), ensure_ascii=False)
     if action not in _STORE_ACTIONS:
         return tool_error(f"Unknown action '{action}'. Use: add, replace, remove", success=False)
     invalid = (_validate_single_op(store, action, target, content, old_text)
-               or _background_delete_gate(action, None, target, content, old_text)
-               or _apply_write_gate(action, target, content, old_text))
+               or _background_delete_gate(action, None, store, target, content, old_text)
+               or _apply_write_gate(action, target, content, old_text, store))
     if invalid is not None:
         return invalid
     return json.dumps(_STORE_ACTIONS[action][0](store, target, content, old_text), ensure_ascii=False)

--- a/tools/memory_tool_store.py
+++ b/tools/memory_tool_store.py
@@ -187,7 +187,8 @@ class MemoryStore:
         return self._consolidation_failure(
             _error(message, current_entries=self._entries_for(target), usage=self._usage(target)))
 
-    def _mutate(self, target: str, mutate, *, skip_drift: bool = False) -> Dict[str, Any]:
+    def _mutate(self, target: str, mutate, *, skip_drift: bool = False,
+                dry_run: bool = False) -> Dict[str, Any]:
         """Lock, re-read from disk, run ``mutate(entries, limit)`` -> ``(new_entries, message)``
         or an error dict, then persist and return the success response. The reload aborts
         on an existing-but-unreadable file (even append-only ``add`` rewrites the whole
@@ -206,12 +207,14 @@ class MemoryStore:
             result = mutate(self._entries_for(target), self._char_limit(target))
             if isinstance(result, dict):
                 return result
+            if dry_run:
+                return {"success": True}
             self._set_entries(target, result[0])
             path.parent.mkdir(parents=True, exist_ok=True)
             self._write_file(path, result[0])
             return self._success_response(target, result[1])
 
-    def add(self, target: str, content: str) -> Dict[str, Any]:
+    def add(self, target: str, content: str, *, _dry_run: bool = False) -> Dict[str, Any]:
         """Append a new entry. Returns error if it would exceed the char limit."""
         content = content.strip()
         if not content:
@@ -231,9 +234,10 @@ class MemoryStore:
             return entries + [content], "Entry added."
         # Append-only: skip the drift guard (appending never clobbers foreign
         # content) but still refuse a failed read — add rewrites the WHOLE file.
-        return self._mutate(target, _add, skip_drift=True)
+        return self._mutate(target, _add, skip_drift=True, dry_run=_dry_run)
 
-    def replace(self, target: str, old_text: str, new_content: str) -> Dict[str, Any]:
+    def replace(self, target: str, old_text: str, new_content: str, *,
+                _dry_run: bool = False) -> Dict[str, Any]:
         """Find entry containing old_text substring, replace it with new_content."""
         new_content = new_content.strip()
         if not old_text.strip():
@@ -242,15 +246,16 @@ class MemoryStore:
             return _error("new_content cannot be empty. Use 'remove' to delete entries.")
         if scan_error := _scan_memory_content(new_content):
             return _error(scan_error)
-        return self._edit(target, old_text.strip(), new_content)
+        return self._edit(target, old_text.strip(), new_content, dry_run=_dry_run)
 
-    def remove(self, target: str, old_text: str) -> Dict[str, Any]:
+    def remove(self, target: str, old_text: str, *, _dry_run: bool = False) -> Dict[str, Any]:
         """Remove the entry containing old_text substring."""
         if not old_text.strip():
             return _error("old_text cannot be empty.")
-        return self._edit(target, old_text.strip(), None)
+        return self._edit(target, old_text.strip(), None, dry_run=_dry_run)
 
-    def _edit(self, target: str, old_text: str, new_content: Optional[str]) -> Dict[str, Any]:
+    def _edit(self, target: str, old_text: str, new_content: Optional[str], *,
+              dry_run: bool = False) -> Dict[str, Any]:
         """Locked replace (``new_content`` set) or remove (None) of the entry matching *old_text*."""
         def _apply(entries, limit):
             idx, ambiguous = _find_unique_match(entries, old_text)
@@ -271,7 +276,7 @@ class MemoryStore:
                     f"or 'remove' other stale or less important entries to make room (see current_entries "
                     f"below), then retry — all in this turn."))
             return replaced, "Entry replaced."
-        return self._mutate(target, _apply)
+        return self._mutate(target, _apply, skip_drift=dry_run, dry_run=dry_run)
 
     @staticmethod
     def _apply_batch_op(working: List[str], act: str, content: str, old_text: str, pos: str) -> Optional[str]:
@@ -296,7 +301,8 @@ class MemoryStore:
         working[idx:idx + 1] = [content] if act == "replace" else []
         return None
 
-    def apply_batch(self, target: str, operations: List[Dict[str, Any]]) -> Dict[str, Any]:
+    def apply_batch(self, target: str, operations: List[Dict[str, Any]], *,
+                    _dry_run: bool = False) -> Dict[str, Any]:
         """Apply add/replace/remove ops atomically against the FINAL budget, so one call
         can free space and add entries. All-or-nothing: any malformed / unmatched op or
         an over-limit result writes NOTHING and returns the first failure plus live state."""
@@ -335,7 +341,33 @@ class MemoryStore:
                     f"{new_total:,}/{limit:,} chars -- over the limit. Remove or shorten more "
                     f"entries in the same batch (see current_entries below), then retry."))
             return working, f"Applied {len(operations)} operation(s)."
-        return self._mutate(target, _apply)
+        return self._mutate(target, _apply, skip_drift=_dry_run, dry_run=_dry_run)
+
+    def preflight(self, target: str, *, action: Optional[str] = None,
+                  content: str = "", old_text: str = "",
+                  operations: Optional[List[Dict[str, Any]]] = None) -> Dict[str, Any]:
+        """Validate against a fresh locked disk snapshot without writing the proposal.
+
+        Approval still replays the operation normally, so proposals that become stale
+        after this check are rejected then. Preflight does not consume the per-turn
+        failure budget or replace the caller's live entry view.
+        """
+        entries = list(self._entries_for(target))
+        failures = self._consolidation_failures
+        self._consolidation_failures = 0
+        try:
+            if operations is not None:
+                return self.apply_batch(target, operations, _dry_run=True)
+            if action == "add":
+                return self.add(target, content, _dry_run=True)
+            if action == "replace":
+                return self.replace(target, old_text, content, _dry_run=True)
+            if action == "remove":
+                return self.remove(target, old_text, _dry_run=True)
+            return _error(f"Unknown action '{action}'. Use add, replace, or remove")
+        finally:
+            self._set_entries(target, entries)
+            self._consolidation_failures = failures
 
     def format_for_system_prompt(self, target: str) -> Optional[str]:
         """Frozen load-time snapshot (NOT live state — mid-session writes don't touch

--- a/tools/memory_tool_store.py
+++ b/tools/memory_tool_store.py
@@ -32,17 +32,21 @@ def _error(message: str, **extra) -> Dict[str, Any]:
     return {"success": False, "error": message, **extra}
 
 
-def _drift_error(path: Path, bak_path: str) -> Dict[str, Any]:
+def _drift_error(path: Path, bak_path: Optional[str] = None) -> Dict[str, Any]:
     """External drift: the file wouldn't round-trip, so flushing would discard content."""
+    backup = f" A snapshot was saved to {bak_path}." if bak_path else ""
+    extra = {"drift_backup": bak_path} if bak_path else {}
     return _error((
         f"Refusing to write {path.name}: file on disk has content that wouldn't round-trip "
         f"through the memory tool (likely added by the patch tool, a shell append, a manual edit, "
-        f"or a concurrent session). A snapshot was saved to {bak_path}. Resolve the drift first — "
+        f"or a concurrent session).{backup} Resolve the drift first — "
         f"either rewrite the file as a clean §-delimited list of entries, or move the extra "
         f"content out — then retry. This guard exists to prevent silent data loss (issue #26045)."
-    ), drift_backup=bak_path, remediation=(
+    ), **extra, remediation=(
         "Open the .bak file, integrate the missing entries into the memory tool one at a time via "
-        "memory(action=add, content=...), then remove or rewrite the original file to a clean state."))
+        "memory(action=add, content=...), then remove or rewrite the original file to a clean state."
+        if bak_path else
+        "Rewrite the original file as a clean §-delimited list of entries, then retry."))
 
 
 def _read_failed_error(path: Path) -> Dict[str, Any]:
@@ -200,9 +204,12 @@ class MemoryStore:
             raw, read_ok = self._read_raw_checked(path)
             if not read_ok:
                 return _read_failed_error(path)
-            bak = None if skip_drift else self._detect_external_drift(target, raw)
+            drifted = not skip_drift and self._has_external_drift(target, raw)
             self._set_entries(target, list(dict.fromkeys(self._parse_entries(raw))))
-            if bak:
+            if drifted:
+                # Preflight must classify the same disk snapshot as approval replay,
+                # but should not create a backup for every rejected proposal.
+                bak = None if dry_run else self._backup_external_drift(path, raw)
                 return _drift_error(path, bak)
             result = mutate(self._entries_for(target), self._char_limit(target))
             if isinstance(result, dict):
@@ -276,7 +283,7 @@ class MemoryStore:
                     f"or 'remove' other stale or less important entries to make room (see current_entries "
                     f"below), then retry — all in this turn."))
             return replaced, "Entry replaced."
-        return self._mutate(target, _apply, skip_drift=dry_run, dry_run=dry_run)
+        return self._mutate(target, _apply, dry_run=dry_run)
 
     @staticmethod
     def _apply_batch_op(working: List[str], act: str, content: str, old_text: str, pos: str) -> Optional[str]:
@@ -341,7 +348,7 @@ class MemoryStore:
                     f"{new_total:,}/{limit:,} chars -- over the limit. Remove or shorten more "
                     f"entries in the same batch (see current_entries below), then retry."))
             return working, f"Applied {len(operations)} operation(s)."
-        return self._mutate(target, _apply, skip_drift=_dry_run, dry_run=_dry_run)
+        return self._mutate(target, _apply, dry_run=_dry_run)
 
     def preflight(self, target: str, *, action: Optional[str] = None,
                   content: str = "", old_text: str = "",
@@ -432,15 +439,17 @@ class MemoryStore:
         except OSError as e:
             raise RuntimeError(f"Failed to write memory file {path}: {e}")
 
-    def _detect_external_drift(self, target: str, raw: str) -> Optional[str]:
-        """``.bak.<ts>`` snapshot path if *raw* shows external drift, else None. Signals:
-        round-trip mismatch, or one entry over the whole-file limit (no tool-written
-        entry can be — an external writer appended free-form text)."""
+    def _has_external_drift(self, target: str, raw: str) -> bool:
+        """Whether *raw* would lose data when parsed and written back."""
         parsed = self._parse_entries(raw)
-        if not raw.strip() or (raw.strip() == ENTRY_DELIMITER.join(parsed)
-                               and max(map(len, parsed), default=0) <= self._char_limit(target)):
-            return None
-        path = self._path_for(target)
+        return bool(raw.strip()) and (
+            raw.strip() != ENTRY_DELIMITER.join(parsed)
+            or max(map(len, parsed), default=0) > self._char_limit(target)
+        )
+
+    @staticmethod
+    def _backup_external_drift(path: Path, raw: str) -> str:
+        """Snapshot drifted content before a real mutation refusal."""
         bak_path = path.with_suffix(path.suffix + f".bak.{int(time.time())}")
         try:
             bak_path.write_text(raw, encoding="utf-8")


### PR DESCRIPTION
## Summary

- preflight memory writes before either approval staging path
- reuse native single-operation and atomic batch validation against a fresh locked disk snapshot
- preserve unattended replace/remove staging and authoritative validation during approval replay

## Root cause

The approval gates staged payloads before `MemoryStore` ran semantic validation. Missing or ambiguous anchors, projected budget overflow, and invalid atomic batches were therefore accepted into the pending queue and failed on every approval attempt.

## Why this PR vs existing PR #109226

PR #109226 validates a shallow copy of the caller's in-memory entry lists. That snapshot can already be stale when another session has changed the memory file, so an invalid proposal can still enter the queue. This PR routes preflight through `MemoryStore._mutate(..., dry_run=True)`, which takes the existing file lock and reloads the current on-disk contents before applying the same validators without persisting a write. Approval replay remains authoritative for changes that occur after staging.

## Testing

- `scripts/run_tests.sh tests/tools/test_memory_tool.py -k 'BackgroundReviewDeleteGate or MemoryBatch or MemoryStoreReplace' -v --tb=short` (17 passed)
- `scripts/run_tests.sh tests/tools/test_memory_tool.py tests/tools/test_write_approval.py -v --tb=short` (72 passed)
- `git diff --check`

Closes #109215
