### PR TITLE
fix(cron): preserve external worker startup diagnostics

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3031,6 +3031,8 @@ def _wait_for_external_cron_worker(
     execution_id: str,
     job_id: Optional[str] = None,
     handoff_files: tuple[Path, ...] = (),
+    stderr_path: Optional[Path] = None,
+    report_stderr: bool = False,
 ) -> bool:
     try:
         return _wait_for_external_cron_worker_body(
@@ -3042,7 +3044,14 @@ def _wait_for_external_cron_worker(
                 _restart_safe_waiter_job_ids.discard(job_id)
         # The execution is terminal or its worker is dead: nobody will read a
         # payload or acknowledgement left behind by a late/unread handoff.
-        for stale in handoff_files:
+        if report_stderr and stderr_path is not None:
+            report_external_worker_stderr(stderr_path, execution_id=execution_id)
+        cleanup_files = (
+            (*handoff_files, stderr_path)
+            if stderr_path is not None
+            else handoff_files
+        )
+        for stale in cleanup_files:
             try:
                 stale.unlink(missing_ok=True)
             except OSError:
@@ -3062,6 +3071,7 @@ def _launch_external_cron_worker(job: dict) -> bool:
     handoff_dir = _get_hermes_home() / "cron" / "external-workers"
     payload_path = handoff_dir / f"{execution_id}.json"
     ack_path = handoff_dir / f"{execution_id}.ready"
+    stderr_path = handoff_dir / f"{execution_id}.stderr"
     command = [
         sys.executable,
         "-m",
@@ -3132,19 +3142,31 @@ def _launch_external_cron_worker(job: dict) -> bool:
     finally:
         reset_secret_scope(secret_token)
     worker_env = systemd_user_bus_env(worker_env)
+    worker_env[EXTERNAL_WORKER_STDERR_CAPTURE_ENV] = "1"
+    stderr_fd: Optional[int] = None
     try:
-        process = subprocess.Popen(
-            scoped_command,
-            cwd=str(Path(__file__).resolve().parent.parent),
-            env=worker_env,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            start_new_session=True,
-            creationflags=windows_hide_flags(),
+        stderr_fd = os.open(
+            stderr_path,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
         )
+        with os.fdopen(stderr_fd, "wb") as stderr_file:
+            stderr_fd = None
+            process = subprocess.Popen(
+                scoped_command,
+                cwd=str(Path(__file__).resolve().parent.parent),
+                env=worker_env,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=stderr_file,
+                start_new_session=True,
+                creationflags=windows_hide_flags(),
+            )
     except BaseException:
+        if stderr_fd is not None:
+            os.close(stderr_fd)
         payload_path.unlink(missing_ok=True)
+        stderr_path.unlink(missing_ok=True)
         raise
 
     with _running_lock:
@@ -3166,6 +3188,8 @@ def _launch_external_cron_worker(job: dict) -> bool:
                     execution_id=execution_id,
                     job_id=job_id,
                     handoff_files=(payload_path,),
+                    stderr_path=stderr_path,
+                    report_stderr=True,
                 )
             finally:
                 ack_path.unlink(missing_ok=True)
@@ -3183,6 +3207,8 @@ def _launch_external_cron_worker(job: dict) -> bool:
                     execution_id=execution_id,
                     job_id=job_id,
                     handoff_files=(payload_path,),
+                    stderr_path=stderr_path,
+                    report_stderr=True,
                 )
             logger.info(
                 "Cron job '%s' handed to restart-safe worker pid=%s execution=%s",
@@ -3195,12 +3221,15 @@ def _launch_external_cron_worker(job: dict) -> bool:
                 execution_id=execution_id,
                 job_id=job_id,
                 handoff_files=(payload_path,),
+                stderr_path=stderr_path,
             )
         returncode = process.poll()
         if returncode is not None:
+            report_external_worker_stderr(stderr_path, execution_id=execution_id)
             with _running_lock:
                 _restart_safe_waiter_job_ids.discard(job_id)
             payload_path.unlink(missing_ok=True)
+            stderr_path.unlink(missing_ok=True)
             raise RuntimeError(
                 f"cron external worker exited before ownership acknowledgement "
                 f"(exit {returncode})"
@@ -3221,6 +3250,8 @@ def _launch_external_cron_worker(job: dict) -> bool:
         execution_id=execution_id,
         job_id=job_id,
         handoff_files=(payload_path, ack_path),
+        stderr_path=stderr_path,
+        report_stderr=True,
     )
 
 
@@ -3287,6 +3318,8 @@ def _run_external_worker_payload(payload_path: Path, ack_path: Path) -> bool:
                     execution_id,
                 )
                 return False
+            if os.environ.pop(EXTERNAL_WORKER_STDERR_CAPTURE_ENV, None) == "1":
+                disable_external_worker_stderr_capture()
             old_external_execution = os.environ.get("_HERMES_CRON_EXTERNAL_WORKER")
             os.environ["_HERMES_CRON_EXTERNAL_WORKER"] = execution_id
             try:
@@ -3798,6 +3831,11 @@ from cron.scheduler_prompt import (  # noqa: E402
 from cron.scheduler_preflight import (  # noqa: E402
     BLOCKED_CONFIG_MARKER, BLOCKED_CONFIG_SILENT_MARKER, _cron_preflight_enabled,
     _is_transient_provider_resolve_error, _preflight_job_config,
+)
+from cron.scheduler_external_worker import (
+    EXTERNAL_WORKER_STDERR_CAPTURE_ENV,
+    disable_external_worker_stderr_capture,
+    report_external_worker_stderr,
 )
 
 

--- a/cron/scheduler_external_worker.py
+++ b/cron/scheduler_external_worker.py
@@ -1,0 +1,88 @@
+"""Diagnostics for restart-safe external cron workers."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# This is an internal child-launch marker, not a user configuration variable.
+EXTERNAL_WORKER_STDERR_CAPTURE_ENV = "_HERMES_CRON_CAPTURE_STDERR"
+_EXTERNAL_WORKER_STDERR_TAIL_BYTES = 16 * 1024
+
+
+def report_external_worker_stderr(stderr_path: Path, *, execution_id: str) -> None:
+    """Log a bounded, always-redacted tail of pre-ack worker stderr.
+
+    The parent owns cleanup of *stderr_path*. Missing diagnostics are normal when
+    a worker exits cleanly or emits nothing, so they are not logged as errors.
+    """
+    try:
+        with stderr_path.open("rb") as stderr_file:
+            stderr_file.seek(0, os.SEEK_END)
+            size = stderr_file.tell()
+            if size == 0:
+                return
+            stderr_file.seek(max(0, size - _EXTERNAL_WORKER_STDERR_TAIL_BYTES))
+            captured = stderr_file.read(_EXTERNAL_WORKER_STDERR_TAIL_BYTES)
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        logger.warning(
+            "Could not read captured stderr for cron external worker %s (%s)",
+            execution_id,
+            type(exc).__name__,
+        )
+        return
+
+    try:
+        from agent.redact import redact_sensitive_text
+
+        text = captured.decode("utf-8", errors="replace")
+        if size > _EXTERNAL_WORKER_STDERR_TAIL_BYTES:
+            text = (
+                f"[stderr truncated; showing the last {_EXTERNAL_WORKER_STDERR_TAIL_BYTES} bytes]\n"
+                + text
+            )
+        # Keep tracebacks readable while defanging terminal-control bytes before
+        # they enter the structured log stream.
+        text = "".join(
+            char if char in "\n\t" or ord(char) >= 0x20 else f"\\x{ord(char):02x}"
+            for char in text
+        )
+        redacted = redact_sensitive_text(text, force=True)
+    except Exception as exc:
+        # Never emit an unredacted fallback when the redactor itself is unavailable.
+        logger.warning(
+            "Could not redact captured stderr for cron external worker %s (%s); "
+            "diagnostic omitted",
+            execution_id,
+            type(exc).__name__,
+        )
+        return
+
+    if redacted and redacted.strip():
+        logger.error(
+            "Cron external worker %s emitted stderr before ownership acknowledgement:\n%s",
+            execution_id,
+            redacted.rstrip(),
+        )
+
+
+def disable_external_worker_stderr_capture() -> None:
+    """Return child fd 2 to the pre-existing detached-worker null sink."""
+    try:
+        devnull_fd = os.open(os.devnull, os.O_WRONLY)
+        try:
+            os.dup2(devnull_fd, 2)
+        finally:
+            os.close(devnull_fd)
+    except (OSError, ValueError) as exc:
+        # Diagnostics are best effort; the worker must still finish its durable
+        # execution rather than fail solely because stderr could not be detached.
+        logger.debug(
+            "Could not disable external worker stderr capture (%s)",
+            type(exc).__name__,
+        )

--- a/tests/cron/test_restart_safe_worker.py
+++ b/tests/cron/test_restart_safe_worker.py
@@ -146,6 +146,9 @@ def test_external_worker_adopts_execution_and_runs_payload_once(
             observed_homes.append(get_hermes_home().resolve()) or True
         )
     )
+    disable_capture = Mock()
+    monkeypatch.setattr(scheduler, "disable_external_worker_stderr_capture", disable_capture)
+    monkeypatch.setenv(scheduler.EXTERNAL_WORKER_STDERR_CAPTURE_ENV, "1")
     monkeypatch.setattr("cron.executions.adopt_claimed_execution", adopted)
     monkeypatch.setattr(scheduler, "run_one_job", run)
 
@@ -153,6 +156,8 @@ def test_external_worker_adopts_execution_and_runs_payload_once(
 
     adopted.assert_called_once_with("exec-1")
     run.assert_called_once()
+    disable_capture.assert_called_once_with()
+    assert scheduler.EXTERNAL_WORKER_STDERR_CAPTURE_ENV not in os.environ
     assert run.call_args.args[0]["id"] == "job-1"
     expected_home = (tmp_path / "profile").resolve()
     assert observed_homes == [expected_home, expected_home]
@@ -263,6 +268,78 @@ def test_launch_external_worker_uses_restart_safe_scope_and_acknowledges(
     assert payloads[0]["multiplex_active"] is True
     # Once the attempt is terminal the parent reaps its own handoff artifacts.
     assert not (tmp_path / "cron/external-workers/exec-1.json").exists()
+
+
+def test_external_worker_reports_redacted_stderr_before_ack(
+    tmp_path, monkeypatch, caplog
+):
+    import cron.scheduler as scheduler
+
+    job = {"id": "job-startup", "execution_id": "exec-startup", "prompt": "work"}
+    monkeypatch.setattr(scheduler, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "tools.process_registry.restart_safe_gateway_child_argv",
+        lambda command, *, unit_suffix: ["scope", "--", *command],
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "mark_execution_handoff_pending",
+        lambda _execution_id: {"id": "exec-startup", "handoff_pending": 1},
+    )
+
+    secret = "sk-abcdefghijklmnopqrstuvwxyz"
+
+    class FakeProcess:
+        returncode = 9
+
+        def poll(self):
+            return self.returncode
+
+    def popen(_command, **kwargs):
+        assert kwargs["stderr"] is not subprocess.DEVNULL
+        kwargs["stderr"].write(f"worker bootstrap failed: API_KEY={secret}\n".encode())
+        kwargs["stderr"].flush()
+        return FakeProcess()
+
+    monkeypatch.setattr(scheduler.subprocess, "Popen", popen)
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(RuntimeError, match="exited before ownership acknowledgement"):
+            scheduler._launch_external_cron_worker(job)
+
+    assert "worker bootstrap failed" in caplog.text
+    assert secret not in caplog.text
+    assert "API_KEY=***" in caplog.text
+    assert not (tmp_path / "cron/external-workers/exec-startup.stderr").exists()
+
+
+def test_external_worker_wait_reports_delayed_stderr_and_cleans_it(
+    tmp_path, monkeypatch, caplog
+):
+    import cron.scheduler as scheduler
+
+    stderr_path = tmp_path / "worker.stderr"
+    secret = "ghp_abcdefghijklmnopqrstuvwxyz"
+    stderr_path.write_bytes(f"worker stayed alive: TOKEN={secret}\n".encode())
+    process = Mock()
+    process.wait.return_value = 0
+    monkeypatch.setattr(
+        scheduler,
+        "get_execution",
+        lambda _execution_id: {"status": "completed"},
+    )
+
+    with caplog.at_level("ERROR"):
+        assert scheduler._wait_for_external_cron_worker(
+            process,
+            execution_id="exec-delayed",
+            stderr_path=stderr_path,
+            report_stderr=True,
+        ) is True
+
+    assert "worker stayed alive" in caplog.text
+    assert secret not in caplog.text
+    assert not stderr_path.exists()
 
 
 def test_external_worker_exit_rechecks_exact_execution_before_failure(monkeypatch):


### PR DESCRIPTION
Fixes #109243

Este PR é complementar ao PR #109252, de KoNit-K, que é o trabalho proprietário para o núcleo do problema de orçamento de acknowledgement (5 s contra cold start). Não substitui, não supersede e não reutiliza commits ou código daquele PR. O objetivo aqui é fechar a lacuna independente de diagnóstico descrita na mesma issue: falhas de inicialização do worker são encaminhadas para `DEVNULL` e desaparecem.

## Resumo

- captura o stderr do worker externo somente durante a fase de inicialização/ownership acknowledgement;
- registra uma cauda limitada e sempre redigida quando o worker encerra antes do ack ou o handoff entra no caminho de ownership-uncertain;
- retorna o fd 2 do worker para o `DEVNULL` original assim que o ack durável é publicado, evitando I/O contínuo durante o job;
- remove o artefato temporário junto com os demais arquivos do handoff;
- preserva integralmente o CAS de ownership, a regra de não fazer fallback in-process e a recuperação at-most-once.

## Problema observado

A issue #109243 reporta um worker frio que demora aproximadamente 12,42 s para iniciar, enquanto a implementação em `cron/scheduler.py` usa uma janela fixa de 5,0 s para observar o arquivo `.ready`. O PR #109252 trata esse orçamento de tempo.

A investigação na base atual (`origin/main` em `d62716c7043e57ef7a29e81a02ddbc19334e29df`) encontrou uma segunda falha concreta no mesmo caminho:

- o gateway chama `subprocess.Popen(..., stderr=subprocess.DEVNULL)`;
- o worker só chama `setup_logging()` depois que `python -m cron.scheduler` já importou o módulo e chegou ao bloco `__main__`;
- uma exceção durante import/bootstrap pode, portanto, ocorrer antes de qualquer logger Hermes estar configurado;
- o processo pai vê apenas um exit code, sem stderr no journal, em arquivo de log ou no diagnóstico da execução.

A premissa do timeout precisa ser descrita com precisão: na base atual, expirar a sondagem de 5 s não faz fallback in-process nem necessariamente marca a execução como falha imediata. O código entra no waiter de ownership incerta para evitar duplicação. O defeito de disponibilidade é real na fronteira do ack; o diagnóstico silencioso é reproduzível independentemente e não é coberto pelo PR #109252.

O teste RED adicionado reproduziu a lacuna diretamente na base: o fake de `Popen` recebeu `stderr=-3`, que é `subprocess.DEVNULL`, e não havia caminho para observar `worker bootstrap failed`.

## Causa-raiz

A escolha de `DEVNULL` protege o comportamento detached normal, mas também descarta a única saída que existe para erros anteriores à inicialização do logging. O protocolo atual tem um momento seguro para resolver isso: depois que o filho adota duravelmente o execution ledger e publica o ack, o pai já pode continuar tratando a execução exclusivamente pelo ledger/processo. Antes desse ponto, o stderr precisa ser preservado de forma local, limitada e segura.

Isso é distinto de:

- #107184/#107678: race de leitura de ack parcialmente escrito, tratado pelo PR #107678 com publicação atômica;
- #106607/#106627: recuperação de owner morto antes de uma adoção lenta, tratada pelo PR #106627;
- #109243/#109252: orçamento de startup/ack do worker externo.

## Impacto e alcance

Escopo estrito: somente o handoff de external cron worker em topologia gerenciada.

Arquivos alterados:

- `cron/scheduler.py`: cria o sink por execução, passa-o ao `Popen`, reporta-o nos caminhos de ack ausente/malformado/mismatch/exit antecipado e o limpa com o handoff;
- `cron/scheduler_external_worker.py`: novo sibling com leitura limitada, defanging, redaction forçada e desarme do capture;
- `tests/cron/test_restart_safe_worker.py`: contratos de falha de bootstrap, timeout/waiter, redaction, cleanup e desarme pós-ack.

Não há mudança de dependência, configuração pública, schema, protocolo de ack, provider externo, pool de workers ou caminho unmanaged/in-process.

O custo normal é um único arquivo local de stderr por worker enquanto o ack não foi observado. O relatório lê no máximo 16 KiB da cauda, não cria thread, não faz polling de banco adicional e não lê o arquivo após o worker ter obtido o ack; nesse momento o filho troca fd 2 por `DEVNULL`. A complexidade adicional é O(1) de metadados mais o tamanho do stderr escrito durante bootstrap; a leitura diagnóstica é O(min(bytes, 16 KiB)) e usa memória limitada.

## Solução

1. O pai cria `<HERMES_HOME>/cron/external-workers/<execution_id>.stderr` com `O_EXCL` e modo `0600`, sob o diretório já protegido `0700`.
2. O arquivo é passado como `stderr` ao `Popen`; stdin e stdout continuam em `DEVNULL`.
3. Um marcador interno de ambiente (`_HERMES_CRON_CAPTURE_STDERR`) informa ao filho que esse descritor é temporário. Não é uma opção de usuário nem uma nova variável de configuração.
4. Em exit antes do ack, ack ilegível/mismatch ou expiração da sondagem, o pai lê no máximo os últimos 16 KiB depois que o processo está morto ou o waiter terminou.
5. Antes de enviar o conteúdo ao logger, o texto é decodificado com replacement, caracteres de controle são neutralizados e `redact_sensitive_text(..., force=True)` é aplicado. Se o redator não puder ser carregado, o diagnóstico é omitido em vez de emitir conteúdo não redigido.
6. Após o filho adotar a execução e publicar o ack durável, o marcador é consumido e fd 2 volta para `os.devnull`. Isso mantém o comportamento detached original para a execução longa.
7. A limpeza continua sujeita à barreira existente: payload/ack/stderr só são removidos pelo waiter depois de estado terminal ou morte confirmada do worker. Nenhum timeout libera claim, inicia segunda execução ou autoriza fallback.

## Alternativas consideradas

- Aumentar 5 s para um orçamento de cold start: é o núcleo já implementado pelo PR #109252; não foi duplicado aqui. A medição reportada pela issue é 12,42 s, portanto um valor fixo de 12 s ainda exigiria decisão/evidência adicional.
- Tornar o timeout configurável: é uma possível evolução do núcleo, mas tocaria resolução/configuração e conflitaria com a propriedade do PR #109252; não é necessário para o diagnóstico complementar.
- Publicar um ack imediato de “starting” e outro de “ready”: reduz a janela, mas muda o protocolo e o significado da adoção; exigiria migrar consumidores e estados duráveis.
- Prewarm/pool persistente: a arquitetura atual usa um processo isolado por execução, profile e scope; pool exigiria novo broker, isolamento de secrets, cancelamento e recuperação. É infraestrutura fora do escopo desta issue/follow-up.
- Capturar `stderr=PIPE` em thread: poderia limitar memória, mas introduziria um pipe que deixa de ser seguro quando o gateway reinicia e o worker detached continua vivo. O arquivo local preserva a topologia de restart-safe.

## Compatibilidade e riscos residuais

- `mark_execution_handoff_pending()`, `adopt_claimed_execution()`, validação de `execution_id`, `finish_execution()`, recovery e o no-fallback path não foram alterados semanticamente.
- O caminho unmanaged continua retornando `False` antes de criar qualquer processo/arquivo.
- O sink usa permissões explícitas `0600` e o diretório existente `0700`; nenhum conteúdo de `.env` ou credential value é colocado no payload.
- O log sempre passa pela redaction forçada. O conteúdo bruto existe apenas no sink local protegido durante o bootstrap; como ocorre com os demais artefatos de handoff, uma interrupção abrupta antes da limpeza pode deixar um arquivo temporário para a recuperação/inspeção local.
- Se o desarme do fd 2 falhar, o worker continua a execução durável e registra somente o tipo da exceção em nível debug; não transforma diagnóstico best-effort em falha de job.
- O PR não afirma que o problema de 5 s está resolvido sozinho; #109252 continua sendo o fix principal do orçamento de ack.

## Testes e verificação

Base e reprodução:

- Base: `origin/main` `d62716c7043e57ef7a29e81a02ddbc19334e29df`.
- RED, antes da implementação: `scripts/run_tests.sh tests/cron/test_restart_safe_worker.py -k test_external_worker_reports_redacted_stderr_before_ack` → 1 failed; o fake recebeu `stderr=-3` (`DEVNULL`).
- GREEN focal: `scripts/run_tests.sh tests/cron/test_restart_safe_worker.py -k 'test_external_worker_reports_redacted_stderr_before_ack or test_external_worker_wait_reports_delayed_stderr_and_cleans_it or test_launch_external_worker_uses_restart_safe_scope_and_acknowledges or test_external_worker_adopts_execution_and_runs_payload_once'` → 4 passed, 0 failed.
- Arquivo completo: `scripts/run_tests.sh tests/cron/test_restart_safe_worker.py` → 19 passed, 0 failed, 2 skipped (Linux-only no host Windows).
- Caminhos relacionados: `scripts/run_tests.sh tests/cron/test_execution_ledger.py tests/cron/test_scheduled_occurrence.py tests/cron/test_scheduler.py tests/cron/test_restart_safe_worker.py` → 152 passed, 0 failed, 2 skipped.
- E2E local da fronteira real `subprocess -> stderr -> redaction -> log` em diretório temporário → `e2e=ok`.
- `python -m compileall -q cron/scheduler.py cron/scheduler_external_worker.py tests/cron/test_restart_safe_worker.py` → sucesso.
- Ruff check dos três arquivos → `All checks passed!`.
- Ruff format do novo `cron/scheduler_external_worker.py` → `1 file already formatted`.
- `python scripts/check_compat_pointers.py` → `no in-tree dependency on 2091 plugin-compat pointers`.
- `git diff --check` → sem erros.

Suíte ampla:

- `scripts/run_tests.sh tests/cron/` → 1204 passed, 14 failed, 35 skipped. As 14 falhas ocorreram em cinco arquivos não alterados (`test_file_permissions.py`, `test_lifecycle_guard_budget.py`, `test_media_delivery_parity.py`, `test_cron_workdir.py`, `test_missed_window_catchup.py`) por contratos existentes de permissões/normalização de caminhos POSIX versus o host Windows; não envolvem o novo módulo nem o handoff testado. Dois arquivos adicionais (`test_cron_tick_stale_yield.py` e `test_script_claim_heartbeat.py`) falharam na primeira tentativa e passaram no retry canônico, classificados pelo runner como flaky preexistente.
- A checagem `ruff format --check` do `scheduler.py` inteiro ainda aponta formatação preexistente a partir da linha 39; não foi aplicado reformat cosmético a um facade de 3.800+ linhas. `ruff check` passa.
- O host local é Windows; os testes `linux_only` foram pulados e a execução real do wrapper `systemd-run --user --scope` deve ser confirmada no CI Linux.

Graphify:

- `graphify query`, `explain` e `path` foram usados para mapear `_launch_external_cron_worker()` e `_run_external_worker_payload()` antes da alteração.
- `graphify update .` e `graphify update . --no-cluster` foram tentados após a alteração. A extração chegou a `3310/3310` arquivos, mas a ferramenta não gravou o `graph.json` dentro dos limites de 420 s/600 s e foi encerrada para não deixar processo pendurado. Nenhum arquivo rastreado foi alterado pelo índice.

CI remoto ainda não havia sido executado no momento da abertura deste PR.

## Segurança

Este é um fix de confiabilidade/observabilidade, não uma vulnerabilidade oficial sob `SECURITY.md`: não há evidência de escape de isolamento, acesso externo não autorizado ou exfiltração. A mudança preserva a fronteira de ownership por CAS e reduz o risco operacional de emitir logs brutos ao aplicar redaction forçada antes do logger. O sink é profile-local e protegido por permissões; nenhum secret é incluído no payload ou no corpo deste PR.

## Estado de publicação

- Branch: `fix/cron-external-worker-diagnostics-109243`.
- Commit: `dda72ca0413075423244d3616feca98dd8662078`.
- Base local/remote verificada: `d62716c7043e57ef7a29e81a02ddbc19334e29df`.
- Fork de publicação: `JoaoMarcos44/hermes-agent`.
- PR #109252 permanece aberto, de KoNit-K, com o fix principal de cold-start ack; esta contribuição deve ser avaliada como complementar.
