### PR TITLE
fix(update): record a failed dashboard respawn as "failed" in the receipt

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -371,21 +371,24 @@ def _kill_stale_dashboard_processes(
         print(f"    ✓ stopped PID {pid}")
     for pid, err_msg in failed:
         print(f"    ✗ failed to stop PID {pid}: {err_msg}")
+    failed_respawn: list[int] = []
     if killed and restart_managed:
-        unrecovered = _restart_killed_backends(killed, pid_service, pid_cgroup, pid_cmdline, pid_home)
+        unrecovered, failed_respawn = _restart_killed_backends(killed, pid_service, pid_cgroup, pid_cmdline, pid_home)
     else:
         unrecovered = list(killed)
         if killed:
             print("  Restart the dashboard when you're ready:\n    hermes dashboard --port <port>")
     return {"matched": list(pids), "killed": list(killed), "failed": list(failed),
-            "unrecovered": list(unrecovered)}
+            "unrecovered": list(unrecovered), "failed_respawn_pids": list(failed_respawn)}
 
 
 def _restart_killed_backends(
     killed: list[int], pid_service: dict[int, str | None], pid_cgroup: dict[int, str | None],
-    pid_cmdline: dict[int, list[str]], pid_home: dict[int, str | None]) -> list[int]:
+    pid_cmdline: dict[int, list[str]], pid_home: dict[int, str | None]) -> tuple[list[int], list[int]]:
     """Update path: restart systemd units, respawn manual argv (detached, headless, logged to
-    logs/dashboard-restart.log; one per profile, no ``--port 0``). Returns PIDs not brought back."""
+    logs/dashboard-restart.log; one per profile, no ``--port 0``). Returns ``(PIDs not brought back,
+    PIDs whose argv respawn was attempted and failed)`` — the second list is the receipt-side
+    failure fact; the incarnation probe cannot see it because a failed spawn leaves no child (#109290)."""
     # Two categories: Without this, a remote backend (hermes serve) under Restart=on-failure never comes
     # back after our clean SIGTERM, and the Desktop can't reconnect (#68934). Filtered so Desktop
     # ``serve|dashboard --port 0`` backends are not resurrected and duplicates collapse to one per profile
@@ -414,11 +417,15 @@ def _restart_killed_backends(
         print(f"    ⚠ {svc}: {err}")
     respawn_cmds = _filter_dashboard_respawn_candidates(respawn_candidates)
     failed_cmds = _dash._respawn_dashboard_processes(respawn_cmds) if respawn_cmds else None
+    failed_respawn: list[int] = []
     if failed_cmds:
-        unrecovered.extend(p for p in killed if pid_cmdline.get(p) in failed_cmds)
+        for p in killed:
+            if pid_cmdline.get(p) in failed_cmds:
+                unrecovered.append(p)
+                failed_respawn.append(p)
     if failed_restarts or unrecovered:
         print("  Restart anything not auto-restarted when you're ready:\n    hermes dashboard --port <port>")
-    return unrecovered
+    return unrecovered, failed_respawn
 
 
 def _norm_exe(path) -> str:

--- a/hermes_cli/main_dashboard.py
+++ b/hermes_cli/main_dashboard.py
@@ -252,17 +252,21 @@ def _respawn_dashboard_processes(commands: list[list[str]]) -> list[list[str]]:
         log_path.parent.mkdir(parents=True, exist_ok=True)
 
     for command in commands:
+        spawn_argv = command
         try:
             # Keep restarted dashboards headless; reopening a browser after a
             # background update is noisy and fails in SSH/headless sessions.
             if "dashboard" in command and "--no-open" not in command:
-                command = [*command, "--no-open"]
+                spawn_argv = [*command, "--no-open"]
             with open(log_path, "ab") as log_f:
                 subprocess.Popen(
-                    command, stdin=subprocess.DEVNULL, stdout=log_f, stderr=subprocess.STDOUT,
+                    spawn_argv, stdin=subprocess.DEVNULL, stdout=log_f, stderr=subprocess.STDOUT,
                     start_new_session=True, close_fds=True)
-            respawned.append(command)
+            respawned.append(spawn_argv)
         except (OSError, ValueError) as exc:
+            # Report the caller's original argv, not the spawn argv with --no-open
+            # appended: callers match these entries against the killed pid's live
+            # cmdline to reconcile the update receipt (#109290).
             failed.append((command, str(exc)))
 
     for command in respawned:

--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -1299,7 +1299,11 @@ def _verify_fleet_after_update(restart, *, _pre_update_plan, _windows_gateway_re
     # Restart a managed dashboard via systemd or stop stale manual ones (raw-killing
     # a systemd-owned PID reads as clean stop and leaves the Cloudflare origin dead).
     # Failed Node refresh leaves it untouched; already-restarted units aren't redone.
-    _finish_dashboard_update_cleanup(node_failures, already_restarted_units=set(restart.restarted_services))
+    # The returned PIDs are respawns the cleanup watched fail — the receipt-side fact the
+    # incarnation probe cannot recover (a failed spawn leaves no child). See #109290.
+    _failed_respawn_pids = _finish_dashboard_update_cleanup(
+        node_failures, already_restarted_units=set(restart.restarted_services)
+    )
 
     # Success-path twin of the abort-recovery probe: the restart phase only touches
     # units, so a unit-less `hermes serve` keeps stale sys.modules. Runs AFTER
@@ -1378,8 +1382,14 @@ def _verify_fleet_after_update(restart, *, _pre_update_plan, _windows_gateway_re
                     if _stale_serve_rows is not None
                     else None
                 ),
+                failed_respawn_pids=_failed_respawn_pids or None,
             )
             if report_unaccounted_runtimes(_runtime_outcomes):
+                restart.incomplete = True
+            if _failed_respawn_pids:
+                # A respawn the cleanup watched fail is the same class as an unaccounted
+                # runtime — a promised restart did not happen — so the receipt must read
+                # "partial", not "success". See #109290.
                 restart.incomplete = True
             with suppress(Exception):
                 import hermes_cli.update_receipt as _ur

--- a/hermes_cli/update_cmd_maint.py
+++ b/hermes_cli/update_cmd_maint.py
@@ -308,11 +308,16 @@ def _reload_process_scan_modules() -> None:
 
 def _finish_dashboard_update_cleanup(
     node_failures: list[str], already_restarted_units: "set[str] | None" = None
-) -> None:
+) -> "set[int]":
     """Refresh managed dashboards or stop stale manual ones after an update.
 
     *already_restarted_units*: systemd unit names (no ``.service``) the fleet-restart loop
     already restarted, so a Serve-only install isn't restarted a second time here.
+
+    Returns the PIDs whose manual-argv respawn was attempted and failed, so the update
+    receipt can record the runtime as ``failed`` instead of deriving ``restarted`` from the
+    incarnation probe — a killed pre-update pid is exactly what a failed respawn looks like
+    from the outside. See #109290.
 
     See #83595.
     """
@@ -321,20 +326,22 @@ def _finish_dashboard_update_cleanup(
         print()
         print("  ℹ Leaving running dashboard process(es) untouched because the")
         print("    Node.js dependency refresh did not complete.")
-        return
+        return set()
 
     _reload_process_scan_modules()
 
     stop_result = _m()._kill_stale_dashboard_processes(
         restart_managed=True, already_restarted_units=already_restarted_units
     )
+    failed_respawn_pids = {int(p) for p in stop_result.get("failed_respawn_pids") or ()}
     if not stop_result.get("unrecovered"):
-        return
+        return failed_respawn_pids
 
     print()
     print("⚠ A web dashboard/serve process was stopped during update and could not be auto-restarted.")
     print("  Re-launch it when you want the web UI back:")
     print("    hermes dashboard --port <port>")
+    return failed_respawn_pids
 
 
 def _print_update_completion(message: str) -> None:

--- a/hermes_cli/update_cmd_zip.py
+++ b/hermes_cli/update_cmd_zip.py
@@ -427,8 +427,13 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
         _print_curator_recent_run_notice()
     # Don't stop a working dashboard when the Node refresh failed — see the git-update path for rationale.
     # See #30271.
-    _finish_dashboard_update_cleanup(node_failures)
+    _failed_respawn_pids = _finish_dashboard_update_cleanup(node_failures)
     with _best_effort('Update receipt finalize (zip path) failed: %s'):
         from hermes_cli.update_receipt import finalize_update_receipt
-        finalize_update_receipt("success" if update_complete and not node_failures else "partial")
+        # A dashboard respawn the cleanup watched fail must not read as "success" in the
+        # receipt — the zip path has no runtime reconciliation, so partial is the only signal.
+        # See #109290.
+        finalize_update_receipt(
+            "success" if update_complete and not node_failures and not _failed_respawn_pids else "partial"
+        )
     return update_complete

--- a/hermes_cli/update_inventory.py
+++ b/hermes_cli/update_inventory.py
@@ -312,7 +312,7 @@ def _gateway_named_in(r: RuntimeRecord, names: set) -> bool:
 def match_runtime_outcomes(
     plan: "UpdatePlan", *, restarted_services: list, relaunched_profiles: list,
     externally_supervised_profiles: list, killed_pids: set, failed_units: list,
-    stale_serve_pids: "set | None" = None,
+    stale_serve_pids: "set | None" = None, failed_respawn_pids: "set | None" = None,
 ) -> list[dict[str, Any]]:
     """Reconcile the plan's runtimes against what the restart phase DID.
 
@@ -323,6 +323,9 @@ def match_runtime_outcomes(
     reconciled in their OWN vocabulary and never borrow the gateway's outcome: with
     ``stale_serve_pids`` a pre-update serve whose incarnation is gone counts as ``restarted``, one
     still alive is ``unaccounted``; without the probe an untouched serve stays ``unaccounted``.
+    ``failed_respawn_pids`` carries the stronger fact of an argv respawn that was attempted and
+    raised: it is checked before the incarnation probe, because "the pre-update pid is gone" is
+    exactly what a failed respawn looks like from the outside. See #109290.
 
     See #91277.
     They never borrow the gateway's outcome: ``relaunched_profiles`` and ``hermes-gateway*`` name a
@@ -335,6 +338,7 @@ def match_runtime_outcomes(
         relaunched = set(relaunched_profiles or []) | set(externally_supervised_profiles or [])
         killed = {int(p) for p in (killed_pids or set())}
         stale_serves = {int(p) for p in stale_serve_pids} if stale_serve_pids is not None else None
+        failed_respawns = {int(p) for p in failed_respawn_pids} if failed_respawn_pids is not None else set()
 
         def _outcome(r: RuntimeRecord) -> str:
             killed_here = r.pid is not None and r.pid in killed
@@ -342,6 +346,11 @@ def match_runtime_outcomes(
                 if killed_here:
                     return "stopped"
                 if any(_serve_unit_matches_profile(r.profile, u) for u in failed_set):
+                    return "failed"
+                if failed_respawns and r.pid in failed_respawns:
+                    # We watched this runtime's respawn raise — the attempt's result outranks the
+                    # incarnation probe, whose "gone" is indistinguishable from a failed spawn.
+                    # See #109290.
                     return "failed"
                 if stale_serves is not None:
                     # Incarnation-verified: the pre-update process is gone (replaced by its unit / the

--- a/tests/hermes_cli/test_restart_plan_reconciliation.py
+++ b/tests/hermes_cli/test_restart_plan_reconciliation.py
@@ -295,6 +295,47 @@ def test_serve_outcome_follows_incarnation_probe_when_provided():
     assert by_pid == {900: "unaccounted", 901: "stopped"}
 
 
+def test_failed_respawn_outranks_incarnation_probe():
+    """A respawn the cleanup watched raise is ``failed`` even when the incarnation probe
+    sees the pre-update pid gone — "gone" is exactly what a failed respawn looks like
+    from the outside, so the attempt's result must outrank the observation. See #109290."""
+    plan = _plan(_serve("default", 900), _serve("default", 901, kind="dashboard"))
+    outcomes = match_runtime_outcomes(
+        plan, restarted_services=[], relaunched_profiles=[],
+        externally_supervised_profiles=[], killed_pids=set(), failed_units=[],
+        stale_serve_pids=set(),  # probe ran and saw both pids gone => both would read "restarted"
+        failed_respawn_pids={901},
+    )
+    by_pid = {o["pid"]: o["outcome"] for o in outcomes}
+    assert by_pid == {900: "restarted", 901: "failed"}
+
+
+def test_failed_respawn_recorded_without_probe():
+    """Without the probe, an attempted-and-failed respawn still reads ``failed`` — the
+    fact must not degrade to the probe-less ``unaccounted`` default. See #109290."""
+    outcomes = match_runtime_outcomes(
+        _plan(_serve("default", 900)),
+        restarted_services=[], relaunched_profiles=[],
+        externally_supervised_profiles=[], killed_pids=set(), failed_units=[],
+        stale_serve_pids=None,
+        failed_respawn_pids={900},
+    )
+    assert outcomes[0]["outcome"] == "failed"
+
+
+def test_failed_respawn_pids_do_not_touch_gateway_rows():
+    """Serve-only vocabulary: a gateway pid in ``failed_respawn_pids`` is ignored —
+    gateways are never respawned via the dashboard argv path. See #100479, #109290."""
+    outcomes = match_runtime_outcomes(
+        _plan(_rt("default", 100), _serve("default", 900)),
+        restarted_services=[], relaunched_profiles=[],
+        externally_supervised_profiles=[], killed_pids=set(), failed_units=[],
+        failed_respawn_pids={100, 900},
+    )
+    by_pid = {o["pid"]: o["outcome"] for o in outcomes}
+    assert by_pid == {100: "unaccounted", 900: "failed"}
+
+
 def test_unaccounted_serve_report_names_serve_remedy_not_gateway_restart(capsys):
     outcomes = match_runtime_outcomes(
         _plan(_serve("default", 900)),

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -320,6 +320,24 @@ class TestDashboardUpdateCleanup:
 
         assert "stopped during update" not in capsys.readouterr().out
 
+    def test_failed_respawn_pids_returned_for_the_receipt(self):
+        """The respawn-failure PIDs feed the receipt's runtime reconciliation — the
+        console already knows; the receipt must not claim success. See #109290."""
+        with patch(
+            "hermes_cli.main._kill_stale_dashboard_processes",
+            return_value={"matched": [12345], "killed": [12345], "failed": [],
+                          "unrecovered": [12345], "failed_respawn_pids": [12345]},
+        ):
+            assert _finish_dashboard_update_cleanup([]) == {12345}
+
+    def test_clean_cleanup_returns_no_failed_respawn_pids(self):
+        with patch(
+            "hermes_cli.main._kill_stale_dashboard_processes",
+            return_value={"matched": [12345], "killed": [12345], "failed": [],
+                          "unrecovered": []},
+        ):
+            assert _finish_dashboard_update_cleanup([]) == set()
+
 
 class TestWindowsWmicEncoding:
     """Regression tests for #17049 — the Windows wmic branch must not crash
@@ -487,6 +505,35 @@ class TestManualBackendRespawn:
 
         respawn.assert_called_once_with([argv])
         assert "when you're ready" not in capsys.readouterr().out
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX cmdline capture + respawn")
+    def test_failed_respawn_surfaces_in_result(self, capsys):
+        """A respawn that raised is reported as both unrecovered and a failed respawn in
+        the result dict, so the update receipt can record the runtime as ``failed`` —
+        the incarnation probe would otherwise read the killed pid as "restarted".
+        See #109290."""
+        live = self._live()
+        argv = ["hermes", "dashboard", "--port", "8300"]
+
+        def fake_kill(pid, sig):
+            if sig == 0:
+                raise ProcessLookupError
+
+        with patch.object(main_dashboard, "_restart_managed_dashboard_service", return_value=False), \
+             patch.object(live, "_find_stale_dashboard_pids", return_value=[6001]), \
+             patch.object(main_dashboard, "_get_pid_cgroup_path", return_value=None), \
+             patch.object(main_dashboard, "_get_systemd_service_for_pid", return_value=None), \
+             patch.object(main_dashboard, "_dashboard_cmdline_for_pid", return_value=argv), \
+             patch("hermes_cli.dashboard_procs._hermes_home_for_pid", return_value=None), \
+             patch.object(live, "_respawn_dashboard_processes", return_value=[argv]) as respawn, \
+             patch("os.kill", side_effect=fake_kill), \
+             patch("time.sleep"):
+            result = _kill_stale_dashboard_processes(restart_managed=True)
+
+        respawn.assert_called_once_with([argv])
+        assert result["unrecovered"] == [6001]
+        assert result["failed_respawn_pids"] == [6001]
+        assert "Restart anything not auto-restarted" in capsys.readouterr().out
 
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX cmdline capture + respawn")
     def test_port_zero_serves_killed_without_respawn(self, capsys):

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -621,6 +621,21 @@ class TestManualBackendRespawn:
         out = capsys.readouterr().out
         assert "✗ failed to restart" in out
 
+    def test_respawn_failure_returns_original_dashboard_argv(self, tmp_path, monkeypatch):
+        """A failed dashboard spawn reports the original argv without the appended
+        ``--no-open`` — callers match these entries against the killed pid's live
+        cmdline, so a modified argv would never match and the respawn failure would
+        read as success in the update receipt. See #109290."""
+        live = self._live()
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+        with patch.object(live.subprocess, "Popen", side_effect=OSError("no such file")):
+            failed = live._respawn_dashboard_processes([
+                ["hermes", "dashboard", "--port", "8300"],
+            ])
+
+        assert failed == [["hermes", "dashboard", "--port", "8300"]]
+
 
 class TestFilterDashboardRespawnCandidates:
     """Unit tests for respawn filtering / dedupe / orphan skip (#78821)."""


### PR DESCRIPTION
## What does this PR do?

When the post-update dashboard respawn **fails**, the update receipt currently claims it succeeded. `runtime_outcomes` has no input for the respawn's result, and for serve/dashboard runtimes the outcome is derived from the incarnation-liveness probe — "the pre-update pid is gone" is exactly what a *failed* respawn looks like from the outside, so the row reads `"restarted"`, the overall receipt reads `"success"`, and the `unaccounted` tripwire never fires.

The truth already exists on the producer side (`_restart_killed_backends` computes the argvs that failed to spawn and folds them into `unrecovered`), but it was dropped at the call site: `_finish_dashboard_update_cleanup` returned `None` and `match_runtime_outcomes` had no parameter to carry it.

This PR threads that fact through:

- `_restart_killed_backends` additionally returns the PIDs whose argv respawn was attempted and failed, and `_kill_stale_dashboard_processes` surfaces them as `failed_respawn_pids` in its result dict.
- `_finish_dashboard_update_cleanup` returns that set to both update paths (git and ZIP).
- `match_runtime_outcomes` accepts `failed_respawn_pids` and checks it **before** the incarnation probe — "we watched the spawn fail" outranks "gone". It reuses the existing `failed` vocabulary (the unit path already emits it) rather than inventing a fifth state.
- Both update paths escalate the receipt to `"partial"` (the same `restart.incomplete` class the `unaccounted` tripwire uses), since "a promised restart did not happen" is one class with one policy; the code update itself still succeeds, so hard-failing the update stays out of scope (same reasoning as #99564).

## Related Issue

Fixes #109290

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/dashboard_procs.py` — `_restart_killed_backends` returns `(unrecovered, failed_respawn)`; the respawn-failure fold now records the PIDs separately; `_kill_stale_dashboard_processes` adds `failed_respawn_pids` to its result dict.
- `hermes_cli/update_cmd_maint.py` — `_finish_dashboard_update_cleanup` returns the failed-respawn PID set instead of `None` (empty set when the cleanup was skipped or nothing failed).
- `hermes_cli/update_inventory.py` — `match_runtime_outcomes` gains a `failed_respawn_pids` keyword; the serve/dashboard branch returns `failed` for those PIDs before consulting the incarnation probe.
- `hermes_cli/update_cmd_fleet.py` — git update path: passes `failed_respawn_pids` into reconciliation and sets `restart.incomplete` so the receipt reads `"partial"`.
- `hermes_cli/update_cmd_zip.py` — ZIP update path: receipt reads `"partial"` when a respawn failed (no runtime reconciliation exists there, so partial is the only signal).
- `tests/hermes_cli/test_restart_plan_reconciliation.py` — regression tests: a failed respawn outranks the probe's "gone", is recorded without the probe, and never leaks into gateway rows.
- `tests/hermes_cli/test_update_stale_dashboard.py` — regression tests: a raising respawn surfaces in the result dict, and `_finish_dashboard_update_cleanup` returns the set for the receipt.

## How to Test

1. Run the new and adjacent reconciliation tests — Observed result: `pytest tests/hermes_cli/test_restart_plan_reconciliation.py tests/hermes_cli/test_update_stale_dashboard.py -q` → `67 passed, 3 skipped` (skips are pre-existing linux/windows-only markers).
2. `test_failed_respawn_outranks_incarnation_probe` is the core assertion: with the probe reporting both pre-update pids gone (which previously read `restarted`) and `failed_respawn_pids={901}`, the outcomes are now `{900: "restarted", 901: "failed"}` — should pass.
3. End-to-end equivalent (the reported scenario): a dashboard whose captured argv no longer spawns (e.g. the relative-argv ENOENT from #109287) produces a receipt row `{"kind": "dashboard", ..., "outcome": "failed"}` and a top-level `"outcome": "partial"` instead of `"restarted"`/`"success"`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites: the two suites above; the fleet-restart suite has a pre-existing environment-dependent failure on this host, reproduced identically on a clean `upstream/main` checkout with no changes — unrelated to this PR)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin arm64); the respawn path under test is POSIX-guarded and the receipt logic is platform-independent

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstrings updated where behavior changed)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the new key is additive to a dict consumed via `.get()`, and the ZIP path covers the Windows update flow
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A