### PR TITLE
fix(curator): skip absolute symlinks in backups

### DIFF
--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -134,6 +134,16 @@ def _mkdir(path: Path, what: str, *, exist_ok: bool) -> bool:
         return False
 
 
+def _snapshot_filter(member: tarfile.TarInfo) -> Optional[tarfile.TarInfo]:
+    if any(part in _EXCLUDE_TOP_LEVEL for part in Path(member.name).parts):
+        return None
+    # Rollback's data filter rejects absolute link targets. Do not dereference
+    # them here: their contents live outside the skills tree.
+    if member.issym() and os.path.isabs(member.linkname):
+        return None
+    return member
+
+
 def snapshot_skills(reason: str = "manual", *, protect_ids: Optional[Set[str]] = None) -> Optional[Path]:
     """Create a tar.gz snapshot of ``~/.hermes/skills/`` and prune old ones. Returns the snapshot dir, or None when
     skipped (disabled, skills dir missing, IO error) — logged at debug so the curator never aborts a pass over a
@@ -161,7 +171,7 @@ def snapshot_skills(reason: str = "manual", *, protect_ids: Optional[Set[str]] =
                 if entry.name not in _EXCLUDE_TOP_LEVEL:
                     # arcname relative to skills/ so extraction drops back in cleanly; the filter excludes nested _EXCLUDE_TOP_LEVEL paths too.
                     tf.add(str(entry), arcname=entry.name, recursive=True,
-                           filter=lambda ti: None if any(p in _EXCLUDE_TOP_LEVEL for p in Path(ti.name).parts) else ti)
+                           filter=_snapshot_filter)
         # Cron capture is additive and never fails the snapshot; the manifest records whether it happened so rollback can say "no cron data".
         _write_manifest(dest, reason, archive, _count_skill_files(skills), _backup_cron_jobs_into(dest))
     except (OSError, tarfile.TarError) as e:

--- a/tests/agent/test_curator_backup.py
+++ b/tests/agent/test_curator_backup.py
@@ -189,6 +189,28 @@ def test_rollback_rejects_unsafe_tarball(backup_env, monkeypatch):
     assert "unsafe" in msg.lower() or "refus" in msg.lower() or "extract" in msg.lower()
 
 
+def test_snapshot_with_absolute_symlink_is_rollback_restorable(backup_env):
+    """A successful snapshot must not contain a link rollback will reject."""
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+    skill_file = _write_skill(skills, "alpha", body="snapshot state") / "SKILL.md"
+    external = backup_env["home"] / "external.txt"
+    external.write_text("outside skills\n", encoding="utf-8")
+    absolute_link = skill_file.parent / "external-link"
+    absolute_link.symlink_to(external)
+
+    snap = cb.snapshot_skills(reason="absolute-symlink")
+    assert snap is not None
+    skill_file.write_text("current state\n", encoding="utf-8")
+
+    ok, msg, restored = cb.rollback(backup_id=snap.name)
+
+    assert ok, msg
+    assert restored == snap
+    assert "snapshot state" in skill_file.read_text(encoding="utf-8")
+    assert not absolute_link.exists()
+
+
 # ---------------------------------------------------------------------------
 # Integration with run_curator_review
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Prevents curator snapshots from containing absolute symlink members that the rollback path's strict tar extraction filter rejects.

The snapshot filter now omits absolute symlinks instead of dereferencing them. This keeps data outside the skills tree out of the archive and leaves rollback's fail-closed extraction policy unchanged.

## Related Issue

Fixes #109331

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a reusable snapshot tar filter that preserves existing excluded-path behavior and drops absolute symlink members.
- Add an end-to-end regression that snapshots a live skills tree containing an absolute symlink and successfully restores that snapshot.

## Proof Receipt

- Base: `origin/main` at `1c671beab29164d8931c5d01c5739502267089d8`
- BEFORE (RED): the focused regression failed with `snapshot extract failed (state restored): 'alpha/external-link' is a link to an absolute path`.
- AFTER (GREEN): the same focused regression passed (`1 passed, 0 failed`).
- CONTROL: the complete affected test file passed (`17 passed, 0 failed`).
- P0 self-review: `0` findings across Detection, Fail-open, Forbidden, RED validity, and diff scope.

## How to Test

```bash
HERMES_PYTHON=/path/to/python-with-pytest scripts/run_tests.sh \
  tests/agent/test_curator_backup.py -q
```

## Risk

Absolute symlinks are intentionally omitted from snapshots because restoring them would require weakening strict extraction or preserving references to paths outside the skills tree. Relative symlinks retain their existing behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; this is a filesystem backup/rollback fix covered by the regression above.
