### PR TITLE
feat(tools): add Discord guild message search

### DIFF
--- a/tests/tools/test_discord_tool_search.py
+++ b/tests/tools/test_discord_tool_search.py
@@ -1,0 +1,116 @@
+"""Guild message search in the Discord REST tool."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import tools.discord_tool as dt
+
+
+class TestSearchMessages:
+    def _run(self, monkeypatch, payload, status=200, capture=None):
+        def fake_req(method, path, token, params=None, body=None, timeout=15):
+            if capture is not None:
+                capture.append((method, path, params))
+            return payload
+
+        monkeypatch.setattr(dt, "_discord_request", fake_req)
+        return json.loads(dt._search_messages("tok", guild_id="1", query="deploy"))
+
+    def test_flattens_nested_hit_groups(self, monkeypatch):
+        payload = {
+            "messages": [
+                [{"id": "10", "content": "deploy done", "channel_id": "99",
+                  "author": {"id": "5", "username": "scott"}}],
+                [{"id": "11", "content": "deploy failed", "channel_id": "98",
+                  "author": {"id": "6", "username": "remi"}}],
+            ],
+            "total_results": 2,
+            "doing_deep_historical_index": False,
+        }
+        out = self._run(monkeypatch, payload)
+        assert out["count"] == 2
+        assert [m["id"] for m in out["messages"]] == ["10", "11"]
+        assert out["messages"][0]["channel_id"] == "99"
+        assert out["total_results"] == 2
+
+    def test_index_not_ready_returns_structured_signal(self, monkeypatch):
+        """202 has no `messages` key; the agent must be told to retry, not see zero hits."""
+        payload = {"message": "indexing", "code": 110000,
+                   "documents_indexed": 42, "retry_after": 5}
+        out = self._run(monkeypatch, payload)
+        assert out["index_not_ready"] is True
+        assert out["retry_after_seconds"] == 5
+        assert "messages" not in out
+
+    def test_requires_at_least_one_filter(self, monkeypatch):
+        monkeypatch.setattr(dt, "_discord_request",
+                            lambda *a, **k: pytest.fail("must not call the API"))
+        out = json.loads(dt._search_messages("tok", guild_id="1"))
+        assert "error" in out
+        assert "at least one filter" in out["error"]
+
+    def test_clamps_limit_and_offset_to_server_schema(self, monkeypatch):
+        cap = []
+        monkeypatch.setattr(
+            dt, "_discord_request",
+            lambda m, p, t, params=None, body=None, timeout=15: cap.append(params) or {"messages": []})
+        dt._search_messages("tok", guild_id="1", query="x", limit=500, offset=99999)
+        assert cap[0]["limit"] == "25"
+        assert cap[0]["offset"] == str(dt._SEARCH_MAX_OFFSET)
+
+    def test_truncates_overlong_content_query(self, monkeypatch):
+        cap = []
+        monkeypatch.setattr(
+            dt, "_discord_request",
+            lambda m, p, t, params=None, body=None, timeout=15: cap.append(params) or {"messages": []})
+        dt._search_messages("tok", guild_id="1", query="z" * 5000)
+        assert len(cap[0]["content"]) == dt._SEARCH_MAX_CONTENT_LENGTH
+
+    def test_filter_only_search_without_query_is_allowed(self, monkeypatch):
+        cap = []
+        monkeypatch.setattr(
+            dt, "_discord_request",
+            lambda m, p, t, params=None, body=None, timeout=15: cap.append(params) or {"messages": []})
+        dt._search_messages("tok", guild_id="1", has="image")
+        assert cap[0]["has"] == "image"
+        assert "content" not in cap[0]
+
+    def test_hits_the_guild_search_route(self, monkeypatch):
+        cap = []
+        self._run(monkeypatch, {"messages": []}, capture=cap)
+        assert cap[0][0] == "GET"
+        assert cap[0][1] == "/guilds/1/messages/search"
+
+
+class TestRegistration:
+    def test_search_messages_is_in_the_core_toolset(self):
+        assert "search_messages" in dt._CORE_ACTION_NAMES
+        assert "search_messages" in dt._CORE_ACTIONS
+        assert "search_messages" not in dt._ADMIN_ACTIONS
+
+    def test_only_guild_id_is_required(self):
+        assert dt._REQUIRED_PARAMS["search_messages"] == ["guild_id"]
+
+    def test_new_params_are_plumbed_through_handler_defaults(self):
+        for key in ("author_id", "has", "offset"):
+            assert key in dt._HANDLER_DEFAULTS
+
+    def test_schema_exposes_search_params(self):
+        schema = dt._build_schema(["search_messages"], {}, tool_name="discord")
+        props = schema["parameters"]["properties"]
+        for key in ("author_id", "has", "offset", "query"):
+            assert key in props
+
+    def test_content_intent_note_covers_search(self):
+        caps = {"detected": True, "has_message_content": False}
+        schema = dt._build_schema(["search_messages"], caps, tool_name="discord")
+        assert "MESSAGE_CONTENT" in schema["description"]
+
+    def test_403_hint_directs_to_fetch_messages_fallback(self):
+        msg = dt._enrich_403("search_messages", "{}")
+        assert "fetch_messages" in msg

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -345,6 +345,68 @@ def _fetch_messages(
     return _listing("messages", [_message_summary(msg) for msg in messages])
 
 
+# Guild message search bounds, mirroring the server-side schema so the API rejects fewer calls:
+# limit 1-25, offset <= 9975, content query <= 1024 chars.
+_SEARCH_MAX_LIMIT = 25
+_SEARCH_MAX_OFFSET = 9975
+_SEARCH_MAX_CONTENT_LENGTH = 1024
+
+# `has` filter values accepted by the search API; each also has a negating "-" form.
+_SEARCH_HAS_VALUES = (
+    "link", "embed", "file", "image", "video", "sound", "sticker", "poll", "snapshot")
+
+
+def _search_messages(
+    token: str, guild_id: str, query: Optional[str] = None, channel_id: Optional[str] = None,
+    author_id: Optional[str] = None, has: Optional[str] = None, limit: int = 25,
+    offset: int = 0, **_kwargs: Any) -> str:
+    """Guild-wide message search (GET /guilds/{id}/messages/search).
+
+    Bot-accessible and rate-limited at 10/1s for bots, but the guild must have the search
+    feature enabled and the index may still be warming, which answers 202 rather than 200.
+    Results come back as a list of single-element hit groups; they are flattened here.
+    """
+    params: Dict[str, str] = {
+        "limit": str(max(1, min(int(limit or 25), _SEARCH_MAX_LIMIT))),
+        "offset": str(max(0, min(int(offset or 0), _SEARCH_MAX_OFFSET))),
+    }
+    if query:
+        params["content"] = str(query)[:_SEARCH_MAX_CONTENT_LENGTH]
+    for key, value in (("channel_id", channel_id), ("author_id", author_id), ("has", has)):
+        if value:
+            params[key] = str(value)
+    if not any(k in params for k in ("content", "author_id", "has", "channel_id")):
+        return tool_error(
+            "search_messages needs at least one filter: query, author_id, has, or channel_id.")
+
+    result = _discord_request("GET", f"/guilds/{guild_id}/messages/search", token, params=params)
+
+    # 202 while the guild's search index builds: same JSON shape minus `messages`.
+    if isinstance(result, dict) and "messages" not in result:
+        return json.dumps({
+            "index_not_ready": True,
+            "message": result.get("message", "Search index is still building for this guild."),
+            "documents_indexed": result.get("documents_indexed"),
+            "retry_after_seconds": result.get("retry_after"),
+        })
+
+    groups = (result or {}).get("messages") or []
+    hits: List[Dict[str, Any]] = []
+    for group in groups:
+        for msg in (group or []):
+            if isinstance(msg, dict) and msg.get("id"):
+                summary = _message_summary(msg)
+                summary["channel_id"] = msg.get("channel_id")
+                hits.append(summary)
+    return json.dumps({
+        "messages": hits,
+        "count": len(hits),
+        "total_results": (result or {}).get("total_results"),
+        "offset": int(params["offset"]),
+        "indexing_in_progress": bool((result or {}).get("doing_deep_historical_index")),
+    })
+
+
 def _list_pins(token: str, channel_id: str, **_kwargs: Any) -> str:
     """Pinned messages (content truncated for overview)."""
     messages = _discord_request("GET", f"/channels/{channel_id}/pins", token)
@@ -400,6 +462,9 @@ _ACTION_MANIFEST = [
     ("member_info", _member_info, "(guild_id, user_id)", "lookup a specific member"),
     ("search_members", _search_members, "(guild_id, query)", "find members by name prefix"),
     ("fetch_messages", _fetch_messages, "(channel_id)", "recent messages; optional before/after snowflakes"),
+    ("search_messages", _search_messages, "(guild_id)",
+     "search messages across a server by text/author/attachment type; far cheaper than paging "
+     "fetch_messages. Needs at least one of query/author_id/has/channel_id"),
     ("list_pins", _list_pins, "(channel_id)", "pinned messages in a channel"),
     ("pin_message", _pin_message, "(channel_id, message_id)", "pin a message"),
     ("unpin_message", _unpin_message, "(channel_id, message_id)", "unpin a message"),
@@ -415,7 +480,8 @@ _REQUIRED_PARAMS: Dict[str, List[str]] = {
 
 # Two tools share one action table: ``discord`` (core, the participation trio every bot
 # user wants) and ``discord_admin`` (everything else).
-_CORE_ACTION_NAMES = frozenset({"fetch_messages", "search_members", "create_thread"})
+_CORE_ACTION_NAMES = frozenset(
+    {"fetch_messages", "search_messages", "search_members", "create_thread"})
 _CORE_ACTIONS = {k: v for k, v in _ACTIONS.items() if k in _CORE_ACTION_NAMES}
 _ADMIN_ACTIONS = {k: v for k, v in _ACTIONS.items() if k not in _CORE_ACTION_NAMES}
 
@@ -478,8 +544,39 @@ _SCHEMA_PROPERTIES: Dict[str, Any] = {
     "user_id": {"type": "string", "description": "Discord user ID."},
     "role_id": {"type": "string", "description": "Discord role ID."},
     "message_id": {"type": "string", "description": "Discord message ID."},
-    "query": {"type": "string", "description": "Member name prefix to search for (search_members)."},
+    "query": {
+        "type": "string",
+        "description": "Search text. Member name prefix for search_members; message content for search_messages.",
+    },
     "name": {"type": "string", "description": "New thread name (create_thread)."},
+    "author_id": {
+        "type": "string",
+        "description": "Restrict search_messages to messages from this user ID.",
+    },
+    "has": {
+        "type": "string",
+        "enum": list(_SEARCH_HAS_VALUES) + [f"-{v}" for v in _SEARCH_HAS_VALUES],
+        "description": (
+            "Restrict search_messages to messages containing this kind of content; "
+            "the '-' forms exclude it (e.g. 'image', '-link')."
+        ),
+    },
+    "offset": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": _SEARCH_MAX_OFFSET,
+        "description": "Result offset for paging search_messages (default 0).",
+    },
+    "limit": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 100,
+        "description": (
+            "Max results (default 50). Applies to fetch_messages, search_members, "
+            "search_messages (search_messages caps at 25)."
+        ),
+    },
+
     "limit": {
         "type": "integer",
         "minimum": 1,
@@ -514,7 +611,7 @@ def _build_schema(
     manifest_block = "\n".join(
         f"  {name}{sig}  — {desc}" for name, _fn, sig, desc in _ACTION_MANIFEST if name in actions)
     content_note = ""
-    affected_actions = {"fetch_messages", "list_pins"} & set(actions)
+    affected_actions = {"fetch_messages", "list_pins", "search_messages"} & set(actions)
     if affected_actions and caps.get("detected") and caps.get("has_message_content") is False:
         content_note = _CONTENT_NOTE.format(names=" and ".join(sorted(affected_actions)))
     lead, guidance = _TOOL_DESCRIPTIONS.get(tool_name, _TOOL_DESCRIPTIONS["discord"])
@@ -558,6 +655,11 @@ _ACTION_403_HINT = {
         f"{_ROLE_HIERARCHY} Roles can only be assigned below the bot's own position in the role hierarchy."),
     "remove_role": _ROLE_HIERARCHY,
     "fetch_messages": _VIEW_HISTORY,
+    "search_messages": (
+        "Guild message search was refused. Either the bot lacks VIEW_CHANNEL/READ_MESSAGE_HISTORY "
+        "in the guild, or Discord has disabled search for bots on this deployment. "
+        "Fall back to fetch_messages with before/after paging."),
+    "list_pins": _VIEW_HISTORY,
     "list_pins": _VIEW_HISTORY,
     "channel_info": "Bot cannot view this channel (missing VIEW_CHANNEL).",
     "search_members": (
@@ -581,7 +683,8 @@ def check_discord_tool_requirements() -> bool:
 # ── handlers ─────────────────────────────────────────────────────────────────
 _HANDLER_DEFAULTS = {
     "guild_id": "", "channel_id": "", "user_id": "", "role_id": "", "message_id": "", "query": "",
-    "name": "", "limit": 50, "before": "", "after": "", "auto_archive_duration": 1440}
+    "name": "", "limit": 50, "before": "", "after": "", "auto_archive_duration": 1440,
+    "author_id": "", "has": "", "offset": 0}
 
 
 def _run_discord_action(action: str, valid_actions: Dict[str, Any], tool_label: str, **params: Any) -> str:


### PR DESCRIPTION
## What does this PR do?

Finding an old message with the Discord tool meant walking `fetch_messages` cursor by cursor, one HTTP call per 100 messages. `GET /guilds/{id}/messages/search` is a public, bot-accessible endpoint with a dedicated bot rate tier, so a lookup that took dozens of calls takes one.

Adds `search_messages` to the core `discord` toolset, filterable by message text, author, channel and attachment type.

Two response-shape details are handled explicitly, and they are the parts worth reviewing:

**Hits come back as nested single-element groups**, not a flat list. They are flattened, and `channel_id` is carried onto each hit since results span channels.

**A guild whose search index is still warming answers 202 with no `messages` key.** That is surfaced as a structured `index_not_ready` result carrying `retry_after_seconds`, so a warming index is never silently reported to the model as "no results". This is the failure mode most likely to produce a confidently wrong answer, so it gets an explicit signal rather than an empty list.

Limit, offset and query length are clamped to the server-side schema (25 / 9975 / 1024) so fewer calls are rejected outright. A 403 is mapped to guidance pointing back at `fetch_messages`, since deployments can disable search for bots.

## Related Issue

No existing issue. Searched open and closed PRs: #4677 (open, adds Discord read tools) and #19749 (open, clamps limits in `_search_members`/`_fetch_messages`) are adjacent but neither adds search.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/discord_tool.py` — adds `_search_messages`, its bounding constants, the schema properties (`author_id`, `has`, `offset`), the 403 hint, and registers the action in `_ACTION_MANIFEST` and the core toolset
- `tests/tools/test_discord_tool_search.py` — new, 13 tests

## How to Test

```bash
pytest tests/tools/test_discord_tool_search.py tests/tools/test_discord_tool.py -q
```

Against a real bot token and guild:

```bash
hermes -q "search this server for messages mentioning deploys"
```

Mutation tested — 7 mutants (unflattened hit groups, 202 treated as zero hits, unclamped limit, untruncated query, empty filter set still calling the API, toolset demotion, dropped handler params), all killed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run the Discord test suite: 9 failures on a clean `main` checkout, 9 on this branch, zero new (the 9 are pre-existing and network-dependent — they fetch `cdn.discordapp.com`)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu, Linux 7.0.0-28-generic, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the action carries its own description and the tool's schema is self-documenting
- [x] N/A — no config keys added
- [x] N/A — no architecture or workflow change
- [x] Cross-platform: pure stdlib, no platform-specific behavior
- [x] I've updated tool descriptions/schemas — new action added to `_ACTION_MANIFEST` with its required-param signature, plus three new schema properties

## Not yet verified

Exercised against the documented route contract and a mocked transport, **not against a live guild**. The response-shape handling (nested groups, 202) is written from the endpoint's contract; a smoke test on a real server before merge would be worth it. Flagging rather than burying it.

## Notes for the reviewer

Independent of my companion PR adding 429 retry to the same file — this branch applies to `main` on its own, and the two merge in either order. Search benefits from the retry work given its 10/1s bot tier, but does not require it.
