### PR TITLE
fix(gateway): tolerate the macOS clock-adjusted start-time fingerprint

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -217,9 +217,9 @@ def terminate_pid(
     Windows ``force`` REQUIRES a matching ``expected_start_time`` (taskkill on a recycled PID has
     killed svchost.exe); POSIX optional, but a provided mismatch refuses the kill everywhere.
 
-    On POSIX an expectation is optional, but when the caller provides one and it no longer matches the live
-    process, the kill is refused on every platform — a mismatched fingerprint always means the PID was
-    recycled. See #89614.
+    On POSIX an expectation is optional, but when the caller provides one and it differs beyond the
+    clock-adjustment tolerance (``_START_TIME_TOLERANCE_CS``), the kill is refused on every platform —
+    that means the PID was recycled. See #89614.
     """
     if force and (_IS_WINDOWS or expected_start_time is not None):
         if expected_start_time is None:
@@ -251,10 +251,21 @@ def terminate_pid(
         raise OSError(details or f"taskkill failed for PID {pid}")
 
 
+# Start-time fingerprints are centisecond ints (``_get_process_start_time``). On macOS psutil's
+# ``create_time()`` applies a whole-second clock-update correction against the ``boot_time()``
+# snapshot taken at psutil's import IN THAT PROCESS (``adjust_proc_create_time``), so two processes
+# legitimately measure the same PID seconds apart. Exact equality therefore read a live gateway as a
+# recycled PID: the desktop rendered "Messaging gateway stopped" while the gateway was up and
+# polling. These guards exist to catch PID REUSE, and a PID is not recycled within seconds, so a
+# delta this small must not count as a different process object.
+_START_TIME_TOLERANCE_CS = 200
+
+
 def _start_times_agree(current: Any, *recorded: Any) -> bool:
-    """Same process object: all fingerprints > 0 and within 1ms of ``current``; raises on junk."""
+    """Same process object: all fingerprints > 0 and within the clock-adjustment tolerance of
+    ``current``; raises on junk (callers turn that into a refusal)."""
     cur = float(current)
-    return cur > 0 and all(r > 0 and abs(r - cur) <= 0.001 for r in map(float, recorded))
+    return cur > 0 and all(r > 0 and abs(r - cur) <= _START_TIME_TOLERANCE_CS for r in map(float, recorded))
 
 
 def _scope_hash(identity: str) -> str:
@@ -505,8 +516,15 @@ def _pid_from_record(record: Optional[dict[str, Any]], key: str = "pid") -> Opti
 
 
 def _start_times_conflict(recorded_start: Any, current_start: Any) -> bool:
-    """PID-reuse guard: True only when BOTH start times are known and differ."""
-    return None not in (recorded_start, current_start) and current_start != recorded_start
+    """PID-reuse guard: True only when BOTH start times are known and differ by more than the
+    clock-adjustment tolerance (``_START_TIME_TOLERANCE_CS``). An unparseable pair falls back to
+    plain inequality: a fingerprint we cannot compare is never evidence of the same process."""
+    if None in (recorded_start, current_start):
+        return False
+    try:
+        return abs(int(current_start) - int(recorded_start)) > _START_TIME_TOLERANCE_CS
+    except (TypeError, ValueError):
+        return current_start != recorded_start
 
 
 def _live_pid_from_record(record: Optional[dict[str, Any]]) -> Optional[int]:
@@ -1168,7 +1186,7 @@ def _pid_marker_names_self(target_pid: int, target_start_time: Any) -> bool:
     if target_pid != os.getpid():
         return False
     our_start_time = _get_process_start_time(target_pid)
-    return None in (target_start_time, our_start_time) or target_start_time == our_start_time
+    return not _start_times_conflict(target_start_time, our_start_time)
 
 
 def _consume_pid_marker_for_self(path: Path, *, ttl_s: int) -> bool:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -374,6 +374,34 @@ class TestGatewayRuntimeStatus:
                 == 139
             ), cmdline
 
+    def test_runtime_status_running_pid_tolerates_clock_adjusted_start_time(self, monkeypatch):
+        """macOS regression: psutil's ``create_time()`` carries a whole-second clock-update
+        correction computed against a ``boot_time()`` snapshot taken per process, so the gateway's
+        own record and a later reader legitimately disagree by seconds.  Exact equality read that as
+        a recycled PID: the desktop badge said "Messaging gateway stopped" while the gateway was up
+        and polling Telegram.
+
+        The same guard must still refuse a record whose start time is genuinely stale.
+        """
+        payload = {
+            "pid": 139,
+            "gateway_state": "running",
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "gateway", "run"],
+            "start_time": 178923524513,
+        }
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: "hermes gateway run")
+
+        # One second off the writer's fingerprint: the same process object.
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 178923524413)
+        assert status.get_runtime_status_running_pid(payload) == 139
+
+        # Minutes off: the PID really was recycled.
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 178923524513 - 6000)
+        assert status.get_runtime_status_running_pid(payload) is None
+
 
     def test_command_line_belongs_to_profile_normalizes_separators(self):
         """A Windows argv renders HERMES_HOME with backslashes while the
@@ -482,6 +510,21 @@ class TestTerminatePid:
             status.terminate_pid(123, force=True, expected_start_time=456)
 
         assert calls == []
+
+    def test_force_kill_tolerates_clock_adjusted_start_time(self, monkeypatch):
+        """Sibling of the liveness guard: a caller-supplied fingerprint that differs only by the
+        macOS clock-update correction names the same process, so the kill must proceed; a genuinely
+        different start time still refuses."""
+        monkeypatch.setattr(status, "_IS_WINDOWS", True)
+        monkeypatch.setattr(status.subprocess, "run",
+                            lambda *a, **k: SimpleNamespace(returncode=0, stdout="", stderr=""))
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 1100)
+
+        status.terminate_pid(123, force=True, expected_start_time=1000)  # 1s drift, same process
+
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 7000)
+        with pytest.raises(OSError, match="process identity changed"):
+            status.terminate_pid(123, force=True, expected_start_time=1000)
 
 
 class TestScopedLocks:
@@ -1496,13 +1539,16 @@ def test_strict_gateway_identity_raises_on_malformed_active_metadata(
 def test_strict_gateway_identity_rejects_reused_pid(tmp_path, monkeypatch):
     pid_path = tmp_path / "gateway.pid"
     lock_path = tmp_path / "gateway.lock"
+    # Fingerprints are centiseconds, and the delta is what separates a recycled PID from the
+    # clock-update noise psutil adds on macOS (_START_TIME_TOLERANCE_CS): a reuse is minutes
+    # away, so the fixture must not sit inside the tolerance window.
     record = {"pid": 123, "start_time": 10.0, "kind": "hermes-gateway"}
     pid_path.write_text(json.dumps(record), encoding="utf-8")
     lock_path.write_text(json.dumps(record), encoding="utf-8")
     monkeypatch.setattr(status, "_get_gateway_lock_path", lambda _path=None: lock_path)
     monkeypatch.setattr(status, "_is_gateway_runtime_lock_active_strict", lambda _path=None: True)
     monkeypatch.setattr(status, "_pid_exists", lambda _pid: True)
-    monkeypatch.setattr(status, "_get_process_start_time", lambda _pid: 20.0)
+    monkeypatch.setattr(status, "_get_process_start_time", lambda _pid: 100_000.0)
 
     with pytest.raises(RuntimeError, match="identity changed"):
         status.get_running_pid_identity_strict(pid_path)


### PR DESCRIPTION
## Symptom

The desktop renders **"Messaging gateway stopped"** (and `/api/status` reports the gateway down) while the gateway process is alive, connected to Telegram, and answering messages.

## Root cause

`gateway.status._build_pid_record()` stores a start-time fingerprint to guard against PID reuse, and every comparison site required **exact equality**.

On macOS, psutil's `create_time()` is not stable across processes: `psutil._psosx.adjust_proc_create_time()` adds a whole-second clock-update correction computed against the `boot_time()` snapshot taken **at psutil's import in that process**. A gateway therefore writes a fingerprint its own later readers measure seconds apart:

```
record in gateway_state.json : 178923524513
measured by a reader process : 178923524413      # delta = exactly 100 cs = 1.0 s
_get_process_start_time(pid) : 178923524413
_live_pid_from_record(record): None   ->  liveness False  ->  "Messaging gateway stopped"
```

Reproduced on two consecutive gateway starts (PID 1819 and, after a clean `hermes gateway restart`, PID 91180 — both wrote a fingerprint exactly +1.0 s from the reader's measurement; `INIT_BOOT_TIME - boot_time()` reads 0.0 in the reader). Same-machine E2E against the live record:

```
before: resolve_gateway_liveness() -> running=False, pid=None, source='none'
after : resolve_gateway_liveness() -> running=True,  pid=91180, source='pid'
```

## Fix

Compare fingerprints within a tolerance instead of for equality, in one shared predicate used by every site (the whole bug class, not just the liveness read):

- `_start_times_conflict()` — liveness reads (`_live_pid_from_record`, `get_running_pid`, `get_runtime_status_running_pid`, `acquire_scoped_lock`)
- `_start_times_agree()` — `terminate_pid(force=True)` and `get_running_pid_identity_strict()`
- `_pid_marker_names_self()` — takeover/planned-stop marker matching (now reuses the same predicate)

`_START_TIME_TOLERANCE_CS = 200` (2 s). These guards exist to catch **PID reuse**, and a PID is not recycled within seconds — a genuinely stale record is minutes away and is still refused.

## Tests

Two invariant tests, both proven red on base (`0 passed, 2 failed`) and green with the fix:

- `test_runtime_status_running_pid_tolerates_clock_adjusted_start_time` — a record 1 s off the live measurement is the same process; a record minutes off is still refused.
- `test_force_kill_tolerates_clock_adjusted_start_time` — same contract on the sibling force-kill guard.

One existing test (`test_strict_gateway_identity_rejects_reused_pid`) needed its fixture widened: it compared `10.0` vs `20.0`, i.e. **0.1 s** apart in the centisecond fingerprint unit, which only counted as "reused PID" because the comparison was exact. A real reuse is minutes away; the fixture now reflects that and the assertion is unchanged.

## Environment note

`tests/gateway/test_status.py`: 78 passed, 0 failed. A wider run of `tests/gateway/` in an ad-hoc venv had pre-existing failures from missing dev extras (`pytest_asyncio`, ...); running that same set on base vs. this branch, the **only** difference in outcomes is the two new tests (2889 failed on base → 2887 with the fix, same failing-file set otherwise).
