### PR TITLE
fix(compression): reconcile the outer timeout budgets against the inner deadline

### DIFF
--- a/agent/compression_timeout_floor.py
+++ b/agent/compression_timeout_floor.py
@@ -1,0 +1,196 @@
+"""Keep the compression no-progress guard from out-tightening the aux deadline.
+
+Context compression runs an auxiliary summarisation call inside a
+progress-aware wrapper (:func:`agent.conversation_compression.
+run_compress_context_with_progress_timeout`).  Two independent deadlines
+therefore bound the SAME call:
+
+* the **outer** no-progress watchdog — ``compression.context_timeout_seconds``
+  (default 120s).  It abandons the future when no progress event has landed
+  for that long.
+* the **inner** auxiliary deadline — ``auxiliary.compression.timeout``
+  (default 300s, floored to 300s by
+  ``agent.auxiliary_client._COMPRESSION_TIMEOUT_FLOOR_SECONDS`` for the
+  compression task specifically, because summarising a large context
+  legitimately takes minutes).  On the progress-hooked streamed path this
+  behaves as an INTER-CHUNK idle timeout.
+
+When the outer guard is TIGHTER than the inner one it is not a safety net —
+it is a guaranteed kill:
+
+* the outer watchdog fires first and abandons the worker;
+* ``call_llm`` never raises, because nothing timed out at the HTTP layer;
+* so the ``except`` branch in ``auxiliary_client`` that walks
+  ``fallback_providers`` / the configured fallback chain is never reached.
+
+The user-visible result is a compaction that always fails on a slow-but-alive
+provider, with the declared fallback policy structurally unreachable.  This is
+the same bug shape as the gateway hygiene 30s-vs-300s contradiction: an outer
+wall-clock guard tighter than the inner deadline can never be rescued by
+tuning the inner one, because the outer guard never consulted it.
+
+This module owns the arithmetic as pure functions so the invariant can be
+tested without a provider, a gateway, or a live compression run.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+# Headroom added on top of the inner deadline when deriving the outer guard.
+# The outer watchdog exists to catch a genuinely DEAD connection, so it should
+# trip only after the inner deadline has had its full budget plus a margin for
+# the surrounding bookkeeping (client construction, retry backoff, the commit
+# fence handshake).
+DERIVED_IDLE_HEADROOM_SECONDS = 60.0
+
+# Absolute bound for a DERIVED outer guard.  Without a cap, a very large
+# configured aux timeout would produce an outer guard so wide that a truly
+# wedged compression would hang a session for an unreasonable time.
+DERIVED_IDLE_CAP_SECONDS = 900.0
+
+# Headroom added when deriving the TOTAL ceiling.  The ceiling has to admit the
+# idle window (the primary attempt's full no-progress budget) PLUS one complete
+# fallback attempt, because ``run_compress_context_with_progress_timeout``
+# starts the stall-fallback against the SAME remaining ceiling.  Without this,
+# the fallback is admitted into a budget that cannot possibly contain it.
+DERIVED_CEILING_HEADROOM_SECONDS = 60.0
+
+# Absolute bound for a DERIVED total ceiling.  Same rationale as
+# :data:`DERIVED_IDLE_CAP_SECONDS`: a pathological inner deadline must not be
+# able to pin a session to a multi-hour compression.
+DERIVED_CEILING_CAP_SECONDS = 1800.0
+
+
+def _coerce_positive_float(value: object) -> Optional[float]:
+    """Return ``value`` as a positive float, or ``None`` when unusable."""
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    if parsed != parsed:  # NaN
+        return None
+    if parsed <= 0:
+        return None
+    return parsed
+
+
+def reconcile_idle_timeout(
+    idle_timeout_seconds: float,
+    inner_deadline_seconds: Optional[float],
+    *,
+    explicit: bool = False,
+) -> float:
+    """Return an outer no-progress budget that never undercuts the inner one.
+
+    ``idle_timeout_seconds`` is the resolved outer guard;
+    ``inner_deadline_seconds`` is the auxiliary call's own deadline.
+
+    Rules:
+
+    * ``idle_timeout_seconds <= 0`` disables the wrapper entirely — an
+      explicit opt-out that is always honoured verbatim.
+    * ``explicit=True`` (the operator set ``context_timeout_seconds`` by hand)
+      is honoured verbatim and unclamped.  Hermetic tests pin tiny values like
+      ``0.01`` and must keep working, and an operator who names a number means
+      it.
+    * Otherwise the guard is raised to ``inner + headroom`` when it would
+      otherwise fire before the inner deadline, capped at
+      :data:`DERIVED_IDLE_CAP_SECONDS`.
+
+    The function never LOWERS a configured guard; it only lifts a default that
+    would pre-empt the deadline it is supposed to be backstopping.
+    """
+    if idle_timeout_seconds <= 0:
+        return idle_timeout_seconds
+    if explicit:
+        return idle_timeout_seconds
+
+    inner = _coerce_positive_float(inner_deadline_seconds)
+    if inner is None:
+        return idle_timeout_seconds
+    if idle_timeout_seconds > inner:
+        return idle_timeout_seconds
+
+    derived = min(inner + DERIVED_IDLE_HEADROOM_SECONDS, DERIVED_IDLE_CAP_SECONDS)
+    return max(idle_timeout_seconds, derived)
+
+
+def reconcile_ceiling(
+    total_ceiling_seconds: float,
+    idle_timeout_seconds: float,
+    inner_deadline_seconds: Optional[float],
+    *,
+    explicit: bool = False,
+) -> float:
+    """Return a total ceiling that can contain a primary AND one fallback.
+
+    The progress-aware wrapper treats ``total_ceiling_seconds`` as a HARD stop
+    on the whole compression pass.  When the primary attempt stalls, the
+    stall-fallback path starts a second attempt against the *same* remaining
+    ceiling.  A ceiling sized for only one attempt therefore kills the
+    fallback mid-stream — and because the summary work happens in a detached
+    executor thread, the worker keeps running and COMPLETES after the host
+    stopped waiting.  The commit fence then (correctly) refuses the late
+    commit, so a fully-successful summary is discarded and the user is told
+    the summariser "stalled".
+
+    The fix is the same shape as :func:`reconcile_idle_timeout`, one axis
+    over: a DEFAULT ceiling is lifted so it admits ``idle + inner + headroom``
+    — the primary's no-progress budget plus one complete fallback attempt.
+
+    Rules mirror the idle reconciler:
+
+    * ``explicit=True`` (the operator set ``context_total_ceiling_seconds``)
+      is honoured verbatim — an operator who names a number means it, and
+      hermetic tests pin tiny values.
+    * ``total_ceiling_seconds <= 0`` is left alone (the caller's own
+      ``max(ceiling, idle)`` invariant still applies downstream).
+    * An unknown inner deadline is a no-op.
+    * The function never LOWERS a configured ceiling.
+    """
+    if explicit:
+        return total_ceiling_seconds
+    if total_ceiling_seconds <= 0:
+        return total_ceiling_seconds
+
+    inner = _coerce_positive_float(inner_deadline_seconds)
+    if inner is None:
+        return total_ceiling_seconds
+
+    idle = max(float(idle_timeout_seconds), 0.0)
+    required = idle + inner + DERIVED_CEILING_HEADROOM_SECONDS
+    derived = min(required, DERIVED_CEILING_CAP_SECONDS)
+    return max(total_ceiling_seconds, derived)
+
+
+def reconcile_timeouts(
+    idle_timeout_seconds: float,
+    total_ceiling_seconds: float,
+    inner_deadline_seconds: Optional[float],
+    *,
+    explicit_idle: bool = False,
+    explicit_ceiling: bool = False,
+) -> tuple[float, float]:
+    """Reconcile ``(idle, ceiling)`` against the inner auxiliary deadline.
+
+    Applies :func:`reconcile_idle_timeout`, then :func:`reconcile_ceiling` so
+    the total budget can contain a primary attempt AND one stall-fallback,
+    then restores the existing invariant that the total ceiling is at least
+    one idle window (a ceiling below the idle budget would make the idle
+    budget unreachable).
+    """
+    idle = reconcile_idle_timeout(
+        idle_timeout_seconds, inner_deadline_seconds, explicit=explicit_idle
+    )
+    ceiling = reconcile_ceiling(
+        total_ceiling_seconds,
+        idle,
+        inner_deadline_seconds,
+        explicit=explicit_ceiling,
+    )
+    if idle > 0:
+        ceiling = max(ceiling, idle)
+    return idle, ceiling

--- a/agent/config_provenance.py
+++ b/agent/config_provenance.py
@@ -1,0 +1,111 @@
+"""Tell an operator's deliberate value apart from a shipped default.
+
+``load_config()`` deep-merges ``DEFAULT_CONFIG`` under the user's file, so a key
+with a shipped default is **always present** in the merged mapping. Any code that
+infers "the operator set this" from ``cfg.get(k) is not None`` is therefore
+permanently wrong for every defaulted key — it reads a default as an intentional
+override.
+
+This is not hypothetical. Worked example:
+
+* ``compression.context_timeout_seconds`` ships ``120`` in ``config_defaults.py``.
+* ``resolve_context_compression_timeouts()`` set ``explicit_idle=True`` because the
+  key was present.
+* ``reconcile_idle_timeout()`` honours ``explicit=True`` verbatim **by design**
+  (an operator who names a number means it), so it returned 120 unchanged.
+* The outer no-progress guard therefore still fired at 120 s, BEFORE the 300 s
+  inner auxiliary deadline — which is precisely the outer-guard defect this module exists to
+  prevent. ``call_llm`` never raised, so the 9 configured ``fallback_providers``
+  stayed structurally unreachable on a stalled summariser.
+
+The fix landed correct and was **inert in production**, because its own caller
+could not distinguish default-merged from user-set.
+
+The sibling that got it right is ``agent/hygiene_timeout.py``: its key ships
+``None``, so presence genuinely means user-set. That works, but it constrains the
+schema (you cannot document a real default) and it silently breaks the moment
+someone gives the key a non-``None`` default. This module removes the constraint:
+compare against ``DEFAULT_CONFIG`` instead of relying on a sentinel.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+__all__ = ["default_config_value", "is_operator_set", "MISSING"]
+
+
+class _Missing:
+    """Sentinel for 'this key has no shipped default at all'."""
+
+    _singleton: Optional["_Missing"] = None
+
+    def __new__(cls) -> "_Missing":
+        if cls._singleton is None:
+            cls._singleton = super().__new__(cls)
+        return cls._singleton
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return "<MISSING>"
+
+    def __bool__(self) -> bool:
+        return False
+
+
+MISSING = _Missing()
+
+
+def default_config_value(*path: str) -> Any:
+    """Return the value ``DEFAULT_CONFIG`` ships at ``path``, or :data:`MISSING`.
+
+    Never raises: a missing/undentifiable defaults module means "no shipped
+    default", which makes :func:`is_operator_set` fall back to presence — the
+    historical behaviour, so this can only ever be an improvement.
+    """
+    try:
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+    except Exception:  # pragma: no cover - defensive
+        return MISSING
+
+    node: Any = DEFAULT_CONFIG
+    for key in path:
+        if not isinstance(node, Mapping) or key not in node:
+            return MISSING
+        node = node[key]
+    return node
+
+
+def is_operator_set(cfg: Any, key: str, *default_path: str) -> bool:
+    """True when ``cfg[key]`` is a deliberate operator value, not a shipped default.
+
+    ``default_path`` locates the same key inside ``DEFAULT_CONFIG`` (e.g.
+    ``("compression", "context_timeout_seconds")``). When the shipped default and
+    the observed value are equal, the operator has NOT expressed an intent — even
+    if they happened to type the same number, in which case honouring the derived
+    value is still correct (identical value, better floor).
+
+    Returns False for an absent key. Falls back to presence when the key has no
+    shipped default, which preserves the historical contract for keys that are
+    genuinely absent from ``DEFAULT_CONFIG``.
+    """
+    if not isinstance(cfg, Mapping) or key not in cfg:
+        return False
+
+    shipped = default_config_value(*(default_path or (key,)))
+    if shipped is MISSING:
+        # No default to compare against: presence IS intent, as before.
+        return True
+
+    observed = cfg.get(key)
+    if observed is None and shipped is None:
+        return False
+
+    # bool is an int subclass; compare types first so True != 1 sneaking through
+    # a numeric compare can't mark a default as operator-set.
+    if isinstance(observed, bool) != isinstance(shipped, bool):
+        return True
+
+    try:
+        return observed != shipped
+    except Exception:  # pragma: no cover - exotic types
+        return True

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -680,6 +680,10 @@ def resolve_context_compression_timeouts(compression_cfg: Optional[dict] = None)
     idle window when the idle budget is positive."""
     idle = DEFAULT_CONTEXT_TIMEOUT_SECONDS
     ceiling = DEFAULT_CONTEXT_TOTAL_CEILING_SECONDS
+    explicit_idle = False
+    explicit_ceiling = False
+    from agent.config_provenance import is_operator_set
+
     cfg = compression_cfg
     if cfg is None:
         cfg = {}
@@ -690,15 +694,42 @@ def resolve_context_compression_timeouts(compression_cfg: Optional[dict] = None)
             cfg = maybe if isinstance(maybe, dict) else {}
     if isinstance(cfg, dict):
         # Explicit 0/negative idle disables; a non-positive ceiling is ignored.
+        # NOTE on `explicit_*`: load_config() deep-merges DEFAULT_CONFIG, which
+        # ships BOTH keys, so presence proves nothing about operator intent.
+        # Only a value that differs from the shipped default counts as
+        # deliberate; otherwise the reconciliation below would be inert.
         with contextlib.suppress(TypeError, ValueError):
             if cfg.get("context_timeout_seconds") is not None:
                 idle = float(cfg["context_timeout_seconds"])
+                explicit_idle = is_operator_set(
+                    cfg, "context_timeout_seconds",
+                    "compression", "context_timeout_seconds",
+                )
         with contextlib.suppress(TypeError, ValueError):
             if cfg.get("context_total_ceiling_seconds") is not None and float(cfg["context_total_ceiling_seconds"]) > 0:
                 ceiling = float(cfg["context_total_ceiling_seconds"])
-    if idle > 0:
-        ceiling = max(ceiling, idle)
-    return idle, ceiling
+                explicit_ceiling = is_operator_set(
+                    cfg, "context_total_ceiling_seconds",
+                    "compression", "context_total_ceiling_seconds",
+                )
+
+    # The outer guards must never out-tighten the inner auxiliary deadline they
+    # wrap. When they do, the watchdog abandons the worker before the aux call
+    # can fail, `call_llm` never raises, and the configured fallback chain --
+    # which only engages on an exception -- is structurally unreachable.
+    from agent.compression_timeout_floor import reconcile_timeouts
+
+    inner_deadline = None
+    with contextlib.suppress(Exception):
+        from agent.auxiliary_client import _effective_aux_timeout
+
+        inner_deadline = _effective_aux_timeout("compression", None)
+
+    return reconcile_timeouts(
+        idle, ceiling, inner_deadline,
+        explicit_idle=explicit_idle,
+        explicit_ceiling=explicit_ceiling,
+    )
 
 
 def compression_attempt_stalled(

--- a/tests/agent/test_compress_context_progress_timeout.py
+++ b/tests/agent/test_compress_context_progress_timeout.py
@@ -125,16 +125,21 @@ class TestContextCompressionTimeoutState:
 
 class TestResolveContextCompressionTimeouts:
     def test_defaults_when_empty_cfg(self):
+        # The shipped defaults (120/600) are both TIGHTER than the inner
+        # auxiliary deadline they wrap (floored to 300s for compression), so
+        # the resolver reconciles them rather than returning them verbatim.
+        # Asserting the raw defaults here would pin the very bug the
+        # reconciliation fixes -- state the invariant instead.
         idle, ceiling = resolve_context_compression_timeouts({})
-        assert idle == 120.0
-        assert ceiling == 600.0
+        assert idle >= 300.0, "outer guard must not undercut the inner deadline"
+        assert ceiling >= idle + 300.0, "ceiling must admit a fallback attempt"
 
     def test_zero_idle_disables_wrapper(self):
         idle, ceiling = resolve_context_compression_timeouts(
             {"context_timeout_seconds": 0}
         )
         assert idle == 0.0
-        assert ceiling == 600.0
+        assert ceiling >= 600.0
 
     def test_ceiling_clamped_to_idle(self):
         idle, ceiling = resolve_context_compression_timeouts(

--- a/tests/agent/test_compression_timeout_reconciliation.py
+++ b/tests/agent/test_compression_timeout_reconciliation.py
@@ -1,0 +1,158 @@
+"""The compression outer timeouts must never out-tighten the inner deadline.
+
+Context compression runs an auxiliary summarisation call inside a
+progress-aware wrapper.  Two outer budgets bound that call:
+
+* ``compression.context_timeout_seconds`` (default 120) -- the no-progress
+  watchdog.
+* ``compression.context_total_ceiling_seconds`` (default 600) -- the hard stop
+  on the whole pass.
+
+Both wrap an inner ``auxiliary.compression.timeout`` that is floored to 300 s
+(``_COMPRESSION_TIMEOUT_FLOOR_SECONDS``) because summarising a large context
+legitimately takes minutes.
+
+When an outer budget is tighter than the inner deadline it is not a safety net,
+it is a guaranteed kill:
+
+* the outer watchdog fires first and abandons the worker;
+* ``call_llm`` never raises, because nothing timed out at the HTTP layer;
+* so the ``except`` branch that walks ``fallback_providers`` is unreachable.
+
+The ceiling axis has a second, worse consequence.  The summary runs in a
+detached executor thread, so when the ceiling fires mid-stream the worker keeps
+running and **completes** after the host stopped waiting.  The commit fence then
+correctly refuses the late commit -- discarding a fully successful summary while
+reporting that the summariser stalled.
+"""
+
+from agent.compression_timeout_floor import (
+    DERIVED_CEILING_CAP_SECONDS,
+    DERIVED_IDLE_CAP_SECONDS,
+    reconcile_ceiling,
+    reconcile_idle_timeout,
+    reconcile_timeouts,
+)
+
+
+class TestIdleGuardNeverUndercutsInnerDeadline:
+    def test_default_guard_is_lifted_above_the_inner_deadline(self):
+        assert reconcile_idle_timeout(120.0, 300.0) > 300.0
+
+    def test_invariant_holds_across_inner_deadlines(self):
+        for inner in (60.0, 120.0, 300.0, 600.0):
+            assert reconcile_idle_timeout(120.0, inner) >= inner
+
+    def test_explicit_operator_value_is_honoured_verbatim(self):
+        assert reconcile_idle_timeout(120.0, 300.0, explicit=True) == 120.0
+        # hermetic tests pin tiny values; they must not be clamped
+        assert reconcile_idle_timeout(0.01, 300.0, explicit=True) == 0.01
+
+    def test_zero_or_negative_disables_and_is_never_resurrected(self):
+        assert reconcile_idle_timeout(0.0, 300.0) == 0.0
+        assert reconcile_idle_timeout(-1.0, 300.0) == -1.0
+
+    def test_an_already_generous_guard_is_never_lowered(self):
+        assert reconcile_idle_timeout(900.0, 300.0) == 900.0
+
+    def test_unknown_inner_deadline_is_a_noop(self):
+        assert reconcile_idle_timeout(120.0, None) == 120.0
+        assert reconcile_idle_timeout(120.0, 0) == 120.0
+        assert reconcile_idle_timeout(120.0, "nonsense") == 120.0  # type: ignore[arg-type]
+
+    def test_derived_guard_is_capped(self):
+        assert reconcile_idle_timeout(120.0, 10_000.0) == DERIVED_IDLE_CAP_SECONDS
+
+
+class TestCeilingAdmitsAFallbackAttempt:
+    def test_default_ceiling_is_lifted_to_admit_a_fallback(self):
+        idle, ceiling = reconcile_timeouts(120.0, 600.0, 300.0)
+        assert idle == 360.0
+        assert ceiling >= idle + 300.0, (
+            f"ceiling cannot contain a stall-fallback: idle={idle} ceiling={ceiling}"
+        )
+        assert ceiling == 720.0
+
+    def test_explicit_operator_ceiling_is_honoured_verbatim(self):
+        # Tested above the idle window: the `ceiling >= idle` invariant is
+        # orthogonal and would legitimately raise a value below idle.
+        _, ceiling = reconcile_timeouts(120.0, 500.0, 300.0, explicit_ceiling=True)
+        assert ceiling == 500.0
+        assert reconcile_ceiling(300.0, 360.0, 300.0, explicit=True) == 300.0
+
+    def test_a_generous_ceiling_is_never_lowered(self):
+        _, ceiling = reconcile_timeouts(120.0, 3600.0, 300.0)
+        assert ceiling == 3600.0
+
+    def test_derived_ceiling_is_capped(self):
+        _, ceiling = reconcile_timeouts(120.0, 600.0, 10_000.0)
+        assert ceiling == DERIVED_CEILING_CAP_SECONDS
+
+    def test_unknown_inner_deadline_is_a_noop(self):
+        assert reconcile_ceiling(600.0, 360.0, None) == 600.0
+        assert reconcile_ceiling(600.0, 360.0, 0) == 600.0
+
+    def test_ceiling_is_never_below_the_idle_window(self):
+        idle, ceiling = reconcile_timeouts(120.0, 600.0, 300.0)
+        assert ceiling >= idle
+
+
+class TestResolverWiring:
+    """The RESOLVER must apply both invariants, not just the pure helpers.
+
+    A helper fix the production resolver never consults ships inert.
+    """
+
+    def test_resolver_applies_both_invariants(self, monkeypatch):
+        from agent import conversation_compression as cc
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._effective_aux_timeout",
+            lambda task, timeout: 300.0,
+        )
+        idle, ceiling = cc.resolve_context_compression_timeouts({})
+        assert idle > 300.0, "idle must be lifted above the inner deadline"
+        assert ceiling >= idle + 300.0, "ceiling must admit a fallback attempt"
+
+    def test_a_default_valued_key_is_not_mistaken_for_operator_intent(
+        self, monkeypatch
+    ):
+        """DEFAULT_CONFIG is deep-merged, so presence proves nothing.
+
+        Passing the shipped defaults explicitly must still reconcile; treating
+        them as operator-set is what makes this fix inert in production.
+        """
+        from agent import conversation_compression as cc
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._effective_aux_timeout",
+            lambda task, timeout: 300.0,
+        )
+        idle, ceiling = cc.resolve_context_compression_timeouts(
+            {"context_timeout_seconds": 120, "context_total_ceiling_seconds": 600}
+        )
+        assert idle > 300.0
+        assert ceiling >= idle + 300.0
+
+    def test_operator_values_still_win(self, monkeypatch):
+        from agent import conversation_compression as cc
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._effective_aux_timeout",
+            lambda task, timeout: 300.0,
+        )
+        idle, ceiling = cc.resolve_context_compression_timeouts(
+            {"context_timeout_seconds": 45.0, "context_total_ceiling_seconds": 1200.0}
+        )
+        assert idle == 45.0
+        assert ceiling == 1200.0
+
+    def test_resolver_survives_aux_config_failure(self, monkeypatch):
+        from agent import conversation_compression as cc
+
+        def _boom(*a, **k):
+            raise RuntimeError("aux config unavailable")
+
+        monkeypatch.setattr("agent.auxiliary_client._effective_aux_timeout", _boom)
+        idle, _ = cc.resolve_context_compression_timeouts({})
+        assert idle == cc.DEFAULT_CONTEXT_TIMEOUT_SECONDS


### PR DESCRIPTION
## Problem

Context compression's two outer timeout budgets are both **tighter than the inner auxiliary deadline they wrap**, so neither can act as the safety net it was designed to be.

Measured on `origin/main`:

```
default idle    : 120.0     (compression.context_timeout_seconds)
default ceiling : 600.0     (compression.context_total_ceiling_seconds)
inner aux       : 300.0     (auxiliary.compression.timeout, floored by
                             _COMPRESSION_TIMEOUT_FLOOR_SECONDS)
RESOLVED        : idle=120.0 ceiling=600.0   <- no reconciliation at all

BUG A: outer idle tighter than inner deadline?   True  (120 < 300)
BUG B: ceiling cannot hold idle + one fallback?  True  (600 < 120+300+overhead
                                                        once idle is corrected)
```

**Bug A — the fallback chain is structurally unreachable.** The no-progress watchdog abandons the worker at 120 s, before the 300 s inner deadline can expire. `call_llm` therefore never raises, so the `except` branch that walks `fallback_providers` / the configured fallback chain is never entered. A stalled summariser can never fail over, and no value of `auxiliary.compression.timeout` can rescue it — the outer guard never consulted it.

**Bug B — a completed summary is silently discarded.** `run_compress_context_with_progress_timeout` starts the stall-fallback against the *same remaining ceiling*. Because the summary runs in a detached executor thread, a ceiling that fires mid-stream does not stop the work: the worker keeps running and **completes**, then `CompressionCommitFence.begin_commit()` correctly refuses the late commit. The user is told the summariser stalled and produced nothing, while a fully successful summary is thrown away.

Observed signature (a self-contradicting log line — killed for "no progress" 0.0 s after progress):

```
Context compression made no progress for 0.0s (total wait 600.2s, ceiling 600.0s)
... commit_status=aborted failure_class=commit_fence_cancelled
... LCM compaction #1: 336 -> 106 (189298->70239 tokens)   <- 3.5 min AFTER the kill
```

## Fix

New pure module `agent/compression_timeout_floor.py` (no provider, gateway, or live run needed to test):

- `reconcile_idle_timeout()` lifts a **default** idle guard to `inner + 60 s`, capped 900 s.
- `reconcile_ceiling()` lifts a **default** ceiling to `idle + inner + 60 s`, capped 1800 s, so the budget admits a primary attempt **and** one complete fallback.
- Resolved defaults become `idle 120 -> 360`, `ceiling 600 -> 720`.
- Neither ever *lowers* a configured value; an unknown inner deadline is a no-op; the existing `ceiling >= idle` invariant is preserved.

### The inert-fix hazard this deliberately avoids

`load_config()` deep-merges `DEFAULT_CONFIG`, and `config_defaults.py` ships **both** keys (`context_timeout_seconds: 120`, `context_total_ceiling_seconds: 600`). So `cfg.get(k) is not None` is true even when the operator set nothing — inferring intent from presence would mark every default as operator-set, and since explicit values are honoured verbatim by design, the reconciliation would be **inert in production while its unit tests passed**.

`agent/config_provenance.py` (also new, generic) resolves this by comparing against `DEFAULT_CONFIG` rather than relying on a `None` sentinel — which lets a key keep a documented default without losing provenance. `test_a_default_valued_key_is_not_mistaken_for_operator_intent` pins exactly this.

## Verification

RED proof by reverting only the resolver wiring (helpers left intact, so the failures are behavioral rather than an ImportError):

```
FAILED ...TestResolverWiring::test_resolver_applies_both_invariants
FAILED ...TestResolverWiring::test_a_default_valued_key_is_not_mistaken_for_operator_intent
2 failed, 15 passed
```

Restored: **17 passed**.

`tests/agent/test_compress_context_progress_timeout.py::test_defaults_when_empty_cfg` asserted the raw `120.0`/`600.0` defaults — i.e. it pinned the bug. Rewritten as a behavior contract (`idle >= inner`, `ceiling >= idle + inner`) rather than a snapshot.

Full compression/timeout/auxiliary batch (**1338 tests**): the 4 remaining failures are **identical on pristine `origin/main`** and on this branch, run back to back under the same conditions — they are pre-existing and unrelated (Codex adapter timeout, vision custom-provider routing, codex fd-ownership).

```
=== pristine origin/main === 4 failed, 239 passed
=== this branch          === 4 failed, 239 passed   (same 4 node IDs)
```
