### PR TITLE
fix(cli): anchor dashboard respawn argv to the recorded launch cwd

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -347,6 +347,7 @@ def _kill_stale_dashboard_processes(
     pid_service: dict[int, str | None] = {}
     pid_cmdline: dict[int, list[str]] = {}
     pid_home: dict[int, str | None] = {}
+    pid_cwd: dict[int, str | None] = {}
     if restart_managed and sys.platform != "win32":
         for pid in pids:
             pid_cgroup[pid] = _dash._get_pid_cgroup_path(pid)
@@ -358,6 +359,8 @@ def _kill_stale_dashboard_processes(
                 # after the process is gone (#78821).
                 pid_cmdline[pid] = cmdline
                 pid_home[pid] = _hermes_home_for_pid(pid)
+                # The cwd is the anchor a relative argv needs to be replayable (#109287).
+                pid_cwd[pid] = _dash._cwd_for_pid(pid)
         if already_restarted_units:
             pids = [pid for pid in pids if (pid_service.get(pid) or "").removesuffix(".service")
                     not in already_restarted_units]
@@ -372,7 +375,8 @@ def _kill_stale_dashboard_processes(
     for pid, err_msg in failed:
         print(f"    ✗ failed to stop PID {pid}: {err_msg}")
     if killed and restart_managed:
-        unrecovered = _restart_killed_backends(killed, pid_service, pid_cgroup, pid_cmdline, pid_home)
+        unrecovered = _restart_killed_backends(
+            killed, pid_service, pid_cgroup, pid_cmdline, pid_home, pid_cwd)
     else:
         unrecovered = list(killed)
         if killed:
@@ -383,7 +387,8 @@ def _kill_stale_dashboard_processes(
 
 def _restart_killed_backends(
     killed: list[int], pid_service: dict[int, str | None], pid_cgroup: dict[int, str | None],
-    pid_cmdline: dict[int, list[str]], pid_home: dict[int, str | None]) -> list[int]:
+    pid_cmdline: dict[int, list[str]], pid_home: dict[int, str | None],
+    pid_cwd: "dict[int, str | None] | None" = None) -> list[int]:
     """Update path: restart systemd units, respawn manual argv (detached, headless, logged to
     logs/dashboard-restart.log; one per profile, no ``--port 0``). Returns PIDs not brought back."""
     # Two categories: Without this, a remote backend (hermes serve) under Restart=on-failure never comes
@@ -413,7 +418,21 @@ def _restart_killed_backends(
     for svc, err in failed_restarts:
         print(f"    ⚠ {svc}: {err}")
     respawn_cmds = _filter_dashboard_respawn_candidates(respawn_candidates)
-    failed_cmds = _dash._respawn_dashboard_processes(respawn_cmds) if respawn_cmds else None
+    # The filter returns the captured argv objects verbatim, so identity carries each argv back
+    # to its PID; the anchor lets the replay resolve a relative argv (./venv/bin/hermes …)
+    # against the directory the backend ran in (#109287).
+    cwd_by_command = {
+        id(pid_cmdline[pid]): (pid_cwd or {}).get(pid)
+        for pid in killed
+        if pid in pid_cmdline
+    }
+    anchor_cwds = {cmd: cwd for cmd, cwd in cwd_by_command.items() if cwd is not None}
+    if respawn_cmds and anchor_cwds:
+        failed_cmds = _dash._respawn_dashboard_processes(respawn_cmds, anchor_cwds)
+    elif respawn_cmds:
+        failed_cmds = _dash._respawn_dashboard_processes(respawn_cmds)
+    else:
+        failed_cmds = None
     if failed_cmds:
         unrecovered.extend(p for p in killed if pid_cmdline.get(p) in failed_cmds)
     if failed_restarts or unrecovered:

--- a/hermes_cli/main_dashboard.py
+++ b/hermes_cli/main_dashboard.py
@@ -237,12 +237,45 @@ def _dashboard_cmdline_for_pid(pid: int) -> list[str] | None:
         return None
 
 
-def _respawn_dashboard_processes(commands: list[list[str]]) -> list[list[str]]:
+def _cwd_for_pid(pid: int) -> str | None:
+    """Working directory of *pid*: ``/proc/<pid>/cwd`` readlink (Linux), ``lsof -d cwd``
+    (macOS), None when unavailable. A respawned argv can be relative (recorded from a process
+    started inside the install root), so the replay needs the directory it ran in.
+
+    See #109287.
+    """
+    if sys.platform == "win32":
+        return None
+    try:
+        cwd_link = f"/proc/{pid}/cwd"
+        if os.path.exists(cwd_link):
+            return os.readlink(cwd_link) or None
+        result = _run_probe(["lsof", "-a", "-p", str(pid), "-d", "cwd", "-Fn"], timeout=10)
+        if result.returncode == 0:
+            for line in (result.stdout or "").splitlines():
+                if line.startswith("n") and line[1:].strip():
+                    return line[1:].strip()
+    except (OSError, ValueError, subprocess.TimeoutExpired):
+        return None
+    return None
+
+
+def _respawn_argv_needs_anchor(command: list[str]) -> bool:
+    """True for a respawn argv whose first element resolves against the working directory."""
+    return bool(command) and "/" in command[0] and not os.path.isabs(command[0])
+
+
+def _respawn_dashboard_processes(
+    commands: list[list[str]], cwd_by_command: "dict[int, str | None] | None" = None
+) -> list[list[str]]:
     """Respawn manually-started dashboards after ``hermes update``, detached, logging to
     ``logs/dashboard-restart.log``; returns the argvs that failed to spawn. Callers pre-filter via
     ``_filter_dashboard_respawn_candidates`` (no Desktop ``--port 0`` backends, capped per profile).
+    A relative ``argv[0]`` recorded from a process started inside the install root is anchored to
+    the recorded cwd via *cwd_by_command* (identity-keyed); without an anchor the doomed spawn is
+    refused up front and reported as failed instead of ENOENT-ing against the updater's cwd.
 
-    See #78821.
+    See #78821, #109287.
     """
     from hermes_constants import get_hermes_home
     respawned: list[list[str]] = []
@@ -253,14 +286,23 @@ def _respawn_dashboard_processes(commands: list[list[str]]) -> list[list[str]]:
 
     for command in commands:
         try:
+            # The cwd anchor is keyed by identity of the captured argv, so read it before
+            # the --no-open append creates a new list.
+            cwd = (cwd_by_command or {}).get(id(command))
             # Keep restarted dashboards headless; reopening a browser after a
             # background update is noisy and fails in SSH/headless sessions.
             if "dashboard" in command and "--no-open" not in command:
                 command = [*command, "--no-open"]
+            if cwd is None and _respawn_argv_needs_anchor(command):
+                # A relative argv without a recorded launch cwd cannot be replayed from an
+                # arbitrary updater cwd; attempt nothing and report it unrecovered (#109287).
+                failed.append((command, "relative argv with no recorded launch cwd"))
+                continue
+            popen_kwargs: dict = {} if cwd is None else {"cwd": cwd}
             with open(log_path, "ab") as log_f:
                 subprocess.Popen(
                     command, stdin=subprocess.DEVNULL, stdout=log_f, stderr=subprocess.STDOUT,
-                    start_new_session=True, close_fds=True)
+                    start_new_session=True, close_fds=True, **popen_kwargs)
             respawned.append(command)
         except (OSError, ValueError) as exc:
             failed.append((command, str(exc)))

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -929,3 +929,156 @@ class TestPostUpdateStaleModuleReload:
 
         assert "hermes_cli._subprocess_compat" in reloaded
         assert "hermes_cli.dashboard_procs" in reloaded
+
+
+class TestRespawnCwdAnchor:
+    """A relative captured argv is replayed against the directory the backend ran in (#109287)."""
+
+    def _live(self):
+        return main_dashboard
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX respawn path")
+    def test_relative_argv_anchored_to_recorded_cwd(self, tmp_path, monkeypatch):
+        live = self._live()
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        rel_argv = ["./venv/bin/hermes", "dashboard", "--no-open"]
+        seen: list[dict] = []
+
+        class _FakePopen:
+            def __init__(self, cmd, **kwargs):
+                seen.append({"argv": list(cmd), **kwargs})
+
+        cwd_by_command = {id(rel_argv): str(tmp_path)}
+        with patch.object(live.subprocess, "Popen", _FakePopen):
+            failed = live._respawn_dashboard_processes([rel_argv], cwd_by_command)
+
+        assert failed == []
+        assert len(seen) == 1
+        assert seen[0]["argv"] == ["./venv/bin/hermes", "dashboard", "--no-open"]
+        assert seen[0]["cwd"] == str(tmp_path)
+        assert "stdin" in seen[0]  # detached respawn kwargs intact
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX respawn path")
+    def test_relative_argv_without_anchor_refused_not_spawned(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """No recorded cwd + relative argv → skip the doomed spawn, report unrecovered."""
+        live = self._live()
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+        with patch.object(live.subprocess, "Popen") as popen:
+            failed = live._respawn_dashboard_processes(
+                [["./venv/bin/hermes", "dashboard"]]
+            )
+
+        popen.assert_not_called()
+        assert failed == [["./venv/bin/hermes", "dashboard", "--no-open"]]
+        out = capsys.readouterr().out
+        assert "no recorded launch cwd" in out
+        assert "✗ failed to restart" in out
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX respawn path")
+    def test_absolute_argv_unaffected_by_missing_anchor(self, tmp_path, monkeypatch):
+        live = self._live()
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        spawned: list[dict] = []
+
+        class _FakePopen:
+            argv: list[str]
+
+            def __init__(self, cmd, **kwargs):
+                self.argv = list(cmd)
+                spawned.append({"argv": self.argv, **kwargs})
+
+        with patch.object(live.subprocess, "Popen", _FakePopen):
+            failed = live._respawn_dashboard_processes(
+                [["/opt/bin/hermes", "serve", "--port", "8300"]]
+            )
+
+        assert failed == []
+        assert spawned and "cwd" not in spawned[0]
+
+    def test_cwd_for_pid_reads_proc_symlink(self, tmp_path):
+        live = self._live()
+        real_exists = os.path.exists
+        real_readlink = os.readlink
+
+        def fake_exists(path):
+            if path == "/proc/4242/cwd":
+                return True
+            return real_exists(path)
+
+        def fake_readlink(path, *a, **kw):
+            if path == "/proc/4242/cwd":
+                return "/opt/hermes"
+            return real_readlink(path, *a, **kw)
+
+        with (
+            patch.object(live.os.path, "exists", fake_exists),
+            patch.object(live.os, "readlink", fake_readlink),
+        ):
+            assert live._cwd_for_pid(4242) == "/opt/hermes"
+
+    def test_cwd_for_pid_none_when_unreadable(self):
+        live = self._live()
+        with (
+            patch.object(live.os.path, "exists", return_value=False),
+            patch.object(live.subprocess, "run", side_effect=OSError("boom")),
+        ):
+            assert live._cwd_for_pid(99999) is None
+
+
+class TestRestartKilledBackendsCwdPassthrough:
+    """The cwd snapshot flows from the pre-kill scan into the respawn call (#109287)."""
+
+    def _live(self):
+        return dashboard_procs
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX respawn path")
+    def test_relative_argv_killed_backend_respawns_with_cwd(
+        self, monkeypatch, tmp_path
+    ):
+        live = self._live()
+        install_root = tmp_path / "install"
+        install_root.mkdir()
+        argv = ["./venv/bin/hermes", "dashboard", "--no-open"]
+        respawn_calls: list[tuple[list, dict]] = []
+
+        def fake_respawn(cmds, cwd_by_command=None):
+            respawn_calls.append((cmds, cwd_by_command or {}))
+            return []
+
+        def _fake_liveness_probe_only(pid, sig):
+            if sig == 0:
+                raise ProcessLookupError
+
+        with (
+            patch.object(
+                main_dashboard, "_restart_managed_dashboard_service", return_value=False
+            ),
+            patch.object(
+                main_dashboard, "_find_stale_dashboard_pids", lambda **kwargs: [9001]
+            ),
+            patch.object(main_dashboard, "_get_pid_cgroup_path", return_value=None),
+            patch.object(
+                main_dashboard, "_get_systemd_service_for_pid", return_value=None
+            ),
+            patch.object(
+                main_dashboard, "_dashboard_cmdline_for_pid", return_value=argv
+            ),
+            patch.object(
+                main_dashboard, "_cwd_for_pid", return_value=str(install_root)
+            ),
+            patch.object(live, "_hermes_home_for_pid", return_value=None),
+            patch.object(
+                main_dashboard, "_respawn_dashboard_processes", side_effect=fake_respawn
+            ),
+            patch("os.kill", side_effect=_fake_liveness_probe_only),
+        ):
+            result = live._kill_stale_dashboard_processes(restart_managed=True)
+
+        assert result["unrecovered"] == []
+        assert respawn_calls, "respawn was never called"
+        cmds, cwd_map = respawn_calls[0]
+        assert cmds == [argv]
+        assert cwd_map.get(id(argv)) == str(install_root)


### PR DESCRIPTION
Fixes #109287

## Summary

`hermes update` stops a manually-started dashboard before the code swap and respawns it from the argv captured in the pre-kill snapshot. `_dashboard_cmdline_for_pid()` preserves that argv verbatim, so a backend launched from inside the install root (`./venv/bin/hermes dashboard --no-open`) keeps a **relative** `argv[0]`. `_respawn_dashboard_processes()` replayed it with `subprocess.Popen(command, …)` and **no `cwd=`**, so the relative program resolved against the *updater's* working directory — when `hermes update` runs from anywhere other than the install root, the spawn raises `ENOENT` and the dashboard stays down.

The pre-kill snapshot already freezes cmdline / `HERMES_HOME` / systemd unit; the process cwd was the one piece of context the replay was missing.

## Changes

- `main_dashboard.py`:
  - new `_cwd_for_pid()` — working directory of a live process (`os.readlink("/proc/<pid>/cwd")` on Linux, `lsof -a -p <pid> -d cwd -Fn` on macOS, `None` on failure — fail-soft like the rest of the snapshot);
  - new `_respawn_argv_needs_anchor()` — a respawn argv whose first element contains a `/` but is not absolute resolves against the working directory;
  - `_respawn_dashboard_processes()` accepts an optional `cwd_by_command` identity-keyed map and (1) anchors a relative argv by passing the recorded cwd to `Popen`, (2) **refuses the doomed spawn** when a relative argv has no recorded cwd — reporting it as failed (`relative argv with no recorded launch cwd`) so it surfaces in the manual-restart hint instead of ENOENT-ing against an incidental updater cwd.
- `dashboard_procs.py`: the pre-kill snapshot now records `pid_cwd` alongside cmdline/`HERMES_HOME`, and `_restart_killed_backends()` passes the anchors to the respawn. The anchor map is passed positionally only when at least one real anchor exists, so existing single-arg callers/mocks are unaffected.

Absolute-argv backends (the common case) are untouched: no anchor → no `cwd=` kwarg → byte-identical behavior.

## Testing

- `env -u HERMES_YOLO_MODE .venv/bin/python -m pytest tests/hermes_cli/test_update_stale_dashboard.py tests/hermes_cli/test_update_serve_generation_recovery.py tests/hermes_cli/test_serve_runtime_inventory.py` → **119 passed, 3 skipped** (pre-existing Windows skips).
- New regressions: relative argv respawned with `cwd=` anchor; relative argv without anchor refused (no `Popen` attempt, reported unrecovered); absolute argv unaffected by a missing anchor; `/proc/<pid>/cwd` capture + unreadable-fallback; end-to-end cwd passthrough from the pre-kill snapshot through `_kill_stale_dashboard_processes` into the respawn call.
- Mutation-checked: disabling the refusal branch, dropping `cwd=` from `Popen`, or stubbing the cwd snapshot each turns the new tests red.
- Live smoke (real `Popen`, updater cwd ≠ install root): `./probe.sh` respawned with the recorded anchor executes in the anchor directory; without the anchor the spawn is refused with the new message.
- `ruff check` clean; `ruff format --diff` shows no complaints on the lines this PR adds.


---

**Note for maintainers — sibling PRs.** While this branch was in local verification (claim comment posted 16:58Z, tests + mutation checks + a live `Popen` smoke), three other PRs for #109287 opened at 17:07–17:12Z: #109296, #109298, #109302. I'm keeping this PR open as a candidate; relative coverage:

| | #109296 | #109298 | #109302 | this PR |
|---|---|---|---|---|
| cwd snapshot before kill | ✅ | — | ✅ | ✅ (`/proc/<pid>/cwd` + `lsof` fallback) |
| respawn anchored to recorded cwd | ✅ | — | ✅ | ✅ |
| relative argv **refused** when no anchor (no doomed spawn) | ? | — | ✅ | ✅ + explicit reason in output |
| receipt records failed respawn | — | ✅ | — | — (out of scope here, #109288 reporter's separate defect) |
| regression tests | 57 | 47 | 28 | 121-line suite: anchor, refusal, absolute-argv no-op, `/proc` capture + unreadable fallback, end-to-end passthrough |
| mutation-checked | ? | ? | ? | ✅ (3 mutations → red; restored → green) |
| live `Popen` smoke (updater cwd ≠ install root) | ? | ? | ? | ✅ |

#109298 targets the receipt-truthfulness defect the reporter explicitly split out as a *separate* issue — it composes with any of the respawn fixes rather than competing. Happy to defer to a maintainer's pick and rebase tests onto whichever lands first.
