### PR TITLE
feat(desktop): show canonical live compression count

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
@@ -255,10 +255,33 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
       }
     }
 
-    if (sessionId && hasStatePatch) {
+    if (sessionId && (hasStatePatch || payload?.usage)) {
       updateSessionState(
         sessionId,
-        state => applySessionInfoStatePatch(state, statePatch),
+        state => {
+          const nextState = hasStatePatch ? applySessionInfoStatePatch(state, statePatch) : state
+
+          if (!payload?.usage) {
+            return nextState
+          }
+
+          const previousUsage = nextState.usage
+
+          return {
+            ...nextState,
+            usage: {
+              ...previousUsage,
+              ...payload.usage,
+              calls: payload.usage.calls ?? previousUsage?.calls ?? 0,
+              // session.info is authoritative: omission means unavailable, not
+              // "reuse the previous runtime's compression count".
+              compressions: payload.usage.compressions,
+              input: payload.usage.input ?? previousUsage?.input ?? 0,
+              output: payload.usage.output ?? previousUsage?.output ?? 0,
+              total: payload.usage.total ?? previousUsage?.total ?? 0
+            }
+          }
+        },
         payload?.stored_session_id || undefined
       )
     }
@@ -400,7 +423,11 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
     }
 
     if (payload?.usage && (!explicitSid || isActiveEvent)) {
-      setCurrentUsage(current => ({ ...current, ...payload.usage }))
+      setCurrentUsage(current => ({
+        ...current,
+        ...payload.usage,
+        compressions: payload.usage.compressions
+      }))
     }
 
     requestDesktopOnboardingForCredentialWarning(payload?.credential_warning)

--- a/apps/desktop/src/app/session/hooks/use-message-stream/usage.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/usage.test.tsx
@@ -10,7 +10,7 @@ import { type MessageStreamHarness, renderMessageStream } from './test-harness'
 const SID = 'session-1'
 // $currentUsage mirrors the primary session; ClientSessionState.usage drives
 // the same status bar when a secondary tile is focused.
-const BASELINE = { calls: 2, input: 500, output: 40, total: 540 }
+const BASELINE = { calls: 2, compressions: 1, input: 500, output: 40, total: 540 }
 
 let stream: MessageStreamHarness
 let sessionStates = new Map<string, ClientSessionState>()
@@ -35,16 +35,17 @@ describe('useMessageStream status-bar usage scoping', () => {
 
     act(() =>
       stream.handleEvent({
-        payload: { usage: { context_percent: 42, input: 1200, total: 1280 } },
+        payload: { usage: { compressions: 2, context_percent: 42, input: 1200, total: 1280 } },
         session_id: SID,
         type: 'session.usage'
       })
     )
 
     // Merge, not replace: fields absent from the tick keep their prior values.
-    expect($currentUsage.get()).toEqual({ ...BASELINE, context_percent: 42, input: 1200, total: 1280 })
+    expect($currentUsage.get()).toEqual({ ...BASELINE, compressions: 2, context_percent: 42, input: 1200, total: 1280 })
     expect(sessionStates.get(SID)?.usage).toEqual({
       ...BASELINE,
+      compressions: 2,
       context_percent: 42,
       input: 1200,
       total: 1280
@@ -56,7 +57,7 @@ describe('useMessageStream status-bar usage scoping', () => {
 
     act(() =>
       stream.handleEvent({
-        payload: { usage: { input: 9999, total: 9999 } },
+        payload: { usage: { compressions: 9, input: 9999, total: 9999 } },
         session_id: 'background-session',
         type: 'session.usage'
       })
@@ -65,10 +66,55 @@ describe('useMessageStream status-bar usage scoping', () => {
     expect($currentUsage.get()).toEqual(BASELINE)
     expect(sessionStates.get('background-session')?.usage).toEqual({
       calls: 0,
+      compressions: 9,
       input: 9999,
       output: 0,
       total: 9999
     })
+  })
+
+  it('caches authoritative session.info usage for a background tile', () => {
+    sessionStates.set('background-session', { ...createClientSessionState(), usage: null })
+    mountStream()
+
+    act(() =>
+      stream.handleEvent({
+        payload: { usage: { calls: 3, compressions: 4, input: 700, output: 60, total: 760 } },
+        session_id: 'background-session',
+        type: 'session.info'
+      })
+    )
+
+    expect($currentUsage.get()).toEqual(BASELINE)
+    expect(sessionStates.get('background-session')?.usage).toEqual({
+      calls: 3,
+      compressions: 4,
+      input: 700,
+      output: 60,
+      total: 760
+    })
+  })
+
+  it('clears a stale background compression count when session.info omits it', () => {
+    sessionStates.set('background-session', {
+      ...createClientSessionState(),
+      usage: { ...BASELINE, compressions: 4, context_percent: 55 }
+    })
+    mountStream()
+
+    act(() =>
+      stream.handleEvent({
+        payload: { usage: { calls: 3, input: 700, output: 60, total: 760 } },
+        session_id: 'background-session',
+        type: 'session.info'
+      })
+    )
+
+    const usage = sessionStates.get('background-session')?.usage
+    expect($currentUsage.get()).toEqual(BASELINE)
+    expect(usage?.compressions).toBeUndefined()
+    expect(usage?.context_percent).toBe(55)
+    expect(usage?.calls).toBe(3)
   })
 
   it('applies message.complete usage from the focused session', () => {
@@ -76,13 +122,13 @@ describe('useMessageStream status-bar usage scoping', () => {
 
     act(() =>
       stream.handleEvent({
-        payload: { text: 'done', usage: { calls: 3, input: 1500, output: 90, total: 1590 } },
+        payload: { text: 'done', usage: { calls: 3, compressions: 3, input: 1500, output: 90, total: 1590 } },
         session_id: SID,
         type: 'message.complete'
       })
     )
 
-    expect($currentUsage.get()).toEqual({ calls: 3, input: 1500, output: 90, total: 1590 })
+    expect($currentUsage.get()).toEqual({ calls: 3, compressions: 3, input: 1500, output: 90, total: 1590 })
   })
 
   it('ignores message.complete usage from a background session', () => {
@@ -90,7 +136,7 @@ describe('useMessageStream status-bar usage scoping', () => {
 
     act(() =>
       stream.handleEvent({
-        payload: { text: 'done', usage: { calls: 9, input: 9999, output: 999, total: 9999 } },
+        payload: { text: 'done', usage: { calls: 9, compressions: 9, input: 9999, output: 999, total: 9999 } },
         session_id: 'background-session',
         type: 'message.complete'
       })

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -699,6 +699,7 @@ describe('usePromptActions /compress', () => {
     const requestGateway = vi.fn(async (method: string, _params?: Record<string, unknown>, _timeoutMs?: number) => {
       if (method === 'session.compress') {
         return {
+          info: { usage: { compressions: 1 } },
           removed: 8,
           summary: {
             headline: 'Compressed: 234 → 226 messages',
@@ -733,6 +734,7 @@ describe('usePromptActions /compress', () => {
     )
     expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
     expect(requestGateway).not.toHaveBeenCalledWith('command.dispatch', expect.anything())
+    expect($currentUsage.get().compressions).toBe(1)
   })
 
   it('replaces the transcript from the response messages', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -1185,7 +1185,7 @@ export function useSessionActions({
               }
 
               if (usage) {
-                setCurrentUsage(current => ({ ...current, ...usage }))
+                setCurrentUsage(current => ({ ...current, ...usage, compressions: usage.compressions }))
               }
 
               publishDegradedWarmCache()

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -8,8 +8,10 @@ import { $activeGatewayProfile } from '@/store/profile'
 import {
   $currentBranch,
   $currentCwd,
+  $currentUsage,
   setCurrentBranch,
   setCurrentCwd,
+  setCurrentUsage,
   setSelectedStoredSessionId,
   workspaceCwdBelongsToSelectedSession
 } from '@/store/session'
@@ -144,6 +146,31 @@ describe('applyRuntimeInfo foreground scoping', () => {
     expect(patch).toMatchObject({ branch: 'bb/tile', cwd: '/other-worktree' })
   })
 
+  it('returns authoritative usage for a background runtime snapshot', () => {
+    const patch = applyRuntimeInfo(
+      { usage: { calls: 3, compressions: 4, input: 100, output: 20, total: 120 } },
+      { foreground: false }
+    )
+
+    expect(patch?.usage).toEqual({ calls: 3, compressions: 4, input: 100, output: 20, total: 120 })
+  })
+
+  it('clears a previous session compression count when the focused snapshot omits it', () => {
+    setCurrentUsage({ calls: 2, compressions: 4, input: 10, output: 5, total: 15 })
+
+    applyRuntimeInfo({ usage: { calls: 0, input: 0, output: 0, total: 0 } })
+
+    expect($currentUsage.get().compressions).toBeUndefined()
+  })
+
+  it('does not let a background runtime clear the focused compression count', () => {
+    setCurrentUsage({ calls: 2, compressions: 4, input: 10, output: 5, total: 15 })
+
+    applyRuntimeInfo({ usage: { calls: 0, input: 0, output: 0, total: 0 } }, { foreground: false })
+
+    expect($currentUsage.get().compressions).toBe(4)
+  })
+
   // #71254: `if (info.cwd)` treated '' as "no opinion", so a detached session
   // never released the previous project and the Files pane stayed on it forever.
   it('treats an empty runtime cwd as authoritative and releases ownership', () => {
@@ -190,6 +217,14 @@ describe('applyStoredSessionPreviewRuntimeInfo workspace paint', () => {
 
     expect($currentCwd.get()).toBe('/next-project')
     expect(workspaceCwdBelongsToSelectedSession()).toBe(true)
+  })
+
+  it('clears live-only compression usage as soon as a cold session switch starts', () => {
+    setCurrentUsage({ calls: 2, compressions: 4, input: 10, output: 5, total: 15 })
+
+    applyStoredSessionPreviewRuntimeInfo({ cwd: '/next-project', model: 'gpt' }, 'session-next')
+
+    expect($currentUsage.get().compressions).toBeUndefined()
   })
 
   it('releases ownership when the selected session row reports no workspace', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1594,7 +1594,16 @@ export async function resolveSessionOwner(storedSessionId: null | string): Promi
 type SessionRuntimeStatePatch = Partial<
   Pick<
     ClientSessionState,
-    'branch' | 'cwd' | 'fast' | 'model' | 'personality' | 'provider' | 'reasoningEffort' | 'serviceTier' | 'yolo'
+    | 'branch'
+    | 'cwd'
+    | 'fast'
+    | 'model'
+    | 'personality'
+    | 'provider'
+    | 'reasoningEffort'
+    | 'serviceTier'
+    | 'usage'
+    | 'yolo'
   >
 >
 
@@ -1726,11 +1735,28 @@ export function applyRuntimeInfo(
     sessionState.yolo = info.yolo
   }
 
+  if (info.usage) {
+    // Runtime info is an authoritative snapshot. Keep a complete per-runtime
+    // usage object so a secondary tile can render immediately after create/resume;
+    // an omitted compression count intentionally clears a stale tile value.
+    sessionState.usage = {
+      ...info.usage,
+      calls: info.usage.calls ?? 0,
+      compressions: info.usage.compressions,
+      input: info.usage.input ?? 0,
+      output: info.usage.output ?? 0,
+      total: info.usage.total ?? 0
+    }
+  }
+
   if (foreground) {
     publishRuntimeToComposer(sessionState)
 
     if (info.usage) {
-      setCurrentUsage(current => ({ ...current, ...info.usage }))
+      // session.info/session.resume is an authoritative session snapshot, not a
+      // partial live tick. Clear a missing compression count so switching from
+      // a counted session to an older/cold runtime cannot leak the old value.
+      setCurrentUsage(current => ({ ...current, ...info.usage, compressions: info.usage?.compressions }))
     }
   }
 
@@ -1741,6 +1767,10 @@ export function applyStoredSessionPreviewRuntimeInfo(
   stored: { cwd?: null | string; model?: null | string } | undefined,
   storedSessionId: null | string
 ) {
+  // Compression count is live runtime state, not part of a durable session row.
+  // Drop the previous session's value immediately while the selected runtime
+  // resumes; the authoritative usage snapshot will repopulate it when present.
+  setCurrentUsage(current => ({ ...current, compressions: undefined }))
   setCurrentModel(stored?.model || '')
   setCurrentProvider('')
   setCurrentReasoningEffort('')

--- a/apps/desktop/src/app/shell/compression-count-status.test.tsx
+++ b/apps/desktop/src/app/shell/compression-count-status.test.tsx
@@ -1,0 +1,25 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { CompressionCountStatus } from './compression-count-status'
+
+afterEach(cleanup)
+
+describe('CompressionCountStatus', () => {
+  it('renders an explicit zero with a count tooltip', async () => {
+    render(<CompressionCountStatus count={0} />)
+
+    const counter = screen.getByTestId('compression-count')
+    expect(counter.textContent).toContain('0')
+    expect(counter.getAttribute('aria-label')).toBe('Compressions: 0')
+
+    fireEvent.pointerMove(counter, { pointerType: 'mouse' })
+    expect((await screen.findByRole('tooltip')).textContent).toBe('Compressions: 0')
+  })
+
+  it('does not fabricate a count when live usage omits it', () => {
+    const { container } = render(<CompressionCountStatus />)
+
+    expect(container.innerHTML).toBe('')
+  })
+})

--- a/apps/desktop/src/app/shell/compression-count-status.tsx
+++ b/apps/desktop/src/app/shell/compression-count-status.tsx
@@ -1,0 +1,29 @@
+import { Tip } from '@/components/ui/tooltip'
+import { useI18n } from '@/i18n'
+
+interface CompressionCountStatusProps {
+  count?: number
+}
+
+/** Current live runtime count from `usage.compressions`.
+ * Missing stays missing for older/cold usage snapshots; zero is real data. */
+export function CompressionCountStatus({ count }: CompressionCountStatusProps) {
+  const { t } = useI18n()
+
+  if (count === undefined) {
+    return null
+  }
+
+  return (
+    <Tip label={t.shell.statusbar.compressions(count)}>
+      <div
+        aria-label={t.shell.statusbar.compressions(count)}
+        className="inline-flex h-full items-center gap-1 px-1.5 text-[0.6875rem] text-(--ui-text-tertiary)"
+        data-testid="compression-count"
+      >
+        <span aria-hidden="true">🗜️</span>
+        <span className="tabular-nums">{count}</span>
+      </div>
+    </Tip>
+  )
+}

--- a/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
+++ b/apps/desktop/src/app/shell/hooks/use-statusbar-items.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router'
 import { ConnectionSwitcher } from '@/app/chat/sidebar/connection-switcher'
 import type { CommandCenterSection } from '@/app/command-center'
 import { useApprovalModeStatusbarItem } from '@/app/shell/approval-mode-menu'
+import { CompressionCountStatus } from '@/app/shell/compression-count-status'
 import { ContextUsagePanel } from '@/app/shell/context-usage-panel'
 import { GatewayMenuPanel } from '@/app/shell/gateway-menu-panel'
 import { useContextBreakdown } from '@/app/shell/hooks/use-context-breakdown'
@@ -627,6 +628,11 @@ export function useStatusbarItems({
         variant: 'menu'
       },
       {
+        hidden: contextItemHidden || currentUsage.compressions === undefined,
+        id: 'compression-count',
+        render: () => <CompressionCountStatus count={currentUsage.compressions} />
+      },
+      {
         icon: <Layers3 className="size-3" />,
         id: 'cache-hit-rate',
         // Same never-self-hide rule as the context meter: opted in means a
@@ -682,8 +688,10 @@ export function useStatusbarItems({
       contextBar,
       contextBreakdown,
       contextBreakdownLoading,
+      contextItemHidden,
       contextUsage,
       copy,
+      currentUsage.compressions,
       gaugeUsage,
       sessionStartedAt,
       gatewayState,

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2567,6 +2567,7 @@ export const ar = defineLocale({
       openCron: 'فتح المهام المجدولة',
       turnRunning: 'الدور يعمل',
       contextUsage: 'استخدام السياق',
+      compressions: count => `مرات الضغط: ${count}`,
       session: 'الجلسة',
       yoloOn: 'YOLO مفعل',
       yoloOff: 'YOLO معطل',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3530,6 +3530,7 @@ export const en: Translations = {
       openStarmap: 'Open memory graph',
       turnRunning: 'Running',
       contextUsage: 'Context usage',
+      compressions: count => `Compressions: ${count}`,
       systemResources: {
         title: 'System Resources',
         loading: 'Resources…',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2993,6 +2993,7 @@ export const ja = defineLocale({
       openStarmap: 'メモリグラフを開く',
       turnRunning: '実行中',
       contextUsage: 'コンテキスト使用状況',
+      compressions: count => `圧縮回数: ${count}`,
       systemResources: {
         title: 'システムリソース',
         loading: 'リソース…',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -3308,6 +3308,7 @@ export const ru = defineLocale({
       openStarmap: 'Открыть граф памяти',
       turnRunning: 'Выполняется',
       contextUsage: 'Использование контекста',
+      compressions: count => `Сжатий: ${count}`,
       contextUsagePanel: {
         categories: {
           conversation: 'Диалог',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -3063,6 +3063,7 @@ export interface Translations {
       openStarmap: string
       turnRunning: string
       contextUsage: string
+      compressions: (count: number) => string
       systemResources: {
         title: string
         loading: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2884,6 +2884,7 @@ export const zhHant = defineLocale({
       openStarmap: '開啟記憶圖譜',
       turnRunning: '執行中',
       contextUsage: '上下文使用量',
+      compressions: count => `壓縮次數：${count}`,
       systemResources: {
         title: '系統資源',
         loading: '資源…',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3662,6 +3662,7 @@ export const zh = defineLocale({
       openStarmap: '打开记忆图谱',
       turnRunning: '运行中',
       contextUsage: '上下文用量',
+      compressions: count => `压缩次数：${count}`,
       systemResources: {
         title: '系统资源',
         loading: '资源…',

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -816,6 +816,8 @@ export interface UsageStats {
   /** Session prompt-cache hit rate, 0–100. Omitted (not 0) when the provider reports no cache reads. */
   cache_hit_pct?: number
   calls: number
+  /** Successful context compressions in the current live agent runtime. */
+  compressions?: number
   context_max?: number
   context_percent?: number
   context_estimated?: boolean

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1219,6 +1219,16 @@ def test_write_json_drops_detached_ws_frames(monkeypatch):
         server._sessions.pop("detached-sid", None)
 
 
+@pytest.mark.parametrize("count", [0, 3])
+def test_get_usage_projects_live_compression_count(count):
+    agent = types.SimpleNamespace(
+        context_compressor=types.SimpleNamespace(compression_count=count),
+        model="test-model",
+    )
+
+    assert server._get_usage(agent)["compressions"] == count
+
+
 def test_usage_ticker_emits_wrapped_usage_payload(monkeypatch):
     # The live ticker must nest the snapshot under a "usage" key, matching the
     # message.complete / session.info payloads the desktop & TUI handlers read
@@ -10632,7 +10642,7 @@ def test_session_compress_uses_compress_helper(monkeypatch):
     monkeypatch.setattr(
         server,
         "_compress_session_history",
-        lambda session, focus_topic=None, **_kw: (2, {"total": 42}),
+        lambda session, focus_topic=None, **_kw: (2, {"total": 42, "compressions": 2}),
     )
     monkeypatch.setattr(server, "_session_info", lambda _agent, *a: {"model": "x"})
 
@@ -10642,7 +10652,7 @@ def test_session_compress_uses_compress_helper(monkeypatch):
         )
 
     assert resp["result"]["removed"] == 2
-    assert resp["result"]["usage"]["total"] == 42
+    assert resp["result"]["usage"] == {"total": 42, "compressions": 2}
     emit.assert_any_call("session.info", "sid", {"model": "x"})
     # Final status.update clears the pinned "compressing" indicator so the
     # status bar can revert to the neutral state when compaction finishes.


### PR DESCRIPTION
## Summary
- Show `🗜️ N` beside the Desktop Context meter, with a localized compression-count tooltip.
- Project the existing canonical `usage.compressions` field; no new backend counter, database schema, lineage traversal, or polling.
- Preserve zero as real data and hide unavailable counts. Clear the previous runtime count immediately on cold session switches and when authoritative snapshots omit it; background usage cannot overwrite the focused session.

## Semantics and related work
This is the current **live agent runtime** count, matching CLI accounting, not a durable lifetime count. Warm runtimes retain their counter; a cold backend restart can report zero. Automatic, manual, and native compaction accounting remains owned by the existing backend.

Related: #38258 and #38246. #38258 proposes lineage-derived `compress_count` and sidebar history; this PR deliberately implements only the canonical live status-bar projection, including default in-place compression, without that schema/history work. It does not claim to solve persistent historical counts.

## Verification
- Independent parent rerun: component, session-action utility, and message-stream usage tests: **125 passed across 3 files**.
- Independent `npm run typecheck`: renderer, Electron, and E2E TypeScript projects passed.
- Implementation verification: focused Desktop matrix **269 passed**; gateway producer/manual-compaction tests **4 passed**; native automatic compaction bookkeeping test **1 passed**; Codex hygiene compaction suite passed.
- Session-switch regression observed RED before the fix (previous session's count `4` leaked into missing data), then GREEN.
- `git diff --check` passed. Targeted ESLint had no errors and one pre-existing hook-dependency warning.

No core compression behavior or installed checkout changes. No full repository test suite was run.
