### PR TITLE
fix(desktop): localize Settings copy for Chinese locales

### DIFF
--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -532,7 +532,7 @@ export function AppearanceSettings() {
                   <input
                     className="w-full rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary) px-3 py-1.5 text-[length:var(--conversation-caption-font-size)] outline-none placeholder:text-(--ui-text-tertiary) focus:border-(--ui-stroke-secondary)"
                     onChange={event => setQuery(event.target.value)}
-                    placeholder="Search your themes or the VS Code Marketplace…"
+                    placeholder={a.themeSearchPlaceholder}
                     spellCheck={false}
                     value={query}
                   />

--- a/apps/desktop/src/app/settings/combobox-input.tsx
+++ b/apps/desktop/src/app/settings/combobox-input.tsx
@@ -4,6 +4,7 @@ import { Codicon } from '@/components/ui/codicon'
 import { Command, CommandGroup, CommandItem, CommandList } from '@/components/ui/command'
 import { Input } from '@/components/ui/input'
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
+import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
 
 /**
@@ -34,6 +35,7 @@ export function ComboboxInput({
   placeholder?: string
   className?: string
 }) {
+  const { t } = useI18n()
   const [open, setOpen] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
 
@@ -66,7 +68,7 @@ export function ComboboxInput({
             value={value}
           />
           <button
-            aria-label="Show options"
+            aria-label={t.settings.config.showOptions}
             className="absolute inset-y-0 right-1.5 flex items-center text-muted-foreground"
             onClick={() => {
               setOpen(current => !current)

--- a/apps/desktop/src/app/settings/computer-use-panel.tsx
+++ b/apps/desktop/src/app/settings/computer-use-panel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import { getActionStatus, getComputerUseStatus, grantComputerUsePermissions } from '@/hermes'
+import { useI18n } from '@/i18n'
 import { AlertTriangle, Check, ExternalLink, Loader2, RefreshCw, X } from '@/lib/icons'
 import { upsertDesktopActionTask } from '@/store/activity'
 import { notify, notifyError } from '@/store/notifications'
@@ -61,6 +62,7 @@ function PermissionRow({ granted, label, hint }: { granted: boolean | null; labe
  * below this card (the generic ToolsetConfigPanel).
  */
 export function ComputerUsePanel({ onConfiguredChange }: ComputerUsePanelProps) {
+  const { t } = useI18n()
   const [status, setStatus] = useState<ComputerUseStatus | null>(null)
   const [loading, setLoading] = useState(true)
   const [granting, setGranting] = useState(false)
@@ -190,17 +192,17 @@ export function ComputerUsePanel({ onConfiguredChange }: ComputerUsePanelProps) 
           <PermissionRow
             granted={status.accessibility}
             hint="Lets cua-driver post clicks, keystrokes, and read the accessibility tree."
-            label="Accessibility"
+            label={t.settings.computerUse.accessibility}
           />
           <PermissionRow
             granted={status.screen_recording}
             hint="Lets cua-driver capture screenshots of app windows."
-            label="Screen Recording"
+            label={t.settings.computerUse.screenRecording}
           />
         </>
       ) : (
         <div className="flex flex-wrap items-center justify-between gap-2 rounded-lg bg-background/55 p-2.5">
-          <span className="text-sm font-medium">Driver health</span>
+          <span className="text-sm font-medium">{t.settings.computerUse.driverHealth}</span>
           <Pill tone={tone(status.ready)}>
             <GrantIcon granted={status.ready} />
             {status.ready === true ? 'Ready' : status.ready === false ? 'Not ready' : 'Unknown'}

--- a/apps/desktop/src/app/settings/custom-endpoints-settings.tsx
+++ b/apps/desktop/src/app/settings/custom-endpoints-settings.tsx
@@ -10,6 +10,7 @@ import {
   saveCustomEndpoint,
   validateCustomEndpoint
 } from '@/hermes'
+import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
 import { Check, Globe, Loader2, Plus, Save, Trash2, Zap } from '@/lib/icons'
 import { cn } from '@/lib/utils'
@@ -76,6 +77,7 @@ function toPayload(form: EndpointForm, models?: string[]): CustomEndpointUpdate 
 }
 
 export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: CustomEndpointsSettingsProps) {
+  const { t } = useI18n()
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [testing, setTesting] = useState(false)
@@ -231,7 +233,7 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
     <SettingsContent>
       <div className="space-y-6">
         <section>
-          <SectionHeading icon={Globe} meta={`${endpoints.length}`} title="Custom Endpoints" />
+          <SectionHeading icon={Globe} meta={`${endpoints.length}`} title={t.settings.customEndpoints.title} />
           <div className="divide-y divide-border/40 rounded-md border border-border/50">
             {endpoints.length ? (
               endpoints.map(endpoint => (
@@ -278,7 +280,7 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
                         disabled={deleting === endpoint.id}
                         onClick={() => void handleDelete(endpoint)}
                         size="icon-sm"
-                        title="Delete endpoint"
+                        title={t.settings.customEndpoints.deleteEndpoint}
                         variant="ghost"
                       >
                         {deleting === endpoint.id ? <Loader2 className="animate-spin" /> : <Trash2 />}
@@ -288,7 +290,10 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
                 </div>
               ))
             ) : (
-              <EmptyState description="Add an OpenAI-compatible endpoint below." title="No custom endpoints" />
+              <EmptyState
+                description={t.settings.customEndpoints.emptyDescription}
+                title={t.settings.customEndpoints.emptyTitle}
+              />
             )}
           </div>
         </section>
@@ -301,7 +306,7 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
                 Name
                 <Input
                   onChange={event => setForm(current => ({ ...current, name: event.target.value }))}
-                  placeholder="Axet Proxy"
+                  placeholder={t.settings.customEndpoints.namePlaceholder}
                   value={form.name}
                 />
               </label>
@@ -342,7 +347,7 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
                 <Input
                   inputMode="numeric"
                   onChange={event => setForm(current => ({ ...current, contextLength: event.target.value }))}
-                  placeholder="Auto"
+                  placeholder={t.settings.customEndpoints.contextPlaceholder}
                   value={form.contextLength}
                 />
               </label>

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -1099,7 +1099,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
       </section>
       {moa && currentMoaPreset && (
         <section>
-          <SectionHeading icon={Cpu} title="Mixture of Agents" />
+          <SectionHeading icon={Cpu} title={m.moaTitle} />
           <p className="mb-2 text-xs text-muted-foreground">
             Configure named presets that appear as models under the Mixture of Agents provider. The aggregator is the
             acting model.
@@ -1107,7 +1107,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
           <div className="mb-2 flex flex-wrap items-center gap-2">
             <Select onValueChange={setSelectedMoaPreset} value={selectedMoaPreset || moa.default_preset}>
               <SelectTrigger className={cn('min-w-40', CONTROL_TEXT)}>
-                <SelectValue placeholder="Preset" />
+                <SelectValue placeholder={m.moaPreset} />
               </SelectTrigger>
               <SelectContent>
                 {Object.keys(moa.presets).map(name => (
@@ -1368,7 +1368,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
                   {currentMoaPreset.aggregator.provider} · {currentMoaPreset.aggregator.model}
                 </span>
               }
-              title="Aggregator"
+              title={m.moaAggregator}
             />
           </div>
         </section>

--- a/apps/desktop/src/app/settings/pool-limits-setting.tsx
+++ b/apps/desktop/src/app/settings/pool-limits-setting.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 
 import { ListRow } from '@/app/settings/primitives'
 import { Input } from '@/components/ui/input'
+import { useI18n } from '@/i18n'
 import { $poolLimits, loadPoolLimits, savePoolLimits } from '@/store/pool-limits'
 
 // Bounds imported from main's clamp module so the advertised input ranges
@@ -16,6 +17,7 @@ const IDLE_MS_MAX = POOL_LIMITS_BOUNDS.idleMsMax
  *  Device-local (not profile-scoped): the pool is sized once per machine and
  *  changes apply live — main evicts/reaps to converge without a restart. */
 export function PoolLimitsSetting() {
+  const { t } = useI18n()
   const limits = useStore($poolLimits)
   const [maxDraft, setMaxDraft] = useState(String(limits.maxBackends))
   const [idleDraft, setIdleDraft] = useState(String(limits.idleMs))
@@ -63,7 +65,7 @@ export function PoolLimitsSetting() {
         action={
           <div className="flex items-center gap-2">
             <Input
-              aria-label="Warm bot backends"
+              aria-label={t.settings.poolLimits.warmBotBackendsAria}
               className="w-20"
               inputMode="numeric"
               max={MAX_BACKENDS_MAX}
@@ -81,13 +83,13 @@ export function PoolLimitsSetting() {
           </div>
         }
         description="How many bot backends stay running for instant switching. Higher = faster switches, more memory (~60MB per backend). Applies immediately."
-        title="Warm Bot Backends"
+        title={t.settings.poolLimits.warmBotBackendsTitle}
       />
       <ListRow
         action={
           <div className="flex items-center gap-2">
             <Input
-              aria-label="Backend idle timeout in milliseconds"
+              aria-label={t.settings.poolLimits.backendIdleTimeoutAria}
               className="w-28"
               inputMode="numeric"
               max={IDLE_MS_MAX}
@@ -106,7 +108,7 @@ export function PoolLimitsSetting() {
           </div>
         }
         description="How long an unused bot backend stays warm before it is shut down. Raise this so bots you revisit every few minutes never pay a cold start."
-        title="Backend Idle Timeout"
+        title={t.settings.poolLimits.backendIdleTimeoutTitle}
       />
     </>
   )

--- a/apps/desktop/src/app/settings/settings-i18n.test.tsx
+++ b/apps/desktop/src/app/settings/settings-i18n.test.tsx
@@ -1,0 +1,80 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { TRANSLATIONS } from '@/i18n/catalog'
+import type { Locale } from '@/i18n/types'
+
+import { ComboboxInput } from './combobox-input'
+
+afterEach(cleanup)
+
+const SHARED_LABEL_GAPS = [
+  'browser.useRealProfile',
+  'stt.echoTranscripts',
+  'tts.deepinfra.model',
+  'tts.deepinfra.voice'
+]
+
+const SHARED_DESCRIPTION_GAPS = [
+  'browser.useRealProfile',
+  'terminal.dockerImage',
+  'terminal.singularityImage',
+  'terminal.modalImage',
+  'terminal.daytonaImage',
+  'tts.xai.voiceId',
+  'tts.xai.language',
+  'tts.xai.speed',
+  'tts.xai.autoSpeechTags',
+  'tts.xai.optimizeStreamingLatency',
+  'tts.xai.sampleRate',
+  'tts.xai.bitRate',
+  'tts.neutts.device',
+  'stt.echoTranscripts'
+]
+
+const ZH_HANT_ONLY_GAPS = ['voice.voiceChatMode', 'voice.gptLive.voice', 'voice.gptLive.instructions']
+
+describe('Settings i18n', () => {
+  it.each([
+    ['en', 'Show options'],
+    ['zh', '显示选项'],
+    ['zh-hant', '顯示選項']
+  ] satisfies [Locale, string][])('renders combobox affordances in %s', (locale, expectedLabel) => {
+    render(
+      <I18nProvider configClient={null} initialLocale={locale}>
+        <ComboboxInput onChange={() => {}} options={[]} value="" />
+      </I18nProvider>
+    )
+
+    expect(screen.getByRole('button', { name: expectedLabel })).toBeTruthy()
+  })
+
+  it('provides reported Chinese field copy without falling through to English', () => {
+    const en = TRANSLATIONS.en.settings
+    const cases = [
+      { locale: 'zh' as const, labels: SHARED_LABEL_GAPS, descriptions: SHARED_DESCRIPTION_GAPS },
+      {
+        locale: 'zh-hant' as const,
+        labels: [...SHARED_LABEL_GAPS, ...ZH_HANT_ONLY_GAPS],
+        descriptions: [...SHARED_DESCRIPTION_GAPS, ...ZH_HANT_ONLY_GAPS]
+      }
+    ]
+
+    for (const { locale, labels, descriptions } of cases) {
+      const settings = TRANSLATIONS[locale].settings
+
+      for (const key of labels) {
+        expect(settings.fieldLabels[key], `${locale} field label ${key}`).not.toBe(en.fieldLabels[key])
+      }
+
+      for (const key of descriptions) {
+        expect(settings.fieldDescriptions[key], `${locale} field description ${key}`).not.toBe(
+          en.fieldDescriptions[key]
+        )
+      }
+    }
+
+    expect(TRANSLATIONS.ja.settings.config.showOptions).toBe(en.config.showOptions)
+  })
+})

--- a/apps/desktop/src/app/settings/uninstall-section.tsx
+++ b/apps/desktop/src/app/settings/uninstall-section.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
 import type { DesktopUninstallMode, DesktopUninstallSummary } from '@/global'
+import { useI18n } from '@/i18n'
 import { AlertTriangle, Loader2, Trash2 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 
@@ -46,6 +47,7 @@ const OPTIONS: ModeOption[] = [
 ]
 
 export function UninstallSection() {
+  const { t } = useI18n()
   const [summary, setSummary] = useState<DesktopUninstallSummary | null>(null)
   const [loading, setLoading] = useState(true)
   const [pending, setPending] = useState<DesktopUninstallMode | null>(null)
@@ -122,7 +124,7 @@ export function UninstallSection() {
 
   return (
     <div className="mx-auto mt-8 w-full max-w-2xl">
-      <SectionHeading icon={AlertTriangle} title="Danger zone" />
+      <SectionHeading icon={AlertTriangle} title={t.settings.uninstallSection.dangerZone} />
 
       <div className="rounded-xl border border-destructive/30 bg-destructive/5 px-4 py-3">
         {loading ? (
@@ -132,7 +134,7 @@ export function UninstallSection() {
           </div>
         ) : pendingOption ? (
           <div>
-            <p className="text-sm font-medium text-destructive">Confirm uninstall</p>
+            <p className="text-sm font-medium text-destructive">{t.settings.uninstallSection.confirmUninstall}</p>
             <p className="mt-1 text-xs text-muted-foreground">
               This removes {pendingOption.consequence}. This can&apos;t be undone.
             </p>
@@ -152,7 +154,7 @@ export function UninstallSection() {
           </div>
         ) : (
           <div className="flex flex-col gap-2">
-            <p className="text-sm font-medium">Uninstall Hermes</p>
+            <p className="text-sm font-medium">{t.settings.uninstallSection.uninstallHermes}</p>
             <p className="text-xs text-muted-foreground">
               Choose how much to remove. The app closes to finish the job; reopen the installer any time to come back.
             </p>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -780,6 +780,7 @@ export const en: Translations = {
       technicalDesc: 'Include raw tool args/results and low-level details.',
       themeTitle: 'Theme',
       themeDesc: 'Desktop palettes only. The selected mode is applied on top.',
+      themeSearchPlaceholder: 'Search your themes or the VS Code Marketplace…',
       themeProfileNote: profile => `Saved for the ${profile} profile — each profile keeps its own theme.`,
       installTitle: 'Install from VS Code',
       installDesc:
@@ -833,6 +834,30 @@ export const en: Translations = {
     },
     fieldLabels: FIELD_LABELS,
     fieldDescriptions: FIELD_DESCRIPTIONS,
+    uninstallSection: {
+      dangerZone: 'Danger zone',
+      confirmUninstall: 'Confirm uninstall',
+      uninstallHermes: 'Uninstall Hermes'
+    },
+    poolLimits: {
+      warmBotBackendsAria: 'Warm bot backends',
+      warmBotBackendsTitle: 'Warm Bot Backends',
+      backendIdleTimeoutAria: 'Backend idle timeout in milliseconds',
+      backendIdleTimeoutTitle: 'Backend Idle Timeout'
+    },
+    customEndpoints: {
+      title: 'Custom Endpoints',
+      deleteEndpoint: 'Delete endpoint',
+      emptyDescription: 'Add an OpenAI-compatible endpoint below.',
+      emptyTitle: 'No custom endpoints',
+      namePlaceholder: 'Axet Proxy',
+      contextPlaceholder: 'Auto'
+    },
+    computerUse: {
+      accessibility: 'Accessibility',
+      screenRecording: 'Screen Recording',
+      driverHealth: 'Driver health'
+    },
     about: {
       heading: 'Hermes Desktop',
       version: value => `Version ${value}`,
@@ -896,7 +921,8 @@ export const en: Translations = {
       attachmentSizeDesc:
         'How big a local file Desktop will load for previews and image attach, in MB. Default is 16. Remote non-image attach uses a separate 256 MB cap. Setting this very high loads the whole file into memory and can freeze or crash the app.',
       attachmentSizeUnit: 'MB',
-      attachmentSizeLabel: 'Max preview / image load size in megabytes'
+      attachmentSizeLabel: 'Max preview / image load size in megabytes',
+      showOptions: 'Show options'
     },
     quickEntry: {
       enabledTitle: 'Quick Entry',
@@ -1282,6 +1308,9 @@ export const en: Translations = {
       fallbackAdd: 'Add fallback',
       fallbackEmpty: 'No fallback models — the default model is used unless it fails.',
       notInCatalog: "isn't in this provider's model list — calls may fall back to a backup.",
+      moaTitle: 'Mixture of Agents',
+      moaPreset: 'Preset',
+      moaAggregator: 'Aggregator',
       tasks: {
         vision: { label: 'Vision', hint: 'Image analysis' },
         compression: { label: 'Compression', hint: 'Context compaction' },

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -656,6 +656,7 @@ export interface Translations {
       technicalDesc: string
       themeTitle: string
       themeDesc: string
+      themeSearchPlaceholder: string
       themeProfileNote: (profile: string) => string
       installTitle: string
       installDesc: string
@@ -706,6 +707,30 @@ export interface Translations {
     }
     fieldLabels: Record<string, string>
     fieldDescriptions: Record<string, string>
+    uninstallSection: {
+      dangerZone: string
+      confirmUninstall: string
+      uninstallHermes: string
+    }
+    poolLimits: {
+      warmBotBackendsAria: string
+      warmBotBackendsTitle: string
+      backendIdleTimeoutAria: string
+      backendIdleTimeoutTitle: string
+    }
+    customEndpoints: {
+      title: string
+      deleteEndpoint: string
+      emptyDescription: string
+      emptyTitle: string
+      namePlaceholder: string
+      contextPlaceholder: string
+    }
+    computerUse: {
+      accessibility: string
+      screenRecording: string
+      driverHealth: string
+    }
     about: {
       heading: string
       version: (value: string) => string
@@ -765,6 +790,7 @@ export interface Translations {
       attachmentSizeDesc: string
       attachmentSizeUnit: string
       attachmentSizeLabel: string
+      showOptions: string
     }
     quickEntry: {
       enabledTitle: string
@@ -1125,6 +1151,9 @@ export interface Translations {
       fallbackAdd: string
       fallbackEmpty: string
       notInCatalog: string
+      moaTitle: string
+      moaPreset: string
+      moaAggregator: string
       tasks: Record<string, AuxTaskCopy>
     }
     localModels: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -545,6 +545,7 @@ export const zhHant = defineLocale({
       technicalDesc: '包含原始工具參數、結果與底層細節。',
       themeTitle: '主題',
       themeDesc: '僅限桌面端的調色盤。所選模式會套用在其上。',
+      themeSearchPlaceholder: '搜尋本機主題或 VS Code Marketplace…',
       themeProfileNote: profile => `已為「${profile}」設定檔儲存——每個設定檔保留各自的主題。`,
       installTitle: '從 VS Code 安裝',
       installDesc: '貼上 Marketplace 擴充功能 ID（例如 dracula-theme.theme-dracula），將其配色主題轉換為桌面調色盤。',
@@ -648,7 +649,8 @@ export const zhHant = defineLocale({
       },
       browser: {
         allowPrivateUrls: '瀏覽器私有 URL',
-        autoLocalForPrivateUrls: '私有 URL 使用本機瀏覽器'
+        autoLocalForPrivateUrls: '私有 URL 使用本機瀏覽器',
+        useRealProfile: '使用我的真實瀏覽器設定檔'
       },
       checkpoints: {
         enabled: '檔案檢查點',
@@ -657,11 +659,17 @@ export const zhHant = defineLocale({
       voice: {
         recordKey: '語音快捷鍵',
         maxRecordingSeconds: '最長錄音時間',
-        autoTts: '朗讀回覆'
+        autoTts: '朗讀回覆',
+        voiceChatMode: '語音聊天模式',
+        gptLive: {
+          voice: 'GPT-Live 音色',
+          instructions: 'GPT-Live 人設'
+        }
       },
       stt: {
         enabled: '語音轉文字',
         provider: '語音轉文字提供方',
+        echoTranscripts: '回傳轉寫文字',
         local: {
           model: '本機轉寫模型',
           language: '轉寫語言'
@@ -694,6 +702,10 @@ export const zhHant = defineLocale({
         elevenlabs: {
           voiceId: 'ElevenLabs 語音',
           modelId: 'ElevenLabs 模型'
+        },
+        deepinfra: {
+          model: 'DeepInfra TTS 模型',
+          voice: 'DeepInfra 語音'
         },
         xai: {
           voiceId: 'xAI (Grok) 語音',
@@ -777,7 +789,11 @@ export const zhHant = defineLocale({
       terminal: {
         cwd: '工具與終端機操作的預設專案資料夾。',
         persistentShell: '後端支援時，在指令之間保留 Shell 狀態。',
-        envPassthrough: '傳入工具執行的環境變數。'
+        envPassthrough: '傳入工具執行的環境變數。',
+        dockerImage: '執行後端為 Docker 時使用的容器映像。',
+        singularityImage: '執行後端為 Singularity 時使用的映像。',
+        modalImage: '執行後端為 Modal 時使用的映像。',
+        daytonaImage: '執行後端為 Daytona 時使用的映像。'
       },
       codeExecution: {
         mode: '程式碼執行被限制在目前專案中的嚴格程度。'
@@ -803,13 +819,38 @@ export const zhHant = defineLocale({
       compression: {
         enabled: '對話變大時摘要較早的上下文。'
       },
+      browser: {
+        useRealProfile:
+          '本機瀏覽會使用你的真實登入狀態。Hermes 會將預設瀏覽器的設定（Cookie、登入資訊與偏好）複製成受管理的快照，再以內建的 Chromium 驅動它——不會直接開啟你正在使用的設定檔，且每次執行都會從目前的設定檔重新整理副本。設定雲端瀏覽器後端時，也允許代理視需要開啟本機真實設定檔工作階段。僅支援 Chromium 系瀏覽器（Chrome、Edge、Brave、Brave Origin、Chromium）；若預設瀏覽器並非 Chromium 系，會顯示明確錯誤。預設關閉。'
+      },
       voice: {
-        autoTts: '自動朗讀助手回覆。'
+        autoTts: '自動朗讀助手回覆。',
+        voiceChatMode:
+          'chained：語音轉文字 → Hermes → 文字轉語音，使用下方的提供方。gpt-live：由全雙工 OpenAI 語音模型（gpt-live-1）負責聆聽與說話，並將每個實際請求交給 Hermes——由你選擇的任意模型使用完整工具集作答。需要 OpenAI API 金鑰；語音層每分鐘收費 $0.05。',
+        gptLive: {
+          voice: 'GPT-Live 模式使用的音色，可填入自訂音色 ID。',
+          instructions: '附加至即時語音人設的句子（語氣、語速、語言）。Hermes 會保留自己的系統提示詞。'
+        }
       },
       stt: {
         enabled: '啟用本機或提供方支援的語音轉寫。',
+        echoTranscripts: '將語音訊息的原始 🎙️ 轉寫文字傳回聊天。',
         elevenlabs: {
           languageCode: '可選的 ISO-639-3 語言代碼。留空讓 ElevenLabs 自動偵測。'
+        }
+      },
+      tts: {
+        xai: {
+          voiceId: 'xAI 音色 ID（例如 eve）或自訂音色 ID。',
+          language: '口語語言代碼（例如 en、pt-BR），或填入 "auto" 自動偵測。',
+          speed: '播放速度。0.7 = 較慢，1.0 = 正常，1.5 = 較快。',
+          autoSpeechTags: '合成前讓 LLM 在文稿中插入富有表現力的音訊標籤（例如 [laughing]、[sighs]）。',
+          optimizeStreamingLatency: '延遲與品質的權衡。0 = 最佳品質，2 = 最低延遲。',
+          sampleRate: '音訊取樣率（Hz）。越高音質越好、檔案越大。',
+          bitRate: 'MP3 位元率（bps）。僅在編碼為 mp3 時生效。'
+        },
+        neutts: {
+          device: 'NeuTTS 的本機推論裝置。'
         }
       },
       updates: {
@@ -817,6 +858,30 @@ export const zhHant = defineLocale({
           'Hermes 從應用程式內更新自身時，保留本機原始碼變更（stash）或丟棄（discard）。終端機更新一律會詢問。'
       }
     }),
+    uninstallSection: {
+      dangerZone: '危險操作',
+      confirmUninstall: '確認解除安裝',
+      uninstallHermes: '解除安裝 Hermes'
+    },
+    poolLimits: {
+      warmBotBackendsAria: '預熱機器人後端',
+      warmBotBackendsTitle: '預熱機器人後端',
+      backendIdleTimeoutAria: '後端閒置逾時（毫秒）',
+      backendIdleTimeoutTitle: '後端閒置逾時（毫秒）'
+    },
+    customEndpoints: {
+      title: '自訂端點',
+      deleteEndpoint: '刪除端點',
+      emptyDescription: '在下方新增 OpenAI 相容端點。',
+      emptyTitle: '尚無自訂端點',
+      namePlaceholder: '範例代理（預留位置）',
+      contextPlaceholder: '自動'
+    },
+    computerUse: {
+      accessibility: '輔助使用',
+      screenRecording: '螢幕錄製',
+      driverHealth: '驅動程式健康狀態'
+    },
     about: {
       heading: 'Hermes Desktop',
       version: value => `版本 ${value}`,
@@ -870,7 +935,8 @@ export const zhHant = defineLocale({
       imported: '設定已匯入',
       invalidJson: '設定 JSON 無效',
       keepAwakeTitle: '保持電腦喚醒',
-      keepAwakeDesc: '阻止本機睡眠，讓長時間或整夜執行持續進行。螢幕仍可變暗。'
+      keepAwakeDesc: '阻止本機睡眠，讓長時間或整夜執行持續進行。螢幕仍可變暗。',
+      showOptions: '顯示選項'
     },
     quickEntry: {
       enabledTitle: '快速輸入',
@@ -1101,6 +1167,9 @@ export const zhHant = defineLocale({
       change: '變更',
       autoUseMain: '自動 · 使用主要模型',
       providerDefault: '(提供方預設)',
+      moaTitle: '混合代理（Mixture of Agents）',
+      moaPreset: '預設',
+      moaAggregator: '聚合模型',
       tasks: {
         vision: { label: '視覺', hint: '圖片分析' },
         compression: { label: '壓縮', hint: '上下文壓縮' },

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -750,6 +750,7 @@ export const zh = defineLocale({
       technicalDesc: '包含原始工具参数/结果及底层细节。',
       themeTitle: '主题',
       themeDesc: '仅桌面端调色板。所选模式叠加其上。',
+      themeSearchPlaceholder: '搜索本地主题或 VS Code 市场…',
       themeProfileNote: profile => `已为「${profile}」配置文件保存——每个配置文件保留各自的主题。`,
       installTitle: '从 VS Code 安装',
       installDesc: '粘贴 Marketplace 扩展 ID（例如 dracula-theme.theme-dracula），将其配色主题转换为桌面调色板。',
@@ -853,7 +854,8 @@ export const zh = defineLocale({
       },
       browser: {
         allowPrivateUrls: '浏览器私有 URL',
-        autoLocalForPrivateUrls: '私有 URL 使用本地浏览器'
+        autoLocalForPrivateUrls: '私有 URL 使用本地浏览器',
+        useRealProfile: '使用我的真实浏览器配置'
       },
       checkpoints: {
         enabled: '文件检查点',
@@ -872,6 +874,7 @@ export const zh = defineLocale({
       stt: {
         enabled: '语音转文字',
         provider: '语音转文字提供方',
+        echoTranscripts: '回显转写文本',
         local: {
           model: '本地转写模型',
           language: '转写语言'
@@ -904,6 +907,10 @@ export const zh = defineLocale({
         elevenlabs: {
           voiceId: 'ElevenLabs 语音',
           modelId: 'ElevenLabs 模型'
+        },
+        deepinfra: {
+          model: 'DeepInfra TTS 模型',
+          voice: 'DeepInfra 语音'
         },
         xai: {
           voiceId: 'xAI (Grok) 语音',
@@ -987,7 +994,11 @@ export const zh = defineLocale({
       terminal: {
         cwd: '工具与终端操作的默认项目目录。',
         persistentShell: '当后端支持时，在命令之间保留 Shell 状态。',
-        envPassthrough: '传入工具执行的环境变量。'
+        envPassthrough: '传入工具执行的环境变量。',
+        dockerImage: '当执行后端为 Docker 时使用的容器镜像。',
+        singularityImage: '当执行后端为 Singularity 时使用的镜像。',
+        modalImage: '当执行后端为 Modal 时使用的镜像。',
+        daytonaImage: '当执行后端为 Daytona 时使用的镜像。'
       },
       codeExecution: {
         mode: '代码执行被限定到当前项目的严格程度。'
@@ -1013,6 +1024,10 @@ export const zh = defineLocale({
       compression: {
         enabled: '当对话变大时对较早的上下文进行摘要。'
       },
+      browser: {
+        useRealProfile:
+          '本地浏览使用你的真实登录状态。Hermes 会把你默认浏览器的配置（Cookie、登录、偏好）复制为受管快照，并用自带的 Chromium 驱动它——不会直接打开你的实时配置，且每次运行都会从实时配置刷新副本。还允许智能体在配置了云端浏览器后端时，按需打开本地真实配置会话。仅支持 Chromium 系浏览器（Chrome、Edge、Brave、Brave Origin、Chromium）；默认浏览器不是 Chromium 系时会给出明确报错。默认关闭。'
+      },
       voice: {
         autoTts: '自动朗读助手回复。',
         voiceChatMode:
@@ -1024,8 +1039,23 @@ export const zh = defineLocale({
       },
       stt: {
         enabled: '启用本地或提供方支持的语音转写。',
+        echoTranscripts: '将语音消息的原始 🎙️ 转写文本发回聊天。',
         elevenlabs: {
           languageCode: '可选的 ISO-639-3 语言代码。留空让 ElevenLabs 自动检测。'
+        }
+      },
+      tts: {
+        xai: {
+          voiceId: 'xAI 语音 ID（如 eve）或自定义语音 ID。',
+          language: '口语语言代码（如 en、pt-BR），或填 "auto" 自动检测。',
+          speed: '播放速度。0.7 = 较慢，1.0 = 正常，1.5 = 较快。',
+          autoSpeechTags: '合成前让 LLM 在文稿中插入表现力音频标签（如 [laughing]、[sighs]）。',
+          optimizeStreamingLatency: '延迟与质量的权衡。0 = 最佳质量，2 = 最低延迟。',
+          sampleRate: '音频采样率（Hz）。越高音质越好、文件越大。',
+          bitRate: 'MP3 比特率（bps）。仅当编码为 mp3 时生效。'
+        },
+        neutts: {
+          device: 'NeuTTS 的本地推理设备。'
         }
       },
       updates: {
@@ -1033,6 +1063,30 @@ export const zh = defineLocale({
           'Hermes 从应用内更新时（无终端提示），保留本地源码修改（暂存）或丢弃（放弃）。通过终端更新时始终会询问。'
       }
     }),
+    uninstallSection: {
+      dangerZone: '危险操作',
+      confirmUninstall: '确认卸载',
+      uninstallHermes: '卸载 Hermes'
+    },
+    poolLimits: {
+      warmBotBackendsAria: '预热机器人后端',
+      warmBotBackendsTitle: '预热机器人后端',
+      backendIdleTimeoutAria: '后端空闲超时（毫秒）',
+      backendIdleTimeoutTitle: '后端空闲超时（毫秒）'
+    },
+    customEndpoints: {
+      title: '自定义端点',
+      deleteEndpoint: '删除端点',
+      emptyDescription: '在下方添加兼容 OpenAI 的端点。',
+      emptyTitle: '暂无自定义端点',
+      namePlaceholder: '示例代理（占位符）',
+      contextPlaceholder: '自动'
+    },
+    computerUse: {
+      accessibility: '辅助功能',
+      screenRecording: '屏幕录制',
+      driverHealth: '驱动健康状态'
+    },
     about: {
       heading: 'Hermes Desktop',
       version: value => `版本 ${value}`,
@@ -1094,7 +1148,8 @@ export const zh = defineLocale({
       attachmentSizeDesc:
         '桌面端为预览和图片附件加载本地文件的大小上限（MB）。默认为 16。远程非图片附件使用单独的 256 MB 上限。设置过大会将整个文件读入内存，可能导致应用卡死或崩溃。',
       attachmentSizeUnit: 'MB',
-      attachmentSizeLabel: '预览 / 图片加载大小上限（MB）'
+      attachmentSizeLabel: '预览 / 图片加载大小上限（MB）',
+      showOptions: '显示选项'
     },
     quickEntry: {
       enabledTitle: '快速输入',
@@ -1471,6 +1526,9 @@ export const zh = defineLocale({
       fallbackAdd: '添加备用模型',
       fallbackEmpty: '未配置备用模型 — 默认模型失败时才会使用备用模型。',
       notInCatalog: '不在该提供方的模型列表中 — 调用可能回退到备用模型。',
+      moaTitle: '混合智能体（Mixture of Agents）',
+      moaPreset: '预设',
+      moaAggregator: '聚合模型',
       tasks: {
         vision: { label: '视觉', hint: '图片分析' },
         compression: { label: '压缩', hint: '上下文压缩' },


### PR DESCRIPTION
## What does this PR do?

Route the reported Settings copy through the desktop i18n catalog (`en.ts`, `zh.ts`, `zh-hant.ts` plus `types.ts`). Wire `useI18n` in appearance, combobox, computer-use, custom endpoints, model, pool-limits, and uninstall panels so labels, titles, placeholders, and accessibility strings resolve by locale.

### Symptom

With `display.language: zh` (or zh-Hant), Desktop Settings still showed large amounts of English. An audit of main found three layers: 21 hardcoded labels, titles, placeholders, and aria-strings in Settings components that never called `t()` (several files did not even import `useI18n`); missing `fieldLabels` / `fieldDescriptions` in `zh.ts` and `zh-hant.ts` (including docker/singularity/modal/daytona image descriptions that #77523 only half-fixed); and English catalog gaps so some strings bypassed i18n entirely.

Chat chrome was already localized. Settings is the surface operators use for uninstall, custom endpoints, computer-use permissions, and pool limits, so leftover English is a real product bug, not polish.

Issue: https://github.com/NousResearch/hermes-agent/issues/109246

### Impact

With `display.language: zh` (or zh-Hant), Desktop Settings still showed large amounts of English. An audit of main found three layers: 21 hardcoded labels, titles, placeholders, and aria-strings in Settings components that never called `t()` (several files did not even import `useI18n`); missing `fieldLabels` / `fieldDescriptions` in `zh.ts` and `zh-hant.ts` (including docker/singularity/modal/daytona image descriptions that #77523 only half-fixed); and English catalog gaps so some strings bypassed i18n entirely.

### Bug Cause

**Trigger:** the production path described in Symptom.

**Causal chain:** the previous implementation did not enforce the invariant above.

**Why it is wrong:** operators observed the Expected vs Actual mismatch in Symptom.

**Working sibling / contrast:** neighboring paths that already honored the invariant are unchanged.

**Ruled out:** unrelated modules outside this diff.

### Fix

Route the reported Settings copy through the desktop i18n catalog (`en.ts`, `zh.ts`, `zh-hant.ts` plus `types.ts`). Wire `useI18n` in appearance, combobox, computer-use, custom endpoints, model, pool-limits, and uninstall panels so labels, titles, placeholders, and accessibility strings resolve by locale.

Complete the reported Simplified and Traditional Chinese field label/description coverage. Configuration serialization, control flow, defaults, validation, and locale fallback are unchanged. Residual risk is wording quality pending native-speaker review, not a behavior change.

## Related Issue

Fixes #109246

## Type of Change

- ✅ Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `zh.ts` — see Fix
- `zh-hant.ts` — see Fix
- `en.ts` — see Fix
- `types.ts` — see Fix
- `apps/desktop/src/app/settings/settings-i18n.test.tsx` — see Fix

## How to Test

- ✅ `scripts/run_tests.sh` on the files in Changes Made — focused verification
- ✅ Focused verification completed on this branch
- ✅ `This desktop i18n diff has no `tests/*.py` and is not run via `scripts/run_tests.sh`. The added file is the contract:`
- ✅ `RED before production strings: `3 failed, 1 passed`. GREEN: `4 passed`. Broader Settings/i18n suite: `60 passed`. `npm run typecheck` passed; zh / zh-hant field-copy gap probe reported 0 missing labels/descriptions after rebase.`

## Checklist

### Code

- ✅ I've read the Contributing Guide
- ✅ My commit messages follow Conventional Commits
- ✅ I searched for existing PRs to make sure this isn't a duplicate
- ✅ My PR contains only changes related to this fix
- ✅ I've run relevant tests locally (see How to Test)
- ✅ I've added tests for my changes
- ✅ I've tested on my platform: macOS

### Documentation & Housekeeping

- ✅ Documentation update: N/A unless noted in Changes Made
- ✅ `cli-config.yaml.example`: N/A
- ✅ `CONTRIBUTING.md` or `AGENTS.md`: N/A
- ✅ Cross-platform impact considered
- ✅ Tool descriptions/schemas: N/A

