### PR TITLE
fix(tui): refresh all live sessions on reload.mcp

### DIFF
--- a/tests/tui_gateway/test_mcp_reload_all_sessions.py
+++ b/tests/tui_gateway/test_mcp_reload_all_sessions.py
@@ -6,8 +6,12 @@ missing/unknown (desktop callers pass ``activeSessionId ?? undefined``) it
 refreshed NO agent while still answering ``{'status': 'reloaded'}``. Every
 other live session kept its stale ``agent.tools`` until ``/new``.
 
-Invariant: after reload.mcp, every live session's agent reflects the new tool
-registry, and each session gets its own ``session.info`` push.
+Invariants: after reload.mcp, every live session's agent reflects the new tool
+registry; each refreshed session gets its own ``session.info`` push; compute-host
+sessions are forwarded to the host (its own reload.mcp fans out there); running
+sessions defer to the next turn boundary; a replaced session is never refreshed
+or emitted through; a failed session reports partial instead of a success-shaped
+stale session.info.
 """
 
 from __future__ import annotations
@@ -58,8 +62,8 @@ def _agent(tool_names):
     return a
 
 
-def _live_session(sid: str, agent, transport) -> dict:
-    return {
+def _live_session(sid: str, agent, transport, **overrides) -> dict:
+    session = {
         "agent": agent,
         "session_key": sid,
         "history": [],
@@ -75,17 +79,19 @@ def _live_session(sid: str, agent, transport) -> dict:
         "profile_home": None,
         "transport": transport,
     }
+    session.update(overrides)
+    return session
 
 
 @pytest.fixture()
-def reload_env(monkeypatch, tmp_path):
+def reload_env(monkeypatch):
     """Stub the global pool rebuild; keep the real per-agent refresh path."""
     defs = [_tool(n) for n in ("read_file", "terminal", "mcp_new_server_tool")]
     monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kw: list(defs))
     # get_tool_definitions is also reachable through tools.mcp_tool; keep both in step.
     monkeypatch.setattr(mcp_tool, "get_tool_definitions", lambda **kw: list(defs), raising=False)
-    monkeypatch.setattr(_mcp_lifecycle, "shutdown_mcp_servers", lambda: None)
-    monkeypatch.setattr(_mcp_discovery, "discover_mcp_tools", lambda: None)
+    monkeypatch.setattr(_mcp_lifecycle, "shutdown_mcp_servers", lambda **kw: None)
+    monkeypatch.setattr(_mcp_discovery, "discover_mcp_tools", lambda *a, **kw: [])
     monkeypatch.setattr(srv, "_compute_mcp_rev", lambda: "rev-a")
 
     saved = (srv._mcp_reload_gen, srv._mcp_reload_loaded_rev)
@@ -120,6 +126,7 @@ def test_reload_mcp_refreshes_every_live_session(two_sessions):
     result = srv._methods["reload.mcp"](1, {"session_id": "s1", "confirm": True})
 
     assert result["result"]["status"] == "reloaded"
+    assert result["result"]["sessions_refreshed"] == 2
     for sid, agent in agents.items():
         assert "mcp_new_server_tool" in agent.valid_tool_names
         assert any(t["function"]["name"] == "mcp_new_server_tool" for t in agent.tools)
@@ -139,3 +146,201 @@ def test_reload_mcp_without_requester_session_still_refreshes(two_sessions, para
     for sid, agent in agents.items():
         assert "mcp_new_server_tool" in agent.valid_tool_names
         assert _info_sids(transports[sid]) == [sid]
+
+
+def test_reload_mcp_defers_running_session_to_turn_boundary(reload_env, monkeypatch):
+    """A mid-turn sibling must not have its tools swapped under it: the refresh
+    is queued (``pending_mcp_refresh``) and applied at the next turn start."""
+    running_agent, idle_agent = _agent(["read_file"]), _agent(["read_file"])
+    running_t, idle_t = _Recorder(), _Recorder()
+    srv._sessions["busy"] = _live_session("busy", running_agent, running_t, running=True)
+    srv._sessions["idle"] = _live_session("idle", idle_agent, idle_t)
+    try:
+        result = srv._methods["reload.mcp"](1, {"session_id": "idle", "confirm": True})
+
+        assert result["result"]["sessions_refreshed"] == 1
+        assert result["result"]["sessions_deferred"] == 1
+        assert "mcp_new_server_tool" not in running_agent.valid_tool_names
+        assert srv._sessions["busy"]["pending_mcp_refresh"] is True
+        assert _info_sids(running_t) == []  # no success-shaped info for a session not yet refreshed
+        assert "mcp_new_server_tool" in idle_agent.valid_tool_names
+
+        srv._apply_pending_mcp_refresh("busy", srv._sessions["busy"])
+
+        assert "mcp_new_server_tool" in running_agent.valid_tool_names
+        assert "pending_mcp_refresh" not in srv._sessions["busy"]
+        assert _info_sids(running_t) == ["busy"]
+    finally:
+        srv._sessions.pop("busy", None)
+        srv._sessions.pop("idle", None)
+
+
+def test_reload_mcp_skips_session_replaced_after_snapshot(reload_env, monkeypatch):
+    """A sid removed/replaced between the _sessions snapshot and its refresh
+    must not be mutated or emitted through the replacement's transport."""
+    old_agent, new_agent = _agent(["read_file"]), _agent(["read_file"])
+    old_t, new_t = _Recorder(), _Recorder()
+    old_sess = _live_session("s1", old_agent, old_t)
+    srv._sessions["s1"] = old_sess
+
+    real_uses_host = srv._session_uses_compute_host
+    calls = {"n": 0}
+
+    def _swap_on_check(sess):
+        # Call 1 is the requester's compute-host check (pre-snapshot); call 2 is the
+        # loop's — swap there to simulate the replace landing after the snapshot.
+        calls["n"] += 1
+        if sess is old_sess and calls["n"] > 1:
+            srv._sessions["s1"] = _live_session("s1", new_agent, new_t)
+        return real_uses_host(sess)
+
+    monkeypatch.setattr(srv, "_session_uses_compute_host", _swap_on_check)
+    try:
+        result = srv._methods["reload.mcp"](1, {"session_id": "s1", "confirm": True})
+
+        assert result["result"]["status"] == "reloaded"
+        assert "mcp_new_server_tool" not in old_agent.valid_tool_names
+        assert "mcp_new_server_tool" not in new_agent.valid_tool_names
+        assert _info_sids(old_t) == [] and _info_sids(new_t) == []
+    finally:
+        srv._sessions.pop("s1", None)
+
+
+def test_reload_mcp_reports_partial_failure(two_sessions, monkeypatch):
+    """One session's refresh raising must not fail the reload or the siblings:
+    the failure lands in sessions_failed and no session.info is emitted for it."""
+    agents, transports = two_sessions
+
+    import tools.mcp_tool_agent as mcp_agent_mod
+    real_refresh = mcp_agent_mod.refresh_agent_mcp_tools
+
+    def _flaky(agent, **kw):
+        if agent is agents["s2"]:
+            raise RuntimeError("boom")
+        return real_refresh(agent, **kw)
+
+    monkeypatch.setattr(mcp_agent_mod, "refresh_agent_mcp_tools", _flaky)
+
+    result = srv._methods["reload.mcp"](1, {"session_id": "s1", "confirm": True})
+
+    assert result["result"]["status"] == "reloaded"
+    assert result["result"]["sessions_refreshed"] == 1
+    assert result["result"]["sessions_failed"] == {"s2": "boom"}
+    assert "mcp_new_server_tool" in agents["s1"].valid_tool_names
+    assert "mcp_new_server_tool" not in agents["s2"].valid_tool_names
+    assert _info_sids(transports["s1"]) == ["s1"]
+    assert _info_sids(transports["s2"]) == []
+
+
+class _FakeSupervisor:
+    def __init__(self, ack):
+        self.ack = ack
+        self.calls = []
+
+    def reload_mcp(self, sid, *, request_id=None):
+        self.calls.append(sid)
+        return self.ack
+
+
+def _host_env(reload_env, monkeypatch, ack):
+    """Turn isolation on; one host-owned session + one local session."""
+    monkeypatch.setattr(srv, "_turn_isolation_enabled", lambda cfg=None: True)
+    supervisor = _FakeSupervisor(ack)
+    monkeypatch.setattr(srv, "_get_compute_host_supervisor", lambda *a, **k: supervisor)
+    host_t, local_t = _Recorder(), _Recorder()
+    host_agent, local_agent = _agent(["read_file"]), _agent(["read_file"])
+    srv._sessions["host-s"] = _live_session(
+        "host-s", host_agent, host_t, _compute_host_active=True)
+    srv._sessions["local-s"] = _live_session("local-s", local_agent, local_t)
+    return supervisor, host_agent, local_agent, host_t, local_t
+
+
+def _drop_host_env():
+    srv._sessions.pop("host-s", None)
+    srv._sessions.pop("local-s", None)
+
+
+def test_reload_mcp_forwards_to_compute_host_sessions(reload_env, monkeypatch):
+    """A local requester with a compute-host sibling: the host session is NOT
+    refreshed in-process (its agent lives in the host) — one forward covers it,
+    and the host's own reload.mcp fans out to every session it owns."""
+    supervisor, host_agent, local_agent, host_t, local_t = _host_env(
+        reload_env, monkeypatch,
+        ack={"type": "reload_mcp.ack", "response": {"result": {"status": "reloaded"}}})
+    try:
+        result = srv._methods["reload.mcp"](1, {"session_id": "local-s", "confirm": True})
+
+        assert result["result"]["status"] == "reloaded"
+        assert result["result"]["compute_host_sessions"] == ["host-s"]
+        assert supervisor.calls == ["host-s"]
+        assert "mcp_new_server_tool" in local_agent.valid_tool_names
+        assert "mcp_new_server_tool" not in host_agent.valid_tool_names
+        assert _info_sids(local_t) == ["local-s"]
+        assert _info_sids(host_t) == []
+    finally:
+        _drop_host_env()
+
+
+def test_reload_mcp_host_requester_also_reloads_local_sessions(reload_env, monkeypatch):
+    """The old early return skipped local siblings when the requester was a
+    compute-host session; now the forward happens AND the local pool reloads."""
+    supervisor, host_agent, local_agent, host_t, local_t = _host_env(
+        reload_env, monkeypatch,
+        ack={"type": "reload_mcp.ack", "response": {"result": {"status": "reloaded"}}})
+    try:
+        result = srv._methods["reload.mcp"](1, {"session_id": "host-s", "confirm": True})
+
+        assert result["result"]["status"] == "reloaded"
+        assert result["result"]["turn_isolation"] is True
+        assert supervisor.calls == ["host-s"]
+        assert "mcp_new_server_tool" in local_agent.valid_tool_names
+        assert "mcp_new_server_tool" not in host_agent.valid_tool_names
+    finally:
+        _drop_host_env()
+
+
+def test_reload_mcp_host_ack_error_is_not_success(reload_env, monkeypatch):
+    """An ack wrapper is not proof: a child JSON-RPC error inside
+    reload_mcp.ack must surface as compute_host_error, not silent success."""
+    supervisor, host_agent, local_agent, host_t, local_t = _host_env(
+        reload_env, monkeypatch,
+        ack={"type": "reload_mcp.ack",
+             "response": {"error": {"code": 5015, "message": "discovery blew up"}}})
+    try:
+        result = srv._methods["reload.mcp"](1, {"session_id": "local-s", "confirm": True})
+
+        assert result["result"]["status"] == "reloaded"
+        assert "discovery blew up" in result["result"]["compute_host_error"]
+        assert "mcp_new_server_tool" in local_agent.valid_tool_names
+    finally:
+        _drop_host_env()
+
+
+def test_reload_mcp_discovers_per_session_profile(reload_env, monkeypatch, tmp_path):
+    """The unscoped shutdown tears down every profile's connections, so
+    rediscovery must run once per live session's profile scope — ambient-only
+    discovery would leave non-ambient profiles' servers dead."""
+    import hermes_constants
+
+    profile_home = tmp_path / "profile-b"
+    profile_home.mkdir()
+    homes_seen = []
+    monkeypatch.setattr(
+        _mcp_discovery, "discover_mcp_tools",
+        lambda *a, **kw: homes_seen.append(hermes_constants.hermes_home_key()) or [])
+
+    agent_a, agent_b = _agent(["read_file"]), _agent(["read_file"])
+    srv._sessions["pa"] = _live_session("pa", agent_a, _Recorder())
+    srv._sessions["pb"] = _live_session("pb", agent_b, _Recorder(), profile_home=str(profile_home))
+    try:
+        result = srv._methods["reload.mcp"](1, {"session_id": "pa", "confirm": True})
+
+        assert result["result"]["status"] == "reloaded"
+        assert "mcp_new_server_tool" in agent_a.valid_tool_names
+        assert "mcp_new_server_tool" in agent_b.valid_tool_names
+        ambient = hermes_constants.hermes_home_key()
+        assert ambient in homes_seen
+        assert hermes_constants.hermes_home_key(profile_home) in homes_seen
+    finally:
+        srv._sessions.pop("pa", None)
+        srv._sessions.pop("pb", None)

--- a/tests/tui_gateway/test_mcp_reload_all_sessions.py
+++ b/tests/tui_gateway/test_mcp_reload_all_sessions.py
@@ -1,0 +1,141 @@
+"""reload.mcp must refresh EVERY live session's cached agent tools.
+
+The handler rebuilt the process-global MCP pool but refreshed only the
+requesting session's agent snapshot — and when ``params['session_id']`` was
+missing/unknown (desktop callers pass ``activeSessionId ?? undefined``) it
+refreshed NO agent while still answering ``{'status': 'reloaded'}``. Every
+other live session kept its stale ``agent.tools`` until ``/new``.
+
+Invariant: after reload.mcp, every live session's agent reflects the new tool
+registry, and each session gets its own ``session.info`` push.
+"""
+
+from __future__ import annotations
+
+import threading
+import types
+
+import pytest
+
+import model_tools
+import tools.mcp_tool as mcp_tool
+from tools import mcp_tool_discovery as _mcp_discovery
+from tools import mcp_tool_lifecycle as _mcp_lifecycle
+import tui_gateway.server as srv
+
+
+def _tool(name):
+    return {"type": "function", "function": {"name": name, "description": "", "parameters": {}}}
+
+
+class _Recorder:
+    """Session transport that captures every frame written to it."""
+
+    def __init__(self):
+        self.frames = []
+
+    def write(self, obj) -> bool:
+        self.frames.append(obj)
+        return True
+
+
+def _agent(tool_names):
+    a = types.SimpleNamespace()
+    a.tools = [_tool(n) for n in tool_names]
+    a.valid_tool_names = set(tool_names)
+    a.enabled_toolsets = None
+    a.disabled_toolsets = None
+    a.model = "test-model"
+    a.provider = "test"
+    a.api_key = "test-key"
+    a.session_id = ""
+    a.reasoning_config = None
+    a.service_tier = None
+    a.context_compressor = None
+    a._session_db = None
+    a._cached_system_prompt = ""
+    a._bot_mode_protocol = False
+    return a
+
+
+def _live_session(sid: str, agent, transport) -> dict:
+    return {
+        "agent": agent,
+        "session_key": sid,
+        "history": [],
+        "history_lock": threading.RLock(),
+        "history_version": 0,
+        "inflight_turn": None,
+        "running": False,
+        "attached_images": [],
+        "image_counter": 0,
+        "cwd": "",
+        "cols": 80,
+        "source": "tui",
+        "profile_home": None,
+        "transport": transport,
+    }
+
+
+@pytest.fixture()
+def reload_env(monkeypatch, tmp_path):
+    """Stub the global pool rebuild; keep the real per-agent refresh path."""
+    defs = [_tool(n) for n in ("read_file", "terminal", "mcp_new_server_tool")]
+    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kw: list(defs))
+    # get_tool_definitions is also reachable through tools.mcp_tool; keep both in step.
+    monkeypatch.setattr(mcp_tool, "get_tool_definitions", lambda **kw: list(defs), raising=False)
+    monkeypatch.setattr(_mcp_lifecycle, "shutdown_mcp_servers", lambda: None)
+    monkeypatch.setattr(_mcp_discovery, "discover_mcp_tools", lambda: None)
+    monkeypatch.setattr(srv, "_compute_mcp_rev", lambda: "rev-a")
+
+    saved = (srv._mcp_reload_gen, srv._mcp_reload_loaded_rev)
+    srv._mcp_reload_gen = 0
+    srv._mcp_reload_loaded_rev = ""
+    yield
+    srv._mcp_reload_gen, srv._mcp_reload_loaded_rev = saved
+
+
+@pytest.fixture()
+def two_sessions(reload_env):
+    """Two live sessions whose agents hold a stale pre-reload snapshot."""
+    agents = {sid: _agent(["read_file", "terminal"]) for sid in ("s1", "s2")}
+    transports = {sid: _Recorder() for sid in agents}
+    for sid, agent in agents.items():
+        srv._sessions[sid] = _live_session(sid, agent, transports[sid])
+    yield agents, transports
+    for sid in agents:
+        srv._sessions.pop(sid, None)
+
+
+def _info_sids(transport: _Recorder) -> list:
+    return [f["params"]["session_id"] for f in transport.frames
+            if f.get("method") == "event" and f.get("params", {}).get("type") == "session.info"]
+
+
+def test_reload_mcp_refreshes_every_live_session(two_sessions):
+    """A reload requested by s1 must rebuild s2's snapshot too — the pool is
+    process-global, so a per-requester refresh leaves siblings stale."""
+    agents, transports = two_sessions
+
+    result = srv._methods["reload.mcp"](1, {"session_id": "s1", "confirm": True})
+
+    assert result["result"]["status"] == "reloaded"
+    for sid, agent in agents.items():
+        assert "mcp_new_server_tool" in agent.valid_tool_names
+        assert any(t["function"]["name"] == "mcp_new_server_tool" for t in agent.tools)
+        assert _info_sids(transports[sid]) == [sid]
+
+
+@pytest.mark.parametrize("params", [{"confirm": True}, {"session_id": "no-such-session", "confirm": True}],
+                         ids=["missing", "unknown"])
+def test_reload_mcp_without_requester_session_still_refreshes(two_sessions, params):
+    """Desktop callers can send no/unknown session_id; the reload must not
+    silently refresh zero agents while reporting success."""
+    agents, transports = two_sessions
+
+    result = srv._methods["reload.mcp"](1, params)
+
+    assert result["result"]["status"] == "reloaded"
+    for sid, agent in agents.items():
+        assert "mcp_new_server_tool" in agent.valid_tool_names
+        assert _info_sids(transports[sid]) == [sid]

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -282,18 +282,25 @@ def _(rid, params: dict) -> dict:
     # (generation-only coalescing).
     req_rev = str(params.get("rev") or "")
 
-    def _refresh_session_agent() -> None:
-        """Rebuild THIS session's cached tool snapshot + push session.info (the agent never
-        re-reads the registry). Runs under _mcp_reload_lock so a concurrent reload can't
-        tear the registry down mid-refresh."""
-        if not session:
-            return
-        agent = session["agent"]
-        try:  # enabled_override re-resolves toolsets so a server enabled in config this session is picked up
-            _mcp_agent.refresh_agent_mcp_tools(agent, enabled_override=_load_enabled_toolsets(), quiet_mode=True)
-        except Exception as _exc:
-            logger.warning("Failed to refresh cached agent tools after /reload-mcp: %s", _exc)
-        _emit("session.info", params.get("session_id", ""), _session_info(agent, session))
+    def _refresh_session_agents() -> None:
+        """Rebuild EVERY live session's cached tool snapshot + push session.info (agents never
+        re-read the registry). The pool is process-global, so refreshing only the requester leaves
+        siblings stale — and a missing/unknown session_id would refresh nothing at all. Runs under
+        _mcp_reload_lock so a concurrent reload can't tear the registry down mid-refresh."""
+        with _sessions_lock:
+            sessions = list(_sessions.items())
+        for sid, sess in sessions:
+            agent = sess.get("agent")
+            # agent=None: lazy session (nothing cached to refresh). Compute-host sessions: the
+            # agent lives in the host process — the RPC forwards there separately.
+            if agent is None or _session_uses_compute_host(sess):
+                continue
+            try:  # enabled_override re-resolves toolsets so a server enabled in config this session is picked up
+                _mcp_agent.refresh_agent_mcp_tools(
+                    agent, enabled_override=_load_enabled_toolsets(_session_source(sess)), quiet_mode=True)
+            except Exception as _exc:
+                logger.warning("Failed to refresh cached agent tools after /reload-mcp: %s", _exc)
+            _emit_session_info_for_session(sid, sess)
 
     def _do_full_reload() -> None:
         """shutdown+discover+refresh under the lock, then mark a completed generation. Config
@@ -309,7 +316,7 @@ def _(rid, params: dict) -> dict:
             if after == loaded:
                 break
             loaded = after
-        _refresh_session_agent()
+        _refresh_session_agents()
         _mcp_reload_loaded_rev = loaded
         _mcp_reload_gen += 1
 
@@ -325,7 +332,7 @@ def _(rid, params: dict) -> dict:
     gen_before = _mcp_reload_gen
     with _mcp_reload_lock:
         coalesced = _mcp_reload_gen > gen_before and (not req_rev or req_rev == _mcp_reload_loaded_rev)
-        _refresh_session_agent() if coalesced else _do_full_reload()
+        _refresh_session_agents() if coalesced else _do_full_reload()
     return _finish_reload(rid, params, coalesced=coalesced)
 
 

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -268,13 +268,6 @@ def _(rid, params: dict) -> dict:
             "Reply `/reload-mcp now` to proceed, or `/reload-mcp always` to proceed and "
             "silence this prompt permanently.")
         return _ok(rid, {"status": "confirm_required", "message": message})
-    if session and _session_uses_compute_host(session):
-        try:
-            ack = _get_compute_host_supervisor().reload_mcp(
-                str(params.get("session_id") or ""), request_id=f"reload-mcp-{rid}")
-        except Exception as exc:
-            return _err(rid, 5019, f"compute-host reload_mcp failed: {exc}")
-        return _ok(rid, {"status": "reloaded", "turn_isolation": True, "host_ack": ack})
     _mcp_agent, _mcp_lifecycle, _mcp_discovery = (
         _tools_mod("tools.mcp_tool_agent"), _tools_mod("tools.mcp_tool_lifecycle"), _tools_mod("tools.mcp_tool_discovery"))
     global _mcp_reload_gen, _mcp_reload_loaded_rev
@@ -282,30 +275,89 @@ def _(rid, params: dict) -> dict:
     # (generation-only coalescing).
     req_rev = str(params.get("rev") or "")
 
-    def _refresh_session_agents() -> None:
+    def _forward_to_host(sid: str):
+        """One reload_mcp control frame to the compute host. The host re-enters ``reload.mcp``
+        in ITS process, which fans the refresh out to every session it owns — one forward covers
+        all host-side sessions (HostSupervisor owns a single child). Returns (ack, error): the
+        ``reload_mcp.ack`` envelope is NOT proof of success — the child's JSON-RPC response is
+        inspected for ``result`` vs ``error``/``control.error``."""
+        try:
+            ack = _get_compute_host_supervisor().reload_mcp(sid, request_id=f"reload-mcp-{rid}")
+        except Exception as exc:
+            return None, f"compute-host reload_mcp failed: {exc}"
+        resp = ack.get("response") if isinstance(ack, dict) else None
+        if isinstance(resp, dict) and "result" in resp:
+            return ack, None
+        msg = ((resp or {}).get("error") or {}).get("message") or (ack or {}).get("message") \
+            or (ack or {}).get("error") or "no result in reload_mcp.ack"
+        return ack, f"compute-host reload_mcp failed: {msg}"
+
+    # A compute-host requester is forwarded FIRST (its agent lives in the host process), then —
+    # unlike the old early return — local siblings still get the in-process reload below.
+    host_ack = None
+    if session and _session_uses_compute_host(session):
+        host_ack, host_err = _forward_to_host(str(params.get("session_id") or ""))
+        if host_err:
+            return _err(rid, 5019, host_err)
+        if not any(
+                s.get("agent") is not None and not _session_uses_compute_host(s)
+                for s in list(_sessions.values())):
+            return _ok(rid, {"status": "reloaded", "turn_isolation": True, "host_ack": host_ack})
+
+    def _refresh_session_agents() -> dict:
         """Rebuild EVERY live session's cached tool snapshot + push session.info (agents never
         re-read the registry). The pool is process-global, so refreshing only the requester leaves
         siblings stale — and a missing/unknown session_id would refresh nothing at all. Runs under
-        _mcp_reload_lock so a concurrent reload can't tear the registry down mid-refresh."""
+        _mcp_reload_lock so a concurrent reload can't tear the registry down mid-refresh.
+
+        Per-session rules: compute-host sessions are forwarded once to the host (its own reload.mcp
+        fans out there); running sessions defer to the next turn boundary (``pending_mcp_refresh``,
+        applied by _apply_pending_mcp_refresh before request assembly — a mid-turn swap would let a
+        sibling issue against the old schema and validate against the new); a replaced/removed sid
+        is re-validated before refresh AND before emit so a stale agent's info never lands on the
+        replacement's transport. Returns a per-session report for _finish_reload."""
+        report = {"refreshed": 0, "deferred": 0, "failed": {}, "compute_host_sessions": []}
         with _sessions_lock:
             sessions = list(_sessions.items())
         for sid, sess in sessions:
-            agent = sess.get("agent")
-            # agent=None: lazy session (nothing cached to refresh). Compute-host sessions: the
-            # agent lives in the host process — the RPC forwards there separately.
-            if agent is None or _session_uses_compute_host(sess):
+            if _session_uses_compute_host(sess):
+                report["compute_host_sessions"].append(sid)
                 continue
+            if sess.get("agent") is None:
+                continue  # lazy session: nothing cached to refresh
+            with _sessions_lock:
+                if _sessions.get(sid) is not sess:
+                    continue  # replaced/removed since the snapshot
+                if sess.get("running"):
+                    sess["pending_mcp_refresh"] = True
+                    report["deferred"] += 1
+                    continue
             try:  # enabled_override re-resolves toolsets so a server enabled in config this session is picked up
-                _mcp_agent.refresh_agent_mcp_tools(
-                    agent, enabled_override=_load_enabled_toolsets(_session_source(sess)), quiet_mode=True)
+                with _session_profile_runtime_scope(sess):
+                    _mcp_agent.refresh_agent_mcp_tools(
+                        sess["agent"],
+                        enabled_override=_load_enabled_toolsets(_session_source(sess)), quiet_mode=True)
             except Exception as _exc:
                 logger.warning("Failed to refresh cached agent tools after /reload-mcp: %s", _exc)
+                report["failed"][sid] = str(_exc)
+                continue  # no success-shaped session.info for a session that didn't refresh
+            report["refreshed"] += 1
+            with _sessions_lock:
+                if _sessions.get(sid) is not sess:
+                    continue
             _emit_session_info_for_session(sid, sess)
+        if report["compute_host_sessions"] and host_ack is None:
+            report["host_ack"], host_err = _forward_to_host(report["compute_host_sessions"][0])
+            if host_err:
+                report["host_error"] = host_err
+        return report
 
-    def _do_full_reload() -> None:
+    def _do_full_reload() -> dict:
         """shutdown+discover+refresh under the lock, then mark a completed generation. Config
         can change WHILE discover connects: re-hash and repeat until stable so the marked
-        generation matches what loaded."""
+        generation matches what loaded. Discovery runs once per live session's profile scope —
+        the unscoped shutdown tears down every profile's connections, so ambient-only discovery
+        would leave non-ambient profiles' servers dead (gateway multiplex precedent: #95518)."""
         global _mcp_reload_gen, _mcp_reload_loaded_rev
         loaded = _compute_mcp_rev()
         for _ in range(_MCP_RELOAD_MAX_PASSES):
@@ -316,24 +368,33 @@ def _(rid, params: dict) -> dict:
             if after == loaded:
                 break
             loaded = after
-        _refresh_session_agents()
+        with _sessions_lock:
+            homes = {s.get("profile_home") for s in _sessions.values()}
+        for home in sorted(homes - {None}):
+            try:
+                with _session_profile_runtime_scope({"profile_home": home}):
+                    _mcp_discovery.discover_mcp_tools()
+            except Exception as _exc:
+                logger.warning("MCP rediscovery failed for profile %s: %s", home, _exc)
+        report = _refresh_session_agents()
         _mcp_reload_loaded_rev = loaded
         _mcp_reload_gen += 1
+        return report
 
     # LEADER (won the non-blocking acquire) runs the full reload. FOLLOWER waits, then — still
     # holding the lock — coalesces only if a reload COMPLETED meanwhile (generation advanced
     # ⇒ leader didn't throw) AND it loaded the requested revision; otherwise it re-runs.
     if _mcp_reload_lock.acquire(blocking=False):
         try:
-            _do_full_reload()
+            report = _do_full_reload()
         finally:
             _mcp_reload_lock.release()
-        return _finish_reload(rid, params, coalesced=False)
+        return _finish_reload(rid, params, coalesced=False, refresh=report, host_ack=host_ack)
     gen_before = _mcp_reload_gen
     with _mcp_reload_lock:
         coalesced = _mcp_reload_gen > gen_before and (not req_rev or req_rev == _mcp_reload_loaded_rev)
-        _refresh_session_agents() if coalesced else _do_full_reload()
-    return _finish_reload(rid, params, coalesced=coalesced)
+        report = _refresh_session_agents() if coalesced else _do_full_reload()
+    return _finish_reload(rid, params, coalesced=coalesced, refresh=report, host_ack=host_ack)
 
 
 # ─── Command catalog / dispatch ──────────────────────────────────────────────

--- a/tui_gateway/prompt_turn.py
+++ b/tui_gateway/prompt_turn.py
@@ -469,6 +469,9 @@ def _prepare_turn_input(sid: str, session: dict, st: _TurnRun, text: Any, images
         _apply_pending_model_switch(sid, session)
         _sync_agent_model_with_config(sid, session)
         _sync_agent_compression_with_config(sid, session)
+    # A reload.mcp deferred while this session was mid-turn lands here — inside the profile scope
+    # bound above, before request assembly — regardless of the one_turn_restore skip.
+    _apply_pending_mcp_refresh(sid, session)
     _sync_bot_capabilities(sid, session)  # Bot Chat: adopt Settings->Capabilities edits
     st.agent = agent = session["agent"]
     # Snapshot after the model sync: a deferred switch's history mutation belongs to this turn.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3108,15 +3108,32 @@ def _compute_mcp_rev() -> str:
     return ""
 
 
-def _finish_reload(rid, params: dict, *, coalesced: bool) -> dict:
-    """Shared tail for both reload paths: honor ``always`` (persist the confirm opt-out) and return the ok payload."""
+def _finish_reload(rid, params: dict, *, coalesced: bool, refresh: dict | None = None,
+                   host_ack: dict | None = None) -> dict:
+    """Shared tail for both reload paths: honor ``always`` (persist the confirm opt-out) and return the ok payload.
+    ``refresh`` is _refresh_session_agents' per-session report; ``host_ack`` is set when the requester was
+    forwarded to the compute host (its sessions refresh inside the host's own reload.mcp fan-out)."""
     if bool(params.get("always", False)):
         try:
             from cli import save_config_value
             save_config_value("approvals.mcp_reload_confirm", False)
         except Exception as _exc:
             logger.warning("Failed to persist mcp_reload_confirm=false: %s", _exc)
-    return _ok(rid, {"status": "reloaded", "loaded_rev": _mcp_reload_loaded_rev, **({"coalesced": True} if coalesced else {})})
+    payload = {"status": "reloaded", "loaded_rev": _mcp_reload_loaded_rev,
+               **({"coalesced": True} if coalesced else {})}
+    if refresh is not None:
+        payload["sessions_refreshed"] = refresh["refreshed"]
+        if refresh["deferred"]:
+            payload["sessions_deferred"] = refresh["deferred"]
+        if refresh["failed"]:
+            payload["sessions_failed"] = refresh["failed"]
+        if refresh["compute_host_sessions"]:
+            payload["compute_host_sessions"] = refresh["compute_host_sessions"]
+        if refresh.get("host_error"):
+            payload["compute_host_error"] = refresh["host_error"]
+    if host_ack is not None:
+        payload.update(turn_isolation=True, host_ack=host_ack)
+    return _ok(rid, payload)
 
 
 _TUI_HIDDEN: frozenset[str] = frozenset({"sethome", "set-home", "commands", "approve", "deny"})

--- a/tui_gateway/session_compression.py
+++ b/tui_gateway/session_compression.py
@@ -188,6 +188,25 @@ def _apply_pending_model_switch(sid: str, session: dict) -> None:
     except Exception as e:
         _emit("error", sid, {"message": f"Could not switch model: {e}"})
 
+def _apply_pending_mcp_refresh(sid: str, session: dict) -> None:
+    """Apply a tool-snapshot rebuild deferred by ``reload.mcp`` while this session was mid-turn
+    (``session["pending_mcp_refresh"]``). Runs on the TURN thread at turn start — inside the
+    session's profile scope, before request assembly — so the swap can't split a live turn's
+    issue/validate reads. A failed refresh keeps the stale snapshot and never blocks the turn."""
+    if not session.pop("pending_mcp_refresh", None):
+        return
+    agent = session.get("agent")
+    if agent is None:
+        return
+    try:
+        from tools.mcp_tool_agent import refresh_agent_mcp_tools
+        refresh_agent_mcp_tools(
+            agent, enabled_override=_load_enabled_toolsets(_session_source(session)), quiet_mode=True)
+    except Exception as exc:
+        logger.warning("Deferred MCP tool refresh failed for %s: %s", sid, exc)
+        return
+    _emit_session_info_for_session(sid, session)
+
 
 class CompressionLockHeld(Exception):
     """Raised by _compress_session_history when a concurrent compression_locks row skipped compression."""


### PR DESCRIPTION
## What does this PR do?

`reload.mcp` rebuilds the process-global MCP pool but refreshed only the requesting session's cached agent tool snapshot — and when `params['session_id']` was missing/unknown (desktop callers send `activeSessionId ?? undefined`), it refreshed **zero** agents while still answering `{'status': 'reloaded'}`.

The MCP pool is process-global; `agent.tools` snapshots are per-agent. So every other live session kept stale tools until `/new` (which discards conversation history). The between-turns self-heal doesn't cover this: TUI/desktop agents get a concrete `enabled_toolsets` list at build time, so newly-added servers never reach non-requesting sessions, and removing all servers never heals (`has_registered_mcp_tools` gate in `turn_context.py`).

The fix renames `_refresh_session_agent` → `_refresh_session_agents` and fans the refresh out over every live session: snapshot `_sessions` under `_sessions_lock`, skip `agent is None` (lazy sessions) and `_session_uses_compute_host` sessions (their agents live in the host process — the RPC already forwards there separately), resolve `enabled_override` per session via `_session_source(sess)` (the same input `_make_agent` uses), and emit `session.info` per session id via the existing `_emit_session_info_for_session` helper. Both call sites (leader `_do_full_reload` and the coalesced-follower branch) use it, so `_mcp_reload_lock` serialization and rev coalescing are unchanged.

Scope notes: disjoint from open PR #103152 (the `slash.exec` mirror — different file, different gap). The messaging gateway's separate gap (its reload path never passes `enabled_override` in `run_turn.py`) is intentionally left for a follow-up PR.

## Related Issue

Fixes #109382

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/methods_tools.py` — `_refresh_session_agent` → `_refresh_session_agents`: iterate all live sessions (snapshot under `_sessions_lock`), skip lazy (`agent is None`) and compute-host sessions, per-session `enabled_override` via `_load_enabled_toolsets(_session_source(sess))`, per-session `session.info` emit via `_emit_session_info_for_session`; both call sites updated.
- `tests/tui_gateway/test_mcp_reload_all_sessions.py` — new invariant tests exercising the real `srv._methods["reload.mcp"]` dispatch and the real `refresh_agent_mcp_tools` rebuild path (only the global pool rebuild — `shutdown_mcp_servers`/`discover_mcp_tools`/`get_tool_definitions` — is stubbed, matching `test_mcp_reload_rev.py` conventions).

## How to Test

1. Repro on base: two live sessions, request `reload.mcp` from one — the other's `agent.valid_tool_names` never gains the newly-registered tool; with a missing/unknown `session_id`, no agent is refreshed despite `status: reloaded`.
2. `scripts/run_tests.sh tests/tui_gateway/test_mcp_reload_all_sessions.py` — 3 tests, all RED on base, all GREEN on this branch (see Logs).
3. Neighbor regression: `scripts/run_tests.sh tests/tui_gateway/test_mcp_reload_rev.py tests/hermes_cli/test_mcp_reload_confirm_gate.py tests/gateway/test_mcp_reload_refreshes_cached_agents.py tests/gateway/test_multiplex_mcp_discovery.py tests/tui_gateway/test_session_platform_resolution.py` — all pass. Full `tests/tui_gateway/` dir: 17 failures in 10 files + 1 collection error, re-run on base with identical results — all pre-existing Windows-env issues (compute-host child processes, config profile scope, entry import), unrelated to this change. `tests/tools/test_refresh_agent_mcp_tools.py` has 6 `ModuleNotFoundError: snowballstemmer` failures on this machine (missing dep in the system python), identical on base.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the canonical `scripts/run_tests.sh` on the changed area + neighbor suites instead (full ~39k-test suite not run locally); all touched-area tests pass, and the only failures anywhere are pre-existing Windows-env issues verified identical on base
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Python 3.13)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (internal handler behavior; docstring updated inline)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (platform-agnostic; exercised on Windows 11)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no tool schema changes)

## Screenshots / Logs

RED on base (`1c671beab2`):

```
FAILED tests/tui_gateway/test_mcp_reload_all_sessions.py::test_reload_mcp_refreshes_every_live_session
FAILED tests/tui_gateway/test_mcp_reload_all_sessions.py::test_reload_mcp_without_requester_session_still_refreshes[missing]
FAILED tests/tui_gateway/test_mcp_reload_all_sessions.py::test_reload_mcp_without_requester_session_still_refreshes[unknown]
```

e.g. `assert 'mcp_new_server_tool' in {'read_file', 'terminal'}` — the sibling session's snapshot stayed stale; with missing/unknown `session_id` both sessions stayed stale while the RPC returned `status: reloaded`.

GREEN on this branch:

```
=== Summary: 1 files, 3 tests passed, 0 failed (100% complete) in 6.4s ===
  tests\tui_gateway\test_mcp_reload_all_sessions.py (3✓)
```

Neighbors: `test_mcp_reload_rev.py` 5✓, `test_mcp_reload_confirm_gate.py` 4✓, `test_mcp_reload_refreshes_cached_agents.py` 3✓, `test_multiplex_mcp_discovery.py` 8✓, `test_session_platform_resolution.py` 20✓.
