### PR TITLE
test(desktop): make the JS suite pass on Node 22–24 and macOS

### DIFF
--- a/apps/desktop/electron/managed-ssh-update.test.ts
+++ b/apps/desktop/electron/managed-ssh-update.test.ts
@@ -288,7 +288,9 @@ test('POSIX managed launcher executes the updater command and atomically publish
       {
         ssh: { exec: async () => '' },
         platform: 'Linux',
-        hermesPath: '/bin/true',
+        // Portable no-op updater: /bin/true exists on Linux but not on macOS
+        // (which ships /usr/bin/true) — the check runs on developer machines too.
+        hermesPath: '/usr/bin/true',
         hermesHome: home
       },
       CORRELATION

--- a/apps/desktop/vitest.setup.ts
+++ b/apps/desktop/vitest.setup.ts
@@ -1,33 +1,40 @@
 import { configure } from '@testing-library/react'
 
+// Keep ONE storage implementation across every supported Node version.
+//
 // Node 26 defines its own `localStorage` accessor on the global object, which
 // returns `undefined` unless the process was started with --localstorage-file
 // (it warns: "localStorage is not available because --localstorage-file was
 // not provided"). In the jsdom environment `globalThis` IS the window, so that
 // accessor shadows jsdom's Storage and every `localStorage.getItem(...)` in a
-// test throws "Cannot read properties of undefined". Install a real in-memory
-// Storage when the global resolves to nothing, before any test module reads it.
-if (typeof (globalThis as any).localStorage === 'undefined') {
-  const store = new Map<string, string>()
+// test throws "Cannot read properties of undefined".
+//
+// Node 22/24 do not define that accessor, so jsdom's proxy Storage used to
+// leak through instead: it mirrors stored keys as named properties and
+// silently ignores instance-level patches (`vi.spyOn(localStorage, 'setItem')`
+// never fires while the write goes straight through). Storage-failure tests
+// (e.g. voice-prefs' quota/denied paths) therefore only misbehaved outside
+// CI. Install the same in-memory Storage on every supported Node, before any
+// test module reads it, so local runs match CI exactly.
+const store = new Map<string, string>()
 
-  const storage: Storage = {
-    get length() {
-      return store.size
-    },
-    key: (i: number) => [...store.keys()][i] ?? null,
-    getItem: (k: string) => store.get(String(k)) ?? null,
-    setItem: (k: string, v: string) => void store.set(String(k), String(v)),
-    removeItem: (k: string) => void store.delete(String(k)),
-    clear: () => store.clear(),
-  }
+const storage: Storage = {
+  get length() {
+    return store.size
+  },
+  key: (i: number) => [...store.keys()][i] ?? null,
+  getItem: (k: string) => store.get(String(k)) ?? null,
+  setItem: (k: string, v: string) => void store.set(String(k), String(v)),
+  removeItem: (k: string) => void store.delete(String(k)),
+  clear: () => store.clear(),
+}
 
-  for (const target of [globalThis, (globalThis as any).window].filter(Boolean)) {
-    Object.defineProperty(target, 'localStorage', {
-      value: storage,
-      configurable: true,
-      writable: true,
-    })
-  }
+for (const target of [globalThis, (globalThis as any).window].filter(Boolean)) {
+  Object.defineProperty(target, 'localStorage', {
+    value: storage,
+    configurable: true,
+    writable: true,
+  })
 }
 
 // jsdom has no layout or intersection delivery. Tests of observer behavior


### PR DESCRIPTION
## Summary

Two small test-infra fixes so the desktop JS suite passes outside the CI image (Node 22–24 and macOS), not just on the Ubuntu + Node 26 combination CI uses:

1. **`apps/desktop/vitest.setup.ts`** — install the in-memory `Storage` shim on every supported Node instead of only when the global resolves to `undefined` (Node 26 behavior). On Node 22/24 jsdom's proxy `Storage` leaked through: it mirrors stored keys as named properties and silently ignores instance-level patches — `vi.spyOn(localStorage, 'setItem')` never fires while the write goes straight through — so the storage-failure tests in `voice-prefs.test.ts` failed deterministically outside CI (2 failures locally, 7/7 after this change). No behavior change on Node 26.

2. **`apps/desktop/electron/managed-ssh-update.test.ts`** — `/bin/true` exists on Linux only; macOS ships `/usr/bin/true`, so the POSIX managed-launcher test published exit `127` there (`env: /bin/true: No such file or directory`, captured from the launcher's own output log). `/usr/bin/true` exists on both platforms and keeps the launcher code path fully exercised.

Both issues are invisible to CI by construction: every workflow runs Ubuntu with Node 26.

## Testing

macOS arm64, Node 22.23.2, full `npm run check`: green — 11,903 tests passed, 0 failures, including the packaged Electron build + DMG validation (desktop ui 7557 · electron 2210 + 6 skipped · tui 1769 + 3 skipped · web 298 · tests-js 69). Test-infra only; no product code touched.
