### PR TITLE
fix(wecom): groups get the final answer only, and only when it is confirmed

### DIFF
--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -36,6 +36,8 @@ from gateway.platforms._shared import get_scoped_secret as _get_scoped_secret
 from plugins.platforms.wecom.send_queue import ChatSendQueueMixin
 from plugins.platforms.wecom.media import WeComMediaMixin, APP_CMD_SEND
 from plugins.platforms.wecom.streaming import (
+    GROUP_FINAL_ACK_STRICT_DEFAULT,
+    GROUP_FINAL_ONLY_DEFAULT,
     WeComStreamMixin, ReplyQueue, StreamTurn, APP_CMD_RESPONSE,
     STREAM_NOT_SUBSCRIBED_ERRCODE, MAX_STREAM_CONTENT_LENGTH,
     STREAM_SAFE_DURATION_SECONDS, STREAM_KEEPALIVE_INTERVAL_SECONDS, STREAM_KEEPALIVE_ENABLED_DEFAULT,
@@ -155,6 +157,10 @@ class WeComAdapter(WeComStreamMixin, WeComMediaMixin, ChatSendQueueMixin, BasePl
         self._stream_safe_duration_seconds = _extra_float("stream_safe_duration_seconds", STREAM_SAFE_DURATION_SECONDS)
         self._stream_keepalive_enabled = bool(extra.get("stream_keepalive_enabled", STREAM_KEEPALIVE_ENABLED_DEFAULT))
         self._stream_keepalive_interval_seconds = _extra_float("stream_keepalive_interval_seconds", STREAM_KEEPALIVE_INTERVAL_SECONDS)
+        # Group-chat policy (2026-09-12): a group sees only the finished answer, and its finalize
+        # must be positively acked — see the policy note in streaming.py.
+        self._group_final_only = bool(extra.get("group_final_only", GROUP_FINAL_ONLY_DEFAULT))
+        self._group_final_ack_strict = bool(extra.get("group_final_ack_strict", GROUP_FINAL_ACK_STRICT_DEFAULT))
         self._device_id = uuid.uuid4().hex
         self._last_chat_req_ids: Dict[str, str] = {}
         # Turns keyed f"{chat_id}:{req_id|turn_id}"; expired chats clear on the next inbound req_id.

--- a/plugins/platforms/wecom/streaming.py
+++ b/plugins/platforms/wecom/streaming.py
@@ -34,6 +34,52 @@ STREAM_KEEPALIVE_INTERVAL_SECONDS = 120.0
 STREAM_KEEPALIVE_ENABLED_DEFAULT = False
 
 
+# ---------------------------------------------------------------------------
+# Group-chat policy (2026-09-12)
+# ---------------------------------------------------------------------------
+# A WeCom **group** must only ever see the finished answer. The gateway's stream
+# consumer routes every tool-progress line into the native bubble
+# (``stream_consumer.accepts_tool_progress`` is true whenever native streaming is
+# active and WeCom advertises ``SUPPORTS_NATIVE_STREAMING``), so without a policy
+# at the adapter — the only layer that knows the chat is a group — a group sees
+# "Reading skill …", "🖥️ Running python3 …" and the raw script bodies, while the
+# final answer can be swallowed by the suppression path (the gateway believes the
+# streamed delivery landed). Two knobs, both scoped to groups; DMs are untouched:
+#
+#   1. ``group_final_only`` (default True) — only the turn-final frame is written
+#      to a group. The seed frame still opens the WeCom "thinking" bubble (so the
+#      group gets feedback and the stream stays valid) and the tool-progress
+#      overlay is additionally stripped from whatever does go out.
+#   2. ``group_final_ack_strict`` (default True) — a group finalize frame must be
+#      POSITIVELY acked by WeCom. The upstream default converts an ack timeout
+#      into "assumed delivered" and suppresses the normal final send; in a group
+#      that can mean the answer never arrives. With this on, an unconfirmed
+#      finalize declines and the caller falls back to ``send()`` — the group may
+#      see the answer twice (bubble + message), which beats never seeing it.
+#
+# Config keys (``platforms.wecom.extra``): ``group_final_only``,
+# ``group_final_ack_strict``. Set ``group_final_only: false`` to restore the
+# previous streaming behaviour for groups.
+GROUP_FINAL_ONLY_DEFAULT = True
+GROUP_FINAL_ACK_STRICT_DEFAULT = True
+# stream_consumer composes a native frame as "<text>\n\n---\n<tool-progress>".
+GROUP_PROGRESS_SEPARATOR = "\n\n---\n"
+
+
+def ack_confirmed(response: Any) -> bool:
+    """True only when WeCom positively acked the frame.
+
+    ``_send_reply_queued`` returns an assumed-delivery marker on ack timeout
+    (``ack_pending``); that is not a confirmation, and group finalizes must not
+    suppress the fallback send on the strength of it.
+    """
+    if not isinstance(response, dict):
+        return False
+    if response.get("ack_pending") or response.get("confirmed") is False:
+        return False
+    return response.get("errcode", 0) in (0, None)
+
+
 class WeComStreamExpiredError(RuntimeError):
     """Raised on errcode 846608/846604: the stream/req_id reply flow is dead; fall back to ``aibot_send_msg``."""
 
@@ -118,13 +164,18 @@ class WeComStreamMixin:
         if not is_final:  # fire-and-forget; pending_ack stays registered so later frames can skip
             return {"errcode": 0, "errmsg": "sent_nonblocking"}
         try:
-            return await asyncio.wait_for(future, timeout=self._REPLY_ACK_TIMEOUT)
+            resolved = await asyncio.wait_for(future, timeout=self._REPLY_ACK_TIMEOUT)
         except asyncio.TimeoutError:
             # Bytes went out, ack is late — WeCom already rendered it; raising caused duplicates.
             logger.warning("[%s] Final frame ack timeout (req_id=%s) — treating as delivered (matches official wecom-openclaw-plugin behaviour). No fallback send.", self.name, normalized)
-            return {"errcode": 0, "errmsg": "ack_timeout_assumed_delivered", "ack_pending": True}
+            # ``confirmed: False`` keeps the timeout distinguishable from a real ack: group
+            # policy (``group_final_ack_strict``) declines the finalize on it and lets send() deliver.
+            return {"errcode": 0, "errmsg": "ack_timeout_assumed_delivered", "ack_pending": True, "confirmed": False}
         finally:
             self._release_pending(queue, normalized, frame)
+        if not isinstance(resolved, dict):
+            return {"errcode": 0, "errmsg": "ack_resolved_non_dict", "confirmed": False}
+        return {**resolved, "confirmed": True}
 
     async def _drain_pending_ack(self, queue: ReplyQueue, req_id: str) -> None:
         """Before a final frame: wait (bounded) for the pending intermediate's ack, then clear it."""
@@ -172,6 +223,27 @@ class WeComStreamMixin:
         """Explicit ``reply_to`` (cached message id) → last inbound req_id for the chat → None."""
         return self._reply_req_id_for_message(reply_to) or self._last_chat_req_ids.get(str(chat_id or "").strip()) or None
 
+    # ---- Group-chat policy helpers (see the module-level policy note) ----
+
+    def _is_group_chat(self, chat_id: Optional[str]) -> bool:
+        """True when this chat is a WeCom group (populated in ``_admit_inbound``)."""
+        return str(chat_id or "").strip() in self._group_chat_ids
+
+    def _group_final_only_on(self) -> bool:
+        """Group "final answer only" policy (default on)."""
+        return bool(getattr(self, "_group_final_only", GROUP_FINAL_ONLY_DEFAULT))
+
+    def _group_ack_strict_on(self) -> bool:
+        """Group "finalize must be positively acked" policy (default on)."""
+        return bool(getattr(self, "_group_final_ack_strict", GROUP_FINAL_ACK_STRICT_DEFAULT))
+
+    @staticmethod
+    def _strip_tool_progress(text: str) -> str:
+        """Drop the tool-progress overlay the stream consumer appends below the rule."""
+        if not text or GROUP_PROGRESS_SEPARATOR not in text:
+            return text
+        return text.split(GROUP_PROGRESS_SEPARATOR, 1)[0].rstrip()
+
     @staticmethod
     def _cancel_keepalive(turn: StreamTurn) -> None:
         handle, turn.keepalive_handle = turn.keepalive_handle, None
@@ -217,6 +289,13 @@ class WeComStreamMixin:
         if turn.finalized or turn.expired or turn._intermediate_frames_sent >= MAX_INTERMEDIATE_FRAMES:
             return  # cap reached: no room for intermediates; let finalize / Layer 2 run
         content = turn.accumulated_text or ""
+        if self._is_group_chat(turn.chat_id) and self._group_final_only_on():
+            # Group policy: keep-alive frames carry the accumulated text — never write it to a group.
+            # Keep the timer armed so a live stream can still be finalized; if the stream window
+            # lapses, the finalize declines and send() delivers the answer as a message.
+            logger.debug("[%s] Group final-only: skipping keep-alive content frame (chat=%s)", self.name, turn.chat_id)
+            self._arm_keepalive(turn, turn_id=turn_id)
+            return
         if not content.strip():
             self._arm_keepalive(turn, turn_id=turn_id)
             return
@@ -311,9 +390,27 @@ class WeComStreamMixin:
                 self._expire_turn(turn, turn_id)
                 return False
         self._cancel_keepalive(turn)
+        group = self._is_group_chat(chat)
+        strict_ack = group and self._group_ack_strict_on()
+        if group and self._group_final_only_on():
+            # Belt and braces: even the final frame must not carry the tool-progress overlay.
+            stripped = self._strip_tool_progress(text)
+            if stripped != text:
+                logger.debug("[%s] Group finalize: stripped tool-progress overlay (chat=%s)", self.name, chat)
+            text = stripped
         # A final frame identical to the last intermediate is silently dropped — differ via ZWSP.
         final_text = text + "\u200b" if text and text == turn.last_sent_content else text
-        await self._send_stream_reply(turn.req_id, turn.stream_id, final_text, finish=True)
+        response = await self._send_stream_reply(turn.req_id, turn.stream_id, final_text, finish=True)
+        if strict_ack and not ack_confirmed(response):
+            # 2026-09-12 incident: WeCom never acked the finalize, the gateway marked the reply as
+            # delivered and skipped the normal send — the group never saw the answer. Decline here
+            # so send() delivers it (a possible duplicate beats a missing answer in a group).
+            logger.warning(
+                "[%s] Group finalize ack unconfirmed (chat=%s, req_id=%s, errmsg=%s) — declining streamed delivery, falling back to normal send.",
+                self.name, chat, turn.req_id, response.get("errmsg", "?"),
+            )
+            self._retire_turn(turn, turn_id)
+            return False
         turn.finalized = True
         self._stream_turns.pop(f"{chat}:{turn_id or turn.req_id}", None)
         return True
@@ -335,6 +432,13 @@ class WeComStreamMixin:
                 return await self._finalize_turn(turn, text, chat, turn_id)
             # Fire-and-forget: the gateway decides when to push (identity dedup in stream_consumer.py).
             turn.accumulated_text = text
+            if self._is_group_chat(chat) and self._group_final_only_on():
+                # Group policy: withhold every intermediate frame (assistant text *and* the
+                # tool-progress lines the consumer composed into it). The seed frame above already
+                # opened the "thinking" bubble, so the group still gets feedback; the finalize
+                # frame carries the finished answer.
+                logger.debug("[%s] Group final-only: withholding intermediate frame (chat=%s, len=%d)", self.name, chat, len(text or ""))
+                return True
             if turn._intermediate_frames_sent >= MAX_INTERMEDIATE_FRAMES or text == turn.last_sent_content:
                 return True  # cap reached (finalize drains the rest) or nothing new
             await self._send_stream_reply(turn.req_id, turn.stream_id, text, finish=False)

--- a/tests/gateway/test_wecom_group_final_only.py
+++ b/tests/gateway/test_wecom_group_final_only.py
@@ -1,0 +1,294 @@
+"""Behavior-contract tests for the WeCom **group-chat** answer policy (2026-09-12).
+
+Incident (2026-09-12 12:04, a production group): the group saw the bot's tool /
+script frames ("Reading skill …", "🖥️ Running python3 …", script bodies) while
+the 174-char final answer never reached the members.  Two independent causes,
+both fixed in ``plugins/platforms/wecom/streaming.py``:
+
+Fix A — ``group_final_only`` (default on).  WeCom advertises
+``SUPPORTS_NATIVE_STREAMING``, so the gateway's stream consumer routes every
+tool-progress line into the native bubble itself
+(``stream_consumer.accepts_tool_progress`` → ``on_tool_progress``, composed as
+``"<text>\\n\\n---\\n<progress>"``).  For a **group** the adapter now withholds
+every non-final frame and strips the progress overlay from the frame that does
+go out, so only the finished answer is ever written to the group.  DMs keep the
+previous streaming behaviour.  Toggle = ``extra['group_final_only']``.
+
+Fix B — ``group_final_ack_strict`` (default on).  Upstream converts an ack
+timeout into "assumed delivered" and lets the gateway suppress the normal final
+send; in a group that can mean the answer never arrives.  For a group the
+finalize frame must now be POSITIVELY acked, otherwise the finalize declines
+(return False) so the consumer's ``send()`` fallback delivers the answer as a
+message.  Toggle = ``extra['group_final_ack_strict']``.
+
+These drive the REAL ``WeComAdapter._send_stream_frame_inner`` / ``_finalize_turn``
+with only the byte-level ``_send_stream_reply`` seam faked, so the actual control
+flow runs.  Assertions read observable adapter state: the return value (what the
+consumer keys its fallback on), what actually reached the wire, whether the turn
+survived, and the group set membership.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.wecom.adapter import WeComAdapter
+from plugins.platforms.wecom.streaming import (
+    GROUP_FINAL_ACK_STRICT_DEFAULT,
+    GROUP_FINAL_ONLY_DEFAULT,
+    GROUP_PROGRESS_SEPARATOR,
+    ack_confirmed,
+)
+
+GROUP_CHAT = "group-chat-1"
+DM_CHAT = "dm-chat-1"
+REQ_ID = "req-group"
+TURN_ID = "turn-group"
+
+ANSWER = "今天的活动 14:00 开场，已确认 7 人到场，现场交付清单已发群里。"
+PROGRESS = "🖥️ Running python3 scripts/check_status.py …\nReading skill ops-toolkit …"
+# What stream_consumer composes for a native frame: answer text, then the tool-progress overlay.
+COMPOSED_GROUP_TURN = f"{ANSWER}{GROUP_PROGRESS_SEPARATOR}{PROGRESS}"
+ACK_TIMEOUT = {"errcode": 0, "errmsg": "ack_timeout_assumed_delivered", "ack_pending": True, "confirmed": False}
+ACK_OK = {"errcode": 0, "errmsg": "ok", "confirmed": True}
+
+
+def _make_adapter(*, group: bool, extra: dict | None = None) -> WeComAdapter:
+    """Real adapter with only the byte-level stream writer faked."""
+    merged = {"stream_keepalive_enabled": False, **(extra or {})}
+    adapter = WeComAdapter(PlatformConfig(enabled=True, extra=merged))
+    chat = GROUP_CHAT if group else DM_CHAT
+    adapter._last_chat_req_ids[chat] = REQ_ID
+    if group:
+        adapter._group_chat_ids.add(GROUP_CHAT)
+    return adapter
+
+
+def _frames(mock: AsyncMock, *, finish: bool | None = None) -> list:
+    calls = mock.await_args_list
+    if finish is None:
+        return calls
+    return [c for c in calls if c.kwargs.get("finish") is finish]
+
+
+def _contents(mock: AsyncMock, *, finish: bool | None = None) -> list[str]:
+    return [c.args[2] for c in _frames(mock, finish=finish)]
+
+
+# ===========================================================================
+# Fix A — a group only ever receives the finished answer
+# ===========================================================================
+
+
+class TestGroupFinalOnly:
+    @pytest.mark.asyncio
+    async def test_group_intermediate_frames_are_withheld(self):
+        """Group + mid-turn text (answer and tool progress) → nothing reaches the wire,
+        but the turn still accumulates so the finalize can deliver it."""
+        adapter = _make_adapter(group=True)
+        try:
+            reply = AsyncMock(return_value=ACK_OK)
+            adapter._send_stream_reply = reply
+
+            ok = await adapter._send_stream_frame_inner(
+                COMPOSED_GROUP_TURN, chat=GROUP_CHAT, finalize=False, turn_id=TURN_ID,
+            )
+
+            assert ok is True, "withholding is not a failure — the consumer must not fall back mid-turn"
+            assert _contents(reply, finish=False) == ["<think></think>"], (
+                "the seed frame opens the thinking bubble; no content frame may follow it"
+            )
+            assert PROGRESS not in "".join(_contents(reply))
+            assert ANSWER not in "".join(_contents(reply))
+            turn = adapter._stream_turns[f"{GROUP_CHAT}:{TURN_ID}"]
+            assert turn.accumulated_text == COMPOSED_GROUP_TURN, "text is still accumulated for the finalize"
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_group_final_frame_drops_the_tool_progress_overlay(self):
+        """The finalize frame carries the answer only — belt and braces on top of withholding."""
+        adapter = _make_adapter(group=True)
+        try:
+            reply = AsyncMock(return_value=ACK_OK)
+            adapter._send_stream_reply = reply
+
+            ok = await adapter._send_stream_frame_inner(
+                "", chat=GROUP_CHAT, finalize=False, turn_id=TURN_ID,
+            )
+            assert ok is True
+            ok = await adapter._send_stream_frame_inner(
+                COMPOSED_GROUP_TURN, chat=GROUP_CHAT, finalize=True, turn_id=TURN_ID,
+            )
+
+            assert ok is True
+            finals = _contents(reply, finish=True)
+            assert len(finals) == 1, "exactly one finalize frame"
+            assert finals[0] == ANSWER, "tool-progress overlay stripped from the group final frame"
+            assert PROGRESS not in finals[0]
+            assert f"{GROUP_CHAT}:{TURN_ID}" not in adapter._stream_turns, "turn cleaned up after finalize"
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_group_keepalive_never_writes_accumulated_text(self):
+        """Keep-alive exists to refresh the stream window; it must not leak mid-turn text to a group."""
+        adapter = _make_adapter(group=True, extra={"stream_keepalive_enabled": True})
+        try:
+            reply = AsyncMock(return_value=ACK_OK)
+            adapter._send_stream_reply = reply
+            await adapter._send_stream_frame_inner(COMPOSED_GROUP_TURN, chat=GROUP_CHAT, finalize=False, turn_id=TURN_ID)
+            turn = adapter._stream_turns[f"{GROUP_CHAT}:{TURN_ID}"]
+            reply.reset_mock()
+
+            await adapter._keepalive_send(turn, TURN_ID)
+
+            assert _contents(reply) == [], "no keep-alive content frame for a group"
+            assert turn.keepalive_handle is not None, "timer stays armed so a live stream can still finalize"
+            assert turn.last_sent_content != COMPOSED_GROUP_TURN
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_group_final_only_can_be_disabled(self):
+        """Toggle: with the policy off, a group streams like a DM (toggle-validation)."""
+        adapter = _make_adapter(group=True, extra={"group_final_only": False})
+        try:
+            reply = AsyncMock(return_value=ACK_OK)
+            adapter._send_stream_reply = reply
+
+            await adapter._send_stream_frame_inner("mid-turn text", chat=GROUP_CHAT, finalize=False, turn_id=TURN_ID)
+
+            assert "mid-turn text" in _contents(reply, finish=False), "policy off → intermediates stream again"
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_dm_intermediate_frames_still_stream(self):
+        """Regression guard: direct messages keep the previous behaviour."""
+        adapter = _make_adapter(group=False)
+        try:
+            reply = AsyncMock(return_value=ACK_OK)
+            adapter._send_stream_reply = reply
+
+            await adapter._send_stream_frame_inner("mid-turn text", chat=DM_CHAT, finalize=False, turn_id=TURN_ID)
+
+            assert "mid-turn text" in _contents(reply, finish=False), "DM intermediates unchanged"
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_group_progress_hint_without_separator_is_untouched(self):
+        """No overlay present → the finalize text goes out verbatim."""
+        adapter = _make_adapter(group=True)
+        try:
+            reply = AsyncMock(return_value=ACK_OK)
+            adapter._send_stream_reply = reply
+            await adapter._send_stream_frame_inner("", chat=GROUP_CHAT, finalize=False, turn_id=TURN_ID)
+
+            await adapter._send_stream_frame_inner("纯答案，无进度叠加层", chat=GROUP_CHAT, finalize=True, turn_id=TURN_ID)
+
+            assert _contents(reply, finish=True) == ["纯答案，无进度叠加层"]
+        finally:
+            await adapter.disconnect()
+
+
+# ===========================================================================
+# Fix B — a group finalize must be positively acked, else fall back to send()
+# ===========================================================================
+
+
+class TestGroupFinalAckStrict:
+    @pytest.mark.asyncio
+    async def test_group_finalize_unconfirmed_ack_declines_for_the_send_fallback(self):
+        """Ack timeout (assumed delivered upstream) must NOT silence the group answer."""
+        adapter = _make_adapter(group=True)
+        try:
+            reply = AsyncMock(return_value=ACK_TIMEOUT)
+            adapter._send_stream_reply = reply
+
+            await adapter._send_stream_frame_inner("", chat=GROUP_CHAT, finalize=False, turn_id=TURN_ID)
+            ok = await adapter._send_stream_frame_inner(ANSWER, chat=GROUP_CHAT, finalize=True, turn_id=TURN_ID)
+
+            assert ok is False, "unconfirmed group finalize declines → consumer send() delivers the answer"
+            assert f"{GROUP_CHAT}:{TURN_ID}" not in adapter._stream_turns, "declined turn is retired"
+            assert GROUP_CHAT not in adapter._stream_expired_chats, "chat not expired: a later turn may stream again"
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_group_finalize_confirmed_ack_succeeds(self):
+        adapter = _make_adapter(group=True)
+        try:
+            reply = AsyncMock(return_value=ACK_OK)
+            adapter._send_stream_reply = reply
+
+            await adapter._send_stream_frame_inner("", chat=GROUP_CHAT, finalize=False, turn_id=TURN_ID)
+            ok = await adapter._send_stream_frame_inner(ANSWER, chat=GROUP_CHAT, finalize=True, turn_id=TURN_ID)
+
+            assert ok is True, "positively acked group finalize is delivered in the bubble"
+            assert f"{GROUP_CHAT}:{TURN_ID}" not in adapter._stream_turns
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_dm_finalize_ack_timeout_keeps_upstream_behaviour(self):
+        """Regression guard: in a DM a late ack is still trusted (no duplicate send)."""
+        adapter = _make_adapter(group=False)
+        try:
+            reply = AsyncMock(return_value=ACK_TIMEOUT)
+            adapter._send_stream_reply = reply
+
+            await adapter._send_stream_frame_inner("", chat=DM_CHAT, finalize=False, turn_id=TURN_ID)
+            ok = await adapter._send_stream_frame_inner(ANSWER, chat=DM_CHAT, finalize=True, turn_id=TURN_ID)
+
+            assert ok is True, "DM behaviour unchanged: ack timeout still counts as delivered"
+        finally:
+            await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_group_ack_strict_can_be_disabled(self):
+        """Toggle: with strict ack off, a group trusts the timeout like a DM (toggle-validation)."""
+        adapter = _make_adapter(group=True, extra={"group_final_ack_strict": False})
+        try:
+            reply = AsyncMock(return_value=ACK_TIMEOUT)
+            adapter._send_stream_reply = reply
+
+            await adapter._send_stream_frame_inner("", chat=GROUP_CHAT, finalize=False, turn_id=TURN_ID)
+            ok = await adapter._send_stream_frame_inner(ANSWER, chat=GROUP_CHAT, finalize=True, turn_id=TURN_ID)
+
+            assert ok is True
+        finally:
+            await adapter.disconnect()
+
+
+# ===========================================================================
+# Policy plumbing
+# ===========================================================================
+
+
+class TestPolicyPlumbing:
+    def test_defaults_are_on(self):
+        assert GROUP_FINAL_ONLY_DEFAULT is True
+        assert GROUP_FINAL_ACK_STRICT_DEFAULT is True
+        adapter = _make_adapter(group=True)
+        assert adapter._group_final_only is True
+        assert adapter._group_final_ack_strict is True
+
+    def test_policy_applies_to_groups_only(self):
+        adapter = _make_adapter(group=True)
+        assert adapter._is_group_chat(GROUP_CHAT) is True
+        assert adapter._is_group_chat(DM_CHAT) is False
+        assert adapter._is_group_chat("") is False
+        assert adapter._is_group_chat(None) is False
+
+    def test_ack_confirmed_distinguishes_timeout_from_ack(self):
+        assert ack_confirmed(ACK_TIMEOUT) is False, "assumed-delivery timeout is not a confirmation"
+        assert ack_confirmed(ACK_OK) is True
+        assert ack_confirmed({"errcode": 0}) is True, "plain success payload counts"
+        assert ack_confirmed({"errcode": 0, "confirmed": False}) is False
+        assert ack_confirmed(None) is False
+        assert ack_confirmed("nope") is False

--- a/website/docs/user-guide/messaging/wecom.md
+++ b/website/docs/user-guide/messaging/wecom.md
@@ -102,6 +102,18 @@ and the reply renders token-by-token in a single bubble as the model
 generates it. Tool-call progress is folded into the same bubble. Native
 streaming is enabled by default (`display.platforms.wecom.streaming: true` in
 `config.yaml`); set it to `false` to restore single-shot delivery.
+
+**Group chats differ on purpose.** Every member of a group sees whatever is
+written into the bubble, so a group is answer-only: the adapter withholds every
+intermediate frame (assistant text, tool-progress lines such as `🖥️ Running
+python3 …`, command bodies) and strips the tool-progress overlay from the frame
+that does go out, so only the finished answer reaches the group. The thinking
+bubble still appears the moment the turn starts, and direct messages keep
+streaming as before. A group finalize frame must also be *positively* acked by
+WeCom: if the ack never arrives, the stream is declined and the answer is
+delivered as a normal message instead of being silently suppressed — a group may
+therefore see the answer twice, which beats never seeing it. Both behaviours are
+configurable per bot (`group_final_only`, `group_final_ack_strict`).
 :::
 
 ## Configuration Options
@@ -121,6 +133,8 @@ Set these in `config.yaml` under `platforms.wecom.extra`:
 | `stream_keepalive_enabled` | `false` | Send periodic keepalive frames to refresh WeCom's ~6-minute reply-stream window on long turns |
 | `stream_keepalive_interval_seconds` | `120` | Keepalive frame cadence when enabled |
 | `stream_safe_duration_seconds` | `330` | Stream age after which finalize prefers the reliable proactive send |
+| `group_final_only` | `true` | Groups receive only the finished answer: intermediate frames (assistant text + tool progress) are withheld, and the progress overlay is stripped from the final frame. Set `false` to stream in groups like DMs |
+| `group_final_ack_strict` | `true` | A group finalize frame must be positively acked by WeCom; an unconfirmed finalize declines and the answer is sent as a normal message instead of being suppressed |
 
 ## Access Policies
 


### PR DESCRIPTION
# Fix: WeCom group chats get the final answer only — and only when it is confirmed

## Summary

Two bugs made a WeCom **group** see the agent's internals and then miss the answer:

1. **Tool-progress leaked into the group.** WeCom declares `SUPPORTS_NATIVE_STREAMING`,
   so `gateway/stream_consumer.py` routes every tool-progress line into the native
   bubble (`accepts_tool_progress` → `on_tool_progress`, composed as
   `"<text>\n\n---\n<progress>"`). The group saw "Reading skill …",
   "🖥️ Running python3 …" and raw script bodies.
2. **An unconfirmed finalize suppressed the answer.** `_send_reply_queued` converts an
   ack timeout into "assumed delivered" (`ack_timeout_assumed_delivered`), `_finalize_turn`
   reports success, `stream_consumer_transport` keeps its optimistic
   `_mark_final_delivered()`, and the gateway logs
   `Suppressing normal final send … content_delivered=True` — the final answer is never
   sent. When the finalize frame does not render, the group never sees the answer.

## Incident (2026-09-12 12:04 CST)

A production WeCom group (id redacted): the group received tool and
script frames while the 174-character final answer reached no member. The gateway log line
above is the smoking gun: it trusted the streamed delivery.

## Reproduction on current `main`

Driving the real `_send_stream_frame_inner` with only `_send_stream_reply` faked:

```
① group intermediate frames : 2 frames written, 1 carrying
"
```

## Fix

Both changes are scoped to groups; direct messages keep the previous behaviour
(the adapter is the only layer that knows a chat is a group).

| Knob (`platforms.wecom.extra`) | Default | Behaviour |
| --- | --- | --- |
| `group_final_only` | `true` | Withhold every non-final frame for a group (the seed frame still opens the thinking bubble and keeps the stream valid); strip the tool-progress overlay from the frame that does go out; keep-alive frames (which carry accumulated text) are withheld as well |
| `group_final_ack_strict` | `true` | A group finalize must be positively acked. `_send_reply_queued` tags its result `confirmed: true/false`; an unconfirmed group finalize returns `False` instead of pretending success, so the consumer's existing rollback clears the delivered flags and `send()` delivers the answer. A group may see the answer twice — that beats never seeing it |

After the patch:

```
① group intermediate frames : 1 frame written (thinking seed), 0 carrying content
② finalize with ack timeout : returns False, logs
"Group finalize ack unconfirmed … falling back to normal send"
```

## Tests

`tests/gateway/test_wecom_group_final_only.py` — 13 cases: withholding, progress
stripping, keep-alive withholding, strict-ack decline, confirmed-ack success, DM
regression guards, both toggles, and the `ack_confirmed` helper.

Green on a fresh `main` checkout with the patch applied:

```
tests/gateway/test_wecom_group_final_only.py 
tests/gateway/test_wecom.py 
tests/gateway/test_wecom_stream_dup_fix.py
→ 83 passed, 3 skipped
```

## External test-suite status (for reviewers)

Running the whole `tests/gateway` suite on this machine: **8226 passed, 16 failed**. The 16 are
unrelated to WeCom — discord/feishu/teams/telegram/session-store/multiplex — and none of them
involve the adapter this PR touches:

- 12 of them pass when their files are run on their own (order/state sensitivity in the big run);
- the remaining 4 (`test_feishu.py::TestDedupTTL::test_concurrent_dedup_persists_land_in_order`,
  `test_multiplex_routing_authz.py::test_completion_preflight_runs_in_target_profile_scope`,
  `test_session_store_prune.py::test_session_store_default_db_uses_runtime_hermes_home`,
  `test_teams_pipeline_runtime_wiring.py::test_build_pipeline_runtime_skips_sender_when_adapter_layer_is_unavailable`)
  fail **identically on a clean `main` checkout without this patch** — pre-existing in this
  environment, not introduced here.

## Notes for review

- No new core tool, no new `HERMES_*` env var; both knobs are `config.yaml`
  (`platforms.wecom.extra`) settings with behaviour-preserving defaults for DMs.
- `_send_reply_queued`'s return dict gains one additive key (`confirmed`); existing
  readers key off `errcode`/`errmsg` and are unaffected.
- The group path is verified structurally (adapter state, wire frames) rather than by a
  live WeCom group round-trip; the incident log line is the field evidence.
