### PR TITLE
feat(anthropic): recognize xKiro as Bearer Messages endpoint

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -17,8 +17,8 @@ from agent.anthropic_credentials import _is_oauth_token
 from agent.anthropic_endpoints import (
     _base_url_needs_context_1m_beta, _is_azure_anthropic_endpoint, _is_kimi_coding_endpoint,
     _is_minimax_anthropic_endpoint, _is_nous_portal_endpoint, _is_opencode_endpoint,
-    _is_third_party_anthropic_endpoint, _model_name_is_kimi_family, _normalize_base_url_text,
-    _requires_bearer_auth,
+    _is_third_party_anthropic_endpoint, _is_xkiro_endpoint, _model_name_is_kimi_family,
+    _normalize_base_url_text, _requires_bearer_auth,
 )
 from agent.anthropic_message_convert import (
     convert_messages_to_anthropic, convert_tools_to_anthropic, normalize_model_name,
@@ -546,9 +546,9 @@ def build_anthropic_kwargs(
     ``fast_mode`` adds ``extra_body.speed="fast"`` plus the fast-mode beta on native Anthropic only."""
     system, anthropic_messages = convert_messages_to_anthropic(messages, base_url=base_url, model=model)
     anthropic_tools = convert_tools_to_anthropic(tools) if tools else []
-    # Nous Portal routes on its own catalog ids (``anthropic/claude-opus-4.8``); normalizing would
-    # make the model unresolvable there (prefix AND dots kept).
-    if not _is_nous_portal_endpoint(base_url):
+    # Nous Portal and xKiro route on full catalog ids (``anthropic/claude-opus-4.8``);
+    # normalizing would make the model unresolvable there (prefix AND dots kept).
+    if not (_is_nous_portal_endpoint(base_url) or _is_xkiro_endpoint(base_url)):
         model = normalize_model_name(model, preserve_dots=preserve_dots)
     # Non-positive/non-finite values fail locally instead of 400-ing upstream.
     effective_max_tokens = _resolve_anthropic_messages_max_tokens(max_tokens, model, context_length=context_length)

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -17,7 +17,7 @@ from agent.anthropic_credentials import _is_oauth_token
 from agent.anthropic_endpoints import (
     _base_url_needs_context_1m_beta, _is_azure_anthropic_endpoint, _is_kimi_coding_endpoint,
     _is_minimax_anthropic_endpoint, _is_nous_portal_endpoint, _is_opencode_endpoint,
-    _is_third_party_anthropic_endpoint, _is_xkiro_endpoint, _model_name_is_kimi_family,
+    _is_third_party_anthropic_endpoint, _model_name_is_kimi_family,
     _normalize_base_url_text, _requires_bearer_auth,
 )
 from agent.anthropic_message_convert import (
@@ -535,6 +535,7 @@ def build_anthropic_kwargs(
     reasoning_config: Optional[Dict[str, Any]], tool_choice: Optional[str] = None,
     is_oauth: bool = False, preserve_dots: bool = False, context_length: Optional[int] = None,
     base_url: str | None = None, fast_mode: bool = False, drop_context_1m_beta: bool = False,
+    preserve_anthropic_model_id: bool = False,
 ) -> Dict[str, Any]:
     """Build kwargs for anthropic.messages.create(). ``max_tokens`` is the OUTPUT cap for one
     response; ``context_length`` is the TOTAL window (input + output). ``max_tokens=None`` uses the
@@ -546,9 +547,10 @@ def build_anthropic_kwargs(
     ``fast_mode`` adds ``extra_body.speed="fast"`` plus the fast-mode beta on native Anthropic only."""
     system, anthropic_messages = convert_messages_to_anthropic(messages, base_url=base_url, model=model)
     anthropic_tools = convert_tools_to_anthropic(tools) if tools else []
-    # Nous Portal and xKiro route on full catalog ids (``anthropic/claude-opus-4.8``);
-    # normalizing would make the model unresolvable there (prefix AND dots kept).
-    if not (_is_nous_portal_endpoint(base_url) or _is_xkiro_endpoint(base_url)):
+    # Nous Portal predates provider-declared request quirks. New relays that route
+    # on full catalog ids opt in through ProviderProfile instead of growing a
+    # hostname allowlist here.
+    if not (_is_nous_portal_endpoint(base_url) or preserve_anthropic_model_id):
         model = normalize_model_name(model, preserve_dots=preserve_dots)
     # Non-positive/non-finite values fail locally instead of 400-ing upstream.
     effective_max_tokens = _resolve_anthropic_messages_max_tokens(max_tokens, model, context_length=context_length)

--- a/agent/anthropic_endpoints.py
+++ b/agent/anthropic_endpoints.py
@@ -120,11 +120,6 @@ def _is_nous_portal_endpoint(base_url: str | None) -> bool:
     return bool(override_host) and base_url_hostname(base_url or "") == override_host
 
 
-def _is_xkiro_endpoint(base_url: str | None) -> bool:
-    """xKiro's Anthropic-compatible API (Bearer auth, verbatim ``vendor/model`` ids)."""
-    return base_url_host_matches(base_url or "", "api.xkiro.com")
-
-
 def _requires_bearer_auth(base_url: str | None) -> bool:
     """Providers needing ``Authorization: Bearer`` instead of ``x-api-key``: MiniMax, Azure AI
     Foundry, Palantir Foundry's LLM proxy, CommandCode, Nous Portal, xKiro. Palantir/CommandCode/xKiro
@@ -136,7 +131,7 @@ def _requires_bearer_auth(base_url: str | None) -> bool:
         or "azure.com" in normalized
         or base_url_host_matches(normalized, "palantirfoundry.com")
         or base_url_host_matches(normalized, "api.commandcode.ai")
-        or _is_xkiro_endpoint(normalized)
+        or base_url_host_matches(normalized, "api.xkiro.com")
     )
 
 

--- a/agent/anthropic_endpoints.py
+++ b/agent/anthropic_endpoints.py
@@ -120,10 +120,15 @@ def _is_nous_portal_endpoint(base_url: str | None) -> bool:
     return bool(override_host) and base_url_hostname(base_url or "") == override_host
 
 
+def _is_xkiro_endpoint(base_url: str | None) -> bool:
+    """xKiro's Anthropic-compatible API (Bearer auth, verbatim ``vendor/model`` ids)."""
+    return base_url_host_matches(base_url or "", "api.xkiro.com")
+
+
 def _requires_bearer_auth(base_url: str | None) -> bool:
     """Providers needing ``Authorization: Bearer`` instead of ``x-api-key``: MiniMax, Azure AI
-    Foundry, Palantir Foundry's LLM proxy, CommandCode, Nous Portal. Palantir/CommandCode use
-    hostname matching (not substring) so ``evil.com/palantirfoundry`` paths don't trigger it."""
+    Foundry, Palantir Foundry's LLM proxy, CommandCode, Nous Portal, xKiro. Palantir/CommandCode/xKiro
+    use hostname matching (not substring) so ``evil.com/palantirfoundry`` paths don't trigger it."""
     normalized = _normalized_lower(base_url)
     return (
         _is_nous_portal_endpoint(base_url)
@@ -131,6 +136,7 @@ def _requires_bearer_auth(base_url: str | None) -> bool:
         or "azure.com" in normalized
         or base_url_host_matches(normalized, "palantirfoundry.com")
         or base_url_host_matches(normalized, "api.commandcode.ai")
+        or _is_xkiro_endpoint(normalized)
     )
 
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1239,6 +1239,11 @@ def _consume_ephemeral_max_output(agent):
 def _build_anthropic_kwargs(agent, api_messages, tools_for_api, reasoning_config, request_overrides):
     ctx_len = getattr(agent, "context_compressor", None)
     ephemeral_out = _consume_ephemeral_max_output(agent)
+    preserve_anthropic_model_id = False
+    with contextlib.suppress(Exception):
+        from providers import get_provider_profile
+        profile = get_provider_profile(agent.provider)
+        preserve_anthropic_model_id = bool(getattr(profile, "preserve_anthropic_model_id", False))
     anthropic_kwargs = agent._get_transport().build_kwargs(model=agent.model,
         messages=agent._prepare_anthropic_messages_for_api(api_messages), tools=tools_for_api,
         max_tokens=ephemeral_out if ephemeral_out is not None else agent.max_tokens,
@@ -1247,7 +1252,8 @@ def _build_anthropic_kwargs(agent, api_messages, tools_for_api, reasoning_config
         context_length=ctx_len.context_length if ctx_len else None,
         base_url=getattr(agent, "_anthropic_base_url", None),
         fast_mode=request_overrides.get("speed") == "fast",
-        drop_context_1m_beta=bool(getattr(agent, "_oauth_1m_beta_disabled", False)))
+        drop_context_1m_beta=bool(getattr(agent, "_oauth_1m_beta_disabled", False)),
+        preserve_anthropic_model_id=preserve_anthropic_model_id)
     # Portal reads ``tags`` / ``session_id`` on its Messages route too, but the profile hook
     # is only consulted by the OpenAI-wire transport — merge here to keep sticky routing.
     return _merge_nous_portal_messages_extra_body(agent, anthropic_kwargs)

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -26,6 +26,7 @@ def _unprefix_oauth_tool_name(name: str) -> str:
 # build_kwargs params forwarded to build_anthropic_kwargs, with the defaults applied when absent.
 _BUILD_KWARG_DEFAULTS = {
     "max_tokens": 16384, "reasoning_config": None, "tool_choice": None, "is_oauth": False, "preserve_dots": False,
+    "preserve_anthropic_model_id": False,
     "context_length": None, "base_url": None, "fast_mode": False, "drop_context_1m_beta": False,
 }
 

--- a/providers/base.py
+++ b/providers/base.py
@@ -102,6 +102,10 @@ class ProviderProfile:
     default_headers: dict[str, str] = field(default_factory=dict)
 
     # ── Request-level quirks ─────────────────────────────────
+    # Keep the provider's catalog model id verbatim on the Anthropic Messages
+    # wire instead of reducing it to Anthropic's canonical ``claude-*`` form.
+    # Relays that route on namespaced ids (for example ``vendor/model``) opt in.
+    preserve_anthropic_model_id: bool = False
     # Temperature: None = use caller's default, OMIT_TEMPERATURE = don't send
     fixed_temperature: Any = None
     default_max_tokens: int | None = None

--- a/tests/agent/test_xkiro_anthropic_allowlist.py
+++ b/tests/agent/test_xkiro_anthropic_allowlist.py
@@ -1,14 +1,19 @@
 """xKiro Anthropic Messages needs Bearer auth and verbatim catalog ids.
 
-The standalone plugin lives outside this tree. Core only allowlists the
-official host so `/v1/messages` does not send `x-api-key` or strip
-``vendor/model`` prefixes.
+The standalone plugin lives outside this tree. Core allowlists the official
+host for Bearer auth; model-id preservation is a generic provider-profile
+capability so custom xKiro endpoints work without another hostname exception.
 """
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import patch
+
 from agent.anthropic_adapter import build_anthropic_kwargs
 from agent.anthropic_endpoints import _is_xkiro_endpoint, _requires_bearer_auth
+from agent.chat_completion_helpers import _build_anthropic_kwargs
+from providers.base import ProviderProfile
 
 
 def test_requires_bearer_auth_recognizes_xkiro():
@@ -24,7 +29,7 @@ def test_bearer_auth_does_not_match_lookalike_hosts():
     assert _is_xkiro_endpoint("https://evil.example/api.xkiro.com/v1") is False
 
 
-def test_build_anthropic_kwargs_keeps_xkiro_vendor_model_id():
+def test_build_anthropic_kwargs_keeps_provider_declared_vendor_model_id():
     kwargs = build_anthropic_kwargs(
         model="anthropic/claude-sonnet-4.6",
         messages=[{"role": "user", "content": "hi"}],
@@ -32,6 +37,7 @@ def test_build_anthropic_kwargs_keeps_xkiro_vendor_model_id():
         max_tokens=1024,
         reasoning_config=None,
         base_url="https://api.xkiro.com/v1",
+        preserve_anthropic_model_id=True,
     )
     assert kwargs["model"] == "anthropic/claude-sonnet-4.6"
 
@@ -46,3 +52,44 @@ def test_build_anthropic_kwargs_still_normalizes_unrelated_hosts():
         base_url="https://api.anthropic.com",
     )
     assert kwargs["model"] == "claude-sonnet-4-6"
+
+
+def test_xkiro_hostname_alone_does_not_control_model_normalization():
+    kwargs = build_anthropic_kwargs(
+        model="anthropic/claude-sonnet-4.6",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        max_tokens=1024,
+        reasoning_config=None,
+        base_url="https://api.xkiro.com/v1",
+    )
+    assert kwargs["model"] == "claude-sonnet-4-6"
+
+
+def test_anthropic_request_uses_provider_model_id_contract():
+    profile = ProviderProfile(name="relay", preserve_anthropic_model_id=True)
+    transport = SimpleNamespace(build_kwargs=lambda **kwargs: kwargs)
+    agent = SimpleNamespace(
+        provider="relay",
+        model="vendor/claude-sonnet-4.6",
+        context_compressor=None,
+        _ephemeral_max_output_tokens=None,
+        max_tokens=1024,
+        _is_anthropic_oauth=False,
+        _anthropic_base_url="https://relay.example/v1",
+        _oauth_1m_beta_disabled=False,
+        _get_transport=lambda: transport,
+        _prepare_anthropic_messages_for_api=lambda messages: messages,
+        _anthropic_preserve_dots=lambda: False,
+    )
+
+    with patch("providers.get_provider_profile", return_value=profile):
+        kwargs = _build_anthropic_kwargs(
+            agent,
+            [{"role": "user", "content": "hi"}],
+            None,
+            None,
+            {},
+        )
+
+    assert kwargs["preserve_anthropic_model_id"] is True

--- a/tests/agent/test_xkiro_anthropic_allowlist.py
+++ b/tests/agent/test_xkiro_anthropic_allowlist.py
@@ -1,0 +1,48 @@
+"""xKiro Anthropic Messages needs Bearer auth and verbatim catalog ids.
+
+The standalone plugin lives outside this tree. Core only allowlists the
+official host so `/v1/messages` does not send `x-api-key` or strip
+``vendor/model`` prefixes.
+"""
+
+from __future__ import annotations
+
+from agent.anthropic_adapter import build_anthropic_kwargs
+from agent.anthropic_endpoints import _is_xkiro_endpoint, _requires_bearer_auth
+
+
+def test_requires_bearer_auth_recognizes_xkiro():
+    assert _requires_bearer_auth("https://api.xkiro.com/v1") is True
+    assert _requires_bearer_auth("https://api.xkiro.com/v1/messages") is True
+    assert _requires_bearer_auth("https://API.XKIRO.COM/v1") is True
+
+
+def test_bearer_auth_does_not_match_lookalike_hosts():
+    assert _requires_bearer_auth("https://api.anthropic.com") is False
+    assert _requires_bearer_auth("https://api.xkiro.com.evil.example/v1") is False
+    assert _requires_bearer_auth("https://evil.example/api.xkiro.com/v1") is False
+    assert _is_xkiro_endpoint("https://evil.example/api.xkiro.com/v1") is False
+
+
+def test_build_anthropic_kwargs_keeps_xkiro_vendor_model_id():
+    kwargs = build_anthropic_kwargs(
+        model="anthropic/claude-sonnet-4.6",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        max_tokens=1024,
+        reasoning_config=None,
+        base_url="https://api.xkiro.com/v1",
+    )
+    assert kwargs["model"] == "anthropic/claude-sonnet-4.6"
+
+
+def test_build_anthropic_kwargs_still_normalizes_unrelated_hosts():
+    kwargs = build_anthropic_kwargs(
+        model="anthropic/claude-sonnet-4.6",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        max_tokens=1024,
+        reasoning_config=None,
+        base_url="https://api.anthropic.com",
+    )
+    assert kwargs["model"] == "claude-sonnet-4-6"

--- a/tests/agent/test_xkiro_anthropic_allowlist.py
+++ b/tests/agent/test_xkiro_anthropic_allowlist.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from agent.anthropic_adapter import build_anthropic_kwargs
-from agent.anthropic_endpoints import _is_xkiro_endpoint, _requires_bearer_auth
+from agent.anthropic_endpoints import _requires_bearer_auth
 from agent.chat_completion_helpers import _build_anthropic_kwargs
 from providers.base import ProviderProfile
 
@@ -26,7 +26,6 @@ def test_bearer_auth_does_not_match_lookalike_hosts():
     assert _requires_bearer_auth("https://api.anthropic.com") is False
     assert _requires_bearer_auth("https://api.xkiro.com.evil.example/v1") is False
     assert _requires_bearer_auth("https://evil.example/api.xkiro.com/v1") is False
-    assert _is_xkiro_endpoint("https://evil.example/api.xkiro.com/v1") is False
 
 
 def test_build_anthropic_kwargs_keeps_provider_declared_vendor_model_id():


### PR DESCRIPTION
## Summary
xKiro's Anthropic Messages route needs two distinct behaviors:

- **Bearer auth** instead of Anthropic's native `x-api-key`. This remains pinned to the official `api.xkiro.com` hostname, matching the existing CommandCode auth treatment and avoiding lookalike-host matches.
- **Verbatim catalog model IDs** such as `anthropic/claude-sonnet-4.6`. This is now declared by the provider profile through `preserve_anthropic_model_id=True`, rather than inferred from the xKiro hostname.

The separation is intentional: authentication scheme is an endpoint property, while model-ID shape is a provider/catalog contract. Keeping preservation profile-driven also supports user-configured xKiro base URLs and other Anthropic-compatible relays without growing the Nous Portal special case into a provider hostname allowlist.

The xKiro provider itself remains a standalone plugin: https://github.com/donovan-yohan/hermes-plugin-xkiro. Its Anthropic profile opts into the new contract in [`6c24b9f`](https://github.com/donovan-yohan/hermes-plugin-xkiro/commit/6c24b9fed8e8d09a615dcee8c2f839190f9adddc), assigned after construction so the plugin remains importable on older Hermes versions.

This PR does not add a bundled provider, pricing hooks, picker flags, or auxiliary-transport changes.

Supersedes the broader in-tree provider work in #107923 and the original plugin-only #100146 (those still need this narrow core support for Messages).

## Compatibility

- CommandCode is unchanged: it still opts into Bearer auth by hostname and uses bare `claude-*` IDs, so it does not enable model-ID preservation.
- Nous Portal retains its existing compatibility fallback; new providers should use the profile declaration.
- Providers default to the current normalization behavior unless they explicitly opt in.

## Verification

- `HERMES_TEST_WORKERS=1 scripts/run_tests.sh tests/agent/test_xkiro_anthropic_allowlist.py tests/plugins/model_providers/test_commandcode_profile.py`
  - 40 passed
- Broader request-path run also covered `tests/run_agent/test_run_agent.py::TestBuildApiKwargsAnthropicMaxTokens`.
- `ruff check` passed for all five changed files.
- `git diff --check` passed.

Two unrelated Nous client-construction tests require the optional `anthropic` SDK, which is absent from this checkout's test venv; the remaining Nous wire tests passed.