### PR TITLE
fix(dashboard): refuse a defaults-regression PUT /api/config over a populated config

### DIFF
--- a/apps/desktop/src/api/config.ts
+++ b/apps/desktop/src/api/config.ts
@@ -96,13 +96,13 @@ export function getHermesConfigSchema(profile?: null | string): Promise<ConfigSc
 export function saveHermesConfig(
   config: HermesConfigRecord,
   profile?: null | string,
-  { preserveLanguage = false }: { preserveLanguage?: boolean } = {}
+  { preserveLanguage = false, allowDefaultsRegression = false }: { preserveLanguage?: boolean; allowDefaultsRegression?: boolean } = {}
 ): Promise<{ ok: boolean }> {
   return hermesApi<{ ok: boolean }>({
     ...profileScoped(profile),
     path: preserveLanguage ? '/api/config?preserve_language=true' : '/api/config',
     method: 'PUT',
-    body: { config }
+    body: { config, allow_defaults_regression: allowDefaultsRegression }
   })
 }
 

--- a/apps/desktop/src/app/settings/index.tsx
+++ b/apps/desktop/src/app/settings/index.tsx
@@ -162,7 +162,10 @@ export function SettingsView({ onClose, onConfigSaved, onMainModelChanged }: Set
     }
 
     try {
-      await saveHermesConfig(await getHermesConfigDefaults())
+      // The user just confirmed the destructive reset; the backend otherwise
+      // refuses records that reset configured sections to factory defaults
+      // (a cross-machine overwrite looks identical, #109357).
+      await saveHermesConfig(await getHermesConfigDefaults(), null, { allowDefaultsRegression: true })
       triggerHaptic('success')
       onConfigSaved?.()
     } catch (err) {

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -11,6 +11,10 @@ from pydantic import BaseModel, SecretStr, StrictBool, field_validator
 class ConfigUpdate(BaseModel):
     config: dict
     profile: Optional[str] = None
+    # Escape hatch for an explicit, user-confirmed "reset to defaults" — the
+    # PUT handler refuses records that reset already-populated sections across
+    # machines (a Desktop cross-connection write, #109357) without this flag.
+    allow_defaults_regression: bool = False
 
 class EnvVarUpdate(BaseModel):
     key: str

--- a/hermes_cli/web_routers/config_env.py
+++ b/hermes_cli/web_routers/config_env.py
@@ -109,6 +109,51 @@ async def get_egress_status():
     return {"text": format_status_text()}
 
 
+# A settings write whose payload resets explicitly-set leaves to factory defaults
+# across this many top-level sections is a cross-machine defaults overwrite, not
+# a user edit: the desktop can write the record it read from backend A to backend
+# B after a connection switch, where every hand-tuned value on B arrives as the
+# factory default of A's pristine install (46 regressed leaves over 7+ sections
+# in #109357, vs 0 for a legitimate save — a per-tab form reset stays inside one
+# section and never trips this).
+_DEFAULTS_REGRESSION_SECTION_LIMIT = 3
+
+
+def _flatten_config_leaves(config: Dict[str, Any], _prefix: Tuple[str, ...] = ()):
+    """Yield ``(path_tuple, value)`` for every scalar leaf; nested dicts recurse,
+    every other type (lists included) is a leaf."""
+    for key, value in (config or {}).items():
+        path = _prefix + (key,)
+        if isinstance(value, dict):
+            yield from _flatten_config_leaves(value, path)
+        else:
+            yield path, value
+
+
+def _defaults_regressed_sections(existing_raw: Dict[str, Any], incoming: Dict[str, Any]) -> set:
+    """Top-level sections this write would reset from a user-set value to the factory default.
+
+    A leaf counts only when all three hold: the factory default exists, the raw
+    on-disk document explicitly holds a non-default value for it (a user choice
+    — a YAML explicit ``None`` counts as unset), and the incoming record carries
+    the factory default for it. Leaves the incoming record omits are left alone
+    by the deep-merge and never count.
+    """
+    defaults_flat = dict(_flatten_config_leaves(DEFAULT_CONFIG))
+    disk_flat = dict(_flatten_config_leaves(existing_raw))
+    incoming_flat = dict(_flatten_config_leaves(incoming))
+    sections = set()
+    for path, default_value in defaults_flat.items():
+        if path not in disk_flat or path not in incoming_flat:
+            continue
+        disk_value = disk_flat[path]
+        if disk_value is None or disk_value == default_value:
+            continue
+        if incoming_flat[path] == default_value:
+            sections.add(path[0])
+    return sections
+
+
 @router.put("/api/config")
 async def update_config(
     body: ConfigUpdate, profile: Optional[str] = None, preserve_language: bool = False
@@ -123,6 +168,24 @@ async def update_config(
             with _CONFIG_MUTATION_LOCK:
                 existing = read_raw_config()
                 incoming = _denormalize_config_from_web(body.config)
+                if not body.allow_defaults_regression:
+                    regressed = _defaults_regressed_sections(existing, incoming)
+                    if len(regressed) >= _DEFAULTS_REGRESSION_SECTION_LIMIT:
+                        # Fail closed BEFORE merging or saving: this shape is a
+                        # defaults-built document replacing a populated one —
+                        # detectable wholesale destruction (#109357). An explicit
+                        # user-confirmed reset (or the raw editor) opts in.
+                        listed = ", ".join(sorted(regressed)[:5])
+                        raise HTTPException(
+                            status_code=400,
+                            detail=(
+                                f"Refusing to save: this update would reset already-configured "
+                                f"settings to factory defaults across sections [{listed}]. A "
+                                "settings record from another machine/profile looks exactly like "
+                                "this. To reset on purpose, resend with "
+                                "allow_defaults_regression=true or edit the raw config."
+                            ),
+                        )
                 merged = _deep_merge(existing, incoming)
                 # Compare normalized approvals.mode across the in-memory
                 # documents, not config blocks and not cache re-reads: the page

--- a/tests/hermes_cli/test_config_defaults_regression.py
+++ b/tests/hermes_cli/test_config_defaults_regression.py
@@ -1,0 +1,188 @@
+"""PUT /api/config must refuse a defaults-built record overwriting a populated config.
+
+A Desktop connection switch can write the settings record read from backend A to
+backend B (#109357): every hand-tuned leaf on B then arrives holding A's factory
+default, and the deep-merge write destroys B's live configuration wholesale. The
+guard fails closed when explicitly-set leaves regress to factory defaults across
+several top-level sections at once — a legitimate save never has that shape
+(0 regressions; a per-tab form reset stays inside one section).
+"""
+
+import pytest
+
+
+class TestDefaultsRegressedSectionsHelper:
+    """Unit tests for the pure comparison helper."""
+
+    def _sections(self, existing, incoming):
+        from hermes_cli.web_routers.config_env import _defaults_regressed_sections
+        return _defaults_regressed_sections(existing, incoming)
+
+    def test_no_regressions_when_values_match_disk(self):
+        existing = {"agent": {"max_turns": 50, "gateway_timeout": 1800}}
+        incoming = {"agent": {"max_turns": 50, "gateway_timeout": 1800}}
+        assert self._sections(existing, incoming) == set()
+
+    def test_explicit_yaml_none_on_disk_is_not_a_user_choice(self):
+        # ``gateway_timeout:`` (YAML empty) must not read as a deliberate
+        # override of the 1800 default, else a normal defaulted record
+        # would count it as a regression.
+        existing = {"agent": {"gateway_timeout": None}}
+        incoming = {"agent": {"gateway_timeout": 1800}}
+        assert self._sections(existing, incoming) == set()
+
+    def test_leaf_omitted_by_incoming_is_not_a_regression(self):
+        # Deep-merge semantics: an omitted leaf keeps the disk value.
+        existing = {"agent": {"max_turns": 50}, "session": {"terminal_continue": False}}
+        incoming = {"agent": {"max_turns": 50}}
+        assert self._sections(existing, incoming) == set()
+
+    def test_scalar_default_vs_dict_disk_never_mismatches(self):
+        # DEFAULT_CONFIG ships ``model`` as a string; a configured host stores a
+        # dict. The paths never align, so the model section is simply not
+        # comparable and must not crash or fabricate regressions.
+        existing = {"model": {"default": "x", "provider": "openai"}}
+        incoming = {"model": ""}
+        assert self._sections(existing, incoming) == set()
+
+    def test_sections_collected_per_top_level_key(self):
+        existing = {
+            "agent": {"max_turns": 50},
+            "session": {"terminal_continue": False},
+            "database": {"journal_mode": "delete"},
+        }
+        incoming = {
+            "agent": {"max_turns": None},
+            "session": {"terminal_continue": True},
+            "database": {"journal_mode": "wal"},
+        }
+        assert self._sections(existing, incoming) == {"agent", "session", "database"}
+
+
+class TestPutConfigDefaultsRegressionGuard:
+    """API-level tests: the cross-machine defaults write is refused, everything
+    a legitimate client does still saves."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_test_client(self, monkeypatch, _isolate_hermes_home):
+        try:
+            from starlette.testclient import TestClient
+        except ImportError:
+            pytest.skip("fastapi/starlette not installed")
+
+        import hermes_state
+        from hermes_constants import get_hermes_home
+        from hermes_cli.web_server import app, _SESSION_HEADER_NAME, _SESSION_TOKEN
+
+        monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", get_hermes_home() / "state.db")
+
+        self.client = TestClient(app)
+        self.client.headers[_SESSION_HEADER_NAME] = _SESSION_TOKEN
+
+    def _seed_configured_host(self):
+        """Three sections of deliberate non-default values, like a hand-tuned host."""
+        from hermes_cli.config import save_config
+
+        save_config({
+            "agent": {"max_turns": 50, "gateway_timeout": 900},
+            "session": {"terminal_continue": False},
+            "database": {"journal_mode": "delete"},
+        })
+
+    def _defaults_record_resetting(self, *leaf_edits):
+        """GET the live record (defaults + seeded values) then reset the seeded
+        leaves back to factory defaults — the exact payload a pristine install's
+        record would carry for this host."""
+        record = self.client.get("/api/config").json()
+        for dotted, section in leaf_edits:
+            keys = dotted.split(".")
+            node = record
+            for key in keys[:-1]:
+                node = node[key]
+            node[keys[-1]] = section
+        assert record["agent"]["max_turns"] is None
+        return record
+
+    def test_cross_machine_defaults_record_rejected_and_disk_untouched(self):
+        from hermes_cli.config import read_raw_config
+
+        self._seed_configured_host()
+        record = self._defaults_record_resetting(
+            ("agent.max_turns", None),
+            ("agent.gateway_timeout", 1800),
+            ("session.terminal_continue", True),
+            ("database.journal_mode", "wal"),
+        )
+
+        resp = self.client.put("/api/config", json={"config": record})
+
+        assert resp.status_code == 400
+        assert "factory defaults" in resp.json()["detail"]
+        # Fail closed: nothing was merged or saved.
+        disk = read_raw_config()
+        assert disk["agent"]["max_turns"] == 50
+        assert disk["session"]["terminal_continue"] is False
+        assert disk["database"]["journal_mode"] == "delete"
+
+    def test_two_section_regression_still_saves(self):
+        """Below the section limit (a user resetting one tab plus one stray key,
+        or any two-section deliberate change) must keep saving normally."""
+        from hermes_cli.config import load_config
+
+        self._seed_configured_host()
+        record = self._defaults_record_resetting(
+            ("agent.max_turns", None),
+            ("session.terminal_continue", True),
+        )
+
+        resp = self.client.put("/api/config", json={"config": record})
+
+        assert resp.status_code == 200, resp.text
+        assert load_config()["agent"]["max_turns"] is None
+        assert load_config()["session"]["terminal_continue"] is True
+
+    def test_normal_settings_save_unaffected(self):
+        from hermes_cli.config import load_config
+
+        self._seed_configured_host()
+        record = self.client.get("/api/config").json()
+        record["agent"]["max_turns"] = 75
+
+        resp = self.client.put("/api/config", json={"config": record})
+
+        assert resp.status_code == 200, resp.text
+        assert load_config()["agent"]["max_turns"] == 75
+        # Untouched deliberate settings survive the save.
+        assert load_config()["agent"]["gateway_timeout"] == 900
+
+    def test_explicit_defaults_reset_allowed_with_flag(self):
+        from hermes_cli.config import load_config
+
+        self._seed_configured_host()
+        record = self._defaults_record_resetting(
+            ("agent.max_turns", None),
+            ("agent.gateway_timeout", 1800),
+            ("session.terminal_continue", True),
+            ("database.journal_mode", "wal"),
+        )
+
+        resp = self.client.put(
+            "/api/config",
+            json={"config": record, "allow_defaults_regression": True},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert load_config()["agent"]["gateway_timeout"] == 1800
+
+    def test_partial_update_omitted_sections_not_regressions(self):
+        from hermes_cli.config import load_config
+
+        self._seed_configured_host()
+
+        resp = self.client.put(
+            "/api/config", json={"config": {"agent": {"max_turns": 75}}}
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert load_config()["agent"]["max_turns"] == 75
+        assert load_config()["session"]["terminal_continue"] is False


### PR DESCRIPTION
## What does this PR do?

Adds a server-side guard to `PUT /api/config` that fails closed when an incoming settings record would reset explicitly-configured leaves to factory defaults across several top-level sections at once.

As reported in #109357, a Desktop connection-switch sequence can write the settings record read from a **local** backend to a **remote** host: the remote's live `config.yaml` is then overwritten by the client laptop's pristine factory record, destroying every hand-tuned setting and leaving the host with `No LLM provider configured`. That write is structurally detectable — the reporter measured 46 leaves regressing to `DEFAULT_CONFIG` values for the poisoned write versus 0 for a legitimate settings save. This PR turns that measurement into a 400 so the destructive save becomes a refused request instead of a full outage.

The comparison flattens the incoming (denormalized) record, the raw on-disk config, and `DEFAULT_CONFIG`: a leaf counts as a regression only when the factory default exists, the raw disk document explicitly holds a **non-default** value for it (an explicit YAML `null` counts as unset), and the incoming record carries the factory default for it. Leaves omitted by the partial-update deep-merge semantics never count. Refusal fires **before** the merge and `save_config()`, so nothing is written when the guard trips.

The threshold is *3+ distinct top-level sections*, which separates the two populations cleanly: a per-tab form reset (or any deliberate user change, including changing a couple of values back to defaults) stays inside one or two sections and saves normally, while a cross-machine defaults document regresses every configured section at once.

This is the server-side leg of the fix (Expected behaviour, bullet 3 in the issue). It complements #109363, which pins the request routing client-side so the wrong-host write is not issued in the first place — the guard remains the backstop for any other path that can still deliver a defaults-built record to a populated config (other dashboards, scripts, future routing bugs).

## Related Issue

Fixes #109357

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_routers/config_env.py`: added `_flatten_config_leaves()` / `_defaults_regressed_sections()` helpers and the guard in `update_config()` — raise 400 before merge/save when defaults regressions span ≥3 top-level sections, unless the request opts in.
- `hermes_cli/web_models.py`: `ConfigUpdate.allow_defaults_regression` escape hatch (default `False`) for an explicit, user-confirmed reset.
- `apps/desktop/src/api/config.ts`: `saveHermesConfig()` gains an `allowDefaultsRegression` option forwarded as `allow_defaults_regression` in the PUT body.
- `apps/desktop/src/app/settings/index.tsx`: the destructive, confirmation-gated *Reset to defaults* flow sends the flag so the legitimate whole-config reset keeps working.
- `tests/hermes_cli/test_config_defaults_regression.py`: 10 tests — fail-closed rejection with the disk untouched, below-threshold saves, normal saves, the escape hatch, partial updates, plus helper unit tests for the YAML-null, omitted-leaf, and scalar/dict `model` cases.

## How to Test

```
.venv/bin/python -m pytest tests/hermes_cli/test_config_defaults_regression.py tests/hermes_cli/test_web_server_approvals_broadcast.py -q
```

Observed result: 22 passed (10 new + 12 existing approvals broadcast), 0 failed. The broader config API surface (`test_web_server.py` config tests, dashboard auth, offloop, profile unification) was also run with no new failures.

Manual check for the guard itself: seed a config with deliberate non-default values in 3+ sections, GET `/api/config`, reset those leaves to defaults in the record, PUT it — observed result: `400` with "Refusing to save: this update would reset already-configured settings to factory defaults across sections [...]", and `config.yaml` on disk is unchanged. Resend with `allow_defaults_regression: true` — observed result: `200`, reset applied.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable (REST behavior change; covered by the tests above).