### PR TITLE
fix(profiles): keep renamed multiplexed profiles from returning as ghosts

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1652,14 +1652,30 @@ def rename_profile(old_name: str, new_name: str) -> Path:
     if new_dir.exists():
         raise FileExistsError(f"Profile '{new_canon}' already exists.")
 
-    # 1. Stop gateway if running
+    # 1. Stop a dedicated gateway, or unroute this name from the live multiplexer before
+    # moving its home. Multiplexed profiles have no gateway.pid of their own; without the
+    # tombstone their still-live writers can recreate the old directory before reconcile.
+    multiplexed = _served_by_running_multiplexer(old_canon)
     if _check_gateway_running(old_dir):
         _cleanup_gateway_service(old_canon, old_dir)
         _stop_gateway_process(old_dir)
+    if multiplexed:
+        mark_named_profile_deleted(old_dir)
+        _notify_multiplexer(old_canon)
 
     # 2. Rename directory
-    old_dir.rename(new_dir)
+    try:
+        old_dir.rename(new_dir)
+    except Exception:
+        if multiplexed:
+            clear_named_profile_deleted(old_dir)
+            _notify_multiplexer(old_canon)
+        raise
+    clear_named_profile_deleted(new_dir)
     print(f"✓ Renamed {old_dir.name} → {new_dir.name}")
+
+    if multiplexed:
+        _notify_multiplexer(new_canon)
 
     # 3. Update profile-scoped Honcho host blocks, preserving aiPeer identity
     _migrate_honcho_profile_host(old_canon, new_canon, new_dir)

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -741,6 +741,49 @@ class TestRenameProfile:
         assert new_dir.is_dir()
         assert new_dir == tmp_path / ".hermes" / "profiles" / "newname"
 
+    def test_multiplexed_rename_unroutes_old_name_before_move(self, profile_env):
+        from hermes_constants import named_profile_is_deleted
+
+        create_profile("oldname", no_alias=True)
+        old_dir = get_profile_dir("oldname")
+        new_dir = get_profile_dir("newname")
+        notifications = []
+
+        def notify(name):
+            notifications.append(name)
+            if name == "oldname":
+                assert old_dir.is_dir()
+                assert named_profile_is_deleted(old_dir)
+            else:
+                assert not old_dir.exists()
+                assert new_dir.is_dir()
+                assert not named_profile_is_deleted(new_dir)
+
+        with patch("hermes_cli.profiles._served_by_running_multiplexer", return_value=True), \
+             patch("hermes_cli.profiles._notify_multiplexer", side_effect=notify), \
+             patch("hermes_cli.profiles.check_alias_collision", return_value="skip"):
+            rename_profile("oldname", "newname")
+
+        assert notifications == ["oldname", "newname"]
+        assert named_profile_is_deleted(old_dir)
+
+    def test_failed_multiplexed_rename_restores_old_route(self, profile_env):
+        from hermes_constants import named_profile_is_deleted
+
+        create_profile("oldname", no_alias=True)
+        old_dir = get_profile_dir("oldname")
+        notifications = []
+
+        with patch("hermes_cli.profiles._served_by_running_multiplexer", return_value=True), \
+             patch("hermes_cli.profiles._notify_multiplexer", side_effect=notifications.append), \
+             patch.object(Path, "rename", side_effect=OSError("busy")):
+            with pytest.raises(OSError, match="busy"):
+                rename_profile("oldname", "newname")
+
+        assert old_dir.is_dir()
+        assert not named_profile_is_deleted(old_dir)
+        assert notifications == ["oldname", "oldname"]
+
     def test_renames_root_honcho_host_without_changing_ai_peer(self, profile_env):
         tmp_path = profile_env
         create_profile("ssi_health", no_alias=True)


### PR DESCRIPTION
## What does this PR do?

Renaming a profile while a multiplexed gateway serves it now retires the old identity before moving the profile home, then hot-serves the new identity. The old tombstone remains until an explicit profile creation reuses that name, so delayed or stale writers cannot make the old profile visible again.

### Symptom

After `hermes profile rename foo bar` under a running multiplexer, `foo` can reappear as an empty ghost profile and return to the gateway's served profile set.

### Impact

Operators see both the old and new profile names as running, and the ghost old profile persists across gateway restarts.

### Bug Cause

**Trigger:** `hermes_cli/profiles.py:rename_profile` when `_check_gateway_running(old_dir)` is false for a secondary profile served by the default multiplexer.

**Causal chain:**
1. The rename path moves `profiles/foo` to `profiles/bar` without first retiring `foo` from the multiplexer.
2. Runtime components still bound to `foo` can recreate its home, while no old-name tombstone excludes that directory.
3. Profile reconciliation adopts `foo` again and exposes it as a served ghost profile.

**Why it is wrong:** A multiplexed secondary has no dedicated `gateway.pid`, so the standalone gateway check cannot represent its live runtime ownership.

**Working sibling / contrast:** `delete_profile` tombstones the profile and notifies the multiplexer before removing its directory, which prevents stale runtime writes from reviving it.

**Ruled out:** The filesystem move itself is not sufficient protection because the live multiplexer still owns old-name runtime components and periodically reconciles profile directories.

### Fix

Detect when the old profile is served by the live multiplexer, tombstone and signal the old identity before the move, retain that tombstone against delayed stale writers, clear any tombstone attached to the new identity, and signal the new identity after the move. If the filesystem move fails, restore and re-signal the old identity before propagating the error.

## Related Issue
N/A
## Why this PR vs existing PRs #109269 and #109271

This branch keeps `profiles/.deleted/<old>` after a successful move. In `hermes_cli/profiles.py`, PR #109269 clears that guard immediately even though `_notify_multiplexer` is best-effort and may return while a timed-out reconcile is still pending, so delayed old-name writers can recreate a visible profile. PR #109271 retains the guard but never calls `_notify_multiplexer`, leaving old adapters and open runtime resources active and never hot-serving the new identity. This branch closes both paths and also restores the old route if `Path.rename` fails.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/profiles.py` - unroute and tombstone the old multiplexed identity before rename, hot-serve the new identity, and roll back routing state on move failure.
- `tests/hermes_cli/test_profiles.py` - cover successful notification ordering and failed-move rollback.

## How to Test

1. Start a default gateway with `gateway.multiplex_profiles: true` serving a secondary profile `foo`.
2. Run `hermes profile rename foo bar` and verify `foo` stays absent while `bar` is served without a restart.
3. Run `scripts/run_tests.sh tests/hermes_cli/test_profiles.py -k multiplexed_rename`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs and statically compared the competing implementations
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A
- [x] Config example updates are N/A
- [x] Architecture guide updates are N/A
- [x] I've considered cross-platform impact; the rollback covers filesystem move failures including locked paths
- [x] Tool description/schema updates are N/A

## Screenshots / Logs

N/A
