### PR TITLE
fix(disk-cleanup): isolate auto-delete to owned roots and turns

### DIFF
--- a/plugins/disk-cleanup/README.md
+++ b/plugins/disk-cleanup/README.md
@@ -1,10 +1,9 @@
 # disk-cleanup
 
-Tracks and cleans ephemeral files in roots Hermes explicitly owns:
-process-registered `hermes-*` directories directly beneath the platform temp
-directory, generated media caches, and cron run output. A directory name alone
-does not establish ownership, and neither does a filename such as `test_*` or
-`tmp_*`.
+Tracks and cleans generated media caches, cron run output, and exact files in
+the platform temp directory that Hermes observed as absent immediately before
+a tool call created them. A directory name, terminal output, manual category,
+or filename such as `test_*` / `tmp_*` never establishes ownership.
 
 Originally contributed by [@LVT382009](https://github.com/LVT382009) as a
 skill in PR #12212.  Ported to the plugin system so the behaviour runs
@@ -15,7 +14,8 @@ never needs to remember to call a tool.
 
 | Hook | Behaviour |
 |---|---|
-| `post_tool_call` | When `write_file` / `terminal` / `patch` creates a file inside a Hermes-owned ephemeral root, track it silently. |
+| `pre_tool_call` | Before `write_file` / `patch`, record explicit platform-temp paths that do not yet exist. |
+| `post_tool_call` | Track owned-root files, plus exact new platform-temp files after a successful matching file-tool call. Terminal text can never establish external-temp ownership. |
 | `on_session_end` | Delete only immediate-cleanup files tracked by that exact turn. Concurrent and long-running bot turns remain isolated. |
 
 Deletion rules:
@@ -48,14 +48,16 @@ Deletion rules:
 - Arbitrary workspace and durable Hermes files survive regardless of filename
 - One turn ending cannot delete files tracked by another active turn
 - Malformed or stale tracking entries are skipped fail-closed
-- System temp roots must be observed and registered in the current process;
-  registration is bound to the root's filesystem identity, so a replaced root
-  and records left by an earlier process are skipped
+- System-temp ownership is exact-file only: the path must be absent before the
+  matching successful `write_file` / `patch` call and the new regular file is bound to its filesystem
+  identity. Pre-existing files, replacements, directories, output-only paths,
+  manual categories, and records left by an earlier process are skipped
 - Backup/restore is scoped to `tracked.json` — the plugin never touches
   agent logs
 - Atomic writes: `.tmp` → backup → rename
 
 The owned roots are `$HERMES_HOME/cache/vision/temp_vision_images/`,
 `$HERMES_HOME/cache/video/temp_video_files/`, `$HERMES_HOME/cron/output/`
-(plus the legacy `cronjobs/output/` alias), and process-registered platform temp
-directories whose top-level name starts with `hermes-`.
+(plus the legacy `cronjobs/output/` alias). Outside those roots, only the exact
+regular platform-temp file proven new by the matching tool call is owned; its
+parent directory is never swept.

--- a/plugins/disk-cleanup/README.md
+++ b/plugins/disk-cleanup/README.md
@@ -1,9 +1,10 @@
 # disk-cleanup
 
-Tracks and cleans ephemeral files in roots Hermes explicitly owns: platform
-temporary directories named `hermes-*`, generated media caches, and cron run
-output. It never treats a filename such as `test_*` or `tmp_*` as proof that a
-file is disposable.
+Tracks and cleans ephemeral files in roots Hermes explicitly owns:
+process-registered `hermes-*` directories directly beneath the platform temp
+directory, generated media caches, and cron run output. A directory name alone
+does not establish ownership, and neither does a filename such as `test_*` or
+`tmp_*`.
 
 Originally contributed by [@LVT382009](https://github.com/LVT382009) as a
 skill in PR #12212.  Ported to the plugin system so the behaviour runs
@@ -47,11 +48,14 @@ Deletion rules:
 - Arbitrary workspace and durable Hermes files survive regardless of filename
 - One turn ending cannot delete files tracked by another active turn
 - Malformed or stale tracking entries are skipped fail-closed
+- System temp roots must be observed and registered in the current process;
+  registration is bound to the root's filesystem identity, so a replaced root
+  and records left by an earlier process are skipped
 - Backup/restore is scoped to `tracked.json` — the plugin never touches
   agent logs
 - Atomic writes: `.tmp` → backup → rename
 
 The owned roots are `$HERMES_HOME/cache/vision/temp_vision_images/`,
 `$HERMES_HOME/cache/video/temp_video_files/`, `$HERMES_HOME/cron/output/`
-(plus the legacy `cronjobs/output/` alias), and platform temp directories whose
-top-level name starts with `hermes-`.
+(plus the legacy `cronjobs/output/` alias), and process-registered platform temp
+directories whose top-level name starts with `hermes-`.

--- a/plugins/disk-cleanup/README.md
+++ b/plugins/disk-cleanup/README.md
@@ -1,8 +1,9 @@
 # disk-cleanup
 
-Auto-tracks and cleans up ephemeral files created during Hermes Agent
-sessions — test scripts, temp outputs, cron logs, stale chrome profiles.
-Scoped strictly to `$HERMES_HOME` and `/tmp/hermes-*`.
+Tracks and cleans ephemeral files in roots Hermes explicitly owns: platform
+temporary directories named `hermes-*`, generated media caches, and cron run
+output. It never treats a filename such as `test_*` or `tmp_*` as proof that a
+file is disposable.
 
 Originally contributed by [@LVT382009](https://github.com/LVT382009) as a
 skill in PR #12212.  Ported to the plugin system so the behaviour runs
@@ -13,17 +14,17 @@ never needs to remember to call a tool.
 
 | Hook | Behaviour |
 |---|---|
-| `post_tool_call` | When `write_file` / `terminal` / `patch` creates a file matching `test_*`, `tmp_*`, or `*.test.*` inside `HERMES_HOME`, track it silently as `test` / `temp` / `cron-output`. |
-| `on_session_end` | If any test files were auto-tracked during this turn, run `quick` cleanup (no prompts). |
+| `post_tool_call` | When `write_file` / `terminal` / `patch` creates a file inside a Hermes-owned ephemeral root, track it silently. |
+| `on_session_end` | Delete only immediate-cleanup files tracked by that exact turn. Concurrent and long-running bot turns remain isolated. |
 
-Deletion rules (same as the original PR):
+Deletion rules:
 
 | Category | Threshold | Confirmation |
 |---|---|---|
-| `test` | every session end | Never |
+| `test` | end of the creating turn | Never |
 | `temp` | >7 days since tracked | Never |
 | `cron-output` | >14 days since tracked | Never |
-| empty dirs under HERMES_HOME | always | Never |
+| empty dirs in owned ephemeral roots | always | Never |
 | `research` | >30 days, beyond 10 newest | Always (deep only) |
 | `chrome-profile` | >14 days since tracked | Always (deep only) |
 | files >500 MB | never auto | Always (deep only) |
@@ -41,11 +42,16 @@ Deletion rules (same as the original PR):
 
 ## Safety
 
-- `is_safe_path()` rejects anything outside `HERMES_HOME` or `/tmp/hermes-*`
-- Windows mounts (`/mnt/c` etc.) are rejected
-- The state directory `$HERMES_HOME/disk-cleanup/` is itself excluded
-- `$HERMES_HOME/logs/`, `memories/`, `sessions/`, `skills/`, `plugins/`,
-  and config files are never tracked
+- Auto-deletion requires both an eligible category and current membership in an
+  explicit owned root; stored tracking data is revalidated immediately before deletion
+- Arbitrary workspace and durable Hermes files survive regardless of filename
+- One turn ending cannot delete files tracked by another active turn
+- Malformed or stale tracking entries are skipped fail-closed
 - Backup/restore is scoped to `tracked.json` — the plugin never touches
   agent logs
 - Atomic writes: `.tmp` → backup → rename
+
+The owned roots are `$HERMES_HOME/cache/vision/temp_vision_images/`,
+`$HERMES_HOME/cache/video/temp_video_files/`, `$HERMES_HOME/cron/output/`
+(plus the legacy `cronjobs/output/` alias), and platform temp directories whose
+top-level name starts with `hermes-`.

--- a/plugins/disk-cleanup/__init__.py
+++ b/plugins/disk-cleanup/__init__.py
@@ -69,6 +69,8 @@ def _on_post_tool_call(tool_name: str = "", args: Optional[Dict[str, Any]] = Non
             category = dg.guess_category(p) if p.exists() else None
         except (OSError, RuntimeError, ValueError):
             continue
+        if category is None and dg.register_system_temp_root(p):
+            category = dg.guess_category(p)
         if category is not None:
             with _lock:
                 tracked = dg.track(str(p), category, silent=True)
@@ -108,7 +110,8 @@ Subcommands:
 
 Categories: temp | test | research | download | chrome-profile | cron-output | other
 
-Automatic deletion is limited to Hermes-owned cache/cron roots and /tmp/hermes-*.
+Automatic deletion is limited to Hermes-owned cache/cron roots and process-registered
+hermes-* roots directly beneath the platform temporary directory.
 Arbitrary workspace files are never classified as disposable by filename.
 """
 

--- a/plugins/disk-cleanup/__init__.py
+++ b/plugins/disk-cleanup/__init__.py
@@ -20,9 +20,10 @@ from . import disk_cleanup as dg
 logger = logging.getLogger(__name__)
 
 
-# Immediate-cleanup paths keyed by turn_id. The lock also serializes tracked.json updates from
-# concurrent tool hooks so one turn cannot overwrite or delete another turn's entries.
+# Immediate-cleanup paths keyed by turn_id. External temp files additionally require a matching
+# pre-tool observation proving that the exact path did not exist before Hermes ran the tool.
 _recent_test_tracks: Dict[str, Set[str]] = {}
+_pending_absent_temp_paths: Dict[str, tuple[str, Set[str]]] = {}
 _lock = threading.Lock()
 
 _TERMINAL_PATH_REGEX = re.compile(r"(?:^|\s)(/[^\s'\"`]+|\~/[^\s'\"`]+)")
@@ -51,40 +52,87 @@ _PATH_EXTRACTORS: Dict[str, Callable[[Dict[str, Any], str], Set[str]]] = {
     "write_file": _extract_path_arg,
     "patch": _extract_path_arg,
     "terminal": _extract_paths_from_terminal}
+_CREATION_PROOF_TOOLS = frozenset({"write_file", "patch"})
+
+
+def _turn_key(turn_id: str, task_id: str, session_id: str) -> str:
+    return turn_id or task_id or session_id or "default"
+
+
+def _on_pre_tool_call(
+    tool_name: str = "", args: Optional[Dict[str, Any]] = None,
+    task_id: str = "", session_id: str = "", turn_id: str = "",
+    tool_call_id: str = "", **_: Any,
+) -> None:
+    """Record absent temp paths from tool arguments; never infer ownership from names."""
+    extractor = _PATH_EXTRACTORS.get(tool_name)
+    if (
+        tool_name not in _CREATION_PROOF_TOOLS
+        or not tool_call_id
+        or not isinstance(args, dict)
+        or extractor is None
+    ):
+        return
+    absent: Set[str] = set()
+    for path_str in extractor(args, ""):
+        try:
+            path = Path(path_str).expanduser()
+            key = dg._system_temp_file_key(path)
+            if key is not None and not path.exists():
+                absent.add(key)
+        except (OSError, RuntimeError, ValueError):
+            continue
+    with _lock:
+        _pending_absent_temp_paths[tool_call_id] = (
+            _turn_key(turn_id, task_id, session_id), absent
+        )
 
 
 def _on_post_tool_call(tool_name: str = "", args: Optional[Dict[str, Any]] = None, result: Any = None,
                        task_id: str = "", session_id: str = "", turn_id: str = "",
-                       tool_call_id: str = "", **_: Any) -> None:
+                       tool_call_id: str = "", status: str = "", **_: Any) -> None:
     """Auto-track ephemeral files created by recent tool calls. Best-effort, never raises."""
     extractor = _PATH_EXTRACTORS.get(tool_name)
     if not isinstance(args, dict) or extractor is None:
         return
-    for path_str in extractor(args, result if isinstance(result, str) else ""):
-        try:
-            p = Path(path_str).expanduser()
-        except Exception:
-            continue
-        try:
-            category = dg.guess_category(p) if p.exists() else None
-        except (OSError, RuntimeError, ValueError):
-            continue
-        if category is None and dg.register_system_temp_root(p):
-            category = dg.guess_category(p)
-        if category is not None:
-            with _lock:
+    candidates = extractor(args, result if isinstance(result, str) else "")
+    with _lock:
+        pending = _pending_absent_temp_paths.pop(tool_call_id, None) if tool_call_id else None
+        absent = (
+            pending[1]
+            if pending is not None and pending[0] == _turn_key(turn_id, task_id, session_id)
+            else set()
+        )
+        for path_str in candidates:
+            try:
+                p = Path(path_str).expanduser()
+                category = dg.guess_category(p) if p.exists() else None
+            except (OSError, RuntimeError, ValueError):
+                continue
+            if (
+                category is None
+                and status == "ok"
+                and dg._system_temp_file_key(p) in absent
+                and dg._register_created_system_temp_file(p)
+            ):
+                category = dg.guess_category(p)
+            if category is not None:
                 tracked = dg.track(str(p), category, silent=True)
                 if tracked and category == "test":
                     _recent_test_tracks.setdefault(
-                        turn_id or task_id or session_id or "default", set()).add(str(p.resolve()))
+                        _turn_key(turn_id, task_id, session_id), set()).add(str(p.resolve()))
 
 
 def _on_session_end(
     session_id: str = "", task_id: str = "", turn_id: str = "",
     completed: bool = True, interrupted: bool = False, **_: Any) -> None:
     """Run quick cleanup if any test files were tracked during this turn."""
+    key = _turn_key(turn_id, task_id, session_id)
     with _lock:
-        paths = _recent_test_tracks.pop(turn_id or task_id or session_id or "default", None)
+        for call_id, (pending_key, _paths) in list(_pending_absent_temp_paths.items()):
+            if pending_key == key:
+                _pending_absent_temp_paths.pop(call_id, None)
+        paths = _recent_test_tracks.pop(key, None)
         if not paths:
             return
         try:
@@ -110,8 +158,9 @@ Subcommands:
 
 Categories: temp | test | research | download | chrome-profile | cron-output | other
 
-Automatic deletion is limited to Hermes-owned cache/cron roots and process-registered
-hermes-* roots directly beneath the platform temporary directory.
+Automatic deletion is limited to Hermes-owned cache/cron roots and exact platform-temp
+files proven new by a matching successful write_file/patch call. Terminal text never
+grants ownership.
 Arbitrary workspace files are never classified as disposable by filename.
 """
 
@@ -189,6 +238,7 @@ def _handle_slash(raw_args: str) -> Optional[str]:
 
 
 def register(ctx) -> None:
+    ctx.register_hook("pre_tool_call", _on_pre_tool_call)
     ctx.register_hook("post_tool_call", _on_post_tool_call)
     ctx.register_hook("on_session_end", _on_session_end)
     ctx.register_command("disk-cleanup", handler=_handle_slash,

--- a/plugins/disk-cleanup/__init__.py
+++ b/plugins/disk-cleanup/__init__.py
@@ -1,7 +1,7 @@
 """disk-cleanup plugin — auto-cleanup of ephemeral Hermes session files.
 
-``post_tool_call`` silently tracks test/temp paths created by write_file/patch/terminal;
-``on_session_end`` runs :func:`disk_cleanup.quick` when any test file was tracked this turn;
+``post_tool_call`` silently tracks paths inside Hermes-owned ephemeral roots;
+``on_session_end`` removes only immediate-cleanup paths tracked by that exact turn;
 ``/disk-cleanup`` exposes status / dry-run / quick / deep / track / forget.
 """
 
@@ -20,8 +20,8 @@ from . import disk_cleanup as dg
 logger = logging.getLogger(__name__)
 
 
-# Test files newly tracked this turn, keyed by task_id (or session_id) so on_session_end can
-# decide whether to run cleanup. Locked: post_tool_call fires concurrently on parallel calls.
+# Immediate-cleanup paths keyed by turn_id. The lock also serializes tracked.json updates from
+# concurrent tool hooks so one turn cannot overwrite or delete another turn's entries.
 _recent_test_tracks: Dict[str, Set[str]] = {}
 _lock = threading.Lock()
 
@@ -54,7 +54,8 @@ _PATH_EXTRACTORS: Dict[str, Callable[[Dict[str, Any], str], Set[str]]] = {
 
 
 def _on_post_tool_call(tool_name: str = "", args: Optional[Dict[str, Any]] = None, result: Any = None,
-                       task_id: str = "", session_id: str = "", tool_call_id: str = "", **_: Any) -> None:
+                       task_id: str = "", session_id: str = "", turn_id: str = "",
+                       tool_call_id: str = "", **_: Any) -> None:
     """Auto-track ephemeral files created by recent tool calls. Best-effort, never raises."""
     extractor = _PATH_EXTRACTORS.get(tool_name)
     if not isinstance(args, dict) or extractor is None:
@@ -64,26 +65,31 @@ def _on_post_tool_call(tool_name: str = "", args: Optional[Dict[str, Any]] = Non
             p = Path(path_str).expanduser()
         except Exception:
             continue
-        category = dg.guess_category(p) if p.exists() else None
-        if category is not None and dg.track(str(p), category, silent=True) and category == "test":
+        try:
+            category = dg.guess_category(p) if p.exists() else None
+        except (OSError, RuntimeError, ValueError):
+            continue
+        if category is not None:
             with _lock:
-                _recent_test_tracks.setdefault(task_id or session_id or "default", set()).add(str(p))
+                tracked = dg.track(str(p), category, silent=True)
+                if tracked and category == "test":
+                    _recent_test_tracks.setdefault(
+                        turn_id or task_id or session_id or "default", set()).add(str(p.resolve()))
 
 
 def _on_session_end(
-    session_id: str = "", completed: bool = True, interrupted: bool = False, **_: Any) -> None:
+    session_id: str = "", task_id: str = "", turn_id: str = "",
+    completed: bool = True, interrupted: bool = False, **_: Any) -> None:
     """Run quick cleanup if any test files were tracked during this turn."""
-    # Drain the session bucket plus every task-scoped bucket (subagents record into their own).
     with _lock:
-        had_tracks = bool(_recent_test_tracks.pop(session_id or "default", None) or _recent_test_tracks)
-        _recent_test_tracks.clear()
-    if not had_tracks:
-        return
-    try:
-        summary = dg.quick()
-    except Exception as exc:
-        logger.debug("disk-cleanup quick cleanup failed: %s", exc)
-        return
+        paths = _recent_test_tracks.pop(turn_id or task_id or session_id or "default", None)
+        if not paths:
+            return
+        try:
+            summary = dg.quick(only_paths=paths)
+        except Exception as exc:
+            logger.debug("disk-cleanup quick cleanup failed: %s", exc)
+            return
     if summary["deleted"] or summary["empty_dirs"]:
         dg._log(f"AUTO_QUICK (session_end): deleted={summary['deleted']} "
                 f"dirs={summary['empty_dirs']} freed={dg.fmt_size(summary['freed'])}")
@@ -102,8 +108,8 @@ Subcommands:
 
 Categories: temp | test | research | download | chrome-profile | cron-output | other
 
-All operations are scoped to HERMES_HOME and /tmp/hermes-*.
-Test files are auto-tracked on write_file / terminal and auto-cleaned at session end.
+Automatic deletion is limited to Hermes-owned cache/cron roots and /tmp/hermes-*.
+Arbitrary workspace files are never classified as disposable by filename.
 """
 
 

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -1,7 +1,7 @@
 """disk_cleanup — ephemeral file cleanup library behind the disk-cleanup plugin.
 
-Rules: files in Hermes-owned temporary roots delete at task end; managed cache
-artifacts after 7 days; cron-output after 14 days. Prompt-only: research
+Rules: exact platform-temp files proven new by a successful file-tool call delete at task end;
+managed cache artifacts after 7 days; cron-output after 14 days. Prompt-only: research
 (keep 10 newest, > 30 days), chrome-profile > 14 days, any file > 500 MB.
 Arbitrary paths under HERMES_HOME are never inferred to be disposable by name.
 """
@@ -14,6 +14,7 @@ import json
 import logging
 import os
 import shutil
+import stat
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
@@ -24,7 +25,7 @@ from hermes_constants import get_hermes_home
 logger = logging.getLogger(__name__)
 
 _LARGE_FILE_BYTES = 500 * 1024 * 1024
-_REGISTERED_SYSTEM_TEMP_ROOTS: Dict[str, Tuple[int, int]] = {}
+_REGISTERED_SYSTEM_TEMP_FILES: Dict[Tuple[str, str], Tuple[int, int]] = {}
 
 
 def _state_file(name: str) -> Path:
@@ -33,7 +34,7 @@ def _state_file(name: str) -> Path:
 
 
 def is_safe_path(path: Path) -> bool:
-    """Accept paths inside the profile or a process-registered Hermes temp root."""
+    """Accept profile paths or exact temp files proven new by a tool call."""
     try:
         lexical = _absolute_without_symlinks(path)
         resolved = path.resolve()
@@ -45,7 +46,7 @@ def is_safe_path(path: Path) -> bool:
         return _is_descendant(resolved, resolved_home)
     if _is_descendant(resolved, resolved_home):
         return True
-    return _system_temp_owner_root(path) is not None
+    return _registered_system_temp_file(path) is not None
 
 
 def _log(message: str) -> None:
@@ -132,7 +133,10 @@ def _is_descendant(path: Path, root: Path) -> bool:
 
 def _temp_roots() -> Set[Tuple[Path, Path]]:
     roots = set()
-    for candidate in (Path(tempfile.gettempdir()), Path("/tmp")):
+    candidates = [Path(tempfile.gettempdir())]
+    if os.name != "nt":
+        candidates.append(Path("/tmp"))
+    for candidate in candidates:
         with contextlib.suppress(OSError):
             lexical = _absolute_without_symlinks(candidate)
             resolved = candidate.resolve()
@@ -141,65 +145,86 @@ def _temp_roots() -> Set[Tuple[Path, Path]]:
     return roots
 
 
-def _candidate_system_temp_owner_root(path: Path) -> Optional[Path]:
-    """Find a real direct ``hermes-*`` child of a platform temp directory."""
+def _system_temp_file_key(path: Path) -> Optional[str]:
+    """Canonical key for a non-symlink path below a platform temp root."""
     try:
         lexical = _absolute_without_symlinks(path)
-        resolved = path.resolve()
+        resolved = path.resolve(strict=False)
         lexical_home = _absolute_without_symlinks(get_hermes_home())
         resolved_home = get_hermes_home().resolve()
     except (OSError, RuntimeError, ValueError):
         return None
-    # A lexical path that starts inside HOME but resolves outside is a symlink
-    # escape, not a system-temp candidate.
-    if _is_descendant(lexical, lexical_home):
+    if _is_descendant(lexical, lexical_home) or _is_descendant(resolved, resolved_home):
         return None
     for lexical_temp, resolved_temp in _temp_roots():
-        with contextlib.suppress(ValueError, OSError):
-            rel = lexical.relative_to(lexical_temp)
-            if len(rel.parts) < 2 or not rel.parts[0].startswith("hermes-"):
-                continue
-            lexical_owner = lexical_temp / rel.parts[0]
-            if lexical_owner.is_symlink() or not lexical_owner.is_dir():
-                continue
-            owner = lexical_owner.resolve()
-            owner_rel = owner.relative_to(resolved_temp)
-            if len(owner_rel.parts) != 1 or not _is_descendant(resolved, owner):
-                continue
-            # A test/profile HOME may itself be named hermes-*; never grant its
-            # outer directory ownership over sibling paths.
-            if resolved_home == owner or _is_descendant(resolved_home, owner):
-                continue
-            return owner
+        try:
+            lexical_rel = lexical.relative_to(lexical_temp)
+            resolved_rel = resolved.relative_to(resolved_temp)
+        except ValueError:
+            continue
+        if not lexical_rel.parts or lexical_rel != resolved_rel:
+            continue
+        current = lexical_temp
+        try:
+            for part in lexical_rel.parts:
+                current /= part
+                if current.is_symlink():
+                    raise ValueError("system temp candidate crosses a symlink")
+        except (OSError, ValueError):
+            continue
+        return str(resolved)
     return None
 
 
-def register_system_temp_root(path: Path) -> bool:
-    """Register a temp root observed in this process from an explicit file track."""
-    owner = _candidate_system_temp_owner_root(path)
-    if owner is None:
+def _register_created_system_temp_file(path: Path) -> bool:
+    """Register one temp file proven new by a matching successful Hermes file-tool call."""
+    key = _system_temp_file_key(path)
+    if key is None:
         return False
     try:
-        stat = owner.stat()
+        file_stat = Path(key).lstat()
+        profile_key = str(get_hermes_home().resolve())
     except (OSError, RuntimeError, ValueError):
         return False
-    _REGISTERED_SYSTEM_TEMP_ROOTS[str(owner)] = (stat.st_dev, stat.st_ino)
+    if not stat.S_ISREG(file_stat.st_mode):
+        return False
+    _REGISTERED_SYSTEM_TEMP_FILES[(profile_key, key)] = (file_stat.st_dev, file_stat.st_ino)
     return True
 
 
-def _system_temp_owner_root(path: Path) -> Optional[Path]:
-    """Return *path*'s still-identical temp root when this process registered it."""
-    owner = _candidate_system_temp_owner_root(path)
-    if owner is None:
+def _registered_system_temp_file(path: Path) -> Optional[Path]:
+    """Return the still-identical exact temp file registered by this process."""
+    key = _system_temp_file_key(path)
+    if key is None:
         return None
-    expected = _REGISTERED_SYSTEM_TEMP_ROOTS.get(str(owner))
+    try:
+        profile_key = str(get_hermes_home().resolve())
+    except (OSError, RuntimeError, ValueError):
+        return None
+    registration_key = (profile_key, key)
+    expected = _REGISTERED_SYSTEM_TEMP_FILES.get(registration_key)
     if expected is None:
         return None
     try:
-        current = owner.stat()
+        current = Path(key).lstat()
     except (OSError, RuntimeError, ValueError):
         return None
-    return owner if (current.st_dev, current.st_ino) == expected else None
+    if not stat.S_ISREG(current.st_mode):
+        _REGISTERED_SYSTEM_TEMP_FILES.pop(registration_key, None)
+        return None
+    if (current.st_dev, current.st_ino) != expected:
+        _REGISTERED_SYSTEM_TEMP_FILES.pop(registration_key, None)
+        return None
+    return Path(key)
+
+
+def _forget_registered_system_temp_file(path: Path) -> None:
+    key = _system_temp_file_key(path)
+    if key is None:
+        return
+    with contextlib.suppress(OSError, RuntimeError, ValueError):
+        profile_key = str(get_hermes_home().resolve())
+        _REGISTERED_SYSTEM_TEMP_FILES.pop((profile_key, key), None)
 
 
 def _managed_category(path: Path) -> Optional[str]:
@@ -219,8 +244,7 @@ def _managed_category(path: Path) -> Optional[str]:
     with contextlib.suppress(ValueError):
         resolved.relative_to(resolved_home)
         return None
-    owner = _system_temp_owner_root(resolved)
-    return "test" if owner is not None and resolved != owner else None
+    return "test" if _registered_system_temp_file(path) is not None else None
 
 
 def _managed_sweep_root(path: Path) -> Optional[Path]:
@@ -232,11 +256,7 @@ def _managed_sweep_root(path: Path) -> Optional[Path]:
         with contextlib.suppress(ValueError):
             if resolved.relative_to(root).parts:
                 return root
-    with contextlib.suppress(ValueError):
-        resolved.relative_to(get_hermes_home().resolve())
-        return None
-    owner = _system_temp_owner_root(resolved)
-    return owner if owner is not None and resolved != owner else None
+    return None
 
 @functools.lru_cache(maxsize=8)  # keyed by home: a multiplexed process serves several profiles
 def _protected_cron_paths(home: Path) -> frozenset:
@@ -271,8 +291,6 @@ def track(path_str: str, category: str, silent: bool = False) -> bool:
         category = "other"
     try:
         lexical_path = Path(path_str).expanduser()
-        if category == "test" and guess_category(lexical_path) is None:
-            register_system_temp_root(lexical_path)
         path = lexical_path.resolve()
         exists = path.exists()
     except (OSError, RuntimeError, ValueError):
@@ -288,10 +306,14 @@ def track(path_str: str, category: str, silent: bool = False) -> bool:
         _log(f"REJECT: {path} ({category} is not owned by disk-cleanup)")
         return False
     try:
-        size = path.stat().st_size if path.is_file() else 0
+        file_stat = lexical_path.lstat()
     except OSError:
         _log(f"SKIP: {path} (cannot stat)")
         return False
+    if not stat.S_ISREG(file_stat.st_mode):
+        _log(f"REJECT: {path} (only regular files can be tracked)")
+        return False
+    size = file_stat.st_size
     tracked = load_tracked()
     if any(isinstance(item, dict) and item.get("path") == str(path) for item in tracked):
         return False
@@ -360,20 +382,35 @@ def _prompt_group(item: Dict, age: int) -> Optional[str]:
     return "large" if item["size"] > _LARGE_FILE_BYTES else None
 
 
+def _is_current_owned_file(item: Dict, path: Path) -> bool:
+    """Revalidate the complete automatic-deletion boundary for one file."""
+    try:
+        file_stat = path.lstat()
+        canonical = path.resolve(strict=True)
+    except (OSError, RuntimeError, ValueError):
+        return False
+    try:
+        return (
+            path.is_absolute()
+            and canonical == path
+            and stat.S_ISREG(file_stat.st_mode)
+            and is_safe_path(path)
+            and guess_category(path) == item.get("category")
+            and not _is_protected_cron_path(path)
+        )
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
 def _delete_item(item: Dict) -> Tuple[bool, Optional[str]]:
     """Revalidate and delete one owned item. Returns ``(deleted, error)``."""
     p = Path(str(item.get("path", "")))
     try:
-        p = p.resolve()
-        if guess_category(p) != item.get("category"):
+        if not _is_current_owned_file(item, p):
             _log(f"SKIP unmanaged path before delete: {p}")
             return False, None
-        if p.is_file():
-            p.unlink()
-        elif p.is_dir():
-            shutil.rmtree(p)
-        else:
-            return False, None
+        p.unlink()
+        _forget_registered_system_temp_file(p)
     except (OSError, RuntimeError, ValueError) as e:
         _log(f"ERROR deleting {p}: {e}")
         return False, f"{p}: {e}"
@@ -386,11 +423,10 @@ def dry_run() -> Tuple[List[Dict], List[Dict]]:
     auto, prompt = [], []
     for item, p, age in _live_items(load_tracked(), datetime.now(timezone.utc)):
         cat = item.get("category")
-        if _is_auto_delete(cat, age) and guess_category(p) != cat:
-            continue
         if _is_auto_delete(cat, age):
-            auto.append(item)
-        elif _prompt_group(item, age):
+            if _is_current_owned_file(item, p):
+                auto.append(item)
+        elif _prompt_group(item, age) and is_safe_path(p):
             prompt.append(item)
     return auto, prompt
 
@@ -411,14 +447,11 @@ def quick(only_paths: Optional[Set[str]] = None) -> Dict[str, Any]:
             new_tracked.append(item)
             continue
         cat = item.get("category")
-        if _is_auto_delete(cat, age) and guess_category(p) != cat:
-            _log(f"SKIP stale {cat} entry: {p} (outside an owned ephemeral root)")
-            continue
-        if _is_protected_cron_path(p):
-            _log(f"SKIP protected cron path: {p}")
-            continue
         if not _is_auto_delete(cat, age):
             new_tracked.append(item)
+            continue
+        if not _is_current_owned_file(item, p):
+            _log(f"SKIP stale {cat} entry: {p} (not a current owned regular file)")
             continue
         if root := _managed_sweep_root(p):
             sweep_roots.add(root)
@@ -435,29 +468,43 @@ def quick(only_paths: Optional[Set[str]] = None) -> Dict[str, Any]:
     return {"deleted": deleted, "empty_dirs": empty_removed, "freed": freed, "errors": errors}
 
 
-def _subdirs(dirpath: Path, exclude: frozenset) -> List[Path]:
+def _is_real_descendant_dir(path: Path, root: Path) -> bool:
     try:
-        return [c for c in dirpath.iterdir() if c.is_dir() and not c.is_symlink() and c.name not in exclude]
+        return path.resolve(strict=True) == path and _is_descendant(path, root)
+    except (OSError, RuntimeError, ValueError):
+        return False
+
+
+def _subdirs(dirpath: Path, root: Path, exclude: frozenset) -> List[Path]:
+    try:
+        return [
+            child for child in dirpath.iterdir()
+            if child.name not in exclude and _is_real_descendant_dir(child, root)
+        ]
     except OSError:
         return []
 
 
 def _sweep_empty_dirs(root: Path) -> int:
     """Remove empty descendants of one explicitly owned ephemeral root."""
+    if root not in _managed_hermes_roots() or root.is_symlink():
+        return 0
     removed = 0
     stack: List[Tuple[Path, bool]] = [
-        (top, False) for top in _subdirs(root, _EMPTY_DIR_SWEEP_PRUNE_DIRS)]
+        (top, False) for top in _subdirs(root, root, _EMPTY_DIR_SWEEP_PRUNE_DIRS)]
     while stack:
         dirpath, visited = stack.pop()
         if visited:
             with contextlib.suppress(OSError):
-                if not any(dirpath.iterdir()):
+                if _is_real_descendant_dir(dirpath, root) and not any(dirpath.iterdir()):
                     dirpath.rmdir()
                     removed += 1
                     _log(f"DELETED: {dirpath} (empty dir)")
             continue
         stack.append((dirpath, True))
-        stack.extend((child, False) for child in _subdirs(dirpath, _EMPTY_DIR_SWEEP_PRUNE_DIRS))
+        stack.extend(
+            (child, False) for child in _subdirs(dirpath, root, _EMPTY_DIR_SWEEP_PRUNE_DIRS)
+        )
     return removed
 
 

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -1,9 +1,9 @@
 """disk_cleanup — ephemeral file cleanup library behind the disk-cleanup plugin.
 
-Rules: test files delete at task end (age >= 0); temp after 7 days; cron-output
-after 14 days; empty dirs under HERMES_HOME always. Prompt-only: research
+Rules: files in Hermes-owned temporary roots delete at task end; managed cache
+artifacts after 7 days; cron-output after 14 days. Prompt-only: research
 (keep 10 newest, > 30 days), chrome-profile > 14 days, any file > 500 MB.
-Scope: strictly HERMES_HOME and /tmp/hermes-*; never ~/.hermes/logs/ or system dirs.
+Arbitrary paths under HERMES_HOME are never inferred to be disposable by name.
 """
 
 from __future__ import annotations
@@ -13,9 +13,10 @@ import functools
 import json
 import logging
 import shutil
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple
 
 from hermes_constants import get_hermes_home
 
@@ -31,11 +32,14 @@ def _state_file(name: str) -> Path:
 
 def is_safe_path(path: Path) -> bool:
     """Accept only paths under HERMES_HOME or ``/tmp/hermes-*`` (rejects /mnt/c etc.)."""
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return False
     with contextlib.suppress(ValueError, OSError):
-        path.resolve().relative_to(get_hermes_home())
+        resolved.relative_to(get_hermes_home().resolve())
         return True
-    parts = path.parts
-    return len(parts) >= 3 and parts[1] == "tmp" and parts[2].startswith("hermes-")
+    return _system_temp_owner_root(resolved) is not None
 
 
 def _log(message: str) -> None:
@@ -54,14 +58,17 @@ def load_tracked() -> List[Dict[str, Any]]:
     tf.parent.mkdir(parents=True, exist_ok=True)
     if not tf.exists():
         return []
-    with contextlib.suppress(ValueError):
-        return json.loads(tf.read_text(encoding="utf-8"))
+    with contextlib.suppress(ValueError, OSError):
+        data = json.loads(tf.read_text(encoding="utf-8"))
+        if isinstance(data, list):
+            return data
     bak = tf.with_suffix(".json.bak")
     if bak.exists():
         with contextlib.suppress(Exception):
             data = json.loads(bak.read_text(encoding="utf-8"))
-            _log("WARN: tracked.json corrupted — restored from .bak")
-            return data
+            if isinstance(data, list):
+                _log("WARN: tracked.json corrupted — restored from .bak")
+                return data
     _log("WARN: tracked.json corrupted, no backup — starting fresh")
     return []
 
@@ -80,27 +87,67 @@ def save_tracked(tracked: List[Dict[str, Any]]) -> None:
 ALLOWED_CATEGORIES = {
     "temp", "test", "research", "download", "chrome-profile", "cron-output", "other"}
 
-# Top-level HERMES_HOME dirs whose empty subdirs are never swept (last row: user project trees).
-_EMPTY_DIR_PROTECTED_TOP_LEVEL = frozenset({
-    "logs", "memories", "sessions", "cron", "cronjobs",
-    "cache", "skills", "plugins", "disk-cleanup", "optional-skills",
-    "hermes-agent", "backups", "profiles", ".worktrees",
-    "patches", "projects", "skins", "themes", "contributors"})
-
 _EMPTY_DIR_SWEEP_PRUNE_DIRS = frozenset({
     ".git", "node_modules", "venv", ".venv", "site-packages", "__pycache__"})
 
-# Top-level HERMES_HOME entries guess_category() never auto-tracks: state, logs, memory,
-# sessions, config/secrets, and user project trees (test_* inside projects/ is not disposable).
-_NEVER_TRACK_TOP_LEVEL = frozenset({
-    "disk-cleanup", "logs", "memories", "sessions", "config.yaml",
-    "skills", "plugins", ".env", "USER.md", "MEMORY.md", "SOUL.md",
-    "auth.json", "hermes-agent",
-    # User-authored project trees — never sweep empty directories inside these (#75403).
-    # User-authored and project trees — never auto-delete files inside these just because they happen to be
-    # named test_* or tmp_* (#75403, also #32164, #37721).
-    "patches", "projects", "skins", "themes", "contributors",
-    "profiles", "backups", "optional-skills"})
+_MANAGED_HERMES_ROOTS = {
+    ("cache", "vision", "temp_vision_images"): "temp",
+    ("cache", "video", "temp_video_files"): "temp",
+    ("cron", "output"): "cron-output",
+    ("cronjobs", "output"): "cron-output",
+}
+
+
+def _managed_hermes_roots() -> Dict[Path, str]:
+    home = get_hermes_home().resolve()
+    return {home.joinpath(*parts).resolve(): category
+            for parts, category in _MANAGED_HERMES_ROOTS.items()}
+
+
+def _system_temp_owner_root(path: Path) -> Optional[Path]:
+    """Return the ``hermes-*`` owner root containing *path*, including macOS /tmp aliases."""
+    roots = set()
+    for candidate in (Path(tempfile.gettempdir()), Path("/tmp")):
+        with contextlib.suppress(OSError):
+            roots.add(candidate.resolve())
+    for root in roots:
+        with contextlib.suppress(ValueError):
+            rel = path.resolve().relative_to(root)
+            if rel.parts and rel.parts[0].startswith("hermes-"):
+                return root / rel.parts[0]
+    return None
+
+
+def _managed_category(path: Path) -> Optional[str]:
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return None
+    for root, category in _managed_hermes_roots().items():
+        with contextlib.suppress(ValueError):
+            if resolved.relative_to(root).parts:
+                return category
+    with contextlib.suppress(ValueError):
+        resolved.relative_to(get_hermes_home().resolve())
+        return None
+    owner = _system_temp_owner_root(resolved)
+    return "test" if owner is not None and resolved != owner else None
+
+
+def _managed_sweep_root(path: Path) -> Optional[Path]:
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return None
+    for root in _managed_hermes_roots():
+        with contextlib.suppress(ValueError):
+            if resolved.relative_to(root).parts:
+                return root
+    with contextlib.suppress(ValueError):
+        resolved.relative_to(get_hermes_home().resolve())
+        return None
+    owner = _system_temp_owner_root(resolved)
+    return owner if owner is not None and resolved != owner else None
 
 @functools.lru_cache(maxsize=8)  # keyed by home: a multiplexed process serves several profiles
 def _protected_cron_paths(home: Path) -> frozenset:
@@ -108,7 +155,9 @@ def _protected_cron_paths(home: Path) -> frozenset:
     ``jobs.json``, ``.tick.lock``) never deleted regardless of stored category (stale tracked.json).
     Never widen to everything under ``cron/output/``: run artifacts there are disposable; only
     wholesale deletion of ``output/`` is fatal."""
-    return frozenset(str(x) for parent in ("cron", "cronjobs") for base in (home / parent,)
+    home = home.resolve()
+    return frozenset(str(x.resolve()) for parent in ("cron", "cronjobs")
+                     for base in (home / parent,)
                      for x in (base, base / "output", base / "jobs.json", base / ".tick.lock"))
 
 
@@ -131,16 +180,28 @@ def track(path_str: str, category: str, silent: bool = False) -> bool:
     if category not in ALLOWED_CATEGORIES:
         _log(f"WARN: unknown category '{category}', using 'other'")
         category = "other"
-    path = Path(path_str).resolve()
-    if not path.exists():
+    try:
+        path = Path(path_str).resolve()
+        exists = path.exists()
+    except (OSError, RuntimeError, ValueError):
+        _log(f"SKIP: invalid path {path_str!r}")
+        return False
+    if not exists:
         _log(f"SKIP: {path} (does not exist)")
         return False
     if not is_safe_path(path):
         _log(f"REJECT: {path} (outside HERMES_HOME)")
         return False
-    size = path.stat().st_size if path.is_file() else 0
+    if category in {"test", "temp", "cron-output"} and guess_category(path) != category:
+        _log(f"REJECT: {path} ({category} is not owned by disk-cleanup)")
+        return False
+    try:
+        size = path.stat().st_size if path.is_file() else 0
+    except OSError:
+        _log(f"SKIP: {path} (cannot stat)")
+        return False
     tracked = load_tracked()
-    if any(item["path"] == str(path) for item in tracked):
+    if any(isinstance(item, dict) and item.get("path") == str(path) for item in tracked):
         return False
     tracked.append({"path": str(path), "timestamp": datetime.now(timezone.utc).isoformat(),
                     "category": category, "size": size})
@@ -155,7 +216,14 @@ def forget(path_str: str) -> int:
     """Remove a path from tracking without deleting the file."""
     p = Path(path_str).resolve()
     tracked = load_tracked()
-    kept = [i for i in tracked if Path(i["path"]).resolve() != p]
+    kept = []
+    for item in tracked:
+        try:
+            matches = Path(item["path"]).resolve() == p
+        except (KeyError, OSError, RuntimeError, TypeError, ValueError):
+            matches = False
+        if not matches:
+            kept.append(item)
     removed = len(tracked) - len(kept)
     if removed:
         save_tracked(kept)
@@ -166,9 +234,22 @@ def forget(path_str: str) -> int:
 def _live_items(tracked: List[Dict], now: datetime, *, log_stale: bool = False) -> Iterator[Tuple[Dict, Path, int]]:
     """Yield ``(item, path, age_days)`` for entries whose path still exists."""
     for item in tracked:
-        p = Path(item["path"])
-        if p.exists():
-            yield item, p, (now - datetime.fromisoformat(item["timestamp"])).days
+        try:
+            if not isinstance(item, dict):
+                raise TypeError("entry is not an object")
+            p = Path(item["path"])
+            age = (now - datetime.fromisoformat(item["timestamp"])).days
+            category = item["category"]
+            size = item["size"]
+            if category not in ALLOWED_CATEGORIES or not isinstance(size, (int, float)) or size < 0:
+                raise ValueError("invalid category or size")
+            exists = p.exists()
+        except (KeyError, OSError, RuntimeError, TypeError, ValueError) as exc:
+            if log_stale:
+                _log(f"SKIP malformed tracking entry: {exc}")
+            continue
+        if exists:
+            yield item, p, age
         elif log_stale:
             _log(f"STALE: {p} (removed from tracking)")
 
@@ -187,33 +268,33 @@ def _prompt_group(item: Dict, age: int) -> Optional[str]:
     return "large" if item["size"] > _LARGE_FILE_BYTES else None
 
 
-def _delete_item(item: Dict) -> Optional[str]:
-    """Delete a tracked file/dir and audit-log it. Returns an error string on OSError, else None."""
-    p = Path(item["path"])
+def _delete_item(item: Dict) -> Tuple[bool, Optional[str]]:
+    """Revalidate and delete one owned item. Returns ``(deleted, error)``."""
+    p = Path(str(item.get("path", "")))
     try:
+        p = p.resolve()
+        if guess_category(p) != item.get("category"):
+            _log(f"SKIP unmanaged path before delete: {p}")
+            return False, None
         if p.is_file():
             p.unlink()
         elif p.is_dir():
             shutil.rmtree(p)
-    except OSError as e:
+        else:
+            return False, None
+    except (OSError, RuntimeError, ValueError) as e:
         _log(f"ERROR deleting {p}: {e}")
-        return f"{p}: {e}"
+        return False, f"{p}: {e}"
     _log(f"DELETED: {p} ({item['category']}, {fmt_size(item['size'])})")
-    return None
-
-
-# Stored categories re-validated against guess_category() before use: old tracked.json entries
-# may carry "cron-output" for control-plane files or "test" for files under protected trees.
-_STALE_SKIP_NOTE = {"cron-output": "", "test": " — under protected tree"}
+    return True, None
 
 
 def dry_run() -> Tuple[List[Dict], List[Dict]]:
     """Return (auto_delete_list, needs_prompt_list) without touching files."""
     auto, prompt = [], []
     for item, p, age in _live_items(load_tracked(), datetime.now(timezone.utc)):
-        cat = item["category"]
-        # Stale cron-output entries are skipped by quick(); omit them here too.
-        if cat == "cron-output" and guess_category(p) != "cron-output":
+        cat = item.get("category")
+        if _is_auto_delete(cat, age) and guess_category(p) != cat:
             continue
         if _is_auto_delete(cat, age):
             auto.append(item)
@@ -222,32 +303,41 @@ def dry_run() -> Tuple[List[Dict], List[Dict]]:
     return auto, prompt
 
 
-def quick() -> Dict[str, Any]:
+def quick(only_paths: Optional[Set[str]] = None) -> Dict[str, Any]:
     """Safe deterministic cleanup — no prompts. Returns ``{deleted, empty_dirs, freed, errors}``."""
     deleted = freed = 0
     new_tracked: List[Dict] = []
     errors: List[str] = []
+    selected = None if only_paths is None else {str(Path(path).resolve()) for path in only_paths}
+    sweep_roots = set(_managed_hermes_roots()) if selected is None else set()
     for item, p, age in _live_items(load_tracked(), datetime.now(timezone.utc), log_stale=True):
-        cat = item["category"]
-        if cat in _STALE_SKIP_NOTE and (re_cat := guess_category(p)) != cat:
-            # Misclassified stale entry — drop it rather than delete the file.
-            _log(f"SKIP stale {cat} entry: {p} (re-classified as {re_cat!r}{_STALE_SKIP_NOTE[cat]})")
+        try:
+            item_path = str(p.resolve())
+        except (OSError, RuntimeError):
             continue
-        # Hard safety net even if re-validation above somehow let it through.
+        if selected is not None and item_path not in selected:
+            new_tracked.append(item)
+            continue
+        cat = item.get("category")
+        if _is_auto_delete(cat, age) and guess_category(p) != cat:
+            _log(f"SKIP stale {cat} entry: {p} (outside an owned ephemeral root)")
+            continue
         if _is_protected_cron_path(p):
             _log(f"SKIP protected cron path: {p}")
             continue
         if not _is_auto_delete(cat, age):
             new_tracked.append(item)
             continue
-        err = _delete_item(item)
-        if err is None:
-            freed += item["size"]
+        if root := _managed_sweep_root(p):
+            sweep_roots.add(root)
+        was_deleted, err = _delete_item(item)
+        if was_deleted:
+            freed += item.get("size", 0)
             deleted += 1
-        else:
+        elif err is not None:
             errors.append(err)
             new_tracked.append(item)
-    empty_removed = _sweep_empty_dirs(get_hermes_home())
+    empty_removed = sum(_sweep_empty_dirs(root) for root in sweep_roots)
     save_tracked(new_tracked)
     _log(f"QUICK_SUMMARY: {deleted} files, {empty_removed} dirs, {fmt_size(freed)}")
     return {"deleted": deleted, "empty_dirs": empty_removed, "freed": freed, "errors": errors}
@@ -260,13 +350,11 @@ def _subdirs(dirpath: Path, exclude: frozenset) -> List[Path]:
         return []
 
 
-def _sweep_empty_dirs(hermes_home: Path) -> int:
-    """Remove empty dirs under HERMES_HOME without recursing into durable/heavy trees (a full
-    rglob over a checkout+venv under HERMES_HOME can stall the gateway loop for minutes).
-    Iterative post-order so parents emptied by child removal are caught."""
+def _sweep_empty_dirs(root: Path) -> int:
+    """Remove empty descendants of one explicitly owned ephemeral root."""
     removed = 0
     stack: List[Tuple[Path, bool]] = [
-        (top, False) for top in _subdirs(hermes_home, _EMPTY_DIR_PROTECTED_TOP_LEVEL | _EMPTY_DIR_SWEEP_PRUNE_DIRS)]
+        (top, False) for top in _subdirs(root, _EMPTY_DIR_SWEEP_PRUNE_DIRS)]
     while stack:
         dirpath, visited = stack.pop()
         if visited:
@@ -285,13 +373,15 @@ def status() -> Dict[str, Any]:
     """Return per-category breakdown and top 10 largest tracked files."""
     tracked = load_tracked()
     cats: Dict[str, Dict] = {}
-    for item in tracked:
+    existing = []
+    valid = list(_live_items(tracked, datetime.now(timezone.utc), log_stale=True))
+    for item, p, _age in valid:
         c = cats.setdefault(item["category"], {"count": 0, "size": 0})
         c["count"] += 1
         c["size"] += item["size"]
-    existing = sorted(((i["path"], i["size"], i["category"]) for i in tracked
-                       if Path(i["path"]).exists()), key=lambda x: x[1], reverse=True)
-    return {"categories": cats, "top10": existing[:10], "total_tracked": len(tracked)}
+        existing.append((str(p), item["size"], item["category"]))
+    existing.sort(key=lambda x: x[1], reverse=True)
+    return {"categories": cats, "top10": existing[:10], "total_tracked": len(valid)}
 
 
 def format_status(s: Dict[str, Any]) -> str:
@@ -310,24 +400,6 @@ def format_status(s: Dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-_TEST_PATTERNS = ("test_", "tmp_")
-_TEST_SUFFIXES = (".test.py", ".test.js", ".test.ts", ".test.md")
-
-
 def guess_category(path: Path) -> Optional[str]:
-    """Category label for *path*, or None if we shouldn't track it (``post_tool_call`` hook)."""
-    if not is_safe_path(path):
-        return None
-    with contextlib.suppress(ValueError):  # not under HERMES_HOME (/tmp/hermes-*) — name rules only
-        rel = path.resolve().relative_to(get_hermes_home())
-        top = rel.parts[0] if rel.parts else ""
-        if top in _NEVER_TRACK_TOP_LEVEL:
-            return None
-        if top in ("cron", "cronjobs"):
-            # Only the disposable ``output/`` subtree; control-plane state (jobs.json,
-            # .tick.lock) must never be tracked — deleting it wipes the scheduler registry.
-            return "cron-output" if len(rel.parts) >= 3 and rel.parts[1] == "output" else None
-        if top == "cache":
-            return "temp"
-    name = path.name
-    return "test" if name.startswith(_TEST_PATTERNS) or name.endswith(_TEST_SUFFIXES) else None
+    """Return a category only when *path* belongs to an explicit ephemeral owner root."""
+    return _managed_category(path)

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -12,6 +12,7 @@ import contextlib
 import functools
 import json
 import logging
+import os
 import shutil
 import tempfile
 from datetime import datetime, timezone
@@ -23,6 +24,7 @@ from hermes_constants import get_hermes_home
 logger = logging.getLogger(__name__)
 
 _LARGE_FILE_BYTES = 500 * 1024 * 1024
+_REGISTERED_SYSTEM_TEMP_ROOTS: Dict[str, Tuple[int, int]] = {}
 
 
 def _state_file(name: str) -> Path:
@@ -31,15 +33,19 @@ def _state_file(name: str) -> Path:
 
 
 def is_safe_path(path: Path) -> bool:
-    """Accept only paths under HERMES_HOME or ``/tmp/hermes-*`` (rejects /mnt/c etc.)."""
+    """Accept paths inside the profile or a process-registered Hermes temp root."""
     try:
+        lexical = _absolute_without_symlinks(path)
         resolved = path.resolve()
-    except OSError:
+        lexical_home = _absolute_without_symlinks(get_hermes_home())
+        resolved_home = get_hermes_home().resolve()
+    except (OSError, RuntimeError, ValueError):
         return False
-    with contextlib.suppress(ValueError, OSError):
-        resolved.relative_to(get_hermes_home().resolve())
+    if _is_descendant(lexical, lexical_home):
+        return _is_descendant(resolved, resolved_home)
+    if _is_descendant(resolved, resolved_home):
         return True
-    return _system_temp_owner_root(resolved) is not None
+    return _system_temp_owner_root(path) is not None
 
 
 def _log(message: str) -> None:
@@ -100,35 +106,118 @@ _MANAGED_HERMES_ROOTS = {
 
 def _managed_hermes_roots() -> Dict[Path, str]:
     home = get_hermes_home().resolve()
-    return {home.joinpath(*parts).resolve(): category
-            for parts, category in _MANAGED_HERMES_ROOTS.items()}
+    roots = {}
+    for parts, category in _MANAGED_HERMES_ROOTS.items():
+        root = home.joinpath(*parts)
+        try:
+            # The owned boundary itself and each existing ancestor beneath HOME
+            # must be real directories, never a symlink to external storage.
+            if root.resolve(strict=False) != root:
+                continue
+        except (OSError, RuntimeError):
+            continue
+        roots[root] = category
+    return roots
 
 
-def _system_temp_owner_root(path: Path) -> Optional[Path]:
-    """Return the ``hermes-*`` owner root containing *path*, including macOS /tmp aliases."""
+def _absolute_without_symlinks(path: Path) -> Path:
+    return Path(os.path.abspath(os.fspath(path.expanduser())))
+
+
+def _is_descendant(path: Path, root: Path) -> bool:
+    with contextlib.suppress(ValueError):
+        return bool(path.relative_to(root).parts)
+    return False
+
+
+def _temp_roots() -> Set[Tuple[Path, Path]]:
     roots = set()
     for candidate in (Path(tempfile.gettempdir()), Path("/tmp")):
         with contextlib.suppress(OSError):
-            roots.add(candidate.resolve())
-    for root in roots:
-        with contextlib.suppress(ValueError):
-            rel = path.resolve().relative_to(root)
-            if rel.parts and rel.parts[0].startswith("hermes-"):
-                return root / rel.parts[0]
+            lexical = _absolute_without_symlinks(candidate)
+            resolved = candidate.resolve()
+            roots.add((lexical, resolved))
+            roots.add((resolved, resolved))
+    return roots
+
+
+def _candidate_system_temp_owner_root(path: Path) -> Optional[Path]:
+    """Find a real direct ``hermes-*`` child of a platform temp directory."""
+    try:
+        lexical = _absolute_without_symlinks(path)
+        resolved = path.resolve()
+        lexical_home = _absolute_without_symlinks(get_hermes_home())
+        resolved_home = get_hermes_home().resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+    # A lexical path that starts inside HOME but resolves outside is a symlink
+    # escape, not a system-temp candidate.
+    if _is_descendant(lexical, lexical_home):
+        return None
+    for lexical_temp, resolved_temp in _temp_roots():
+        with contextlib.suppress(ValueError, OSError):
+            rel = lexical.relative_to(lexical_temp)
+            if len(rel.parts) < 2 or not rel.parts[0].startswith("hermes-"):
+                continue
+            lexical_owner = lexical_temp / rel.parts[0]
+            if lexical_owner.is_symlink() or not lexical_owner.is_dir():
+                continue
+            owner = lexical_owner.resolve()
+            owner_rel = owner.relative_to(resolved_temp)
+            if len(owner_rel.parts) != 1 or not _is_descendant(resolved, owner):
+                continue
+            # A test/profile HOME may itself be named hermes-*; never grant its
+            # outer directory ownership over sibling paths.
+            if resolved_home == owner or _is_descendant(resolved_home, owner):
+                continue
+            return owner
     return None
+
+
+def register_system_temp_root(path: Path) -> bool:
+    """Register a temp root observed in this process from an explicit file track."""
+    owner = _candidate_system_temp_owner_root(path)
+    if owner is None:
+        return False
+    try:
+        stat = owner.stat()
+    except (OSError, RuntimeError, ValueError):
+        return False
+    _REGISTERED_SYSTEM_TEMP_ROOTS[str(owner)] = (stat.st_dev, stat.st_ino)
+    return True
+
+
+def _system_temp_owner_root(path: Path) -> Optional[Path]:
+    """Return *path*'s still-identical temp root when this process registered it."""
+    owner = _candidate_system_temp_owner_root(path)
+    if owner is None:
+        return None
+    expected = _REGISTERED_SYSTEM_TEMP_ROOTS.get(str(owner))
+    if expected is None:
+        return None
+    try:
+        current = owner.stat()
+    except (OSError, RuntimeError, ValueError):
+        return None
+    return owner if (current.st_dev, current.st_ino) == expected else None
 
 
 def _managed_category(path: Path) -> Optional[str]:
     try:
+        lexical = _absolute_without_symlinks(path)
         resolved = path.resolve()
-    except OSError:
+        lexical_home = _absolute_without_symlinks(get_hermes_home())
+        resolved_home = get_hermes_home().resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if _is_descendant(lexical, lexical_home) and not _is_descendant(resolved, resolved_home):
         return None
     for root, category in _managed_hermes_roots().items():
         with contextlib.suppress(ValueError):
             if resolved.relative_to(root).parts:
                 return category
     with contextlib.suppress(ValueError):
-        resolved.relative_to(get_hermes_home().resolve())
+        resolved.relative_to(resolved_home)
         return None
     owner = _system_temp_owner_root(resolved)
     return "test" if owner is not None and resolved != owner else None
@@ -137,7 +226,7 @@ def _managed_category(path: Path) -> Optional[str]:
 def _managed_sweep_root(path: Path) -> Optional[Path]:
     try:
         resolved = path.resolve()
-    except OSError:
+    except (OSError, RuntimeError, ValueError):
         return None
     for root in _managed_hermes_roots():
         with contextlib.suppress(ValueError):
@@ -181,7 +270,10 @@ def track(path_str: str, category: str, silent: bool = False) -> bool:
         _log(f"WARN: unknown category '{category}', using 'other'")
         category = "other"
     try:
-        path = Path(path_str).resolve()
+        lexical_path = Path(path_str).expanduser()
+        if category == "test" and guess_category(lexical_path) is None:
+            register_system_temp_root(lexical_path)
+        path = lexical_path.resolve()
         exists = path.exists()
     except (OSError, RuntimeError, ValueError):
         _log(f"SKIP: invalid path {path_str!r}")

--- a/plugins/disk-cleanup/plugin.yaml
+++ b/plugins/disk-cleanup/plugin.yaml
@@ -1,6 +1,6 @@
 name: disk-cleanup
-version: 2.0.0
-description: "Auto-track and clean up ephemeral files (test scripts, temp outputs, cron logs) created during Hermes sessions. Runs via plugin hooks — no agent action required."
+version: 2.1.0
+description: "Track and clean files in Hermes-owned temporary roots. Turn cleanup is isolated, automatic, and requires no agent action."
 author: "@LVT382009 (original), NousResearch (plugin port)"
 hooks:
   - post_tool_call

--- a/plugins/disk-cleanup/plugin.yaml
+++ b/plugins/disk-cleanup/plugin.yaml
@@ -1,7 +1,8 @@
 name: disk-cleanup
-version: 2.1.0
-description: "Track and clean files in Hermes-owned temporary roots. Turn cleanup is isolated, automatic, and requires no agent action."
+version: 2.2.0
+description: "Clean owned cache/cron files and exact platform-temp files proven new by a tool call."
 author: "@LVT382009 (original), NousResearch (plugin port)"
 hooks:
+  - pre_tool_call
   - post_tool_call
   - on_session_end

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -37,10 +37,19 @@ def _isolate_env(tmp_path, monkeypatch):
 
 @pytest.fixture
 def _managed_tmp_root():
-    """A real platform temp root that is explicitly owned by Hermes."""
+    """A real but unowned platform temp root for ownership-boundary tests."""
     root = Path(tempfile.mkdtemp(prefix="hermes-disk-cleanup-"))
     yield root
     shutil.rmtree(root, ignore_errors=True)
+
+
+def _owned_test_root(module, hermes_home):
+    """Add an isolated test-only immediate-cleanup root to one loaded module."""
+    parts = ("cache", "disk-cleanup", "turn-files")
+    module._MANAGED_HERMES_ROOTS[parts] = "test"
+    root = hermes_home.joinpath(*parts)
+    root.mkdir(parents=True, exist_ok=True)
+    return root
 
 
 def _load_lib():
@@ -71,6 +80,7 @@ def _load_plugin_init():
         ns = types.ModuleType("hermes_plugins")
         ns.__path__ = []
         sys.modules["hermes_plugins"] = ns
+    sys.modules.pop("hermes_plugins.disk_cleanup.disk_cleanup", None)
     mod = importlib.util.module_from_spec(spec)
     mod.__package__ = "hermes_plugins.disk_cleanup"
     mod.__path__ = [str(plugin_dir)]
@@ -129,33 +139,29 @@ class TestGuessCategory:
         assert summary["deleted"] == 0
         assert all(path.exists() for path in sentinels)
 
-    def test_system_temp_root_requires_process_registration(self, _managed_tmp_root):
+    def test_system_temp_name_and_manual_category_do_not_establish_ownership(
+        self, _isolate_env, _managed_tmp_root
+    ):
         dg = _load_lib()
         p = _managed_tmp_root / "anything.log"
         p.write_text("x", encoding="utf-8")
         assert dg.guess_category(p) is None
         assert dg.is_safe_path(p) is False
-        assert dg.register_system_temp_root(p) is True
-        assert dg.guess_category(p) == "test"
-        assert dg.is_safe_path(p) is True
+        assert dg.track(str(p), "test", silent=True) is False
 
-    def test_replaced_system_temp_root_loses_registration(self, _managed_tmp_root):
-        dg = _load_lib()
-        original_file = _managed_tmp_root / "original.log"
-        original_file.write_text("x", encoding="utf-8")
-        assert dg.register_system_temp_root(original_file) is True
-
-        displaced = _managed_tmp_root.with_name(f"{_managed_tmp_root.name}-displaced")
-        _managed_tmp_root.rename(displaced)
-        _managed_tmp_root.mkdir()
-        replacement_file = _managed_tmp_root / "replacement.log"
-        replacement_file.write_text("durable", encoding="utf-8")
-        try:
-            assert dg.guess_category(replacement_file) is None
-            assert dg.is_safe_path(replacement_file) is False
-        finally:
-            shutil.rmtree(_managed_tmp_root)
-            displaced.rename(_managed_tmp_root)
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True, exist_ok=True)
+        tracked_file.write_text(json.dumps([{
+            "path": str(p),
+            "category": "test",
+            "timestamp": "2025-01-01T00:00:00+00:00",
+            "size": p.stat().st_size,
+        }]), encoding="utf-8")
+        auto, _prompt = dg.dry_run()
+        summary = dg.quick()
+        assert auto == []
+        assert summary["deleted"] == 0
+        assert p.read_text(encoding="utf-8") == "x"
 
     def test_owned_cache_file(self, _isolate_env):
         dg = _load_lib()
@@ -323,14 +329,41 @@ class TestStaleCronEntryMigration:
 
 
 class TestTrackForgetQuick:
-    def test_track_then_quick_deletes_test(self, _managed_tmp_root):
+    def test_track_then_quick_deletes_test(self, _isolate_env):
         dg = _load_lib()
-        p = _managed_tmp_root / "test_a.py"
+        p = _owned_test_root(dg, _isolate_env) / "test_a.py"
         p.write_text("x", encoding="utf-8")
         assert dg.track(str(p), "test", silent=True) is True
         summary = dg.quick()
         assert summary["deleted"] == 1
         assert not p.exists()
+
+    def test_auto_cleanup_never_recursively_deletes_a_tracked_directory(
+        self, _isolate_env
+    ):
+        dg = _load_lib()
+        directory = (
+            _isolate_env / "cache" / "vision" / "temp_vision_images" / "durable-dir"
+        )
+        directory.mkdir(parents=True)
+        victim = directory / "victim.txt"
+        victim.write_text("durable", encoding="utf-8")
+        assert dg.track(str(directory), "temp", silent=True) is False
+
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True, exist_ok=True)
+        tracked_file.write_text(json.dumps([{
+            "path": str(directory),
+            "category": "temp",
+            "timestamp": "2025-01-01T00:00:00+00:00",
+            "size": 0,
+        }]), encoding="utf-8")
+
+        auto, _prompt = dg.dry_run()
+        summary = dg.quick()
+        assert auto == []
+        assert summary["deleted"] == 0
+        assert victim.read_text(encoding="utf-8") == "durable"
 
 
     def test_forget_removes_entry(self, _isolate_env):
@@ -363,9 +396,9 @@ class TestStatus:
 
 
 class TestDryRun:
-    def test_classifies_by_category(self, _isolate_env, _managed_tmp_root):
+    def test_classifies_by_category(self, _isolate_env):
         dg = _load_lib()
-        test_f = _managed_tmp_root / "test_x.py"
+        test_f = _owned_test_root(dg, _isolate_env) / "test_x.py"
         test_f.write_text("x", encoding="utf-8")
         big = _isolate_env / "big.bin"
         big.write_bytes(b"z" * 10)
@@ -381,9 +414,83 @@ class TestDryRun:
 # ---------------------------------------------------------------------------
 
 class TestPostToolCallHook:
-    def test_write_file_in_owned_temp_root_tracked(self, _isolate_env, _managed_tmp_root):
+    def test_preexisting_system_temp_file_is_never_claimed(
+        self, _isolate_env, _managed_tmp_root
+    ):
         pi = _load_plugin_init()
-        p = _managed_tmp_root / "created.py"
+        victim = _managed_tmp_root / "victim.txt"
+        victim.write_text("durable", encoding="utf-8")
+        output_only = _managed_tmp_root / "output-only.txt"
+
+        pi._on_pre_tool_call(
+            tool_name="terminal",
+            args={"command": f"cat {victim}"},
+            task_id="unowned", session_id="unowned", turn_id="unowned-turn",
+            tool_call_id="unowned-call",
+        )
+        output_only.write_text("not-created-by-the-command", encoding="utf-8")
+        pi._on_post_tool_call(
+            tool_name="terminal",
+            args={"command": f"cat {victim}"},
+            result=f"{victim}\n{output_only}\n",
+            task_id="unowned", session_id="unowned", turn_id="unowned-turn",
+            tool_call_id="unowned-call",
+        )
+        pi._on_session_end(
+            session_id="unowned", task_id="unowned", turn_id="unowned-turn",
+            completed=True, interrupted=False,
+        )
+
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        assert not tracked_file.exists() or json.loads(
+            tracked_file.read_text(encoding="utf-8")
+        ) == []
+        assert victim.read_text(encoding="utf-8") == "durable"
+        assert output_only.read_text(encoding="utf-8") == "not-created-by-the-command"
+
+    def test_new_system_temp_file_is_exactly_owned_and_replacement_survives(
+        self, _isolate_env, _managed_tmp_root, monkeypatch
+    ):
+        pi = _load_plugin_init()
+        paths = [
+            _managed_tmp_root / "unchanged.txt",
+            _managed_tmp_root / "replaced.txt",
+            _managed_tmp_root / "failed-call.txt",
+        ]
+        for index, path in enumerate(paths):
+            call_id = f"created-call-{index}"
+            args = {"path": str(path), "content": "created"}
+            pi._on_pre_tool_call(
+                tool_name="write_file", args=args, task_id="created",
+                session_id="created", turn_id="created-turn", tool_call_id=call_id,
+            )
+            path.write_text("created", encoding="utf-8")
+            pi._on_post_tool_call(
+                tool_name="write_file", args=args, result="OK", task_id="created",
+                session_id="created", turn_id="created-turn", tool_call_id=call_id,
+                status="error" if index == 2 else "ok",
+            )
+
+        other_profile = _isolate_env.parent / "other-profile"
+        other_profile.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(other_profile))
+        assert pi.dg.guess_category(paths[0]) is None
+        monkeypatch.setenv("HERMES_HOME", str(_isolate_env))
+
+        paths[1].unlink()
+        paths[1].write_text("replacement", encoding="utf-8")
+        pi._on_session_end(
+            session_id="created", task_id="created", turn_id="created-turn",
+            completed=True, interrupted=False,
+        )
+
+        assert not paths[0].exists()
+        assert paths[1].read_text(encoding="utf-8") == "replacement"
+        assert paths[2].read_text(encoding="utf-8") == "created"
+
+    def test_write_file_in_owned_temp_root_tracked(self, _isolate_env):
+        pi = _load_plugin_init()
+        p = _owned_test_root(pi.dg, _isolate_env) / "created.py"
         p.write_text("x", encoding="utf-8")
         pi._on_post_tool_call(
             tool_name="write_file",
@@ -397,9 +504,9 @@ class TestPostToolCallHook:
         assert data[0]["category"] == "test"
 
 
-    def test_terminal_command_picks_up_paths(self, _isolate_env, _managed_tmp_root):
+    def test_terminal_command_picks_up_paths(self, _isolate_env):
         pi = _load_plugin_init()
-        p = _managed_tmp_root / "created.log"
+        p = _owned_test_root(pi.dg, _isolate_env) / "created.log"
         p.write_text("x", encoding="utf-8")
         pi._on_post_tool_call(
             tool_name="terminal",
@@ -425,9 +532,10 @@ class TestPostToolCallHook:
 
 
 class TestOnSessionEndHook:
-    def test_only_cleans_the_turn_that_ended(self, _isolate_env, _managed_tmp_root):
+    def test_only_cleans_the_turn_that_ended(self, _isolate_env):
         pi = _load_plugin_init()
-        paths = [_managed_tmp_root / "turn-a.txt", _managed_tmp_root / "turn-b.txt"]
+        root = _owned_test_root(pi.dg, _isolate_env)
+        paths = [root / "turn-a.txt", root / "turn-b.txt"]
         for turn_id, p in zip(("turn-a", "turn-b"), paths):
             p.write_text("x", encoding="utf-8")
             pi._on_post_tool_call(

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -129,11 +129,33 @@ class TestGuessCategory:
         assert summary["deleted"] == 0
         assert all(path.exists() for path in sentinels)
 
-    def test_owned_system_temp_file(self, _managed_tmp_root):
+    def test_system_temp_root_requires_process_registration(self, _managed_tmp_root):
         dg = _load_lib()
         p = _managed_tmp_root / "anything.log"
         p.write_text("x", encoding="utf-8")
+        assert dg.guess_category(p) is None
+        assert dg.is_safe_path(p) is False
+        assert dg.register_system_temp_root(p) is True
         assert dg.guess_category(p) == "test"
+        assert dg.is_safe_path(p) is True
+
+    def test_replaced_system_temp_root_loses_registration(self, _managed_tmp_root):
+        dg = _load_lib()
+        original_file = _managed_tmp_root / "original.log"
+        original_file.write_text("x", encoding="utf-8")
+        assert dg.register_system_temp_root(original_file) is True
+
+        displaced = _managed_tmp_root.with_name(f"{_managed_tmp_root.name}-displaced")
+        _managed_tmp_root.rename(displaced)
+        _managed_tmp_root.mkdir()
+        replacement_file = _managed_tmp_root / "replacement.log"
+        replacement_file.write_text("durable", encoding="utf-8")
+        try:
+            assert dg.guess_category(replacement_file) is None
+            assert dg.is_safe_path(replacement_file) is False
+        finally:
+            shutil.rmtree(_managed_tmp_root)
+            displaced.rename(_managed_tmp_root)
 
     def test_owned_cache_file(self, _isolate_env):
         dg = _load_lib()
@@ -141,6 +163,41 @@ class TestGuessCategory:
         p.parent.mkdir(parents=True)
         p.write_text("x", encoding="utf-8")
         assert dg.guess_category(p) == "temp"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="symlink creation requires privileges")
+    @pytest.mark.parametrize("escape_at_root", [True, False])
+    def test_managed_cache_symlink_escape_is_never_deleted(
+        self, _isolate_env, escape_at_root
+    ):
+        dg = _load_lib()
+        managed = _isolate_env / "cache" / "vision" / "temp_vision_images"
+        external = _isolate_env.parent / f"external-cache-{escape_at_root}"
+        external.mkdir()
+        victim = external / "victim.txt"
+        victim.write_text("durable", encoding="utf-8")
+        if escape_at_root:
+            managed.parent.mkdir(parents=True)
+            managed.symlink_to(external, target_is_directory=True)
+            tracked_path = victim.resolve()
+        else:
+            managed.mkdir(parents=True)
+            (managed / "escape").symlink_to(external, target_is_directory=True)
+            tracked_path = managed / "escape" / victim.name
+
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True, exist_ok=True)
+        tracked_file.write_text(json.dumps([{
+            "path": str(tracked_path),
+            "category": "temp",
+            "timestamp": "2025-01-01T00:00:00+00:00",
+            "size": victim.stat().st_size,
+        }]), encoding="utf-8")
+
+        auto, _prompt = dg.dry_run()
+        summary = dg.quick()
+        assert auto == []
+        assert summary["deleted"] == 0
+        assert victim.read_text(encoding="utf-8") == "durable"
 
     def test_skips_protected_top_level(self, _isolate_env):
         dg = _load_lib()

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -95,12 +95,19 @@ class TestIsSafePath:
         dg = _load_lib()
         assert dg.is_safe_path(Path("/etc/passwd")) is False
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="symlink creation requires privileges")
+    def test_rejects_symlink_escape(self, _isolate_env):
+        dg = _load_lib()
+        link = _isolate_env / "escape"
+        link.symlink_to(Path(__file__).resolve())
+        assert dg.is_safe_path(link) is False
+
 
 class TestGuessCategory:
     def test_filename_does_not_imply_ownership(self, _isolate_env):
         dg = _load_lib()
         sentinels = []
-        for dirname in ("scripts", "node", "lsp", "browser-profile", "cache"):
+        for dirname in ("scripts", "projects", "node", "lsp", "browser-profile", "cache"):
             parent = _isolate_env / dirname
             parent.mkdir()
             p = parent / "test_durable.py"

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -4,9 +4,8 @@ Covers the bundled plugin at ``plugins/disk-cleanup/``:
 
   * ``disk_cleanup`` library: track / forget / dry_run / quick / status,
     ``is_safe_path`` and ``guess_category`` filtering.
-  * Plugin ``__init__``: ``post_tool_call`` hook auto-tracks files created
-    by ``write_file`` / ``terminal``; ``on_session_end`` hook runs quick
-    cleanup when anything was tracked during the turn.
+  * Plugin ``__init__``: ``post_tool_call`` auto-tracks files created in
+    owned temporary roots; ``on_session_end`` cleans only the ending turn.
   * Slash command handler: status / dry-run / quick / track / forget /
     unknown subcommand behaviours.
   * Bundled-plugin discovery via ``PluginManager.discover_and_load``.
@@ -14,7 +13,9 @@ Covers the bundled plugin at ``plugins/disk-cleanup/``:
 
 import importlib
 import json
+import shutil
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -32,6 +33,14 @@ def _isolate_env(tmp_path, monkeypatch):
     hermes_home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     yield hermes_home
+
+
+@pytest.fixture
+def _managed_tmp_root():
+    """A real platform temp root that is explicitly owned by Hermes."""
+    root = Path(tempfile.mkdtemp(prefix="hermes-disk-cleanup-"))
+    yield root
+    shutil.rmtree(root, ignore_errors=True)
 
 
 def _load_lib():
@@ -79,7 +88,7 @@ class TestIsSafePath:
         dg = _load_lib()
         p = _isolate_env / "subdir" / "file.txt"
         p.parent.mkdir()
-        p.write_text("x")
+        p.write_text("x", encoding="utf-8")
         assert dg.is_safe_path(p) is True
 
     def test_rejects_outside_hermes_home(self, _isolate_env):
@@ -88,30 +97,50 @@ class TestIsSafePath:
 
 
 class TestGuessCategory:
-    def test_test_prefix(self, _isolate_env):
+    def test_filename_does_not_imply_ownership(self, _isolate_env):
         dg = _load_lib()
-        p = _isolate_env / "test_foo.py"
-        p.write_text("x")
+        sentinels = []
+        for dirname in ("scripts", "node", "lsp", "browser-profile", "cache"):
+            parent = _isolate_env / dirname
+            parent.mkdir()
+            p = parent / "test_durable.py"
+            p.write_text("x", encoding="utf-8")
+            sentinels.append(p)
+            assert dg.guess_category(p) is None
+
+        tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
+        tracked_file.parent.mkdir(parents=True)
+        tracked_file.write_text(json.dumps([{
+            "path": str(path),
+            "category": "test",
+            "timestamp": "2025-01-01T00:00:00+00:00",
+            "size": 1,
+        } for path in sentinels]), encoding="utf-8")
+        auto, _prompt = dg.dry_run()
+        summary = dg.quick()
+        assert auto == []
+        assert summary["deleted"] == 0
+        assert all(path.exists() for path in sentinels)
+
+    def test_owned_system_temp_file(self, _managed_tmp_root):
+        dg = _load_lib()
+        p = _managed_tmp_root / "anything.log"
+        p.write_text("x", encoding="utf-8")
         assert dg.guess_category(p) == "test"
 
-    def test_tmp_prefix(self, _isolate_env):
+    def test_owned_cache_file(self, _isolate_env):
         dg = _load_lib()
-        p = _isolate_env / "tmp_foo.log"
-        p.write_text("x")
-        assert dg.guess_category(p) == "test"
-
-    def test_dot_test_suffix(self, _isolate_env):
-        dg = _load_lib()
-        p = _isolate_env / "mything.test.js"
-        p.write_text("x")
-        assert dg.guess_category(p) == "test"
+        p = _isolate_env / "cache" / "vision" / "temp_vision_images" / "image.png"
+        p.parent.mkdir(parents=True)
+        p.write_text("x", encoding="utf-8")
+        assert dg.guess_category(p) == "temp"
 
     def test_skips_protected_top_level(self, _isolate_env):
         dg = _load_lib()
         logs_dir = _isolate_env / "logs"
         logs_dir.mkdir()
         p = logs_dir / "test_log.txt"
-        p.write_text("x")
+        p.write_text("x", encoding="utf-8")
         # Even though it matches test_* pattern, logs/ is excluded.
         assert dg.guess_category(p) is None
 
@@ -121,7 +150,7 @@ class TestGuessCategory:
         output_dir = _isolate_env / "cron" / "output" / "job_123"
         output_dir.mkdir(parents=True)
         p = output_dir / "run.md"
-        p.write_text("x")
+        p.write_text("x", encoding="utf-8")
         assert dg.guess_category(p) == "cron-output"
 
 
@@ -131,13 +160,13 @@ class TestGuessCategory:
         cron_dir = _isolate_env / "cronjobs"
         cron_dir.mkdir()
         p = cron_dir / "jobs.json"
-        p.write_text("[]")
+        p.write_text("[]", encoding="utf-8")
         assert dg.guess_category(p) is None
 
     def test_ordinary_file_returns_none(self, _isolate_env):
         dg = _load_lib()
         p = _isolate_env / "notes.md"
-        p.write_text("x")
+        p.write_text("x", encoding="utf-8")
         assert dg.guess_category(p) is None
 
 
@@ -157,24 +186,28 @@ class TestStaleCronEntryMigration:
         cron_dir = _isolate_env / "cron"
         cron_dir.mkdir()
         jobs_json = cron_dir / "jobs.json"
-        jobs_json.write_text('{"jobs": []}')
+        jobs_json.write_text('{"jobs": []}', encoding="utf-8")
 
         # Simulate a stale tracked.json entry from before #34840 by
         # directly writing the tracked file (track() would reject it).
         tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
         tracked_file.parent.mkdir(parents=True, exist_ok=True)
-        tracked_file.write_text(json.dumps([{
-            "path": str(jobs_json),
-            "category": "cron-output",
-            "timestamp": "2025-01-01T00:00:00+00:00",  # very old
-            "size": 123,
-        }]))
+        tracked_file.write_text(json.dumps([
+            {
+                "path": str(jobs_json),
+                "category": "cron-output",
+                "timestamp": "2025-01-01T00:00:00+00:00",  # very old
+                "size": 123,
+            },
+            {"damaged": True},
+            "not-an-object",
+        ]), encoding="utf-8")
 
         summary = dg.quick()
         assert summary["deleted"] == 0, "cron/jobs.json must not be deleted"
         assert jobs_json.exists(), "jobs.json must still exist"
         # The stale entry should have been dropped from tracking.
-        remaining = json.loads(tracked_file.read_text())
+        remaining = json.loads(tracked_file.read_text(encoding="utf-8"))
         assert len(remaining) == 0
 
 
@@ -184,7 +217,7 @@ class TestStaleCronEntryMigration:
         cron_dir = _isolate_env / "cron"
         cron_dir.mkdir()
         jobs_json = cron_dir / "jobs.json"
-        jobs_json.write_text("[]")
+        jobs_json.write_text("[]", encoding="utf-8")
 
         tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
         tracked_file.parent.mkdir(parents=True, exist_ok=True)
@@ -193,7 +226,7 @@ class TestStaleCronEntryMigration:
             "category": "cron-output",
             "timestamp": "2025-01-01T00:00:00+00:00",
             "size": 123,
-        }]))
+        }]), encoding="utf-8")
 
         auto, prompt = dg.dry_run()
         assert len(auto) == 0, "stale cron-output for jobs.json must not appear"
@@ -205,7 +238,7 @@ class TestStaleCronEntryMigration:
         output_dir = _isolate_env / "cron" / "output" / "job_1"
         output_dir.mkdir(parents=True)
         run_md = output_dir / "run.md"
-        run_md.write_text("x")
+        run_md.write_text("x", encoding="utf-8")
 
         # Old enough to be deleted (>14 days)
         from datetime import datetime, timezone, timedelta
@@ -218,7 +251,7 @@ class TestStaleCronEntryMigration:
             "category": "cron-output",
             "timestamp": old_ts,
             "size": 10,
-        }]))
+        }]), encoding="utf-8")
 
         summary = dg.quick()
         assert summary["deleted"] == 1, "valid old cron-output should be deleted"
@@ -226,10 +259,10 @@ class TestStaleCronEntryMigration:
 
 
 class TestTrackForgetQuick:
-    def test_track_then_quick_deletes_test(self, _isolate_env):
+    def test_track_then_quick_deletes_test(self, _managed_tmp_root):
         dg = _load_lib()
-        p = _isolate_env / "test_a.py"
-        p.write_text("x")
+        p = _managed_tmp_root / "test_a.py"
+        p.write_text("x", encoding="utf-8")
         assert dg.track(str(p), "test", silent=True) is True
         summary = dg.quick()
         assert summary["deleted"] == 1
@@ -239,8 +272,8 @@ class TestTrackForgetQuick:
     def test_forget_removes_entry(self, _isolate_env):
         dg = _load_lib()
         p = _isolate_env / "keep.tmp"
-        p.write_text("x")
-        dg.track(str(p), "temp", silent=True)
+        p.write_text("x", encoding="utf-8")
+        dg.track(str(p), "other", silent=True)
         assert dg.forget(str(p)) == 1
         assert p.exists()  # forget does NOT delete the file
 
@@ -255,28 +288,28 @@ class TestStatus:
     def test_status_with_entries(self, _isolate_env):
         dg = _load_lib()
         p = _isolate_env / "big.tmp"
-        p.write_text("y" * 100)
-        dg.track(str(p), "temp", silent=True)
+        p.write_text("y" * 100, encoding="utf-8")
+        dg.track(str(p), "other", silent=True)
         s = dg.status()
         assert s["total_tracked"] == 1
         assert len(s["top10"]) == 1
         rendered = dg.format_status(s)
-        assert "temp" in rendered
+        assert "other" in rendered
         assert "big.tmp" in rendered
 
 
 class TestDryRun:
-    def test_classifies_by_category(self, _isolate_env):
+    def test_classifies_by_category(self, _isolate_env, _managed_tmp_root):
         dg = _load_lib()
-        test_f = _isolate_env / "test_x.py"
-        test_f.write_text("x")
+        test_f = _managed_tmp_root / "test_x.py"
+        test_f.write_text("x", encoding="utf-8")
         big = _isolate_env / "big.bin"
         big.write_bytes(b"z" * 10)
         dg.track(str(test_f), "test", silent=True)
         dg.track(str(big), "other", silent=True)
         auto, prompt = dg.dry_run()
         # test → auto, other → neither (doesn't hit any rule)
-        assert any(i["path"] == str(test_f) for i in auto)
+        assert any(Path(i["path"]) == test_f.resolve() for i in auto)
 
 
 # ---------------------------------------------------------------------------
@@ -284,34 +317,34 @@ class TestDryRun:
 # ---------------------------------------------------------------------------
 
 class TestPostToolCallHook:
-    def test_write_file_test_pattern_tracked(self, _isolate_env):
+    def test_write_file_in_owned_temp_root_tracked(self, _isolate_env, _managed_tmp_root):
         pi = _load_plugin_init()
-        p = _isolate_env / "test_created.py"
-        p.write_text("x")
+        p = _managed_tmp_root / "created.py"
+        p.write_text("x", encoding="utf-8")
         pi._on_post_tool_call(
             tool_name="write_file",
             args={"path": str(p), "content": "x"},
             result="OK",
-            task_id="t1", session_id="s1",
+            task_id="t1", session_id="s1", turn_id="turn-1",
         )
         tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
-        data = json.loads(tracked_file.read_text())
+        data = json.loads(tracked_file.read_text(encoding="utf-8"))
         assert len(data) == 1
         assert data[0]["category"] == "test"
 
 
-    def test_terminal_command_picks_up_paths(self, _isolate_env):
+    def test_terminal_command_picks_up_paths(self, _isolate_env, _managed_tmp_root):
         pi = _load_plugin_init()
-        p = _isolate_env / "tmp_created.log"
-        p.write_text("x")
+        p = _managed_tmp_root / "created.log"
+        p.write_text("x", encoding="utf-8")
         pi._on_post_tool_call(
             tool_name="terminal",
             args={"command": f"touch {p}"},
             result=f"created {p}\n",
-            task_id="t3", session_id="s3",
+            task_id="t3", session_id="s3", turn_id="turn-3",
         )
         tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
-        data = json.loads(tracked_file.read_text())
+        data = json.loads(tracked_file.read_text(encoding="utf-8"))
         assert any(Path(i["path"]) == p.resolve() for i in data)
 
     def test_ignores_unrelated_tool(self, _isolate_env):
@@ -324,23 +357,34 @@ class TestPostToolCallHook:
         )
         # read_file should never trigger tracking.
         tracked_file = _isolate_env / "disk-cleanup" / "tracked.json"
-        assert not tracked_file.exists() or tracked_file.read_text().strip() == "[]"
+        assert not tracked_file.exists() or tracked_file.read_text(encoding="utf-8").strip() == "[]"
 
 
 class TestOnSessionEndHook:
-    def test_runs_quick_when_test_files_tracked(self, _isolate_env):
+    def test_only_cleans_the_turn_that_ended(self, _isolate_env, _managed_tmp_root):
         pi = _load_plugin_init()
-        p = _isolate_env / "test_cleanup.py"
-        p.write_text("x")
-        pi._on_post_tool_call(
-            tool_name="write_file",
-            args={"path": str(p), "content": "x"},
-            result="OK",
-            task_id="", session_id="s1",
+        paths = [_managed_tmp_root / "turn-a.txt", _managed_tmp_root / "turn-b.txt"]
+        for turn_id, p in zip(("turn-a", "turn-b"), paths):
+            p.write_text("x", encoding="utf-8")
+            pi._on_post_tool_call(
+                tool_name="write_file",
+                args={"path": str(p), "content": "x"},
+                result="OK",
+                task_id="task", session_id="session", turn_id=turn_id,
+            )
+
+        pi._on_session_end(
+            session_id="session", task_id="task", turn_id="turn-a",
+            completed=True, interrupted=False,
         )
-        assert p.exists()
-        pi._on_session_end(session_id="s1", completed=True, interrupted=False)
-        assert not p.exists(), "test file should be auto-deleted"
+        assert not paths[0].exists()
+        assert paths[1].exists(), "ending one turn must not clean another turn's file"
+
+        pi._on_session_end(
+            session_id="session", task_id="task", turn_id="turn-b",
+            completed=True, interrupted=False,
+        )
+        assert not paths[1].exists()
 
     def test_noop_when_no_test_tracked(self, _isolate_env):
         pi = _load_plugin_init()
@@ -375,7 +419,8 @@ class TestBundledDiscovery:
         """Write plugins.enabled allow-list to config.yaml."""
         import yaml
         cfg_path = hermes_home / "config.yaml"
-        cfg_path.write_text(yaml.safe_dump({"plugins": {"enabled": list(names)}}))
+        cfg_path.write_text(
+            yaml.safe_dump({"plugins": {"enabled": list(names)}}), encoding="utf-8")
 
     def test_disk_cleanup_discovered_but_not_loaded_by_default(self, _isolate_env):
         """Bundled plugins are discovered but NOT loaded without opt-in."""
@@ -400,7 +445,7 @@ class TestBundledDiscovery:
                 "enabled": ["disk-cleanup"],
                 "disabled": ["disk-cleanup"],
             }
-        }))
+        }), encoding="utf-8")
         from hermes_cli import plugins as pmod
         mgr = pmod.PluginManager()
         mgr.discover_and_load()

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -71,23 +71,23 @@ Memory providers (`plugins/memory/*`) and context engines (`plugins/context_engi
 
 ### disk-cleanup
 
-Auto-tracks and removes ephemeral files created during sessions — test scripts, temp outputs, cron logs, stale chrome profiles — without requiring the agent to remember to call a tool.
+Tracks and removes files in ephemeral roots Hermes explicitly owns — generated media caches, cron run output, and platform temp directories named `hermes-*` — without requiring the agent to remember to call a tool. A filename such as `test_*` or `tmp_*` never establishes ownership by itself.
 
 **How it works:**
 
 | Hook | Behaviour |
 |---|---|
-| `post_tool_call` | When `write_file` / `terminal` / `patch` creates a file matching `test_*`, `tmp_*`, or `*.test.*` inside `HERMES_HOME` or `/tmp/hermes-*`, track it silently as `test` / `temp` / `cron-output`. |
-| `on_session_end` | If any test files were auto-tracked during the turn, run the safe `quick` cleanup and log a one-line summary. Stays silent otherwise. |
+| `post_tool_call` | When `write_file` / `terminal` / `patch` creates a file inside a Hermes-owned ephemeral root, track it silently. |
+| `on_session_end` | Delete only immediate-cleanup files tracked by that exact turn and log a one-line summary. Concurrent and long-running bot turns remain isolated. |
 
 **Deletion rules:**
 
 | Category | Threshold | Confirmation |
 |---|---|---|
-| `test` | every session end | Never |
+| `test` | end of the creating turn | Never |
 | `temp` | >7 days since tracked | Never |
 | `cron-output` | >14 days since tracked | Never |
-| empty dirs under HERMES_HOME | always | Never |
+| empty dirs in owned ephemeral roots | always | Never |
 | `research` | >30 days, beyond 10 newest | Always (deep only) |
 | `chrome-profile` | >14 days since tracked | Always (deep only) |
 | files >500 MB | never auto | Always (deep only) |
@@ -111,7 +111,7 @@ Auto-tracks and removes ephemeral files created during sessions — test scripts
 | `tracked.json.bak` | Atomic-write backup of the above |
 | `cleanup.log` | Append-only audit trail of every track / skip / reject / delete |
 
-**Safety** — cleanup only ever touches paths under `HERMES_HOME` or `/tmp/hermes-*`. Windows mounts (`/mnt/c/...`) are rejected. Well-known top-level state dirs (`logs/`, `memories/`, `sessions/`, `cron/`, `cache/`, `skills/`, `plugins/`, `disk-cleanup/` itself) are never removed even when empty — a fresh install does not get gutted on first session end.
+**Safety** — automatic deletion requires current membership in an explicit owned root: `$HERMES_HOME/cache/vision/temp_vision_images/`, `$HERMES_HOME/cache/video/temp_video_files/`, `$HERMES_HOME/cron/output/` (plus `cronjobs/output/`), or a platform temp directory whose top-level name starts with `hermes-`. Candidates are revalidated immediately before deletion, malformed tracking records are skipped, and one turn cannot clean another active turn's files. All other workspace and Hermes paths are durable regardless of their filename.
 
 **Enabling:** `hermes plugins enable disk-cleanup` (or check the box in `hermes plugins`).
 

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -71,13 +71,14 @@ Memory providers (`plugins/memory/*`) and context engines (`plugins/context_engi
 
 ### disk-cleanup
 
-Tracks and removes files in ephemeral roots Hermes explicitly owns — generated media caches, cron run output, and platform temp directories named `hermes-*` — without requiring the agent to remember to call a tool. A filename such as `test_*` or `tmp_*` never establishes ownership by itself.
+Tracks and removes generated media caches, cron run output, and exact platform-temp files that Hermes observed as absent immediately before a tool call created them. A directory name, terminal output, manual category, or filename such as `test_*` / `tmp_*` never establishes ownership.
 
 **How it works:**
 
 | Hook | Behaviour |
 |---|---|
-| `post_tool_call` | When `write_file` / `terminal` / `patch` creates a file inside a Hermes-owned ephemeral root, track it silently. |
+| `pre_tool_call` | Before `write_file` / `patch`, record explicit platform-temp paths that do not yet exist. |
+| `post_tool_call` | Track owned-root files, plus exact new platform-temp files after a successful matching file-tool call. Terminal text can never establish external-temp ownership. |
 | `on_session_end` | Delete only immediate-cleanup files tracked by that exact turn and log a one-line summary. Concurrent and long-running bot turns remain isolated. |
 
 **Deletion rules:**
@@ -111,7 +112,7 @@ Tracks and removes files in ephemeral roots Hermes explicitly owns — generated
 | `tracked.json.bak` | Atomic-write backup of the above |
 | `cleanup.log` | Append-only audit trail of every track / skip / reject / delete |
 
-**Safety** — automatic deletion requires current membership in an explicit owned root: `$HERMES_HOME/cache/vision/temp_vision_images/`, `$HERMES_HOME/cache/video/temp_video_files/`, `$HERMES_HOME/cron/output/` (plus `cronjobs/output/`), or a platform temp directory whose top-level name starts with `hermes-`. Candidates are revalidated immediately before deletion, malformed tracking records are skipped, and one turn cannot clean another active turn's files. All other workspace and Hermes paths are durable regardless of their filename.
+**Safety** — automatic deletion requires current membership in an explicit owned root: `$HERMES_HOME/cache/vision/temp_vision_images/`, `$HERMES_HOME/cache/video/temp_video_files/`, or `$HERMES_HOME/cron/output/` (plus `cronjobs/output/`). Outside those roots, ownership is limited to the exact regular platform-temp file proven new by a matching successful `write_file` / `patch` call and bound to that file's filesystem identity; terminal text and its parent directory never grant ownership. Candidates are revalidated immediately before deletion, pre-existing/replaced files and malformed tracking records are skipped, and one turn cannot clean another active turn's files. All other workspace and Hermes paths are durable regardless of their filename.
 
 **Enabling:** `hermes plugins enable disk-cleanup` (or check the box in `hermes plugins`).
 


### PR DESCRIPTION
## What does this PR do?

Makes the bundled disk-cleanup plugin fail closed. Automatic deletion is limited to fixed Hermes-owned cache and cron-output roots, and turn-end cleanup can delete only the exact file generations owned by that profile and turn.

This removes the filename heuristics that classified arbitrary `test_*`, `tmp_*`, or `*.test.*` paths under `HERMES_HOME` as disposable. It also deliberately removes automatic ownership for general platform-temp paths: creating a file beneath `/tmp` does not establish permission to discard it.

The ownership-root direction builds on #88045 and the related worktree protections discussed in #80842. This PR preserves that useful direction while adding profile/turn isolation, file-generation identity, and directory-handle-anchored deletion. Thanks to @feiyu3241241 and @benjaminbrumbaugh for the earlier analysis.

## Related issues

Addresses #83378
Addresses #107343

## Type of change

- [x] Bug fix
- [x] Security fix
- [x] Documentation update
- [x] Tests

## Changes made

- Replace basename and general platform-temp inference with four fixed Hermes-owned roots:
  - `cache/vision/temp_vision_images`
  - `cache/video/temp_video_files`
  - `cron/output`
  - legacy `cronjobs/output`
- Persist each cleanup obligation with its profile, originating turn owner, file device/inode/size/mtime/ctime, and owned-root device/inode.
- Treat path reuse and in-place rewrites as new generations; an older turn can never acquire authority over a newer file at the same path.
- Reject whole-root and inner-ancestor symlink escapes, non-canonical paths, cross-profile records, replaced files, prior-process records, and malformed legacy state.
- Anchor automatic unlink to a verified root and parent directory handle with `O_NOFOLLOW`; unsupported platforms fail closed without an unsafe pathname fallback.
- Auto-delete regular files only. Recursive tracked-directory deletion is removed; empty-directory sweeping remains limited to real descendants of the fixed roots.
- Scope immediate turn-end cleanup by profile and `turn_id`, and serialize plugin cleanup/state operations.
- Run aged cache/cron retention on every completed turn, so long-running bot sessions clean incrementally without waiting for process exit.
- Keep slash commands and their existing output shapes compatible.
- Bump the plugin to `2.3.0` and document the ownership boundary.

No migration is required. Unsafe or stale tracking entries are discarded fail closed without deleting their target files.

## Verification

- `scripts/run_tests.sh tests/plugins/test_disk_cleanup_plugin.py`: 41 passed, 0 failed
- Real `PluginManager` discovery, registered hook dispatch, and slash-command handler exercised
- Ruff: passed
- `git diff --check`: passed
- Windows footgun scan on all changed Python files: passed
- Complete repository suite: not run

The focused regressions cover durable state/workspace sentinels, arbitrary platform-temp files and Git source, same-path replacement and in-place rewrite generations, same turn IDs across profiles, two concurrent turns, managed-root and inner-ancestor symlink attacks, malformed tracking state, protected cron control-plane files, regular-file-only deletion, and safe empty-directory sweeping.
