### PR TITLE
fix(identity,api-server): ledger survives non-UTF-8 argv; RequestKey test tolerates aiohttp <3.14 (follow-up to #109156, #109157)

### DIFF
--- a/hermes_cli/process_identity.py
+++ b/hermes_cli/process_identity.py
@@ -267,7 +267,9 @@ def _append_entry(entry: LedgerEntry) -> bool:
         pruned.append(asdict(entry))
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
-            atomic_json_write(path, pruned, mode=0o600)
+            # argv may carry surrogate-escaped bytes (non-UTF-8 paths); ensure_ascii keeps the
+            # utf-8 text handle from raising UnicodeEncodeError (a ValueError, not an OSError).
+            atomic_json_write(path, pruned, mode=0o600, ensure_ascii=True)
             return True
         except OSError:
             logger.debug("spawn ledger write failed", exc_info=True)

--- a/tests/gateway/test_api_server_runs_import_isolation.py
+++ b/tests/gateway/test_api_server_runs_import_isolation.py
@@ -22,4 +22,5 @@ def test_missing_requestkey_keeps_web_module_bound():
         sys.modules["aiohttp.web_request"] = real
         importlib.reload(api_server_runs)
 
-    assert api_server_runs.RequestKey is aiohttp.web_request.RequestKey
+    # aiohttp < 3.14 has no RequestKey; the module binds None there, so compare against getattr.
+    assert api_server_runs.RequestKey is getattr(aiohttp.web_request, "RequestKey", None)

--- a/tests/hermes_cli/test_process_identity.py
+++ b/tests/hermes_cli/test_process_identity.py
@@ -134,6 +134,19 @@ def test_register_self_writes_and_prunes_dead(tmp_path):
     assert me["create_time"] == pytest.approx(50.0, abs=0.01)
 
 
+def test_register_self_survives_non_utf8_argv(tmp_path):
+    ledger = tmp_path / "spawn-ledger.json"
+    fake = _fake_psutil({999: 50.0})
+    bad_argv = ["hermes", "serve", os.fsdecode(b"/tmp/project-\xff")]  # surrogate-escaped path
+    with patch.dict(sys.modules, {"psutil": fake}), \
+         patch.object(pi, "_ledger_path", return_value=ledger), \
+         patch.object(pi.os, "getpid", return_value=999), \
+         patch.object(sys, "argv", bad_argv):
+        assert pi.register_self("serve", project_root=Path("/x/install")) is True
+    me = next(e for e in json.loads(ledger.read_text(encoding="utf-8")) if e["pid"] == 999)
+    assert me["argv"] == " ".join(bad_argv)
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits are platform-specific")
 def test_register_self_writes_ledger_with_0600(tmp_path):
     ledger = tmp_path / "spawn-ledger.json"

--- a/utils.py
+++ b/utils.py
@@ -217,10 +217,17 @@ def atomic_write_text(path: Union[str, Path], content: str, *, encoding: str = "
                   mode=_mode_for_write(path, create_mode, preserve=preserve_mode), preserve_owner=preserve_mode)
 
 
-def atomic_json_write(path: Union[str, Path], data: Any, *, indent: int = 2, mode: int | None = None, **dump_kwargs: Any) -> None:
-    """Write JSON to *path* atomically (temp file + fsync + replace)."""
+def atomic_json_write(
+    path: Union[str, Path], data: Any, *, indent: int = 2, mode: int | None = None,
+    ensure_ascii: bool = False, **dump_kwargs: Any,
+) -> None:
+    """Write JSON to *path* atomically (temp file + fsync + replace).
+
+    ``ensure_ascii=True`` lets callers persist surrogate-escaped strings (non-UTF-8 argv/paths)
+    that a utf-8 text handle would otherwise reject with ``UnicodeEncodeError``.
+    """
     path = Path(path)
-    _atomic_write(path, lambda f: json.dump(data, f, indent=indent, ensure_ascii=False, **dump_kwargs),
+    _atomic_write(path, lambda f: json.dump(data, f, indent=indent, ensure_ascii=ensure_ascii, **dump_kwargs),
                   prefix=f".{path.stem}_", mode=mode if mode is not None else _preserve_file_mode(path))
 
 


### PR DESCRIPTION
The spawn ledger now records a process whose argv contains a non-UTF-8 path instead of silently dropping the registration, and the `RequestKey` import-isolation test passes on every aiohttp version the guarded import supports.

Follow-up to #109156 (@codeshipsingh) and #109157 (@Decent9967) — review found two defects after merge:

- **Ledger encoding** — `hermes_cli/process_identity.py::_append_entry` moved to `utils.atomic_json_write`, which dumps with `ensure_ascii=False` through a utf-8 text handle. An argv token holding surrogate-escaped bytes (`os.fsdecode(b'/tmp/project-\xff')`) makes `json.dump` raise `UnicodeEncodeError` — a `ValueError`, so the `except OSError` misses it and callers that swallow exceptions lose the registration. `atomic_json_write` gains an explicit `ensure_ascii` keyword (default unchanged, `False`) and the ledger passes `ensure_ascii=True`, restoring the pre-#109156 `json.dumps` behaviour while keeping `mode=0o600`.
- **RequestKey test** — `tests/gateway/test_api_server_runs_import_isolation.py` ended with `assert api_server_runs.RequestKey is aiohttp.web_request.RequestKey`, which `AttributeError`s on aiohttp < 3.14 — the very versions the guarded import exists for. Now compares against `getattr(aiohttp.web_request, "RequestKey", None)`.

Root cause: the salvage swapped `json.dumps` (ASCII-escaping) for a helper that defaults to raw UTF-8 output, and the test asserted the new-version shape only.

## Validation

| Check | Result |
|---|---|
| `tests/hermes_cli/test_process_identity.py` | 24 passed |
| `tests/gateway/test_api_server_runs_import_isolation.py` | 1 passed (aiohttp 3.14.3 locally; `getattr` path also exercises the `None` branch on < 3.14) |
| `tests/hermes_cli/test_atomic_json_write.py`, `tests/test_atomic_replace_symlinks.py`, `tests/tools/test_watch_patterns.py`, `tests/test_honcho_client_config.py` (other `atomic_json_write` callers) | 61 passed, 4 skipped |
| Red-on-base: `test_register_self_survives_non_utf8_argv` with `origin/main` `process_identity.py` swapped in | 1 failed (UnicodeEncodeError) → passes with fix |
| `ruff check` touched files / `check-windows-footguns.py --all` / `check_compat_pointers.py` / `git diff --check` | clean |

## Infographic

![infographic](https://v3b.fal.media/files/b/0aaa248d/PRCnu6wOyLiUaSmy-5nd8_2xMDkhkf.png)
