### PR TITLE
fix(plugin): exclude test trees from guard scans

### DIFF
--- a/tests/tools/test_plugin_guard.py
+++ b/tests/tools/test_plugin_guard.py
@@ -75,6 +75,46 @@ class TestCleanPlugin:
         assert result.verdict == "safe"
 
 
+class TestTestTreeExclusion:
+    @pytest.mark.parametrize("test_dir", ["tests", "test"])
+    def test_recognized_test_trees_are_not_scanned(self, tmp_path, test_dir):
+        files = dict(BASE_FILES)
+        files[f"{test_dir}/fixture.sh"] = (
+            "cp /tmp/config-fixture ~/.hermes/config.yaml\n"
+        )
+        files[f"{test_dir}/fixture.exe"] = "binary fixture\n"
+        plugin = _mk_plugin(tmp_path, files)
+
+        result = scan_plugin(plugin)
+
+        assert result.verdict == "safe", [
+            (finding.pattern_id, finding.file) for finding in result.findings
+        ]
+        assert not result.findings
+
+    @pytest.mark.parametrize(
+        "rel_path",
+        [
+            "runtime/fixture.sh",
+            "docs/fixture.md",
+            "testing/fixture.sh",
+            "test_fixture.sh",
+        ],
+    )
+    def test_non_test_tree_files_remain_scanned(self, tmp_path, rel_path):
+        files = dict(BASE_FILES)
+        files[rel_path] = "cp /tmp/config-fixture ~/.hermes/config.yaml\n"
+        plugin = _mk_plugin(tmp_path, files)
+
+        result = scan_plugin(plugin)
+
+        assert result.verdict == "dangerous"
+        assert any(
+            finding.severity == "critical" and finding.file == rel_path
+            for finding in result.findings
+        )
+
+
 class TestMaliciousPlugin:
     def test_ssh_dir_exfil_in_code_is_flagged(self, tmp_path):
         files = dict(BASE_FILES)

--- a/tools/plugin_guard.py
+++ b/tools/plugin_guard.py
@@ -20,10 +20,10 @@ from tools.skills_guard import (
 
 PLUGIN_SCANNER_VERSION = "plugin-guard-v1"
 
-# Never scanned: VCS internals, caches, vendored envs.
+# Never scanned: VCS internals, caches, vendored envs, non-runtime test trees.
 EXCLUDED_DIRS = {
     ".git", "__pycache__", "node_modules", ".venv", "venv",
-    ".mypy_cache", ".pytest_cache", ".ruff_cache", ".tox"}
+    ".mypy_cache", ".pytest_cache", ".ruff_cache", ".tox", "test", "tests"}
 
 # Code files, where "reads an env secret" / "HTTP call with a key" is normal (requires_env).
 CODE_FILE_EXTENSIONS = {".py", ".js", ".ts", ".sh", ".bash", ".rb", ".pl", ".php"}


### PR DESCRIPTION
## Summary

- exclude exact `test/` and `tests/` directory components from plugin guard traversal
- apply the exclusion through the shared walker so structural and content scans agree
- keep runtime code, documentation, and ambiguous test-like paths under the existing security scan

Fixes #109391.

## Why this is narrow

The plugin guard already centralizes VCS, cache, and environment exclusions in `_walk()`. Adding the two recognized non-runtime test directory names there prevents test fixtures from deciding the install verdict without weakening finding severities, adding a waiver, or excluding agent-facing documentation.

## Proof receipt

Before the implementation, the focused regression selection failed for both recognized test directory names:

```text
scripts/run_tests.sh tests/tools/test_plugin_guard.py -k TestTestTreeExclusion
2 failed, 2 passed
```

Both failures reported a structural `binary_file` finding and a content `hermes_config_mod_shell` finding from the test tree, producing a `dangerous` verdict.

After the implementation:

```text
scripts/run_tests.sh tests/tools/test_plugin_guard.py
23 passed, 0 failed
```

Controls verify that equivalent critical content in `runtime/fixture.sh` and `docs/fixture.md` remains dangerous. Additional controls keep `testing/fixture.sh` and root `test_fixture.sh` scanned, preventing substring-based exclusions.

## Risk

A plugin that intentionally places runtime code beneath a directory component named exactly `test` or `tests` will now treat that code as non-runtime test material. This matches the recognized test-tree contract and does not affect other path names.

## Review gate

- implementation self-review P0: 0
- `git diff --check`: passed
- independent review fallback: not triggered (two files, under 200 changed lines, no auth/crypto/state schema/gateway routing)
