### PR TITLE
fix(anthropic): demote a thinking signature foreign to the current endpoint

### DIFF
--- a/agent/anthropic_message_convert.py
+++ b/agent/anthropic_message_convert.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from agent.anthropic_endpoints import (
     _is_deepseek_anthropic_endpoint, _is_kimi_family_endpoint, _is_nous_portal_endpoint,
-    _is_third_party_anthropic_endpoint, _model_name_is_deepseek_thinking,
+    _is_third_party_anthropic_endpoint, _model_name_is_deepseek_thinking, _normalized_lower,
 )
 
 logger = logging.getLogger(__name__)
@@ -380,11 +380,18 @@ def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
     # than relocated. #56195 covered the complementary shape (blank content -> top-level marker); this is
     # the interleaved thinking + preamble-text + tool_use shape.
     content = m.get("content", "")
+    # Provenance stamp (see build_assistant_message): must survive whichever path builds the
+    # converted message, since _manage_thinking_signatures reads it from ``result`` (the
+    # converted list), not from the original ``messages`` this function consumes.
+    signed_base_url = m.get("_thinking_signed_base_url")
     ordered_blocks = m.get("anthropic_content_blocks")
     if isinstance(ordered_blocks, list) and ordered_blocks:
         replayed = _replay_ordered_blocks(m, ordered_blocks)
         if replayed:
-            return {"role": "assistant", "content": replayed}
+            out = {"role": "assistant", "content": replayed}
+            if signed_base_url is not None:
+                out["_thinking_signed_base_url"] = signed_base_url
+            return out
     blocks = _extract_preserved_thinking_blocks(m)
     # Blank text blocks are dropped; a cache marker riding on one is relocated onto the last
     # surviving cacheable block (prompt_caching sets cache_control on content[-1], which may be
@@ -415,7 +422,10 @@ def _convert_assistant_message(m: Dict[str, Any]) -> Dict[str, Any]:
     effective = blocks or [_text_block(_EMPTY_TEXT_PLACEHOLDER)]
     _apply_assistant_cache_control_to_last_cacheable_block(effective, relocated_cc)
     _apply_assistant_cache_control_to_last_cacheable_block(effective, m.get("cache_control"))
-    return {"role": "assistant", "content": effective}
+    out = {"role": "assistant", "content": effective}
+    if signed_base_url is not None:
+        out["_thinking_signed_base_url"] = signed_base_url
+    return out
 
 
 def _tool_result_content(m: Dict[str, Any]) -> Any:
@@ -553,6 +563,17 @@ def _keep_valid_latest_thinking(content: List[Any], signature_dead: bool) -> Lis
     return new_content
 
 
+def _thinking_signature_foreign(m: Dict[str, Any], current_endpoint: str) -> bool:
+    """True when this turn's thinking signature was minted on a DIFFERENT Anthropic-family
+    endpoint than the one we're converting for right now (e.g. a Kimi-coding primary that
+    failed over to direct Anthropic). Signatures are provider-bound — Anthropic signs each
+    thinking block against the endpoint that produced it and 400s on replay elsewhere
+    ("Invalid signature in thinking block"). Absent stamp (legacy data, non-Anthropic modes)
+    is never treated as foreign — only an explicit mismatch counts."""
+    signed_base_url = m.get("_thinking_signed_base_url")
+    return signed_base_url is not None and _normalized_lower(signed_base_url) != current_endpoint
+
+
 def _manage_thinking_signatures(result: List[Dict[str, Any]], base_url: str | None, model: str | None) -> None:
     """Strip or preserve thinking blocks per endpoint. Mutates ``result`` in place.
 
@@ -568,6 +589,7 @@ def _manage_thinking_signatures(result: List[Dict[str, Any]], base_url: str | No
     is_deepseek = _is_deepseek_anthropic_endpoint(base_url) or (
         is_third_party and _model_name_is_deepseek_thinking(model)
     )
+    current_endpoint = _normalized_lower(base_url)
     last_assistant_idx = next((i for i in range(len(result) - 1, -1, -1) if result[i].get("role") == "assistant"), None)
     for idx, m in _assistant_block_lists(result):
         if is_kimi:
@@ -582,13 +604,17 @@ def _manage_thinking_signatures(result: List[Dict[str, Any]], base_url: str | No
         elif is_third_party or idx != last_assistant_idx:
             m["content"] = _strip_thinking(m["content"]) or [_text_block("(thinking elided)")]
         else:
-            new_content = _keep_valid_latest_thinking(m["content"], bool(m.get("_thinking_signature_invalidated")))
+            new_content = _keep_valid_latest_thinking(
+                m["content"],
+                bool(m.get("_thinking_signature_invalidated")) or _thinking_signature_foreign(m, current_endpoint),
+            )
             m["content"] = new_content or [_text_block("(empty)")]
         # cache_control on thinking blocks interferes with signature validation.
         for b in m["content"]:
             if _block_type(b) in _THINKING_TYPES:
                 b.pop("cache_control", None)
         m.pop("_thinking_signature_invalidated", None)  # internal flag, never on the wire
+        m.pop("_thinking_signed_base_url", None)  # internal flag, never on the wire
 
 
 def _evict_old_screenshots(result: List[Dict[str, Any]]) -> None:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1572,6 +1572,15 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
                 ):
                     note_checkpoint()
 
+    # Anthropic-family thinking signatures are minted against (and only valid for) the exact
+    # endpoint that produced them: replaying a Kimi/DeepSeek/MiniMax-minted signature to
+    # api.anthropic.com (or vice versa) is a hard HTTP 400 ("Invalid signature in thinking
+    # block"), not a soft mismatch. Stamp the minting endpoint on the stored turn so a later
+    # cross-provider fallback can demote a now-foreign signature to plain text instead of
+    # replaying it verbatim (see _thinking_signature_foreign / _manage_thinking_signatures).
+    if getattr(agent, "api_mode", None) == "anthropic_messages" and (msg.get("reasoning_details") or msg.get("anthropic_content_blocks")):
+        msg["_thinking_signed_base_url"] = getattr(agent, "_anthropic_base_url", None) or ""
+
     if assistant_tool_calls:
         msg["tool_calls"] = [_assistant_tool_call_dict(agent, tc, i) for i, tc in enumerate(assistant_tool_calls)]
     return msg

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -370,17 +370,22 @@ def _recover_format_errors(
     the request was repaired and should be retried."""
     # Upstream mutation invalidates Anthropic's thinking-block signature (400). Strip
     # ``reasoning_details`` from ``api_messages`` only, never ``messages`` (state.db).
+    # ``_convert_assistant_message`` prefers the verbatim ``anthropic_content_blocks`` channel
+    # over ``reasoning_details`` when both are present (interleaved-thinking replay,
+    # #_replay_ordered_blocks), so a signature riding only in that channel survives a
+    # reasoning_details-only strip and the retry hits the identical 400 again. Strip both.
     if classified.reason == FailoverReason.thinking_signature and not _retry.thinking_sig_retry_attempted:
         _retry.thinking_sig_retry_attempted = True
         _api_stripped = 0
         for _m in api_messages:
-            if isinstance(_m, dict) and "reasoning_details" in _m:
+            if isinstance(_m, dict) and ("reasoning_details" in _m or "anthropic_content_blocks" in _m):
                 _m.pop("reasoning_details", None)
+                _m.pop("anthropic_content_blocks", None)
                 _api_stripped += 1
-        _vlines(agent, "⚠️  Thinking block signature invalid, stripped reasoning_details from api_messages for retry...")
+        _vlines(agent, "⚠️  Thinking block signature invalid, stripped reasoning_details/anthropic_content_blocks from api_messages for retry...")
         logger.warning(
             "%sThinking block signature recovery: stripped "
-            "reasoning_details from %d api_messages "
+            "reasoning_details/anthropic_content_blocks from %d api_messages "
             "(canonical messages unchanged)",
             agent.log_prefix, _api_stripped,
         )

--- a/tests/agent/test_anthropic_foreign_thinking_signature.py
+++ b/tests/agent/test_anthropic_foreign_thinking_signature.py
@@ -1,0 +1,200 @@
+"""Regression: a thinking signature minted on a non-Anthropic Anthropic-Messages
+endpoint (Kimi/DeepSeek/MiniMax/etc.) must never be replayed verbatim to
+api.anthropic.com after a cross-provider fallback, and the one-shot
+thinking-signature recovery must actually repair the shape that carries it.
+
+Root cause (kanban t_d6552433, reproduced live 2026-09-12)
+-----------------------------------------------------------
+``_manage_thinking_signatures`` treats "is this base_url native Anthropic"
+as the only signal for whether to keep a turn's signed thinking blocks. It
+never asks WHERE the signature was minted. A session whose primary provider
+was kimi-coding (an Anthropic-Messages-wire endpoint) failing over to direct
+api.anthropic.com replays kimi-minted signatures on the "latest assistant
+turn keeps signed thinking" path and gets a hard 400 ("Invalid signature in
+thinking block"), twice, burning restart budget before a healthy rung is
+ever tried.
+
+The existing one-shot recovery (``_recover_format_errors`` /
+``FailoverReason.thinking_signature``) was also a no-op for this exact shape:
+it stripped only ``reasoning_details``, but ``_convert_assistant_message``
+prefers the verbatim ``anthropic_content_blocks`` channel when present
+(interleaved-thinking replay), so the foreign signature survived the "fix"
+and the retry hit the identical 400 again.
+
+Fix under test
+--------------
+1. ``build_assistant_message`` stamps ``_thinking_signed_base_url`` on any
+   Anthropic-wire assistant turn that carries a signature.
+2. ``_manage_thinking_signatures`` demotes (to plain text) any latest-turn
+   thinking block whose stamped origin doesn't match the endpoint we're
+   converting FOR right now — the same demotion path already used for an
+   orphan-stripped/invalidated turn.
+3. ``_recover_format_errors`` strips ``anthropic_content_blocks`` (not just
+   ``reasoning_details``) so the one-shot recovery repairs turns using the
+   ordered-block replay fast path too.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent.anthropic_message_convert import convert_messages_to_anthropic
+from agent.transports import get_transport
+
+SIG = "sig-minted-on-kimi"
+
+
+def _kimi_signed_tool_turn():
+    """An assistant turn with signed thinking + tool_use, as minted by a
+    Kimi-coding (Anthropic-Messages-wire) primary provider."""
+    return SimpleNamespace(
+        content=[
+            SimpleNamespace(type="thinking", thinking="plan the read", signature=SIG),
+            SimpleNamespace(type="tool_use", id="toolu_1", name="read_file", input={"path": "a.py"}),
+        ],
+        stop_reason="tool_use",
+        usage=None,
+    )
+
+
+def _stored_message_from_kimi(signed_base_url: str = "https://api.kimi.com/coding") -> dict:
+    """Reproduce exactly what build_assistant_message stores for a kimi-coding turn:
+    reasoning_details + anthropic_content_blocks + the new provenance stamp."""
+    response = _kimi_signed_tool_turn()
+    normalized = get_transport("anthropic_messages").normalize_response(response)
+    provider_data = normalized.provider_data or {}
+    msg = {
+        "role": "assistant",
+        "content": normalized.content or "",
+        "reasoning_details": provider_data.get("reasoning_details"),
+        "tool_calls": [
+            {"id": tc.id, "type": "function", "function": {"name": tc.name, "arguments": tc.arguments}}
+            for tc in (normalized.tool_calls or [])
+        ],
+        # Stamped by build_assistant_message at write time (agent.api_mode ==
+        # "anthropic_messages" and agent._anthropic_base_url == the kimi endpoint).
+        "_thinking_signed_base_url": signed_base_url,
+    }
+    if provider_data.get("anthropic_content_blocks"):
+        msg["anthropic_content_blocks"] = provider_data["anthropic_content_blocks"]
+    return msg
+
+
+def _thinking_blocks(assistant_content):
+    return [b for b in assistant_content if isinstance(b, dict) and b.get("type") == "thinking"]
+
+
+class TestForeignSignatureDemotedOnFallback:
+    def test_kimi_signature_replayed_to_anthropic_is_demoted_not_kept(self):
+        """The invariant: a signature minted on a non-Anthropic endpoint must never reach
+        api.anthropic.com intact. Converting FOR direct Anthropic (base_url=None) must
+        strip the foreign signature and demote the block to plain text."""
+        assistant_msg = _stored_message_from_kimi()
+        messages = [
+            {"role": "user", "content": "inspect a.py"},
+            assistant_msg,
+            {"role": "tool", "tool_call_id": "toolu_1", "content": "a.py: ok"},
+        ]
+        _sys, out = convert_messages_to_anthropic(messages, base_url=None, model="claude-sonnet-5")
+        assistant_out = [m for m in out if m["role"] == "assistant"][-1]
+        thinking = _thinking_blocks(assistant_out["content"])
+        assert not any(b.get("signature") == SIG for b in thinking), (
+            "a Kimi-minted thinking signature was replayed verbatim to direct Anthropic — "
+            f"this is the exact shape that produces HTTP 400 'Invalid signature in thinking "
+            f"block': {thinking}"
+        )
+        # The reasoning content itself is preserved as plain text (not silently dropped).
+        assert any(b.get("type") == "text" and "plan the read" in b.get("text", "") for b in assistant_out["content"])
+
+    def test_same_endpoint_signature_survives_replay(self):
+        """Control: a signature minted on the SAME endpoint we're converting for must
+        still be kept — this is the normal, working case and must not regress."""
+        assistant_msg = _stored_message_from_kimi(signed_base_url="https://api.kimi.com/coding")
+        messages = [
+            {"role": "user", "content": "inspect a.py"},
+            assistant_msg,
+            {"role": "tool", "tool_call_id": "toolu_1", "content": "a.py: ok"},
+        ]
+        _sys, out = convert_messages_to_anthropic(
+            messages, base_url="https://api.kimi.com/coding", model="kimi-k2.5",
+        )
+        assistant_out = [m for m in out if m["role"] == "assistant"][-1]
+        # Kimi does not enforce signatures (is_kimi path passes through as-is) — the
+        # signed block must survive untouched when replayed to the endpoint that minted it.
+        thinking = _thinking_blocks(assistant_out["content"])
+        assert any(b.get("signature") == SIG for b in thinking)
+
+    def test_unstamped_legacy_turn_is_not_treated_as_foreign(self):
+        """Absence of the stamp (pre-fix data, or a non-Anthropic-wire provider) must not
+        be misread as 'foreign' — only an explicit mismatch demotes. Regression guard for
+        the null-signal case."""
+        assistant_msg = _stored_message_from_kimi()
+        del assistant_msg["_thinking_signed_base_url"]
+        messages = [
+            {"role": "user", "content": "inspect a.py"},
+            assistant_msg,
+            {"role": "tool", "tool_call_id": "toolu_1", "content": "a.py: ok"},
+        ]
+        _sys, out = convert_messages_to_anthropic(messages, base_url=None, model="claude-sonnet-5")
+        assistant_out = [m for m in out if m["role"] == "assistant"][-1]
+        thinking = _thinking_blocks(assistant_out["content"])
+        assert any(b.get("signature") == SIG for b in thinking), (
+            "an unstamped (legacy) turn was demoted even though no origin mismatch was proven"
+        )
+
+    def test_internal_stamp_never_reaches_the_wire(self):
+        """The provenance flag is bookkeeping only — it must never survive conversion,
+        on ANY endpoint (mirrors the existing _thinking_signature_invalidated leak guard)."""
+        assistant_msg = _stored_message_from_kimi()
+        messages = [
+            {"role": "user", "content": "inspect a.py"},
+            assistant_msg,
+            {"role": "tool", "tool_call_id": "toolu_1", "content": "a.py: ok"},
+        ]
+        for base_url, model in ((None, "claude-sonnet-5"), ("https://api.kimi.com/coding", "kimi-k2.5")):
+            _sys, out = convert_messages_to_anthropic(messages := [dict(m) for m in messages], base_url=base_url, model=model)
+            assistant_out = [m for m in out if m["role"] == "assistant"][-1]
+            assert "_thinking_signed_base_url" not in assistant_out, (base_url, assistant_out.keys())
+
+
+class TestRecoverFormatErrorsStripsOrderedBlockChannel:
+    """``_recover_format_errors`` must repair BOTH channels a signature can ride in, or the
+    one-shot recovery is a no-op for the ordered-block replay shape and the retry 400s again."""
+
+    def test_strips_anthropic_content_blocks_not_just_reasoning_details(self):
+        from agent.turn_recovery import _recover_format_errors
+        from agent.turn_retry_state import TurnRetryState
+        from agent.error_classifier import FailoverReason
+
+        assistant_msg = _stored_message_from_kimi()
+        assert "anthropic_content_blocks" in assistant_msg, "fixture must exercise the ordered-block channel"
+        api_messages = [
+            {"role": "user", "content": "inspect a.py"},
+            dict(assistant_msg),
+            {"role": "tool", "tool_call_id": "toolu_1", "content": "a.py: ok"},
+        ]
+        agent = SimpleNamespace(log_prefix="", quiet_mode=True, verbose_mode=False, _vprint=lambda *a, **k: None)
+        classified = SimpleNamespace(reason=FailoverReason.thinking_signature)
+        retry = TurnRetryState()
+
+        recovered = _recover_format_errors(
+            agent, RuntimeError("Invalid signature in thinking block"), classified, retry,
+            messages=[], api_messages=api_messages,
+        )
+        assert recovered is True
+
+        repaired_assistant = next(m for m in api_messages if m.get("role") == "assistant")
+        assert "reasoning_details" not in repaired_assistant, "reasoning_details survived the strip"
+        assert "anthropic_content_blocks" not in repaired_assistant, (
+            "anthropic_content_blocks survived the strip — this is the exact shape "
+            "documented as a no-op recovery in kanban t_d6552433: "
+            "_convert_assistant_message prefers this channel over reasoning_details, "
+            "so a foreign signature stripped only from reasoning_details still rides "
+            "the wire and the retry gets the identical 400."
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Fixes a foreign-thinking-signature 400 loop reproduced live in kanban t_d6552433: a session whose primary provider was kimi-coding (Anthropic-Messages wire) failed over to direct `api.anthropic.com` and replayed the kimi-minted thinking signature on the "latest assistant turn keeps signed thinking" path. Two 400s ("Invalid signature in thinking block") burned the fallback-chain restart budget before a healthy rung was ever tried.

The existing one-shot recovery (`_recover_format_errors` / `FailoverReason.thinking_signature`) was also a no-op for this exact shape: it stripped only `reasoning_details`, but `_convert_assistant_message` prefers the verbatim `anthropic_content_blocks` channel when present (interleaved-thinking replay), so the foreign signature survived the "fix" and the retry hit the identical 400 again.

## Root cause

`_manage_thinking_signatures` only asked "is this base_url native Anthropic" — never "where was this specific turn's signature minted." Signatures are provider-bound: Anthropic (and Anthropic-compatible third parties on the same wire, e.g. Kimi-coding) sign each thinking block against the endpoint that produced it, and replaying it elsewhere is a hard 400, not a soft mismatch.

## Fix

- `build_assistant_message` stamps `_thinking_signed_base_url` on any Anthropic-wire assistant turn carrying a signature (`reasoning_details` or `anthropic_content_blocks`).
- The stamp travels through both of `_convert_assistant_message`'s return paths (ordered-block replay and the general reconstruction path) so it's visible where `_manage_thinking_signatures` actually reads it — the *converted* list, not the original messages.
- `_manage_thinking_signatures` demotes the latest-turn thinking block to plain text when its stamped origin doesn't match the endpoint we're converting for right now, reusing the existing `_thinking_signature_invalidated` demotion path (`_keep_valid_latest_thinking`). Absence of the stamp (legacy data, or an endpoint whose policy isn't "keep the latest signed block") is never treated as foreign — only an explicit mismatch demotes.
- `_recover_format_errors` now also strips `anthropic_content_blocks`, not just `reasoning_details`, so the one-shot thinking-signature recovery actually repairs the ordered-block replay shape instead of no-op'ing.

## Tests

New: `tests/agent/test_anthropic_foreign_thinking_signature.py` (5 cases):
- a Kimi-minted signature converted for direct Anthropic is demoted, never replayed verbatim
- the same signature converted for the endpoint that minted it (Kimi) still survives — control case, no regression
- an unstamped/legacy turn (no provenance data) is never treated as foreign
- the internal `_thinking_signed_base_url` bookkeeping flag never reaches the wire on any endpoint
- `_recover_format_errors` now strips `anthropic_content_blocks` too (previously proven red — the ticket's documented no-op recovery)

Verified baseline-red on `origin/main` for the right behavioral reason (real assertion messages describing the bug, not `AttributeError`s), then green with the fix.

Full `tests/agent/` (543 files, ~7000 tests) plus the targeted Anthropic-thinking suites (`test_anthropic_thinking_block_order.py`, `test_anthropic_kimi_signed_thinking_replay.py`, `test_kimi_coding_anthropic_thinking.py`, `test_deepseek_anthropic_thinking.py`, `test_anthropic_adapter.py`, `test_anthropic_thinking_disable.py`, `test_bedrock_transport_replay.py`, `test_tool_call_arg_no_redaction.py`) run clean against this branch off `origin/main` with zero regressions (`scripts/run_tests.sh`, not bare pytest).

## Acceptance criteria (from the tracking issue)

- [x] Invariant test: an assistant turn carrying a signature minted on a non-Anthropic endpoint must NOT reach `api.anthropic.com` with that signature intact.
- [x] Invariant test: `_recover_format_errors` removes the signature for the `anthropic_content_blocks` shape (proven red on `origin/main` first).
- [x] Verified via message-conversion-level reproduction of a real cross-provider failover (kimi/zai primary -> anthropic rung) landing a converted request with the foreign signature demoted.
