### PR TITLE
fix(agent): codex iteration-limit summary no longer 400s on tool_choice without tools (#94139, salvage #108747/#32777)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2074,6 +2074,8 @@ def _summary_text(agent, response, **normalize_kwargs) -> str:
 def _codex_summary_attempt(agent, api_messages: list, api_request_id: str):
     def _attempt(retry_count: int) -> str:
         codex_kwargs = agent._build_api_kwargs(api_messages)
+        # The transport emits these three as one block (transports/codex.py build_kwargs);
+        # strict Responses backends 400 on tool_choice/parallel_tool_calls without tools.
         codex_kwargs.pop("tools", None)
         codex_kwargs.pop("tool_choice", None)
         codex_kwargs.pop("parallel_tool_calls", None)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2075,6 +2075,8 @@ def _codex_summary_attempt(agent, api_messages: list, api_request_id: str):
     def _attempt(retry_count: int) -> str:
         codex_kwargs = agent._build_api_kwargs(api_messages)
         codex_kwargs.pop("tools", None)
+        codex_kwargs.pop("tool_choice", None)
+        codex_kwargs.pop("parallel_tool_calls", None)
         return _summary_text(agent, agent._run_codex_stream(codex_kwargs))
     return _attempt
 

--- a/contributors/emails/328204342+trnorga@users.noreply.github.com
+++ b/contributors/emails/328204342+trnorga@users.noreply.github.com
@@ -1,0 +1,2 @@
+trnorga
+# PR #108747 salvage

--- a/contributors/emails/61507425+Julientalbot@users.noreply.github.com
+++ b/contributors/emails/61507425+Julientalbot@users.noreply.github.com
@@ -1,0 +1,2 @@
+Julientalbot
+# PR #32777 / #108747 salvage

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2905,6 +2905,48 @@ class TestHandleMaxIterations:
             for item in input_items
         )
 
+    def test_codex_summary_strips_tool_controls_when_tools_removed(self, agent):
+        agent.api_mode = "codex_responses"
+        agent.provider = "openai-codex"
+        agent.base_url = "https://chatgpt.com/backend-api/codex"
+        agent._base_url_lower = agent.base_url.lower()
+        agent._base_url_hostname = "chatgpt.com"
+        agent.model = "gpt-5.5"
+        agent._cached_system_prompt = "You are helpful."
+        captured = {}
+
+        monkey_kwargs = {
+            "model": "gpt-5.5",
+            "input": [{"role": "user", "content": "do stuff"}],
+            "tools": [{"type": "function", "name": "web_search"}],
+            "tool_choice": "auto",
+            "parallel_tool_calls": True,
+        }
+
+        def fake_run_codex_stream(kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                status="completed",
+                output=[
+                    SimpleNamespace(
+                        type="message",
+                        status="completed",
+                        content=[SimpleNamespace(type="output_text", text="Summary")],
+                    )
+                ],
+            )
+
+        with (
+            patch.object(agent, "_build_api_kwargs", return_value=monkey_kwargs.copy()),
+            patch.object(agent, "_run_codex_stream", side_effect=fake_run_codex_stream),
+        ):
+            result = agent._handle_max_iterations([{"role": "user", "content": "do stuff"}], 90)
+
+        assert result == "Summary"
+        assert "tools" not in captured
+        assert "tool_choice" not in captured
+        assert "parallel_tool_calls" not in captured
+
     def test_api_sanitizer_matches_responses_call_id_when_id_differs(self, agent):
         messages = [
             {

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2905,54 +2905,11 @@ class TestHandleMaxIterations:
             for item in input_items
         )
 
-    def test_codex_summary_strips_tool_controls_when_tools_removed(self, agent):
-        agent.api_mode = "codex_responses"
-        agent.provider = "openai-codex"
-        agent.base_url = "https://chatgpt.com/backend-api/codex"
-        agent._base_url_lower = agent.base_url.lower()
-        agent._base_url_hostname = "chatgpt.com"
-        agent.model = "gpt-5.5"
-        agent._cached_system_prompt = "You are helpful."
-        captured = {}
-
-        monkey_kwargs = {
-            "model": "gpt-5.5",
-            "input": [{"role": "user", "content": "do stuff"}],
-            "tools": [{"type": "function", "name": "web_search"}],
-            "tool_choice": "auto",
-            "parallel_tool_calls": True,
-        }
-
-        def fake_run_codex_stream(kwargs):
-            captured.update(kwargs)
-            return SimpleNamespace(
-                status="completed",
-                output=[
-                    SimpleNamespace(
-                        type="message",
-                        status="completed",
-                        content=[SimpleNamespace(type="output_text", text="Summary")],
-                    )
-                ],
-            )
-
-        with (
-            patch.object(agent, "_build_api_kwargs", return_value=monkey_kwargs.copy()),
-            patch.object(agent, "_run_codex_stream", side_effect=fake_run_codex_stream),
-        ):
-            result = agent._handle_max_iterations([{"role": "user", "content": "do stuff"}], 90)
-
-        assert result == "Summary"
-        assert "tools" not in captured
-        assert "tool_choice" not in captured
-        assert "parallel_tool_calls" not in captured
-
-    def test_codex_summary_retry_also_strips_tool_controls(self, agent):
-        """The retry attempt must be as toolless as the first one.
-
-        Iteration-limit summaries retry once when the first summary comes back empty; both
-        attempts build their body through the same codex path, so both must drop the tool-control
-        block the transport emits alongside ``tools`` (agent/transports/codex.py).
+    def test_codex_summary_strips_tool_controls_on_every_attempt(self, agent):
+        """Iteration-limit summaries retry once on an empty answer; both attempts share one
+        ``_attempt`` closure, and both must go out without ``tools``, ``tool_choice`` and
+        ``parallel_tool_calls`` — the transport emits the three as one block, and strict
+        Responses backends 400 on ``tool_choice`` without ``tools``.
         """
         agent.api_mode = "codex_responses"
         agent.provider = "openai-codex"
@@ -2961,19 +2918,13 @@ class TestHandleMaxIterations:
         agent._base_url_hostname = "chatgpt.com"
         agent.model = "gpt-5.5"
         agent._cached_system_prompt = "You are helpful."
-
+        leaked_controls = {"tools", "tool_choice", "parallel_tool_calls"}
+        # Precondition against the real transport: the main-loop request carries all three.
+        assert leaked_controls <= agent._build_api_kwargs([{"role": "user", "content": "do stuff"}]).keys()
         bodies = []
-        tool_laden = {
-            "model": "gpt-5.5",
-            "input": [{"role": "user", "content": "do stuff"}],
-            "tools": [{"type": "function", "name": "web_search"}],
-            "tool_choice": "auto",
-            "parallel_tool_calls": True,
-        }
 
         def fake_run_codex_stream(kwargs):
             bodies.append(dict(kwargs))
-            # First attempt returns an empty summary so the caller takes the retry path.
             text = "" if len(bodies) == 1 else "Summary"
             return SimpleNamespace(
                 status="completed",
@@ -2986,18 +2937,13 @@ class TestHandleMaxIterations:
                 ],
             )
 
-        with (
-            patch.object(agent, "_build_api_kwargs", return_value=tool_laden.copy()),
-            patch.object(agent, "_run_codex_stream", side_effect=fake_run_codex_stream),
-        ):
+        with patch.object(agent, "_run_codex_stream", side_effect=fake_run_codex_stream):
             result = agent._handle_max_iterations([{"role": "user", "content": "do stuff"}], 90)
 
         assert result == "Summary"
         assert len(bodies) == 2, f"expected one retry after the empty summary, got {len(bodies)} attempts"
         for attempt_index, sent in enumerate(bodies):
-            assert "tools" not in sent, f"attempt {attempt_index}: tools leaked into the summary call"
-            assert "tool_choice" not in sent, f"attempt {attempt_index}: tool_choice leaked"
-            assert "parallel_tool_calls" not in sent, f"attempt {attempt_index}: parallel_tool_calls leaked"
+            assert not leaked_controls & sent.keys(), f"attempt {attempt_index}: {sorted(leaked_controls & sent.keys())} leaked"
 
     def test_api_sanitizer_matches_responses_call_id_when_id_differs(self, agent):
         messages = [

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2947,6 +2947,58 @@ class TestHandleMaxIterations:
         assert "tool_choice" not in captured
         assert "parallel_tool_calls" not in captured
 
+    def test_codex_summary_retry_also_strips_tool_controls(self, agent):
+        """The retry attempt must be as toolless as the first one.
+
+        Iteration-limit summaries retry once when the first summary comes back empty; both
+        attempts build their body through the same codex path, so both must drop the tool-control
+        block the transport emits alongside ``tools`` (agent/transports/codex.py).
+        """
+        agent.api_mode = "codex_responses"
+        agent.provider = "openai-codex"
+        agent.base_url = "https://chatgpt.com/backend-api/codex"
+        agent._base_url_lower = agent.base_url.lower()
+        agent._base_url_hostname = "chatgpt.com"
+        agent.model = "gpt-5.5"
+        agent._cached_system_prompt = "You are helpful."
+
+        bodies = []
+        tool_laden = {
+            "model": "gpt-5.5",
+            "input": [{"role": "user", "content": "do stuff"}],
+            "tools": [{"type": "function", "name": "web_search"}],
+            "tool_choice": "auto",
+            "parallel_tool_calls": True,
+        }
+
+        def fake_run_codex_stream(kwargs):
+            bodies.append(dict(kwargs))
+            # First attempt returns an empty summary so the caller takes the retry path.
+            text = "" if len(bodies) == 1 else "Summary"
+            return SimpleNamespace(
+                status="completed",
+                output=[
+                    SimpleNamespace(
+                        type="message",
+                        status="completed",
+                        content=[SimpleNamespace(type="output_text", text=text)],
+                    )
+                ],
+            )
+
+        with (
+            patch.object(agent, "_build_api_kwargs", return_value=tool_laden.copy()),
+            patch.object(agent, "_run_codex_stream", side_effect=fake_run_codex_stream),
+        ):
+            result = agent._handle_max_iterations([{"role": "user", "content": "do stuff"}], 90)
+
+        assert result == "Summary"
+        assert len(bodies) == 2, f"expected one retry after the empty summary, got {len(bodies)} attempts"
+        for attempt_index, sent in enumerate(bodies):
+            assert "tools" not in sent, f"attempt {attempt_index}: tools leaked into the summary call"
+            assert "tool_choice" not in sent, f"attempt {attempt_index}: tool_choice leaked"
+            assert "parallel_tool_calls" not in sent, f"attempt {attempt_index}: parallel_tool_calls leaked"
+
     def test_api_sanitizer_matches_responses_call_id_when_id_differs(self, agent):
         messages = [
             {


### PR DESCRIPTION
The codex/Responses iteration-limit summary call no longer sends `tool_choice`/`parallel_tool_calls` without `tools`, so strict Responses backends (xAI) return the summary instead of a 400.

Salvage of #108747 by @trnorga, which itself rebased #32777 by @Julientalbot. Both commits are cherry-picked so their authorship is preserved.

## Changes

- `agent/chat_completion_helpers.py::_codex_summary_attempt` — pops `tool_choice` and `parallel_tool_calls` alongside `tools` (Julien Talbot's fix, relocated by trnorga onto the single `_attempt(retry_count)` closure that serves the first call and the retry). One WHY comment added: the transport emits the three keys as one block (`agent/transports/codex.py::build_kwargs`).
- `tests/run_agent/test_run_agent.py` — the two contributor tests stubbed `_build_api_kwargs` with a hand-written dict; replaced by one test that drives the real `CodexTransport.build_kwargs` (the fixture agent carries a tool) and asserts both attempts — the first and the empty-summary retry — go out without any of the three keys.
- `contributors/emails/` — mappings for both contributors.

## Root cause

`_codex_summary_attempt` reused the main-loop request and popped only `tools`; `build_kwargs` emits `tools` + `tool_choice: "auto"` + `parallel_tool_calls: true` together whenever tools are present, so the summary went out with controls and no tools array. Responses defaults are `auto`/`true`, so omitting them is a no-op everywhere else (chatgpt.com Codex, direct OpenAI, xAI, GitHub Models, Azure).

## Validation

| check | result |
|---|---|
| contributor live repro (xAI `grok-4.6`, `HERMES_MAX_ITERATIONS=2`) | before: `400 A tool_choice was set on the request but no tools were specified.` → after: real summary (#108747 body) |
| real-transport probe (fixture agent with a tool, `_run_codex_stream` captured) | `origin/main`: both attempts carry `tool_choice`/`parallel_tool_calls`; this branch: neither |
| new test with `agent/chat_completion_helpers.py` reverted to `origin/main` | fails `attempt 0: ['parallel_tool_calls', 'tool_choice'] leaked`; passes with the fix |
| `scripts/run_tests.sh` on the 6 files exercising the summary path + `tests/agent/transports/` + `test_codex_responses_adapter.py` | 737 passed, 0 failed |
| `scripts/run_tests.sh tests/agent/ -k codex` | 573 passed, 0 failed |
| ruff, `check_compat_pointers.py`, `check-windows-footguns.py --all` | clean |

## Review thread on #108747

The `extra_body` point (a user-configured `custom_providers[].extra_body: {tool_choice: ...}` would survive): confirmed technically reachable — the openai SDK merges `extra_body` into the top-level JSON — but the transport already emits those keys natively, no doc/default/example puts them in `extra_body`, and no Hermes request path key-scrubs user `extra_body`. It is a pre-existing condition independent of this diff, left as-is.

Related: #94139 (same symptom), #61777, #95796, #104377 (later fixes for the same bug; #104377's error-regex recap fallback is not carried — the fix removes the 400 at the source).
