### PR TITLE
fix(botmaker): respect installation root and specialist roster

### DIFF
--- a/optional-skills/autonomous-ai-agents/botmaker/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/botmaker/SKILL.md
@@ -26,12 +26,12 @@ Details: `references/soul-craft.md` (SOUL + human gate), `references/process.md`
 - `Bots/` in the vault needs a specialist note, roster row, or `making-bots.md` changelog
 - A shared skill is about to be copied into a profile (stop; symlink files instead)
 
-Don't use for: operating the inference server, ComfyUI, or any service; general coding; rewriting default `~/.hermes/SOUL.md`; spawning `botmaker-2`. `@hermes` is not the bot coordinator — you are.
+Don't use for: operating the inference server, ComfyUI, or any service; general coding; rewriting default `$hermes_root/SOUL.md`; spawning `botmaker-2`. `@hermes` is not the bot coordinator — you are.
 
 ## Prerequisites
 
 - Hermes CLI (`hermes profile create --help`)
-- Canonical skills live under `~/.hermes/skills/` (default Hermes home), **not** `$HERMES_HOME/skills` when you are the botmaker profile
+- Resolve the installation root as `hermes_root` before any write (`references/process.md` §Installation root). Canonical skills live under `$hermes_root/skills/`, **not** the active named profile's skills directory. Never substitute a different installation's default path.
 - Vault: `<your-vault-path>` (see `references/vault.md`). Vault documentation is an optional convention — if the user has no vault, skip the vault steps.
 - Human guide, fleet roster, changelog: vault `Bots/making-bots.md` (create it on first ship). Method lives here only; fleet state lives there only — patch a lesson's one owner and log one changelog line.
 
@@ -49,7 +49,7 @@ Don't use for: operating the inference server, ComfyUI, or any service; general 
 |---|---|
 | New bot | Alias preflight (Procedure C) → Interview → SOUL draft → human sign-off → `hermes profile create NAME --no-skills --description "…"` |
 | Pin a brain | `hermes -p NAME config set model.provider …` then `model.default …`. Then **unset** the copied `base_url` / `api_key` (create copies your default profile's model block, whatever it currently is) |
-| Shared skill | Canonical `~/.hermes/skills/<cat>/<name>/`; profile files via `scripts/link_skill_tree.py`. Never a directory symlink. Load linked `references/` with `read_file` on the canonical path |
+| Shared skill | Canonical `$hermes_root/skills/<cat>/<name>/`; profile files via `scripts/link_skill_tree.py`. Never a directory symlink. Load linked `references/` with `read_file` on the canonical path |
 | Vault after cert | `Bots/<name>.md` (`type: bot-reference`), roster row on `making-bots.md`, one line on `Home.md` |
 | Child memory | Child writes it. You do not. |
 
@@ -62,7 +62,7 @@ Ask, and do not proceed until 1–3 are sharp:
 1. One-sentence job. If "and also," split into two bots. Job may be a CLI, an HTTP API, a GUI sock — ComfyUI counts. "CLI-only" is how we *create* the profile, not what the specialist is allowed to operate.
 2. Failure the brain must survive → model pin (if the bot's job lives on a local box, that usually means a hosted provider — the bot must still think when the box is down).
 3. What it is not.
-4. Does default Hermes need the same skill? → canonical under `~/.hermes/skills/` + file-level symlinks.
+4. Does default Hermes need the same skill? → canonical under `$hermes_root/skills/` + file-level symlinks.
 5. Who is the client to ping (`@hermes`, another specialist, nobody).
 6. Voice: inherit vs write. Inheritance is tone, not the model's stock identity — that is costume unless the bot *is* a persona bot (if your fleet has one).
 
@@ -88,11 +88,11 @@ If **either** finds anything: `--no-alias` (rationale and the landmines: `refere
 
 - `--no-skills`; never `--clone` / desktop clone. Pin the brain, then unset the copied `base_url`/`api_key`; `config get model` must show only `default` + `provider`.
 - **Peers + memory provider — check after every create** (site-specific; commands and verification: `references/process.md` §Independence). The invariant: every rostered profile has every peer it must reach. Do not print keys.
-- Sibling-profile CLI from this profile: always prefix `HERMES_HOME=$HOME/.hermes`.
+- Sibling-profile CLI: use the verified installation root from `references/process.md`, with an unset-variable guard. Stop if root discovery fails or points outside the intended installation.
 - By default, `SOUL.md` writes prompt your human (`security.protected_instruction_files: true`) — that prompt is the human gate materialized. If your fleet disabled it for headless provisioning (see `profile/config.yaml` in this repo), the signature is the only gate: no human-signed draft or signed spec, no write. If a write is blocked anyway, stop — do **not** sneak it in via the shell.
 - Never hand-edit `config.yaml` — `config set` only (your human may hand-edit their own; you do not). Never copy credentials. Never print `auth.api_key` / `secret_key`.
 
-Then: write signed `SOUL.md`, thin `memories/USER.md` — if the skill is shared, include the **lockstep sentence**: one line stating that the canonical skill lives under `~/.hermes/skills/<category>/<name>/`, the profile files are symlinks, and process changes patch the canonical tree (so later sessions do not re-flag the drift). Then empty-or-tiny `memories/MEMORY.md` (the child fills this). Install the runbook skill; link shared skills file-level (`references/process.md` §Shared skills). Not every specialist needs a custom skill — `@hostadmin` is `hermes-agent` + earned MEMORY. Do not invent a runbook so the folder looks complete.
+Then: write signed `SOUL.md`, thin `memories/USER.md` — if the skill is shared, include the **lockstep sentence**: one line stating that the canonical skill lives under `$hermes_root/skills/<category>/<name>/`, the profile files are symlinks, and process changes patch the canonical tree (so later sessions do not re-flag the drift). Then empty-or-tiny `memories/MEMORY.md` (the child fills this). Install the runbook skill; link shared skills file-level (`references/process.md` §Shared skills). Not every specialist needs a custom skill — `@hostadmin` is `hermes-agent` + earned MEMORY. Do not invent a runbook so the folder looks complete.
 
 Stop. Do not fill the child's `MEMORY.md`. Do not add a vault roster row yet.
 
@@ -139,4 +139,4 @@ A new bot is done when:
 6. `SOUL.md` matches the signed draft (one screen).
 7. Shared skills: `ls -l` on profile `SKILL.md` shows `l` (symlink), canonical is a regular file. `rglob` from the profile skills dir finds `SKILL.md`.
 8. After certification only: vault note + roster row + Home line + `making-bots.md` changelog.
-9. `python3 "$HOME/.hermes/skills/autonomous-ai-agents/botmaker/scripts/drift_check.py"` exits 0.
+9. `python3 "${hermes_root:?resolve installation root first}/skills/autonomous-ai-agents/botmaker/scripts/drift_check.py" --hermes-root "$hermes_root"` exits 0. The roster check validates listed specialists exist; personas, daily drivers, and uncertified profiles need no row.

--- a/optional-skills/autonomous-ai-agents/botmaker/references/process.md
+++ b/optional-skills/autonomous-ai-agents/botmaker/references/process.md
@@ -6,6 +6,19 @@ Interview → SOUL draft → human sign-off → scaffold → child's Bot Chat (f
 
 You draft. The child earns. If you fill `MEMORY.md`, you faked the training loop.
 
+## Installation root
+
+Before any write, discover the root through the same Hermes CLI that owns this session. `hermes -p default config path` uses Hermes's root resolver even from a named profile; it respects custom homes. Do not overwrite `HERMES_HOME` before discovery.
+
+```bash
+unset hermes_root
+root_config="$(hermes -p default config path)" &&
+hermes_root="$(python3 -c 'from pathlib import Path; import sys; p = Path(sys.argv[1]); assert p.is_absolute() and p.name == "config.yaml", "unexpected config path"; print(p.resolve().parent)' "$root_config")" &&
+test -d "$hermes_root"
+```
+
+If any step fails, stop. Verify the resolved root is the intended installation before creating profiles, writing config/SOUL/memory, or linking skills. Never fall back to another installation or create a replacement root to make a missing path work. `hermes_root` is a local shell variable, not a new Hermes setting; resolve it again in a fresh shell. File tools and persisted instructions need the concrete absolute path, not the literal variable. Keep the default SOUL at that root off-limits. Do not change approval settings to perform this discovery or provisioning.
+
 ## Independence
 
 If the bot operates a service — CLI, HTTP API, GUI control socket, ComfyUI, whatever — **do not run the bot on that service's inference path.**
@@ -39,32 +52,32 @@ hermes honcho sync
 hermes -p NAME config set memory.provider honcho
 ```
 
-Verify `hermes honcho peers` shows the profile with a real user peer (not `(not set)`). If `hermes honcho --target-profile NAME status` says not connected, inherit `apiKey`/`baseUrl`/`requestTimeout` from host `hermes` into `hermes_<name>` in `~/.hermes/honcho.json`. Do not print them. Docs: https://hermes-agent.nousresearch.com/docs/user-guide/features/memory-providers#new-profile-fresh-honcho-peer
+Verify `hermes honcho peers` shows the profile with a real user peer (not `(not set)`). If `hermes honcho --target-profile NAME status` says not connected, inherit `apiKey`/`baseUrl`/`requestTimeout` from host `hermes` into `hermes_<name>` in `$hermes_root/honcho.json`. Do not print them. Docs: https://hermes-agent.nousresearch.com/docs/user-guide/features/memory-providers#new-profile-fresh-honcho-peer
 
 ## Scaffold sequence
 
 Alias preflight (next section) first, then:
 
 ```text
-HERMES_HOME="$HOME/.hermes" hermes profile create NAME --no-skills --description "one or two sentences"
-HERMES_HOME="$HOME/.hermes" hermes -p NAME config set model.provider <provider>
-HERMES_HOME="$HOME/.hermes" hermes -p NAME config set model.default <model>
-HERMES_HOME="$HOME/.hermes" hermes -p NAME config unset model.base_url
-HERMES_HOME="$HOME/.hermes" hermes -p NAME config unset model.api_key
-HERMES_HOME="$HOME/.hermes" hermes profile describe NAME --text "same one or two sentences"
+HERMES_HOME="${hermes_root:?resolve installation root first}" hermes profile create NAME --no-skills --description "one or two sentences"
+HERMES_HOME="${hermes_root:?resolve installation root first}" hermes -p NAME config set model.provider <provider>
+HERMES_HOME="${hermes_root:?resolve installation root first}" hermes -p NAME config set model.default <model>
+HERMES_HOME="${hermes_root:?resolve installation root first}" hermes -p NAME config unset model.base_url
+HERMES_HOME="${hermes_root:?resolve installation root first}" hermes -p NAME config unset model.api_key
+HERMES_HOME="${hermes_root:?resolve installation root first}" hermes profile describe NAME --text "same one or two sentences"
 ```
 
 Site-specific follow-ups — ours, shown as worked examples; adapt or delete (details above):
 
 ```text
 # external peer bridge:
-HERMES_HOME="$HOME/.hermes" hermes -p NAME peer add <peer> --url <peer-url> --key "$(head -1 <keyfile>)"
+HERMES_HOME="${hermes_root:?resolve installation root first}" hermes -p NAME peer add <peer> --url <peer-url> --key "$(head -1 <keyfile>)"
 # Honcho memory provider:
-HERMES_HOME="$HOME/.hermes" hermes honcho sync
-HERMES_HOME="$HOME/.hermes" hermes -p NAME config set memory.provider honcho
+HERMES_HOME="${hermes_root:?resolve installation root first}" hermes honcho sync
+HERMES_HOME="${hermes_root:?resolve installation root first}" hermes -p NAME config set memory.provider honcho
 ```
 
-The `HERMES_HOME` prefix matters: inside a named profile `$HERMES_HOME` is `~/.hermes/profiles/<name>`, not `~/.hermes` — unprefixed sibling CLI (`profile create`, `-p NAME config`, `profile describe`) can hit the wrong home. Canonical skills stay under `$HOME/.hermes/skills/`.
+Inside a named profile `$HERMES_HOME` is `$hermes_root/profiles/<name>`. Hermes already resolves sibling profiles against their installation root; the explicit prefixes above pin commands to the verified root rather than replacing it with a hardcoded default. Canonical skills stay under `$hermes_root/skills/`.
 
 `hermes profile describe` writes the roster one-liner (`profile.yaml`) other bots read — not a group-chat log. It does not set the display **title**, which lives in `profile.yaml`: write `ui_meta.hermes-bots.title` there after describe (`config get ui_meta` reads empty until then). And don't "fix" `config get toolsets` off the wrapper key — the spec list is `platform_toolsets.cli`.
 
@@ -90,9 +103,9 @@ Extra skills are context tax and off-mission bait. Three is already a lot (`botm
 
 ## Shared skills (file-level links)
 
-Canonical tree: `~/.hermes/skills/<category>/<name>/` (default Hermes loads this).
+Canonical tree: `$hermes_root/skills/<category>/<name>/` (default Hermes loads this).
 
-Profile path: `~/.hermes/profiles/<bot>/skills/<category>/<name>/` — **real directories**, every *file* a relative symlink.
+Profile path: `$hermes_root/profiles/<bot>/skills/<category>/<name>/` — **real directories**, every *file* a relative symlink.
 
 Never symlink the skill directory itself. Hermes venv is Python 3.11; `Path.rglob("SKILL.md")` does not descend directory symlinks → empty index → the bot cannot see the skill. File-level `SKILL.md` inside a real dir **is** found.
 
@@ -101,12 +114,12 @@ Never symlink the skill directory itself. Hermes venv is Python 3.11; `Path.rglo
 Linker (this skill):
 
 ```text
-python3 "$HOME/.hermes/skills/autonomous-ai-agents/botmaker/scripts/link_skill_tree.py" \
-  "$HOME/.hermes/skills/<category>/<name>" \
-  "$HOME/.hermes/profiles/<bot>/skills/<category>/<name>"
+python3 "${hermes_root:?resolve installation root first}/skills/autonomous-ai-agents/botmaker/scripts/link_skill_tree.py" \
+  "$hermes_root/skills/<category>/<name>" \
+  "$hermes_root/profiles/<bot>/skills/<category>/<name>"
 ```
 
-Writes through the profile path hit the same inode. If a rewrite unlinks first, `ls -l` shows a regular file instead of `l` — that is a second copy starting again. Relink; do not keep both. `skill_manage` patch on a linked `SKILL.md` does that unlink — patch canonical with the file `patch` tool instead. `skill_manage` `file_path` and `skill_view(..., file_path=…)` on `references/` both fail: `Path.resolve()` follows the file symlink into `~/.hermes/skills/…`, then `relative_to` the profile skill dir rejects it. Workaround: `read_file` the canonical path. Do not tell bots to `skill_view` linked references until Hermes allows it.
+Writes through the profile path hit the same inode. If a rewrite unlinks first, `ls -l` shows a regular file instead of `l` — that is a second copy starting again. Relink; do not keep both. `skill_manage` patch on a linked `SKILL.md` does that unlink — patch canonical with the file `patch` tool instead. `skill_manage` `file_path` and `skill_view(..., file_path=…)` on `references/` both fail: `Path.resolve()` follows the file symlink into `$hermes_root/skills/…`, then `relative_to` the profile skill dir rejects it. Workaround: `read_file` the canonical path. Do not tell bots to `skill_view` linked references until Hermes allows it.
 
 Child `SOUL.md` writes: the gate is the signature — mechanics in `soul-craft.md` §Human gate.
 

--- a/optional-skills/autonomous-ai-agents/botmaker/references/soul-craft.md
+++ b/optional-skills/autonomous-ai-agents/botmaker/references/soul-craft.md
@@ -33,7 +33,7 @@ Botmaker's own voice is editorial craftsman — allergic to costume, picky about
 
 Rewrite a child SOUL only when a **constraint was earned** (the blind-restart class of change), not because the personality drifted. Personality nits go in USER.md or get dropped.
 
-Default `~/.hermes/SOUL.md` is off-limits. Your human does not want it customized to death.
+Default `$hermes_root/SOUL.md` is off-limits. Your human does not want it customized to death.
 
 There is no doctor class. A specialist's runbook includes how to diagnose its own job (CLI, HTTP API, GUI). Botmaker diagnoses the fleet and this process. Do not mint a generic troubleshooter.
 

--- a/optional-skills/autonomous-ai-agents/botmaker/references/vault.md
+++ b/optional-skills/autonomous-ai-agents/botmaker/references/vault.md
@@ -23,6 +23,8 @@ Load your notes skill (if you have one) for filesystem conventions. This file is
 
 Exceptions are dated and expire; none should stay active. (Ours: botmaker's own note briefly existed as *certification pending* during bootstrap. Do not copy that onto children.)
 
+The drift checker verifies rostered profiles exist in the selected installation. It does not require every profile to be rostered: certification determines membership, not directory discovery. Add the new specialist's row as part of the post-certification checklist.
+
 ## Notes
 
 | Note | Frontmatter | Role |
@@ -50,7 +52,7 @@ The roster table on `making-bots.md` is the fleet-state source of truth — whic
 
 ## One home per rule
 
-Every rule has exactly one home — method in the skill tree (`~/.hermes/skills/autonomous-ai-agents/botmaker/`, write the canonical path; profile files are symlinks), fleet state in the roster table on `Bots/making-bots.md`, history in its changelog. When a lesson lands, patch its one owner and add one changelog line naming that owner.
+Every rule has exactly one home — method in the skill tree (`$hermes_root/skills/autonomous-ai-agents/botmaker/`, write the canonical path; profile files are symlinks), fleet state in the roster table on `Bots/making-bots.md`, history in its changelog. When a lesson lands, patch its one owner and add one changelog line naming that owner.
 
 If `making-bots.md` is fresher than this tree, backport before adding anything new — lockstep failed one-directionally for us until we adopted this rule.
 

--- a/optional-skills/autonomous-ai-agents/botmaker/scripts/drift_check.py
+++ b/optional-skills/autonomous-ai-agents/botmaker/scripts/drift_check.py
@@ -3,7 +3,7 @@
 
 Run after every mint and every doc patch:
 
-    python3 ~/.hermes/skills/autonomous-ai-agents/botmaker/scripts/drift_check.py
+    python3 /path/to/botmaker/scripts/drift_check.py --hermes-root /path/to/hermes-home
 
 Exit 0 = clean. Nonzero = drift; each violation prints on its own line.
 
@@ -11,8 +11,8 @@ Checks:
   1. Owner-only markers: mechanics phrases live only in their owner file.
   2. Forbidden strings (frozen enumerations, retired premises) are absent
      from the live scope (skill tree + botmaker profile SOUL/memories).
-  3. The specialist roster table in the vault's making-bots.md matches the
-     profiles that actually exist under ~/.hermes/profiles/. Point the
+  3. Every specialist roster entry names an existing profile in the selected
+     Hermes root. Non-specialists and uncertified profiles need no row. Point the
      BOTMAKER_VAULT_GUIDE env var at your vault's Bots/making-bots.md;
      the check is skipped (with a warning) if it is not set.
   4. Botmaker's profile skill links are file-level symlinks and rglob
@@ -25,28 +25,11 @@ Extend OWNER_ONLY / FORBIDDEN as your fleet earns its own rules.
 """
 from __future__ import annotations
 
+import argparse
 import os
 import re
 import sys
 from pathlib import Path
-
-HOME = Path.home()
-SKILL_TREE = HOME / ".hermes/skills/autonomous-ai-agents/botmaker"
-PROFILE = HOME / ".hermes/profiles/botmaker"
-PROFILES_DIR = HOME / ".hermes/profiles"
-VAULT_GUIDE = Path(os.environ["BOTMAKER_VAULT_GUIDE"]) if os.environ.get("BOTMAKER_VAULT_GUIDE") else None
-
-SKILL_DOCS = [
-    SKILL_TREE / "SKILL.md",
-    SKILL_TREE / "references/process.md",
-    SKILL_TREE / "references/soul-craft.md",
-    SKILL_TREE / "references/vault.md",
-]
-PROFILE_DOCS = [
-    PROFILE / "SOUL.md",
-    PROFILE / "memories/MEMORY.md",
-    PROFILE / "memories/USER.md",
-]
 
 # Phrase -> the one file (relative to the skill tree) allowed to contain it.
 OWNER_ONLY = {
@@ -69,15 +52,36 @@ ROSTER_ROW = re.compile(r"^\|\s*`@[\w-]+`\s*\|\s*`([\w-]+)`\s*\|")
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--hermes-root", required=True, type=Path,
+        help="Verified installation root, not a named profile's home",
+    )
+    args = parser.parse_args()
+    if not args.hermes_root.is_absolute() or not args.hermes_root.is_dir():
+        parser.error("--hermes-root must be an existing absolute directory")
+    # Explicit scope: never silently inspect a different installation under HOME.
+    hermes_root = args.hermes_root.resolve()
+    skill_tree = hermes_root / "skills/autonomous-ai-agents/botmaker"
+    profiles_dir = hermes_root / "profiles"
+    profile = profiles_dir / "botmaker"
+    vault_guide = os.environ.get("BOTMAKER_VAULT_GUIDE")
+    vault_guide = Path(vault_guide) if vault_guide else None
+    skill_docs = [skill_tree / name for name in (
+        "SKILL.md", "references/process.md", "references/soul-craft.md", "references/vault.md",
+    )]
+    profile_docs = [profile / name for name in (
+        "SOUL.md", "memories/MEMORY.md", "memories/USER.md",
+    )]
     errors: list[str] = []
 
     docs: dict[Path, str] = {}
-    for path in SKILL_DOCS:
+    for path in skill_docs:
         if not path.exists():
             errors.append(f"missing file: {path}")
             continue
         docs[path] = path.read_text(encoding="utf-8")
-    for path in PROFILE_DOCS:
+    for path in profile_docs:
         if path.exists():
             docs[path] = path.read_text(encoding="utf-8")
 
@@ -89,7 +93,7 @@ def main() -> int:
             if phrase not in text:
                 continue
             try:
-                rel = str(path.relative_to(SKILL_TREE))
+                rel = path.relative_to(skill_tree).as_posix()
             except ValueError:
                 rel = str(path)
             if rel in allowed:
@@ -106,27 +110,25 @@ def main() -> int:
                 if phrase in line:
                     errors.append(f"forbidden {phrase!r} at {path}:{i}")
 
-    # 3. Roster table vs profiles on disk.
-    if VAULT_GUIDE and VAULT_GUIDE.exists():
+    # 3. The roster lists certified specialists, not every profile in the installation.
+    if vault_guide and vault_guide.exists():
         rostered = {
             m.group(1)
-            for line in VAULT_GUIDE.read_text(encoding="utf-8").splitlines()
+            for line in vault_guide.read_text(encoding="utf-8").splitlines()
             if (m := ROSTER_ROW.match(line))
         }
         on_disk = {
             p.name
-            for p in PROFILES_DIR.iterdir()
+            for p in profiles_dir.iterdir()
             if p.is_dir() and not p.name.startswith(".")
-        } if PROFILES_DIR.is_dir() else set()
-        for name in sorted(on_disk - rostered):
-            errors.append(f"profile exists but has no roster row: {name}")
+        } if profiles_dir.is_dir() else set()
         for name in sorted(rostered - on_disk):
             errors.append(f"roster row names a missing profile: {name}")
     else:
         print("note: BOTMAKER_VAULT_GUIDE not set (or file missing) — roster check skipped")
 
     # 4a. Botmaker's own links: file-level symlinks, discovery intact.
-    skills_dir = PROFILE / "skills"
+    skills_dir = profile / "skills"
     if skills_dir.is_dir():
         link = skills_dir / "autonomous-ai-agents/botmaker/SKILL.md"
         if link.exists() and not link.is_symlink():
@@ -137,8 +139,8 @@ def main() -> int:
 
     # 4b. Whole fleet: a directory symlink anywhere under a profile's skills/
     #     is invisible to rglob — the class defect, checked on every profile.
-    if PROFILES_DIR.is_dir():
-        for prof in sorted(PROFILES_DIR.iterdir()):
+    if profiles_dir.is_dir():
+        for prof in sorted(profiles_dir.iterdir()):
             if not prof.is_dir() or prof.name.startswith("."):
                 continue
             prof_skills = prof / "skills"

--- a/tests/skills/test_botmaker_skill.py
+++ b/tests/skills/test_botmaker_skill.py
@@ -1,0 +1,67 @@
+"""Botmaker checks the selected installation and its certified roster."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+
+SKILL = Path(__file__).resolve().parents[2] / "optional-skills/autonomous-ai-agents/botmaker"
+
+
+def _install(root):
+    skill = root / "skills/autonomous-ai-agents/botmaker"
+    shutil.copytree(SKILL, skill)
+    return skill / "scripts/drift_check.py"
+
+
+def _check(script, root, home, guide, active_home):
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "USERPROFILE": str(home),
+        "HERMES_HOME": str(active_home),
+        "BOTMAKER_VAULT_GUIDE": str(guide),
+    }
+    return subprocess.run(
+        [sys.executable, str(script), "--hermes-root", str(root)],
+        env=env, capture_output=True, text=True, check=False,
+    )
+
+
+@pytest.mark.parametrize("custom", [False, True])
+def test_drift_checks_selected_root_from_a_named_profile(tmp_path, custom):
+    home = tmp_path / "user"
+    root = home / ("custom hermes" if custom else ".hermes")
+    script = _install(root)
+    (root / "profiles/researcher").mkdir(parents=True)
+    guide = tmp_path / "making-bots.md"
+    guide.write_text("| `@researcher` | `researcher` | hosted | research |\n", encoding="utf-8")
+    result = _check(script, root, home, guide, root / "profiles/coordinator")
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    # An existing roster entry must be checked against this root, not another install.
+    (root / "profiles/researcher").rmdir()
+    result = _check(script, root, home, guide, root / "profiles/coordinator")
+    assert result.returncode == 1
+    assert "roster row names a missing profile: researcher" in result.stdout
+
+
+def test_roster_allows_non_specialists_but_rejects_missing_members(tmp_path):
+    home = tmp_path / "user"
+    root = home / ".hermes"
+    script = _install(root)
+    for name in ("researcher", "persona", "daily-driver", "awaiting-certification"):
+        (root / "profiles" / name).mkdir(parents=True)
+    guide = tmp_path / "making-bots.md"
+    guide.write_text("| `@researcher` | `researcher` | hosted | research |\n", encoding="utf-8")
+    result = _check(script, root, home, guide, root)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    guide.write_text("| `@missing` | `missing` | hosted | research |\n", encoding="utf-8")
+    result = _check(script, root, home, guide, root)
+    assert result.returncode == 1
+    assert "roster row names a missing profile: missing" in result.stdout

--- a/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-botmaker.md
+++ b/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-botmaker.md
@@ -42,12 +42,12 @@ Details: `references/soul-craft.md` (SOUL + human gate), `references/process.md`
 - `Bots/` in the vault needs a specialist note, roster row, or `making-bots.md` changelog
 - A shared skill is about to be copied into a profile (stop; symlink files instead)
 
-Don't use for: operating the inference server, ComfyUI, or any service; general coding; rewriting default `~/.hermes/SOUL.md`; spawning `botmaker-2`. `@hermes` is not the bot coordinator — you are.
+Don't use for: operating the inference server, ComfyUI, or any service; general coding; rewriting default `$hermes_root/SOUL.md`; spawning `botmaker-2`. `@hermes` is not the bot coordinator — you are.
 
 ## Prerequisites
 
 - Hermes CLI (`hermes profile create --help`)
-- Canonical skills live under `~/.hermes/skills/` (default Hermes home), **not** `$HERMES_HOME/skills` when you are the botmaker profile
+- Resolve the installation root as `hermes_root` before any write (`references/process.md` §Installation root). Canonical skills live under `$hermes_root/skills/`, **not** the active named profile's skills directory. Never substitute a different installation's default path.
 - Vault: `<your-vault-path>` (see `references/vault.md`). Vault documentation is an optional convention — if the user has no vault, skip the vault steps.
 - Human guide, fleet roster, changelog: vault `Bots/making-bots.md` (create it on first ship). Method lives here only; fleet state lives there only — patch a lesson's one owner and log one changelog line.
 
@@ -65,7 +65,7 @@ Don't use for: operating the inference server, ComfyUI, or any service; general 
 |---|---|
 | New bot | Alias preflight (Procedure C) → Interview → SOUL draft → human sign-off → `hermes profile create NAME --no-skills --description "…"` |
 | Pin a brain | `hermes -p NAME config set model.provider …` then `model.default …`. Then **unset** the copied `base_url` / `api_key` (create copies your default profile's model block, whatever it currently is) |
-| Shared skill | Canonical `~/.hermes/skills/<cat>/<name>/`; profile files via `scripts/link_skill_tree.py`. Never a directory symlink. Load linked `references/` with `read_file` on the canonical path |
+| Shared skill | Canonical `$hermes_root/skills/<cat>/<name>/`; profile files via `scripts/link_skill_tree.py`. Never a directory symlink. Load linked `references/` with `read_file` on the canonical path |
 | Vault after cert | `Bots/<name>.md` (`type: bot-reference`), roster row on `making-bots.md`, one line on `Home.md` |
 | Child memory | Child writes it. You do not. |
 
@@ -78,7 +78,7 @@ Ask, and do not proceed until 1–3 are sharp:
 1. One-sentence job. If "and also," split into two bots. Job may be a CLI, an HTTP API, a GUI sock — ComfyUI counts. "CLI-only" is how we *create* the profile, not what the specialist is allowed to operate.
 2. Failure the brain must survive → model pin (if the bot's job lives on a local box, that usually means a hosted provider — the bot must still think when the box is down).
 3. What it is not.
-4. Does default Hermes need the same skill? → canonical under `~/.hermes/skills/` + file-level symlinks.
+4. Does default Hermes need the same skill? → canonical under `$hermes_root/skills/` + file-level symlinks.
 5. Who is the client to ping (`@hermes`, another specialist, nobody).
 6. Voice: inherit vs write. Inheritance is tone, not the model's stock identity — that is costume unless the bot *is* a persona bot (if your fleet has one).
 
@@ -104,11 +104,11 @@ If **either** finds anything: `--no-alias` (rationale and the landmines: `refere
 
 - `--no-skills`; never `--clone` / desktop clone. Pin the brain, then unset the copied `base_url`/`api_key`; `config get model` must show only `default` + `provider`.
 - **Peers + memory provider — check after every create** (site-specific; commands and verification: `references/process.md` §Independence). The invariant: every rostered profile has every peer it must reach. Do not print keys.
-- Sibling-profile CLI from this profile: always prefix `HERMES_HOME=$HOME/.hermes`.
+- Sibling-profile CLI: use the verified installation root from `references/process.md`, with an unset-variable guard. Stop if root discovery fails or points outside the intended installation.
 - By default, `SOUL.md` writes prompt your human (`security.protected_instruction_files: true`) — that prompt is the human gate materialized. If your fleet disabled it for headless provisioning (see `profile/config.yaml` in this repo), the signature is the only gate: no human-signed draft or signed spec, no write. If a write is blocked anyway, stop — do **not** sneak it in via the shell.
 - Never hand-edit `config.yaml` — `config set` only (your human may hand-edit their own; you do not). Never copy credentials. Never print `auth.api_key` / `secret_key`.
 
-Then: write signed `SOUL.md`, thin `memories/USER.md` — if the skill is shared, include the **lockstep sentence**: one line stating that the canonical skill lives under `~/.hermes/skills/<category>/<name>/`, the profile files are symlinks, and process changes patch the canonical tree (so later sessions do not re-flag the drift). Then empty-or-tiny `memories/MEMORY.md` (the child fills this). Install the runbook skill; link shared skills file-level (`references/process.md` §Shared skills). Not every specialist needs a custom skill — `@hostadmin` is `hermes-agent` + earned MEMORY. Do not invent a runbook so the folder looks complete.
+Then: write signed `SOUL.md`, thin `memories/USER.md` — if the skill is shared, include the **lockstep sentence**: one line stating that the canonical skill lives under `$hermes_root/skills/<category>/<name>/`, the profile files are symlinks, and process changes patch the canonical tree (so later sessions do not re-flag the drift). Then empty-or-tiny `memories/MEMORY.md` (the child fills this). Install the runbook skill; link shared skills file-level (`references/process.md` §Shared skills). Not every specialist needs a custom skill — `@hostadmin` is `hermes-agent` + earned MEMORY. Do not invent a runbook so the folder looks complete.
 
 Stop. Do not fill the child's `MEMORY.md`. Do not add a vault roster row yet.
 
@@ -155,4 +155,4 @@ A new bot is done when:
 6. `SOUL.md` matches the signed draft (one screen).
 7. Shared skills: `ls -l` on profile `SKILL.md` shows `l` (symlink), canonical is a regular file. `rglob` from the profile skills dir finds `SKILL.md`.
 8. After certification only: vault note + roster row + Home line + `making-bots.md` changelog.
-9. `python3 "$HOME/.hermes/skills/autonomous-ai-agents/botmaker/scripts/drift_check.py"` exits 0.
+9. `python3 "${hermes_root:?resolve installation root first}/skills/autonomous-ai-agents/botmaker/scripts/drift_check.py" --hermes-root "$hermes_root"` exits 0. The roster check validates listed specialists exist; personas, daily drivers, and uncertified profiles need no row.


### PR DESCRIPTION
## What does this PR do?

Follow-up fixes for #109308, **targeting `feat/skill-botmaker`, not `main`**. This is a small delta on top of @teknium1's port of @techjanitor's botmaker skill; it does not replace the original contribution.

## Proposed priority: P2 / Medium

Addresses the two medium review findings and the accidental cross-installation write concern associated with the first:

1. **Wrong installation root.** The scaffolding instructions forced `HERMES_HOME="$HOME/.hermes"`, while the drift checker independently hardcoded the same default. On a custom-home installation, this redirects profile/config/SOUL/skill work into a different installation instead of using the session's actual root.
2. **Roster contradicts certification rules.** The checker required every profile directory to appear in the specialist roster, even though the skill explicitly excludes personas, daily drivers, and uncertified profiles.

## Changes Made

- Discover the root via the existing `hermes -p default config path` CLI before overriding the environment; carry that verified root through scaffolding, shared-skill links, default-SOUL protection, and verification.
- Guard write-command examples against an unset/empty root and explicitly stop on failed discovery or an unintended installation. No fallback root, credential copying, or approval-setting changes are introduced.
- Require an explicit existing absolute `--hermes-root` for `drift_check.py`, keeping the standalone checker dependency-free and scoped to the selected installation.
- Validate that roster entries refer to existing profiles without requiring every profile to be rostered. Adding a certified specialist remains part of the shipping checklist.
- Add regression coverage and regenerate only botmaker's documentation page using the existing generator.

**Security scope:** the home-path change prevents accidental writes to another installation; this is not a claim of an OS-isolation escape or a newly demonstrated exploitable vulnerability. The human sign-off and protected-instruction approval behavior remain unchanged.

## Related PR / Credit

Related: https://github.com/NousResearch/hermes-agent/pull/109308

Credit to @techjanitor for the original skill and @teknium1 for the Hermes port. The original commits and MIT attribution are preserved. This PR contains only the follow-up fix commit above that branch.

## How to Test / Verification

- [x] RED on the original branch: custom-root and mixed-fleet regressions failed for the reported reasons; standard-root case passed.
- [x] `scripts/run_tests.sh tests/skills/ -j 8 -q` — **1,638 passed, 0 failed**, including three botmaker cases across two invariant tests.
- [x] `ruff check optional-skills/autonomous-ai-agents/botmaker/scripts/ tests/skills/test_botmaker_skill.py` — passed.
- [x] `git diff --check` — passed.
- [x] Executed the documented root-discovery block against the real CLI in temporary standard and custom homes (including a path with spaces), starting from a named profile. Created a temporary `--no-skills --no-alias` profile and set its model in each selected root; the custom-home run did not create or write the default installation.
- [x] Regenerated the botmaker page with `website/scripts/generate-skill-docs.py`'s renderer.

Validation ran on Linux. No live user profiles were modified. Full repository tests, a full docs-site build, and the interactive human-approved certification conversation were not run.

## Checklist

- [x] Read the contribution and security policies; searched existing issues/PRs.
- [x] Conventional commit; only the scoped fix, docs, and regression tests.
- [x] Relevant documentation updated; no dependencies, core config keys, or tool schemas changed.
- [x] Existing contributor attribution preserved.
- [ ] Full repository test suite (not run; focused skills suite above).
