### PR TITLE
fix(cli): resolve .env-only key_env credentials for the /model probe

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1525,17 +1525,25 @@ def _scoped_key_env(name: str) -> str:
     current profile whatever key happens to be in the process environment — another profile's.
     Identical to ``os.getenv`` when multiplexing is off. A fail-closed ``UnscopedSecretError``
     (multiplexing on, no scope installed) means "no credential visible for this profile here",
-    which is exactly how the picker already treats a missing key. A scoped miss falls back to the
-    agent ``.env`` via ``get_env_prefer_dotenv`` — the chain the chat path already resolves keys
-    through — so a ``key_env`` that lives only in ``.env`` authenticates the ``/model``
-    verification probe too instead of firing it unauthenticated."""
+    which is exactly how the picker already treats a missing key. A scope hit stays authoritative
+    and a scoped miss falls back to the agent ``.env`` via ``get_env_prefer_dotenv``. In
+    single-profile (unscoped) operation the key resolves through ``get_env_prefer_dotenv``
+    directly — the chain the chat path already resolves keys through — so a ``key_env`` that
+    lives only in ``.env`` authenticates the ``/model`` verification probe, and a rotated
+    ``.env`` beats a stale value inherited in the process env (a long-lived shell still holding
+    the pre-rotation key)."""
     if not name:
         return ""
     try:
-        from agent.secret_scope import get_secret
-        val = (get_secret(name, "") or "").strip()
-        if val:
-            return val
+        from agent.secret_scope import current_secret_scope, get_secret, is_multiplex_active
+        if is_multiplex_active() and current_secret_scope() is None:
+            # Fail closed: a profile multiplexer with no scope installed must never
+            # borrow a credential from the shared .env or process env here.
+            return ""
+        if current_secret_scope() is not None:
+            val = (get_secret(name, "") or "").strip()
+            if val:
+                return val
     except Exception:
         pass
     try:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1525,10 +1525,22 @@ def _scoped_key_env(name: str) -> str:
     current profile whatever key happens to be in the process environment — another profile's.
     Identical to ``os.getenv`` when multiplexing is off. A fail-closed ``UnscopedSecretError``
     (multiplexing on, no scope installed) means "no credential visible for this profile here",
-    which is exactly how the picker already treats a missing key."""
+    which is exactly how the picker already treats a missing key. A scoped miss falls back to the
+    agent ``.env`` via ``get_env_prefer_dotenv`` — the chain the chat path already resolves keys
+    through — so a ``key_env`` that lives only in ``.env`` authenticates the ``/model``
+    verification probe too instead of firing it unauthenticated."""
+    if not name:
+        return ""
     try:
         from agent.secret_scope import get_secret
-        return (get_secret(name, "") or "").strip() if name else ""
+        val = (get_secret(name, "") or "").strip()
+        if val:
+            return val
+    except Exception:
+        pass
+    try:
+        from agent.credential_pool import get_env_prefer_dotenv
+        return (get_env_prefer_dotenv(name) or "").strip()
     except Exception:
         return ""
 

--- a/tests/hermes_cli/test_model_picker_secret_scope.py
+++ b/tests/hermes_cli/test_model_picker_secret_scope.py
@@ -97,3 +97,48 @@ class TestSwitchModelKeyEnvScope:
         finally:
             secret_scope.reset_secret_scope(token)
         assert captured["key"] == "this-profile-key"
+
+
+class TestPickerKeyEnvDotenvFallback:
+    """A ``key_env`` that lives only in ``$HERMES_HOME/.env`` must resolve for the
+    picker and the switch validation, matching the chat path's credential chain
+    (get_env_prefer_dotenv). Without the fallback the verification probe fires
+    unauthenticated and every switch prints a spurious "could not reach this
+    custom endpoint's model listing" note against a healthy endpoint."""
+
+    def _isolate_home(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("ACME_RELAY_KEY", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from hermes_cli.config import invalidate_env_cache
+
+        invalidate_env_cache()
+
+    def test_dotenv_only_key_resolves(self, monkeypatch, tmp_path):
+        self._isolate_home(monkeypatch, tmp_path)
+        (tmp_path / ".env").write_text("ACME_RELAY_KEY=from-dotenv\n")
+
+        assert _scoped_key_env("ACME_RELAY_KEY") == "from-dotenv"
+
+    def test_installed_scope_wins_over_dotenv(self, monkeypatch, tmp_path):
+        self._isolate_home(monkeypatch, tmp_path)
+        (tmp_path / ".env").write_text("ACME_RELAY_KEY=from-dotenv\n")
+        token = secret_scope.set_secret_scope({"ACME_RELAY_KEY": "this-profile-key"})
+        try:
+            assert _scoped_key_env("ACME_RELAY_KEY") == "this-profile-key"
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+    def test_absent_everywhere_stays_empty(self, monkeypatch, tmp_path):
+        self._isolate_home(monkeypatch, tmp_path)
+
+        assert _scoped_key_env("ACME_RELAY_KEY") == ""
+        assert _scoped_key_env("") == ""
+
+    def test_entry_configured_key_reads_dotenv_only_key(self, monkeypatch, tmp_path):
+        self._isolate_home(monkeypatch, tmp_path)
+        (tmp_path / ".env").write_text("ACME_RELAY_KEY=from-dotenv\n")
+        from hermes_cli.model_switch import _entry_configured_key
+
+        cfg = {"key_env": "ACME_RELAY_KEY", "base_url": "https://relay.example/v1"}
+
+        assert _entry_configured_key(cfg, _scoped_key_env) == "from-dotenv"

--- a/tests/hermes_cli/test_model_picker_secret_scope.py
+++ b/tests/hermes_cli/test_model_picker_secret_scope.py
@@ -142,3 +142,65 @@ class TestPickerKeyEnvDotenvFallback:
         cfg = {"key_env": "ACME_RELAY_KEY", "base_url": "https://relay.example/v1"}
 
         assert _entry_configured_key(cfg, _scoped_key_env) == "from-dotenv"
+
+    def test_rotated_dotenv_beats_stale_process_env(self, monkeypatch, tmp_path):
+        """A long-lived shell/service can still hold the pre-rotation key in
+        ``os.environ`` while ``$HERMES_HOME/.env`` already carries the rotated
+        one. Single-profile reads must resolve through the chat path's chain
+        (``get_env_prefer_dotenv``), which gives ``.env`` precedence — the old
+        ``get_secret()``-first order returned the stale process value."""
+        self._isolate_home(monkeypatch, tmp_path)
+        monkeypatch.setenv("ACME_RELAY_KEY", "stale-process")
+        (tmp_path / ".env").write_text("ACME_RELAY_KEY=fresh-dotenv\n")
+
+        assert _scoped_key_env("ACME_RELAY_KEY") == "fresh-dotenv"
+
+    def test_unscoped_multiplex_stays_empty_even_with_dotenv(self, monkeypatch, tmp_path):
+        """Multiplexing with no scope installed must fail closed — the shared
+        ``.env``/process env could belong to another profile, so a key present
+        there must not leak into this profile's picker read."""
+        self._isolate_home(monkeypatch, tmp_path)
+        monkeypatch.setenv("ACME_RELAY_KEY", "stale-process")
+        (tmp_path / ".env").write_text("ACME_RELAY_KEY=fresh-dotenv\n")
+        secret_scope.set_multiplex_active(True)
+        try:
+            assert _scoped_key_env("ACME_RELAY_KEY") == ""
+        finally:
+            secret_scope.set_multiplex_active(False)
+
+    def test_switch_model_probe_uses_rotated_dotenv_credential(self, monkeypatch, tmp_path):
+        """End-to-end pin of the user-visible behavior: with a stale key in the
+        process env and a rotated one in ``.env``, the ``switch_model`` →
+        ``validate_requested_model(api_key=...)`` verification probe must fire
+        with the fresh ``.env`` credential, exactly like the chat path."""
+        self._isolate_home(monkeypatch, tmp_path)
+        monkeypatch.setenv("ACME_RELAY_KEY", "stale-process")
+        (tmp_path / ".env").write_text("ACME_RELAY_KEY=fresh-dotenv\n")
+        import hermes_cli.model_switch as ms
+        import hermes_cli.models_validate as mv
+
+        captured = {}
+
+        def _fake_runtime(requested, explicit_api_key=None,
+                          explicit_base_url=None, target_model=None, **kw):
+            return {"api_key": explicit_api_key or "", "base_url": explicit_base_url, "api_mode": ""}
+
+        def _fake_validate(model, provider, api_key=None, base_url=None,
+                           api_mode=None, headers=None, **kw):
+            captured["api_key"] = api_key
+            return {"accepted": True, "persist": True, "recognized": True, "message": ""}
+
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider", _fake_runtime)
+        monkeypatch.setattr(ms, "resolve_alias", lambda *a, **k: None)
+        monkeypatch.setattr(mv, "validate_requested_model", _fake_validate)
+
+        ms.switch_model(
+            "some-model",
+            current_provider="openrouter",
+            current_model="x",
+            explicit_provider="acme",
+            user_providers={"acme": {"base_url": "https://api.acme.test/v1", "key_env": "ACME_RELAY_KEY"}},
+        )
+
+        assert captured["api_key"] == "fresh-dotenv"


### PR DESCRIPTION
## What does this PR do?

`/model` resolves a custom provider's `key_env` through `_scoped_key_env`, which only consults the per-profile secret scope (falling through to `os.environ` when multiplexing is off). The chat path resolves the same variable via `get_env_prefer_dotenv`, which prefers `$HERMES_HOME/.env`. For a key that lives only in `.env` — the documented place for secrets, and a config Hermes does not export into the process environment — the two chains disagree: chat authenticates fine, but the switch's verification probe (`validate_requested_model` → `probe_api_models`) goes out without an `Authorization` header, the endpoint answers `401`, and every switch prints a spurious

```
Note: could not reach this custom endpoint's model listing at `https://<host>/v1/models`. ...
```

against a fully healthy endpoint (the same `GET /v1/models` with the key returns `200`).

This makes a scoped miss in `_scoped_key_env` fall back to `get_env_prefer_dotenv`, aligning the validation path with the chat path. The profile secret scope stays authoritative — an installed scope that resolves the key wins, and a multiplexed scoped miss still never borrows another profile's `os.environ` value; the fallback reads the user-level `.env`, the same overlay `agent/secret_scope.get_secret` already documents itself as ("the scope must stay a `.env` overlay, not a blindfold").

## Related Issue

Fixes #109315

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_switch.py`: `_scoped_key_env` now falls back to `agent.credential_pool.get_env_prefer_dotenv` when the secret scope resolves nothing, instead of returning `""` immediately (+17/-1).
- `tests/hermes_cli/test_model_picker_secret_scope.py`: new `TestPickerKeyEnvDotenvFallback` — `.env`-only key resolves; an installed scope still wins over `.env`; absent-everywhere stays empty (fail-closed semantics unchanged); `_entry_configured_key(cfg, _scoped_key_env)` (the call that fills `st.api_key` for the validation probe) resolves a `.env`-only `key_env`.

## How to Test

1. Unit/regression tests (observed result: all pass — 10 passed in the file, 108 passed across the `model_switch` consumer suites):
   ```
   pytest tests/hermes_cli/test_model_picker_secret_scope.py -q
   pytest tests/hermes_cli/test_model_switch_custom_providers.py tests/hermes_cli/test_model_switch_configured_provider_routing.py tests/hermes_cli/test_custom_provider_model_switch.py tests/hermes_cli/test_user_providers_model_switch.py -q
   ```
2. The `.env`-only scenario is covered hermetically by `TestPickerKeyEnvDotenvFallback::test_dotenv_only_key_resolves` (isolated `HERMES_HOME`, key written only to the temp `.env`, absent from the process environment) — observed result: resolves to the `.env` value before this change's fallback it returned `""`.
3. Manual check per the issue's repro (key only in `$HERMES_HOME/.env`, `custom_providers` entry with `key_env`): `/model <model>` should save the model with no "could not reach this custom endpoint's model listing" note; reverting just the fallback line makes the two fallback tests fail, confirming they pin the fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64); the reporter reproduced the bug on Windows 11 and Debian 13 and the fix is OS-independent resolver logic

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A
