### PR TITLE
feat(api-server): honor validated per-run workspace on /v1/runs

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3578,7 +3578,7 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
     def _bind_api_server_session(
         *, chat_id: str = "", session_key: str = "", session_id: str = "", profile: str = "",
         browser_control_principal: str = "", browser_control_transport_family: str = "",
-        session_history_delivery: str = "") -> list:
+        session_history_delivery: str = "", cwd: str = "") -> list:
         """Bind an API turn with push disabled and history delivery default-denied.
 
         Only routes whose continuation reads SessionDB may pass "1". An omitted
@@ -3592,7 +3592,8 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
             platform="api_server", chat_id=chat_id, session_key=session_key, session_id=session_id,
             profile=profile, browser_control_principal=browser_control_principal,
             browser_control_transport_family=browser_control_transport_family,
-            async_delivery=False, cron_session="", session_history_delivery=session_history_delivery)
+            async_delivery=False, cron_session="", session_history_delivery=session_history_delivery,
+            cwd=cwd)
 
     def _turn_runtime_metadata(
         self, agent: Any, *, route: Optional[Dict[str, Any]], requested_runtime: Optional[Dict[str, Any]],

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -74,6 +74,58 @@ def _run_not_found(_openai_error, run_id: str) -> "web.Response":
     return _json_error(_openai_error, f"Run not found: {run_id}", code="run_not_found", status=404)
 
 
+def _workspace_contained_in_root(candidate: str, root: str) -> Optional[str]:
+    """Return the canonical *candidate* only when it is *root* itself or beneath it.
+
+    A lexical ``startswith`` is not a containment check: it accepts sibling prefixes
+    (``/workspace-other``) and ``..`` traversal, and a symlink inside the tree can point
+    anywhere. Require an absolute candidate, realpath both sides, then require equality
+    or descent. Resolution failures fail closed (``None``).
+    """
+    try:
+        candidate = str(candidate or "").strip()
+        if not candidate or not os.path.isabs(candidate):
+            return None
+        root_real = os.path.realpath(root)
+        cand_real = os.path.realpath(candidate)
+        if cand_real == root_real or cand_real.startswith(root_real + os.sep):
+            return cand_real
+    except Exception:
+        return None
+    return None
+
+
+def _request_run_workspace(body: Any) -> str:
+    """Validated per-run working directory from a ``/v1/runs`` body; empty when absent or rejected.
+
+    A client (Hermes WebUI gateway mode) may ask for its session's canonical workspace;
+    the gateway is the final filesystem authority and honors the request only when the
+    path resolves inside its OWN working tree (the configured ``terminal.cwd`` / launch
+    dir, per the active profile, via ``resolve_agent_cwd()``) and exists as a directory
+    here. Anything else — a sibling prefix, a ``..`` or symlink escape, or a path from
+    the client's mount namespace that does not exist on this host — is ignored with a
+    warning, leaving default cwd behavior. Never raises: the run itself is still admitted.
+    """
+    if not isinstance(body, dict):
+        return ""
+    raw = body.get("workspace")
+    if not isinstance(raw, str) or not raw.strip():
+        return ""
+    try:
+        from agent.runtime_cwd import resolve_agent_cwd
+        root = str(resolve_agent_cwd())
+    except Exception:
+        logger.warning("[api_server] run workspace %r ignored: gateway cwd root unresolvable", raw)
+        return ""
+    contained = _workspace_contained_in_root(raw, root)
+    if contained is None or not os.path.isdir(contained):
+        logger.warning(
+            "[api_server] run workspace %r ignored: not an existing directory at/under "
+            "the gateway working root %r", raw, root)
+        return ""
+    return contained
+
+
 def _uses_room_run_auth(self, request: "web.Request") -> bool:
     return request.path.endswith("/v1/runs") and bool(self._room_grant_token(request))
 
@@ -332,6 +384,9 @@ class _RunLaunch:
     browser_control_principal: Any
     browser_control_transport_family: Any
     turn_author: Optional[Dict[str, Any]] = None  # memory-attribution label only; grants nothing
+    # Validated client-requested working directory (``""`` = gateway default); already
+    # contained under this gateway's own working root by ``_request_run_workspace``.
+    workspace: str = ""
 
     @property
     def approval_session_key(self) -> str:
@@ -421,6 +476,9 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
         turn_author = _api_server._request_turn_author(body)
     except ValueError as exc:
         return _json_error(_openai_error, str(exc), code="invalid_author", status=400)
+    # Revalidated HERE, in the gateway's own filesystem: the client's containment check
+    # cannot prove mount equivalence or preempt filesystem races at this receiver.
+    workspace = _request_run_workspace(body)
     conversation_history, instructions, stored_session_id, history_err = (
         _resolve_conversation_history(self, body, raw_input, _openai_error=_openai_error))
     if history_err is not None:
@@ -498,7 +556,7 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
         request_profile=_api_server._api_request_profile.get(),
         browser_control_principal=_api_server._api_request_browser_control_principal.get(),
         browser_control_transport_family=_api_server._api_request_browser_control_transport_family.get(),
-        turn_author=turn_author)
+        turn_author=turn_author, workspace=workspace)
     self._activate_admitted_request()
     task = self._active_run_tasks[run_id] = asyncio.create_task(_execute_run(self, launch, _api_server=_api_server))
     with suppress(TypeError):
@@ -521,10 +579,12 @@ def _run_agent_sync(self, run: _RunLaunch, agent, approval_notify, *, _api_serve
     # accumulate until the OS refuses new process spawns.
     from tools.approval import register_gateway_notify, unregister_gateway_notify
     from tools.approval_context import reset_current_session_key, set_current_session_key
+    from tools.terminal_tool import clear_task_env_overrides, register_task_env_overrides
     session_id = run.session_id
     effective_task_id = session_id or run.run_id
     # (token, reset) pairs unwound in the finally block; bound only once each step succeeds.
     resets: list[tuple[Any, Callable]] = []
+    workspace_registered = False
     with self._profile_scope(run.request_profile):
         try:
             # Contextvars, not process env: concurrent runs must not share identity.
@@ -545,9 +605,19 @@ def _run_agent_sync(self, run: _RunLaunch, agent, approval_notify, *, _api_serve
                 # so it stays default-denied until a merge contract exists for that chain;
                 # likewise a caller-supplied conversation_history is authoritative for the
                 # turn and never reads the delivery row, so it is denied the same way.
-                session_history_delivery="1" if run.session_history_delivery else "")
+                session_history_delivery="1" if run.session_history_delivery else "",
+                # Pin the logical cwd so the system prompt, context-file discovery, and
+                # coding context agree with the task-scoped tool cwd bound below.
+                cwd=run.workspace)
             if session_tokens:
                 resets.append((session_tokens, clear_session_vars))
+            if run.workspace:
+                # Task-scoped tool cwd binding (the seam ACP uses for editor workspaces):
+                # the terminal and file layers resolve a registered per-task cwd override
+                # before any env-side cwd, so tool execution lands in the validated
+                # session workspace. Cleared in the finally on every terminal path.
+                register_task_env_overrides(effective_task_id, {"cwd": run.workspace})
+                workspace_registered = True
             if run.agent_kwargs["room_dispatch"] is not None:
                 policy = RoomExecutionPolicy.from_mapping(run.agent_kwargs["room_execution_policy"] or {})
                 resets.append((bind_room_execution_policy(policy), reset_room_execution_policy))
@@ -563,6 +633,9 @@ def _run_agent_sync(self, run: _RunLaunch, agent, approval_notify, *, _api_serve
         finally:
             # Clear ownership now so a later stop can't reap work this run left running.
             _api_server._clear_turn_process_ownership(agent)
+            if workspace_registered:
+                with suppress(Exception):
+                    clear_task_env_overrides(effective_task_id)
             # Declared-conversation binding, same precedence gate as _run_agent.
             if run.declared_selected:
                 self._bind_declared_conversation(

--- a/tests/gateway/test_api_server_runs_workspace.py
+++ b/tests/gateway/test_api_server_runs_workspace.py
@@ -1,0 +1,286 @@
+"""Tests for the /v1/runs ``workspace`` field: admission-time containment
+validation against the gateway's OWN working root, task-scoped tool-cwd
+binding during the run, and cleanup on the terminal path.
+
+Covers:
+- ``_workspace_contained_in_root`` — realpath containment matrix (sibling
+  prefix, ``..`` traversal, symlink escape, non-absolute, exact root)
+- ``_request_run_workspace`` — body extraction, fail-closed root resolution,
+  nonexistent-directory rejection
+- POST /v1/runs end-to-end — a validated workspace reaches the run's
+  task-scoped terminal/filesystem cwd (``resolve_task_overrides`` /
+  ``get_session_cwd``) and the logical cwd (``resolve_agent_cwd``), and is
+  cleared when the run completes; an out-of-root workspace is ignored while
+  the run is still admitted at the default cwd.
+"""
+
+import asyncio
+import os
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from unittest.mock import MagicMock, patch
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    cors_middleware,
+    security_headers_middleware,
+)
+from gateway.platforms.api_server_runs import (
+    _request_run_workspace,
+    _workspace_contained_in_root,
+)
+
+
+# ---------------------------------------------------------------------------
+# Harness (mirrors tests/gateway/test_api_server_runs.py)
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter(api_key: str = "") -> APIServerAdapter:
+    extra = {"key": api_key} if api_key else {}
+    return APIServerAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _create_runs_app(adapter: APIServerAdapter) -> web.Application:
+    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    app = web.Application(middlewares=mws)
+    app["api_server_adapter"] = adapter
+    app.router.add_post("/v1/runs", adapter._handle_runs)
+    app.router.add_get("/v1/runs/{run_id}", adapter._handle_get_run)
+    return app
+
+
+def _capturing_agent(captured: dict) -> MagicMock:
+    """Mock agent recording the cwd surfaces the terminal/file layers resolve
+    DURING run_conversation (executor thread, run context bound)."""
+    from agent.runtime_cwd import resolve_agent_cwd
+    from tools.terminal_tool import get_session_cwd, resolve_task_overrides
+
+    def _run(user_message=None, conversation_history=None, task_id=None, **kwargs):
+        captured["task_id"] = task_id
+        captured["agent_cwd"] = str(resolve_agent_cwd())
+        captured["task_override_cwd"] = resolve_task_overrides(task_id).get("cwd")
+        captured["session_cwd_record"] = get_session_cwd(task_id)
+        return {"final_response": "done"}
+
+    mock_agent = MagicMock()
+    mock_agent.run_conversation.side_effect = _run
+    mock_agent.session_prompt_tokens = 0
+    mock_agent.session_completion_tokens = 0
+    mock_agent.session_total_tokens = 0
+    return mock_agent
+
+
+async def _wait_completed(cli, run_id: str) -> None:
+    for _ in range(40):
+        status = await (await cli.get(f"/v1/runs/{run_id}")).json()
+        if status["status"] == "completed":
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError(f"run {run_id} did not complete")
+
+
+# ---------------------------------------------------------------------------
+# _workspace_contained_in_root — pure containment matrix (real filesystem)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceContainedInRoot:
+    def test_exact_root_allowed(self, tmp_path):
+        root = tmp_path / "workspace"
+        root.mkdir()
+        assert _workspace_contained_in_root(str(root), str(root)) == os.path.realpath(root)
+
+    def test_child_directory_allowed(self, tmp_path):
+        root = tmp_path / "workspace"
+        child = root / "project"
+        child.mkdir(parents=True)
+        assert _workspace_contained_in_root(str(child), str(root)) == os.path.realpath(child)
+
+    def test_dotdot_that_stays_inside_normalizes_to_contained(self, tmp_path):
+        root = tmp_path / "workspace"
+        child = root / "project"
+        child.mkdir(parents=True)
+        candidate = str(root / "other" / ".." / "project")
+        assert _workspace_contained_in_root(candidate, str(root)) == os.path.realpath(child)
+
+    def test_sibling_prefix_rejected(self, tmp_path):
+        root = tmp_path / "workspace"
+        sibling = tmp_path / "workspace-other"
+        sibling.mkdir()
+        root.mkdir()
+        assert _workspace_contained_in_root(str(sibling), str(root)) is None
+
+    def test_dotdot_escape_rejected(self, tmp_path):
+        root = tmp_path / "workspace"
+        root.mkdir()
+        outside = tmp_path / "secret"
+        outside.mkdir()
+        candidate = str(root / ".." / "secret")
+        assert _workspace_contained_in_root(candidate, str(root)) is None
+
+    def test_symlink_escape_rejected(self, tmp_path):
+        root = tmp_path / "workspace"
+        root.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        link = root / "escape"
+        try:
+            link.symlink_to(outside)
+        except OSError as exc:  # Windows without symlink privilege
+            pytest.skip(f"cannot create symlink: {exc}")
+        assert _workspace_contained_in_root(str(link), str(root)) is None
+
+    def test_symlink_within_root_canonicalized(self, tmp_path):
+        root = tmp_path / "workspace"
+        real = root / "real"
+        real.mkdir(parents=True)
+        link = root / "alias"
+        try:
+            link.symlink_to(real)
+        except OSError as exc:
+            pytest.skip(f"cannot create symlink: {exc}")
+        assert _workspace_contained_in_root(str(link), str(root)) == os.path.realpath(real)
+
+    @pytest.mark.parametrize("candidate", ["", "   ", "relative/path", "./workspace", "project"])
+    def test_non_absolute_or_empty_rejected(self, tmp_path, candidate):
+        root = tmp_path / "workspace"
+        root.mkdir()
+        assert _workspace_contained_in_root(candidate, str(root)) is None
+
+    def test_root_resolution_error_fails_closed(self, tmp_path, monkeypatch):
+        def _boom(_):
+            raise OSError("unresolvable")
+
+        monkeypatch.setattr(os.path, "realpath", _boom)
+        assert _workspace_contained_in_root("/workspace/x", "/workspace") is None
+
+
+# ---------------------------------------------------------------------------
+# _request_run_workspace — body extraction + root authority
+# ---------------------------------------------------------------------------
+
+
+class TestRequestRunWorkspace:
+    @pytest.mark.parametrize("body", [
+        {}, {"workspace": ""}, {"workspace": "   "}, {"workspace": None},
+        {"workspace": 42}, {"workspace": ["/workspace"]}, "not-a-dict", None,
+    ])
+    def test_absent_or_malformed_returns_empty(self, body):
+        assert _request_run_workspace(body) == ""
+
+    def test_valid_child_returns_canonical_path(self, tmp_path, monkeypatch):
+        root = tmp_path / "workspace"
+        child = root / "project"
+        child.mkdir(parents=True)
+        monkeypatch.setattr(
+            "agent.runtime_cwd.resolve_agent_cwd", lambda: root)
+        assert _request_run_workspace({"workspace": str(child)}) == os.path.realpath(child)
+
+    def test_out_of_root_rejected(self, tmp_path, monkeypatch):
+        root = tmp_path / "workspace"
+        root.mkdir()
+        outside = tmp_path / "workspace-evil"
+        outside.mkdir()
+        monkeypatch.setattr("agent.runtime_cwd.resolve_agent_cwd", lambda: root)
+        assert _request_run_workspace({"workspace": str(outside)}) == ""
+
+    def test_nonexistent_contained_dir_rejected(self, tmp_path, monkeypatch):
+        root = tmp_path / "workspace"
+        root.mkdir()
+        monkeypatch.setattr("agent.runtime_cwd.resolve_agent_cwd", lambda: root)
+        assert _request_run_workspace({"workspace": str(root / "ghost")}) == ""
+
+    def test_root_resolution_error_fails_closed(self, monkeypatch):
+        def _boom():
+            raise OSError("cwd deleted")
+
+        monkeypatch.setattr("agent.runtime_cwd.resolve_agent_cwd", _boom)
+        assert _request_run_workspace({"workspace": "/workspace/x"}) == ""
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/runs end-to-end — binding during the run, cleanup at completion
+# ---------------------------------------------------------------------------
+
+
+class TestRunWorkspaceEndToEnd:
+    @pytest.mark.asyncio
+    async def test_valid_workspace_binds_tool_cwd_and_clears_on_completion(
+        self, tmp_path, monkeypatch
+    ):
+        root = tmp_path / "workspace"
+        project = root / "project"
+        project.mkdir(parents=True)
+        # The gateway's own working root (terminal.cwd authority), scope-aware
+        # via TERMINAL_CWD; resolve_agent_cwd() stays the REAL resolver.
+        monkeypatch.setenv("TERMINAL_CWD", str(root))
+
+        adapter = _make_adapter()
+        app = _create_runs_app(adapter)
+        captured: dict = {}
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", return_value=_capturing_agent(captured)):
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "ws-session",
+                          "workspace": str(project)},
+                )
+                assert resp.status == 202
+                run_id = (await resp.json())["run_id"]
+                await _wait_completed(cli, run_id)
+
+        expected = os.path.realpath(project)
+        # Logical cwd (system prompt / context discovery / coding context)…
+        assert captured["agent_cwd"] == expected
+        # …and the task-scoped terminal/filesystem tool cwd agree.
+        assert captured["task_override_cwd"] == expected
+        assert captured["session_cwd_record"] == expected
+        # Terminal-path cleanup: override AND cwd record dropped after completion.
+        from tools.terminal_tool import get_session_cwd, resolve_task_overrides
+        assert resolve_task_overrides(captured["task_id"]) == {}
+        assert get_session_cwd(captured["task_id"]) is None
+
+    @pytest.mark.asyncio
+    async def test_no_workspace_keeps_gateway_default_cwd(self, tmp_path, monkeypatch):
+        root = tmp_path / "workspace"
+        root.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", str(root))
+
+        adapter = _make_adapter()
+        app = _create_runs_app(adapter)
+        captured: dict = {}
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", return_value=_capturing_agent(captured)):
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                assert resp.status == 202
+                await _wait_completed(cli, (await resp.json())["run_id"])
+
+        assert captured["agent_cwd"] == os.path.realpath(root)
+        assert captured["task_override_cwd"] is None
+        assert captured["session_cwd_record"] is None
+
+    @pytest.mark.asyncio
+    async def test_out_of_root_workspace_ignored_but_run_admitted(self, tmp_path, monkeypatch):
+        root = tmp_path / "workspace"
+        root.mkdir()
+        outside = tmp_path / "workspace-evil"
+        outside.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", str(root))
+
+        adapter = _make_adapter()
+        app = _create_runs_app(adapter)
+        captured: dict = {}
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", return_value=_capturing_agent(captured)):
+                resp = await cli.post(
+                    "/v1/runs", json={"input": "hello", "workspace": str(outside)})
+                assert resp.status == 202
+                await _wait_completed(cli, (await resp.json())["run_id"])
+
+        # Fail-safe: default gateway cwd, no task override registered.
+        assert captured["agent_cwd"] == os.path.realpath(root)
+        assert captured["task_override_cwd"] is None

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -451,6 +451,22 @@ When `session_id` identifies an existing Hermes session and no explicit
 that session's active transcript. Session turn leases serialize concurrent
 writers and refresh the transcript after a contended wait.
 
+A run may carry an optional `workspace` string naming the session's working
+directory. The gateway is the final filesystem authority: it honors the field
+only when the path is absolute, exists as a directory on this host, and
+resolves (after symlink resolution) to the gateway's own working root — the
+configured `terminal.cwd`, or the launch directory when none is configured —
+or a path beneath it. An accepted workspace becomes the run's task-scoped
+terminal and filesystem cwd (the same binding the ACP adapter uses for editor
+workspaces) and the logical cwd shown in the system prompt, and is cleared
+when the run reaches a terminal state. Anything else — a sibling prefix such
+as `/workspace-other`, a `..` or symlink escape, a relative path, or a
+directory that does not exist on the gateway — is ignored with a warning and
+the run keeps the default working directory. Deployments that share a
+workspace between a frontend container and the gateway (for example both
+mounting `/workspace`) should set the gateway's `terminal.cwd` to that mount
+so per-session subdirectories validate.
+
 ### GET /v1/runs/\{run_id\}
 
 Poll the current run state. This is useful for dashboards that need status without holding an SSE connection open, or for UIs that reconnect after navigation.


### PR DESCRIPTION
## Problem

`POST /v1/runs` clients can include a `workspace` field naming the session's working directory (Hermes WebUI's gateway mode sends the browser session's canonical workspace so file/terminal tools land in the shared workspace — see nesquena/hermes-webui#7440). The gateway never consumed the field: `_handle_runs` had no workspace read and `_request_agent_overrides` dropped it, so tool execution stayed in the gateway default cwd and the field was a transport-only no-op. In a two-container deployment (frontend + gateway both mounting `/workspace`) this meant agent file writes went to the gateway container's home instead of the shared workspace.

## What changed

The gateway is now the final filesystem authority for `workspace`:

- **Admission-time revalidation** (`_request_run_workspace`): the field is honored only when it is an absolute path that exists as a directory *on this host* and realpath-resolves to the gateway's own working root (configured `terminal.cwd`, else launch dir — profile scope-aware via `resolve_agent_cwd()`) or a path beneath it. Sibling prefixes (`/workspace-other`), `..` traversal, symlink escapes, relative paths, and paths that don't exist on the gateway are ignored with a warning; the run is still admitted at the default cwd (fail-safe — matches the client's omission contract, and other API clients are unaffected).
- **Task-scoped binding** (`_run_agent_sync`): an accepted workspace is registered via `register_task_env_overrides(task_id, {"cwd": ...})` — the same seam the ACP adapter uses for editor workspaces — so the terminal (`_plan_execution`/`_resolve_command_cwd`) and file (`file_tools_paths`) layers resolve it before any env-side cwd. The logical session cwd is pinned alongside (`set_session_vars(cwd=...)`) so the system prompt, context-file discovery, and coding context agree with the tool cwd.
- **Terminal-path cleanup**: `clear_task_env_overrides` + `clear_session_vars` drop the override and cwd record when the run finishes, fails, or is cancelled.

No behavior change for requests without `workspace`.

## Tests

New `tests/gateway/test_api_server_runs_workspace.py` (28 tests):

- Realpath containment matrix on a real filesystem (exact root allowed, child allowed, sibling prefix / `..` escape / symlink escape rejected, in-root symlink canonicalized, non-absolute rejected, resolution error fails closed).
- Body extraction: missing/empty/non-string/non-dict → ignored; nonexistent contained dir rejected; unresolvable gateway root fails closed.
- **End-to-end through the real HTTP handler**: POST /v1/runs with a valid workspace → during `run_conversation` the real `resolve_agent_cwd()`, `resolve_task_overrides()`, and `get_session_cwd()` all resolve the workspace (proving tool cwd, not only request JSON), and after completion the override and cwd record are gone. Out-of-root workspace → run admitted at default cwd with no override. No workspace → unchanged default behavior.

Focused suites: the new file plus all 21 existing `api_server` test modules (313 tests) pass; `runtime_cwd`/`terminal_scope` suites pass; `ruff check` clean.

## Notes for reviewers

- The client half (WebUI) already validates containment in *its* filesystem and omits the field otherwise; this PR is the independent receiver-side validation the contract requires (client validation cannot prove mount equivalence or preempt filesystem races at the gateway).
- `terminal.cwd` is the containment root, so a deployment opts into per-session workspaces by configuring its workspace mount as `terminal.cwd` (e.g. `/workspace` in Docker); without that, only paths under the launch directory are accepted.