### PR TITLE
fix(update): don't revive successful restart receipts after HEAD changes

### DIFF
--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -120,6 +120,20 @@ def _receipt_reports_stale_runtime(expected_sha: str | None = None) -> bool:
     if not expected_sha:
         return False
 
+    # A successful receipt records the fleet at that update's target, not at
+    # whatever HEAD a later manual Git integration installs. Keep incomplete and
+    # legacy receipts on the existing current-checkout comparison; explicit stale
+    # rows below remain restart evidence even in a nominally successful receipt.
+    post_update = receipt.get("post_update")
+    if (
+        (receipt.get("outcome") == "success" or receipt.get("exit_code") == 0)
+        and not _receipt_looks_unfinished(receipt)
+        and isinstance(post_update, dict)
+        and isinstance(post_update.get("sha"), str)
+        and post_update["sha"]
+    ):
+        expected_sha = post_update["sha"]
+
     def _sha_mismatch(code_sha) -> bool:
         return bool(code_sha) and str(code_sha) != str(expected_sha)
 

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -261,6 +261,49 @@ def test_successful_receipt_with_pre_update_plan_shas_does_not_retrigger(
     assert update_cmd._pending_fleet_restart_needed() is False
 
 
+@pytest.mark.parametrize(
+    ("changes", "pending"),
+    [
+        pytest.param({}, False, id="successful-before-later-checkout-change"),
+        pytest.param({"outcome": None, "exit_code": 0}, False, id="exit-zero-success"),
+        pytest.param(
+            {"fleet": [{"profile": "default", "code_sha": "a" * 40, "state": "stale"}]},
+            True, id="explicit-stale-row",
+        ),
+        pytest.param({"outcome": "partial"}, True, id="partial"),
+        pytest.param({"gateway_restart": {"incomplete": True}}, True, id="incomplete"),
+        pytest.param({"exit_code": 1}, True, id="failed-exit"),
+        pytest.param({"post_update": {}}, True, id="legacy-without-target"),
+        pytest.param({"post_update": {"sha": "c" * 40}}, True, id="fleet-missed-update-target"),
+    ],
+)
+def test_historical_fleet_uses_successful_updates_own_target(monkeypatch, capsys, changes, pending):
+    """Later Git integration cannot retroactively make a completed restart fail."""
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: "b" * 40)
+    receipt = {
+        "outcome": "success",
+        "post_update": {"sha": "a" * 40},
+        "gateway_restart": {"incomplete": False},
+        "fleet": [{"profile": "default", "code_sha": "a" * 40, "state": "current"}],
+        "plan": {"runtimes": [{"kind": "serve", "profile": "default"}]},
+    }
+    receipt.update(changes)
+    receipt_dir = get_hermes_home() / "logs" / "update_receipts"
+    receipt_dir.mkdir(parents=True)
+    path = receipt_dir / "latest.json"
+    original = json.dumps(receipt)
+    path.write_text(original, encoding="utf-8")
+
+    assert update_cmd_fleet._receipt_reports_stale_runtime() is pending
+    update_cmd_fleet._warn_pending_fleet_restart_on_startup()
+    assert ("did not restart running gateways" in capsys.readouterr().err) is pending
+    assert path.read_text(encoding="utf-8") == original
+
+    # A newer interrupted update's explicit marker still takes precedence.
+    update_cmd._fleet_restart_pending_marker_path().touch()
+    assert update_cmd_fleet._pending_fleet_restart_needed() is True
+
+
 def test_successful_command_boundary_receipt_without_fleet_does_not_retrigger(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary

Compare a successful update receipt's fleet snapshot with **that update's `post_update.sha`**, not a later checkout HEAD. Keep current-checkout comparison for incomplete receipts and legacy receipts without a recorded target.

## Reproduction and cause

1. `hermes update` succeeds at commit A; `latest.json` records `outcome: success`, a completed gateway restart, `post_update.sha: A`, and a `current` fleet row at A.
2. A subsequent manual Git integration advances the checkout to B. Gateways are restarted and report B.
3. CLI/Desktop startup compares the historical fleet row at A with B, retroactively classifies the successful update as owing a restart, and prints “A previous `hermes update` pulled new code but did not restart running gateways.”
4. In the observed receipt, `plan.runtimes` also includes `serve`, so the existing gateway-only reconciliation cannot discharge this invented obligation. Repeated gateway restarts and a WSL reboot do not change the historical receipt.

The live gateway was verified through its control socket as `current` on the installed HEAD. There was no `fleet_restart_pending` marker.

This fixes the erroneous historical comparison, rather than weakening non-gateway ownership checks or pretending that a gateway restart completed a previous update. A receipt is evidence about its own update, not a fresh observation of a later Git checkout.

## Preserved behavior

- Explicit `state: stale` rows and fleet SHAs that missed the recorded update target still indicate pending work.
- Partial/failed receipts, incomplete restart reports, and legacy receipts retain the existing comparison.
- An explicit pending marker retains precedence, including over a successful older receipt.
- No receipt rewriting/deletion, new state, process scans, restart behavior, or warning-text changes.
- This is not a new live-code-skew detector for manual Git operations.

## Validation

- Regression first: original production code returned **1 failed / 5 passed** on the initial focused parameter matrix; the failure was the successful-receipt/later-HEAD case.
- Final canonical run: `scripts/run_tests.sh tests/hermes_cli/test_update_fleet_restart_pending.py --file-retries 0` — **29 passed, 0 failed**, Python 3.11.15. Eight new parameter cases cover the boundary, warning emission, immutable receipt, and marker precedence.
- Ruff on both changed files and `git diff --check`: passed.
- Read-only replay with the actual local receipt and installed checkout SHA: patched pending-warning decision is `False`; receipt unchanged.
- Full local suite not run. GitHub CI is separate, head-specific evidence.

## Related work / scope

Related to #107402. Unlike #107417 / #107821 / #109058, this does not skip or reconcile non-gateway runtimes: it prevents a completed historical update from acquiring a new restart obligation merely because HEAD later moved. Unlike #104427, this is a successful post-restart fleet snapshot, not an unfinished pre-pull receipt. Those unfinished-update/reconciliation cases remain outside this patch.
