### PR TITLE
fix(kanban): expose idempotency keys in task JSON

### DIFF
--- a/hermes_cli/kanban_output.py
+++ b/hermes_cli/kanban_output.py
@@ -21,6 +21,7 @@ _TASK_DICT_FIELDS = (
     "created_by", "created_at", "started_at", "completed_at", "result",
     "skills", "max_retries", "model_override", "provider_override",
     "session_id", "workflow_template_id", "current_step_key", "completion_contract", "last_failure_error",
+    "idempotency_key",
 )
 _SHOW_RUN_FIELDS = (
     "id", "profile", "step_key", "status", "outcome", "summary", "error",

--- a/tests/hermes_cli/test_kanban_idempotency_key_exposed.py
+++ b/tests/hermes_cli/test_kanban_idempotency_key_exposed.py
@@ -1,0 +1,62 @@
+"""``idempotency_key`` must survive the trip back out through the CLI.
+
+Automation that files a task under a dedup key needs to recognise that task
+later — to notice it is already open, to comment on it, to decide whether to
+file again. ``create`` returns an id but never says whether it deduped, and
+every other lookup is by id, so without the key on the way out the only
+available handle is ``title``. That is not a key: a human editing the title
+detaches the automation from its own task, silently.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+from hermes_cli.kanban_output import _task_to_dict
+
+
+@pytest.fixture
+def board(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kbc.init_db()
+    conn = kbc.connect()
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def test_idempotency_key_is_serialized(board):
+    tid = kb.create_task(board, title="nightly import failed",
+                         idempotency_key="import:nightly")
+    payload = _task_to_dict(kb.get_task(board, tid))
+    assert payload["idempotency_key"] == "import:nightly"
+
+
+def test_absent_key_serializes_as_none(board):
+    """A hand-created task has no key, and must not blow up serialization."""
+    tid = kb.create_task(board, title="written by a human")
+    payload = _task_to_dict(kb.get_task(board, tid))
+    assert payload["idempotency_key"] is None
+
+
+def test_key_survives_a_title_edit(board):
+    """The reason title is not a substitute for the key."""
+    tid = kb.create_task(board, title="original title",
+                         idempotency_key="alert:disk-full")
+    with kbc.write_txn(board):
+        board.execute(
+            "UPDATE tasks SET title = ? WHERE id = ?",
+            ("disk full on prod-3 (renamed by hand)", tid),
+        )
+
+    payload = _task_to_dict(kb.get_task(board, tid))
+    assert payload["title"] != "original title"
+    assert payload["idempotency_key"] == "alert:disk-full"


### PR DESCRIPTION
## Problem

Kanban tasks store and enforce `idempotency_key`, but `hermes kanban create/list/show --json` omit it. Automation therefore cannot verify mutation readback or safely reconcile a crash after card creation.

## Change

- Add the existing `Task.idempotency_key` field to canonical task JSON serialization.
- Cover populated, absent, and title-edited round trips.
- Preserve the original contributor's authorship by salvaging the focused commit from #81299 onto current `main` and adapting its imports after the Kanban module split.

## Evidence

- Regression test proved red on current behavior: 3 failed with missing `idempotency_key`.
- `HERMES_PYTHON=$(command -v python3.12) scripts/run_tests.sh tests/hermes_cli/test_kanban_idempotency_key_exposed.py`: 3 passed.
- `git diff --check origin/main...HEAD`: passed.

## Scope

Purely additive JSON output; no storage, schema, mutation, or CLI input behavior changes.

Relates to #81297 and supersedes the focused portion of #81299 without carrying its stale branch drift.