### PR TITLE
fix(approval): prevent silent destruction of Hermes persisted data

### DIFF
--- a/evals/gateway_completion/delivery_lifecycle.py
+++ b/evals/gateway_completion/delivery_lifecycle.py
@@ -67,7 +67,6 @@ async def main():
                     effective_task_id=label,
                     task_id=label,
                     session_key=key,
-                    workdir=str(HOME),
                     cwd=str(HOME),
                     effective_pty=False,
                     notify_on_complete=notify,

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -406,7 +406,7 @@ class TestHermesHomeHardline:
 
         replay = json.loads(terminal_module.terminal_tool(command=command, force=True))
         assert replay["status"] == "blocked"
-        assert replay["exit_code"] == 1
+        assert replay["exit_code"] == -1
 
 
 class TestFindExecFullPathRm:

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -430,8 +430,16 @@ class TestHermesHomeHardline:
             "find $HERMES_HOME -exec cp {} /tmp/backup \\;",
             "busybox sqlite3 $HERMES_HOME/state.db 'select 1'",
             "sqlite3 $HERMES_HOME/state.db '.backup /tmp/state.db.bak'",
+            f"cd {tmp_path} && rm scratch.txt",
+            f"cd {tmp_path} && : > scratch.txt",
+            "rm ../scratch.txt",
+            f"cp -t {tmp_path} ./a $HERMES_HOME/SOUL.md",
+            f"cp --target-directory={tmp_path} $HERMES_HOME/SOUL.md ./a",
+            f"install -t {tmp_path} ./a $HERMES_HOME/SOUL.md",
+            "printf hello | xargs echo rm",
+            f"printf ./a | xargs cp -t {tmp_path}",
         ):
-            assert detect_hardline_command(command) == (False, None), command
+            assert detect_hardline_command(command, cwd=str(home)) == (False, None), command
 
         # Heredoc bodies may feed an executable consumer, so the security floor
         # deliberately does not exempt command-looking lines based on the producer.
@@ -460,6 +468,34 @@ class TestHermesHomeHardline:
         assert detect_hardline_command("find . -delete", cwd=str(home))[0] is True
         assert detect_hardline_command("rm ../state.db", cwd=str(home / "sub"))[0] is True
         assert detect_hardline_command("cd /missing || rm state.db", cwd=str(home))[0] is True
+
+    def test_terminal_replay_uses_the_executed_session_cwd(self, monkeypatch, tmp_path):
+        home = tmp_path / "profile"
+        workspace = tmp_path / "workspace"
+        home.mkdir()
+        workspace.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(terminal_module, "_task_env_overrides", {})
+        monkeypatch.setattr(terminal_module, "_session_cwd", {})
+        monkeypatch.setattr(terminal_module, "_active_environments", {})
+
+        for mode, force in (("ordinary", False), ("yolo", False), ("force", True)):
+            task_id = f"managed-cwd-{mode}"
+            target = home / f"{mode}.db"
+            target.write_text("keep", encoding="utf-8")
+            terminal_module.register_task_env_overrides(task_id, {"cwd": str(workspace)})
+            cd_result = json.loads(terminal_module.terminal_tool(
+                command=f'cd "{home}"', task_id=task_id,
+            ))
+            assert cd_result["exit_code"] == 0
+            monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", mode == "yolo")
+
+            result = json.loads(terminal_module.terminal_tool(
+                command=f'rm "{target.name}"', task_id=task_id, force=force,
+            ))
+
+            assert result["status"] == "blocked"
+            assert target.read_text(encoding="utf-8") == "keep"
 
 
 class TestFindExecFullPathRm:

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -373,9 +373,18 @@ class TestHermesHomeHardline:
             "sqlite3 -cmd 'DELETE FROM messages' $HERMES_HOME/state.db",
             "sqlite3 -cmd 'UPDATE messages SET content = 0' $HERMES_HOME/state.db",
             "sqlite3 $HERMES_HOME/state.db '.restore /tmp/replacement.db'",
+            "sqlite3 $HERMES_HOME/state.db < /tmp/mutate.sql",
+            "cat /tmp/mutate.sql | sqlite3 $HERMES_HOME/state.db",
+            "sqlite3 -init /tmp/mutate.sql $HERMES_HOME/state.db",
+            "sqlite3 -vfs unix-dotfile $HERMES_HOME/state.db",
             "rm -rf ${HERMES_HOME:?}/state.db",
             "rm ${HERMES_HOME%/}/state.db",
+            "rm.exe $HERMES_HOME/state.db",
+            "busybox rm $HERMES_HOME/state.db",
+            "xargs rm $HERMES_HOME/state.db",
+            "find $HERMES_HOME -exec rm {} \\;",
             'printf x >&"$HERMES_HOME/state.db"',
+            'printf x 3<>"$HERMES_HOME/state.db" >&3',
             "cp -at$HERMES_HOME /tmp/replacement",
             "mv -vt$HERMES_HOME /tmp/replacement",
             "install -Dt$HERMES_HOME /tmp/replacement",
@@ -399,6 +408,8 @@ class TestHermesHomeHardline:
             "truncate -s0 /tmp/state.db",
             'git commit -m "do not rm $HERMES_HOME/state.db"',
             "sqlite3 $HERMES_HOME/state.db 'select count(*) from messages'",
+            "sqlite3 $HERMES_HOME/state.db \"select 'a;b'\"",
+            "sqlite3 $HERMES_HOME/state.db '/* read */ select 1; -- more\nselect 2'",
         ):
             assert detect_hardline_command(command) == (False, None), command
 

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -468,8 +468,19 @@ class TestHermesHomeHardline:
         assert detect_hardline_command("find . -delete", cwd=str(home))[0] is True
         assert detect_hardline_command("cmd.exe /c del state.db", cwd=str(home))[0] is True
         assert detect_hardline_command("powershell Remove-Item state.db", cwd=str(home))[0] is True
+        assert detect_hardline_command(
+            "target=$HERMES_HOME/state.db; rm \"$target\"", cwd=str(tmp_path),
+        )[0] is True
+        assert detect_hardline_command("printf 'state.db\\n' | xargs rm", cwd=str(home))[0] is True
+        assert detect_hardline_command(
+            "find $HERMES_HOME -exec echo {} \\; -exec rm {} \\;",
+        )[0] is True
         assert detect_hardline_command("rm ../state.db", cwd=str(home / "sub"))[0] is True
         assert detect_hardline_command("cd /missing || rm state.db", cwd=str(home))[0] is True
+
+        linked_home = tmp_path / "linked-profile"
+        linked_home.symlink_to(home, target_is_directory=True)
+        assert detect_hardline_command("rm state.db", cwd=str(linked_home))[0] is True
 
     def test_terminal_replay_uses_the_executed_session_cwd(self, monkeypatch, tmp_path):
         home = tmp_path / "profile"

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -478,6 +478,10 @@ class TestHermesHomeHardline:
         monkeypatch.setattr(terminal_module, "_task_env_overrides", {})
         monkeypatch.setattr(terminal_module, "_session_cwd", {})
         monkeypatch.setattr(terminal_module, "_active_environments", {})
+        shell_home = (
+            f"/{home.drive[0].lower()}{home.as_posix()[2:]}"
+            if home.drive else home.as_posix()
+        )
 
         for mode, force in (("ordinary", False), ("yolo", False), ("force", True)):
             task_id = f"managed-cwd-{mode}"
@@ -485,7 +489,7 @@ class TestHermesHomeHardline:
             target.write_text("keep", encoding="utf-8")
             terminal_module.register_task_env_overrides(task_id, {"cwd": str(workspace)})
             cd_result = json.loads(terminal_module.terminal_tool(
-                command=f'cd "{home.as_posix()}" && pwd', task_id=task_id,
+                command=f'cd "{shell_home}" && pwd', task_id=task_id,
             ))
             assert cd_result["exit_code"] == 0
             assert os.path.samefile(terminal_module.get_session_cwd(task_id), home)

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -383,6 +383,13 @@ class TestHermesHomeHardline:
             "busybox rm $HERMES_HOME/state.db",
             "xargs rm $HERMES_HOME/state.db",
             "find $HERMES_HOME -exec rm {} \\;",
+            "find $HERMES_HOME -delete",
+            "dd if=/dev/zero of=$HERMES_HOME/state.db",
+            "rsync /tmp/replacement $HERMES_HOME/state.db",
+            "cmd.exe /c del $HERMES_HOME/state.db",
+            "powershell Remove-Item $HERMES_HOME/state.db",
+            'rm -rf "$HERMES_HOME"*',
+            "rm -rf ~/.hermes*",
             'printf x >&"$HERMES_HOME/state.db"',
             'printf x 3<>"$HERMES_HOME/state.db" >&3',
             "cp -at$HERMES_HOME /tmp/replacement",
@@ -410,6 +417,12 @@ class TestHermesHomeHardline:
             "sqlite3 $HERMES_HOME/state.db 'select count(*) from messages'",
             "sqlite3 $HERMES_HOME/state.db \"select 'a;b'\"",
             "sqlite3 $HERMES_HOME/state.db '/* read */ select 1; -- more\nselect 2'",
+            "sqlite3 $HERMES_HOME/state.db 'with row as (select 1) select * from row'",
+            "sqlite3 $HERMES_HOME/state.db 'pragma table_info(messages)'",
+            "sqlite3 -cmd '.mode json' $HERMES_HOME/state.db 'select 1'",
+            "busybox cp $HERMES_HOME/state.db /tmp/backup",
+            "find $HERMES_HOME -exec cp {} /tmp/backup \\;",
+            "busybox sqlite3 $HERMES_HOME/state.db 'select 1'",
         ):
             assert detect_hardline_command(command) == (False, None), command
 
@@ -430,6 +443,12 @@ class TestHermesHomeHardline:
         replay = json.loads(terminal_module.terminal_tool(command=command, force=True))
         assert replay["status"] == "blocked"
         assert replay["exit_code"] == -1
+
+    def test_relative_targets_are_blocked_inside_managed_cwd(self, monkeypatch, tmp_path):
+        home = tmp_path / "profile"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        assert detect_hardline_command("cd $HERMES_HOME && rm state.db")[0] is True
+        assert detect_hardline_command("truncate -s0 state.db", cwd=str(home))[0] is True
 
 
 class TestFindExecFullPathRm:

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -430,8 +430,8 @@ class TestHermesHomeHardline:
             "find $HERMES_HOME -exec cp {} /tmp/backup \\;",
             "busybox sqlite3 $HERMES_HOME/state.db 'select 1'",
             "sqlite3 $HERMES_HOME/state.db '.backup /tmp/state.db.bak'",
-            f"cd {tmp_path} && rm scratch.txt",
-            f"cd {tmp_path} && : > scratch.txt",
+            f"cd {tmp_path.as_posix()} && rm scratch.txt",
+            f"cd {tmp_path.as_posix()} && : > scratch.txt",
             "rm ../scratch.txt",
             f"cp -t {tmp_path} ./a $HERMES_HOME/SOUL.md",
             f"cp --target-directory={tmp_path} $HERMES_HOME/SOUL.md ./a",
@@ -485,16 +485,17 @@ class TestHermesHomeHardline:
             target.write_text("keep", encoding="utf-8")
             terminal_module.register_task_env_overrides(task_id, {"cwd": str(workspace)})
             cd_result = json.loads(terminal_module.terminal_tool(
-                command=f'cd "{home}"', task_id=task_id,
+                command=f'cd "{home.as_posix()}"', task_id=task_id,
             ))
             assert cd_result["exit_code"] == 0
+            assert os.path.samefile(terminal_module.get_session_cwd(task_id), home)
             monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", mode == "yolo")
 
             result = json.loads(terminal_module.terminal_tool(
                 command=f'rm "{target.name}"', task_id=task_id, force=force,
             ))
 
-            assert result["status"] == "blocked"
+            assert result.get("status") == "blocked", result
             assert target.read_text(encoding="utf-8") == "keep"
 
 

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -485,7 +485,7 @@ class TestHermesHomeHardline:
             target.write_text("keep", encoding="utf-8")
             terminal_module.register_task_env_overrides(task_id, {"cwd": str(workspace)})
             cd_result = json.loads(terminal_module.terminal_tool(
-                command=f'cd "{home.as_posix()}"', task_id=task_id,
+                command=f'cd "{home.as_posix()}" && pwd', task_id=task_id,
             ))
             assert cd_result["exit_code"] == 0
             assert os.path.samefile(terminal_module.get_session_cwd(task_id), home)

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -349,6 +349,44 @@ class TestHermesConfigWriteProtection:
             assert dangerous is False, cmd
 
 
+class TestHermesHomeHardline:
+    def test_destructive_operations_on_managed_state_are_blocked(self, monkeypatch, tmp_path):
+        home = tmp_path / "profile"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        commands = (
+            f"mv {home} /tmp/lost",
+            f"rm {home / 'state.db'}",
+            "> $HERMES_HOME/state.db",
+            "truncate -s0 ${HERMES_HOME}/state.db",
+            "shred -u ~/.hermes/state.db",
+            "unlink $HOME/.hermes/state.db",
+            "tee $HERMES_HOME/state.db </dev/null",
+            "cp /dev/null $HERMES_HOME/state.db",
+            "sqlite3 $HERMES_HOME/state.db 'delete from messages where 1=1'",
+        )
+        for command in commands:
+            blocked, description = detect_hardline_command(command)
+            assert blocked is True, command
+            assert "Hermes data directory" in description
+
+        result = approval_module.check_all_command_guards("rm $HERMES_HOME/state.db", "local")
+        assert result["approved"] is False
+        assert "BLOCKED" in result["message"]
+
+    def test_reads_backups_unrelated_paths_and_quoted_prose_stay_safe(self, monkeypatch, tmp_path):
+        home = tmp_path / "profile"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        for command in (
+            f"cat {home / 'state.db'}",
+            f"cp {home / 'state.db'} /tmp/state.db.backup",
+            f"mv /tmp/state.db {home / 'state.db'}",
+            "rm /tmp/state.db",
+            "truncate -s0 /tmp/state.db",
+            'git commit -m "do not rm $HERMES_HOME/state.db"',
+        ):
+            assert detect_hardline_command(command) == (False, None), command
+
+
 class TestFindExecFullPathRm:
     """Detect find -exec with full-path rm bypasses."""
 

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1,5 +1,6 @@
 """Tests for the dangerous command approval module."""
 
+import json
 import os
 import threading
 import time
@@ -12,6 +13,7 @@ import pytest
 import tools.approval as approval_module
 from tools import approval_context
 from tools import approval_smart
+from tools import terminal_tool as terminal_module
 from hermes_constants import get_hermes_home
 from tools.approval import approve_session, detect_dangerous_command, detect_hardline_command, is_approved, load_permanent, prompt_dangerous_approval
 from tools.approval_context import _get_approval_mode
@@ -362,7 +364,14 @@ class TestHermesHomeHardline:
             "unlink $HOME/.hermes/state.db",
             "tee $HERMES_HOME/state.db </dev/null",
             "cp /dev/null $HERMES_HOME/state.db",
+            "cp /tmp/replacement $HERMES_HOME/state.db",
+            "install -m 600 /tmp/replacement $HERMES_HOME/state.db",
+            "mv /tmp/replacement $HERMES_HOME/state.db",
+            "mv -t /tmp /tmp/safe $HERMES_HOME/state.db",
+            "cp /dev/null -t $HERMES_HOME",
             "sqlite3 $HERMES_HOME/state.db 'delete from messages where 1=1'",
+            "sqlite3 -cmd 'DELETE FROM messages' $HERMES_HOME/state.db",
+            "rm -rf ${HERMES_HOME:?}/state.db",
         )
         for command in commands:
             blocked, description = detect_hardline_command(command)
@@ -379,12 +388,25 @@ class TestHermesHomeHardline:
         for command in (
             f"cat {home / 'state.db'}",
             f"cp {home / 'state.db'} /tmp/state.db.backup",
-            f"mv /tmp/state.db {home / 'state.db'}",
             "rm /tmp/state.db",
             "truncate -s0 /tmp/state.db",
             'git commit -m "do not rm $HERMES_HOME/state.db"',
+            "cat > /tmp/notes.txt <<'EOF'\nrm $HERMES_HOME/state.db\nEOF",
         ):
             assert detect_hardline_command(command) == (False, None), command
+
+    def test_full_guard_floor_survives_yolo_and_force(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+        command = "rm $HERMES_HOME/state.db"
+
+        monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", True)
+        result = approval_module.check_all_command_guards(command, "local")
+        assert result["approved"] is False
+        assert result.get("outcome") == "blocked"
+
+        replay = json.loads(terminal_module.terminal_tool(command=command, force=True))
+        assert replay["status"] == "blocked"
+        assert replay["exit_code"] == 1
 
 
 class TestFindExecFullPathRm:

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -386,8 +386,14 @@ class TestHermesHomeHardline:
             "find $HERMES_HOME -delete",
             "dd if=/dev/zero of=$HERMES_HOME/state.db",
             "rsync /tmp/replacement $HERMES_HOME/state.db",
+            "rsync --remove-source-files $HERMES_HOME/ /tmp/backup/",
+            "sed -i s/x/y/ $HERMES_HOME/state.db",
+            "perl -pi -e s/x/y/ $HERMES_HOME/state.db",
+            "tar --remove-files -cf /tmp/backup.tar $HERMES_HOME/state.db",
             "cmd.exe /c del $HERMES_HOME/state.db",
             "powershell Remove-Item $HERMES_HOME/state.db",
+            'cmd.exe /c del "%HERMES_HOME%\\state.db"',
+            "powershell -Command 'Remove-Item $env:HERMES_HOME/state.db'",
             'rm -rf "$HERMES_HOME"*',
             "rm -rf ~/.hermes*",
             'printf x >&"$HERMES_HOME/state.db"',
@@ -423,6 +429,7 @@ class TestHermesHomeHardline:
             "busybox cp $HERMES_HOME/state.db /tmp/backup",
             "find $HERMES_HOME -exec cp {} /tmp/backup \\;",
             "busybox sqlite3 $HERMES_HOME/state.db 'select 1'",
+            "sqlite3 $HERMES_HOME/state.db '.backup /tmp/state.db.bak'",
         ):
             assert detect_hardline_command(command) == (False, None), command
 
@@ -449,6 +456,10 @@ class TestHermesHomeHardline:
         monkeypatch.setenv("HERMES_HOME", str(home))
         assert detect_hardline_command("cd $HERMES_HOME && rm state.db")[0] is True
         assert detect_hardline_command("truncate -s0 state.db", cwd=str(home))[0] is True
+        assert detect_hardline_command("cd $HERMES_HOME && : > state.db")[0] is True
+        assert detect_hardline_command("find . -delete", cwd=str(home))[0] is True
+        assert detect_hardline_command("rm ../state.db", cwd=str(home / "sub"))[0] is True
+        assert detect_hardline_command("cd /missing || rm state.db", cwd=str(home))[0] is True
 
 
 class TestFindExecFullPathRm:

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -402,7 +402,7 @@ class TestHermesHomeHardline:
         monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", True)
         result = approval_module.check_all_command_guards(command, "local")
         assert result["approved"] is False
-        assert result.get("outcome") == "blocked"
+        assert result["hardline"] is True
 
         replay = json.loads(terminal_module.terminal_tool(command=command, force=True))
         assert replay["status"] == "blocked"

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -371,7 +371,14 @@ class TestHermesHomeHardline:
             "cp /dev/null -t $HERMES_HOME",
             "sqlite3 $HERMES_HOME/state.db 'delete from messages where 1=1'",
             "sqlite3 -cmd 'DELETE FROM messages' $HERMES_HOME/state.db",
+            "sqlite3 -cmd 'UPDATE messages SET content = 0' $HERMES_HOME/state.db",
+            "sqlite3 $HERMES_HOME/state.db '.restore /tmp/replacement.db'",
             "rm -rf ${HERMES_HOME:?}/state.db",
+            "rm ${HERMES_HOME%/}/state.db",
+            'printf x >&"$HERMES_HOME/state.db"',
+            "cp -at$HERMES_HOME /tmp/replacement",
+            "mv -vt$HERMES_HOME /tmp/replacement",
+            "install -Dt$HERMES_HOME /tmp/replacement",
         )
         for command in commands:
             blocked, description = detect_hardline_command(command)
@@ -391,9 +398,14 @@ class TestHermesHomeHardline:
             "rm /tmp/state.db",
             "truncate -s0 /tmp/state.db",
             'git commit -m "do not rm $HERMES_HOME/state.db"',
-            "cat > /tmp/notes.txt <<'EOF'\nrm $HERMES_HOME/state.db\nEOF",
+            "sqlite3 $HERMES_HOME/state.db 'select count(*) from messages'",
         ):
             assert detect_hardline_command(command) == (False, None), command
+
+        # Heredoc bodies may feed an executable consumer, so the security floor
+        # deliberately does not exempt command-looking lines based on the producer.
+        piped = "cat <<'EOF' | sh\nrm $HERMES_HOME/state.db\nEOF"
+        assert detect_hardline_command(piped)[0] is True
 
     def test_full_guard_floor_survives_yolo_and_force(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -466,6 +466,8 @@ class TestHermesHomeHardline:
         assert detect_hardline_command("truncate -s0 state.db", cwd=str(home))[0] is True
         assert detect_hardline_command("cd $HERMES_HOME && : > state.db")[0] is True
         assert detect_hardline_command("find . -delete", cwd=str(home))[0] is True
+        assert detect_hardline_command("cmd.exe /c del state.db", cwd=str(home))[0] is True
+        assert detect_hardline_command("powershell Remove-Item state.db", cwd=str(home))[0] is True
         assert detect_hardline_command("rm ../state.db", cwd=str(home / "sub"))[0] is True
         assert detect_hardline_command("cd /missing || rm state.db", cwd=str(home))[0] is True
 

--- a/tests/tui_gateway/test_subprocess_encoding.py
+++ b/tests/tui_gateway/test_subprocess_encoding.py
@@ -95,11 +95,12 @@ def test_shell_exec_uses_utf8_replace():
     handler = server._methods["shell.exec"]
     with patch("subprocess.run", return_value=_make_completed_process()) as mock_run:
         # A harmless, non-dangerous command that passes the approval gate.
-        with patch("tools.approval_detection.detect_hardline_command", return_value=(False, "")), \
+        with patch("tools.approval_detection.detect_hardline_command", return_value=(False, "")) as hardline, \
              patch("tools.approval_detection.detect_dangerous_command", return_value=(False, None, "")):
             resp = handler(1, {"command": "echo hello"})
         assert mock_run.called, "subprocess.run was not invoked"
         kwargs = mock_run.call_args[1]
+        assert hardline.call_args.kwargs["cwd"] == kwargs["cwd"]
         assert kwargs.get("encoding") == "utf-8", (
             f"shell.exec subprocess.run must set encoding='utf-8' (got {kwargs.get('encoding')!r})"
         )

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1054,6 +1054,14 @@ def check_all_command_guards(command: str, env_type: str,
     )
 
 
+def check_unconditional_command_floors(command: str, env_type: str,
+                                       has_host_access: bool = False) -> dict:
+    """Run only command guards that explicit approval must never bypass."""
+    if _should_skip_container_guards(env_type, has_host_access=has_host_access):
+        return _user_deny_block(command) or _approved()
+    return _floor_block(command, sudo_guard=True) or _approved()
+
+
 _EXECUTE_CODE_DESCRIPTION = (
     "execute_code script execution. The script can spawn subprocesses or "
     "mutate files without passing through terminal command approval; approval is one-shot for this run."

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -884,12 +884,12 @@ def _user_deny_block(command: str) -> dict | None:
     return _user_deny_block_result(deny_pattern)
 
 
-def _floor_block(command: str, *, sudo_guard: bool = False) -> dict | None:
+def _floor_block(command: str, *, sudo_guard: bool = False, cwd: str | None = None) -> dict | None:
     """Unconditional floors, BEFORE yolo / mode=off / cron approve-mode so no
     session-level setting can bypass them: hardline catastrophic commands,
     password-piping to ``sudo -S`` with no SUDO_PASSWORD configured (full guard
     only), and the user's own approvals.deny rules ("never, even under yolo")."""
-    is_hardline, hardline_desc = detect_hardline_command(command)
+    is_hardline, hardline_desc = detect_hardline_command(command, cwd=cwd)
     if is_hardline:
         logger.warning("Hardline block: %s (command: %s)", hardline_desc, command[:200])
         return _hardline_block_result(hardline_desc, command)
@@ -993,7 +993,8 @@ def _tirith_scan(command: str) -> dict:
 
 def check_all_command_guards(command: str, env_type: str,
                              approval_callback=None,
-                             has_host_access: bool = False) -> dict:
+                             has_host_access: bool = False,
+                             cwd: str | None = None) -> dict:
     """Run all pre-exec security checks and return a single approval decision. Tirith and
     dangerous-command findings are presented as ONE combined approval request, so a gateway
     force=True replay cannot bypass one check when only the other was shown to the user.
@@ -1001,7 +1002,7 @@ def check_all_command_guards(command: str, env_type: str,
     if _should_skip_container_guards(env_type, has_host_access=has_host_access):
         return _user_deny_block(command) or _approved()
 
-    blocked = _floor_block(command, sudo_guard=True)
+    blocked = _floor_block(command, sudo_guard=True, cwd=cwd)
     if blocked is not None:
         return blocked
 
@@ -1055,11 +1056,12 @@ def check_all_command_guards(command: str, env_type: str,
 
 
 def check_unconditional_command_floors(command: str, env_type: str,
-                                       has_host_access: bool = False) -> dict:
+                                       has_host_access: bool = False,
+                                       cwd: str | None = None) -> dict:
     """Run only command guards that explicit approval must never bypass."""
     if _should_skip_container_guards(env_type, has_host_access=has_host_access):
         return _user_deny_block(command) or _approved()
-    return _floor_block(command, sudo_guard=True) or _approved()
+    return _floor_block(command, sudo_guard=True, cwd=cwd) or _approved()
 
 
 _EXECUTE_CODE_DESCRIPTION = (

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -437,6 +437,18 @@ def _normalize_command_for_detection(command: str) -> str:
     # first: on Windows it nests under the user home, and folding the user home first would eat the prefix it needs.
     command = _rewrite_resolved_hermes_home(command)
     command = _rewrite_resolved_user_home(command)
+    command = re.sub(
+        r"(?:%HERMES_HOME%|\$env:HERMES_HOME|\$\{env:HERMES_HOME\})[/\\]",
+        "$HERMES_HOME/", command, flags=re.IGNORECASE,
+    )
+    command = re.sub(
+        r"(?:%HERMES_HOME%|\$env:HERMES_HOME|\$\{env:HERMES_HOME\})(?=$|[\s'\"])",
+        "$HERMES_HOME", command, flags=re.IGNORECASE,
+    )
+    command = re.sub(
+        r"(?:%HOME%|\$env:HOME|\$\{env:HOME\})[/\\]\.hermes",
+        "$HOME/.hermes", command, flags=re.IGNORECASE,
+    )
     # Strip backslash-escapes (r\m -> rm) and empty-string literals (r''m -> rm).
     command = re.sub(r'\\([^\n])', r'\1', command)
     command = re.sub(r"''|\"\"", '', command)

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -1516,13 +1516,22 @@ def _dispatcher_targets_hermes(
                 " ".join(shlex.quote(arg) for arg in payload if arg not in {";", "+"})
             )
         return False
-    if dispatcher == "cmd":
-        destructive_re = r"(?:^|\s)(?:del|erase|rd|rmdir)(?:\s|$)"
-    else:
-        destructive_re = r"(?:^|\s)(?:del|erase|rd|ri|rm|remove-item)(?:\s|$)"
-    destructive = any(re.search(destructive_re, arg, re.IGNORECASE) for arg in argv[1:])
-    path_words = [word for arg in argv[1:] for word in re.split(r"\s+", arg)]
-    return destructive and any(_is_hermes_managed_path(arg.strip("'\"")) for arg in path_words)
+    destructive_names = (
+        {"del", "erase", "rd", "rmdir"}
+        if dispatcher == "cmd" else
+        {"del", "erase", "rd", "ri", "rm", "remove-item"}
+    )
+    payload_words = [word for arg in argv[1:] for word in re.split(r"\s+", arg) if word]
+    for index, word in enumerate(payload_words):
+        if word.strip("'\";,(){}").lower() not in destructive_names:
+            continue
+        targets = (
+            target.strip("'\";,(){}") for target in payload_words[index + 1:]
+            if target and not target.startswith("-")
+        )
+        if any(_operand_is_managed(target, cwd_candidates) for target in targets):
+            return True
+    return False
 
 
 _XARGS_OPTIONS_WITH_ARG = frozenset({

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -1194,7 +1194,7 @@ _HERMES_HOME_DESTRUCTION_DESCRIPTION = "destructive operation on Hermes data dir
 _HERMES_HOME_ROOTS = ("~/.hermes", "$hermes_home", "${hermes_home}", "$home/.hermes", "${home}/.hermes")
 _HERMES_DESTRUCTIVE_NAMES = frozenset({
     "rm", "mv", "truncate", "shred", "unlink", "tee", "cp", "dd", "install",
-    "rsync", "sqlite3",
+    "perl", "rsync", "ruby", "sed", "sqlite3", "tar",
 })
 _HERMES_OPTIONS_WITH_ARG = {
     "mv": {"-S", "--suffix", "-t", "--target-directory"},
@@ -1212,6 +1212,12 @@ _HERMES_OPTIONS_WITH_ARG = {
 }
 def _is_hermes_managed_path(word: str) -> bool:
     path = word.lower().replace("\\", "/").rstrip("/")
+    path = path.replace("%hermes_home%", "$hermes_home")
+    path = path.replace("$env:hermes_home", "$hermes_home")
+    path = path.replace("${env:hermes_home}", "$hermes_home")
+    path = path.replace("%home%/.hermes", "$home/.hermes")
+    path = path.replace("$env:home/.hermes", "$home/.hermes")
+    path = path.replace("${env:home}/.hermes", "$home/.hermes")
     if path.startswith("${hermes_home"):
         close = path.find("}")
         if close != -1 and (close == len(path) - 1 or path[close + 1] == "/"):
@@ -1243,8 +1249,7 @@ def _relative_operand_is_managed(word: str, managed_cwd: bool) -> bool:
         return False
     if len(word) > 1 and word[1] == ":":
         return False
-    normalized = word.replace("\\", "/")
-    return normalized not in {".", ".."} and not normalized.startswith("../")
+    return True
 
 
 def _managed_cwd_before(command: str, start: int, cwd: str | None) -> bool:
@@ -1256,14 +1261,8 @@ def _managed_cwd_before(command: str, start: int, cwd: str | None) -> bool:
             argv = shlex.split(_shell_command_segment(command, command_start), posix=True)
         except ValueError:
             continue
-        if len(argv) < 2:
-            managed = False
-        elif _is_hermes_managed_path(argv[1]):
+        if len(argv) >= 2 and _is_hermes_managed_path(argv[1]):
             managed = True
-        elif argv[1].startswith(("/", "~")) or (len(argv[1]) > 1 and argv[1][1] == ":"):
-            managed = False
-        elif managed and (argv[1] == ".." or argv[1].startswith("../")):
-            managed = False
     return managed
 
 
@@ -1303,7 +1302,7 @@ def _command_operands(argv: list[str], command_name: str) -> tuple[list[str], di
     return operands, option_values
 
 
-def _has_hermes_redirect(command: str) -> bool:
+def _has_hermes_redirect(command: str, cwd: str | None = None) -> bool:
     """Detect an output redirection whose shell target is inside HERMES_HOME."""
     for kind, index, _, quote in _scan_shell(command, subst="uq"):
         if kind != "char" or quote is not None or command[index] != ">":
@@ -1320,19 +1319,21 @@ def _has_hermes_redirect(command: str) -> bool:
         target = _deobfuscate_shell_word_for_detection(target)
         if descriptor_form and (target == "-" or target.isdigit()):
             continue
-        if _is_hermes_managed_path(target):
+        if (_is_hermes_managed_path(target)
+                or _relative_operand_is_managed(target, _managed_cwd_before(command, index, cwd))):
             return True
     return False
 
 
 def _detect_hermes_home_destruction(command: str, cwd: str | None = None) -> bool:
     """Hard-block destructive verbs only when they target Hermes-managed state."""
-    if _has_hermes_redirect(command):
+    if _has_hermes_redirect(command, cwd=cwd):
         return True
     for word_start, _, word in _iter_shell_command_word_spans(command):
         name = _hermes_destructive_executable_name(word)
         segment = _shell_command_segment(command, word_start)
-        if name in _HERMES_COMMAND_DISPATCHERS and _dispatcher_targets_hermes(segment):
+        managed_cwd = _managed_cwd_before(command, word_start, cwd)
+        if name in _HERMES_COMMAND_DISPATCHERS and _dispatcher_targets_hermes(segment, managed_cwd=managed_cwd):
             return True
         if name not in _HERMES_DESTRUCTIVE_NAMES:
             continue
@@ -1341,7 +1342,6 @@ def _detect_hermes_home_destruction(command: str, cwd: str | None = None) -> boo
         except ValueError:
             continue
         operands, option_values = _command_operands(argv, name)
-        managed_cwd = _managed_cwd_before(command, word_start, cwd)
         is_managed = lambda arg: (_is_hermes_managed_path(arg)
                                   or _relative_operand_is_managed(arg, managed_cwd))
         if name in {"rm", "truncate", "shred", "unlink", "tee"}:
@@ -1361,6 +1361,19 @@ def _detect_hermes_home_destruction(command: str, cwd: str | None = None) -> boo
                 return True
         elif name == "rsync" and len(operands) >= 2 and is_managed(operands[-1]):
             return True
+        elif name == "rsync" and "--remove-source-files" in argv:
+            if any(is_managed(arg) for arg in operands[:-1]):
+                return True
+        elif name in {"sed", "perl", "ruby"}:
+            in_place = any(
+                arg == "--in-place" or (arg.startswith("-") and not arg.startswith("--") and "i" in arg[1:])
+                for arg in argv[1:]
+            )
+            if in_place and any(is_managed(arg) for arg in operands):
+                return True
+        elif name == "tar" and "--remove-files" in argv:
+            if any(is_managed(arg) for arg in operands):
+                return True
         elif name == "dd":
             for operand in operands:
                 key, separator, value = operand.partition("=")
@@ -1384,7 +1397,7 @@ def _hermes_destructive_executable_name(word: str) -> str:
 _HERMES_COMMAND_DISPATCHERS = frozenset({"busybox", "cmd", "find", "powershell", "pwsh", "xargs"})
 
 
-def _dispatcher_targets_hermes(segment: str) -> bool:
+def _dispatcher_targets_hermes(segment: str, *, managed_cwd: bool = False) -> bool:
     """Detect managed paths passed to destructive applets/dispatcher payloads."""
     try:
         argv = shlex.split(segment, posix=True)
@@ -1394,14 +1407,19 @@ def _dispatcher_targets_hermes(segment: str) -> bool:
         return False
     dispatcher = _hermes_destructive_executable_name(argv[0])
     if dispatcher == "busybox" and len(argv) > 1:
-        return _detect_hermes_home_destruction(" ".join(shlex.quote(arg) for arg in argv[1:]))
+        return _detect_hermes_home_destruction(
+            " ".join(shlex.quote(arg) for arg in argv[1:]),
+            cwd=os.environ.get("HERMES_HOME") if managed_cwd else None,
+        )
     if dispatcher == "xargs":
-        for index, arg in enumerate(argv[1:], start=1):
+        for arg in argv[1:]:
             if _hermes_destructive_executable_name(arg) in _HERMES_DESTRUCTIVE_NAMES:
-                return _detect_hermes_home_destruction(" ".join(shlex.quote(item) for item in argv[index:]))
+                # xargs receives paths dynamically; an explicitly destructive
+                # payload is never safe to replay through the hardline floor.
+                return True
         return False
     if dispatcher == "find":
-        roots_managed = any(_is_hermes_managed_path(arg) for arg in argv[1:])
+        roots_managed = managed_cwd or any(_is_hermes_managed_path(arg) for arg in argv[1:])
         if roots_managed and "-delete" in argv:
             return True
         for marker in ("-exec", "-execdir"):
@@ -1413,15 +1431,17 @@ def _dispatcher_targets_hermes(segment: str) -> bool:
             )
         return False
     if dispatcher == "cmd":
-        destructive = any(arg.lower() in {"del", "erase", "rd", "rmdir"} for arg in argv[1:])
+        destructive_re = r"(?:^|\s)(?:del|erase|rd|rmdir)(?:\s|$)"
     else:
-        destructive = any(arg.lower() in {"del", "erase", "rd", "ri", "rm", "remove-item"} for arg in argv[1:])
-    return destructive and any(_is_hermes_managed_path(arg) for arg in argv[1:])
+        destructive_re = r"(?:^|\s)(?:del|erase|rd|ri|rm|remove-item)(?:\s|$)"
+    destructive = any(re.search(destructive_re, arg, re.IGNORECASE) for arg in argv[1:])
+    path_words = [word for arg in argv[1:] for word in re.split(r"\s+", arg)]
+    return destructive and any(_is_hermes_managed_path(arg.strip("'\"")) for arg in path_words)
 
 
 _SQLITE_READ_ONLY_PREFIXES = frozenset({"select", "explain", "values"})
 _SQLITE_READ_ONLY_DOT_COMMANDS = (
-    ".databases", ".dump", ".headers", ".indexes", ".mode", ".nullvalue",
+    ".backup", ".databases", ".dump", ".headers", ".indexes", ".mode", ".nullvalue",
     ".schema", ".separator", ".show", ".tables", ".width",
 )
 _SQLITE_READ_ONLY_PRAGMAS = frozenset({

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -1307,7 +1307,12 @@ def _cwd_candidates_before(command: str, start: int, cwd: str | None) -> set[str
         os.path.normpath(os.path.abspath(os.path.expanduser(cwd))) if cwd else None
     }
     spans = list(_iter_shell_command_word_spans(command[:start]))
-    for index, (command_start, _, word) in enumerate(spans):
+    target_command_start = start
+    prior_spans = spans
+    if spans and not _connector_after(command, spans[-1][0], start):
+        target_command_start = spans[-1][0]
+        prior_spans = spans[:-1]
+    for index, (command_start, _, word) in enumerate(prior_spans):
         if os.path.basename(_deobfuscate_shell_word_for_detection(word)).lower() != "cd":
             continue
         try:
@@ -1321,8 +1326,8 @@ def _cwd_candidates_before(command: str, start: int, cwd: str | None) -> set[str
             for candidate in candidates
         }
         connector = _connector_after(command, command_start, start)
-        next_start = spans[index + 1][0] if index + 1 < len(spans) else start
-        immediate = next_start == start
+        next_start = spans[index + 1][0] if index + 1 < len(spans) else target_command_start
+        immediate = next_start == target_command_start
         if connector == "&&" and immediate:
             candidates = resolved
         elif connector == "||" and immediate:

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -1204,7 +1204,10 @@ _HERMES_OPTIONS_WITH_ARG = {
     },
     "truncate": {"-o", "--io-blocks", "-r", "--reference", "-s", "--size"},
     "shred": {"-n", "--iterations", "-s", "--size", "--random-source"},
-    "sqlite3": {"-cmd", "-init", "-newline", "-nullvalue", "-separator"},
+    "sqlite3": {
+        "-cmd", "-init", "-lookaside", "-maxsize", "-mmap", "-newline",
+        "-nullvalue", "-pagecache", "-separator", "-vfs",
+    },
 }
 def _is_hermes_managed_path(word: str) -> bool:
     path = word.lower().replace("\\", "/").rstrip("/")
@@ -1260,7 +1263,7 @@ def _has_hermes_redirect(command: str) -> bool:
     for kind, index, _, quote in _scan_shell(command, subst="uq"):
         if kind != "char" or quote is not None or command[index] != ">":
             continue
-        if index and command[index - 1] in "<>":
+        if index and command[index - 1] == ">":
             continue
         target_start = index + 1
         descriptor_form = target_start < len(command) and command[target_start] == "&"
@@ -1282,11 +1285,14 @@ def _detect_hermes_home_destruction(command: str) -> bool:
     if _has_hermes_redirect(command):
         return True
     for word_start, _, word in _iter_shell_command_word_spans(command):
-        name = os.path.basename(_deobfuscate_shell_word_for_detection(word)).lower()
+        name = _hermes_destructive_executable_name(word)
+        segment = _shell_command_segment(command, word_start)
+        if name in _HERMES_COMMAND_DISPATCHERS and _dispatcher_targets_hermes(segment):
+            return True
         if name not in _HERMES_DESTRUCTIVE_NAMES:
             continue
         try:
-            argv = shlex.split(_shell_command_segment(command, word_start), posix=True)
+            argv = shlex.split(segment, posix=True)
         except ValueError:
             continue
         operands, option_values = _command_operands(argv, name)
@@ -1305,23 +1311,90 @@ def _detect_hermes_home_destruction(command: str) -> bool:
             if (any(_is_hermes_managed_path(arg) for arg in targets)
                     or (len(operands) >= 2 and _is_hermes_managed_path(operands[-1]))):
                 return True
-        elif name == "sqlite3" and operands and _is_hermes_managed_path(operands[0]):
-            sql = operands[1:] + option_values.get("-cmd", [])
-            if sql and not all(_sqlite_payload_is_read_only(payload) for payload in sql):
+        elif name == "sqlite3" and any(_is_hermes_managed_path(arg) for arg in operands):
+            database_index = next(index for index, arg in enumerate(operands) if _is_hermes_managed_path(arg))
+            sql = operands[database_index + 1:] + option_values.get("-cmd", [])
+            if (option_values.get("-init")
+                    or not sql
+                    or not all(_sqlite_payload_is_read_only(payload) for payload in sql)):
                 return True
     return False
 
 
-_SQLITE_READ_ONLY_PREFIXES = ("select", "explain", "values")
+def _hermes_destructive_executable_name(word: str) -> str:
+    name = os.path.basename(_deobfuscate_shell_word_for_detection(word)).lower()
+    return name[:-4] if name.endswith(".exe") else name
+
+
+_HERMES_COMMAND_DISPATCHERS = frozenset({"busybox", "find", "xargs"})
+
+
+def _dispatcher_targets_hermes(segment: str) -> bool:
+    """Detect managed paths passed to destructive applets/dispatcher payloads."""
+    try:
+        argv = shlex.split(segment, posix=True)
+    except ValueError:
+        return False
+    if not argv or _hermes_destructive_executable_name(argv[0]) not in _HERMES_COMMAND_DISPATCHERS:
+        return False
+    has_destructive_payload = any(
+        _hermes_destructive_executable_name(arg) in _HERMES_DESTRUCTIVE_NAMES
+        for arg in argv[1:]
+    )
+    return has_destructive_payload and any(_is_hermes_managed_path(arg) for arg in argv[1:])
+
+
+_SQLITE_READ_ONLY_PREFIXES = frozenset({"select", "explain", "values"})
 _SQLITE_READ_ONLY_DOT_COMMANDS = (".databases", ".dump", ".indexes", ".schema", ".show", ".tables")
 
 
 def _sqlite_payload_is_read_only(payload: str) -> bool:
     """Accept only SQLite payloads whose statements are structurally read-only."""
-    statements = [statement.strip().lower() for statement in re.split(r"[;\n]+", payload) if statement.strip()]
+    statements, current = [], []
+    quote, line_comment, block_comment, index = None, False, False, 0
+    while index < len(payload):
+        char = payload[index]
+        following = payload[index + 1] if index + 1 < len(payload) else ""
+        if line_comment:
+            if char == "\n":
+                line_comment = False
+                current.append(" ")
+        elif block_comment:
+            if char == "*" and following == "/":
+                block_comment = False
+                index += 1
+        elif quote:
+            current.append(char)
+            if char == quote:
+                if following == quote:
+                    current.append(following)
+                    index += 1
+                else:
+                    quote = None
+        elif char in "'\"":
+            quote = char
+            current.append(char)
+        elif char == "-" and following == "-":
+            line_comment = True
+            index += 1
+        elif char == "/" and following == "*":
+            block_comment = True
+            index += 1
+        elif char == ";":
+            if "".join(current).strip():
+                statements.append("".join(current).strip().lower())
+            current = []
+        else:
+            current.append(char)
+        index += 1
+    if "".join(current).strip():
+        statements.append("".join(current).strip().lower())
+    if quote or block_comment:
+        return False
     return bool(statements) and all(
-        statement.startswith(_SQLITE_READ_ONLY_PREFIXES)
-        or statement.split(None, 1)[0] in _SQLITE_READ_ONLY_DOT_COMMANDS
+        ((match := re.match(r"([a-z]+|\.[a-z]+)\b", statement)) is not None
+         and (match.group(1) in _SQLITE_READ_ONLY_PREFIXES
+              or match.group(1) in _SQLITE_READ_ONLY_DOT_COMMANDS))
         for statement in statements
     )
 

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -446,7 +446,7 @@ def _normalize_command_for_detection(command: str) -> str:
 
 
 # Shell metacharacters, quotes, and whitespace that terminate a path token.
-_PATH_TOKEN_STOP = r"""\s'"`;|&<>()*?[]"""
+_PATH_TOKEN_STOP = r"""\s'"`;|&<>()*?\[\]"""
 _PATH_TAIL = r"(?P<tail>(?:[/\\][^/\\" + _PATH_TOKEN_STOP + r"]*)+)"
 
 

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -1244,7 +1244,40 @@ def _is_hermes_managed_path(word: str) -> bool:
     )
 
 
-def _resolved_hermes_operand(word: str, cwd: str | None) -> str | None:
+_SHELL_ASSIGNMENT_RE = re.compile(
+    r"(?:^|[;&|\n])\s*([A-Za-z_][A-Za-z0-9_]*)="
+    r"(?:\"([^\"]*)\"|'([^']*)'|([^\s;&|]+))(?=\s*(?:[;&|\n]|$))"
+)
+
+
+def _assignments_before(command: str, start: int) -> dict[str, str]:
+    assignments: dict[str, str] = {}
+    for match in _SHELL_ASSIGNMENT_RE.finditer(command[:start]):
+        assignments[match.group(1)] = next(
+            value for value in match.groups()[1:] if value is not None
+        )
+    return assignments
+
+
+def _expand_shell_assignments(word: str, assignments: dict[str, str] | None) -> str:
+    if not assignments:
+        return word
+    expanded = word
+    for _ in range(8):
+        updated = re.sub(
+            r"\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))",
+            lambda match: assignments.get(match.group(1) or match.group(2), match.group(0)),
+            expanded,
+        )
+        if updated == expanded:
+            break
+        expanded = updated
+    return expanded
+
+
+def _resolved_hermes_operand(
+    word: str, cwd: str | None, assignments: dict[str, str] | None = None,
+) -> str | None:
     """Resolve a shell path spelling enough to compare it with HERMES_HOME."""
     if not word:
         return None
@@ -1253,7 +1286,7 @@ def _resolved_hermes_operand(word: str, cwd: str | None) -> str | None:
         home = os.path.abspath(str(get_hermes_home().expanduser()))
     except Exception:
         return None
-    path = word.replace("\\", "/")
+    path = _expand_shell_assignments(word, assignments).replace("\\", "/")
     lowered = path.lower()
     for root in _HERMES_HOME_ROOTS:
         if lowered == root or lowered.startswith(root + "/"):
@@ -1272,18 +1305,21 @@ def _resolved_path_is_managed(path: str | None) -> bool:
         return False
     try:
         from hermes_constants import get_hermes_home
-        home = os.path.normcase(os.path.abspath(str(get_hermes_home().expanduser())))
-        candidate = os.path.normcase(os.path.abspath(path))
+        home = os.path.normcase(os.path.realpath(os.path.abspath(str(get_hermes_home().expanduser()))))
+        candidate = os.path.normcase(os.path.realpath(os.path.abspath(path)))
         return os.path.commonpath((home, candidate)) == home
     except (OSError, ValueError):
         return False
 
 
-def _operand_is_managed(word: str, cwd_candidates: set[str | None]) -> bool:
-    if _is_hermes_managed_path(word):
+def _operand_is_managed(
+    word: str, cwd_candidates: set[str | None], assignments: dict[str, str] | None = None,
+) -> bool:
+    expanded = _expand_shell_assignments(word, assignments)
+    if _is_hermes_managed_path(expanded):
         return True
     return any(
-        _resolved_path_is_managed(_resolved_hermes_operand(word, candidate))
+        _resolved_path_is_managed(_resolved_hermes_operand(expanded, candidate))
         for candidate in cwd_candidates
     )
 
@@ -1321,8 +1357,9 @@ def _cwd_candidates_before(command: str, start: int, cwd: str | None) -> set[str
             continue
         if len(argv) < 2 or argv[1] == "-":
             continue
+        assignments = _assignments_before(command, command_start)
         resolved = {
-            _resolved_hermes_operand(argv[1], candidate)
+            _resolved_hermes_operand(argv[1], candidate, assignments)
             for candidate in candidates
         }
         connector = _connector_after(command, command_start, start)
@@ -1392,7 +1429,10 @@ def _has_hermes_redirect(command: str, cwd: str | None = None) -> bool:
         target = _deobfuscate_shell_word_for_detection(target)
         if descriptor_form and (target == "-" or target.isdigit()):
             continue
-        if _operand_is_managed(target, _cwd_candidates_before(command, index, cwd)):
+        if _operand_is_managed(
+            target, _cwd_candidates_before(command, index, cwd),
+            _assignments_before(command, index),
+        ):
             return True
     return False
 
@@ -1416,7 +1456,8 @@ def _detect_hermes_home_destruction(command: str, cwd: str | None = None) -> boo
         except ValueError:
             continue
         operands, option_values = _command_operands(argv, name)
-        is_managed = lambda arg: _operand_is_managed(arg, cwd_candidates)
+        assignments = _assignments_before(command, word_start)
+        is_managed = lambda arg: _operand_is_managed(arg, cwd_candidates, assignments)
         if name in {"rm", "truncate", "shred", "unlink", "tee"}:
             if any(is_managed(arg) for arg in operands):
                 return True
@@ -1495,26 +1536,41 @@ def _dispatcher_targets_hermes(
         payload = _xargs_payload(argv)
         if not payload:
             return False
-        return any(
+        if any(
             _detect_hermes_home_destruction(
                 " ".join(shlex.quote(arg) for arg in payload), cwd=candidate,
             )
             for candidate in cwd_candidates
-        )
+        ):
+            return True
+        return _xargs_has_unresolved_destructive_input(payload)
     if dispatcher == "find":
-        roots_managed = any(
-            _operand_is_managed(arg, cwd_candidates) for arg in argv[1:]
-            if not arg.startswith("-")
+        expression_start = next(
+            (index for index, arg in enumerate(argv[1:], start=1) if arg.startswith("-")),
+            len(argv),
         )
+        roots_managed = any(_operand_is_managed(arg, cwd_candidates) for arg in argv[1:expression_start])
         if roots_managed and "-delete" in argv:
             return True
-        for marker in ("-exec", "-execdir"):
-            if marker not in argv:
+        for index, arg in enumerate(argv):
+            if arg not in {"-exec", "-execdir"}:
                 continue
-            payload = ["$HERMES_HOME" if arg == "{}" else arg for arg in argv[argv.index(marker) + 1:]]
-            return roots_managed and _detect_hermes_home_destruction(
-                " ".join(shlex.quote(arg) for arg in payload if arg not in {";", "+"})
+            end = next(
+                (payload_index for payload_index in range(index + 1, len(argv))
+                 if argv[payload_index] in {";", "+"}),
+                len(argv),
             )
+            payload = [
+                "$HERMES_HOME" if roots_managed and word == "{}" else word
+                for word in argv[index + 1:end]
+            ]
+            if any(
+                _detect_hermes_home_destruction(
+                    " ".join(shlex.quote(word) for word in payload), cwd=candidate,
+                )
+                for candidate in cwd_candidates
+            ):
+                return True
         return False
     destructive_names = (
         {"del", "erase", "rd", "rmdir"}
@@ -1557,6 +1613,25 @@ def _xargs_payload(argv: list[str]) -> list[str]:
         else:
             index += 1
     return argv[index:]
+
+
+def _xargs_has_unresolved_destructive_input(payload: list[str]) -> bool:
+    """Fail closed when xargs supplies unknown operands to a mutating command."""
+    if not payload:
+        return False
+    if _hermes_destructive_executable_name(payload[0]) == "busybox":
+        payload = payload[1:]
+        if not payload:
+            return False
+    name = _hermes_destructive_executable_name(payload[0])
+    if name not in _HERMES_DESTRUCTIVE_NAMES:
+        return False
+    if name in {"cp", "install"}:
+        _, option_values = _command_operands(payload, name)
+        return not (
+            option_values.get("-t") or option_values.get("--target-directory")
+        )
+    return True
 
 
 _SQLITE_READ_ONLY_PREFIXES = frozenset({"select", "explain", "values"})

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -1192,36 +1192,89 @@ def _shell_command_segment(command: str, start: int) -> str:
 _HERMES_HOME_DESTRUCTION_DESCRIPTION = "destructive operation on Hermes data directory"
 _HERMES_HOME_ROOTS = ("~/.hermes", "$hermes_home", "${hermes_home}", "$home/.hermes", "${home}/.hermes")
 _HERMES_DESTRUCTIVE_SQL_RE = re.compile(r"\b(?:delete\s+from|drop\s+(?:table|database))\b", re.IGNORECASE)
-_HERMES_DESTRUCTIVE_NAMES = frozenset({"rm", "mv", "truncate", "shred", "unlink", "tee", "cp", "sqlite3"})
+_HERMES_DESTRUCTIVE_NAMES = frozenset({
+    "rm", "mv", "truncate", "shred", "unlink", "tee", "cp", "install", "sqlite3",
+})
 _HERMES_OPTIONS_WITH_ARG = {
     "mv": {"-S", "--suffix", "-t", "--target-directory"},
     "cp": {"-S", "--suffix", "-t", "--target-directory"},
+    "install": {
+        "-g", "--group", "-m", "--mode", "-o", "--owner", "-S", "--suffix",
+        "--strip-program", "-t", "--target-directory",
+    },
     "truncate": {"-o", "--io-blocks", "-r", "--reference", "-s", "--size"},
     "shred": {"-n", "--iterations", "-s", "--size", "--random-source"},
     "sqlite3": {"-cmd", "-init", "-newline", "-nullvalue", "-separator"},
 }
+_HERMES_PARAMETER_VALUE_RE = re.compile(
+    r"^\$\{(?P<name>hermes_home|home)(?::?[?=-][^}]*)?\}", re.IGNORECASE,
+)
 
 
 def _is_hermes_managed_path(word: str) -> bool:
     path = word.lower().replace("\\", "/").rstrip("/")
+    path = _HERMES_PARAMETER_VALUE_RE.sub(
+        lambda match: "$hermes_home" if match.group("name").lower() == "hermes_home" else "$home",
+        path,
+    )
     return any(path == root or path.startswith(root + "/") for root in _HERMES_HOME_ROOTS)
 
 
-def _command_operands(argv: list[str], command_name: str) -> list[str]:
-    """Return positional operands while skipping the destructive command's value-taking options."""
-    operands, skip_next, options = [], False, True
+def _command_operands(argv: list[str], command_name: str) -> tuple[list[str], dict[str, list[str]]]:
+    """Return positional operands and values owned by relevant command options."""
+    operands, option_values, pending_option, options = [], {}, None, True
     with_arg = _HERMES_OPTIONS_WITH_ARG.get(command_name, set())
     for arg in argv[1:]:
-        if skip_next:
-            skip_next = False
+        if pending_option:
+            option_values.setdefault(pending_option, []).append(arg)
+            pending_option = None
         elif options and arg == "--":
             options = False
         elif options and arg.startswith("-") and arg != "-":
-            option = arg.split("=", 1)[0]
-            skip_next = "=" not in arg and option in with_arg
+            option, separator, value = arg.partition("=")
+            if option in with_arg:
+                if separator:
+                    option_values.setdefault(option, []).append(value)
+                else:
+                    pending_option = option
+            elif len(arg) > 2 and arg[:2] in with_arg:
+                option_values.setdefault(arg[:2], []).append(arg[2:])
         else:
             operands.append(arg)
-    return operands
+    return operands, option_values
+
+
+_INERT_HEREDOC_CONSUMERS = frozenset({"cat", "tee"})
+_QUOTED_HEREDOC_RE = re.compile(r"<<(?P<tabs>-?)[ \t]*(?P<quote>['\"])(?P<delimiter>[^'\"\n]+)(?P=quote)")
+
+
+def _strip_inert_heredoc_bodies(command: str) -> str:
+    """Mask quoted cat/tee heredoc data so its lines are not treated as commands."""
+    lines = command.splitlines(keepends=True)
+    index = 0
+    while index < len(lines):
+        match = _QUOTED_HEREDOC_RE.search(lines[index])
+        if not match:
+            index += 1
+            continue
+        commands = list(_iter_shell_command_word_spans(lines[index][:match.start()]))
+        name = (
+            os.path.basename(_deobfuscate_shell_word_for_detection(commands[-1][2])).lower()
+            if commands else ""
+        )
+        delimiter = match.group("delimiter")
+        strip_tabs = bool(match.group("tabs"))
+        body_index = index + 1
+        while body_index < len(lines):
+            candidate = lines[body_index].rstrip("\r\n")
+            if (candidate.lstrip("\t") if strip_tabs else candidate) == delimiter:
+                break
+            if name in _INERT_HEREDOC_CONSUMERS:
+                ending = lines[body_index][len(lines[body_index].rstrip("\r\n")):]
+                lines[body_index] = ending
+            body_index += 1
+        index = body_index + 1
+    return "".join(lines)
 
 
 def _has_hermes_redirect(command: str) -> bool:
@@ -1243,6 +1296,7 @@ def _has_hermes_redirect(command: str) -> bool:
 
 def _detect_hermes_home_destruction(command: str) -> bool:
     """Hard-block destructive verbs only when they target Hermes-managed state."""
+    command = _strip_inert_heredoc_bodies(command)
     if _has_hermes_redirect(command):
         return True
     for word_start, _, word in _iter_shell_command_word_spans(command):
@@ -1253,19 +1307,25 @@ def _detect_hermes_home_destruction(command: str) -> bool:
             argv = shlex.split(_shell_command_segment(command, word_start), posix=True)
         except ValueError:
             continue
-        operands = _command_operands(argv, name)
+        operands, option_values = _command_operands(argv, name)
         if name in {"rm", "truncate", "shred", "unlink", "tee"}:
             if any(_is_hermes_managed_path(arg) for arg in operands):
                 return True
         elif name == "mv":
             sources = operands if len(operands) == 1 else operands[:-1]
-            if any(_is_hermes_managed_path(arg) for arg in sources):
+            targets = option_values.get("-t", []) + option_values.get("--target-directory", [])
+            if (any(_is_hermes_managed_path(arg) for arg in sources)
+                    or any(_is_hermes_managed_path(arg) for arg in targets)
+                    or (len(operands) >= 2 and _is_hermes_managed_path(operands[-1]))):
                 return True
-        elif name == "cp" and len(operands) >= 2:
-            if operands[0] in {"/dev/null", "/dev/zero"} and _is_hermes_managed_path(operands[-1]):
+        elif name in {"cp", "install"}:
+            targets = option_values.get("-t", []) + option_values.get("--target-directory", [])
+            if (any(_is_hermes_managed_path(arg) for arg in targets)
+                    or (len(operands) >= 2 and _is_hermes_managed_path(operands[-1]))):
                 return True
         elif name == "sqlite3" and operands and _is_hermes_managed_path(operands[0]):
-            if _HERMES_DESTRUCTIVE_SQL_RE.search(" ".join(operands[1:])):
+            sql = operands[1:] + option_values.get("-cmd", [])
+            if _HERMES_DESTRUCTIVE_SQL_RE.search(" ".join(sql)):
                 return True
     return False
 

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -454,9 +454,9 @@ _PATH_TAIL = r"(?P<tail>(?:[/\\][^/\\" + _PATH_TOKEN_STOP + r"]*)+)"
 def _home_prefix_fold_regex(path: str, include_bare: bool = False):
     """Compile a regex matching *path* as an absolute directory prefix.
     Components match with either separator so native Windows, forward-slash, and mixed forms all
-    fold; the caller normalizes the tail's backslashes to ``/``. A non-empty tail is required, so a
-    bare home is never folded. Returns ``None`` for an unset/degenerate path (fewer than two
-    components: ``/``, ``C:\\``, ``""``) so a stray HOME cannot rewrite unrelated prefixes."""
+    fold; the caller normalizes the tail's backslashes to ``/``. Callers may opt into folding the
+    bare path as well. Returns ``None`` for an unset/degenerate path (fewer than two components:
+    ``/``, ``C:\\``, ``""``) so a stray HOME cannot rewrite unrelated prefixes."""
     components = [c for c in re.split(r"[/\\]+", path) if c] if path else []
     if len(components) < 2:
         return None
@@ -1192,6 +1192,7 @@ def _shell_command_segment(command: str, start: int) -> str:
 _HERMES_HOME_DESTRUCTION_DESCRIPTION = "destructive operation on Hermes data directory"
 _HERMES_HOME_ROOTS = ("~/.hermes", "$hermes_home", "${hermes_home}", "$home/.hermes", "${home}/.hermes")
 _HERMES_DESTRUCTIVE_SQL_RE = re.compile(r"\b(?:delete\s+from|drop\s+(?:table|database))\b", re.IGNORECASE)
+_HERMES_DESTRUCTIVE_NAMES = frozenset({"rm", "mv", "truncate", "shred", "unlink", "tee", "cp", "sqlite3"})
 _HERMES_OPTIONS_WITH_ARG = {
     "mv": {"-S", "--suffix", "-t", "--target-directory"},
     "cp": {"-S", "--suffix", "-t", "--target-directory"},
@@ -1244,10 +1245,9 @@ def _detect_hermes_home_destruction(command: str) -> bool:
     """Hard-block destructive verbs only when they target Hermes-managed state."""
     if _has_hermes_redirect(command):
         return True
-    destructive_names = {"rm", "mv", "truncate", "shred", "unlink", "tee", "cp", "sqlite3"}
     for word_start, _, word in _iter_shell_command_word_spans(command):
         name = os.path.basename(_deobfuscate_shell_word_for_detection(word)).lower()
-        if name not in destructive_names:
+        if name not in _HERMES_DESTRUCTIVE_NAMES:
             continue
         try:
             argv = shlex.split(_shell_command_segment(command, word_start), posix=True)

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -169,7 +169,7 @@ def _check_sudo_stdin_guard(command: str) -> tuple:
     return (False, None)
 
 
-def detect_hardline_command(command: str) -> tuple:
+def detect_hardline_command(command: str, cwd: str | None = None) -> tuple:
     """Check hardline patterns (NEVER bypassable, even in YOLO) -> (is_hardline, description)."""
     if _command_parser_limit_exceeded(command):
         return (True, _PARSER_LIMIT_DESCRIPTION)
@@ -178,7 +178,7 @@ def detect_hardline_command(command: str) -> tuple:
     if malformed_grep:
         return (True, _MALFORMED_EXEC_DESCRIPTION)
     for command_variant in _command_detection_variants(command):
-        if _detect_hermes_home_destruction(command_variant):
+        if _detect_hermes_home_destruction(command_variant, cwd=cwd):
             return (True, _HERMES_HOME_DESTRUCTION_DESCRIPTION)
         variant_lower = command_variant.lower()
         masked_lower: str | None = None
@@ -446,7 +446,7 @@ def _normalize_command_for_detection(command: str) -> str:
 
 
 # Shell metacharacters, quotes, and whitespace that terminate a path token.
-_PATH_TOKEN_STOP = r"""\s'"`;|&<>()"""
+_PATH_TOKEN_STOP = r"""\s'"`;|&<>()*?[]"""
 _PATH_TAIL = r"(?P<tail>(?:[/\\][^/\\" + _PATH_TOKEN_STOP + r"]*)+)"
 
 
@@ -1193,7 +1193,8 @@ def _shell_command_segment(command: str, start: int) -> str:
 _HERMES_HOME_DESTRUCTION_DESCRIPTION = "destructive operation on Hermes data directory"
 _HERMES_HOME_ROOTS = ("~/.hermes", "$hermes_home", "${hermes_home}", "$home/.hermes", "${home}/.hermes")
 _HERMES_DESTRUCTIVE_NAMES = frozenset({
-    "rm", "mv", "truncate", "shred", "unlink", "tee", "cp", "install", "sqlite3",
+    "rm", "mv", "truncate", "shred", "unlink", "tee", "cp", "dd", "install",
+    "rsync", "sqlite3",
 })
 _HERMES_OPTIONS_WITH_ARG = {
     "mv": {"-S", "--suffix", "-t", "--target-directory"},
@@ -1219,7 +1220,51 @@ def _is_hermes_managed_path(word: str) -> bool:
         close = path.find("}")
         if close != -1 and path[close + 1:].startswith("/.hermes"):
             return True
-    return any(path == root or path.startswith(root + "/") for root in _HERMES_HOME_ROOTS)
+    return any(
+        path == root or (path.startswith(root) and path[len(root):len(root) + 1] in {"/", "*", "?", "["})
+        for root in _HERMES_HOME_ROOTS
+    )
+
+
+def _cwd_is_in_hermes_home(cwd: str | None) -> bool:
+    if not cwd:
+        return False
+    try:
+        from hermes_constants import get_hermes_home
+        home = os.path.normcase(os.path.abspath(str(get_hermes_home().expanduser())))
+        candidate = os.path.normcase(os.path.abspath(os.path.expanduser(cwd)))
+        return candidate == home or candidate.startswith(home + os.sep)
+    except Exception:
+        return False
+
+
+def _relative_operand_is_managed(word: str, managed_cwd: bool) -> bool:
+    if not managed_cwd or not word or word.startswith(("/", "~", "$")):
+        return False
+    if len(word) > 1 and word[1] == ":":
+        return False
+    normalized = word.replace("\\", "/")
+    return normalized not in {".", ".."} and not normalized.startswith("../")
+
+
+def _managed_cwd_before(command: str, start: int, cwd: str | None) -> bool:
+    managed = _cwd_is_in_hermes_home(cwd)
+    for command_start, _, word in _iter_shell_command_word_spans(command[:start]):
+        if os.path.basename(_deobfuscate_shell_word_for_detection(word)).lower() != "cd":
+            continue
+        try:
+            argv = shlex.split(_shell_command_segment(command, command_start), posix=True)
+        except ValueError:
+            continue
+        if len(argv) < 2:
+            managed = False
+        elif _is_hermes_managed_path(argv[1]):
+            managed = True
+        elif argv[1].startswith(("/", "~")) or (len(argv[1]) > 1 and argv[1][1] == ":"):
+            managed = False
+        elif managed and (argv[1] == ".." or argv[1].startswith("../")):
+            managed = False
+    return managed
 
 
 def _command_operands(argv: list[str], command_name: str) -> tuple[list[str], dict[str, list[str]]]:
@@ -1280,7 +1325,7 @@ def _has_hermes_redirect(command: str) -> bool:
     return False
 
 
-def _detect_hermes_home_destruction(command: str) -> bool:
+def _detect_hermes_home_destruction(command: str, cwd: str | None = None) -> bool:
     """Hard-block destructive verbs only when they target Hermes-managed state."""
     if _has_hermes_redirect(command):
         return True
@@ -1296,23 +1341,33 @@ def _detect_hermes_home_destruction(command: str) -> bool:
         except ValueError:
             continue
         operands, option_values = _command_operands(argv, name)
+        managed_cwd = _managed_cwd_before(command, word_start, cwd)
+        is_managed = lambda arg: (_is_hermes_managed_path(arg)
+                                  or _relative_operand_is_managed(arg, managed_cwd))
         if name in {"rm", "truncate", "shred", "unlink", "tee"}:
-            if any(_is_hermes_managed_path(arg) for arg in operands):
+            if any(is_managed(arg) for arg in operands):
                 return True
         elif name == "mv":
             sources = operands if len(operands) == 1 else operands[:-1]
             targets = option_values.get("-t", []) + option_values.get("--target-directory", [])
-            if (any(_is_hermes_managed_path(arg) for arg in sources)
-                    or any(_is_hermes_managed_path(arg) for arg in targets)
-                    or (len(operands) >= 2 and _is_hermes_managed_path(operands[-1]))):
+            if (any(is_managed(arg) for arg in sources)
+                    or any(is_managed(arg) for arg in targets)
+                    or (len(operands) >= 2 and is_managed(operands[-1]))):
                 return True
         elif name in {"cp", "install"}:
             targets = option_values.get("-t", []) + option_values.get("--target-directory", [])
-            if (any(_is_hermes_managed_path(arg) for arg in targets)
-                    or (len(operands) >= 2 and _is_hermes_managed_path(operands[-1]))):
+            if (any(is_managed(arg) for arg in targets)
+                    or (len(operands) >= 2 and is_managed(operands[-1]))):
                 return True
-        elif name == "sqlite3" and any(_is_hermes_managed_path(arg) for arg in operands):
-            database_index = next(index for index, arg in enumerate(operands) if _is_hermes_managed_path(arg))
+        elif name == "rsync" and len(operands) >= 2 and is_managed(operands[-1]):
+            return True
+        elif name == "dd":
+            for operand in operands:
+                key, separator, value = operand.partition("=")
+                if separator and key.lower() == "of" and is_managed(value):
+                    return True
+        elif name == "sqlite3" and any(is_managed(arg) for arg in operands):
+            database_index = next(index for index, arg in enumerate(operands) if is_managed(arg))
             sql = operands[database_index + 1:] + option_values.get("-cmd", [])
             if (option_values.get("-init")
                     or not sql
@@ -1326,7 +1381,7 @@ def _hermes_destructive_executable_name(word: str) -> str:
     return name[:-4] if name.endswith(".exe") else name
 
 
-_HERMES_COMMAND_DISPATCHERS = frozenset({"busybox", "find", "xargs"})
+_HERMES_COMMAND_DISPATCHERS = frozenset({"busybox", "cmd", "find", "powershell", "pwsh", "xargs"})
 
 
 def _dispatcher_targets_hermes(segment: str) -> bool:
@@ -1337,15 +1392,42 @@ def _dispatcher_targets_hermes(segment: str) -> bool:
         return False
     if not argv or _hermes_destructive_executable_name(argv[0]) not in _HERMES_COMMAND_DISPATCHERS:
         return False
-    has_destructive_payload = any(
-        _hermes_destructive_executable_name(arg) in _HERMES_DESTRUCTIVE_NAMES
-        for arg in argv[1:]
-    )
-    return has_destructive_payload and any(_is_hermes_managed_path(arg) for arg in argv[1:])
+    dispatcher = _hermes_destructive_executable_name(argv[0])
+    if dispatcher == "busybox" and len(argv) > 1:
+        return _detect_hermes_home_destruction(" ".join(shlex.quote(arg) for arg in argv[1:]))
+    if dispatcher == "xargs":
+        for index, arg in enumerate(argv[1:], start=1):
+            if _hermes_destructive_executable_name(arg) in _HERMES_DESTRUCTIVE_NAMES:
+                return _detect_hermes_home_destruction(" ".join(shlex.quote(item) for item in argv[index:]))
+        return False
+    if dispatcher == "find":
+        roots_managed = any(_is_hermes_managed_path(arg) for arg in argv[1:])
+        if roots_managed and "-delete" in argv:
+            return True
+        for marker in ("-exec", "-execdir"):
+            if marker not in argv:
+                continue
+            payload = ["$HERMES_HOME" if arg == "{}" else arg for arg in argv[argv.index(marker) + 1:]]
+            return roots_managed and _detect_hermes_home_destruction(
+                " ".join(shlex.quote(arg) for arg in payload if arg not in {";", "+"})
+            )
+        return False
+    if dispatcher == "cmd":
+        destructive = any(arg.lower() in {"del", "erase", "rd", "rmdir"} for arg in argv[1:])
+    else:
+        destructive = any(arg.lower() in {"del", "erase", "rd", "ri", "rm", "remove-item"} for arg in argv[1:])
+    return destructive and any(_is_hermes_managed_path(arg) for arg in argv[1:])
 
 
 _SQLITE_READ_ONLY_PREFIXES = frozenset({"select", "explain", "values"})
-_SQLITE_READ_ONLY_DOT_COMMANDS = (".databases", ".dump", ".indexes", ".schema", ".show", ".tables")
+_SQLITE_READ_ONLY_DOT_COMMANDS = (
+    ".databases", ".dump", ".headers", ".indexes", ".mode", ".nullvalue",
+    ".schema", ".separator", ".show", ".tables", ".width",
+)
+_SQLITE_READ_ONLY_PRAGMAS = frozenset({
+    "compile_options", "database_list", "foreign_key_list", "index_info",
+    "index_list", "integrity_check", "quick_check", "table_info", "table_list",
+})
 
 
 def _sqlite_payload_is_read_only(payload: str) -> bool:
@@ -1391,12 +1473,22 @@ def _sqlite_payload_is_read_only(payload: str) -> bool:
         statements.append("".join(current).strip().lower())
     if quote or block_comment:
         return False
-    return bool(statements) and all(
-        ((match := re.match(r"([a-z]+|\.[a-z]+)\b", statement)) is not None
-         and (match.group(1) in _SQLITE_READ_ONLY_PREFIXES
-              or match.group(1) in _SQLITE_READ_ONLY_DOT_COMMANDS))
-        for statement in statements
-    )
+    def read_only(statement: str) -> bool:
+        match = re.match(r"([a-z]+|\.[a-z]+)\b", statement)
+        if match is None:
+            return False
+        keyword = match.group(1)
+        if keyword in _SQLITE_READ_ONLY_PREFIXES or keyword in _SQLITE_READ_ONLY_DOT_COMMANDS:
+            return True
+        if keyword == "pragma":
+            pragma = re.match(r"pragma\s+(?:[a-z_]+\.)?([a-z_]+)\b", statement)
+            return pragma is not None and pragma.group(1) in _SQLITE_READ_ONLY_PRAGMAS
+        if keyword == "with":
+            return (re.search(r"\bselect\b", statement) is not None
+                    and re.search(r"\b(?:delete|insert|replace|update)\b", statement) is None)
+        return False
+
+    return bool(statements) and all(read_only(statement) for statement in statements)
 
 
 def _split_env_string(payload: str) -> list[str] | None:

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -462,9 +462,10 @@ def _home_prefix_fold_regex(path: str, include_bare: bool = False):
         return None
     # Optional leading root separator; a Windows drive letter is a component.
     prefix = r"[/\\]*" + r"[/\\]+".join(re.escape(c) for c in components)
+    flags = re.IGNORECASE if os.name == "nt" else 0
     if include_bare:
-        return re.compile(prefix + rf"(?:{_PATH_TAIL})?(?=[{_PATH_TOKEN_STOP}]|$)")
-    return re.compile(prefix + _PATH_TAIL)
+        return re.compile(prefix + rf"(?:{_PATH_TAIL})?(?=[{_PATH_TOKEN_STOP}]|$)", flags)
+    return re.compile(prefix + _PATH_TAIL, flags)
 
 
 def _fold_home_prefixes(command: str, paths, replacement: str, *, include_bare: bool = False) -> str:
@@ -1191,7 +1192,6 @@ def _shell_command_segment(command: str, start: int) -> str:
 
 _HERMES_HOME_DESTRUCTION_DESCRIPTION = "destructive operation on Hermes data directory"
 _HERMES_HOME_ROOTS = ("~/.hermes", "$hermes_home", "${hermes_home}", "$home/.hermes", "${home}/.hermes")
-_HERMES_DESTRUCTIVE_SQL_RE = re.compile(r"\b(?:delete\s+from|drop\s+(?:table|database))\b", re.IGNORECASE)
 _HERMES_DESTRUCTIVE_NAMES = frozenset({
     "rm", "mv", "truncate", "shred", "unlink", "tee", "cp", "install", "sqlite3",
 })
@@ -1206,17 +1206,16 @@ _HERMES_OPTIONS_WITH_ARG = {
     "shred": {"-n", "--iterations", "-s", "--size", "--random-source"},
     "sqlite3": {"-cmd", "-init", "-newline", "-nullvalue", "-separator"},
 }
-_HERMES_PARAMETER_VALUE_RE = re.compile(
-    r"^\$\{(?P<name>hermes_home|home)(?::?[?=-][^}]*)?\}", re.IGNORECASE,
-)
-
-
 def _is_hermes_managed_path(word: str) -> bool:
     path = word.lower().replace("\\", "/").rstrip("/")
-    path = _HERMES_PARAMETER_VALUE_RE.sub(
-        lambda match: "$hermes_home" if match.group("name").lower() == "hermes_home" else "$home",
-        path,
-    )
+    if path.startswith("${hermes_home"):
+        close = path.find("}")
+        if close != -1 and (close == len(path) - 1 or path[close + 1] == "/"):
+            return True  # Ambiguous parameter operators fail closed at a managed-path operand.
+    if path.startswith("${home"):
+        close = path.find("}")
+        if close != -1 and path[close + 1:].startswith("/.hermes"):
+            return True
     return any(path == root or path.startswith(root + "/") for root in _HERMES_HOME_ROOTS)
 
 
@@ -1232,49 +1231,28 @@ def _command_operands(argv: list[str], command_name: str) -> tuple[list[str], di
             options = False
         elif options and arg.startswith("-") and arg != "-":
             option, separator, value = arg.partition("=")
+            if option.startswith("--") and option not in with_arg:
+                matches = [candidate for candidate in with_arg if candidate.startswith(option)]
+                option = matches[0] if len(matches) == 1 else option
             if option in with_arg:
                 if separator:
                     option_values.setdefault(option, []).append(value)
                 else:
                     pending_option = option
-            elif len(arg) > 2 and arg[:2] in with_arg:
-                option_values.setdefault(arg[:2], []).append(arg[2:])
+            elif not arg.startswith("--"):
+                for index, letter in enumerate(arg[1:], start=1):
+                    short_option = "-" + letter
+                    if short_option not in with_arg:
+                        continue
+                    attached = arg[index + 1:]
+                    if attached:
+                        option_values.setdefault(short_option, []).append(attached)
+                    else:
+                        pending_option = short_option
+                    break
         else:
             operands.append(arg)
     return operands, option_values
-
-
-_INERT_HEREDOC_CONSUMERS = frozenset({"cat", "tee"})
-_QUOTED_HEREDOC_RE = re.compile(r"<<(?P<tabs>-?)[ \t]*(?P<quote>['\"])(?P<delimiter>[^'\"\n]+)(?P=quote)")
-
-
-def _strip_inert_heredoc_bodies(command: str) -> str:
-    """Mask quoted cat/tee heredoc data so its lines are not treated as commands."""
-    lines = command.splitlines(keepends=True)
-    index = 0
-    while index < len(lines):
-        match = _QUOTED_HEREDOC_RE.search(lines[index])
-        if not match:
-            index += 1
-            continue
-        commands = list(_iter_shell_command_word_spans(lines[index][:match.start()]))
-        name = (
-            os.path.basename(_deobfuscate_shell_word_for_detection(commands[-1][2])).lower()
-            if commands else ""
-        )
-        delimiter = match.group("delimiter")
-        strip_tabs = bool(match.group("tabs"))
-        body_index = index + 1
-        while body_index < len(lines):
-            candidate = lines[body_index].rstrip("\r\n")
-            if (candidate.lstrip("\t") if strip_tabs else candidate) == delimiter:
-                break
-            if name in _INERT_HEREDOC_CONSUMERS:
-                ending = lines[body_index][len(lines[body_index].rstrip("\r\n")):]
-                lines[body_index] = ending
-            body_index += 1
-        index = body_index + 1
-    return "".join(lines)
 
 
 def _has_hermes_redirect(command: str) -> bool:
@@ -1282,21 +1260,25 @@ def _has_hermes_redirect(command: str) -> bool:
     for kind, index, _, quote in _scan_shell(command, subst="uq"):
         if kind != "char" or quote is not None or command[index] != ">":
             continue
-        if ((index and command[index - 1] in "<>")
-                or (index + 1 < len(command) and command[index + 1] == "&")):
+        if index and command[index - 1] in "<>":
             continue
         target_start = index + 1
+        descriptor_form = target_start < len(command) and command[target_start] == "&"
+        if descriptor_form:
+            target_start += 1
         while target_start < len(command) and command[target_start] in ">| \t":
             target_start += 1
         _, _, target = _read_shell_word(command, target_start)
-        if _is_hermes_managed_path(_deobfuscate_shell_word_for_detection(target)):
+        target = _deobfuscate_shell_word_for_detection(target)
+        if descriptor_form and (target == "-" or target.isdigit()):
+            continue
+        if _is_hermes_managed_path(target):
             return True
     return False
 
 
 def _detect_hermes_home_destruction(command: str) -> bool:
     """Hard-block destructive verbs only when they target Hermes-managed state."""
-    command = _strip_inert_heredoc_bodies(command)
     if _has_hermes_redirect(command):
         return True
     for word_start, _, word in _iter_shell_command_word_spans(command):
@@ -1325,9 +1307,23 @@ def _detect_hermes_home_destruction(command: str) -> bool:
                 return True
         elif name == "sqlite3" and operands and _is_hermes_managed_path(operands[0]):
             sql = operands[1:] + option_values.get("-cmd", [])
-            if _HERMES_DESTRUCTIVE_SQL_RE.search(" ".join(sql)):
+            if sql and not all(_sqlite_payload_is_read_only(payload) for payload in sql):
                 return True
     return False
+
+
+_SQLITE_READ_ONLY_PREFIXES = ("select", "explain", "values")
+_SQLITE_READ_ONLY_DOT_COMMANDS = (".databases", ".dump", ".indexes", ".schema", ".show", ".tables")
+
+
+def _sqlite_payload_is_read_only(payload: str) -> bool:
+    """Accept only SQLite payloads whose statements are structurally read-only."""
+    statements = [statement.strip().lower() for statement in re.split(r"[;\n]+", payload) if statement.strip()]
+    return bool(statements) and all(
+        statement.startswith(_SQLITE_READ_ONLY_PREFIXES)
+        or statement.split(None, 1)[0] in _SQLITE_READ_ONLY_DOT_COMMANDS
+        for statement in statements
+    )
 
 
 def _split_env_string(payload: str) -> list[str] | None:

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -178,6 +178,8 @@ def detect_hardline_command(command: str) -> tuple:
     if malformed_grep:
         return (True, _MALFORMED_EXEC_DESCRIPTION)
     for command_variant in _command_detection_variants(command):
+        if _detect_hermes_home_destruction(command_variant):
+            return (True, _HERMES_HOME_DESTRUCTION_DESCRIPTION)
         variant_lower = command_variant.lower()
         masked_lower: str | None = None
         for pattern_re, description, quote_masked in HARDLINE_PATTERNS_COMPILED:
@@ -449,7 +451,7 @@ _PATH_TAIL = r"(?P<tail>(?:[/\\][^/\\" + _PATH_TOKEN_STOP + r"]*)+)"
 
 
 @functools.lru_cache(maxsize=64)
-def _home_prefix_fold_regex(path: str):
+def _home_prefix_fold_regex(path: str, include_bare: bool = False):
     """Compile a regex matching *path* as an absolute directory prefix.
     Components match with either separator so native Windows, forward-slash, and mixed forms all
     fold; the caller normalizes the tail's backslashes to ``/``. A non-empty tail is required, so a
@@ -459,16 +461,21 @@ def _home_prefix_fold_regex(path: str):
     if len(components) < 2:
         return None
     # Optional leading root separator; a Windows drive letter is a component.
-    return re.compile(r"[/\\]*" + r"[/\\]+".join(re.escape(c) for c in components) + _PATH_TAIL)
+    prefix = r"[/\\]*" + r"[/\\]+".join(re.escape(c) for c in components)
+    if include_bare:
+        return re.compile(prefix + rf"(?:{_PATH_TAIL})?(?=[{_PATH_TOKEN_STOP}]|$)")
+    return re.compile(prefix + _PATH_TAIL)
 
 
-def _fold_home_prefixes(command: str, paths, replacement: str) -> str:
+def _fold_home_prefixes(command: str, paths, replacement: str, *, include_bare: bool = False) -> str:
     """Fold each resolved home prefix in *command* to *replacement* (no trailing separator; the tail
     supplies it). Longest first so a deeper home folds before a shorter overlapping one that would clobber it."""
     for path in dict.fromkeys(sorted((p for p in paths if p), key=len, reverse=True)):
-        pattern = _home_prefix_fold_regex(path)
+        pattern = _home_prefix_fold_regex(path, include_bare)
         if pattern is not None:
-            command = pattern.sub(lambda m: replacement + m.group("tail").replace("\\", "/"), command)
+            command = pattern.sub(
+                lambda m: replacement + (m.group("tail") or "").replace("\\", "/"), command
+            )
     return command
 
 
@@ -492,7 +499,7 @@ def _rewrite_resolved_hermes_home(command: str) -> str:
         paths = [str(home), str(home.resolve(strict=False))]
     except Exception:
         return command
-    return _fold_home_prefixes(command, paths, "~/.hermes")
+    return _fold_home_prefixes(command, paths, "~/.hermes", include_bare=True)
 
 
 _PARAM_REPLACEMENT_RE = re.compile(r"\$\{[^}/\s]+/[^}/]*/(?P<replacement>[^}]*)\}")
@@ -1180,6 +1187,87 @@ def _shell_command_segment(command: str, start: int) -> str:
             end = i
             break
     return command[start:end].strip()
+
+
+_HERMES_HOME_DESTRUCTION_DESCRIPTION = "destructive operation on Hermes data directory"
+_HERMES_HOME_ROOTS = ("~/.hermes", "$hermes_home", "${hermes_home}", "$home/.hermes", "${home}/.hermes")
+_HERMES_DESTRUCTIVE_SQL_RE = re.compile(r"\b(?:delete\s+from|drop\s+(?:table|database))\b", re.IGNORECASE)
+_HERMES_OPTIONS_WITH_ARG = {
+    "mv": {"-S", "--suffix", "-t", "--target-directory"},
+    "cp": {"-S", "--suffix", "-t", "--target-directory"},
+    "truncate": {"-o", "--io-blocks", "-r", "--reference", "-s", "--size"},
+    "shred": {"-n", "--iterations", "-s", "--size", "--random-source"},
+    "sqlite3": {"-cmd", "-init", "-newline", "-nullvalue", "-separator"},
+}
+
+
+def _is_hermes_managed_path(word: str) -> bool:
+    path = word.lower().replace("\\", "/").rstrip("/")
+    return any(path == root or path.startswith(root + "/") for root in _HERMES_HOME_ROOTS)
+
+
+def _command_operands(argv: list[str], command_name: str) -> list[str]:
+    """Return positional operands while skipping the destructive command's value-taking options."""
+    operands, skip_next, options = [], False, True
+    with_arg = _HERMES_OPTIONS_WITH_ARG.get(command_name, set())
+    for arg in argv[1:]:
+        if skip_next:
+            skip_next = False
+        elif options and arg == "--":
+            options = False
+        elif options and arg.startswith("-") and arg != "-":
+            option = arg.split("=", 1)[0]
+            skip_next = "=" not in arg and option in with_arg
+        else:
+            operands.append(arg)
+    return operands
+
+
+def _has_hermes_redirect(command: str) -> bool:
+    """Detect an output redirection whose shell target is inside HERMES_HOME."""
+    for kind, index, _, quote in _scan_shell(command, subst="uq"):
+        if kind != "char" or quote is not None or command[index] != ">":
+            continue
+        if ((index and command[index - 1] in "<>")
+                or (index + 1 < len(command) and command[index + 1] == "&")):
+            continue
+        target_start = index + 1
+        while target_start < len(command) and command[target_start] in ">| \t":
+            target_start += 1
+        _, _, target = _read_shell_word(command, target_start)
+        if _is_hermes_managed_path(_deobfuscate_shell_word_for_detection(target)):
+            return True
+    return False
+
+
+def _detect_hermes_home_destruction(command: str) -> bool:
+    """Hard-block destructive verbs only when they target Hermes-managed state."""
+    if _has_hermes_redirect(command):
+        return True
+    destructive_names = {"rm", "mv", "truncate", "shred", "unlink", "tee", "cp", "sqlite3"}
+    for word_start, _, word in _iter_shell_command_word_spans(command):
+        name = os.path.basename(_deobfuscate_shell_word_for_detection(word)).lower()
+        if name not in destructive_names:
+            continue
+        try:
+            argv = shlex.split(_shell_command_segment(command, word_start), posix=True)
+        except ValueError:
+            continue
+        operands = _command_operands(argv, name)
+        if name in {"rm", "truncate", "shred", "unlink", "tee"}:
+            if any(_is_hermes_managed_path(arg) for arg in operands):
+                return True
+        elif name == "mv":
+            sources = operands if len(operands) == 1 else operands[:-1]
+            if any(_is_hermes_managed_path(arg) for arg in sources):
+                return True
+        elif name == "cp" and len(operands) >= 2:
+            if operands[0] in {"/dev/null", "/dev/zero"} and _is_hermes_managed_path(operands[-1]):
+                return True
+        elif name == "sqlite3" and operands and _is_hermes_managed_path(operands[0]):
+            if _HERMES_DESTRUCTIVE_SQL_RE.search(" ".join(operands[1:])):
+                return True
+    return False
 
 
 def _split_env_string(payload: str) -> list[str] | None:

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -1244,38 +1244,94 @@ def _is_hermes_managed_path(word: str) -> bool:
     )
 
 
-def _cwd_is_in_hermes_home(cwd: str | None) -> bool:
-    if not cwd:
+def _resolved_hermes_operand(word: str, cwd: str | None) -> str | None:
+    """Resolve a shell path spelling enough to compare it with HERMES_HOME."""
+    if not word:
+        return None
+    try:
+        from hermes_constants import get_hermes_home
+        home = os.path.abspath(str(get_hermes_home().expanduser()))
+    except Exception:
+        return None
+    path = word.replace("\\", "/")
+    lowered = path.lower()
+    for root in _HERMES_HOME_ROOTS:
+        if lowered == root or lowered.startswith(root + "/"):
+            return os.path.normpath(home + path[len(root):].replace("/", os.sep))
+    if (len(path) > 1 and path[1] == ":") or path.startswith("/"):
+        return os.path.normpath(os.path.abspath(path))
+    if path.startswith("~"):
+        return os.path.normpath(os.path.abspath(os.path.expanduser(path)))
+    if cwd:
+        return os.path.normpath(os.path.abspath(os.path.join(cwd, path)))
+    return None
+
+
+def _resolved_path_is_managed(path: str | None) -> bool:
+    if not path:
         return False
     try:
         from hermes_constants import get_hermes_home
         home = os.path.normcase(os.path.abspath(str(get_hermes_home().expanduser())))
-        candidate = os.path.normcase(os.path.abspath(os.path.expanduser(cwd)))
-        return candidate == home or candidate.startswith(home + os.sep)
-    except Exception:
+        candidate = os.path.normcase(os.path.abspath(path))
+        return os.path.commonpath((home, candidate)) == home
+    except (OSError, ValueError):
         return False
 
 
-def _relative_operand_is_managed(word: str, managed_cwd: bool) -> bool:
-    if not managed_cwd or not word or word.startswith(("/", "~", "$")):
-        return False
-    if len(word) > 1 and word[1] == ":":
-        return False
-    return True
+def _operand_is_managed(word: str, cwd_candidates: set[str | None]) -> bool:
+    if _is_hermes_managed_path(word):
+        return True
+    return any(
+        _resolved_path_is_managed(_resolved_hermes_operand(word, candidate))
+        for candidate in cwd_candidates
+    )
 
 
-def _managed_cwd_before(command: str, start: int, cwd: str | None) -> bool:
-    managed = _cwd_is_in_hermes_home(cwd)
-    for command_start, _, word in _iter_shell_command_word_spans(command[:start]):
+def _connector_after(command: str, command_start: int, limit: int) -> str:
+    for kind, index, _, quote in _scan_shell(command, command_start, subst="uq"):
+        if index >= limit:
+            break
+        if kind != "char" or quote is not None:
+            continue
+        if command.startswith(("&&", "||"), index):
+            return command[index:index + 2]
+        if command[index] in ";\n|":
+            return command[index]
+    return ""
+
+
+def _cwd_candidates_before(command: str, start: int, cwd: str | None) -> set[str | None]:
+    """Track cwd possibilities through preceding shell `cd` commands."""
+    candidates: set[str | None] = {
+        os.path.normpath(os.path.abspath(os.path.expanduser(cwd))) if cwd else None
+    }
+    spans = list(_iter_shell_command_word_spans(command[:start]))
+    for index, (command_start, _, word) in enumerate(spans):
         if os.path.basename(_deobfuscate_shell_word_for_detection(word)).lower() != "cd":
             continue
         try:
             argv = shlex.split(_shell_command_segment(command, command_start), posix=True)
         except ValueError:
             continue
-        if len(argv) >= 2 and _is_hermes_managed_path(argv[1]):
-            managed = True
-    return managed
+        if len(argv) < 2 or argv[1] == "-":
+            continue
+        resolved = {
+            _resolved_hermes_operand(argv[1], candidate)
+            for candidate in candidates
+        }
+        connector = _connector_after(command, command_start, start)
+        next_start = spans[index + 1][0] if index + 1 < len(spans) else start
+        immediate = next_start == start
+        if connector == "&&" and immediate:
+            candidates = resolved
+        elif connector == "||" and immediate:
+            pass
+        elif connector == "|":
+            pass  # A pipeline component's cwd does not change its parent shell.
+        else:
+            candidates |= resolved
+    return candidates
 
 
 def _command_operands(argv: list[str], command_name: str) -> tuple[list[str], dict[str, list[str]]]:
@@ -1331,8 +1387,7 @@ def _has_hermes_redirect(command: str, cwd: str | None = None) -> bool:
         target = _deobfuscate_shell_word_for_detection(target)
         if descriptor_form and (target == "-" or target.isdigit()):
             continue
-        if (_is_hermes_managed_path(target)
-                or _relative_operand_is_managed(target, _managed_cwd_before(command, index, cwd))):
+        if _operand_is_managed(target, _cwd_candidates_before(command, index, cwd)):
             return True
     return False
 
@@ -1344,8 +1399,10 @@ def _detect_hermes_home_destruction(command: str, cwd: str | None = None) -> boo
     for word_start, _, word in _iter_shell_command_word_spans(command):
         name = _hermes_destructive_executable_name(word)
         segment = _shell_command_segment(command, word_start)
-        managed_cwd = _managed_cwd_before(command, word_start, cwd)
-        if name in _HERMES_COMMAND_DISPATCHERS and _dispatcher_targets_hermes(segment, managed_cwd=managed_cwd):
+        cwd_candidates = _cwd_candidates_before(command, word_start, cwd)
+        if name in _HERMES_COMMAND_DISPATCHERS and _dispatcher_targets_hermes(
+            segment, cwd_candidates=cwd_candidates,
+        ):
             return True
         if name not in _HERMES_DESTRUCTIVE_NAMES:
             continue
@@ -1354,22 +1411,23 @@ def _detect_hermes_home_destruction(command: str, cwd: str | None = None) -> boo
         except ValueError:
             continue
         operands, option_values = _command_operands(argv, name)
-        is_managed = lambda arg: (_is_hermes_managed_path(arg)
-                                  or _relative_operand_is_managed(arg, managed_cwd))
+        is_managed = lambda arg: _operand_is_managed(arg, cwd_candidates)
         if name in {"rm", "truncate", "shred", "unlink", "tee"}:
             if any(is_managed(arg) for arg in operands):
                 return True
         elif name == "mv":
-            sources = operands if len(operands) == 1 else operands[:-1]
             targets = option_values.get("-t", []) + option_values.get("--target-directory", [])
+            sources = operands if targets or len(operands) == 1 else operands[:-1]
+            positional_targets = [] if targets or len(operands) < 2 else operands[-1:]
             if (any(is_managed(arg) for arg in sources)
                     or any(is_managed(arg) for arg in targets)
-                    or (len(operands) >= 2 and is_managed(operands[-1]))):
+                    or any(is_managed(arg) for arg in positional_targets)):
                 return True
         elif name in {"cp", "install"}:
             targets = option_values.get("-t", []) + option_values.get("--target-directory", [])
+            positional_targets = [] if targets or len(operands) < 2 else operands[-1:]
             if (any(is_managed(arg) for arg in targets)
-                    or (len(operands) >= 2 and is_managed(operands[-1]))):
+                    or any(is_managed(arg) for arg in positional_targets)):
                 return True
         elif name == "rsync" and len(operands) >= 2 and is_managed(operands[-1]):
             return True
@@ -1409,7 +1467,9 @@ def _hermes_destructive_executable_name(word: str) -> str:
 _HERMES_COMMAND_DISPATCHERS = frozenset({"busybox", "cmd", "find", "powershell", "pwsh", "xargs"})
 
 
-def _dispatcher_targets_hermes(segment: str, *, managed_cwd: bool = False) -> bool:
+def _dispatcher_targets_hermes(
+    segment: str, *, cwd_candidates: set[str | None] | None = None,
+) -> bool:
     """Detect managed paths passed to destructive applets/dispatcher payloads."""
     try:
         argv = shlex.split(segment, posix=True)
@@ -1418,20 +1478,29 @@ def _dispatcher_targets_hermes(segment: str, *, managed_cwd: bool = False) -> bo
     if not argv or _hermes_destructive_executable_name(argv[0]) not in _HERMES_COMMAND_DISPATCHERS:
         return False
     dispatcher = _hermes_destructive_executable_name(argv[0])
+    cwd_candidates = cwd_candidates or {None}
     if dispatcher == "busybox" and len(argv) > 1:
-        return _detect_hermes_home_destruction(
-            " ".join(shlex.quote(arg) for arg in argv[1:]),
-            cwd=os.environ.get("HERMES_HOME") if managed_cwd else None,
+        return any(
+            _detect_hermes_home_destruction(
+                " ".join(shlex.quote(arg) for arg in argv[1:]), cwd=candidate,
+            )
+            for candidate in cwd_candidates
         )
     if dispatcher == "xargs":
-        for arg in argv[1:]:
-            if _hermes_destructive_executable_name(arg) in _HERMES_DESTRUCTIVE_NAMES:
-                # xargs receives paths dynamically; an explicitly destructive
-                # payload is never safe to replay through the hardline floor.
-                return True
-        return False
+        payload = _xargs_payload(argv)
+        if not payload:
+            return False
+        return any(
+            _detect_hermes_home_destruction(
+                " ".join(shlex.quote(arg) for arg in payload), cwd=candidate,
+            )
+            for candidate in cwd_candidates
+        )
     if dispatcher == "find":
-        roots_managed = managed_cwd or any(_is_hermes_managed_path(arg) for arg in argv[1:])
+        roots_managed = any(
+            _operand_is_managed(arg, cwd_candidates) for arg in argv[1:]
+            if not arg.startswith("-")
+        )
         if roots_managed and "-delete" in argv:
             return True
         for marker in ("-exec", "-execdir"):
@@ -1449,6 +1518,31 @@ def _dispatcher_targets_hermes(segment: str, *, managed_cwd: bool = False) -> bo
     destructive = any(re.search(destructive_re, arg, re.IGNORECASE) for arg in argv[1:])
     path_words = [word for arg in argv[1:] for word in re.split(r"\s+", arg)]
     return destructive and any(_is_hermes_managed_path(arg.strip("'\"")) for arg in path_words)
+
+
+_XARGS_OPTIONS_WITH_ARG = frozenset({
+    "-a", "--arg-file", "-d", "--delimiter", "-E", "--eof", "-I", "--replace",
+    "-L", "--max-lines", "-n", "--max-args", "-P", "--max-procs", "-s", "--max-chars",
+    "--process-slot-var",
+})
+
+
+def _xargs_payload(argv: list[str]) -> list[str]:
+    """Return xargs' fixed command and arguments, excluding xargs options."""
+    index = 1
+    while index < len(argv):
+        arg = argv[index]
+        if arg == "--":
+            index += 1
+            break
+        if not arg.startswith("-") or arg == "-":
+            break
+        option = arg.partition("=")[0]
+        if option in _XARGS_OPTIONS_WITH_ARG and "=" not in arg:
+            index += 2
+        else:
+            index += 1
+    return argv[index:]
 
 
 _SQLITE_READ_ONLY_PREFIXES = frozenset({"select", "explain", "values"})

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1072,7 +1072,8 @@ def _yield_kwargs(command: str, **ctx) -> dict:
 def _run_foreground(
     command: str, env: Any, plan: _ExecPlan, *,
     task_id: Optional[str], session_id: Optional[str], session_key: str,
-    workdir: Optional[str], approval_note: Optional[str], clear_interrupt: bool,
+    workdir: Optional[str], command_cwd: str,
+    approval_note: Optional[str], clear_interrupt: bool,
 ) -> str:
     """Execute in the foreground with retry on transient errors, then finalize."""
     max_retries = 3
@@ -1089,9 +1090,6 @@ def _run_foreground(
 
     for retry_count in range(max_retries + 1):
         try:
-            command_cwd = _resolve_command_cwd(
-                workdir=workdir, default_cwd=plan.cwd, session_key=session_key, env_type=env_type,
-            )
             # bounded_capture: model-facing output keeps a head/tail window
             # while streaming so a verbose command can't OOM the gateway;
             # internal env.execute() consumers stay unbounded.
@@ -1222,12 +1220,21 @@ def terminal_tool(
         from tools.approval import get_current_session_key
 
         session_key = get_current_session_key(default="") or (task_id or "")
+        command_cwd = _resolve_command_cwd(
+            workdir=workdir,
+            default_cwd=cwd,
+            session_key=session_key,
+            env_type=env_type,
+        )
 
-        _pre_exec_block(command, env=env, env_type=env_type, cwd=cwd, workdir=workdir, session_key=session_key)
+        _pre_exec_block(
+            command, env=env, env_type=env_type, cwd=command_cwd,
+            workdir=workdir, session_key=session_key,
+        )
         # Pre-exec security checks (tirith + dangerous command detection);
         # force=True means the user already confirmed.
         verdict = _run_approval_guards(
-            command, env_type, plan.config, force=force, cwd=workdir or cwd,
+            command, env_type, plan.config, force=force, cwd=command_cwd,
         )
 
         pty_disabled = pty and _command_requires_pipe_stdin(command)
@@ -1238,7 +1245,7 @@ def terminal_tool(
         if background:
             result = spawn_background_process(
                 command=command, env=env, env_type=env_type, effective_task_id=effective_task_id,
-                task_id=task_id, session_key=session_key, workdir=workdir, cwd=cwd,
+                task_id=task_id, session_key=session_key, cwd=command_cwd,
                 effective_pty=pty and not pty_disabled, notify_on_complete=notify_on_complete,
                 watch_patterns=watch_patterns, approval_note=verdict.note,
                 pty_disabled_reason=_PTY_DISABLED_REASON if pty_disabled else None,
@@ -1249,7 +1256,8 @@ def terminal_tool(
         return _run_foreground(
             command, env, plan,
             task_id=task_id, session_id=session_id, session_key=session_key,
-            workdir=workdir, approval_note=verdict.note, clear_interrupt=verdict.approved_run,
+            workdir=workdir, command_cwd=command_cwd,
+            approval_note=verdict.note, clear_interrupt=verdict.approved_run,
         )
     except _Rejected as r:
         return r.result_json

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -120,6 +120,7 @@ def _current_session_profile() -> str:
 
 from tools.approval import (
     check_all_command_guards as _check_all_guards_impl,
+    check_unconditional_command_floors as _check_unconditional_floors_impl,
 )
 
 
@@ -149,6 +150,13 @@ def _check_all_guards(command: str, env_type: str,
     return _check_all_guards_impl(command, env_type,
                                   approval_callback=_get_approval_callback(),
                                   has_host_access=has_host_access)
+
+
+def _check_unconditional_floors(command: str, env_type: str,
+                                has_host_access: bool = False) -> dict:
+    return _check_unconditional_floors_impl(
+        command, env_type, has_host_access=has_host_access,
+    )
 
 
 from tools.environments.base import EnvironmentConnectionError
@@ -835,12 +843,15 @@ class _ApprovalVerdict:
 
 
 def _run_approval_guards(command: str, env_type: str, config: Dict[str, Any], *, force: bool) -> _ApprovalVerdict:
-    """Run tirith + dangerous-command guards; ``force`` skips them entirely.
+    """Run command guards; ``force`` skips only the user-approved layer.
     Raises :class:`_Rejected` when the command may not run (denied, or pending
     gateway approval)."""
-    if force:
-        return _ApprovalVerdict(approved_run=True)
-    approval = _check_all_guards(command, env_type, has_host_access=_docker_has_host_access(config))
+    host_access = _docker_has_host_access(config)
+    approval = (
+        _check_unconditional_floors(command, env_type, has_host_access=host_access)
+        if force else
+        _check_all_guards(command, env_type, has_host_access=host_access)
+    )
     if not approval["approved"]:
         if approval.get("status") == "pending_approval":  # gateway ask mode
             raise _Rejected(_error_json(
@@ -858,6 +869,8 @@ def _run_approval_guards(command: str, env_type: str, config: Dict[str, Any], *,
             "Use the approval prompt to allow it, or rephrase the command."
         )
         raise _Rejected(_error_json(approval.get("message", fallback_msg), status="blocked"))
+    if force:
+        return _ApprovalVerdict(approved_run=True)
     desc = approval.get("description", "flagged as dangerous")
     if approval.get("user_approved"):
         return _ApprovalVerdict(

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -145,17 +145,19 @@ def _docker_has_host_access(config: Dict[str, Any]) -> bool:
 
 
 def _check_all_guards(command: str, env_type: str,
-                      has_host_access: bool = False) -> dict:
+                      has_host_access: bool = False,
+                      cwd: Optional[str] = None) -> dict:
     """Delegate to consolidated guard (tirith + dangerous cmd) with CLI callback."""
     return _check_all_guards_impl(command, env_type,
                                   approval_callback=_get_approval_callback(),
-                                  has_host_access=has_host_access)
+                                  has_host_access=has_host_access, cwd=cwd)
 
 
 def _check_unconditional_floors(command: str, env_type: str,
-                                has_host_access: bool = False) -> dict:
+                                has_host_access: bool = False,
+                                cwd: Optional[str] = None) -> dict:
     return _check_unconditional_floors_impl(
-        command, env_type, has_host_access=has_host_access,
+        command, env_type, has_host_access=has_host_access, cwd=cwd,
     )
 
 
@@ -842,15 +844,16 @@ class _ApprovalVerdict:
     approved_run: bool = False
 
 
-def _run_approval_guards(command: str, env_type: str, config: Dict[str, Any], *, force: bool) -> _ApprovalVerdict:
+def _run_approval_guards(command: str, env_type: str, config: Dict[str, Any], *,
+                         force: bool, cwd: Optional[str] = None) -> _ApprovalVerdict:
     """Run command guards; ``force`` skips only the user-approved layer.
     Raises :class:`_Rejected` when the command may not run (denied, or pending
     gateway approval)."""
     host_access = _docker_has_host_access(config)
     approval = (
-        _check_unconditional_floors(command, env_type, has_host_access=host_access)
+        _check_unconditional_floors(command, env_type, has_host_access=host_access, cwd=cwd)
         if force else
-        _check_all_guards(command, env_type, has_host_access=host_access)
+        _check_all_guards(command, env_type, has_host_access=host_access, cwd=cwd)
     )
     if not approval["approved"]:
         if approval.get("status") == "pending_approval":  # gateway ask mode
@@ -1223,7 +1226,9 @@ def terminal_tool(
         _pre_exec_block(command, env=env, env_type=env_type, cwd=cwd, workdir=workdir, session_key=session_key)
         # Pre-exec security checks (tirith + dangerous command detection);
         # force=True means the user already confirmed.
-        verdict = _run_approval_guards(command, env_type, plan.config, force=force)
+        verdict = _run_approval_guards(
+            command, env_type, plan.config, force=force, cwd=workdir or cwd,
+        )
 
         pty_disabled = pty and _command_requires_pipe_stdin(command)
         if plan.promoted_from_foreground_timeout is not None:

--- a/tools/terminal_tool_background.py
+++ b/tools/terminal_tool_background.py
@@ -128,7 +128,7 @@ def _register_completion_watcher(process_registry, proc_session, session_key) ->
 
 def spawn_background_process(
     *, command: str, env: Any, env_type: str, effective_task_id: str, task_id: Optional[str],
-    session_key: str, workdir: Optional[str], cwd: str, effective_pty: bool,
+    session_key: str, cwd: str, effective_pty: bool,
     notify_on_complete: bool, watch_patterns: Optional[List[str]], approval_note: Optional[str],
     pty_disabled_reason: Optional[str],
 ) -> str:
@@ -138,16 +138,11 @@ def spawn_background_process(
     exit_code 0 immediately, so the stale-interrupt kill cannot occur here.
     """
     from tools.process_registry import process_registry
-    from tools.terminal_tool import (
-        _redact_terminal_error_text, _resolve_command_cwd, _resolve_notification_flag_conflict,
-    )
+    from tools.terminal_tool import _redact_terminal_error_text, _resolve_notification_flag_conflict
 
-    effective_cwd = _resolve_command_cwd(
-        workdir=workdir, default_cwd=cwd, session_key=session_key, env_type=env_type,
-    )
     try:
         proc_session = _spawn(
-            process_registry, env=env, env_type=env_type, command=command, cwd=effective_cwd,
+            process_registry, env=env, env_type=env_type, command=command, cwd=cwd,
             effective_task_id=effective_task_id, task_id=task_id, session_key=session_key,
             effective_pty=effective_pty,
         )

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -165,11 +165,15 @@ def _capture_run_kwargs(timeout: int) -> dict:
 
 
 def _captured_exec(rid, cmd, timeout: int, *, on_result, timeout_err: tuple, fail_code: int,
-                   shell: bool = False, env: "dict | None" = None) -> dict:
+                   shell: bool = False, env: "dict | None" = None,
+                   cwd: "str | None" = None) -> dict:
     """Run ``cmd`` captured (see ``_capture_run_kwargs``) and hand the CompletedProcess to
     ``on_result``; TimeoutExpired → ``timeout_err`` (code, message), other errors → ``fail_code``."""
     try:
-        return on_result(subprocess.run(cmd, cwd=os.getcwd(), shell=shell, env=env, **_capture_run_kwargs(timeout)))
+        return on_result(subprocess.run(
+            cmd, cwd=cwd or os.getcwd(), shell=shell, env=env,
+            **_capture_run_kwargs(timeout),
+        ))
     except subprocess.TimeoutExpired:
         return _err(rid, *timeout_err)
     except Exception as e:
@@ -1438,9 +1442,10 @@ def _(rid, params: dict) -> dict:
     cmd = params.get("command", "")
     if not cmd:
         return _err(rid, 4004, "empty command")
+    command_cwd = os.getcwd()
     try:
         approval = _tools_mod("tools.approval_detection")
-        is_hardline, hardline_desc = approval.detect_hardline_command(cmd)
+        is_hardline, hardline_desc = approval.detect_hardline_command(cmd, cwd=command_cwd)
         if is_hardline:
             return _err(rid, 4005, f"blocked (hardline): {hardline_desc}. Use the agent for dangerous commands.")
         is_dangerous, _, desc = approval.detect_dangerous_command(cmd)
@@ -1450,6 +1455,7 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5001, "shell.exec unavailable: approval safety module not importable")
     return _captured_exec(
         rid, cmd, 30, shell=True, fail_code=5003, timeout_err=(5002, "command timed out (30s)"),
+        cwd=command_cwd,
         on_result=lambda r: _ok(rid, {"stdout": r.stdout[-4000:], "stderr": r.stderr[-2000:], "code": r.returncode}))
 
 


### PR DESCRIPTION
## What does this PR do?

Destructive terminal commands can currently move, delete, or overwrite the active Hermes data directory without reaching any approval gate. This change adds an unconditional floor scoped to the resolved HERMES_HOME and its shell-variable spellings, while leaving reads, backups, unrelated paths, and quoted prose unaffected.

### Symptom

Commands such as `mv $HERMES_HOME /tmp/lost`, `rm $HERMES_HOME/state.db`, `truncate -s0 $HERMES_HOME/state.db`, and `sqlite3 $HERMES_HOME/state.db 'delete from messages where 1=1'` are silently approved.

### Impact

An agent can lose sessions, memories, configuration, plugins, and other persisted state even when the user has not approved the destructive operation.

### Bug Cause

**Trigger:** `tools/approval_detection.py:172` / `detect_hardline_command`

**Causal chain:**
1. A terminal command targets HERMES_HOME or one of its children with a destructive verb that is not globally dangerous.
2. Existing normalization only gives special handling to individual config and environment files, while the hardline rules cover only bare system and user-home roots.
3. The command matches neither the hardline floor nor `DANGEROUS_PATTERNS`, so `check_all_command_guards` returns `approved=True`.

**Why it is wrong:** Hermes-managed state is the writable persistence boundary for the agent, but destructive operations against it have weaker protection than equivalent file-tool operations.

**Working sibling / contrast:** Recursive `rm -rf` is caught by the generic dangerous-command rule, and terminal writes to `config.yaml` and `.env` already have dedicated patterns.

**Ruled out:** Tirith does not close this gap; the reported commands receive an allow verdict there as well, so the built-in approval floor must own the invariant.

### Fix

Normalize both the exact resolved HERMES_HOME and its descendants, then structurally inspect command-position verbs, operands, output redirects, and destructive SQLite statements. The new floor is limited to Hermes-managed paths and preserves benign reads, backups, inbound moves, unrelated destructive operations, and prose containing command text.

## Related Issue

Fixes #109367

## Type of Change

- [x] Security fix

## Changes Made

- `tools/approval_detection.py` - hard-block destructive command operands and redirects targeting the active Hermes data directory.
- `tests/tools/test_approval.py` - cover reported destructive forms, the real guard result, and benign contrast cases.

## How to Test

1. Set `HERMES_HOME` to a temporary profile directory.
2. Run the reported command forms through `detect_hardline_command` and `check_all_command_guards`.
3. Run `scripts/run_tests.sh tests/tools/test_approval.py -k HermesHomeHardline` after PR creation per repository workflow.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

N/A - command-classification behavior is covered by automated tests.
