### PR TITLE
fix(desktop): do not fail build if get-windows is missing on any platform

### DIFF
--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -587,23 +587,15 @@ export function stageGetWindows(
   const destRoot = resolve(projectRoot, 'dist/node_modules/get-windows')
 
   if (!srcRoot) {
-    // npm may omit an optional dependency whose install script fails. That is
-    // expected on Linux and win32-arm64 because get-windows 9.3.0 publishes no
-    // native prebuilt for either target. The runtime import already fails soft,
-    // so disable only window enumeration instead of failing the Desktop build.
-    // Other Windows architectures and macOS have supported native payloads and
-    // remain fail-closed so a broken package cannot ship silently.
-    const canDegrade = platform === 'linux' || (platform === 'win32' && arch === 'arm64')
-    if (canDegrade) {
-      console.warn(
-        `[stage-native-deps] get-windows not installed (optional dep skipped for ${platform}-${arch}); ` +
-          'read_window_below will be unavailable in this build'
-      )
-      return undefined
-    }
-    throw new Error(
-      `[stage-native-deps] get-windows is not installed; cannot stage its ${platform}-${arch} native payload`
+    // npm may omit an optional dependency whose install script fails, or an in-place
+    // update may fail to extract it due to file locks (#90829). The runtime import
+    // already fails soft, so we disable only window enumeration instead of failing
+    // the entire Desktop build (which would strand users on an old version).
+    console.warn(
+      `[stage-native-deps] get-windows not installed (optional dep skipped for ${platform}-${arch}); ` +
+        'read_window_below will be unavailable in this build'
     )
+    return undefined
   }
 
   // Only a win32 host can produce the win32 binding, so a cross-platform pack


### PR DESCRIPTION
Fixes #90829

### Root Cause
During in-place CLI updates (`hermes update`) on Windows, the Desktop app + Gateway processes are often still running, keeping some `node_modules` files locked. `npm install` gracefully recovers or warns when extracting files fails (`TAR_ENTRY_ERROR`), which occasionally leaves optional dependencies like `get-windows` half-installed (binary present, but missing `package.json`).

The packaging script (`apps/desktop/scripts/stage-native-deps.mjs`) correctly caught this omission, but its fail-open degradation was strictly limited to `linux` and `win32-arm64`. For `win32-x64` (a supported target), a missing optional dep triggered a fatal `throw`, aborting the `npm run build` phase entirely. The updater could not pack the new Desktop build, silently falling back to the previous executable forever.

### Fix
Changed `stage-native-deps.mjs` to allow `get-windows` to gracefully degrade across *all* platforms instead of throwing.

The runtime already falls back cleanly (by disabling `read_window_below` enumeration) if the binding is missing. By removing the strict `win32-x64` gate, an extraction failure during a daily CLI update will no longer permanently strand the user on a broken or outdated Desktop build.
