### PR TITLE
fix(cron): allow cold external worker startup

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3049,6 +3049,9 @@ def _wait_for_external_cron_worker(
                 pass
 
 
+_EXTERNAL_WORKER_COLD_START_ACK_TIMEOUT_SECONDS = 12.0
+
+
 def _launch_external_cron_worker(job: dict) -> bool:
     """Launch *job* outside a managed gateway cgroup when required.
 
@@ -3150,7 +3153,7 @@ def _launch_external_cron_worker(job: dict) -> bool:
     with _running_lock:
         _restart_safe_waiter_job_ids.add(job_id)
 
-    deadline = time.monotonic() + 5.0
+    deadline = time.monotonic() + _EXTERNAL_WORKER_COLD_START_ACK_TIMEOUT_SECONDS
     while time.monotonic() < deadline:
         if ack_path.exists():
             try:
@@ -3212,9 +3215,10 @@ def _launch_external_cron_worker(job: dict) -> bool:
     # handoff: that could duplicate side effects.  The execution owner/dead-owner
     # recovery ledger remains the authority.
     logger.warning(
-        "Cron external worker for job '%s' did not acknowledge within 5s; "
+        "Cron external worker for job '%s' did not acknowledge within %.0fs; "
         "leaving the durable execution claim untouched",
         job_id,
+        _EXTERNAL_WORKER_COLD_START_ACK_TIMEOUT_SECONDS,
     )
     return _wait_for_external_cron_worker(
         process,

--- a/tests/cron/test_restart_safe_worker.py
+++ b/tests/cron/test_restart_safe_worker.py
@@ -265,6 +265,65 @@ def test_launch_external_worker_uses_restart_safe_scope_and_acknowledges(
     assert not (tmp_path / "cron/external-workers/exec-1.json").exists()
 
 
+def test_launch_external_worker_allows_delayed_cold_start_acknowledgement(
+    tmp_path, monkeypatch
+):
+    import cron.scheduler as scheduler
+
+    job = {"id": "job-cold", "execution_id": "exec-cold", "prompt": "work"}
+    monkeypatch.setattr(scheduler, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "tools.process_registry.restart_safe_gateway_child_argv",
+        lambda command, *, unit_suffix: ["scope", "--", *command],
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "mark_execution_handoff_pending",
+        lambda _execution_id: {"id": "exec-cold", "handoff_pending": 1},
+    )
+
+    class FakeClock:
+        now = 0.0
+
+        def monotonic(self):
+            return self.now
+
+        def sleep(self, seconds):
+            self.now += seconds
+            if self.now >= 6.0 and not ack_path.exists():
+                ack_path.write_text(
+                    json.dumps({"pid": 4321, "execution_id": "exec-cold"}),
+                    encoding="utf-8",
+                )
+
+    clock = FakeClock()
+    ack_path = tmp_path / "cron/external-workers/exec-cold.ready"
+
+    class FakeProcess:
+        returncode = None
+
+        def poll(self):
+            return self.returncode
+
+        def wait(self, timeout=None):
+            assert clock.now >= 6.0, "scheduler stopped waiting before cold-start ack"
+            raise subprocess.TimeoutExpired(cmd="worker", timeout=timeout)
+
+    monkeypatch.setattr(
+        scheduler.subprocess, "Popen", lambda *_args, **_kwargs: FakeProcess()
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "get_execution",
+        lambda _execution_id: {"id": "exec-cold", "status": "completed"},
+    )
+    monkeypatch.setattr(scheduler.time, "monotonic", clock.monotonic)
+    monkeypatch.setattr(scheduler.time, "sleep", clock.sleep)
+
+    assert scheduler._launch_external_cron_worker(job) is True
+    assert clock.now >= 6.0
+
+
 def test_external_worker_exit_rechecks_exact_execution_before_failure(monkeypatch):
     import cron.scheduler as scheduler
 


### PR DESCRIPTION
## What does this PR do?

Extend the external-worker acknowledgement window from 5 seconds to a named 12-second cold-start budget in `cron/scheduler.py`. Keep the existing ownership-uncertain timeout path so durable claims stay authoritative and execution never falls back in-process.

### Symptom

`_launch_external_cron_worker` gave the child `python -m cron.scheduler --external-worker-file …` only five seconds to adopt the durable claim and write the ack file. A cold worker start on a real host measured ~12 seconds (`--help` 12.42s cold vs 0.11s warm). The gateway then abandoned a handoff the worker was executing correctly.

Jobs fail in bursts after process or host idle (cold import/I/O), then look healthy once warm. This is distinct from ack-file mid-write (#107184) and dead-owner recovery (#106607). Recovery already allows `HANDOFF_ADOPTION_GRACE_SECONDS = 30`; the live acknowledgement path disagreed by 6x. Expected: wait long enough for a cold start. Actual: timeout at 5.05s and classify the job as a failed dispatch.

Issue: https://github.com/NousResearch/hermes-agent/issues/109243

### Impact

`_launch_external_cron_worker` gave the child `python -m cron.scheduler --external-worker-file …` only five seconds to adopt the durable claim and write the ack file. A cold worker start on a real host measured ~12 seconds (`--help` 12.42s cold vs 0.11s warm).

### Bug Cause

**Trigger:** the production path described in Symptom.

**Causal chain:** the previous implementation did not enforce the invariant above.

**Why it is wrong:** operators observed the Expected vs Actual mismatch in Symptom.

**Working sibling / contrast:** neighboring paths that already honored the invariant are unchanged.

**Ruled out:** unrelated modules outside this diff.

### Fix

Extend the external-worker acknowledgement window from 5 seconds to a named 12-second cold-start budget in `cron/scheduler.py`. Keep the existing ownership-uncertain timeout path so durable claims stay authoritative and execution never falls back in-process.

Claim fencing, worker-exit recovery, and the no-fallback timeout behavior are unchanged. The observable tradeoff is that a genuinely unacknowledged live worker is classified as ownership-uncertain seven seconds later. No change to job payloads, ack-file format, or Linux-only restart tests.

## Related Issue

Fixes #109243

## Type of Change

- ✅ Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py` — see Fix
- `tests/cron/test_restart_safe_worker.py` — see Fix

## How to Test

- ✅ `scripts/run_tests.sh` on the files in Changes Made — focused verification
- ✅ Focused verification completed on this branch
- ✅ `scripts/run_tests.sh tests/cron/test_restart_safe_worker.py -k test_launch_external_worker_allows_delayed_cold_start_acknowledgement`
- ✅ `scripts/run_tests.sh tests/cron/test_restart_safe_worker.py`
- ✅ `test_launch_external_worker_allows_delayed_cold_start_acknowledgement` uses a fake clock: acknowledgement arrives at 6.0s, after the old 5s deadline. Before the change the waiter entered the timeout path at ~5.05s (`1 failed`). After the 12s budget: `1 passed`.
- ✅ Full file: `18 passed, 2 skipped` on macOS (existing Linux-only tests). Those skips are unchanged; this PR only adds the delayed-ack regression.

## Checklist

### Code

- ✅ I've read the Contributing Guide
- ✅ My commit messages follow Conventional Commits
- ✅ I searched for existing PRs to make sure this isn't a duplicate
- ✅ My PR contains only changes related to this fix
- ✅ I've run relevant tests locally (see How to Test)
- ✅ I've added tests for my changes
- ✅ I've tested on my platform: macOS

### Documentation & Housekeeping

- ✅ Documentation update: N/A unless noted in Changes Made
- ✅ `cli-config.yaml.example`: N/A
- ✅ `CONTRIBUTING.md` or `AGENTS.md`: N/A
- ✅ Cross-platform impact considered
- ✅ Tool descriptions/schemas: N/A

