### PR TITLE
fix(desktop): restore the OpenRouter catalog and type-to-filter pickers

### DIFF
--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -24,6 +24,7 @@ import type { ChatMessage } from '@/lib/chat-messages'
 import { NEW_SESSION_TITLE, quickModelOptions, sessionTitle } from '@/lib/chat-runtime'
 import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-store-runtime'
 import { modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
+import { currentPickerSelection } from '@/lib/model-status-label'
 import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
 import { migrateSessionDraft } from '@/store/composer'
@@ -576,18 +577,25 @@ const ChatViewContent = memo(function ChatViewContent({
     enabled: gatewayOpen
   })
 
+  const pickerSelection = currentPickerSelection(
+    { model: currentModel, provider: currentProvider },
+    modelOptionsQuery.data
+  )
+
   const quickModels = useMemo(
-    () => quickModelOptions(modelOptionsQuery.data, currentProvider, currentModel),
-    [currentModel, currentProvider, modelOptionsQuery.data]
+    () => quickModelOptions(modelOptionsQuery.data, pickerSelection.provider, pickerSelection.model),
+    [modelOptionsQuery.data, pickerSelection.model, pickerSelection.provider]
   )
 
   const chatBarState = useMemo<ChatBarState>(
     () => ({
       model: {
-        model: currentModel,
-        provider: currentProvider,
+        model: pickerSelection.model,
+        provider: pickerSelection.provider,
         canSwitch: gatewayOpen,
-        loading: !gatewayOpen || (!currentModel && !currentProvider),
+        loading:
+          !gatewayOpen ||
+          (!pickerSelection.model && !pickerSelection.provider && modelOptionsQuery.isPending),
         modelMenuContent,
         quickModels
       },
@@ -601,7 +609,15 @@ const ChatViewContent = memo(function ChatViewContent({
         active: false
       }
     }),
-    [contextSuggestions, currentModel, currentProvider, gatewayOpen, modelMenuContent, quickModels]
+    [
+      contextSuggestions,
+      gatewayOpen,
+      modelMenuContent,
+      modelOptionsQuery.isPending,
+      pickerSelection.model,
+      pickerSelection.provider,
+      quickModels
+    ]
   )
 
   // Drop files anywhere in the conversation area, not just on the composer

--- a/apps/desktop/src/app/cron/index.tsx
+++ b/apps/desktop/src/app/cron/index.tsx
@@ -1340,7 +1340,7 @@ function CronEditorDialog({
                   <SelectTrigger className="h-9 rounded-md" id="cron-model">
                     <SelectValue />
                   </SelectTrigger>
-                  <SelectContent>
+                  <SelectContent searchable>
                     <SelectItem value={MODEL_DEFAULT_VALUE}>{c.modelDefault}</SelectItem>
                     {!modelChoiceKnown && (
                       <SelectItem className="font-mono" value={modelChoice}>

--- a/apps/desktop/src/app/settings/fallback-models-field.tsx
+++ b/apps/desktop/src/app/settings/fallback-models-field.tsx
@@ -128,7 +128,7 @@ export function FallbackModelsField({
               <SelectTrigger className={cn('min-w-36', CONTROL_TEXT)}>
                 <SelectValue placeholder={m.provider} />
               </SelectTrigger>
-              <SelectContent>
+              <SelectContent searchable>
                 {providers.map(provider => (
                   <SelectItem key={provider.slug} value={provider.slug}>
                     {provider.name}
@@ -140,7 +140,7 @@ export function FallbackModelsField({
               <SelectTrigger className={cn('min-w-52 flex-1', CONTROL_TEXT)}>
                 <SelectValue placeholder={m.model} />
               </SelectTrigger>
-              <SelectContent>
+              <SelectContent searchable>
                 {modelItems.map(model => (
                   <SelectItem key={model} value={model}>
                     {model}

--- a/apps/desktop/src/app/settings/index.tsx
+++ b/apps/desktop/src/app/settings/index.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/lib/icons'
 import { isEditableTarget } from '@/lib/keybinds/combo'
 import { typeToFocusChar } from '@/lib/keybinds/composer-focus-keys'
+import { isPickerSearchOpen } from '@/lib/picker-typeahead'
 import { cn } from '@/lib/utils'
 import { $commandPaletteOpen, openCommandPalettePage } from '@/store/command-palette'
 import { confirm } from '@/store/confirm'
@@ -321,7 +322,7 @@ export function SettingsView({ onClose, onConfigSaved, onMainModelChanged }: Set
   // reflex as the chat surface's type-to-focus, pointed at search instead.
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      if ($commandPaletteOpen.get() || isEditableTarget(event.target)) {
+      if ($commandPaletteOpen.get() || isEditableTarget(event.target) || isPickerSearchOpen()) {
         return
       }
 

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -843,7 +843,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
             <SelectTrigger className={cn('min-w-40', CONTROL_TEXT)}>
               <SelectValue placeholder={m.provider} />
             </SelectTrigger>
-            <SelectContent>
+            <SelectContent searchable>
               {mainProviderOptions.map(provider => (
                 <SelectItem key={provider.slug || 'none'} value={provider.slug || 'none'}>
                   {provider.name}
@@ -887,7 +887,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
                 <SelectTrigger className={cn('min-w-60', CONTROL_TEXT)}>
                   <SelectValue placeholder={m.model} />
                 </SelectTrigger>
-                <SelectContent>
+                <SelectContent searchable>
                   {withActive(selectedProviderModels, selectedModel).map(model => (
                     <SelectItem key={model} value={model}>
                       {model}
@@ -1041,7 +1041,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
                           <SelectTrigger className={cn('min-w-32', CONTROL_TEXT)}>
                             <SelectValue placeholder={m.provider} />
                           </SelectTrigger>
-                          <SelectContent>
+                          <SelectContent searchable>
                             {providerOptions.map(provider => (
                               <SelectItem key={provider.slug || 'none'} value={provider.slug || 'none'}>
                                 {provider.name}
@@ -1056,7 +1056,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
                           <SelectTrigger className={cn('min-w-48', CONTROL_TEXT)}>
                             <SelectValue placeholder={m.model} />
                           </SelectTrigger>
-                          <SelectContent>
+                          <SelectContent searchable>
                             {withActive(auxDraftProviderModels, auxDraft.model).map(model => (
                               <SelectItem key={model} value={model}>
                                 {model}
@@ -1109,7 +1109,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
               <SelectTrigger className={cn('min-w-40', CONTROL_TEXT)}>
                 <SelectValue placeholder="Preset" />
               </SelectTrigger>
-              <SelectContent>
+              <SelectContent searchable>
                 {Object.keys(moa.presets).map(name => (
                   <SelectItem key={name} value={name}>
                     {name}
@@ -1233,7 +1233,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
                       <SelectTrigger className={cn('min-w-32', CONTROL_TEXT)}>
                         <SelectValue placeholder={m.provider} />
                       </SelectTrigger>
-                      <SelectContent>
+                      <SelectContent searchable>
                         {withActive(
                           moaSlotProviderOptions.map(p => p.slug || 'none'),
                           slot.provider
@@ -1262,7 +1262,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
                       <SelectTrigger className={cn('min-w-48', CONTROL_TEXT)}>
                         <SelectValue placeholder={m.model} />
                       </SelectTrigger>
-                      <SelectContent>
+                      <SelectContent searchable>
                         {withActive(modelsForProvider(slot.provider), slot.model).map(model => (
                           <SelectItem key={model} value={model}>
                             {model}
@@ -1323,7 +1323,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
                     <SelectTrigger className={cn('min-w-32', CONTROL_TEXT)}>
                       <SelectValue placeholder={m.provider} />
                     </SelectTrigger>
-                    <SelectContent>
+                    <SelectContent searchable>
                       {withActive(
                         moaSlotProviderOptions.map(p => p.slug || 'none'),
                         currentMoaPreset.aggregator.provider
@@ -1350,7 +1350,7 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
                     <SelectTrigger className={cn('min-w-48', CONTROL_TEXT)}>
                       <SelectValue placeholder={m.model} />
                     </SelectTrigger>
-                    <SelectContent>
+                    <SelectContent searchable>
                       {withActive(
                         modelsForProvider(currentMoaPreset.aggregator.provider),
                         currentMoaPreset.aggregator.model

--- a/apps/desktop/src/app/shell/model-catalog-menu.tsx
+++ b/apps/desktop/src/app/shell/model-catalog-menu.tsx
@@ -24,6 +24,7 @@ import { useI18n } from '@/i18n'
 import { catalogProviderMatches, modelOptionsQueryKey, requestModelOptions } from '@/lib/model-options'
 import { displayModelName, modelDisplayParts } from '@/lib/model-status-label'
 import { DEFAULT_REASONING_EFFORT, reasoningEffortLabel } from '@/lib/reasoning-effort'
+import { usePickerFilterCapture } from '@/lib/picker-typeahead'
 import { foldIncludes, normalize } from '@/lib/text'
 import { useStoreSelector } from '@/lib/use-session-slice'
 import { cn } from '@/lib/utils'
@@ -133,6 +134,8 @@ export function ModelCatalogMenu({
   const copyPicker = t.modelPicker
   const closeMenu = useContext(ModelMenuCloseContext)
   const [search, setSearch] = useState('')
+  const searchRef = useRef<HTMLInputElement>(null)
+  usePickerFilterCapture(true, searchRef, setSearch)
   const collapsedProviders = useStoreCollapsed()
   const defaultEffort = useDefaultEffort()
   // Which models the user curated in Edit Models. Read HERE rather than taken
@@ -405,6 +408,7 @@ export function ModelCatalogMenu({
     <>
       <DropdownMenuSearch
         aria-label={copy.search}
+        ref={searchRef}
         onKeyDown={event => {
           // Claim arrows and Enter from Radix so DOM focus stays in the input
           // and Enter commits the highlighted row without a DownArrow first.

--- a/apps/desktop/src/components/ui/dropdown-menu.tsx
+++ b/apps/desktop/src/components/ui/dropdown-menu.tsx
@@ -75,6 +75,7 @@ function DropdownMenuSearch({
 function DropdownMenuContent({
   className,
   collisionPadding = 8,
+  onOpenAutoFocus,
   portalContainer,
   sideOffset = 4,
   ...props
@@ -100,6 +101,22 @@ function DropdownMenuContent({
         // (avoidCollisions defaults on); the padding stops it kissing the edge.
         collisionPadding={collisionPadding}
         data-slot="dropdown-menu-content"
+        onOpenAutoFocus={event => {
+          onOpenAutoFocus?.(event)
+
+          if (event.defaultPrevented) {
+            return
+          }
+
+          const search = event.currentTarget.querySelector<HTMLInputElement>(
+            '[data-slot="dropdown-menu-search"] input'
+          )
+
+          if (search) {
+            event.preventDefault()
+            search.focus()
+          }
+        }}
         sideOffset={sideOffset}
         {...props}
       />

--- a/apps/desktop/src/components/ui/dropdown-menu.tsx
+++ b/apps/desktop/src/components/ui/dropdown-menu.tsx
@@ -33,15 +33,12 @@ function DropdownMenuTrigger({ ...props }: React.ComponentProps<typeof DropdownM
  * menu's typeahead from eating keystrokes, and still lets arrow/enter/escape
  * drive the list. Drop it in as the first child of a `DropdownMenuContent`.
  */
-function DropdownMenuSearch({
-  className,
-  onChange,
-  onKeyDown,
-  onValueChange,
-  ...props
-}: Omit<React.ComponentProps<'input'>, 'type'> & {
-  onValueChange?: (value: string) => void
-}) {
+const DropdownMenuSearch = React.forwardRef<
+  HTMLInputElement,
+  Omit<React.ComponentProps<'input'>, 'type'> & {
+    onValueChange?: (value: string) => void
+  }
+>(function DropdownMenuSearch({ className, onChange, onKeyDown, onValueChange, ...props }, ref) {
   return (
     <div className="px-2.5 py-1.5" data-slot="dropdown-menu-search">
       <input
@@ -61,6 +58,7 @@ function DropdownMenuSearch({
 
           onKeyDown?.(event)
         }}
+        ref={ref}
         // Search fields here filter ids, slugs, and model names — dictionary
         // squiggles under them are noise (matching the composer/settings
         // inputs, which already disable spellcheck).
@@ -70,7 +68,7 @@ function DropdownMenuSearch({
       />
     </div>
   )
-}
+})
 
 function DropdownMenuContent({
   className,

--- a/apps/desktop/src/components/ui/select-search.test.tsx
+++ b/apps/desktop/src/components/ui/select-search.test.tsx
@@ -1,0 +1,42 @@
+import { createElement } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { countSelectItems, filterSelectChildren, selectItemMatchesQuery } from './select-search'
+
+function item(value: string, label = value) {
+  return createElement('div', { value, 'data-slot': 'select-item' }, label)
+}
+
+function group(...children: ReturnType<typeof item>[]) {
+  return createElement('div', { 'data-slot': 'select-group' }, ...children)
+}
+
+describe('select-search', () => {
+  it('matches model ids, labels, and folded punctuation', () => {
+    const row = item('openai/gpt-5.6-luna-pro', 'GPT 5.6 Luna Pro')
+
+    expect(selectItemMatchesQuery(row, 'luna')).toBe(true)
+    expect(selectItemMatchesQuery(row, 'gpt-5.6')).toBe(true)
+    expect(selectItemMatchesQuery(row, 'gpt 5 6 luna')).toBe(true)
+    expect(selectItemMatchesQuery(row, 'claude')).toBe(false)
+  })
+
+  it('filters items and drops empty groups', () => {
+    const tree = [
+      group(item('openai/gpt-5.6-luna-pro'), item('anthropic/claude-sonnet-5')),
+      item('openrouter/pareto-code')
+    ]
+
+    const filtered = filterSelectChildren(tree, 'luna')
+    const remaining = createElement('div', null, filtered)
+
+    expect(countSelectItems(remaining)).toBe(1)
+    expect(selectItemMatchesQuery(item('openai/gpt-5.6-luna-pro'), 'luna')).toBe(true)
+  })
+
+  it('keeps the full list when the query is empty', () => {
+    const tree = [item('a'), item('b')]
+
+    expect(filterSelectChildren(tree, '   ')).toEqual(tree)
+  })
+})

--- a/apps/desktop/src/components/ui/select-search.ts
+++ b/apps/desktop/src/components/ui/select-search.ts
@@ -1,0 +1,123 @@
+import type { ReactElement, ReactNode } from 'react'
+import { Children, cloneElement, isValidElement } from 'react'
+
+import { modelSearchText } from '@/lib/model-search-text'
+import { foldIncludes } from '@/lib/text'
+
+type SelectNodeProps = {
+  children?: ReactNode
+  'data-slot'?: string
+  textValue?: string
+  value?: unknown
+}
+
+function asElement(node: ReactNode): ReactElement<SelectNodeProps> | null {
+  return isValidElement<SelectNodeProps>(node) ? node : null
+}
+
+/** `<SelectItem>` always carries a string `value`. Groups and labels do not. */
+export function isSelectItemElement(node: ReactNode): node is ReactElement<SelectNodeProps> {
+  const element = asElement(node)
+
+  return Boolean(element && typeof element.props.value === 'string')
+}
+
+function childText(node: ReactNode): string {
+  return Children.toArray(node)
+    .map(child => {
+      if (typeof child === 'string' || typeof child === 'number') {
+        return String(child)
+      }
+
+      const element = asElement(child)
+
+      return element ? childText(element.props.children) : ''
+    })
+    .join(' ')
+}
+
+/** Haystack for one `<SelectItem>`: value, visible label, and model aliases. */
+export function selectItemSearchText(element: ReactElement<SelectNodeProps>): string {
+  const value = String(element.props.value ?? '')
+  const label = element.props.textValue || childText(element.props.children)
+  const aliases = value ? modelSearchText(value) : ''
+
+  return [value, label, aliases].filter(Boolean).join(' ')
+}
+
+export function selectItemMatchesQuery(element: ReactElement<SelectNodeProps>, query: string): boolean {
+  return foldIncludes(selectItemSearchText(element), query)
+}
+
+function hasMatchingItem(node: ReactNode, query: string): boolean {
+  return Children.toArray(node).some(child => {
+    const element = asElement(child)
+
+    if (!element) {
+      return false
+    }
+
+    if (isSelectItemElement(element)) {
+      return selectItemMatchesQuery(element, query)
+    }
+
+    return hasMatchingItem(element.props.children, query)
+  })
+}
+
+function hasItemDescendant(node: ReactNode): boolean {
+  return Children.toArray(node).some(child => {
+    const element = asElement(child)
+
+    if (!element) {
+      return false
+    }
+
+    return isSelectItemElement(element) || hasItemDescendant(element.props.children)
+  })
+}
+
+/** Keep groups that still have a matching item; drop non-matching items. */
+export function filterSelectChildren(children: ReactNode, query: string): ReactNode {
+  const q = String(query || '').trim()
+
+  if (!q) {
+    return children
+  }
+
+  return Children.map(children, child => {
+    const element = asElement(child)
+
+    if (!element) {
+      return child
+    }
+
+    if (isSelectItemElement(element)) {
+      return selectItemMatchesQuery(element, q) ? element : null
+    }
+
+    const nested = element.props.children
+
+    if (hasItemDescendant(nested)) {
+      return hasMatchingItem(nested, q) ? cloneElement(element, undefined, filterSelectChildren(nested, q)) : null
+    }
+
+    return element
+  })
+}
+
+export function countSelectItems(node: ReactNode): number {
+  return Children.toArray(node).reduce<number>((total, child) => {
+    const element = asElement(child)
+
+    if (!element) {
+      return total
+    }
+
+    if (isSelectItemElement(element)) {
+      return total + 1
+    }
+
+    return total + countSelectItems(element.props.children)
+  }, 0)
+}

--- a/apps/desktop/src/components/ui/select-searchable.test.tsx
+++ b/apps/desktop/src/components/ui/select-searchable.test.tsx
@@ -1,0 +1,52 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './select'
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
+
+afterEach(cleanup)
+
+describe('SelectContent searchable', () => {
+  it('filters items as you type', () => {
+    render(
+      <Select defaultOpen value="openai/gpt-5.6-luna-pro">
+        <SelectTrigger aria-label="model">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent searchable>
+          <SelectItem value="openai/gpt-5.6-luna-pro">openai/gpt-5.6-luna-pro</SelectItem>
+          <SelectItem value="anthropic/claude-sonnet-5">anthropic/claude-sonnet-5</SelectItem>
+        </SelectContent>
+      </Select>
+    )
+
+    const input = screen.getByRole('textbox', { name: 'Search…' })
+    fireEvent.change(input, { target: { value: 'luna' } })
+
+    expect(screen.getByRole('option', { name: 'openai/gpt-5.6-luna-pro' })).not.toBeNull()
+    expect(screen.queryByRole('option', { name: 'anthropic/claude-sonnet-5' })).toBeNull()
+  })
+
+  it('shows an empty state when nothing matches', () => {
+    render(
+      <Select defaultOpen>
+        <SelectTrigger aria-label="model">
+          <SelectValue placeholder="pick" />
+        </SelectTrigger>
+        <SelectContent searchable>
+          <SelectItem value="openai/gpt-5.6-luna-pro">openai/gpt-5.6-luna-pro</SelectItem>
+        </SelectContent>
+      </Select>
+    )
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search…' }), { target: { value: 'zzz-none' } })
+
+    expect(screen.getByText('No results')).not.toBeNull()
+    expect(screen.queryByText('openai/gpt-5.6-luna-pro')).toBeNull()
+  })
+})

--- a/apps/desktop/src/components/ui/select-searchable.test.tsx
+++ b/apps/desktop/src/components/ui/select-searchable.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './select'
@@ -28,6 +28,32 @@ describe('SelectContent searchable', () => {
     const input = screen.getByRole('textbox', { name: 'Search…' })
     fireEvent.change(input, { target: { value: 'luna' } })
 
+    expect(screen.getByRole('option', { name: 'openai/gpt-5.6-luna-pro' })).not.toBeNull()
+    expect(screen.queryByRole('option', { name: 'anthropic/claude-sonnet-5' })).toBeNull()
+  })
+
+  it('filters when typing lands on a row instead of the search field', () => {
+    render(
+      <Select defaultOpen value="anthropic/claude-sonnet-5">
+        <SelectTrigger aria-label="model">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent searchable>
+          <SelectItem value="openai/gpt-5.6-luna-pro">openai/gpt-5.6-luna-pro</SelectItem>
+          <SelectItem value="anthropic/claude-sonnet-5">anthropic/claude-sonnet-5</SelectItem>
+        </SelectContent>
+      </Select>
+    )
+
+    const option = screen.getByRole('option', { name: 'anthropic/claude-sonnet-5' })
+    option.focus()
+    act(() => {
+      fireEvent.keyDown(option, { key: 'g' })
+    })
+
+    const input = screen.getByRole('textbox', { name: 'Search…' })
+    expect(input).toHaveProperty('value', 'g')
+    expect(document.activeElement).toBe(input)
     expect(screen.getByRole('option', { name: 'openai/gpt-5.6-luna-pro' })).not.toBeNull()
     expect(screen.queryByRole('option', { name: 'anthropic/claude-sonnet-5' })).toBeNull()
   })

--- a/apps/desktop/src/components/ui/select.tsx
+++ b/apps/desktop/src/components/ui/select.tsx
@@ -4,7 +4,10 @@ import * as React from 'react'
 import { Codicon } from '@/components/ui/codicon'
 import { type ControlVariantProps, controlVariants } from '@/components/ui/control'
 import { usePopoverPortalContainer } from '@/components/ui/dialog-portal-context'
+import { countSelectItems, filterSelectChildren } from '@/components/ui/select-search'
 import { cn } from '@/lib/utils'
+
+const SELECT_NAV_KEYS = new Set(['ArrowDown', 'ArrowUp', 'Enter', 'Escape', 'Tab'])
 
 function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
   return <SelectPrimitive.Root data-slot="select" {...props} />
@@ -41,13 +44,30 @@ function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.V
 function SelectContent({
   className,
   children,
+  onCloseAutoFocus,
   position = 'popper',
+  searchPlaceholder = 'Search…',
+  searchable = false,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+}: React.ComponentProps<typeof SelectPrimitive.Content> & {
+  /** Autofocused filter. Open the select and type to narrow items. */
+  searchable?: boolean
+  searchPlaceholder?: string
+}) {
   // Portal into the enclosing dialog (if any) so the dropdown is a DOM
   // descendant of the dialog — keeps focus inside and stops the dialog closing
   // when the dropdown is dismissed. Falls back to document.body outside a dialog.
   const container = usePopoverPortalContainer()
+  const searchRef = React.useRef<HTMLInputElement>(null)
+  const [query, setQuery] = React.useState('')
+  const filtered = searchable ? filterSelectChildren(children, query) : children
+  const empty = searchable && Boolean(query.trim()) && countSelectItems(filtered) === 0
+
+  React.useEffect(() => {
+    if (searchable) {
+      searchRef.current?.focus()
+    }
+  }, [searchable])
 
   return (
     <SelectPrimitive.Portal container={container}>
@@ -56,19 +76,51 @@ function SelectContent({
           'relative z-(--z-modal-popover) max-h-72 min-w-32 overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=top]:slide-in-from-bottom-2 data-[side=right]:slide-in-from-left-2',
           position === 'popper' &&
             'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+          searchable && 'flex flex-col',
           className
         )}
         data-slot="select-content"
+        onCloseAutoFocus={event => {
+          setQuery('')
+          onCloseAutoFocus?.(event)
+        }}
         position={position}
         {...props}
       >
+        {searchable && (
+          <div className="border-b border-border px-2 py-1.5" data-slot="select-search">
+            <input
+              aria-label={searchPlaceholder}
+              autoFocus
+              className="h-6 w-full bg-transparent text-xs leading-none text-foreground placeholder:text-muted-foreground focus:outline-none"
+              onChange={event => setQuery(event.target.value)}
+              onKeyDown={event => {
+                if (!SELECT_NAV_KEYS.has(event.key)) {
+                  event.stopPropagation()
+                }
+              }}
+              placeholder={searchPlaceholder}
+              ref={searchRef}
+              spellCheck={false}
+              type="text"
+              value={query}
+            />
+          </div>
+        )}
         <SelectPrimitive.Viewport
           className={cn(
             'p-1',
-            position === 'popper' && 'h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width)'
+            searchable
+              ? 'max-h-60 w-full min-w-(--radix-select-trigger-width) overflow-y-auto'
+              : position === 'popper' &&
+                'h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width)'
           )}
         >
-          {children}
+          {empty ? (
+            <div className="px-2 py-1.5 text-xs text-muted-foreground">No results</div>
+          ) : (
+            filtered
+          )}
         </SelectPrimitive.Viewport>
       </SelectPrimitive.Content>
     </SelectPrimitive.Portal>

--- a/apps/desktop/src/components/ui/select.tsx
+++ b/apps/desktop/src/components/ui/select.tsx
@@ -5,6 +5,7 @@ import { Codicon } from '@/components/ui/codicon'
 import { type ControlVariantProps, controlVariants } from '@/components/ui/control'
 import { usePopoverPortalContainer } from '@/components/ui/dialog-portal-context'
 import { countSelectItems, filterSelectChildren } from '@/components/ui/select-search'
+import { usePickerFilterCapture } from '@/lib/picker-typeahead'
 import { cn } from '@/lib/utils'
 
 const SELECT_NAV_KEYS = new Set(['ArrowDown', 'ArrowUp', 'Enter', 'Escape', 'Tab'])
@@ -68,6 +69,8 @@ function SelectContent({
       searchRef.current?.focus()
     }
   }, [searchable])
+
+  usePickerFilterCapture(searchable, searchRef, setQuery)
 
   return (
     <SelectPrimitive.Portal container={container}>

--- a/apps/desktop/src/lib/picker-typeahead.test.ts
+++ b/apps/desktop/src/lib/picker-typeahead.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { applyPickerFilterKey, isPickerFilterKey, isPickerSearchOpen } from './picker-typeahead'
+
+describe('picker-typeahead', () => {
+  it('treats printable keys as filter keys', () => {
+    expect(isPickerFilterKey({ altKey: false, ctrlKey: false, key: 'l', metaKey: false })).toBe(true)
+    expect(isPickerFilterKey({ altKey: false, ctrlKey: false, key: 'Enter', metaKey: false })).toBe(false)
+    expect(isPickerFilterKey({ altKey: false, ctrlKey: true, key: 'l', metaKey: false })).toBe(false)
+  })
+
+  it('edits the query from keystrokes', () => {
+    expect(applyPickerFilterKey('', 'l')).toBe('l')
+    expect(applyPickerFilterKey('lun', 'a')).toBe('luna')
+    expect(applyPickerFilterKey('luna', 'Backspace')).toBe('lun')
+    expect(applyPickerFilterKey('luna', 'Delete')).toBe('')
+  })
+
+  it('detects an open picker search field', () => {
+    const host = document.createElement('div')
+    host.innerHTML = '<div data-slot="select-search"><input /></div>'
+    document.body.appendChild(host)
+
+    expect(isPickerSearchOpen()).toBe(true)
+
+    host.remove()
+    expect(isPickerSearchOpen()).toBe(false)
+  })
+})

--- a/apps/desktop/src/lib/picker-typeahead.ts
+++ b/apps/desktop/src/lib/picker-typeahead.ts
@@ -1,0 +1,94 @@
+import { type Dispatch, type RefObject, type SetStateAction, useEffect } from 'react'
+
+const NAV_KEYS = new Set(['ArrowDown', 'ArrowUp', 'Enter', 'Escape', 'Tab', 'Home', 'End', 'PageUp', 'PageDown'])
+
+const PICKER_SEARCH =
+  '[data-slot="select-search"] input, [data-slot="dropdown-menu-search"] input'
+
+/** A model picker overlay is open — Settings type-to-search / composer
+ *  type-to-focus must stand down even if Radix left focus on a row. */
+export function isPickerSearchOpen(): boolean {
+  return Boolean(
+    document.querySelector(
+      `${PICKER_SEARCH}, [data-slot="select-content"][data-state="open"], [data-slot="dropdown-menu-content"][data-state="open"]`
+    )
+  )
+}
+
+/** Printable / edit keys that should filter a picker, not jump the list. */
+export function isPickerFilterKey(event: KeyboardEvent | { altKey: boolean; ctrlKey: boolean; key: string; metaKey: boolean }): boolean {
+  if (event.metaKey || event.ctrlKey || event.altKey) {
+    return false
+  }
+
+  if (NAV_KEYS.has(event.key)) {
+    return false
+  }
+
+  return event.key === 'Backspace' || event.key === 'Delete' || event.key.length === 1
+}
+
+export function applyPickerFilterKey(previous: string, key: string): string {
+  if (key === 'Backspace') {
+    return previous.slice(0, -1)
+  }
+
+  if (key === 'Delete') {
+    return ''
+  }
+
+  return `${previous}${key}`
+}
+
+/** True when the event already landed in a real text field (leave it alone). */
+export function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false
+  }
+
+  if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+    return !target.readOnly && !target.disabled
+  }
+
+  return target.isContentEditable
+}
+
+/** While a searchable picker is mounted, printable keys filter it — even
+ *  when Radix parked focus on a list row and Settings/chat type-to-search
+ *  would otherwise steal the keystroke. */
+export function usePickerFilterCapture(
+  active: boolean,
+  searchRef: RefObject<HTMLInputElement | null>,
+  setQuery: Dispatch<SetStateAction<string>>
+): void {
+  useEffect(() => {
+    if (!active) {
+      return
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!isPickerFilterKey(event)) {
+        return
+      }
+
+      const input = searchRef.current
+
+      if (!input?.isConnected) {
+        return
+      }
+
+      if (event.target === input) {
+        return
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+      setQuery(previous => applyPickerFilterKey(previous, event.key))
+      input.focus()
+    }
+
+    window.addEventListener('keydown', onKeyDown, true)
+
+    return () => window.removeEventListener('keydown', onKeyDown, true)
+  }, [active, searchRef, setQuery])
+}

--- a/apps/desktop/src/plugins/hermes-bots/model-picker.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/model-picker.tsx
@@ -242,7 +242,7 @@ export function ModelPicker({ bot = null, value, onChange, placeholderModel = 'g
           <SelectTrigger className="h-8 rounded-md">
             <SelectValue />
           </SelectTrigger>
-          <SelectContent>
+          <SelectContent searchable>
             <SelectItem value={NONE}>Inherit (launch profile)</SelectItem>
             {providers.map(p => (
               <SelectItem key={p.slug} value={p.slug}>
@@ -267,7 +267,7 @@ export function ModelPicker({ bot = null, value, onChange, placeholderModel = 'g
             <SelectTrigger className="h-8 rounded-md">
               <SelectValue />
             </SelectTrigger>
-            <SelectContent>
+            <SelectContent searchable>
               {models.map(m => (
                 <SelectItem key={m} value={m}>
                   {m}

--- a/apps/desktop/src/store/model-visibility.test.ts
+++ b/apps/desktop/src/store/model-visibility.test.ts
@@ -268,6 +268,16 @@ describe('featured defaults', () => {
     expect(visible.has(modelVisibilityKey('ollama', 'qwen3:latest'))).toBe(true)
     expect(visible.has(modelVisibilityKey('ollama', 'llama3.2:latest'))).toBe(true)
   })
+
+  it('does not hide OpenRouter behind a featured shortlist', () => {
+    const models = Array.from({ length: 80 }, (_, i) => `vendor/model-${i}`)
+    const openrouter = featuredProvider('openrouter', models, models.slice(0, 3))
+
+    const visible = defaultVisibleKeys([openrouter])
+
+    expect(visible.size).toBe(80)
+    expect(visible.has(modelVisibilityKey('openrouter', 'vendor/model-79'))).toBe(true)
+  })
 })
 
 describe('setProviderVisibility', () => {

--- a/apps/desktop/src/store/model-visibility.ts
+++ b/apps/desktop/src/store/model-visibility.ts
@@ -7,7 +7,7 @@ const STORAGE_KEY = 'hermes.desktop.visible-models'
 
 /** Models shown per provider in the status-bar dropdown before the user has
  *  customized the list. Backend `models` are already relevance-ordered. */
-export const DEFAULT_VISIBLE_PER_PROVIDER = 50
+export const DEFAULT_VISIBLE_PER_PROVIDER = 999
 
 /** Stable key for a provider/model pair (`::` avoids colliding with model ids
  *  that contain a single colon, e.g. `model:tag`). */
@@ -121,10 +121,17 @@ function expandProviderDefaults(provider: ModelOptionProvider, target: Set<strin
   const families = collapseModelFamilies(provider.models ?? [])
 
   const featured = provider.featured_models ?? []
-
-  const defaults = featured.length
+  const slug = (provider.slug || '').toLowerCase()
+  // OpenRouter (and the other uncapped aggregators) must show the full catalog.
+  // Using featured-only here is the "50 → none" regression: a missing/unmatched
+  // shortlist collapses the picker to the current model.
+  const uncapped = slug === 'openrouter' || slug === 'opencode-zen' || slug === 'opencode-go'
+  const cap = DEFAULT_VISIBLE_PER_PROVIDER
+  const defaults = !uncapped && featured.length
     ? families.filter(family => featured.includes(family.id))
-    : families.slice(0, DEFAULT_VISIBLE_PER_PROVIDER)
+    : cap
+      ? families.slice(0, cap)
+      : families
 
   for (const family of defaults) {
     target.add(modelVisibilityKey(provider.slug, family.id))

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -139,10 +139,12 @@ def build_models_payload(
         rows = _reorder_canonical(rows)
     if pricing:
         _apply_pricing(rows, force_fresh_nous_tier=force_fresh_nous_tier, cached_only=pricing_cache_only)
+    if featured:
+        # Featured first so a large OpenRouter catalog can cheapen capabilities
+        # (only the shortlist does per-model models.dev lookups).
+        _apply_featured(rows, current_model=ctx.current_model)
     if capabilities:
         _apply_capabilities(rows)
-    if featured:
-        _apply_featured(rows)
     _apply_custom_aliases(rows)
 
     return {"providers": rows, "model": ctx.current_model, "provider": ctx.current_provider}
@@ -285,8 +287,14 @@ def _apply_capabilities(rows: list[dict]) -> None:
         slug = row.get("slug") or ""
         caps: dict[str, dict[str, Any]] = {}
         read_reasoning_catalog = _reasoning_catalog_reader(slug.lower())
+        models = row.get("models") or []
+        priority = set(row.get("featured_models") or [])
+        cheap = len(models) > 80 and bool(priority)
 
-        for model in row.get("models") or []:
+        for model in models:
+            if cheap and model not in priority:
+                caps[model] = {"fast": bool(model_supports_fast_mode(model)), "reasoning": True}
+                continue
             reasoning = True
             if get_model_capabilities is not None and slug:
                 try:
@@ -320,18 +328,34 @@ def _apply_capabilities(rows: list[dict]) -> None:
 _FEATURED_PER_LAB = 5
 
 
-def _apply_featured(rows: list[dict]) -> None:
+def _apply_featured(rows: list[dict], current_model: str = "") -> None:
     """Attach a ``featured_models`` shortlist to each aggregator row: newest ``_FEATURED_PER_LAB`` per
     vendor by models.dev ``release_date`` (ranked within the row, never vs. today, so it is stable);
-    ties keep curated order. Non-aggregators get an empty list and keep top-N behaviour."""
+    ties keep curated order. Non-aggregators get an empty list and keep top-N behaviour.
+
+    OpenRouter is special: the live catalog is hundreds of ids. Using 5-per-lab across that dump
+    produced 100+ "featured" rows, which made the Desktop chat picker spin and fail to land on
+    the current model. Featured stays the curated agentic shortlist plus the active pick; search
+    still sees every live id on ``models``.
+    """
     try:
         from agent.models_dev import get_model_info
     except Exception:
         get_model_info = None  # type: ignore[assignment]
 
+    current = str(current_model or "").strip()
     for row in rows:
         slug = str(row.get("slug") or "").strip().lower()
         models = row.get("models") or []
+
+        if slug == "openrouter":
+            from hermes_cli.models import OPENROUTER_MODELS
+            present = {str(mid) for mid in models}
+            featured = [mid for mid, _ in OPENROUTER_MODELS if mid in present]
+            if current and current in present and current not in featured:
+                featured.insert(0, current)
+            row["featured_models"] = featured
+            continue
 
         by_lab: dict[str, list[tuple[int, str, str]]] = {}  # only multi-lab aggregators get a shortlist
         for pos, model in enumerate(models):

--- a/hermes_cli/model_switch_providers.py
+++ b/hermes_cli/model_switch_providers.py
@@ -21,7 +21,7 @@ from utils import base_url_host_matches
 logger = logging.getLogger("hermes_cli.model_switch")
 
 # Aggregators whose full catalogs (70+ models) must stay visible: never capped by max_models.
-_UNCAPPED_PICKER_PROVIDERS: frozenset[str] = frozenset({"opencode-zen", "opencode-go"})
+_UNCAPPED_PICKER_PROVIDERS: frozenset[str] = frozenset({"opencode-zen", "opencode-go", "openrouter"})
 
 
 def _save_discovered_models_to_config(

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -543,7 +543,7 @@ def _fetch_live_catalog_index(url: str, timeout: float, opener) -> Optional[tupl
 
 def fetch_openrouter_models(
     timeout: float = 8.0, *, force_refresh: bool = False) -> list[tuple[str, str]]:
-    """Return the curated OpenRouter picker list, refreshed from the live catalog when possible."""
+    """Return the OpenRouter picker list: curated ids first, then every other live tool-capable model."""
     # The curated list is filtered from this profile's manifest (``model_catalog.*`` config, its
     # ``<home>/cache`` copy), so a routed profile keeps its own slot instead of the module one.
     from hermes_cli.models_profile_cache import profile_slot_get, profile_slot_set
@@ -596,6 +596,17 @@ def fetch_openrouter_models(
         else:
             desc = "free" if _openrouter_model_is_free(live_item.get("pricing")) else ""
         curated.append((preferred_id, desc))
+
+    # Hermes used to cap this picker at 50, then set the cap to None. None is
+    # unlimited on the slice path, but this function still returned only the
+    # curated handful — or a single injected current model when that handful
+    # missed the live catalog. Append the rest of the live tool-capable list.
+    seen = {mid for mid, _ in curated}
+    for mid, live_item in live_by_id.items():
+        if mid in seen or not _openrouter_model_supports_tools(live_item):
+            continue
+        desc = "free" if _openrouter_model_is_free(live_item.get("pricing")) else ""
+        curated.append((mid, desc))
 
     if not curated:
         return list(cached or fallback)

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -683,5 +683,48 @@ def _apply_featured_with_dates(rows, dates: dict[str, str]):
         inventory._apply_featured(rows)
 
 
+def test_openrouter_featured_is_curated_plus_current():
+    """A 5-per-lab dump of the live OpenRouter catalog flooded the Desktop chat
+    picker. Featured must stay the curated shortlist plus the active pick."""
+    from hermes_cli import inventory
+    from hermes_cli.models import OPENROUTER_MODELS
+
+    curated = [mid for mid, _ in OPENROUTER_MODELS]
+    current = "openai/gpt-5.6-luna-pro"
+    extra = [f"vendor/extra-{i}" for i in range(90)]
+    rows = [{
+        "slug": "openrouter",
+        "models": curated + extra + [current] if current not in curated else curated + extra,
+    }]
+
+    inventory._apply_featured(rows, current_model=current)
+
+    featured = rows[0]["featured_models"]
+    assert current in featured
+    assert all(mid in featured for mid in curated if mid in rows[0]["models"])
+    assert "vendor/extra-0" not in featured
+    assert len(featured) < 80
 
 
+def test_openrouter_capabilities_skip_non_featured_lookups():
+    from hermes_cli import inventory
+
+    featured = ["openai/gpt-5.6-luna-pro"]
+    models = featured + [f"vendor/extra-{i}" for i in range(90)]
+    rows = [{"slug": "openrouter", "models": models, "featured_models": featured}]
+
+    calls: list[tuple[str, str]] = []
+
+    class _Meta:
+        supports_reasoning = True
+
+    def _fake_caps(slug, model):
+        calls.append((slug, model))
+        return _Meta()
+
+    with patch("agent.models_dev.get_model_capabilities", side_effect=_fake_caps):
+        inventory._apply_capabilities(rows)
+
+    assert calls == [("openrouter", "openai/gpt-5.6-luna-pro")]
+    assert rows[0]["capabilities"]["vendor/extra-0"]["reasoning"] is True
+    assert rows[0]["capabilities"]["openai/gpt-5.6-luna-pro"]["reasoning"] is True

--- a/tests/hermes_cli/test_inventory_pricing.py
+++ b/tests/hermes_cli/test_inventory_pricing.py
@@ -133,7 +133,7 @@ def test_model_options_cold_pricing_fetch_runs_off_the_request_path(monkeypatch)
     )
     monkeypatch.setattr(inv, "_moa_provider_row", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(inv, "_apply_capabilities", lambda _rows: None)
-    monkeypatch.setattr(inv, "_apply_featured", lambda _rows: None)
+    monkeypatch.setattr(inv, "_apply_featured", lambda _rows, **_kwargs: None)
     monkeypatch.setattr(inv, "_pricing_prewarm_threads", {})
 
     try:

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -108,6 +108,33 @@ class TestFetchOpenRouterModels:
         # Image-only model advertised supported_parameters WITHOUT tools → must be dropped.
         assert "google/gemini-3-pro-image-preview" not in ids
 
+    def test_includes_live_models_beyond_the_curated_shortlist(self, monkeypatch):
+        """The Settings/OpenRouter picker must list the live catalog, not only ~50 curated ids."""
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return (
+                    b'{"data":['
+                    b'{"id":"anthropic/claude-opus-4.6","supported_parameters":["tools"]},'
+                    b'{"id":"vendor/only-on-openrouter","supported_parameters":["tools"]}'
+                    b']}'
+                )
+
+        monkeypatch.setattr(_models_mod, "OPENROUTER_MODELS", [("anthropic/claude-opus-4.6", "")])
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        with (
+            patch("hermes_cli.model_catalog.get_curated_openrouter_models", return_value=[("anthropic/claude-opus-4.6", "")]),
+            patch("hermes_cli.models._urlopen_model_catalog_request", return_value=_Resp()),
+        ):
+            models = fetch_openrouter_models(force_refresh=True)
+
+        assert [mid for mid, _ in models] == ["anthropic/claude-opus-4.6", "vendor/only-on-openrouter"]
+
 
 
 class TestOpenRouterToolSupportHelper:

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -16538,7 +16538,7 @@ def test_model_save_key_uses_credential_lifecycle_and_picker_context(monkeypatch
     build_payload.assert_called_once_with(
         picker_ctx,
         picker_hints=True,
-        max_models=50,
+        max_models=999,
     )
 
 

--- a/tui_gateway/methods_complete.py
+++ b/tui_gateway/methods_complete.py
@@ -312,7 +312,7 @@ def _(rid, params: dict) -> dict:
     os.environ[env_var] = api_key  # so the refreshed inventory sees it
     # Shared inventory builder (lock-step with model.options / dashboard); picker_hints carries `authenticated`.
     from hermes_cli.inventory import build_models_payload
-    payload = build_models_payload(_model_picker_context(_session_agent(params)), picker_hints=True, max_models=50)
+    payload = build_models_payload(_model_picker_context(_session_agent(params)), picker_hints=True, max_models=999)
     provider_data = next((p for p in payload["providers"] if p["slug"] == slug), None)
     if provider_data is None:  # key saved but provider didn't appear — still success
         provider_data = {"slug": slug, "name": pconfig.name, "is_current": False, "models": [], "total_models": 0}


### PR DESCRIPTION
## What does this PR do?

OpenRouter's live catalog is hundreds of tool-capable models. The picker first showed only the curated handful, then (after an unlimited cap) the chat menu featured ~142 lab flagships and often omitted the model you actually had selected. The Settings / cron / bots lists were plain Radix selects, so typing jumped instead of filtering.

This PR:

- Serves the full live tool-capable OpenRouter catalog in Settings (uncapped / 999, not a 50-row slice).
- Keeps OpenRouter `featured_models` as the curated shortlist plus the current pick so the chat menu lands on the active model. Search still sees every live id.
- Skips per-model models.dev capability lookups on the OpenRouter long tail.
- Makes every model/provider select type-to-filter. Opening a picker focuses search; typing filters ids, labels, and aliases (`gpt 5.6` / `gpt-5.6`).
- Focuses the existing chat catalog search field on open so keystrokes filter instead of Radix typeahead.

Related but not a duplicate: #92942 only converts Settings selects to `SearchableSelect` and is currently dirty. This change also fixes the catalog/featured hang and covers chat, cron, and bots.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/models.py` — append every live tool-capable OpenRouter model after the curated list
- `hermes_cli/model_switch_providers.py` — treat OpenRouter as an uncapped picker provider
- `hermes_cli/inventory.py` — OpenRouter featured = curated + current; cheap capabilities; featured before capabilities
- `tui_gateway/methods_complete.py` — `model.save_key` picker cap 999
- `apps/desktop/src/store/model-visibility.ts` — do not hide OpenRouter behind featured-only defaults
- `apps/desktop/src/components/ui/select.tsx` + `select-search.ts` — `searchable` SelectContent
- `apps/desktop/src/components/ui/dropdown-menu.tsx` — focus `DropdownMenuSearch` on open
- Settings / fallback / cron / bots model+provider selects set `searchable`
- `apps/desktop/src/app/chat/index.tsx` — seed the chat pill from catalog current while session store is empty

## How to Test

1. Connect Desktop to a gateway with OpenRouter configured.
2. Open Settings → Model → OpenRouter. The list is the live tool-capable catalog (hundreds of ids), not ~50.
3. Type in that select (e.g. `luna`) — the list filters; the current model still applies.
4. Open the chat model pill. It should show the current model (not spin). Type to filter; Enter selects the highlighted row.
5. Repeat type-to-filter on cron job model override and a bots profile picker.

Automated:

- `python -m pytest tests/hermes_cli/test_inventory.py tests/hermes_cli/test_inventory_pricing.py tests/hermes_cli/test_models.py tests/test_tui_gateway_server.py::test_model_save_key_uses_credential_lifecycle_and_picker_context -q` — 114 passed
- Desktop UI tests for select-search, catalog menu, settings, fallback, bots, and model-picker — 82 passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted pytest files above and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer-only Select/search; CLI catalog is cross-platform
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — covered by the new inventory featured/capability tests and desktop select-search tests.

Made with [Cursor](https://cursor.com)