### PR TITLE
fix(moa): separate context usage and preserve acting output budgets

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6015,7 +6015,7 @@ def _forwards_max_tokens(provider: str, provider_norm: str, model: str, effectiv
 
     No default cap elsewhere (omitted = provider default; avoids max_completion_tokens / ZAI-vision
     quirks). Forward only where mandatory or honored: Anthropic Messages wire (400 without it);
-    NVIDIA NIM (empty choices[] when omitted); MoA reference slots; Gemini native (fixed 65,535
+    NVIDIA NIM (empty choices[] when omitted); MoA reference and aggregator slots; Gemini native (fixed 65,535
     ceiling otherwise); OpenRouter (budgets the FULL window when omitted → 402 on low credit);
     managed local llama-server (uncapped decode with no EOS burns the GPU to the context window).
     """
@@ -6024,7 +6024,7 @@ def _forwards_max_tokens(provider: str, provider_norm: str, model: str, effectiv
         or _nous_on_messages_wire(provider_norm, model)
         or provider_norm in _NVIDIA_PROVIDER_NAMES
         or base_url_host_matches(effective_base, "integrate.api.nvidia.com")
-        or str(task) == "moa_reference"
+        or task in {"moa_reference", "moa_aggregator"}
         or _is_gemini_native_route(provider_norm, effective_base)
         or provider_norm == "openrouter"
         or base_url_host_matches(effective_base, "openrouter.ai")

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -78,6 +78,8 @@ class ContextEngine(ABC):
         ``prompt_tokens``/``completion_tokens``/``total_tokens`` are always present; the
         canonical buckets (``input_tokens``, ``output_tokens``, ``cache_read_tokens``,
         ``cache_write_tokens``, ``reasoning_tokens``) are optional on older hosts.
+        These counts describe the acting model's request. MoA advisor usage is
+        included in session totals, but does not occupy this context window.
         """
 
     @abstractmethod

--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -1106,9 +1106,12 @@ class MoAChatCompletions:
                 stream_kwargs["timeout"] = api_kwargs["timeout"]
         # Pop the runtime's extra_body so the explicit kwarg never collides with **agg_runtime.
         agg_extra_body = _merge_slot_extra_body(agg_runtime.pop("extra_body", None), api_kwargs.get("extra_body"))
+        acting_cap = api_kwargs.get("max_completion_tokens")
+        if acting_cap is None:
+            acting_cap = api_kwargs.get("max_tokens")
         agg_response = call_llm(
             task="moa_aggregator", messages=agg_messages, temperature=prepared["aggregator_temperature"],
-            max_tokens=api_kwargs.get("max_tokens"), tools=tools, extra_body=agg_extra_body,
+            max_tokens=acting_cap, tools=tools, extra_body=agg_extra_body,
             reasoning_config=_aggregator_reasoning_config(aggregator),  # same policy as direct create()
             **stream_kwargs, **agg_runtime,
         )

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -1168,10 +1168,10 @@ def describe_invalid_response(agent: Any, response: Any, api_duration: float) ->
     if provider_name == "Unknown" and response and hasattr(response, 'model') and response.model:
         provider_name = f"model={response.model}"
 
-    if provider_name == "Unknown" and response:
-        resp_attrs = {k: str(v)[:100] for k, v in vars(response).items() if not k.startswith('_')}
-        if agent.verbose_logging:
-            logging.debug(f"Response attributes for invalid response: {resp_attrs}")
+    if provider_name == "Unknown" and response and agent.verbose_logging:
+        attributes = response if isinstance(response, dict) else getattr(response, "__dict__", {})
+        resp_attrs = {k: str(v)[:100] for k, v in attributes.items() if not k.startswith('_')}
+        logging.debug(f"Response attributes for invalid response: {resp_attrs}")
 
     _resp_error_code = None
     if _has_error:

--- a/agent/turn_response_check.py
+++ b/agent/turn_response_check.py
@@ -120,6 +120,17 @@ def check_api_response(
         resp_model = getattr(response, 'model', 'N/A') if response else 'N/A'
         logging.debug(f"API Response received - Model: {resp_model}, Usage: {response.usage if hasattr(response, 'usage') else 'N/A'}")
 
+    # Count each received attempt once, before shape recovery can retry or switch providers.
+    _usage_outcome = record_response_usage(
+        agent, response, messages=messages, api_call_count=api_call_count,
+        api_duration=api_duration, compression_attempts=compression_attempts,
+        max_compression_attempts=max_compression_attempts,
+    )
+    compression_attempts = _usage_outcome.compression_attempts
+    if _usage_outcome.rearmed:
+        _preflight_compression_blocked = False
+        _last_preflight_pressure = None
+
     response_invalid, error_details = validate_response_shape(agent, response)
     if response_invalid:
         _iv = retry_invalid_response(
@@ -141,19 +152,6 @@ def check_api_response(
 
     agent._turn_received_provider_response = True
     finish_reason = _derive_finish_reason(agent, response, messages)
-
-    # A truncated or refused response still consumed tokens. Record usage before
-    # recovery changes the transcript or provider, and consume this attempt's
-    # advisor usage before another MoA fan-out can add to it.
-    _usage_outcome = record_response_usage(
-        agent, response, messages=messages, api_call_count=api_call_count,
-        api_duration=api_duration, compression_attempts=compression_attempts,
-        max_compression_attempts=max_compression_attempts,
-    )
-    compression_attempts = _usage_outcome.compression_attempts
-    if _usage_outcome.rearmed:
-        _preflight_compression_blocked = False
-        _last_preflight_pressure = None
 
     # HTTP-200 refusals are deterministic: one fallback try, else return the refusal.
     if finish_reason == "content_filter":

--- a/agent/turn_response_check.py
+++ b/agent/turn_response_check.py
@@ -142,6 +142,19 @@ def check_api_response(
     agent._turn_received_provider_response = True
     finish_reason = _derive_finish_reason(agent, response, messages)
 
+    # A truncated or refused response still consumed tokens. Record usage before
+    # recovery changes the transcript or provider, and consume this attempt's
+    # advisor usage before another MoA fan-out can add to it.
+    _usage_outcome = record_response_usage(
+        agent, response, messages=messages, api_call_count=api_call_count,
+        api_duration=api_duration, compression_attempts=compression_attempts,
+        max_compression_attempts=max_compression_attempts,
+    )
+    compression_attempts = _usage_outcome.compression_attempts
+    if _usage_outcome.rearmed:
+        _preflight_compression_blocked = False
+        _last_preflight_pressure = None
+
     # HTTP-200 refusals are deterministic: one fallback try, else return the refusal.
     if finish_reason == "content_filter":
         _rv = handle_content_policy_refusal(
@@ -179,18 +192,6 @@ def check_api_response(
         compression_attempts = _tv.compression_attempts
         if _tv.action in ("return", "break", "continue"):
             return _verdict(_tv.action, _tv.result)
-
-    # Fold provider usage into compressor / anchors / session counters / state.db
-    # (agent/turn_usage.py). A rearmed budget also clears the preflight-block latch.
-    _usage_outcome = record_response_usage(
-        agent, response, messages=messages, api_call_count=api_call_count,
-        api_duration=api_duration, compression_attempts=compression_attempts,
-        max_compression_attempts=max_compression_attempts,
-    )
-    compression_attempts = _usage_outcome.compression_attempts
-    if _usage_outcome.rearmed:
-        _preflight_compression_blocked = False
-        _last_preflight_pressure = None
 
     _retry.has_retried_429 = False
     # Clearing Nous rate-limit state proves the limit reset so other sessions may resume.

--- a/agent/turn_usage.py
+++ b/agent/turn_usage.py
@@ -99,16 +99,17 @@ def record_response_usage(
     prompt_tokens = canonical_usage.prompt_tokens
     completion_tokens = canonical_usage.output_tokens
     total_tokens = canonical_usage.total_tokens
-    # Canonical token + cache buckets for context engines; legacy keys stay for back-compat.
+    # Advisor prompts belong to separate requests. Only the acting model's usage
+    # can measure this context or confirm that a compaction reduced it.
     usage_dict = {
-        "prompt_tokens": prompt_tokens,
-        "completion_tokens": completion_tokens,
-        "total_tokens": total_tokens,
-        "input_tokens": canonical_usage.input_tokens,
-        "output_tokens": canonical_usage.output_tokens,
-        "cache_read_tokens": canonical_usage.cache_read_tokens,
-        "cache_write_tokens": canonical_usage.cache_write_tokens,
-        "reasoning_tokens": canonical_usage.reasoning_tokens,
+        "prompt_tokens": aggregator_usage.prompt_tokens,
+        "completion_tokens": aggregator_usage.output_tokens,
+        "total_tokens": aggregator_usage.total_tokens,
+        "input_tokens": aggregator_usage.input_tokens,
+        "output_tokens": aggregator_usage.output_tokens,
+        "cache_read_tokens": aggregator_usage.cache_read_tokens,
+        "cache_write_tokens": aggregator_usage.cache_write_tokens,
+        "reasoning_tokens": aggregator_usage.reasoning_tokens,
     }
     # Capture the boundary latch before update_from_response() consumes it: only the real
     # prompt count right after a compaction rearms the budget.
@@ -131,12 +132,12 @@ def record_response_usage(
     _compression_threshold = int(getattr(compressor, "threshold_tokens", 0) or 0)
     if _loop_mod()._should_rearm_compression_budget(
         compression_attempts, completed_compaction_pending=_completed_compaction_pending,
-        prompt_tokens=prompt_tokens, threshold_tokens=_compression_threshold,
+        prompt_tokens=aggregator_usage.prompt_tokens, threshold_tokens=_compression_threshold,
     ):
         logger.info(
             "Compression budget rearmed after provider-confirmed "
             "recovery: prompt=%s < threshold=%s (attempts were %s/%s)",
-            f"{prompt_tokens:,}",
+            f"{aggregator_usage.prompt_tokens:,}",
             f"{_compression_threshold:,}",
             compression_attempts,
             max_compression_attempts,
@@ -146,7 +147,7 @@ def record_response_usage(
         # (``_preflight_compression_blocked``), else a later pressure spike grows unchecked.
         rearmed = True
 
-    # Stash canonical usage for on_turn_complete(); keep the latest call's.
+    # Context engines observe the acting request at the turn boundary too.
     agent._last_turn_usage = dict(usage_dict)
     # The parent's CURRENT prompt size for headroom math (delegate summary budgets): the
     # aggregator's own prompt, never the MoA-folded total (advisor prompts are not in this context).
@@ -276,7 +277,7 @@ def record_response_usage(
     # not only when we inject cache_control markers.
     cached = canonical_usage.cache_read_tokens
     written = canonical_usage.cache_write_tokens
-    prompt = usage_dict["prompt_tokens"]
+    prompt = prompt_tokens
     if (cached or written) and not agent.quiet_mode:
         hit_pct = (cached / prompt * 100) if prompt > 0 else 0
         agent._vprint(

--- a/agent/turn_usage.py
+++ b/agent/turn_usage.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List
 
 from agent.image_token_cost import calibrate_from_usage
 from agent.usage_anchor import capture_usage_anchor, set_usage_anchor
-from agent.usage_pricing import estimate_usage_cost, normalize_usage
+from agent.usage_pricing import CanonicalUsage, CostResult, estimate_usage_cost, normalize_usage
 
 logger = logging.getLogger("agent.conversation_loop")
 
@@ -67,16 +67,142 @@ def record_response_usage(
     agent: Any, response: Any, *, messages: List[Dict[str, Any]], api_call_count: int,
     api_duration: float, compression_attempts: int, max_compression_attempts: int,
 ) -> ResponseUsageOutcome:
-    """Fold ``response.usage`` into compressor, anchors, session counters, state.db
-    and the API-call log line (see module docstring). No-usage responses only
-    consume a pending compaction verdict. Returns the loop-visible outcome."""
+    """Record acting usage and advisor spend for one received attempt.
+
+    Missing acting usage cannot measure context, but advisor accounting and
+    trace cleanup still run. Return the remaining compaction attempt budget.
+    """
     rearmed = False
     compressor = agent.context_compressor
     # Count every completed provider attempt, including providers that omit usage.
     # Token/cost accounting below stays gated on real usage, but the request itself
     # must remain observable.
     agent.session_api_calls += 1
-    if not (hasattr(response, 'usage') and response.usage):
+    response_usage = response.get("usage") if isinstance(response, dict) else getattr(response, "usage", None)
+    has_acting_usage = bool(response_usage)
+    aggregator_usage = (
+        normalize_usage(response_usage, provider=agent.provider, api_mode=agent.api_mode)
+        if has_acting_usage else CanonicalUsage()
+    )
+    # Advisor spend and traces belong to this attempt even when acting usage is absent.
+    _moa_client, canonical_usage, _moa_ref_cost = _fold_moa_usage(agent, aggregator_usage)
+    prompt_tokens = canonical_usage.prompt_tokens
+    completion_tokens = canonical_usage.output_tokens
+    total_tokens = canonical_usage.total_tokens
+    # Persist consumed spend before a context plug-in or calibration callback can fail.
+    has_accounting = has_acting_usage or canonical_usage.total_tokens or canonical_usage.reasoning_tokens or _moa_ref_cost is not None
+    if has_accounting:
+        agent.session_prompt_tokens += prompt_tokens
+        agent.session_completion_tokens += completion_tokens
+        agent.session_total_tokens += total_tokens
+        agent.session_input_tokens += canonical_usage.input_tokens
+        agent.session_output_tokens += canonical_usage.output_tokens
+        agent.session_cache_read_tokens += canonical_usage.cache_read_tokens
+        agent.session_cache_write_tokens += canonical_usage.cache_write_tokens
+        agent.session_reasoning_tokens += canonical_usage.reasoning_tokens
+        # Rolling history for status-bar averages (last 10).
+        with suppress(Exception):
+            hist = getattr(agent, "_api_latency_history", None)
+            if hist is not None:
+                hist.append(float(api_duration))
+            ohist = getattr(agent, "_api_output_history", None)
+            if ohist is not None:
+                ohist.append(int(canonical_usage.output_tokens or 0))
+
+        _cache_pct = ""
+        if canonical_usage.cache_read_tokens and prompt_tokens:
+            _cache_pct = f" cache={canonical_usage.cache_read_tokens}/{prompt_tokens} ({100*canonical_usage.cache_read_tokens/prompt_tokens:.0f}%)"
+        # write= is the money (cache writes cost 50x a read); id= is what a provider needs to look the
+        # request up; upstream= is who actually served it when the route reports that (OpenRouter's
+        # `provider`). Diagnosing the 1,393-agent run's cache misses took a DB join and a live probe
+        # because none of the three were on this line.
+        if canonical_usage.cache_write_tokens:
+            _cache_pct += f" write={canonical_usage.cache_write_tokens}"
+        _rid = getattr(response, "id", None)
+        _ident = f" id={_rid}" if isinstance(_rid, str) and _rid else ""
+        if not has_acting_usage:
+            _ident += " acting_usage=unavailable"
+        _upstream = getattr(response, "provider", None)
+        if isinstance(_upstream, str) and _upstream:
+            _ident += f" upstream={_upstream}"
+        logger.info(
+            "API call #%d: model=%s provider=%s in=%d out=%d total=%d latency=%.1fs%s%s",
+            agent.session_api_calls, agent.model, agent.provider or "unknown",
+            prompt_tokens, completion_tokens, total_tokens,
+            api_duration, _cache_pct, _ident,
+        )
+        # nous.anthropic_wire=auto: the session's wire is decided once, from this first response.
+        if agent.session_api_calls == 1 and (agent.provider or "") == "nous":
+            with suppress(Exception):
+                from agent.nous_wire import maybe_switch_wire_after_first_response
+                maybe_switch_wire_after_first_response(agent, response, agent.session_api_calls)
+
+        # MoA: agent.model/provider are the virtual preset/"moa" with no pricing entry, silently
+        # dropping aggregator spend. Price at the REAL model/provider from the aggregator slot.
+        _agg_cost_model, _agg_cost_provider, _agg_cost_base_url = agent.model, agent.provider, agent.base_url
+        _agg_slot = getattr(_moa_client, "last_aggregator_slot", None) if _moa_client is not None else None
+        if _agg_slot and _agg_slot.get("model"):
+            _agg_cost_model = _agg_slot["model"]
+            _agg_cost_provider = _agg_slot.get("provider") or agent.provider
+            _agg_cost_base_url = _agg_slot.get("base_url") or agent.base_url
+        cost_result = (
+            estimate_usage_cost(
+                _agg_cost_model, aggregator_usage, provider=_agg_cost_provider,
+                base_url=_agg_cost_base_url, api_key=getattr(agent, "api_key", ""),
+            ) if has_acting_usage else CostResult(None, "unknown", "none", "Acting usage unavailable")
+        )
+        # Cost delta = aggregator + MoA advisor cost (already priced per-advisor at each
+        # advisor's own model rate), so state.db's estimated_cost_usd matches the folded
+        # token counts.
+        _cost_delta = None
+        if cost_result.amount_usd is not None:
+            _cost_delta = float(cost_result.amount_usd)
+            agent.session_estimated_cost_usd += _cost_delta
+        if _moa_ref_cost is not None:
+            try:
+                _moa_cost = float(_moa_ref_cost)
+            except (TypeError, ValueError):  # pragma: no cover - defensive
+                _moa_cost = None
+            if _moa_cost is not None:
+                agent.session_estimated_cost_usd += _moa_cost
+                _cost_delta = (_cost_delta or 0.0) + _moa_cost
+        agent.session_cost_status = cost_result.status
+        agent.session_cost_source = cost_result.source
+
+        # Persist per-call token deltas for any session_id so non-CLI runs can't lose
+        # accounting; gateway/session-store writes use absolute totals and safely overwrite
+        # these deltas. Enqueued, not written (a cold state.db UPDATE here stalled the tool
+        # loop); drained at finalize via _persist_session.
+        if agent._session_db and agent.session_id:
+            try:
+                # Ensure the row exists: under concurrent SQLite load the initial
+                # _ensure_db_session() may fail, and UPDATE on a missing row affects 0 rows.
+                if not agent._session_db_created:
+                    agent._ensure_db_session()
+                agent._session_db.queue_token_counts(
+                    agent.session_id,
+                    input_tokens=canonical_usage.input_tokens,
+                    output_tokens=canonical_usage.output_tokens,
+                    cache_read_tokens=canonical_usage.cache_read_tokens,
+                    cache_write_tokens=canonical_usage.cache_write_tokens,
+                    reasoning_tokens=canonical_usage.reasoning_tokens,
+                    estimated_cost_usd=_cost_delta,
+                    cost_status=cost_result.status,
+                    cost_source=cost_result.source,
+                    billing_provider=agent.provider,
+                    billing_base_url=agent.base_url,
+                    billing_mode="subscription_included"
+                    if cost_result.status == "included" else None,
+                    model=agent.model,
+                    api_call_count=1,
+                )
+            except Exception as e:  # silent loss here undercounts analytics
+                logger.debug(
+                    "Token persistence failed (session=%s, tokens=%d): %s",
+                    agent.session_id, total_tokens, e,
+                )
+
+    if not has_acting_usage:
         if getattr(compressor, "awaiting_real_usage_after_compression", False):
             # No usage -> cannot adjudicate the prior compaction; consume the
             # pending verdict so later readings aren't charged to it and
@@ -85,192 +211,82 @@ def record_response_usage(
         _note_usage_less = getattr(compressor, "note_usage_less_response", None)
         if callable(_note_usage_less):
             _note_usage_less()
-        logger.info(
-            "API call #%d: model=%s provider=%s in=? out=? total=? latency=%.1fs usage=unavailable",
-            agent.session_api_calls, agent.model, agent.provider or "unknown", api_duration,
-        )
-        return ResponseUsageOutcome(compression_attempts=compression_attempts, rearmed=rearmed)
-
-    canonical_usage = normalize_usage(response.usage, provider=agent.provider, api_mode=agent.api_mode)
-    # Aggregator-only usage kept for pricing: advisor tokens are priced at each advisor's
-    # OWN model rate and added as dollars below.
-    aggregator_usage = canonical_usage
-    _moa_client, canonical_usage, _moa_ref_cost = _fold_moa_usage(agent, canonical_usage)
-    prompt_tokens = canonical_usage.prompt_tokens
-    completion_tokens = canonical_usage.output_tokens
-    total_tokens = canonical_usage.total_tokens
-    # Advisor prompts belong to separate requests. Only the acting model's usage
-    # can measure this context or confirm that a compaction reduced it.
-    usage_dict = {
-        "prompt_tokens": aggregator_usage.prompt_tokens,
-        "completion_tokens": aggregator_usage.output_tokens,
-        "total_tokens": aggregator_usage.total_tokens,
-        "input_tokens": aggregator_usage.input_tokens,
-        "output_tokens": aggregator_usage.output_tokens,
-        "cache_read_tokens": aggregator_usage.cache_read_tokens,
-        "cache_write_tokens": aggregator_usage.cache_write_tokens,
-        "reasoning_tokens": aggregator_usage.reasoning_tokens,
-    }
-    # Capture the boundary latch before update_from_response() consumes it: only the real
-    # prompt count right after a compaction rearms the budget.
-    _completed_compaction_pending = bool(
-        getattr(compressor, "_verify_compaction_cleared_threshold", False)
-    )
-    compressor.update_from_response(usage_dict)
-    # Usage-anchored accounting: snapshot exact provider usage against the durable
-    # transcript (main-loop ONLY; MoA uses pre-fold aggregator usage). The display meter
-    # anchors on the turn's FIRST response: later same-turn responses inflate
-    # prompt_tokens with replayed thinking. Display-only; compression math uses real usage.
-    # The provider just priced this request exactly: if the delta since the previous anchor
-    # introduced images, the residual is their real per-image cost (learned before re-anchoring).
-    calibrate_from_usage(agent, messages, aggregator_usage.prompt_tokens)
-    _new_anchor = capture_usage_anchor(
-        aggregator_usage.prompt_tokens, aggregator_usage.output_tokens, messages
-    )
-    if _new_anchor is not None:
-        set_usage_anchor(agent, _new_anchor, turn_base=api_call_count == 1)
-    _compression_threshold = int(getattr(compressor, "threshold_tokens", 0) or 0)
-    if _loop_mod()._should_rearm_compression_budget(
-        compression_attempts, completed_compaction_pending=_completed_compaction_pending,
-        prompt_tokens=aggregator_usage.prompt_tokens, threshold_tokens=_compression_threshold,
-    ):
-        logger.info(
-            "Compression budget rearmed after provider-confirmed "
-            "recovery: prompt=%s < threshold=%s (attempts were %s/%s)",
-            f"{aggregator_usage.prompt_tokens:,}",
-            f"{_compression_threshold:,}",
-            compression_attempts,
-            max_compression_attempts,
-        )
-        compression_attempts = 0
-        # Confirmed recovery also clears the loop's stale insufficient-progress verdict
-        # (``_preflight_compression_blocked``), else a later pressure spike grows unchecked.
-        rearmed = True
-
-    # Context engines observe the acting request at the turn boundary too.
-    agent._last_turn_usage = dict(usage_dict)
-    # The parent's CURRENT prompt size for headroom math (delegate summary budgets): the
-    # aggregator's own prompt, never the MoA-folded total (advisor prompts are not in this context).
-    agent._last_prompt_size_tokens = int(aggregator_usage.prompt_tokens or 0)
-
-    # Persist only provider-confirmed context lengths, not probe tiers.
-    if getattr(compressor, "_context_probed", False):
-        ctx = compressor.context_length
-        if getattr(compressor, "_context_probe_persistable", False):
-            from agent.model_metadata import save_context_length
-
-            save_context_length(agent.model, agent.base_url, ctx)
-            agent._safe_print(f"{agent.log_prefix}💾 Cached context length: {ctx:,} tokens for {agent.model}")
-        compressor._context_probed = False
-        compressor._context_probe_persistable = False
-
-    agent.session_prompt_tokens += prompt_tokens
-    agent.session_completion_tokens += completion_tokens
-    agent.session_total_tokens += total_tokens
-    agent.session_input_tokens += canonical_usage.input_tokens
-    agent.session_output_tokens += canonical_usage.output_tokens
-    agent.session_cache_read_tokens += canonical_usage.cache_read_tokens
-    agent.session_cache_write_tokens += canonical_usage.cache_write_tokens
-    agent.session_reasoning_tokens += canonical_usage.reasoning_tokens
-    # Rolling history for status-bar averages (last 10).
-    with suppress(Exception):
-        hist = getattr(agent, "_api_latency_history", None)
-        if hist is not None:
-            hist.append(float(api_duration))
-        ohist = getattr(agent, "_api_output_history", None)
-        if ohist is not None:
-            ohist.append(int(canonical_usage.output_tokens or 0))
-
-    _cache_pct = ""
-    if canonical_usage.cache_read_tokens and prompt_tokens:
-        _cache_pct = f" cache={canonical_usage.cache_read_tokens}/{prompt_tokens} ({100*canonical_usage.cache_read_tokens/prompt_tokens:.0f}%)"
-    # write= is the money (cache writes cost 50x a read); id= is what a provider needs to look the
-    # request up; upstream= is who actually served it when the route reports that (OpenRouter's
-    # `provider`). Diagnosing the 1,393-agent run's cache misses took a DB join and a live probe
-    # because none of the three were on this line.
-    if canonical_usage.cache_write_tokens:
-        _cache_pct += f" write={canonical_usage.cache_write_tokens}"
-    _rid = getattr(response, "id", None)
-    _ident = f" id={_rid}" if isinstance(_rid, str) and _rid else ""
-    _upstream = getattr(response, "provider", None)
-    if isinstance(_upstream, str) and _upstream:
-        _ident += f" upstream={_upstream}"
-    logger.info(
-        "API call #%d: model=%s provider=%s in=%d out=%d total=%d latency=%.1fs%s%s",
-        agent.session_api_calls, agent.model, agent.provider or "unknown",
-        prompt_tokens, completion_tokens, total_tokens,
-        api_duration, _cache_pct, _ident,
-    )
-    # nous.anthropic_wire=auto: the session's wire is decided once, from this first response.
-    if agent.session_api_calls == 1 and (agent.provider or "") == "nous":
-        with suppress(Exception):
-            from agent.nous_wire import maybe_switch_wire_after_first_response
-            maybe_switch_wire_after_first_response(agent, response, agent.session_api_calls)
-
-    # MoA: agent.model/provider are the virtual preset/"moa" with no pricing entry, silently
-    # dropping aggregator spend. Price at the REAL model/provider from the aggregator slot.
-    _agg_cost_model, _agg_cost_provider, _agg_cost_base_url = agent.model, agent.provider, agent.base_url
-    _agg_slot = getattr(_moa_client, "last_aggregator_slot", None) if _moa_client is not None else None
-    if _agg_slot and _agg_slot.get("model"):
-        _agg_cost_model = _agg_slot["model"]
-        _agg_cost_provider = _agg_slot.get("provider") or agent.provider
-        _agg_cost_base_url = _agg_slot.get("base_url") or agent.base_url
-    cost_result = estimate_usage_cost(
-        _agg_cost_model, aggregator_usage, provider=_agg_cost_provider,
-        base_url=_agg_cost_base_url, api_key=getattr(agent, "api_key", ""),
-    )
-    # Cost delta = aggregator + MoA advisor cost (already priced per-advisor at each
-    # advisor's own model rate), so state.db's estimated_cost_usd matches the folded
-    # token counts.
-    _cost_delta = None
-    if cost_result.amount_usd is not None:
-        _cost_delta = float(cost_result.amount_usd)
-        agent.session_estimated_cost_usd += _cost_delta
-    if _moa_ref_cost is not None:
-        try:
-            _moa_cost = float(_moa_ref_cost)
-        except (TypeError, ValueError):  # pragma: no cover - defensive
-            _moa_cost = None
-        if _moa_cost is not None:
-            agent.session_estimated_cost_usd += _moa_cost
-            _cost_delta = (_cost_delta or 0.0) + _moa_cost
-    agent.session_cost_status = cost_result.status
-    agent.session_cost_source = cost_result.source
-
-    # Persist per-call token deltas for any session_id so non-CLI runs can't lose
-    # accounting; gateway/session-store writes use absolute totals and safely overwrite
-    # these deltas. Enqueued, not written (a cold state.db UPDATE here stalled the tool
-    # loop); drained at finalize via _persist_session.
-    if agent._session_db and agent.session_id:
-        try:
-            # Ensure the row exists: under concurrent SQLite load the initial
-            # _ensure_db_session() may fail, and UPDATE on a missing row affects 0 rows.
-            if not agent._session_db_created:
-                agent._ensure_db_session()
-            agent._session_db.queue_token_counts(
-                agent.session_id,
-                input_tokens=canonical_usage.input_tokens,
-                output_tokens=canonical_usage.output_tokens,
-                cache_read_tokens=canonical_usage.cache_read_tokens,
-                cache_write_tokens=canonical_usage.cache_write_tokens,
-                reasoning_tokens=canonical_usage.reasoning_tokens,
-                estimated_cost_usd=_cost_delta,
-                cost_status=cost_result.status,
-                cost_source=cost_result.source,
-                billing_provider=agent.provider,
-                billing_base_url=agent.base_url,
-                billing_mode="subscription_included"
-                if cost_result.status == "included" else None,
-                model=agent.model,
-                api_call_count=1,
+        agent._last_turn_usage = {}
+        if not canonical_usage.total_tokens and not canonical_usage.reasoning_tokens and _moa_ref_cost is None:
+            logger.info(
+                "API call #%d: model=%s provider=%s in=? out=? total=? latency=%.1fs usage=unavailable",
+                agent.session_api_calls, agent.model, agent.provider or "unknown", api_duration,
             )
-        except Exception as e:  # silent loss here undercounts analytics
-            logger.debug(
-                "Token persistence failed (session=%s, tokens=%d): %s",
-                agent.session_id, total_tokens, e,
-            )
+            return ResponseUsageOutcome(compression_attempts=compression_attempts, rearmed=False)
 
-    if agent.verbose_logging:
+    usage_dict = {}
+    if has_acting_usage:
+        # Advisor prompts belong to separate requests. Only the acting model's usage
+        # can measure this context or confirm that a compaction reduced it.
+        usage_dict = {
+            "prompt_tokens": aggregator_usage.prompt_tokens,
+            "completion_tokens": aggregator_usage.output_tokens,
+            "total_tokens": aggregator_usage.total_tokens,
+            "input_tokens": aggregator_usage.input_tokens,
+            "output_tokens": aggregator_usage.output_tokens,
+            "cache_read_tokens": aggregator_usage.cache_read_tokens,
+            "cache_write_tokens": aggregator_usage.cache_write_tokens,
+            "reasoning_tokens": aggregator_usage.reasoning_tokens,
+        }
+        # Capture the boundary latch before update_from_response() consumes it: only the real
+        # prompt count right after a compaction rearms the budget.
+        _completed_compaction_pending = bool(
+            getattr(compressor, "_verify_compaction_cleared_threshold", False)
+        )
+        compressor.update_from_response(usage_dict)
+        # Usage-anchored accounting: snapshot exact provider usage against the durable
+        # transcript (main-loop ONLY; MoA uses pre-fold aggregator usage). The display meter
+        # anchors on the turn's FIRST response: later same-turn responses inflate
+        # prompt_tokens with replayed thinking. Display-only; compression math uses real usage.
+        # The provider just priced this request exactly: if the delta since the previous anchor
+        # introduced images, the residual is their real per-image cost (learned before re-anchoring).
+        calibrate_from_usage(agent, messages, aggregator_usage.prompt_tokens)
+        _new_anchor = capture_usage_anchor(
+            aggregator_usage.prompt_tokens, aggregator_usage.output_tokens, messages
+        )
+        if _new_anchor is not None:
+            set_usage_anchor(agent, _new_anchor, turn_base=api_call_count == 1)
+        _compression_threshold = int(getattr(compressor, "threshold_tokens", 0) or 0)
+        if _loop_mod()._should_rearm_compression_budget(
+            compression_attempts, completed_compaction_pending=_completed_compaction_pending,
+            prompt_tokens=aggregator_usage.prompt_tokens, threshold_tokens=_compression_threshold,
+        ):
+            logger.info(
+                "Compression budget rearmed after provider-confirmed "
+                "recovery: prompt=%s < threshold=%s (attempts were %s/%s)",
+                f"{aggregator_usage.prompt_tokens:,}",
+                f"{_compression_threshold:,}",
+                compression_attempts,
+                max_compression_attempts,
+            )
+            compression_attempts = 0
+            # Confirmed recovery also clears the loop's stale insufficient-progress verdict
+            # (``_preflight_compression_blocked``), else a later pressure spike grows unchecked.
+            rearmed = True
+
+        # Context engines observe the acting request at the turn boundary too.
+        agent._last_turn_usage = dict(usage_dict)
+        # The parent's CURRENT prompt size for headroom math (delegate summary budgets): the
+        # aggregator's own prompt, never the MoA-folded total (advisor prompts are not in this context).
+        agent._last_prompt_size_tokens = int(aggregator_usage.prompt_tokens or 0)
+
+        # Persist only provider-confirmed context lengths, not probe tiers.
+        if getattr(compressor, "_context_probed", False):
+            ctx = compressor.context_length
+            if getattr(compressor, "_context_probe_persistable", False):
+                from agent.model_metadata import save_context_length
+
+                save_context_length(agent.model, agent.base_url, ctx)
+                agent._safe_print(f"{agent.log_prefix}💾 Cached context length: {ctx:,} tokens for {agent.model}")
+            compressor._context_probed = False
+            compressor._context_probe_persistable = False
+
+    if agent.verbose_logging and has_acting_usage:
         logging.debug(f"Token usage: prompt={usage_dict['prompt_tokens']:,}, completion={usage_dict['completion_tokens']:,}, total={usage_dict['total_tokens']:,}")
 
     # Report cache stats for any provider that returns ``prompt_tokens_details.cached_tokens``,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -430,8 +430,7 @@ class TestBuildCallKwargsMaxTokens:
 
 
     def test_moa_task_exact_match(self):
-        """Only task == "moa_reference" triggers the cap — not the aggregator,
-        not arbitrary 'moa_' prefixed tasks."""
+        """Explicit MoA budgets are retained only for known model-call tasks."""
         from agent.auxiliary_client import _build_call_kwargs
 
         # 'moa_reference' → honored
@@ -444,7 +443,7 @@ class TestBuildCallKwargsMaxTokens:
         )
         assert kw["max_tokens"] == 500
 
-        # 'moa_aggregator' → dropped (aggregator is the acting model, not an advisor)
+        # The acting model has its own budget, including continuation increases.
         kw2 = _build_call_kwargs(
             provider="zai", model="glm-5.2",
             messages=[{"role": "user", "content": "hi"}],
@@ -452,9 +451,9 @@ class TestBuildCallKwargsMaxTokens:
             base_url="https://api.z.ai/api/coding/paas/v4",
             task="moa_aggregator",
         )
-        assert "max_tokens" not in kw2
+        assert kw2["max_tokens"] == 500
 
-        # 'moa_custom_future' → dropped (only moa_reference is whitelisted)
+        # A name prefix alone must not change another task's output policy.
         kw3 = _build_call_kwargs(
             provider="zai", model="glm-5.2",
             messages=[{"role": "user", "content": "hi"}],

--- a/tests/agent/test_moa_context_accounting.py
+++ b/tests/agent/test_moa_context_accounting.py
@@ -1,0 +1,83 @@
+"""MoA context pressure uses one request; billing includes every model attempt."""
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.mark.parametrize("finish_reason", ["stop", "length", "content_filter"])
+def test_moa_response_accounts_spend_without_inflating_context(finish_reason, monkeypatch):
+    from agent.moa_loop import MoAClient
+    from agent.turn_response_check import check_api_response
+    from agent.turn_retry_state import TurnRetryState
+    from agent.usage_pricing import CanonicalUsage
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key", provider="custom", model="test/model",
+        base_url="http://localhost:12345/v1", api_mode="chat_completions",
+        enabled_toolsets=[], quiet_mode=True, skip_context_files=True,
+        skip_memory=True, save_trajectories=False,
+    )
+    agent.provider = "moa"
+    agent.client = MoAClient("test")
+    advisor_usage = CanonicalUsage(input_tokens=230_000, output_tokens=2_000)
+    agent.client.chat.completions._pending_reference_usage = advisor_usage
+    compressor = agent.context_compressor
+    compressor.context_length = 262_144
+    compressor.threshold_tokens = 180_000
+    compressor._verify_compaction_cleared_threshold = True
+    messages = [{"role": "user", "content": "Continue the task."}]
+    response = SimpleNamespace(
+        id="test-response", model="test/model",
+        choices=[SimpleNamespace(
+            index=0, finish_reason=finish_reason,
+            message=SimpleNamespace(content="Partial answer.", tool_calls=[], refusal=None),
+        )],
+        usage=SimpleNamespace(prompt_tokens=8_000, completion_tokens=100, total_tokens=8_100),
+    )
+    monkeypatch.setattr(agent, "_persist_session", lambda *args: None)
+    monkeypatch.setattr(agent, "_cleanup_task_resources", lambda *args: None)
+    try:
+        verdict = check_api_response(
+            agent, response=response, _retry=TurnRetryState(), thinking_spinner=None,
+            messages=messages, api_messages=list(messages), api_kwargs={},
+            active_system_prompt="", conversation_history=[], finish_reason=None,
+            retry_count=0, max_retries=3, compression_attempts=3,
+            max_compression_attempts=3, length_continue_retries=0,
+            truncated_response_parts=[], truncated_tool_call_retries=0,
+            current_turn_user_idx=0, api_call_count=1, api_request_id="test-request",
+            api_start_time=time.time(), effective_task_id="test-task", turn_id="test-turn",
+            _preflight_compression_blocked=True, _last_preflight_pressure=238_000,
+        )
+        assert compressor.last_prompt_tokens == 8_000
+        assert compressor.last_completion_tokens == 100
+        assert agent._last_turn_usage["total_tokens"] == 8_100
+        assert agent.session_prompt_tokens == 8_000 + advisor_usage.prompt_tokens
+        assert agent.session_output_tokens == 100 + advisor_usage.output_tokens
+        assert agent.session_api_calls == 1
+        assert agent.client.consume_reference_usage()[0].total_tokens == 0
+        assert verdict.compression_attempts == 0
+        assert verdict._preflight_compression_blocked is False
+        assert verdict._last_preflight_pressure is None
+    finally:
+        agent.close()
+
+
+@pytest.mark.parametrize("task", ["moa_reference", "moa_aggregator"])
+@pytest.mark.parametrize("model, cap_key", [
+    ("custom-model", "max_tokens"), ("gpt-5", "max_completion_tokens"),
+])
+def test_moa_request_builder_preserves_explicit_output_budget(task, model, cap_key):
+    from agent.auxiliary_client import _build_call_kwargs
+
+    messages = [{"role": "user", "content": "Continue the answer."}]
+    for cap in (None, 8_192, 16_384, 32_768):
+        request = _build_call_kwargs(
+            "custom", model, messages, max_tokens=cap,
+            base_url="https://model.example/v1", task=task,
+        )
+        assert request.get(cap_key) == cap
+        other_key = "max_completion_tokens" if cap_key == "max_tokens" else "max_tokens"
+        assert other_key not in request

--- a/tests/agent/test_moa_context_accounting.py
+++ b/tests/agent/test_moa_context_accounting.py
@@ -81,3 +81,175 @@ def test_moa_request_builder_preserves_explicit_output_budget(task, model, cap_k
         assert request.get(cap_key) == cap
         other_key = "max_completion_tokens" if cap_key == "max_tokens" else "max_tokens"
         assert other_key not in request
+
+
+@pytest.fixture
+def accounting_attempt(monkeypatch):
+    from unittest.mock import Mock
+    from agent.moa_loop import MoAClient
+    from agent.turn_retry_state import TurnRetryState
+    from agent.usage_pricing import CanonicalUsage
+    from run_agent import AIAgent
+
+    agent = AIAgent(api_key="test-key", provider="custom", model="test/model",
+                    base_url="http://localhost:12345/v1", api_mode="chat_completions",
+                    enabled_toolsets=[], quiet_mode=True, skip_context_files=True,
+                    skip_memory=True, save_trajectories=False)
+    agent.provider = "moa"
+    client = MoAClient("test")
+    agent.client = client
+    facade = client.chat.completions
+    facade._pending_reference_usage = CanonicalUsage(input_tokens=230_000, output_tokens=2_000)
+    facade._pending_reference_cost = 0.25
+    facade._pending_trace = {"preset": "test"}
+    monkeypatch.setattr(agent, "_persist_session", lambda *args: None)
+    monkeypatch.setattr(agent, "_cleanup_task_resources", lambda *args: None)
+    database = Mock()
+    agent._session_db = database
+    agent._session_db_created = True
+    agent.session_id = "accounting-test"
+    messages = [{"role": "user", "content": "Continue the task."}]
+    kwargs = dict(_retry=TurnRetryState(), thinking_spinner=None, messages=messages,
+                  api_messages=list(messages), api_kwargs={}, active_system_prompt="",
+                  conversation_history=[], finish_reason=None, retry_count=0, max_retries=3,
+                  compression_attempts=3, max_compression_attempts=3, length_continue_retries=0,
+                  truncated_response_parts=[], truncated_tool_call_retries=0, current_turn_user_idx=0,
+                  api_call_count=1, api_request_id="attempt-1", api_start_time=time.time(),
+                  effective_task_id="test-task", turn_id="test-turn",
+                  _preflight_compression_blocked=True, _last_preflight_pressure=238_000)
+    try:
+        yield agent, client, database, kwargs
+    finally:
+        agent._session_db = None
+        agent.close()
+
+
+@pytest.mark.parametrize("finish", ["stop", "content_filter", "length"])
+def test_missing_acting_usage_still_records_advisors(accounting_attempt, finish):
+    from agent.turn_response_check import check_api_response
+
+    agent, client, database, kwargs = accounting_attempt
+    response = SimpleNamespace(usage=None, choices=[SimpleNamespace(
+        finish_reason=finish, message=SimpleNamespace(content="Partial answer.", tool_calls=[], refusal=None))])
+    check_api_response(agent, response=response, **kwargs)
+    assert agent.session_prompt_tokens == 230_000
+    assert agent.session_output_tokens == 2_000
+    assert agent.session_estimated_cost_usd == pytest.approx(0.25)
+    assert agent.session_api_calls == 1
+    assert client.consume_reference_usage()[0].total_tokens == 0
+    assert client.chat.completions._pending_trace is None
+    assert not agent._last_turn_usage
+    assert agent.context_compressor.last_prompt_tokens != 230_000
+    database.queue_token_counts.assert_called_once()
+    persisted = database.queue_token_counts.call_args.kwargs
+    assert persisted["input_tokens"] == 230_000
+    assert persisted["estimated_cost_usd"] == pytest.approx(0.25)
+
+
+@pytest.mark.parametrize("recovery, as_dict", [
+    ("retry", False), ("fallback", False), ("exhaustion", False), ("fallthrough", False),
+    ("retry", True), ("exhaustion", True),
+])
+def test_malformed_attempt_is_counted_before_recovery(accounting_attempt, monkeypatch, recovery, as_dict):
+    from agent import turn_response_check as check
+
+    agent, client, database, kwargs = accounting_attempt
+    response = SimpleNamespace(usage=SimpleNamespace(prompt_tokens=8000, completion_tokens=100), choices=[])
+    if as_dict:
+        response = {"usage": {"prompt_tokens": 8000, "completion_tokens": 100}, "choices": []}
+    monkeypatch.setattr("agent.turn_recovery.interruptible_backoff_sleep", lambda *a, **kw: None)
+    monkeypatch.setattr(agent, "_try_activate_fallback", lambda: recovery == "fallback")
+    monkeypatch.setattr("agent.conversation_loop._arm_fallback_restart", lambda *a, **kw: "")
+    if recovery == "exhaustion":
+        kwargs["retry_count"] = 2
+    if recovery == "fallthrough":
+        def recover(*args, **kw):
+            assert agent.session_api_calls == 1
+            assert agent.session_prompt_tokens == 238_000
+            response.choices = [SimpleNamespace(finish_reason="stop", message=SimpleNamespace(
+                content="Recovered.", tool_calls=[], refusal=None))]
+            return check.InvalidResponseVerdict("fallthrough", None, "", 0, 3)
+        monkeypatch.setattr(check, "retry_invalid_response", recover)
+    verdict = check.check_api_response(agent, response=response, **kwargs)
+    assert verdict.action == {"retry": "continue", "fallback": "break", "exhaustion": "return",
+                              "fallthrough": "break"}[recovery]
+    assert agent.session_prompt_tokens == 238_000
+    assert agent.session_output_tokens == 2100
+    assert agent.session_api_calls == 1
+    assert client.consume_reference_usage()[0].total_tokens == 0
+    assert client.chat.completions._pending_trace is None
+    database.queue_token_counts.assert_called_once()
+
+
+@pytest.mark.parametrize("cap_key", ["max_tokens", "max_completion_tokens"])
+@pytest.mark.parametrize("cap", [8192, 16384, 32768])
+@pytest.mark.parametrize("stream", [False, True])
+def test_moa_facade_sends_acting_cap_to_http_transport(tmp_path, monkeypatch, cap_key, cap, stream):
+    import json
+    import httpx
+    import openai
+    from agent import auxiliary_client
+    from agent.moa_loop import MoAClient
+
+    home = tmp_path / "profile"
+    home.mkdir()
+    (home / "config.yaml").write_text("""moa:
+  presets:
+    test:
+      reference_models:
+        - provider: custom
+          model: advisor
+      aggregator:
+        provider: custom
+        model: actor
+""", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    requests = []
+    def transport(request):
+        body = json.loads(request.content)
+        requests.append(body)
+        if body.get("stream"):
+            chunk = {"id": "test", "object": "chat.completion.chunk", "created": 0,
+                     "model": body["model"], "choices": [{"index": 0, "finish_reason": "stop",
+                         "delta": {"role": "assistant", "content": "Done."}}]}
+            return httpx.Response(200, headers={"content-type": "text/event-stream"},
+                                  content="data: " + json.dumps(chunk) + "\n\ndata: [DONE]\n\n")
+        return httpx.Response(200, json={"id": "test", "object": "chat.completion", "created": 0,
+            "model": body["model"], "choices": [{"index": 0, "finish_reason": "stop",
+                "message": {"role": "assistant", "content": "Done."}}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12}})
+    with httpx.Client(transport=httpx.MockTransport(transport)) as http_client:
+        sdk = openai.OpenAI(api_key="test-key", base_url="http://model.test/v1", http_client=http_client)
+        monkeypatch.setattr(auxiliary_client, "_get_cached_client", lambda provider, model, **kw: (sdk, model))
+        client = MoAClient("test")
+        response = client.chat.completions.create(
+            model="test", messages=[{"role": "user", "content": "Proceed."}],
+            stream=stream, **{cap_key: cap})
+        if stream:
+            assert list(response)
+    acting = [item for item in requests if item["model"] == "actor"]
+    advisors = [item for item in requests if item["model"] == "advisor"]
+    assert len(acting) == len(advisors) == 1
+    assert acting[0]["max_tokens"] == cap
+    assert "max_completion_tokens" not in acting[0]
+
+
+@pytest.mark.parametrize("has_usage", [True, False])
+def test_context_callback_failure_keeps_attempt_accounting(accounting_attempt, monkeypatch, has_usage):
+    from agent.turn_usage import record_response_usage
+
+    agent, client, database, kwargs = accounting_attempt
+    compressor = agent.context_compressor
+    compressor.awaiting_real_usage_after_compression = True
+    def broken_context(usage):
+        raise RuntimeError("Context plug-in failed")
+    monkeypatch.setattr(compressor, "update_from_response", broken_context)
+    response = SimpleNamespace(usage=SimpleNamespace(prompt_tokens=8000, completion_tokens=100) if has_usage else None)
+    with pytest.raises(RuntimeError, match="Context plug-in failed"):
+        record_response_usage(agent, response, messages=kwargs["messages"], api_call_count=1,
+                              api_duration=1.0, compression_attempts=1, max_compression_attempts=3)
+    assert agent.session_prompt_tokens == 230_000 + (8000 if has_usage else 0)
+    assert agent.session_estimated_cost_usd == pytest.approx(0.25)
+    assert client.consume_reference_usage()[0].total_tokens == 0
+    assert client.chat.completions._pending_trace is None
+    database.queue_token_counts.assert_called_once()


### PR DESCRIPTION
## What does this PR do?

An 8,000-token MoA acting request plus a 230,000-token advisor request can appear to occupy 238,000 tokens in one context. Use acting usage for context pressure and compaction verification. Keep combined usage for billing.

Record each received attempt once before recovery can retry, switch providers, or stop. When acting usage is absent, consume advisor tokens and cost and save the trace while leaving context pressure unknown. Save accounting before context callbacks can fail. Handle dictionary responses in invalid-response diagnostics.

Pass explicit acting output budgets through the real MoA request path, including max_completion_tokens and increases from length-continuation recovery. Keep advisor budgets separate and leave omitted acting budgets omitted. This preserves the advisor-only intent of #70279.

## Related Issue

Found during diagnosis of an impossible MoA context meter and repeated output truncation. Related history: #70279 and #58402.

## Type of Change

- [x] Bug fix

## Validation

Commit 53be1d0d25cbf67db9ce90d1a300fd2ac78e519a: 361 tests passed across 24 related files, plus 4 selected invalid-response and content-filter tests in tests/run_agent/test_run_agent.py. Ruff and git diff --check passed. All tests used scripts/run_tests.sh with an isolated Hermes home on Windows, Python 3.11.

The accounting suite has 30 cases: acting-only context, combined billing, missing usage on success/refusal/truncation, malformed-response retry/fallback/exhaustion/fallthrough, and context callback failures. Output-cap tests use the real MoA facade and OpenAI SDK with an HTTP mock transport, for streaming and non-streaming requests, both input parameter names, and three caps. No live model calls are made.

The original regressions failed on the base. Added missing-usage, malformed-attempt, output-cap, and callback-failure tests also failed before their fixes.

## Checklist

- [x] Read CONTRIBUTING.md and applicable AGENTS.md files.
- [x] Used Conventional Commits.
- [x] Searched existing PRs.
- [x] Added behavior tests and confirmed failures before the fixes.
- [x] Updated the context-engine usage contract.
- [x] No configuration keys, tools, dependencies, or platform-specific code added.
