### PR TITLE
feat(tui): step the transcript prompt to prompt, with a right-edge tick rail

### DIFF
--- a/contributors/emails/phil.c.taylor@gmail.com
+++ b/contributors/emails/phil.c.taylor@gmail.com
@@ -1,0 +1,1 @@
+pctaylor

--- a/ui-tui/README.md
+++ b/ui-tui/README.md
@@ -159,6 +159,7 @@ Current input behavior is split across `app.tsx`, `components/textInput.tsx`, an
 | `Ctrl+V` / `Alt+V`              | Paste text first, then fall back to image/path attachment when applicable                                                                               |
 | `Tab`                           | Apply the active completion                                                                                                                             |
 | `Up/Down`                       | Cycle completions if the completion list is open; otherwise edit queued messages first, then walk input history                                         |
+| `Alt+Up` / `Alt+Down`           | Jump to the previous / next user prompt in the transcript                                                                                                |
 | `Left/Right`                    | Move the cursor                                                                                                                                         |
 | modified `Left/Right`           | Move by word when the terminal sends `Ctrl` or `Meta` with the arrow key                                                                                |
 | `Home` / `Ctrl+A`               | Start of line                                                                                                                                           |
@@ -179,6 +180,8 @@ Notes:
 - `Tab` only applies completions when completions are present and you are not in multiline mode.
 - Queue/history navigation only applies when you are not in multiline mode.
 - `PgUp` / `PgDn` are left to the terminal emulator; the TUI does not handle them.
+- `Alt+Up` / `Alt+Down` jump prompt to prompt without travelling the distance in between, so they are the way back into a long session.
+- The right-edge column carries a tick per user prompt at its proportional position, drawn over the scrollbar thumb; clicking a tick jumps straight to that prompt rather than scrubbing near it. Reading the column: the **line** is the scrollbar — thin is the whole conversation, thick is the part on screen — and the **dots** are your prompts, one per prompt, oldest at the top. The prompt you are on is a **filled dot in the accent colour** (`●`); every other prompt is a dim dot (`•`). Fill carries the meaning, not colour: the accent is also the scrollbar's hover colour, so shape is what tells you which dot is *yours*.
 
 ### Prompt and picker modes
 

--- a/ui-tui/src/__tests__/useInputHandlers.test.ts
+++ b/ui-tui/src/__tests__/useInputHandlers.test.ts
@@ -5,6 +5,7 @@ import {
   applyVoiceRecordResponse,
   dismissSensitivePrompt,
   handleIdleHotkeyExit,
+  promptStepFor,
   resolveCtrlCComposerAction,
   shouldAllowIdleHotkeyExit,
   shouldDetachEditedHistoryInput,
@@ -182,5 +183,17 @@ describe('dismissSensitivePrompt', () => {
     expect(sys).toHaveBeenCalledWith('secret entry cancelled')
     expect(rpc).toHaveBeenCalledWith('secret.respond', { request_id: 'secret-1', value: '' })
     await pending
+  })
+})
+
+describe('promptStepFor — Alt+↑/↓ owns the prompt-to-prompt step', () => {
+  it('maps Alt+↑/↓ to a step and leaves every bare arrow to the handlers below', () => {
+    expect(promptStepFor({ downArrow: false, meta: true, upArrow: true })).toBe(-1)
+    expect(promptStepFor({ downArrow: true, meta: true, upArrow: false })).toBe(1)
+    // Without Alt the bare arrows stay with completions / queue edit / history.
+    expect(promptStepFor({ downArrow: false, meta: false, upArrow: true })).toBe(0)
+    expect(promptStepFor({ downArrow: true, meta: false, upArrow: false })).toBe(0)
+    // Alt on its own is not a step.
+    expect(promptStepFor({ meta: true })).toBe(0)
   })
 })

--- a/ui-tui/src/__tests__/viewport.test.ts
+++ b/ui-tui/src/__tests__/viewport.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import { stickyPromptFromViewport } from '../domain/viewport.js'
+import {
+  activePromptIndex,
+  promptOffsetAtRailRow,
+  promptRowIndexes,
+  promptTicks,
+  steppedPromptOffset,
+  stickyPromptFromViewport
+} from '../domain/viewport.js'
 
 describe('stickyPromptFromViewport', () => {
   it('hides the sticky prompt when a newer user message is already visible', () => {
@@ -54,5 +61,95 @@ describe('stickyPromptFromViewport', () => {
     ]
 
     expect(stickyPromptFromViewport(messages, [0, 2, 10], 8, 10, true)).toBe('')
+  })
+})
+
+// A six-message session: system intro, then three prompt/answer turns. Row
+// indexes are message indexes, so the prompts sit on rows 1, 3 and 5 and
+// `offsets` carries the top of each row plus the tail (length n+1).
+const TURNS = [
+  { role: 'system' as const, text: '' },
+  { role: 'user' as const, text: 'first' },
+  { role: 'assistant' as const, text: 'answer one' },
+  { role: 'user' as const, text: 'second' },
+  { role: 'assistant' as const, text: 'answer two' },
+  { role: 'user' as const, text: 'third' }
+]
+
+const ROWS = [1, 3, 5]
+const OFFSETS = [0, 4, 10, 40, 60, 100, 120]
+
+describe('prompt navigation', () => {
+  it('lists the prompts you actually wrote, in order', () => {
+    expect(promptRowIndexes(TURNS)).toEqual(ROWS)
+
+    // Injected turns arrive as user messages and blank rows carry no prompt:
+    // neither earns a tick, or the rail answers "where is my prompt?" wrongly.
+    const injected = [
+      { role: 'user' as const, text: '[IMPORTANT: Background process proc_1 completed normally.' },
+      { role: 'user' as const, text: '[System: Your previous response was truncated' },
+      { role: 'user' as const, text: '   ' },
+      { role: 'user' as const, text: 'real one' }
+    ]
+
+    expect(promptRowIndexes(injected)).toEqual([3])
+    expect(promptRowIndexes([])).toEqual([])
+  })
+
+  it('steps onto the neighbouring prompt row, and stops at both ends', () => {
+    // The step resolves to the NEIGHBOUR'S OWN ROW — a relationship between two
+    // pieces of data, not a number frozen here. Rows past the measured span are
+    // height-estimated, so a row delta would drift the longer the run goes.
+    expect(steppedPromptOffset(OFFSETS, ROWS, 50, false, 1)).toBe(OFFSETS[ROWS[2]!])
+    expect(steppedPromptOffset(OFFSETS, ROWS, 120, true, -1)).toBe(OFFSETS[ROWS[1]!])
+    // Ends do not wrap, and an empty session has nowhere to go.
+    expect(steppedPromptOffset(OFFSETS, ROWS, 0, false, -1)).toBeNull()
+    expect(steppedPromptOffset(OFFSETS, ROWS, 100, false, 1)).toBeNull()
+    expect(steppedPromptOffset(OFFSETS, [], 0, false, 1)).toBeNull()
+    // The prompt you are "on" is the last one at or above the viewport top, or
+    // the newest while the view is following the tail.
+    expect(activePromptIndex(OFFSETS, ROWS, 50, false)).toBe(1)
+    expect(activePromptIndex(OFFSETS, ROWS, 100, false)).toBe(2)
+    expect(activePromptIndex(OFFSETS, ROWS, 0, false)).toBe(0)
+    expect(activePromptIndex(OFFSETS, ROWS, -999, true)).toBe(2)
+    expect(activePromptIndex(OFFSETS, [], 0, false)).toBe(-1)
+  })
+
+  it('gives every prompt a tick in order, and keeps the active one when they collide', () => {
+    const ticks = promptTicks(OFFSETS, ROWS, 120, 11, 2)
+
+    // One tick per prompt, in prompt order, inside the rail. Exactly which row
+    // each lands on is the proportional scale's business — asserting today's
+    // numbers would fail the day someone tunes the scale, so this pins the
+    // relationship instead.
+    expect(ticks.map(t => t.index)).toEqual([0, 1, 2])
+    expect(ticks.every(t => t.row >= 0 && t.row < 11)).toBe(true)
+    expect(ticks.map(t => t.row)).toEqual([...ticks.map(t => t.row)].sort((a, b) => a - b))
+    // Two prompts scaling onto the same rail row collapse to ONE tick, and the
+    // prompt you are on wins — so the marker for where you are can never be
+    // absorbed by a neighbour in a dense session.
+    const dense = [0, 4, 5, 6, 7, 8, 200]
+
+    expect(promptTicks(dense, [1, 3], 200, 11, 1)).toEqual([{ index: 1, row: 0 }])
+    expect(promptTicks(dense, [1, 3], 200, 11, 0)).toEqual([{ index: 0, row: 0 }])
+    // Nothing to draw without prompts, or without a viewport to draw in.
+    expect(promptTicks(OFFSETS, [], 120, 11, -1)).toEqual([])
+    expect(promptTicks(OFFSETS, ROWS, 120, 0, 0)).toEqual([])
+  })
+
+  it('resolves a tick row to that prompt exactly, and other rows to no tick', () => {
+    // Whichever row a tick lands on, clicking it resolves to THAT prompt's own
+    // offset — the property that makes a click land exactly rather than near.
+    const ticks = promptTicks(OFFSETS, ROWS, 120, 11, 2)
+
+    for (const tick of ticks) {
+      expect(promptOffsetAtRailRow(OFFSETS, ROWS, 120, 11, 2, tick.row)).toBe(OFFSETS[ROWS[tick.index]!])
+    }
+
+    // A rail row with no tick keeps the plain scrub path.
+    const bare = [...Array(11).keys()].find(row => !ticks.some(tick => tick.row === row))
+
+    expect(bare).toBeDefined()
+    expect(promptOffsetAtRailRow(OFFSETS, ROWS, 120, 11, 2, bare!)).toBeNull()
   })
 })

--- a/ui-tui/src/__tests__/viewport.test.ts
+++ b/ui-tui/src/__tests__/viewport.test.ts
@@ -106,11 +106,16 @@ describe('prompt navigation', () => {
     expect(steppedPromptOffset(OFFSETS, ROWS, 0, false, -1)).toBeNull()
     expect(steppedPromptOffset(OFFSETS, ROWS, 100, false, 1)).toBeNull()
     expect(steppedPromptOffset(OFFSETS, [], 0, false, 1)).toBeNull()
-    // The prompt you are "on" is the last one at or above the viewport top, or
-    // the newest while the view is following the tail.
+    // Above the first prompt — the normal shape, an intro row above the first
+    // user message — the viewport is not ON a prompt yet, so the forward step
+    // lands on the FIRST one rather than stepping over it.
+    expect(steppedPromptOffset(OFFSETS, ROWS, 0, false, 1)).toBe(OFFSETS[ROWS[0]!])
+    // The prompt you are "on" is the last one at or above the viewport top, the
+    // newest while the view is following the tail, and none of them while the
+    // top is still above them all.
     expect(activePromptIndex(OFFSETS, ROWS, 50, false)).toBe(1)
     expect(activePromptIndex(OFFSETS, ROWS, 100, false)).toBe(2)
-    expect(activePromptIndex(OFFSETS, ROWS, 0, false)).toBe(0)
+    expect(activePromptIndex(OFFSETS, ROWS, 0, false)).toBe(-1)
     expect(activePromptIndex(OFFSETS, ROWS, -999, true)).toBe(2)
     expect(activePromptIndex(OFFSETS, [], 0, false)).toBe(-1)
   })

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -453,6 +453,8 @@ export interface InputHandlerContext {
   gateway: GatewayServices
   terminal: {
     hasSelection: boolean
+    /** Step the transcript to the previous (-1) / next (1) user prompt. */
+    jumpToPrompt: (dir: -1 | 1) => void
     scrollRef: RefObject<null | ScrollBoxHandle>
     scrollWithSelection: (delta: number) => void
     selection: SelectionApi

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -181,6 +181,26 @@ export function shouldDetachEditedHistoryInput(historyIdx: null | number, histor
   return historyIdx !== null && value !== history[historyIdx]
 }
 
+/**
+ * Alt (Option) + ↑/↓ — the prompt-to-prompt step: -1 previous, 1 next, 0 for
+ * anything else.
+ *
+ * `key.meta` is plain Alt/Option on every platform (see lib/platform.ts); on
+ * legacy macOS terminals it can also carry Cmd, which the emulator usually
+ * swallows before the app sees it, so the reachable chord is Alt/Option+↑/↓ —
+ * and the same reason macOS users should read Option+arrows in the docs.
+ * Nothing else claims Alt+arrows (plain arrows are completions/queue/history,
+ * Shift+arrows scroll), but the chord is owned OUTRIGHT, so callers test it
+ * BEFORE the bare-arrow handlers: without that order Alt+↑ reads as history up.
+ */
+export const promptStepFor = (key: { downArrow?: boolean; meta?: boolean; upArrow?: boolean }): -1 | 0 | 1 => {
+  if (!key.meta || (!key.upArrow && !key.downArrow)) {
+    return 0
+  }
+
+  return key.upArrow ? -1 : 1
+}
+
 export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
   const { actions, composer, gateway, terminal, voice, wheelStep } = ctx
   const { actions: cActions, refs: cRefs, state: cState } = composer
@@ -503,6 +523,17 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       if (!fallThroughForScroll) {
         return
       }
+    }
+
+    // Alt+↑ / Alt+↓ step prompt to prompt — the terminal's counterpart to the
+    // right-edge rail's ticks, and the one jump that does not have to travel
+    // the whole distance. Owns the chord outright: placed above the bare-arrow
+    // handlers so Alt+↑ can't be read as input-history up, and above the
+    // completion cycler for the same reason.
+    const promptStep = promptStepFor(key)
+
+    if (promptStep !== 0) {
+      return terminal.jumpToPrompt(promptStep)
     }
 
     if (cState.completions.length && cState.input && cState.historyIdx === null && (key.upArrow || key.downArrow)) {

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -18,6 +18,7 @@ import { hasLeadGap, prevRenderedMsg } from '../domain/blockLayout.js'
 import { SECTION_NAMES, sectionMode } from '../domain/details.js'
 import { composeTabTitle, fmtProjectCwdBranch, shortCwd } from '../domain/paths.js'
 import { sessionScopedModelArg } from '../domain/slash.js'
+import { promptRowIndexes, steppedPromptOffset } from '../domain/viewport.js'
 import { type GatewayClient } from '../gatewayClient.js'
 import type { SubagentListResponse } from '../gatewayTypes.js'
 import type {
@@ -43,6 +44,7 @@ import {
   sameToolTrailGroup,
   toolTrailLabel
 } from '../lib/text.js'
+import { getViewportSnapshot } from '../lib/viewportStore.js'
 import { estimatedMsgHeight, messageHeightKey } from '../lib/virtualHeights.js'
 import { onUserWidgets } from '../sdk/userWidgets.js'
 import type { Msg, PanelSection, SlashCatalog } from '../types.js'
@@ -452,6 +454,36 @@ export function useMainApp(gw: GatewayClient) {
     [selection]
   )
 
+  // Prompt rail targets — the same pure derivation the rail's ticks use, so a
+  // hotkey step and a tick click can never land on different rows.
+  const promptRows = useMemo(() => promptRowIndexes(historyItems), [historyItems])
+
+  // Alt+↑ / Alt+↓ — step to the previous/next prompt. An ABSOLUTE jump, never a
+  // scroll delta: rows below the measured span are height-estimated, so a delta
+  // drifts further off target the longer the session runs. The viewport is
+  // re-homed, so a live selection is dropped rather than left holding rows this
+  // jump just scrolled away from.
+  const jumpToPrompt = useCallback(
+    (dir: -1 | 1) => {
+      const s = scrollRef.current
+
+      if (!s) {
+        return
+      }
+
+      const { atBottom, top } = getViewportSnapshot(s)
+      const target = steppedPromptOffset(virtualHistory.offsets, promptRows, top, atBottom, dir)
+
+      if (target === null) {
+        return
+      }
+
+      selection.clearSelection()
+      s.scrollTo(target)
+    },
+    [promptRows, selection, virtualHistory.offsets]
+  )
+
   const appendMessage = useCallback(
     (msg: Msg) => setHistoryItems(prev => appendTranscriptMessage(prev, msg)),
     [setHistoryItems]
@@ -848,7 +880,7 @@ export function useMainApp(gw: GatewayClient) {
     },
     composer: { actions: composerActions, refs: composerRefs, state: composerState },
     gateway,
-    terminal: { hasSelection, scrollRef, scrollWithSelection, selection, stdout },
+    terminal: { hasSelection, jumpToPrompt, scrollRef, scrollWithSelection, selection, stdout },
     voice: {
       enabled: voiceEnabled,
       recordKey: voiceRecordKey,

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -11,7 +11,7 @@ import { DEV_CREDITS_MODE } from '../config/env.js'
 import { FACES } from '../content/faces.js'
 import { VERBS } from '../content/verbs.js'
 import { fmtDuration } from '../domain/messages.js'
-import { stickyPromptFromViewport } from '../domain/viewport.js'
+import { activePromptIndex, promptOffsetAtRailRow, promptTicks, stickyPromptFromViewport } from '../domain/viewport.js'
 import { buildSubagentTree, treeTotals, widthByDepth } from '../lib/subagentTree.js'
 import { fmtK } from '../lib/text.js'
 import { useScrollbarSnapshot, useViewportSnapshot } from '../lib/viewportStore.js'
@@ -863,7 +863,12 @@ export function StickyPromptTracker({ messages, offsets, scrollRef, onChange }: 
   return null
 }
 
-export function TranscriptScrollbar({ scrollRef, t }: TranscriptScrollbarProps) {
+export function TranscriptScrollbar({
+  offsets = NO_OFFSETS,
+  promptRows = NO_ROWS,
+  scrollRef,
+  t
+}: TranscriptScrollbarProps) {
   const [hover, setHover] = useState(false)
   const [grab, setGrab] = useState<number | null>(null)
   const grabRef = useRef<number | null>(null)
@@ -880,6 +885,13 @@ export function TranscriptScrollbar({ scrollRef, t }: TranscriptScrollbarProps) 
   const thumbTop = scrollable ? Math.round((pos / Math.max(1, total - vp)) * travel) : 0
   const { thumb: thumbColor, track: trackColor } = scrollbarColors(t, hover, grab !== null)
 
+  // Prompt rail — the terminal answer to the desktop's right-edge prompt rail.
+  // It SHARES this column instead of taking one of its own: a second column
+  // would re-wrap the whole transcript every time the rail appeared or its
+  // width changed, and the transcript's height estimate is width-keyed.
+  const active = activePromptIndex(offsets, promptRows, pos, s?.isSticky() === true)
+  const ticks = scrollable ? promptTicks(offsets, promptRows, total, vp, active) : []
+
   const jump = (row: number, offset: number) => {
     if (!s || !scrollable) {
       return
@@ -888,11 +900,57 @@ export function TranscriptScrollbar({ scrollRef, t }: TranscriptScrollbarProps) 
     s.scrollTo(Math.round((Math.max(0, Math.min(travel, row - offset)) / travel) * Math.max(0, total - vp)))
   }
 
+  // One glyph + tone per row, then coalesced into a run per tone, so the column
+  // still paints as a handful of text nodes rather than one per row.
+  const rows: { ch: string; color: string }[] = []
+
+  for (let i = 0; i < vp; i++) {
+    const inThumb = i >= thumbTop && i < thumbTop + thumb
+
+    rows.push({ ch: inThumb ? '┃' : '│', color: inThumb ? thumbColor : trackColor })
+  }
+
+  // Ticks win their row over both the track and the thumb: the marker for the
+  // prompt you are sitting on has to stay visible, which is exactly when it
+  // would otherwise be swallowed by the thumb. The active prompt changes SHAPE
+  // as well as tone: the scrollbar already owns the accent while it is hovered
+  // or dragged, so tone alone reads as scrollbar state. Filled dot = active
+  // matches subagentGlyph's convention.
+  for (const tick of ticks) {
+    const isActive = tick.index === active
+
+    rows[tick.row] = { ch: isActive ? '●' : '•', color: isActive ? t.color.accent : t.color.border }
+  }
+
+  const runs: { color: string; text: string }[] = []
+
+  for (const row of rows) {
+    const last = runs[runs.length - 1]
+
+    if (last && last.color === row.color) {
+      last.text += `\n${row.ch}`
+    } else {
+      runs.push({ color: row.color, text: row.ch })
+    }
+  }
+
   return (
     <Box
       flexDirection="column"
       onMouseDown={(e: { localRow?: number }) => {
         const row = Math.max(0, Math.min(vp - 1, e.localRow ?? 0))
+        const precise = promptOffsetAtRailRow(offsets, promptRows, total, vp, active, row)
+
+        // A tick is a TARGET, not a scrub handle: land on its prompt exactly
+        // and skip the drag bookkeeping a scrub would otherwise start.
+        if (precise !== null && s) {
+          grabRef.current = null
+          setGrab(null)
+          s.scrollTo(precise)
+
+          return
+        }
+
         const off = row >= thumbTop && row < thumbTop + thumb ? row - thumbTop : Math.floor(thumb / 2)
 
         grabRef.current = off
@@ -913,21 +971,13 @@ export function TranscriptScrollbar({ scrollRef, t }: TranscriptScrollbarProps) 
       {/* Nothing to scroll → draw nothing (the width={1} Box still reserves
           the column). Drawn-blank cells composite to a black bar on
           transparent terminals — same class as the removed opaque fills. */}
-      {!scrollable ? null : (
-        <>
-          {thumbTop > 0 ? (
-            <Text color={trackColor}>{`${'│\n'.repeat(Math.max(0, thumbTop - 1))}${thumbTop > 0 ? '│' : ''}`}</Text>
-          ) : null}
-          {thumb > 0 ? (
-            <Text color={thumbColor}>{`${'┃\n'.repeat(Math.max(0, thumb - 1))}${thumb > 0 ? '┃' : ''}`}</Text>
-          ) : null}
-          {vp - thumbTop - thumb > 0 ? (
-            <Text
-              color={trackColor}
-            >{`${'│\n'.repeat(Math.max(0, vp - thumbTop - thumb - 1))}${vp - thumbTop - thumb > 0 ? '│' : ''}`}</Text>
-          ) : null}
-        </>
-      )}
+      {!scrollable
+        ? null
+        : runs.map((run, i) => (
+            <Text color={run.color} key={i}>
+              {run.text}
+            </Text>
+          ))}
     </Box>
   )
 }
@@ -970,7 +1020,18 @@ interface StickyPromptTrackerProps {
   scrollRef: RefObject<ScrollBoxHandle | null>
 }
 
+// Shared empty rail inputs. Stable identity so a caller that passes nothing
+// (or a session with no prompts yet) never hands the rail a fresh array per
+// render.
+const NO_ROWS: readonly number[] = []
+const NO_OFFSETS: ArrayLike<number> = NO_ROWS
+
 interface TranscriptScrollbarProps {
+  /** Per-message top offsets from the transcript virtualizer; `promptRows`
+   *  index into it. Omitted → the column stays a plain scrollbar. */
+  offsets?: ArrayLike<number>
+  /** Message-row indexes of the user prompts, oldest first. Omitted → no rail. */
+  promptRows?: readonly number[]
   scrollRef: RefObject<ScrollBoxHandle | null>
   t: Theme
 }

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -14,6 +14,7 @@ import { usePet } from '../app/usePet.js'
 import { INLINE_MODE, SHOW_FPS, TERMUX_TUI_MODE } from '../config/env.js'
 import { PLACEHOLDER } from '../content/placeholders.js'
 import { prevRenderedMsg } from '../domain/blockLayout.js'
+import { promptRowIndexes } from '../domain/viewport.js'
 import {
   COMPOSER_PROMPT_GAP_WIDTH,
   composerPromptWidth,
@@ -179,6 +180,11 @@ const TranscriptPane = memo(function TranscriptPane({
     [transcript.historyItems]
   )
 
+  // Prompt rail targets: the message rows of every user prompt, which the rail
+  // maps onto its column and Alt+↑/↓ steps through. Same rows the transcript
+  // already indexes, so a tick and a jump can never disagree.
+  const promptRows = useMemo(() => promptRowIndexes(transcript.historyItems), [transcript.historyItems])
+
   return (
     <>
       <ScrollBox
@@ -259,7 +265,12 @@ const TranscriptPane = memo(function TranscriptPane({
       </ScrollBox>
 
       <NoSelect flexShrink={0} marginLeft={1}>
-        <TranscriptScrollbar scrollRef={transcript.scrollRef} t={ui.theme} />
+        <TranscriptScrollbar
+          offsets={transcript.virtualHistory.offsets}
+          promptRows={promptRows}
+          scrollRef={transcript.scrollRef}
+          t={ui.theme}
+        />
       </NoSelect>
 
       <StickyPromptTracker

--- a/ui-tui/src/content/hotkeys.ts
+++ b/ui-tui/src/content/hotkeys.ts
@@ -24,6 +24,7 @@ export const HOTKEYS: [string, string][] = [
   ['Esc Esc', 'discard draft (recall with ↑)'],
   ['Tab', 'apply completion'],
   ['↑/↓', 'completions / queue edit / history'],
+  ['Alt+↑/↓', 'jump to the previous / next prompt in the transcript'],
   ['Ctrl+X', 'open live session switcher (deletes queued message while editing)'],
   ['Ctrl+T', 'expand live agents (keeps your draft)'],
   ['F7', 'collapse / restore live agent preview'],

--- a/ui-tui/src/domain/viewport.ts
+++ b/ui-tui/src/domain/viewport.ts
@@ -99,10 +99,12 @@ export const promptRowIndexes = (messages: readonly Msg[]): number[] => {
 
 /**
  * Index INTO `rows` of the prompt the viewport sits in: the last prompt at or
- * above the viewport top. Pinned to the bottom the viewport is past every
- * prompt by construction, so the newest one answers without a walk — the same
- * fast path the desktop rail takes while it is following the tail. -1 when the
- * session has no prompts yet.
+ * above the viewport top. -1 while the top is above EVERY prompt — an intro or
+ * banner row above the first user message is the normal shape, so this is a
+ * position, not an error — and likewise in a session with no prompts yet.
+ * Pinned to the bottom the viewport is past every prompt by construction, so
+ * the newest one answers without a walk — the same fast path the desktop rail
+ * takes while it is following the tail.
  */
 export const activePromptIndex = (
   offsets: ArrayLike<number>,
@@ -119,7 +121,7 @@ export const activePromptIndex = (
     return rows.length - 1
   }
 
-  let active = 0
+  let active = -1
 
   for (let i = 0; i < rows.length; i++) {
     // Offsets are a monotone prefix sum, so the first prompt BELOW the
@@ -136,8 +138,11 @@ export const activePromptIndex = (
 
 /**
  * Absolute scroll offset for stepping one prompt from where the viewport is
- * now — the row to land ON. null at either end (and with no prompts at all) so
- * the caller leaves the viewport alone rather than bouncing it.
+ * now — the row to land ON. The bounds check is the whole of it: from -1 (the
+ * viewport above the first prompt) a forward step lands on the FIRST prompt
+ * rather than over it, and a backward step is a no-op. null at either end (and
+ * with no prompts at all) so the caller leaves the viewport alone rather than
+ * bouncing it.
  */
 export const steppedPromptOffset = (
   offsets: ArrayLike<number>,
@@ -146,13 +151,7 @@ export const steppedPromptOffset = (
   sticky: boolean,
   dir: -1 | 1
 ): number | null => {
-  const active = activePromptIndex(offsets, rows, top, sticky)
-
-  if (active < 0) {
-    return null
-  }
-
-  const next = active + dir
+  const next = activePromptIndex(offsets, rows, top, sticky) + dir
 
   if (next < 0 || next >= rows.length) {
     return null

--- a/ui-tui/src/domain/viewport.ts
+++ b/ui-tui/src/domain/viewport.ts
@@ -49,3 +49,174 @@ export const stickyPromptFromViewport = (
 
   return ''
 }
+
+/**
+ * Prompt navigation for the transcript — the terminal answer to the desktop's
+ * right-edge prompt rail.
+ *
+ * Row indexes here are MESSAGE indexes: the virtualizer keeps one entry per
+ * message, so `offsets[rows[i]]` is that prompt's top row in document space and
+ * `scrollTo` on it lands the prompt at the top of the viewport. Kept pure and
+ * DOM-free so the rail's ticks and the hotkeys' steps can never disagree about
+ * which prompt you are on.
+ */
+
+/**
+ * Turns the harness injects AS user messages: background-process notices,
+ * truncation notices, the preserved-task note. The backend names the same set
+ * in `agent/conversation_compression.py` (`_SYNTHETIC_USER_PREFIXES`) and the
+ * desktop rail filters them out too — without this the rail ticks a finished
+ * background job as if you had typed it.
+ */
+const SYNTHETIC_USER_PREFIXES = [
+  '[IMPORTANT: Background process ',
+  '[System: Your previous response was truncated',
+  '[System: The previous response was cut off',
+  '[System: Your previous tool call',
+  '[Your active task list was preserved across context compression]'
+]
+
+/** A turn you actually wrote, rather than one the harness injected. */
+const isOwnPrompt = (msg: Msg): boolean =>
+  msg.role === 'user' &&
+  msg.text.trim() !== '' &&
+  !SYNTHETIC_USER_PREFIXES.some(prefix => msg.text.startsWith(prefix))
+
+/** Message-row indexes of the user prompts, oldest first. */
+export const promptRowIndexes = (messages: readonly Msg[]): number[] => {
+  const rows: number[] = []
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i]
+
+    if (msg && isOwnPrompt(msg)) {
+      rows.push(i)
+    }
+  }
+
+  return rows
+}
+
+/**
+ * Index INTO `rows` of the prompt the viewport sits in: the last prompt at or
+ * above the viewport top. Pinned to the bottom the viewport is past every
+ * prompt by construction, so the newest one answers without a walk — the same
+ * fast path the desktop rail takes while it is following the tail. -1 when the
+ * session has no prompts yet.
+ */
+export const activePromptIndex = (
+  offsets: ArrayLike<number>,
+  rows: readonly number[],
+  top: number,
+  sticky: boolean,
+  slack = 1
+): number => {
+  if (!rows.length) {
+    return -1
+  }
+
+  if (sticky) {
+    return rows.length - 1
+  }
+
+  let active = 0
+
+  for (let i = 0; i < rows.length; i++) {
+    // Offsets are a monotone prefix sum, so the first prompt BELOW the
+    // viewport top ends the walk.
+    if ((offsets[rows[i]!] ?? 0) <= top + slack) {
+      active = i
+    } else {
+      break
+    }
+  }
+
+  return active
+}
+
+/**
+ * Absolute scroll offset for stepping one prompt from where the viewport is
+ * now — the row to land ON. null at either end (and with no prompts at all) so
+ * the caller leaves the viewport alone rather than bouncing it.
+ */
+export const steppedPromptOffset = (
+  offsets: ArrayLike<number>,
+  rows: readonly number[],
+  top: number,
+  sticky: boolean,
+  dir: -1 | 1
+): number | null => {
+  const active = activePromptIndex(offsets, rows, top, sticky)
+
+  if (active < 0) {
+    return null
+  }
+
+  const next = active + dir
+
+  if (next < 0 || next >= rows.length) {
+    return null
+  }
+
+  return offsets[rows[next]!] ?? null
+}
+
+export interface PromptTick {
+  /** Prompt index INTO `rows` — 0 is the oldest. */
+  index: number
+  /** Rail row the tick draws on, 0-based from the top of the viewport. */
+  row: number
+}
+
+/**
+ * Map every prompt's document offset onto a row of the right-edge rail.
+ * Proportional, like the scrollbar thumb beside it, oldest at the top. Prompts
+ * that round onto the same row collapse to ONE tick — and the ACTIVE prompt
+ * wins the collision, so the marker telling you where you are can never be
+ * absorbed by a neighbour in a dense session.
+ */
+export const promptTicks = (
+  offsets: ArrayLike<number>,
+  rows: readonly number[],
+  total: number,
+  viewportHeight: number,
+  activeIndex: number
+): PromptTick[] => {
+  if (!rows.length || viewportHeight <= 0) {
+    return []
+  }
+
+  const last = viewportHeight - 1
+  const span = Math.max(1, total)
+  const byRow = new Map<number, number>()
+
+  for (let i = 0; i < rows.length; i++) {
+    const scaled = Math.round(((offsets[rows[i]!] ?? 0) / span) * last)
+    const row = Math.max(0, Math.min(last, scaled))
+    const held = byRow.get(row)
+
+    if (held === undefined || i === activeIndex) {
+      byRow.set(row, i)
+    }
+  }
+
+  return [...byRow].map(([row, index]) => ({ index, row })).sort((a, b) => a.row - b.row)
+}
+
+/**
+ * Document offset a rail row stands for, so clicking a tick lands on the prompt
+ * EXACTLY instead of on the thumb's proportional guess. null when the row holds
+ * no tick, which leaves the plain scrub behaviour untouched.
+ */
+export const promptOffsetAtRailRow = (
+  offsets: ArrayLike<number>,
+  rows: readonly number[],
+  total: number,
+  viewportHeight: number,
+  activeIndex: number,
+  row: number
+): number | null => {
+  const hit = promptTicks(offsets, rows, total, viewportHeight, activeIndex).find(t => t.row === row)
+
+  return hit ? (offsets[rows[hit.index]!] ?? null) : null
+}

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -110,6 +110,7 @@ Keybindings match the [Classic CLI](cli.md#keybindings) exactly. The only behavi
 - **Slash autocompletion** opens as a floating panel with descriptions, not an inline dropdown.
 - **`Ctrl+X`** opens the live session switcher. When a queued message is highlighted (sent while the agent was still running), it still deletes that queued message instead. **`Esc`** cancels editing and unhighlights without deleting.
 - **`Ctrl+G` / `Ctrl+X Ctrl+E`** — open the current input buffer in `$EDITOR` for multi-line / long-prompt composition; save-and-exit sends the contents back as the prompt.
+- **`Alt+Up` / `Alt+Down`** (**Option** on macOS) jump to the previous / next prompt in the transcript — the short way back to your own last message when a reply runs long. The right-edge column marks where each of your prompts sits; the mark for the one you are on is filled, and clicking a mark jumps to it.
 
 ## Slash commands
 


### PR DESCRIPTION
## What does this PR do?

The transcript could only ever be navigated by rows — the scrollbar knows rows, the input
history knows what you typed — and one reply can run for dozens of screens. Between two of
your own prompts there was no way across but scrubbing the scrollbar.

This adds prompt-to-prompt navigation to the TUI. `Alt+Up` / `Alt+Down` step from one of
your messages to the previous / next one, and the scrollbar column paints one tick per
prompt: the prompt you are on is a **filled dot**, every other prompt a dim one, and
clicking a tick jumps straight to it.

The shape of it: derive everything from data the TUI already holds (`promptRowIndexes` over
the virtual row list), keep the navigation pure and testable in `domain/viewport.ts`, and
paint it in the scrollbar that already occupies that column rather than adding a second rail
— a second column would re-wrap and re-measure the whole transcript, since the height cache
is width-keyed.

## Related Issue

Part of #47809 — the right-edge index of conversation history. The desktop shipped its
version (#51094); the terminal surface was the unclaimed one.

This is not a duplicate of #66248 (a branching overlay over the transcript, not linear prompt
stepping) nor #65308 (Ctrl+Home / Ctrl+End, top and bottom of the transcript — complementary,
no chord overlap).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `ui-tui/src/domain/viewport.ts` — the pure navigation: `promptRowIndexes`,
  `activePromptIndex`, `steppedPromptOffset`, `promptTicks`, `promptOffsetAtRailRow`. A step
  resolves to an **absolute row target, not a row delta**: rows outside the measured span are
  height-estimated, so a delta drifts further off the longer the session runs.
  `activePromptIndex` reports `-1` while the viewport top is still above the first prompt — an
  intro row above the first user message is the normal shape — so a forward step lands on that
  first prompt rather than over it (review caught the walk that was seeded at 0 and skipped it;
  fixed in `2e7d0d9a77`).
- Prompt rows count only the prompts **you wrote**. Turns the harness injects as user
  messages — background-process notices, truncation notices, the preserved-task note, the same
  set `agent/conversation_compression.py` names in `_SYNTHETIC_USER_PREFIXES` — and blank rows
  get no tick. The desktop rail already filters the same class
  (`apps/desktop/.../thread/timeline-data.ts`, `PROCESS_NOTIFICATION_RE`); without this the
  rail would tick a finished background job as if it were something you typed. The same
  messages reach the TUI transcript as user turns
  (`tests/test_tui_gateway_server.py` asserts one lands in the turn sent to the agent).
- `ui-tui/src/components/appChrome.tsx` — `TranscriptScrollbar` now takes the prompt rows,
  paints one tick per prompt over its track, marks the active one, and jumps on click. Ticks
  win their row over the thumb, so the marker stays visible exactly when the thumb would
  otherwise cover it. The accent tone in that column already means "scrollbar hovered or
  grabbed" (`overlayPrimitives.tsx`), so the active marker carries its meaning in **shape**
  (filled vs dim dot) rather than in colour. The column still paints as a handful of text
  runs, coalesced by tone — not one node per row.
- `ui-tui/src/components/appLayout.tsx` — resolves the prompt rows (the visible-row index of
  each prompt) and passes them down.
- `ui-tui/src/app/useMainApp.ts` — `jumpToPrompt(dir)`: finds the current prompt, steps, and
  scrolls to the target row, dropping a live selection since the viewport is re-homed.
- `ui-tui/src/app/useInputHandlers.ts` — `Alt+Up` / `Alt+Down` routed through the exported,
  unit-tested `promptStepFor`, **above** the completion cycler and the history handlers
  (otherwise `Alt+Up` is read as input-history-up).
- `ui-tui/src/app/interfaces.ts` — `jumpToPrompt` on the terminal context.
- `ui-tui/src/content/hotkeys.ts` — the in-app hotkey help lists the chord.
- `ui-tui/README.md` and `website/docs/user-guide/tui.md` — the column's encoding and the key,
  in the repo README and on the docs site.
- Tests: 4 invariant tests over the geometry in `ui-tui/src/__tests__/viewport.test.ts`, 1 over
  the chord in `ui-tui/src/__tests__/useInputHandlers.test.ts`. Deliberately not one per
  function — these are the contracts (step lands on the prompt's own row and neither end
  wraps; the active prompt survives a tick collision; a tick row resolves to the prompt
  exactly; injected turns get no tick), and they fail on `main` at import, since the functions
  do not exist there yet.
- `contributors/emails/phil.c.taylor@gmail.com` — required by the attribution check.

## How to Test

1. `cd ui-tui && npm run check` — build + typecheck + vitest + eslint: **168 files, 1776
   tests passed, 0 errors** on this branch (the 2 warnings are pre-existing, in files this PR
   does not touch). That command is the unit CI runs for this workspace: `node
   .github/scripts/run-workspace-checks.mjs` fires every workspace's `check` (ui-tui, desktop,
   web) on Node 26, and `scripts/check-windows-footguns.py --all` is clean.
2. Start the TUI from source: `cd ui-tui && npm run dev` (`hermes --tui` executes
   `ui-tui/dist/entry.js`, which is stale until you `npm run build`). Open a session longer
   than one screen — `/resume` for an existing long one.
3. Press `Alt+Up` / `Alt+Down` (`Option+Up/Down` on macOS): the view steps prompt to prompt.
   At the oldest and the newest prompt the step is a no-op — deliberately no wrap.
4. In the right column: the prompt you are on is a filled dot in accent, every other prompt is
   a dim dot; the thin lines are the scrollbar track and the thick run is the thumb.
5. Click a tick: the view lands on that prompt, not near it.
6. The case that used to fail: hover or drag the scrollbar so the thumb turns accent — the
   filled dot has to stay identifiable *inside* the thumb. A colour-only marker disappears
   there, which is why the active marker is a distinct glyph.
7. Run a background process that finishes while the session is open: the notice it injects
   gets **no tick**.

Expected: ticks sit proportionally to where the prompts are in the transcript, the filled dot
follows scrolling, and a conversation that fits on one screen shows no rail at all (there is
nothing to navigate).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) — `feat(tui): …`
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls); the neighbouring work (#66248, #65308, #70032) adds no prompt stepping, see Related Issue
- [x] My PR contains **only** changes related to this feature — 10 `ui-tui/**` files, the TUI page on the docs site, and the one-line contributor mapping CI requires
- [ ] I've run `pytest tests/ -q` — **N/A for a JS-only change.** This diff touches only `ui-tui/**`, so `scripts/ci/classify_changes.py` does not route it to the Python jobs; I did not run the Python suite and am not claiming it.
- [x] I've added tests for my changes (see above)
- [x] I've tested on my platform: macOS 26.6.2 (Darwin), Node 26.8.1 / npm 11.19.0 — **both iTerm2 and Ghostty**, since the two differ in how they deliver the Alt/Option modifier

### Documentation & Housekeeping

- [x] Updated relevant documentation — `ui-tui/README.md`, `ui-tui/src/content/hotkeys.ts` and `website/docs/user-guide/tui.md`
- [x] `cli-config.yaml.example` — N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow change
- [x] Considered cross-platform impact — no file, process or POSIX-specific code; no new
      dependencies; `scripts/check-windows-footguns.py --all` clean. The chord rides the
      terminal's modifier bits (`key.meta` = Alt/Option per `lib/platform.ts`)
- [x] Tool descriptions/schemas — N/A, no tool changes

## Screenshots / Logs

No recorded terminal session attached — a TUI capture is not reviewable in a browser. The
column's encoding, as documented in `ui-tui/README.md`:

```
│   scrollbar track (the whole transcript)
┃   thumb (the part currently visible)
•   one of your prompts
●   the prompt you are on, in accent
```

Lint/test tail from step 1:

```
 Test Files  168 passed (168)
      Tests  1776 passed (1776)

✖ 2 problems (0 errors, 2 warnings)   ← pre-existing, in files this PR does not touch
```

## Follow-ups, deliberately not in this PR

- **Harness landmarks get no tick.** Injected turns — background-process notices, truncation
  notices, the preserved-task note — are filtered out, matching the desktop rail. Giving them
  their own mark class (a dim `◆` beside the prompt dot) is proposed in #109393 instead of
  being folded in here, so this stays one logical change for review. My own preference runs
  that way; I kept parity first because the rail's contract should mean the same thing on both
  surfaces.

## Known limits

- Only prompts in the loaded transcript get ticks. The desktop's coverage issues
  (#98865, #101939, #52816) are a different layer — the desktop's bounded runtime window —
  and are not this code path.
- The synthetic-prefix list is mirrored from `agent/conversation_compression.py` into
  `domain/viewport.ts`; there is no cross-language shared source for it today, so a new
  prefix needs the same edit on both sides.
- The visual encoding has no renderer-level test: `ui-tui/src/__tests__` tests pure functions
  and has no ink render harness, so the glyph choice is verified by UAT on macOS instead.