### PR TITLE
fix(profiles): prevent ghost profile after rename

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1657,8 +1657,15 @@ def rename_profile(old_name: str, new_name: str) -> Path:
         _cleanup_gateway_service(old_canon, old_dir)
         _stop_gateway_process(old_dir)
 
-    # 2. Rename directory
-    old_dir.rename(new_dir)
+    # 2. Retire the old identity before moving its directory so stale activity cannot
+    # recreate a shell that profile enumeration mistakes for a live profile.
+    mark_named_profile_deleted(old_dir)
+    try:
+        old_dir.rename(new_dir)
+    except Exception:
+        clear_named_profile_deleted(old_dir)
+        raise
+    clear_named_profile_deleted(new_dir)
     print(f"✓ Renamed {old_dir.name} → {new_dir.name}")
 
     # 3. Update profile-scoped Honcho host blocks, preserving aiPeer identity

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -741,6 +741,19 @@ class TestRenameProfile:
         assert new_dir.is_dir()
         assert new_dir == tmp_path / ".hermes" / "profiles" / "newname"
 
+    def test_rename_tombstones_old_identity_against_stale_directory(self, profile_env):
+        old_dir = create_profile("oldname", no_alias=True)
+
+        with patch("hermes_cli.profiles.check_alias_collision", return_value="skip"):
+            rename_profile("oldname", "newname")
+
+        old_dir.mkdir()
+
+        listed = {profile.name for profile in list_profiles() if not profile.is_default}
+        served = {name for name, _path in profiles_to_serve(multiplex=True) if name != "default"}
+        assert listed == {"newname"}
+        assert served == {"newname"}
+
     def test_renames_root_honcho_host_without_changing_ai_peer(self, profile_env):
         tmp_path = profile_env
         create_profile("ssi_health", no_alias=True)
@@ -1159,5 +1172,4 @@ class TestResolveProfileEnvSpelling:
         # No HERMES_HOME: the platform default root applies (existing contract).
         monkeypatch.delenv("HERMES_HOME", raising=False)
         assert Path(resolve_profile_env("default")) == _get_default_hermes_home()
-
 


### PR DESCRIPTION
## What does this PR do?

Tombstone the old named-profile identity before moving its directory. If the filesystem rename fails, clear that tombstone and keep the new identity live so a failed in-process rename does not hide the old profile permanently.

### Symptom

`hermes profile rename` under a live multiplexer (`gateway.multiplex_profiles: true`) resurrects the old name as an empty ghost. `profile list` briefly looks correct, then a new `profiles/<old>/` tree appears (generic `SOUL.md`, empty `state.db`, fresh cron/logs) and `served_profiles` re-adopts it.

Discovery treats every valid, non-tombstoned directory under `profiles/` as live. Rename moved the directory but never retired the old identity. A multiplexed secondary has no `gateway.pid` of its own, so the “stop if running” teardown is skipped. Unlike `delete_profile`, rename did not write `profiles/.deleted/<name>` or notify the multiplexer, so stale adapters and logging immediately `mkdir` the old home. `profile delete` does not show this; only rename does.

Issue: https://github.com/NousResearch/hermes-agent/issues/109267

### Impact

`hermes profile rename` under a live multiplexer (`gateway.multiplex_profiles: true`) resurrects the old name as an empty ghost. `profile list` briefly looks correct, then a new `profiles/<old>/` tree appears (generic `SOUL.md`, empty `state.db`, fresh cron/logs) and `served_profiles` re-adopts it.

### Bug Cause

**Trigger:** the production path described in Symptom.

**Causal chain:** the previous implementation did not enforce the invariant above.

**Why it is wrong:** operators observed the Expected vs Actual mismatch in Symptom.

**Working sibling / contrast:** neighboring paths that already honored the invariant are unchanged.

**Ruled out:** unrelated modules outside this diff.

### Fix

Tombstone the old named-profile identity before moving its directory. If the filesystem rename fails, clear that tombstone and keep the new identity live so a failed in-process rename does not hide the old profile permanently.

`hermes_cli/profiles.py` now follows the same unroute-before-mutate idea as delete: the old name is marked deleted so `mkdir_under_hermes_home` and multiplex discovery refuse to recreate it, even if a running gateway still holds handles bound to the old path. A process kill between the tombstone write and `rename()` can temporarily hide the old profile; that is the same class of window delete already accepts.

This PR does not rewrite `reconcile_served_profiles` and does not stop the whole multiplexer. Scope is rename identity + the focused regression.

## Related Issue

Fixes #109267

## Type of Change

- ✅ Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/profiles.py` — see Fix
- `tests/hermes_cli/test_profiles.py` — see Fix

## How to Test

- ✅ `scripts/run_tests.sh tests/hermes_cli/test_profiles.py -k test_rename_tombstones_old_identity_against_stale_directory`
- ✅ `test_rename_tombstones_old_identity_against_stale_directory` renames `oldname` → `newname`, then recreates a stale `oldname` directory the way a live gateway would. It asserts both `list_profiles()` and `profiles_to_serve(multiplex=True)` expose only `newname`. Before the fix: `AssertionError: assert {'newname', 'oldname'} == {'newname'}` (`1 failed`). After the fix: `1 passed`. Adjacent `test_renames_directory` still covers the happy-path move.

## Checklist

### Code

- ✅ I've read the Contributing Guide
- ✅ My commit messages follow Conventional Commits
- ✅ I searched for existing PRs to make sure this isn't a duplicate
- ✅ My PR contains only changes related to this fix
- ✅ I've run relevant tests locally (see How to Test)
- ✅ I've added tests for my changes
- ✅ I've tested on my platform: macOS

### Documentation & Housekeeping

- ✅ Documentation update: N/A unless noted in Changes Made
- ✅ `cli-config.yaml.example`: N/A
- ✅ `CONTRIBUTING.md` or `AGENTS.md`: N/A
- ✅ Cross-platform impact considered
- ✅ Tool descriptions/schemas: N/A

