### PR TITLE
fix(kanban): preserve blocked state during board reads

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -420,8 +420,9 @@ def _cmd_list(args: argparse.Namespace) -> int:
     if args.mine and not assignee:
         assignee = _profile_author()
     with kbc.connect_closing() as conn:
-        # Cheap mini-dispatch so list reflects dependencies cleared since the last tick.
-        kb.recompute_ready(conn)
+        # Keep dependency freshness for todo cards without recovering blocked
+        # cards from a read path; blocked recovery belongs to dispatch/lifecycle.
+        kb.recompute_ready(conn, include_blocked=False)
         tasks = kb.list_tasks(
             conn, assignee=assignee, status=args.status, tenant=args.tenant, session_id=args.session,
             include_archived=args.archived, order_by=getattr(args, "sort", None),

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2004,7 +2004,9 @@ def _resume_status_from_events(conn: sqlite3.Connection, task_id: str) -> str:
     return "ready"
 
 
-def recompute_ready(conn: sqlite3.Connection, failure_limit: int = None) -> int:
+def recompute_ready(
+    conn: sqlite3.Connection, failure_limit: int = None, *, include_blocked: bool = True,
+) -> int:
     """Promote ``todo``/``blocked`` tasks whose parents are all done/archived;
     returns the count. Opens its own IMMEDIATE txn — call OUTSIDE any write txn.
 
@@ -2013,6 +2015,11 @@ def recompute_ready(conn: sqlite3.Connection, failure_limit: int = None) -> int:
     trip). Limit order matches ``_record_task_failure``: ``max_retries`` >
     ``failure_limit`` > ``DEFAULT_FAILURE_LIMIT``.
 
+    ``include_blocked=False`` keeps read-time dependency reconciliation for
+    ``todo`` tasks while deferring blocked-task recovery to an explicit
+    dispatcher or lifecycle path. The default preserves the full dispatcher
+    behavior, including recovery of non-sticky circuit-breaker blocks.
+
     1. The most recent block event was a worker-initiated ``kanban_block`` — those stay blocked until an
     explicit ``kanban_unblock`` (#28712).
     """
@@ -2020,11 +2027,13 @@ def recompute_ready(conn: sqlite3.Connection, failure_limit: int = None) -> int:
         failure_limit = DEFAULT_FAILURE_LIMIT
     promoted = 0
     with write_txn(conn):
-        todo_rows = conn.execute(
+        candidate_statuses = ("todo", "blocked") if include_blocked else ("todo",)
+        placeholders = ",".join("?" for _ in candidate_statuses)
+        candidate_rows = conn.execute(
             "SELECT id, status, consecutive_failures, max_retries "
-            "FROM tasks WHERE status IN ('todo', 'blocked')"
+            f"FROM tasks WHERE status IN ({placeholders})", candidate_statuses,
         ).fetchall()
-        for row in todo_rows:
+        for row in candidate_rows:
             task_id = row["id"]
             cur_status = row["status"]
             if cur_status == "blocked" and _has_sticky_block(conn, task_id):

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2017,8 +2017,15 @@ def recompute_ready(
 
     ``include_blocked=False`` keeps read-time dependency reconciliation for
     ``todo`` tasks while deferring blocked-task recovery to an explicit
-    dispatcher or lifecycle path. The default preserves the full dispatcher
-    behavior, including recovery of non-sticky circuit-breaker blocks.
+    dispatcher or lifecycle path. The default (``True``) preserves the full
+    dispatcher behavior, including recovery of non-sticky circuit-breaker blocks.
+
+    Compatibility note: with ``include_blocked=False``, board read surfaces (CLI
+    ``list`` and agent ``kanban_list``) intentionally skip all blocked tasks,
+    including non-sticky circuit-breaker blocks below the failure limit. In
+    deployments operating without a continuous background dispatcher, transient
+    circuit-breaker blocks do not auto-recover on read and must be recovered via
+    the dispatcher or explicit lifecycle operations.
 
     1. The most recent block event was a worker-initiated ``kanban_block`` — those stay blocked until an
     explicit ``kanban_unblock`` (#28712).

--- a/tests/hermes_cli/test_kanban_read_reconciliation.py
+++ b/tests/hermes_cli/test_kanban_read_reconciliation.py
@@ -27,9 +27,27 @@ def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return home
 
 
-def _create_blocked_task() -> str:
+def _create_initial_blocked_task(title: str = "approval gate") -> str:
+    """Create a task with initial_status='blocked' via public API."""
     with kbc.connect() as conn:
-        return kb.create_task(conn, title="approval gate", initial_status="blocked")
+        return kb.create_task(conn, title=title, initial_status="blocked")
+
+
+def _create_legacy_blocked_task(title: str = "legacy gate") -> str:
+    """Construct a legacy / non-sticky blocked row without a ``blocked`` event.
+
+    Simulates pre-#109334 rows or direct DB triage where a card has status
+    'blocked' but no sticky 'blocked' event in ``task_events``. Because it
+    lacks a sticky block event, default ``recompute_ready()`` would auto-promote
+    it to 'ready'. Testing read surfaces against this guarantees that the
+    protection comes from ``include_blocked=False`` rather than from sticky
+    event checking (which passes automatically once #109334 lands).
+    """
+    with kbc.connect() as conn:
+        task_id = kb.create_task(conn, title=title)
+        conn.execute("UPDATE tasks SET status = 'blocked' WHERE id = ?", (task_id,))
+        conn.commit()
+        return task_id
 
 
 def _task_state(task_id: str) -> tuple[str, list[str]]:
@@ -39,9 +57,13 @@ def _task_state(task_id: str) -> tuple[str, list[str]]:
         return task.status, [event.kind for event in kb.list_events(conn, task_id)]
 
 
-def test_cli_list_does_not_recover_blocked_tasks(kanban_home: Path) -> None:
-    """A CLI list must not release a blocked task as a read side effect."""
-    task_id = _create_blocked_task()
+def test_cli_list_does_not_recover_legacy_blocked_tasks(kanban_home: Path) -> None:
+    """A CLI list must not recover legacy/non-sticky blocked rows.
+
+    This directly tests the ``include_blocked=False`` read-surface filter
+    against rows that do not have a sticky block event in task_events.
+    """
+    task_id = _create_legacy_blocked_task("legacy cli gate")
 
     payload = json.loads(kc.run_slash("list --json --status blocked"))
 
@@ -52,9 +74,9 @@ def test_cli_list_does_not_recover_blocked_tasks(kanban_home: Path) -> None:
     assert "promoted" not in events
 
 
-def test_tool_list_does_not_recover_blocked_tasks(kanban_home: Path) -> None:
-    """The orchestrator list tool must preserve the same read boundary."""
-    task_id = _create_blocked_task()
+def test_tool_list_does_not_recover_legacy_blocked_tasks(kanban_home: Path) -> None:
+    """The orchestrator list tool must not recover legacy/non-sticky blocked rows."""
+    task_id = _create_legacy_blocked_task("legacy tool gate")
 
     from tools import kanban_tools as kt
 
@@ -62,6 +84,19 @@ def test_tool_list_does_not_recover_blocked_tasks(kanban_home: Path) -> None:
 
     assert payload["promoted"] == 0
     assert [task["id"] for task in payload["tasks"]] == [task_id]
+    status, events = _task_state(task_id)
+    assert status == "blocked"
+    assert "promoted" not in events
+
+
+def test_cli_list_does_not_recover_initial_blocked_tasks(kanban_home: Path) -> None:
+    """A CLI list must not release a task created with initial_status='blocked'."""
+    task_id = _create_initial_blocked_task()
+
+    payload = json.loads(kc.run_slash("list --json --status blocked"))
+
+    assert [task["id"] for task in payload] == [task_id]
+    assert payload[0]["status"] == "blocked"
     status, events = _task_state(task_id)
     assert status == "blocked"
     assert "promoted" not in events
@@ -81,6 +116,48 @@ def test_cli_list_keeps_todo_reconciliation(kanban_home: Path) -> None:
     assert listed["status"] == "ready"
     with kbc.connect() as conn:
         assert kb.get_task(conn, child_id).status == "ready"
+
+
+def test_read_skips_circuit_breaker_recovery_contract(kanban_home: Path) -> None:
+    """Document intentional trade-off: reads do not recover transient circuit-breaker blocks.
+
+    Even if consecutive_failures < failure_limit (which default recompute_ready
+    auto-recovers), list reads treat all blocked states as stable and observational.
+    In deployments using list without a background dispatcher, circuit-breaker
+    cards do not auto-recover on read; recovery is deferred to dispatch/lifecycle.
+    """
+    with kbc.connect() as conn:
+        task_id = kb.create_task(conn, title="circuit-breaker candidate")
+        conn.execute(
+            "UPDATE tasks SET status = 'blocked', consecutive_failures = 1, "
+            "last_failure_error = 'transient timeout' WHERE id = ?",
+            (task_id,),
+        )
+        conn.commit()
+
+    # CLI read preserves blocked state
+    payload = json.loads(kc.run_slash("list --json --status blocked"))
+    assert [task["id"] for task in payload] == [task_id]
+    status, events = _task_state(task_id)
+    assert status == "blocked"
+    assert "promoted" not in events
+
+    # Tool read preserves blocked state and reports promoted=0
+    from tools import kanban_tools as kt
+
+    tool_payload = json.loads(kt._handle_list({"status": "blocked", "limit": 10}))
+    assert tool_payload["promoted"] == 0
+    status, events = _task_state(task_id)
+    assert status == "blocked"
+    assert "promoted" not in events
+
+    # In contrast, default recompute_ready (run by dispatcher) recovers it
+    with kbc.connect() as conn:
+        promoted = kb.recompute_ready(conn)
+        assert promoted == 1
+        task = kb.get_task(conn, task_id)
+        assert task.status == "ready"
+        assert task.consecutive_failures == 1
 
 
 def test_dispatch_recompute_keeps_nonsticky_block_recovery(kanban_home: Path) -> None:

--- a/tests/hermes_cli/test_kanban_read_reconciliation.py
+++ b/tests/hermes_cli/test_kanban_read_reconciliation.py
@@ -1,0 +1,94 @@
+"""Read-path regression coverage for Kanban readiness reconciliation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Use a real isolated board for each read-path scenario."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return home
+
+
+def _create_blocked_task() -> str:
+    with kbc.connect() as conn:
+        return kb.create_task(conn, title="approval gate", initial_status="blocked")
+
+
+def _task_state(task_id: str) -> tuple[str, list[str]]:
+    with kbc.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        return task.status, [event.kind for event in kb.list_events(conn, task_id)]
+
+
+def test_cli_list_does_not_recover_blocked_tasks(kanban_home: Path) -> None:
+    """A CLI list must not release a blocked task as a read side effect."""
+    task_id = _create_blocked_task()
+
+    payload = json.loads(kc.run_slash("list --json --status blocked"))
+
+    assert [task["id"] for task in payload] == [task_id]
+    assert payload[0]["status"] == "blocked"
+    status, events = _task_state(task_id)
+    assert status == "blocked"
+    assert "promoted" not in events
+
+
+def test_tool_list_does_not_recover_blocked_tasks(kanban_home: Path) -> None:
+    """The orchestrator list tool must preserve the same read boundary."""
+    task_id = _create_blocked_task()
+
+    from tools import kanban_tools as kt
+
+    payload = json.loads(kt._handle_list({"status": "blocked", "limit": 10}))
+
+    assert payload["promoted"] == 0
+    assert [task["id"] for task in payload["tasks"]] == [task_id]
+    status, events = _task_state(task_id)
+    assert status == "blocked"
+    assert "promoted" not in events
+
+
+def test_cli_list_keeps_todo_reconciliation(kanban_home: Path) -> None:
+    """Read-time todo reconciliation remains available for compatibility."""
+    with kbc.connect() as conn:
+        parent_id = kb.create_task(conn, title="parent")
+        child_id = kb.create_task(conn, title="dependent", parents=[parent_id])
+        conn.execute("UPDATE tasks SET status = 'done' WHERE id = ?", (parent_id,))
+        conn.commit()
+
+    payload = json.loads(kc.run_slash("list --json"))
+    listed = next(task for task in payload if task["id"] == child_id)
+
+    assert listed["status"] == "ready"
+    with kbc.connect() as conn:
+        assert kb.get_task(conn, child_id).status == "ready"
+
+
+def test_dispatch_recompute_keeps_nonsticky_block_recovery(kanban_home: Path) -> None:
+    """The dispatcher-facing default still recovers a transient block."""
+    with kbc.connect() as conn:
+        task_id = kb.create_task(conn, title="transient block")
+        conn.execute("UPDATE tasks SET status = 'blocked' WHERE id = ?", (task_id,))
+        conn.commit()
+
+        assert kb.recompute_ready(conn) == 1
+        assert kb.get_task(conn, task_id).status == "ready"

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -521,9 +521,9 @@ def _handle_list(args: dict, **kw) -> str:
     _check(limit >= 1, "limit must be >= 1")
     _check(limit <= KANBAN_LIST_MAX_LIMIT, f"limit must be <= {KANBAN_LIST_MAX_LIMIT}")
     with _board(args.get("board")) as (kb, conn):
-        # Match CLI list: dependencies cleared since the last dispatcher tick
-        # should be visible to orchestrators immediately.
-        promoted = kb.recompute_ready(conn)
+        # Match CLI list: refresh todo dependencies, but leave blocked recovery
+        # to the dispatcher or an explicit lifecycle operation.
+        promoted = kb.recompute_ready(conn, include_blocked=False)
         # One extra row lets the output report truncation without dumping the board.
         rows = kb.list_tasks(
             conn, assignee=args.get("assignee"), status=args.get("status"),

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -848,6 +848,12 @@ hermes kanban gc [--event-retention-days N]            # workspaces + old events
 
 All commands are also available as a slash command in the interactive CLI and in the messaging gateway (see [`/kanban` slash command](#kanban-slash-command) below).
 
+`list` and the orchestrator `kanban_list` tool refresh dependency readiness for
+`todo` cards, but do not recover `blocked` cards. Blocked-task recovery remains
+owned by the dispatcher and explicit lifecycle operations, so inspecting the
+board cannot release a human-approval gate. The `promoted` value returned by
+`kanban_list` therefore counts only the `todo` cards refreshed by that query.
+
 `--max-retries` is a per-task circuit-breaker override for the dispatcher. `--max-retries 1` blocks the task on the first non-successful attempt, while `--max-retries 3` allows two retries and blocks on the third failure. Omit it to use `kanban.failure_limit` from `config.yaml`, then the built-in default.
 
 ### Concurrency, scheduling, and child promotion config

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -854,6 +854,17 @@ owned by the dispatcher and explicit lifecycle operations, so inspecting the
 board cannot release a human-approval gate. The `promoted` value returned by
 `kanban_list` therefore counts only the `todo` cards refreshed by that query.
 
+**Compatibility trade-off (circuit-breaker recovery):** Default `recompute_ready`
+auto-recovers transient circuit-breaker blocks whose `consecutive_failures` is
+below the failure limit. Because `list` and `kanban_list` filter candidate
+recomputation strictly to `todo` tasks (`include_blocked=False`), board reads
+intentionally skip all blocked cards, including non-sticky circuit-breaker
+blocks. In deployments using `hermes kanban list` as a manual mini-dispatch
+without a running background dispatcher daemon, transient circuit-breaker blocks
+will not auto-recover on read; recovering those cards requires running the
+dispatcher (`hermes kanban dispatch`), a dispatcher tick, or an explicit
+lifecycle command (`hermes kanban retry`, `hermes kanban promote`, or unblock).
+
 `--max-retries` is a per-task circuit-breaker override for the dispatcher. `--max-retries 1` blocks the task on the first non-successful attempt, while `--max-retries 3` allows two retries and blocks on the third failure. Omit it to use `kanban.failure_limit` from `config.yaml`, then the built-in default.
 
 ### Concurrency, scheduling, and child promotion config


### PR DESCRIPTION
## Summary

Fixes #109260

Complements #109334, the canonical create-time sticky-block fix. This follow-up closes the confirmed read-path loophole without removing the existing list freshness behavior for dependency-gated `todo` cards.

`hermes kanban list` and the orchestrator `kanban_list` tool now ask `recompute_ready()` to reconcile `todo` cards only. They no longer recover `blocked` cards as a side effect of a board read. The dispatcher and lifecycle callers retain the default behavior that also recovers non-sticky circuit-breaker blocks.

This is intentionally not a replacement for #109334: the canonical event fix remains required so a newly created blocked card is protected during dispatcher/lifecycle recomputation as well. This PR adds the read-side defense and preserves the existing `promoted` response field for `todo` reconciliation.

## Problem observed

On current `origin/main` (`1c671beab29164d8931c5d01c5739502267089d8`), an isolated real CLI probe produced:

- `hermes kanban create ... --initial-status blocked --json` returned status `blocked`.
- The task initially had only a `created` event.
- `hermes kanban list --json --status blocked` immediately caused the task to disappear from the blocked filter because it had been promoted to `ready`.
- A subsequent task read showed a durable `promoted` event.
- No dispatcher or gateway tick was running.

The same behavior was confirmed through the agent-facing `kanban_list` handler.

## Root cause

`recompute_ready()` is a mutating state transition, not a query: it opens a write transaction, scans `todo` and `blocked` rows, updates eligible statuses, and appends `promoted` events.

Both read surfaces called it unconditionally:

- `hermes_cli/kanban.py:_cmd_list()`
- `tools/kanban_tools.py:_handle_list()`

The existing function deliberately includes `blocked` rows because the dispatcher must recover non-sticky circuit-breaker blocks. A task created directly with `initial_status="blocked"` may not yet have the lifecycle event recognized by `_has_sticky_block()`; for a parentless task, the empty parent set satisfies the existing dependency predicate and the read-side recompute changes it to `ready`.

The canonical PR #109334 repairs the missing creation-time event. This follow-up separates the read caller's candidate policy from the dispatcher policy, so even legacy or otherwise non-sticky blocked rows cannot be recovered by list discovery.

## Impact and scope

Affected:

- CLI `hermes kanban list` / `ls`.
- Orchestrator-facing `kanban_list`.
- Initially blocked or other blocked cards that lack a sticky event and would otherwise be eligible for recovery during a read.

Preserved:

- Dispatcher recomputation still includes `blocked` by default.
- Lifecycle mutation paths such as completion, unlink, archive, and explicit status transitions retain their existing recomputation behavior.
- Eligible `todo` dependency cards still become `ready` during CLI/tool list calls, preserving the existing freshness contract and `promoted` count semantics.
- `show`, dashboard `GET /board`, and lower-level `get_task`/`list_tasks` behavior is unchanged; those paths were already status-read-only.

Security and integrity:

- This is technically relevant to workflow authorization and durable-state integrity because an inspection request could release a human-approval gate.
- It does not alter Hermes's documented OS-level isolation boundary, credentials, profiles, tenants, or surface authorization. It is handled as a correctness/integrity fix, not an official security advisory.

Performance:

- The new flag changes only the candidate status filter. The read path still performs one bounded candidate query and the existing `todo` reconciliation work; it does not add a second scan or per-card backfill.
- Dispatcher/lifecycle callers use the unchanged default candidate set, so their asymptotic behavior and I/O pattern are preserved.

## Solution

`recompute_ready()` now accepts a keyword-only `include_blocked` policy, defaulting to `True` for backward compatibility.

- `include_blocked=True`: existing dispatcher/lifecycle behavior; candidates are `todo` and `blocked`.
- `include_blocked=False`: read callers reconcile `todo` only; blocked recovery is deferred to dispatcher or explicit lifecycle operations.

The candidate SQL uses parameterized placeholders for the internal one- or two-status tuple. No schema migration, new status, environment variable, or duplicate readiness implementation is introduced.

The new regression file covers:

1. CLI list does not recover a blocked task or append `promoted`.
2. `kanban_list` does not recover a blocked task and reports `promoted: 0`.
3. CLI list still reconciles an eligible `todo` dependency.
4. Default dispatcher-facing `recompute_ready()` still recovers a non-sticky transient block.

Alternatives considered:

- Removing all `recompute_ready()` calls from list surfaces, as proposed by open PR #81823, would make reads fully observational but also remove the existing immediate `todo` freshness behavior. That PR is a separate, broader and currently conflicting alternative.
- Removing all `blocked` rows from `recompute_ready()` would break the intentional circuit-breaker recovery path.
- Inferring stickiness from the `created` payload or adding a new schema gate would duplicate or widen the canonical lifecycle model; #109334 already owns the create-time event correction.
- Making `dispatch --dry-run` read-only is covered by separate open work (#104119) and is outside this follow-up.

## Compatibility and residual risks

- `include_blocked` defaults to `True`, so existing direct callers are unchanged.
- The `kanban_list` JSON shape remains unchanged; `promoted` now counts only `todo` rows reconciled by that read, and remains `0` when the listed work is blocked.
- Existing legacy cards created before #109334 can still require the canonical event fix or an explicit migration for dispatcher protection. This PR specifically prevents their recovery through CLI/tool list reads; it does not silently backfill board state.
- A list read still uses the normal Kanban connection and may perform ordinary database initialization/migration work on a fresh or legacy database. This PR is a status-transition boundary, not a physically read-only SQLite connection redesign.

## Tests and verification

| Command | Purpose | Result |
|---|---|---|
| `scripts/run_tests.sh tests/hermes_cli/test_kanban_read_reconciliation.py -q` before production change | TDD RED proof on `origin/main` | 2 failed, 2 passed; both failures were the reported CLI/tool promotion behavior |
| `scripts/run_tests.sh tests/hermes_cli/test_kanban_read_reconciliation.py -q` | Focused regression | 4 passed, 0 failed |
| `scripts/run_tests.sh tests/hermes_cli/test_kanban_read_reconciliation.py tests/hermes_cli/test_kanban_blocked_sticky.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_block_kinds.py tests/hermes_cli/test_kanban_cli.py tests/tools/test_kanban_tools.py` | Changed path plus adjacent Kanban coverage | 80 passed, 2 failed |
| `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_block_kinds.py tests/hermes_cli/test_kanban_review_lifecycle_complete.py tests/hermes_cli/test_kanban_specify_db.py` on clean `origin/main` | Failure attribution for the overlapping database/lifecycle files | 57 passed, 2 failed; the same two pre-existing Windows failures reproduced: `test_rate_limit_exit_requeues_without_counting_failure` and `test_worktree_workspace_explicit_target_materializes_linked_worktree` |
| `scripts/run_tests.sh tests/hermes_cli/test_kanban_swarm.py tests/hermes_cli/test_kanban_specify_db.py tests/hermes_cli/test_kanban_decompose_db.py tests/plugins/test_kanban_dashboard_plugin.py` | Additional recompute/lifecycle/dashboard coverage | 48 passed, 0 failed |
| `python -m py_compile hermes_cli/kanban_db.py hermes_cli/kanban.py tools/kanban_tools.py tests/hermes_cli/test_kanban_read_reconciliation.py` | Syntax validation | Passed |
| `ruff check hermes_cli/kanban_db.py hermes_cli/kanban.py tools/kanban_tools.py tests/hermes_cli/test_kanban_read_reconciliation.py` | Python lint | Passed |
| `git diff --check` | Patch whitespace validation | Passed |
| `graphify update . --no-cluster` | Required post-edit graph synchronization | Passed; graph rebuilt with 227,746 nodes and 505,553 edges. Four unrelated repository files were reported as partially extractable syntax inputs. |
| `npm run check` | Repository JS/workspace check | Blocked by the environment before any changed JS path was checked: the worktree had no `node_modules`, and the root run failed on missing TypeScript/React/Vitest dependencies. A follow-up `npm ci --ignore-scripts` was rejected with `EBADENGINE` because the host has Node `v22.16.0`/npm `11.4.1`, while the repository requires Node `^22.22.0 || ^24.11.0 || >=26.0.0` and npm `<11.10.0 || >=11.17.0`. |

The branch was created from current `origin/main` in an isolated worktree. It contains one commit authored and committed by `joaomarcos`, with no foreign trailers or unrelated commits.

## Files and documentation

- `hermes_cli/kanban_db.py` — keyword-only candidate policy for `recompute_ready()`.
- `hermes_cli/kanban.py` — CLI list passes `include_blocked=False`.
- `tools/kanban_tools.py` — `kanban_list` passes `include_blocked=False`.
- `tests/hermes_cli/test_kanban_read_reconciliation.py` — RED/GREEN regression and non-regression coverage.
- `website/docs/user-guide/features/kanban.md` — documents that list refreshes `todo` readiness but does not recover blocked cards.

Related work:

- Canonical create-time event fix: #109334.
- Broader fully non-mutating list alternative: #81823.
- Dry-run mutation fix: #104119.
- Promotion row-count audit fix: #107340.

This PR is an original complementary implementation. It does not copy, cherry-pick, rewrite, or supersede another contributor's commit or branch.
