### PR TITLE
fix(auth): let custom providers start dashboard sessions

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1392,16 +1392,28 @@ def _logged_in_oauth_active_provider(*, skip_free_tier: bool = False) -> Optiona
 
 
 def _config_model_provider() -> Tuple[Any, Optional[str]]:
-    """``(model_cfg, provider)`` from config.yaml when ``model.provider`` names a registry provider.
+    """``(model_cfg, provider)`` when ``model.provider`` names a configured route.
 
     The normal chat/gateway path resolves config.provider upstream in resolve_requested_provider();
     this is the safety net for the lone direct caller (main.py resolve_provider("auto"))."""
     try:
         from hermes_cli.config import load_config
-        model_cfg = (load_config() or {}).get("model")
+        config = load_config() or {}
+        model_cfg = config.get("model")
         provider = model_cfg.get("provider") if isinstance(model_cfg, dict) else None
         provider = provider.strip().lower() if isinstance(provider, str) else ""
-        return model_cfg, (provider if provider in PROVIDER_REGISTRY else None)
+        if not provider or provider == "auto":
+            return model_cfg, None
+        if provider.startswith("custom:"):
+            from hermes_cli.runtime_provider_custom import has_named_custom_provider
+            return model_cfg, (provider if has_named_custom_provider(provider) else None)
+        try:
+            resolved = resolve_provider(provider)
+        except AuthError:
+            return model_cfg, None
+        if resolved == "custom" and not _optional_base_url(model_cfg.get("base_url")):
+            return model_cfg, None
+        return model_cfg, (provider if is_runtime_provider_routable(provider) else None)
     except Exception as e:
         logger.debug("Could not read config.yaml model.provider for auto-resolution: %s", e)
         return None, None

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1411,8 +1411,10 @@ def _config_model_provider() -> Tuple[Any, Optional[str]]:
             resolved = resolve_provider(provider)
         except AuthError:
             return model_cfg, None
-        if resolved == "custom" and not _optional_base_url(model_cfg.get("base_url")):
-            return model_cfg, None
+        if resolved == "custom":
+            custom_base_url = _scoped_key_env_reader()("CUSTOM_BASE_URL")
+            if not (_optional_base_url(model_cfg.get("base_url")) or _optional_base_url(custom_base_url)):
+                return model_cfg, None
         return model_cfg, (provider if is_runtime_provider_routable(provider) else None)
     except Exception as e:
         logger.debug("Could not read config.yaml model.provider for auto-resolution: %s", e)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1412,8 +1412,18 @@ def _config_model_provider() -> Tuple[Any, Optional[str]]:
         except AuthError:
             return model_cfg, None
         if resolved == "custom":
+            from hermes_cli.runtime_provider_custom import has_named_custom_provider
             custom_base_url = _scoped_key_env_reader()("CUSTOM_BASE_URL")
-            if not (_optional_base_url(model_cfg.get("base_url")) or _optional_base_url(custom_base_url)):
+            has_custom_route = bool(
+                _optional_base_url(model_cfg.get("base_url"))
+                or _optional_base_url(custom_base_url)
+                or has_named_custom_provider(provider)
+            )
+            if not has_custom_route:
+                from hermes_cli.local_runtime.endpoint import LLAMACPP_ALIASES, resolve_llamacpp_endpoint
+                if provider in LLAMACPP_ALIASES:
+                    has_custom_route = resolve_llamacpp_endpoint(config=config, wait_for_boot_s=0) is not None
+            if not has_custom_route:
                 return model_cfg, None
         return model_cfg, (provider if is_runtime_provider_routable(provider) else None)
     except Exception as e:

--- a/tests/hermes_cli/test_provider_precedence.py
+++ b/tests/hermes_cli/test_provider_precedence.py
@@ -30,7 +30,8 @@ def _no_aws(monkeypatch):
 
 def _clear_provider_env(monkeypatch):
     for var in ("OPENAI_API_KEY", "OPENROUTER_API_KEY", "GLM_API_KEY", "ZAI_API_KEY",
-                "KIMI_API_KEY", "MINIMAX_API_KEY", "HERMES_INFERENCE_PROVIDER"):
+                "KIMI_API_KEY", "MINIMAX_API_KEY", "CUSTOM_BASE_URL", "CUSTOM_API_KEY",
+                "HERMES_INFERENCE_PROVIDER"):
         monkeypatch.delenv(var, raising=False)
 
 
@@ -69,6 +70,16 @@ class TestProviderPrecedence:
         )
 
         assert resolve_provider("auto", skip_free_tier=True) == "custom:llama-local"
+
+    def test_custom_base_url_env_counts_as_inference_route(self, monkeypatch):
+        """Bootstrap and runtime accept the same scoped bare-custom endpoint source."""
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        _logged_out(monkeypatch)
+        _config(monkeypatch, {"provider": "custom", "default": "local-model"})
+        monkeypatch.setenv("CUSTOM_BASE_URL", "http://127.0.0.1:8080/v1")
+
+        assert resolve_provider("auto", skip_free_tier=True) == "custom"
 
     @pytest.mark.parametrize("model_cfg", [
         {"provider": "custom", "default": "local-model"},

--- a/tests/hermes_cli/test_provider_precedence.py
+++ b/tests/hermes_cli/test_provider_precedence.py
@@ -19,8 +19,8 @@ def _login(monkeypatch, provider_id):
                         lambda p: {"logged_in": p == provider_id})
 
 
-def _config(monkeypatch, model_cfg):
-    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"model": model_cfg})
+def _config(monkeypatch, model_cfg, **extra):
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"model": model_cfg, **extra})
 
 
 def _no_aws(monkeypatch):
@@ -42,6 +42,56 @@ class TestProviderPrecedence:
         _login(monkeypatch, "anthropic")           # stale OAuth login
         _config(monkeypatch, {"provider": "zai", "default": "glm-4.6"})
         assert resolve_provider("auto") == "zai"
+
+    @pytest.mark.parametrize("provider", ["custom", "openrouter"])
+    def test_config_special_provider_counts_as_inference_route(self, monkeypatch, provider):
+        """Dashboard readiness accepts configured routes outside the auth registry."""
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        _logged_out(monkeypatch)
+        _config(monkeypatch, {
+            "provider": provider,
+            "default": "local-model",
+            "base_url": "http://127.0.0.1:8080/v1",
+        })
+
+        assert resolve_provider("auto", skip_free_tier=True) == provider
+
+    def test_config_named_custom_provider_counts_as_inference_route(self, monkeypatch):
+        """Named custom routes are ready only when their provider definition exists."""
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        _logged_out(monkeypatch)
+        _config(
+            monkeypatch,
+            {"provider": "custom:llama-local", "default": "local-model"},
+            providers={"llama-local": {"base_url": "http://127.0.0.1:8080/v1"}},
+        )
+
+        assert resolve_provider("auto", skip_free_tier=True) == "custom:llama-local"
+
+    @pytest.mark.parametrize("model_cfg", [
+        {"provider": "custom", "default": "local-model"},
+        {"provider": "custom:missing", "default": "local-model"},
+    ])
+    def test_incomplete_custom_provider_is_not_an_inference_route(self, monkeypatch, model_cfg):
+        """Bootstrap readiness rejects custom identities that runtime resolution cannot build."""
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        _logged_out(monkeypatch)
+        _config(monkeypatch, model_cfg, providers={})
+
+        with pytest.raises(AuthError, match="No inference provider configured"):
+            resolve_provider("auto", skip_free_tier=True)
+
+    def test_config_auto_provider_continues_resolution(self, monkeypatch):
+        """The auto sentinel is not itself a resolved inference route."""
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        _login(monkeypatch, "anthropic")
+        _config(monkeypatch, {"provider": "auto", "default": "some-model"})
+
+        assert resolve_provider("auto") == "anthropic"
 
     def test_env_key_beats_stale_oauth(self, monkeypatch):
         """An exported provider API key wins over a logged-in OAuth active_provider."""

--- a/tests/hermes_cli/test_provider_precedence.py
+++ b/tests/hermes_cli/test_provider_precedence.py
@@ -81,6 +81,32 @@ class TestProviderPrecedence:
 
         assert resolve_provider("auto", skip_free_tier=True) == "custom"
 
+    def test_bare_custom_provider_entry_counts_as_inference_route(self, monkeypatch):
+        """A providers.custom endpoint is routable without duplicating model.base_url."""
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        _logged_out(monkeypatch)
+        _config(
+            monkeypatch,
+            {"provider": "custom", "default": "local-model"},
+            providers={"custom": {"base_url": "http://127.0.0.1:8080/v1"}},
+        )
+
+        assert resolve_provider("auto", skip_free_tier=True) == "custom"
+
+    def test_available_llamacpp_endpoint_counts_as_inference_route(self, monkeypatch):
+        """Dashboard readiness recognizes the managed endpoint used by runtime routing."""
+        _clear_provider_env(monkeypatch)
+        _no_aws(monkeypatch)
+        _logged_out(monkeypatch)
+        _config(monkeypatch, {"provider": "llamacpp", "default": "local-model"})
+        monkeypatch.setattr(
+            "hermes_cli.local_runtime.endpoint.resolve_llamacpp_endpoint",
+            lambda **kwargs: {"base_url": "http://127.0.0.1:18434/v1", "api_key": "local-key"},
+        )
+
+        assert resolve_provider("auto", skip_free_tier=True) == "llamacpp"
+
     @pytest.mark.parametrize("model_cfg", [
         {"provider": "custom", "default": "local-model"},
         {"provider": "custom:missing", "default": "local-model"},


### PR DESCRIPTION
## What does this PR do?

Dashboard startup now recognizes configured OpenRouter and custom inference routes instead of reporting "Setup Required" for a usable configuration. The fix reuses runtime provider resolution, validates bare and named custom routes, and preserves fallback behavior for `auto`, unknown providers, and incomplete custom definitions.

### Symptom

A dashboard started with `model.provider: custom` or `model.provider: openrouter` can publish `setup.ready` with `provider_configured: false` and `other_providers: false`, preventing the embedded session from starting even though the same configuration works in CLI and gateway chat.

### Impact

Users of OpenAI-compatible custom endpoints or an explicitly configured OpenRouter route can be blocked from dashboard chat until they rerun setup or switch providers.

### Bug Cause

**Trigger:** `hermes_cli/auth.py:1394` / `_config_model_provider()` / `model.provider` is a runtime route outside `PROVIDER_REGISTRY`.

**Causal chain:**
1. Dashboard bootstrap asks `resolve_provider("auto", skip_free_tier=True)` whether another inference route is configured.
2. `_config_model_provider()` discards every provider not present in `PROVIDER_REGISTRY`, including the special `custom` and `openrouter` runtime identities.
3. Resolution falls through to `no_provider_configured`, so bootstrap publishes a false setup-not-ready state.

**Why it is wrong:** Provider configuration is filtered through the auth registry even though runtime routing deliberately supports additional provider identities.

**Working sibling / contrast:** Direct runtime resolution already accepts `custom` and `openrouter`, which is why CLI and gateway chat can use the same configuration.

**Ruled out:** This is not a dashboard frontend state bug; the incorrect `provider_configured` value originates in the backend provider-resolution ladder before the setup event is rendered.

### Fix

Validate configured providers against runtime routing rather than registry membership alone. Bare custom routes must include a base URL, named custom routes must resolve to a configured definition, and the `auto` sentinel continues down the normal resolution ladder.

## Related Issue

Closes #109247

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/auth.py` - recognize valid runtime provider routes during dashboard bootstrap inventory.
- `tests/hermes_cli/test_provider_precedence.py` - cover OpenRouter, bare custom, named custom, incomplete custom, and `auto` behavior at the resolver boundary.

## How to Test

1. Configure `model.provider` as `custom` with a non-empty `model.base_url`.
2. Start dashboard bootstrap and inspect the resulting setup status.
3. Run the focused provider precedence suite:

```bash
scripts/run_tests.sh tests/hermes_cli/test_provider_precedence.py
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] Documentation changes are N/A; behavior and regression coverage are self-contained
- [x] `cli-config.yaml.example` changes are N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` changes are N/A; no architecture or workflow changed
- [x] Cross-platform impact is limited to pure provider-resolution logic
- [x] Tool description and schema changes are N/A

## Screenshots / Logs

N/A - this is backend setup-state resolution with automated regression coverage.
