### PR TITLE
fix(cli): preserve build outputs during ZIP updates and self-heal missing Desktop builds

### DIFF
--- a/hermes_cli/update_cmd_deps.py
+++ b/hermes_cli/update_cmd_deps.py
@@ -820,7 +820,11 @@ def _rebuild_desktop_after_update(
     from hermes_cli.update_cmd import _m
     # The release tree is git-ignored and can vanish mid-update; pre-update presence suffices.
     # Never make people who never used Desktop pay for an Electron build.
-    has_desktop_app = had_desktop_app_before_update or _desktop_app_present(desktop_dir)
+    has_desktop_app = (
+        had_desktop_app_before_update
+        or _desktop_app_present(desktop_dir)
+        or _m()._desktop_stamp_path().is_file()
+    )
     if not (
         (desktop_dir / "package.json").exists() and _m()._resolve_node_runtime_npm() and has_desktop_app):
         return True

--- a/hermes_cli/update_cmd_zip.py
+++ b/hermes_cli/update_cmd_zip.py
@@ -286,6 +286,15 @@ def _download_and_swap_zip(branch: str, zip_url: str) -> None:
         extracted = _extracted_root(tmp_dir, branch)
         entries = [i for i in os.listdir(extracted) if i not in _ZIP_PRESERVED_TOP_LEVEL]
         project_root = str(_m().PROJECT_ROOT)
+        stashed_outputs = []
+        for rel_path in ("apps/desktop/release", "apps/desktop/dist", "hermes_cli/web_dist"):
+            src = os.path.join(project_root, os.path.normpath(rel_path))
+            if os.path.exists(src):
+                dst = os.path.join(tmp_dir, "stash_" + rel_path.replace("/", "_"))
+                with suppress(Exception):
+                    shutil.move(src, dst)
+                    stashed_outputs.append((dst, src))
+
         _require_staging_space(extracted, entries, project_root)
         staged = _stage_entries(extracted, entries, project_root)
         try:
@@ -294,16 +303,28 @@ def _download_and_swap_zip(branch: str, zip_url: str) -> None:
             recheck_reason = _zip_overlay_block_reason(_m().PROJECT_ROOT, ignore_staging_artifacts=True)
             if recheck_reason is not None:
                 _discard_staged(staged)
+                for dst, src in stashed_outputs:
+                    with suppress(Exception):
+                        os.makedirs(os.path.dirname(src), exist_ok=True)
+                        shutil.move(dst, src)
                 print(f"✗ ZIP fallback aborted before the swap: {recheck_reason}.")
                 print("  Files appeared in the checkout while the update was downloading; committing the swap would delete them.")
                 print(_STASH_HINT)
                 _m().sys.exit(1)
             _commit_staged_replacements(staged)
+            for dst, src in stashed_outputs:
+                with suppress(Exception):
+                    os.makedirs(os.path.dirname(src), exist_ok=True)
+                    shutil.move(dst, src)
         except Exception:
             # Rollback restored swapped entries but staging copies for the rest remain; drop them or the
             # retry's up-front free-space check (runs BEFORE per-entry leftover cleanup) fails on our litter.
             # Safe post-rollback: _discard_staged skips paths that no longer exist.
             _discard_staged(staged)
+            for dst, src in stashed_outputs:
+                with suppress(Exception):
+                    os.makedirs(os.path.dirname(src), exist_ok=True)
+                    shutil.move(dst, src)
             raise
         print(f"✓ Updated {len(staged)} items from ZIP")
     except Exception as e:


### PR DESCRIPTION
Fixes #90495

### Root Cause
When `hermes update` fell back to the ZIP path (e.g. on Windows when antivirus locks `git` files), it constructed the new tree by replacing top-level directories. Because `apps/desktop/release`, `apps/desktop/dist`, and `hermes_cli/web_dist` are git-ignored build outputs nested inside those directories, the swap effectively deleted them. 

If the update then failed during the Python dependency phase, the Desktop app was left entirely missing (`Hermes.exe` deleted). Worse, the next run of `hermes update` would conclude that the Desktop app was never installed (since `has_desktop_app` only checked the pre-update presence of the binary), leaving the user permanently stranded without a Desktop build until they manually invoked `--force-build`.

### Fix
1. **Preserve build outputs during ZIP swap**: `_download_and_swap_zip` now stashes the three major build output directories (`apps/desktop/release`, `apps/desktop/dist`, `hermes_cli/web_dist`) in a temporary directory before staging the replacements, and restores them after the swap commits (or rolls back). This ensures the dashboard UI and Desktop app are never wiped out by an interrupted update.
2. **Self-heal broken installs**: `_rebuild_desktop_after_update` now checks for the presence of the `desktop-build-stamp.json` file in `$HERMES_HOME`. Since this file lives outside the repository tree, it survives the ZIP swap. If it exists, it serves as durable proof that the Desktop app *was* installed on this machine, bypassing the `has_desktop_app` short-circuit and forcing a rebuild if the binary is missing. This self-heals installs that were already broken by this bug.
