### PR TITLE
fix(curator): skip absolute symlinks in skill snapshots instead of archiving unrestorable links

### DIFF
--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -12,6 +12,7 @@ import contextlib
 import json
 import logging
 import os
+import posixpath
 import re
 import shutil
 import tarfile
@@ -107,11 +108,40 @@ def get_keep() -> int:
 
 
 # --- Snapshot ---
-def _is_absolute_link_target(linkname: str) -> bool:
-    """True when a symlink's recorded target is absolute: POSIX ``/``, a Windows drive
-    letter (``C:\\...``), or a UNC path (``\\\\server\\share``). Rollback's tarfile
-    ``"data"`` extraction filter refuses such links, so snapshots must not archive them."""
-    return linkname.startswith("/") or linkname.startswith("\\\\") or (len(linkname) >= 2 and linkname[1] == ":")
+_WIN_DRIVE_LETTERS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+
+def _link_target_kind(linkname: str) -> str:
+    """Classify a symlink's recorded target purely from its string, so snapshots and rollback agree
+    on every platform (the host filesystem is never consulted). Returns one of:
+    ``posix-abs`` (``/...``), ``win-abs`` (UNC ``\\\\server\\share``, device ``\\\\?\\``/``\\\\.\\``,
+    or rooted-with-drive ``C:\\...`` and rooted-without-drive ``\\foo``), ``drive-relative``
+    (``C:`` / ``C:foo`` — anchored to the drive's current directory, not portable), or ``relative``."""
+    if linkname.startswith("/"):
+        return "posix-abs"
+    if linkname.startswith("\\"):
+        return "win-abs"
+    if len(linkname) >= 2 and linkname[1] == ":" and linkname[0] in _WIN_DRIVE_LETTERS:
+        if len(linkname) == 2 or linkname[2] not in "\\/":
+            return "drive-relative"
+        return "win-abs"
+    return "relative"
+
+
+def _unrestorable_symlink(member_name: str, linkname: str) -> Optional[str]:
+    """Why the symlink at tar member *member_name* cannot be archived into a snapshot that
+    rollback's extraction must restore, or None when it is safe to archive. Mirrors the checks of
+    tarfile's ``"data"`` extraction filter (#109331): absolute and drive-relative targets are
+    refused outright, and a relative target that resolves above the extraction root raises
+    ``LinkOutsideDestinationError`` at extract time (e.g. ``alpha/escape -> ../../outside``).
+    Tar member paths are POSIX-style, so the escape check uses ``posixpath`` on every host."""
+    kind = _link_target_kind(linkname)
+    if kind != "relative":
+        return kind
+    resolved = posixpath.normpath(posixpath.join(posixpath.dirname(member_name), linkname))
+    if resolved == ".." or resolved.startswith("../"):
+        return "relative-escape"
+    return None
 
 
 def _count_skill_files(base: Path) -> int:
@@ -122,7 +152,7 @@ def _count_skill_files(base: Path) -> int:
 
 
 def _write_manifest(dest: Path, reason: str, archive_path: Path, skills_counted: int, cron_info: Dict[str, Any],
-                    skipped_absolute_links: Optional[List[str]] = None) -> None:
+                    skipped_symlinks: Optional[List[Dict[str, str]]] = None) -> None:
     cron_jobs: Dict[str, Any] = {"backed_up": bool(cron_info.get("backed_up", False)), "jobs_count": int(cron_info.get("jobs_count", 0))}
     if not cron_info.get("backed_up"):
         cron_jobs["reason"] = cron_info.get("reason", "not captured")
@@ -130,8 +160,8 @@ def _write_manifest(dest: Path, reason: str, archive_path: Path, skills_counted:
         cron_jobs["parse_warning"] = cron_info["parse_warning"]
     manifest = {"id": dest.name, "reason": reason, "created_at": datetime.now(timezone.utc).isoformat(), "archive": archive_path.name,
                 "archive_bytes": archive_path.stat().st_size, "skill_files": skills_counted, "cron_jobs": cron_jobs}
-    if skipped_absolute_links:
-        manifest["skipped_absolute_links"] = skipped_absolute_links
+    if skipped_symlinks:
+        manifest["skipped_symlinks"] = skipped_symlinks
     (dest / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
 
 
@@ -165,18 +195,21 @@ def snapshot_skills(reason: str = "manual", *, protect_ids: Optional[Set[str]] =
         return None
 
     archive = dest / _ARCHIVE_NAME
-    skipped_absolute_links: List[str] = []
+    skipped_symlinks: List[Dict[str, str]] = []
 
     def _snapshot_member(ti: tarfile.TarInfo):
         # arcname relative to skills/ so extraction drops back in cleanly; the filter excludes nested _EXCLUDE_TOP_LEVEL paths too.
         if any(p in _EXCLUDE_TOP_LEVEL for p in Path(ti.name).parts):
             return None
-        # An absolute symlink records an absolute linkname, which rollback's extraction filter
-        # (tarfile "data") refuses — a snapshot that cannot be restored must not be reported as
-        # success. Skip the link member and record it in the manifest instead (#109331).
-        if ti.issym() and _is_absolute_link_target(ti.linkname):
-            skipped_absolute_links.append(ti.name)
-            return None
+        # A symlink whose target the tar "data" extraction filter would refuse (absolute, drive-relative,
+        # or resolving above the skills root) must not be archived — a snapshot that cannot be restored
+        # must not be reported as success. Skip the member and record path+target in the manifest so
+        # rollback can rebuild the link (#109331).
+        if ti.issym():
+            why = _unrestorable_symlink(ti.name, ti.linkname)
+            if why is not None:
+                skipped_symlinks.append({"path": ti.name, "target": ti.linkname, "reason": why})
+                return None
         return ti
 
     try:
@@ -186,7 +219,7 @@ def snapshot_skills(reason: str = "manual", *, protect_ids: Optional[Set[str]] =
                     tf.add(str(entry), arcname=entry.name, recursive=True, filter=_snapshot_member)
         # Cron capture is additive and never fails the snapshot; the manifest records whether it happened so rollback can say "no cron data".
         _write_manifest(dest, reason, archive, _count_skill_files(skills), _backup_cron_jobs_into(dest),
-                        skipped_absolute_links=skipped_absolute_links)
+                        skipped_symlinks=skipped_symlinks)
     except (OSError, tarfile.TarError) as e:
         logger.debug("Curator snapshot failed: %s", e, exc_info=True)
         shutil.rmtree(dest, ignore_errors=True)  # clean up partial snapshot
@@ -350,6 +383,41 @@ def _restore_excluded_subtrees(staged: Path, skills: Path) -> None:
         dirnames[:] = [d for d in dirnames if d not in _EXCLUDE_TOP_LEVEL]
 
 
+def _restore_skipped_symlinks(snapshot_dir: Path, skills: Path) -> int:
+    """Rebuild the symlinks the snapshot skipped at backup time (targets the tarfile ``"data"``
+    extraction filter refuses — absolute, drive-relative, or escaping). Their ``path``+``target`` live in the
+    manifest so the snapshot stays a complete, undoable image of the live tree: rollback is a
+    same-machine operation, so the recorded target is still valid here (#109331). Never raises;
+    returns how many links were rebuilt."""
+    links = _read_manifest(snapshot_dir).get("skipped_symlinks")
+    if not isinstance(links, list):
+        return 0
+    restored = 0
+    for link in links:
+        if not isinstance(link, dict):
+            continue
+        path, target = link.get("path"), link.get("target")
+        if not isinstance(path, str) or not path or not isinstance(target, str) or not target:
+            continue
+        # The manifest is machine-written but treated as untrusted input: a hand-edited entry
+        # must never place a link outside skills/ or resurrect an excluded top-level name.
+        parts = Path(path).parts
+        if path.startswith(("/", "\\")) or ".." in parts or any(p in _EXCLUDE_TOP_LEVEL for p in parts):
+            logger.debug("Refusing to restore skipped symlink with unsafe path %r", path)
+            continue
+        dest = skills / path
+        if dest.exists() or dest.is_symlink():  # extraction already placed something there — it wins
+            continue
+        if not dest.parent.is_dir():  # parent wasn't part of the snapshot; nothing to hang the link on
+            continue
+        try:
+            os.symlink(target, dest)
+            restored += 1
+        except OSError as e:
+            logger.debug("Could not restore skipped symlink %s -> %s: %s", path, target, e)
+    return restored
+
+
 def _unstage(moved: List[Tuple[Path, Path]]) -> List[str]:
     """Move staged entries back to their original paths; returns names that could not be restored. ``shutil.move``
     moves *into* an existing destination dir, so partial-extract debris would bury the real skill
@@ -447,10 +515,17 @@ def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]
     _restore_excluded_subtrees(staged, skills)
     shutil.rmtree(staged, ignore_errors=True)
 
+    # Skipped symlinks (unrestorable through the data filter) are rebuilt from the manifest so the
+    # restored tree — and any later rollback to this snapshot's own safety snapshot — keeps them.
+    restored_links = _restore_skipped_symlinks(target, skills)
+
     # Cron reconciliation failures don't fail the rollback — the skills tree (the main guarantee) is already restored.
     cron_report = _restore_cron_skill_links(target)
     logger.info("Curator rollback: restored from %s (cron_report=%s)", target.name, cron_report)
-    return (True, "; ".join(filter(None, [f"restored from snapshot {target.name}", _cron_summary(cron_report)])), target)
+    summary = f"restored from snapshot {target.name}"
+    if restored_links:
+        summary += f"; rebuilt {restored_links} skipped symlink(s)"
+    return (True, "; ".join(filter(None, [summary, _cron_summary(cron_report)])), target)
 
 
 # --- Human-readable summary for CLI ---

--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -107,6 +107,13 @@ def get_keep() -> int:
 
 
 # --- Snapshot ---
+def _is_absolute_link_target(linkname: str) -> bool:
+    """True when a symlink's recorded target is absolute: POSIX ``/``, a Windows drive
+    letter (``C:\\...``), or a UNC path (``\\\\server\\share``). Rollback's tarfile
+    ``"data"`` extraction filter refuses such links, so snapshots must not archive them."""
+    return linkname.startswith("/") or linkname.startswith("\\\\") or (len(linkname) >= 2 and linkname[1] == ":")
+
+
 def _count_skill_files(base: Path) -> int:
     try:
         return sum(1 for p in base.rglob("SKILL.md") if not is_excluded_skill_path(p))
@@ -114,7 +121,8 @@ def _count_skill_files(base: Path) -> int:
         return 0
 
 
-def _write_manifest(dest: Path, reason: str, archive_path: Path, skills_counted: int, cron_info: Dict[str, Any]) -> None:
+def _write_manifest(dest: Path, reason: str, archive_path: Path, skills_counted: int, cron_info: Dict[str, Any],
+                    skipped_absolute_links: Optional[List[str]] = None) -> None:
     cron_jobs: Dict[str, Any] = {"backed_up": bool(cron_info.get("backed_up", False)), "jobs_count": int(cron_info.get("jobs_count", 0))}
     if not cron_info.get("backed_up"):
         cron_jobs["reason"] = cron_info.get("reason", "not captured")
@@ -122,6 +130,8 @@ def _write_manifest(dest: Path, reason: str, archive_path: Path, skills_counted:
         cron_jobs["parse_warning"] = cron_info["parse_warning"]
     manifest = {"id": dest.name, "reason": reason, "created_at": datetime.now(timezone.utc).isoformat(), "archive": archive_path.name,
                 "archive_bytes": archive_path.stat().st_size, "skill_files": skills_counted, "cron_jobs": cron_jobs}
+    if skipped_absolute_links:
+        manifest["skipped_absolute_links"] = skipped_absolute_links
     (dest / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
 
 
@@ -155,15 +165,28 @@ def snapshot_skills(reason: str = "manual", *, protect_ids: Optional[Set[str]] =
         return None
 
     archive = dest / _ARCHIVE_NAME
+    skipped_absolute_links: List[str] = []
+
+    def _snapshot_member(ti: tarfile.TarInfo):
+        # arcname relative to skills/ so extraction drops back in cleanly; the filter excludes nested _EXCLUDE_TOP_LEVEL paths too.
+        if any(p in _EXCLUDE_TOP_LEVEL for p in Path(ti.name).parts):
+            return None
+        # An absolute symlink records an absolute linkname, which rollback's extraction filter
+        # (tarfile "data") refuses — a snapshot that cannot be restored must not be reported as
+        # success. Skip the link member and record it in the manifest instead (#109331).
+        if ti.issym() and _is_absolute_link_target(ti.linkname):
+            skipped_absolute_links.append(ti.name)
+            return None
+        return ti
+
     try:
         with tarfile.open(archive, "w:gz", compresslevel=6) as tf:
             for entry in sorted(skills.iterdir()):
                 if entry.name not in _EXCLUDE_TOP_LEVEL:
-                    # arcname relative to skills/ so extraction drops back in cleanly; the filter excludes nested _EXCLUDE_TOP_LEVEL paths too.
-                    tf.add(str(entry), arcname=entry.name, recursive=True,
-                           filter=lambda ti: None if any(p in _EXCLUDE_TOP_LEVEL for p in Path(ti.name).parts) else ti)
+                    tf.add(str(entry), arcname=entry.name, recursive=True, filter=_snapshot_member)
         # Cron capture is additive and never fails the snapshot; the manifest records whether it happened so rollback can say "no cron data".
-        _write_manifest(dest, reason, archive, _count_skill_files(skills), _backup_cron_jobs_into(dest))
+        _write_manifest(dest, reason, archive, _count_skill_files(skills), _backup_cron_jobs_into(dest),
+                        skipped_absolute_links=skipped_absolute_links)
     except (OSError, tarfile.TarError) as e:
         logger.debug("Curator snapshot failed: %s", e, exc_info=True)
         shutil.rmtree(dest, ignore_errors=True)  # clean up partial snapshot

--- a/tests/agent/test_curator_backup.py
+++ b/tests/agent/test_curator_backup.py
@@ -52,6 +52,71 @@ def _write_skill(skills_dir: Path, name: str, body: str = "body") -> Path:
 
 
 
+def test_snapshot_skips_absolute_symlink_and_records_manifest(backup_env, tmp_path):
+    """An absolute symlink (e.g. the installed cua-driver link) records an absolute
+    linkname that rollback's extraction filter refuses (#109331). The snapshot must
+    omit the member and record it in the manifest so every successful snapshot is
+    restorable by ``curator rollback`` on the same installation."""
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+    _write_skill(skills, "alpha")
+    external = tmp_path / "external-driver"
+    external.mkdir()
+    (skills / "cua-driver").symlink_to(external)  # absolute target
+
+    snap = cb.snapshot_skills(reason="manual")
+    assert snap is not None
+
+    with tarfile.open(snap / "skills.tar.gz", "r:gz") as tf:
+        names = tf.getnames()
+    assert "alpha/SKILL.md" in names
+    assert "cua-driver" not in names
+
+    manifest = json.loads((snap / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["skipped_absolute_links"] == ["cua-driver"]
+
+
+def test_snapshot_with_absolute_symlink_round_trips_through_rollback(backup_env, tmp_path):
+    """End-to-end regression: a snapshot created on an installation whose live skills
+    tree contains an absolute symlink must pass rollback validation unchanged."""
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+    _write_skill(skills, "alpha")
+    external = tmp_path / "external-driver"
+    external.mkdir()
+    (skills / "cua-driver").symlink_to(external)
+
+    snap = cb.snapshot_skills(reason="manual")
+    assert snap is not None
+
+    _write_skill(skills, "gamma")  # diverge the live tree after the snapshot
+    ok, msg, _ = cb.rollback(backup_id=snap.name)
+    assert ok, msg
+
+    assert (skills / "alpha" / "SKILL.md").exists()
+    assert not (skills / "gamma").exists()
+    assert not (skills / "cua-driver").exists()  # skipped at backup time, recorded in manifest
+
+
+def test_snapshot_keeps_relative_symlink_member(backup_env):
+    """Only absolute link targets are skipped; an in-tree relative symlink is a
+    legitimate skills-tree member and must keep being archived."""
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+    _write_skill(skills, "alpha")
+    (skills / "rel-link").symlink_to("alpha")  # relative target
+
+    snap = cb.snapshot_skills(reason="manual")
+    assert snap is not None
+
+    with tarfile.open(snap / "skills.tar.gz", "r:gz") as tf:
+        names = tf.getnames()
+    assert "rel-link" in names
+
+    manifest = json.loads((snap / "manifest.json").read_text(encoding="utf-8"))
+    assert "skipped_absolute_links" not in manifest
+
+
 def test_snapshot_uniquifies_when_same_second(backup_env, monkeypatch):
     """Two snapshots in the same wallclock second must not clobber each
     other. The module appends a counter to the second snapshot's id."""

--- a/tests/agent/test_curator_backup.py
+++ b/tests/agent/test_curator_backup.py
@@ -73,12 +73,13 @@ def test_snapshot_skips_absolute_symlink_and_records_manifest(backup_env, tmp_pa
     assert "cua-driver" not in names
 
     manifest = json.loads((snap / "manifest.json").read_text(encoding="utf-8"))
-    assert manifest["skipped_absolute_links"] == ["cua-driver"]
+    assert manifest["skipped_symlinks"] == [{"path": "cua-driver", "target": str(external), "reason": "posix-abs"}]
 
 
 def test_snapshot_with_absolute_symlink_round_trips_through_rollback(backup_env, tmp_path):
     """End-to-end regression: a snapshot created on an installation whose live skills
-    tree contains an absolute symlink must pass rollback validation unchanged."""
+    tree contains an absolute symlink must pass rollback validation unchanged, and the
+    skipped link must be rebuilt from the manifest so the restore loses nothing."""
     cb = backup_env["cb"]
     skills = backup_env["skills"]
     _write_skill(skills, "alpha")
@@ -95,16 +96,93 @@ def test_snapshot_with_absolute_symlink_round_trips_through_rollback(backup_env,
 
     assert (skills / "alpha" / "SKILL.md").exists()
     assert not (skills / "gamma").exists()
-    assert not (skills / "cua-driver").exists()  # skipped at backup time, recorded in manifest
+    # skipped at backup time, rebuilt at rollback time — same-machine target is still valid
+    assert (skills / "cua-driver").is_symlink()
+    assert os.readlink(skills / "cua-driver") == str(external)
+    assert "rebuilt 1 skipped symlink" in msg
 
 
-def test_snapshot_keeps_relative_symlink_member(backup_env):
-    """Only absolute link targets are skipped; an in-tree relative symlink is a
-    legitimate skills-tree member and must keep being archived."""
+def test_snapshot_skips_escaping_relative_symlink(backup_env, tmp_path):
+    """A relative target that resolves above the skills root (``alpha/escape -> ../../outside``)
+    passes the old absolute-only check but is refused by tarfile's "data" filter at extract time
+    (LinkOutsideDestinationError) — the snapshot must skip it too (#109331)."""
     cb = backup_env["cb"]
     skills = backup_env["skills"]
     _write_skill(skills, "alpha")
-    (skills / "rel-link").symlink_to("alpha")  # relative target
+    (tmp_path / "outside").mkdir()
+    (skills / "alpha" / "escape").symlink_to("../../outside")
+
+    snap = cb.snapshot_skills(reason="manual")
+    assert snap is not None
+
+    with tarfile.open(snap / "skills.tar.gz", "r:gz") as tf:
+        names = tf.getnames()
+    assert "alpha/SKILL.md" in names
+    assert "alpha/escape" not in names
+
+    manifest = json.loads((snap / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["skipped_symlinks"] == [{"path": "alpha/escape", "target": "../../outside", "reason": "relative-escape"}]
+
+
+def test_snapshot_with_escaping_relative_symlink_round_trips_through_rollback(backup_env, tmp_path):
+    """Nested escaping-relative-link round trip: snapshot + rollback over a tree containing
+    ``alpha/escape -> ../../outside`` must succeed and rebuild the link (on Python < 3.12 the
+    extract falls back unfiltered, so the rebuild is what keeps the two paths consistent)."""
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+    _write_skill(skills, "alpha")
+    (tmp_path / "outside").mkdir()
+    (skills / "alpha" / "escape").symlink_to("../../outside")
+
+    snap = cb.snapshot_skills(reason="manual")
+    assert snap is not None
+
+    _write_skill(skills, "gamma")
+    ok, msg, _ = cb.rollback(backup_id=snap.name)
+    assert ok, msg
+
+    assert (skills / "alpha" / "SKILL.md").exists()
+    assert (skills / "alpha" / "escape").is_symlink()
+    assert os.readlink(skills / "alpha" / "escape") == "../../outside"
+
+
+def test_rollback_to_safety_snapshot_restores_skipped_symlinks(backup_env, tmp_path):
+    """The pre-rollback safety snapshot is the documented undo handle: rolling back to it
+    (undoing a rollback) must also rebuild the skipped symlinks it recorded — otherwise undo
+    silently loses the links a second time (#109331)."""
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+    _write_skill(skills, "alpha")
+    external = tmp_path / "external-driver"
+    external.mkdir()
+    (skills / "cua-driver").symlink_to(external)
+
+    snap = cb.snapshot_skills(reason="manual")
+    assert snap is not None
+    _write_skill(skills, "gamma")  # diverge, then roll back (creating the safety snapshot)
+    ok, msg, _ = cb.rollback(backup_id=snap.name)
+    assert ok, msg
+    assert not (skills / "gamma").exists()
+
+    safety = cb.list_backups()[0]  # newest snapshot = the pre-rollback safety snapshot of the gamma tree
+    assert safety["reason"] == f"pre-rollback to {snap.name}"
+
+    ok, msg, _ = cb.rollback(backup_id=safety["id"])  # undo: back to the diverged tree
+    assert ok, msg
+    assert (skills / "gamma" / "SKILL.md").exists()
+    assert (skills / "cua-driver").is_symlink()
+    assert os.readlink(skills / "cua-driver") == str(external)
+
+
+def test_snapshot_keeps_relative_symlink_member(backup_env):
+    """Only unrestorable link targets are skipped; in-tree relative symlinks — including ones
+    that hop up a level but stay inside the tree — are legitimate members and keep being archived."""
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+    _write_skill(skills, "alpha")
+    _write_skill(skills, "beta")
+    (skills / "rel-link").symlink_to("alpha")  # relative target at the archive root
+    (skills / "alpha" / "up-link").symlink_to("../beta")  # hops up one level, still in-tree
 
     snap = cb.snapshot_skills(reason="manual")
     assert snap is not None
@@ -112,9 +190,48 @@ def test_snapshot_keeps_relative_symlink_member(backup_env):
     with tarfile.open(snap / "skills.tar.gz", "r:gz") as tf:
         names = tf.getnames()
     assert "rel-link" in names
+    assert "alpha/up-link" in names
 
     manifest = json.loads((snap / "manifest.json").read_text(encoding="utf-8"))
-    assert "skipped_absolute_links" not in manifest
+    assert "skipped_symlinks" not in manifest
+
+
+@pytest.mark.parametrize("linkname, expected", [
+    ("/opt/driver", "posix-abs"),
+    ("//double/slash", "posix-abs"),
+    ("\\\\server\\share\\drv", "win-abs"),      # UNC
+    ("\\\\?\\C:\\drv", "win-abs"),               # device path
+    ("\\rooted-no-drive", "win-abs"),            # rooted, resolves against the current drive
+    ("C:\\Users\\x\\drv", "win-abs"),            # drive-absolute
+    ("C:drv", "drive-relative"),                 # drive-relative: anchored to the drive's CWD
+    ("C:", "drive-relative"),
+    ("z:", "drive-relative"),                    # lower-case drive letter
+    ("alpha", "relative"),
+    ("../beta", "relative"),                     # escape decision happens per-member, not here
+    ("foo:bar", "relative"),                     # colon after a non-drive character is a plain name
+])
+def test_link_target_kind_classifies_windows_targets_without_the_filesystem(linkname, expected):
+    """Pure-string classification, independent of the host platform: tar member names are
+    POSIX-style and Windows targets keep their native spelling, so both must classify
+    identically on every OS (#109331)."""
+    from agent import curator_backup
+    assert curator_backup._link_target_kind(linkname) == expected
+
+
+def test_unrestorable_symlink_resolves_targets_per_member():
+    """The escape check mirrors tarfile's "data" filter: a relative linkname is resolved against
+    the member's own directory, so the same target can be safe for one member and escaping for
+    a deeper one."""
+    from agent import curator_backup
+    assert curator_backup._unrestorable_symlink("escape", "../outside") == "relative-escape"       # root member, up one
+    assert curator_backup._unrestorable_symlink("alpha/escape", "../../outside") == "relative-escape"
+    assert curator_backup._unrestorable_symlink("alpha/escape", "../../../outside") == "relative-escape"
+    assert curator_backup._unrestorable_symlink("alpha/up-link", "../beta") is None                # hops up, stays in-tree
+    assert curator_backup._unrestorable_symlink("rel-link", "alpha") is None                       # plain in-tree target
+    assert curator_backup._unrestorable_symlink("deep/a/b/link", "../../../../x") == "relative-escape"
+    assert curator_backup._unrestorable_symlink("deep/a/b/link", "../../../in") is None            # exactly back to root
+    assert curator_backup._unrestorable_symlink("cua-driver", "C:drv") == "drive-relative"
+    assert curator_backup._unrestorable_symlink("cua-driver", "/abs") == "posix-abs"
 
 
 def test_snapshot_uniquifies_when_same_second(backup_env, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

A snapshot created by `hermes curator backup` could be rejected by `hermes curator rollback` on the same unchanged installation: a symlink under `skills/` whose target the extraction filter cannot honor (e.g. the installed `cua-driver` absolute link) was archived as-is by `tarfile.add(..., recursive=True)`, and rollback's extraction filter (tarfile `"data"` on Python 3.12+) refuses such members — so a self-created snapshot was unrestorable through the curator CLI.

This keeps the strict rollback rejection (per #23794) untouched and fixes the creation side instead. The snapshot member filter now classifies every symlink member against the same rules the `"data"` filter applies at extract time:

- absolute targets (POSIX `/...`, Windows drive-absolute `C:\...`, rooted-without-drive `\foo`, UNC `\\server\share`, device `\\?\`) are skipped;
- relative targets that resolve above the skills root from the member's own directory (`alpha/escape -> ../../outside` → `LinkOutsideDestinationError` at extract time) are skipped too — this closes the gap a reviewer reproduced that the absolute-only check missed;
- drive-relative targets (`C:`, `C:foo`) are skipped as non-portable (anchored to a drive's current directory), instead of being mislabeled absolute; colon-after-non-drive names (`foo:bar`) stay plain relatives;
- every skipped link is recorded in the manifest under `skipped_symlinks` as `{path, target, reason}`.

And rollback now rebuilds the skipped links from the manifest after a successful extract: rollback is a same-machine operation, so the recorded target is still valid, and the pre-rollback safety snapshot (the documented undo handle) records the same metadata — keeping every snapshot a complete, undoable image of the live tree instead of one that silently loses links.

## Related Issue

Fixes #109331

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/curator_backup.py`: replaced the absolute-only check with `_link_target_kind()` (pure-string, platform-independent POSIX/Windows classification) and `_unrestorable_symlink()` (adds the per-member relative-escape resolution mirroring tarfile's `"data"` filter).
- `agent/curator_backup.py`: `snapshot_skills()` skips unrestorable symlink members and records `{path, target, reason}` objects in the manifest under `skipped_symlinks`.
- `agent/curator_backup.py`: added `_restore_skipped_symlinks()` — rollback rebuilds the recorded links after extraction (manifest treated as untrusted input: unsafe paths, `..` segments, and excluded top-level names are refused; existing extracted entries win); the rollback summary reports how many links were rebuilt.
- `tests/agent/test_curator_backup.py`: regressions for member omission + manifest record (absolute and escaping-relative), end-to-end snapshot→rollback round trips for both link kinds, a rollback-to-safety-snapshot (undo) test proving links survive being rolled back twice, in-tree relative links kept (including `../beta`-style hops that stay inside the tree), and platform-independent classification unit tests over Windows path strings.

## How to Test

1. `mkdir -p ~/.hermes/skills/alpha && printf -- '---\nname: alpha\ndescription: t\nversion: 1.0\n---\n' > ~/.hermes/skills/alpha/SKILL.md`
2. `ln -s /some/dir/outside ~/.hermes/skills/cua-driver` (any absolute symlink) and `ln -s ../../outside ~/.hermes/skills/alpha/escape` (escaping relative symlink)
3. `hermes curator backup` — should succeed.
4. Inspect the newest snapshot: `tar tzf <snapshot>/skills.tar.gz` — should NOT list `cua-driver` or `alpha/escape`; `manifest.json` should record both under `skipped_symlinks` with `path`, `target`, and `reason` (`posix-abs` / `relative-escape`). Observed result: both members omitted, manifest records both.
5. `hermes curator rollback` — should restore cleanly. Observed result: rollback succeeds, the archived skills are restored, and both skipped links are rebuilt pointing at their original targets; the summary reports `rebuilt 2 skipped symlink(s)`.
6. `hermes curator rollback` again (to the safety snapshot) — the undo path also rebuilds the links. Observed result: links present after undo.
7. `python -m pytest tests/agent/test_curator_backup.py -q` — should pass (35 passed). Also verified against a real Python 3.12 `tarfile` `"data"` filter: the reviewer's `alpha/escape -> ../../outside` repro raises `LinkOutsideDestinationError` on the unfiltered archive shape, while the patched snapshot extracts cleanly and rollback rebuilds both links.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11.15; the extraction-filter path additionally verified directly under Python 3.12.13's real `"data"` filter (repro confirmed, patched archive extracts cleanly)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
