### PR TITLE
fix(updater): complete Node update in one Windows handoff run

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -596,7 +596,7 @@ def _print_update_check_result(behind: int | None, compare_branch: str) -> None:
 
 
 def _repair_venv_on_current_checkout(
-    *, assume_yes, gateway_mode, pre_update_snapshot_id, desktop_dir,
+    *, assume_yes, gateway_mode, pre_update_snapshot_id,
     had_desktop_app_before_update, active_lazy_features, active_tool_dependencies,
     _windows_gateway_resume) -> bool:
     """Reinstall ``.[all]`` + lazy/tool deps into an unhealthy (or handed-off) venv; returns
@@ -630,15 +630,17 @@ def _repair_venv_on_current_checkout(
         print("  Close all Hermes windows/gateways and re-run: hermes update")
         return False
     print("✓ Dependencies repaired!")
-    # Check for config migrations (#91360).
-    _check_and_apply_config_migration(
-        assume_yes=assume_yes, gateway_mode=gateway_mode, pre_update_snapshot_id=pre_update_snapshot_id)
-    # The hand-off child never reaches the commits-pulled rebuild; do it here.
-    if _rebuild_desktop_after_update(desktop_dir, had_desktop_app_before_update=had_desktop_app_before_update):
-        return _print_verified_update_completion("✓ Update complete!")
-    _print_update_completion(
-        "⚠ Update partially complete — the desktop app was not rebuilt and is still on the previous build.")
-    return False
+    # The hand-off child never reaches the commits-pulled Node/web/Desktop
+    # phase. Finish through the current-checkout repair path, whose npm digest
+    # gate keeps this cheap when the pulled manifests did not change.
+    return _repair_node_deps_on_current_checkout(
+        _print_verified_update_completion,
+        assume_yes=assume_yes,
+        gateway_mode=gateway_mode,
+        pre_update_snapshot_id=pre_update_snapshot_id,
+        completion_message="✓ Update complete!",
+        had_desktop_app_before_update=had_desktop_app_before_update,
+    )
 
 
 def _pip_install_prefix(uv_bin) -> tuple[list[str], dict | None]:
@@ -657,7 +659,7 @@ def _pip_install_prefix(uv_bin) -> tuple[list[str], dict | None]:
 
 
 def _repair_current_checkout(
-    *, assume_yes, gateway_mode, pre_update_snapshot_id, desktop_dir,
+    *, assume_yes, gateway_mode, pre_update_snapshot_id,
     had_desktop_app_before_update, active_lazy_features, active_tool_dependencies,
     upstream_checked, _windows_gateway_resume) -> bool:
     """Already-up-to-date path: keep the managed runtime current, repair a broken venv.
@@ -685,7 +687,7 @@ def _repair_current_checkout(
     if handed_off_sync or not healthy:
         current_checkout_complete = _repair_venv_on_current_checkout(
             assume_yes=assume_yes, gateway_mode=gateway_mode,
-            pre_update_snapshot_id=pre_update_snapshot_id, desktop_dir=desktop_dir,
+            pre_update_snapshot_id=pre_update_snapshot_id,
             had_desktop_app_before_update=had_desktop_app_before_update,
             active_lazy_features=active_lazy_features,
             active_tool_dependencies=active_tool_dependencies,
@@ -1173,7 +1175,7 @@ def _finalize_receipt(status: str, debug_message: str) -> None:
 
 def _finish_already_up_to_date(
     git_cmd, branch: str, current_branch: str, _plan, *, assume_yes: bool, gateway_mode: bool,
-    gw_input_fn, pre_update_snapshot_id, desktop_dir, had_desktop_app_before_update: bool,
+    gw_input_fn, pre_update_snapshot_id, had_desktop_app_before_update: bool,
     active_lazy_features, active_tool_dependencies, _windows_gateway_resume) -> None:
     """"Already up to date" path: restore stash/branch, repair the checkout, catch up the fleet.
     ``sys.exit(1)`` when the repair is incomplete (after gateway exit code + partial receipt)."""
@@ -1198,7 +1200,7 @@ def _finish_already_up_to_date(
 
     current_checkout_complete = _repair_current_checkout(
         assume_yes=assume_yes, gateway_mode=gateway_mode,
-        pre_update_snapshot_id=pre_update_snapshot_id, desktop_dir=desktop_dir,
+        pre_update_snapshot_id=pre_update_snapshot_id,
         had_desktop_app_before_update=had_desktop_app_before_update,
         active_lazy_features=active_lazy_features,
         active_tool_dependencies=active_tool_dependencies, upstream_checked=_plan.upstream_checked,
@@ -1373,7 +1375,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             _finish_already_up_to_date(
                 git_cmd, branch, current_branch, _plan, assume_yes=assume_yes,
                 gateway_mode=gateway_mode, gw_input_fn=gw_input_fn,
-                pre_update_snapshot_id=pre_update_snapshot_id, desktop_dir=desktop_dir,
+                pre_update_snapshot_id=pre_update_snapshot_id,
                 had_desktop_app_before_update=had_desktop_app_before_update,
                 active_lazy_features=opts.active_lazy_features,
                 active_tool_dependencies=opts.active_tool_dependencies,

--- a/tests/hermes_cli/test_update_handoff_desktop_rebuild.py
+++ b/tests/hermes_cli/test_update_handoff_desktop_rebuild.py
@@ -52,3 +52,39 @@ def test_failed_desktop_rebuild_withholds_success_completion():
     assert complete is False
     for call in completion.call_args_list:
         assert not call[0][0].startswith("✓")
+
+
+def test_handoff_venv_repair_finishes_node_and_web_phase(tmp_path):
+    """A successful Python repair must not bypass the remaining update work."""
+    project_root = tmp_path / "hermes"
+    venv_python = project_root / "venv" / "Scripts" / "python.exe"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.touch()
+
+    with (
+        patch.object(update_cmd, "venv_python_path", return_value=venv_python),
+        patch.object(update_cmd, "_pip_install_prefix", return_value=(["uv", "pip"], None)),
+        patch.object(update_cmd, "_venv_core_imports_healthy", return_value=(True, "ok")),
+        patch.object(update_cmd, "_write_update_incomplete_marker"),
+        patch.object(update_cmd, "_update_node_dependencies", return_value=[]) as update_node,
+        patch.object(update_cmd, "_check_and_apply_config_migration"),
+        patch.object(update_cmd, "_rebuild_desktop_after_update", return_value=True),
+        patch.object(update_cmd, "_print_verified_update_completion", return_value=True) as completion,
+        patch("hermes_cli.managed_uv.ensure_uv", return_value="uv"),
+        patch.object(update_cmd, "_m") as m,
+    ):
+        m.return_value.PROJECT_ROOT = project_root
+        complete = update_cmd._repair_venv_on_current_checkout(
+            assume_yes=True,
+            gateway_mode=False,
+            pre_update_snapshot_id=None,
+            had_desktop_app_before_update=False,
+            active_lazy_features=(),
+            active_tool_dependencies=(),
+            _windows_gateway_resume=None,
+        )
+
+    assert complete is True
+    update_node.assert_called_once_with()
+    m.return_value._build_web_ui.assert_called_once_with(project_root / "web")
+    completion.assert_called_once_with("✓ Update complete!")


### PR DESCRIPTION
## What does this PR do?

Windows npm installs no longer need a second `hermes update` run to refresh Node workspaces and rebuild the web UI after the updater hands dependency installation from `hermes.exe` to the venv Python child. The handoff child now finishes through the existing current-checkout repair path before it can report the update complete.

### Symptom

After a code pull on Windows, the handoff child repaired Python dependencies and printed `Update complete!`, but the npm workspace install and web UI build did not run until the next `hermes update` invocation.

### Impact

The first run reported success while Node dependencies could still match the previous lockfile and the web UI could still be stale.

### Bug Cause

**Trigger:** `hermes_cli/update_cmd.py` / `_repair_current_checkout()` when `HERMES_UPDATE_REEXEC=1`

**Causal chain:**
1. `hermes.exe` pulls new code and hands the dependency sync to the venv Python child.
2. The child enters `_repair_venv_on_current_checkout()`, repairs Python dependencies, and returns after config migration and the Desktop rebuild.
3. The Node workspace refresh and web UI build in the normal post-pull path are unreachable, but the child still prints a successful completion banner.

**Why it is wrong:** The handoff path claimed the update was complete before all dependency and build phases associated with the pulled checkout had run.

**Working sibling / contrast:** The already-current checkout path uses `_repair_node_deps_on_current_checkout()`, which self-gates npm work by the manifest digest, runs the web build, propagates Node failures, applies config migration, and rebuilds Desktop before reporting completion.

**Ruled out:** The npm manifest digest gate is not suppressing the first-run work; the handoff branch never called the gated Node repair helper at all, while the second run did call it and performed the refresh.

### Fix

Route the successful handoff Python repair into `_repair_node_deps_on_current_checkout()` with the handoff completion message. This reuses the existing Node failure handling and self-gating behavior while ensuring Node, web, config, and Desktop work all finish before success is reported. A regression test drives the handoff repair and asserts that both the Node refresh and web build execute.

## Related Issue

Closes #109373

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd.py` - finish the Windows handoff child through the complete current-checkout Node, web, config, and Desktop repair path.
- `tests/hermes_cli/test_update_handoff_desktop_rebuild.py` - verify the handoff repair invokes the Node refresh and web build before completion.

## How to Test

1. Run the focused updater regression tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_update_handoff_desktop_rebuild.py tests/hermes_cli/test_update_current_node_repair.py
```

Result: 52 tests passed across the two focused files and `tests/hermes_cli/test_cmd_update.py`.

2. On Windows, invoke `hermes update` through the npm-installed `hermes.exe` shim while upstream has new commits.
3. Confirm the handoff child performs the npm workspace refresh and web UI build before printing `Update complete!`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I ran the repository test entry on the related updater tests and all 52 tests passed
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A
- [x] `cli-config.yaml.example` updates are N/A
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A
- [x] I've considered cross-platform impact; the changed path is Windows-specific and reuses the existing cross-platform repair helper
- [x] Tool description and schema updates are N/A
