### PR TITLE
fix(agent): defer an oversized tool surface instead of failing the turn

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -35,6 +35,7 @@ from agent.gemini_native_adapter import is_native_gemini_base_url
 # boxes. Non-Ollama remotes (sglang, vLLM, OpenAI-compat) expose Ollama-compat endpoints that can
 # misidentify and, without an api_key, return 401 on every leg (issue #89863).
 from agent.model_metadata import is_local_endpoint
+from agent.tool_surface_overflow import apply_deferred_tool_surface
 from agent.message_content import flatten_message_text
 from agent.message_metadata import append_message, stamp_message_timestamp
 from agent.message_sanitization import (_sanitize_surrogates, _repair_tool_call_arguments)
@@ -1384,6 +1385,9 @@ def _build_api_kwargs_for_mode(agent, api_messages: list, tools_for_api: list | 
     reasoning_config = _reasoning_config_for_wire(agent)
     if tools_for_api is None:
         tools_for_api = agent.tools
+    # Overflow recovery may have re-rendered the surface deferred for this turn
+    # (agent/tool_surface_overflow.py).
+    tools_for_api = apply_deferred_tool_surface(agent, tools_for_api)
     # The one place request_overrides are consumed: static /fast values are already pinned
     # in agent.request_overrides; auto/cold windows layer the fast override per request.
     request_overrides = effective_request_overrides(agent)

--- a/agent/tool_surface_overflow.py
+++ b/agent/tool_surface_overflow.py
@@ -1,0 +1,44 @@
+"""Per-turn tool surface for requests the active route cannot hold.
+
+Tool definitions are the one part of a request that compaction cannot shrink: with 50+ MCP tools
+the schemas are 20-30K tokens on their own, so a route whose window is smaller than the system
+prompt plus that floor rejects every attempt however much of the transcript is summarized.
+
+Progressive disclosure (``tools/tool_search.py``) is the configured answer — MCP and plugin schemas
+are replaced by the tool_search/tool_describe/tool_call bridge. A session that still carries those
+schemas inline (bridge off by config, or its assembly failed) has no way out. ``agent/turn_overflow.py``
+re-renders such a surface through that same bridge when a provider-proven overflow shows the inline
+schemas cannot fit, and retries the turn. Every tool stays reachable — the model loads a schema with
+``tool_describe`` and invokes it with ``tool_call`` — so nothing is dropped.
+
+The rendered surface is turn-scoped: the request builder substitutes it for ``agent.tools`` and the
+turn prologue clears it, so the next turn starts from the configured surface again.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+_AGENT_ATTR = "_overflow_deferred_tool_surface"
+
+
+def deferred_tool_surface(agent: Any) -> Optional[List[Any]]:
+    """Tool definitions recorded for the rest of this turn, or ``None`` when none are."""
+    surface = getattr(agent, _AGENT_ATTR, None)
+    return surface if isinstance(surface, list) and surface else None
+
+
+def apply_deferred_tool_surface(agent: Any, tools: Any) -> Any:
+    """``tools`` replaced by the recorded surface — the input list when none is recorded."""
+    surface = deferred_tool_surface(agent)
+    return surface if surface is not None else tools
+
+
+def record_deferred_tool_surface(agent: Any, tool_defs: List[Any]) -> None:
+    """Serve *tool_defs* in place of ``agent.tools`` for the remainder of this turn."""
+    setattr(agent, _AGENT_ATTR, list(tool_defs))
+
+
+def reset_deferred_tool_surface(agent: Any) -> None:
+    """Clear the record so the next turn starts from the configured tool surface."""
+    setattr(agent, _AGENT_ATTR, None)

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -24,6 +24,7 @@ from agent.memory_provider import is_trivial_prompt
 from agent.message_metadata import append_message, stamp_message_timestamp
 from agent.model_metadata import estimate_messages_tokens_rough, estimate_request_tokens_rough
 from agent.image_token_cost import bind_image_token_cost
+from agent.tool_surface_overflow import reset_deferred_tool_surface
 from agent.usage_anchor import anchored_context_tokens, restore_usage_anchor
 from agent.turn_author import parse_turn_author
 
@@ -504,6 +505,7 @@ def _reset_per_turn_agent_state(agent: Any) -> None:
         setattr(agent, name, value)
     agent._turn_failed_file_mutations = {}
     agent._turn_file_mutation_paths = set()
+    reset_deferred_tool_surface(agent)
     agent._tool_guardrails.reset_for_turn()
     _reset_consol = getattr(agent._memory_store, "reset_consolidation_failures", None)
     if callable(_reset_consol):

--- a/agent/turn_overflow.py
+++ b/agent/turn_overflow.py
@@ -355,6 +355,80 @@ def _adopt_provider_context_limit(st: _Recovery, error_msg: str, old_ctx: int) -
     return None
 
 
+def _usable_input_tokens(agent: Any) -> int:
+    """Active route's input budget in tokens: the window minus the reserved output space.
+
+    Same effective-input rule the compressor derives its trigger from
+    (``context_compressor._compute_threshold_tokens``); 0 when the window is unknown.
+    """
+    compressor = getattr(agent, "context_compressor", None)
+    context_length = int(getattr(compressor, "context_length", 0) or 0)
+    if context_length <= 0:
+        return 0
+    reserved = (
+        getattr(agent, "_ephemeral_max_output_tokens", None)
+        or getattr(agent, "max_tokens", 0)
+        or 0
+    )
+    return max(0, context_length - int(reserved))
+
+
+def _defer_tool_schemas_for_overflow(st: _Recovery) -> Optional[OverflowVerdict]:
+    """Re-render the inline tool surface through the tool_search bridge and retry when the schemas
+    alone push the request past the active route's input budget. ``None`` when the surface is
+    already deferred, holds nothing deferrable, or the request stays over budget without those
+    schemas (messages, not schemas, are the problem) — the compression ladder owns those cases.
+
+    Nothing is dropped from the session: the bridge keeps every tool reachable through
+    ``tool_describe``/``tool_call``, which is what makes this a degraded surface rather than a
+    dead agent. ``tools.tool_search.enabled: off`` is overridden for the turn — the alternative
+    is a rejected turn, and the user's other knobs (listing, defer set) still apply.
+    """
+    from dataclasses import replace
+
+    from agent.tool_surface_overflow import record_deferred_tool_surface
+    from agent.model_metadata import (
+        _estimate_tools_tokens_rough, _tool_name_for_cache, estimate_request_tokens_rough,
+    )
+    from tools.tool_search import BRIDGE_TOOL_NAMES, assemble_tool_defs, load_config
+
+    agent = st.agent
+    tools = getattr(agent, "tools", None) or []
+    budget = _usable_input_tokens(agent)
+    if not tools or budget <= 0:
+        return None
+    if any(_tool_name_for_cache(t) in BRIDGE_TOOL_NAMES for t in tools):
+        return None
+    config = load_config()
+    if config.enabled == "off":
+        config = replace(config, enabled="on")
+    assembly = assemble_tool_defs(tools, context_length=budget, config=config)
+    if not assembly.activated:
+        return None
+    # The system prompt is carried outside ``api_messages``, and it is part of the same floor.
+    request_tokens = estimate_request_tokens_rough(
+        st.api_messages, system_prompt=getattr(agent, "_cached_system_prompt", "") or "",
+        tools=tools,
+    )
+    saved = _estimate_tools_tokens_rough(tools) - _estimate_tools_tokens_rough(assembly.tool_defs)
+    if saved <= 0 or request_tokens - saved >= budget:
+        return None
+    record_deferred_tool_surface(agent, assembly.tool_defs)
+    agent._buffer_status(
+        f"⚠️  Request exceeds {agent.model}'s {budget:,}-token input budget even with the transcript "
+        f"compacted — moved {assembly.deferred_count} tool definition(s) (~{assembly.deferred_tokens:,} "
+        f"tokens) behind tool_search for this turn; every tool stays reachable via tool_describe/"
+        f"tool_call."
+    )
+    logger.warning(
+        "%sRequest over the active route's input budget with inline tool schemas: deferred %d tool "
+        "definition(s) (~%d tokens) behind the tool_search bridge and retrying (tier %d, listing %s).",
+        agent.log_prefix, assembly.deferred_count, assembly.deferred_tokens,
+        assembly.tier, assembly.listing_form,
+    )
+    return st.done("continue")
+
+
 def _recover_context_length(st: _Recovery, _retry: TurnRetryState, error_msg: str) -> OverflowVerdict:
     """Context-length error. Two shapes: "prompt too long" = INPUT overflows the window
     (shrink context_length + compress); "max_tokens too large" = input fits but
@@ -385,6 +459,13 @@ def _recover_context_length(st: _Recovery, _retry: TurnRetryState, error_msg: st
         )
 
     new_ctx = _adopt_provider_context_limit(st, error_msg, old_ctx)
+
+    # Compaction rewrites messages only; the tool schemas are a floor it cannot touch. When those
+    # schemas alone are what overflows, re-render them deferred (progressive disclosure) instead of
+    # spending compression attempts that cannot help.
+    deferred = _defer_tool_schemas_for_overflow(st)
+    if deferred is not None:
+        return deferred
 
     exhausted = st.count_attempt()
     if exhausted is not None:

--- a/tests/agent/test_overflow_defers_tool_schemas.py
+++ b/tests/agent/test_overflow_defers_tool_schemas.py
@@ -1,0 +1,204 @@
+"""Regression tests: overflow recovery re-renders an inline tool surface deferred.
+
+#6465 reported a session carrying 53 MCP tools plus 17 built-in tools whose provider rejected
+every request: the tool schemas did not fit the window, and compaction cannot shrink them (it
+rewrites messages only). Every compression pass re-sent the same floor, so the turn ended at
+"cannot compress further" with a tool surface that never got to run.
+
+The fix re-renders such a surface through the progressive-disclosure bridge
+(`tools/tool_search.py`) when the schemas alone are what overflows, and retries the turn. The
+schemas leave the request, the session keeps every tool — the model loads one with
+`tool_describe` and invokes it with `tool_call` — and nothing is changed when the transcript is
+what does not fit (compaction owns that case).
+
+Both tests drive a real ``AIAgent.run_conversation`` against a mocked client.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+from agent.model_metadata import _estimate_tools_tokens_rough, estimate_request_tokens_rough
+from tools.registry import registry
+from tools.tool_search import BRIDGE_TOOL_NAMES
+
+# The window a small-window fallback (or a local 32K model) provides.
+_WINDOW_TOKENS = 32_000
+_CORE_TOOL_NAMES = ("read_file", "terminal", "web_search")
+# 60 MCP servers' worth of definitions at ~850 tokens each: the payload class the report carried
+# (53 MCP tools), and several times the 32K window on its own.
+_MCP_TOOL_COUNT = 60
+_MCP_DESCRIPTION_CHARS = 3_400
+_MCP_PREFIX = "mcp__"
+_MCP_SERVER = "overflow-probe"
+
+
+def _tool_def(name: str, description: str) -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description,
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+
+def _core_tool_defs() -> list:
+    return [_tool_def(name, f"{name} tool") for name in _CORE_TOOL_NAMES]
+
+
+def _mcp_tool_defs() -> list:
+    filler = "MCP tool description. " * (_MCP_DESCRIPTION_CHARS // 23)
+    return [_tool_def(f"{_MCP_PREFIX}{_MCP_SERVER}__tool_{i}", filler) for i in range(_MCP_TOOL_COUNT)]
+
+
+def _register_mcp_tools() -> None:
+    """Real registrations: deferral eligibility is resolved from the registry's toolset
+    (``mcp-<server>``), exactly as ``tools/mcp_tool.py`` registers a discovered server."""
+    for i in range(_MCP_TOOL_COUNT):
+        name = f"{_MCP_PREFIX}{_MCP_SERVER}__tool_{i}"
+        registry.register(
+            name=name,
+            toolset=f"mcp-{_MCP_SERVER}",
+            schema=_tool_def(name, "MCP tool")["function"],
+            handler=lambda args, **kwargs: "{}",
+        )
+
+
+def _tool_names(tools) -> list:
+    return [(t.get("function") or {}).get("name") or t.get("name") or "" for t in tools or []]
+
+
+def _mock_response(content="Hello", finish_reason="stop", tool_calls=None):
+    msg = SimpleNamespace(content=content, tool_calls=tool_calls, reasoning_content=None, reasoning=None)
+    resp = SimpleNamespace(choices=[SimpleNamespace(message=msg, finish_reason=finish_reason)], model="test/model")
+    resp.usage = None
+    return resp
+
+
+def _context_overflow_error() -> Exception:
+    """A 400 the classifier routes to ``context_overflow``; its window figure is higher than this
+    test's window, so the provider limit is not adopted and the configured window stands."""
+    err = Exception(
+        "Error code: 400 - {'error': {'message': "
+        "\"This endpoint's maximum context length is 128000 tokens. "
+        "However, you requested about 200000 tokens. "
+        "Please reduce the length of the messages.\"}}"
+    )
+    err.status_code = 400
+    return err
+
+
+@pytest.fixture()
+def agent():
+    _register_mcp_tools()
+    defs = _core_tool_defs() + _mcp_tool_defs()
+    with (
+        patch("model_tools.get_tool_definitions", return_value=defs),
+        patch("model_tools.check_toolset_requirements", return_value={}),
+        patch("agent.process_bootstrap.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    a.client = MagicMock()
+    a._cached_system_prompt = "You are helpful."
+    a._use_prompt_caching = False
+    a.compression_enabled = True
+    a.save_trajectories = False
+    a.context_compressor.context_length = _WINDOW_TOKENS
+    return a
+
+
+def _input_budget(agent) -> int:
+    """The window minus the reserved output space — the budget the deferral gate must respect."""
+    return _WINDOW_TOKENS - (agent.max_tokens or 0)
+
+
+def _run(agent, history):
+    """Run one turn with compaction stubbed to a no-op (compaction is not the mechanism under
+    test, and a real pass would call the auxiliary model)."""
+    with (
+        patch.object(agent, "_compress_context") as compress,
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        compress.return_value = (history, "system prompt")
+        result = agent.run_conversation("hello", conversation_history=history)
+    return result, compress
+
+
+def _prefill():
+    return [
+        {"role": "user", "content": "previous question"},
+        {"role": "assistant", "content": "previous answer"},
+    ]
+
+
+def test_defers_inline_schemas_when_they_alone_do_not_fit(agent):
+    """The tool floor is what overflows: the schemas move behind the bridge and the turn runs."""
+    calls = agent.client.chat.completions.create
+    calls.side_effect = [_context_overflow_error(), _mock_response(content="Recovered")]
+
+    result, _compress = _run(agent, _prefill())
+
+    assert calls.call_count >= 2, "the rejected request must be retried against the same route"
+    first, last = calls.call_args_list[0].kwargs, calls.call_args_list[-1].kwargs
+
+    # Premise, measured on the actual payloads: the inline schemas alone overflow the window, and
+    # the request fits once they are behind the bridge.
+    budget = _input_budget(agent)
+    sent_full = estimate_request_tokens_rough(
+        first["messages"], system_prompt=agent._cached_system_prompt, tools=agent.tools
+    )
+    assert sent_full > budget
+    assert sent_full - _estimate_tools_tokens_rough(agent.tools) + _estimate_tools_tokens_rough(
+        last["tools"]
+    ) < budget
+
+    # The rejected request carried the whole surface; the retry keeps the built-in tools and
+    # swaps the MCP schemas for the bridge, so every deferred tool stays reachable.
+    assert [n for n in _tool_names(first["tools"]) if n.startswith(_MCP_PREFIX)]
+    retried = _tool_names(last["tools"])
+    assert not [n for n in retried if n.startswith(_MCP_PREFIX)]
+    assert set(_CORE_TOOL_NAMES) <= set(retried)
+    assert BRIDGE_TOOL_NAMES <= set(retried)
+
+    # agent.tools is untouched: the deferral is a request-level surface, not a toolset mutation —
+    # the next turn starts from the configured surface again.
+    assert [n for n in _tool_names(agent.tools) if n.startswith(_MCP_PREFIX)]
+
+    assert result.get("failed") is not True
+    assert result["final_response"] == "Recovered"
+
+
+def test_does_not_defer_when_the_transcript_is_what_does_not_fit(agent):
+    """Messages over the budget with the schemas deferred: compaction stays the only lever."""
+    calls = agent.client.chat.completions.create
+    calls.side_effect = [_context_overflow_error(), _mock_response(content="Recovered")]
+
+    # ~50K tokens of transcript: deferring the schemas cannot bring this under a 32K window.
+    history = [
+        {"role": "user", "content": "x" * 200_000},
+        {"role": "assistant", "content": "noted"},
+    ]
+    result, _compress = _run(agent, history)
+
+    from agent.tool_surface_overflow import deferred_tool_surface
+
+    assert deferred_tool_surface(agent) is None, "the transcript, not the schemas, is what overflows"
+    for call in calls.call_args_list:
+        sent = _tool_names(call.kwargs["tools"])
+        assert [n for n in sent if n.startswith(_MCP_PREFIX)], (
+            "a request the deferred surface cannot rescue must keep the configured surface"
+        )
+        assert not BRIDGE_TOOL_NAMES & set(sent)
+    assert result.get("failed") is True

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -155,6 +155,22 @@ does not re-fire every turn. Two paths run a real attempt anyway:
   the next failure would extend the ladder (#100661). If that attempt fails,
   the cooldown is recorded normally.
 
+#### The tool-schema floor
+
+Compaction rewrites messages; it cannot touch the request's tool definitions. With 50+ MCP tools
+the schemas are 20-30K tokens on their own, and a route whose window is smaller than the system
+prompt plus that floor rejects every request no matter how much of the transcript is summarized.
+
+When a provider-proven overflow arrives and the MCP definitions alone are what push the request
+past the route's input budget (`context_length - max_tokens`), overflow recovery
+(`agent/turn_overflow.py` + `agent/mcp_tool_shed.py`) sheds those definitions and retries the
+same turn. Built-in tools — terminal, files, search, delegation — are never dropped, so the
+agent keeps working with a reduced tool surface instead of failing. Nothing is shed when the
+transcript is what does not fit (that stays the compression path's job), and the shed is
+turn-scoped: the next turn starts with the full surface again. The user sees a
+`dropped N MCP tool definition(s)` notice; trimming MCP servers (`hermes tools`) keeps it from
+recurring.
+
 
 ## Configuration
 

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -127,6 +127,10 @@ When triggered, Hermes:
 
 The switch is seamless — your conversation history, tool calls, and context are preserved. The agent continues from exactly where it left off, just using a different model.
 
+:::info Fallback models with small context windows
+A fallback model can have a far smaller context window than your primary (a local 32K model, a free-tier endpoint). Tool definitions are the part of a request that compaction cannot shrink, and with 50+ MCP tools the schemas alone can exceed such a window — every request is then rejected no matter how much history is compacted away. Hermes handles that case by dropping the MCP tool definitions for the affected turn (built-in tools — terminal, files, search, delegation — always stay) and retrying, instead of failing the turn. If this fires repeatedly, choose a fallback with a larger window or trim MCP servers with `hermes tools`.
+:::
+
 :::warning Fallback resets the prompt cache
 Prompt caches are keyed to the model (and on most providers, the account) serving the request. When fallback fires, the new provider:model has no cached prefix for your conversation, so the next request re-reads the entire history at full input-token price instead of the ~75–90% discounted cached rate. The same applies when the turn ends and the primary is restored — that first request back on the primary is a full re-read too (unless the primary's cache TTL hasn't expired). This is unavoidable — it's the cost of staying alive through an outage — but it's why a long session that bounces between providers can cost noticeably more than one that stays put.
 :::


### PR DESCRIPTION
## Problem

#6465 (closed) reported a session with 53 MCP tools + 17 built-in tools where the fallback
provider rejected every request: the tool payload did not fit the model's window. The fix
there stripped **all** tools, which the reviewer correctly rejected — "that's not graceful
degradation, it's a broken agent", with the direction: *selectively trim MCP tools while
preserving core tools*.

This PR implements that direction, but not by deleting capability. Tool definitions are the
one part of a request that compaction cannot shrink: `ContextCompressor` rewrites messages,
while the schemas ride every attempt unchanged. On a route whose window is below the
system-prompt + tool-schema floor, each compression pass reports "insufficient progress", the
request is rejected again, and the turn ends terminally:

```
📦 Pre-API compression: ~49,382 request tokens near the context/output limit. Compacting before the next model call.
WARNING Pre-API compression made insufficient progress: ~49,382 -> ~49,382 request tokens; skipping additional preflight passes
ERROR   Context compression failed after 3 attempts; rebuilt request remains over threshold at ~49,382 tokens.
```

(reproduced on current `main` by the new test, see below)

## Approach

`agent/turn_overflow.py` gains one step in the context-length recovery, after the
provider-reported limit is adopted and before the compression attempts that cannot help:
re-render the inline surface through the **existing** progressive-disclosure bridge
(`tools/tool_search.py::assemble_tool_defs`) and retry the same turn.

- The schemas leave the request; built-in tools stay direct; **every** deferred tool stays
  reachable — the model loads one with `tool_describe` and invokes it with `tool_call`. That
  is what makes this "selectively trim MCP tools while preserving core tools" without turning
  the agent into a chatbot.
- The step fires only when it provably helps: it is skipped unless removing those schemas
  brings the request under the route's input budget (`context_length - max_tokens`). A
  transcript that does not fit is still the compression ladder's job.
- The surface is turn-scoped (`agent/tool_surface_overflow.py`): `_build_api_kwargs_for_mode`
  substitutes it (covering the main request and the iteration-summary call), and
  `_reset_per_turn_agent_state` clears it, so `agent.tools` is never mutated and the next
  turn starts from the configured surface.
- `tools.tool_search.enabled: off` is overridden for that turn only — the alternative is a
  rejected turn — while the user's other knobs (listing, `defer`) still apply. Yell if you'd
  rather a bridge-off config fail than degrade; it's a one-line change.

## Scope / not in this PR

- 413 (`payload_too_large`) keeps its byte-scored recovery untouched; this is the
  context-length arm, which is what the report hit.
- Sessions where the bridge is already active are unaffected (`agent.tools` carries no
  deferrable schemas, so the step returns immediately) and the default config is a no-op for
  it. The step exists for the configs where schemas *are* inline — `tool_search` off, or its
  assembly failing (that path logs and passes the raw schemas through).
- No new config knob: the gate is the route's own budget, with no magic numbers.
- Translations: the `zh-Hans` copies of both docs already trail the English by hundreds of
  lines, so this updates English only.

## Tests

`tests/agent/test_overflow_defers_tool_schemas.py` (real `AIAgent.run_conversation`, mocked
client, MCP tools genuinely registered in the registry):

1. `test_defers_inline_schemas_when_they_alone_do_not_fit` — the premise is asserted on the
   payloads (full surface exceeds the window; deferred surface fits), then that the retry
   keeps every built-in tool, carries the bridge, drops the MCP schemas, leaves `agent.tools`
   untouched, and completes the turn.
2. `test_does_not_defer_when_the_transcript_is_what_does_not_fit` — a ~50K-token transcript
   keeps the configured surface and no bridge is injected.

**Red on base:** with the source hunks stashed, test 1 fails with the terminal failure quoted
above; with the fix both pass.

```
scripts/run_tests.sh tests/agent/test_overflow_defers_tool_schemas.py \
  tests/run_agent/test_overflow_overhead_aware_tokens.py tests/agent/test_413_image_payload_recovery.py \
  tests/run_agent/test_1630_context_overflow_loop.py tests/agent/test_turn_context_overflow_warning.py \
  tests/run_agent/test_provider_fallback.py tests/tools/test_tool_search.py tests/tools/test_deferral_fixes.py
→ 8 files, 132 tests passed

scripts/run_tests.sh tests/agent/ tests/run_agent/
→ 18 failures / 12 files, identical with this diff stashed: all `ImportError: The 'anthropic'
  package is required for the Anthropic provider` (this checkout's venv lacks the optional SDK)
```

## Prompt caching

The deferred surface changes the cached tool prefix mid-turn. Shedding it is only reached
after the provider has already rejected the request, so the alternative is a failed turn —
same tradeoff the sanctioned cache break (compaction) makes in the same ladder.
