### PR TITLE
fix(cli): unroute the old name before renaming a multiplexed profile

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1656,10 +1656,25 @@ def rename_profile(old_name: str, new_name: str) -> Path:
     if _check_gateway_running(old_dir):
         _cleanup_gateway_service(old_canon, old_dir)
         _stop_gateway_process(old_dir)
+    multiplexed = _served_by_running_multiplexer(old_canon)
+    if multiplexed:
+        # A multiplexed secondary has no gateway.pid of its own, so the guard above missed
+        # it: the multiplexer still holds adapters and SQLite/logging handles bound to the
+        # old name. Tombstone before rename so its stale mkdirs cannot relist the old name
+        # live, and let it un-route the old name and release its handles into the directory
+        # (the same unroute-before-mutate discipline as delete_profile).
+        mark_named_profile_deleted(old_dir)
+        _notify_multiplexer(old_canon)
 
     # 2. Rename directory
     old_dir.rename(new_dir)
     print(f"✓ Renamed {old_dir.name} → {new_dir.name}")
+
+    if multiplexed:
+        # The old home no longer exists, so nothing can mkdir it back; drop the tombstone
+        # (rename is not delete) and hot-serve the renamed profile like create_profile.
+        clear_named_profile_deleted(old_dir)
+        _notify_multiplexer(new_canon)
 
     # 3. Update profile-scoped Honcho host blocks, preserving aiPeer identity
     _migrate_honcho_profile_host(old_canon, new_canon, new_dir)

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -741,6 +741,53 @@ class TestRenameProfile:
         assert new_dir.is_dir()
         assert new_dir == tmp_path / ".hermes" / "profiles" / "newname"
 
+    def test_rename_under_running_multiplexer_tombstones_old_and_hot_serves_new(
+        self, profile_env
+    ):
+        tmp_path = profile_env
+        old_dir = tmp_path / ".hermes" / "profiles" / "oldname"
+        served = []
+        notified = []
+
+        with patch("hermes_cli.gateway.named_profile_served_by_running_multiplexer",
+                   side_effect=lambda name: served.append(name) or True), \
+             patch("hermes_cli.gateway_multiplex_served.notify_multiplexer_profiles_changed",
+                   side_effect=lambda canon: notified.append(canon)), \
+             patch("hermes_cli.profiles.check_alias_collision", return_value="skip"):
+            create_profile("oldname", no_alias=True)
+            assert old_dir.is_dir()
+            served.clear()
+            notified.clear()
+            rename_profile("oldname", "newname")
+
+        # The old name was detected as multiplexed, un-routed before the rename, then the
+        # renamed profile was hot-served — the create_profile notification is patched out
+        # too, so this order is purely rename_profile's.
+        assert served == ["oldname"]
+        assert notified == ["oldname", "newname"]
+        # Directory moved; no tombstone left behind (rename is not delete); old name stays gone.
+        assert not old_dir.exists()
+        assert (tmp_path / ".hermes" / "profiles" / "newname").is_dir()
+        assert not (tmp_path / ".hermes" / "profiles" / ".deleted" / "oldname").exists()
+
+    def test_rename_without_multiplexer_skips_tombstone_and_notify(self, profile_env):
+        tmp_path = profile_env
+        notified = []
+
+        with patch("hermes_cli.gateway.named_profile_served_by_running_multiplexer",
+                   return_value=False), \
+             patch("hermes_cli.gateway_multiplex_served.notify_multiplexer_profiles_changed",
+                   side_effect=lambda canon: notified.append(canon)), \
+             patch("hermes_cli.profiles.check_alias_collision", return_value="skip"):
+            create_profile("oldname", no_alias=True)
+            notified.clear()
+            rename_profile("oldname", "newname")
+
+        # A non-multiplexed rename keeps its historical behavior: no tombstone, no notify.
+        assert notified == []
+        assert (tmp_path / ".hermes" / "profiles" / "newname").is_dir()
+        assert not (tmp_path / ".hermes" / "profiles" / ".deleted" / "oldname").exists()
+
     def test_renames_root_honcho_host_without_changing_ai_peer(self, profile_env):
         tmp_path = profile_env
         create_profile("ssi_health", no_alias=True)


### PR DESCRIPTION
## What does this PR do?

Renaming a profile while the default gateway multiplexes it resurrected the old name as a ghost served profile. `rename_profile` only guarded the teardown with `_check_gateway_running`, which reports a multiplexed secondary as stopped (it has no `gateway.pid` of its own — `_served_by_running_multiplexer` exists for exactly this case but was never called here). So the rename ran while the multiplexer still held adapters, a cron ticker, logging and SessionDB handles bound to the old name; those live components immediately re-created `profiles/<old>` (no tombstone → `mkdir_under_hermes_home` does not refuse it), and `reconcile_served_profiles` then re-adopted the ghost.

This gives `rename_profile` the same unroute-before-mutate discipline `delete_profile` already has, then hot-serves the new name like `create_profile`:

1. detect a live multiplexed old profile via `_served_by_running_multiplexer(old_canon)`
2. before `old_dir.rename(new_dir)`: `mark_named_profile_deleted(old_dir)` + `_notify_multiplexer(old_canon)` so the multiplexer stops the old adapters, evicts cached agents and releases its handles into the directory
3. after the rename: `clear_named_profile_deleted(old_dir)` (the old home is gone so nothing can mkdir it back; rename is not delete) and `_notify_multiplexer(new_canon)` to hot-serve the renamed profile immediately

## Related Issue

Fixes #109267

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/profiles.py` — in `rename_profile()`, detect `_served_by_running_multiplexer(old_canon)`; when true, tombstone the old name (`mark_named_profile_deleted`) and `_notify_multiplexer(old_canon)` before the directory rename, and `clear_named_profile_deleted(old_dir)` + `_notify_multiplexer(new_canon)` after it
- `tests/hermes_cli/test_profiles.py` — two regression tests: rename under a running multiplexer un-routes the old name and hot-serves the new one (notify order asserted, no tombstone left behind, old dir stays gone); rename without a multiplexer keeps the historical behavior (no tombstone, no notify)

## How to Test

1. `python -m pytest tests/hermes_cli/test_profiles.py -k rename -q` — Observed result: 4 passed (2 new + 2 existing)
2. `python -m pytest tests/hermes_cli/test_profiles.py tests/hermes_cli/test_deleted_profile_tombstone.py tests/gateway/test_multiplex_lifecycle.py -q` — Observed result: 83 passed, 2 skipped
3. Live repro from the issue (multiplexer serving profile `foo`): `hermes profile rename foo bar` — should pass with `profiles/foo` gone and staying gone, `served_profiles` containing `bar`, never `foo`, and no ghost row in `hermes profile list`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.contributing-commits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the tombstone/notify sequence mirrors delete_profile's, which already runs cross-platform; no new paths or syscalls are introduced
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A