### PR TITLE
fix(cli): merge startup alias base_url into _explicit_base_url (fixes #107191, #103933)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2684,7 +2684,7 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
         # --api-key wins; otherwise a URL-bearing startup alias carries its own credential.
         # See #28660.
         self._explicit_api_key = api_key or _startup_api_key_override or None
-        self._explicit_base_url = base_url
+        self._explicit_base_url = base_url or _startup_base_url_override or None
 
         # Resolved lazily at use-time via _ensure_runtime_credentials().
         self.requested_provider = (


### PR DESCRIPTION
## Problem

\model_aliases:\ entries with a custom \ase_url\ (e.g. a local llama.cpp server) were silently ignored at CLI startup. The \_startup_base_url_override\ was correctly captured from \esolve_startup_model_route()\, but then only assigned to \self.base_url\. The sibling field \self._explicit_base_url\ — which is what \_ensure_runtime_credentials()\ reads when forwarding the URL to the runtime resolver — was assigned only from the raw \ase_url\ CLI arg (which \hermes chat\ doesn't even expose). Result: the request fell through to OpenRouter with a 401.

## Fix

One line, mirroring the existing \_startup_api_key_override\ merge on the line above it:

\\\python
# Before
self._explicit_base_url = base_url

# After  
self._explicit_base_url = base_url or _startup_base_url_override or None
\\\

The CLI flag \ase_url\ still wins when both are set, matching the \CLI args > config file\ precedence documented in the function docstring.

Fixes #107191, also covers the same root cause in #103933.