### PR TITLE
fix(desktop): bump Electron 40.10.2 → 42.10.1 to fix macOS print-dialog crash (SIGSEGV in PrintCore)

### DIFF
--- a/apps/desktop/electron/desktop-electron-pin.test.ts
+++ b/apps/desktop/electron/desktop-electron-pin.test.ts
@@ -107,3 +107,23 @@ test('lockfile resolves the pinned electron', () => {
     )
   }
 })
+
+// electron#50827: when UpdatePrinterSettings() fails while prefilling the
+// native macOS print dialog, Electron passed nil to
+// -[NSPrintPanel runModalWithPrintInfo:] and the app crashed in PrintCore
+// (PJCSessionHasApplicationSetPrinter) the moment the dialog was built —
+// every print click in the preview pane crashed Hermes desktop on macOS 26
+// (Hermes#101880). Fixed by electron#50843 (commit 3edba12), backported to
+// 41-x-y (#51728) and 42-x-y (#50853). There is no 40-x-y backport, so any
+// 40.x pin re-ships the crash.
+test('pinned electron carries the print-dialog crash fix (electron#50843)', () => {
+  const spec = electronSpec(desktopPkg())
+  const major = Number.parseInt(spec.split('.')[0] ?? '', 10)
+
+  assert.ok(
+    major >= 41,
+    `electron pin "${spec}" predates the print-dialog crash fix ` +
+      '(electron#50843, backported to 41-x-y in #51728; no 40-x-y backport — ' +
+      'crashes every macOS print via Hermes#101880). Do not downgrade to 40.x.'
+  )
+})

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -175,7 +175,7 @@
     "bippy": "0.5.43",
     "concurrently": "10.0.4",
     "cross-env": "10.1.0",
-    "electron": "40.10.2",
+    "electron": "42.10.1",
     "electron-builder": "26.15.3",
     "esbuild": "0.28.1",
     "jsdom": "29.1.1",
@@ -188,7 +188,7 @@
     "wait-on": "9.0.10"
   },
   "build": {
-    "electronVersion": "40.10.2",
+    "electronVersion": "42.10.1",
     "appId": "com.nousresearch.hermes",
     "productName": "Hermes",
     "executableName": "Hermes",

--- a/contributors/emails/mchughson@sportsculture.io
+++ b/contributors/emails/mchughson@sportsculture.io
@@ -1,0 +1,2 @@
+sportsculture
+# PR #109268 author

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
     },
     "apps/bootstrap-installer": {
       "name": "@hermes/bootstrap-installer",
-      "version": "0.0.1",
+      "version": "0.21.1",
       "dependencies": {
         "@nous-research/ui": "0.18.2",
         "@tailwindcss/typography": "0.5.20",
@@ -160,7 +160,7 @@
         "bippy": "0.5.43",
         "concurrently": "10.0.4",
         "cross-env": "10.1.0",
-        "electron": "40.10.2",
+        "electron": "42.10.1",
         "electron-builder": "26.15.3",
         "esbuild": "0.28.1",
         "jsdom": "29.1.1",
@@ -414,28 +414,6 @@
         "node": "^22.18.0 || >=24.11.0"
       }
     },
-    "apps/desktop/node_modules/@electron/get": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "env-paths": "^2.2.0",
-        "fs-extra": "^8.1.0",
-        "got": "^11.8.5",
-        "progress": "^2.0.3",
-        "semver": "^6.2.0",
-        "sumchecker": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "global-agent": "^3.0.0"
-      }
-    },
     "apps/desktop/node_modules/@rolldown/plugin-babel": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@rolldown/plugin-babel/-/plugin-babel-0.2.3.tgz",
@@ -481,35 +459,6 @@
         }
       }
     },
-    "apps/desktop/node_modules/electron": {
-      "version": "40.10.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-40.10.2.tgz",
-      "integrity": "sha512-Xj3Hy0Imbu4g0gDIW55w/jJYz94nMO2JRSGYA3LyAn5SwaERCelgZrA21vfH+Bi//SWAWQXddHsMwCqauyMT8g==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@electron/get": "^2.0.0",
-        "@types/node": "^24.9.0",
-        "extract-zip": "^2.0.1"
-      },
-      "bin": {
-        "electron": "cli.js"
-      },
-      "engines": {
-        "node": ">= 12.20.55"
-      }
-    },
-    "apps/desktop/node_modules/electron/node_modules/@types/node": {
-      "version": "24.13.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
-      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.18.0"
-      }
-    },
     "apps/desktop/node_modules/ignore": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
@@ -535,13 +484,6 @@
       "engines": {
         "node": "20 || >=22"
       }
-    },
-    "apps/desktop/node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
-      "license": "MIT"
     },
     "apps/shared": {
       "name": "@hermes/shared",
@@ -1671,6 +1613,16 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.5.tgz",
+      "integrity": "sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/@electron/asar": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
@@ -1800,6 +1752,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.1.0.tgz",
+      "integrity": "sha512-3kSBtG8ObcTVfXanm5vVJ6UnBLEVmVsRk1M+vGqCuMBV+XLCbJYuWQful+yIy0GQDsSlK0kHEriEHn7SPk4EnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
+        "progress": "^2.0.3",
+        "semver": "^7.6.3",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "optionalDependencies": {
+        "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@electron/get/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@electron/get/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@electron/notarize": {
@@ -2139,7 +2138,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2156,7 +2154,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2173,7 +2170,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2190,7 +2186,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2207,7 +2202,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2224,7 +2218,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2241,7 +2234,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2258,7 +2250,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2275,7 +2266,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2292,7 +2282,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2309,7 +2298,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2326,7 +2314,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2343,7 +2330,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2360,7 +2346,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2377,7 +2362,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2394,7 +2378,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2411,7 +2394,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2428,7 +2410,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2445,7 +2426,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2462,7 +2442,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2479,7 +2458,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2496,7 +2474,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2513,7 +2490,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2530,7 +2506,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2547,7 +2522,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2564,7 +2538,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6915,17 +6888,6 @@
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "license": "MIT"
     },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.64.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.64.0.tgz",
@@ -9986,6 +9948,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/electron": {
+      "version": "42.10.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.10.1.tgz",
+      "integrity": "sha512-ITc1HPeoDzsxCCaH6MFsN67Nq2nUiJf5N9pBWxzhUpFfKJF0IwiAkKT3emg1lPbvC4OfFE+Cdwe4vhgdOZ1YKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
+      },
+      "bin": {
+        "electron": "cli.js",
+        "install-electron": "install.js"
+      },
+      "engines": {
+        "node": ">= 22.12.0"
+      }
+    },
     "node_modules/electron-builder": {
       "version": "26.15.3",
       "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.3.tgz",
@@ -10362,6 +10343,23 @@
       "engines": {
         "node": ">=6 <7 || >=8"
       }
+    },
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/electron/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
@@ -10908,27 +10906,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -11189,21 +11166,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
       }
     },
     "node_modules/fs.realpath": {
@@ -15492,13 +15454,6 @@
         "url": "https://github.com/sponsors/jet2jet"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -18049,7 +18004,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -19357,19 +19311,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
-      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "esbuild@0.28.1": true,
     "node-pty@1.1.0": true,
     "electron-winstaller@5.4.0": true,
-    "electron@40.10.2": true,
+    "electron@42.10.1": true,
     "fsevents@2.3.2": true,
     "fsevents@2.3.3": true,
     "get-windows@9.3.0": true


### PR DESCRIPTION
Fixes #101880

## What does this PR do?

Bumps the desktop app's Electron pin from **40.10.2 → 42.10.1** so the macOS print
dialog carries the upstream fix for the crash behind #101880.

**The bug:** printing from the desktop preview pane (PDF file previews, Google Docs —
anything that opens Chromium's print dialog) crashes the whole app with `SIGSEGV` in
macOS PrintCore (`PJCSessionHasApplicationSetPrinter`) while `NSPrintPanel
runModalWithPrintInfo:` builds the dialog. Root cause is upstream:
[electron/electron#50827](https://github.com/electron/electron/issues/50827) — when
`UpdatePrinterSettings()` fails, `OnError()` nullifies `print_info_` and
`AskUserForSettings()` passes nil to `runModalWithPrintInfo:`. Fixed by
[electron/electron#50843](https://github.com/electron/electron/pull/50843)
("avoid crash in `window.print()` when prefilling native print dialog", commit
`3edba12`), backported to **41-x-y** (#51728) and **42-x-y** (#50853). There is **no
40-x-y backport**, and the app pinned `electron: 40.10.2` exactly — so every shipped
build crashes on print.

**Receipts (matching signature on three machines):**

- Issue #101880: macOS 26.5.2 / Hermes 0.17.0 — `KERN_INVALID_ADDRESS at 0x148`
- Issue #101880 comment (lordjc): macOS 26.2 / Electron 40.10.2 — `0x100`, two crashes 10s apart
- This PR's author: macOS 26.6.2 / Hermes 0.17.0 — `0x148`, crashes on every print click
  (`Hermes-2026-09-12-094305.ips`, `Hermes-2026-09-12-094546.ips`), top frames identical:
  `PrintCore PJCSessionHasApplicationSetPrinter` → `PrintingUI` →
  `AppKit -[NSWindowController _windowDidLoad]` → `-[NSPrintPanel runModalWithPrintInfo:]`
  → `Electron Framework` (main-queue dispatch)

## Changes Made

- `apps/desktop/package.json`: `electron` `40.10.2` → `42.10.1` and `build.electronVersion` to match
- `package.json` (root): `allowScripts` pin `electron@40.10.2` → `electron@42.10.1`
- `package-lock.json`: regenerated with `npm install --package-lock-only`
- `apps/desktop/electron/desktop-electron-pin.test.ts`: new invariant test — the pin must
  carry the print-crash fix (electron ≥ 41); red on the old pin, documents why 40.x is
  not safe to return to

**Why 42.10.1 specifically:** the repo's `.npmrc` enforces `min-release-age=14`, so the
newest 42.x (42.11.3, released 2026-09-08) cannot resolve yet; 42.10.1 (2026-08-25)
clears the gate and contains the fix (both backports predate every 42.x stable).
Rides Chromium 148.0.7778.280 (from 144). The Electron 41/42 native
`@electron-internal/extract-zip` install path — the reason the pin originally froze at
40.10.2 (see `desktop-electron-pin.test.ts` header) — now resolves via `@electron/get`
5.1.0 + extract-zip 1.0.5, and full `npm ci` with scripts passes on Linux (Node 26).
The historical Node-26 install failure (#51619) was fixed in June and is labeled
42-x-y; this repo's CI also installs on Node 26.

## How to Test

1. `npm ci` in the repo root (with scripts, as CI does) — Electron 42.10.1 downloads and unpacks cleanly
2. `node .github/scripts/run-workspace-checks.mjs` — all workspace checks pass
3. On macOS: open a PDF (or a Google Doc) in the desktop preview pane, click Print —
   the print dialog opens instead of hard-crashing the app

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
