### PR TITLE
fix(models): dedupe Anthropic catalog entries that differ only in wire spelling

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1177,10 +1177,22 @@ def _resolve_copilot_catalog_api_key() -> str:
     return ""
 
 
-def _model_dedup_key(model_id: str) -> str:
+def _model_dedup_key(model_id: str, provider: str = "") -> str:
     """Case-insensitive dedup key folded through the picker-search alias table, so a bare live wire
-    id and its curated public slug (Kimi ``k3`` / ``kimi-k3``) don't both survive a merge."""
+    id and its curated public slug (Kimi ``k3`` / ``kimi-k3``) don't both survive a merge.
+
+    With *provider*, the key is additionally folded to that provider's WIRE spelling. Anthropic
+    rewrites dots to hyphens on the wire, so curated ``claude-fable-5.1`` and the live/models.dev
+    ``claude-fable-5-1`` are ONE model; without the fold both survive and every picker lists it
+    twice. Folding is keyed off the provider's own normalizer, so a provider that does not rewrite
+    ids is unaffected."""
     key = str(model_id).strip().lower()
+    if provider:
+        try:
+            from hermes_cli.model_normalize import normalize_model_for_provider
+            key = normalize_model_for_provider(key, provider).strip().lower() or key
+        except Exception:
+            pass
     try:
         from hermes_cli.model_search import model_alias_canonical
         return model_alias_canonical(key)
@@ -1198,7 +1210,25 @@ def _merge_with_models_dev(provider: str, curated: list[str]) -> list[str]:
         mdev = []
     if not mdev:
         return list(curated)
-    return _merge_unique(_merge_unique([], mdev), curated)
+    # Provider-aware key: models.dev publishes Anthropic ids in WIRE spelling (claude-fable-5-1)
+    # while the curated catalog carries the public slug (claude-fable-5.1). A plain lowercase key
+    # treats the pair as two models and every picker lists it twice.
+    def key(model_id: str) -> str:
+        return _model_dedup_key(model_id, provider)
+
+    # On a collision, prefer the curated SPELLING but never override mere casing: models.dev casing
+    # wins for same-characters ids (``MiniMax-M2.7`` over curated ``minimax-m2.7``), while a genuine
+    # respelling (dot vs hyphen) resolves to the curated public slug — the picker renders that, and a
+    # saved selection keyed on the slug would otherwise break.
+    curated_by_key = {key(m): m for m in reversed(curated)}
+
+    def pick(mdev_id: str) -> str:
+        slug = curated_by_key.get(key(mdev_id))
+        if slug is None or slug.lower() == str(mdev_id).lower():
+            return mdev_id
+        return slug
+
+    return _merge_unique(_merge_unique([], [pick(m) for m in mdev], key=key), curated, key=key)
 
 
 def _openai_discovery_base_url(provider: str) -> str:
@@ -1294,8 +1324,11 @@ def _anthropic_catalog(normalized: str, force_refresh: bool) -> list[str]:
     if not live:
         return curated
     # The live /v1/models dump lags newly-routed curated aliases (reachable before enumerated):
-    # curated first, then live-only extras, so a fresh curated model never disappears.
-    return live if cfg_base_url else _merge_unique(curated, live)
+    # curated first, then live-only extras, so a fresh curated model never disappears. The key is
+    # provider-aware because Anthropic's live listing uses wire spelling (claude-fable-5-1) for the
+    # curated public slug (claude-fable-5.1) — a bare lowercase key lists that model twice.
+    return live if cfg_base_url else _merge_unique(
+        curated, live, key=lambda m: _model_dedup_key(m, "anthropic"))
 
 
 def _openai_catalog(normalized: str, force_refresh: bool) -> Optional[list[str]]:

--- a/tests/hermes_cli/test_model_catalog_wire_dedupe.py
+++ b/tests/hermes_cli/test_model_catalog_wire_dedupe.py
@@ -1,0 +1,34 @@
+"""Wire-spelling dedupe in provider catalog merges (#anthropic claude-fable-5.1 duplicate)."""
+
+from hermes_cli.models import _merge_unique, _model_dedup_key
+
+
+def test_dedup_key_folds_a_providers_wire_spelling():
+    """Anthropic rewrites dots to hyphens on the wire, so the public slug and the wire id are ONE
+    model. Without the fold the picker lists `claude-fable-5.1` and `claude-fable-5-1` separately."""
+    slug_key = _model_dedup_key("claude-fable-5.1", "anthropic")
+    wire_key = _model_dedup_key("claude-fable-5-1", "anthropic")
+
+    assert slug_key == wire_key
+
+    # Distinct models must NOT collapse into each other.
+    assert _model_dedup_key("claude-fable-5", "anthropic") != slug_key
+    assert _model_dedup_key("claude-opus-5", "anthropic") != slug_key
+
+    # Without a provider the key cannot know about the rewrite — the two stay distinct, which is
+    # why the merge call sites must pass the provider.
+    assert _model_dedup_key("claude-fable-5.1") != _model_dedup_key("claude-fable-5-1")
+
+
+def test_merge_keeps_one_entry_per_model_and_prefers_the_public_slug():
+    """A curated/live merge of the same model under both spellings yields one row, spelled as the
+    curated public slug — the picker renders that, and saved selections are keyed on it."""
+    curated = ["claude-fable-5.1", "claude-opus-5"]
+    live = ["claude-fable-5-1", "claude-opus-5", "claude-haiku-4-5"]
+
+    merged = _merge_unique(curated, live, key=lambda m: _model_dedup_key(m, "anthropic"))
+
+    assert merged.count("claude-fable-5.1") == 1
+    assert "claude-fable-5-1" not in merged
+    # Live-only models still arrive — dedupe must not become a filter.
+    assert "claude-haiku-4-5" in merged


### PR DESCRIPTION
## Symptom

Every model picker lists one Anthropic model twice. On a plain `anthropic` setup the
catalog returns 14 models where 13 are real:

```
claude-fable-5.1     <-- curated public slug
...
claude-fable-5-1     <-- same model, wire spelling
```

The desktop "Edit models" dialog renders the second one as **"Fable 5 1"**, so it reads as
a separate (oddly named) model rather than a duplicate.

## Root cause

`anthropic` is a member of `_DOT_TO_HYPHEN_PROVIDERS` (`hermes_cli/model_normalize.py`), so
its wire id rewrites dots to hyphens: the curated slug `claude-fable-5.1` goes on the wire as
`claude-fable-5-1`. models.dev publishes the **wire** spelling, while `_PROVIDER_MODELS`
carries the **public slug**.

`_merge_with_models_dev` keyed its dedupe on `lower()` only, so the two spellings were never
recognised as one model and both survived the merge. `_anthropic_catalog` had the identical
defect in its curated/live `/v1/models` merge.

Affects every catalog consumer: the desktop model menu, `/model`, `hermes model`, and the
auxiliary-task pickers.

## Fix

`_model_dedup_key` takes an optional `provider` and folds the key through that provider's own
normalizer before the existing alias table. Providers that do not rewrite ids are unaffected,
because the fold is the provider's own function. The two merge sites pass the provider.

**Collision resolution is deliberately narrow.** The curated *spelling* wins, but only when
the characters genuinely differ. models.dev casing still wins for same-characters ids
(`MiniMax-M2.7` over curated `minimax-m2.7`) — that contract is pinned by the existing
`test_merge_case_insensitive_dedup`, which my first attempt broke and which drove this shape.
Preferring the wire id on a respelling would render "Fable 5 1" in the picker and break any
selection saved under the slug.

## Verification

Behavioral before/after on the merge helper with the real-world shapes
(models.dev = wire spelling, curated = slug):

```
########## BEFORE (unfixed main) ##########
fable entries: ['claude-fable-5-1', 'claude-fable-5.1']
RESULT=BUG  (one model listed twice)

########## AFTER (with fix) ##########
fable entries: ['claude-fable-5.1']
RESULT=OK  (deduped, spelling: claude-fable-5.1)
```

End to end against a real `anthropic` credential, through
`build_model_options_payload(..., refresh=True)`:

- before: `total_models: 14`, both spellings present
- after: `total_models: 13`, `claude-fable-5.1` survives, `claude-fable-5-1` gone

(The refresh matters — `cached_provider_model_ids` serves a stale disk catalog via SWR, so a
non-refreshing read keeps reporting the old 14 until the TTL lapses.)

Tests, on this branch's base:

```
tests/hermes_cli/test_model_catalog_wire_dedupe.py        2 passed   (new)
tests/hermes_cli/test_models_dev_preferred_merge.py       5 passed
tests/hermes_cli/test_inventory.py                       19 passed
tests/hermes_cli/test_catalog_variants.py                12 passed
tests/hermes_cli/test_cached_fetch_api_models.py         27 passed
tests/hermes_cli/test_configured_builtin_models.py        1 passed
tests/hermes_cli/test_anthropic_pool_model_discovery.py   2 passed
                                                   == 68 passed ==
```

The two new tests assert relationships, not a catalog snapshot: that the slug and wire keys
for one model are equal, that distinct models do not collapse into each other, and that a
merge yields one entry spelled as the public slug while live-only models still arrive (dedupe
must not become a filter).
