### PR TITLE
fix(install): give node-gyp local headers to dodge an undici proxy crash

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2685,6 +2685,22 @@ install_node_deps() {
         return 0
     fi
 
+    # Point node-gyp at the Hermes-managed Node instead of letting it download
+    # headers over the network -- but only when that Node actually exists:
+    # HAS_NODE can also mean a pre-existing system Node we left untouched, and
+    # nodedir pointing at nothing is worse than leaving it unset. Without this,
+    # node-gyp's bundled undici HTTP client crashes outright (`AssertionError:
+    # assert(!this.paused)` in client-h1.js) on some fraction of requests made
+    # through an HTTP(S)_PROXY -- a known upstream node-gyp/undici bug, not
+    # something in our control, and one every native rebuild (node-pty and
+    # friends) is exposed to whenever HTTP_PROXY/HTTPS_PROXY is set (as our
+    # sandbox's E2E tests do, and as corporate proxies commonly do for real
+    # users too). The official Node tarball node-bootstrap.sh extracts already
+    # ships include/node/*.h, so this needs no download at all.
+    if [ -f "$HERMES_HOME/node/include/node/node_version.h" ]; then
+        export npm_config_nodedir="$HERMES_HOME/node"
+    fi
+
     if [ -f "$INSTALL_DIR/package.json" ]; then
         log_info "Installing Node.js dependencies (browser tools)..."
         cd "$INSTALL_DIR"


### PR DESCRIPTION
## Summary
- Third distinct bug found in the E2E installer saga (after the CA-cert mismatch and node-gyp `nodedir` fixes in #3): node-gyp's bundled undici HTTP client intermittently crashes (`AssertionError: assert(!this.paused)` in `client-h1.js`) when it fetches Node headers over `HTTP_PROXY`/`HTTPS_PROXY` — a known upstream node-gyp/undici bug, not something fixable directly here.
- `scripts/install.sh` now points `npm_config_nodedir` at `$HERMES_HOME/node` (guarded by an `include/node/node_version.h` existence check) so node-gyp uses local headers and skips the network request entirely, avoiding the buggy code path.
- The original failure was intermittent (~2 of 5 installer test tags on a given scheduled run), unlike the earlier two bugs which were 100% reproducible.

## Test plan
- [x] GitHub Actions run [34705557651](https://github.com/Suhaimiab/hermes-agent/actions/runs/34705557651) on this branch: all 5 installer test tags passed
- [ ] Monitor next scheduled Install & Update E2E run on `main` after merge to confirm the intermittent crash no longer recurs (given intermittency, one clean run is evidence, not absolute proof)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RoDri2oy7EXWbverv1prG2