### PR TITLE
feat(skills): botmaker — mint specialist Hermes bots (port of techjanitor/botmaker, first Hermes-native community skill)

### DIFF
--- a/optional-skills/autonomous-ai-agents/botmaker/LICENSE.txt
+++ b/optional-skills/autonomous-ai-agents/botmaker/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 techjanitor
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/optional-skills/autonomous-ai-agents/botmaker/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/botmaker/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: botmaker
+description: "Design, scaffold, and certify specialist Hermes bots."
+version: 0.2.0
+author: techjanitor (adapted by Nous Research)
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [hermes, bots, profiles, soul]
+    category: autonomous-ai-agents
+    related_skills: [hermes-agent]
+    upstream: https://github.com/techjanitor/botmaker (pinned 93eb3b6d3976b115a372598fa5c02c4f6ab63ed2)
+---
+
+# Botmaker
+
+Design, scaffold, certify, and document specialist Hermes bots. Load this skill on every in-scope question. You draft; the child earns. Seeding files is not a bot.
+
+Details: `references/soul-craft.md` (SOUL + human gate), `references/process.md` (mechanics), `references/vault.md` (vault conventions). Shared-skill linker: `scripts/link_skill_tree.py`. Drift tripwire: `scripts/drift_check.py`.
+
+## When to Use
+
+- Your human wants a new specialist bot, or a SOUL drafted for one — in chat, or as a task card assigned to `botmaker` (if your fleet dispatches work by kanban). A card carrying a human-signed SOUL spec satisfies the human gate.
+- An existing specialist bot's identity/job/voice is wrong and needs a SOUL rewrite (human gate)
+- `Bots/` in the vault needs a specialist note, roster row, or `making-bots.md` changelog
+- A shared skill is about to be copied into a profile (stop; symlink files instead)
+
+Don't use for: operating the inference server, ComfyUI, or any service; general coding; rewriting default `~/.hermes/SOUL.md`; spawning `botmaker-2`. `@hermes` is not the bot coordinator — you are.
+
+## Prerequisites
+
+- Hermes CLI (`hermes profile create --help`)
+- Canonical skills live under `~/.hermes/skills/` (default Hermes home), **not** `$HERMES_HOME/skills` when you are the botmaker profile
+- Vault: `<your-vault-path>` (see `references/vault.md`). Vault documentation is an optional convention — if the user has no vault, skip the vault steps.
+- Human guide, fleet roster, changelog: vault `Bots/making-bots.md` (create it on first ship). Method lives here only; fleet state lives there only — patch a lesson's one owner and log one changelog line.
+
+## How to Run
+
+1. Interview. Refuse to scaffold until job / independence failure / not-list are sharp. See Procedure.
+2. Draft a one-screen SOUL (`references/soul-craft.md`). Stop. Your human signs it.
+3. Scaffold (`references/process.md`). **Alias preflight first.** `--no-skills`, pin the brain, file-level skill links, USER.md lockstep sentence if the skill is shared.
+4. Kickoff in the **child's** Bot Chat. Do not babysit its tools. Do not write its `MEMORY.md`.
+5. After certification: vault note + roster row (`references/vault.md`). Not before.
+
+## Quick Reference
+
+| Need | Do |
+|---|---|
+| New bot | Alias preflight (Procedure C) → Interview → SOUL draft → human sign-off → `hermes profile create NAME --no-skills --description "…"` |
+| Pin a brain | `hermes -p NAME config set model.provider …` then `model.default …`. Then **unset** the copied `base_url` / `api_key` (create copies your default profile's model block, whatever it currently is) |
+| Shared skill | Canonical `~/.hermes/skills/<cat>/<name>/`; profile files via `scripts/link_skill_tree.py`. Never a directory symlink. Load linked `references/` with `read_file` on the canonical path |
+| Vault after cert | `Bots/<name>.md` (`type: bot-reference`), roster row on `making-bots.md`, one line on `Home.md` |
+| Child memory | Child writes it. You do not. |
+
+## Procedure
+
+### A. Interview (before any `profile create`)
+
+Ask, and do not proceed until 1–3 are sharp:
+
+1. One-sentence job. If "and also," split into two bots. Job may be a CLI, an HTTP API, a GUI sock — ComfyUI counts. "CLI-only" is how we *create* the profile, not what the specialist is allowed to operate.
+2. Failure the brain must survive → model pin (if the bot's job lives on a local box, that usually means a hosted provider — the bot must still think when the box is down).
+3. What it is not.
+4. Does default Hermes need the same skill? → canonical under `~/.hermes/skills/` + file-level symlinks.
+5. Who is the client to ping (`@hermes`, another specialist, nobody).
+6. Voice: inherit vs write. Inheritance is tone, not the model's stock identity — that is costume unless the bot *is* a persona bot (if your fleet has one).
+
+### B. SOUL draft
+
+Write one screen. Identity (job name first), Job, Hard constraints as their own heading, Voice, What you are not, Disagreement. No live pins, no IPs, no last-incident notes, no "helpful assistant," no pasted stock-model `# Style` block. Full rules in `references/soul-craft.md`.
+
+**Human gate:** do not run `hermes profile create` until your human signs the draft — chat sign-off or a signed spec on the task card (`references/soul-craft.md` §Human gate). Iterate in the conversation or on the card, not on disk.
+
+### C. Scaffold
+
+Full mechanics and the command sequence: `references/process.md`. The stop points:
+
+**Alias preflight — mandatory, before any `profile create NAME`.** The default alias wrapper can destroy a real CLI through a `~/.local/bin` symlink:
+
+```text
+zsh -lc 'which -a NAME'
+# and, even if which is empty:
+test -e "$HOME/.local/bin/NAME" || test -L "$HOME/.local/bin/NAME"
+```
+
+If **either** finds anything: `--no-alias` (rationale and the landmines: `references/process.md` §--no-skills).
+
+- `--no-skills`; never `--clone` / desktop clone. Pin the brain, then unset the copied `base_url`/`api_key`; `config get model` must show only `default` + `provider`.
+- **Peers + memory provider — check after every create** (site-specific; commands and verification: `references/process.md` §Independence). The invariant: every rostered profile has every peer it must reach. Do not print keys.
+- Sibling-profile CLI from this profile: always prefix `HERMES_HOME=$HOME/.hermes`.
+- By default, `SOUL.md` writes prompt your human (`security.protected_instruction_files: true`) — that prompt is the human gate materialized. If your fleet disabled it for headless provisioning (see `profile/config.yaml` in this repo), the signature is the only gate: no human-signed draft or signed spec, no write. If a write is blocked anyway, stop — do **not** sneak it in via the shell.
+- Never hand-edit `config.yaml` — `config set` only (your human may hand-edit their own; you do not). Never copy credentials. Never print `auth.api_key` / `secret_key`.
+
+Then: write signed `SOUL.md`, thin `memories/USER.md` — if the skill is shared, include the **lockstep sentence**: one line stating that the canonical skill lives under `~/.hermes/skills/<category>/<name>/`, the profile files are symlinks, and process changes patch the canonical tree (so later sessions do not re-flag the drift). Then empty-or-tiny `memories/MEMORY.md` (the child fills this). Install the runbook skill; link shared skills file-level (`references/process.md` §Shared skills). Not every specialist needs a custom skill — `@hostadmin` is `hermes-agent` + earned MEMORY. Do not invent a runbook so the folder looks complete.
+
+Stop. Do not fill the child's `MEMORY.md`. Do not add a vault roster row yet.
+
+### D. Certification (child's Bot Chat)
+
+Kickoff: first look at the real box/job → one failure path → client ping if there is a client. The child patches its own skill + `MEMORY.md`. You may `message_agent` one job ("first look") and then get out.
+
+Certified when it has done the job against the live system, rewritten the stale bits of its runbook (if it has one), and pinged the client (or you agreed there isn't one). A first look that finds nothing broken is still a first look — do not invent a failure to practice. Your human saying "document it in the vault" is a ship signal. Uncertified profiles do not get a `Bots/<name>.md` or a roster row unless your human overrides.
+
+### E. Vault
+
+Only after D. See `references/vault.md`.
+
+## Failure modes (symptom → owner)
+
+One line each; mechanics live with the owner.
+
+| Symptom | Rule | Where |
+|---|---|---|
+| Skill invisible / empty index | never directory-symlink a skill (rglob) | `references/process.md` §Shared skills |
+| `skill_view`/`skill_manage` `file_path` rejected | file-symlink escape — `read_file` canonical | `references/process.md` §Shared skills |
+| Second copy after a patch | `skill_manage` unlinks — patch canonical, `ls -l` | `references/process.md` §Shared skills |
+| "Independent" bot on default's provider | unset the create-leftover `base_url`/`api_key` | `references/process.md` §Independence |
+| DM acks then vanishes | a peer missing on the sender profile | `references/process.md` §Independence |
+| Honcho peer `(not set)` | (Honcho users) `honcho sync` + `memory.provider honcho` | `references/process.md` §Independence |
+| Real CLI destroyed by alias | preflight before `profile create` | `references/process.md` §--no-skills |
+| `Unknown skill(s)` at worker init | link the injected skill file-level; don't always-load | `references/process.md` §--no-skills |
+| `ui_meta` empty / `toolsets` says `hermes-cli` | title in `profile.yaml`; spec list is `platform_toolsets.cli` | `references/process.md` §Scaffold sequence |
+| Worker files to the wrong board / sibling inherits kanban env | strip `HERMES_KANBAN_*`; one terminal call per worker | `references/process.md` §Kanban intake |
+| Child sounds like a costume | identity = job name; inherit tone, not self | `references/soul-craft.md` |
+| SOUL written unsigned | the signature is the gate | `references/soul-craft.md` §Human gate |
+| Uncertified bot in the vault; persona in `Bots/` | write after certification only | `references/vault.md` |
+| Filling child MEMORY · `botmaker-2` · default SOUL · operating services | constitution | `profile/SOUL.md` |
+
+## Verification
+
+A new bot is done when:
+
+1. `hermes profile list` shows it on the pinned model, not silently riding your default profile's.
+2. `hermes -p NAME config get model` is only provider + default.
+3. `.no-bundled-skills` exists in the profile root.
+4. (If your fleet has peers) `hermes -p NAME peer list` shows every peer it must reach — or DMs will ack then vanish.
+5. (Honcho users) `hermes honcho peers` lists NAME with a real user peer (not `(not set)`). `memory.provider` is `honcho`.
+6. `SOUL.md` matches the signed draft (one screen).
+7. Shared skills: `ls -l` on profile `SKILL.md` shows `l` (symlink), canonical is a regular file. `rglob` from the profile skills dir finds `SKILL.md`.
+8. After certification only: vault note + roster row + Home line + `making-bots.md` changelog.
+9. `python3 "$HOME/.hermes/skills/autonomous-ai-agents/botmaker/scripts/drift_check.py"` exits 0.

--- a/optional-skills/autonomous-ai-agents/botmaker/references/process.md
+++ b/optional-skills/autonomous-ai-agents/botmaker/references/process.md
@@ -1,0 +1,141 @@
+# Process
+
+When to load: scaffolding, pinning, linking, or verifying a specialist bot profile — the full command mechanics.
+
+Interview → SOUL draft → human sign-off → scaffold → child's Bot Chat (first look, failure path, client ping) → child rewrites runbook/MEMORY → vault.
+
+You draft. The child earns. If you fill `MEMORY.md`, you faked the training loop.
+
+## Independence
+
+If the bot operates a service — CLI, HTTP API, GUI control socket, ComfyUI, whatever — **do not run the bot on that service's inference path.**
+
+`@gpuops` set the pattern: when our default Hermes pointed its model at the local inference server, default died whenever that server died — so the operator that *manages* the server is pinned to a hosted provider. Pins change (ours have); current pins live in your vault roster (`Bots/making-bots.md`) — the invariant doesn't. A ComfyUI specialist is the same class: talks *to* the API; must still think when the GPU box is busy or down.
+
+Same machine is fine; same inference path is not.
+
+Pin `model.provider` / `model.default` with `hermes -p NAME config set`. Never hand-edit `config.yaml` — `config set` only (your human may hand-edit their own; you do not). Do not copy `auth.json` between profiles — shared pools already rotate. Never print `auth.api_key` / `secret_key`.
+
+**Create leftover:** `hermes profile create` copies your default profile's model block, whatever it currently is (for us, historically a local `base_url` — e.g. `http://127.0.0.1:8000/v1`). After pinning you **must** unset `model.base_url` and `model.api_key`. Verify:
+
+```text
+hermes -p NAME config get model
+```
+
+Must print only `default` and `provider`. If a `base_url` survives, the "independent" bot rides default's provider.
+
+**Peers after create (site-specific; adapt or delete).** Peer *validation* reads the shared root config; *delivery* reads the *sending profile's* config — a new bot will dispatch `message_agent` to a peer as valid and then die silently in delivery until the peer is registered on that profile. Register every peer the bot must reach, immediately after create (our fleet invariant: every rostered profile has every peer it must reach — roster: vault `Bots/making-bots.md`):
+
+```text
+hermes -p NAME peer add <peer> --url <peer-url> --key "$(head -1 <keyfile>)"
+```
+
+Verify: `hermes -p NAME peer list` shows the peer. Do not print the key. If your fleet has no external peers, delete this step.
+
+**Honcho peer after create (only if you use the Honcho memory provider).** Never `--clone`, so no fresh AI peer. `hermes honcho sync` backfills (idempotent), then set the provider — create leaves it empty:
+
+```text
+hermes honcho sync
+hermes -p NAME config set memory.provider honcho
+```
+
+Verify `hermes honcho peers` shows the profile with a real user peer (not `(not set)`). If `hermes honcho --target-profile NAME status` says not connected, inherit `apiKey`/`baseUrl`/`requestTimeout` from host `hermes` into `hermes_<name>` in `~/.hermes/honcho.json`. Do not print them. Docs: https://hermes-agent.nousresearch.com/docs/user-guide/features/memory-providers#new-profile-fresh-honcho-peer
+
+## Scaffold sequence
+
+Alias preflight (next section) first, then:
+
+```text
+HERMES_HOME="$HOME/.hermes" hermes profile create NAME --no-skills --description "one or two sentences"
+HERMES_HOME="$HOME/.hermes" hermes -p NAME config set model.provider <provider>
+HERMES_HOME="$HOME/.hermes" hermes -p NAME config set model.default <model>
+HERMES_HOME="$HOME/.hermes" hermes -p NAME config unset model.base_url
+HERMES_HOME="$HOME/.hermes" hermes -p NAME config unset model.api_key
+HERMES_HOME="$HOME/.hermes" hermes profile describe NAME --text "same one or two sentences"
+```
+
+Site-specific follow-ups — ours, shown as worked examples; adapt or delete (details above):
+
+```text
+# external peer bridge:
+HERMES_HOME="$HOME/.hermes" hermes -p NAME peer add <peer> --url <peer-url> --key "$(head -1 <keyfile>)"
+# Honcho memory provider:
+HERMES_HOME="$HOME/.hermes" hermes honcho sync
+HERMES_HOME="$HOME/.hermes" hermes -p NAME config set memory.provider honcho
+```
+
+The `HERMES_HOME` prefix matters: inside a named profile `$HERMES_HOME` is `~/.hermes/profiles/<name>`, not `~/.hermes` — unprefixed sibling CLI (`profile create`, `-p NAME config`, `profile describe`) can hit the wrong home. Canonical skills stay under `$HOME/.hermes/skills/`.
+
+`hermes profile describe` writes the roster one-liner (`profile.yaml`) other bots read — not a group-chat log. It does not set the display **title**, which lives in `profile.yaml`: write `ui_meta.hermes-bots.title` there after describe (`config get ui_meta` reads empty until then). And don't "fix" `config get toolsets` off the wrapper key — the spec list is `platform_toolsets.cli`.
+
+## --no-skills
+
+**Alias preflight before `profile create NAME` — mandatory.** Hermes writes `~/.local/bin/<name>` (`exec hermes -p <name>`), and `Path.write_text()` follows symlinks, so a wrapper can overwrite a real CLI in place — war story: a profile that shared its name with an installed CLI overwrote the real 107MB binary living at the far end of a `~/.local/bin` symlink; the alias wrapper was written *through* the link, straight over the binary. Built-in `which` collision check is useless under launchd PATH (`/usr/bin:/bin:/usr/sbin:/sbin` — no `~/.local/bin`); do not trust this process's `which` either.
+
+```text
+zsh -lc 'which -a NAME'
+# and, even if which is empty:
+test -e "$HOME/.local/bin/NAME" || test -L "$HOME/.local/bin/NAME"
+```
+
+If **either** finds anything: `--no-alias`, or `hermes profile alias NAME --name CUSTOM` only after the same two checks pass for `CUSTOM`. `~/.local/bin/NAME` as a **symlink** is the binary-destroying case. Common landmine: some popular AI-coding CLIs install their command as such a symlink; so does any CLI whose entry point lives in, or resolves through, `~/.local/bin`. Hermes only reserves `hermes`, `default`, `test`, `tmp`. If a CLI later acts like Hermes (`exec hermes -p` in a tiny file): delete the impostor, reinstall the real tool, rename or drop the Hermes alias.
+
+Never `--clone` / `--clone-from`. Desktop clone is the same bug (copies SOUL, skills, memory, leftover model block). Desktop create-empty is fine.
+
+`--no-skills` writes `.no-bundled-skills`; `hermes update` will not dump the bundle on this profile. Essential `hermes-agent` still seeds as a **real copy** — leave it; sync owns it. File-linking it to canonical instead is also acceptable (two of our bots do; the link tracks canonical) — never a directory symlink.
+
+A review-lane bot still needs its review skill **discoverable** on the profile even when it is not pinned. Any automation that injects `--skills <review-skill>` dies at init on a `--no-skills` tree that cannot resolve the name (`Unknown skill(s): <review-skill>`). Link the canonical skill file-level. Do not always-load it.
+
+Extra skills are context tax and off-mission bait. Three is already a lot (`botmaker` itself: its own runbook + `hermes-agent`, plus a notes skill if you keep a vault). A coordinator seat may earn more; each one is still a tax — trim when context strain shows.
+
+## Shared skills (file-level links)
+
+Canonical tree: `~/.hermes/skills/<category>/<name>/` (default Hermes loads this).
+
+Profile path: `~/.hermes/profiles/<bot>/skills/<category>/<name>/` — **real directories**, every *file* a relative symlink.
+
+Never symlink the skill directory itself. Hermes venv is Python 3.11; `Path.rglob("SKILL.md")` does not descend directory symlinks → empty index → the bot cannot see the skill. File-level `SKILL.md` inside a real dir **is** found.
+
+`skill_manage` delete refuses if the skill **dir** is a symlink (will not `rmtree` through a redirect). Sandbox skill mounts skip symlinks — acceptable for a runbook the bot reads; do not put secrets in the skill either way.
+
+Linker (this skill):
+
+```text
+python3 "$HOME/.hermes/skills/autonomous-ai-agents/botmaker/scripts/link_skill_tree.py" \
+  "$HOME/.hermes/skills/<category>/<name>" \
+  "$HOME/.hermes/profiles/<bot>/skills/<category>/<name>"
+```
+
+Writes through the profile path hit the same inode. If a rewrite unlinks first, `ls -l` shows a regular file instead of `l` — that is a second copy starting again. Relink; do not keep both. `skill_manage` patch on a linked `SKILL.md` does that unlink — patch canonical with the file `patch` tool instead. `skill_manage` `file_path` and `skill_view(..., file_path=…)` on `references/` both fail: `Path.resolve()` follows the file symlink into `~/.hermes/skills/…`, then `relative_to` the profile skill dir rejects it. Workaround: `read_file` the canonical path. Do not tell bots to `skill_view` linked references until Hermes allows it.
+
+Child `SOUL.md` writes: the gate is the signature — mechanics in `soul-craft.md` §Human gate.
+
+## Kanban intake (if your fleet provisions from cards)
+
+Cards assigned to `botmaker` arrive as headless workers (`HERMES_KANBAN_*` set; no approval surface — that is why the write prompt is off for this profile; see `soul-craft.md` §Human gate, and `profile/config.yaml` in this repo). A human-signed spec on the card is the signature: no signature, no scaffold, no SOUL write. End every worker run with exactly one terminal kanban call (`kanban_request_review` **is** that call in review lanes). Strip `HERMES_KANBAN_*` before any sibling spawn or sibling kanban CLI — inherited env silently retargets boards (`env -u HERMES_KANBAN_DB -u HERMES_KANBAN_BOARD … hermes kanban --board <slug>`).
+
+## Generate-the-experience
+
+Do not hand the child a finished runbook and a stuffed MEMORY.
+
+Kickoff in the child's Bot Chat:
+
+1. First look at the real box or job (status script, live files, not vibes).
+2. One failure path, practiced (the thing that will hurt at 2am).
+3. Client ping if there is a client (`@hermes` was `@gpuops`'s check that bot-to-bot actually works).
+
+The child patches its own skill + MEMORY. You may send one `message_agent` ("first look") and then get out.
+
+Certified when it has done the job against the live system and rewritten the stale bits. A clean first look is enough if your human ships it ("document it in the vault"). Uncertified profiles do not get a roster row unless your human overrides. Do not invent a 2am failure to practice.
+
+## Bot-to-bot
+
+Useful as a **health primitive** (can this bot reach another bot?) and as a client-path check. Not as a substitute for the child doing the work.
+
+Do not impersonate children. Do not DM them a finished MEMORY.
+
+## Blast radius
+
+Specialists + living guide + this skill. You are the bot coordinator — of bots, nothing else; `@hermes` is not. Touch a shipped child's SOUL only when your human explicitly sends you there. Never default Hermes SOUL. There is no doctor class — each specialist diagnoses its own job; you diagnose the fleet.
+
+Do not spawn `botmaker-2`.

--- a/optional-skills/autonomous-ai-agents/botmaker/references/soul-craft.md
+++ b/optional-skills/autonomous-ai-agents/botmaker/references/soul-craft.md
@@ -1,0 +1,44 @@
+# SOUL craft
+
+When to load: drafting or rewriting a specialist bot's SOUL.md, or running the human sign-off gate.
+
+A good specialist SOUL is one screen. If it does not fit, you put procedure in a skill.
+
+## Required sections
+
+1. **Identity** — the job name first (`You are Botmaker` / `You are the local inference-server operator`), then which model and profile, said plainly if asked. Not the vendor's web app. Not default Hermes. Not the child bots (if this is Botmaker) / not the service (if this is an operator). `You are <model-name>, running here as X` is costume unless the bot *is* the persona bot.
+2. **Job** — first paragraph is "You are the X." Then "load skill Y on every in-scope question and follow it." Bullet the in-scope work. One job.
+3. **Hard constraints** — earned, not decorative. Example from `@gpuops`: never blindly restart the inference service (the background-relaunch flags — `open -gj` — drop the app's GUI icon). If you cannot name a constraint that would actually hurt, you do not have one yet — that is fine; do not invent some.
+4. **Voice** — chosen, not a stock-model paste. Inheritance is allowed when the bot *is* that model *and* your human wants that voice. The next bot should get a voice on purpose.
+5. **What you are not** — the useful half of the prompt. Cuts off-mission work.
+6. **Disagreement** — correct your human without a victory lap; one clarifying question when the job is fuzzy; "I don't know" beats a confident guess.
+
+## Do not put in SOUL
+
+- Live pins, IPs, last-incident notes (those go in `MEMORY.md` or the skill)
+- Bot-to-bot protocol (already injected by Hermes)
+- "You are a helpful assistant"
+- The runbook (that is `SKILL.md` + `references/`)
+- Biography of your human (default profile / People notes)
+
+## Voice
+
+Wit is seasoning, not the meal. No corporate warmth, no "Great question!", no sycophancy.
+
+Botmaker's own voice is editorial craftsman — allergic to costume, picky about "what you are not." Children do **not** automatically get that voice. Ask (interview item 6).
+
+`@gpuops` inherited its model's stock voice because it runs on that model and your human wanted that. Do not cargo-cult it — and do not copy `@gpuops`'s `# Style` block or stock-model identity onto the next child. Inheritance is tone, not self.
+
+## After ship
+
+Rewrite a child SOUL only when a **constraint was earned** (the blind-restart class of change), not because the personality drifted. Personality nits go in USER.md or get dropped.
+
+Default `~/.hermes/SOUL.md` is off-limits. Your human does not want it customized to death.
+
+There is no doctor class. A specialist's runbook includes how to diagnose its own job (CLI, HTTP API, GUI). Botmaker diagnoses the fleet and this process. Do not mint a generic troubleshooter.
+
+## Human gate
+
+The gate is the signature, not the write. Do not write `SOUL.md` on disk, and do not `hermes profile create`, until your human signs the draft — chat sign-off or a signed spec on the task card both count. Iterate in the conversation or on the card. A chat sign-off is your human approving the *specific draft on the table*, in their own words — standing go-ahead phrases qualify when they answer that draft, never as blanket authority. Keep the phrase list in botmaker's `memories/USER.md`.
+
+Mechanics: by default, Hermes prompts your human on every `SOUL.md` write (`security.protected_instruction_files: true`). That prompt is this gate materialized, and it is the right default. We turned it off on this one profile because headless workers have no approval surface — one burned its whole approval window on a prompt nobody could see and shipped a stub. That removed the prompt, not the rule: an unsigned SOUL write is a protocol violation regardless of what the tooling allows. If you flip the flag, understand that you have removed the last mechanical safeguard between a confused bot and your agent's instructions — the signed-draft discipline is then the only gate. Do not flip it casually, and never fleet-wide.

--- a/optional-skills/autonomous-ai-agents/botmaker/references/vault.md
+++ b/optional-skills/autonomous-ai-agents/botmaker/references/vault.md
@@ -1,0 +1,57 @@
+# Vault (`Bots/`)
+
+When to load: documenting a certified bot in the fleet vault (optional — skip if the user keeps no vault).
+
+Botmaker owns `Bots/` in the fleet vault. This layer assumes an Obsidian vault because that is what we run; any notes system with frontmatter and links works — adapt the conventions, keep the rule: **nothing gets documented before certification.**
+
+Vault path:
+
+`<your-vault-path>`
+
+Quote it in shell if it contains spaces (cloud-synced vault paths often do). File tools take the absolute path.
+
+Load your notes skill (if you have one) for filesystem conventions. This file is the *bot* layer on top.
+
+## Section owners
+
+- `Bots/` — `@botmaker`: specialist notes, `making-bots.md`, the roster.
+- Other sections belong to whoever writes them — a planning bot's `Plans/`, a nightly tidy cron's `Sessions/`. Read any section; write only your own. Do not own `Servers/` or `Services/` except links.
+
+## When to write
+
+**After certification.** Seeding a profile is not a ship. Uncertified bots do not get `Bots/<name>.md` or a roster row. Personas and the daily driver never get one at all — specialists only.
+
+Exceptions are dated and expire; none should stay active. (Ours: botmaker's own note briefly existed as *certification pending* during bootstrap. Do not copy that onto children.)
+
+## Notes
+
+| Note | Frontmatter | Role |
+|---|---|---|
+| `Bots/<name>.md` | `type: bot-reference`, `created`, `updated`, `profile`, `host`, `status`, `tags` | Specialist reference after certification. Not a SOUL dump. Training loop + runbook pointer + independence pin + pitfalls. |
+| `Bots/making-bots.md` | `type: living-guide` | Human guide + fleet roster + changelog. Roster table at top — add a row when a bot **ships**. Changelog at bottom, append-only. |
+| `Home.md` | `type: vault-root` | One index line under **Bots**. Never append running logs. |
+| `Sessions/YYYY-MM-DD-<slug>.md` | `type: session` | What we did this session. Wikilink the bot note + `making-bots`. One Index line, newest first. |
+
+`status:` values: `certification-pending` \| `shipped — YYYY-MM-DD`. `host:` names the machine the profile lives on.
+
+Match your vault's existing tone: YAML frontmatter, wiki-style links, short, no credentials. Once your first specialist is certified, its note becomes the worked example — steal structure, not facts.
+
+## Roster
+
+`making-bots.md` table:
+
+```markdown
+| `@name` | `name` | <model> / <provider> | one-line job |
+```
+
+`Home.md` **Bots** section: `[[name]] — \`@name\`, one-line job`.
+
+The roster table on `making-bots.md` is the fleet-state source of truth — which profiles exist, current pins (including your default profile's), peer and memory coverage. Enumerate fleet state there and nowhere else; a fleet enumeration baked into a skill rots the day the fleet changes.
+
+## One home per rule
+
+Every rule has exactly one home — method in the skill tree (`~/.hermes/skills/autonomous-ai-agents/botmaker/`, write the canonical path; profile files are symlinks), fleet state in the roster table on `Bots/making-bots.md`, history in its changelog. When a lesson lands, patch its one owner and add one changelog line naming that owner.
+
+If `making-bots.md` is fresher than this tree, backport before adding anything new — lockstep failed one-directionally for us until we adopted this rule.
+
+Ops source of truth for a *child* bot is that child's skill, not the vault note. The vault note points at the skill.

--- a/optional-skills/autonomous-ai-agents/botmaker/scripts/drift_check.py
+++ b/optional-skills/autonomous-ai-agents/botmaker/scripts/drift_check.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Drift tripwire for the botmaker doc layer (one home per rule).
+
+Run after every mint and every doc patch:
+
+    python3 ~/.hermes/skills/autonomous-ai-agents/botmaker/scripts/drift_check.py
+
+Exit 0 = clean. Nonzero = drift; each violation prints on its own line.
+
+Checks:
+  1. Owner-only markers: mechanics phrases live only in their owner file.
+  2. Forbidden strings (frozen enumerations, retired premises) are absent
+     from the live scope (skill tree + botmaker profile SOUL/memories).
+  3. The specialist roster table in the vault's making-bots.md matches the
+     profiles that actually exist under ~/.hermes/profiles/. Point the
+     BOTMAKER_VAULT_GUIDE env var at your vault's Bots/making-bots.md;
+     the check is skipped (with a warning) if it is not set.
+  4. Botmaker's profile skill links are file-level symlinks and rglob
+     discovery still finds SKILL.md — and no profile in the fleet has a
+     directory symlink anywhere under its skills/ tree (invisible to
+     Python 3.11 rglob).
+
+Reads only documentation files; never reads config values or .env files.
+Extend OWNER_ONLY / FORBIDDEN as your fleet earns its own rules.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+HOME = Path.home()
+SKILL_TREE = HOME / ".hermes/skills/autonomous-ai-agents/botmaker"
+PROFILE = HOME / ".hermes/profiles/botmaker"
+PROFILES_DIR = HOME / ".hermes/profiles"
+VAULT_GUIDE = Path(os.environ["BOTMAKER_VAULT_GUIDE"]) if os.environ.get("BOTMAKER_VAULT_GUIDE") else None
+
+SKILL_DOCS = [
+    SKILL_TREE / "SKILL.md",
+    SKILL_TREE / "references/process.md",
+    SKILL_TREE / "references/soul-craft.md",
+    SKILL_TREE / "references/vault.md",
+]
+PROFILE_DOCS = [
+    PROFILE / "SOUL.md",
+    PROFILE / "memories/MEMORY.md",
+    PROFILE / "memories/USER.md",
+]
+
+# Phrase -> the one file (relative to the skill tree) allowed to contain it.
+OWNER_ONLY = {
+    "does not descend": "references/process.md",
+    "config unset model.base_url": "references/process.md",
+    "which -a NAME": "references/process.md",
+}
+# SKILL.md keeps the two preflight commands as its Procedure C stop point.
+OWNER_ONLY_EXTRA_ALLOWED = {"which -a NAME": ["SKILL.md"]}
+
+# Frozen enumerations and retired premises. None of these may appear in the
+# live scope; vault history (changelog, training stories) is out of scope.
+FORBIDDEN = [
+    "already have it",
+    "already done",
+    "will prompt your human",
+]
+
+ROSTER_ROW = re.compile(r"^\|\s*`@[\w-]+`\s*\|\s*`([\w-]+)`\s*\|")
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    docs: dict[Path, str] = {}
+    for path in SKILL_DOCS:
+        if not path.exists():
+            errors.append(f"missing file: {path}")
+            continue
+        docs[path] = path.read_text(encoding="utf-8")
+    for path in PROFILE_DOCS:
+        if path.exists():
+            docs[path] = path.read_text(encoding="utf-8")
+
+    # 1. Owner-only markers.
+    for phrase, owner_rel in OWNER_ONLY.items():
+        allowed = {owner_rel, *OWNER_ONLY_EXTRA_ALLOWED.get(phrase, [])}
+        found_in_owner = False
+        for path, text in docs.items():
+            if phrase not in text:
+                continue
+            try:
+                rel = str(path.relative_to(SKILL_TREE))
+            except ValueError:
+                rel = str(path)
+            if rel in allowed:
+                found_in_owner = found_in_owner or rel == owner_rel
+            else:
+                errors.append(f"marker escaped its owner: {phrase!r} in {path}")
+        if not found_in_owner:
+            errors.append(f"marker missing from owner {owner_rel}: {phrase!r}")
+
+    # 2. Forbidden strings in the live scope.
+    for phrase in FORBIDDEN:
+        for path, text in docs.items():
+            for i, line in enumerate(text.splitlines(), 1):
+                if phrase in line:
+                    errors.append(f"forbidden {phrase!r} at {path}:{i}")
+
+    # 3. Roster table vs profiles on disk.
+    if VAULT_GUIDE and VAULT_GUIDE.exists():
+        rostered = {
+            m.group(1)
+            for line in VAULT_GUIDE.read_text(encoding="utf-8").splitlines()
+            if (m := ROSTER_ROW.match(line))
+        }
+        on_disk = {
+            p.name
+            for p in PROFILES_DIR.iterdir()
+            if p.is_dir() and not p.name.startswith(".")
+        } if PROFILES_DIR.is_dir() else set()
+        for name in sorted(on_disk - rostered):
+            errors.append(f"profile exists but has no roster row: {name}")
+        for name in sorted(rostered - on_disk):
+            errors.append(f"roster row names a missing profile: {name}")
+    else:
+        print("note: BOTMAKER_VAULT_GUIDE not set (or file missing) — roster check skipped")
+
+    # 4a. Botmaker's own links: file-level symlinks, discovery intact.
+    skills_dir = PROFILE / "skills"
+    if skills_dir.is_dir():
+        link = skills_dir / "autonomous-ai-agents/botmaker/SKILL.md"
+        if link.exists() and not link.is_symlink():
+            errors.append(f"expected file-level symlink, found otherwise: {link}")
+        discovered = {p.parent.name for p in skills_dir.rglob("SKILL.md")}
+        if "botmaker" not in discovered:
+            errors.append("rglob discovery lost skill: botmaker")
+
+    # 4b. Whole fleet: a directory symlink anywhere under a profile's skills/
+    #     is invisible to rglob — the class defect, checked on every profile.
+    if PROFILES_DIR.is_dir():
+        for prof in sorted(PROFILES_DIR.iterdir()):
+            if not prof.is_dir() or prof.name.startswith("."):
+                continue
+            prof_skills = prof / "skills"
+            if not prof_skills.is_dir():
+                continue
+            for path in prof_skills.rglob("*"):
+                if path.is_dir() and path.is_symlink():
+                    errors.append(f"directory symlink (invisible to rglob): {path}")
+
+    if errors:
+        print(f"DRIFT: {len(errors)} violation(s)")
+        for err in errors:
+            print(f"  - {err}")
+        return 1
+    print("drift_check: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/optional-skills/autonomous-ai-agents/botmaker/scripts/link_skill_tree.py
+++ b/optional-skills/autonomous-ai-agents/botmaker/scripts/link_skill_tree.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Create a real-dir + file-level-symlink copy of a skill tree.
+
+Hermes (Python 3.11) Path.rglob("SKILL.md") does not descend directory
+symlinks. File-level links inside a real directory are found.
+
+Usage:
+  python3 link_skill_tree.py CANONICAL_DIR DEST_DIR
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+SKIP_NAMES = {".DS_Store", ".git", "__pycache__"}
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: link_skill_tree.py CANONICAL_DIR DEST_DIR", file=sys.stderr)
+        return 2
+
+    src = Path(sys.argv[1]).expanduser().resolve()
+    dest = Path(sys.argv[2]).expanduser()
+
+    if not src.is_dir():
+        print(f"canonical is not a directory: {src}", file=sys.stderr)
+        return 1
+    if dest.exists() and dest.is_symlink():
+        print(f"refusing: dest is a directory symlink: {dest}", file=sys.stderr)
+        return 1
+
+    dest.mkdir(parents=True, exist_ok=True)
+    dest = dest.resolve()
+
+    linked = 0
+    for root, dirs, files in os.walk(src, followlinks=False):
+        root_p = Path(root)
+        rel = root_p.relative_to(src)
+        dirs[:] = [
+            d
+            for d in dirs
+            if d not in SKIP_NAMES and not (root_p / d).is_symlink()
+        ]
+        dest_root = dest if rel == Path(".") else dest / rel
+        dest_root.mkdir(parents=True, exist_ok=True)
+
+        for name in files:
+            if name in SKIP_NAMES:
+                continue
+            s = root_p / name
+            if not s.is_file():
+                continue
+            resolved = s.resolve()
+            d = dest_root / name
+            target = Path(os.path.relpath(resolved, start=d.parent))
+            if d.exists() or d.is_symlink():
+                if d.is_symlink() and d.resolve() == resolved:
+                    linked += 1
+                    continue
+                print(f"refusing to clobber: {d}", file=sys.stderr)
+                return 1
+            d.symlink_to(target)
+            linked += 1
+
+    print(f"linked {linked} files → {dest}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -33,6 +33,7 @@ hermes skills uninstall <skill-name>
 |-------|-------------|
 | [**antigravity-cli**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-antigravity-cli) | Operate the Antigravity CLI (agy): plugins, auth, sandbox. |
 | [**blackbox**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-blackbox) | Delegate coding tasks to the Blackbox AI multi-model CLI. |
+| [**botmaker**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-botmaker) | Design, scaffold, and certify specialist Hermes bots. |
 | [**dynamic-workflow**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-dynamic-workflow) | Plan-in-code fan-outs, adversarial verification, waves. |
 | [**grok**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-grok) | Delegate coding to xAI Grok Build CLI (features, PRs). |
 | [**honcho**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho) | Configure and troubleshoot Honcho memory for Hermes. |

--- a/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-botmaker.md
+++ b/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-botmaker.md
@@ -1,0 +1,158 @@
+---
+title: "Botmaker — Design, scaffold, and certify specialist Hermes bots"
+sidebar_label: "Botmaker"
+description: "Design, scaffold, and certify specialist Hermes bots"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Botmaker
+
+Design, scaffold, and certify specialist Hermes bots.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/autonomous-ai-agents/botmaker` |
+| Path | `optional-skills/autonomous-ai-agents/botmaker` |
+| Version | `0.2.0` |
+| Author | techjanitor (adapted by Nous Research) |
+| License | MIT |
+| Platforms | linux, macos |
+| Tags | `hermes`, `bots`, `profiles`, `soul` |
+| Related skills | [`hermes-agent`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Botmaker
+
+Design, scaffold, certify, and document specialist Hermes bots. Load this skill on every in-scope question. You draft; the child earns. Seeding files is not a bot.
+
+Details: `references/soul-craft.md` (SOUL + human gate), `references/process.md` (mechanics), `references/vault.md` (vault conventions). Shared-skill linker: `scripts/link_skill_tree.py`. Drift tripwire: `scripts/drift_check.py`.
+
+## When to Use
+
+- Your human wants a new specialist bot, or a SOUL drafted for one — in chat, or as a task card assigned to `botmaker` (if your fleet dispatches work by kanban). A card carrying a human-signed SOUL spec satisfies the human gate.
+- An existing specialist bot's identity/job/voice is wrong and needs a SOUL rewrite (human gate)
+- `Bots/` in the vault needs a specialist note, roster row, or `making-bots.md` changelog
+- A shared skill is about to be copied into a profile (stop; symlink files instead)
+
+Don't use for: operating the inference server, ComfyUI, or any service; general coding; rewriting default `~/.hermes/SOUL.md`; spawning `botmaker-2`. `@hermes` is not the bot coordinator — you are.
+
+## Prerequisites
+
+- Hermes CLI (`hermes profile create --help`)
+- Canonical skills live under `~/.hermes/skills/` (default Hermes home), **not** `$HERMES_HOME/skills` when you are the botmaker profile
+- Vault: `<your-vault-path>` (see `references/vault.md`). Vault documentation is an optional convention — if the user has no vault, skip the vault steps.
+- Human guide, fleet roster, changelog: vault `Bots/making-bots.md` (create it on first ship). Method lives here only; fleet state lives there only — patch a lesson's one owner and log one changelog line.
+
+## How to Run
+
+1. Interview. Refuse to scaffold until job / independence failure / not-list are sharp. See Procedure.
+2. Draft a one-screen SOUL (`references/soul-craft.md`). Stop. Your human signs it.
+3. Scaffold (`references/process.md`). **Alias preflight first.** `--no-skills`, pin the brain, file-level skill links, USER.md lockstep sentence if the skill is shared.
+4. Kickoff in the **child's** Bot Chat. Do not babysit its tools. Do not write its `MEMORY.md`.
+5. After certification: vault note + roster row (`references/vault.md`). Not before.
+
+## Quick Reference
+
+| Need | Do |
+|---|---|
+| New bot | Alias preflight (Procedure C) → Interview → SOUL draft → human sign-off → `hermes profile create NAME --no-skills --description "…"` |
+| Pin a brain | `hermes -p NAME config set model.provider …` then `model.default …`. Then **unset** the copied `base_url` / `api_key` (create copies your default profile's model block, whatever it currently is) |
+| Shared skill | Canonical `~/.hermes/skills/<cat>/<name>/`; profile files via `scripts/link_skill_tree.py`. Never a directory symlink. Load linked `references/` with `read_file` on the canonical path |
+| Vault after cert | `Bots/<name>.md` (`type: bot-reference`), roster row on `making-bots.md`, one line on `Home.md` |
+| Child memory | Child writes it. You do not. |
+
+## Procedure
+
+### A. Interview (before any `profile create`)
+
+Ask, and do not proceed until 1–3 are sharp:
+
+1. One-sentence job. If "and also," split into two bots. Job may be a CLI, an HTTP API, a GUI sock — ComfyUI counts. "CLI-only" is how we *create* the profile, not what the specialist is allowed to operate.
+2. Failure the brain must survive → model pin (if the bot's job lives on a local box, that usually means a hosted provider — the bot must still think when the box is down).
+3. What it is not.
+4. Does default Hermes need the same skill? → canonical under `~/.hermes/skills/` + file-level symlinks.
+5. Who is the client to ping (`@hermes`, another specialist, nobody).
+6. Voice: inherit vs write. Inheritance is tone, not the model's stock identity — that is costume unless the bot *is* a persona bot (if your fleet has one).
+
+### B. SOUL draft
+
+Write one screen. Identity (job name first), Job, Hard constraints as their own heading, Voice, What you are not, Disagreement. No live pins, no IPs, no last-incident notes, no "helpful assistant," no pasted stock-model `# Style` block. Full rules in `references/soul-craft.md`.
+
+**Human gate:** do not run `hermes profile create` until your human signs the draft — chat sign-off or a signed spec on the task card (`references/soul-craft.md` §Human gate). Iterate in the conversation or on the card, not on disk.
+
+### C. Scaffold
+
+Full mechanics and the command sequence: `references/process.md`. The stop points:
+
+**Alias preflight — mandatory, before any `profile create NAME`.** The default alias wrapper can destroy a real CLI through a `~/.local/bin` symlink:
+
+```text
+zsh -lc 'which -a NAME'
+# and, even if which is empty:
+test -e "$HOME/.local/bin/NAME" || test -L "$HOME/.local/bin/NAME"
+```
+
+If **either** finds anything: `--no-alias` (rationale and the landmines: `references/process.md` §--no-skills).
+
+- `--no-skills`; never `--clone` / desktop clone. Pin the brain, then unset the copied `base_url`/`api_key`; `config get model` must show only `default` + `provider`.
+- **Peers + memory provider — check after every create** (site-specific; commands and verification: `references/process.md` §Independence). The invariant: every rostered profile has every peer it must reach. Do not print keys.
+- Sibling-profile CLI from this profile: always prefix `HERMES_HOME=$HOME/.hermes`.
+- By default, `SOUL.md` writes prompt your human (`security.protected_instruction_files: true`) — that prompt is the human gate materialized. If your fleet disabled it for headless provisioning (see `profile/config.yaml` in this repo), the signature is the only gate: no human-signed draft or signed spec, no write. If a write is blocked anyway, stop — do **not** sneak it in via the shell.
+- Never hand-edit `config.yaml` — `config set` only (your human may hand-edit their own; you do not). Never copy credentials. Never print `auth.api_key` / `secret_key`.
+
+Then: write signed `SOUL.md`, thin `memories/USER.md` — if the skill is shared, include the **lockstep sentence**: one line stating that the canonical skill lives under `~/.hermes/skills/<category>/<name>/`, the profile files are symlinks, and process changes patch the canonical tree (so later sessions do not re-flag the drift). Then empty-or-tiny `memories/MEMORY.md` (the child fills this). Install the runbook skill; link shared skills file-level (`references/process.md` §Shared skills). Not every specialist needs a custom skill — `@hostadmin` is `hermes-agent` + earned MEMORY. Do not invent a runbook so the folder looks complete.
+
+Stop. Do not fill the child's `MEMORY.md`. Do not add a vault roster row yet.
+
+### D. Certification (child's Bot Chat)
+
+Kickoff: first look at the real box/job → one failure path → client ping if there is a client. The child patches its own skill + `MEMORY.md`. You may `message_agent` one job ("first look") and then get out.
+
+Certified when it has done the job against the live system, rewritten the stale bits of its runbook (if it has one), and pinged the client (or you agreed there isn't one). A first look that finds nothing broken is still a first look — do not invent a failure to practice. Your human saying "document it in the vault" is a ship signal. Uncertified profiles do not get a `Bots/<name>.md` or a roster row unless your human overrides.
+
+### E. Vault
+
+Only after D. See `references/vault.md`.
+
+## Failure modes (symptom → owner)
+
+One line each; mechanics live with the owner.
+
+| Symptom | Rule | Where |
+|---|---|---|
+| Skill invisible / empty index | never directory-symlink a skill (rglob) | `references/process.md` §Shared skills |
+| `skill_view`/`skill_manage` `file_path` rejected | file-symlink escape — `read_file` canonical | `references/process.md` §Shared skills |
+| Second copy after a patch | `skill_manage` unlinks — patch canonical, `ls -l` | `references/process.md` §Shared skills |
+| "Independent" bot on default's provider | unset the create-leftover `base_url`/`api_key` | `references/process.md` §Independence |
+| DM acks then vanishes | a peer missing on the sender profile | `references/process.md` §Independence |
+| Honcho peer `(not set)` | (Honcho users) `honcho sync` + `memory.provider honcho` | `references/process.md` §Independence |
+| Real CLI destroyed by alias | preflight before `profile create` | `references/process.md` §--no-skills |
+| `Unknown skill(s)` at worker init | link the injected skill file-level; don't always-load | `references/process.md` §--no-skills |
+| `ui_meta` empty / `toolsets` says `hermes-cli` | title in `profile.yaml`; spec list is `platform_toolsets.cli` | `references/process.md` §Scaffold sequence |
+| Worker files to the wrong board / sibling inherits kanban env | strip `HERMES_KANBAN_*`; one terminal call per worker | `references/process.md` §Kanban intake |
+| Child sounds like a costume | identity = job name; inherit tone, not self | `references/soul-craft.md` |
+| SOUL written unsigned | the signature is the gate | `references/soul-craft.md` §Human gate |
+| Uncertified bot in the vault; persona in `Bots/` | write after certification only | `references/vault.md` |
+| Filling child MEMORY · `botmaker-2` · default SOUL · operating services | constitution | `profile/SOUL.md` |
+
+## Verification
+
+A new bot is done when:
+
+1. `hermes profile list` shows it on the pinned model, not silently riding your default profile's.
+2. `hermes -p NAME config get model` is only provider + default.
+3. `.no-bundled-skills` exists in the profile root.
+4. (If your fleet has peers) `hermes -p NAME peer list` shows every peer it must reach — or DMs will ack then vanish.
+5. (Honcho users) `hermes honcho peers` lists NAME with a real user peer (not `(not set)`). `memory.provider` is `honcho`.
+6. `SOUL.md` matches the signed draft (one screen).
+7. Shared skills: `ls -l` on profile `SKILL.md` shows `l` (symlink), canonical is a regular file. `rglob` from the profile skills dir finds `SKILL.md`.
+8. After certification only: vault note + roster row + Home line + `making-bots.md` changelog.
+9. `python3 "$HOME/.hermes/skills/autonomous-ai-agents/botmaker/scripts/drift_check.py"` exits 0.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -321,6 +321,7 @@ const sidebars: SidebarsConfig = {
                   items: [
                     'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-antigravity-cli',
                     'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-blackbox',
+                    'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-botmaker',
                     'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-dynamic-workflow',
                     'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-grok',
                     'user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho',


### PR DESCRIPTION
Hermes gains **botmaker** — notable because it is the first trending community skill **written natively for Hermes Agent** (profiles, SOUL.md, Bot Chat, `hermes profile create`): interview → one-screen SOUL draft → human sign-off gate → scaffold with alias preflight and model pinning → certification → fleet roster.

## Why
- **Trending + ecosystem signal**: `techjanitor/botmaker`, **277★ in its first ~10 days**, surfaced in the GitHub created-30d sweep searching "agent skill". A community member shipping polished Hermes-native fleet tooling is exactly the signal this scout exists to catch.
- Encodes real operational pitfalls: the alias wrapper destroying a real CLI via `~/.local/bin` symlink, `profile create` copying the default profile's `base_url`/`api_key`, file-level (never directory) symlinks for shared skills.

## Changes
- `optional-skills/autonomous-ai-agents/botmaker/` — SKILL.md (142 lines), `references/` (process, soul-craft, vault conventions — vault marked optional), `scripts/` (`drift_check.py`, `link_skill_tree.py` vendored verbatim), `LICENSE.txt` (MIT, techjanitor).
- Upstream pinned `93eb3b6`. Light-touch edits only: linter-conformant description, platforms `[linux, macos]` (prose uses zsh/symlinks), one "Claude Code" alias-landmine example genericized, author's personal fleet files (profile/, SOUL.md, config.yaml) excluded.
- Docs: own catalog row, generated page, one sidebar line only.

## Validation
| Check | Result |
|---|---|
| `py_compile` + `ruff check` on both scripts | ✓ clean, unmodified |
| encoding audit (all reads `encoding='utf-8'`) | ✓ |
| `OptionalSkillSource().fetch("official/autonomous-ai-agents/botmaker")` | ✓ all 7 files |
| Loader frontmatter parse (desc 53 chars, ends '.') | ✓ |
| `scripts/run_tests.sh tests/skills/` | ✓ 1,635 passed, 0 failed |
| Vendor-string grep outside attribution | 0 hits |

Upstream credit: [techjanitor/botmaker](https://github.com/techjanitor/botmaker) (MIT). Not live-run e2e (creating bots is an interactive, human-gated workflow); scripts and loader integration verified.

## Infographic
![botmaker infographic](https://v3b.fal.media/files/b/0aaa2745/aJ1ASgg4QIxPBdcLw1VqI_SnfotCbJ.png)
