### PR TITLE
fix: scope execute_code out of dispatcher workers by default

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -331,6 +331,22 @@ def _select_tool_names(enabled_toolsets: Optional[List[str]], disabled_toolsets:
     # disabled toolset are strictly stripped out. See issue #17309.
     if disabled_toolsets:
         _apply_toolset_selection(tools, disabled_toolsets, quiet_mode, disable=True)
+
+    # Dispatcher-owned Kanban workers default to the auditable file/terminal
+    # surface.  ``execute_code`` runs a nested in-process tool loop and is
+    # deliberately opt-in for a task that names the narrow ``code_execution``
+    # toolset.  Keeping the tool out of the model schema avoids turning an
+    # ordinary implementation choice into a late owner-approval request.
+    dispatcher_worker = (
+        bool(os.environ.get("HERMES_KANBAN_TASK"))
+        and not _is_delegated_child_context()
+        and _is_dispatcher_owned_worker()
+    )
+    code_execution_explicit = (
+        enabled_toolsets is not None and "code_execution" in enabled_toolsets
+    )
+    if dispatcher_worker and not code_execution_explicit:
+        tools.discard("execute_code")
     return tools
 
 

--- a/tests/test_dispatcher_worker_tool_scope.py
+++ b/tests/test_dispatcher_worker_tool_scope.py
@@ -1,0 +1,43 @@
+"""Dispatcher workers must not surface nested code execution by default."""
+
+from __future__ import annotations
+
+import model_tools
+
+
+def _names(monkeypatch, enabled=None, disabled=None, *, task=True, dispatcher=True):
+    if task:
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_worker")
+    else:
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setattr(model_tools, "_is_delegated_child_context", lambda: False)
+    monkeypatch.setattr(model_tools, "_is_dispatcher_owned_worker", lambda: dispatcher)
+    return model_tools._select_tool_names(enabled, disabled, quiet_mode=True)
+
+
+def test_dispatcher_worker_default_drops_execute_code(monkeypatch):
+    assert "execute_code" not in _names(monkeypatch, ["hermes-cli"])
+
+
+def test_dispatcher_worker_all_toolsets_default_drops_execute_code(monkeypatch):
+    assert "execute_code" not in _names(monkeypatch, None)
+
+
+def test_dispatcher_worker_explicit_code_execution_opt_in(monkeypatch):
+    assert "execute_code" in _names(monkeypatch, ["hermes-cli", "code_execution"])
+
+
+def test_disabled_code_execution_wins_over_explicit_opt_in(monkeypatch):
+    assert "execute_code" not in _names(
+        monkeypatch,
+        ["hermes-cli", "code_execution"],
+        ["code_execution"],
+    )
+
+
+def test_interactive_operator_keeps_execute_code(monkeypatch):
+    assert "execute_code" in _names(monkeypatch, ["hermes-cli"], task=False)
+
+
+def test_non_dispatcher_context_keeps_execute_code(monkeypatch):
+    assert "execute_code" in _names(monkeypatch, ["hermes-cli"], dispatcher=False)


### PR DESCRIPTION
## Summary

- remove `execute_code` from dispatcher-owned Kanban workers by default
- preserve it for interactive/operator contexts
- preserve explicit opt-in through the narrow `code_execution` toolset
- keep `disabled_toolsets` precedence

## Why

Workers currently see a tool that Fleet Policy later blocks, creating avoidable card failures and false owner-approval churn. This change removes the unsafe default capability at schema assembly time while keeping deliberate specialist opt-in.

## Verification

- `python -m pytest -q tests/test_dispatcher_worker_tool_scope.py tests/hermes_cli/test_tools_config.py`
- 58 passed, 0 failed, 6 skipped
- exact commit: `9b9f7b1c55de0e1e8d30d386380f7e784cb28a92`

No runtime configuration, model, provider, pool, or credential changes.
