### PR TITLE
fix(desktop): show automatic and manual compression activity

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -155,10 +155,6 @@ def _record_codex_app_server_compaction(agent, turn, *, approx_tokens: int | Non
     thread_id, turn_id = getattr(turn, "thread_id", None) or "", getattr(turn, "turn_id", None) or ""
     logger.info("codex app-server compaction observed: session=%s thread=%s turn=%s force=%s",
                 getattr(agent, "session_id", None) or "none", thread_id, turn_id, force)
-    if not force:
-        with suppress(Exception):
-            from agent.conversation_compression import COMPACTION_STATUS
-            agent._emit_status(COMPACTION_STATUS)
     compressor = getattr(agent, "context_compressor", None)
     if compressor is not None:
         compressor.compression_count = getattr(compressor, "compression_count", 0) + 1
@@ -283,7 +279,8 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
     """Build the ``on_event`` callback for ``CodexAppServerSession(on_event=...)``.
 
     Tool items fire ``tool_progress_callback`` plus the stable-ID ``tool_start_callback`` /
-    ``tool_complete_callback`` card hooks; deltas go to ``_fire_stream_delta`` / ``_fire_reasoning_delta``;
+    ``tool_complete_callback`` card hooks; compaction items fire the standard live
+    compacting/compacted status lifecycle; deltas go to ``_fire_stream_delta`` / ``_fire_reasoning_delta``;
     a completed agentMessage goes to ``_emit_interim_assistant_message`` (the gateway's ``already_streamed``
     check dedupes against streamed deltas). Every callback is guarded so a buggy display hook cannot
     tear down the turn loop."""
@@ -335,12 +332,23 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
             agent_cb("_emit_interim_assistant_message", "_emit_interim_assistant_message raised",
                      args=({"role": "assistant", "content": text},))
 
+    def _fire_compaction_status(completed: bool) -> None:
+        from agent.conversation_compression import COMPACTION_DONE_STATUS, COMPACTION_STATUS
+        if completed:
+            agent_cb("status_callback", "status_callback raised on native compaction completion",
+                     args=("compacted", COMPACTION_DONE_STATUS))
+        else:
+            agent_cb("_emit_status", "status callback raised on native compaction start",
+                     args=(COMPACTION_STATUS,))
+
     def _on_item(params: dict, completed: bool) -> None:
         item = params.get("item")
         if not isinstance(item, dict):
             return
         item_type = item.get("type") or ""
-        if item_type in _CODEX_TOOL_ITEM_TYPES:
+        if item_type == "contextCompaction":
+            _fire_compaction_status(completed)
+        elif item_type in _CODEX_TOOL_ITEM_TYPES:
             (_fire_tool_completed if completed else _fire_tool_started)(item)
         elif completed and item_type == "agentMessage":
             _fire_agent_message_completed(item)

--- a/apps/desktop/src/app/session/hooks/use-message-stream/compaction-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/compaction-event.test.tsx
@@ -57,6 +57,16 @@ describe('useMessageStream compaction lifecycle', () => {
     expect($compactingSessions.get()).toEqual({ [OTHER_SID]: true })
   })
 
+  it('starts the compaction phase for the manual compression status kind', () => {
+    mountStream()
+
+    emit('status.update', { kind: 'compressing', text: 'compressing context…' })
+    expect($compactingSessions.get()).toEqual({ [SID]: true })
+
+    emit('status.update', { kind: 'status', text: 'ready' })
+    expect($compactingSessions.get()).toEqual({})
+  })
+
   // #97948: a manual /compress whose RPC answered `pending` (the compute host
   // outlived the gateway's wait) has no turn-end hydrate — the `compacted`
   // edge is the only signal the transcript changed.

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.ts
@@ -33,7 +33,7 @@ export function handleStatusEvent(ctx: GatewayEventContext): boolean {
   } = deps
 
   if (event.type === 'status.update') {
-    if (sessionId && payload?.kind === 'compacting') {
+    if (sessionId && (payload?.kind === 'compacting' || payload?.kind === 'compressing')) {
       setSessionCompacting(sessionId, true)
       compactedTurnRef.current.add(sessionId)
     } else if (sessionId && payload?.kind === 'compacted') {
@@ -50,6 +50,12 @@ export function handleStatusEvent(ctx: GatewayEventContext): boolean {
       if (isActiveEvent && state && !state.busy && !state.awaitingResponse && !state.streamId) {
         void hydrateFromStoredSession(3, state.storedSessionId, sessionId)
       }
+    } else if (sessionId && payload?.kind === 'status' && coerceGatewayText(payload?.text).trim() === 'ready') {
+      // Manual session.compress bookends its dedicated `compressing` status
+      // with the legacy generic status text `ready`, including no-op and
+      // failure exits.
+      reconcileSessionCompacting(sessionId, 'terminal')
+      compactedTurnRef.current.delete(sessionId)
     } else if (sessionId && payload?.kind === 'process') {
       // The gateway's notification poller announces background process
       // completions / watch matches here — re-sync the status stack.

--- a/apps/desktop/src/components/assistant-ui/thread/duplicate-activity-indicator.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/duplicate-activity-indicator.test.tsx
@@ -212,4 +212,16 @@ describe('TurnActivityIndicator tail gating (#68634)', () => {
     expect(document.querySelectorAll('[data-slot="aui_response-loading"]').length).toBe(1)
     expect(document.querySelectorAll('[data-slot="aui_turn-activity"]').length).toBe(0)
   })
+
+  it('shows compaction status in an idle thread during manual compression', () => {
+    const settled = {
+      ...runningAssistantMessage('assistant-1', 'Saved'),
+      status: { type: 'complete', reason: 'stop' }
+    } as ThreadMessage
+
+    const { container } = render(<Harness messages={[userMessage('user-1', 'Keep this context'), settled]} />)
+
+    expect(screen.getByRole('status', { name: 'Summarizing thread' })).toBeTruthy()
+    expect(container.querySelector('[data-slot="aui_manual-compaction"]')).not.toBeNull()
+  })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/duplicate-activity-indicator.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/duplicate-activity-indicator.test.tsx
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { __resetElapsedTimerRegistryForTests } from '@/components/chat/activity-timer'
 import { setSessionCompacting } from '@/store/compaction'
+import { clearAllPrompts, setApprovalRequest } from '@/store/prompts'
 import { $activeSessionId, $turnStartedAt } from '@/store/session'
 
 import { stubThreadEnvironment, stubThreadViewportSize, userMessage } from '../test-utils'
@@ -89,6 +90,7 @@ describe('TurnActivityIndicator tail gating (#68634)', () => {
   afterEach(() => {
     cleanup()
     setSessionCompacting(sessionId, false)
+    clearAllPrompts(sessionId)
     $activeSessionId.set(null)
     $turnStartedAt.set(null)
     __resetElapsedTimerRegistryForTests()
@@ -211,6 +213,34 @@ describe('TurnActivityIndicator tail gating (#68634)', () => {
 
     expect(document.querySelectorAll('[data-slot="aui_response-loading"]').length).toBe(1)
     expect(document.querySelectorAll('[data-slot="aui_turn-activity"]').length).toBe(0)
+  })
+
+  it('shows automatic compaction even while the tail still has an in-flight tool row', () => {
+    const toolTail = {
+      ...runningAssistantMessage('assistant-1', ''),
+      content: [{ type: 'tool-call', toolCallId: 'terminal-1', toolName: 'terminal', args: {}, argsText: '{}' }]
+    } as ThreadMessage
+
+    const { container } = render(<Harness messages={[userMessage('user-1', 'Keep going'), toolTail]} />)
+
+    expect(screen.getByRole('status', { name: 'Summarizing thread' })).toBeTruthy()
+    expect(container.querySelector('[data-slot="aui_turn-activity"]')).not.toBeNull()
+  })
+
+  it('shows automatic compaction while stale awaiting-input chrome is still present', () => {
+    setApprovalRequest({
+      command: 'npm test',
+      description: 'run tests',
+      requestId: 'approval-1',
+      sessionId
+    })
+
+    const { container } = render(
+      <Harness messages={[userMessage('user-1', 'Keep going'), runningAssistantMessage('assistant-1', 'Working')]} />
+    )
+
+    expect(screen.getByRole('status', { name: 'Summarizing thread' })).toBeTruthy()
+    expect(container.querySelector('[data-slot="aui_turn-activity"]')).not.toBeNull()
   })
 
   it('shows compaction status in an idle thread during manual compression', () => {

--- a/apps/desktop/src/components/assistant-ui/thread/index.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/index.tsx
@@ -3,7 +3,11 @@ import { createContext, memo, useCallback, useContext, useMemo, useRef, useState
 import { ChatEmptySlot } from '@/components/assistant-ui/chat-empty-slot'
 import { AssistantMessage } from '@/components/assistant-ui/thread/assistant-message'
 import { ThreadMessageList } from '@/components/assistant-ui/thread/list'
-import { BackgroundResumeNotice, CenteredThreadSpinner } from '@/components/assistant-ui/thread/status'
+import {
+  BackgroundResumeNotice,
+  CenteredThreadSpinner,
+  ManualCompactionIndicator
+} from '@/components/assistant-ui/thread/status'
 import { SystemMessage } from '@/components/assistant-ui/thread/system-message'
 import { ThreadTimeline } from '@/components/assistant-ui/thread/timeline'
 import { type RestoreMessageTarget } from '@/components/assistant-ui/thread/types'
@@ -165,7 +169,15 @@ export const Thread = memo(function Thread({
   // element every render defeats the bail-out and drags the whole transcript
   // into the switch's render pass. It takes no props, so one element is
   // always correct.
-  const loadingIndicator = useMemo(() => <BackgroundResumeNotice />, [])
+  const loadingIndicator = useMemo(
+    () => (
+      <>
+        <BackgroundResumeNotice />
+        <ManualCompactionIndicator />
+      </>
+    ),
+    []
+  )
 
   return (
     <ThreadEditContext.Provider value={editContext}>

--- a/apps/desktop/src/components/assistant-ui/thread/status.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status.tsx
@@ -384,8 +384,16 @@ export const TurnActivityIndicator: FC = () => {
   // question the user is answering, and a tool call carrying its own timer.
   // A live local-model load is a named wait too — it must not wait out the
   // quiet window (the load IS the story from second one).
+  // Compression is authoritative phase state, not an inference from the tail.
+  // Its start can overtake the preceding tool.complete frame in the renderer,
+  // leaving the old tool row apparently in flight, and stale prompt chrome can
+  // briefly keep awaitingInput true. Neither generic suppression may hide the
+  // explicit compacting lifecycle.
   const active =
-    working && !awaitingInput && !toolNarrating && (Boolean(hint) || localLoad !== null || quietSince !== undefined)
+    working &&
+    (!awaitingInput || compacting) &&
+    (!toolNarrating || compacting) &&
+    (Boolean(hint) || localLoad !== null || quietSince !== undefined)
 
   // Compaction owns the whole turn, so it keeps counting from the turn's start;
   // anything else counts from the moment the turn last produced something — the

--- a/apps/desktop/src/components/assistant-ui/thread/status.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status.tsx
@@ -267,6 +267,37 @@ export const ResponseLoadingIndicator: FC = () => {
   )
 }
 
+/** Manual compression runs outside a model turn, so assistant-ui does not
+ * create the running assistant placeholder that normally owns this status.
+ * Keep the same in-thread treatment without making the idle session look like
+ * a model response is streaming. */
+export const ManualCompactionIndicator: FC = () => {
+  const { busy, compacting } = useThreadSessionStatus()
+
+  const assistantRunning = useAuiState(
+    s => s.thread.isRunning || s.thread.messages.some(message => message.status?.type === 'running')
+  )
+
+  const active = compacting && !busy && !assistantRunning
+  const elapsed = useElapsedSeconds(active)
+
+  if (!active) {
+    return null
+  }
+
+  return (
+    <StatusRow data-slot="aui_manual-compaction" label={COMPACTION_LABEL}>
+      <StatusPulse
+        aria-hidden="true"
+        className="dither inline-block size-3 rounded-[2px] text-midground/80"
+        kind="opacity"
+      />
+      <WaitHint hint={COMPACTION_LABEL} />
+      <ActivityTimerText seconds={elapsed} />
+    </StatusRow>
+  )
+}
+
 // Parked-background affordance: a top-level delegate_task runs in the
 // background, so the parent turn ends and the app goes idle while the subagent
 // keeps working and its result re-enters as a fresh turn later. Instead of a

--- a/tests/agent/test_codex_app_server_event_bridge.py
+++ b/tests/agent/test_codex_app_server_event_bridge.py
@@ -34,6 +34,8 @@ def _make_stub_agent() -> SimpleNamespace:
     """Minimal stand-in for AIAgent that records every callback fire."""
     return SimpleNamespace(
         tool_progress_callback=MagicMock(name="tool_progress_callback"),
+        status_callback=MagicMock(name="status_callback"),
+        _emit_status=MagicMock(name="_emit_status"),
         _fire_stream_delta=MagicMock(name="_fire_stream_delta"),
         _fire_reasoning_delta=MagicMock(name="_fire_reasoning_delta"),
         _emit_interim_assistant_message=MagicMock(
@@ -245,6 +247,22 @@ class TestToolProgressDispatch:
         assert calls[0].args[1] == "web_search"
         assert calls[0].args[2] == "hermes agent docs"
         assert calls[0].args[3] == {"query": "hermes agent docs"}
+
+
+class TestCompactionStatusDispatch:
+    def test_native_compaction_item_fires_live_start_and_terminal_status(self):
+        from agent.conversation_compression import COMPACTION_DONE_STATUS, COMPACTION_STATUS
+
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        item = {"type": "contextCompaction", "id": "compact-1"}
+
+        bridge(_item_started(item))
+        agent._emit_status.assert_called_once_with(COMPACTION_STATUS)
+        agent.status_callback.assert_not_called()
+
+        bridge(_item_completed(item))
+        agent.status_callback.assert_called_once_with("compacted", COMPACTION_DONE_STATUS)
 
 
 


### PR DESCRIPTION
## Summary

Restore in-thread compression activity for **automatic and manual** paths without inserting model-history messages.

### Automatic compression

- Native Codex `contextCompaction` item-start/item-completed events now bridge to the standard live `compacting`/`compacted` lifecycle. Previously the bridge ignored these items, and post-turn bookkeeping emitted a misleading start only after compaction had finished, with no matching completion. Remove that late start; keep bookkeeping unchanged.
- An explicit compaction phase now takes precedence over generic tool-wait and awaiting-input suppression in `TurnActivityIndicator`. Stale tool/prompt chrome must not hide an authoritative compression status.
- Existing regular idle/preflight/reactive compression status routing and structured completion remain unchanged.

### Manual compression

- Recognize the existing `session.compress` lifecycle (`compressing` → generic `status: ready`) in Desktop's per-session compaction store.
- Render the animated “Summarizing thread” row inside an idle thread while compression runs outside a model turn. Keep the running-assistant indicator as the sole owner during a normal active response.

The row is transient presentation state, not a persisted model-history message. No compression algorithm, provider input, conversation roles, or prompt caching changes.

## Verification

New regressions observed failing before their respective fixes:
- Manual start did not set compaction state; an idle compacting thread rendered no row.
- Native Codex compaction items emitted neither the live start nor terminal status.
- Automatic compaction was hidden by an in-flight tool row or stale awaiting-input state.

Independent parent validation of the final candidate:
- **27 Python tests passed**: `test_codex_app_server_event_bridge.py` and `test_compaction_status.py`, canonical runner with `--file-retries 0`.
- **21 UI tests passed**: compaction event lifecycle, thread single-indicator/suppression cases, compaction store.
- Desktop renderer/Electron/E2E TypeScript checks, targeted Ruff, and `git diff --check` passed.
- Targeted ESLint passed during implementation verification. Full suite and a live Electron/model compression session were not run; the assertions exercise producer contracts and the actual renderer components, not an installed-app visual claim.

## Related work

Distinct from #108427 (heartbeat deadline), #106719 (numeric context meter), #44418 (sidebar activity after session rotation), and #92591 (preview safety). This PR addresses dropped producer events and suppressed in-thread presentation, not those adjacent mechanisms.
