### PR TITLE
fix(cron): land ended_at for successful jobs after a transient cleanup stall (#76914)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1825,6 +1825,40 @@ def _final_response_from_result(result: dict, job_id: str, job_name: str, AIAgen
     return final_response
 
 
+def _safe_lineage_title(session_db, job_id: str, base_title: str):
+    """Next free lineage title via ``get_next_title_in_lineage`` without letting a poisoned
+    bounded proxy (disabled / timed out) or a missing method escape — returns *base_title*
+    unchanged on any failure (#76914)."""
+    try:
+        return getattr(session_db, "get_next_title_in_lineage", lambda b: b)(base_title)
+    except (Exception, KeyboardInterrupt) as e:
+        logger.debug("Job '%s': lineage title probe failed: %s", job_id, e)
+        return base_title
+
+
+def _ended_session_via_retry(session_db, session_id: str, end_reason: str, job_id: str) -> bool:
+    """One bounded, direct (un-proxied) ``end_session`` attempt after the bounded proxy path
+    failed (#76914).
+
+    A transient system stall (load spike, fsync latency) can push the first finalization
+    write past the cleanup timeout; the bounded proxy then fail-fasts every later step, the
+    ``end_session`` raise is swallowed, and the ``ended_at`` tombstone never lands — a
+    *successful* job leaves a zombie row that prune/archive (pinned to ``ended_at IS NOT
+    NULL``) can never reach. The stall is transient by observation (same job self-recovers
+    on its next run), so one more bounded attempt on the raw store lands it; a genuinely
+    damaged store times out again and we are no worse than before. ``end_session`` is
+    first-reason-wins, so a racing abandoned first attempt cannot corrupt the reason.
+    """
+    def _direct_end() -> None:
+        session_db.end_session(session_id, end_reason)
+
+    ok = _run_cron_cleanup_with_timeout(
+        _direct_end, job_id=job_id, label="session finalization (end_session retry)")
+    if not ok:
+        logger.debug("Job '%s': end_session retry did not land", job_id)
+    return ok
+
+
 def _finalize_cron_session(session_db, agent, job_id: str, job_name: str, cron_session_id: str) -> None:
     """Title, classify, end and release the cron session after the agent turn has returned."""
     # Bound every DB op so storage failure cannot hold the dispatch guard.
@@ -1862,8 +1896,11 @@ def _finalize_cron_session(session_db, agent, job_id: str, job_name: str, cron_s
         logger.debug("Job '%s': failed to set cron session title: %s", job_id, e)
         # Never leave the session untitled.
         # Try the next free title in the lineage, then a bare id-stamped title. See #50535.
+        # The lineage probe runs on the possibly-poisoned bounded proxy — it may fail-fast
+        # (disabled) or time out; both must fall through to the bare id-stamped title, never
+        # escape this finally block (#76914: an escape skipped end_session + release entirely).
         for _fallback in (
-            getattr(_session_db, "get_next_title_in_lineage", lambda b: b)(f"cron {job_id}"),
+            _safe_lineage_title(_session_db, job_id, f"cron {job_id}"),
             f"cron {job_id} {_final_cron_session_id[-6:]}"):
             try:
                 if _set_cron_session_title(_session_db, _final_cron_session_id, _fallback):
@@ -1903,10 +1940,16 @@ def _finalize_cron_session(session_db, agent, job_id: str, job_name: str, cron_s
         # SQLite handle (#94736). The reason is durably booked, so disarm only the
         # agent's redundant row-finalization; its resource teardown still runs in
         # _teardown_cron_agent.
-        if agent is not None:
-            agent._end_session_on_close = False
+        _ended = True
     except (Exception, KeyboardInterrupt) as e:
-        logger.debug("Job '%s': failed to end session: %s", job_id, e)
+        # #76914: the bounded proxy fail-fasts (or times out) after a transient stall —
+        # that swallow lost the ended_at tombstone for a *successful* job. Give the write
+        # one bounded direct attempt on the raw store before the handle is released.
+        _ended = _ended_session_via_retry(session_db, _final_cron_session_id, _end_reason, job_id)
+        if not _ended:
+            logger.debug("Job '%s': failed to end session: %s", job_id, e)
+    if _ended and agent is not None:
+        agent._end_session_on_close = False
     try:
         from hermes_state_registry import release_or_close
         release_or_close(_session_db)

--- a/tests/cron/test_cleanup_timeout.py
+++ b/tests/cron/test_cleanup_timeout.py
@@ -6,12 +6,13 @@ agent resource finalizer stops returning after the model turn has ended.
 
 from __future__ import annotations
 
+import sqlite3
 import threading
 import time
 from concurrent.futures import Future
 from unittest.mock import MagicMock, patch
 
-from cron.scheduler import _teardown_cron_agent, run_job
+from cron.scheduler import _finalize_cron_session, _teardown_cron_agent, run_job
 from cron.scheduler_detached_worker import defer_teardown_to_running_worker
 
 
@@ -161,3 +162,174 @@ def test_dispatch_guard_releases_after_sessiondb_finalization_hang(tmp_path):
         release.set()
         sched._running_job_ids.discard("cleanup-guard-hang")
         sched._shutdown_parallel_pool()
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for #76914: a transient cleanup-timeout stall during cron
+# post-run finalization must not leave sessions.ended_at NULL on a successful
+# job. The bounded proxy's fail-fast (disable after first timeout) was designed
+# for a *damaged connection*; a transient system stall trips it too, and the
+# subsequent end_session raise is swallowed — the ended_at write never lands.
+# ---------------------------------------------------------------------------
+
+
+class _StallableSessionDB:
+    """Minimal SessionDB double. end_session mirrors the real first-reason-wins
+    semantics (a second call is a no-op), and selected methods can be stalled
+    past the cleanup timeout to reproduce a transient system stall."""
+
+    def __init__(self, stall_methods: set[str], stall_duration: float):
+        self.stall_methods = stall_methods
+        self.stall_duration = stall_duration
+        self._stalled: set[str] = set()
+        self.calls: list[tuple[str, tuple]] = []
+        self.ended_reasons: dict[str, str] = {}
+        self.closed = False
+
+    def _maybe_stall(self, name: str) -> None:
+        # Transient stall: only the FIRST invocation of a method is slow (the abandoned
+        # attempt eventually completes — matches the production evidence in #76914 where
+        # the same job self-recovers on its next run).
+        if name in self.stall_methods and name not in self._stalled:
+            self._stalled.add(name)
+            time.sleep(self.stall_duration)
+
+    def get_compression_tip(self, session_id):
+        self.calls.append(("get_compression_tip", (session_id,)))
+        self._maybe_stall("get_compression_tip")
+        return None
+
+    def get_next_title_in_lineage(self, base_title):
+        self.calls.append(("get_next_title_in_lineage", (base_title,)))
+        return f"{base_title} #2"
+
+    def session_lifecycle_statuses(self, session_ids):
+        self.calls.append(("session_lifecycle_statuses", (tuple(session_ids),)))
+        return {sid: "complete" for sid in session_ids}
+
+    def set_session_title(self, session_id, title):
+        self.calls.append(("set_session_title", (session_id, title)))
+        self._maybe_stall("set_session_title")
+        return title
+
+    def end_session(self, session_id, end_reason):
+        self.calls.append(("end_session", (session_id, end_reason)))
+        self._maybe_stall("end_session")
+        # First end_reason wins — mirrors hermes_state_sessions.end_session.
+        self.ended_reasons.setdefault(session_id, end_reason)
+
+    def close(self):
+        self.calls.append(("close", ()))
+        self.closed = True
+
+
+def _finalize_with_stall(tmp_path, stall_methods, release):
+    """Run the REAL _finalize_cron_session over a REAL _BoundedCronSessionDB
+    wrapping the stallable store, with the cleanup timeout patched tiny and the
+    registry release patched to a no-op so the double is never handed to the
+    real registry. Returns (store, agent) for assertions."""
+    store = _StallableSessionDB(stall_methods, stall_duration=0.4)
+    agent = MagicMock()
+    agent._end_session_on_close = True
+    with patch("cron.scheduler._cron_cleanup_timeout_seconds", return_value=0.02), \
+         patch("hermes_state_registry.release_or_close") as release_patch:
+        release_patch.return_value = None
+        _finalize_cron_session(store, agent, "job-76914", "job 76914", "sess-1")
+    return store, agent
+
+
+def test_finalize_retry_writes_ended_at_after_title_stall(tmp_path):
+    """T1 (RED): set_session_title stalls past the timeout → proxy disabled →
+    end_session fail-fasts → the ended_at write MUST still land via one direct
+    bounded retry on the raw store, and the agent must be disarmed."""
+    release = threading.Event()
+    try:
+        store, agent = _finalize_with_stall(tmp_path, {"set_session_title"}, release)
+        assert store.ended_reasons.get("sess-1") == "cron_complete", (
+            "ended_at write lost after transient title-stall timeout: "
+            f"calls={store.calls}")
+        assert agent._end_session_on_close is False, (
+            "agent left armed after retry succeeded — close() would double-end "
+            "the session (#94736)")
+    finally:
+        release.set()
+
+
+def test_finalize_retry_writes_ended_at_after_end_session_stall(tmp_path):
+    """T2 (RED): end_session's own first call stalls past the timeout → proxy
+    disabled by its own timeout → same direct retry must land the write."""
+    release = threading.Event()
+    try:
+        store, agent = _finalize_with_stall(tmp_path, {"end_session"}, release)
+        assert store.ended_reasons.get("sess-1") == "cron_complete", (
+            f"ended_at write lost after end_session timeout: calls={store.calls}")
+        assert agent._end_session_on_close is False
+    finally:
+        release.set()
+
+
+def test_finalize_retry_failure_keeps_agent_armed(tmp_path):
+    """T3 (guard): when the retry itself fails (genuinely damaged store), the
+    agent stays armed (close() may still land the write later) and nothing
+    propagates out of the finally block."""
+    release = threading.Event()
+    try:
+        store = _StallableSessionDB(set(), stall_duration=0.0)
+
+        def _broken_end(session_id, end_reason):
+            raise sqlite3.OperationalError("disk I/O error")
+
+        store.end_session = _broken_end
+        agent = MagicMock()
+        agent._end_session_on_close = True
+        with patch("cron.scheduler._cron_cleanup_timeout_seconds", return_value=0.02), \
+             patch("hermes_state_registry.release_or_close"):
+            _finalize_cron_session(store, agent, "job-76914", "job 76914", "sess-1")
+        assert agent._end_session_on_close is True, (
+            "agent disarmed even though ended_at never landed")
+    finally:
+        release.set()
+
+
+def test_finalize_retry_is_bounded(tmp_path):
+    """T4 (guard): a hanging retry must return within the cleanup bound — the
+    retry adds no unbounded write path."""
+    release = threading.Event()
+    hang = threading.Event()
+    try:
+        store = _StallableSessionDB(set(), stall_duration=0.0)
+
+        def _hanging_end(session_id, end_reason):
+            hang.wait()
+
+        def _hanging_title(session_id, title):
+            hang.wait()
+
+        store.end_session = _hanging_end
+        store.set_session_title = _hanging_title
+        agent = MagicMock()
+        agent._end_session_on_close = True
+        started = time.monotonic()
+        with patch("cron.scheduler._cron_cleanup_timeout_seconds", return_value=0.02), \
+             patch("hermes_state_registry.release_or_close"):
+            _finalize_cron_session(store, agent, "job-76914", "job 76914", "sess-1")
+        elapsed = time.monotonic() - started
+        assert elapsed < 5.0, f"finalize took {elapsed:.1f}s; retry is unbounded"
+        assert agent._end_session_on_close is True
+    finally:
+        hang.set()
+        release.set()
+
+
+def test_finalize_normal_path_ends_session_once(tmp_path):
+    """T5 (guard): with no stall, end_session lands exactly once via the proxy,
+    no retry, and the agent is disarmed — current semantics preserved."""
+    release = threading.Event()
+    try:
+        store, agent = _finalize_with_stall(tmp_path, set(), release)
+        end_calls = [c for c in store.calls if c[0] == "end_session"]
+        assert len(end_calls) == 1, f"expected exactly one end_session, got {end_calls}"
+        assert store.ended_reasons.get("sess-1") == "cron_complete"
+        assert agent._end_session_on_close is False
+    finally:
+        release.set()


### PR DESCRIPTION
## What

A transient system stall during cron post-run finalization (e.g. `set_session_title` exceeding the 10s cleanup bound under a load spike) trips `_BoundedCronSessionDB`'s fail-fast: the proxy disables itself (by design, commit 569b7a34b1 — for a *damaged connection*), the subsequent `end_session` raise is swallowed at debug, and a **successful** job leaves `sessions.ended_at` NULL — a zombie row that prune/archive (pinned to `ended_at IS NOT NULL`, #92740) can never reach. Self-reinforcing: db grows → latency rises → more timeouts. Production evidence in the issue: 5 occurrences / 17 days; the same job self-recovers on its next run, proving the stall is transient, not connection damage.

The latent self-heal does not fire either: on failure `agent._end_session_on_close` stays armed so `agent.close()` would retry `end_session` on the raw store — but `_finalize_cron_session` already ran `release_or_close()`, so the handle is gone and `_quietly` swallows it. Zombie rows carry backfilled titles but NULL `ended_at`, confirming exactly this sequencing.

## How

- **One bounded direct retry**: when the bounded proxy's `end_session` fails (disabled fail-fast OR its own timeout), `_ended_session_via_retry` gives the critical `ended_at` write ONE direct attempt on the raw store, bounded by the same `_run_cron_cleanup_with_timeout` — no new unbounded write path, and the leak-at-most-one-cleanup-worker-per-step invariant is preserved (the retry is one extra bounded step, abandoned on timeout like any other).
- **Disarm only on success**: `agent._end_session_on_close` is cleared only when a write actually landed — otherwise `agent.close()` would reopen the just-released SQLite handle (#94736). A genuinely damaged store times out again and behaves exactly like today (agent stays armed, nothing propagates).
- **Race-safe**: `end_session` is first-reason-wins (`WHERE ... AND ended_at IS NULL`), so a racing abandoned first attempt cannot corrupt the reason.
- **Bonus containment (found during RED)**: the title-fallback lineage probe ran through the possibly-poisoned proxy *during tuple construction, outside any try/except* — a title stall there raised `RuntimeError` out of `_finalize_cron_session`, skipping `end_session` AND `release_or_close` entirely (leaking the handle). `_safe_lineage_title` contains it; any failure falls through to the bare id-stamped title.

## Scope

Layer-scoped to the transient-cleanup-stall layer reported 2026-09-12 (the only layer with zero open-PR coverage). The issue's other layers are covered by open PRs #68631/#50881 (quiet-CLI finalize), #65478 (orphan sweep), #92744 (retention surface) — deliberately not duplicated. #76995 (closed unmerged) had no tests and did not address the fail-fast mechanism.

## Verification

- **RED on pristine main** (`origin/main @ d62716c704`, reviewer-verified): 3 new tests fail with the exact production symptoms — lost `ended_at` write after a title stall (reporter's headline), lost write after `end_session`'s own timeout (2026-08-26 case), and the `RuntimeError` lineage-probe escape.
- **GREEN post-fix, post-rebase onto current main**: `tests/cron/test_cleanup_timeout.py` 9/9 (5 new: T1-T5); `test_scheduler/test_run_one_job/test_parallel_pool` 124/124; `tests/state/ tests/hermes_state/` + shared-registry 512 passed / 23 skipped (platform-gated); `ruff check` clean; `git diff --check` clean; one focused commit ahead of main.
- Guards cover: retry failure keeps the agent armed (T3), a hanging retry stays bounded (T4), and the normal path ends the session exactly once with no retry (T5) — current semantics preserved.

Fixes #76914 (transient-stall layer).

Auto-published by Moonsong via Path B automated pipeline.