### PR TITLE
fix(kanban): initial_status=blocked gates survive board reads and dispatcher ticks (#109260, salvage #108170)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1366,6 +1366,13 @@ def create_task(
                         "provider_override": provider_override,
                     },
                 )
+                if task_status == "blocked":
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {"reason": "initial_status", "status": "blocked", "actor": created_by or "user"},
+                    )
                 # ACK-edge: the originating channel hears a child BLOCK, not just the fan-in.
                 inherit_creator_origin(conn, task_id, creator_task_id, created_at=now)
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -156,9 +156,22 @@ def test_protocol_violation_loop_is_broken(kanban_home: Path) -> None:
             assert kb.get_task(conn, tid).status == "blocked"
 
 
-# ---------------------------------------------------------------------------
-# Schema-init recovery on legacy DBs is covered by
-# tests/hermes_cli/test_kanban_db.py::test_connect_migrates_legacy_db_before_optional_column_indexes
-# (landed via #28754 / #28781).  The original PR shipped a duplicate test
-# here; dropped during salvage to avoid two assertions of the same contract.
-# ---------------------------------------------------------------------------
+def test_created_with_initial_status_blocked_is_not_promoted_by_recompute_ready(kanban_home: Path) -> None:
+    """Verify a task created with initial_status='blocked' remains blocked when parents complete."""
+    with kbc.connect() as conn:
+        parent_id = kb.create_task(conn, title="parent task")
+        child_id = kb.create_task(
+            conn, title="gated child task", parents=[parent_id], initial_status="blocked"
+        )
+        assert kb.get_task(conn, child_id).status == "blocked"
+
+        # Complete parent task
+        kb.claim_task(conn, parent_id)
+        kb.complete_task(conn, parent_id, result="done")
+        assert kb.get_task(conn, parent_id).status == "done"
+
+        # recompute_ready must NOT promote the blocked child task
+        promoted = kb.recompute_ready(conn)
+        assert promoted == 0
+        assert kb.get_task(conn, child_id).status == "blocked"
+


### PR DESCRIPTION
Tasks created with `initial_status="blocked"` now stay blocked until an explicit `kanban_unblock` — any board read (`hermes kanban list`, the `kanban_list` tool) or dispatcher tick no longer silently promotes the human gate to `ready` (fixes #109260, fixes #107398, refs #39609, salvage of #108170 by @salch-cred).

## Root cause
`create_task(initial_status="blocked")` wrote only a `created` event, so `_has_sticky_block` found no `blocked` event and `recompute_ready` classified the row as auto-recoverable — and since `_cmd_list` / `kanban_list` call `recompute_ready` on every invocation ("cheap mini-dispatch"), even a bare `hermes kanban list` flipped the gate in ~1 s, exactly as #109260 measured.

## Changes
- `create_task` emits a `blocked` event (`reason: initial_status`) when the task is born blocked, so the existing sticky guard in `recompute_ready` engages from birth — same mechanism as an explicit `kanban_block`.
- Invariant test: a gated child stays `blocked` across `recompute_ready` after its parent completes.

## Validation
Live E2E on this branch (temp `HERMES_HOME`, real SQLite), before → after on the same probe:

- No-parent human gate + `recompute_ready`: before `ready`, after **`blocked`**
- Parent completes, gated child: before `ready`, after **`blocked`**
- Explicit `kanban_unblock` then `recompute_ready`: `ready` both before and after (release path intact)
- Link-edit trigger (`link_tasks` → `recompute_ready`): `blocked` after (covered by the same gate)

`scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_blocked_sticky.py` — all green. ruff, windows-footguns, compat pointers, attribution audit: clean.

**Live repro:** `recompute_ready` on origin/main promotes a birth-blocked task (`promoted=1, status=ready`); on this branch the same probe yields `promoted=0, status=blocked`, and explicit unblock still releases.

## Credit
Salvaged from #108170 by @salch-cred (earliest minimal mechanism in the cluster; #107793 and #64830 address the same class — this authorship-preserving cherry-pick supersedes them once landed).

## Infographic
![infographic](https://v3b.fal.media/files/b/0aaa2877/KpBdUgO3T10nxs72R-JUK_uQ0HKXyw.png)
