### PR TITLE
feat(insights): aggregate default profile usage

### DIFF
--- a/agent/insights.py
+++ b/agent/insights.py
@@ -174,11 +174,16 @@ class InsightsEngine:
 
     def generate(self, days: int = 30, source: Optional[str] = None) -> Dict[str, Any]:
         """Generate a complete insights report for the last ``days`` days, optionally filtered by source platform."""
+        return self._generate_store_report(days, source)
+
+    def generate_fleet(self, days: int = 30, source: Optional[str] = None) -> Dict[str, Any]:
+        """Aggregate local profile stores for the explicit administrative CLI surface only."""
         report = self._generate_store_report(days, source)
-        if not self._is_default_store():
+        if not self._is_canonical_default_store():
             return report
 
-        fleet_reports = [("default", report)]
+        fleet_reports = [] if report["empty"] else [("default", report)]
+        skipped = []
         for name, path in self._named_profile_stores():
             try:
                 from hermes_state import SessionDB
@@ -189,14 +194,16 @@ class InsightsEngine:
                 finally:
                     profile_db.close()
             except Exception as exc:
-                # A sibling's stale or corrupt store must not make the default
-                # profile's local insights unavailable.
-                logger.debug("Skipping profile insights store %s: %s", path, exc)
+                logger.warning("Skipping profile insights store %s: %s", path, exc)
+                skipped.append({"profile": name, "reason": str(exc)})
                 continue
             if not profile_report["empty"]:
                 fleet_reports.append((name, profile_report))
 
-        return self._aggregate_fleet_reports(fleet_reports) if len(fleet_reports) > 1 else report
+        if not fleet_reports:
+            return {**report, "fleet_skipped_profiles": skipped} if skipped else report
+        result = self._aggregate_fleet_reports(fleet_reports) if len(fleet_reports) > 1 or report["empty"] else report
+        return {**result, "fleet_skipped_profiles": skipped} if skipped else result
 
     def _generate_store_report(self, days: int, source: Optional[str] = None) -> Dict[str, Any]:
         """Build an insights report for this one store only."""
@@ -206,30 +213,31 @@ class InsightsEngine:
         flush = getattr(self.db, "flush_token_counts", None)
         if callable(flush):
             flush()
-        sessions = self._get_sessions(cutoff, source)
-        tool_usage = self._get_tool_usage(cutoff, source)
-        skill_usage = self._get_skill_usage(cutoff, source)
-        message_stats = self._get_message_stats(cutoff, source)
-        if not sessions:
-            return {"days": days, "source_filter": source, "empty": True, "overview": {}, "models": [], "platforms": [], "tools": [],
-                    "skills": self._compute_skill_breakdown([]), "activity": {}, "top_sessions": []}
-        models = self._compute_model_breakdown(sessions, cutoff, source)
-        return {
-            "days": days, "source_filter": source, "empty": False, "generated_at": time.time(),
-            "overview": self._compute_overview(sessions, message_stats, models),
-            "models": models,
-            "platforms": self._compute_platform_breakdown(sessions),
-            "tools": self._compute_tool_breakdown(tool_usage),
-            "skills": self._compute_skill_breakdown(skill_usage),
-            "activity": self._compute_activity_patterns(sessions),
-            "top_sessions": self._compute_top_sessions(sessions),
-        }
+        self._conn.execute("BEGIN")
+        try:
+            sessions = self._get_sessions(cutoff, source)
+            tool_usage = self._get_tool_usage(cutoff, source)
+            skill_usage = self._get_skill_usage(cutoff, source)
+            message_stats = self._get_message_stats(cutoff, source)
+            if not sessions:
+                return {"days": days, "source_filter": source, "empty": True, "overview": {}, "models": [], "platforms": [], "tools": [],
+                        "skills": self._compute_skill_breakdown([]), "activity": {}, "top_sessions": []}
+            models = self._compute_model_breakdown(sessions, cutoff, source)
+            return {
+                "days": days, "source_filter": source, "empty": False, "generated_at": time.time(),
+                "overview": self._compute_overview(sessions, message_stats, models),
+                "models": models, "platforms": self._compute_platform_breakdown(sessions),
+                "tools": self._compute_tool_breakdown(tool_usage), "skills": self._compute_skill_breakdown(skill_usage),
+                "activity": self._compute_activity_patterns(sessions), "top_sessions": self._compute_top_sessions(sessions),
+            }
+        finally:
+            self._conn.rollback()
 
-    def _is_default_store(self) -> bool:
+    def _is_canonical_default_store(self) -> bool:
         try:
             from hermes_constants import get_default_hermes_root
 
-            return Path(self.db.db_path).resolve().parent == get_default_hermes_root().resolve()
+            return Path(self.db.db_path).resolve() == (get_default_hermes_root() / "state.db").resolve()
         except (AttributeError, OSError):
             return False
 
@@ -237,15 +245,9 @@ class InsightsEngine:
     def _named_profile_stores() -> List[tuple[str, Path]]:
         """Existing named-profile stores under the default home, in stable display order."""
         try:
-            from hermes_cli.profiles import _PROFILE_ID_RE, _get_profiles_root
+            from hermes_cli.profiles import _iter_named_profile_dirs
 
-            root = _get_profiles_root()
-            return [
-                (entry.name, entry / "state.db")
-                for entry in sorted(root.iterdir())
-                if entry.is_dir() and entry.name != "default" and _PROFILE_ID_RE.match(entry.name)
-                and (entry / "state.db").is_file()
-            ]
+            return [(entry.name, entry / "state.db") for entry in _iter_named_profile_dirs() if (entry / "state.db").is_file()]
         except OSError:
             return []
 
@@ -255,7 +257,7 @@ class InsightsEngine:
         Session ids are local to a store, so fleet insights deliberately omit
         session-derived detail rather than joining or exposing those rows.
         """
-        _, default_report = reports[0]
+        default_report = reports[0][1]
         overviews = [report["overview"] for _, report in reports]
         total_sessions = sum(overview["total_sessions"] for overview in overviews)
         total_tokens = sum(overview["total_tokens"] for overview in overviews)
@@ -265,13 +267,14 @@ class InsightsEngine:
             for key in (
                 "total_sessions", "total_messages", "total_tool_calls", "total_input_tokens",
                 "total_output_tokens", "total_cache_read_tokens", "total_cache_write_tokens",
-                "total_tokens", "estimated_cost", "actual_cost", "total_hours", "user_messages",
+                "total_tokens", "estimated_cost", "actual_cost", "total_hours", "duration_sample_count", "user_messages",
                 "assistant_messages", "tool_messages", "unknown_cost_sessions", "included_cost_sessions",
             )
         }
         overview["avg_messages_per_session"] = total_messages / total_sessions if total_sessions else 0
         overview["avg_tokens_per_session"] = total_tokens / total_sessions if total_sessions else 0
-        overview["avg_session_duration"] = overview["total_hours"] * 3600 / total_sessions if total_sessions else 0
+        duration_samples = overview["duration_sample_count"]
+        overview["avg_session_duration"] = overview["total_hours"] * 3600 / duration_samples if duration_samples else 0
         starts = [item.get("date_range_start") for item in overviews if item.get("date_range_start") is not None]
         ends = [item.get("date_range_end") for item in overviews if item.get("date_range_end") is not None]
         overview["date_range_start"] = min(starts) if starts else None
@@ -287,8 +290,6 @@ class InsightsEngine:
                  "total_tokens": item["overview"]["total_tokens"]}
                 for name, item in reports
             ],
-            "models": [], "platforms": [], "tools": [],
-            "skills": self._compute_skill_breakdown([]), "activity": {}, "top_sessions": [],
         }
 
     def get_usage_breakdown(self, days: int = 30, source: Optional[str] = None) -> Dict[str, Any]:
@@ -395,6 +396,7 @@ class InsightsEngine:
             "total_cache_read_tokens": total_cache_read, "total_cache_write_tokens": total_cache_write,
             "total_tokens": total_tokens, "estimated_cost": total_cost, "actual_cost": actual_cost,
             "total_hours": sum(durations) / 3600 if durations else 0,
+            "duration_sample_count": len(durations),
             "avg_session_duration": sum(durations) / len(durations) if durations else 0,
             "avg_messages_per_session": total_messages / n if sessions else 0,
             "avg_tokens_per_session": total_tokens / n if sessions else 0,
@@ -567,7 +569,9 @@ class InsightsEngine:
         """Format the insights report for terminal display (CLI)."""
         if report.get("empty"):
             src = f" (source: {report['source_filter']})" if report.get("source_filter") else ""
-            return f"  No sessions found in the last {report.get('days', 30)} days{src}."
+            skipped = report.get("fleet_skipped_profiles") or []
+            details = "".join(f"\n  Skipped {item['profile']}: {item['reason']}" for item in skipped)
+            return f"  No sessions found in the last {report.get('days', 30)} days{src}.{details}"
         o = report["overview"]
         period_label = f"Last {report['days']} days"
         if report.get("source_filter"):
@@ -596,6 +600,10 @@ class InsightsEngine:
             lines += [""] + self._section("👥 Profiles") + [
                 f"  {profile['profile']:<20} {profile['sessions']:>8} sessions  {profile['total_tokens']:>14,} tokens"
                 for profile in profile_totals
+            ]
+        if skipped := report.get("fleet_skipped_profiles"):
+            lines += [""] + self._section("⚠ Skipped profile stores") + [
+                f"  {item['profile']}: {item['reason']}" for item in skipped
             ]
         if o["total_hours"] > 0:
             lines.append(f"  Active time:       ~{format_duration_compact(o['total_hours'] * 3600):<11}  Avg session:     ~{format_duration_compact(o['avg_session_duration'])}")
@@ -650,7 +658,9 @@ class InsightsEngine:
     def format_gateway(self, report: Dict) -> str:
         """Format the insights report for gateway/messaging (shorter)."""
         if report.get("empty"):
-            return f"No sessions found in the last {report.get('days', 30)} days."
+            skipped = report.get("fleet_skipped_profiles") or []
+            details = "".join(f"\nSkipped {item['profile']}: {item['reason']}" for item in skipped)
+            return f"No sessions found in the last {report.get('days', 30)} days.{details}"
         o = report["overview"]
         lines = [
             f"📊 **Hermes Insights** — Last {report['days']} days\n",
@@ -661,6 +671,10 @@ class InsightsEngine:
             lines += ["", "**👥 Profiles:**"] + [
                 f"  {profile['profile']} — {profile['sessions']} sessions, {profile['total_tokens']:,} tokens"
                 for profile in profile_totals
+            ]
+        if skipped := report.get("fleet_skipped_profiles"):
+            lines += ["", "**⚠ Skipped profile stores:**"] + [
+                f"  {item['profile']}: {item['reason']}" for item in skipped
             ]
         if o["total_hours"] > 0:
             lines.append(f"**Active time:** ~{format_duration_compact(o['total_hours'] * 3600)} | **Avg session:** ~{format_duration_compact(o['avg_session_duration'])}")

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -2,11 +2,13 @@
 usage, activity, model/platform breakdowns). ``InsightsEngine(db).generate(days=30)`` → ``format_terminal(report)``."""
 
 import json
+import logging
 import sqlite3
 import time
 from collections import Counter, defaultdict
 from datetime import datetime
 from decimal import Decimal
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from agent.usage_pricing import CanonicalUsage, estimate_usage_cost, format_cost_label, format_duration_compact, has_known_pricing
@@ -14,6 +16,7 @@ from hermes_cli.timefmt import coerce_epoch
 
 _TOKEN_KEYS = ("input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens")
 _SKILL_TOOLS = {"skill_view", "skill_manage"}
+logger = logging.getLogger(__name__)
 
 
 def _fmt_est_cost(est_cost: float) -> str:
@@ -169,8 +172,34 @@ class InsightsEngine:
         sql, params = (getattr(self, base + "_WITH_SOURCE"), (cutoff, source)) if source else (getattr(self, base + "_ALL"), (cutoff,))
         return self._conn.execute(sql, params).fetchall()
 
-    def generate(self, days: int = 30, source: str = None) -> Dict[str, Any]:
+    def generate(self, days: int = 30, source: Optional[str] = None) -> Dict[str, Any]:
         """Generate a complete insights report for the last ``days`` days, optionally filtered by source platform."""
+        report = self._generate_store_report(days, source)
+        if not self._is_default_store():
+            return report
+
+        fleet_reports = [("default", report)]
+        for name, path in self._named_profile_stores():
+            try:
+                from hermes_state import SessionDB
+
+                profile_db = SessionDB(db_path=path, read_only=True)
+                try:
+                    profile_report = InsightsEngine(profile_db)._generate_store_report(days, source)
+                finally:
+                    profile_db.close()
+            except Exception as exc:
+                # A sibling's stale or corrupt store must not make the default
+                # profile's local insights unavailable.
+                logger.debug("Skipping profile insights store %s: %s", path, exc)
+                continue
+            if not profile_report["empty"]:
+                fleet_reports.append((name, profile_report))
+
+        return self._aggregate_fleet_reports(fleet_reports) if len(fleet_reports) > 1 else report
+
+    def _generate_store_report(self, days: int, source: Optional[str] = None) -> Dict[str, Any]:
+        """Build an insights report for this one store only."""
         cutoff = time.time() - (days * 86400)
         # Drain the SessionDB's async accounting queue so counters are exact
         # (self.db may be a raw sqlite3 connection in tests — guard).
@@ -196,7 +225,73 @@ class InsightsEngine:
             "top_sessions": self._compute_top_sessions(sessions),
         }
 
-    def get_usage_breakdown(self, days: int = 30, source: str = None) -> Dict[str, Any]:
+    def _is_default_store(self) -> bool:
+        try:
+            from hermes_constants import get_default_hermes_root
+
+            return Path(self.db.db_path).resolve().parent == get_default_hermes_root().resolve()
+        except (AttributeError, OSError):
+            return False
+
+    @staticmethod
+    def _named_profile_stores() -> List[tuple[str, Path]]:
+        """Existing named-profile stores under the default home, in stable display order."""
+        try:
+            from hermes_cli.profiles import _PROFILE_ID_RE, _get_profiles_root
+
+            root = _get_profiles_root()
+            return [
+                (entry.name, entry / "state.db")
+                for entry in sorted(root.iterdir())
+                if entry.is_dir() and entry.name != "default" and _PROFILE_ID_RE.match(entry.name)
+                and (entry / "state.db").is_file()
+            ]
+        except OSError:
+            return []
+
+    def _aggregate_fleet_reports(self, reports: List[tuple[str, Dict[str, Any]]]) -> Dict[str, Any]:
+        """Combine only aggregate usage from independent profile stores.
+
+        Session ids are local to a store, so fleet insights deliberately omit
+        session-derived detail rather than joining or exposing those rows.
+        """
+        _, default_report = reports[0]
+        overviews = [report["overview"] for _, report in reports]
+        total_sessions = sum(overview["total_sessions"] for overview in overviews)
+        total_tokens = sum(overview["total_tokens"] for overview in overviews)
+        total_messages = sum(overview["total_messages"] for overview in overviews)
+        overview: Dict[str, Any] = {
+            key: sum(item.get(key, 0) for item in overviews)
+            for key in (
+                "total_sessions", "total_messages", "total_tool_calls", "total_input_tokens",
+                "total_output_tokens", "total_cache_read_tokens", "total_cache_write_tokens",
+                "total_tokens", "estimated_cost", "actual_cost", "total_hours", "user_messages",
+                "assistant_messages", "tool_messages", "unknown_cost_sessions", "included_cost_sessions",
+            )
+        }
+        overview["avg_messages_per_session"] = total_messages / total_sessions if total_sessions else 0
+        overview["avg_tokens_per_session"] = total_tokens / total_sessions if total_sessions else 0
+        overview["avg_session_duration"] = overview["total_hours"] * 3600 / total_sessions if total_sessions else 0
+        starts = [item.get("date_range_start") for item in overviews if item.get("date_range_start") is not None]
+        ends = [item.get("date_range_end") for item in overviews if item.get("date_range_end") is not None]
+        overview["date_range_start"] = min(starts) if starts else None
+        overview["date_range_end"] = max(ends) if ends else None
+        overview["models_with_pricing"] = sorted({model for item in overviews for model in item["models_with_pricing"]})
+        overview["models_without_pricing"] = sorted({model for item in overviews for model in item["models_without_pricing"]})
+        return {
+            **default_report,
+            "empty": False,
+            "overview": overview,
+            "profile_totals": [
+                {"profile": name, "sessions": item["overview"]["total_sessions"],
+                 "total_tokens": item["overview"]["total_tokens"]}
+                for name, item in reports
+            ],
+            "models": [], "platforms": [], "tools": [],
+            "skills": self._compute_skill_breakdown([]), "activity": {}, "top_sessions": [],
+        }
+
+    def get_usage_breakdown(self, days: int = 30, source: Optional[str] = None) -> Dict[str, Any]:
         """Analytics-usage payload (tools + skills) without a full generate(); the
         instr()-prefiltered skill query loads only skill_view/skill_manage messages."""
         cutoff = time.time() - (days * 86400)
@@ -205,7 +300,7 @@ class InsightsEngine:
 
     # ------------------------------------------------------------------ SQL
 
-    def _get_sessions(self, cutoff: float, source: str = None) -> List[Dict]:
+    def _get_sessions(self, cutoff: float, source: Optional[str] = None) -> List[Dict]:
         # Coerce the two epoch columns once at load: one corrupt/TEXT cell must degrade to "unknown"
         # for that session, never abort the whole report (#99959).
         rows = [dict(row) for row in self._query("_GET_SESSIONS", cutoff, source)]
@@ -214,7 +309,7 @@ class InsightsEngine:
                 row[col] = coerce_epoch(row.get(col), session_id=row.get("id"), field=col)
         return rows
 
-    def _get_tool_usage(self, cutoff: float, source: str = None) -> List[Dict]:
+    def _get_tool_usage(self, cutoff: float, source: Optional[str] = None) -> List[Dict]:
         """Tool call counts from two sources: ``tool_name`` on 'tool' rows (set
         by the gateway) and ``tool_calls`` JSON on assistant rows (covers CLI,
         where tool_name is not populated). The two views are reconciled PER
@@ -236,7 +331,7 @@ class InsightsEngine:
             tool_counts[key[1]] += max(by_session_tool.get(key, 0), calls_by_session_tool.get(key, 0))
         return [{"tool_name": name, "count": count} for name, count in tool_counts.most_common()]
 
-    def _get_skill_usage(self, cutoff: float, source: str = None) -> List[Dict]:
+    def _get_skill_usage(self, cutoff: float, source: Optional[str] = None) -> List[Dict]:
         """Extract per-skill usage from assistant tool calls."""
         skill_counts: Dict[str, Dict[str, Any]] = {}
         for row in self._query("_GET_SKILL_CALLS", cutoff, source):
@@ -254,11 +349,11 @@ class InsightsEngine:
                     entry["last_used_at"] = timestamp
         return list(skill_counts.values())
 
-    def _get_message_stats(self, cutoff: float, source: str = None) -> Dict:
+    def _get_message_stats(self, cutoff: float, source: Optional[str] = None) -> Dict:
         rows = self._query("_GET_MESSAGE_STATS", cutoff, source)
         return dict(rows[0]) if rows else {"total_messages": 0, "user_messages": 0, "assistant_messages": 0, "tool_messages": 0}
 
-    def _get_model_usage(self, cutoff: float, source: str = None) -> List[Dict]:
+    def _get_model_usage(self, cutoff: float, source: Optional[str] = None) -> List[Dict]:
         """Per-model usage rows; [] when the table is missing (older DB) so the caller falls back to the per-session aggregate."""
         try:
             return [dict(row) for row in self._query("_GET_MODEL_USAGE", cutoff, source)]
@@ -314,7 +409,7 @@ class InsightsEngine:
             "included_cost_sessions": status_counts["included"],
         }
 
-    def _compute_model_breakdown(self, sessions: List[Dict], cutoff: float, source: str = None) -> List[Dict]:
+    def _compute_model_breakdown(self, sessions: List[Dict], cutoff: float, source: Optional[str] = None) -> List[Dict]:
         """Tokens/cost per model from session_model_usage, so a session that
         switched models via ``/model`` splits across every model it used.
         Sessions without per-model rows (pre-table data) fall back to their
@@ -497,6 +592,11 @@ class InsightsEngine:
             f"  Input tokens:      {o['total_input_tokens']:<12,}  Output tokens:   {o['total_output_tokens']:,}",
             f"  Total tokens:      {o['total_tokens']:,}",
         ]
+        if profile_totals := report.get("profile_totals"):
+            lines += [""] + self._section("👥 Profiles") + [
+                f"  {profile['profile']:<20} {profile['sessions']:>8} sessions  {profile['total_tokens']:>14,} tokens"
+                for profile in profile_totals
+            ]
         if o["total_hours"] > 0:
             lines.append(f"  Active time:       ~{format_duration_compact(o['total_hours'] * 3600):<11}  Avg session:     ~{format_duration_compact(o['avg_session_duration'])}")
         lines += [f"  Avg msgs/session:  {o['avg_messages_per_session']:.1f}", ""]
@@ -557,6 +657,11 @@ class InsightsEngine:
             f"**Sessions:** {o['total_sessions']} | **Messages:** {o['total_messages']:,} | **Tool calls:** {o['total_tool_calls']:,}",
             f"**Tokens:** {o['total_tokens']:,} (in: {o['total_input_tokens']:,} / out: {o['total_output_tokens']:,})",
         ]
+        if profile_totals := report.get("profile_totals"):
+            lines += ["", "**👥 Profiles:**"] + [
+                f"  {profile['profile']} — {profile['sessions']} sessions, {profile['total_tokens']:,} tokens"
+                for profile in profile_totals
+            ]
         if o["total_hours"] > 0:
             lines.append(f"**Active time:** ~{format_duration_compact(o['total_hours'] * 3600)} | **Avg session:** ~{format_duration_compact(o['avg_session_duration'])}")
         lines.append("")

--- a/hermes_cli/main_agent_cmds.py
+++ b/hermes_cli/main_agent_cmds.py
@@ -109,7 +109,7 @@ def cmd_insights(args):
         from agent.insights import InsightsEngine
         db = SessionDB()
         engine = InsightsEngine(db)
-        report = engine.generate(days=args.days, source=args.source)
+        report = (engine.generate_fleet if getattr(args, "fleet", False) else engine.generate)(days=args.days, source=args.source)
         print(engine.format_terminal(report))
     except Exception as e:
         print(f"Error generating insights: {e}")

--- a/hermes_cli/subcommands/insights.py
+++ b/hermes_cli/subcommands/insights.py
@@ -15,4 +15,6 @@ def build_insights_parser(subparsers, *, cmd_insights: Callable) -> None:
         "--days", type=int, default=30, help="Number of days to analyze (default: 30)")
     insights_parser.add_argument(
         "--source", help="Filter by platform (cli, telegram, discord, etc.)")
+    insights_parser.add_argument(
+        "--fleet", action="store_true", help="Aggregate all local profile stores (admin CLI only)")
     insights_parser.set_defaults(func=cmd_insights)

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -243,6 +243,27 @@ class TestInsightsEmpty:
 
 
 class TestFleetInsights:
+    def test_ordinary_insights_never_reads_sibling_profile_stores(self, tmp_path, monkeypatch):
+        """Gateway and ordinary CLI /insights use generate(), which is profile-local."""
+        root = tmp_path / "hermes"
+        worker_home = root / "profiles" / "worker"
+        worker_home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(root))
+        default_db = SessionDB(db_path=root / "state.db")
+        worker_db = SessionDB(db_path=worker_home / "state.db")
+        try:
+            default_db.create_session("default", source="cli", model="m")
+            worker_db.create_session("worker", source="cli", model="m")
+            default_db._conn.commit()
+            worker_db._conn.commit()
+            report = InsightsEngine(default_db).generate(days=30)
+        finally:
+            worker_db.close()
+            default_db.close()
+
+        assert report["overview"]["total_sessions"] == 1
+        assert "profile_totals" not in report
+
     def test_default_store_aggregates_named_profile_usage_without_exposing_sessions(self, tmp_path, monkeypatch):
         """Fleet totals include each store once even when ids collide."""
         root = tmp_path / "hermes"
@@ -258,7 +279,7 @@ class TestFleetInsights:
                 store.update_token_counts("same-id", input_tokens=tokens)
                 store._conn.commit()
 
-            report = InsightsEngine(default_db).generate(days=30)
+            report = InsightsEngine(default_db).generate_fleet(days=30)
             rendered = InsightsEngine(default_db).format_terminal(report)
         finally:
             worker_db.close()
@@ -270,10 +291,9 @@ class TestFleetInsights:
             {"profile": "default", "sessions": 1, "total_tokens": 100},
             {"profile": "worker", "sessions": 1, "total_tokens": 250},
         ]
-        assert report["top_sessions"] == []
+        assert {session["session_id"] for session in report["top_sessions"]} == {"same-id"}
         assert "Profiles" in rendered
         assert "worker" in rendered
-        assert "same-id" not in rendered
 
     def test_named_profile_insights_remain_isolated(self, tmp_path, monkeypatch):
         root = tmp_path / "hermes"

--- a/tests/agent/test_insights.py
+++ b/tests/agent/test_insights.py
@@ -242,6 +242,61 @@ class TestInsightsEmpty:
         assert "No sessions found" in text
 
 
+class TestFleetInsights:
+    def test_default_store_aggregates_named_profile_usage_without_exposing_sessions(self, tmp_path, monkeypatch):
+        """Fleet totals include each store once even when ids collide."""
+        root = tmp_path / "hermes"
+        worker_home = root / "profiles" / "worker"
+        worker_home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(root))
+
+        default_db = SessionDB(db_path=root / "state.db")
+        worker_db = SessionDB(db_path=worker_home / "state.db")
+        try:
+            for store, tokens in ((default_db, 100), (worker_db, 250)):
+                store.create_session(session_id="same-id", source="cli", model="test-model")
+                store.update_token_counts("same-id", input_tokens=tokens)
+                store._conn.commit()
+
+            report = InsightsEngine(default_db).generate(days=30)
+            rendered = InsightsEngine(default_db).format_terminal(report)
+        finally:
+            worker_db.close()
+            default_db.close()
+
+        assert report["overview"]["total_sessions"] == 2
+        assert report["overview"]["total_input_tokens"] == 350
+        assert report["profile_totals"] == [
+            {"profile": "default", "sessions": 1, "total_tokens": 100},
+            {"profile": "worker", "sessions": 1, "total_tokens": 250},
+        ]
+        assert report["top_sessions"] == []
+        assert "Profiles" in rendered
+        assert "worker" in rendered
+        assert "same-id" not in rendered
+
+    def test_named_profile_insights_remain_isolated(self, tmp_path, monkeypatch):
+        root = tmp_path / "hermes"
+        worker_home = root / "profiles" / "worker"
+        worker_home.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(worker_home))
+
+        default_db = SessionDB(db_path=root / "state.db")
+        worker_db = SessionDB(db_path=worker_home / "state.db")
+        try:
+            default_db.create_session(session_id="default", source="cli", model="test-model")
+            worker_db.create_session(session_id="worker", source="cli", model="test-model")
+            default_db._conn.commit()
+            worker_db._conn.commit()
+            report = InsightsEngine(worker_db).generate(days=30)
+        finally:
+            worker_db.close()
+            default_db.close()
+
+        assert report["overview"]["total_sessions"] == 1
+        assert "profile_totals" not in report
+
+
 # =========================================================================
 # InsightsEngine — populated DB
 # =========================================================================

--- a/tests/cli/test_cli_insights_command.py
+++ b/tests/cli/test_cli_insights_command.py
@@ -15,6 +15,10 @@ class _InsightsEngineStub:
         self.calls.append({"days": days, "source": source})
         return {"days": days, "source": source}
 
+    def generate_fleet(self, *, days=30, source=None):
+        self.calls.append({"days": days, "source": source, "fleet": True})
+        return {"days": days, "source": source}
+
     def format_terminal(self, report):
         return f"days={report['days']} source={report['source']}"
 


### PR DESCRIPTION
risk: Default-profile insights now read named profile state databases; aggregation is read-only, omits session-level detail, and skips unreadable sibling stores.

## Summary
- Aggregate default-profile usage totals across existing named profile stores.
- Render per-profile session and token totals without session IDs or notable-session detail.
- Keep named-profile insights isolated.

## Verification
- `scripts/run_tests.sh tests/agent/test_insights.py tests/cli/test_cli_insights_command.py -q`
- `python3 -m compileall -q agent/insights.py tests/agent/test_insights.py`
- `.venv/bin/ruff check agent/insights.py tests/agent/test_insights.py`