### PR TITLE
fix(retry): jitter Anthropic Retry-After backoff to prevent thundering herd

### DIFF
--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -79,6 +79,19 @@ def jittered_backoff(attempt: int, *, base_delay: float = 5.0, max_delay: float 
     return delay + random.Random(seed).uniform(0, jitter_ratio * delay)
 
 
+def jitter_retry_after(seconds: float, *, max_jitter: float = 30.0, jitter_ratio: float = 0.2) -> float:
+    """Add bounded, positive-only jitter to a provider-mandated cooldown."""
+    global _jitter_counter
+    with _jitter_lock:
+        _jitter_counter += 1
+        tick = _jitter_counter
+
+    # Seed from time + counter so coarse clocks still decorrelate.
+    seed = (time.time_ns() ^ (tick * 0x9E3779B9)) & 0xFFFFFFFF
+    extra_delay = min(jitter_ratio * seconds, max_jitter)
+    return seconds + random.Random(seed).uniform(0, extra_delay)
+
+
 def _error_text(error: Any) -> str:
     """Best-effort flattened provider error text for retry classification."""
     parts = [error, getattr(error, "message", None), getattr(error, "body", None), getattr(error, "response", None)]

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -1027,7 +1027,7 @@ def compute_error_backoff(
     buffered; long Z.AI Coding waits surface immediately."""
     # Imported lazily so tests that patch ``agent.retry_utils.jittered_backoff`` /
     # ``adaptive_rate_limit_backoff`` (incl. the run_agent conftest fast-backoff fixture) intercept.
-    from agent.retry_utils import adaptive_rate_limit_backoff, jittered_backoff, parse_retry_after_seconds
+    from agent.retry_utils import adaptive_rate_limit_backoff, jitter_retry_after, jittered_backoff, parse_retry_after_seconds
 
     # Respect Retry-After on every retryable provider error, not just 429s. Retryable
     # 5xx responses (e.g. Cloudflare 520/524) also carry the header or a structured
@@ -1047,13 +1047,18 @@ def compute_error_backoff(
     if _retry_after is not None:
         # Cap at 10 minutes. Anthropic Tier 1 input-token buckets reset in ~171s, so a 120s cap
         # caused us to retry before the actual reset window and re-trip the limit. 600s covers all
-        # realistic provider reset windows while still rejecting pathological values. (#26293)
+        # realistic provider reset windows while still rejecting pathological values. Add up to 20%
+        # positive-only jitter (at most 30s) after that cap: during the Sep 8 incident, concurrent
+        # Anthropic retries nearly all waited the same 600s and retried together. The small tail
+        # keeps 600s the practical ceiling without re-synchronizing capped callers. (#26293)
         _retry_after = min(_retry_after, 600)
         if _retry_after <= 0:
             # A zero/expired cooldown (retry-after: 0, or an HTTP-date in the
             # past, which the parser clamps to 0.0) carries no usable wait —
             # treat it as absent so we never hot-loop the provider.
             _retry_after = None
+        else:
+            _retry_after = jitter_retry_after(_retry_after)
     wait_time = _retry_after if _retry_after is not None else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
     _backoff_policy = None
     _adaptive = is_rate_limited or is_zai_coding_overload

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1968,25 +1968,27 @@ class TestRetryAfterCap:
         return next(((m, s) for m, s in captured if status_marker in m), ("", ""))
 
     def test_retry_after_under_cap_is_honored(self, agent):
-        # 300s > old 120s cap but < new 600s cap → used verbatim.
+        # 300s > old 120s cap but < new 600s cap; positive-only jitter may
+        # extend, but never shorten, the provider cooldown.
         error = self._retryable_error(429, {"retry-after": "300"})
         status, _ = self._drive_once(agent, error, "Waiting")
-        assert "Waiting 300.0s" in status
+        wait = float(status.split("Waiting ", 1)[1].split("s", 1)[0])
+        assert 300.0 <= wait <= 330.0
 
     @pytest.mark.parametrize(
-        ("headers", "body", "expected_wait", "expected_surface"),
+        ("headers", "body", "minimum_wait", "expected_surface"),
         [
             # Long cooldowns (> 60s) surface immediately...
-            ({"Retry-After": "120"}, {}, "120.0", "emit"),
-            ({}, {"status": 524, "retry_after": 120}, "120.0", "emit"),
-            ({}, {"status": 524, "error": {"retry_after": 120}}, "120.0", "emit"),
+            ({"Retry-After": "120"}, {}, 120.0, "emit"),
+            ({}, {"status": 524, "retry_after": 120}, 120.0, "emit"),
+            ({}, {"status": 524, "error": {"retry_after": 120}}, 120.0, "emit"),
             # Above the 600s ceiling → capped, never used verbatim.
-            ({"Retry-After": "3600"}, {}, "600.0", "emit"),
+            ({"Retry-After": "3600"}, {}, 600.0, "emit"),
             # ...short cooldowns keep the buffered status line.
-            ({"Retry-After": "30"}, {}, "30.0", "buffer"),
+            ({"Retry-After": "30"}, {}, 30.0, "buffer"),
             # No cooldown on header or body → falls through to jittered
             # backoff (patched to 0.0 by the conftest fixture), no crash.
-            ({}, {"status": 524}, "0.0", "buffer"),
+            ({}, {"status": 524}, 0.0, "buffer"),
         ],
         ids=(
             "header",
@@ -1998,12 +2000,14 @@ class TestRetryAfterCap:
         ),
     )
     def test_retry_after_on_cloudflare_524_is_honored(
-        self, agent, headers, body, expected_wait, expected_surface
+        self, agent, headers, body, minimum_wait, expected_surface
     ):
         """A retryable 5xx must not bypass the provider's cooldown."""
         error = self._retryable_error(524, headers, body)
         status, surface = self._drive_once(agent, error, "Retrying in")
-        assert f"Retrying in {expected_wait}s" in status
+        wait = float(status.split("Retrying in ", 1)[1].split("s", 1)[0])
+        assert wait >= minimum_wait
+        assert wait <= 630.0
         assert surface == expected_surface
 
 

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -5,7 +5,7 @@ import threading
 import agent.retry_utils as retry_utils
 from types import SimpleNamespace
 
-from agent.retry_utils import adaptive_rate_limit_backoff, is_zai_coding_overload_error, jittered_backoff
+from agent.retry_utils import adaptive_rate_limit_backoff, is_zai_coding_overload_error, jitter_retry_after, jittered_backoff
 
 
 def test_backoff_is_exponential():
@@ -99,6 +99,21 @@ def test_backoff_uses_locked_tick_for_seed(monkeypatch):
 
     assert len(recorded_seeds) == 2
     assert len(set(recorded_seeds)) == 2, f"Expected unique seeds, got {recorded_seeds}"
+
+
+def test_retry_after_jitter_spreads_identical_cooldowns():
+    """Identical provider cooldowns must not synchronize concurrent retries."""
+    waits = [jitter_retry_after(600.0) for _ in range(20)]
+
+    assert len(set(waits)) > 1
+    assert all(wait <= 630.0 for wait in waits)
+
+
+def test_retry_after_jitter_never_retries_early():
+    """Jitter may only extend a provider-mandated cooldown."""
+    retry_after = 120.0
+
+    assert all(jitter_retry_after(retry_after) >= retry_after for _ in range(20))
 
 
 def _zai_overload_error():


### PR DESCRIPTION
Anthropic `rate_limit_error` (429) retries derived from the provider's Retry-After header use a deterministic `min(_retry_after, 600)` cap with no randomization. During a real production incident (Sep 8, 30+ concurrent kanban subagents hitting the same account-wide limit), log analysis showed 19 of 20 capped retries computed to the EXACT same 600.0s wait — every concurrent thread that got rate-limited retried in the same instant, re-tripping the same account-wide bucket instead of letting it recover.

`agent/retry_utils.py` already ships `jittered_backoff()` specifically to prevent this class of thundering-herd retry spike, but it was only wired into the no-Retry-After fallback path — never into the Retry-After-derived wait itself, which is exactly the path real Anthropic 429s take (they always carry a Retry-After header/body field).

**Fix:** added `jitter_retry_after()` to `agent/retry_utils.py`, reusing the existing `_jitter_counter`/`_jitter_lock` seeding pattern from `jittered_backoff()`. It adds bounded, **positive-only** jitter (up to 20% extra, capped at 30s) on top of the already-capped Retry-After value — so concurrent callers that observed an identical Retry-After decorrelate their actual retry moments, while never retrying before the provider's stated cooldown (retrying early just re-trips the same bucket, the exact failure mode the existing 600s-cap comment already warns about). `agent/turn_recovery.py`'s `compute_error_backoff()` now applies it right after the existing cap/zero-check. The Z.AI adaptive-overload path and the no-Retry-After `jittered_backoff` fallback are untouched.

**Tests** (`tests/test_retry_utils.py`): two new invariant tests — (1) 20 calls with the same 600s input produce more than one distinct wait (thundering-herd regression guard, fails on current `main`, which returns a byte-identical delay for a byte-identical input), and (2) the jittered wait is never less than the original Retry-After value (never-retry-early guarantee). Updated `tests/run_agent/test_run_agent.py`'s `TestRetryAfterCap` assertions from exact-value checks to bounded-range checks to tolerate the new jitter.

**Verified:** `scripts/run_tests.sh tests/test_retry_utils.py tests/agent/test_turn_recovery_retry_notice.py tests/run_agent/test_run_agent.py` — 298 passed, 0 failed. `coderabbit review --agent`: 0 findings across all 4 changed files. `pr-agent review` (diff-file mode, hermes-agent.toml config): 0 key issues, tests present, no security concerns.