### PR TITLE
fix(slack): render compact tool previews as inline code

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2839,6 +2839,11 @@ class SlackAdapter(BasePlatformAdapter):
             logger.debug("[Slack] block render failed; using plain text", exc_info=True)
             return None
 
+    def format_tool_preview(self, preview) -> str:
+        """Keep compact tool arguments out of mrkdwn emphasis conversion."""
+        # Substitute embedded delimiters in the display text only.
+        return f"`{preview.text.replace('`', 'ˋ')}`"
+
     def format_message(self, content: str) -> str:
         """Convert standard markdown to Slack mrkdwn.
         Tables are fenced first; code is protected from later passes; broadcast mentions are escaped

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2577,6 +2577,35 @@ class TestSendTyping:
 class TestFormatMessage:
     """Test markdown to Slack mrkdwn conversion."""
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("target,pattern", [
+        ("files", "*test*.py"),
+        ("content", r"test_.*_.*\.py"),
+    ])
+    async def test_tool_progress_preserves_search_pattern(self, adapter, target, pattern):
+        from gateway.run_turn_runner import TurnRunner
+
+        args = {"target": target, "pattern": pattern}
+        ctx = SimpleNamespace(source=None, progress_mode="all", last_was_terminal_block=[False])
+        runner = SimpleNamespace(_adapter_for_source=lambda source: adapter)
+        message = TurnRunner(runner, ctx)._progress_build_message("search_files", pattern, args)
+        client = adapter._app.client
+        client.chat_postMessage.return_value = {"ok": True, "ts": "123.456"}
+        client.chat_update.return_value = {"ok": True, "ts": "123.456"}
+
+        assert (await adapter.send("C123", message)).success
+        assert (await adapter.edit_message("C123", "123.456", message)).success
+        for method in (client.chat_postMessage, client.chat_update):
+            assert method.call_args.kwargs["text"].endswith(f"`{pattern}`")
+        assert args == {"target": target, "pattern": pattern}
+
+    def test_tool_preview_backticks_do_not_break_code_span(self, adapter):
+        from agent.display import ToolPreview
+
+        preview = ToolPreview(text="`*test*`.py")
+        rendered = adapter.format_message(adapter.format_tool_preview(preview))
+        assert rendered == "`ˋ*test*ˋ.py`"
+        assert preview.text == "`*test*`.py"
 
     def test_italic_asterisk_conversion(self, adapter):
         assert adapter.format_message("*hello*") == "_hello_"


### PR DESCRIPTION
## What does this PR do?

Compact Slack tool progress renders `*test*.py` as `_test_.py` (italics), hiding the asterisks. Wrap the preview in inline code so regex/glob syntax survives Markdown-to-mrkdwn conversion. Actual tool arguments are unchanged.

## Related Issue

Fixes #109335

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/slack/adapter.py`: override `format_tool_preview`; substitute embedded backticks in display text so they cannot break the code span.
- `tests/gateway/test_slack.py`: exercise the real progress builder through Slack send/edit, check unchanged search arguments, and cover embedded backticks.
- Scope: compact previews only; verbose JSON output is unchanged.

Known follow-up: fallback tool labels, such as `browser_exec` and `x_search`, still add redundant outer quotation marks around inline-code previews. That separate display issue is intentionally unchanged in this PR.

## How to Test

1. In Slack with compact tool progress enabled, run `search_files` with `target="files"` and `pattern="*test*.py"`. Both stars should remain visible in the progress message.
2. Run:
   ```sh
   scripts/run_tests.sh tests/gateway/test_slack*.py tests/gateway/test_run_progress_topics.py
   ```

Local result: **512 passed across 34 files**, on macOS with Python 3.11. The glob/regex regressions failed on upstream before the fix. Compilation and `git diff --check` also pass. The full repository suite was not run.

## Checklist

- [x] I've read the Contributing Guide.
- [x] Commit messages follow Conventional Commits.
- [x] I searched existing PRs; no duplicate fix found.
- [x] Only changes related to this fix.
- [ ] I've run `pytest tests/ -q` and all tests pass — affected suites only, as above.
- [x] Added regression tests.
- [x] Tested on macOS.
- [x] Documentation: method docstring updated; no user-facing setup changes.
- [x] Config, architecture/workflow docs, and tool schemas: N/A.
- [x] Cross-platform impact considered: platform-independent string formatting in the Slack adapter only.

## Screenshots / Logs

**Before**

![Before: Slack interprets the search pattern as italics](https://github.com/user-attachments/assets/5eddded9-4316-4149-bca2-c4b1daa06a1c)

**After**

![After: inline code preserves the literal asterisks](https://github.com/user-attachments/assets/76a59c78-efe9-456b-a9d9-af17a010e741)
