### PR TITLE
fix(desktop,cli): avoid EIO and path corruption during install with non-ASCII user profiles

### DIFF
--- a/apps/desktop/scripts/stage-native-deps.mjs
+++ b/apps/desktop/scripts/stage-native-deps.mjs
@@ -79,6 +79,20 @@ function copyGlobByExt(srcDir, destDir, extensions) {
   }
 }
 
+function copyDirRecursive(srcDir, destDir) {
+  if (!existsSync(srcDir)) return
+  mkdirSync(destDir, { recursive: true })
+  for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
+    const srcPath = join(srcDir, entry.name)
+    const destPath = join(destDir, entry.name)
+    if (entry.isDirectory()) {
+      copyDirRecursive(srcPath, destPath)
+    } else {
+      cpSync(srcPath, destPath)
+    }
+  }
+}
+
 /**
  * Copies the locally-compiled build/Release output (used when no prebuild
  * was available and node-pty was built from source for the host machine).
@@ -96,7 +110,7 @@ function copyBuildRelease(srcDir, destDir) {
   mkdirSync(destDir, { recursive: true })
   for (const entry of readdirSync(srcDir, { withFileTypes: true })) {
     if (entry.isDirectory()) {
-      cpSync(join(srcDir, entry.name), join(destDir, entry.name), { recursive: true })
+      copyDirRecursive(join(srcDir, entry.name), join(destDir, entry.name))
       continue
     }
     if (entry.name === 'spawn-helper' || /\.(node|dll|exe)$/.test(entry.name)) {
@@ -261,7 +275,7 @@ export function stageNodePtyInto(srcRoot, destRoot, { platform = process.platfor
     mkdirSync(destPrebuild, { recursive: true })
     for (const entry of readdirSync(prebuildDir, { withFileTypes: true })) {
       if (entry.name === 'conpty' && entry.isDirectory()) {
-        cpSync(join(prebuildDir, 'conpty'), join(destPrebuild, 'conpty'), { recursive: true })
+        copyDirRecursive(join(prebuildDir, 'conpty'), join(destPrebuild, 'conpty'))
         continue
       }
       if (entry.isFile() && /\.(node|dll|exe)$/.test(entry.name)) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -12,6 +12,12 @@
 #
 # ============================================================================
 
+# Ensure UTF-8 encoding for all output/input to prevent path distortion on non-ASCII usernames
+$OutputEncoding = [System.Text.Encoding]::UTF8
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+[Console]::InputEncoding = [System.Text.Encoding]::UTF8
+$env:LC_ALL = "en_US.UTF-8"
+
 param(
     [switch]$NoVenv,
     [switch]$SkipSetup,
@@ -30,8 +36,8 @@ param(
     # existing tree pass -ForceCommit.
     [switch]$ForceCommit,
     [string]$Tag = "",
-    [string]$HermesHome = $(if ($env:HERMES_HOME) { $env:HERMES_HOME } else { "$env:LOCALAPPDATA\hermes" }),
-    [string]$InstallDir = $(if ($env:HERMES_HOME) { "$env:HERMES_HOME\hermes-agent" } else { "$env:LOCALAPPDATA\hermes\hermes-agent" }),
+    [string]$HermesHome = $(if ($env:HERMES_HOME) { $env:HERMES_HOME } elseif ("$env:LOCALAPPDATA" -match '[^\x00-\x7F]') { "C:\hermes" } else { "$env:LOCALAPPDATA\hermes" }),
+    [string]$InstallDir = $(if ($env:HERMES_HOME) { "$env:HERMES_HOME\hermes-agent" } elseif ("$env:LOCALAPPDATA" -match '[^\x00-\x7F]') { "C:\hermes\hermes-agent" } else { "$env:LOCALAPPDATA\hermes\hermes-agent" }),
 
     # --- Stage protocol (additive; default invocation behaves as before) ----
     # See the "Stage protocol" section near the bottom of the file for the
@@ -345,14 +351,14 @@ if ($PSBoundParameters.ContainsKey('HermesHome')) {
     $HermesHome = ConvertTo-LongPath $HermesHome
 } else {
     $HermesHome = ConvertTo-LongPath $(
-        if ($env:HERMES_HOME) { $env:HERMES_HOME } else { "$env:LOCALAPPDATA\hermes" }
+        if ($env:HERMES_HOME) { $env:HERMES_HOME } elseif ("$env:LOCALAPPDATA" -match '[^\x00-\x7F]') { "C:\hermes" } else { "$env:LOCALAPPDATA\hermes" }
     )
 }
 if ($PSBoundParameters.ContainsKey('InstallDir')) {
     $InstallDir = ConvertTo-LongPath $InstallDir
 } else {
     $InstallDir = ConvertTo-LongPath $(
-        if ($env:HERMES_HOME) { "$env:HERMES_HOME\hermes-agent" } else { "$env:LOCALAPPDATA\hermes\hermes-agent" }
+        if ($env:HERMES_HOME) { "$env:HERMES_HOME\hermes-agent" } elseif ("$env:LOCALAPPDATA" -match '[^\x00-\x7F]') { "C:\hermes\hermes-agent" } else { "$env:LOCALAPPDATA\hermes\hermes-agent" }
     )
 }
 if ($script:NormalizedProfilePaths) {


### PR DESCRIPTION
Fixes #70779

### Root Causes
When installing Hermes on Windows with a username containing non-ASCII/Unicode characters (e.g., `Pınar`), the installer fails due to two intertwined path-handling bugs:
1. **PowerShell Path Distortion:** The Windows shell executes with non-UTF-8 character encodings by default, causing paths passed to child processes or downloaded archives to be mangled (e.g., `C:\Users\PÄ±nar` or short paths like `C:\Users\PNAR~1`), eventually leading to "An object at the specified path does not exist" errors when trying to read or extract `.zip` files.
2. **Node Native Dependency Staging (`EIO` error):** When packaging Desktop native modules (`stage-native-deps.mjs`), `fs.cpSync({ recursive: true })` uses an internal libuv binding `cpSyncCopyDir` that triggers a low-level access denied (`EIO`) failure when recursively copying pre-built binary folders inside long or non-ASCII root paths.

### Fix
1. **Force UTF-8 PowerShell Encoding:** Set `$OutputEncoding`, `[Console]::OutputEncoding`, `[Console]::InputEncoding`, and `$env:LC_ALL` to strictly use UTF-8 at the top of `install.ps1`.
2. **Safe `HERMES_HOME` Fallback:** The installer now actively detects if `$env:LOCALAPPDATA` contains non-ASCII characters (`'[^\x00-\x7F]'`). If it does, `HERMES_HOME` and `InstallDir` default to the globally safe path `C:\hermes` (and `C:\hermes\hermes-agent`) instead of the corrupted user profile path.
3. **Bypass Node's `cpSyncCopyDir`:** Replaced the crashing `fs.cpSync(..., { recursive: true })` inside `stage-native-deps.mjs` with a new `copyDirRecursive` helper. This cleanly recursively walks the directory with standard `readdirSync` and uses non-recursive `cpSync` on files, which correctly handles Windows paths without failing in `libuv`.
