### PR TITLE
feat(kanban): show live worker context on card hover

### DIFF
--- a/apps/desktop/src/plugins/kanban/api.ts
+++ b/apps/desktop/src/plugins/kanban/api.ts
@@ -31,6 +31,7 @@ import type {
   KanbanTask,
   KanbanTaskDetail,
   OrchestrationSettings,
+  TaskContextUsage,
   TaskEstimate,
   WorkerLog
 } from './types'
@@ -173,6 +174,9 @@ export const fetchBoard = (archived: boolean) =>
   call<KanbanBoard>(withBoard('/board', archived ? { include_archived: 'true' } : {}))
 
 export const fetchTask = (id: string) => call<KanbanTaskDetail>(withBoard(`/tasks/${id}`))
+
+/** Current occupancy for the exact live worker; fetched only when a card is hovered. */
+export const fetchTaskContext = (id: string) => call<TaskContextUsage>(withBoard(`/tasks/${id}/context`))
 
 /** Worker stdout/stderr tail (last 16 KiB — plenty for the drawer). */
 export const fetchLog = (id: string) => call<WorkerLog>(withBoard(`/tasks/${id}/log`, { tail: '16384' }))

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -74,6 +74,7 @@ import {
   fetchBoard,
   fetchBoards,
   fetchProfiles,
+  fetchTaskContext,
   patchTask,
   PROFILES_KEY
 } from './api'
@@ -237,7 +238,15 @@ function CardFooter({ arc, task }: { arc: ArcState | null; task: KanbanTask }) {
   )
 }
 
-function Card({
+export function formatContextTokens(tokens: number): string {
+  if (tokens < 1_000) {return String(tokens)}
+
+  if (tokens < 1_000_000) {return `${Math.round(tokens / 1_000)}k`}
+
+  return `${Math.round(tokens / 100_000) / 10}m`
+}
+
+export function Card({
   columns,
   onDelete,
   onMove,
@@ -260,49 +269,71 @@ function Card({
   const summary = task.latest_summary || task.body
   const fallback = useDefaultAssignee()
   const arc = arcState(task, fallback)
+  const boardSlug = useValue($boardSlug)
+  const [contextHovered, setContextHovered] = useState(false)
+
+  const contextQuery = useQuery({
+    queryKey: ['kanban', 'task-context', boardSlug, task.id, task.current_run_id, task.worker_pid],
+    queryFn: () => fetchTaskContext(task.id),
+    enabled: contextHovered && task.status === 'running',
+    staleTime: 5_000,
+    retry: false
+  })
+
+  const contextTip = task.status === 'running' && contextQuery.data?.available
+    ? k.contextUsage(
+        formatContextTokens(contextQuery.data.context_used),
+        formatContextTokens(contextQuery.data.context_max),
+        contextQuery.data.estimated
+      )
+    : k.contextUnavailable
 
   return (
     <ContextMenu>
-      <ContextMenuTrigger asChild>
-        <div
-          className={cn(
-            'group relative flex cursor-grab flex-col gap-2 rounded-md border border-(--ui-stroke-tertiary) border-l-2 bg-(--ui-bg-elevated) p-2.5',
-            // Hover matches the provider-picker rows: a quiet primary fill;
-            // selected = the theme's focus color (same as a focused input).
-            'transition-colors hover:bg-primary/[0.06] active:cursor-grabbing',
-            selected && 'border-(--dt-composer-ring) bg-[color-mix(in_srgb,var(--dt-composer-ring)_7%,transparent)]',
-            dragging && 'opacity-40'
-          )}
-          draggable
-          onClick={event => (event.metaKey || event.ctrlKey ? onToggleSelect(task.id) : onOpen(task.id))}
-          onDragEnd={() => setDragging(false)}
-          onDragStart={event => {
-            event.dataTransfer.setData('text/plain', task.id)
-            event.dataTransfer.effectAllowed = 'move'
-            // Snapshot the drag image before dimming the source, so the ghost
-            // stays a solid card (dimming first would bake 40% into it).
-            event.dataTransfer.setDragImage(event.currentTarget, event.nativeEvent.offsetX, event.nativeEvent.offsetY)
-            setDragging(true)
-          }}
-          style={{ '--kanban-tone': meta.tone, borderLeftColor: meta.tone } as CSSProperties}
-        >
-          {/* Machine-activity arc: animates ONLY while an agent is actually on
-              the card (claimed + working; amber when the heartbeat is gone).
-              Queued attachment is the footer's named-agent chip — a moving
-              border on an idle card would lie. Hidden during drag/selection
-              so those states stay legible. */}
-          {(arc === 'running' || arc === 'stale') && !dragging && !selected && (
-            <span aria-hidden className={cn('kanban-arc', arc === 'stale' && 'kanban-arc--stale')} />
-          )}
-          <span className="line-clamp-2 text-[0.8125rem] font-medium leading-snug text-foreground">
-            {task.title || task.id}
-          </span>
-          {summary && (
-            <span className="line-clamp-2 text-[0.6875rem] leading-snug text-(--ui-text-tertiary)">{summary}</span>
-          )}
-          <CardFooter arc={arc} task={task} />
-        </div>
-      </ContextMenuTrigger>
+      <Tip label={contextTip}>
+        <ContextMenuTrigger asChild>
+          <div
+            className={cn(
+              'group relative flex cursor-grab flex-col gap-2 rounded-md border border-(--ui-stroke-tertiary) border-l-2 bg-(--ui-bg-elevated) p-2.5',
+              // Hover matches the provider-picker rows: a quiet primary fill;
+              // selected = the theme's focus color (same as a focused input).
+              'transition-colors hover:bg-primary/[0.06] active:cursor-grabbing',
+              selected && 'border-(--dt-composer-ring) bg-[color-mix(in_srgb,var(--dt-composer-ring)_7%,transparent)]',
+              dragging && 'opacity-40'
+            )}
+            draggable
+            onClick={event => (event.metaKey || event.ctrlKey ? onToggleSelect(task.id) : onOpen(task.id))}
+            onDragEnd={() => setDragging(false)}
+            onDragStart={event => {
+              event.dataTransfer.setData('text/plain', task.id)
+              event.dataTransfer.effectAllowed = 'move'
+              // Snapshot the drag image before dimming the source, so the ghost
+              // stays a solid card (dimming first would bake 40% into it).
+              event.dataTransfer.setDragImage(event.currentTarget, event.nativeEvent.offsetX, event.nativeEvent.offsetY)
+              setDragging(true)
+            }}
+            onPointerEnter={() => setContextHovered(true)}
+            onPointerLeave={() => setContextHovered(false)}
+            style={{ '--kanban-tone': meta.tone, borderLeftColor: meta.tone } as CSSProperties}
+          >
+            {/* Machine-activity arc: animates ONLY while an agent is actually on
+                the card (claimed + working; amber when the heartbeat is gone).
+                Queued attachment is the footer's named-agent chip — a moving
+                border on an idle card would lie. Hidden during drag/selection
+                so those states stay legible. */}
+            {(arc === 'running' || arc === 'stale') && !dragging && !selected && (
+              <span aria-hidden className={cn('kanban-arc', arc === 'stale' && 'kanban-arc--stale')} />
+            )}
+            <span className="line-clamp-2 text-[0.8125rem] font-medium leading-snug text-foreground">
+              {task.title || task.id}
+            </span>
+            {summary && (
+              <span className="line-clamp-2 text-[0.6875rem] leading-snug text-(--ui-text-tertiary)">{summary}</span>
+            )}
+            <CardFooter arc={arc} task={task} />
+          </div>
+        </ContextMenuTrigger>
+      </Tip>
       <ContextMenuContent>
         <ContextMenuItem onSelect={() => onOpen(task.id)}>
           <Codicon name="link-external" size="0.85rem" />

--- a/apps/desktop/src/plugins/kanban/context-tooltip.test.tsx
+++ b/apps/desktop/src/plugins/kanban/context-tooltip.test.tsx
@@ -1,0 +1,93 @@
+import type { PluginRestOptions } from '@hermes/plugin-sdk'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+
+// Test harness supplies the host's locale registration, as plugin loading does.
+// eslint-disable-next-line no-restricted-imports
+import { registerPluginLocales } from '@/i18n/plugin-i18n'
+
+import { bindApi } from './api'
+import { Card } from './board'
+import { KANBAN_LOCALES } from './i18n'
+
+vi.mock('@/hermes', () => ({ setApiRequestProfile: vi.fn() }))
+
+let client: QueryClient
+let disposeApi: () => void
+let disposeLocales: () => void
+
+const rest = vi.fn(async (path: string, _options?: PluginRestOptions): Promise<unknown> => {
+  if (path === '/orchestration') {return { default_assignee: '' }}
+
+  if (path === '/tasks/t_worker/context') {
+    return {
+      available: true,
+      context_used: 41_818,
+      context_max: 200_000,
+      estimated: true,
+      source: 'provider_usage_plus_estimate'
+    }
+  }
+
+  throw new Error(`Unexpected REST request: ${path}`)
+})
+
+beforeEach(() => {
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  disposeLocales = registerPluginLocales('kanban', KANBAN_LOCALES)
+  disposeApi = bindApi(
+    async <T,>(path: string, options?: PluginRestOptions) => (await rest(path, options)) as T,
+    { get: (_key, fallback) => fallback, set: vi.fn(), remove: vi.fn() },
+    () => vi.fn()
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  client.clear()
+  disposeApi()
+  disposeLocales()
+  vi.useRealTimers()
+  vi.clearAllMocks()
+})
+
+it('fetches worker context only when the running card is hovered', async () => {
+  render(
+    <QueryClientProvider client={client}>
+      <Card
+        columns={['running']}
+        onDelete={vi.fn()}
+        onMove={vi.fn()}
+        onOpen={vi.fn()}
+        onToggleSelect={vi.fn()}
+        selected={false}
+        task={{ id: 't_worker', title: 'Worker task', status: 'running', current_run_id: 17, worker_pid: 4321 }}
+      />
+    </QueryClientProvider>
+  )
+
+  await waitFor(() => expect(rest).toHaveBeenCalledWith('/orchestration', undefined))
+  expect(rest).not.toHaveBeenCalledWith('/tasks/t_worker/context', undefined)
+
+  const card = screen.getByText('Worker task').closest('[draggable="true"]')
+  expect(card).not.toBeNull()
+  fireEvent.pointerEnter(card!)
+
+  await waitFor(() => expect(rest).toHaveBeenCalledWith('/tasks/t_worker/context', undefined))
+  await waitFor(() =>
+    expect(client.getQueryData(['kanban', 'task-context', '', 't_worker', 17, 4321])).toMatchObject({
+      context_used: 41_818,
+      context_max: 200_000,
+      estimated: true
+    })
+  )
+
+  fireEvent.pointerLeave(card!)
+  vi.useFakeTimers()
+  act(() => {
+    fireEvent.pointerMove(card!, { pointerType: 'mouse' })
+    vi.advanceTimersByTime(300)
+  })
+  expect(screen.getByRole('tooltip').textContent).toContain('Context 42k / 200k tokens (estimated)')
+})

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -40,6 +40,8 @@ type KanbanMessages = {
   wontRun: string
   wontRunTip: string
   noHeartbeat: string
+  contextUsage: (used: string, max: string, estimated: boolean) => string
+  contextUnavailable: string
   expand: (label: string) => string
   collapse: (label: string) => string
   newTaskIn: (label: string) => string
@@ -253,6 +255,8 @@ export const en: KanbanMessages = {
   wontRunTip:
     'Ready cards only run once a profile is assigned. Open the card and set an assignee, or configure a default assignee in orchestration settings.',
   noHeartbeat: 'no heartbeat',
+  contextUsage: (used, max, estimated) => `Context ${used} / ${max} tokens${estimated ? ' (estimated)' : ''}`,
+  contextUnavailable: 'Context unavailable',
   expand: label => `Expand ${label}`,
   collapse: label => `Collapse ${label}`,
   newTaskIn: label => `New task in ${label}`,
@@ -465,6 +469,8 @@ const ja: KanbanMessages = {
   wontRunTip:
     'Ready のカードはプロフィールが割り当てられて初めて実行されます。カードを開いて担当を設定するか、オーケストレーション設定でデフォルトの担当を設定してください。',
   noHeartbeat: 'ハートビートなし',
+  contextUsage: (used, max, estimated) => `コンテキスト ${used} / ${max} トークン${estimated ? '（推定）' : ''}`,
+  contextUnavailable: 'コンテキストを取得できません',
   expand: label => `${label} を展開`,
   collapse: label => `${label} を折りたたむ`,
   newTaskIn: label => `${label} に新しいタスク`,
@@ -675,6 +681,8 @@ const zh: KanbanMessages = {
   wontRun: '不会运行',
   wontRunTip: '就绪卡片只有在分配了配置档后才会运行。打开卡片设置负责人，或在编排设置中配置默认负责人。',
   noHeartbeat: '无心跳',
+  contextUsage: (used, max, estimated) => `上下文 ${used} / ${max} 词元${estimated ? '（估算）' : ''}`,
+  contextUnavailable: '上下文不可用',
   expand: label => `展开 ${label}`,
   collapse: label => `折叠 ${label}`,
   newTaskIn: label => `在 ${label} 新建任务`,
@@ -883,6 +891,8 @@ const zhHant: KanbanMessages = {
   wontRun: '不會執行',
   wontRunTip: '就緒卡片只有在指派了設定檔後才會執行。開啟卡片設定負責人，或在編排設定中設定預設負責人。',
   noHeartbeat: '無心跳',
+  contextUsage: (used, max, estimated) => `內容長度 ${used} / ${max} 詞元${estimated ? '（估算）' : ''}`,
+  contextUnavailable: '內容長度不可用',
   expand: label => `展開 ${label}`,
   collapse: label => `摺疊 ${label}`,
   newTaskIn: label => `在 ${label} 新增任務`,

--- a/apps/desktop/src/plugins/kanban/types.ts
+++ b/apps/desktop/src/plugins/kanban/types.ts
@@ -21,6 +21,7 @@ export interface KanbanTask {
   warnings?: null | { count: number; highest_severity?: null | string }
   /** Worker liveness (present on running cards) — drives the arc + run clock. */
   started_at?: null | number
+  current_run_id?: null | number
   worker_pid?: null | number
   last_heartbeat_at?: null | number
 }
@@ -37,6 +38,17 @@ export interface KanbanBoard {
   latest_event_id: number
   now: number
 }
+
+/** On-demand current-context readout for the card's exact live worker. */
+export type TaskContextUsage =
+  | { available: false }
+  | {
+      available: true
+      context_used: number
+      context_max: number
+      estimated: boolean
+      source: 'provider_usage' | 'provider_usage_plus_estimate'
+    }
 
 /** A structured recovery action attached to a diagnostic. */
 export interface DiagnosticAction {

--- a/cli.py
+++ b/cli.py
@@ -2970,7 +2970,7 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
                 config=self.config,
                 # Writer identity: a re-claim by this process replaces its own entry.
                 # See #94595.
-                metadata={"live_session_id": str(self.session_id)},
+                metadata=self._active_session_metadata(),
             )
         except Exception as exc:
             logger.warning("Failed to claim active session slot: %s", exc)
@@ -2982,6 +2982,39 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
         with suppress(Exception):
             atexit.register(self._release_active_session)
         return True
+
+    def _active_session_metadata(self) -> dict[str, Any]:
+        """Live writer identity, with exact Kanban incarnation and initialized context window."""
+        metadata: dict[str, Any] = {"live_session_id": str(self.session_id)}
+        task_id = os.getenv("HERMES_KANBAN_TASK", "")
+        if not task_id:
+            return metadata
+        metadata.update({
+            "kanban_task_id": task_id,
+            "kanban_run_id": os.getenv("HERMES_KANBAN_RUN_ID", ""),
+            "kanban_board": os.getenv("HERMES_KANBAN_BOARD", ""),
+        })
+        compressor = getattr(getattr(self, "agent", None), "context_compressor", None)
+        try:
+            context_max = int(getattr(compressor, "context_length", 0) or 0)
+        except Exception:
+            context_max = 0
+        if context_max > 0:
+            metadata["context_max"] = context_max
+        return metadata
+
+    def _refresh_active_session_metadata(self) -> None:
+        """Publish metadata that only becomes known after the worker agent initializes."""
+        lease = getattr(self, "_active_session_lease", None)
+        if lease is None or not os.getenv("HERMES_KANBAN_TASK"):
+            return
+        try:
+            from hermes_cli.active_sessions import transfer_active_session
+
+            transfer_active_session(
+                lease, session_id=str(self.session_id), metadata=self._active_session_metadata())
+        except Exception:
+            logger.debug("Failed to refresh active Kanban session metadata", exc_info=True)
 
     def _release_active_session(self) -> None:
         lease = getattr(self, "_active_session_lease", None)

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -575,6 +575,9 @@ class CLIAgentSetupMixin:
             # ``cli._active_agent_ref`` None forever — so memory shutdown never ran on /exit (#49287).
             import cli as _cli
             _cli._active_agent_ref = self.agent
+            # A single-query Kanban worker claims its lease before the deferred agent exists.
+            # Refresh once initialization has resolved the worker's effective context window.
+            getattr(self, "_refresh_active_session_metadata")()
             # Route agent status output through prompt_toolkit so ANSI escapes aren't garbled by
             # patch_stdout's StdoutProxy (#2262), holding lines while a response box streams so a
             # subagent/background completion notice never splits the reply mid-paragraph.

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -889,26 +889,38 @@ class SessionMessagesMixin:
                 seen.add(current)
             return best if best is not None else session_id
 
-    def _fetch_conversation_rows(self, session_ids: List[str], active_clause: str, *, with_session_id: bool):
+    def _fetch_conversation_rows(
+        self, session_ids: List[str], active_clause: str, *, with_session_id: bool, offset: int = 0,
+    ):
         """``_CONVERSATION_ROW_COLUMNS`` rows for *session_ids* ORDER BY id (timestamps are not monotonic
         and would break tool-call adjacency)."""
+        if offset and len(session_ids) != 1:
+            raise ValueError("conversation offset requires exactly one session")
         return self._read_all(
             f"SELECT {'session_id, ' if with_session_id else ''}{self._CONVERSATION_ROW_COLUMNS} "
             f"FROM messages WHERE session_id IN ({_placeholders(session_ids)})"
-            f"{active_clause} ORDER BY id", tuple(session_ids))
+            f"{active_clause} ORDER BY id"
+            f"{' LIMIT -1 OFFSET ?' if offset else ''}",
+            (*session_ids, int(offset)) if offset else tuple(session_ids))
 
     def get_messages_as_conversation(self, session_id: str, include_ancestors: bool = False,
                                      include_inactive: bool = False, repair_alternation: bool = False,
                                      include_row_ids: bool = False,
-                                     include_compacted: bool = False) -> List[Dict[str, Any]]:
+                                     include_compacted: bool = False,
+                                     offset: int = 0) -> List[Dict[str, Any]]:
         """Load messages in OpenAI format. ``include_compacted`` (deduped display history) is for DISPLAY reads
         only: the model-fed restore must not regrow what compaction summarized away. ``repair_alternation``
         repairs the loaded list for LIVE REPLAY callers (a durable ``user;user`` pair would re-trigger the
         per-request repair forever), preserving summary markers before repair so derivative context
         cannot merge with an original user turn; the stored transcript is never mutated."""
+        if offset < 0:
+            raise ValueError("conversation offset must be non-negative")
+        if offset and (include_ancestors or include_compacted):
+            raise ValueError("conversation offset is incompatible with lineage/display reads")
         rows = self._fetch_conversation_rows(
             self._resume_lineage_ids(session_id) if include_ancestors else [session_id],
-            self._active_clause(include_inactive, include_compacted), with_session_id=False)
+            self._active_clause(include_inactive, include_compacted), with_session_id=False,
+            offset=offset)
         if include_compacted:
             rows = self._dedupe_display_generations(rows)
         return self._rows_to_conversation(rows, session_id=session_id, include_ancestors=include_ancestors,

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -129,6 +129,88 @@ def _require_run(conn: sqlite3.Connection, run_id: int) -> kanban_db.Run:
     return _require(kanban_db.get_run, conn, run_id, "run")
 
 
+def _worker_profile_home(profile: str) -> Path:
+    """Profile-scoped home that owns a dispatched worker's session store."""
+    from hermes_cli.profiles import resolve_profile_env
+
+    return Path(resolve_profile_env(profile))
+
+
+def _worker_context_payload(task: kanban_db.Task, *, board: str) -> dict[str, Any]:
+    """Current worker occupancy, attached by exact live PID/session identity.
+
+    ``tasks.session_id`` is the originating human conversation, not the worker.
+    The active-session lease is the existing process→session identity seam; the
+    persisted provider anchor then yields current context rather than lifetime
+    input/output counters. Any missing/stale rung fails closed to unavailable.
+    """
+    if task.status != "running" or not task.assignee or not task.worker_pid or task.current_run_id is None:
+        return {"available": False}
+
+    try:
+        from agent.usage_anchor import anchored_context_tokens
+        from hermes_cli.active_sessions import active_session_registry_snapshot
+        from hermes_state import SessionDB
+
+        profile_home = _worker_profile_home(task.assignee)
+        matches = [
+            entry for entry in active_session_registry_snapshot(profile_home, strict=True)
+            if int(entry.get("pid") or 0) == int(task.worker_pid)
+            and str(entry.get("surface") or "") == "cli"
+            and str((entry.get("metadata") or {}).get("kanban_task_id") or "") == task.id
+            and str((entry.get("metadata") or {}).get("kanban_run_id") or "") == str(task.current_run_id)
+            and str((entry.get("metadata") or {}).get("kanban_board") or "") == board
+        ]
+        if len(matches) != 1:
+            return {"available": False}
+        session_id = str(matches[0].get("session_id") or "")
+        if not session_id:
+            return {"available": False}
+
+        metadata = matches[0].get("metadata") or {}
+        context_max = int(metadata.get("context_max") or 0)
+        if context_max <= 0:
+            return {"available": False}
+
+        db = SessionDB(profile_home / "state.db", read_only=True)
+        try:
+            session = db.get_session(session_id)
+            if not session or session.get("source") != "kanban":
+                return {"available": False}
+            anchor = db.get_session_model_config_value(session_id, "_usage_anchor", None)
+            if not isinstance(anchor, dict):
+                return {"available": False}
+            base_count = int(anchor.get("base_count") or 0)
+            prompt_tokens = int(anchor.get("prompt_tokens") or 0)
+            if base_count <= 0 or prompt_tokens <= 0:
+                return {"available": False}
+            # Only the priced boundary row plus the unpriced tail are needed. A
+            # hover must not reconstruct a worker's entire (potentially huge) transcript.
+            tail = db.get_messages_as_conversation(session_id, offset=base_count - 1)
+        finally:
+            db.close()
+        # The sliced conversation starts at the priced boundary. Rebase only
+        # its position; retain the canonical fingerprint and accounting rules.
+        context_used = anchored_context_tokens(tail, {**anchor, "base_count": 1})
+        if context_used is None or context_used <= 0:
+            return {"available": False}
+
+        delta = tail[1:]
+        if delta and isinstance(delta[0], dict) and delta[0].get("role") == "assistant":
+            delta = delta[1:]
+        estimated = bool(delta)
+        return {
+            "available": True,
+            "context_used": int(context_used),
+            "context_max": context_max,
+            "estimated": estimated,
+            "source": "provider_usage_plus_estimate" if estimated else "provider_usage",
+        }
+    except Exception:
+        log.debug("kanban worker context unavailable for task %s", task.id, exc_info=True)
+        return {"available": False}
+
+
 def _require_ok(ok: bool) -> None:
     """404 when a kanban_db mutator reports the task vanished mid-request."""
     if not ok:
@@ -366,6 +448,20 @@ def get_task(
                 {"id": c.id, "title": c.title, "status": c.status, "latest_summary": child_summaries.get(c.id), "result": c.result}
                 for c in children],
             "runs": [asdict(r) for r in kanban_db.list_runs(conn, task_id, state_type=run_state_type, state_name=run_state_name)]}
+
+
+@router.get("/tasks/{task_id}/context")
+def get_task_context(task_id: str, board: Optional[str] = Query(None)):
+    """Lightweight, on-demand context occupancy for the task's current worker."""
+    resolved_board = _resolve_board(board) or kanban_db.get_current_board()
+    with closing(_conn(board=resolved_board)) as conn:
+        task = _require_task(conn, task_id)
+        identity = (task.status, task.assignee, task.worker_pid, task.current_run_id)
+        payload = _worker_context_payload(task, board=resolved_board)
+        current = _require_task(conn, task_id)
+        if identity != (current.status, current.assignee, current.worker_pid, current.current_run_id):
+            return {"available": False}
+        return payload
 
 
 # --- POST /tasks ------------------------------------------------------------

--- a/tests/plugins/test_kanban_context_usage.py
+++ b/tests/plugins/test_kanban_context_usage.py
@@ -1,0 +1,274 @@
+"""On-demand Kanban worker context occupancy."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import hermes_state
+from agent.usage_anchor import capture_usage_anchor, set_usage_anchor
+from cli import HermesCLI
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_dispatch as kbd
+from hermes_cli.active_sessions import active_session_registry_snapshot, try_acquire_active_session
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+
+def _load_plugin():
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
+    spec = importlib.util.spec_from_file_location("hermes_kanban_plugin_context_test", plugin_file)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def context_client(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+
+    mod = _load_plugin()
+    monkeypatch.setattr(mod, "_worker_profile_home", lambda _profile: home)
+    app = FastAPI()
+    app.include_router(mod.router, prefix="/api/plugins/kanban")
+    return TestClient(app), home
+
+
+def _running_task(title: str) -> tuple[str, int]:
+    with kbc.connect_closing() as conn:
+        task_id = kb.create_task(conn, title=title, assignee="default", initial_status="running")
+        assert kb.claim_task(conn, task_id) is not None
+        kbd._set_worker_pid(conn, task_id, os.getpid())
+        run_id = kb.get_task(conn, task_id).current_run_id
+    assert run_id is not None
+    return task_id, run_id
+
+
+def _worker_lease(home: Path, session_id: str, task_id: str, run_id: int, *, context_max: int = 200_000):
+    return try_acquire_active_session(
+        session_id=session_id,
+        surface="cli",
+        config={},
+        registry_home=home,
+        metadata={
+            "live_session_id": session_id,
+            "kanban_task_id": task_id,
+            "kanban_run_id": str(run_id),
+            "kanban_board": "default",
+            "context_max": context_max,
+        },
+    )
+
+
+def test_context_endpoint_uses_the_current_worker_session_not_task_origin(context_client, monkeypatch):
+    client, home = context_client
+    messages = [
+        {"role": "user", "content": "worker prompt"},
+        {"role": "assistant", "content": "worker response"},
+        {"role": "user", "content": "new tool result"},
+    ]
+    worker_session = "worker-session"
+    parent_session = "parent-session"
+
+    db = SessionDB(home / "state.db")
+    try:
+        db.create_session(worker_session, source="kanban", model="worker-model")
+        for message in messages:
+            db.append_message(worker_session, message["role"], content=message["content"])
+        anchor = capture_usage_anchor(41_000, 800, messages[:2])
+        db.patch_session_model_config(worker_session, {"_usage_anchor": anchor})
+        db.create_session(parent_session, source="desktop", model="parent-model")
+    finally:
+        db.close()
+
+    task_id, run_id = _running_task("worker context")
+    lease, refusal = _worker_lease(home, worker_session, task_id, run_id)
+    assert lease is not None and refusal is None
+    real_session_db = hermes_state.SessionDB
+    read_only_modes = []
+
+    def recording_session_db(*args, **kwargs):
+        read_only_modes.append(kwargs.get("read_only", False))
+        return real_session_db(*args, **kwargs)
+
+    monkeypatch.setattr(hermes_state, "SessionDB", recording_session_db)
+    try:
+        payload = client.get(f"/api/plugins/kanban/tasks/{task_id}/context").json()
+    finally:
+        lease.release()
+
+    assert payload == {
+        "available": True,
+        "context_used": 41_818,
+        "context_max": 200_000,
+        "estimated": True,
+        "source": "provider_usage_plus_estimate",
+    }
+    assert read_only_modes == [True]
+
+
+def test_context_endpoint_reads_only_the_anchor_tail(context_client, monkeypatch):
+    client, home = context_client
+    worker_session = "large-worker-session"
+    prefix = [{"role": "user", "content": f"old-{index}"} for index in range(200)]
+    anchor = capture_usage_anchor(50_000, 1_000, prefix)
+
+    db = SessionDB(home / "state.db")
+    try:
+        db.create_session(worker_session, source="kanban", model="worker-model")
+        for message in prefix:
+            db.append_message(worker_session, message["role"], content=message["content"])
+        db.append_message(worker_session, "assistant", content="priced reply")
+        db.append_message(worker_session, "user", content="small live tail")
+        db.patch_session_model_config(worker_session, {"_usage_anchor": anchor})
+    finally:
+        db.close()
+
+    task_id, run_id = _running_task("bounded read")
+
+    original_tail_read = SessionDB.get_messages_as_conversation
+    observed_offsets = []
+
+    def require_bounded_reconstruction(self, *args, **kwargs):
+        observed_offsets.append(kwargs.get("offset"))
+        return original_tail_read(self, *args, **kwargs)
+
+    monkeypatch.setattr(SessionDB, "get_messages_as_conversation", require_bounded_reconstruction)
+    lease, refusal = _worker_lease(home, worker_session, task_id, run_id)
+    assert lease is not None and refusal is None
+    try:
+        payload = client.get(f"/api/plugins/kanban/tasks/{task_id}/context").json()
+    finally:
+        lease.release()
+
+    assert payload["available"] is True
+    assert payload["context_used"] > 51_000
+    assert observed_offsets == [len(prefix) - 1]
+
+
+def test_context_endpoint_rejects_a_different_kanban_run(context_client):
+    client, home = context_client
+    db = SessionDB(home / "state.db")
+    try:
+        db.create_session("other-run", source="kanban", model="worker-model")
+        db.append_message("other-run", "user", content="prompt")
+        anchor = capture_usage_anchor(1_000, 100, [{"role": "user", "content": "prompt"}])
+        db.patch_session_model_config("other-run", {"_usage_anchor": anchor})
+    finally:
+        db.close()
+
+    task_id, run_id = _running_task("reassigned")
+    lease, refusal = _worker_lease(home, "other-run", task_id, run_id + 1)
+    assert lease is not None and refusal is None
+    try:
+        assert client.get(f"/api/plugins/kanban/tasks/{task_id}/context").json() == {"available": False}
+    finally:
+        lease.release()
+
+
+def test_context_endpoint_rechecks_task_identity_after_the_worker_read(context_client, monkeypatch):
+    client, _home = context_client
+    task_id, _run_id = _running_task("racing reassignment")
+    mod = sys.modules["hermes_kanban_plugin_context_test"]
+
+    def reassign_during_read(_task, *, board):
+        with kbc.connect_closing(board=board) as conn:
+            conn.execute("UPDATE tasks SET worker_pid = worker_pid + 1 WHERE id = ?", (task_id,))
+            conn.commit()
+        return {
+            "available": True,
+            "context_used": 10,
+            "context_max": 100,
+            "estimated": False,
+            "source": "provider_usage",
+        }
+
+    monkeypatch.setattr(mod, "_worker_context_payload", reassign_during_read)
+
+    assert client.get(f"/api/plugins/kanban/tasks/{task_id}/context").json() == {"available": False}
+
+
+def test_context_endpoint_reports_unavailable_without_exact_live_worker_identity(context_client):
+    client, _home = context_client
+    with kbc.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="not running", assignee="default", initial_status="blocked")
+
+    assert client.get(f"/api/plugins/kanban/tasks/{task_id}/context").json() == {"available": False}
+
+
+def test_cli_worker_lease_publishes_run_identity_and_effective_context(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_worker")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "17")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "board-a")
+
+    cli = object.__new__(HermesCLI)
+    cli.session_id = "worker-session"
+    cli.config = {}
+    cli._active_session_lease = None
+    cli.agent = None
+
+    try:
+        assert cli._claim_active_session("cli") is True
+        initial = active_session_registry_snapshot(home, strict=True)[0]
+        assert "context_max" not in initial["metadata"]
+        cli.agent = type("Agent", (), {
+            "context_compressor": type("Compressor", (), {"context_length": 272_000})()
+        })()
+        cli._refresh_active_session_metadata()
+        entry = active_session_registry_snapshot(home, strict=True)[0]
+        assert entry["metadata"] == {
+            "live_session_id": "worker-session",
+            "kanban_task_id": "t_worker",
+            "kanban_run_id": "17",
+            "kanban_board": "board-a",
+            "context_max": 272_000,
+        }
+    finally:
+        cli._release_active_session()
+
+
+def test_real_agent_persists_kanban_source_and_usage_anchor(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_SESSION_SOURCE", "kanban")
+    db = SessionDB(home / "state.db")
+    agent = AIAgent(
+        model="fixture-model",
+        provider="openai-compat",
+        api_key="fixture",
+        base_url="http://127.0.0.1:1/v1",
+        enabled_toolsets=[],
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        save_trajectories=False,
+        session_id="real-worker-session",
+        session_db=db,
+    )
+    try:
+        agent._ensure_db_session()
+        messages = [{"role": "user", "content": "work kanban task t_worker"}]
+        db.append_message(agent.session_id, "user", content=messages[0]["content"])
+        anchor = capture_usage_anchor(12_345, 321, messages)
+        set_usage_anchor(agent, anchor)
+
+        row = db.get_session(agent.session_id)
+        assert row["source"] == "kanban"
+        assert db.get_session_model_config_value(agent.session_id, "_usage_anchor") == anchor
+    finally:
+        agent.close()


### PR DESCRIPTION
## Summary

Show the current worker's context occupancy on a running Kanban card hover: **Context 42k / 200k tokens**. Estimated post-response growth is explicitly marked; missing or stale evidence displays **Context unavailable**, never a fabricated zero.

## Data path and ownership

- Fetch `/tasks/{task_id}/context` only while a running card is hovered, with a five-second query cache and no periodic polling/retry loop.
- Resolve the worker via the existing profile-scoped active-session registry, including its process-incarnation validation. Match CLI surface, PID, board, task and run identity; never use the card's originating human `session_id` as the worker.
- Publish the dispatched task/run/board identity with the CLI lease, then refresh its metadata once the worker agent initializes so the denominator is the initialized compressor's actual context limit, not a later profile config lookup.
- Read the worker session DB in **read-only mode**. Use its persisted provider usage anchor and the canonical `anchored_context_tokens` accounting. Load only the boundary row and subsequent transcript tail via an optional conversation offset; no full prompt rebuild or full transcript deserialization on hover.
- Recheck the task PID/run identity before returning; key the client cache by board, task, worker PID and current run so reruns cannot inherit a previous result.

No database schema migration, new background poller, lifetime-token substitution, or guessed context maximum.

## Verification

Independent parent checks on the final candidate:
- `scripts/run_tests.sh tests/plugins/test_kanban_context_usage.py --file-retries 0`: **7 passed**. Real SQLite/active-session leases cover worker identity, bounded tail reads, read-only DB access, run mismatch and reassignment races. Includes a real AIAgent source/usage-anchor persistence probe without an inference request.
- Real card component hover test: **1 passed**; exercises the request and rendered context tooltip.
- Desktop renderer, Electron and E2E TypeScript projects passed.
- Targeted Ruff and `git diff --check` passed; targeted Desktop ESLint passed during implementation review.

Existing workers started before this change cannot publish the added lease metadata and honestly show unavailable until restarted. The numerator is the latest persisted provider measurement plus an explicitly estimated persisted tail, not per-token streaming instrumentation. No installed Electron visual run or full local test suite was performed.

## Related work

#103739 adds tooltips for individual card icons; this is worker context occupancy on the card and may require a small UI merge if both land. #106917 handles Desktop statusbar live context and is not modified or required. This feature does not change global context-meter polling or calculation semantics.
