### PR TITLE
fix(redact): redact secrets from config and shell rc reads

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -756,6 +756,11 @@ _FILE_READ_COMMANDS = frozenset({
     "cat", "head", "tail", "type", "bat", "less", "more", "nl",
     "zcat", "tac", "view", "batcat",
 })
+_SECRET_BEARING_FILE_BASENAMES = frozenset({
+    ".bashrc", ".bash_profile", ".bash_login", ".profile",
+    ".zshrc", ".zprofile", ".zlogin", ".zshenv",
+})
+_TEXT_FILE_READ_COMMANDS = frozenset({"grep", "awk", "sed"})
 
 
 def _command_segments(command: str) -> list[str]:
@@ -782,6 +787,39 @@ def _command_reads_env_file(command: str | None) -> bool:
     return False
 
 
+def _is_secret_bearing_file_arg(arg: str) -> bool:
+    """Recognize explicit Hermes config and standard shell startup paths."""
+    path = arg.strip("\"'").replace("\\", "/")
+    if "$" in path:
+        return False
+    parts = [part.lower() for part in path.split("/") if part]
+    if not parts:
+        return False
+    if parts[-1] in _SECRET_BEARING_FILE_BASENAMES:
+        return True
+    return parts[-1] == "config.yaml" and ".hermes" in parts[:-1]
+
+
+def _command_reads_secret_bearing_file(command: str | None) -> bool:
+    """True for direct stdout reads of known secret-bearing config files."""
+    if not command or not isinstance(command, str):
+        return False
+    for seg in _command_segments(command):
+        tokens = seg.split()  # preserve Windows path separators; see _command_reads_env_file
+        if not tokens:
+            continue
+        reader = tokens[0].rsplit("/", 1)[-1].lower()
+        if reader in _FILE_READ_COMMANDS:
+            if any(_is_secret_bearing_file_arg(arg) for arg in tokens[1:] if not arg.startswith("-")):
+                return True
+            continue
+        if reader in _TEXT_FILE_READ_COMMANDS:
+            positional = [arg for arg in tokens[1:] if not arg.startswith("-")]
+            if any(_is_secret_bearing_file_arg(arg) for arg in positional[1:]):
+                return True
+    return False
+
+
 def is_env_dump_command(command: str | None) -> bool:
     """True if any pipeline/sequence segment starts with an _ENV_DUMP_COMMANDS
     token. Conservative: unrecognized → False (callers fall back to code_file=True)."""
@@ -799,11 +837,15 @@ def is_env_dump_command(command: str | None) -> bool:
 
 def redact_terminal_output(output: str, command: str | None = None, *, force: bool = False) -> str:
     """Single redaction policy for ALL terminal-output surfaces: the ENV-assignment
-    pass runs only when ``command`` is an env dump or reads a ``.env`` file
+    pass runs when ``command`` is an env dump or reads a secret-bearing file
     (otherwise code_file=True avoids false positives on source/config dumps)."""
     if not output:
         return output
-    code_file = not (is_env_dump_command(command) or _command_reads_env_file(command))
+    code_file = not (
+        is_env_dump_command(command)
+        or _command_reads_env_file(command)
+        or _command_reads_secret_bearing_file(command)
+    )
     return redact_sensitive_text(output, force=force, code_file=code_file)
 
 

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -968,6 +968,53 @@ class TestTerminalOutputRedaction:
         assert "abc123secret" not in red
         assert "export MISTRAL_API_KEY=*** # prod key" in red
 
+    @pytest.mark.parametrize(
+        ("command", "output", "secret"),
+        [
+            ("cat ~/.hermes/config.yaml", "api_key: hermesConfigSecret123", "hermesConfigSecret123"),
+            (
+                "head ~/.hermes/profiles/work/config.yaml",
+                "provider.token=profileConfigSecret456",
+                "profileConfigSecret456",
+            ),
+            ("tail ~/.bashrc", "export SERVICE_TOKEN=bashRcSecret789", "bashRcSecret789"),
+            ("grep TOKEN ~/.zshrc", "SERVICE_TOKEN=zshRcSecret123", "zshRcSecret123"),
+            (
+                "awk -F= '/TOKEN/ {print $2}' ~/.profile",
+                "SERVICE_TOKEN=profileSecret456",
+                "profileSecret456",
+            ),
+            ("sed -n '1,20p' ~/.zprofile", "api_key: zprofileSecret789", "zprofileSecret789"),
+        ],
+    )
+    def test_secret_bearing_file_commands_mask_assignments(self, command, output, secret):
+        from agent.redact import redact_terminal_output
+
+        assert secret not in redact_terminal_output(output, command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "cat config.yaml",
+            "cat /project/config.yaml",
+            "cat ~/.hermes/config.example.yaml",
+            "cat ~/.hermes/config.template.yaml",
+            "cat ~/.bashrc.example",
+            'cat "$HERMES_HOME/config.yaml"',
+            "grep TOKEN app.py",
+            "awk '/TOKEN/' settings.yaml",
+            "sed -n '1,20p' template.yaml",
+        ],
+    )
+    def test_secret_bearing_file_detection_preserves_fail_open_controls(self, command):
+        from agent.redact import redact_terminal_output
+
+        output = "SERVICE_TOKEN=placeholder_value_here"
+        assert redact_terminal_output(output, command) == output
+        assert "realEnvSecret123" not in redact_terminal_output(
+            "SERVICE_TOKEN=realEnvSecret123", "cat .env"
+        )
+
 
 
     def test_disabled_passes_through(self, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

`agent/redact.py` now treats reads of Hermes `config.yaml` and standard Bash/Zsh startup files as secret-bearing terminal commands. Direct readers plus `grep`, `awk`, and `sed` are covered when the path is a known secret-bearing file; arbitrary YAML or unrelated text-processing commands stay on the existing source-safe path.

### Symptom

`redact_terminal_output()` enabled assignment redaction only for environment dumps and commands recognized as reading `.env` files. Reads of Hermes `config.yaml` and standard Bash/Zsh startup files therefore kept `code_file=True`, skipping the existing ENV/YAML assignment passes even when the output contained credential-shaped values. Issue #109362 shows the same token masked under `cat ~/.hermes/.env` but leaked under `cat ~/.hermes/config.yaml`, `grep` of that file, and `awk`/`cat` of `~/.bashrc`. That matters because `mcp_servers.*.env` is where `hermes mcp add --env` writes API tokens, so model-facing terminal output could exfiltrate secrets that the `.env` path already masked.

### Impact

`redact_terminal_output()` enabled assignment redaction only for environment dumps and commands recognized as reading `.env` files. Reads of Hermes `config.yaml` and standard Bash/Zsh startup files therefore kept `code_file=True`, skipping the existing ENV/YAML assignment passes even when the output contained credential-shaped values.

### Bug Cause

**Trigger:** the production path described in Symptom.

**Causal chain:** the previous implementation did not enforce the invariant above.

**Why it is wrong:** operators observed the Expected vs Actual mismatch in Symptom.

**Working sibling / contrast:** neighboring paths that already honored the invariant are unchanged.

**Ruled out:** unrelated modules outside this diff.

### Fix

`agent/redact.py` now treats reads of Hermes `config.yaml` and standard Bash/Zsh startup files as secret-bearing terminal commands. Direct readers plus `grep`, `awk`, and `sed` are covered when the path is a known secret-bearing file; arbitrary YAML or unrelated text-processing commands stay on the existing source-safe path. Existing `.env` and environment-dump behavior is unchanged. Detection is conservative: indirect shell wrappers and unresolved variable paths remain outside the predicate. This is defense-in-depth for model-facing terminal output; it does not claim to remove secrets already persisted elsewhere.

Fixes #109362

## Related Issue

Fixes #109362

## Type of Change

- ✅ Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/redact.py` — see Fix
- `tests/agent/test_redact.py` — see Fix

## How to Test

- ✅ `scripts/run_tests.sh tests/agent/test_redact.py -k test_secret_bearing_file_commands_mask_assignments` failed before the production change (6 failed, 126 deselected). After the change, `scripts/run_tests.sh tests/agent/test_redact.py -k secret_bearing_file` reports 15 passed, 117 deselected, and `scripts/run_tests.sh tests/agent/test_redact.py` reports 132 passed. The new cases in `tests/agent/test_redact.py` prove `config.yaml` and shell-rc readers, including `grep`/`awk`/`sed`, mask assignment-shaped secrets. Control cases keep ordinary `config.yaml` names in other trees, project YAML, example/template files, unresolved variable paths, and unrelated `grep`/`awk`/`sed` commands on the source-safe path. Developer P0 self-review found 0 findings.`
- ✅ `scripts/run_tests.sh tests/agent/test_redact.py -k test_secret_bearing_file_commands_mask_assignments`
- ✅ `scripts/run_tests.sh tests/agent/test_redact.py -k secret_bearing_file`
- ✅ Focused verification completed on this branch

## Checklist

### Code

- ✅ I've read the Contributing Guide
- ✅ My commit messages follow Conventional Commits
- ✅ I searched for existing PRs to make sure this isn't a duplicate
- ✅ My PR contains only changes related to this fix
- ✅ I've run relevant tests locally (see How to Test)
- ✅ I've added tests for my changes
- ✅ I've tested on my platform: macOS

### Documentation & Housekeeping

- ✅ Documentation update: N/A unless noted in Changes Made
- ✅ `cli-config.yaml.example`: N/A
- ✅ `CONTRIBUTING.md` or `AGENTS.md`: N/A
- ✅ Cross-platform impact considered
- ✅ Tool descriptions/schemas: N/A

