### PR TITLE
fix(kanban): replay completions when sessions reconnect

### DIFF
--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -312,6 +312,7 @@ class TestNotificationPollerLoopKanbanWiring:
         import threading
 
         return {
+            "agent": object(),
             "session_key": SESSION_KEY,
             "history_lock": threading.Lock(),
             "running": running,
@@ -362,3 +363,90 @@ class TestNotificationPollerLoopKanbanWiring:
         assert any(tid in text for text in submits), submits
         assert session["_kanban_pending"] == []
         assert session["running"] is True
+
+    def test_resumed_session_replays_before_agent_build_then_dispatches_once(self, monkeypatch):
+        import threading
+        import tui_gateway.server as server
+
+        tid = _create_subscribed_task()
+        _complete(tid, summary="completed while disconnected")
+        session = {
+            "agent": None,
+            "session_key": SESSION_KEY,
+            "history_lock": threading.Lock(),
+            "running": False,
+        }
+        emitted: list[str] = []
+        submitted: list[str] = []
+        monkeypatch.setattr(
+            server,
+            "_emit",
+            lambda event, _sid, payload=None: emitted.append(payload["text"])
+            if event == "status.update" and payload
+            else None,
+        )
+        monkeypatch.setattr(
+            server,
+            "_run_prompt_submit",
+            lambda _rid, _sid, _session, text: submitted.append(text),
+        )
+
+        server._notif_poll_kanban("resumed-runtime", session)
+
+        assert any(tid in text for text in emitted)
+        assert submitted == []
+        assert len(session["_kanban_pending"]) == 1
+        cursor_after_replay = _sub_rows(tid)[0]["last_event_id"]
+
+        session["agent"] = object()
+        server._notif_poll_kanban("resumed-runtime", session)
+
+        assert len(submitted) == 1
+        assert tid in submitted[0]
+        assert session["_kanban_pending"] == []
+        assert _sub_rows(tid)[0]["last_event_id"] == cursor_after_replay
+
+    def test_cold_resume_starts_replay_before_agent_build(self, tmp_path, monkeypatch):
+        import threading
+        from hermes_state import SessionDB
+        import tui_gateway.server as server
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(SESSION_KEY, source="tui", model="test/model")
+        tid = _create_subscribed_task()
+        _complete(tid, summary="offline completion")
+        emitted: list[str] = []
+
+        def start_replay(sid, session):
+            server._notif_poll_kanban(sid, session)
+            return threading.Event()
+
+        monkeypatch.setattr(server, "_get_db", lambda: db)
+        monkeypatch.setattr(server, "_start_notification_poller", start_replay)
+        monkeypatch.setattr(server, "_schedule_agent_build", lambda _sid: None)
+        monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+        monkeypatch.setattr(server, "_maybe_schedule_auto_continue", lambda *_args: None)
+        monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+        monkeypatch.setattr(
+            server,
+            "_emit",
+            lambda event, _sid, payload=None: emitted.append(payload["text"])
+            if event == "status.update" and payload
+            else None,
+        )
+
+        response = server.handle_request({
+            "id": "resume-offline-kanban",
+            "method": "session.resume",
+            "params": {"session_id": SESSION_KEY},
+        })
+
+        try:
+            assert "error" not in response
+            assert any(tid in text for text in emitted)
+            runtime_id = response["result"]["session_id"]
+            assert server._sessions[runtime_id]["_kanban_pending"]
+            assert _sub_rows(tid)[0]["last_event_id"] > 0
+        finally:
+            server._sessions.pop(response.get("result", {}).get("session_id", ""), None)
+            db.close()

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -512,7 +512,10 @@ class _Resume:
     def claim(self, sid: str, record: dict) -> dict | None:
         """Register ``record`` live under the resume lock, or reuse a concurrent winner's session."""
         live = _claim_or_reuse_live(sid, self.target, record, None)
-        return None if live is None else _resume_reuse_live(self, *live)
+        if live is not None:
+            return _resume_reuse_live(self, *live)
+        _ensure_notification_poller(sid, record)
+        return None
 
     def restore(self):
         """``(sanitized model history, display history, raw history)`` for a cold/eager resume."""

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -940,10 +940,20 @@ def _wire_session_agent(sid: str, key: str, agent) -> bool:
 
 def _start_session_services(sid: str, key: str, current: dict) -> None:
     """Start the notification poller and fire the session-reset boundary hook."""
-    with _sessions_lock:
-        if (rec := _sessions.get(sid)) is not None:
-            rec["_notif_stop"] = _start_notification_poller(sid, rec)
+    _ensure_notification_poller(sid, current)
     _notify_session_boundary("on_session_reset", key, _session_source(current))
+
+
+def _ensure_notification_poller(sid: str, current: dict) -> None:
+    """Start this live record's poller once, including before a resumed agent is built."""
+    with _sessions_lock:
+        rec = _sessions.get(sid)
+        if rec is not current:
+            return
+        stop = rec.get("_notif_stop")
+        if stop is not None and not stop.is_set():
+            return
+        rec["_notif_stop"] = _start_notification_poller(sid, rec)
 
 
 def _await_resume_history(sid: str, current: dict) -> bool:

--- a/tui_gateway/session_notifications.py
+++ b/tui_gateway/session_notifications.py
@@ -373,6 +373,8 @@ def _notif_poll_kanban(sid: str, session: dict) -> None:
         _emit("status.update", sid, {"kind": "process", "text": text})
     if texts:
         session.setdefault("_kanban_pending", []).extend(texts)
+    if session.get("agent") is None:
+        return
     if not session.get("_kanban_pending") or not _notif_claim_turn(session):
         return
     with session["history_lock"]:


### PR DESCRIPTION
## Summary

Kanban completions created while the originating session was disconnected were not consistently replayed after reconnect. Cold session resume registered the live session before the notification poller started, and an early poll could attempt a turn before the agent was ready.

This starts the poller as part of cold resume through an idempotent session-service helper and buffers replayed Kanban notifications until the agent is available.

## Testing

- `HERMES_PYTHON=/home/cc/miniconda3/bin/python scripts/run_tests.sh tests/tui_gateway/test_kanban_notify_poller.py tests/tui_gateway/test_finalize_session_persist.py tests/gateway/test_kanban_notifier.py tests/gateway/test_kanban_routed_transport.py`

## Reviewers

@teknium1
@DavidMetcalfe

Closes #108410