### PR TITLE
fix(approval): only the documented words grant; anything else is a denial

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -894,7 +894,9 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         approval = _optional_module("tools.approval", "[whatsapp_cloud] approval resolver unavailable")
         if approval is None:
             return False
-        count = approval.resolve_gateway_approval(session_key, choice)
+        # The button id carries "approve"/"deny"; the approval gate's vocabulary is once/session/always/deny
+        # and grants on nothing else, so send the word it documents ("approve" is a one-shot allow).
+        count = approval.resolve_gateway_approval(session_key, "once" if choice == "approve" else choice)
         # A tap after the wait timed out (count == 0) must not claim approval:
         # the command was already denied fail-closed.
         if count:

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1121,7 +1121,9 @@ class TestDispatchInteractiveReplyApproval:
         handled = await adapter._dispatch_interactive_reply(raw, {})
 
         assert handled is True
-        assert calls == [("sess-app-1", "approve")]
+        # The Approve button id still says "approve"; the word sent to the approval gate must be
+        # one the gate's vocabulary grants on ("once" — a tap is a one-shot allow).
+        assert calls == [("sess-app-1", "once")]
         assert "app1" not in adapter._exec_approval_state
         confirm_payload = adapter._http_client.post.call_args.kwargs["json"]
         assert confirm_payload["type"] == "text"
@@ -1204,7 +1206,9 @@ class TestDispatchInteractiveReplyAuthorization:
         handled = await adapter._dispatch_interactive_reply(raw, {})
 
         assert handled is True
-        assert calls == [("sess-app-1", "approve")]
+        # The Approve button id still says "approve"; the word sent to the approval gate must be
+        # one the gate's vocabulary grants on ("once" — a tap is a one-shot allow).
+        assert calls == [("sess-app-1", "once")]
 
 
 @pytest.mark.usefixtures("authorized_interactive_env")

--- a/tests/tools/test_approval_out_of_vocabulary.py
+++ b/tests/tools/test_approval_out_of_vocabulary.py
@@ -1,0 +1,206 @@
+"""The approval vocabulary is a contract, not a comment: only the documented words grant.
+
+``prompt_dangerous_approval`` documents ``once | session | always | deny | timeout``, but the three
+decision points in ``tools/approval.py`` used to grant on anything that was not exactly a refusal.
+So an answer the gate did not recognise — ``None`` from a callback whose UI went away, ``""`` from a
+cancelled prompt, ``"no"``/``"approve"`` from a third-party callback, plugin transport or platform
+button written to the obvious rather than the documented word — APPROVED the dangerous command.
+
+These tests pin the contract in both directions on all three answer channels (CLI approval callback,
+gateway ``resolve_gateway_approval``, selected plugin transport): every documented granting word
+still grants, ``deny``/``timeout`` refuse, and everything outside the vocabulary refuses too.
+Silence and confusion are not consent.
+"""
+import os
+import threading
+import time
+
+import pytest
+
+from tools import approval as approval_module
+from tools import approval_context
+from tools.approval_detection import detect_dangerous_command
+
+# The documented vocabulary. Only the first three may ever produce approved=True.
+GRANTING = ["once", "session", "always"]
+REFUSING = ["deny", "timeout"]
+
+#: Answers no surface is allowed to turn into consent. ``"approve"``/``"allow"``/``"yes"`` are the
+#: words a callback author reaches for instead of the documented ones; ``""``/``None`` are what a
+#: cancelled or vanished prompt produces; the rest are junk that must never read as a grant.
+OUT_OF_VOCABULARY = ["", "   ", "no", "n", "y", "yes", "approve", "allow", "ok", "cancelled",
+                     "null", "None", "granted", "once please", "deny\nonce", "\x00", "0", "1",
+                     None, 0, 1, True, [], {"choice": "once"}]
+
+DANGEROUS = "rm -rf /tmp/hermes-approval-vocabulary-test"
+
+
+def _reset_approval_state():
+    approval_module._session_approved.clear()
+    approval_module._permanent_approved.clear()
+    approval_module._gateway_queues.clear()
+    approval_module._gateway_notify_cbs.clear()
+    approval_module._pending.clear()
+
+
+@pytest.fixture(autouse=True)
+def _manual_approvals(monkeypatch, request):
+    """A dangerous command with no cached approval, in manual mode, so every test reaches a human.
+
+    Each test gets its own session key: a ``session``/``always`` grant is remembered, and a cached
+    approval would short-circuit the next test before it ever asked.
+    """
+    session_key = f"test:vocab:{request.node.name}"
+    monkeypatch.setenv("HERMES_SESSION_KEY", session_key)
+    monkeypatch.setattr(approval_context, "_get_approval_config",
+                        lambda: {"mode": "manual", "timeout": 5})
+    _reset_approval_state()
+    try:
+        yield session_key
+    finally:
+        _reset_approval_state()
+
+
+def _guard(**kwargs) -> dict:
+    return approval_module.check_all_command_guards(DANGEROUS, "local", **kwargs)
+
+
+# ── Channel 1: the interactive CLI approval callback ────────────────────────
+
+
+@pytest.fixture
+def _cli(monkeypatch):
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+
+
+@pytest.mark.usefixtures("_cli")
+@pytest.mark.parametrize("answer", GRANTING)
+def test_cli_callback_granting_word_still_grants(answer):
+    """The fix must not break the gate it protects: the documented words keep working."""
+    assert _guard(approval_callback=lambda *a, **k: answer)["approved"] is True
+
+
+@pytest.mark.usefixtures("_cli")
+@pytest.mark.parametrize("answer", GRANTING)
+def test_cli_callback_granting_word_survives_whitespace_and_case(answer):
+    assert _guard(approval_callback=lambda *a, **k: f"  {answer.upper()}  ")["approved"] is True
+
+
+@pytest.mark.usefixtures("_cli")
+@pytest.mark.parametrize("answer", REFUSING)
+def test_cli_callback_refusing_word_refuses(answer):
+    assert _guard(approval_callback=lambda *a, **k: answer)["approved"] is False
+
+
+@pytest.mark.usefixtures("_cli")
+@pytest.mark.parametrize("answer", OUT_OF_VOCABULARY)
+def test_cli_callback_outside_the_vocabulary_refuses(answer):
+    result = _guard(approval_callback=lambda *a, **k: answer)
+    assert result["approved"] is False, f"{answer!r} must not approve {DANGEROUS!r}"
+    assert result.get("user_consent") is not True
+
+
+@pytest.mark.usefixtures("_cli")
+def test_a_callback_that_raises_refuses():
+    def boom(*a, **k):
+        raise RuntimeError("the approval UI died")
+
+    assert _guard(approval_callback=boom)["approved"] is False
+
+
+@pytest.mark.usefixtures("_cli")
+@pytest.mark.parametrize("answer", OUT_OF_VOCABULARY)
+def test_an_unrecognised_answer_is_not_remembered(answer):
+    """A refused answer must leave no cached approval behind: the next command has to ask again."""
+    _guard(approval_callback=lambda *a, **k: answer)
+    assert _guard(approval_callback=lambda *a, **k: "deny")["approved"] is False
+    pattern_key = detect_dangerous_command(DANGEROUS)[1]
+    assert approval_module.is_approved(os.environ["HERMES_SESSION_KEY"], pattern_key) is False
+
+
+# ── Channel 2: the gateway queue (/approve, a button tap, an RPC client) ────
+
+
+@pytest.fixture
+def _gateway(monkeypatch):
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+
+
+def _answer_through_the_gateway(session_key: str, choice) -> dict:
+    """Run the gate on a worker thread and answer its pending prompt with *choice*."""
+    notified: list = []
+    approval_module.register_gateway_notify(session_key, notified.append)
+    holder: dict = {}
+    worker = threading.Thread(target=lambda: holder.update(result=_guard()))
+    worker.start()
+    try:
+        for _ in range(500):  # the waiter enqueues before notify returns
+            if approval_module._gateway_queues.get(session_key):
+                break
+            time.sleep(0.01)
+        assert approval_module.resolve_gateway_approval(session_key, choice) == 1, (
+            "no waiter to answer — the gate never asked")
+        worker.join(timeout=10)
+    finally:
+        approval_module.register_gateway_notify(session_key, None)
+    assert notified, "a dangerous command with a gateway listener MUST raise a prompt"
+    assert "result" in holder, "the approval wait never returned"
+    return holder["result"]
+
+
+@pytest.mark.usefixtures("_gateway")
+@pytest.mark.parametrize("choice", GRANTING)
+def test_gateway_granting_word_still_grants(_manual_approvals, choice):
+    assert _answer_through_the_gateway(_manual_approvals, choice)["approved"] is True
+
+
+@pytest.mark.usefixtures("_gateway")
+@pytest.mark.parametrize("choice", REFUSING)
+def test_gateway_refusing_word_refuses(_manual_approvals, choice):
+    assert _answer_through_the_gateway(_manual_approvals, choice)["approved"] is False
+
+
+@pytest.mark.usefixtures("_gateway")
+@pytest.mark.parametrize("choice", OUT_OF_VOCABULARY)
+def test_gateway_answer_outside_the_vocabulary_refuses(_manual_approvals, choice):
+    result = _answer_through_the_gateway(_manual_approvals, choice)
+    assert result["approved"] is False, f"{choice!r} must not approve {DANGEROUS!r}"
+    assert result.get("user_consent") is not True
+
+
+# ── Channel 3: an operator-selected plugin approval transport ───────────────
+
+
+def _fake_transport(monkeypatch, choice):
+    """Stand in for a selected transport that answered *choice* (no plugin machinery needed)."""
+    monkeypatch.setattr(approval_module, "_present_with_selected_transport",
+                        lambda **kwargs: {"selected": True, "choice": choice,
+                                          "failure": None, "fallback": None, "name": "fake"})
+
+
+@pytest.mark.usefixtures("_cli")
+@pytest.mark.parametrize("choice", GRANTING)
+def test_transport_granting_word_still_grants(monkeypatch, choice):
+    _fake_transport(monkeypatch, choice)
+    assert _guard()["approved"] is True
+
+
+@pytest.mark.usefixtures("_cli")
+@pytest.mark.parametrize("choice", REFUSING)
+def test_transport_refusing_word_refuses(monkeypatch, choice):
+    _fake_transport(monkeypatch, choice)
+    assert _guard()["approved"] is False
+
+
+# ``None`` is excluded: it is the transport's documented "no transport selected" signal, which falls
+# through to the built-in surfaces rather than deciding anything.
+@pytest.mark.usefixtures("_cli")
+@pytest.mark.parametrize("choice", [a for a in OUT_OF_VOCABULARY if a is not None])
+def test_transport_answer_outside_the_vocabulary_refuses(monkeypatch, choice):
+    _fake_transport(monkeypatch, choice)
+    result = _guard(approval_callback=lambda *a, **k: "once")  # must never be consulted
+    assert result["approved"] is False, f"{choice!r} must not approve {DANGEROUS!r}"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -35,7 +35,8 @@ from tools.approval_floors import (
     _user_deny_block_result,
 )
 from tools.approval_gateway_wait import _await_gateway_decision
-from tools.approval_prompt import _present_with_selected_transport, _transport_choice, prompt_dangerous_approval
+from tools.approval_prompt import (_canonical_choice, _GRANTING_CHOICES, _present_with_selected_transport,
+                                   _transport_choice, prompt_dangerous_approval)
 from tools.approval_smart import _smart_verdict
 
 logger = logging.getLogger(__name__)
@@ -722,6 +723,8 @@ def _human_decision(spec: _GateSpec, *, command: str, description: str,
                        outcome=outcome, **extra)
 
     def grant(choice: str) -> dict:
+        # Only the documented granting words reach here: every site below canonicalises its answer first
+        # (an unrecognised one is a denial, never consent — see approval_prompt._canonical_choice).
         # A smart-DENY owner override is always one operation, even if an older client returns "session" or "always".
         if not smart_denied:
             _persist_choice(session_key, choice, warnings)
@@ -739,7 +742,8 @@ def _human_decision(spec: _GateSpec, *, command: str, description: str,
         if denied is not None:
             return denied
         if choice is not None:
-            if choice == "deny":
+            choice = _canonical_choice(choice)
+            if choice not in _GRANTING_CHOICES:
                 _record_denial(session_key)
                 return deny(spec.transport_denied, "denied")
             return grant(choice)
@@ -776,7 +780,8 @@ def _human_decision(spec: _GateSpec, *, command: str, description: str,
                 return deny(spec.gateway_refused, "timeout", reason="timed out without user response",
                             reason_addendum="", timeout_addendum=" Silence is not consent.",
                             deny_reason=deny_reason)
-            if choice is None or choice == "deny":
+            choice = _canonical_choice(choice)  # /approve, a button tap or an RPC client may say anything
+            if choice not in _GRANTING_CHOICES:
                 return deny(spec.gateway_refused, "denied", reason="denied by user",
                             reason_addendum=(f' Reason given by the user: "{deny_reason}".' if deny_reason else ""),
                             timeout_addendum="", deny_reason=deny_reason)
@@ -803,12 +808,13 @@ def _human_decision(spec: _GateSpec, *, command: str, description: str,
     hook_kwargs = dict(command=prompt_command, description=prompt_description, pattern_key=pattern_key,
                        pattern_keys=list(pattern_keys), session_key=session_key, surface="cli")
     approval_context._fire_approval_hook("pre_approval_request", **hook_kwargs)
-    choice = prompt_dangerous_approval(prompt_command, prompt_description, allow_permanent=allow_permanent,
-                                       smart_denied=smart_denied, approval_callback=approval_callback)
+    choice = _canonical_choice(prompt_dangerous_approval(
+        prompt_command, prompt_description, allow_permanent=allow_permanent,
+        smart_denied=smart_denied, approval_callback=approval_callback))
     approval_context._fire_approval_hook("post_approval_response", **hook_kwargs, choice=choice)
     if choice == "timeout":
         return deny(spec.cli_timeout, "timeout")
-    if choice == "deny":
+    if choice not in _GRANTING_CHOICES:
         # No _record_denial(): the breaker counts consecutive guardian LLM
         # DENY verdicts, not deliberate human denials.
         return deny(spec.cli_denied, "denied")

--- a/tools/approval_prompt.py
+++ b/tools/approval_prompt.py
@@ -34,7 +34,8 @@ def prompt_dangerous_approval(command: str, description: str, timeout_seconds: i
 
     Returns 'once', 'session', 'always', 'deny', or 'timeout'. 'timeout' means no
     user response — still blocked (fail-closed), but callers report "no response"
-    rather than an explicit denial.
+    rather than an explicit denial. The vocabulary is enforced, not merely
+    documented: an answer outside it (including a callback's) becomes 'deny'.
 
     See #81887.
     """
@@ -78,6 +79,29 @@ def _read_choice(prompt: str, timeout_seconds: int) -> str | None:
     return None if thread.is_alive() else result["choice"]
 
 
+_GRANTING_CHOICES = frozenset({"once", "session", "always"})
+_CANONICAL_CHOICES = _GRANTING_CHOICES | frozenset({"deny", "timeout"})
+
+
+def _canonical_choice(answer) -> str:
+    """Map an answer onto the documented vocabulary, denying anything else.
+
+    The decision sites in ``tools/approval.py`` grant unless the answer is a known refusal, so a
+    value nothing recognises — ``None`` from a callback that lost its UI, ``""`` from a cancelled
+    prompt, ``"no"`` from a third-party or plugin callback written to the obvious rather than the
+    documented word — used to APPROVE the operation. Silence and confusion are not consent; only
+    the listed words are.
+    """
+    if isinstance(answer, str):
+        normalized = answer.strip().lower()
+        normalized = _CLI_CHOICE_ALIASES.get(normalized, normalized)
+        if normalized in _CANONICAL_CHOICES:
+            return normalized
+    logger.warning("Approval answer %r is not one of %s; treating it as a denial.",
+                   answer, sorted(_CANONICAL_CHOICES))
+    return "deny"
+
+
 def _ask_human(command: str, description: str, timeout_seconds: int, allow_permanent: bool,
                approval_callback, allow_session: bool, smart_denied: bool) -> str:
     # Redact before any user-visible rendering; the original `command` still executes after approval. Same redactor as
@@ -94,7 +118,7 @@ def _ask_human(command: str, description: str, timeout_seconds: int, allow_perma
             callback_kwargs = {"allow_permanent": allow_permanent,
                                **({"allow_session": False} if not allow_session else {}),
                                **({"smart_denied": True} if smart_denied else {})}
-            return approval_callback(display_command, display_description, **callback_kwargs)
+            return _canonical_choice(approval_callback(display_command, display_description, **callback_kwargs))
         except Exception as e:
             logger.error("Approval callback failed: %s", e, exc_info=True)
             return "deny"


### PR DESCRIPTION
## What

`prompt_dangerous_approval` documents its answer vocabulary as `once | session | always | deny | timeout`, but nothing enforced it. The three decision points in `_human_decision` (selected plugin transport, gateway queue, CLI prompt) each granted on **every** answer that was not exactly a known refusal, and `grant()` only ever returns an approval. So any answer the gate did not recognise **approved the dangerous command**:

- `None` from a callback whose UI went away, or `""` from a cancelled prompt (`_read_choice`'s exception path returns `""`);
- `"no"` / `"yes"` / `"cancelled"` from a third-party or plugin callback, an approval transport, or a gateway client written to the obvious word rather than the documented one;
- `"timeout"` arriving as a transport's or gateway client's *choice* — a refusal on the CLI path, a grant on the other two.

Silence and confusion are not consent; only the listed words are.

## Fix

`_canonical_choice` normalises an answer (strip/lower, plus the existing CLI letter aliases) and returns `deny` for anything outside the vocabulary, logging what it refused. It is applied to the approval callback's answer and at all three decision points, which now grant only on `once` / `session` / `always`.

Sibling call paths, per the contribution rubric: the WhatsApp Cloud adapter was the one shipped surface speaking a non-canonical dialect — its Approve button resolved with the word `"approve"`, which granted only because the gate accepted anything. It now sends `"once"` (a tap is a one-shot allow); the button id is unchanged.

## Tests

`tests/tools/test_approval_out_of_vocabulary.py` pins the contract in both directions on all three channels: every granting word still grants, `deny` / `timeout` still refuse, and every out-of-vocabulary answer refuses.

Proven red on base — the same file applied to the parent commit (`044a77b3b6`, current `main`) with the fix reverted:

```
42 passed, 72 failed
>  assert result["approved"] is False, f"{answer!r} must not approve {DANGEROUS!r}"
E  assert True is False
```

Green with the fix: **114 passed, 0 failed** (`scripts/run_tests.sh tests/tools/test_approval_out_of_vocabulary.py`).

## Blast radius

Honest reading: the shipped CLI/TUI callbacks all return canonical tokens, so no current user is exposed through them — the hole was one non-conforming callback away. The WhatsApp Cloud Approve button was the exception: it worked *only* because the gate accepted anything, and it is fixed here.

## Interaction with #22578

#22578 ("configurable approval aliases") adds configurable accepted words, in `gateway/config.py` and `gateway/run.py`. If it lands, the alias mapping should feed `_canonical_choice` (an alias is just another way to spell a documented word) rather than being consulted by the grant check — otherwise a configured alias would again be able to widen what grants. Happy to rebase either way.
