### PR TITLE
fix(cron): resolve gateway liveness from request home

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -57,7 +57,10 @@ def _builtin_gateway_liveness() -> Optional[bool]:
         # inside the gateway it must never say "not running"). A crashing probe is "unknown".
         with contextlib.suppress(Exception):
             from gateway.status import is_gateway_runtime_lock_active
-            if is_gateway_runtime_lock_active():
+            from hermes_constants import get_hermes_home
+
+            gateway_lock = get_hermes_home() / "gateway.lock"
+            if is_gateway_runtime_lock_active(gateway_lock):
                 return True
         from hermes_cli.gateway import (
             find_gateway_pids, named_profile_served_by_running_multiplexer)

--- a/tests/cron/test_87033_cronjob_gateway_liveness.py
+++ b/tests/cron/test_87033_cronjob_gateway_liveness.py
@@ -19,6 +19,8 @@ Contract pinned here:
 from __future__ import annotations
 
 import json
+import multiprocessing
+import os
 
 import pytest
 
@@ -55,6 +57,18 @@ def _create_job() -> dict:
             deliver="local",
         )
     )
+
+
+def _hold_gateway_runtime_lock(home: str, ready, release) -> None:
+    """Hold a real gateway lock in another process until the test releases it."""
+    os.environ["HERMES_HOME"] = home
+    from gateway import status as gateway_status
+
+    acquired = gateway_status.acquire_gateway_runtime_lock()
+    ready.send(acquired)
+    if acquired:
+        release.wait(timeout=30)
+        gateway_status.release_gateway_runtime_lock()
 
 
 class TestCreateSurfacesGatewayLiveness:
@@ -242,6 +256,71 @@ class TestRuntimeLockFirstLiveness:
         assert result["success"] is True
         assert result["gateway_running"] is True
         assert "warning" not in result
+
+    @pytest.mark.parametrize(
+        ("action", "process_home"),
+        (("create", None), ("list", "mismatched")),
+    )
+    def test_live_context_home_lock_propagates_without_warning(
+        self, hermes_env, monkeypatch, action, process_home
+    ):
+        """A request-local profile must probe its own live gateway lock (#109360)."""
+        from unittest.mock import patch
+
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+        from tools.cronjob_tools import cronjob
+
+        context_home = hermes_env / "profiles" / "request-local"
+        context_home.mkdir(parents=True)
+        token = set_hermes_home_override(context_home)
+        process_context = multiprocessing.get_context("spawn")
+        ready, child_ready = process_context.Pipe(duplex=False)
+        release = process_context.Event()
+        lock_owner = process_context.Process(
+            target=_hold_gateway_runtime_lock,
+            args=(str(context_home), child_ready, release),
+        )
+        try:
+            lock_owner.start()
+            child_ready.close()
+            assert ready.poll(10), "child gateway lock owner did not start"
+            assert ready.recv() is True
+            try:
+                if process_home is None:
+                    monkeypatch.delenv("HERMES_HOME")
+                else:
+                    monkeypatch.setenv("HERMES_HOME", str(hermes_env / process_home))
+
+                with (
+                    patch(
+                        "hermes_cli.cron._active_cron_provider_name",
+                        return_value="builtin",
+                    ),
+                    patch("hermes_cli.gateway.find_gateway_pids", return_value=[]),
+                    patch(
+                        "hermes_cli.gateway.named_profile_served_by_running_multiplexer",
+                        return_value=False,
+                    ),
+                ):
+                    if action == "create":
+                        result = _create_job()
+                    else:
+                        _create_job()
+                        result = json.loads(cronjob(action="list"))
+
+                assert result["success"] is True
+                assert result["gateway_running"] is True
+                assert "warning" not in result
+            finally:
+                release.set()
+                lock_owner.join(timeout=10)
+                assert lock_owner.exitcode == 0
+        finally:
+            ready.close()
+            reset_hermes_home_override(token)
 
     def test_lock_inactive_falls_back_to_pid_scan(self):
         from unittest.mock import patch


### PR DESCRIPTION
## What does this PR do?

Builtin cron gateway liveness now resolves the runtime lock from the request-local `get_hermes_home()`. Existing PID and multiplexer fallbacks still apply when the lock probe is inactive or unavailable.

### Symptom

`_builtin_gateway_liveness()` called `is_gateway_runtime_lock_active()` without an explicit path. That helper then resolved `gateway.lock` from the process environment, while cron tool requests may select a different Hermes home through the request-local `get_hermes_home()` override. A live gateway lock in the request-local home was therefore missed, and the cronjob tool returned a false “gateway not running” warning. Issue #109360 covers create/list surfaces that looked dead whenever process `HERMES_HOME` was unset or pointed at a different tree than the request context, even though a real gateway held the lock in the request home.

### Impact

`_builtin_gateway_liveness()` called `is_gateway_runtime_lock_active()` without an explicit path. That helper then resolved `gateway.lock` from the process environment, while cron tool requests may select a different Hermes home through the request-local `get_hermes_home()` override.

### Bug Cause

**Trigger:** the production path described in Symptom.

**Causal chain:** the previous implementation did not enforce the invariant above.

**Why it is wrong:** operators observed the Expected vs Actual mismatch in Symptom.

**Working sibling / contrast:** neighboring paths that already honored the invariant are unchanged.

**Ruled out:** unrelated modules outside this diff.

### Fix

Builtin cron gateway liveness now resolves the runtime lock from the request-local `get_hermes_home()`. Existing PID and multiplexer fallbacks still apply when the lock probe is inactive or unavailable. Gateway identity writes and the status helper’s process-home default remain unchanged; the production change only passes the request-local lock path into the existing helper. Create and list therefore report `gateway_running: true` without a warning when a spawned process holds the real lock in the context-local home, even if process `HERMES_HOME` is unset or mismatched.

Fixes #109360

## Related Issue

Fixes #109360

## Type of Change

- ✅ Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/cron.py` — see Fix
- `tests/cron/test_87033_cronjob_gateway_liveness.py` — see Fix

## How to Test

- ✅ `scripts/run_tests.sh tests/cron/test_87033_cronjob_gateway_liveness.py -q -k live_context_home_lock_propagates_without_warning` is the focused pair from this diff. Before the production change both request paths failed: create with unset `HERMES_HOME` and list with mismatched `HERMES_HOME` reported `gateway_running` False instead of True. After the change that filter reports 2 passed. The full module `scripts/run_tests.sh tests/cron/test_87033_cronjob_gateway_liveness.py -q` reports 18 passed. Adjacent `scripts/run_tests.sh tests/tools/test_cronjob_tools.py -q` reports 73 passed and was used as an affected-suite smoke check (that file is not in this diff). The new cases prove create and list honor a live context-home lock without emitting a gateway-not-running warning.`
- ✅ `scripts/run_tests.sh tests/cron/test_87033_cronjob_gateway_liveness.py -q -k live_context_home_lock_propagates_without_warning`
- ✅ `scripts/run_tests.sh tests/cron/test_87033_cronjob_gateway_liveness.py -q`
- ✅ Focused verification completed on this branch

## Checklist

### Code

- ✅ I've read the Contributing Guide
- ✅ My commit messages follow Conventional Commits
- ✅ I searched for existing PRs to make sure this isn't a duplicate
- ✅ My PR contains only changes related to this fix
- ✅ I've run relevant tests locally (see How to Test)
- ✅ I've added tests for my changes
- ✅ I've tested on my platform: macOS

### Documentation & Housekeeping

- ✅ Documentation update: N/A unless noted in Changes Made
- ✅ `cli-config.yaml.example`: N/A
- ✅ `CONTRIBUTING.md` or `AGENTS.md`: N/A
- ✅ Cross-platform impact considered
- ✅ Tool descriptions/schemas: N/A

