### PR TITLE
fix(profiles): rename under a live multiplexer no longer resurrects the old name

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1657,9 +1657,26 @@ def rename_profile(old_name: str, new_name: str) -> Path:
         _cleanup_gateway_service(old_canon, old_dir)
         _stop_gateway_process(old_dir)
 
+    # 1b. Unroute the old name from a live multiplexer BEFORE the rename. A multiplexed
+    # secondary has no gateway.pid of its own, so the check above reports it stopped while
+    # the default gateway still holds its adapters, cron ticker, logging and SQLite handles.
+    # Tombstone + notify so the multiplexer stops those adapters and releases its handles
+    # into old_dir; without it the live components immediately re-``mkdir`` the old home
+    # (no tombstone → ``mkdir_under_hermes_home`` does not refuse it) and the periodic
+    # reconcile re-adopts the resurrected dir as a ghost served profile.
+    served_by_mux = _served_by_running_multiplexer(old_canon)
+    if served_by_mux:
+        mark_named_profile_deleted(old_dir)
+        _notify_multiplexer(old_canon)
+
     # 2. Rename directory
     old_dir.rename(new_dir)
     print(f"✓ Renamed {old_dir.name} → {new_dir.name}")
+    # The tombstone lived at profiles/.deleted/<old_name>; old_dir is gone now so it can no
+    # longer resurrect, and new_dir carries no tombstone. Clear the stale marker so a future
+    # profile reusing the old name is not treated as deleted.
+    if served_by_mux:
+        clear_named_profile_deleted(old_dir)
 
     # 3. Update profile-scoped Honcho host blocks, preserving aiPeer identity
     _migrate_honcho_profile_host(old_canon, new_canon, new_dir)
@@ -1675,6 +1692,11 @@ def rename_profile(old_name: str, new_name: str) -> Path:
 
     # 5. Update active_profile if it pointed to old name
     _retarget_active_profile(old_canon, new_canon, f"✓ Active profile updated: {new_canon}")
+
+    # 6. Ask a live multiplexer to hot-serve the renamed profile now (mirrors create); it
+    # also rescans periodically, so a missed signal only delays serving.
+    if served_by_mux:
+        _notify_multiplexer(new_canon)
     return new_dir
 
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1669,8 +1669,16 @@ def rename_profile(old_name: str, new_name: str) -> Path:
         mark_named_profile_deleted(old_dir)
         _notify_multiplexer(old_canon)
 
-    # 2. Rename directory
-    old_dir.rename(new_dir)
+    # 2. Rename directory. If the move fails (cross-device EXDEV, permissions, a racing
+    # writer), undo the unroute above so we never strand the profile as tombstoned-but-present:
+    # restore its directory to the served set and clear the marker before re-raising.
+    try:
+        old_dir.rename(new_dir)
+    except Exception:
+        if served_by_mux:
+            clear_named_profile_deleted(old_dir)
+            _notify_multiplexer(old_canon)
+        raise
     print(f"✓ Renamed {old_dir.name} → {new_dir.name}")
     # The tombstone lived at profiles/.deleted/<old_name>; old_dir is gone now so it can no
     # longer resurrect, and new_dir carries no tombstone. Clear the stale marker so a future

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -768,6 +768,62 @@ class TestRenameProfile:
         assert cfg["hosts"]["hermes_heimdall"]["aiPeer"] == "ssi_health"
         assert cfg["hosts"]["hermes_heimdall"]["peerName"] == "user-peer"
 
+    def test_multiplexed_rename_unroutes_old_then_hot_serves_new(self, profile_env):
+        """A profile served by a live multiplexer is unrouted (tombstone + notify) BEFORE the
+        directory move, and the new name is hot-served after — so the old name cannot be
+        re-``mkdir``'d back into a ghost served profile (issue: rename resurrects old name)."""
+        tmp_path = profile_env
+        create_profile("oldname", no_alias=True)
+        old_dir = tmp_path / ".hermes" / "profiles" / "oldname"
+        new_dir = tmp_path / ".hermes" / "profiles" / "newname"
+
+        calls = []
+
+        def _record_notify(name):
+            # Snapshot the world at each multiplexer signal to pin ordering.
+            calls.append({
+                "name": name,
+                "old_exists": old_dir.exists(),
+                "new_exists": new_dir.exists(),
+                "old_tombstoned": profiles.named_profile_is_deleted(old_dir),
+            })
+
+        with patch("hermes_cli.profiles.check_alias_collision", return_value="skip"), \
+             patch("hermes_cli.profiles._served_by_running_multiplexer", return_value=True), \
+             patch("hermes_cli.profiles._notify_multiplexer", side_effect=_record_notify):
+            rename_profile("oldname", "newname")
+
+        # Old name unrouted before the move: first signal names oldname, while old_dir still
+        # exists and is tombstoned so no live component can re-create it.
+        assert calls[0]["name"] == "oldname"
+        assert calls[0]["old_exists"] is True
+        assert calls[0]["old_tombstoned"] is True
+        # New name hot-served after the move completed.
+        assert calls[-1]["name"] == "newname"
+        assert calls[-1]["new_exists"] is True
+        assert calls[-1]["old_exists"] is False
+        # End state: old gone, new present, and no stale tombstone left to poison a future
+        # profile that reuses the old name.
+        assert not old_dir.exists()
+        assert new_dir.is_dir()
+        assert not profiles.named_profile_is_deleted(old_dir)
+
+    def test_unmultiplexed_rename_does_not_signal_multiplexer(self, profile_env):
+        """No live multiplexer serves this profile → rename must not tombstone or ping it
+        (guards against over-firing the unroute path on a single-profile install)."""
+        tmp_path = profile_env
+        create_profile("oldname", no_alias=True)
+        old_dir = tmp_path / ".hermes" / "profiles" / "oldname"
+
+        with patch("hermes_cli.profiles.check_alias_collision", return_value="skip"), \
+             patch("hermes_cli.profiles._served_by_running_multiplexer", return_value=False), \
+             patch("hermes_cli.profiles._notify_multiplexer") as notify:
+            new_dir = rename_profile("oldname", "newname")
+
+        notify.assert_not_called()
+        assert not profiles.named_profile_is_deleted(old_dir)
+        assert new_dir.is_dir()
+
 
 # ===================================================================
 # TestExportImport

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -824,6 +824,29 @@ class TestRenameProfile:
         assert not profiles.named_profile_is_deleted(old_dir)
         assert new_dir.is_dir()
 
+    def test_multiplexed_rename_failure_rolls_back_unroute(self, profile_env):
+        """If the directory move fails, the pre-move unroute is undone: the old name is
+        re-served (tombstone cleared, multiplexer re-notified) instead of left stranded as
+        tombstoned-but-present (which would make the profile vanish, worse than a ghost)."""
+        tmp_path = profile_env
+        create_profile("oldname", no_alias=True)
+        old_dir = tmp_path / ".hermes" / "profiles" / "oldname"
+
+        signals = []
+        with patch("hermes_cli.profiles.check_alias_collision", return_value="skip"), \
+             patch("hermes_cli.profiles._served_by_running_multiplexer", return_value=True), \
+             patch("hermes_cli.profiles._notify_multiplexer", side_effect=signals.append), \
+             patch("hermes_cli.profiles.Path.rename", side_effect=OSError("EXDEV")):
+            with pytest.raises(OSError, match="EXDEV"):
+                rename_profile("oldname", "newname")
+
+        # Old dir still there, tombstone cleared, and the last signal re-served the old name.
+        assert old_dir.is_dir()
+        assert not profiles.named_profile_is_deleted(old_dir)
+        assert signals[0] == "oldname"   # unroute on the way in
+        assert signals[-1] == "oldname"  # rollback re-serves it, never "newname"
+        assert "newname" not in signals
+
 
 # ===================================================================
 # TestExportImport


### PR DESCRIPTION
## Bug Description

Renaming a profile while the gateway multiplexer (`gateway.multiplex_profiles: true`) is running resurrects the **old** profile name as an empty ghost directory that the multiplexer then re-adopts and serves — a stale row in `hermes profile list`, an extra entry in `served_profiles`, and a re-created `profiles/<old>/` tree that survives gateway restarts.

Fixes #109267

## Root Cause

A multiplexed secondary profile has no `gateway.pid` of its own, so `rename_profile`'s `_check_gateway_running(old_dir)` reports it stopped and skips the teardown block. Unlike `delete_profile`, `rename_profile` never tombstoned the old name nor called `_notify_multiplexer`. So at the moment `old_dir.rename(new_dir)` runs, the default gateway still holds the old profile's adapters, cron ticker, logging and SQLite handles. Those live components immediately re-`mkdir` the old home — and because the old name carries no `profiles/.deleted/<name>` tombstone, `mkdir_under_hermes_home` does not refuse it — after which the periodic `reconcile_served_profiles` watcher re-adopts the populated dir as a ghost served profile.

This is the rename-shaped sibling of `2d121aa322` ("deleted profiles leave no stale runtime entries"), which hardened only the *delete* reconcile path.

## Fix

Give `rename_profile` the same unroute-before-mutate discipline `delete_profile` already has, gated on the old name actually being served by a live multiplexer (`_served_by_running_multiplexer`, which already exists for exactly this "no pid of its own" case):

- Before the move: `mark_named_profile_deleted(old_dir)` + `_notify_multiplexer(old_canon)` so the multiplexer stops the old adapters, evicts cached agents, and releases its SQLite/memory-store handles into `old_dir` (the existing `_unserve_profile` path).
- After the move: `clear_named_profile_deleted(old_dir)` to drop the now-stale tombstone (the dir is gone; `new_dir` carries none → served normally).
- Then `_notify_multiplexer(new_canon)` to hot-serve the renamed profile immediately (mirrors `create_profile`).

Non-multiplexed renames (single-profile installs, or a profile with its own standalone gateway) take none of these branches — no tombstone, no signal.

## How to Verify

1. With `gateway.multiplex_profiles: true` and a running default gateway serving at least one secondary `foo`, run `hermes profile rename foo bar`.
2. `ls ~/.hermes/profiles/` → `foo` is gone and stays gone (previously `profiles/foo/` reappeared within seconds).
3. `hermes profile list` shows `bar`, never a ghost `foo` row; `served_profiles` in `gateway_state.json` contains `bar`, never `foo` — no gateway restart required.

## Test Plan

- [x] Added regression tests in `tests/hermes_cli/test_profiles.py::TestRenameProfile`:
  - `test_multiplexed_rename_unroutes_old_then_hot_serves_new` — pins ordering (old name tombstoned + signalled *before* the move while `old_dir` still exists; new name signalled *after*; no stale tombstone left). **Proven red on base** (`IndexError` — `_notify_multiplexer` never fires).
  - `test_unmultiplexed_rename_does_not_signal_multiplexer` — guards against over-firing the unroute path when nothing serves the profile.
- [x] Existing tests still pass: `tests/hermes_cli/test_profiles.py` (57 passed, 2 skipped), plus `test_web_profiles_off_loop.py` / `test_profile_display_name.py` (30 passed). `ruff` clean.
- [x] Manual verification of the resurrection behavior on a live launchd multiplex install.

## Risk Assessment

Low — the new behavior is fully gated on `_served_by_running_multiplexer(old_canon)`, reuses the exact teardown/tombstone/notify helpers `delete_profile` already relies on, and leaves the non-multiplexed rename path byte-for-byte unchanged. Blast radius is confined to `rename_profile`.
