### PR TITLE
fix(tools): retry Discord REST calls through 429 rate limits

### DIFF
--- a/tests/tools/test_discord_tool_ratelimit.py
+++ b/tests/tools/test_discord_tool_ratelimit.py
@@ -1,0 +1,143 @@
+"""429 rate-limit retry in the Discord REST tool."""
+
+import json
+import sys
+import types
+import urllib.error
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import tools.discord_tool as dt
+
+
+def _http_error(status, body, headers=None):
+    return urllib.error.HTTPError(
+        url="https://discord.com/api/v10/x", code=status, msg="err",
+        hdrs=types.SimpleNamespace(get=lambda k, d=None: (headers or {}).get(k, d)),
+        fp=BytesIO(json.dumps(body).encode() if isinstance(body, dict) else body.encode()))
+
+
+class _Resp:
+    def __init__(self, payload, status=200):
+        self.status = status
+        self._b = json.dumps(payload).encode()
+
+    def read(self, n=-1):
+        return self._b[:n] if n and n > 0 else self._b
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_cooldown():
+    dt._global_rate_limit_until[0] = 0.0
+    yield
+    dt._global_rate_limit_until[0] = 0.0
+
+
+class TestRetryAfterParsing:
+    def test_prefers_json_body_over_header(self):
+        # The header rounds to whole seconds; the body is sub-second precise.
+        hdrs = types.SimpleNamespace(get=lambda k, d=None: {"Retry-After": "1"}.get(k, d))
+        assert dt._parse_retry_after(hdrs, '{"retry_after": 0.15}') == pytest.approx(0.15)
+
+    def test_falls_back_to_header_when_body_unparseable(self):
+        hdrs = types.SimpleNamespace(get=lambda k, d=None: {"Retry-After": "2"}.get(k, d))
+        assert dt._parse_retry_after(hdrs, "not json") == pytest.approx(2.0)
+
+    def test_returns_none_when_neither_present(self):
+        hdrs = types.SimpleNamespace(get=lambda k, d=None: d)
+        assert dt._parse_retry_after(hdrs, "") is None
+
+    def test_negative_delay_clamped_to_zero(self):
+        assert dt._parse_retry_after(None, '{"retry_after": -5}') == 0.0
+
+
+class TestRateLimitRetry:
+    def test_retries_after_429_then_succeeds(self, monkeypatch):
+        calls = []
+        slept = []
+        monkeypatch.setattr(dt.time, "sleep", lambda s: slept.append(s))
+
+        def fake_open(req, timeout=None):
+            calls.append(req.full_url)
+            if len(calls) == 1:
+                raise _http_error(429, {"retry_after": 0.25, "global": False})
+            return _Resp({"ok": True})
+
+        monkeypatch.setattr(dt.urllib.request, "urlopen", fake_open)
+        assert dt._discord_request("GET", "/x", "tok") == {"ok": True}
+        assert len(calls) == 2
+        assert slept == [pytest.approx(0.25)]
+
+    def test_gives_up_after_max_retries(self, monkeypatch):
+        monkeypatch.setattr(dt.time, "sleep", lambda s: None)
+        monkeypatch.setattr(
+            dt.urllib.request, "urlopen",
+            lambda req, timeout=None: (_ for _ in ()).throw(_http_error(429, {"retry_after": 0.01})))
+        with pytest.raises(dt.DiscordAPIError) as exc:
+            dt._discord_request("GET", "/x", "tok")
+        assert exc.value.status == 429
+        assert "after 3 retries" in exc.value.body
+
+    def test_delay_above_cap_is_not_slept(self, monkeypatch):
+        """A 600s thread-rename cooldown must surface as an error, not stall the turn."""
+        slept = []
+        monkeypatch.setattr(dt.time, "sleep", lambda s: slept.append(s))
+        monkeypatch.setattr(
+            dt.urllib.request, "urlopen",
+            lambda req, timeout=None: (_ for _ in ()).throw(_http_error(429, {"retry_after": 600})))
+        with pytest.raises(dt.DiscordAPIError) as exc:
+            dt._discord_request("PATCH", "/channels/1", "tok")
+        assert "above the" in exc.value.body
+        assert slept == []
+
+    def test_non_429_error_is_not_retried(self, monkeypatch):
+        calls = []
+
+        def fake_open(req, timeout=None):
+            calls.append(1)
+            raise _http_error(403, {"message": "Missing Permissions"})
+
+        monkeypatch.setattr(dt.urllib.request, "urlopen", fake_open)
+        with pytest.raises(dt.DiscordAPIError) as exc:
+            dt._discord_request("GET", "/x", "tok")
+        assert exc.value.status == 403
+        assert len(calls) == 1
+
+    def test_global_429_sets_process_wide_cooldown(self, monkeypatch):
+        monkeypatch.setattr(dt.time, "sleep", lambda s: None)
+        seq = [_http_error(429, {"retry_after": 0.2, "global": True}), _Resp({"ok": True})]
+
+        def fake_open(req, timeout=None):
+            item = seq.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return item
+
+        monkeypatch.setattr(dt.urllib.request, "urlopen", fake_open)
+        dt._discord_request("GET", "/x", "tok")
+        assert dt._global_rate_limit_until[0] > 0
+
+    def test_body_is_resent_on_retry(self, monkeypatch):
+        """The payload must survive the retry; a consumed buffer would send an empty body."""
+        bodies = []
+        monkeypatch.setattr(dt.time, "sleep", lambda s: None)
+
+        def fake_open(req, timeout=None):
+            bodies.append(req.data)
+            if len(bodies) == 1:
+                raise _http_error(429, {"retry_after": 0.01})
+            return _Resp({"ok": True})
+
+        monkeypatch.setattr(dt.urllib.request, "urlopen", fake_open)
+        dt._discord_request("POST", "/x", "tok", body={"name": "hi"})
+        assert bodies[0] == bodies[1] == b'{"name": "hi"}'

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -32,6 +32,17 @@ _DISCORD_ERROR_BODY_MAX_BYTES = 64 * 1024
 _FLAGS_GUILD_MEMBERS = (1 << 14) | (1 << 15)
 _FLAGS_MESSAGE_CONTENT = (1 << 18) | (1 << 19)
 
+# 429 handling. Discord answers a rate limit with a retry_after delay rather than a bucket
+# reservation, so the client sleeps and retries. The sleep cap keeps a long per-route cooldown
+# (e.g. the 600s bucket that governs thread renames) from silently stalling an agent turn —
+# past the cap the delay is returned as an error the model can act on.
+_DISCORD_RATE_LIMIT_MAX_RETRIES = 3
+_DISCORD_RATE_LIMIT_MAX_SLEEP = 30.0
+
+# A global 429 applies to the whole token, so it pauses every thread, not just the caller.
+_global_rate_limit_lock = threading.Lock()
+_global_rate_limit_until = [0.0]
+
 
 class DiscordAPIError(Exception):
     def __init__(self, status: int, body: str):
@@ -52,33 +63,116 @@ def _get_bot_token() -> Optional[str]:
     return (get_secret("DISCORD_BOT_TOKEN", "") or "").strip() or None
 
 
+def _parse_retry_after(headers: Any, error_body: str) -> Optional[float]:
+    """Seconds to wait from a 429, preferring the JSON body over the header.
+
+    Discord sends ``retry_after`` in both places; the JSON body is sub-second precise while
+    ``Retry-After`` is integer seconds and rounds 0.15s up to 1s. Returns None when neither
+    is parseable, which the caller treats as "not a rate limit we understand".
+    """
+    try:
+        parsed = json.loads(error_body)
+        if isinstance(parsed, dict) and parsed.get("retry_after") is not None:
+            return max(0.0, float(parsed["retry_after"]))
+    except (ValueError, TypeError):
+        pass
+    try:
+        raw = headers.get("Retry-After") if headers is not None else None
+        if raw is not None:
+            return max(0.0, float(raw))
+    except (ValueError, TypeError, AttributeError):
+        pass
+    return None
+
+
+def _apply_global_rate_limit_pause() -> None:
+    """Block until any global 429 cooldown set by another thread has elapsed."""
+    while True:
+        with _global_rate_limit_lock:
+            remaining = _global_rate_limit_until[0] - time.monotonic()
+        if remaining <= 0:
+            return
+        time.sleep(min(remaining, _DISCORD_RATE_LIMIT_MAX_SLEEP))
+
+
+def _record_global_rate_limit(delay: float) -> None:
+    with _global_rate_limit_lock:
+        _global_rate_limit_until[0] = max(_global_rate_limit_until[0], time.monotonic() + delay)
+
+
 def _discord_request(
     method: str, path: str, token: str, params: Optional[Dict[str, str]] = None,
     body: Optional[Dict[str, Any]] = None, timeout: int = 15) -> Any:
-    """Make a request to the Discord REST API."""
+    """Make a request to the Discord REST API, retrying through 429 rate limits.
+
+    Discord returns 429 with a ``retry_after`` delay rather than a bucket reservation, so the
+    only correct client behaviour is to sleep and retry. Bounded by
+    ``_DISCORD_RATE_LIMIT_MAX_RETRIES`` attempts and ``_DISCORD_RATE_LIMIT_MAX_SLEEP`` per sleep;
+    a delay longer than the cap is surfaced as an error instead of stalling the agent turn.
+    A ``global`` 429 additionally pauses every other caller in this process.
+    """
     url = f"{DISCORD_API_BASE}{path}"
     if params:
         url += "?" + urllib.parse.urlencode(params)
-    req = urllib.request.Request(
-        url, data=None if body is None else json.dumps(body).encode("utf-8"), method=method,
-        headers={
-            "Authorization": f"Bot {token}", "Content-Type": "application/json",
-            "User-Agent": "Hermes-Agent (https://github.com/NousResearch/hermes-agent)"})
-    try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            if resp.status == 204:
-                return None
-            body = _read_limited_response_body(resp, _DISCORD_RESPONSE_BODY_MAX_BYTES, label="response body")
-            return json.loads(body.decode("utf-8"))
-    except urllib.error.HTTPError as e:
+    payload = None if body is None else json.dumps(body).encode("utf-8")
+
+    for attempt in range(_DISCORD_RATE_LIMIT_MAX_RETRIES + 1):
+        _apply_global_rate_limit_pause()
+        req = urllib.request.Request(
+            url, data=payload, method=method,
+            headers={
+                "Authorization": f"Bot {token}", "Content-Type": "application/json",
+                "User-Agent": "Hermes-Agent (https://github.com/NousResearch/hermes-agent)"})
         try:
-            error_body = _read_limited_response_body(
-                e, _DISCORD_ERROR_BODY_MAX_BYTES, label="error body").decode("utf-8", errors="replace")
-        except DiscordAPIError as too_large:
-            error_body = too_large.body
-        except Exception:
-            error_body = ""
-        raise DiscordAPIError(e.code, error_body) from e
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                if resp.status == 204:
+                    return None
+                raw = _read_limited_response_body(
+                    resp, _DISCORD_RESPONSE_BODY_MAX_BYTES, label="response body")
+                return json.loads(raw.decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            try:
+                error_body = _read_limited_response_body(
+                    e, _DISCORD_ERROR_BODY_MAX_BYTES, label="error body").decode("utf-8", errors="replace")
+            except DiscordAPIError as too_large:
+                error_body = too_large.body
+            except Exception:
+                error_body = ""
+
+            if e.code != 429:
+                raise DiscordAPIError(e.code, error_body) from e
+
+            delay = _parse_retry_after(getattr(e, "headers", None), error_body)
+            if delay is None:
+                raise DiscordAPIError(e.code, error_body or "Rate limited with no retry_after.") from e
+            if delay > _DISCORD_RATE_LIMIT_MAX_SLEEP:
+                raise DiscordAPIError(
+                    e.code,
+                    f"Rate limited for {delay:.1f}s, above the {_DISCORD_RATE_LIMIT_MAX_SLEEP}s "
+                    f"client cap; not waiting. Original body: {error_body}") from e
+            if attempt >= _DISCORD_RATE_LIMIT_MAX_RETRIES:
+                raise DiscordAPIError(
+                    e.code,
+                    f"Rate limited after {_DISCORD_RATE_LIMIT_MAX_RETRIES} retries. "
+                    f"Original body: {error_body}") from e
+
+            is_global = False
+            try:
+                parsed = json.loads(error_body)
+                is_global = bool(isinstance(parsed, dict) and parsed.get("global"))
+            except (ValueError, TypeError):
+                pass
+            if not is_global and getattr(e, "headers", None) is not None:
+                is_global = str(e.headers.get("X-RateLimit-Global", "")).lower() == "true"
+            if is_global:
+                _record_global_rate_limit(delay)
+
+            logger.info(
+                "discord: 429 on %s %s; sleeping %.2fs (attempt %d/%d, global=%s)",
+                method, path, delay, attempt + 1, _DISCORD_RATE_LIMIT_MAX_RETRIES, is_global)
+            time.sleep(delay)
+
+    raise DiscordAPIError(429, "Rate limit retry loop exhausted.")
 
 
 _CHANNEL_TYPE_NAMES = {


### PR DESCRIPTION
## What does this PR do?

`tools/discord_tool.py` issues raw `urllib` requests and had no 429 handling at all, so any rate limit surfaced as a hard error mid-turn and the action was lost. The gateway adapter already backs off in its own paths; the REST tool did not.

Requests now honor `retry_after` and retry, bounded at 3 attempts with a 30s per-sleep cap.

Three decisions worth a reviewer's attention:

**The sleep cap returns an error instead of waiting.** Discord's per-route cooldown for channel name/topic edits is 2 requests per 600s and governs thread renames. Without a cap, one rename could silently freeze an agent turn for ten minutes. Failing with the actual delay lets the model decide what to do. This is the same instinct as #96101 on the gateway side.

**The JSON body is preferred over the `Retry-After` header.** The header is integer seconds and rounds a 0.15s delay up to a full second; the body is sub-second precise.

**The request payload is built once outside the retry loop.** Rebuilding it from a consumed buffer would send a retried POST/PATCH with an empty body.

A `global` 429 applies to the whole token, so it pauses every thread in the process rather than just the calling one.

## Related Issue

No existing issue. Searched open and closed PRs for prior art: #44558 (closed, gateway send retry) and #22398 / #32761 (typing-indicator 429, gateway side) are adjacent but all sit in the gateway adapter, not the REST tool.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/discord_tool.py` — `_discord_request` retries through 429; adds `_parse_retry_after`, `_apply_global_rate_limit_pause`, `_record_global_rate_limit` and the bounding constants
- `tests/tools/test_discord_tool_ratelimit.py` — new, 10 tests

## How to Test

```bash
pytest tests/tools/test_discord_tool_ratelimit.py tests/tools/test_discord_tool.py -q
```

Covers: retry-then-succeed, give-up after max retries, over-cap delay not slept, non-429 not retried, global cooldown recorded, payload resent intact, and the body-over-header precedence.

Mutation tested — 5 mutants (no retry, no sleep cap, header preferred over body, payload consumed on retry, global 429 not recorded), all killed by the suite.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the Discord test suite: 9 failures on a clean `main` checkout, 9 on this branch, zero new (the 9 are pre-existing and network-dependent — they fetch `cdn.discordapp.com`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu, Linux 7.0.0-28-generic, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on the new helpers) — behavior is internal to the tool, no user-facing docs affected
- [x] N/A — no config keys added
- [x] N/A — no architecture or workflow change
- [x] Cross-platform: pure stdlib (`time.sleep`, `threading.Lock`), no platform-specific behavior
- [x] N/A — no tool schema or description change

## Notes for the reviewer

The 30s cap and 3-attempt bound are judgement calls. If the project would rather wait out long cooldowns than fail fast, that is a one-constant change and I'm happy to flip it.
