### PR TITLE
fix(slack): preserve literal tool previews

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2839,6 +2839,14 @@ class SlackAdapter(BasePlatformAdapter):
             logger.debug("[Slack] block render failed; using plain text", exc_info=True)
             return None
 
+    def format_tool_preview(self, preview: Any) -> str:
+        """Render tool-preview text literally inside a robust mrkdwn code span."""
+        text = preview.text
+        longest_run = max((len(run) for run in re.findall(r"`+", text)), default=0)
+        delimiter = "`" * (longest_run + 1)
+        padding = " " if longest_run else ""
+        return f"{delimiter}{padding}{text}{padding}{delimiter}"
+
     def format_message(self, content: str) -> str:
         """Convert standard markdown to Slack mrkdwn.
         Tables are fenced first; code is protected from later passes; broadcast mentions are escaped
@@ -2888,8 +2896,8 @@ class SlackAdapter(BasePlatformAdapter):
         # Escaping unescapes first in ONE regex pass (sequential replaces would decode
         # "&amp;lt;" twice). ``None`` marks the escape step.
         passes = (
-            (r"(```(?:[^\n]*\n)?[\s\S]*?```)", _protect_fence, 0),
-            (r"(`[^`]+`)", lambda m: _ph(m.group(0)), 0),
+            (r"((?<!`)```(?!`)(?:[^\n]*\n)?[\s\S]*?(?<!`)```(?!`))", _protect_fence, 0),
+            (r"(?<!`)(`+)(?!`)([^\n]+?)\1(?!`)", lambda m: _ph(m.group(0)), 0),
             (r"(?<!!)\[([^\]]+)\]\(([^()]*(?:\([^()]*\)[^()]*)*)\)", _convert_markdown_link, 0),
             (r"(<(?:[@#!]|(?:https?|mailto|tel):)[^>\n]+>)", lambda m: _ph(m.group(1)), 0),
             (r"^(>+\s)", lambda m: _ph(m.group(0)), re.MULTILINE),

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2570,6 +2570,37 @@ class TestSendTyping:
 
 
 # ---------------------------------------------------------------------------
+# Tool-progress previews
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("preview", "inline_code"),
+    [
+        ("send*rhubarb*.py", "`send*rhubarb*.py`"),
+        ("ordinary preview", "`ordinary preview`"),
+        ("find `needle`", "`` find `needle` ``"),
+        ("find ```needle```", "```` find ```needle``` ````"),
+    ],
+)
+def test_tool_progress_preview_is_literal_inline_code(adapter, preview, inline_code):
+    from gateway.stream_events import ToolCallChunk
+
+    line = adapter.format_tool_event(
+        ToolCallChunk("search_files", preview=preview), preview_max_len=80
+    )
+
+    assert line is not None
+    assert adapter.format_message(line).endswith(f': "{inline_code}"')
+
+
+def test_tool_preview_formatting_does_not_change_assistant_markdown(adapter):
+    assert adapter.format_message("Use **bold** and *italic*.") == (
+        "Use *bold* and _italic_."
+    )
+
+
+# ---------------------------------------------------------------------------
 # TestFormatMessage — Markdown → mrkdwn conversion
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- render Slack tool-progress previews as literal inline code so regex and glob metacharacters are not interpreted as mrkdwn
- choose a delimiter longer than any embedded backtick run and preserve those spans through Slack message formatting
- keep ordinary assistant Markdown conversion unchanged

Fixes #109335.

## Root cause

Slack tool events used the base `format_tool_preview` implementation, so preview text was inserted directly into progress-message chrome. The complete line then passed through `SlackAdapter.format_message`, where a preview such as `send*rhubarb*.py` was converted to `send_rhubarb_.py` as italic mrkdwn.

## Proof receipt

Base: `1c671beab29164d8931c5d01c5739502267089d8`

Before the implementation, the focused regression selection produced 3 failures and 1 passing control. The reported pattern was observed as `send_rhubarb_.py` instead of preserving its asterisks.

After the implementation, the same selection passed all 5 cases, covering:

- `send*rhubarb*.py`
- ordinary preview text
- embedded single and triple backtick runs
- unchanged assistant bold and italic conversion

## Tests

```text
scripts/run_tests.sh tests/gateway/test_slack.py -k 'tool_progress_preview_is_literal_inline_code or tool_preview_formatting_does_not_change_assistant_markdown'
# 5 passed, 0 failed

scripts/run_tests.sh tests/gateway/test_slack.py
# 240 passed, 0 failed

python -m ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack.py
# All checks passed

git diff --check
# clean
```

## Scope and risk

The change is limited to the Slack adapter and focused Slack gateway tests. It does not change other platforms, authentication, routing, persistence, or general assistant-message formatting. The remaining platform-level risk is Slack client rendering of previews containing unusual long backtick runs; those cases are preserved deterministically and covered by formatter regression tests.

Developer P0 self-review: 0 findings.
