### PR TITLE
fix(cron): keep fire-claim heartbeat live under delivery fence

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -242,18 +242,19 @@ def _jobs_lock():
     otherwise a `cron pause` could be clobbered and keep firing). Nested calls in one thread
     reuse the held lock. Without a flock backend, or on flock timeout (logged loudly), it
     degrades to in-process-only locking: a briefly torn cross-process write beats a dead
-    scheduler."""
+    scheduler. Yields whether the cross-process lock is held so sensitive callers can fail closed."""
     depth = getattr(_jobs_lock_state, "depth", 0)
     if depth:
         _jobs_lock_state.depth = depth + 1
         try:
-            yield
+            yield getattr(_jobs_lock_state, "cross_process_locked", False)
         finally:
             _jobs_lock_state.depth -= 1
         return
 
     with _jobs_file_lock:
         _jobs_lock_state.depth = 1
+        _jobs_lock_state.cross_process_locked = False
         # jobs.json stamp as of this section's load_jobs(): lets _save_jobs_unlocked skip the
         # shrink-merge parse when the file provably hasn't changed. Reset on entry/exit so stale
         # stamps from unlocked loads or prior sections can never suppress a needed merge.
@@ -265,7 +266,9 @@ def _jobs_lock():
                 ensure_dirs()
                 lock_fd = open(_jobs_lock_file(), "a+", encoding="utf-8")
                 lock_fd.seek(0)
-                if _acquire_flock(lock_fd, _JOBS_LOCK_TIMEOUT_SECONDS) is False:
+                flock_result = _acquire_flock(lock_fd, _JOBS_LOCK_TIMEOUT_SECONDS)
+                _jobs_lock_state.cross_process_locked = flock_result is True
+                if flock_result is False:
                     logger.error(
                         "Timed out after %.0fs waiting for the cron "
                         "jobs lock (%s) — another process is holding "
@@ -280,12 +283,13 @@ def _jobs_lock():
                 logger.warning("jobs.json cross-process lock unavailable (%s); "
                                "proceeding with in-process lock only", e)
             try:
-                yield
+                yield _jobs_lock_state.cross_process_locked
             finally:
                 if lock_fd is not None:
                     _release_flock(lock_fd)
         finally:
             _jobs_lock_state.depth = 0
+            _jobs_lock_state.cross_process_locked = False
             _jobs_lock_state.load_stamp = None
 
 
@@ -2599,12 +2603,25 @@ def claim_job_for_fire(
 
 
 def heartbeat_fire_claim(job_id: str, *, expected_owner: str) -> bool:
-    """Refresh an active ``fire_claim`` without extending another owner's lease: an execution may
-    outlive the TTL, and the owner check stops a stale runner from refreshing a recovered claim."""
+    """Refresh an active ``fire_claim`` without extending another owner's lease.
+
+    Heartbeats intentionally bypass the fire fence: the owned external side effect holds that
+    fence for its full duration, while its heartbeat runs on another thread.  The jobs lock and
+    owner comparison still make the refresh atomic and prevent a stale runner from extending a
+    replacement owner's claim.
+    """
     def apply(jobs, _i, job):
         return _refresh_claim(jobs, job.get("fire_claim"), expected_owner)
 
-    return _under_fire_fence(job_id, lambda: _with_job(job_id, apply, False))
+    with _jobs_lock() as cross_process_locked:
+        if not cross_process_locked:
+            logger.error("Cron fire-claim heartbeat could not lock jobs.json; failing closed")
+            return False
+        jobs = load_jobs()
+        for i, job in enumerate(jobs):
+            if job.get("id") == job_id:
+                return apply(jobs, i, job)
+    return False
 
 
 # Completed one-shots are retained in jobs.json (final status stays inspectable) and pruned by

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -217,6 +217,75 @@ def test_fire_claim_fence_rejects_stale_owner(temp_home):
         assert owns_claim is False
 
 
+def test_same_owner_heartbeat_refreshes_while_fire_fence_is_held(temp_home, monkeypatch):
+    """A long delivery must not lose its claim merely because its heartbeat runs concurrently."""
+    import cron.jobs as jobs
+
+    job = jobs.create_job(prompt="x", schedule="every 5m", name="fenced-heartbeat")
+    claimed = jobs.claim_job_for_fire(job["id"], return_job=True)
+    assert isinstance(claimed, dict)
+    owner = claimed["fire_claim"]["by"]
+    monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.1)
+    completed = threading.Event()
+    result = {}
+
+    def heartbeat():
+        result["refreshed"] = jobs.heartbeat_fire_claim(job["id"], expected_owner=owner)
+        completed.set()
+
+    with jobs.fire_claim_fence(job["id"], expected_owner=owner) as owns_claim:
+        assert owns_claim is True
+        before = jobs.get_job(job["id"])["fire_claim"]["at"]
+        thread = threading.Thread(target=heartbeat)
+        thread.start()
+        assert completed.wait(timeout=2), "same-owner heartbeat waited past the fire-fence timeout"
+        assert result["refreshed"] is True
+        assert jobs.get_job(job["id"])["fire_claim"]["at"] != before
+
+    thread.join(timeout=2)
+    assert thread.is_alive() is False
+
+
+@pytest.mark.parametrize(
+    "replacement_claim,lock_failure",
+    [
+        ({"at": "2099-01-01T00:00:00+00:00", "by": "replacement-owner"}, "timeout"),
+        (None, "unavailable"),
+    ],
+    ids=["replacement-owner", "terminal-clear"],
+)
+def test_fire_claim_heartbeat_fails_closed_without_jobs_flock(
+    temp_home, monkeypatch, replacement_claim, lock_failure,
+):
+    """A stale heartbeat must not overwrite state changed by the jobs-lock holder."""
+    import copy
+    import json
+
+    import cron.jobs as jobs
+
+    job = jobs.create_job(prompt="x", schedule="every 5m", name="unlocked-heartbeat")
+    claimed = jobs.claim_job_for_fire(job["id"], return_job=True)
+    assert isinstance(claimed, dict)
+    owner = claimed["fire_claim"]["by"]
+    stale_snapshot = copy.deepcopy(jobs.load_jobs())
+    jobs_file = jobs._current_cron_store().jobs_file
+
+    def replace_then_time_out(_lock_fd, _timeout):
+        replacement_jobs = copy.deepcopy(stale_snapshot)
+        replacement_jobs[0]["fire_claim"] = copy.deepcopy(replacement_claim)
+        jobs_file.write_text(json.dumps({"jobs": replacement_jobs}), encoding="utf-8")
+        if lock_failure == "unavailable":
+            raise OSError("jobs flock unavailable")
+        return False
+
+    monkeypatch.setattr(jobs, "_acquire_flock", replace_then_time_out)
+    monkeypatch.setattr(jobs, "load_jobs", lambda: copy.deepcopy(stale_snapshot))
+
+    assert jobs.heartbeat_fire_claim(job["id"], expected_owner=owner) is False
+    persisted = json.loads(jobs_file.read_text(encoding="utf-8"))["jobs"][0]
+    assert persisted["fire_claim"] == replacement_claim
+
+
 def test_same_process_fire_fence_refuses_second_claim_after_timeout(temp_home, monkeypatch):
     """A wedged local holder must not indefinitely block another claimant."""
     import cron.jobs as jobs


### PR DESCRIPTION
## Summary
- let an owned fire-claim heartbeat refresh while the delivery thread holds the per-job fire fence
- retain fail-closed cross-process safety when the jobs-file flock is unavailable
- add regression coverage for same-owner liveness, replacement-owner safety, and terminal revocation

## Root cause
The heartbeat thread reacquired the same process-local fire fence held for the full external side effect. Because the lock is thread-owned, the legitimate same-owner heartbeat timed out and was interpreted as ownership loss.

## Verification
- regression test observed red on current main
- `scripts/run_tests.sh tests/cron/`: 1251 passed, 0 failed, 1 platform skip
- static added-line security scan: 0 findings
- independent review: passed after one fix cycle

## Attribution
- Autor GitHub: rbueno69-git
- Solicitante: Rogerio Bueno via scheduled internal audit
- Aprovador de merge/deploy: não aplicável; this is a draft PR only
