### PR TITLE
fix(desktop): treat Windows drive and UNC paths as absolute in local previews

### DIFF
--- a/apps/desktop/src/lib/local-preview.test.ts
+++ b/apps/desktop/src/lib/local-preview.test.ts
@@ -197,3 +197,27 @@ describe('PDF previews', () => {
     expect(readDesktopFileDataUrl).not.toHaveBeenCalled()
   })
 })
+
+describe('absolute local paths on Windows', () => {
+  const cwd = 'C:\\Users\\dev'
+
+  it('keeps a drive-letter path with backslashes intact', () => {
+    expect(localPreviewTarget('C:\\Users\\dev\\Desktop\\notes.md', cwd)?.path).toBe(
+      'C:\\Users\\dev\\Desktop\\notes.md'
+    )
+  })
+
+  it('keeps a drive-letter path with forward slashes intact', () => {
+    expect(localPreviewTarget('C:/Users/dev/Desktop/notes.md', cwd)?.path).toBe(
+      'C:/Users/dev/Desktop/notes.md'
+    )
+  })
+
+  it('keeps a UNC path intact', () => {
+    expect(localPreviewTarget('\\\\server\\share\\notes.md', cwd)?.path).toBe('\\\\server\\share\\notes.md')
+  })
+
+  it('still resolves a genuinely relative path against the cwd', () => {
+    expect(localPreviewTarget('notes.md', cwd)?.path).toBe('C:\\Users\\dev/notes.md')
+  })
+})

--- a/apps/desktop/src/lib/local-preview.ts
+++ b/apps/desktop/src/lib/local-preview.ts
@@ -64,6 +64,13 @@ function joinPath(base: string, rel: string) {
   return `${base.replace(/\/+$/, '')}/${rel.replace(/^\.?\//, '')}`
 }
 
+// Absolute local paths are not POSIX-only: Windows drive letters (`C:\`, `C:/`) and UNC
+// shares (`\\server\share`) are absolute too. Testing only for a leading `/` treated them as
+// relative, so joinPath prefixed the cwd onto an already-absolute path — a path that cannot
+// exist, surfacing as "Text preview failed: file does not exist" from hermes:readFileText.
+// Kept in sync with the Windows detection in pathToFileUrl below.
+const ABSOLUTE_LOCAL_PATH = /^(?:\/|[a-z]:[\\/]|\\\\)/i
+
 function pathToFileUrl(path: string) {
   const isWindowsUnc = path.startsWith('\\\\')
   const normalized = isWindowsUnc || /^[a-z]:[\\/]/i.test(path) ? path.replace(/\\/g, '/') : path
@@ -197,7 +204,7 @@ export function localPreviewTarget(rawTarget: string, cwd?: string | null): Prev
     } catch {
       path = raw.replace(/^file:\/\//i, '')
     }
-  } else if (!raw.startsWith('/') && cwd) {
+  } else if (!ABSOLUTE_LOCAL_PATH.test(raw) && cwd) {
     path = joinPath(cwd, raw)
   }
 


### PR DESCRIPTION
## What / why

`localPreviewTarget()` decided "is this path absolute?" by testing for a leading `/` only. On Windows a drive-letter path (`C:\Users\me\notes.md`, or `C:/Users/me/notes.md`) therefore fell into the cwd-relative branch, and `joinPath()` prefixed the cwd onto an already-absolute path:

```
input:    C:\Users\me\Desktop\notes.md     (cwd = C:\Users\me)
resolved: C:\Users\me/C:\Users\me/Desktop/notes.md
```

That path cannot exist, so opening any local file from a chat message failed with:

```
Error invoking remote method 'hermes:readFileText':
Error: Text preview failed: file does not exist.
```

Reproduced on Windows 11 with Hermes 0.21.2, opening a `.md` file whose path appears in a chat message. POSIX paths are unaffected (they start with `/` and never entered the branch).

## Fix

`apps/desktop/src/lib/local-preview.ts`

- Add `ABSOLUTE_LOCAL_PATH = /^(?:\/|[a-z]:[\\/]|\\\\)/i` — recognizes POSIX-absolute, drive-letter (either separator), and UNC forms. This mirrors the Windows detection `pathToFileUrl()` in the same module already uses, so the two agree.
- Use it in place of `!raw.startsWith('/')`.

Genuinely relative paths still resolve against `cwd`; the `file://` branch is untouched.

## How to test

Unit (platform-independent):

```
cd apps/desktop && npx vitest run src/lib/local-preview.test.ts
```

Result here: **21 passed** (17 existing + 4 added: drive letter with backslashes, drive letter with forward slashes, UNC path, and a relative path that must still join with cwd — the last one guards against over-correcting).

Manual (Windows):

1. Put any local file path in a chat message, e.g. `C:\Users\me\Desktop\notes.md`.
2. Click it so the preview rail opens it.
3. Before: `Text preview failed: file does not exist`. After: the file renders.

The same file with a POSIX path (`/tmp/notes.md`) behaves identically before and after.

## Platforms tested

Windows 11 (where the bug reproduces). The change is platform-neutral — it only widens the "absolute" predicate; both the POSIX branch and the relative-path branch are covered by the tests above.
