### PR TITLE
feat(discord): render agent replies as Components V2

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1090,6 +1090,12 @@ class DiscordAdapter(DiscordMediaMixin, BasePlatformAdapter):
         # Reply threading mode: "off", "first" (default; first chunk only), "all" (every chunk).
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
         self._slash_commands: bool = self.config.extra.get("slash_commands", True)
+        # Components V2 rendering for final replies (discord.components_v2 / DISCORD_COMPONENTS_V2).
+        # Off by default: v2's 4000-char whole-tree text budget is SMALLER than the legacy
+        # 8x2000 chunked path, so it is an opt-in presentation upgrade that silently falls
+        # back to chunked text whenever a reply does not fit.
+        self._components_v2: bool = _env_bool(
+            "DISCORD_COMPONENTS_V2", bool(self.config.extra.get("components_v2", False)))
         # Bot's last message ID per channel: lets history backfill skip the full channel.history() scan.
         self._last_self_message_id: Dict[str, str] = {}
         # Bot-authored lifecycle/status message IDs that must not bound history after restart.
@@ -2816,6 +2822,41 @@ class DiscordAdapter(DiscordMediaMixin, BasePlatformAdapter):
         kept.append(notice)
         return kept
 
+    async def _try_send_components_v2(
+        self, channel: Any, content: str, reference: Any, chat_id: str,
+        thread_id: Optional[str], nonconversational: bool,
+    ) -> Optional[SendResult]:
+        """Send *content* as a Components V2 message, or return ``None`` to use chunked text.
+
+        ``None`` is the normal outcome for anything that exceeds v2's 4000-char whole-tree
+        text budget, and for every failure: this is a presentation upgrade, so it must never
+        be the reason a reply fails to arrive.
+        """
+        if not self._components_v2:
+            return None
+        try:
+            from plugins.platforms.discord.components_v2 import build_layout_view
+
+            view = build_layout_view(self.format_message(content))
+            if view is None:
+                return None
+            # A v2 message carries its text inside components; `content` must stay unset or
+            # Discord rejects the send outright.
+            msg = await channel.send(view=view, reference=reference)
+        except Exception as e:
+            logger.warning(
+                "[%s] Components V2 send failed (%s); falling back to chunked text.", self.name, e)
+            return None
+        message_id = str(msg.id)
+        target_id = thread_id or chat_id
+        if nonconversational:
+            await self._nonconversational_messages.mark_many([message_id])
+        elif not _looks_like_nonconversational_history_message(content):
+            self._last_self_message_id[target_id] = message_id
+        return SendResult(
+            success=True, message_id=message_id,
+            raw_response={"message_ids": [message_id], "components_v2": True})
+
     async def send(
         self,
         chat_id: str,
@@ -2856,11 +2897,17 @@ class DiscordAdapter(DiscordMediaMixin, BasePlatformAdapter):
                 result = await self._send_to_forum(channel, content)
                 return await self._record_response_async(reply_to, result, content, final_delivery)
             formatted = self.format_message(content)
+            reference = self._reply_reference_for_send(reply_to, channel)
+            # Components V2 first: one structured message instead of N chunks. Returns None
+            # whenever the reply does not fit v2's budgets, which falls through to chunking.
+            v2_result = await self._try_send_components_v2(
+                channel, content, reference, chat_id, thread_id, nonconversational)
+            if v2_result is not None:
+                return await self._record_response_async(reply_to, v2_result, content, final_delivery)
             chunks = self._cap_split_chunks(
                 self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
             )
             message_ids = []
-            reference = self._reply_reference_for_send(reply_to, channel)
             for i, chunk in enumerate(chunks):
                 if self._reply_to_mode == "all":
                     chunk_reference = reference
@@ -6941,6 +6988,7 @@ _YAML_BOOL_ENV_KEYS = (
     ("require_mention", "DISCORD_REQUIRE_MENTION"),
     ("thread_require_mention", "DISCORD_THREAD_REQUIRE_MENTION"),
     ("bots_require_inline_mention", "DISCORD_BOTS_REQUIRE_INLINE_MENTION"),
+    ("components_v2", "DISCORD_COMPONENTS_V2"),
 )
 # (public websocket_* key, legacy liveness_* alias, env bridge var)
 _YAML_WEBSOCKET_LIVENESS_KEYS = (

--- a/plugins/platforms/discord/components_v2.py
+++ b/plugins/platforms/discord/components_v2.py
@@ -1,0 +1,128 @@
+"""Components V2 rendering for agent replies.
+
+Discord's v2 component system lets one message carry structured layout (containers, text
+blocks, separators) instead of a wall of markdown split across several messages. Hermes
+replies are long and mixed prose/code, so v2 turns a multi-message spill into one scannable
+message.
+
+Three server-side limits drive every decision here, all verified against the API source
+rather than the developer docs:
+
+* ``MESSAGE_MAX_TOTAL_COMPONENTS_V2 = 40`` — total components anywhere in the tree, with no
+  separate top-level cap.
+* ``MAX_DISPLAYABLE_TEXT_SIZE = 4000`` — the **sum** of text across the whole tree, not a
+  per-component budget. This is the important one: it is smaller than what the legacy
+  chunker can deliver (8 x 2000), so v2 cannot be a blanket replacement for long replies.
+* ``MAX_COMPONENT_DEPTH = 3``.
+
+Because of the 4000-char total, :func:`build_layout_view` is deliberately partial: it
+returns ``None`` whenever the content does not fit, and the caller falls back to the
+existing chunked path. Rendering is therefore always an optimisation, never a constraint on
+what Hermes can say.
+
+One-way door: ``MessageFlags.IS_COMPONENTS_V2`` cannot be removed from a message once set,
+and a v2 message rejects the legacy ``content`` field entirely. A message that starts life
+as v2 must stay v2 for every subsequent edit, which is why the streaming edit path does not
+use this module.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Server-side budgets (discord_api message_components/constants.py). Kept slightly under the
+# real limits so format inflation on Discord's side cannot push a valid view over.
+MAX_TOTAL_COMPONENTS = 40
+MAX_DISPLAYABLE_TEXT = 4000
+_TEXT_BUDGET = MAX_DISPLAYABLE_TEXT - 64
+_COMPONENT_BUDGET = MAX_TOTAL_COMPONENTS - 4
+
+# A single TextDisplay tops out at the same 4000 chars as the whole tree.
+MAX_TEXT_DISPLAY = 4000
+
+_FENCE_RE = re.compile(r"```[\s\S]*?(?:```|\Z)", re.MULTILINE)
+
+
+def _split_fenced(text: str) -> List[Tuple[str, str]]:
+    """Split into ``(kind, chunk)`` segments where kind is ``code`` or ``prose``.
+
+    Fenced code is kept intact so a block is never divided across components, which would
+    break syntax highlighting and leave a dangling fence.
+    """
+    segments: List[Tuple[str, str]] = []
+    cursor = 0
+    for match in _FENCE_RE.finditer(text):
+        if match.start() > cursor:
+            prose = text[cursor:match.start()]
+            if prose.strip():
+                segments.append(("prose", prose))
+        block = match.group()
+        if block.strip():
+            segments.append(("code", block))
+        cursor = match.end()
+    tail = text[cursor:]
+    if tail.strip():
+        segments.append(("prose", tail))
+    return segments
+
+
+def plan_segments(content: str) -> Optional[List[Tuple[str, str]]]:
+    """Plan the component tree for *content*, or ``None`` when v2 is not a good fit.
+
+    Returns ``None`` (meaning "use the legacy chunked path") when the content is empty,
+    exceeds the 4000-char total text budget, or would need more components than the budget
+    allows. Callers must treat ``None`` as normal, not as an error.
+
+    Exactly two conditions reject a plan: the summed text budget and the component count.
+    Nothing splits prose by length, because ``_TEXT_BUDGET`` sits below the 4000-char
+    single-component ceiling — any run of prose long enough to overflow one TextDisplay has
+    already overflowed the whole-tree budget and been rejected. Segmentation therefore comes
+    only from fenced code blocks, which is also what makes the output readable.
+    """
+    text = (content or "").strip()
+    segments: List[Tuple[str, str]] = [
+        (kind, chunk) for kind, chunk in _split_fenced(text) if chunk.strip()]
+
+    if not segments:
+        return None
+    if sum(len(chunk) for _kind, chunk in segments) > _TEXT_BUDGET:
+        return None
+    # Each segment is a TextDisplay; separators sit between them, plus the Container itself.
+    separators = max(0, len(segments) - 1)
+    if len(segments) + separators + 1 > _COMPONENT_BUDGET:
+        return None
+    return segments
+
+
+def build_layout_view(content: str, *, accent_colour: Optional[int] = None):
+    """Build a ``LayoutView`` for *content*, or ``None`` to fall back to chunked text.
+
+    Import is deferred so this module stays importable (and unit-testable) without discord.py.
+    """
+    segments = plan_segments(content)
+    if segments is None:
+        return None
+    try:
+        import discord
+    except ImportError:
+        return None
+
+    separator_cls = getattr(discord.ui, "Separator", None)
+    try:
+        container = discord.ui.Container(accent_colour=accent_colour)
+        for index, (_kind, chunk) in enumerate(segments):
+            if index and separator_cls is not None:
+                container.add_item(separator_cls())
+            container.add_item(discord.ui.TextDisplay(chunk))
+        view = discord.ui.LayoutView(timeout=None)
+        view.add_item(container)
+        return view
+    except Exception:
+        # Any library-side rejection (budget maths, version drift) degrades to legacy text
+        # rather than dropping the reply.
+        logger.debug("components v2 view construction failed; using legacy text", exc_info=True)
+        return None

--- a/tests/gateway/conftest.py
+++ b/tests/gateway/conftest.py
@@ -231,6 +231,46 @@ def _ensure_discord_mock() -> None:
         def clear_items(self):
             self.children.clear()
 
+    # ── Components V2 layout primitives ──────────────────────────────────────
+    # Structural fakes: enough to count components and read back text, so the v2
+    # render path is exercised without the real library.
+    class _FakeTextDisplay:
+        def __init__(self, content, **_):
+            self.content = content
+        def to_component_dict(self):
+            return {"type": 10, "content": self.content}
+
+    class _FakeSeparator:
+        def __init__(self, **_):
+            pass
+        def to_component_dict(self):
+            return {"type": 14}
+
+    class _FakeContainer:
+        def __init__(self, *children, accent_colour=None, **_):
+            self.accent_colour = accent_colour
+            self.children = list(children)
+        def add_item(self, item):
+            self.children.append(item)
+            return self
+        def to_component_dict(self):
+            return {"type": 17, "components": [c.to_component_dict() for c in self.children]}
+
+    class _FakeLayoutView:
+        def __init__(self, timeout=None):
+            self.timeout = timeout
+            self.children = []
+        def add_item(self, item):
+            self.children.append(item)
+            return self
+        @property
+        def _total_children(self):
+            return sum(1 + len(getattr(c, "children", [])) for c in self.children)
+        def has_components_v2(self):
+            return True
+        def to_components(self):
+            return [c.to_component_dict() for c in self.children]
+
     class _FakeSelect:
         def __init__(self, *, placeholder=None, options=None, custom_id=None, **_):
             self.placeholder = placeholder
@@ -276,6 +316,12 @@ def _ensure_discord_mock() -> None:
         Select=_FakeSelect,
         Button=_FakeButton,
         button=lambda *a, **k: (lambda fn: fn),
+        # Components V2 layout primitives. Real enough to assert structure and the
+        # 40-component budget without requiring the genuine library.
+        LayoutView=_FakeLayoutView,
+        Container=_FakeContainer,
+        TextDisplay=_FakeTextDisplay,
+        Separator=_FakeSeparator,
     )
     discord_mod.ButtonStyle = SimpleNamespace(
         success=1, primary=2, secondary=2, danger=3,

--- a/tests/gateway/test_discord_components_v2.py
+++ b/tests/gateway/test_discord_components_v2.py
@@ -1,0 +1,118 @@
+"""Components V2 planning for Discord agent replies."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_ROOT))
+
+# tests/gateway/conftest.py installs a mock `discord` at import time and this file must not
+# disturb it. Do NOT call _ensure_discord_mock() here: it mints a *fresh* MagicMock, and the
+# new object breaks isinstance identity (discord.Thread, discord.ForumChannel) for every
+# sibling file that captured the old one at collection.
+#
+# The load below is by path rather than through `plugins.platforms.discord`, whose __init__
+# imports the adapter. The renderer has no import-time discord dependency; build_layout_view
+# imports lazily at call time and resolves to whatever conftest installed.
+
+
+def _load_components_v2():
+    """Load the renderer straight from its file, bypassing the package __init__."""
+    path = _ROOT / "plugins" / "platforms" / "discord" / "components_v2.py"
+    spec = importlib.util.spec_from_file_location("_hermes_components_v2_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+c2 = _load_components_v2()
+
+
+class TestPlanSegments:
+    def test_empty_content_falls_back(self):
+        assert c2.plan_segments("") is None
+        assert c2.plan_segments("   \n  ") is None
+
+    def test_simple_prose_is_one_segment(self):
+        segs = c2.plan_segments("hello world")
+        assert segs == [("prose", "hello world")]
+
+    def test_over_total_text_budget_falls_back(self):
+        """The 4000-char limit is the SUM across the tree, and is smaller than 8x2000."""
+        assert c2.plan_segments("x" * 5000) is None
+
+    def test_just_under_budget_is_rendered(self):
+        assert c2.plan_segments("x" * 3000) is not None
+
+    def test_code_fence_kept_intact(self):
+        content = "before\n\n```python\nprint(1)\nprint(2)\n```\n\nafter"
+        segs = c2.plan_segments(content)
+        kinds = [k for k, _ in segs]
+        assert "code" in kinds
+        code = [c for k, c in segs if k == "code"][0]
+        assert code.startswith("```python")
+        assert code.rstrip().endswith("```")
+        assert "print(1)" in code and "print(2)" in code
+
+    def test_code_block_is_never_split_across_segments(self):
+        content = "```\n" + ("line\n" * 200) + "```"
+        segs = c2.plan_segments(content)
+        if segs is not None:
+            code_segs = [c for k, c in segs if k == "code"]
+            assert len(code_segs) == 1
+
+    def test_oversized_single_code_block_falls_back(self):
+        """A fence too big to split is also past the whole-tree budget, so v2 declines."""
+        assert c2.plan_segments("```\n" + "x" * 4500 + "\n```") is None
+
+    def test_prose_under_the_component_limit_stays_one_segment(self):
+        """Packing into as few components as possible preserves the 40-component budget;
+        visual structure comes from fenced blocks, not from splitting every paragraph."""
+        content = "\n\n".join("para " + str(i) + " " + "y" * 900 for i in range(4))
+        segs = c2.plan_segments(content)
+        assert segs is not None
+        assert len(segs) == 1
+        assert len(segs[0][1]) <= c2.MAX_TEXT_DISPLAY
+
+    def test_long_prose_without_fences_falls_back_to_chunked_text(self):
+        """No prose length-splitting: past the whole-tree budget the legacy chunker wins."""
+        assert c2.plan_segments("\n\n".join("z" * 900 for _ in range(10))) is None
+
+    def test_no_segment_exceeds_single_component_limit(self):
+        segs = c2.plan_segments("z" * 3900)
+        assert segs is not None
+        for _kind, chunk in segs:
+            assert len(chunk) <= c2.MAX_TEXT_DISPLAY
+
+    def test_component_count_budget_rejects_too_many_fences(self):
+        """Many small fenced blocks blow the 40-component cap long before the text cap."""
+        content = "\n\n".join("```\nx\n```" for _ in range(30))
+        assert c2.plan_segments(content) is None
+
+    def test_component_count_stays_under_budget_when_accepted(self):
+        content = "\n\n".join("```\nx\n```" for _ in range(5))
+        segs = c2.plan_segments(content)
+        assert segs is not None
+        separators = max(0, len(segs) - 1)
+        assert len(segs) + separators + 1 <= c2.MAX_TOTAL_COMPONENTS
+
+    def test_total_rendered_text_within_budget(self):
+        segs = c2.plan_segments("a" * 1000 + "\n\n" + "b" * 1000)
+        assert segs is not None
+        assert sum(len(c) for _k, c in segs) <= c2.MAX_DISPLAYABLE_TEXT
+
+    def test_mixed_prose_and_multiple_fences(self):
+        content = "intro\n\n```js\nlet a=1;\n```\n\nmid\n\n```sh\nls -la\n```\n\nend"
+        segs = c2.plan_segments(content)
+        assert segs is not None
+        assert len([k for k, _ in segs if k == "code"]) == 2
+        assert len([k for k, _ in segs if k == "prose"]) == 3
+
+    def test_unclosed_fence_does_not_hang_or_drop_text(self):
+        content = "text\n\n```python\nprint('no close')"
+        segs = c2.plan_segments(content)
+        assert segs is not None
+        assert any("no close" in c for _k, c in segs)

--- a/tests/gateway/test_discord_components_v2_send.py
+++ b/tests/gateway/test_discord_components_v2_send.py
@@ -1,0 +1,118 @@
+"""Components V2 send path: flag gating and fallback to chunked text."""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tests.gateway.conftest import _ensure_discord_mock
+
+# Do NOT call _ensure_discord_mock() here. tests/gateway/conftest.py already installs the
+# mock at import time, and calling it again mints a *fresh* MagicMock (it only short-circuits
+# for the real library, which has __file__). That new object replaces the one sibling modules
+# captured at collection, breaking isinstance checks against discord.Thread /
+# discord.ForumChannel and assertions on discord.MessageReference: 15 unrelated gateway tests
+# fail in the same session, while every file still passes in isolation.
+assert "discord" in sys.modules, "tests/gateway/conftest.py should have installed the mock"
+
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+def _adapter(components_v2: bool):
+    a = DiscordAdapter.__new__(DiscordAdapter)
+    # `name` is a read-only property on the base adapter; back it with the config it reads.
+    a.config = SimpleNamespace(name="discord", extra={})
+    a.platform = SimpleNamespace(value="discord")
+    a._components_v2 = components_v2
+    a._last_self_message_id = {}
+    a._nonconversational_messages = SimpleNamespace(mark_many=AsyncMock())
+    a.format_message = lambda c: c
+    return a
+
+
+@pytest.mark.asyncio
+class TestComponentsV2SendGating:
+    async def test_disabled_flag_never_builds_a_view(self):
+        channel = MagicMock()
+        channel.send = AsyncMock()
+        out = await _adapter(False)._try_send_components_v2(
+            channel, "hello", None, "c1", None, False)
+        assert out is None
+        channel.send.assert_not_called()
+
+    async def test_enabled_flag_sends_a_view_and_no_content(self):
+        channel = MagicMock()
+        channel.send = AsyncMock(return_value=SimpleNamespace(id=777))
+        out = await _adapter(True)._try_send_components_v2(
+            channel, "hello there", None, "c1", None, False)
+        assert out is not None
+        assert out.success is True
+        assert out.message_id == "777"
+        kwargs = channel.send.await_args.kwargs
+        assert kwargs.get("view") is not None
+        # A v2 message rejects the legacy content field outright.
+        assert "content" not in kwargs or kwargs["content"] is None
+
+    async def test_oversized_reply_falls_back_to_chunked_path(self):
+        """Past v2's 4000-char whole-tree budget the legacy chunker must still deliver."""
+        channel = MagicMock()
+        channel.send = AsyncMock()
+        out = await _adapter(True)._try_send_components_v2(
+            channel, "x" * 9000, None, "c1", None, False)
+        assert out is None
+        channel.send.assert_not_called()
+
+    async def test_send_failure_degrades_instead_of_losing_the_reply(self):
+        channel = MagicMock()
+        channel.send = AsyncMock(side_effect=RuntimeError("50035 invalid components"))
+        out = await _adapter(True)._try_send_components_v2(
+            channel, "hello", None, "c1", None, False)
+        assert out is None
+
+    async def test_tracks_last_message_id_for_history_backfill(self):
+        channel = MagicMock()
+        channel.send = AsyncMock(return_value=SimpleNamespace(id=42))
+        a = _adapter(True)
+        await a._try_send_components_v2(channel, "hello", None, "c1", None, False)
+        assert a._last_self_message_id["c1"] == "42"
+
+    async def test_thread_id_wins_over_chat_id_for_tracking(self):
+        channel = MagicMock()
+        channel.send = AsyncMock(return_value=SimpleNamespace(id=43))
+        a = _adapter(True)
+        await a._try_send_components_v2(channel, "hello", None, "c1", "t9", False)
+        assert a._last_self_message_id["t9"] == "43"
+        assert "c1" not in a._last_self_message_id
+
+    async def test_nonconversational_marks_instead_of_tracking(self):
+        channel = MagicMock()
+        channel.send = AsyncMock(return_value=SimpleNamespace(id=44))
+        a = _adapter(True)
+        await a._try_send_components_v2(channel, "hello", None, "c1", None, True)
+        a._nonconversational_messages.mark_many.assert_awaited_once_with(["44"])
+        assert a._last_self_message_id == {}
+
+    async def test_reply_reference_is_forwarded(self):
+        channel = MagicMock()
+        channel.send = AsyncMock(return_value=SimpleNamespace(id=45))
+        ref = object()
+        await _adapter(True)._try_send_components_v2(
+            channel, "hello", ref, "c1", None, False)
+        assert channel.send.await_args.kwargs.get("reference") is ref
+
+
+def test_components_v2_yaml_key_bridges_to_env():
+    """discord.components_v2 in config.yaml must reach the adapter.
+
+    The adapter reads DISCORD_COMPONENTS_V2 via os.getenv, and top-level `discord:` keys only
+    reach it through _apply_yaml_config's YAML->env bridge. Without an entry in
+    _YAML_BOOL_ENV_KEYS the key is written to config.yaml, passes validation, and is then
+    silently dropped -- the flag reads False forever with no error anywhere.
+    """
+    from plugins.platforms.discord.adapter import _YAML_BOOL_ENV_KEYS
+
+    assert ("components_v2", "DISCORD_COMPONENTS_V2") in _YAML_BOOL_ENV_KEYS

--- a/tests/plugins/platforms/test_discord_components_v2_view.py
+++ b/tests/plugins/platforms/test_discord_components_v2_view.py
@@ -1,0 +1,110 @@
+"""Components V2 view construction against the real discord.py library.
+
+Kept out of tests/gateway/ deliberately: that package's conftest installs a MagicMock
+`discord`, so discord.ui.Container/LayoutView are not the real classes there and these
+assertions would be vacuous. Planning logic (no discord.py needed) is covered by
+tests/gateway/test_discord_components_v2.py.
+
+The real library is loaded inside each test rather than at module scope, and sys.modules is
+restored afterwards. Importing it at import time would leave a real `discord` cached during
+collection, which makes tests/gateway/conftest.py's `_ensure_discord_mock()` short-circuit
+for gateway files collected later; those files bind `discord` at import and then fail on
+real constructors (`discord.Thread()` wants guild/state/data). That cost 7 unrelated
+failures in slash-auth and image-send, each of which passed in isolation.
+"""
+
+import importlib
+import importlib.util
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_ROOT))
+
+
+@contextmanager
+def real_discord():
+    """Swap in the genuine discord.py for the duration of the block, then restore exactly."""
+    saved = {name: mod for name, mod in sys.modules.items()
+             if name == "discord" or name.startswith("discord.")}
+    for name in list(saved):
+        del sys.modules[name]
+    try:
+        try:
+            module = importlib.import_module("discord")
+        except ImportError:
+            pytest.skip("discord.py is not installed")
+        if not hasattr(module, "__file__"):
+            pytest.skip("a mock discord module is shadowing the real library")
+        if not hasattr(module.ui, "LayoutView"):
+            pytest.skip("discord.py is too old for Components V2")
+        yield module
+    finally:
+        for name in [n for n in sys.modules if n == "discord" or n.startswith("discord.")]:
+            del sys.modules[name]
+        sys.modules.update(saved)
+
+
+def _load_components_v2():
+    """Load the renderer by path; its discord import is lazy and happens at call time."""
+    path = _ROOT / "plugins" / "platforms" / "discord" / "components_v2.py"
+    spec = importlib.util.spec_from_file_location("_hermes_components_v2_view_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestBuildLayoutView:
+    def test_returns_none_when_plan_declines(self):
+        with real_discord():
+            assert _load_components_v2().build_layout_view("x" * 5000) is None
+
+    def test_builds_a_view_for_ordinary_content(self):
+        with real_discord():
+            assert _load_components_v2().build_layout_view("hello\n\nworld") is not None
+
+    def test_view_declares_components_v2(self):
+        """discord.py derives the IS_COMPONENTS_V2 message flag from has_components_v2()."""
+        with real_discord():
+            view = _load_components_v2().build_layout_view("hello")
+            assert view is not None
+            assert view.has_components_v2() is True
+
+    def test_view_stays_within_the_40_component_cap(self):
+        with real_discord():
+            c2 = _load_components_v2()
+            view = c2.build_layout_view("\n\n".join(f"para {i}" for i in range(15)))
+            assert view is not None
+            assert view._total_children <= c2.MAX_TOTAL_COMPONENTS
+
+    def test_code_content_survives_into_the_rendered_components(self):
+        with real_discord():
+            view = _load_components_v2().build_layout_view("intro\n\n```py\nprint('hi')\n```")
+            assert view is not None
+            assert "print('hi')" in str(view.to_components())
+
+    def test_fence_and_prose_become_separate_text_displays(self):
+        with real_discord():
+            view = _load_components_v2().build_layout_view("intro\n\n```py\nx=1\n```")
+            assert view is not None
+            payload = str(view.to_components())
+            assert "intro" in payload and "x=1" in payload
+
+    def test_empty_content_returns_none(self):
+        with real_discord():
+            assert _load_components_v2().build_layout_view("") is None
+
+
+def test_sys_modules_is_left_undisturbed():
+    """Guard the invariant that makes this file safe to run alongside gateway tests."""
+    before = dict(sys.modules)
+    with real_discord() as module:
+        assert hasattr(module, "__file__")
+    after = {n: m for n, m in sys.modules.items()
+             if n == "discord" or n.startswith("discord.")}
+    expected = {n: m for n, m in before.items()
+                if n == "discord" or n.startswith("discord.")}
+    assert after == expected


### PR DESCRIPTION
## What does this PR do?

Long agent replies are chunked into up to 8 separate 2000-char messages (`MAX_SPLIT_MESSAGES`, added after an incident that delivered 60,698 chars as 31 back-to-back messages). This adds an opt-in Components V2 path: one structured message — a `Container` of `TextDisplay` blocks split on fenced code, with `Separator`s between them — instead of a wall of chunks.

**The design constraint worth reviewing.** Discord sums displayable text across the *whole component tree* against a 4000-char cap, not per component. That total is **smaller** than what the existing chunker can deliver, so V2 cannot be a blanket replacement. `build_layout_view` returns `None` for anything that does not fit and the legacy chunked path runs untouched. Send failures degrade the same way. Rendering is always an optimisation, never a constraint on what Hermes can say, and never the reason a reply fails to arrive.

**Streaming edits deliberately stay on legacy text.** The components-v2 message flag cannot be removed once set, and such a message rejects the `content` field, so switching mid-stream would strand the edit target that `edit_message` depends on.

Off by default. Enable with `discord.components_v2: true` or `DISCORD_COMPONENTS_V2=true`.

## Related Issue

No existing issue, and no prior PR — searched open and closed.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/discord/components_v2.py` — new; segment planning and `LayoutView` construction, with the server-side budgets documented at the top
- `plugins/platforms/discord/adapter.py` — `_try_send_components_v2` in the send path, behind the new flag; falls through to the existing chunker on `None`
- `tests/gateway/conftest.py` — adds V2 layout primitives to the shared discord mock
- `tests/gateway/test_discord_components_v2.py`, `tests/gateway/test_discord_components_v2_send.py`, `tests/plugins/platforms/test_discord_components_v2_view.py` — new, 30 tests

## How to Test

```bash
pytest tests/gateway/test_discord_components_v2.py \
       tests/gateway/test_discord_components_v2_send.py \
       tests/plugins/platforms/test_discord_components_v2_view.py -q
```

Manually: set `DISCORD_COMPONENTS_V2=true`, ask for a reply containing a fenced code block, and confirm one message with a container rather than several chunks. Then ask for something over ~4000 chars and confirm it falls back to normal chunked delivery.

Mutation tested — 11 mutants (text budget, component budget, empty content, fence splitting, separator off-by-one, flag ignored, failure propagated instead of degraded, legacy `content` field sent alongside components, backfill tracking dropped, thread targeting, nonconversational marking), all killed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run the Discord test suite: 9 failures on a clean `main` checkout, 9 on this branch, zero new (the 9 are pre-existing and network-dependent — they fetch `cdn.discordapp.com`). Also verified under three randomized test orderings.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu, Linux 7.0.0-28-generic, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — module docstring records the three server-side limits and why the renderer is deliberately partial
- [x] `discord.components_v2` is wired through the plugin's YAML→env bridge (`_YAML_BOOL_ENV_KEYS`), so the documented config key actually reaches the adapter. Happy to add it to `cli-config.yaml.example` too if you'd like it listed alongside the other Discord keys.
- [x] N/A — no architecture or workflow change
- [x] Cross-platform: no platform-specific behavior
- [x] N/A — no tool schema change (gateway adapter, not a tool)

## One bug found by actually enabling it

The first version of this PR shipped a flag that only worked via the env var. `discord.components_v2: true` in `config.yaml` wrote cleanly and passed validation, then got silently dropped: top-level `discord:` keys only reach the adapter through `_apply_yaml_config`'s YAML→env bridge, and `components_v2` was not in `_YAML_BOOL_ENV_KEYS`. No error anywhere, flag just stayed False.

`discord.extra.components_v2` does not work either — `GatewayConfig.from_dict` only reads a top-level `platforms:` mapping, so a nested `extra` under `discord:` never lands.

Fixed by adding the key to the bridge tuple, with a regression test asserting the pair is present. Mutation tested: remove the bridge line and the test fails.

Worth flagging for anyone adding a Discord config key later — writing it into `config.yaml` and reading `self.config.extra` in the adapter looks correct and silently does nothing.

## Notes for the reviewer

**Test isolation.** `tests/gateway/conftest.py` gains V2 layout primitives in the shared mock. Two things there are load-bearing and carry comments explaining why, because both cost real debugging time:

1. The send test must **not** call `_ensure_discord_mock()` — it mints a *fresh* `MagicMock`, and the new object breaks `isinstance` identity (`discord.Thread`, `discord.ForumChannel`) for sibling files that captured the old one at collection.
2. The view test loads the real discord.py **inside each test** via a context manager that restores `sys.modules` exactly, rather than importing at module scope. A leftover real `discord` makes `_ensure_discord_mock()` short-circuit for files collected later, which then fail on real constructors. There's a test asserting that invariant directly.

Both failure modes are order-dependent: every file passes in isolation while 7-15 unrelated tests fail in a full run.

**One deviation worth naming.** Three guards I originally wrote were unreachable, because the whole-tree budget sits below the single-component ceiling — any text large enough to overflow one component has already overflowed the tree. Mutation testing caught this by surviving. Rather than keep dead code defended by tests that pass either way, the guards and a now-unused prose splitter were deleted and the docstring states why segmentation comes only from fenced blocks.
