### PR TITLE
fix(gateway): preserve profile config changes during connection

### DIFF
--- a/gateway/run_adapters.py
+++ b/gateway/run_adapters.py
@@ -827,6 +827,7 @@ class GatewayAdapterLifecycleMixin:
         Each profile connects under its own HERMES_HOME + secret scope; credential/listener collisions
         are refused here — the only point seeing every profile's credentials together."""
         from gateway.run import MultiplexConfigError, _multiplex_profile_homes
+        from gateway.run_profile_reconcile import profile_serve_signature
         if not self._multiplex_on():
             return 0
         try:
@@ -837,9 +838,12 @@ class GatewayAdapterLifecycleMixin:
         connected = 0
         claimed = self._primary_resource_claims(active)
         profile_homes = _multiplex_profile_homes(self.config)
+        self._served_profile_signatures = {}
         for profile_name, profile_home in profile_homes:
             if profile_name == active:
                 continue  # handled by the primary startup loop
+            # Preserve changes made while the initial connection is awaiting I/O.
+            self._served_profile_signatures[profile_name] = profile_serve_signature(profile_home)
             try:
                 connected += await self._start_one_profile_adapters(profile_name, profile_home, claimed)
             except MultiplexConfigError:

--- a/gateway/run_profile_reconcile.py
+++ b/gateway/run_profile_reconcile.py
@@ -116,6 +116,9 @@ class GatewayProfileReconcileMixin:
                 result["removed"].append(name)
             claimed = self._live_resource_claims(active)
             for name in added + changed:
+                # Only acknowledge the configuration observed before connecting;
+                # a setup save during an awaited handshake needs another scan.
+                scan_signature = profile_serve_signature(current[name])
                 try:
                     connected = await self._start_one_profile_adapters(name, current[name], claimed)
                 except MultiplexConfigError as exc:
@@ -125,7 +128,7 @@ class GatewayProfileReconcileMixin:
                 except Exception:
                     logger.error("[MULTIPLEX] Failed to start adapters for profile '%s'", name, exc_info=True)
                     connected = 0
-                sigs[name] = profile_serve_signature(current[name])
+                sigs[name] = scan_signature
                 if name in added:
                     logger.info("[MULTIPLEX] Now serving profile '%s' (%s adapter(s) connected; %s)", name, connected, reason)
                     result["added"].append(name)

--- a/tests/gateway/test_profile_signature_during_connect.py
+++ b/tests/gateway/test_profile_signature_during_connect.py
@@ -1,0 +1,73 @@
+"""A config saved while a profile connects must remain pending for the next scan."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.run import GatewayRunner
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("startup", [False, True])
+async def test_config_saved_during_connect_is_rescanned(tmp_path, monkeypatch, startup):
+    home = tmp_path / ".hermes"
+    profile = home / "profiles" / "worker"
+    profile.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "hermes_cli.profiles.get_active_profile_name", lambda: "default"
+    )
+    (profile / "config.yaml").write_text("model: {default: test}\n", encoding="utf-8")
+    secrets = profile / ".env"
+    secrets.write_text("DISCORD_BOT_TOKEN=discord-test\n", encoding="utf-8")
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner._running = True
+    runner._primary_profile_name = "default"
+    (
+        runner.adapters,
+        runner._profile_adapters,
+        runner._failed_platforms,
+        runner._profile_failed_platforms,
+    ) = {}, {}, {}, {}
+    runner.pairing_store, runner.pairing_stores = MagicMock(), {}
+    runner._busy_text_modes_by_profile, runner._busy_input_modes_by_profile = {}, {}
+    runner._register_config_hooks = lambda *a, **kw: None
+    runner._configure_profile_adapter = lambda *a: None
+    runner._sync_voice_mode_state_to_adapter = lambda *a: None
+    runner._restore_secondary_completion_ledgers = lambda *a: None
+    runner._adapter_credential_claim = lambda *a: None
+    runner._adapter_listener_claim = lambda *a: None
+    runner._create_adapter = lambda platform, config: SimpleNamespace(platform=platform)
+    runner._note_served_profiles([("default", home)])
+    connected = []
+
+    async def connect(adapter, platform):
+        connected.append(platform)
+        if platform == Platform.DISCORD:
+            # Configuration was already read; a second setup operation finishes while
+            # the first adapter is awaiting its transport handshake.
+            secrets.write_text(
+                "DISCORD_BOT_TOKEN=discord-test\nTELEGRAM_BOT_TOKEN=telegram-test\n",
+                encoding="utf-8",
+            )
+        return True
+
+    async def after_added(profiles):
+        pass
+
+    runner._connect_initial_adapter_with_timeout = connect
+    runner._after_profiles_added = after_added
+    if startup:
+        await runner._start_secondary_profile_adapters()
+    else:
+        await runner.reconcile_served_profiles()
+    assert connected == [Platform.DISCORD]
+    await runner.reconcile_served_profiles()
+    assert connected == [Platform.DISCORD, Platform.TELEGRAM]
+    await runner.reconcile_served_profiles()
+    assert connected == [Platform.DISCORD, Platform.TELEGRAM]


### PR DESCRIPTION
## What does this PR do?

Keep a secondary profile's configuration change pending when it is saved during an adapter connection. Previously, adding a Telegram token while Discord was connecting caused the post-connection signature to acknowledge config that had never been loaded; subsequent scans skipped Telegram indefinitely. The next scan now starts the missing adapter once and retains the existing connection.

Capture the profile signature before awaiting adapter startup, both in runtime reconciliation and initial secondary-profile startup. This keeps the existing watcher and live/queued-adapter guards responsible for convergence.

## Related Issue

Fixes #109398

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run_profile_reconcile.py`: record the signature sampled before connection rather than a newer post-connection signature.
- `gateway/run_adapters.py`: seed secondary-profile signatures before initial connections so startup follows the same rule.
- `tests/gateway/test_profile_signature_during_connect.py`: one parametrized invariant covering startup and runtime rescans, real temporary profile config loading, and transport-controlled interleaving. A third scan verifies neither adapter connects twice.

## How to Test

On baseline `e440bf35472c30c2ee5527e884a866c12ad15b91`, both new cases fail: the next scan connects only Discord rather than Discord and Telegram. With the fix, both pass.

Run through the repository's isolated test runner:

```bash
scripts/run_tests.sh \
  tests/gateway/test_profile_signature_during_connect.py \
  tests/gateway/test_multiplex_hot_serve.py \
  tests/gateway/test_multiplex_credential_isolation.py \
  tests/gateway/test_multiplex_lifecycle.py \
  tests/gateway/test_multiplex_adapter_registry.py \
  --file-retries 0 -j 3 -q
```

Executed in two groups: **5 passed + 48 passed = 53 distinct tests**, no failures or skips. The two new cases also passed after formatting. Tests use temporary `HERMES_HOME`/home paths; external network handshakes are substituted, while actual profile loading and adapter startup/reconciliation run.

Ruff checks, new-test formatting, Windows footgun checks, plugin compatibility checks, and `git diff --check` passed.

## Compatibility and risks

Tested on native Windows, Python 3.13. Linux/macOS and live platform handshakes have not been run locally. No config format, tool schema, prompt-cache behavior, or public API changes. A concurrent save can cause one additional rescan; existing live/queued-adapter checks prevent duplicate connections. Existing exception/reconnect and deleted-profile handling remain in place.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit follows Conventional Commits.
- [x] I searched existing Issues and PRs, including closed/merged results and related patches.
- [x] This PR contains only changes related to this fix.
- [ ] I've run the entire `pytest tests/ -q` suite. (Only the relevant 53 tests above were run, through `scripts/run_tests.sh`.)
- [x] I've added regression tests.
- [x] I've tested on my platform: native Windows / Python 3.13.

### Documentation & Housekeeping

- [x] Relevant documentation: N/A; restores the existing hot-serve contract.
- [x] Config example changes: N/A; no keys added or changed.
- [x] Contribution/architecture guide changes: N/A.
- [x] Cross-platform impact considered; remote CI pending.
- [x] Tool descriptions/schemas: N/A.

## Screenshots / Logs

```text
Baseline regression: 2 failed
Fixed regression + hot-serve: 5 passed
Credential isolation + lifecycle + adapter registry: 48 passed
```
