### PR TITLE
fix(desktop): keep context calculation off the RPC reader

### DIFF
--- a/tests/tui_gateway/test_context_breakdown_dispatch.py
+++ b/tests/tui_gateway/test_context_breakdown_dispatch.py
@@ -1,0 +1,81 @@
+import threading
+import types
+
+from tui_gateway import server
+from tui_gateway.transport import Transport
+
+
+def test_context_breakdown_dispatch_releases_reader_and_preserves_response(monkeypatch):
+    """A slow breakdown must not hold the RPC reader thread."""
+    sid = "context-breakdown-pool"
+    expected = {
+        "categories": [{"name": "Messages", "tokens": 123}],
+        "context_max": 4096,
+        "context_percent": 3.0,
+        "context_used": 123,
+        "estimated_total": 123,
+        "context_estimated": True,
+        "context_source": "local_estimate",
+        "model": "fixture",
+    }
+    server._sessions[sid] = {
+        "agent": types.SimpleNamespace(),
+        "session_key": "context-breakdown-session",
+        "history": [{"role": "user", "content": "hello"}],
+        "history_lock": threading.Lock(),
+    }
+
+    compute_started = threading.Event()
+    release_compute = threading.Event()
+    reader_returned = threading.Event()
+    response_written = threading.Event()
+    writes = []
+    dispatch_result = {}
+
+    def slow_breakdown(agent, history):
+        assert agent is server._sessions[sid]["agent"]
+        assert history == [{"role": "user", "content": "hello"}]
+        compute_started.set()
+        assert release_compute.wait(timeout=5.0)
+        return expected
+
+    class RecordingTransport(Transport):
+        def write(self, obj: dict) -> bool:
+            writes.append(obj)
+            response_written.set()
+            return True
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(
+        "agent.context_breakdown.compute_session_context_breakdown", slow_breakdown
+    )
+    transport = RecordingTransport()
+    request = {
+        "id": "breakdown",
+        "method": "session.context_breakdown",
+        "params": {"session_id": sid},
+    }
+
+    def read_request():
+        dispatch_result["value"] = server.dispatch(request, transport)
+        reader_returned.set()
+
+    reader = threading.Thread(target=read_request)
+    reader.start()
+    try:
+        assert compute_started.wait(timeout=2.0)
+        assert reader_returned.wait(timeout=1.0), "breakdown blocked the RPC reader"
+        assert dispatch_result["value"] is None
+        assert response_written.is_set() is False
+
+        ping = server.dispatch({"id": "ping", "method": "ping", "params": {}}, transport)
+        assert ping == {"jsonrpc": "2.0", "id": "ping", "result": {"pong": True}}
+    finally:
+        release_compute.set()
+        reader.join(timeout=5.0)
+        server._sessions.pop(sid, None)
+
+    assert response_written.wait(timeout=1.0)
+    assert writes == [{"jsonrpc": "2.0", "id": "breakdown", "result": expected}]

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -172,7 +172,7 @@ _LONG_HANDLERS = frozenset({
     "projects.record_repos", "projects.for_cwd", "projects.tree", "projects.project_sessions",
     "setup.runtime_check", "setup.status", "voice.toggle", "voice.record", "voice.tts", "wake.start",
     "wake.status", "session.active_list", "session.branch", "session.compress", "session.list",
-    "session.resume", "session.workspace.move", "shell.exec", "skills.manage", "slash.exec",
+    "session.context_breakdown", "session.resume", "session.workspace.move", "shell.exec", "skills.manage", "slash.exec",
     "command.dispatch",  # /goal draft invokes the auxiliary model; never block the RPC reader
 })
 


### PR DESCRIPTION
## Summary

Route `session.context_breakdown` through the existing `_LONG_HANDLERS` pool instead of running it inline on the RPC reader.

The handler rebuilds the system prompt and estimates transcript/tool-schema occupancy. On a large or cold session this synchronous computation delays the reader from accepting subsequent requests. This patch changes dispatch only; it does not change context accounting, add caches, or wait for lazy agent construction.

## Regression and verification

The new test runs the actual `server.dispatch` → registered context handler → bound transport path. Only the expensive computation is replaced with a latch-controlled function. While that computation is blocked, it asserts that:

- dispatch has returned to the reader;
- `ping` can be handled;
- no premature breakdown response was written;
- releasing the computation delivers the exact expected breakdown through the original transport.

The test fails on base with `breakdown blocked the RPC reader` and passes with pooled dispatch. Independent parent repeat of the focused canonical matrix (`--file-retries 0`): **5 passed, 0 failed** across `test_context_breakdown_dispatch.py` and `test_context_breakdown.py`. Ruff and `git diff --check` passed.

This removes reader head-of-line blocking, **not the calculation's own latency**. It does not prove a whole-app speedup or attribute every historical context-meter delay to this one mechanism. Full local suite and installed Electron interaction tests were not run.

## Historical provenance

Related to closed #55787, which identified this pool-routing requirement as part of a larger deferred-resume proposal. Its review explicitly accepted pool routing but objected to changing the handler to `_sess`, because active lazy-watch sessions could then wait for an agent that is intentionally not built. The closing comment requested a fresh current-main PR after the old branch became stale.

This fresh patch carries only the valid routing change and a gateway dispatch regression. **`methods_session.py` is unchanged**, so it does not introduce the rejected lazy-watch build/wait behavior. Distinct from #106917's live occupancy updates and #106719's stale-meter handling.
