### PR TITLE
fix(tui): report live compute-host model in status

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11593,6 +11593,31 @@ def test_session_status_reads_live_gateway_agent(monkeypatch):
     assert "Agent Running: Yes" in out
 
 
+def test_session_status_reads_live_compute_host_metadata(monkeypatch):
+    agent = types.SimpleNamespace(
+        model="stale-gateway-model",
+        provider="stale-gateway-provider",
+    )
+    server._sessions["sid"] = _session(
+        agent=agent,
+        _compute_host_active=True,
+        _metadata_mirror={
+            "model": "live-host-model",
+            "provider": "live-host-provider",
+        },
+    )
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    try:
+        resp = server.handle_request(
+            {"id": "1", "method": "session.status", "params": {"session_id": "sid"}}
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert "Model: live-host-model (live-host-provider)" in resp["result"]["output"]
+
+
 def test_skills_reload_runs_in_gateway_process(monkeypatch):
     import agent.skill_commands as skill_commands
 

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1680,8 +1680,12 @@ def _(rid, params: dict, session: dict) -> dict:
     updated = next((_status_dt(meta[f], created) for f in ("updated_at", "last_updated_at", "last_activity_at")
                     if meta.get(f)), created)
     mirror = _metadata_mirror(session)
-    provider = getattr(agent, "provider", None) or mirror.get("provider") or "unknown"
-    model = getattr(agent, "model", None) or mirror.get("model") or "(unknown)"
+    if session.get("_compute_host_active"):
+        provider = mirror.get("provider") or getattr(agent, "provider", None) or "unknown"
+        model = mirror.get("model") or getattr(agent, "model", None) or "(unknown)"
+    else:
+        provider = getattr(agent, "provider", None) or mirror.get("provider") or "unknown"
+        model = getattr(agent, "model", None) or mirror.get("model") or "(unknown)"
     project = _project_info_for_cwd(_display_session_cwd(session))
     title = (meta.get("title") or "").strip()
     lines = [


### PR DESCRIPTION
## What does this PR do?

In `tui_gateway/methods_session.py`, treat the compute-host metadata mirror as authoritative for model and provider while a session is running on a compute host. Local sessions remain agent-first.

### Symptom

`session.status` (TUI `/status`) can show a model and provider that are no longer serving the session. On a long-lived gateway the resident agent object may still hold a historical route while the session is actually running on a compute host whose mirrored metadata is newer.

Operators use `/status` to confirm which model they are billed through. A stale line with no “historical” label is therefore a billing/attribution lie even when routing itself is correct. Local sessions that have a live resident agent should keep the existing agent-first behavior. Compute-host sessions must not let the gateway object win when a complete mirror exists.

Issue: https://github.com/NousResearch/hermes-agent/issues/109282

### Impact

`session.status` (TUI `/status`) can show a model and provider that are no longer serving the session. On a long-lived gateway the resident agent object may still hold a historical route while the session is actually running on a compute host whose mirrored metadata is newer.

### Bug Cause

**Trigger:** the production path described in Symptom.

**Causal chain:** the previous implementation did not enforce the invariant above.

**Why it is wrong:** operators observed the Expected vs Actual mismatch in Symptom.

**Working sibling / contrast:** neighboring paths that already honored the invariant are unchanged.

**Ruled out:** unrelated modules outside this diff.

### Fix

In `tui_gateway/methods_session.py`, treat the compute-host metadata mirror as authoritative for model and provider while a session is running on a compute host. Local sessions remain agent-first.

If a mirrored field is missing, status falls back field-by-field to the resident agent and then the existing placeholder. The change does not rewrite `session_model_usage`, does not change routing, and does not require a gateway restart to pick up a newer compute-host pair once the mirror is populated. A partially filled mirror can still mix one mirrored field with one agent fallback; that matches the prior field-level fail-open and keeps `/status` available during metadata propagation.

## Related Issue

Fixes #109282

## Type of Change

- ✅ Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tests/test_tui_gateway_server.py` — see Fix
- `tui_gateway/methods_session.py` — see Fix

## How to Test

- ✅ `scripts/run_tests.sh tests/test_tui_gateway_server.py -k test_session_status_reads_live_compute_host_metadata`
- ✅ `scripts/run_tests.sh tests/test_tui_gateway_server.py -k 'test_session_status_reads_live_gateway_agent or test_session_status_reads_live_compute_host_metadata'`
- ✅ `test_session_status_reads_live_compute_host_metadata` plants stale gateway agent metadata and newer mirrored compute-host model/provider. Before the change `/status` rendered `stale-gateway-model (stale-gateway-provider)`. After the change it reports the live mirrored pair (`1 passed`).
- ✅ `test_session_status_reads_live_gateway_agent` is the local-session control: resident agent model/provider still win when there is no compute-host mirror. Combined selection: `2 passed`.

## Checklist

### Code

- ✅ I've read the Contributing Guide
- ✅ My commit messages follow Conventional Commits
- ✅ I searched for existing PRs to make sure this isn't a duplicate
- ✅ My PR contains only changes related to this fix
- ✅ I've run relevant tests locally (see How to Test)
- ✅ I've added tests for my changes
- ✅ I've tested on my platform: macOS

### Documentation & Housekeeping

- ✅ Documentation update: N/A unless noted in Changes Made
- ✅ `cli-config.yaml.example`: N/A
- ✅ `CONTRIBUTING.md` or `AGENTS.md`: N/A
- ✅ Cross-platform impact considered
- ✅ Tool descriptions/schemas: N/A

