### PR TITLE
feat(goals): opt in to automatic goal start

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -38,6 +38,16 @@ runtime:
   nofile_soft_limit: 4096
 
 # =============================================================================
+# Persistent Goals
+# =============================================================================
+# When enabled, the first eligible execution request in a session automatically
+# starts a drafted /goal loop. Explicit /goal commands and sessions with an existing
+# goal are unchanged. Default: false (opt-in because the first eligible request
+# can trigger continuation turns and an auxiliary contract-drafting call).
+goals:
+  auto_start: false
+
+# =============================================================================
 # Model Configuration
 # =============================================================================
 model:

--- a/cli.py
+++ b/cli.py
@@ -3496,6 +3496,8 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
 
         if isinstance(user_input, str) and _PASTE_REF_RE.search(user_input):
             user_input = self._expand_paste_references(user_input)
+        if not is_seeded_query:
+            self._maybe_auto_start_goal(user_input)
         print()
         self._print_user_message_preview(notification_preview or user_input)
 

--- a/gateway/run_goals.py
+++ b/gateway/run_goals.py
@@ -44,6 +44,48 @@ class GatewayGoalsMixin:
         except Exception:
             return 20
 
+    async def _maybe_auto_start_goal(self, event: "MessageEvent", session_id: str, message) -> bool:
+        """Opt-in: draft a goal from a normal gateway message before its first turn."""
+        if getattr(event, "internal", False) or not session_id:
+            return False
+
+        from hermes_cli.goal_command import (
+            goal_auto_start_enabled,
+            goal_objective_text,
+            is_goal_candidate,
+        )
+
+        objective = goal_objective_text(message)
+        if not objective or not is_goal_candidate(objective):
+            return False
+
+        def start():
+            from hermes_cli.config import load_config
+            from hermes_cli.goal_command import auto_start_goal
+            from hermes_cli.goals import GoalManager
+
+            config = getattr(self, "config", None) if isinstance(getattr(self, "config", None), dict) else {}
+            if not config.get("goals"):
+                config = load_config()
+            if not goal_auto_start_enabled(config):
+                return False
+            manager = GoalManager(
+                session_id=session_id,
+                default_max_turns=self._goal_max_turns_from_config(),
+            )
+            return auto_start_goal(manager, objective) is not None
+
+        try:
+            started = await self._run_in_executor_with_context(start)
+        except Exception as exc:
+            # Auto-start is a convenience mode; the original turn must still run when drafting or
+            # persistence is unavailable.
+            logger.debug("automatic gateway goal start failed: %s", exc)
+            return False
+        if started:
+            logger.info("auto-started goal for gateway message: %s", objective[:120])
+        return bool(started)
+
     async def _warm_goals_session_db(self, label: str) -> None:
         """Warm the goals SessionDB cache off-loop (best-effort): a cold cache runs the state.db
         init on the loop thread and freezes the loop. The executor hop keeps the profile home

--- a/gateway/run_goals.py
+++ b/gateway/run_goals.py
@@ -45,7 +45,7 @@ class GatewayGoalsMixin:
             return 20
 
     async def _maybe_auto_start_goal(self, event: "MessageEvent", session_id: str, message) -> bool:
-        """Opt-in: draft a goal from a normal gateway message before its first turn."""
+        """Opt-in: draft a goal from raw user text before the first gateway turn."""
         if getattr(event, "internal", False) or not session_id:
             return False
 

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1948,6 +1948,7 @@ class GatewayTurnMixin:
         history, message_text = prepared.history, prepared.message_text
 
         try:
+            await self._maybe_auto_start_goal(event, session_entry.session_id, message_text)
             hook_ctx = {
                 "platform": source.platform.value if source.platform else "",
                 "user_id": source.user_id,

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1948,7 +1948,9 @@ class GatewayTurnMixin:
         history, message_text = prepared.history, prepared.message_text
 
         try:
-            await self._maybe_auto_start_goal(event, session_entry.session_id, message_text)
+            # Classify only the normalized user-authored text. ``message_text`` may contain
+            # auto-loaded skill instructions or vision enrichment and must remain agent-only input.
+            await self._maybe_auto_start_goal(event, session_entry.session_id, event.text)
             hook_ctx = {
                 "platform": source.platform.value if source.platform else "",
                 "user_id": source.user_id,

--- a/hermes_cli/cli_loops_mixin.py
+++ b/hermes_cli/cli_loops_mixin.py
@@ -338,6 +338,43 @@ class CLILoopsMixin:
             return make
         return self._session_bound_manager("_goal_manager", "goal manager", load)
 
+    def _maybe_auto_start_goal(self, message) -> bool:
+        """Opt-in: turn a normal interactive message into a drafted goal when none exists."""
+        from hermes_cli.config import load_config
+        from hermes_cli.goal_command import (
+            auto_start_goal,
+            goal_auto_start_enabled,
+            goal_objective_text,
+            is_goal_candidate,
+        )
+        from tools.process_registry_notifications import SubagentNotification
+
+        if isinstance(message, SubagentNotification):
+            return False
+        try:
+            config = self.config if isinstance(getattr(self, "config", None), dict) else {}
+            if not config.get("goals"):
+                config = load_config()
+            if not goal_auto_start_enabled(config):
+                return False
+            objective = goal_objective_text(message)
+            if not objective or not is_goal_candidate(objective):
+                return False
+            manager = self._get_goal_manager()
+            if manager is None:
+                return False
+            result = auto_start_goal(manager, objective)
+            if result is None:
+                return False
+            logging.info("auto-started goal for interactive message: %s", objective[:120])
+            from cli import _DIM, _RST, _cprint
+            _cprint(f"  {_DIM}⊙ Auto-started a goal for this message (goals.auto_start=true){_RST}")
+            return True
+        except Exception as exc:
+            # This convenience feature must never prevent the original message from running.
+            logging.debug("automatic goal start failed: %s", exc)
+            return False
+
     def _get_heartbeat_manager(self):
         """HeartbeatManager bound to the current session_id (see ``_session_bound_manager``)."""
         def load():

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1276,6 +1276,9 @@ DEFAULT_CONFIG = {
     # goal is satisfied, else a continuation prompt re-enters the session until done, budget
     # exhausted, or paused. Judge failures fail OPEN; the budget is the backstop.
     "goals": {
+        # When true, the first eligible execution request in a session automatically becomes a drafted goal.
+        # Explicit /goal commands and sessions with an existing goal keep their normal behavior.
+        "auto_start": False,
         # Max continuation turns before auto-pause (/goal resume) — guards against judge false
         # negatives and unbounded spend.
         "max_turns": 20,

--- a/hermes_cli/goal_command.py
+++ b/hermes_cli/goal_command.py
@@ -7,11 +7,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
+import re
+import threading
 from typing import Callable
 
 from hermes_cli import goals
 
 logger = logging.getLogger(__name__)
+
+_AUTO_START_LOCK_GUARD = threading.Lock()
+_AUTO_START_LOCKS: dict[str, threading.Lock] = {}
 
 
 @dataclass(frozen=True)
@@ -153,6 +158,87 @@ def _set(mgr, arg, *, drafting, last_user_message, render, progress):
                    "Hermes keeps working until it is, you pause/clear it, or the budget is "
                    "exhausted. Use /goal status, /goal show, /goal pause, /goal resume, /goal clear.")
     return GoalCommandResult(output, goals.goal_kick_prompt(state.goal, last_user_message), kickoff=True)
+
+
+def goal_objective_text(message) -> str:
+    """Extract the text portion of a normal user message for automatic goal start."""
+    if isinstance(message, list):
+        return "\n".join(
+            str(block.get("text", ""))
+            for block in message
+            if isinstance(block, dict) and block.get("text")
+        ).strip()
+    return str(message or "").strip()
+
+
+_GOAL_ACTION_PATTERNS = (
+    r"\b(?:add|analy[sz]e|audit|build|change|check|clean|compare|configure|create|debug|deploy|delete|edit|fix|generate|implement|install|investigate|migrate|modify|publish|refactor|remove|research|review|run|set up|setup|test|update|verify|write)\b",
+    r"(?:調べて|調査|作って|作成|実装|修正|直して|検証|確認して|実行|追加|変更|設定|導入|インストール|デプロイ|公開|送って|書いて|編集|比較|レビュー|削除|生成|準備|再開)",
+)
+_EXPLANATION_PREFIX = re.compile(
+    r"^(?:(?:what|why|when|where|who|which|how do i|how can i|should i|do i|does it|is it|is there|are there)\b|"
+    r"can you tell me|could you explain|please explain|tell me how|説明して|どうやって|なぜ|何ですか)",
+    flags=re.IGNORECASE,
+)
+
+
+def is_goal_candidate(message) -> bool:
+    """Return whether a normal message is an execution request.
+
+    This intentionally uses a conservative, local heuristic: automatic Goal
+    mode must not turn ordinary questions or short replies into persistent
+    work. False negatives can still use the explicit ``/goal`` command.
+    """
+    text = goal_objective_text(message)
+    if (
+        len(text) < 8
+        or text.startswith("/")
+        or text.lower().startswith("!goal")
+        or _EXPLANATION_PREFIX.match(text)
+    ):
+        return False
+    return any(re.search(pattern, text, re.IGNORECASE) for pattern in _GOAL_ACTION_PATTERNS)
+
+
+def goal_auto_start_enabled(config) -> bool:
+    """Return whether normal messages should create a goal when no goal exists."""
+    try:
+        from utils import is_truthy_value
+
+        goals_config = ((config or {}).get("goals") or {}) if isinstance(config, dict) else {}
+        return is_truthy_value(goals_config.get("auto_start"), default=False)
+    except Exception:
+        return False
+
+
+def auto_start_goal(
+    mgr: goals.GoalManager, objective: str, *, progress: Callable[[str], None] | None = None,
+) -> GoalCommandResult | None:
+    """Draft and persist a goal from a normal message when the session has no goal.
+
+    This intentionally does not enqueue the returned kickoff prompt: the original user message is
+    already the turn being processed. Returning ``None`` means the feature is disabled for this
+    session because it already has an active or paused goal.
+    """
+    objective = goal_objective_text(objective)
+    if not objective:
+        return None
+    with _AUTO_START_LOCK_GUARD:
+        session_lock = _AUTO_START_LOCKS.setdefault(mgr.session_id, threading.Lock())
+    with session_lock:
+        if mgr.has_goal():
+            return None
+        stored = goals.load_goal(mgr.session_id)
+        if stored is not None and stored.status in {"active", "paused"}:
+            return None
+        return _set(
+            mgr,
+            objective,
+            drafting=True,
+            last_user_message=objective,
+            render=_english,
+            progress=progress,
+        )
 
 
 def is_goal_control(arg: str) -> bool:

--- a/tests/hermes_cli/test_goal_auto_start.py
+++ b/tests/hermes_cli/test_goal_auto_start.py
@@ -1,0 +1,132 @@
+"""Opt-in automatic Goal start for ordinary CLI and gateway messages."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from hermes_cli import goals
+from hermes_cli.goal_command import (
+    auto_start_goal,
+    goal_auto_start_enabled,
+    goal_objective_text,
+    is_goal_candidate,
+)
+
+
+def test_goal_helpers_normalize_text_and_gate_config():
+    assert goal_objective_text("  build it  ") == "build it"
+    assert goal_objective_text([{"type": "text", "text": "first"}, {"type": "image_url"}, {"text": "second"}]) == (
+        "first\nsecond"
+    )
+    assert goal_auto_start_enabled({"goals": {"auto_start": True}})
+    assert goal_auto_start_enabled({"goals": {"auto_start": "yes"}})
+    assert not goal_auto_start_enabled({"goals": {"auto_start": False}})
+    assert not goal_auto_start_enabled({})
+    assert is_goal_candidate("Implement the config option and add tests")
+    assert is_goal_candidate("Can you implement this option?")
+    assert is_goal_candidate("この機能を実装してテストも追加して")
+    assert not is_goal_candidate("What is a persistent Goal?")
+    assert not is_goal_candidate("Can you tell me how to fix this?")
+    assert not is_goal_candidate("Should I implement this?")
+    assert not is_goal_candidate("/goal Implement the feature")
+    assert not is_goal_candidate("!goal draft Implement the feature")
+    assert not is_goal_candidate("どうやって実装する？")
+    assert not is_goal_candidate("できる？")
+    assert not is_goal_candidate("Thanks")
+
+
+def test_auto_start_goal_drafts_and_persists_without_a_kickoff(monkeypatch):
+    goals._DB_CACHE.clear()
+    drafted = []
+
+    def draft(objective):
+        drafted.append(objective)
+        return goals.GoalContract(verification="tests pass")
+
+    monkeypatch.setattr(goals, "draft_contract", draft)
+    manager = goals.GoalManager("auto-start")
+
+    result = auto_start_goal(manager, "  make the tests pass  ")
+
+    assert result is not None
+    assert result.kickoff is True
+    assert result.prompt == "make the tests pass"
+    assert drafted == ["make the tests pass"]
+    state = goals.load_goal("auto-start")
+    assert state is not None
+    assert state.goal == "make the tests pass"
+    assert state.has_contract()
+
+
+def test_auto_start_goal_does_not_replace_an_existing_goal(monkeypatch):
+    goals._DB_CACHE.clear()
+    monkeypatch.setattr(goals, "draft_contract", lambda objective: (_ for _ in ()).throw(AssertionError()))
+    manager = goals.GoalManager("existing-goal")
+    manager.set("keep this goal")
+
+    assert auto_start_goal(manager, "new message") is None
+    assert auto_start_goal(goals.GoalManager("existing-goal"), "another message") is None
+    assert goals.load_goal("existing-goal").goal == "keep this goal"
+
+
+def test_cli_auto_start_is_opt_in_and_fail_open(monkeypatch):
+    from hermes_cli.cli_loops_mixin import CLILoopsMixin
+
+    goals._DB_CACHE.clear()
+    manager = goals.GoalManager("cli-auto-start")
+    cli = object.__new__(CLILoopsMixin)
+    cli.session_id = "cli-auto-start"
+    cli._get_goal_manager = lambda: manager
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"goals": {"auto_start": False}})
+    assert not cli._maybe_auto_start_goal("Implement the first message")
+    assert goals.load_goal("cli-auto-start") is None
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"goals": {"auto_start": True}})
+    monkeypatch.setattr(goals, "draft_contract", lambda objective: None)
+    assert cli._maybe_auto_start_goal("Implement the first message")
+    assert goals.load_goal("cli-auto-start").goal == "Implement the first message"
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: (_ for _ in ()).throw(RuntimeError("config unavailable")))
+    assert cli._maybe_auto_start_goal("second message") is False
+
+
+
+def test_gateway_auto_start_uses_normal_events_and_skips_internal_events(monkeypatch):
+    from gateway.run_goals import GatewayGoalsMixin
+
+    goals._DB_CACHE.clear()
+    monkeypatch.setattr(goals, "draft_contract", lambda objective: None)
+
+    class Runner(GatewayGoalsMixin):
+        config = {"goals": {"auto_start": True, "max_turns": 3}}
+
+        async def _run_in_executor_with_context(self, fn):
+            return fn()
+
+    runner = object.__new__(Runner)
+    event = SimpleNamespace(internal=False)
+    assert asyncio.run(runner._maybe_auto_start_goal(event, "gateway-auto-start", "Implement the new feature"))
+    state = goals.load_goal("gateway-auto-start")
+    assert state.goal == "Implement the new feature"
+    assert state.max_turns == 3
+
+    internal_event = SimpleNamespace(internal=True)
+    assert not asyncio.run(runner._maybe_auto_start_goal(internal_event, "internal", "Implement the internal change"))
+    assert goals.load_goal("internal") is None
+
+
+def test_gateway_auto_start_failure_does_not_block_turn():
+    from gateway.run_goals import GatewayGoalsMixin
+
+    class Runner(GatewayGoalsMixin):
+        config = {"goals": {"auto_start": True}}
+
+        async def _run_in_executor_with_context(self, fn):
+            raise RuntimeError("executor unavailable")
+
+    runner = object.__new__(Runner)
+    event = SimpleNamespace(internal=False)
+    assert not asyncio.run(runner._maybe_auto_start_goal(event, "gateway-failure", "Implement the change"))
+    assert goals.load_goal("gateway-failure") is None

--- a/tests/hermes_cli/test_goal_auto_start.py
+++ b/tests/hermes_cli/test_goal_auto_start.py
@@ -106,14 +106,26 @@ def test_gateway_auto_start_uses_normal_events_and_skips_internal_events(monkeyp
             return fn()
 
     runner = object.__new__(Runner)
-    event = SimpleNamespace(internal=False)
-    assert asyncio.run(runner._maybe_auto_start_goal(event, "gateway-auto-start", "Implement the new feature"))
+    event = SimpleNamespace(
+        internal=False,
+        text="Implement the new feature",
+        auto_skill="instructions that say implement unrelated work",
+    )
+    assert asyncio.run(runner._maybe_auto_start_goal(event, "gateway-auto-start", event.text))
     state = goals.load_goal("gateway-auto-start")
     assert state.goal == "Implement the new feature"
     assert state.max_turns == 3
 
-    internal_event = SimpleNamespace(internal=True)
-    assert not asyncio.run(runner._maybe_auto_start_goal(internal_event, "internal", "Implement the internal change"))
+    enriched_event = SimpleNamespace(
+        internal=False,
+        text="hello",
+        auto_skill="instructions that say implement unrelated work",
+    )
+    assert not asyncio.run(runner._maybe_auto_start_goal(enriched_event, "gateway-enriched", enriched_event.text))
+    assert goals.load_goal("gateway-enriched") is None
+
+    internal_event = SimpleNamespace(internal=True, text="Implement the internal change")
+    assert not asyncio.run(runner._maybe_auto_start_goal(internal_event, "internal", internal_event.text))
     assert goals.load_goal("internal") is None
 
 

--- a/website/docs/user-guide/features/goals.md
+++ b/website/docs/user-guide/features/goals.md
@@ -227,7 +227,28 @@ goals:
   # /goal resume. Default 20. Lower this if you want tighter loops;
   # raise it for long-running refactors.
   max_turns: 20
+
+  # Opt in to treating the first eligible execution request in a session as a drafted goal.
+  # Explicit /goal commands and sessions that already have a goal are unchanged.
+  auto_start: false
 ```
+
+### Automatic goal start
+
+Set `goals.auto_start: true` when you want eligible execution requests to enter the persistent-goal loop without
+typing `/goal`. The first eligible request in a session is used as the objective, Hermes asks the
+configured `goal_judge` auxiliary model to draft a completion contract, and the original message is
+then run as the first turn. If drafting is unavailable, Hermes keeps the plain-language objective and
+the normal per-turn judge still applies.
+
+Automatic start is deliberately opt-in: the first eligible request in each new session may create continuation turns
+and may make one additional auxiliary model call. It does not replace an existing active or paused goal,
+does not apply to slash commands, and a drafting or persistence failure never blocks the original turn.
+
+Hermes uses a conservative local heuristic to identify execution requests. Messages with action language
+such as "implement", "fix", "research", "test", or "configure" (and equivalent supported Japanese verbs)
+are eligible; questions, explanations, and short replies remain ordinary turns. This is not an LLM
+classification call, so a false negative should use the explicit `/goal` command.
 
 ### Choosing the judge model
 


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `goals.auto_start` configuration option so ordinary execution requests can enter Hermes' existing persistent Goal loop without requiring an explicit `/goal` command.

The behavior is deliberately conservative and backwards-compatible: the default is `false`, only messages matching a local execution-request heuristic are eligible, questions/explanations/short replies remain ordinary turns, and existing or explicit Goal flows are unchanged.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `goals.auto_start: false` to the default config and `cli-config.yaml.example`.
- Add a shared local classifier for execution requests, with English and Japanese action-language coverage and explicit-question exclusions.
- Start automatic Goals from the CLI and Gateway normal-message paths before the first turn.
- Reuse the existing `GoalManager`, contract drafting, `goals.max_turns`, judge, and continuation-loop behavior.
- Keep explicit `/goal`, `/goal draft`, and Gateway `!goal` flows unchanged.
- Fail open to ordinary message processing if config loading, drafting, or persistence cannot complete.
- Serialize automatic starts per session and re-check persisted Goal state to avoid replacing a concurrent existing Goal.
- Add focused tests covering opt-in behavior, candidate filtering, persistence, existing-Goal protection, CLI/Gateway paths, max-turn propagation, internal events, and fail-open behavior.
- Document configuration, cost/continuation implications, and the conservative heuristic.

## How to Test

1. Enable `goals.auto_start: true` in `~/.hermes/config.yaml`.
2. Send an execution request such as `Implement the config option and add tests`.
3. Confirm that the message becomes the first turn of a persisted Goal and that `goals.max_turns` remains the budget.
4. Send a question, explanation request, short reply, or explicit `/goal` command and confirm it follows the ordinary/explicit path.

Verification performed:

- `scripts/run_tests.sh -j 8 -q tests/hermes_cli/test_goal_auto_start.py tests/hermes_cli/test_goal_dispatch.py tests/hermes_cli/test_goals.py tests/gateway/test_goal_max_turns_config.py tests/gateway/test_goal_verdict_send.py tests/gateway/test_goal_gate_access.py tests/cli/test_cli_goal_kick_prompt.py tests/cli/test_cli_goal_interrupt.py tests/tui_gateway/test_goal_command.py` — 146 passed.
- `uvx ruff check` on all changed Python files — passed.
- `python -m compileall` on all changed Python files — passed.
- The full repository suite was attempted, but this checkout's local environment had unrelated pre-existing failures (missing optional `anthropic` package, timing-sensitive auxiliary-client assertions, and an open-file limit while creating isolated test homes); no Goal implementation assertion failure was observed.
- Documentation diagnostics reported only pre-existing findings outside the added paragraphs: eight textlint list-formatting findings and three existing broken `./kanban` links.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs/issues to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the focused Goal/CLI/Gateway/TUI test suite
- [x] I've added tests for the feature
- [x] I've tested on my platform: macOS 27.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` for the new config key
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact; the implementation uses Python stdlib/config paths and existing shared adapters
- [x] I've updated no tool schemas because this changes Goal routing, not the model tool surface

## Screenshots / Logs

Not applicable.
