### PR TITLE
fix(cron): long fenced deliveries no longer recorded as failed 'ownership lost' (#108341, #100401; salvage #106745)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2604,7 +2604,7 @@ def heartbeat_fire_claim(job_id: str, *, expected_owner: str) -> bool:
     def apply(jobs, _i, job):
         return _refresh_claim(jobs, job.get("fire_claim"), expected_owner)
 
-    return _under_fire_fence(job_id, lambda: _with_job(job_id, apply, False))
+    return _with_job(job_id, apply, False)
 
 
 # Completed one-shots are retained in jobs.json (final status stays inspectable) and pruned by

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2600,7 +2600,10 @@ def claim_job_for_fire(
 
 def heartbeat_fire_claim(job_id: str, *, expected_owner: str) -> bool:
     """Refresh an active ``fire_claim`` without extending another owner's lease: an execution may
-    outlive the TTL, and the owner check stops a stale runner from refreshing a recovered claim."""
+    outlive the TTL, and the owner check stops a stale runner from refreshing a recovered claim.
+    Deliberately NOT under ``_under_fire_fence``: the run thread holds the per-job fence across
+    delivery, and the fence's reentrancy is per thread, so the heartbeat thread would time out and
+    report a false ownership loss. ``_jobs_lock`` already serializes the compare-and-refresh."""
     def apply(jobs, _i, job):
         return _refresh_claim(jobs, job.get("fire_claim"), expected_owner)
 

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -9,14 +9,8 @@ E2E-over-mocks discipline for file-touching code.
 """
 import threading
 import time
-from pathlib import Path
 
 import pytest
-
-try:
-    import fcntl
-except ImportError:  # pragma: no cover - non-POSIX
-    fcntl = None
 
 
 @pytest.fixture
@@ -333,116 +327,34 @@ def test_fresh_claim_from_a_dead_same_host_owner_is_reclaimable(temp_home):
     assert claim_job_for_fire(jid) is True
 
 
-def _hold_jobs_flock(path: Path, release: threading.Event, held: threading.Event):
-    """Hold an exclusive flock on *path* from a separate fd until released.
-
-    flock locks are per-open-file-description, so a second open() in the SAME
-    process contends exactly like another process would.
-    """
-    fd = open(path, "a+", encoding="utf-8")
-    try:
-        fcntl.flock(fd, fcntl.LOCK_EX)
-        held.set()
-        release.wait(timeout=30)
-    finally:
-        try:
-            fcntl.flock(fd, fcntl.LOCK_UN)
-        except OSError:
-            pass
-        fd.close()
-
-
-def test_heartbeat_fire_claim_missing_job_returns_false(temp_home):
+def test_heartbeat_does_not_wait_on_the_fence_its_own_run_holds(temp_home, monkeypatch):
+    """The run thread holds the per-job fire fence across delivery; the heartbeat thread must
+    refresh the claim without taking it, or every long run reads as a false ownership loss."""
     import cron.jobs as jobs
 
-    assert jobs.heartbeat_fire_claim("nope-does-not-exist", expected_owner="anyone") is False
+    job = jobs.create_job(prompt="x", schedule="every 5m", name="long-run")
+    assert jobs.claim_job_for_fire(job["id"]) is True
+    owner = jobs.get_job(job["id"])["fire_claim"]["by"]
+    # Keep the pre-fix path fast: the heartbeat used to block for the full fence timeout (30s).
+    monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.2)
 
+    fence_held, release, result = threading.Event(), threading.Event(), {}
 
-@pytest.mark.skipif(fcntl is None, reason="flock semantics are POSIX-only")
-def test_heartbeat_does_not_pin_fire_fence_while_jobs_lock_contended(temp_home, monkeypatch):
-    """Correct-owner heartbeat must not hold fire_fence across a .jobs.lock wait.
+    def hold_fence():
+        with jobs.fire_claim_fence(job["id"], expected_owner=owner) as owns:
+            result["owns"] = owns
+            fence_held.set()
+            release.wait(timeout=5)
 
-    Contended path: another thread holds ``.jobs.lock`` while the owner calls
-    ``heartbeat_fire_claim``; concurrently ``mark_job_run`` needs the fire fence.
-
-    PRE-FIX: heartbeat wraps ``_with_job`` in ``_under_fire_fence``, so the
-    flock wait keeps fire_fence held and ``mark_job_run`` fails closed (False).
-    POST-FIX: heartbeat only CAS-refreshes via ``_with_job``; mark can take the
-    fence and succeed (or at least is not fence-blocked by the heartbeat).
-    """
-    from datetime import datetime, timedelta
-
-    import cron.jobs as jobs
-
-    job = jobs.create_job(prompt="x", schedule="every 5m", name="fence-hostage")
-    jid = job["id"]
-    assert jobs.claim_job_for_fire(jid) is True
-    claimed = jobs.get_job(jid)["fire_claim"]
-    owner = claimed["by"]
-    claimed_at = datetime.fromisoformat(claimed["at"])
-    monkeypatch.setattr(jobs, "_hermes_now", lambda: claimed_at + timedelta(seconds=30))
-    monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.8)
-
-    lock_path = jobs._jobs_lock_file()
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    lock_path.touch()
-
-    release = threading.Event()
-    held = threading.Event()
-    heartbeat_waiting_on_jobs_lock = threading.Event()
-    results = {}
-    real_acquire = jobs._acquire_flock
-    real_refresh = jobs._refresh_claim
-
-    def wrapped_acquire(lock_fd, timeout):
-        name = Path(getattr(lock_fd, "name", "") or "").name
-        if name == ".jobs.lock":
-            heartbeat_waiting_on_jobs_lock.set()
-        return real_acquire(lock_fd, timeout)
-
-    def wrapped_refresh(job_list, claim, expected_owner):
-        ok = real_refresh(job_list, claim, expected_owner)
-        if ok:
-            results["refreshed_at"] = claim.get("at")
-            results["refreshed_by"] = claim.get("by")
-        return ok
-
-    monkeypatch.setattr(jobs, "_acquire_flock", wrapped_acquire)
-    monkeypatch.setattr(jobs, "_refresh_claim", wrapped_refresh)
-
-    holder = threading.Thread(
-        target=_hold_jobs_flock, args=(lock_path, release, held), daemon=True,
-    )
+    holder = threading.Thread(target=hold_fence, daemon=True)
     holder.start()
-    assert held.wait(timeout=5), "test holder failed to take .jobs.lock"
-
-    def run_heartbeat():
-        results["heartbeat"] = jobs.heartbeat_fire_claim(jid, expected_owner=owner)
-
-    def run_mark():
-        results["mark"] = jobs.mark_job_run(jid, True, expected_fire_owner=owner)
-
     try:
-        hb_thread = threading.Thread(target=run_heartbeat)
-        hb_thread.start()
-        assert heartbeat_waiting_on_jobs_lock.wait(timeout=5), (
-            "heartbeat never reached the .jobs.lock wait inside _with_job/save_jobs"
-        )
-
-        mark_thread = threading.Thread(target=run_mark)
-        mark_thread.start()
-        mark_thread.join(timeout=8)
-        hb_thread.join(timeout=8)
-        assert mark_thread.is_alive() is False
-        assert hb_thread.is_alive() is False
+        assert fence_held.wait(timeout=5)
+        assert jobs.heartbeat_fire_claim(job["id"], expected_owner=owner) is True
+        # A genuine takeover is still detected while the fence is busy.
+        assert jobs.heartbeat_fire_claim(job["id"], expected_owner="replacement-owner") is False
     finally:
         release.set()
         holder.join(timeout=5)
-
-    assert results.get("heartbeat") is True
-    assert results.get("refreshed_by") == owner
-    assert results.get("refreshed_at") != claimed["at"]
-    assert results.get("mark") is True, (
-        "mark_job_run failed closed while heartbeat held fire_fence across the "
-        ".jobs.lock wait (heartbeat must not wrap _with_job in _under_fire_fence)"
-    )
+    assert result == {"owns": True}
+    assert holder.is_alive() is False

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -9,8 +9,14 @@ E2E-over-mocks discipline for file-touching code.
 """
 import threading
 import time
+from pathlib import Path
 
 import pytest
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - non-POSIX
+    fcntl = None
 
 
 @pytest.fixture
@@ -325,3 +331,118 @@ def test_fresh_claim_from_a_dead_same_host_owner_is_reclaimable(temp_home):
     job["fire_claim"]["by"] = f"{socket.gethostname()}:{child.pid}:tok"
     save_jobs(jobs)
     assert claim_job_for_fire(jid) is True
+
+
+def _hold_jobs_flock(path: Path, release: threading.Event, held: threading.Event):
+    """Hold an exclusive flock on *path* from a separate fd until released.
+
+    flock locks are per-open-file-description, so a second open() in the SAME
+    process contends exactly like another process would.
+    """
+    fd = open(path, "a+", encoding="utf-8")
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        held.set()
+        release.wait(timeout=30)
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        fd.close()
+
+
+def test_heartbeat_fire_claim_missing_job_returns_false(temp_home):
+    import cron.jobs as jobs
+
+    assert jobs.heartbeat_fire_claim("nope-does-not-exist", expected_owner="anyone") is False
+
+
+@pytest.mark.skipif(fcntl is None, reason="flock semantics are POSIX-only")
+def test_heartbeat_does_not_pin_fire_fence_while_jobs_lock_contended(temp_home, monkeypatch):
+    """Correct-owner heartbeat must not hold fire_fence across a .jobs.lock wait.
+
+    Contended path: another thread holds ``.jobs.lock`` while the owner calls
+    ``heartbeat_fire_claim``; concurrently ``mark_job_run`` needs the fire fence.
+
+    PRE-FIX: heartbeat wraps ``_with_job`` in ``_under_fire_fence``, so the
+    flock wait keeps fire_fence held and ``mark_job_run`` fails closed (False).
+    POST-FIX: heartbeat only CAS-refreshes via ``_with_job``; mark can take the
+    fence and succeed (or at least is not fence-blocked by the heartbeat).
+    """
+    from datetime import datetime, timedelta
+
+    import cron.jobs as jobs
+
+    job = jobs.create_job(prompt="x", schedule="every 5m", name="fence-hostage")
+    jid = job["id"]
+    assert jobs.claim_job_for_fire(jid) is True
+    claimed = jobs.get_job(jid)["fire_claim"]
+    owner = claimed["by"]
+    claimed_at = datetime.fromisoformat(claimed["at"])
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: claimed_at + timedelta(seconds=30))
+    monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.8)
+
+    lock_path = jobs._jobs_lock_file()
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.touch()
+
+    release = threading.Event()
+    held = threading.Event()
+    heartbeat_waiting_on_jobs_lock = threading.Event()
+    results = {}
+    real_acquire = jobs._acquire_flock
+    real_refresh = jobs._refresh_claim
+
+    def wrapped_acquire(lock_fd, timeout):
+        name = Path(getattr(lock_fd, "name", "") or "").name
+        if name == ".jobs.lock":
+            heartbeat_waiting_on_jobs_lock.set()
+        return real_acquire(lock_fd, timeout)
+
+    def wrapped_refresh(job_list, claim, expected_owner):
+        ok = real_refresh(job_list, claim, expected_owner)
+        if ok:
+            results["refreshed_at"] = claim.get("at")
+            results["refreshed_by"] = claim.get("by")
+        return ok
+
+    monkeypatch.setattr(jobs, "_acquire_flock", wrapped_acquire)
+    monkeypatch.setattr(jobs, "_refresh_claim", wrapped_refresh)
+
+    holder = threading.Thread(
+        target=_hold_jobs_flock, args=(lock_path, release, held), daemon=True,
+    )
+    holder.start()
+    assert held.wait(timeout=5), "test holder failed to take .jobs.lock"
+
+    def run_heartbeat():
+        results["heartbeat"] = jobs.heartbeat_fire_claim(jid, expected_owner=owner)
+
+    def run_mark():
+        results["mark"] = jobs.mark_job_run(jid, True, expected_fire_owner=owner)
+
+    try:
+        hb_thread = threading.Thread(target=run_heartbeat)
+        hb_thread.start()
+        assert heartbeat_waiting_on_jobs_lock.wait(timeout=5), (
+            "heartbeat never reached the .jobs.lock wait inside _with_job/save_jobs"
+        )
+
+        mark_thread = threading.Thread(target=run_mark)
+        mark_thread.start()
+        mark_thread.join(timeout=8)
+        hb_thread.join(timeout=8)
+        assert mark_thread.is_alive() is False
+        assert hb_thread.is_alive() is False
+    finally:
+        release.set()
+        holder.join(timeout=5)
+
+    assert results.get("heartbeat") is True
+    assert results.get("refreshed_by") == owner
+    assert results.get("refreshed_at") != claimed["at"]
+    assert results.get("mark") is True, (
+        "mark_job_run failed closed while heartbeat held fire_fence across the "
+        ".jobs.lock wait (heartbeat must not wrap _with_job in _under_fire_fence)"
+    )


### PR DESCRIPTION
A cron run whose delivery or agent turn holds the per-job fire fence for longer than 30s is no longer recorded as `failed` / "Fire claim ownership lost" after it actually succeeded.

Fixes #108341, fixes #100401. Salvage of #106745 by @KoNit-K (cherry-picked, authorship preserved); test shape from #100418 by @oheckmann74 and #108359 by @Sahilvishnaliya (Co-authored-by).

### Root cause
The run thread holds `_fire_job_lock` (a per-thread RLock + flock) across delivery. The 60s `cron-fire-claim-heartbeat` thread renewed the claim through the same fence, blocked for `_JOBS_LOCK_TIMEOUT_SECONDS` (30s), failed closed to `False`, and the scheduler read that as a takeover: `lost_ownership` set, run interrupted, ledger row written `failed` while the message had already been delivered.

### Change
- `cron/jobs.py` `heartbeat_fire_claim`: refresh under `_jobs_lock` only (same shape as `heartbeat_run_claim`). `_refresh_claim` still compare-and-swaps on `claim["by"] == expected_owner`, so a real takeover keeps returning `False`. Docstring records why the fence is deliberately not taken.
- `tests/cron/test_claim_job_for_fire.py`: one invariant test — worker thread holds `fire_claim_fence`, heartbeat on the calling thread returns `True`, heartbeat for a foreign owner returns `False`. Fails on unfixed `jobs.py` in ~2s.

### Validation
| Check | main d62716c7 | this branch |
|---|---|---|
| heartbeat while another thread holds the fence | `False` after timeout | `True`, ~0ms |
| heartbeat after `claim.by` takeover | `False` | `False` |
| E2E through `scheduler._run_with_fire_claim_heartbeat`, run holds fence 3s > heartbeat period | `lost_ownership` set, "interrupting stale run" | not set, claim retained |
| new test | fails (1.9s) | passes |
| `scripts/run_tests.sh tests/cron/` | — | 1247 passed; 1 failure (`test_ensure_hermes_home_sets_0700`) reproduces on main, unrelated |

Lock ordering audited: every fence+jobs_lock site is fence→jobs_lock; the heartbeat now takes strictly fewer locks, no new ordering. Remaining `_under_fire_fence` users (`claim_job_for_fire`, `mark_job_run`) mutate `by` and run on the owner thread — correct.

### Related open PRs (same bug)
#95432 #97565 #100418 #100965 #102627 #104286 #105724 #106745 #107226 #107844 #108018 #108359 #108471 #109003 #109083 — this PR carries the smallest fix from that cluster; the tri-state/scheduler-side variants are unnecessary once the heartbeat no longer waits on the fence.
