### PR TITLE
fix(memory): stop repeating failed approval replays

### DIFF
--- a/hermes_cli/write_approval_commands.py
+++ b/hermes_cli/write_approval_commands.py
@@ -22,7 +22,12 @@ def _fmt_pending_list(subsystem: str) -> str:
     for r in records:
         origin = r.get("origin", "foreground")
         tag = " [auto]" if origin == "background_review" else ""
-        lines.append(f"  {r['id']}{tag}  {r.get('summary', '')}")
+        status = wa.pending_status(r)
+        status_tag = f" [{status}]" if status != wa.PENDING else ""
+        lines.append(f"  {r['id']}{tag}{status_tag}  {r.get('summary', '')}")
+        if status == wa.NEEDS_REVIEW and r.get("last_error"):
+            error = " ".join(str(r["last_error"]).split())
+            lines.append(f"    Last failure: {error[:240]}")
     lines.append("")
     lines.append(f"Apply: /{subsystem} approve <id>   Reject: /{subsystem} reject <id>")
     if subsystem == wa.SKILLS:
@@ -66,27 +71,56 @@ def _approve(subsystem: str, rest: List[str], memory_store) -> str:
     records = wa.list_pending(subsystem)
     if not records:
         return f"No pending {subsystem} writes."
-    if target.lower() == "all":
-        targets = list(records)
+    approve_all = target.lower() == "all"
+    if approve_all:
+        target_ids = [rec["id"] for rec in records]
     else:
         rec = wa.get_pending(subsystem, target)
         if not rec:
             return f"No pending {subsystem} write with id '{target}'."
-        targets = [rec]
+        target_ids = [rec["id"]]
 
-    applied, failed = 0, []
-    for rec in targets:
-        ok, msg = _apply_one(subsystem, rec, memory_store)
-        if ok:
-            wa.discard_pending(subsystem, rec["id"])
+    applied, failed, skipped = 0, [], []
+    for pending_id in target_ids:
+        outcome = wa.process_pending(
+            subsystem,
+            pending_id,
+            lambda rec: _apply_one(subsystem, rec, memory_store),
+            allow_needs_review=not approve_all,
+            track_failure=subsystem == wa.MEMORY,
+        )
+        state = outcome.get("state")
+        if state == "applied":
             applied += 1
+        elif state == "skipped":
+            if approve_all:
+                status = outcome.get("record", {}).get("status", wa.PENDING)
+                skipped.append((pending_id, status))
+            else:
+                failed.append(f"{pending_id}: pending record is not actionable")
+        elif state == "missing":
+            if not approve_all:
+                return f"No pending {subsystem} write with id '{target}'."
         else:
-            failed.append(f"{rec['id']}: {msg}")
+            failed.append(f"{pending_id}: {outcome.get('error', 'approval failed')}")
 
     out = [f"Approved {applied} {subsystem} write(s)."]
     if failed:
         out.append("Failed:")
         out.extend(f"  {f}" for f in failed)
+    if skipped:
+        needs_review = sum(status == wa.NEEDS_REVIEW for _, status in skipped)
+        if needs_review == len(skipped):
+            message = (
+                f"Skipped {len(skipped)} {subsystem} write(s) marked needs_review. "
+                f"Fix the reported condition, then approve each by id or reject it."
+            )
+        else:
+            message = (
+                f"Skipped {len(skipped)} {subsystem} write(s) that are not actionable. "
+                f"Review each record before approving or rejecting it."
+            )
+        out.append(message)
     return "\n".join(out)
 
 

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -177,6 +177,105 @@ def test_handle_approve_all(hermes_home):
     assert len(store.user_entries) == 2
 
 
+def test_failed_memory_approval_is_marked_and_skipped_by_approve_all(hermes_home):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+    from tools.memory_tool import MemoryStore
+
+    store = MemoryStore(); store.load_from_disk()
+    assert store.add("memory", "alpha")["success"] is True
+    record = wa.stage_write(
+        wa.MEMORY,
+        {"action": "replace", "target": "memory", "old_text": "missing", "content": "replacement"},
+        summary="invalid replacement",
+        origin="foreground",
+    )
+
+    first = handle_pending_subcommand(wa.MEMORY, ["approve", "all"], memory_store=store)
+    assert "Approved 0" in first
+    failed = wa.get_pending(wa.MEMORY, record["id"])
+    assert failed["status"] == "needs_review"
+    assert failed["failure_count"] == 1
+    assert "No entry matched" in failed["last_error"]
+
+    pending = handle_pending_subcommand(wa.MEMORY, ["pending"], memory_store=store)
+    assert "[needs_review]" in pending
+    assert "No entry matched" in pending
+
+    second = handle_pending_subcommand(wa.MEMORY, ["approve", "all"], memory_store=store)
+    assert "Approved 0" in second
+    assert "Skipped 1" in second
+    assert wa.get_pending(wa.MEMORY, record["id"])["failure_count"] == 1
+
+
+def test_failed_memory_approval_can_be_retried_by_id_after_repair(hermes_home):
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+    from tools.memory_tool import MemoryStore
+
+    store = MemoryStore(); store.load_from_disk()
+    assert store.add("memory", "alpha")["success"] is True
+    record = wa.stage_write(
+        wa.MEMORY,
+        {"action": "replace", "target": "memory", "old_text": "missing anchor", "content": "replacement"},
+        summary="repairable replacement",
+        origin="foreground",
+    )
+
+    handle_pending_subcommand(wa.MEMORY, ["approve", "all"], memory_store=store)
+    assert wa.get_pending(wa.MEMORY, record["id"])["status"] == "needs_review"
+    assert store.add("memory", "missing anchor")["success"] is True
+
+    retry = handle_pending_subcommand(
+        wa.MEMORY, ["approve", record["id"]], memory_store=store
+    )
+    assert "Approved 1" in retry
+    assert wa.get_pending(wa.MEMORY, record["id"]) is None
+    assert "replacement" in store.memory_entries
+
+
+def test_pending_failure_transition_serializes_concurrent_approval(hermes_home):
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Event, Lock
+
+    from tools import write_approval as wa
+
+    record = wa.stage_write(
+        wa.MEMORY,
+        {"action": "replace", "target": "memory", "old_text": "missing", "content": "replacement"},
+        summary="concurrent invalid replacement",
+        origin="foreground",
+    )
+    started = Event()
+    release = Event()
+    calls = []
+    calls_lock = Lock()
+
+    def apply(_record):
+        with calls_lock:
+            calls.append(True)
+        started.set()
+        assert release.wait(timeout=5)
+        return False, "deterministic approval failure"
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(
+            wa.process_pending, wa.MEMORY, record["id"], apply, track_failure=True
+        )
+        assert started.wait(timeout=5)
+        second = executor.submit(
+            wa.process_pending, wa.MEMORY, record["id"], apply, track_failure=True
+        )
+        release.set()
+        outcomes = [first.result(timeout=2), second.result(timeout=2)]
+
+    assert len(calls) == 1
+    assert sorted(outcome["state"] for outcome in outcomes) == ["failed", "skipped"]
+    failed = wa.get_pending(wa.MEMORY, record["id"])
+    assert failed["status"] == wa.NEEDS_REVIEW
+    assert failed["failure_count"] == 1
+
+
 def test_handle_approval_on(hermes_home):
     from hermes_cli.write_approval_commands import handle_pending_subcommand
     from tools import write_approval as wa

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -11,6 +11,7 @@ interactive CLI only) or **stages** the write under
 
 from __future__ import annotations
 
+import contextlib
 import difflib
 import json
 import logging
@@ -27,10 +28,22 @@ from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
 
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows uses msvcrt
+    fcntl = None
+try:
+    import msvcrt
+except ImportError:  # pragma: no cover - POSIX uses fcntl
+    msvcrt = None
+
 # Subsystem identifiers
 MEMORY = "memory"
 SKILLS = "skills"
 _SUBSYSTEMS = (MEMORY, SKILLS)
+PENDING = "pending"
+NEEDS_REVIEW = "needs_review"
+_MAX_FAILURE_ERROR_CHARS = 2000
 
 # Per-subsystem config key. Intentionally a single boolean with no "block all writes"
 # state — to disable a subsystem use its own enable flag (e.g. ``memory.memory_enabled``).
@@ -70,6 +83,49 @@ def _pending_files(subsystem: str) -> list:
     return list(d.glob("*.json")) if d.exists() else []
 
 
+def _write_pending_record(path: Path, record: Dict[str, Any]) -> None:
+    """Atomically replace one pending record while its record lock is held."""
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+@contextlib.contextmanager
+def _pending_record_lock(subsystem: str, pending_id: str):
+    """Serialize approval, failure disposition, and rejection for one record."""
+    path = _pending_path(subsystem, pending_id)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    if fcntl is None and msvcrt is None:
+        yield
+        return
+    with open(lock_path, "a+", encoding="utf-8") as fd:
+        if fcntl is not None:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            return
+
+        fd.seek(0, os.SEEK_END)
+        if fd.tell() == 0:
+            fd.write("0")
+            fd.flush()
+        fd.seek(0)
+        msvcrt.locking(fd.fileno(), msvcrt.LK_LOCK, 1)
+        try:
+            yield
+        finally:
+            fd.seek(0)
+            msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
+
+
+def pending_status(record: Dict[str, Any]) -> str:
+    """Return a pending record's lifecycle status, including legacy records."""
+    return record.get("status", PENDING)
+
+
 def stage_write(subsystem: str, payload: Dict[str, Any], *, summary: str, origin: str) -> Dict[str, Any]:
     """Persist a pending write and return its record (``id`` + metadata). ``payload`` is the exact
     kwargs to replay the write on approval; ``origin`` is ``foreground`` or ``background_review``.
@@ -79,14 +135,12 @@ def stage_write(subsystem: str, payload: Dict[str, Any], *, summary: str, origin
     record = {
         "id": pid, "subsystem": subsystem, "action": payload.get("action", ""),
         "summary": (summary or "").strip(), "origin": origin or "foreground",
-        "created_at": time.time(), "payload": payload,
+        "created_at": time.time(), "payload": payload, "status": PENDING,
     }
     try:
         path = _pending_path(subsystem, pid)
         path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(".json.tmp")
-        tmp.write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
-        os.replace(tmp, path)
+        _write_pending_record(path, record)
     except Exception as e:  # pragma: no cover - disk failure path
         logger.error("Failed to stage pending %s write: %s", subsystem, e, exc_info=True)
     return record
@@ -118,12 +172,90 @@ def discard_pending(subsystem: str, pending_id: str) -> bool:
     """Delete a pending record. Returns True if it existed."""
     try:
         path = _pending_path(subsystem, pending_id)
-        if path.exists():
-            path.unlink()
-            return True
+        if not path.exists():
+            return False
+        with _pending_record_lock(subsystem, pending_id):
+            if path.exists():
+                path.unlink()
+                return True
     except Exception as e:  # pragma: no cover
         logger.error("Failed to discard pending %s/%s: %s", subsystem, pending_id, e)
     return False
+
+
+def process_pending(
+    subsystem: str,
+    pending_id: str,
+    apply_fn,
+    *,
+    allow_needs_review: bool = False,
+    track_failure: bool = False,
+) -> Dict[str, Any]:
+    """Apply one record while serializing its state transition.
+
+    Legacy records without ``status`` are active. Memory failures are retained as
+    ``needs_review`` so bulk approval cannot replay the same deterministic failure;
+    an explicit approval by ID may retry that record after the underlying state is
+    repaired. The record lock covers apply plus discard/retention, preventing a
+    concurrent rejection or successful approval from being undone by a late write.
+    """
+    path = _pending_path(subsystem, pending_id)
+    if not path.exists():
+        return {"state": "missing"}
+    try:
+        with _pending_record_lock(subsystem, pending_id):
+            if not path.exists():
+                return {"state": "missing"}
+            try:
+                record = json.loads(path.read_text(encoding="utf-8"))
+            except Exception as exc:
+                logger.warning("Unable to read pending %s/%s: %s", subsystem, pending_id, exc)
+                return {"state": "unreadable", "error": "pending record could not be read"}
+
+            status = pending_status(record)
+            if status != PENDING and not (allow_needs_review and status == NEEDS_REVIEW):
+                return {"state": "skipped", "record": record}
+
+            try:
+                ok, message = apply_fn(record)
+            except Exception as exc:  # pragma: no cover - apply helpers return errors
+                logger.error("Pending %s/%s application failed: %s", subsystem, pending_id, exc, exc_info=True)
+                ok, message = False, str(exc)
+            if ok:
+                try:
+                    path.unlink()
+                except Exception as exc:  # pragma: no cover - filesystem failure
+                    logger.error("Applied pending %s/%s but could not discard it: %s", subsystem, pending_id, exc,
+                                 exc_info=True)
+                    return {
+                        "state": "failed",
+                        "record": record,
+                        "error": "write applied, but its approval record could not be removed; it was not retried",
+                    }
+                return {"state": "applied", "record": record}
+
+            message = str(message or "approval failed")
+            if track_failure:
+                try:
+                    failure_count = int(record.get("failure_count", 0)) + 1
+                except (TypeError, ValueError):
+                    failure_count = 1
+                record = {
+                    **record,
+                    "status": NEEDS_REVIEW,
+                    "failure_count": failure_count,
+                    "last_error": message[:_MAX_FAILURE_ERROR_CHARS],
+                    "failed_at": time.time(),
+                }
+                try:
+                    _write_pending_record(path, record)
+                except Exception as exc:  # pragma: no cover - filesystem failure
+                    logger.error("Pending %s/%s failed and could not record disposition: %s", subsystem, pending_id,
+                                 exc, exc_info=True)
+            return {"state": "failed", "record": record, "error": message}
+    except Exception as exc:  # pragma: no cover - lock/filesystem failure
+        logger.error("Failed to process pending %s/%s: %s", subsystem, pending_id, exc, exc_info=True)
+        return {"state": "failed", "error": str(exc)}
 
 
 def pending_count(subsystem: str) -> int:


### PR DESCRIPTION
## Summary

This PR is a complementary lifecycle fix for #109215. It does not supersede or copy PR #109227.

- Retain failed native-memory approval records with an explicit `needs_review` disposition.
- Prevent `approve all` from replaying the same deterministic failure indefinitely.
- Keep the failed payload and actionable error available through `/memory pending`.
- Preserve explicit retry by ID after the underlying memory state is repaired.
- Serialize approval, failure disposition, and rejection for the same record to prevent concurrent transitions from resurrecting or double-processing a pending record.

The pre-staging semantic validation proposed by #109227 remains the complementary protection for preventing new invalid records from entering the queue. This PR handles records that already exist, become stale after staging, or fail during approval.

## Problem observed

- Current behavior: `_approve()` applies every record returned by `list_pending()` and removes only successful records. A deterministic failure remains indistinguishable from a never-attempted pending record, so every later `/memory approve all` repeats the same failure.
- Expected behavior: a failed memory proposal must remain available for review, but bulk approval must not treat it as ready indefinitely. The user must see the failure and be able to retry it explicitly after repairing the underlying state, or reject it.
- Reproduction: on the clean baseline, the #109215 reproducer staged three invalid proposals (missing anchor, final-budget overflow, and invalid batch). The first approval returned `Approved 0` with three failures; the second approval replayed the same three failures and retained all records.
- RED proof before the production change:
  `scripts/run_tests.sh tests/tools/test_write_approval.py -k 'failed_memory_approval' -v --tb=short`
  produced 2 failures with `KeyError: 'status'` in the new behavior-contract tests, confirming that the baseline did not classify or suppress repeated failures.

## Root cause

`hermes_cli/write_approval_commands.py:_approve()` previously operated on a snapshot of records and called `_apply_one()` directly. The failure branch appended text to the response but performed no state transition. `tools/write_approval.py` persisted only the original payload and staging metadata, so the pending store had no distinction between an actionable record and one that had already failed deterministically.

The old flow also allowed a concurrent approval and rejection/failure update to race: a late failure metadata write could recreate a record after a successful approval had discarded it.

## Impact and scope

- Affected: native-memory pending records processed by `/memory approve`, `/memory apply`, `/memory pending`, and `/memory reject` through the shared approval handler.
- Preserved: native-memory semantics, pre-staging gates, `background_review` replace/remove protection, final-state batch budgets, replay revalidation, provider notification rules, prompt-cache behavior, and the skill approval failure behavior.
- The `skills` path continues to treat failed records as retryable because failure disposition tracking is enabled only for `memory`; the shared record processor still serializes its approval and rejection transitions.
- No configuration migration is required. Existing records without `status` are interpreted as active `pending` records.
- No credentials, secrets, or user memory contents are added to logs or repository artifacts.

## Relationship to existing work

- Complementary to PR #109227 (`fix(memory): reject invalid proposals before staging`): #109227 prevents new semantically invalid memory proposals from being staged by validating against a fresh locked disk snapshot. This PR does not modify its files or implementation; it handles the already-staged/replay lifecycle and repeated approval failures.
- PR #109226 (`fix(memory): validate proposals before staging`) was independently tested and still staged a proposal when the caller's in-memory store was stale relative to disk. It is not reused here.
- #109045 covers only batches whose budget can never fit; #71824/#105896 cover content/threat scanning; #81682 covers duplicate pending proposals; #96059/#76294 cover stale skill replay. None provides this native-memory failure disposition.
- This PR is an independent complementary follow-up, not a duplicate implementation and not a request to close, rewrite, or supersede either contributor-owned PR.

## Solution

- New pending records are marked `status: "pending"`; records created before this change remain compatible through the legacy default.
- `tools/write_approval.py:process_pending()` owns the per-record transition while a platform-native lock is held:
  - reads the current record rather than using a stale caller copy;
  - applies it while serializing against rejection or another approval;
  - discards it only after success;
  - records `status: "needs_review"`, `failure_count`, `last_error`, and `failed_at` after a memory failure;
  - preserves the original payload for inspection and explicit retry;
  - fails closed on unknown lifecycle states and does not recreate a record after it has disappeared.
- `hermes_cli/write_approval_commands.py` uses that transition for both subsystems:
  - `approve all` skips records already marked `needs_review` and reports the count/action;
  - approving a specific ID is an explicit retry and can apply a repaired proposal;
  - `/memory pending` displays the status and a bounded, single-line form of the last error;
  - rejection shares the same record lock.
- The implementation adds no second memory-operation validator and does not change the independent unattended delete/replace gate.

## Alternatives considered

1. Lock the memory file until human approval: rejected because approval can wait on user input or a remote transport, creating long lock holds and reentrancy/deadlock risk.
2. Add another clone/dry-run validator: rejected because it duplicates `MemoryStore` semantics and risks divergence from the authoritative executor. That is the scope addressed by #109227.
3. Add a hash/version/CAS precondition to every pending record: useful for a future stale-after-stage follow-up, but larger than this lifecycle fix and does not by itself stop repeated `approve all` failures.
4. Automatically discard failed records: rejected because it destroys the user's ability to inspect, repair, reject, or explicitly retry the proposal.
5. Mark every approval failure as successful or silently suppress the error: rejected because it would hide failed writes and weaken auditability.

The selected design is the smallest complementary change that fixes the repeated-replay lifecycle while preserving the existing payload and approval boundary.

## Compatibility and residual risks

- Legacy pending JSON without `status` remains approvable.
- Memory failures are retained rather than deleted; `pending_count` continues to include them so they remain discoverable until explicitly rejected or successfully retried.
- An exact-ID approval is intentionally a user-directed retry. It still passes through the authoritative replay validation and cannot bypass memory target checks or the unattended gate.
- A filesystem failure while recording failure metadata is logged and returned as an approval failure; the original pending record is not silently discarded.
- The per-record lock file remains beside the JSON record and is excluded from `*.json` enumeration. It adds O(1) lock metadata and one O(record-size) atomic JSON rewrite only when recording a memory failure. Successful approval keeps the existing apply cost plus the lock acquisition.
- Drifted/unreadable memory files remain governed by the existing #26045 preservation guard; this PR does not claim to repair that separate preflight gap.

## Tests and verification

| Command/test | Purpose | Result |
|---|---|---|
| `scripts/run_tests.sh tests/tools/test_write_approval.py -k 'failed_memory_approval' -v --tb=short` before production code | Prove the new regression tests are RED on the baseline | 0 passed, 2 failed as expected (`KeyError: status`) |
| `scripts/run_tests.sh tests/tools/test_write_approval.py -k 'failed_memory_approval or pending_failure_transition' -v --tb=long` | Verify classification, bulk skip, explicit retry, and concurrent transition | 3 passed, 0 failed |
| Independent real-import reproducer with temporary `HERMES_HOME` | Reproduce three staged invalid proposals and verify the complementary lifecycle | First approval classified all 3 as `needs_review`; second `approve all` reported `Skipped 3`; payloads remained available; memory stayed unchanged |
| `scripts/run_tests.sh tests/tools/test_write_approval.py tests/tools/test_memory_tool.py tests/tools/test_skill_manage_batch.py tests/agent/test_background_review_memory_scope.py tests/agent/test_builtin_memory_disabled_surface.py -q` | Verify approval, native memory, skill sibling, and background-review contracts | 109 passed, 0 failed |
| `ruff check hermes_cli/write_approval_commands.py tools/write_approval.py tests/tools/test_write_approval.py` | Lint changed Python files | Passed |
| `python -m compileall -q hermes_cli/write_approval_commands.py tools/write_approval.py tests/tools/test_write_approval.py` | Compile changed Python files | Passed |
| `git diff --check` | Whitespace/error check | Passed |
| `scripts/run_tests.sh tests/tools/test_skill_manager_tool.py -q` on this branch | Sibling baseline check | 59 passed, 1 failed, 3 skipped; the failure is `WinError 1314` creating a directory symlink and reproduces on a clean `origin/main` worktree, so it is a Windows privilege limitation unrelated to this diff |
| `graphify query`, `graphify explain`, and `graphify path` during investigation | Bound the memory-tool/approval call graph | Query/explain indexed the relevant producer/consumer nodes; directed path was unavailable in the generated graph representation |
| `graphify update . --no-cluster` after edits | Required graph refresh | Timed out after 420 seconds before producing `graph.json`; no graph artifact is included or claimed as updated |

## Changed files

- `tools/write_approval.py` — lifecycle status, atomic record writes, cross-platform per-record serialization, and failure disposition.
- `hermes_cli/write_approval_commands.py` — status-aware listing and approval behavior.
- `tests/tools/test_write_approval.py` — RED/GREEN contracts for repeated failure suppression, explicit repair retry, and concurrent approval serialization.

## Delivery receipt

- Base at branch creation: `476d7223b594824545debcc29df0c53e4fb0c782`.
- Upstream `main` advanced before PR read-back; the persisted PR base is `d62716c7043e57ef7a29e81a02ddbc19334e29df`.
- Branch: `fix/memory-approval-failure-disposition-109215`.
- Commit: `628badcdf0c8b861c5c1b7743168ba1e1fad0617` (`fix(approvals): retain failed memory proposals for review`).
- The branch has not been rebased or force-pushed; GitHub currently reports `MERGEABLE` with merge state `BLOCKED` because no checks are reported.
- The local delivery worktree was clean at commit creation.

Fixes #109215
