### PR TITLE
fix(telegram): auto-migrate v2->v3 topic schema on first read (fixes #103363)

### DIFF
--- a/hermes_state_telegram.py
+++ b/hermes_state_telegram.py
@@ -101,11 +101,18 @@ class SessionTelegramTopicsMixin:
     ``enable``/``bind`` run the migration."""
 
     def _topic_read_one(self, sql: str, params):
-        """``fetchone`` that treats an unmigrated table as None."""
+        """``fetchone`` that auto-applies the v2→v3 schema migration on the first
+        ``OperationalError: no such column: profile_name``, then retries once."""
         try:
             return self._read_one(sql, params)
-        except sqlite3.OperationalError:
-            return None
+        except sqlite3.OperationalError as exc:
+            if "profile_name" not in str(exc):
+                return None
+            try:
+                self.apply_telegram_topic_migration()
+                return self._read_one(sql, params)
+            except Exception:
+                return None
 
     def apply_telegram_topic_migration(self) -> None:
         """Create Telegram DM topic-mode tables on explicit /topic opt-in. Deliberately NOT


### PR DESCRIPTION
## Problem

After upgrading to 0.21.0, existing installs with Telegram DM topic bindings at schema v2 (no \profile_name\ column) silently stopped auto-renaming topics. The root cause: the v2→v3 migration was only triggered by write paths (\enable_telegram_topic_mode\/\ind_telegram_topic\), but the **rename path reads first** via \get_telegram_topic_binding\, which hit \sqlite3.OperationalError: no such column: profile_name\ and silently returned early — never reaching the bind write that would have triggered migration.

## Fix

Changed \_topic_read_one\ to detect \OperationalError\ containing \profile_name\, call \pply_telegram_topic_migration()\ automatically (same idempotent procedure the write paths use), then retry the query once. Any other \OperationalError\ (missing table entirely, etc.) still returns \None\ as before.

This is the same fix pattern applied to #80037 and #20842 (same bug class: write-only migration, silent read failure after schema upgrade).

Fixes #103363.