### PR TITLE
fix(matrix): restore env fallback for blank room config

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -499,7 +499,7 @@ def _csv_set(raw: Any) -> Set[str]:
 def _extra_csv_set(config, key: str, env_name: str) -> Set[str]:
     """Resolve a room/user list from config.extra[key], else the env var."""
     raw = config.extra.get(key)
-    if raw is None:
+    if raw is None or (not isinstance(raw, list) and not str(raw).strip()):
         # Scoped read: under multiplex os.environ is the DEFAULT profile's room/user list.
         raw = _startup_env_secret(env_name)
     return _csv_set(raw)

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -78,6 +78,72 @@ def _make_event(
     )
 
 
+@pytest.fixture
+def matrix_free_rooms_scope(monkeypatch):
+    from agent import secret_scope
+
+    was_multiplexed = secret_scope.is_multiplex_active()
+    monkeypatch.setenv("MATRIX_FREE_RESPONSE_ROOMS", "!process:example.org")
+    secret_scope.set_multiplex_active(True)
+    token = secret_scope.set_secret_scope(
+        {"MATRIX_FREE_RESPONSE_ROOMS": "!scoped-a:example.org, !scoped-b:example.org"}
+    )
+    try:
+        yield
+    finally:
+        secret_scope.reset_secret_scope(token)
+        secret_scope.set_multiplex_active(was_multiplexed)
+
+
+@pytest.mark.parametrize("configured_value", ["", "  \t  "])
+def test_matrix_free_response_rooms_blank_scalar_falls_back_to_scoped_value(
+    configured_value,
+    matrix_free_rooms_scope,
+):
+    from plugins.platforms.matrix.adapter import _extra_csv_set
+
+    config = PlatformConfig(
+        enabled=True,
+        extra={"free_response_rooms": configured_value},
+    )
+
+    assert _extra_csv_set(
+        config,
+        "free_response_rooms",
+        "MATRIX_FREE_RESPONSE_ROOMS",
+    ) == {"!scoped-a:example.org", "!scoped-b:example.org"}
+
+
+@pytest.mark.parametrize(
+    ("configured_value", "expected"),
+    [
+        ("!configured:example.org", {"!configured:example.org"}),
+        (
+            ["!configured-a:example.org", " !configured-b:example.org "],
+            {"!configured-a:example.org", "!configured-b:example.org"},
+        ),
+    ],
+    ids=("scalar", "list"),
+)
+def test_matrix_free_response_rooms_explicit_values_override_scoped_fallback(
+    configured_value,
+    expected,
+    matrix_free_rooms_scope,
+):
+    from plugins.platforms.matrix.adapter import _extra_csv_set
+
+    config = PlatformConfig(
+        enabled=True,
+        extra={"free_response_rooms": configured_value},
+    )
+
+    assert _extra_csv_set(
+        config,
+        "free_response_rooms",
+        "MATRIX_FREE_RESPONSE_ROOMS",
+    ) == expected
+
+
 # ---------------------------------------------------------------------------
 # Mention detection helpers
 # ---------------------------------------------------------------------------
@@ -382,5 +448,4 @@ class TestMatrixConfigBridge:
             == "!room1:example.org,!room2:example.org"
         )
         assert os.getenv("MATRIX_AUTO_THREAD") == "false"
-
 


### PR DESCRIPTION
## What does this PR do?

`plugins/platforms/matrix/adapter.py` now treats blank scalar values like an unset value and resolves the existing scope-aware environment value. Explicit non-empty YAML scalars and YAML lists remain authoritative, including list normalization.

### Symptom

After v0.21.2, an empty or whitespace-only `matrix.free_response_rooms` scalar in `config.yaml` shadowed the environment fallback. `_extra_csv_set` only fell back when the key was absent (`None`); `free_response_rooms: ''` is not `None`, so `_free_rooms` became empty, `is_free_room` was false, and `require_mention` dropped every un-mentioned message. Issue #109358 reports two agents silently losing home-room free-response after a post-update restart: 39 dated backups already carried the empty scalar, which previously never reached `config.extra`. A third agent with the key absent kept working. Discards logged at debug, so INFO-level installs looked like the messages never arrived.

### Impact

After v0.21.2, an empty or whitespace-only `matrix.free_response_rooms` scalar in `config.yaml` shadowed the environment fallback. `_extra_csv_set` only fell back when the key was absent (`None`); `free_response_rooms: ''` is not `None`, so `_free_rooms` became empty, `is_free_room` was false, and `require_mention` dropped every un-mentioned message.

### Bug Cause

**Trigger:** the production path described in Symptom.

**Causal chain:** the previous implementation did not enforce the invariant above.

**Why it is wrong:** operators observed the Expected vs Actual mismatch in Symptom.

**Working sibling / contrast:** neighboring paths that already honored the invariant are unchanged.

**Ruled out:** unrelated modules outside this diff.

### Fix

`plugins/platforms/matrix/adapter.py` now treats blank scalar values like an unset value and resolves the existing scope-aware environment value. Explicit non-empty YAML scalars and YAML lists remain authoritative, including list normalization. The fallback still goes through `_startup_env_secret`, so a scoped miss under multiplexing does not borrow the default profile’s process environment. An explicit empty list keeps its existing “no rooms” meaning. No configuration keys or schemas change; the one-condition fix restores pre-0.21.2 fallback for blank scalars that operators already relied on.

Fixes #109358

## Related Issue

Fixes #109358

## Type of Change

- ✅ Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/matrix/adapter.py` — see Fix
- `tests/gateway/test_matrix_mention.py` — see Fix

## How to Test

- ✅ `scripts/run_tests.sh tests/gateway/test_matrix_mention.py -k matrix_free_response_rooms` is the focused command from this diff. Before the production change it reported 2 failed, 2 passed, 17 deselected: empty and whitespace-only YAML values returned an empty set instead of the scoped `MATRIX_FREE_RESPONSE_ROOMS` set. After the change the same filter reports 4 passed, 0 failed. The new cases in `tests/gateway/test_matrix_mention.py` prove empty and whitespace-only scalars fall back under a multiplexed secret scope, while an explicit non-empty scalar and an explicit YAML list still win. Residual risk is limited to callers who intentionally used a blank scalar to suppress an environment value.`
- ✅ `scripts/run_tests.sh tests/gateway/test_matrix_mention.py -k matrix_free_response_rooms`
- ✅ Focused verification completed on this branch

## Checklist

### Code

- ✅ I've read the Contributing Guide
- ✅ My commit messages follow Conventional Commits
- ✅ I searched for existing PRs to make sure this isn't a duplicate
- ✅ My PR contains only changes related to this fix
- ✅ I've run relevant tests locally (see How to Test)
- ✅ I've added tests for my changes
- ✅ I've tested on my platform: macOS

### Documentation & Housekeeping

- ✅ Documentation update: N/A unless noted in Changes Made
- ✅ `cli-config.yaml.example`: N/A
- ✅ `CONTRIBUTING.md` or `AGENTS.md`: N/A
- ✅ Cross-platform impact considered
- ✅ Tool descriptions/schemas: N/A

