### PR TITLE
fix(state): implement lazy flock single-writer gate to prevent WAL corruption

### DIFF
--- a/hermes_cli/doctor_state.py
+++ b/hermes_cli/doctor_state.py
@@ -276,6 +276,13 @@ def _state_db_wal(f: Finding, should_fix: bool, state_db_path: Path) -> None:
                                        "gateway first, then re-run 'hermes doctor --fix' to checkpoint)")
             import contextlib
             import sqlite3
+            from hermes_state_common import _writer_gate_acquire
+            refusal = _writer_gate_acquire(state_db_path)
+            if refusal:
+                check_warn("WAL checkpoint skipped: state.db is locked by a live writer",
+                           f"({refusal})")
+                return f.issues.append(f"Large WAL file — {refusal}")
+            
             with contextlib.closing(sqlite3.connect(str(state_db_path))) as conn:
                 conn.execute("PRAGMA wal_checkpoint(PASSIVE)")
             check_ok(f"WAL checkpoint performed ({size // 1024}K → {wal_size() // 1024}K)")

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -808,6 +808,12 @@ class SessionDB(
         and the WHOLE callback retried — *fn* must stay idempotent under retry."""
         if patience_s is None:
             patience_s = self._WRITE_PATIENCE_S
+        
+        from hermes_state_common import _writer_gate_acquire
+        refusal = _writer_gate_acquire(self.db_path)
+        if refusal:
+            raise SessionDbLockedError(refusal)
+            
         deadline = time.monotonic() + patience_s
         compression_deadline: Optional[float] = None  # set on the first compression-busy collision
         # One retry for SQLITE_IOERR raised by BEGIN IMMEDIATE itself (callback not run: nothing

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -1209,3 +1209,43 @@ def fts_rebuild_admission(db_path, *, timeout_seconds=None):
                     fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
         finally:
             handle.close()
+
+_held_writer_gates = {}
+_writer_gate_lock = __import__('threading').Lock()
+
+def _writer_gate_acquire(db_path) -> str | None:
+    import os
+    from pathlib import Path
+    if os.environ.get('HERMES_STATE_DB_WRITER_GATE', '').lower() == 'off':
+        return None
+    db_path = Path(db_path).absolute()
+    with _writer_gate_lock:
+        if db_path in _held_writer_gates:
+            return None
+        lock_path = db_path.with_name(db_path.name + '.writer.lock')
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            handle = lock_path.open('a+b')
+        except OSError as exc:
+            return f'REFUSED: Could not open writer lock {lock_path} ({exc}).'
+            
+        is_windows = os.name == 'nt'
+        try:
+            if is_windows:
+                import msvcrt
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            record = None if is_windows else _read_lock_holder_record(handle)
+            holder = _describe_lock_holder(record)
+            handle.close()
+            return f'REFUSED: state.db is currently locked for writing by another process ({holder}). Stop that gateway/process first.'
+            
+        if not is_windows:
+            _write_lock_holder_record(handle)
+            
+        _held_writer_gates[db_path] = handle
+        return None

--- a/hermes_state_repair.py
+++ b/hermes_state_repair.py
@@ -862,10 +862,17 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
     See #50502.
     """
     report: Dict[str, Any] = {"repaired": False, "strategy": None, "backup_path": None, "error": None}
+    
+    db_path = Path(db_path)
+    from hermes_state_common import _writer_gate_acquire
+    refusal = _writer_gate_acquire(db_path)
+    if refusal:
+        report["error"] = refusal
+        return report
+
     # Startup-watchdog lease: repair is I/O-bound (near-zero CPU), which the watchdog's CPU fallback would
     # misread as a parked deadlock. One lease (clamped to _MAX_LEASE_S=900) beats per-chunk renewal complexity.
     report_startup_progress(900.0, phase="state_db_repair")
-    db_path = Path(db_path)
     if not db_path.exists():
         report["error"] = f"{db_path} does not exist"
         return report


### PR DESCRIPTION
Fixes #103339

### Root Cause
When multiple processes simultaneously open `state.db` for writing in WAL mode, the second process's WAL setup can unlink or overwrite the live WAL inode that the first process is still actively writing to, resulting in catastrophic split-brain b-tree corruption. This was primarily triggered by `hosted_rooms` operating cross-profile, or `hermes doctor --fix` running while a gateway was active.

While `hermes_state_repair` attempted to use `_live_writer_holds_db` as a preflight guard, this check is explicitly documented as **fail-open**: if the db is corrupt or in DELETE mode, it returns `False`, completely blinding the guard when it's most needed.

### Fix
Implemented a **lazy flock single-writer gate** to definitively prevent cross-process split-brain writes:
1. **Gate primitive**: Added `_writer_gate_acquire` in `hermes_state_common.py`. On first write, the process takes an exclusive, non-blocking lock (`fcntl.flock(LOCK_EX|LOCK_NB)` / `LK_NBLCK`) on `<state.db>.writer.lock`. This lock is held for the lifetime of the process, and automatically released by the OS upon exit/crash. It is strictly **fail-closed**.
2. **Normal write path**: `SessionDB._execute_write()` calls this gate before doing any `BEGIN IMMEDIATE`.
3. **Repair surgery**: `repair_state_db_schema` explicitly acquires the gate at the top, safely returning a "REFUSED" contract without raising if the db is held by a gateway.
4. **Doctor fallback**: `doctor.py`'s raw `wal_checkpoint` now also explicitly queries the gate before executing `sqlite3.connect`.
5. **Escape Hatch**: Setting `HERMES_STATE_DB_WRITER_GATE=off` bypasses this protection for forensic use on stopped databases.
