### PR TITLE
fix: prefer provider-reported upstream_inference_cost over rate-table estimates

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -61,6 +61,10 @@ class CanonicalUsage:
     reasoning_tokens: int = 0
     request_count: int = 1
     raw_usage: Optional[dict[str, Any]] = None
+    # Actual cost reported by the provider (e.g. Nous portal's
+    # usage.cost_details.upstream_inference_cost). When present, prefer this
+    # over the rate-table estimate in estimate_usage_cost().
+    actual_cost_usd: Optional[Decimal] = None
 
     @property
     def prompt_tokens(self) -> int:
@@ -539,9 +543,28 @@ def normalize_usage(
             cache_read_tokens, cache_write_tokens,
         )
 
+    # Extract actual cost from provider when present (e.g. Nous portal's
+    # usage.cost_details.upstream_inference_cost). This is the authoritative
+    # figure when available — rate-table estimates can diverge significantly.
+    actual_cost_usd: Optional[Decimal] = None
+    cost_details = getattr(u, "cost_details", None) if hasattr(u, "cost_details") else None
+    if cost_details is None:
+        # Fallback for dict-shaped usage objects
+        cost_details = u.get("cost_details") if isinstance(u, dict) else None
+    if cost_details is not None:
+        upstream_cost = getattr(cost_details, "upstream_inference_cost", None)
+        if upstream_cost is None and isinstance(cost_details, dict):
+            upstream_cost = cost_details.get("upstream_inference_cost")
+        if upstream_cost is not None:
+            try:
+                actual_cost_usd = Decimal(str(upstream_cost))
+            except (ValueError, TypeError):
+                pass
+
     return CanonicalUsage(
         input_tokens=input_tokens, output_tokens=output_tokens, cache_read_tokens=cache_read_tokens,
         cache_write_tokens=cache_write_tokens, reasoning_tokens=reasoning_tokens,
+        actual_cost_usd=actual_cost_usd,
     )
 
 
@@ -553,6 +576,16 @@ def estimate_usage_cost(
     model_name: str, usage: CanonicalUsage, *, provider: Optional[str] = None,
     base_url: Optional[str] = None, api_key: Optional[str] = None,
 ) -> CostResult:
+    # Prefer provider-reported actual cost when available (e.g. Nous portal's
+    # usage.cost_details.upstream_inference_cost). Rate-table estimates can
+    # diverge significantly from billed amounts.
+    if usage.actual_cost_usd is not None:
+        return CostResult(
+            amount_usd=usage.actual_cost_usd, status="actual", source="provider_cost_api",
+            label=format_cost_label(usage.actual_cost_usd),
+            notes=("cost_details.upstream_inference_cost",),
+        )
+
     route = resolve_billing_route(model_name, provider=provider, base_url=base_url)
     if route.billing_mode == "subscription_included":
         return CostResult(

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -962,3 +962,53 @@ def test_flat_entries_unaffected_by_tier_machinery():
     )
     # 250k * $0.25/M + 10k * $1.50/M
     assert result.amount_usd == Decimal("0.0775")
+
+
+# ---------------------------------------------------------------------------
+# Provider-reported actual cost (e.g. Nous portal cost_details.upstream_inference_cost)
+# ---------------------------------------------------------------------------
+
+
+class TestProviderReportedCost:
+    """When the provider reports usage.cost_details.upstream_inference_cost,
+    Hermes should prefer it over the rate-table estimate."""
+
+    def test_normalize_extracts_upstream_inference_cost(self):
+        """normalize_usage pulls upstream_inference_cost into actual_cost_usd."""
+        usage = SimpleNamespace(
+            input_tokens=144043,
+            output_tokens=500,
+            cost_details=SimpleNamespace(upstream_inference_cost=Decimal("0.06338552")),
+        )
+        result = normalize_usage(usage, provider="nous", api_mode="chat_completions")
+        assert result.actual_cost_usd == Decimal("0.06338552")
+
+    def test_estimate_prefers_actual_over_rate_table(self):
+        """estimate_usage_cost returns status=actual when upstream cost present."""
+        usage = CanonicalUsage(
+            input_tokens=144043, output_tokens=500,
+            actual_cost_usd=Decimal("0.06338552"),
+        )
+        result = estimate_usage_cost("deepseek/deepseek-v4-flash-0731", usage, provider="nous")
+        assert result.status == "actual"
+        assert result.source == "provider_cost_api"
+        assert result.amount_usd == Decimal("0.06338552")
+        assert "cost_details.upstream_inference_cost" in result.notes
+
+    def test_dict_shaped_cost_details(self):
+        """Dict-shaped usage.cost_details is also handled."""
+        usage = SimpleNamespace(
+            input_tokens=1000,
+            output_tokens=500,
+            cost_details={"upstream_inference_cost": "0.01234"},
+        )
+        result = normalize_usage(usage, provider="nous", api_mode="chat_completions")
+        assert result.actual_cost_usd == Decimal("0.01234")
+
+    def test_missing_cost_details_falls_back_to_rate_table(self):
+        """When no upstream cost, rate-table estimate is used as before."""
+        usage = CanonicalUsage(input_tokens=1000, output_tokens=500)
+        result = estimate_usage_cost("gemini-2.5-pro", usage, provider="google")
+        # Rate-table path: source is official_docs_snapshot or similar
+        assert result.status == "estimated"
+        assert result.amount_usd is not None


### PR DESCRIPTION
## Summary

Closes #108936

The Nous portal returns the actual billed cost per call in `usage.cost_details.upstream_inference_cost`, but Hermes was ignoring it and using its own rate-table estimate, which diverges ~5x from billed amounts for models like `deepseek/deepseek-v4-flash-0731`.

## Fix

1. Add `CanonicalUsage.actual_cost_usd` field for provider-reported cost.
2. `normalize_usage()` now extracts `upstream_inference_cost` from `usage.cost_details`.
3. `estimate_usage_cost()` prefers actual cost when present (returns `status="actual"` + `source="provider_cost_api"`), falling back to rate-table estimate only when absent.

## Test plan

- `test_normalize_extracts_upstream_inference_cost` — upstream cost is extracted into `actual_cost_usd`
- `test_estimate_prefers_actual_over_rate_table` — actual cost wins when present
- `test_dict_shaped_cost_details` — dict-shaped `cost_details` handled
- `test_missing_cost_details_falls_back_to_rate_table` — rate-table fallback when no upstream cost

All 54 tests pass in `tests/agent/test_usage_pricing.py`.