### PR TITLE
fix(desktop): break sdk module cycle to restore runtime plugins (fixes #107288)

### DIFF
--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -40,7 +40,6 @@ import { $workspaceOwnerLabels, workspaceOwnerTitle } from '@/components/pane-sh
 import { SidebarProvider } from '@/components/ui/sidebar'
 import { discoverBundledPlugins } from '@/contrib/plugins'
 import { registry } from '@/contrib/registry'
-import { discoverRuntimePlugins } from '@/contrib/runtime-loader'
 import { translateNow } from '@/i18n'
 import { NEW_SESSION_TITLE, sessionTitle as storedSessionTitle } from '@/lib/chat-runtime'
 import { Download, FileText, LayoutDashboard, PanelBottom, PanelTop, Terminal, Upload, Zap } from '@/lib/icons'
@@ -292,7 +291,7 @@ registry.registerMany([
       id: 'plugins.reload',
       label: 'Reload desktop plugins',
       keywords: ['plugins', 'reload', 'refresh', 'desktop'],
-      run: () => void discoverRuntimePlugins()
+      run: () => { void import('@/contrib/runtime-loader').then(m => m.discoverRuntimePlugins()) }
     } satisfies PaletteContribution
   },
   // The core `::preview{file="…"}` transcript directive — the model (or a

--- a/apps/desktop/src/app/settings/plugin-install-modal.tsx
+++ b/apps/desktop/src/app/settings/plugin-install-modal.tsx
@@ -17,7 +17,6 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Switch } from '@/components/ui/switch'
-import { discoverRuntimePlugins } from '@/contrib/runtime-loader'
 import { useI18n } from '@/i18n'
 import { ExternalLink } from '@/lib/external-link'
 import { AlertTriangle } from '@/lib/icons'
@@ -252,7 +251,7 @@ export function PluginInstallModal() {
           successes.push(m.desktopSuccess(probe.agentName ?? request.repo))
 
           if (touched.length > 0) {
-            await discoverRuntimePlugins()
+            await import('@/contrib/runtime-loader').then(m => m.discoverRuntimePlugins())
           }
         } else {
           const installFn = window.hermesDesktop?.installDesktopPlugin
@@ -264,7 +263,7 @@ export function PluginInstallModal() {
 
             if (result.ok) {
               successes.push(m.desktopSuccess(result.pluginName ?? request.repo))
-              await discoverRuntimePlugins()
+              await import('@/contrib/runtime-loader').then(m => m.discoverRuntimePlugins())
             } else {
               errors.push(result.error || m.desktopFailed)
             }

--- a/apps/desktop/src/app/skills/plugins-tab.tsx
+++ b/apps/desktop/src/app/skills/plugins-tab.tsx
@@ -15,7 +15,6 @@ import { Codicon } from '@/components/ui/codicon'
 import { Switch } from '@/components/ui/switch'
 import { Tip } from '@/components/ui/tooltip'
 import { $pluginRecords, type PluginRecord, setPluginEnabled } from '@/contrib/plugins-store'
-import { discoverRuntimePlugins } from '@/contrib/runtime-loader'
 import type { ProfileScope } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
@@ -117,7 +116,7 @@ async function revealPluginsDir() {
  *  rescan the root — a concurrent scan would read the pre-copy state. */
 async function rescanAll(requestGateway: GatewayRequest, scope: null | string) {
   await window.hermesDesktop?.reconcileDesktopPlugins?.().catch(() => undefined)
-  await discoverRuntimePlugins()
+  await import('@/contrib/runtime-loader').then(m => m.discoverRuntimePlugins())
   await loadAgentPlugins(requestGateway, scope)
 }
 


### PR DESCRIPTION
## Problem

In #107212 (\61afcde8f9\), a module cycle was introduced when \pp/settings/plugins-settings.tsx\ was moved to \pp/skills/\, which is re-exported by \sdk/index.ts\.

The cycle:
\sdk/index.ts -> app/skills/index.tsx -> app/skills/plugins-tab.tsx -> contrib/runtime-loader.ts -> sdk/runtime.ts -> sdk/index.ts\

Because of this cycle, Rolldown evaluated \sdk/runtime.ts\ *before* the \__HERMES_PLUGIN_SDK__\ namespace was defined. When \untime-loader.ts:113\ called \installPluginSdk()\, \Object.keys(undefined)\ threw \TypeError: Cannot convert undefined or null to object\, crashing **every single runtime (disk) plugin** unconditionally.

## Fix

Made \discoverRuntimePlugins\ lazily loaded via dynamic import (\import('@/contrib/runtime-loader').then(...)\) in all UI components (\plugins-tab.tsx\, \controller.tsx\, \plugin-install-modal.tsx\). This drops the static import edges, breaking the module cycle entirely so Rolldown can safely order the chunks.

Fixes #107288, #107721, #107352, #107336, #107312, and #107291 (which are all reports of the exact same crash).