### PR TITLE
Fix Telegram /save adapter lookup

### DIFF
--- a/gateway/slash_commands_session.py
+++ b/gateway/slash_commands_session.py
@@ -771,7 +771,7 @@ class GatewaySessionCommandsMixin:
                     f.write(rendered)
 
             await asyncio.to_thread(_render_and_write)
-            adapter = self.get_adapter(source.platform)
+            adapter = self.adapters.get(source.platform)
             if not adapter:
                 return "Platform adapter not found to send the document."
             await adapter.send_document(chat_id=source.chat_id, file_path=temp_path,

--- a/tests/gateway/test_109258_telegram_save_md_adapter.py
+++ b/tests/gateway/test_109258_telegram_save_md_adapter.py
@@ -1,0 +1,69 @@
+"""Regression coverage for Telegram ``/save`` adapter resolution (#109258)."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.event import MessageEvent
+from gateway.session import SessionSource
+from gateway.slash_commands_session import GatewaySessionCommandsMixin
+
+
+def _event() -> MessageEvent:
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-1",
+        user_id="user-1",
+    )
+    return MessageEvent(text="/save md filename.md", source=source)
+
+
+def _handler(adapter=None) -> GatewaySessionCommandsMixin:
+    handler = GatewaySessionCommandsMixin()
+    handler.adapters = {} if adapter is None else {Platform.TELEGRAM: adapter}
+    handler.async_session_store = SimpleNamespace(
+        get_or_create_session=AsyncMock(
+            return_value=SimpleNamespace(session_id="session-1")
+        )
+    )
+    handler._session_db = SimpleNamespace(
+        export_session=AsyncMock(
+            return_value={
+                "id": "session-1",
+                "messages": [{"role": "user", "content": "Keep this transcript."}],
+            }
+        )
+    )
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_telegram_save_md_uses_registered_adapter():
+    delivered = {}
+
+    async def send_document(**kwargs):
+        delivered.update(kwargs)
+        with open(kwargs["file_path"], encoding="utf-8") as exported:
+            delivered["content"] = exported.read()
+
+    adapter = SimpleNamespace(send_document=AsyncMock(side_effect=send_document))
+    handler = _handler(adapter)
+
+    result = await handler._handle_save_command(_event())
+
+    assert result == "Export complete."
+    assert delivered["chat_id"] == "chat-1"
+    assert delivered["file_name"] == "filename.md"
+    assert delivered["caption"] == "Session export: filename.md"
+    assert "Keep this transcript." in delivered["content"]
+
+
+@pytest.mark.asyncio
+async def test_telegram_save_md_reports_absent_adapter():
+    handler = _handler()
+
+    result = await handler._handle_save_command(_event())
+
+    assert result == "Platform adapter not found to send the document."


### PR DESCRIPTION
## What does this PR do?

Resolve `/save` adapters through the gateway's existing `adapters` registry in `gateway/slash_commands_session.py` (one-line lookup replacement). Keep the current explicit error when no adapter is registered: `Platform adapter not found to send the document.` No change to session rendering, temporary-file lifetime, or CLI `hermes sessions export`.

### Symptom

Telegram `/save md [filename.md]` failed before any document was sent: `Error exporting session: 'GatewayRunner' object has no attribute 'get_adapter'` (also seen as `GatewaySessionCommandsMixin`). Session rendering succeeded; adapter lookup blew up.

`GatewaySessionCommandsMixin._handle_save_command()` called `self.get_adapter(...)`, but the gateway runner has no such method. Other gateway paths resolve platform adapters from `self.adapters`. Expected: export Markdown and deliver it as a Telegram document when the adapter is registered. Actual: AttributeError. The same issue also mentioned a CLI `hermes sessions export` `IsADirectoryError`; this PR does not change CLI export.

Issue: https://github.com/NousResearch/hermes-agent/issues/109258

### Impact

Telegram `/save md [filename.md]` failed before any document was sent: `Error exporting session: 'GatewayRunner' object has no attribute 'get_adapter'` (also seen as `GatewaySessionCommandsMixin`). Session rendering succeeded; adapter lookup blew up.

### Bug Cause

**Trigger:** the production path described in Symptom.

**Causal chain:** the previous implementation did not enforce the invariant above.

**Why it is wrong:** operators observed the Expected vs Actual mismatch in Symptom.

**Working sibling / contrast:** neighboring paths that already honored the invariant are unchanged.

**Ruled out:** unrelated modules outside this diff.

### Fix

Resolve `/save` adapters through the gateway's existing `adapters` registry in `gateway/slash_commands_session.py` (one-line lookup replacement). Keep the current explicit error when no adapter is registered: `Platform adapter not found to send the document.`

No change to session rendering, temporary-file lifetime, or CLI `hermes sessions export`. The test uses a recording adapter and does not call the live Telegram API.

## Related Issue

Fixes #109258

## Type of Change

- ✅ Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/slash_commands_session.py` — see Fix
- `tests/gateway/test_109258_telegram_save_md_adapter.py` — see Fix

## How to Test

- ✅ `scripts/run_tests.sh` on the files in Changes Made — focused verification
- ✅ Focused verification completed on this branch
- ✅ `scripts/run_tests.sh tests/gateway/test_109258_telegram_save_md_adapter.py`
- ✅ The happy-path case runs real session Markdown export and asserts the recording Telegram adapter receives a document (filename + bytes). Before the production change both tests failed with `has no attribute 'get_adapter'`.
- ✅ The absent-adapter control proves a missing registry entry still returns `Platform adapter not found to send the document.` instead of an AttributeError or a silent no-op.

## Checklist

### Code

- ✅ I've read the Contributing Guide
- ✅ My commit messages follow Conventional Commits
- ✅ I searched for existing PRs to make sure this isn't a duplicate
- ✅ My PR contains only changes related to this fix
- ✅ I've run relevant tests locally (see How to Test)
- ✅ I've added tests for my changes
- ✅ I've tested on my platform: macOS

### Documentation & Housekeeping

- ✅ Documentation update: N/A unless noted in Changes Made
- ✅ `cli-config.yaml.example`: N/A
- ✅ `CONTRIBUTING.md` or `AGENTS.md`: N/A
- ✅ Cross-platform impact considered
- ✅ Tool descriptions/schemas: N/A

