### PR TITLE
fix(a2a): keep long-running tasks from being falsely stored as failed

### DIFF
--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -284,6 +284,8 @@ class A2AAdapter(BasePlatformAdapter):
         # FIFO so adapter.send() — which only knows the context — resolves the oldest task.
         self._pending: Dict[str, tuple[str, Future]] = {}
         self._pending_order: Dict[str, deque[str]] = {}
+        # Request ownership outlives reply Futures and also covers synchronous profile forwards.
+        self._active_tasks: set[str] = set()
         self._pending_lock = threading.Lock()
 
     @property
@@ -344,11 +346,11 @@ class A2AAdapter(BasePlatformAdapter):
                 logger.debug("A2A: watchdog error", exc_info=True)
 
     def _fail_orphans_once(self) -> list[str]:
-        """Fail stale tasks that no HTTP/SSE request is still waiting for."""
+        """Fail stale tasks that no request still owns."""
         with self._pending_lock:
-            live_waiters = set(self._pending)
+            active_tasks = set(self._active_tasks)
         timeout = _orphan_timeout()
-        failed = self.tasks.fail_orphans(timeout, exclude=live_waiters)
+        failed = self.tasks.fail_orphans(timeout, exclude=active_tasks)
         for tid in failed:
             logger.warning("A2A: orphaned task %s marked failed (timeout %gs)", tid, timeout)
             protocol.metrics.tasks_failed += 1
@@ -464,12 +466,18 @@ class A2AAdapter(BasePlatformAdapter):
     def _add_pending(self, task_id: str, context_id: str) -> Future:
         fut: Future = Future()
         with self._pending_lock:
+            self._active_tasks.add(task_id)
             self._pending[task_id] = (context_id, fut)
             self._pending_order.setdefault(context_id, deque()).append(task_id)
         return fut
 
+    def _activate_task(self, task_id: str) -> None:
+        with self._pending_lock:
+            self._active_tasks.add(task_id)
+
     def _pop_pending(self, task_id: str) -> None:
         with self._pending_lock:
+            self._active_tasks.discard(task_id)
             entry = self._pending.pop(task_id, None)
             order = self._pending_order.get(entry[0]) if entry else None
             if order and task_id in order:
@@ -528,9 +536,13 @@ class A2AAdapter(BasePlatformAdapter):
         protocol.metrics.inbound_total += 1
         self._register_inline_push(task_id, params, agent=agent)
         if not agent.get("local", True):
-            reply, state = self._forward_to_profile(agent, peer, context_id, framed)
-            self._record_outcome(task_id, context_id, peer, state, reply)
-            return protocol.build_task(task_id, context_id, state, reply, created_at=rec["created_iso"]), None
+            self._activate_task(task_id)
+            try:
+                reply, state = self._forward_to_profile(agent, peer, context_id, framed)
+                self._record_outcome(task_id, context_id, peer, state, reply)
+                return protocol.build_task(task_id, context_id, state, reply, created_at=rec["created_iso"]), None
+            finally:
+                self._pop_pending(task_id)
         if self._loop is None or self._message_handler is None:
             return self._end_task(rec, protocol.STATE_FAILED, "Agent gateway not ready to accept A2A tasks.")
         fut = self._add_pending(task_id, context_id)
@@ -539,9 +551,11 @@ class A2AAdapter(BasePlatformAdapter):
         try:
             asyncio.run_coroutine_threadsafe(self.handle_message(event), self._loop)
         except Exception as e:
-            self._pop_pending(task_id)
             msg = security.redact_outbound(f"Dispatch failed: {e}")
-            return self._end_task(rec, protocol.STATE_FAILED, msg, stored_reply=msg)
+            try:
+                return self._end_task(rec, protocol.STATE_FAILED, msg, stored_reply=msg)
+            finally:
+                self._pop_pending(task_id)
         self.tasks.set_state(task_id, protocol.STATE_WORKING)
         return None, {"task_id": task_id, "context_id": context_id, "peer": peer, "future": fut, "created_iso": rec["created_iso"], "started": time.time()}
 
@@ -600,13 +614,15 @@ class A2AAdapter(BasePlatformAdapter):
         """Record a dispatched task's outcome; returns (state, reply) after redaction and
         input-required detection (a leading marker flags a clarification request)."""
         task_id, context_id, peer = pending["task_id"], pending["context_id"], pending["peer"]
-        self._pop_pending(task_id)
-        reply = security.redact_outbound(reply or "")
-        stripped = reply.lstrip()
-        if state == protocol.STATE_COMPLETED and stripped.upper().startswith(protocol.INPUT_REQUIRED_MARKER):
-            state, reply = protocol.STATE_INPUT_REQUIRED, stripped[len(protocol.INPUT_REQUIRED_MARKER):].strip()
-        self._record_outcome(task_id, context_id, peer, state, reply, started=pending["started"])
-        return state, reply
+        try:
+            reply = security.redact_outbound(reply or "")
+            stripped = reply.lstrip()
+            if state == protocol.STATE_COMPLETED and stripped.upper().startswith(protocol.INPUT_REQUIRED_MARKER):
+                state, reply = protocol.STATE_INPUT_REQUIRED, stripped[len(protocol.INPUT_REQUIRED_MARKER):].strip()
+            self._record_outcome(task_id, context_id, peer, state, reply, started=pending["started"])
+            return state, reply
+        finally:
+            self._pop_pending(task_id)
 
     @staticmethod
     def _await_future(fut: Future, deadline: float, keepalive, on_timeout: tuple[str, str]) -> tuple[str, str]:

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -33,7 +33,7 @@ from . import protocol, security
 logger = logging.getLogger(__name__)
 
 _DEFAULT_PORT = 9900
-_ORPHAN_TIMEOUT, _WATCHDOG_INTERVAL = 300, 60  # seconds: pending task considered orphaned / watchdog period
+_MIN_ORPHAN_TIMEOUT, _WATCHDOG_INTERVAL = 300, 60  # seconds: orphan grace floor / watchdog period
 _MAX_BODY = 1_048_576  # 1MB max request body — prevents DoS via memory exhaustion
 _SSE_KEEPALIVE = 5  # seconds between SSE keepalive comments
 _DEFAULT_DESCRIPTION = "Hermes Agent — a general-purpose agent reachable over A2A."
@@ -67,6 +67,11 @@ def _reply_timeout() -> float:
         return max(1.0, float(os.getenv("A2A_REPLY_TIMEOUT", "300")))
     except (ValueError, TypeError):
         return 300.0
+
+
+def _orphan_timeout() -> float:
+    """Orphan grace must never expire before a configured reply window."""
+    return max(float(_MIN_ORPHAN_TIMEOUT), _reply_timeout())
 
 
 def _default_agent_name() -> str:
@@ -334,11 +339,20 @@ class A2AAdapter(BasePlatformAdapter):
         """Background thread that fails orphaned tasks (keeps them queryable)."""
         while not self._watchdog_stop.wait(_WATCHDOG_INTERVAL):
             try:
-                for tid in self.tasks.fail_orphans(_ORPHAN_TIMEOUT):
-                    logger.warning("A2A: orphaned task %s marked failed (timeout %ds)", tid, _ORPHAN_TIMEOUT)
-                    protocol.metrics.tasks_failed += 1
+                self._fail_orphans_once()
             except Exception:
                 logger.debug("A2A: watchdog error", exc_info=True)
+
+    def _fail_orphans_once(self) -> list[str]:
+        """Fail stale tasks that no HTTP/SSE request is still waiting for."""
+        with self._pending_lock:
+            live_waiters = set(self._pending)
+        timeout = _orphan_timeout()
+        failed = self.tasks.fail_orphans(timeout, exclude=live_waiters)
+        for tid in failed:
+            logger.warning("A2A: orphaned task %s marked failed (timeout %gs)", tid, timeout)
+            protocol.metrics.tasks_failed += 1
+        return failed
 
     def _load_served_agents(self, extra: dict) -> dict[str, dict]:
         """Served-agent routing from ``platforms.a2a.extra.agents`` (top-level ``a2a_served_agents``

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -684,6 +684,7 @@ class A2AAdapter(BasePlatformAdapter):
         """message/stream as an SSE response of JSON-RPC-wrapped StreamResponse events (§9.4)."""
         protocol.metrics.streams_started += 1
         self._sse_headers(handler)
+        pending = None
         try:
             terminal, pending = self._prepare_task(params, peer, agent=agent)
             if terminal is not None:
@@ -694,8 +695,11 @@ class A2AAdapter(BasePlatformAdapter):
             self._sse_write(handler, protocol.sse_data(protocol.stream_task(submitted), req_id))
             self._sse_write(handler, protocol.sse_data(protocol.status_update(task_id, context_id, protocol.STATE_WORKING), req_id))
             state, reply = self._finalize_task(pending, *self._await_reply(pending, keepalive=self._keepalive(handler)))
+            pending = None
             self._emit_terminal(handler, task_id, context_id, state, reply, req_id=req_id)
         except (BrokenPipeError, ConnectionResetError):
+            if pending is not None:
+                self._finalize_task(pending, protocol.STATE_FAILED, "[client disconnected]")
             logger.debug("A2A: stream client disconnected")
 
     def _rpc_tasks_subscribe(self, handler, req_id: Any, params: dict, agent: Optional[dict] = None) -> None:

--- a/plugins/platforms/a2a/protocol.py
+++ b/plugins/platforms/a2a/protocol.py
@@ -414,10 +414,12 @@ class TaskStore:
         next_offset = offset + page_size if offset + page_size < total else 0
         return (page, next_offset, total) if with_total else (page, next_offset)
 
-    def fail_orphans(self, timeout_seconds: int = 300) -> list[str]:
+    def fail_orphans(self, timeout_seconds: float = 300, *, exclude: set[str] | None = None) -> list[str]:
+        excluded = exclude or set()
         with self._lock:
             stale = [tid for tid, rec in self._tasks.items()
-                     if rec["state"] not in TERMINAL_STATES and time.time() - rec["created_at"] > timeout_seconds]
+                     if tid not in excluded and rec["state"] not in TERMINAL_STATES
+                     and time.time() - rec["created_at"] > timeout_seconds]
         return [tid for tid in stale if self.complete(tid, STATE_FAILED, "[task orphaned — no reply produced]")]
 
     def _trim_locked(self) -> None:

--- a/tests/plugins/test_a2a_phase23.py
+++ b/tests/plugins/test_a2a_phase23.py
@@ -499,6 +499,23 @@ class TestTaskStore:
         # Second sweep does nothing (already terminal).
         assert store.fail_orphans(timeout_seconds=300) == []
 
+    def test_watchdog_preserves_live_waiters_and_reply_window(self, monkeypatch):
+        monkeypatch.setenv("A2A_REPLY_TIMEOUT", "600")
+        adapter, _base = _make_live_adapter(monkeypatch)
+        now = time.time()
+        for task_id, age in (("t-live", 700), ("t-orphan", 700), ("t-within-reply-window", 400)):
+            adapter.tasks.create(task_id, "c1", "p")
+            adapter.tasks.set_state(task_id, protocol.STATE_WORKING)
+            adapter.tasks._tasks[task_id]["created_at"] = now - age
+
+        adapter._add_pending("t-live", "c1")
+        assert adapter._fail_orphans_once() == ["t-orphan"]
+        assert adapter.tasks.get("t-live")["state"] == protocol.STATE_WORKING
+        assert adapter.tasks.get("t-within-reply-window")["state"] == protocol.STATE_WORKING
+
+        adapter._pop_pending("t-live")
+        assert adapter._fail_orphans_once() == ["t-live"]
+
     def test_list_newest_first_with_filters(self):
         store = protocol.TaskStore()
         store.create("t1", "c1", "p")

--- a/tests/plugins/test_a2a_phase23.py
+++ b/tests/plugins/test_a2a_phase23.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import json
 import socket
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -499,7 +500,7 @@ class TestTaskStore:
         # Second sweep does nothing (already terminal).
         assert store.fail_orphans(timeout_seconds=300) == []
 
-    def test_watchdog_preserves_live_waiters_and_reply_window(self, monkeypatch):
+    def test_watchdog_preserves_active_requests_and_reply_window(self, monkeypatch):
         monkeypatch.setenv("A2A_REPLY_TIMEOUT", "600")
         adapter, _base = _make_live_adapter(monkeypatch)
         now = time.time()
@@ -509,12 +510,67 @@ class TestTaskStore:
             adapter.tasks._tasks[task_id]["created_at"] = now - age
 
         adapter._add_pending("t-live", "c1")
-        assert adapter._fail_orphans_once() == ["t-orphan"]
+        agent = {"slug": "dev", "tenant": "dev", "profile": "dev", "local": False, "timeout": 900}
+
+        def fake_forward(*_args):
+            forwarded_id = next(tid for tid in adapter.tasks._tasks if tid not in {
+                "t-live", "t-orphan", "t-within-reply-window"
+            })
+            adapter.tasks._tasks[forwarded_id]["created_at"] = now - 700
+            assert adapter._fail_orphans_once() == ["t-orphan"]
+            return "forwarded reply", protocol.STATE_COMPLETED
+
+        monkeypatch.setattr(adapter, "_forward_to_profile", fake_forward)
+        terminal, pending = adapter._prepare_task(
+            {"message": protocol.text_message(protocol.ROLE_USER, "hello", context_id="forwarded")},
+            "peer", agent=agent,
+        )
+
+        assert pending is None
+        assert adapter.tasks.get(terminal["id"])["state"] == protocol.STATE_COMPLETED
         assert adapter.tasks.get("t-live")["state"] == protocol.STATE_WORKING
         assert adapter.tasks.get("t-within-reply-window")["state"] == protocol.STATE_WORKING
 
         adapter._pop_pending("t-live")
         assert adapter._fail_orphans_once() == ["t-live"]
+
+    def test_watchdog_cannot_race_local_finalization(self, monkeypatch):
+        adapter, _base = _make_live_adapter(monkeypatch)
+        rec = adapter.tasks.create("t-live", "c1", "peer")
+        adapter.tasks.set_state("t-live", protocol.STATE_WORKING)
+        adapter.tasks._tasks["t-live"]["created_at"] = time.time() - 700
+        future = adapter._add_pending("t-live", "c1")
+        future.set_result((protocol.STATE_COMPLETED, "reply"))
+        pending = {
+            "task_id": "t-live", "context_id": "c1", "peer": "peer",
+            "future": future, "created_iso": rec["created_iso"], "started": time.time(),
+        }
+
+        original_redact = security.redact_outbound
+        finalizing = threading.Event()
+        resume = threading.Event()
+        result = []
+
+        def pause_while_finalizing(reply):
+            finalizing.set()
+            assert resume.wait(timeout=1)
+            return original_redact(reply)
+
+        monkeypatch.setattr(security, "redact_outbound", pause_while_finalizing)
+        thread = threading.Thread(
+            target=lambda: result.append(adapter._finalize_task(pending, *adapter._await_reply(pending)))
+        )
+        thread.start()
+        assert finalizing.wait(timeout=1)
+        try:
+            assert adapter._fail_orphans_once() == []
+        finally:
+            resume.set()
+            thread.join(timeout=1)
+
+        assert not thread.is_alive()
+        assert result == [(protocol.STATE_COMPLETED, "reply")]
+        assert adapter.tasks.get("t-live")["state"] == protocol.STATE_COMPLETED
 
     def test_list_newest_first_with_filters(self):
         store = protocol.TaskStore()

--- a/tests/plugins/test_a2a_phase23.py
+++ b/tests/plugins/test_a2a_phase23.py
@@ -572,6 +572,41 @@ class TestTaskStore:
         assert result == [(protocol.STATE_COMPLETED, "reply")]
         assert adapter.tasks.get("t-live")["state"] == protocol.STATE_COMPLETED
 
+    def test_stream_disconnect_releases_active_request(self, monkeypatch):
+        adapter, _base = _make_live_adapter(monkeypatch)
+        rec = adapter.tasks.create("t-live", "c1", "peer")
+        adapter.tasks.set_state("t-live", protocol.STATE_WORKING)
+        pending = {
+            "task_id": "t-live", "context_id": "c1", "peer": "peer",
+            "future": adapter._add_pending("t-live", "c1"),
+            "created_iso": rec["created_iso"], "started": time.time(),
+        }
+        monkeypatch.setattr(adapter, "_prepare_task", lambda *_args, **_kwargs: (None, pending))
+
+        class BrokenWriter:
+            def write(self, _chunk):
+                raise BrokenPipeError
+
+        class Handler:
+            wfile = BrokenWriter()
+
+            def send_response(self, _status):
+                pass
+
+            def send_header(self, _name, _value):
+                pass
+
+            def end_headers(self):
+                pass
+
+        adapter._rpc_message_stream(Handler(), 1, {}, "peer")
+
+        stored = adapter.tasks.get("t-live")
+        assert stored["state"] == protocol.STATE_FAILED
+        assert stored["reply"] == "[client disconnected]"
+        assert "t-live" not in adapter._pending
+        assert "t-live" not in adapter._active_tasks
+
     def test_list_newest_first_with_filters(self):
         store = protocol.TaskStore()
         store.create("t1", "c1", "p")


### PR DESCRIPTION
## What does this PR do?

Prevents long-running inbound A2A tasks from being permanently recorded as failed while their HTTP or SSE request is still waiting for the agent. The orphan watchdog now protects live waiter task IDs and uses an orphan grace period that is never shorter than `A2A_REPLY_TIMEOUT`.

### Symptom

With `A2A_REPLY_TIMEOUT` above 300 seconds, a task that runs longer than 300 seconds can still return its real reply to the connected client while `tasks/get` permanently reports `TASK_STATE_FAILED` with no artifacts.

### Impact

Long-running A2A calls can expose contradictory wire and stored results, inflate failure metrics, and make later task queries or subscriptions report a false terminal failure.

### Bug Cause

**Trigger:** `plugins/platforms/a2a/adapter.py` / `A2AAdapter._watchdog_loop`

**Causal chain:**
1. An inbound task is registered in both `TaskStore` and the adapter's live `_pending` waiter map.
2. The watchdog used a fixed 300 second threshold and passed every old non-terminal store record to `TaskStore.fail_orphans()` without checking live waiters.
3. The store became terminal-failed while the request future remained active; the later real completion could not replace that terminal state.

**Why it is wrong:** A live HTTP or SSE waiter is evidence that the task is not orphaned, and the watchdog deadline contradicted the separately configurable reply deadline.

**Working sibling / contrast:** The normal reply-timeout and client-disconnect paths remove the pending waiter before recording their terminal failure, so those tasks remain eligible for cleanup.

**Ruled out:** `TaskStore.complete()` terminal idempotency is not the defect; allowing late replies to overwrite cancellation or timeout would break valid terminal-state semantics.

### Fix

Snapshot live pending task IDs before each watchdog sweep and exclude them from orphan failure. Derive the orphan grace period from the larger of the 300 second cleanup floor and the configured reply timeout. Add an invariant test covering live waiters, stale true orphans, and tasks still inside the configured reply window.

## Related Issue

Closes #109238

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/a2a/adapter.py` - protect live waiters and align the orphan grace period with the reply timeout.
- `plugins/platforms/a2a/protocol.py` - allow an orphan sweep to exclude task IDs that are still owned by active request waiters.
- `tests/plugins/test_a2a_phase23.py` - cover waiter protection and timeout alignment.

## How to Test

1. Run `scripts/run_tests.sh tests/plugins/test_a2a_phase23.py`.
2. Confirm the watchdog leaves a stale task in `TASK_STATE_WORKING` while it has a live waiter.
3. Confirm a stale task without a waiter fails only after the effective reply window.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

N/A
