### PR TITLE
fix(dashboard): restart relative launches after updates

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -418,11 +418,9 @@ def _restart_killed_backends(
     for svc, err in failed_restarts:
         print(f"    ⚠ {svc}: {err}")
     respawn_cmds = _filter_dashboard_respawn_candidates(respawn_candidates)
-    cwd_by_cmdline = {
-        tuple(pid_cmdline[pid]): pid_cwd.get(pid)
-        for pid in killed
-        if pid in pid_cmdline
-    }
+    cwd_by_cmdline: dict[tuple[str, ...], str | None] = {}
+    for pid, command, _home in respawn_candidates:
+        cwd_by_cmdline.setdefault(tuple(command), pid_cwd.get(pid))
     respawn_requests = [(cmd, cwd_by_cmdline.get(tuple(cmd))) for cmd in respawn_cmds]
     failed_cmds = _dash._respawn_dashboard_processes(respawn_requests) if respawn_requests else None
     if failed_cmds:

--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -199,9 +199,9 @@ def _profile_key_for_respawn(argv: list[str], hermes_home: str | None = None) ->
     return f"profile:{_profile_flag_value(argv) or 'default'}"
 
 
-def _filter_dashboard_respawn_candidates(
+def _select_dashboard_respawn_candidates(
     candidates: list[tuple[int, list[str], str | None]], *, own_home: str | None = None
-) -> list[list[str]]:
+) -> list[tuple[int, list[str], str | None]]:
     """Select which killed manual backends ``(pid, argv, hermes_home)`` to respawn after update.
 
     Rules: never resurrect Desktop ``--port 0`` backends; never replay a backend from a
@@ -225,10 +225,10 @@ def _filter_dashboard_respawn_candidates(
         except Exception:
             own_home = ""
     own_key = _normalized_home_for_compare(own_home) if own_home else ""
-    selected: list[list[str]] = []
+    selected: list[tuple[int, list[str], str | None]] = []
     seen_cmdlines: set[tuple[str, ...]] = set()
     seen_profiles: set[str] = set()
-    for _pid, argv, hermes_home in candidates:
+    for pid, argv, hermes_home in candidates:
         if not argv or _is_ephemeral_port_zero_backend(argv):
             continue
         if own_key and hermes_home and _normalized_home_for_compare(hermes_home) != own_key:
@@ -239,8 +239,18 @@ def _filter_dashboard_respawn_candidates(
             continue
         seen_cmdlines.add(norm)
         seen_profiles.add(profile_key)
-        selected.append(list(argv))
+        selected.append((pid, list(argv), hermes_home))
     return selected
+
+
+def _filter_dashboard_respawn_candidates(
+    candidates: list[tuple[int, list[str], str | None]], *, own_home: str | None = None
+) -> list[list[str]]:
+    """Return argv for the manual backends selected for respawn after update."""
+    return [
+        argv for _pid, argv, _home in
+        _select_dashboard_respawn_candidates(candidates, own_home=own_home)
+    ]
 
 
 def _exclude_pids_from_env() -> set[int]:
@@ -417,11 +427,8 @@ def _restart_killed_backends(
             unrecovered.append(pid)
     for svc, err in failed_restarts:
         print(f"    ⚠ {svc}: {err}")
-    respawn_cmds = _filter_dashboard_respawn_candidates(respawn_candidates)
-    cwd_by_cmdline: dict[tuple[str, ...], str | None] = {}
-    for pid, command, _home in respawn_candidates:
-        cwd_by_cmdline.setdefault(tuple(command), pid_cwd.get(pid))
-    respawn_requests = [(cmd, cwd_by_cmdline.get(tuple(cmd))) for cmd in respawn_cmds]
+    selected_candidates = _select_dashboard_respawn_candidates(respawn_candidates)
+    respawn_requests = [(command, pid_cwd.get(pid)) for pid, command, _home in selected_candidates]
     failed_cmds = _dash._respawn_dashboard_processes(respawn_requests) if respawn_requests else None
     if failed_cmds:
         unrecovered.extend(p for p in killed if pid_cmdline.get(p) in failed_cmds)

--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -347,6 +347,7 @@ def _kill_stale_dashboard_processes(
     pid_service: dict[int, str | None] = {}
     pid_cmdline: dict[int, list[str]] = {}
     pid_home: dict[int, str | None] = {}
+    pid_cwd: dict[int, str | None] = {}
     if restart_managed and sys.platform != "win32":
         for pid in pids:
             pid_cgroup[pid] = _dash._get_pid_cgroup_path(pid)
@@ -358,6 +359,7 @@ def _kill_stale_dashboard_processes(
                 # after the process is gone (#78821).
                 pid_cmdline[pid] = cmdline
                 pid_home[pid] = _hermes_home_for_pid(pid)
+                pid_cwd[pid] = _dash._dashboard_cwd_for_pid(pid)
         if already_restarted_units:
             pids = [pid for pid in pids if (pid_service.get(pid) or "").removesuffix(".service")
                     not in already_restarted_units]
@@ -372,7 +374,8 @@ def _kill_stale_dashboard_processes(
     for pid, err_msg in failed:
         print(f"    ✗ failed to stop PID {pid}: {err_msg}")
     if killed and restart_managed:
-        unrecovered = _restart_killed_backends(killed, pid_service, pid_cgroup, pid_cmdline, pid_home)
+        unrecovered = _restart_killed_backends(
+            killed, pid_service, pid_cgroup, pid_cmdline, pid_home, pid_cwd)
     else:
         unrecovered = list(killed)
         if killed:
@@ -383,7 +386,9 @@ def _kill_stale_dashboard_processes(
 
 def _restart_killed_backends(
     killed: list[int], pid_service: dict[int, str | None], pid_cgroup: dict[int, str | None],
-    pid_cmdline: dict[int, list[str]], pid_home: dict[int, str | None]) -> list[int]:
+    pid_cmdline: dict[int, list[str]], pid_home: dict[int, str | None],
+    pid_cwd: dict[int, str | None],
+) -> list[int]:
     """Update path: restart systemd units, respawn manual argv (detached, headless, logged to
     logs/dashboard-restart.log; one per profile, no ``--port 0``). Returns PIDs not brought back."""
     # Two categories: Without this, a remote backend (hermes serve) under Restart=on-failure never comes
@@ -413,7 +418,13 @@ def _restart_killed_backends(
     for svc, err in failed_restarts:
         print(f"    ⚠ {svc}: {err}")
     respawn_cmds = _filter_dashboard_respawn_candidates(respawn_candidates)
-    failed_cmds = _dash._respawn_dashboard_processes(respawn_cmds) if respawn_cmds else None
+    cwd_by_cmdline = {
+        tuple(pid_cmdline[pid]): pid_cwd.get(pid)
+        for pid in killed
+        if pid in pid_cmdline
+    }
+    respawn_requests = [(cmd, cwd_by_cmdline.get(tuple(cmd))) for cmd in respawn_cmds]
+    failed_cmds = _dash._respawn_dashboard_processes(respawn_requests) if respawn_requests else None
     if failed_cmds:
         unrecovered.extend(p for p in killed if pid_cmdline.get(p) in failed_cmds)
     if failed_restarts or unrecovered:

--- a/hermes_cli/main_dashboard.py
+++ b/hermes_cli/main_dashboard.py
@@ -251,6 +251,18 @@ def _dashboard_cwd_for_pid(pid: int) -> str | None:
         return None
 
 
+def _dashboard_launch_prefix_needs_cwd(command: list[str]) -> bool:
+    """Whether a path-qualified relative launch token precedes the backend subcommand."""
+    subcommand_index = next(
+        (index for index, token in enumerate(command) if token in {"serve", "dashboard"}),
+        len(command),
+    )
+    return any(
+        not (path := Path(token)).is_absolute() and path.parent != Path(".")
+        for token in command[:subcommand_index]
+    )
+
+
 def _respawn_dashboard_processes(
     commands: list[list[str] | tuple[list[str], str | None]],
 ) -> list[list[str]]:
@@ -270,8 +282,7 @@ def _respawn_dashboard_processes(
     for request in commands:
         command, cwd = request if isinstance(request, tuple) else (request, None)
         try:
-            executable = Path(command[0])
-            if cwd is None and not executable.is_absolute() and executable.parent != Path("."):
+            if cwd is None and _dashboard_launch_prefix_needs_cwd(command):
                 raise ValueError("original working directory is unavailable for relative argv")
             # Keep restarted dashboards headless; reopening a browser after a
             # background update is noisy and fails in SSH/headless sessions.

--- a/hermes_cli/main_dashboard.py
+++ b/hermes_cli/main_dashboard.py
@@ -237,7 +237,23 @@ def _dashboard_cmdline_for_pid(pid: int) -> list[str] | None:
         return None
 
 
-def _respawn_dashboard_processes(commands: list[list[str]]) -> list[list[str]]:
+def _dashboard_cwd_for_pid(pid: int) -> str | None:
+    """Working directory needed to replay a process's relative argv."""
+    if sys.platform == "win32":
+        return None
+    import psutil
+    try:
+        proc_cwd = f"/proc/{pid}/cwd"
+        if os.path.exists(proc_cwd):
+            return os.readlink(proc_cwd)
+        return psutil.Process(pid).cwd() or None
+    except (OSError, psutil.Error):
+        return None
+
+
+def _respawn_dashboard_processes(
+    commands: list[list[str] | tuple[list[str], str | None]],
+) -> list[list[str]]:
     """Respawn manually-started dashboards after ``hermes update``, detached, logging to
     ``logs/dashboard-restart.log``; returns the argvs that failed to spawn. Callers pre-filter via
     ``_filter_dashboard_respawn_candidates`` (no Desktop ``--port 0`` backends, capped per profile).
@@ -251,8 +267,12 @@ def _respawn_dashboard_processes(commands: list[list[str]]) -> list[list[str]]:
     with contextlib.suppress(OSError):
         log_path.parent.mkdir(parents=True, exist_ok=True)
 
-    for command in commands:
+    for request in commands:
+        command, cwd = request if isinstance(request, tuple) else (request, None)
         try:
+            executable = Path(command[0])
+            if cwd is None and not executable.is_absolute() and executable.parent != Path("."):
+                raise ValueError("original working directory is unavailable for relative argv")
             # Keep restarted dashboards headless; reopening a browser after a
             # background update is noisy and fails in SSH/headless sessions.
             if "dashboard" in command and "--no-open" not in command:
@@ -260,7 +280,7 @@ def _respawn_dashboard_processes(commands: list[list[str]]) -> list[list[str]]:
             with open(log_path, "ab") as log_f:
                 subprocess.Popen(
                     command, stdin=subprocess.DEVNULL, stdout=log_f, stderr=subprocess.STDOUT,
-                    start_new_session=True, close_fds=True)
+                    start_new_session=True, close_fds=True, cwd=cwd)
             respawned.append(command)
         except (OSError, ValueError) as exc:
             failed.append((command, str(exc)))

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -479,13 +479,14 @@ class TestManualBackendRespawn:
              patch.object(main_dashboard, "_get_pid_cgroup_path", return_value=None), \
              patch.object(main_dashboard, "_get_systemd_service_for_pid", return_value=None), \
              patch.object(main_dashboard, "_dashboard_cmdline_for_pid", return_value=argv), \
+             patch.object(main_dashboard, "_dashboard_cwd_for_pid", return_value="/install/root"), \
              patch("hermes_cli.dashboard_procs._hermes_home_for_pid", return_value=None), \
              patch.object(live, "_respawn_dashboard_processes", return_value=[]) as respawn, \
              patch("os.kill", side_effect=fake_kill), \
              patch("time.sleep"):
             _kill_stale_dashboard_processes(restart_managed=True)
 
-        respawn.assert_called_once_with([argv])
+        respawn.assert_called_once_with([(argv, "/install/root")])
         assert "when you're ready" not in capsys.readouterr().out
 
     @pytest.mark.skipif(sys.platform == "win32", reason="POSIX cmdline capture + respawn")
@@ -534,13 +535,14 @@ class TestManualBackendRespawn:
              patch.object(main_dashboard, "_get_pid_cgroup_path", return_value=None), \
              patch.object(main_dashboard, "_get_systemd_service_for_pid", return_value=None), \
              patch.object(main_dashboard, "_dashboard_cmdline_for_pid", return_value=argv), \
+             patch.object(main_dashboard, "_dashboard_cwd_for_pid", return_value="/install/root"), \
              patch("hermes_cli.dashboard_procs._hermes_home_for_pid", return_value=None), \
              patch.object(live, "_respawn_dashboard_processes", return_value=[]) as respawn, \
              patch("os.kill", side_effect=fake_kill), \
              patch("time.sleep"):
             _kill_stale_dashboard_processes(restart_managed=True)
 
-        respawn.assert_called_once_with([argv])
+        respawn.assert_called_once_with([(argv, "/install/root")])
         assert "when you're ready" not in capsys.readouterr().out
 
     def test_respawn_adds_no_open_to_dashboard_commands(self, tmp_path, monkeypatch):
@@ -573,6 +575,30 @@ class TestManualBackendRespawn:
         assert failed == [["hermes", "serve"]]
         out = capsys.readouterr().out
         assert "✗ failed to restart" in out
+
+    def test_respawn_anchors_relative_argv_to_captured_cwd(self, tmp_path, monkeypatch):
+        live = self._live()
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+        with patch.object(live.subprocess, "Popen") as popen:
+            failed = live._respawn_dashboard_processes([
+                (["./venv/bin/python", "./venv/bin/hermes", "dashboard"], "/install/root")
+            ])
+
+        assert failed == []
+        assert popen.call_args.kwargs["cwd"] == "/install/root"
+
+    def test_respawn_rejects_relative_argv_without_captured_cwd(self, tmp_path, monkeypatch):
+        live = self._live()
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+        with patch.object(live.subprocess, "Popen") as popen:
+            failed = live._respawn_dashboard_processes([
+                (["./venv/bin/hermes", "dashboard"], None)
+            ])
+
+        assert failed == [["./venv/bin/hermes", "dashboard"]]
+        popen.assert_not_called()
 
 
 class TestFilterDashboardRespawnCandidates:

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -600,6 +600,33 @@ class TestManualBackendRespawn:
         assert failed == [["./venv/bin/hermes", "dashboard"]]
         popen.assert_not_called()
 
+    def test_respawn_rejects_relative_script_without_captured_cwd(self, tmp_path, monkeypatch):
+        live = self._live()
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        command = [sys.executable, "./bin/hermes_cli/main.py", "dashboard"]
+
+        with patch.object(live.subprocess, "Popen") as popen:
+            failed = live._respawn_dashboard_processes([(command, None)])
+
+        assert failed == [command]
+        popen.assert_not_called()
+
+    def test_duplicate_argv_keeps_first_candidate_cwd(self):
+        from hermes_cli.dashboard_procs import _restart_killed_backends
+
+        argv = ["./venv/bin/hermes", "dashboard", "--port", "8300"]
+        with patch.object(main_dashboard, "_respawn_dashboard_processes", return_value=[]) as respawn:
+            _restart_killed_backends(
+                [101, 202],
+                {101: None, 202: None},
+                {101: None, 202: None},
+                {101: argv, 202: argv},
+                {101: None, 202: None},
+                {101: "/install/first", 202: "/install/second"},
+            )
+
+        respawn.assert_called_once_with([(argv, "/install/first")])
+
 
 class TestFilterDashboardRespawnCandidates:
     """Unit tests for respawn filtering / dedupe / orphan skip (#78821)."""

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -627,6 +627,24 @@ class TestManualBackendRespawn:
 
         respawn.assert_called_once_with([(argv, "/install/first")])
 
+    def test_duplicate_argv_uses_selected_own_home_candidate_cwd(self, tmp_path, monkeypatch):
+        from hermes_cli.dashboard_procs import _restart_killed_backends
+
+        own_home = str(tmp_path / ".hermes")
+        monkeypatch.setenv("HERMES_HOME", own_home)
+        argv = ["./venv/bin/hermes", "dashboard", "--port", "8300"]
+        with patch.object(main_dashboard, "_respawn_dashboard_processes", return_value=[]) as respawn:
+            _restart_killed_backends(
+                [101, 202],
+                {101: None, 202: None},
+                {101: None, 202: None},
+                {101: argv, 202: argv},
+                {101: str(tmp_path / "foreign"), 202: own_home},
+                {101: "/foreign/install", 202: "/own/install"},
+            )
+
+        respawn.assert_called_once_with([(argv, "/own/install")])
+
 
 class TestFilterDashboardRespawnCandidates:
     """Unit tests for respawn filtering / dedupe / orphan skip (#78821)."""


### PR DESCRIPTION
## What does this PR do?

Keeps manually started dashboards available after `hermes update` when their recorded launch command contains relative paths. The updater now snapshots the process working directory before termination, replays the command from that directory, and reports a relative command as unrecovered instead of attempting a spawn without its required anchor.

### Symptom

A dashboard started with a command such as `./venv/bin/hermes dashboard --no-open` is stopped during an update run from another directory, then fails to restart with `ENOENT`.

### Impact

The dashboard remains down after an otherwise successful update and requires a manual restart.

### Bug Cause

**Trigger:** `hermes_cli/main_dashboard.py:240` / `_respawn_dashboard_processes()` receives a captured argv containing relative paths.

**Causal chain:**
1. `hermes_cli/dashboard_procs.py` snapshots the manual process argv before terminating it, but not its working directory.
2. `_respawn_dashboard_processes()` passes that argv to `subprocess.Popen()` without `cwd=`.
3. Relative paths resolve against the updater's incidental working directory, the spawn raises `ENOENT`, and the dashboard stays down.

**Why it is wrong:** Replaying an argv that may contain relative paths without preserving its resolution context changes the command's meaning.

**Working sibling / contrast:** Dashboards recorded with fully absolute argv paths restart because they do not depend on the updater's working directory.

**Ruled out:** The argv capture itself is not flattening or rewriting this command; `/proc/<pid>/cmdline` preserves the relative entries verbatim.

### Fix

Snapshot each manual backend's cwd before the process is killed, carry it alongside the selected respawn command, and pass it to `Popen`. If a path-qualified relative executable has no captured cwd, skip the doomed spawn and return it through the existing unrecovered path. Applying the cwd to every captured command also preserves relative script arguments such as `/usr/bin/python ./venv/bin/hermes`.

## Related Issue

Closes #109287

## Why this PR vs existing PR #109296

This patch closes two correctness gaps in `hermes_cli/main_dashboard.py`. PR #109296 applies a cwd only when `argv[0]` is relative, so an absolute interpreter with a relative script argument, such as `/usr/bin/python ./venv/bin/hermes`, still resolves the script from the updater's directory and can fail. It also retries a path-qualified relative executable with no cwd anchor, despite the issue's requested hardening. This patch preserves cwd for the complete captured argv and routes a missing-anchor command through the existing unrecovered/manual-restart path without a doomed spawn attempt.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main_dashboard.py` - capture a process cwd and replay respawn commands from it, rejecting unanchored path-qualified executables.
- `hermes_cli/dashboard_procs.py` - carry cwd snapshots through manual backend filtering and respawn.
- `tests/hermes_cli/test_update_stale_dashboard.py` - cover cwd propagation and missing-anchor behavior.

## How to Test

1. Start a dashboard from the install root with a relative venv launcher.
2. Run `hermes update` from another directory and confirm the dashboard respawns from its recorded cwd.
3. Run `scripts/run_tests.sh tests/hermes_cli/test_update_stale_dashboard.py` immediately after this PR is opened.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) and statically compared PR #109296 before opening this competing fix.
- [x] My PR contains **only** changes related to this fix (no unrelated commits).
- [x] I've added tests for my changes.
- [x] I've tested on my platform: Windows 11 for platform-independent respawn contract coverage; POSIX runtime verification is delegated to review.

### Documentation & Housekeeping

- [x] Documentation and docstrings are updated where applicable.
- [x] `cli-config.yaml.example` changes are N/A because no config keys changed.
- [x] `CONTRIBUTING.md` and `AGENTS.md` changes are N/A because no architecture or workflow changed.
- [x] Cross-platform impact was considered; cwd capture remains disabled on the Windows-only kill path.
- [x] Tool descriptions and schemas are N/A because no model tool changed.

## Screenshots / Logs

Not applicable; this process-respawn regression is covered by focused tests and POSIX runtime verification.
