### PR TITLE
fix(agent): fall back to /props when /v1/props lacks n_ctx and guard json (#108638)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -915,29 +915,49 @@ def _apply_llamacpp_props(cache: Dict[str, Dict[str, Any]], request_candidate: s
     ``/props`` for older builds). In router mode the bare endpoint 400s, so each LOADED child is read
     via ``/props?model=``; unloaded children are skipped — probing could autoload them."""
     base = request_candidate.rstrip("/").replace("/v1", "")
-    def _props(params=None):
-        resp = requests.get(base + "/v1/props", params=params, headers=headers, timeout=5, verify=verify)
-        if not resp.ok:
-            resp = requests.get(base + "/props", params=params, headers=headers, timeout=5, verify=verify)
-        return resp
+
     def _n_ctx(props: Dict[str, Any]) -> Any:
+        if not isinstance(props, dict):
+            return None
         return (props.get("default_generation_settings") or {}).get("n_ctx")
-    props_resp = _props()
-    if props_resp.ok:
-        props = props_resp.json()
-        n_ctx, model_alias = _n_ctx(props), props.get("model_alias", "")
+
+    def _safe_json(resp) -> Optional[Dict[str, Any]]:
+        try:
+            return resp.json() if resp.ok else None
+        except Exception:
+            return None
+
+    def _fetch_valid_props(params=None) -> Optional[Dict[str, Any]]:
+        """Try /v1/props then /props; return first payload that contains n_ctx, else None."""
+        for path in ("/v1/props", "/props"):
+            try:
+                resp = requests.get(base + path, params=params, headers=headers, timeout=5, verify=verify)
+            except Exception:
+                continue
+            payload = _safe_json(resp)
+            if payload is not None and _n_ctx(payload):
+                return payload
+        return None
+
+    payload = _fetch_valid_props()
+    if payload is not None:
+        n_ctx, model_alias = _n_ctx(payload), payload.get("model_alias", "")
         if n_ctx and model_alias and model_alias in cache:
             cache[model_alias]["context_length"] = n_ctx
         return
     native = requests.get(base + "/models", headers=headers, timeout=5, verify=verify)
     if not native.ok:
         return
-    for child in (native.json() or {}).get("data", [])[:16]:
+    try:
+        data = (native.json() or {}).get("data", [])
+    except Exception:
+        return
+    for child in data[:16]:
         child_id = child.get("id") if isinstance(child, dict) else None
         if not child_id or child_id not in cache or (child.get("status") or {}).get("value") not in ("loaded", "ready"):
             continue
-        pr = _props({"model": child_id})
-        child_ctx = _n_ctx(pr.json()) if pr.ok else None
+        child_payload = _fetch_valid_props({"model": child_id})
+        child_ctx = _n_ctx(child_payload) if child_payload is not None else None
         if child_ctx:
             cache[child_id]["context_length"] = child_ctx
 


### PR DESCRIPTION
Fixes #108638

**Root cause — 3 compounding defects in `_apply_llamacpp_props()` (`agent/model_metadata.py:872`):**

1. `/v1/props` → `/props` fallback gated on `resp.ok` (HTTP status). A build serving both paths with different shapes (200 with `{"object":"props"}` on `/v1/props`, truth on `/props`) never reached the fallback.
2. `props_resp.json()` unguarded — a 200 with an HTML body raises instead of being treated as a miss.
3. The `return` after the assignment sat at the same indentation as `if n_ctx and model_alias ...`, so it fired whether or not `n_ctx` was found — making router-mode per-child probing unreachable for any server answering `/v1/props` with 200.

Resolution then fell through to `/models`-advertised `context_length` (aggregate N for `-c N -np K`) while a single request can only use N/K, so every compression threshold was too large.

**Fix:**
- Try `/v1/props` then `/props`, returning the first payload that actually contains `default_generation_settings.n_ctx` (payload-shape fallback, not just status).
- Guard all `resp.json()` calls; HTML/non-JSON 200s are treated as misses.
- Only `return` early after a valid `n_ctx` payload is found; otherwise fall through to router-mode per-child probing (`/props?model=`).
- Same guards for per-child probes and for `/models` listing in router mode.

**Tests:** `tests/agent/test_model_metadata.py` 126 passed. Manual stub reproducing the reported `/v1/props={object:props}` + `/props={n_ctx:200192}` case, the HTML-body case, and the router-mode case all now resolve to the per-slot `n_ctx`.