### PR TITLE
fix(kanban): stage review-bound handoff artifacts in request_review

### DIFF
--- a/gateway/kanban_watchers_notifier.py
+++ b/gateway/kanban_watchers_notifier.py
@@ -548,9 +548,12 @@ class _KanbanNotification:
             raise RuntimeError(f"adapter send() reported failure: {getattr(_send_res, 'error', None) or 'unknown error'}")
         logger.debug("kanban notifier: delivered %s event for %s to %s/%s on board %s",
                      ev.kind, self.task_id, self.platform_str, sub["chat_id"], self.board_slug)
-        # Upload artifact paths from the completion payload / legacy result as
-        # native files. Only on ``completed`` so retries never spam attachments.
-        if ev.kind == "completed":
+        # Upload artifact paths from the handoff payload / legacy result as
+        # native files. Both handoff kinds stage files for exactly this: a
+        # review-bound card's files exist precisely so the human sees them at
+        # handoff time. Retry exposure matches ``completed`` (the sub cursor is
+        # rewound only when a send failed).
+        if ev.kind in ("completed", "review_requested"):
             try:
                 await self.runner._deliver_kanban_artifacts(
                     adapter=adapter, chat_id=sub["chat_id"], metadata=metadata,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2642,15 +2642,28 @@ def _gate_created_cards(
     return verified_cards
 
 
-def _stage_completion_artifacts(conn: sqlite3.Connection, task_id: str, metadata: dict, now: int) -> None:
+def _stage_completion_artifacts(
+    conn: sqlite3.Connection, task_id: str, metadata: dict, now: int, *,
+    uploaded_by: str = "kanban_complete",
+) -> None:
     """Copy scratch artifacts to the attachments dir and record each as an attachment row."""
     _persist_scratch_completion_artifacts(conn, task_id, metadata)
     for stored_path in metadata.pop("_staged_artifacts", []):
         path = Path(stored_path)
         _insert_completion_attachment(
             conn, task_id, filename=path.name, stored_path=str(path),
-            size=path.stat().st_size, created_at=now,
+            size=path.stat().st_size, created_at=now, uploaded_by=uploaded_by,
         )
+
+
+def _cleaned_artifact_paths(metadata: Any) -> list[str]:
+    """Non-blank string paths declared in ``metadata["artifacts"]``."""
+    if not isinstance(metadata, dict):
+        return []
+    raw = metadata.get("artifacts")
+    if not isinstance(raw, (list, tuple)):
+        return []
+    return [str(p).strip() for p in raw if isinstance(p, str) and str(p).strip()]
 
 
 def _completed_event_payload(
@@ -2672,11 +2685,9 @@ def _completed_event_payload(
     if verified_cards:
         payload["verified_cards"] = verified_cards
     if isinstance(metadata, dict):
-        md_artifacts = metadata.get("artifacts")
-        if isinstance(md_artifacts, (list, tuple)):
-            cleaned = [str(p).strip() for p in md_artifacts if isinstance(p, str) and str(p).strip()]
-            if cleaned:
-                payload["artifacts"] = cleaned
+        cleaned = _cleaned_artifact_paths(metadata)
+        if cleaned:
+            payload["artifacts"] = cleaned
     return payload
 
 
@@ -2835,16 +2846,16 @@ def _copy_capped(src: Path, dest: Path, artifact: str) -> None:
 
 def _insert_completion_attachment(
     conn: sqlite3.Connection, task_id: str, *, filename: str, stored_path: str, size: int,
-    created_at: int,
+    created_at: int, uploaded_by: str = "kanban_complete",
 ) -> None:
     """Record a worker-produced artifact in the existing attachment table."""
     conn.execute(
         "INSERT INTO task_attachments "
         "(task_id, filename, stored_path, content_type, size, uploaded_by, created_at) "
-        "VALUES (?, ?, ?, NULL, ?, 'kanban_complete', ?)",
-        (task_id, filename, stored_path, size, created_at),
+        "VALUES (?, ?, ?, NULL, ?, ?, ?)",
+        (task_id, filename, stored_path, size, uploaded_by, created_at),
     )
-    _append_event(conn, task_id, "attached", {"filename": filename, "size": size, "by": "kanban_complete"})
+    _append_event(conn, task_id, "attached", {"filename": filename, "size": size, "by": uploaded_by})
 
 
 def _unique_attachment_path(directory: Path, filename: str, used: set[Path]) -> Path:
@@ -2994,10 +3005,30 @@ def redact_review_value(value: Any) -> Any:
     return value
 
 
+def _declare_handoff_artifacts(
+    metadata: Optional[dict], artifacts: Optional[Iterable[str]],
+) -> Optional[dict]:
+    """Fold an explicit ``artifacts`` argument into ``metadata["artifacts"]``
+    (order-preserving, deduped). Returns ``metadata`` untouched when there is
+    nothing to add, so callers can pass ``None`` through."""
+    if not artifacts:
+        return metadata
+    items = [str(item).strip() for item in artifacts if item is not None and str(item).strip()]
+    if not items:
+        return metadata
+    updated = dict(metadata) if isinstance(metadata, dict) else {}
+    existing = updated.get("artifacts")
+    merged = list(existing) if isinstance(existing, (list, tuple)) else []
+    merged.extend(items)
+    updated["artifacts"] = list(dict.fromkeys(str(p).strip() for p in merged if str(p).strip()))
+    return updated
+
+
 def request_review(
     conn: sqlite3.Connection, task_id: str, *, summary: Optional[str] = None,
     metadata: Optional[dict] = None, reviewer: Optional[str] = None,
     expected_run_id: Optional[int] = None, force: bool = False, with_reason: bool = False,
+    artifacts: Optional[Iterable[str]] = None,
 ):
     """``running``/``ready`` -> ``review``; never touches block recurrence accounting.
 
@@ -3006,6 +3037,15 @@ def request_review(
     re-review defaults to the latest ``changes_requested`` provenance. A live
     claim is only cleared with proof of ownership (``expected_run_id``) or
     ``force=True``. Returns ``bool``, or ``(ok, reason)`` with ``with_reason``.
+
+    ``artifacts`` (or ``metadata["artifacts"]``) names the handoff's deliverable
+    files; a review handoff is the last implementer transition, and the
+    *reviewer's* completion is what cleans the managed scratch workspace up, so
+    the files are staged into the task's durable attachments dir here and the
+    staged paths ride the ``review_requested`` payload for the notifier to
+    upload. A declared artifact that cannot be preserved raises
+    :class:`ArtifactPreservationError`, rolling the whole transition back: the
+    task stays ``running`` and retryable, with no attachments and no event.
     """
 
     def _ret(ok: bool, reason: Optional[str] = None):
@@ -3013,6 +3053,12 @@ def request_review(
 
     summary = redact_review_value(summary)
     metadata = redact_review_value(metadata)
+    # Declared (explicit arg or metadata["artifacts"]) and prose-referenced files
+    # must be durable BEFORE anything can clean the scratch workspace up: for a
+    # review-bound card the reviewer's completion is the cleanup trigger.
+    metadata = _declare_handoff_artifacts(metadata, artifacts)
+    metadata = _merge_completion_prose_artifacts(conn, task_id, metadata, summary=summary, result=None)
+    now = int(time.time())
     with write_txn(conn):
         if not _parents_satisfied(conn, task_id):
             return _ret(False, "parent dependencies are not satisfied")
@@ -3068,21 +3114,23 @@ def request_review(
             return _ret(
                 False, "task is not in running/ready (or expected_run_id did not match the current run)",
             )
+        if isinstance(metadata, dict):
+            _stage_completion_artifacts(
+                conn, task_id, metadata, now, uploaded_by="kanban_request_review",
+            )
         run_id = _end_or_synthesize_run(
             conn, task_id, outcome="review_requested", status="review",
             summary=summary, metadata=metadata, synthesize=bool(summary or metadata),
         )
-        _append_event(
-            conn,
-            task_id,
-            "review_requested",
-            {
-                "summary": _first_line(summary, 400) or None,
-                "implementer": implementer,
-                "reviewer": reviewer,
-            },
-            run_id=run_id,
-        )
+        payload: dict = {
+            "summary": _first_line(summary, 400) or None,
+            "implementer": implementer,
+            "reviewer": reviewer,
+        }
+        staged = _cleaned_artifact_paths(metadata)
+        if staged:
+            payload["artifacts"] = staged
+        _append_event(conn, task_id, "review_requested", payload, run_id=run_id)
     return _ret(True)
 
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -617,6 +617,84 @@ def test_complete_task_persists_scratch_artifacts_before_cleanup(kanban_home):
     ]
 
 
+def test_review_bound_handoff_preserves_declared_artifacts(kanban_home):
+    """A review-bound card's declared files must outlive the reviewer's
+    completion — that completion is what cleans the scratch workspace up."""
+    with kbc.connect() as conn:
+        t = kb.create_task(conn, title="review bound")
+        task = kb.get_task(conn, t)
+        ws = kbw.resolve_workspace(task)
+        kbw.set_workspace_path(conn, t, ws)
+        artifact = ws / "evidence.json"
+        artifact.write_bytes(b'{"ok": true}')
+        kb.claim_task(conn, t)
+        run_id = kb.get_task(conn, t).current_run_id
+        assert run_id is not None
+        assert kb.request_review(
+            conn, t, summary="ready for review",
+            artifacts=[str(artifact)], expected_run_id=run_id)
+        handoff = [e for e in kb.list_events(conn, t) if e.kind == "review_requested"][-1]
+        assert kb.complete_task(conn, t, summary="approved")
+        attachments = kb.list_attachments(conn, t)
+    persisted = Path(handoff.payload["artifacts"][0])
+    assert not ws.exists(), "scratch workspace should still be cleaned up"
+    assert persisted.exists(), "staged copy must survive scratch cleanup"
+    assert persisted.parent == kb.task_attachments_dir(t)
+    assert persisted.read_bytes() == b'{"ok": true}'
+    assert [(a.filename, a.stored_path) for a in attachments] == [
+        ("evidence.json", str(persisted.resolve()))
+    ]
+
+
+def test_review_bound_handoff_preserves_prose_referenced_artifacts(kanban_home):
+    """Legacy workers name deliverables only by absolute scratch path in prose;
+    the review handoff must stage those too, before the reviewer completes."""
+    with kbc.connect() as conn:
+        t = kb.create_task(conn, title="review bound prose")
+        task = kb.get_task(conn, t)
+        ws = kbw.resolve_workspace(task)
+        kbw.set_workspace_path(conn, t, ws)
+        artifact = ws / "notes.md"
+        artifact.write_bytes(b"# notes\n")
+        kb.claim_task(conn, t)
+        run_id = kb.get_task(conn, t).current_run_id
+        assert run_id is not None
+        assert kb.request_review(
+            conn, t, summary=f"ready for review, deliverable at {artifact}",
+            expected_run_id=run_id)
+        handoff = [e for e in kb.list_events(conn, t) if e.kind == "review_requested"][-1]
+        assert kb.complete_task(conn, t, summary="approved")
+        attachments = kb.list_attachments(conn, t)
+    persisted = Path(handoff.payload["artifacts"][0])
+    assert not ws.exists(), "scratch workspace should still be cleaned up"
+    assert persisted.exists(), "staged copy must survive scratch cleanup"
+    assert persisted.parent == kb.task_attachments_dir(t)
+    assert persisted.read_bytes() == b"# notes\n"
+    assert [(a.filename, a.stored_path) for a in attachments] == [
+        ("notes.md", str(persisted.resolve()))
+    ]
+
+
+def test_review_bound_handoff_rolls_back_when_declared_artifact_missing(kanban_home):
+    """Fail-closed: an unresolvable declared artifact aborts the whole review
+    transition — task stays running/retryable, nothing staged, no event."""
+    with kbc.connect() as conn:
+        t = kb.create_task(conn, title="review bound broken")
+        task = kb.get_task(conn, t)
+        ws = kbw.resolve_workspace(task)
+        kbw.set_workspace_path(conn, t, ws)
+        missing = ws / "missing.png"
+        kb.claim_task(conn, t)
+        run_id = kb.get_task(conn, t).current_run_id
+        assert run_id is not None
+        with pytest.raises(kb.ArtifactPreservationError):
+            kb.request_review(
+                conn, t, summary="ready for review", artifacts=[str(missing)],
+                expected_run_id=run_id)
+        assert kb.get_task(conn, t).status == "running"
+        assert kb.list_attachments(conn, t) == []
+        assert [e for e in kb.list_events(conn, t) if e.kind == "review_requested"] == []
+    assert not missing.exists(), "declared path must be left untouched"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -897,6 +897,80 @@ async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_p
     assert "real.pdf" in documents_uploaded[0]
 
 
+@pytest.mark.asyncio
+async def test_notifier_uploads_review_handoff_artifacts(kanban_home, tmp_path, monkeypatch):
+    """A review handoff's files are uploaded from the durable staged copy —
+    not the scratch original the reviewer's completion is about to delete."""
+    import hermes_cli.kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+    from hermes_cli import kanban_db_notify as kbn
+    from hermes_cli import kanban_db_workspace as kbw
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform
+
+    monkeypatch.setenv("HERMES_MEDIA_ALLOW_DIRS", str(tmp_path))
+
+    conn = kbc.connect()
+    try:
+        tid = kb.create_task(conn, title="review handoff", assignee="worker1")
+        kbn.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat1")
+        ws = kbw.resolve_workspace(kb.get_task(conn, tid))
+        kbw.set_workspace_path(conn, tid, ws)
+        scratch = ws / "report.pdf"
+        scratch.write_bytes(b"%PDF-fake")
+        kb.claim_task(conn, tid)
+        run_id = kb.get_task(conn, tid).current_run_id
+        assert kb.request_review(
+            conn, tid, summary="ready for review", artifacts=[str(scratch)],
+            expected_run_id=run_id)
+        handoff = [e for e in kb.list_events(conn, tid) if e.kind == "review_requested"][-1]
+        attachments = kb.list_attachments(conn, tid)
+    finally:
+        conn.close()
+    staged_path = handoff.payload["artifacts"][0]
+    assert staged_path != str(scratch), "handoff must name the staged copy, not the scratch original"
+    assert staged_path == attachments[0].stored_path
+
+    runner = object.__new__(GatewayRunner)
+    runner._owns_kanban_dispatcher_lock = lambda: True
+    runner._running = True
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_dispatcher_lock_handle = object()
+
+    fake_adapter = MagicMock()
+    fake_adapter.name = "telegram"
+
+    documents_uploaded: list = []
+
+    async def _send(chat_id, msg, metadata=None):
+        runner._running = False
+
+    async def _send_document(chat_id, file_path, metadata=None, **_kw):
+        documents_uploaded.append(file_path)
+
+    fake_adapter.send = AsyncMock(side_effect=_send)
+    fake_adapter.send_document = AsyncMock(side_effect=_send_document)
+    fake_adapter.send_multiple_images = AsyncMock()
+    from gateway.platforms.base import BasePlatformAdapter
+    fake_adapter.extract_local_files = BasePlatformAdapter.extract_local_files
+
+    runner.adapters = {Platform.TELEGRAM: fake_adapter}
+
+    _orig_sleep = asyncio.sleep
+
+    async def _fast_sleep(_):
+        await _orig_sleep(0)
+
+    with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep):
+        await asyncio.wait_for(
+            runner._kanban_notifier_watcher(interval=1),
+            timeout=10.0,
+        )
+
+    assert documents_uploaded == [staged_path]
+    assert str(scratch) not in documents_uploaded
+
+
 # ---------------------------------------------------------------------------
 # Migration backfill: pre-delivery_mode gateway subscriptions keep active wake.
 #

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -658,6 +658,9 @@ def _handle_request_review(args: dict, **kw) -> str:
     if metadata is not None:
         metadata = _redact_metadata(metadata)
         _check(metadata is not None, "metadata could not be safely serialized")
+    artifacts = _coerce_str_list(args.get("artifacts"), "artifacts", "file paths", strip=True)
+    if artifacts:
+        metadata = _merge_artifacts(metadata, artifacts)
     metadata = _stamp_worker_session_metadata(tid, metadata)
     # Reviewer is model-supplied free text stored durably on the event payload.
     reviewer = _redact_opt(args.get("reviewer") or None)
@@ -671,9 +674,19 @@ def _handle_request_review(args: dict, **kw) -> str:
                f"Installed profiles: {', '.join(list_profile_names())}")
     with _board(args.get("board")) as (kb, conn):
         _goal_gate("kanban_request_review", kb.get_task(conn, tid), tid, summary)
-        ok, fail_reason = kb.request_review(
-            conn, tid, summary=summary, metadata=metadata, reviewer=reviewer,
-            expected_run_id=_worker_run_id(tid), with_reason=True)
+        try:
+            ok, fail_reason = kb.request_review(
+                conn, tid, summary=summary, metadata=metadata, reviewer=reviewer,
+                artifacts=artifacts, expected_run_id=_worker_run_id(tid), with_reason=True)
+        except kb.ArtifactPreservationError as artifact_err:
+            # Same contract as kanban_complete (#22923): the transition rolled
+            # back, the task is untouched and retryable — say so explicitly or
+            # the model treats the tool_error as terminal.
+            return tool_error(
+                f"kanban_request_review could not preserve the declared artifacts: {artifact_err}. "
+                f"Your task is still in-flight (no state change) and its scratch workspace was "
+                f"kept. Fix the artifact path or storage error, then retry "
+                f"kanban_request_review with the same handoff.")
         _check(ok, f"could not request review for {tid}: "
                    f"{fail_reason or 'unknown id or not in running/ready'}")
         return _ok_landed(kb, conn, tid, "review")

--- a/tools/kanban_tools_schemas.py
+++ b/tools/kanban_tools_schemas.py
@@ -229,6 +229,24 @@ KANBAN_REQUEST_REVIEW_SCHEMA = _schema(
             ),
             "additionalProperties": True,
         },
+        "artifacts": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Optional list of absolute paths to deliverable "
+                "files this handoff names — generated charts, "
+                "PDFs, spreadsheets, images, archives. Examples: "
+                "['/tmp/q3-revenue.png', '/tmp/report.pdf']. "
+                "A review handoff is the last implementer "
+                "transition, so the kernel copies these into the "
+                "task's durable attachments before the reviewer's "
+                "completion cleans the scratch workspace up, and "
+                "the gateway notifier uploads them as native "
+                "attachments to the subscribed chat. A missing "
+                "declared scratch artifact keeps the task in place "
+                "so you can fix the path and retry."
+            ),
+        },
     },
     ["summary"],
 )


### PR DESCRIPTION
## What does this PR do?

A kanban review handoff now preserves the files it names, the same way a terminal completion already does.

`request_review()` staged nothing. A worker that left a deliverable in its scratch workspace and called `kanban_request_review` handed off a card whose files were never captured, and the reviewer's `complete_task` later deleted that workspace, so the files were unrecoverable. The handoff now stages them durably and delivers them.

- `request_review()` accepts an `artifacts` argument, still honours `metadata["artifacts"]`, and picks up paths named in the summary prose.
- Declared and prose-referenced files are copied into the task's durable attachments dir through the same helper `complete_task` uses.
- The staged paths ride on the `review_requested` event payload.
- The gateway notifier uploads them; its guard widens from `completed` to `review_requested`.

A declared file that is missing still raises `ArtifactPreservationError` and rolls the whole transition back: the task stays `running`, with no attachments and no event, so it is retryable rather than silently accepted.

## Related Issue

Fixes #109275

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py` — `request_review()` gains `artifacts`. `_declare_handoff_artifacts()` folds the explicit argument into `metadata["artifacts"]` (dedup, strip blanks); `_cleaned_artifact_paths()` is factored out of the existing metadata handling so both paths agree. Staging happens inside the same transaction as the state change and the event append, and the `review_requested` payload carries the staged paths.
- `tools/kanban_tools.py`, `tools/kanban_tools_schemas.py` — `kanban_request_review` exposes `artifacts` and turns a preservation failure into a retryable error that says the task is still `running`.
- `gateway/kanban_watchers_notifier.py` — artifact delivery covers `review_requested` as well as `completed`.
- `tests/hermes_cli/test_kanban_db.py` — three tests: declared artifact preserved, prose-referenced artifact preserved, missing declared artifact rolls back with no attachment and no event.
- `tests/hermes_cli/test_kanban_notify.py` — one async test that the notifier uploads a review-bound handoff's file.

## How to Test

```bash
scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/tools/test_kanban_tools.py -q
```

Both files pass on the branch head.

```bash
python -m pytest tests/hermes_cli/test_kanban_notify.py -q
```

28 passed, with `pytest-asyncio` installed. The venv I ran on lacked it, so that file reported all 14 async tests failing there (the pre-existing ones too, with `Unknown pytest.mark.asyncio`); pinning `pytest-asyncio==1.3.0` gives 28 passed.

Affected-file regression, one process, pytest-asyncio pinned — the eight test files covering kanban db, review lifecycle, review surfaces, notify, kanban tools and the two gateway notifier suites:

```
168 passed, 1 skipped in 22.42s
```

The harness prints the resolved `hermes_cli.kanban_db` path on every run, so the result can't come from an installed copy instead of the worktree.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2, Python 3.11.15

The full-suite box is left unchecked on purpose. I ran the eight affected test files plus the canonical runner over the touched ones, not `tests/` entire, so I can't claim the whole suite. Results are above; the async gap is a venv detail, not a failure of the change.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: the tool schema and the `request_review` docstring describe the new argument.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A: no config keys.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A: no architecture change.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A: staging goes through the existing `pathlib`-based helper that `complete_task` already uses.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — `tools/kanban_tools_schemas.py` documents `artifacts` on `kanban_request_review`.

### For New Skills

N/A, this PR doesn't add a skill.

## Screenshots / Logs

```
=== focused: the new tests ===
......                                                                   [100%]
6 passed, 114 deselected in 2.77s

=== affected-file regression (8 files) ===
s....................................................................... [ 42%]
........................................................................ [ 85%]
.........................                                                [100%]
168 passed, 1 skipped in 22.42s
```

## Evidence

- Attributed delta on the affected files: the pre-fix tree gives `4 failed, 164 passed, 1 skipped`; the branch head gives `168 passed, 1 skipped`. Those four are the tests added here, and nothing else changes verdict.
- The new watcher test is load-bearing. Narrowing the notifier guard back to `completed` on this exact head fails precisely `test_notifier_uploads_review_handoff_artifacts` (`1 failed, 27 deselected`); restoring the guard passes it (`1 passed, 27 deselected`).
- Fail-closed rollback: a missing declared artifact raises `ArtifactPreservationError` and leaves the card `running` with no attachments and no event, so the handoff can be retried; retrying with a real path succeeds and stages one attachment.
- `completed` event payloads are unchanged: the keys are `artifacts`, `result_len`, `summary` before and after this patch.

## Rebase note

The branch was rebuilt on top of `main` at `d62716c7043e57ef7a29e81a02ddbc19334e29df` rather than the older base it was developed against, and the affected-file suite plus these checks were re-run after the rebase. The diff is the single commit `a711d5c328f8245918cc46d686ccb4eebfba9276`.

## Duplicate search and neighbour PR

I searched open and closed PRs and issues for kanban artifact and review-handoff work before opening this. The closest neighbour is #104576, which touches the same two production files. It reworks artifact handling on the completion path only: its staging call is guarded by `if not review_parked`, so a review-bound completion still stages nothing, and it never touches `request_review`. Not a duplicate — both can land. Expect textual conflicts in `hermes_cli/kanban_db.py` and `gateway/kanban_watchers_notifier.py` if they are in flight together.

## AI-assistance disclosure

This change was developed with an autonomous AI coding agent (Hermes Agent) in the `yoyodine-industries` fork, and the test evidence above is reproducible from the listed commands.
