### PR TITLE
fix(dump): report the configured MCP server count

### DIFF
--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -245,6 +245,9 @@ def run_dump(args):
     except Exception:
         profile = "(default)"
     toolsets = config.get("toolsets", ["hermes-cli"])
+    # hermes_cli.mcp_config owns the ``mcp_servers`` accessor every MCP surface reads; importing it
+    # here rather than at module scope keeps `hermes dump` off the MCP security/asyncio import cost.
+    from hermes_cli.mcp_config import _get_mcp_servers
     platforms = [name for name, env in _PLATFORM_ENV_VARS.items() if os.getenv(env)]
     lines = [
         "--- hermes dump ---",
@@ -260,7 +263,7 @@ def run_dump(args):
         "", "api_keys:", *_api_key_lines(show_keys),
         "", "features:",
         f"  toolsets:           {', '.join(toolsets) if toolsets else '(default)'}",
-        f"  mcp_servers:        {len(config.get('mcp', {}).get('servers', {}))}",
+        f"  mcp_servers:        {len(_get_mcp_servers(config))}",
         f"  memory_provider:    {config.get('memory', {}).get('provider', '') or 'built-in'}",
         f"  gateway:            {_gateway_status()}",
         f"  platforms:          {', '.join(platforms) if platforms else 'none'}",

--- a/tests/hermes_cli/test_dump_mcp_server_count.py
+++ b/tests/hermes_cli/test_dump_mcp_server_count.py
@@ -1,0 +1,52 @@
+"""`hermes dump` must report the MCP servers that are actually configured.
+
+The ``features:`` line read the legacy nested ``mcp.servers`` path, while MCP
+server definitions live at top-level ``mcp_servers`` — so every dump printed
+``mcp_servers: 0`` however many servers were configured. That line is what
+``hermes debug share`` hands to support, so it read as "no MCP servers
+configured" on every machine.
+
+The count comes from ``mcp_config._get_mcp_servers``, the accessor ``hermes mcp
+list`` uses, so the number cannot drift from the list again.
+"""
+
+from types import SimpleNamespace
+
+
+def _mcp_count(out: str) -> str:
+    for line in out.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("mcp_servers:"):
+            return stripped.split(":", 1)[1].strip()
+    raise AssertionError(f"no 'mcp_servers' line in dump output:\n{out}")
+
+
+def _dump_with(monkeypatch, capsys, tmp_path, config) -> str:
+    from hermes_cli import dump
+    from hermes_cli.config import get_hermes_home
+
+    monkeypatch.setattr(dump, "get_project_root", lambda: tmp_path / "noproject")
+    monkeypatch.setattr(dump, "load_config", lambda: config)
+    get_hermes_home().mkdir(parents=True, exist_ok=True)
+    dump.run_dump(SimpleNamespace(show_keys=False))
+    return capsys.readouterr().out
+
+
+def test_dump_counts_configured_mcp_servers(monkeypatch, capsys, tmp_path):
+    out = _dump_with(
+        monkeypatch, capsys, tmp_path,
+        {
+            "mcp_servers": {
+                "coingecko": {"url": "https://example.com/mcp"},
+                "cua": {"command": "cua-driver"},
+                "phone": {"command": "python", "enabled": False},
+            }
+        },
+    )
+    assert _mcp_count(out) == "3"
+
+
+def test_dump_reports_zero_when_mcp_servers_absent(monkeypatch, capsys, tmp_path):
+    # A bare `mcp_servers:` key in YAML arrives as None; counting it must not raise.
+    out = _dump_with(monkeypatch, capsys, tmp_path, {"mcp_servers": None})
+    assert _mcp_count(out) == "0"


### PR DESCRIPTION
## What does this PR do?

`hermes dump` printed `mcp_servers: 0` on every machine, however many MCP servers were configured.

The `features:` line read the legacy nested `mcp.servers` config path (`config["mcp"]["servers"]`), but `config.mcp` is the MCP **runtime behaviour** section — `hermes_cli/config_defaults.py:492` declares exactly one key there (`auto_reload_on_config_change`) and there is no `servers` key in the schema. Server definitions have lived at top-level `mcp_servers` for as long as every current reader has existed: `mcp_config.py`, `mcp_picker.py`, `mcp_catalog.py`, `mcp_tool_config.py`, `mcp_startup.py`, `banner.py`.

The blast radius is one line — but it is the line `hermes debug share` hands to support, so a triage dump reads as "no MCP servers configured". I hit exactly that while auditing a machine with three servers enabled and had to disprove the dump by hand.

The count now comes from `mcp_config._get_mcp_servers(config)`, the accessor `hermes mcp list` (and the dashboard MCP router, and `hermes security`) already use. That is the point of the change, not a tidy-up: the number can no longer disagree with the list one screen away, and a future key or shape change is edited in one place instead of two.

## Related Issue

Refs #38650 — this fixes its deterministic `hermes dump` **count** path. The issue's other half (the welcome screen labelling pending servers as "failed") is #39181 and is untouched here. Deliberately not `Fixes #38650`, which would close an issue this PR only halves.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/dump.py` — the `mcp_servers` features line counts `mcp_config._get_mcp_servers(config)` instead of the non-existent `config["mcp"]["servers"]`.
- `hermes_cli/dump.py` — that accessor is imported inside `run_dump`, not at module scope: `hermes_cli.mcp_config` pulls in `asyncio` and the MCP security validator, and this file already defers imports to keep `hermes dump` cheap (`_gateway_status`, `get_build_sha`). The same deferred-import pattern is used from `mcp_catalog.py:314`, `security_audit.py:152` and `web_routers/mcp.py`.
- `tests/hermes_cli/test_dump_mcp_server_count.py` (new) — two invariant tests: a 3-server config prints 3; absent/`None` `mcp_servers` prints 0 without raising.

## How to Test

1. On a config with MCP servers configured, run `hermes dump` and read the `features:` block. **Before:** `mcp_servers:        0`. **With this branch, on a real 3-server config:**

   ```
   $ python -m hermes_cli.main dump | grep mcp_servers     # module resolved from this branch
     mcp_servers:        3
   $ grep -c '^  [a-z]' <(sed -n '/^mcp_servers:/,/^[a-z]/p' config.yaml)   # ground truth
   3
   ```

   The same command with the unpatched `hermes_cli/dump.py` loaded from the same config prints `0`.

2. Unit tests — red on `main`, green here:

   ```
   # on base c7efbbdab2 (test added, fix absent)
   $ HERMES_PYTHON=<venv>/python.exe bash scripts/run_tests.sh tests/hermes_cli/test_dump_mcp_server_count.py -q
   E       AssertionError: assert '0' == '3'
   FAILED tests/hermes_cli/test_dump_mcp_server_count.py::test_dump_counts_configured_mcp_servers
   1 failed, 1 passed in 18.98s

   # on this branch
   $ HERMES_PYTHON=<venv>/python.exe bash scripts/run_tests.sh \
       tests/hermes_cli/test_dump_mcp_server_count.py tests/hermes_cli/test_dump_env_visibility.py \
       tests/hermes_cli/test_dump_git_commit.py tests/hermes_cli/test_dump_terminal_backend.py -q
   === Summary: 4 files, 10 tests passed, 0 failed (100% complete) in 37.1s (24 workers) ===
   ```

3. Regression scope — every test file that references `hermes_cli.dump` was run. `tests/hermes_cli/test_debug.py` has **one pre-existing failure**: `TestCaptureLogSnapshot::test_keeps_first_line_when_truncation_on_boundary` (`assert 9 == 10`, log-truncation boundary). It reproduces identically at base `c7efbbdab2` on untouched code in a scratch worktree, and the file has no reference to this line. `tests/docker/test_dump_build_sha.py` was not run to completion (it builds a docker image locally and exceeds the runner timeout); it exercises the git-SHA fallback, contains zero `mcp` references, and cannot reach this line.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see *Prior art* below
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run in full**; the full suite is left to CI. I ran every suite that exercises the changed file and named the scope in *How to Test* step 3, including the one pre-existing failure.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (24H2), git-bash, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A: the printed line had no documented meaning to correct
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A: no config key added or changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A: a pure dict read, no paths, no shell, no encoding
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
# unpatched tree, real config                # this branch, same config
  mcp_servers:        0                        mcp_servers:        3
  skills:             184                      skills:             184
```

---

### Prior art — why not #38734

#38734 (`fix(dump): count configured MCP servers`, opened 2026-06-04) diagnosed this identically and is still open, but it is **CONFLICTING**: it rewrites the body of `_count_mcp_servers`, which the 2026-09-02 refactor (`8b19d33157`, "dead code, unified helpers") deleted when it inlined the same wrong key into the f-string. Its tests call `dump._count_mcp_servers`, so they cannot run on `main` either. The diagnosis there is correct and credit for it belongs to that PR.

Two deliberate differences from that patch:

1. **No restored helper.** It had a single call site — which is why the refactor removed it — so the count is read through the shared accessor instead of a new local function. That keeps one place that knows the key.
2. **No legacy `mcp.servers` fallback.** A repo-wide search finds no config-key reader or writer of that nested path to be compatible with; the branch could only ever count a stale block. (`mcp.servers.*` in `tui_gateway` is an RPC method namespace, not a config path.)
