### PR TITLE
fix(nix): replace deprecated stdenv.isLinux with stdenv.hostPlatform.isLinux

### DIFF
--- a/nix/hermes-agent.nix
+++ b/nix/hermes-agent.nix
@@ -102,7 +102,7 @@ let
     ffmpeg
     tirith
   ]
-  ++ lib.optionals stdenv.isLinux [
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     wl-clipboard
     xclip
   ];
@@ -256,7 +256,7 @@ stdenv.mkDerivation (finalAttrs: {
         ++ [
           devPython
         ]
-        ++ lib.optionals stdenv.isLinux [
+        ++ lib.optionals stdenv.hostPlatform.isLinux [
           cage # for running e2e tests without popping windows
         ];
     };

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -43,7 +43,7 @@
           "voice"
         ]
         # matrix is Linux-only (oqs/liboqs lacks aarch64-darwin wheels).
-        ++ lib.optionals pkgs.stdenv.isLinux [ "matrix" ];
+        ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [ "matrix" ];
       };
     in
     {

--- a/tests/test_nix_deprecations.py
+++ b/tests/test_nix_deprecations.py
@@ -1,0 +1,29 @@
+"""Guard the Nix expressions against deprecated stdenv platform predicates.
+
+nixpkgs deprecated the ``stdenv.is<Platform>`` predicates in favor of
+``stdenv.hostPlatform.is<Platform>``; evaluating the flake on current nixpkgs
+emits one warning per surviving call site (#109322). Keep them from coming
+back now that the last call sites have been migrated.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+NIX_DIR = Path(__file__).resolve().parents[1] / "nix"
+DEPRECATED_PREDICATES = ("stdenv.isLinux", "stdenv.isDarwin")
+
+
+def test_nix_expressions_avoid_deprecated_stdenv_platform_predicates() -> None:
+    offenders: list[str] = []
+    for path in sorted(NIX_DIR.rglob("*.nix")):
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            hits = [pred for pred in DEPRECATED_PREDICATES if pred in line]
+            if hits:
+                offenders.append(
+                    f"{path.relative_to(NIX_DIR)}:{lineno}: {', '.join(hits)}"
+                )
+    assert not offenders, (
+        "deprecated stdenv platform predicates found "
+        "(use stdenv.hostPlatform.* instead):\n" + "\n".join(offenders)
+    )


### PR DESCRIPTION
## What does this PR do?

Evaluating the flake on current nixpkgs emits the deprecation warning
`stdenv.isLinux is deprecated, use stdenv.hostPlatform.isLinux instead`
for every surviving call site, and downstream NixOS configurations
inherit the warning on every rebuild even when their own configuration
already uses the modern API. This migrates the last three call sites to
the `stdenv.hostPlatform` equivalents already used elsewhere under `nix/`
(`checks.nix`, `desktop.nix`), and adds a guard test so the deprecated
predicates cannot silently return.

Note: the `nix/packages.nix` call site is also touched (alone) by the
dormant #101169. This PR covers the full scope listed in #109322 — all
three call sites plus the regression check — and is happy to supersede
or coordinate, maintainer's choice.

## Related Issue

Fixes #109322

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `nix/packages.nix`: `pkgs.stdenv.isLinux` → `pkgs.stdenv.hostPlatform.isLinux` (matrix optional dep)
- `nix/hermes-agent.nix`: `stdenv.isLinux` → `stdenv.hostPlatform.isLinux` (Linux-only runtime deps `wl-clipboard`/`xclip`, and the `cage` dev dep)
- `tests/test_nix_deprecations.py`: new guard test that scans every `.nix` file under `nix/` for the deprecated `stdenv.is<Platform>` predicates

## How to Test

1. `pytest tests/test_nix_deprecations.py -q` — passes: `1 passed` on the migrated tree.
2. Reverting any one of the three call sites back to `stdenv.isLinux` makes the guard test fail with a `file:line` pointer — verified locally (red on revert, green after restore).
3. `nix flake check` on a current nixpkgs no longer emits the `stdenv.isLinux is deprecated` evaluation warning (CI's nix lane covers this; no semantic change — `hostPlatform.isLinux` is the documented replacement, already used by `nix/checks.nix` and `nix/desktop.nix`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/test_nix_deprecations.py -q
.                                                                                                                                                              [100%]
1 passed in 0.10s
```
