### PR TITLE
fix(cli): purge every top-level checkout module, not just five packages

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -97,8 +97,9 @@ from hermes_cli.update_cmd_git import (  # noqa: F401
     _prune_orphan_rescue_refs, _should_skip_upstream_prompt, _sync_fork_with_upstream,
     _sync_with_upstream_if_needed)
 from hermes_cli.update_cmd_maint import (  # noqa: F401
-    _PRE_UPDATE_SNAPSHOT_KEEP, _PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE, _STALE_PURGE_PREFIXES,
-    _STALE_PURGE_PROTECTED, _UPDATE_RUNTIME_RELOAD_MODULES, _clear_stale_sqlite_sidecars,
+    _PRE_UPDATE_SNAPSHOT_KEEP, _PRE_UPDATE_SNAPSHOT_MAX_FILE_SIZE,
+    _STALE_PURGE_EXCLUDED_TOP_LEVEL, _STALE_PURGE_PREFIXES, _STALE_PURGE_PROTECTED,
+    _UPDATE_RUNTIME_RELOAD_MODULES, _clear_stale_sqlite_sidecars,
     _ensure_acp_launcher, _ensure_fhs_path_guard, _finish_dashboard_update_cleanup,
     _format_time_ago, _post_update_sqlite_runtime_status, _print_bundled_skills_sync_report,
     _print_curator_first_run_notice, _print_curator_recent_run_notice,
@@ -106,7 +107,8 @@ from hermes_cli.update_cmd_maint import (  # noqa: F401
     _print_verified_update_completion, _purge_stale_hermes_modules, _read_project_version,
     _reload_process_scan_modules, _reload_updated_runtime_modules,
     _resolve_pre_update_backup_mode, _restore_state_db_from_snapshot,
-    _run_post_update_maintenance, _run_pre_update_backup, _sweep_bytecode_after_update,
+    _run_post_update_maintenance, _run_pre_update_backup, _stale_purge_prefixes,
+    _sweep_bytecode_after_update,
     _update_complete_message, _verify_and_restore_one_state_db,
     _verify_and_restore_state_dbs_post_update)
 logger = logging.getLogger(__name__)

--- a/hermes_cli/update_cmd_maint.py
+++ b/hermes_cli/update_cmd_maint.py
@@ -25,13 +25,22 @@ logger = logging.getLogger("hermes_cli.update_cmd")
 
 _UPDATE_RUNTIME_RELOAD_MODULES = "hermes_constants", "tools.environments.local", "tools.lazy_deps"
 
-#: Package prefixes whose cached modules go stale when the checkout changes under this
-#: process; purged (not reloaded) so any LATER import chain resolves against fresh source.
+#: Fallback for the purge's top-level names when the checkout scan below cannot run; the
+#: live set comes from ``_stale_purge_prefixes()``.
 _STALE_PURGE_PREFIXES = "hermes_cli", "gateway", "tools", "tui_gateway", "agent"
+
+#: Owned by the checkout but never purged: pytest resolves fixtures through the identity of
+#: its own already-imported test modules, and evicting them mid-session breaks that.
+_STALE_PURGE_EXCLUDED_TOP_LEVEL = frozenset({"tests"})
 
 #: Modules EXECUTING the update survive the purge: evicting them buys nothing (running frames
 #: keep them alive) and reloading them mid-flight is the one genuinely unsafe move.
-_STALE_PURGE_PROTECTED = frozenset({"hermes_cli", "hermes_cli.main", "hermes_cli.hermes_logging"})
+#: ``hermes_logging`` is protected for a different reason: its queue listener, handler list and
+#: ``_logging_initialized`` flag are module globals, so a fresh copy starts a SECOND
+#: QueueListener over the same log files while the first one keeps running.
+_STALE_PURGE_PROTECTED = frozenset({
+    "hermes_cli", "hermes_cli.main", "hermes_cli.hermes_logging", "hermes_logging",
+})
 
 #: The updater's own module family (``update_cmd*``, ``update_receipt``, ``update_inventory``,
 #: ``update_lock``, ...) is protected as a prefix: these hold per-run state — the open receipt
@@ -70,6 +79,26 @@ def _reload_modules(names, *, modules, log) -> None:
             log(module_name, exc)
 
 
+def _stale_purge_prefixes() -> frozenset:
+    """Top-level names the checkout owns, for the post-pull purge.
+
+    Scanned, not listed: a hardcoded tuple stops covering each newly added top-level module
+    without anything failing, and the symbol that breaks the next update is in whichever one
+    drifted out — ``utils`` gaining ``base_url_origin`` was the field case.
+    """
+    from hermes_cli.update_cmd import _m
+    names = set(_STALE_PURGE_PREFIXES)
+    try:
+        for entry in Path(_m().PROJECT_ROOT).iterdir():
+            if entry.suffix == ".py" and entry.is_file():
+                names.add(entry.stem)
+            elif (entry / "__init__.py").is_file():
+                names.add(entry.name)
+    except OSError as exc:
+        logger.debug("Could not scan the checkout for purge prefixes: %s", exc)
+    return frozenset(names) - _STALE_PURGE_EXCLUDED_TOP_LEVEL
+
+
 def _purge_stale_hermes_modules() -> None:
     """Evict every cached Hermes module after the checkout changed in-place. Never raises.
 
@@ -82,12 +111,13 @@ def _purge_stale_hermes_modules() -> None:
     with _best_effort('Could not purge stale Hermes modules: %s'):
         importlib.invalidate_caches()
         modules = _m().sys.modules
+        prefixes = _stale_purge_prefixes()
         purged = [
             name for name in list(modules)
             if name not in _STALE_PURGE_PROTECTED
             and not name.startswith(_STALE_PURGE_PROTECTED_PREFIX)
             # Root-package check: startswith() alone also matches unrelated ``gateway_foo``.
-            and name.split(".", 1)[0] in _STALE_PURGE_PREFIXES
+            and name.split(".", 1)[0] in prefixes
             and modules.pop(name, None) is not None
         ]
         if purged:

--- a/tests/hermes_cli/test_update_stale_module_purge.py
+++ b/tests/hermes_cli/test_update_stale_module_purge.py
@@ -172,3 +172,81 @@ def test_purge_keeps_plan_record_class_identity():
     cli_main._purge_stale_hermes_modules()
     from hermes_cli.update_inventory import RuntimeRecord as after
     assert after is before
+
+
+def test_purge_prefixes_cover_checkout_top_level_modules():
+    # The static tuple listed 5 packages and no top-level module, so `utils`,
+    # `hermes_constants` and friends stayed cached through every update.
+    prefixes = update_cmd._stale_purge_prefixes()
+    for name in ("utils", "hermes_constants", "hermes_bootstrap", "plugins", "providers"):
+        assert name in prefixes, f"{name} is not covered by the purge"
+    for name in ("hermes_cli", "gateway", "tools", "tui_gateway", "agent"):
+        assert name in prefixes
+
+
+def test_stale_top_level_utils_scenario_end_to_end():
+    """The 2026-09-12 field failure: `hermes update` from a pre-`base_url_origin`
+    checkout kept the old top-level `utils` cached, and the restart phase's import of
+    `hermes_cli.gateway` died on `from utils import base_url_origin`."""
+    stale = types.ModuleType("utils")
+    real = sys.modules.get("utils")
+    sys.modules["utils"] = stale
+    try:
+        try:
+            from utils import base_url_origin  # noqa: F401
+            raised = False
+        except ImportError:
+            raised = True
+        assert raised, "precondition: stale utils must lack base_url_origin"
+
+        cli_main._purge_stale_hermes_modules()
+
+        from utils import base_url_origin  # noqa: F401
+    finally:
+        sys.modules.pop("utils", None)
+        if real is not None:
+            sys.modules["utils"] = real
+
+
+def test_purge_protects_hermes_logging():
+    # A second copy of hermes_logging starts a second QueueListener over the same log
+    # files while the first keeps running: its listener/handler state is module-global.
+    real = sys.modules.get("hermes_logging")
+    sentinel = _fake_module("hermes_logging")
+    sys.modules["hermes_logging"] = sentinel
+    try:
+        cli_main._purge_stale_hermes_modules()
+        assert sys.modules.get("hermes_logging") is sentinel
+    finally:
+        sys.modules.pop("hermes_logging", None)
+        if real is not None:
+            sys.modules["hermes_logging"] = real
+
+
+def test_purge_spares_the_tests_package():
+    # pytest resolves fixtures through the identity of already-imported test modules.
+    sentinel = _fake_module("tests.hermes_cli._purge_probe")
+    sys.modules["tests.hermes_cli._purge_probe"] = sentinel
+    try:
+        cli_main._purge_stale_hermes_modules()
+        assert sys.modules.get("tests.hermes_cli._purge_probe") is sentinel
+    finally:
+        sys.modules.pop("tests.hermes_cli._purge_probe", None)
+
+
+def test_purge_prefixes_follow_project_root(tmp_path, monkeypatch):
+    # The scan must read main.PROJECT_ROOT, not this module's own __file__: tests and the
+    # installer both relocate the checkout, and a divergent root silently purges nothing.
+    (tmp_path / "zzz_probe.py").write_text("", encoding="utf-8")
+    (tmp_path / "zzz_pkg").mkdir()
+    (tmp_path / "zzz_pkg" / "__init__.py").write_text("", encoding="utf-8")
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", tmp_path)
+
+    prefixes = update_cmd._stale_purge_prefixes()
+    assert {"zzz_probe", "zzz_pkg"} <= prefixes
+    assert set(update_cmd._STALE_PURGE_PREFIXES) <= prefixes
+
+
+def test_purge_prefixes_fall_back_when_root_unreadable(tmp_path, monkeypatch):
+    monkeypatch.setattr(cli_main, "PROJECT_ROOT", tmp_path / "does-not-exist")
+    assert update_cmd._stale_purge_prefixes() == frozenset(update_cmd._STALE_PURGE_PREFIXES)


### PR DESCRIPTION
## What does this PR do?

`_STALE_PURGE_PREFIXES` listed five package names — `hermes_cli`, `gateway`, `tools`, `tui_gateway`, `agent` — so the post-pull purge skipped **every top-level module in the checkout root**. `hermes update` then went on to import freshly pulled source against a cached pre-pull `utils`, `hermes_constants`, `hermes_bootstrap`, `plugins` or `providers`.

Hit in the field on 2026-09-12 (macOS 26, Darwin 25.6.0) updating `0.20.6 → 0.21.2`. That range crosses 3145986c20, which added `base_url_origin` to `utils.py`. The restart phase's deliberate up-front `from hermes_cli.gateway import ...` pulls in `agent.auxiliary_client`, whose module-level `from utils import base_url_origin` resolved against the cached 0.20.6 `utils`:

```
⚠ Update incomplete — gateway auto-restart failed: cannot import name 'base_url_origin' from 'utils' (/Users/…/hermes-agent/utils.py)
```

The whole restart phase aborted, and `fleet_restart_pending` was left behind.

`_purge_stale_hermes_modules`'s own docstring already promises it evicts *every* cached Hermes module, and the module comment criticises `_UPDATE_RUNTIME_RELOAD_MODULES` for being "re-fixed per symptom". The hardcoded five-name tuple had the same shape and drifted the same way — adding `utils` (or the next new top-level module) to the tuple by hand would just restart the cycle.

So this scans `PROJECT_ROOT` instead: top-level `.py` files, plus directories containing an `__init__.py`. That yields 50 names on current `main` rather than 5, and a newly added top-level module cannot silently fall out of coverage again.

## Related Issue

No existing issue — I searched open and closed issues and PRs first, per CONTRIBUTING. Related but distinct: #88371, #90535, #92535, #98037 are other stale-`sys.modules` symptoms, all inside the five covered packages.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd_maint.py`
  - New `_stale_purge_prefixes()` scans `_m().PROJECT_ROOT` for top-level modules and packages, unioned with the existing tuple. `PROJECT_ROOT` rather than `__file__` so a relocated checkout and monkeypatching tests both stay honest.
  - `_STALE_PURGE_PREFIXES` is kept as the fallback when the root is unreadable (`OSError` → debug log, old behaviour).
  - `_purge_stale_hermes_modules()` filters on the scanned set.
  - `hermes_logging` added to `_STALE_PURGE_PROTECTED`. Its queue listener, queued-handler list and `_logging_initialized` flag are module globals, so a purged-and-reimported copy starts a **second** `QueueListener` over the same log files while the first is still running. Note this is the *top-level* `hermes_logging`, distinct from the already-protected `hermes_cli.hermes_logging`.
  - New `_STALE_PURGE_EXCLUDED_TOP_LEVEL = {"tests"}`. pytest resolves fixtures through the identity of its already-imported test modules, and the purge is called directly from several tests.
- `hermes_cli/update_cmd.py` — re-exports `_stale_purge_prefixes` and `_STALE_PURGE_EXCLUDED_TOP_LEVEL`, per the module's "re-imports every name" convention.
- `tests/hermes_cli/test_update_stale_module_purge.py` — four new tests (details below).

## How to Test

Reproduction, without needing a real update:

```python
import sys, types
from hermes_cli import main as cli_main

sys.modules["utils"] = types.ModuleType("utils")     # pre-`base_url_origin` checkout
cli_main._purge_stale_hermes_modules()
from utils import base_url_origin                     # ImportError before this PR
```

Test suite:

1. `pytest tests/hermes_cli/test_update_stale_module_purge.py -q` → **13 passed** (9 existing + 4 new).
2. `scripts/run_tests.sh tests/hermes_cli/ -q` → 16 failures across 6 files.

On (2): those 16 failures are **pre-existing on `main`, not caused by this PR**. I confirmed by stashing this branch's changes and re-running the same six files on a clean tree — byte-identical failure list (`test_update_autostash.py` ×9, `test_dashboard_auth_gate.py` ×2, `test_update_launchd_fleet_restart.py` ×2, `test_session_recovery_lost_and_found.py` ×1, `test_update_head_moved_gate.py` ×1, `test_update_fleet_restart_pending.py` ×1). I have not run the full `tests/` tree.

New tests:

- `test_purge_prefixes_cover_checkout_top_level_modules` — `utils`, `hermes_constants`, `hermes_bootstrap`, `plugins`, `providers` are all covered.
- `test_stale_top_level_utils_scenario_end_to_end` — the field failure above, asserted both ways round.
- `test_purge_protects_hermes_logging` — a sentinel `hermes_logging` survives.
- `test_purge_spares_the_tests_package` — a sentinel under `tests.` survives.
- `test_purge_prefixes_follow_project_root` / `test_purge_prefixes_fall_back_when_root_unreadable` — the scan tracks a monkeypatched `PROJECT_ROOT`, and degrades to the static tuple when the root does not exist.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass — see "How to Test": the purge file is green; `tests/hermes_cli/` has 16 failures that reproduce identically on unmodified `main`. Full tree not run.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26 (Darwin 25.6.0), arm64, Python 3.11

### Documentation & Housekeeping

- [x] Documentation — N/A (behaviour is internal to the updater; the changed constants carry their rationale inline)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — the scan is `pathlib` only, no shell or platform branch; `OSError` falls back to today's behaviour. Reported on macOS, but the bug is platform-independent.
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Before, on a real `0.20.6 → 0.21.2` update:

```
✓ Update complete! (v0.20.6 → v0.21.2) [main @ d62716c704]

⚠ Update incomplete — gateway auto-restart failed: cannot import name 'base_url_origin' from 'utils' (/Users/…/.hermes/hermes-agent/utils.py)
```
