### PR TITLE
fix(update): stop failed dashboard restores from reading as success

### DIFF
--- a/hermes_cli/update_cmd_fleet.py
+++ b/hermes_cli/update_cmd_fleet.py
@@ -1299,7 +1299,13 @@ def _verify_fleet_after_update(restart, *, _pre_update_plan, _windows_gateway_re
     # Restart a managed dashboard via systemd or stop stale manual ones (raw-killing
     # a systemd-owned PID reads as clean stop and leaves the Cloudflare origin dead).
     # Failed Node refresh leaves it untouched; already-restarted units aren't redone.
-    _finish_dashboard_update_cleanup(node_failures, already_restarted_units=set(restart.restarted_services))
+    _failed_serve_pids = set(
+        _finish_dashboard_update_cleanup(
+            node_failures, already_restarted_units=set(restart.restarted_services)
+        ) or []
+    )
+    if _failed_serve_pids:
+        restart.incomplete = True
 
     # Success-path twin of the abort-recovery probe: the restart phase only touches
     # units, so a unit-less `hermes serve` keeps stale sys.modules. Runs AFTER
@@ -1378,6 +1384,7 @@ def _verify_fleet_after_update(restart, *, _pre_update_plan, _windows_gateway_re
                     if _stale_serve_rows is not None
                     else None
                 ),
+                failed_serve_pids=_failed_serve_pids,
             )
             if report_unaccounted_runtimes(_runtime_outcomes):
                 restart.incomplete = True

--- a/hermes_cli/update_cmd_maint.py
+++ b/hermes_cli/update_cmd_maint.py
@@ -308,8 +308,10 @@ def _reload_process_scan_modules() -> None:
 
 def _finish_dashboard_update_cleanup(
     node_failures: list[str], already_restarted_units: "set[str] | None" = None
-) -> None:
+) -> list[int]:
     """Refresh managed dashboards or stop stale manual ones after an update.
+
+    Returns the pre-update PIDs that were stopped but not restored.
 
     *already_restarted_units*: systemd unit names (no ``.service``) the fleet-restart loop
     already restarted, so a Serve-only install isn't restarted a second time here.
@@ -321,20 +323,22 @@ def _finish_dashboard_update_cleanup(
         print()
         print("  ℹ Leaving running dashboard process(es) untouched because the")
         print("    Node.js dependency refresh did not complete.")
-        return
+        return []
 
     _reload_process_scan_modules()
 
     stop_result = _m()._kill_stale_dashboard_processes(
         restart_managed=True, already_restarted_units=already_restarted_units
     )
-    if not stop_result.get("unrecovered"):
-        return
+    unrecovered = list(stop_result.get("unrecovered") or [])
+    if not unrecovered:
+        return []
 
     print()
     print("⚠ A web dashboard/serve process was stopped during update and could not be auto-restarted.")
     print("  Re-launch it when you want the web UI back:")
     print("    hermes dashboard --port <port>")
+    return unrecovered
 
 
 def _print_update_completion(message: str) -> None:

--- a/hermes_cli/update_cmd_zip.py
+++ b/hermes_cli/update_cmd_zip.py
@@ -427,8 +427,10 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
         _print_curator_recent_run_notice()
     # Don't stop a working dashboard when the Node refresh failed — see the git-update path for rationale.
     # See #30271.
-    _finish_dashboard_update_cleanup(node_failures)
+    failed_serve_pids = _finish_dashboard_update_cleanup(node_failures)
     with _best_effort('Update receipt finalize (zip path) failed: %s'):
         from hermes_cli.update_receipt import finalize_update_receipt
-        finalize_update_receipt("success" if update_complete and not node_failures else "partial")
+        finalize_update_receipt(
+            "success" if update_complete and not node_failures and not failed_serve_pids else "partial"
+        )
     return update_complete

--- a/hermes_cli/update_inventory.py
+++ b/hermes_cli/update_inventory.py
@@ -312,7 +312,7 @@ def _gateway_named_in(r: RuntimeRecord, names: set) -> bool:
 def match_runtime_outcomes(
     plan: "UpdatePlan", *, restarted_services: list, relaunched_profiles: list,
     externally_supervised_profiles: list, killed_pids: set, failed_units: list,
-    stale_serve_pids: "set | None" = None,
+    stale_serve_pids: "set | None" = None, failed_serve_pids: "set | None" = None,
 ) -> list[dict[str, Any]]:
     """Reconcile the plan's runtimes against what the restart phase DID.
 
@@ -323,6 +323,8 @@ def match_runtime_outcomes(
     reconciled in their OWN vocabulary and never borrow the gateway's outcome: with
     ``stale_serve_pids`` a pre-update serve whose incarnation is gone counts as ``restarted``, one
     still alive is ``unaccounted``; without the probe an untouched serve stays ``unaccounted``.
+    A PID in ``failed_serve_pids`` is ``failed`` regardless of the incarnation probe because the
+    cleanup path observed its restore attempt fail.
 
     See #91277.
     They never borrow the gateway's outcome: ``relaunched_profiles`` and ``hermes-gateway*`` name a
@@ -335,12 +337,15 @@ def match_runtime_outcomes(
         relaunched = set(relaunched_profiles or []) | set(externally_supervised_profiles or [])
         killed = {int(p) for p in (killed_pids or set())}
         stale_serves = {int(p) for p in stale_serve_pids} if stale_serve_pids is not None else None
+        failed_serves = {int(p) for p in (failed_serve_pids or set())}
 
         def _outcome(r: RuntimeRecord) -> str:
             killed_here = r.pid is not None and r.pid in killed
             if r.kind in _SERVE_KINDS:
                 if killed_here:
                     return "stopped"
+                if r.pid is not None and r.pid in failed_serves:
+                    return "failed"
                 if any(_serve_unit_matches_profile(r.profile, u) for u in failed_set):
                     return "failed"
                 if stale_serves is not None:

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1015,6 +1015,44 @@ class TestCmdUpdateZipBranchRefusal:
         assert "Downloading latest version" not in out
 
 
+def test_zip_update_receipt_is_partial_when_dashboard_restore_fails(
+    tmp_path, monkeypatch
+):
+    from hermes_cli import main as hm
+    from hermes_cli import update_cmd_zip
+    from hermes_cli import update_receipt
+
+    outcomes = []
+    monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(hm, "_capture_active_tool_dependencies", lambda: {})
+    monkeypatch.setattr(hm, "_resolve_update_branch", lambda _args: "main")
+    monkeypatch.setattr(hm, "_abort_dependency_sync_if_self_locked", lambda: None)
+    monkeypatch.setattr(hm, "_build_web_ui", lambda _path: None)
+    monkeypatch.setattr(update_cmd_zip, "_abort_zip_update_if_dirty_tree", lambda: None)
+    monkeypatch.setattr(update_cmd_zip, "_download_and_swap_zip", lambda *_args: None)
+    monkeypatch.setattr(update_cmd_zip, "_reinstall_python_deps_after_zip", lambda _deps: None)
+    monkeypatch.setattr(update_cmd, "_read_project_version", lambda: "0.21.2")
+    monkeypatch.setattr(update_cmd, "_sweep_bytecode_after_update", lambda _branch: None)
+    monkeypatch.setattr(
+        update_cmd, "_validate_critical_modules_import", lambda _root: (True, None, None)
+    )
+    monkeypatch.setattr(update_cmd, "_update_node_dependencies", lambda: [])
+    monkeypatch.setattr(update_cmd, "_rebuild_desktop_after_update", lambda *_a, **_k: True)
+    monkeypatch.setattr(update_cmd, "_print_bundled_skills_sync_report", lambda: None)
+    monkeypatch.setattr(update_cmd, "_verify_and_restore_state_dbs_post_update", lambda: None)
+    monkeypatch.setattr(update_cmd, "_print_update_summary", lambda **_kwargs: True)
+    monkeypatch.setattr(update_cmd, "_print_curator_first_run_notice", lambda: None)
+    monkeypatch.setattr(update_cmd, "_print_curator_recent_run_notice", lambda: None)
+    monkeypatch.setattr(update_cmd, "_finish_dashboard_update_cleanup", lambda _failures: [12345])
+    monkeypatch.setattr(
+        "hermes_cli.model_catalog.seed_cache_from_checkout", lambda _root: False
+    )
+    monkeypatch.setattr(update_receipt, "finalize_update_receipt", outcomes.append)
+
+    assert update_cmd_zip._update_via_zip(SimpleNamespace(branch=None)) is True
+    assert outcomes == ["partial"]
+
+
 def test_is_termux_env_true_for_termux_prefix():
     from hermes_cli import main as hm
 

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -477,6 +477,41 @@ def test_clean_update_escalates_surviving_serve_as_unaccounted(
     assert by_pid == {4444: "restarted", 5555: "unaccounted"}
 
 
+def test_failed_dashboard_respawn_is_recorded_and_escalated(monkeypatch, tmp_path):
+    """A missing old PID proves neither that its replacement spawned nor that update was complete."""
+    from hermes_cli.update_inventory import RuntimeRecord, UpdatePlan, _restart_mechanism
+    import hermes_cli.update_inventory as ui
+
+    args = _update_args()
+    _patch_update_deps(monkeypatch, tmp_path, _make_head_moved_side_effect())
+    plan = UpdatePlan()
+    plan.runtimes = [
+        RuntimeRecord(
+            kind="dashboard", profile="default", pid=5555,
+            supervisor="manual-serve",
+            restart_via=_restart_mechanism("manual-serve", "default"),
+            detail={"create_time": 1000.0},
+        )
+    ]
+    monkeypatch.setattr(ui, "collect_runtime_inventory", lambda: plan)
+    monkeypatch.setattr(update_cmd, "_finish_dashboard_update_cleanup", lambda *a, **k: [5555])
+    monkeypatch.setattr(update_cmd, "_surviving_pre_update_serve_runtimes", lambda _plan: [])
+
+    with pytest.raises(SystemExit) as excinfo:
+        hermes_main.cmd_update(args)
+    assert excinfo.value.code == 1
+
+    latest = get_hermes_home() / "logs" / "update_receipts" / "latest.json"
+    receipt = json.loads(latest.read_text(encoding="utf-8"))
+    assert receipt["outcome"] == "partial"
+    assert receipt["runtime_outcomes"] == [
+        {
+            "kind": "dashboard", "profile": "default", "pid": 5555,
+            "mechanism": "respawn-argv", "outcome": "failed",
+        }
+    ]
+
+
 def test_interrupt_between_pull_and_restart_leaves_marker(
     monkeypatch, tmp_path
 ):

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -320,6 +320,15 @@ class TestDashboardUpdateCleanup:
 
         assert "stopped during update" not in capsys.readouterr().out
 
+    def test_returns_pids_that_cleanup_could_not_restore(self, capsys):
+        with patch(
+            "hermes_cli.main._kill_stale_dashboard_processes",
+            return_value={"unrecovered": [12345]},
+        ):
+            assert _finish_dashboard_update_cleanup([]) == [12345]
+
+        assert "could not be auto-restarted" in capsys.readouterr().out
+
 
 class TestWindowsWmicEncoding:
     """Regression tests for #17049 — the Windows wmic branch must not crash


### PR DESCRIPTION
## What does this PR do?

It prevents update receipts from claiming that a dashboard or serve runtime restarted when post-update cleanup stopped it but could not restore it. The cleanup result now reaches runtime reconciliation, where the row is recorded as `failed`; the overall update is marked `partial` so automation does not treat a dashboard left down as healthy.

### Symptom

After a dashboard respawn fails, the console reports the failure but `runtime_outcomes` records the old PID as `restarted`, and the top-level receipt records `success`.

### Impact

The dashboard remains unavailable while the durable machine-readable receipt tells operators and automation that recovery succeeded.

### Bug Cause

**Trigger:** `hermes_cli/update_cmd_fleet.py` / `_verify_fleet_after_update()` discards the result of `_finish_dashboard_update_cleanup()` before calling `match_runtime_outcomes()`.

**Causal chain:**
1. Post-update cleanup stops a stale dashboard or serve runtime and cannot restore it.
2. `_finish_dashboard_update_cleanup()` prints the failure but returns no bookkeeping to reconciliation.
3. The incarnation probe sees that the pre-update PID is gone and classifies the runtime as `restarted`; `restart.incomplete` remains false, so the receipt records `success`.

**Why it is wrong:** Absence of the old process proves only that it stopped. It cannot prove that a replacement process started, especially when cleanup already knows the runtime was not recovered.

**Working sibling / contrast:** Failed gateway unit restarts already feed `failed_units` into reconciliation and produce `failed`; dashboard and serve cleanup previously dropped its equivalent failure fact.

**Ruled out:** Extending the liveness probe cannot cover a spawn that raises because no replacement child exists to probe. The separate post-spawn early-exit behavior in PR #99564 does not cover this path.

### Fix

Return cleanup's existing `unrecovered` PID list, classify those serve/dashboard rows as `failed` before consulting the incarnation probe, and mark both git and ZIP update receipts `partial`. This covers every cleanup path that confirms a stopped runtime was not restored, including manual respawn and dashboard service restart failures, without changing intentional skip behavior.

## Related Issue

Closes #109290

## Why this PR vs existing PR #109298

This PR covers the complete unrecovered-runtime contract already produced by `hermes_cli/dashboard_procs.py`, not only argv spawn exceptions. PR #109298 leaves dashboard service restart failures outside `failed_respawn_pids`, so an absent old PID can still be recorded as `restarted`. This PR also verifies the real `cmd_update` receipt boundary - the runtime row, top-level `partial` result, and incomplete exit are asserted together - while touching five files instead of extending two dashboard process APIs.

## Type of Change

- [x] Bug fix

## Changes Made

- `hermes_cli/update_cmd_maint.py` - return PIDs stopped but not restored by dashboard cleanup.
- `hermes_cli/update_inventory.py` - classify failed serve/dashboard PIDs before the incarnation probe.
- `hermes_cli/update_cmd_fleet.py` - pass cleanup failures into reconciliation and mark the update incomplete.
- `hermes_cli/update_cmd_zip.py` - record a partial ZIP update receipt when dashboard cleanup cannot restore a runtime.
- `tests/hermes_cli/test_update_fleet_restart_pending.py` - verify the final receipt row, top-level result, and exit status together.

## How to Test

Automated verification completed on Windows 11:

```bash
scripts/run_tests.sh tests/hermes_cli/test_update_fleet_restart_pending.py -k failed_dashboard_respawn
# 1 passed

scripts/run_tests.sh tests/hermes_cli/test_restart_plan_reconciliation.py tests/hermes_cli/test_update_stale_dashboard.py
# 51 passed, 13 skipped by OS markers
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and statically compared this fix with PR #109298
- [x] My PR contains only changes related to this fix
- [x] I've added an end-to-end updater receipt regression test
- [x] I've considered cross-platform impact: the receipt logic is platform-independent and the ZIP update path is covered

### Documentation & Housekeeping

- [x] Relevant function documentation describes the new return and reconciliation contract
- [x] No config keys, contributor workflow, or tool schemas changed
