### PR TITLE
fix(ui): persist and restore review confirmations across desktop, groups and terminals

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -73,7 +73,8 @@ def _optional_lock(agent: Any, attr: str) -> Iterator[None]:
 def prepare_background_review_run(agent: Any) -> Optional[_BackgroundReviewRun]:
     """Install a unique run token on the parent before ``Thread.start()``."""
     run = _BackgroundReviewRun()
-    run.source_session_id = getattr(agent, "session_id", None)
+    from agent.review_summary import REVIEW_SOURCE_SESSION_ID
+    run.source_session_id = REVIEW_SOURCE_SESSION_ID.get() or getattr(agent, "session_id", None)
     try:
         lock = getattr(agent, "_background_review_lock", None)
         if lock is None:

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -73,6 +73,7 @@ def _optional_lock(agent: Any, attr: str) -> Iterator[None]:
 def prepare_background_review_run(agent: Any) -> Optional[_BackgroundReviewRun]:
     """Install a unique run token on the parent before ``Thread.start()``."""
     run = _BackgroundReviewRun()
+    run.source_session_id = getattr(agent, "session_id", None)
     try:
         lock = getattr(agent, "_background_review_lock", None)
         if lock is None:
@@ -1077,12 +1078,11 @@ def _run_review_fork(
     st.review_agent = None
 
 
-def _publish_review_summary(agent: Any, actions: List[str]) -> None:
-    summary = " · ".join(dict.fromkeys(actions))
-    agent._safe_print(f"  💾 Self-improvement review: {summary}")
-    if agent.background_review_callback:
-        with suppress(Exception):
-            agent.background_review_callback(f"💾 Self-improvement review: {summary}")
+def _publish_review_summary(
+    agent: Any, actions: List[str], *, source_session_id: Optional[str] = None,
+) -> None:
+    from agent.review_summary import publish_review_summary
+    publish_review_summary(agent, actions, source_session_id=source_session_id)
 
 
 def _run_review_in_thread(
@@ -1097,6 +1097,8 @@ def _run_review_in_thread(
 
     See #84423.
     """
+    # Completion can overlap a new live turn: never attribute the receipt to its session.
+    source_session_id = getattr(review_run, "source_session_id", None) or getattr(agent, "session_id", None)
     if review_run is not None and review_run.cancel_requested.is_set():
         finish_background_review_run(agent, review_run)
         return
@@ -1150,7 +1152,7 @@ def _run_review_in_thread(
             actions = []
         _log_review_completion(st.review_usage, _classify_review_result(actions))
         if actions:
-            _publish_review_summary(agent, actions)
+            _publish_review_summary(agent, actions, source_session_id=source_session_id)
     except Exception as e:
         logger.warning("Background memory/skill review failed: %s", e)
         if st.review_usage:

--- a/agent/review_idle_queue.py
+++ b/agent/review_idle_queue.py
@@ -12,12 +12,13 @@ fork. Idle truth is the supervisor's /slots held for a settle window.
 
 from __future__ import annotations
 
+import contextvars
 import json
 import logging
 import threading
 import time
 import urllib.request
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Optional
 
 logger = logging.getLogger(__name__)
@@ -64,6 +65,12 @@ class _PendingReview:
     session_key: str
     kwargs: Dict[str, Any]
     enqueued_at: float
+    context: contextvars.Context = field(default_factory=contextvars.copy_context)
+
+    def __post_init__(self) -> None:
+        from agent.review_summary import REVIEW_SOURCE_SESSION_ID
+        if not self.context.get(REVIEW_SOURCE_SESSION_ID):
+            self.context.run(REVIEW_SOURCE_SESSION_ID.set, getattr(self.agent, "session_id", None))
 
 
 class ReviewIdleQueue:
@@ -149,7 +156,7 @@ class ReviewIdleQueue:
             try:
                 item = self._pop_dispatchable()
                 if item is not None:
-                    if not self._still_enabled(item):
+                    if not item.context.run(self._still_enabled, item):
                         logger.info(
                             "Deferred background review dropped: reviews were disabled while it was queued (session=%s)",
                             item.session_key[-12:])
@@ -157,7 +164,7 @@ class ReviewIdleQueue:
                     logger.info(
                         "Dispatching deferred background review (session=%s, waited=%.0fs, queued=%d)",
                         item.session_key[-12:], self._now() - item.enqueued_at, self.pending_count())
-                    item.agent._spawn_background_review_now(**item.kwargs)
+                    item.context.run(item.agent._spawn_background_review_now, **item.kwargs)
             except Exception:  # noqa: BLE001 — dispatcher must survive anything
                 logger.warning("Deferred review dispatch failed", exc_info=True)
             if item is None:

--- a/agent/review_summary.py
+++ b/agent/review_summary.py
@@ -5,12 +5,19 @@ and these receipts are excluded from the model projection on every resume.
 """
 from __future__ import annotations
 
+import contextvars
 import logging
 import time
 import uuid
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+# Deferred reviews retain their origin across /new and bounded requeues. The
+# idle queue captures this in its Context, not on the reusable parent agent.
+REVIEW_SOURCE_SESSION_ID: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "review_source_session_id", default=None,
+)
 
 
 def publish_review_summary(agent: Any, actions: list[str], *, source_session_id: str | None = None) -> None:

--- a/agent/review_summary.py
+++ b/agent/review_summary.py
@@ -1,0 +1,59 @@
+"""Durable, display-only receipts for completed self-improvement work.
+
+The parent owns persistence. The review fork never writes its replay transcript,
+and these receipts are excluded from the model projection on every resume.
+"""
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def publish_review_summary(agent: Any, actions: list[str], *, source_session_id: str | None = None) -> None:
+    if not actions:
+        return
+    text = "💾 Self-improvement review: " + " · ".join(dict.fromkeys(actions))
+    event: dict[str, Any] = {
+        "text": text, "review_id": uuid.uuid4().hex, "timestamp": time.time(),
+    }
+    session_id = source_session_id or getattr(agent, "session_id", None)
+    db = getattr(agent, "_session_db", None)
+    if db is not None and session_id and not getattr(agent, "_persist_disabled", False):
+        try:
+            from hermes_state_errors import CompressionSessionClosedError
+
+            # Follow only compression continuations, not /new or a different profile.
+            # A rotation can win between the lookup and append; retry that race, bounded.
+            for attempt in range(3):
+                target = db.resolve_resume_session_id(session_id) or session_id
+                try:
+                    row_id = db.append_message(
+                        target, "system", text, timestamp=event["timestamp"],
+                        display_kind="review_summary", display_metadata={
+                            "review_id": event["review_id"], "source_session_id": session_id,
+                        },
+                    )
+                    event.update(row_id=row_id, stored_session_id=target)
+                    break
+                except CompressionSessionClosedError:
+                    if attempt == 2:
+                        raise
+        except Exception:
+            # The skill write already happened: do not hide its confirmation or claim
+            # persistence succeeded. Legacy live delivery is still useful on disk failure.
+            logger.warning("Could not persist self-improvement receipt for session=%s", session_id, exc_info=True)
+    event["persisted"] = "row_id" in event
+    agent._safe_print(f"  {text}")
+    # Keep the text callback contract for CLI, messaging and third-party consumers.
+    # The Desktop gateway opts into metadata so live and stored rows share an identity.
+    structured = vars(agent).get("background_review_event_callback")
+    callback = structured if callable(structured) else getattr(agent, "background_review_callback", None)
+    if callable(callback):
+        try:
+            callback(event if callable(structured) else text)
+        except Exception:
+            logger.warning("Could not deliver self-improvement receipt for session=%s", session_id, exc_info=True)

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -865,6 +865,9 @@ def build_turn_context(
     Order matters: the DB session row is created only AFTER the system prompt is built
     (else it persists system_prompt=NULL and costs a cache miss) and BEFORE preflight
     compression."""
+    # Hosts may supply raw display history instead of the model projection.
+    if conversation_history:
+        conversation_history = [m for m in conversation_history if m.get("display_kind") != "review_summary"]
     from agent.turn_context_compaction import run_turn_start_compaction
 
     # Guard stdio against OSError from broken pipes (systemd/headless/daemon).

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -162,6 +162,7 @@ export async function reconcileTileTranscripts({
     try {
       // Passive: a hidden tile's refresh must never cold-start its owner
       // backend or hold a pool slot (#103375); no warm backend = retry next tick.
+      const messagesBeforeRead = $sessionStates.get()[runtimeSessionId]?.messages ?? []
       const latest = await getLatestSessionMessages(storedSessionId, profileScope, { passive: true })
 
       if (
@@ -192,7 +193,8 @@ export async function reconcileTileTranscripts({
           ...state,
           messages: preserveLocalAssistantErrors(
             graftRefreshedTailOntoBackfill(messages, state.messages),
-            state.messages
+            state.messages,
+            messagesBeforeRead
           )
         }),
         storedSessionId
@@ -237,6 +239,7 @@ export async function reconcileActiveTranscript({
         }
       : stored.profile
 
+    const messagesBeforeRead = $sessionStates.get()[runtimeSessionId]?.messages ?? []
     const latest = await getLatestSessionMessages(storedSessionId, profileScope)
 
     if (
@@ -274,7 +277,11 @@ export async function reconcileActiveTranscript({
         // The refresh re-reads only the newest tail page; graft it onto any
         // older pages "Show earlier" already backfilled instead of clobbering
         // them (see transcript-backfill).
-        messages: preserveLocalAssistantErrors(graftRefreshedTailOntoBackfill(messages, state.messages), state.messages)
+        messages: preserveLocalAssistantErrors(
+          graftRefreshedTailOntoBackfill(messages, state.messages),
+          state.messages,
+          messagesBeforeRead
+        )
       }),
       storedSessionId
     )

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -444,6 +444,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
       for (let index = 0; index < Math.max(1, attempts); index += 1) {
         try {
+          const messagesBeforeRead = sessionStateByRuntimeIdRef.current.get(runtimeSessionId)?.messages ?? []
           const latest = await getLatestSessionMessages(storedSessionId, storedProfile)
           const messages = toChatMessages(latest.messages)
           updateSessionState(
@@ -454,7 +455,8 @@ export function ContribWiring({ children }: { children: ReactNode }) {
               // onto any backfilled older pages instead of dropping them.
               messages: preserveLocalAssistantErrors(
                 graftRefreshedTailOntoBackfill(messages, state.messages),
-                state.messages
+                state.messages,
+                messagesBeforeRead
               )
             }),
             storedSessionId

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.ts
@@ -1,5 +1,6 @@
 import { translateNow } from '@/i18n'
 import { textPart } from '@/lib/chat-messages'
+import { reviewSummaryMessage } from '@/lib/chat-messages/review-summary'
 import { coerceGatewayText } from '@/lib/chat-runtime'
 import { isProviderSetupErrorMessage } from '@/lib/provider-setup-errors'
 import { type AgentNoticePayload, clearAgentNotice, nativeNoticeInput, showAgentNotice } from '@/store/agent-notices'
@@ -13,6 +14,8 @@ import { requestDesktopOnboarding } from '@/store/onboarding'
 import { flashPetActivity, setPetActivity } from '@/store/pet'
 import { clearAllPrompts } from '@/store/prompts'
 import { setTurnStartedAt } from '@/store/session'
+import { $focusedStoredSessionId } from '@/store/session-states'
+import { markSessionUnreadFinished } from '@/store/session-unread'
 import { clearActiveSessionTodos } from '@/store/todos'
 
 import type { GatewayEventContext } from './types'
@@ -91,37 +94,30 @@ export function handleStatusEvent(ctx: GatewayEventContext): boolean {
   }
 
   if (event.type === 'review.summary') {
-    // Self-improvement background review saved something to memory/skills
-    // and emitted a persistent summary (Python formats it as
-    // "💾 Self-improvement review: …"). The CLI prints this via
-    // prompt_toolkit and the Ink TUI renders it as a system line; the
-    // desktop has neither, so without this handler the skill/memory
-    // change happens silently. Surface it as a persistent system message
-    // in the transcript so the user is always informed — it must not be a
-    // transient toast that can be missed.
-    //
-    // Typed here with the `review:` marker (same convention as `steer:` /
-    // `slash:`) so SystemMessage can paint it as the memory-write row it
-    // is instead of sniffing the backend's prose. The leading 💾 goes with
-    // it — the row draws its own glyph.
-    const text = coerceGatewayText(payload?.text)
-      .trim()
-      .replace(/^[^\p{L}\p{N}]+/u, '')
+    const receipt = reviewSummaryMessage(payload ?? {}, occurredAt)
 
-    if (text && sessionId) {
+    if (receipt && sessionId) {
       flushQueuedDeltas(sessionId)
-      updateSessionState(sessionId, state => ({
-        ...state,
-        messages: [
-          ...state.messages,
-          {
-            id: `review-summary-${Date.now()}`,
-            role: 'system',
-            parts: [textPart(`review:${text}`, occurredAt)],
-            timestamp: occurredAt
-          }
-        ]
-      }))
+      let added = false
+
+      const next = updateSessionState(sessionId, state => {
+        if (state.messages.some(message => message.id === receipt.id)) {
+          return state
+        }
+
+        added = true
+
+        return { ...state, messages: [...state.messages, receipt] }
+      })
+
+      // Review finishes after the foreground busy->idle edge. Do not fake another
+      // turn, steal focus or re-light an already delivered receipt on replay.
+      const storedId =
+        next.storedSessionId || (typeof payload?.stored_session_id === 'string' ? payload.stored_session_id : null)
+
+      if (added && storedId && storedId !== $focusedStoredSessionId.get()) {
+        markSessionUnreadFinished(storedId)
+      }
     }
 
     return true

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.ts
@@ -1,3 +1,5 @@
+import { registryBackendScopeKey } from '@hermes/shared'
+
 import { translateNow } from '@/i18n'
 import { textPart } from '@/lib/chat-messages'
 import { reviewSummaryMessage } from '@/lib/chat-messages/review-summary'
@@ -7,14 +9,16 @@ import { type AgentNoticePayload, clearAgentNotice, nativeNoticeInput, showAgent
 import { clearClarifyRequest } from '@/store/clarify'
 import { reconcileSessionCompacting, setSessionCompacting } from '@/store/compaction'
 import { refreshBackgroundProcesses } from '@/store/composer-status'
+import { activeGatewayConnectionId } from '@/store/gateway'
 import { applyGoalStatusText } from '@/store/goals'
 import { dispatchNativeNotification } from '@/store/native-notifications'
 import { isDiskFullErrorMessage, notify, notifyError } from '@/store/notifications'
 import { requestDesktopOnboarding } from '@/store/onboarding'
 import { flashPetActivity, setPetActivity } from '@/store/pet'
+import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { clearAllPrompts } from '@/store/prompts'
 import { setTurnStartedAt } from '@/store/session'
-import { $focusedStoredSessionId } from '@/store/session-states'
+import { $focusedRuntimeId, $focusedStoredSessionId, knownOwnerForSession } from '@/store/session-states'
 import { markSessionUnreadFinished } from '@/store/session-unread'
 import { clearActiveSessionTodos } from '@/store/todos'
 
@@ -115,8 +119,24 @@ export function handleStatusEvent(ctx: GatewayEventContext): boolean {
       const storedId =
         next.storedSessionId || (typeof payload?.stored_session_id === 'string' ? payload.stored_session_id : null)
 
-      if (added && storedId && storedId !== $focusedStoredSessionId.get()) {
-        markSessionUnreadFinished(storedId)
+      const profile = normalizeProfileKey(
+        event.profile || next.transcriptProvenance?.profile || deps.activeGatewayProfile
+      )
+
+      const focusedOwner = knownOwnerForSession($focusedRuntimeId.get() || $focusedStoredSessionId.get())
+
+      const focusedProfile =
+        typeof focusedOwner === 'string' ? focusedOwner : focusedOwner?.profile || $activeGatewayProfile.get()
+
+      const focusedConnection =
+        typeof focusedOwner === 'object' && focusedOwner ? focusedOwner.connectionId : activeGatewayConnectionId()
+
+      const fromFocusedOwner =
+        registryBackendScopeKey(event.connectionId ?? activeGatewayConnectionId(), profile) ===
+        registryBackendScopeKey(focusedConnection, normalizeProfileKey(focusedProfile))
+
+      if (added && storedId && !(storedId === $focusedStoredSessionId.get() && fromFocusedOwner)) {
+        markSessionUnreadFinished(storedId, profile)
       }
     }
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/review-summary-durability.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/review-summary-durability.test.tsx
@@ -70,3 +70,57 @@ describe('durable review confirmations', () => {
     expect(refresh([], current)).toHaveLength(0)
   })
 })
+
+// The same stored id in a focused A chat must not swallow a hidden B receipt.
+// Exercise the real unread writer as well: a visible A row is not B's owner.
+describe('review receipt owner scope', () => {
+  it.each([false, true])('marks hidden profile B, not focused A (A row loaded: %s)', async loaded => {
+    const { $activeGatewayProfile } = await import('@/store/profile')
+
+    const { $activeSessionId, $selectedStoredSessionId, $sessions, $unreadFinishedSessionIds } =
+      await import('@/store/session')
+
+    const { $unreadFinishedMarkers } = await import('@/store/session-unread')
+    const { makeSessionInfo } = await import('@/test/session-info')
+    const { clearAllSessionStates } = await import('@/store/session-states')
+    clearAllSessionStates()
+    act(() => {
+      $activeGatewayProfile.set('A')
+      $activeSessionId.set('runtime-A')
+      $selectedStoredSessionId.set('same-id')
+      $sessions.set(loaded ? [makeSessionInfo({ id: 'same-id', profile: 'A' })] : [])
+      $unreadFinishedMarkers.set({})
+      $unreadFinishedSessionIds.set([])
+    })
+    const stream = renderMessageStream('runtime-A')
+    act(() =>
+      stream.handleEvent({
+        type: 'review.summary',
+        session_id: 'runtime-B',
+        profile: 'B',
+        payload: { text: TEXT, review_id: 'scope-b', timestamp: 103, stored_session_id: 'same-id' }
+      })
+    )
+    expect($unreadFinishedMarkers.get().B).toEqual(['same-id'])
+    expect($unreadFinishedMarkers.get().A).toBeUndefined()
+    // The actual focused A receipt stays read; replay of B stays idempotent.
+    act(() =>
+      stream.handleEvent({
+        type: 'review.summary',
+        session_id: 'runtime-A',
+        profile: 'A',
+        payload: { text: TEXT, review_id: 'scope-a', timestamp: 104, stored_session_id: 'same-id' }
+      })
+    )
+    expect($unreadFinishedMarkers.get().A).toBeUndefined()
+    act(() => {
+      clearAllSessionStates()
+      $sessions.set([])
+      $selectedStoredSessionId.set(null)
+      $activeSessionId.set(null)
+      $activeGatewayProfile.set('default')
+      $unreadFinishedMarkers.set({})
+      $unreadFinishedSessionIds.set([])
+    })
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/review-summary-durability.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/review-summary-durability.test.tsx
@@ -1,0 +1,72 @@
+import { act, cleanup } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { graftRefreshedTailOntoBackfill } from '@/app/chat/transcript-backfill'
+import { chatMessageText, preserveLocalAssistantErrors, toChatMessages } from '@/lib/chat-messages'
+import type { SessionMessage } from '@/types/hermes'
+
+import { renderMessageStream } from './test-harness'
+
+const SID = 'review-session'
+const TEXT = "💾 Self-improvement review: Skill 'canary' patched"
+
+const base: SessionMessage[] = [
+  { id: 1, role: 'user', content: 'Inspect it', timestamp: 100 },
+  { id: 2, role: 'assistant', content: 'Done', timestamp: 101 }
+]
+
+const stored = (id: number, reviewId: string): SessionMessage => ({
+  id,
+  role: 'system',
+  content: TEXT,
+  timestamp: 100 + id,
+  display_kind: 'review_summary',
+  display_metadata: { review_id: reviewId }
+})
+
+const refresh = (rows: SessionMessage[], previous: ReturnType<typeof toChatMessages>, beforeRead = previous) =>
+  preserveLocalAssistantErrors(graftRefreshedTailOntoBackfill(toChatMessages(rows), previous), previous, beforeRead)
+
+afterEach(cleanup)
+
+describe('durable review confirmations', () => {
+  it('uses one identity for live delivery, replay, REST hydration and cold reopening', () => {
+    const stream = renderMessageStream(SID)
+    const payload = { text: TEXT, review_id: 'review-a', row_id: 3, timestamp: 103, stored_session_id: SID }
+    act(() => {
+      stream.handleEvent({ type: 'review.summary', session_id: SID, payload })
+      stream.handleEvent({ type: 'review.summary', session_id: SID, payload })
+    })
+    expect(stream.state(SID).messages).toHaveLength(1)
+    const live = stream.state(SID).messages[0]
+    const cold = toChatMessages([stored(3, 'review-a')])[0]
+    expect(cold.id).toBe(live.id)
+    expect(chatMessageText(cold)).toBe(chatMessageText(live))
+    expect(cold.timestamp).toBe(103)
+    const refreshed = refresh([...base, stored(3, 'review-a')], [...toChatMessages(base), live])
+    expect(refreshed.filter(message => message.role === 'system')).toHaveLength(1)
+    expect(refreshed.at(-1)?.id).toBe(live.id)
+  })
+
+  it('keeps a receipt newer than an in-flight snapshot without merging distinct reviews by text', () => {
+    const stream = renderMessageStream(SID)
+    act(() =>
+      stream.handleEvent({
+        type: 'review.summary',
+        session_id: SID,
+        payload: { text: TEXT, review_id: 'review-a', row_id: 3, timestamp: 103 }
+      })
+    )
+    const previous = [...toChatMessages(base), ...stream.state(SID).messages]
+    const stale = refresh(base, previous, toChatMessages(base))
+    expect(stale.filter(message => message.role === 'system')).toHaveLength(1)
+    const current = refresh([...base, stored(3, 'review-a'), stored(4, 'review-b')], stale)
+    const reviews = current.filter(message => message.role === 'system')
+    expect(reviews).toHaveLength(2)
+    expect(reviews[0].id).not.toBe(reviews[1].id)
+    // An authoritative rewind started after delivery must not resurrect its removed receipt.
+    expect(refresh(base, current).filter(message => message.role === 'system')).toHaveLength(0)
+    // An authoritative empty/reset transcript must not resurrect old receipts.
+    expect(refresh([], current)).toHaveLength(0)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/system-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/system-message.tsx
@@ -77,6 +77,7 @@ export const SystemMessage: FC = () => {
         {detail && (
           <span className={cn(SCAFFOLD_LABEL_CLASS, 'tool-memory-legendary-meta min-w-0 wrap-anywhere')}>{detail}</span>
         )}
+        <MessageTimelineTimestamp className="shrink-0" />
       </MessagePrimitive.Root>
     )
   }

--- a/apps/desktop/src/lib/chat-messages/hydration.ts
+++ b/apps/desktop/src/lib/chat-messages/hydration.ts
@@ -5,6 +5,7 @@ import { dedupeGeneratedImageEchoesInParts } from '@/lib/generated-images'
 import type { MessageReaction, SessionMessage } from '@/types/hermes'
 
 import { assistantTextPart, chatMessageText, dedupeRepeatedTextInParts, reasoningPart, textPart } from './parts'
+import { reviewSummaryMessage } from './review-summary'
 import {
   applyStoredToolResult,
   applyStoredToolResultToParts,
@@ -266,6 +267,27 @@ export function toChatMessages(messages: SessionMessage[]): ChatMessage[] {
   }
 
   messages.forEach((message, index) => {
+    if (message.display_kind === 'review_summary') {
+      flushPendingTools(index)
+      activeAssistantIndex = null
+
+      const receipt = reviewSummaryMessage(
+        {
+          ...parseDisplayMetadata(message.display_metadata),
+          text: message.content ?? message.text,
+          timestamp: message.timestamp,
+          row_id: message.row_id ?? (typeof message.id === 'number' ? message.id : undefined)
+        },
+        Date.now() / 1000
+      )
+
+      if (receipt && !result.some(row => row.id === receipt.id)) {
+        result.push(receipt)
+      }
+
+      return
+    }
+
     if (message.role === 'tool') {
       const updatedPendingToolParts = applyStoredToolResultToParts(pendingToolParts, message)
 

--- a/apps/desktop/src/lib/chat-messages/reconciliation.ts
+++ b/apps/desktop/src/lib/chat-messages/reconciliation.ts
@@ -1,4 +1,5 @@
 import { chatMessageText } from './parts'
+import { preserveNewerReviewSummaries } from './review-summary'
 import type { ChatMessage, ChatMessagePart } from './types'
 
 const validTimelineBoundary = (value: unknown): value is number =>
@@ -120,8 +121,13 @@ function reconcileLocalAssistantTimeline(nextMessages: ChatMessage[], currentMes
 
 export function preserveLocalAssistantErrors(
   nextMessages: ChatMessage[],
-  currentMessages: ChatMessage[]
+  currentMessages: ChatMessage[],
+  reviewSnapshot?: ChatMessage[]
 ): ChatMessage[] {
+  if (reviewSnapshot) {
+    nextMessages = preserveNewerReviewSummaries(nextMessages, currentMessages, reviewSnapshot)
+  }
+
   nextMessages = reconcileLocalAssistantTimeline(nextMessages, currentMessages)
   const localById = new Map(currentMessages.map(message => [message.id, message]))
 

--- a/apps/desktop/src/lib/chat-messages/review-summary.ts
+++ b/apps/desktop/src/lib/chat-messages/review-summary.ts
@@ -1,0 +1,76 @@
+import { textPart } from './parts'
+import type { ChatMessage } from './types'
+
+interface ReviewSummaryPayload {
+  text?: unknown
+  review_id?: unknown
+  timestamp?: unknown
+  row_id?: unknown
+}
+
+let liveSequence = 0
+
+/** One projection for the gateway event and the durable REST/resume receipt. */
+export function reviewSummaryMessage(payload: ReviewSummaryPayload, fallbackTime: number): ChatMessage | null {
+  const text = typeof payload.text === 'string' ? payload.text.trim().replace(/^[^\p{L}\p{N}]+/u, '') : ''
+
+  if (!text) {
+    return null
+  }
+
+  const rowId =
+    typeof payload.row_id === 'number' && Number.isSafeInteger(payload.row_id) && payload.row_id > 0
+      ? payload.row_id
+      : undefined
+
+  const reviewId =
+    typeof payload.review_id === 'string' && payload.review_id.trim()
+      ? payload.review_id.trim()
+      : rowId !== undefined
+        ? `row-${rowId}`
+        : null
+
+  const timestamp =
+    typeof payload.timestamp === 'number' && Number.isFinite(payload.timestamp) && payload.timestamp > 0
+      ? payload.timestamp
+      : fallbackTime
+
+  return {
+    id: reviewId ? `review-summary:${reviewId}` : `review-summary-live:${++liveSequence}`,
+    role: 'system',
+    parts: [textPart(`review:${text}`, timestamp)],
+    timestamp,
+    ...(rowId !== undefined ? { rowId } : {})
+  }
+}
+
+/** A fetch started before a receipt was committed must not erase its newer live event.
+ * Only carry durable rows received DURING this read. Empty/reset history and earlier rows
+ * remain authoritative (do not resurrect rewound messages or grow an unbounded cache). */
+export function preserveNewerReviewSummaries(
+  next: ChatMessage[],
+  previous: ChatMessage[],
+  beforeRead: ChatMessage[]
+): ChatMessage[] {
+  if (!next.length || !previous.length) {
+    return next
+  }
+
+  const watermark = next.reduce((max, message) => Math.max(max, message.rowId ?? 0), 0)
+
+  if (!watermark) {
+    return next
+  }
+
+  const ids = new Set([...next, ...beforeRead].map(message => message.id))
+
+  const newer = previous.filter(
+    message =>
+      message.role === 'system' &&
+      message.id.startsWith('review-summary:') &&
+      (message.rowId ?? 0) > watermark &&
+      !ids.has(message.id)
+  )
+
+  return newer.length ? [...next, ...newer] : next
+}

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-timeline.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-timeline.test.tsx
@@ -72,3 +72,28 @@ it('keeps every public member reply readable in room arrival order across interl
     expect(text).toContain(name)
   }
 })
+
+it('interleaves read-only review receipts by authored time without adding them to group dialogue', async () => {
+  Element.prototype.scrollIntoView = vi.fn()
+  const { $groupChats } = await import('./group-chat')
+  const { GroupChatWorkspace } = await import('./group-chat-view')
+  const log = [
+    { id: 'before', from: { kind: 'user' as const, name: 'You' }, text: 'BEFORE', at: 1000 },
+    { id: 'after', from: { kind: 'member' as const, name: 'Builder' }, text: 'AFTER', at: 3000 }
+  ]
+  $groupChats.set({
+    Room: {
+      log,
+      watermarks: {},
+      reviewReceipts: [{ id: 'r1', at: 2000, text: 'REVIEW SAVED', member: 'Builder', memberKey: 'Builder' }]
+    }
+  })
+  const { container } = render(<GroupChatWorkspace group="Room" members={[]} />)
+  const text = container.textContent || ''
+  expect(text.indexOf('REVIEW SAVED')).toBeGreaterThan(text.indexOf('BEFORE'))
+  expect(text.indexOf('AFTER')).toBeGreaterThan(text.indexOf('REVIEW SAVED'))
+  expect(container.querySelector('[data-review-receipt="r1"] time')?.getAttribute('datetime')).toBe(
+    '1970-01-01T00:00:02.000Z'
+  )
+  expect($groupChats.get().Room.log).toEqual(log)
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
@@ -93,6 +93,8 @@ import {
 } from './group-panes'
 import type { GroupComposerDraft, GroupDraftSetter } from './group-panes'
 import { sendToGroupChat, stopGroupThread } from './group-rounds'
+import { watchGroupReviewReceipts } from './group-review-receipts'
+import { GroupReviewRow } from './group-review-row'
 import { clearGroupClarify, renameGroupClarify } from './group-turns'
 import { botsText, useBots } from './i18n'
 import { displayName, slugify } from './labels'
@@ -465,6 +467,9 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
     running: false
   }
 
+  // eslint-disable-next-line no-restricted-syntax -- owns external gateway subscriptions/route leases while this room is visible
+  useEffect(() => (visible ? watchGroupReviewReceipts(group, members) : undefined), [group, members, visible])
+
   const composerKey = groupComposerDraftKey(group, room)
   const composerKeyRef = useRef(composerKey)
   const [composerDraft, setComposerDraft] = useState(() => groupComposerDraftSnapshot(composerKey))
@@ -555,7 +560,7 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
         block: 'end'
       })
     }
-  }, [room.log.length, room.running])
+  }, [room.log.length, room.reviewReceipts?.length, room.running])
 
   // Retained-pane reopen (#89835 follow-up): a hot-mounted room pane stays
   // mounted while another workspace tab is active, so returning to it never
@@ -1044,7 +1049,16 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
   const threadEnds = new Map<string, number>()
   room.log.forEach((entry, index) => threadEnds.set(groupThreadOf(entry), index))
   const logChildren: ReactNode[] = []
+  const receipts = [...(room.reviewReceipts || [])].sort((a, b) => a.at - b.at)
+  let receiptIndex = 0
+  const appendReceiptsBefore = (at: number) => {
+    while (receiptIndex < receipts.length && receipts[receiptIndex].at <= at) {
+      const receipt = receipts[receiptIndex++]
+      logChildren.push(<GroupReviewRow key={`review:${receipt.id}`} receipt={receipt} />)
+    }
+  }
   room.log.forEach((entry, index) => {
+    appendReceiptsBefore(entry.at)
     logChildren.push(renderEntry(entry, index))
     const id = groupThreadOf(entry)
 
@@ -1100,6 +1114,8 @@ export function GroupChatWorkspace({ group, members, onBack, visible = true }: G
       )
     )
   })
+
+  appendReceiptsBefore(Infinity)
 
   return (
     <div

--- a/apps/desktop/src/plugins/hermes-bots/group-chat.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat.ts
@@ -738,6 +738,7 @@ export function durableGroupChatRooms(all: Record<string, GroupChat> = $groupCha
 
     durable[name] = {
       log: room.log,
+      reviewReceipts: room.reviewReceipts || [],
       watermarks: room.watermarks || {},
       sessions: room.sessions || {},
       stranded: room.stranded || {},
@@ -1332,6 +1333,7 @@ export function updateGroupChat(
 
       durable[name] = {
         log: room.log,
+        reviewReceipts: room.reviewReceipts || [],
         watermarks: room.watermarks,
         sessions: room.sessions || {},
         sessionOwners: room.sessionOwners || {},

--- a/apps/desktop/src/plugins/hermes-bots/group-review-receipts.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-review-receipts.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, expect, it, vi } from 'vitest'
+
+const fixture = vi.hoisted(() => ({
+  listeners: new Map<string, (event: unknown) => void>(),
+  read: vi.fn(), release: vi.fn(), active: 'source-A'
+}))
+
+vi.mock('@hermes/plugin-sdk', async () => {
+  const { pluginSdkMock, createGroupGateway } = await import('./group-test-utils')
+  const base = await pluginSdkMock(createGroupGateway().host)
+
+  return { ...base, host: { ...base.host,
+    activeConnectionId: () => fixture.active,
+    listReviewSummaries: fixture.read,
+    retainProfile: vi.fn(async () => fixture.release),
+    onEvent: (type: string, handler: (event: unknown) => void) => {
+      fixture.listeners.set(type, handler)
+
+      return () => fixture.listeners.delete(type)
+    }
+  } }
+})
+import { $groupChats, durableGroupChatRooms } from './group-chat'
+import { groupMemberKey } from './group-membership'
+import { mergeGroupReviewReceipts, readGroupReviewReceipts, watchGroupReviewReceipts } from './group-review-receipts'
+import type { GroupMember } from './types'
+
+const tick = async () => { for (let i = 0; i < 12; i++) { await Promise.resolve() } }
+
+const row = (id: string, text: string, timestamp = 10) => ({
+  content: text, display_kind: 'review_summary', display_metadata: { review_id: id }, timestamp
+})
+
+const member: GroupMember = { name: 'Builder' }
+beforeEach(() => {
+  fixture.read.mockReset().mockResolvedValue({ messages: [] })
+  fixture.release.mockReset()
+  fixture.listeners.clear()
+  fixture.active = 'source-A'
+  $groupChats.set({ Room: { roomId: 'room-1', log: [], watermarks: {}, sessions: { Builder: 'hidden-group' } } })
+})
+
+it('backfills hidden-session receipts, deduplicates live/reopen, and leaves the model log untouched', async () => {
+  fixture.read.mockResolvedValue({ messages: [row('r1', 'Saved group technique')] })
+  let stop = watchGroupReviewReceipts('Room', [member])
+  await tick()
+  expect($groupChats.get().Room.reviewReceipts).toHaveLength(1)
+  expect($groupChats.get().Room.reviewReceipts?.[0].at).toBe(10000)
+  fixture.active = 'source-B'
+  // An unrelated PRIVATE Bot Chat event is just an invalidation. Its text
+  // must never be copied; only the exact captured hidden-session read counts.
+  fixture.listeners.get('review.summary')?.({ connectionId: 'source-B', payload: { text: 'PRIVATE' } })
+  await tick()
+  expect(fixture.read.mock.calls.every(([route, sid]) => route.connectionId === 'source-A' && sid === 'hidden-group')).toBe(true)
+  expect(JSON.stringify($groupChats.get().Room.reviewReceipts)).not.toContain('PRIVATE')
+  expect($groupChats.get().Room.log).toEqual([])
+  expect($groupChats.get().Room.watermarks).toEqual({})
+  expect(durableGroupChatRooms().Room.reviewReceipts).toHaveLength(1)
+  stop()
+  expect(fixture.release).toHaveBeenCalledTimes(1)
+  fixture.active = 'source-A'
+  stop = watchGroupReviewReceipts('Room', [member])
+  await tick()
+  expect($groupChats.get().Room.reviewReceipts).toHaveLength(1)
+  stop()
+})
+
+it('qualifies same-named members by connection and keeps aliases on their backend target', async () => {
+  const members: GroupMember[] = ['A', 'B'].map(connectionId => ({ name: 'Builder', sourceScoped: true,
+    connectionId, route: { connectionId, mode: 'remote', profile: 'Builder', targetProfile: 'actual-profile' } }))
+
+  $groupChats.set({ Room: { roomId: 'room-1', log: [], watermarks: {}, sessions:
+    Object.fromEntries(members.map(m => [groupMemberKey(m), `hidden-${m.connectionId}`])) } })
+  fixture.read.mockImplementation(async (route, sid) => ({ messages: [row('same-id', `${route.connectionId}:${sid}`)] }))
+  const stop = watchGroupReviewReceipts('Room', members)
+  await tick()
+  const receipts = $groupChats.get().Room.reviewReceipts || []
+  expect(receipts).toHaveLength(2)
+  expect(new Set(receipts.map(r => r.id)).size).toBe(2)
+  expect(fixture.read.mock.calls.every(([route]) => route.targetProfile === 'actual-profile')).toBe(true)
+  stop()
+})
+
+it('follows a renamed room but discards reads after disband and same-name recreation', async () => {
+  let resolve!: (result: { messages: unknown[] }) => void
+  fixture.read.mockReturnValue(new Promise(r => { resolve = r }))
+  let stop = watchGroupReviewReceipts('Room', [member])
+  await tick()
+  $groupChats.set({ Renamed: $groupChats.get().Room })
+  resolve({ messages: [row('r1', 'rename receipt')] })
+  await tick()
+  expect($groupChats.get().Renamed.reviewReceipts).toHaveLength(1)
+  stop()
+  fixture.read.mockReturnValue(new Promise(r => { resolve = r }))
+  stop = watchGroupReviewReceipts('Renamed', [member])
+  await tick()
+  $groupChats.set({})
+  $groupChats.set({ Renamed: { roomId: 'different', log: [], watermarks: {}, sessions: { Builder: 'hidden-group' } } })
+  resolve({ messages: [row('r2', 'must be discarded')] })
+  await tick()
+  expect($groupChats.get().Renamed.reviewReceipts).toBeUndefined()
+  stop()
+})
+
+it('bounds and validates the display cache without classifying ordinary prose as reviews', () => {
+  const rows = Array.from({ length: 80 }, (_, i) => row(`r${i}`, 'saved', i + 1))
+  const receipts = readGroupReviewReceipts([...rows, { content: 'Self-improvement review' }, row('bad', 'bad', NaN)], member, 'owner')
+  const bounded = mergeGroupReviewReceipts([], receipts)
+  expect(bounded).toHaveLength(50)
+  expect(bounded[0].at).toBe(31000)
+  expect(mergeGroupReviewReceipts(bounded, bounded)).toEqual(bounded)
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-review-receipts.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-review-receipts.test.ts
@@ -2,33 +2,46 @@ import { beforeEach, expect, it, vi } from 'vitest'
 
 const fixture = vi.hoisted(() => ({
   listeners: new Map<string, (event: unknown) => void>(),
-  read: vi.fn(), release: vi.fn(), active: 'source-A'
+  read: vi.fn(),
+  release: vi.fn(),
+  active: 'source-A'
 }))
 
 vi.mock('@hermes/plugin-sdk', async () => {
   const { pluginSdkMock, createGroupGateway } = await import('./group-test-utils')
   const base = await pluginSdkMock(createGroupGateway().host)
 
-  return { ...base, host: { ...base.host,
-    activeConnectionId: () => fixture.active,
-    listReviewSummaries: fixture.read,
-    retainProfile: vi.fn(async () => fixture.release),
-    onEvent: (type: string, handler: (event: unknown) => void) => {
-      fixture.listeners.set(type, handler)
+  return {
+    ...base,
+    host: {
+      ...base.host,
+      activeConnectionId: () => fixture.active,
+      listReviewSummaries: fixture.read,
+      retainProfile: vi.fn(async () => fixture.release),
+      onEvent: (type: string, handler: (event: unknown) => void) => {
+        fixture.listeners.set(type, handler)
 
-      return () => fixture.listeners.delete(type)
+        return () => fixture.listeners.delete(type)
+      }
     }
-  } }
+  }
 })
 import { $groupChats, durableGroupChatRooms } from './group-chat'
 import { groupMemberKey } from './group-membership'
 import { mergeGroupReviewReceipts, readGroupReviewReceipts, watchGroupReviewReceipts } from './group-review-receipts'
 import type { GroupMember } from './types'
 
-const tick = async () => { for (let i = 0; i < 12; i++) { await Promise.resolve() } }
+const tick = async () => {
+  for (let i = 0; i < 12; i++) {
+    await Promise.resolve()
+  }
+}
 
 const row = (id: string, text: string, timestamp = 10) => ({
-  content: text, display_kind: 'review_summary', display_metadata: { review_id: id }, timestamp
+  content: text,
+  display_kind: 'review_summary',
+  display_metadata: { review_id: id },
+  timestamp
 })
 
 const member: GroupMember = { name: 'Builder' }
@@ -51,7 +64,9 @@ it('backfills hidden-session receipts, deduplicates live/reopen, and leaves the 
   // must never be copied; only the exact captured hidden-session read counts.
   fixture.listeners.get('review.summary')?.({ connectionId: 'source-B', payload: { text: 'PRIVATE' } })
   await tick()
-  expect(fixture.read.mock.calls.every(([route, sid]) => route.connectionId === 'source-A' && sid === 'hidden-group')).toBe(true)
+  expect(
+    fixture.read.mock.calls.every(([route, sid]) => route.connectionId === 'source-A' && sid === 'hidden-group')
+  ).toBe(true)
   expect(JSON.stringify($groupChats.get().Room.reviewReceipts)).not.toContain('PRIVATE')
   expect($groupChats.get().Room.log).toEqual([])
   expect($groupChats.get().Room.watermarks).toEqual({})
@@ -66,12 +81,24 @@ it('backfills hidden-session receipts, deduplicates live/reopen, and leaves the 
 })
 
 it('qualifies same-named members by connection and keeps aliases on their backend target', async () => {
-  const members: GroupMember[] = ['A', 'B'].map(connectionId => ({ name: 'Builder', sourceScoped: true,
-    connectionId, route: { connectionId, mode: 'remote', profile: 'Builder', targetProfile: 'actual-profile' } }))
+  const members: GroupMember[] = ['A', 'B'].map(connectionId => ({
+    name: 'Builder',
+    sourceScoped: true,
+    connectionId,
+    route: { connectionId, mode: 'remote', profile: 'Builder', targetProfile: 'actual-profile' }
+  }))
 
-  $groupChats.set({ Room: { roomId: 'room-1', log: [], watermarks: {}, sessions:
-    Object.fromEntries(members.map(m => [groupMemberKey(m), `hidden-${m.connectionId}`])) } })
-  fixture.read.mockImplementation(async (route, sid) => ({ messages: [row('same-id', `${route.connectionId}:${sid}`)] }))
+  $groupChats.set({
+    Room: {
+      roomId: 'room-1',
+      log: [],
+      watermarks: {},
+      sessions: Object.fromEntries(members.map(m => [groupMemberKey(m), `hidden-${m.connectionId}`]))
+    }
+  })
+  fixture.read.mockImplementation(async (route, sid) => ({
+    messages: [row('same-id', `${route.connectionId}:${sid}`)]
+  }))
   const stop = watchGroupReviewReceipts('Room', members)
   await tick()
   const receipts = $groupChats.get().Room.reviewReceipts || []
@@ -83,7 +110,11 @@ it('qualifies same-named members by connection and keeps aliases on their backen
 
 it('follows a renamed room but discards reads after disband and same-name recreation', async () => {
   let resolve!: (result: { messages: unknown[] }) => void
-  fixture.read.mockReturnValue(new Promise(r => { resolve = r }))
+  fixture.read.mockReturnValue(
+    new Promise(r => {
+      resolve = r
+    })
+  )
   let stop = watchGroupReviewReceipts('Room', [member])
   await tick()
   $groupChats.set({ Renamed: $groupChats.get().Room })
@@ -91,7 +122,11 @@ it('follows a renamed room but discards reads after disband and same-name recrea
   await tick()
   expect($groupChats.get().Renamed.reviewReceipts).toHaveLength(1)
   stop()
-  fixture.read.mockReturnValue(new Promise(r => { resolve = r }))
+  fixture.read.mockReturnValue(
+    new Promise(r => {
+      resolve = r
+    })
+  )
   stop = watchGroupReviewReceipts('Renamed', [member])
   await tick()
   $groupChats.set({})
@@ -104,7 +139,11 @@ it('follows a renamed room but discards reads after disband and same-name recrea
 
 it('bounds and validates the display cache without classifying ordinary prose as reviews', () => {
   const rows = Array.from({ length: 80 }, (_, i) => row(`r${i}`, 'saved', i + 1))
-  const receipts = readGroupReviewReceipts([...rows, { content: 'Self-improvement review' }, row('bad', 'bad', NaN)], member, 'owner')
+  const receipts = readGroupReviewReceipts(
+    [...rows, { content: 'Self-improvement review' }, row('bad', 'bad', NaN)],
+    member,
+    'owner'
+  )
   const bounded = mergeGroupReviewReceipts([], receipts)
   expect(bounded).toHaveLength(50)
   expect(bounded[0].at).toBe(31000)

--- a/apps/desktop/src/plugins/hermes-bots/group-review-receipts.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-review-receipts.ts
@@ -1,0 +1,165 @@
+/** Review receipts belong to a member's hidden room session, not its Bot Chat.
+ * Events only invalidate: never trust an event's text as room history. Re-read
+ * the exact stored session on its captured source, so private chat reviews and
+ * identically named bots on other connections cannot leak into a room. */
+import { host } from '@hermes/plugin-sdk'
+
+import { $groupChats, updateGroupChat } from './group-chat'
+import { followGroupChat, groupMemberKey } from './group-membership'
+import { botConnectionRoute } from './routing'
+import type { GroupMember, GroupReviewReceipt, ProfileRoute } from './types'
+
+export function mergeGroupReviewReceipts(
+  previous: GroupReviewReceipt[], incoming: GroupReviewReceipt[]
+): GroupReviewReceipt[] {
+  const byId = new Map(previous.map(receipt => [receipt.id, receipt]))
+
+  for (const receipt of incoming) {
+    byId.set(receipt.id, receipt)
+  }
+
+  return [...byId.values()].sort((a, b) => a.at - b.at || a.id.localeCompare(b.id)).slice(-50)
+}
+
+export function readGroupReviewReceipts(rows: unknown, member: GroupMember, owner: string): GroupReviewReceipt[] {
+  if (!Array.isArray(rows)) {
+    return []
+  }
+
+  return rows.flatMap(row => {
+    if (!row || row.display_kind !== 'review_summary') {
+      return []
+    }
+
+    const id = row.display_metadata?.review_id
+    const text = typeof row.content === 'string' ? row.content : row.text
+    const at = row.timestamp
+
+    if (typeof id !== 'string' || !id || typeof text !== 'string' || !text.trim() ||
+        typeof at !== 'number' || !Number.isFinite(at) || at <= 0) {
+      return []
+    }
+
+    return [{ id: `${owner}:${id}`, at: at * 1000, text, member: member.name, memberKey: groupMemberKey(member) }]
+  })
+}
+
+function captureRoute(member: GroupMember): ProfileRoute | null {
+  try {
+    const route = botConnectionRoute(member)
+
+    if (route) {
+      return { ...route }
+    }
+
+    // Capture the ambient source ONCE for legacy local roster rows; a later
+    // foreground switch must never retarget an already-started read.
+    const connectionId = host.activeConnectionId?.() || 'local'
+
+    return { connectionId, mode: connectionId === 'local' ? 'local' : 'remote',
+      profile: member.name, targetProfile: member.name }
+  } catch {
+    return null
+  }
+}
+
+export function watchGroupReviewReceipts(group: string, members: GroupMember[]): () => void {
+  if (typeof host.listReviewSummaries !== 'function') {
+    return () => undefined // older shell: cached receipts remain readable
+  }
+
+  let disposed = false
+  const releases: Array<() => void> = []
+  const binding = followGroupChat(group, name => { group = name })
+
+  const owners = members.flatMap(member => {
+    const route = captureRoute(member)
+
+    return route ? [{ member, route, key: groupMemberKey(member) }] : []
+  })
+
+  let running = false
+  let dirty = false
+
+  const refresh = async () => {
+    dirty = true
+
+    if (running || disposed || !binding.isLive()) {
+      return
+    }
+
+    running = true
+
+    try {
+      while (dirty && !disposed && binding.isLive()) {
+        dirty = false
+        await Promise.all(owners.map(async ({ member, route, key }) => {
+          const stored = $groupChats.get()[group]?.sessions?.[key]
+
+          if (typeof stored !== 'string' || !stored) {
+            return
+          }
+
+          try {
+            const result = await host.listReviewSummaries(route, stored)
+
+            if (disposed || !binding.isLive() || $groupChats.get()[group]?.sessions?.[key] !== stored) {
+              return
+            }
+
+            const receipts = readGroupReviewReceipts(result.messages, member,
+              `${route.connectionId}:${route.targetProfile}:${key}`)
+
+            const previous = $groupChats.get()[group]?.reviewReceipts || []
+            const merged = mergeGroupReviewReceipts(previous, receipts)
+
+            if (JSON.stringify(merged) !== JSON.stringify(previous)) {
+              updateGroupChat(group, room => ({ ...room, reviewReceipts: merged }), { sync: false })
+            }
+          } catch {
+            // Old backend, missing/removed profile or transient connection:
+            // preserve the cache; next summary/reconnect/open retries it.
+          }
+        }))
+      }
+    } finally {
+      running = false
+    }
+  }
+
+  if (typeof host.onEvent === 'function') {
+    for (const type of ['review.summary', 'gateway.ready', 'message.complete']) {
+      releases.push(host.onEvent(type, event => {
+        if (!event.connectionId || owners.some(owner => owner.route.connectionId === event.connectionId)) {
+          void refresh()
+        }
+      }))
+    }
+  }
+
+  // Keep event taps alive while the room is visible. This is not ownership
+  // of agent work: the backend independently protects reviews after close.
+  if (typeof host.retainProfile === 'function') {
+    for (const { route } of owners) {
+      void host.retainProfile(route).then(release => {
+        if (disposed) {
+          release()
+        } else {
+          releases.push(release)
+          void refresh() // a newly-connected route may have missed the first read
+        }
+      }).catch(() => undefined)
+    }
+  }
+
+  void refresh()
+
+  return () => {
+    disposed = true
+    binding.dispose()
+
+    for (const release of releases) {
+      release()
+    }
+  }
+}

--- a/apps/desktop/src/plugins/hermes-bots/group-review-receipts.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-review-receipts.ts
@@ -10,7 +10,8 @@ import { botConnectionRoute } from './routing'
 import type { GroupMember, GroupReviewReceipt, ProfileRoute } from './types'
 
 export function mergeGroupReviewReceipts(
-  previous: GroupReviewReceipt[], incoming: GroupReviewReceipt[]
+  previous: GroupReviewReceipt[],
+  incoming: GroupReviewReceipt[]
 ): GroupReviewReceipt[] {
   const byId = new Map(previous.map(receipt => [receipt.id, receipt]))
 
@@ -35,8 +36,15 @@ export function readGroupReviewReceipts(rows: unknown, member: GroupMember, owne
     const text = typeof row.content === 'string' ? row.content : row.text
     const at = row.timestamp
 
-    if (typeof id !== 'string' || !id || typeof text !== 'string' || !text.trim() ||
-        typeof at !== 'number' || !Number.isFinite(at) || at <= 0) {
+    if (
+      typeof id !== 'string' ||
+      !id ||
+      typeof text !== 'string' ||
+      !text.trim() ||
+      typeof at !== 'number' ||
+      !Number.isFinite(at) ||
+      at <= 0
+    ) {
       return []
     }
 
@@ -56,8 +64,12 @@ function captureRoute(member: GroupMember): ProfileRoute | null {
     // foreground switch must never retarget an already-started read.
     const connectionId = host.activeConnectionId?.() || 'local'
 
-    return { connectionId, mode: connectionId === 'local' ? 'local' : 'remote',
-      profile: member.name, targetProfile: member.name }
+    return {
+      connectionId,
+      mode: connectionId === 'local' ? 'local' : 'remote',
+      profile: member.name,
+      targetProfile: member.name
+    }
   } catch {
     return null
   }
@@ -70,7 +82,9 @@ export function watchGroupReviewReceipts(group: string, members: GroupMember[]):
 
   let disposed = false
   const releases: Array<() => void> = []
-  const binding = followGroupChat(group, name => { group = name })
+  const binding = followGroupChat(group, name => {
+    group = name
+  })
 
   const owners = members.flatMap(member => {
     const route = captureRoute(member)
@@ -93,34 +107,39 @@ export function watchGroupReviewReceipts(group: string, members: GroupMember[]):
     try {
       while (dirty && !disposed && binding.isLive()) {
         dirty = false
-        await Promise.all(owners.map(async ({ member, route, key }) => {
-          const stored = $groupChats.get()[group]?.sessions?.[key]
+        await Promise.all(
+          owners.map(async ({ member, route, key }) => {
+            const stored = $groupChats.get()[group]?.sessions?.[key]
 
-          if (typeof stored !== 'string' || !stored) {
-            return
-          }
-
-          try {
-            const result = await host.listReviewSummaries(route, stored)
-
-            if (disposed || !binding.isLive() || $groupChats.get()[group]?.sessions?.[key] !== stored) {
+            if (typeof stored !== 'string' || !stored) {
               return
             }
 
-            const receipts = readGroupReviewReceipts(result.messages, member,
-              `${route.connectionId}:${route.targetProfile}:${key}`)
+            try {
+              const result = await host.listReviewSummaries(route, stored)
 
-            const previous = $groupChats.get()[group]?.reviewReceipts || []
-            const merged = mergeGroupReviewReceipts(previous, receipts)
+              if (disposed || !binding.isLive() || $groupChats.get()[group]?.sessions?.[key] !== stored) {
+                return
+              }
 
-            if (JSON.stringify(merged) !== JSON.stringify(previous)) {
-              updateGroupChat(group, room => ({ ...room, reviewReceipts: merged }), { sync: false })
+              const receipts = readGroupReviewReceipts(
+                result.messages,
+                member,
+                `${route.connectionId}:${route.targetProfile}:${key}`
+              )
+
+              const previous = $groupChats.get()[group]?.reviewReceipts || []
+              const merged = mergeGroupReviewReceipts(previous, receipts)
+
+              if (JSON.stringify(merged) !== JSON.stringify(previous)) {
+                updateGroupChat(group, room => ({ ...room, reviewReceipts: merged }), { sync: false })
+              }
+            } catch {
+              // Old backend, missing/removed profile or transient connection:
+              // preserve the cache; next summary/reconnect/open retries it.
             }
-          } catch {
-            // Old backend, missing/removed profile or transient connection:
-            // preserve the cache; next summary/reconnect/open retries it.
-          }
-        }))
+          })
+        )
       }
     } finally {
       running = false
@@ -129,11 +148,13 @@ export function watchGroupReviewReceipts(group: string, members: GroupMember[]):
 
   if (typeof host.onEvent === 'function') {
     for (const type of ['review.summary', 'gateway.ready', 'message.complete']) {
-      releases.push(host.onEvent(type, event => {
-        if (!event.connectionId || owners.some(owner => owner.route.connectionId === event.connectionId)) {
-          void refresh()
-        }
-      }))
+      releases.push(
+        host.onEvent(type, event => {
+          if (!event.connectionId || owners.some(owner => owner.route.connectionId === event.connectionId)) {
+            void refresh()
+          }
+        })
+      )
     }
   }
 
@@ -141,14 +162,17 @@ export function watchGroupReviewReceipts(group: string, members: GroupMember[]):
   // of agent work: the backend independently protects reviews after close.
   if (typeof host.retainProfile === 'function') {
     for (const { route } of owners) {
-      void host.retainProfile(route).then(release => {
-        if (disposed) {
-          release()
-        } else {
-          releases.push(release)
-          void refresh() // a newly-connected route may have missed the first read
-        }
-      }).catch(() => undefined)
+      void host
+        .retainProfile(route)
+        .then(release => {
+          if (disposed) {
+            release()
+          } else {
+            releases.push(release)
+            void refresh() // a newly-connected route may have missed the first read
+          }
+        })
+        .catch(() => undefined)
     }
   }
 

--- a/apps/desktop/src/plugins/hermes-bots/group-review-row.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-review-row.tsx
@@ -8,11 +8,19 @@ export function GroupReviewRow({ receipt }: { receipt: GroupReviewReceipt }) {
     <div className="flex min-w-0 items-start gap-1.5 px-2 py-0.5 text-xs" data-review-receipt={receipt.id}>
       <Codicon className="shrink-0 text-(--tool-memory-legendary-icon)" name="lightbulb" />
       <span className="tool-memory-legendary-title shrink-0">{receipt.member}</span>
-      <span className="tool-memory-legendary-meta min-w-0 whitespace-pre-wrap wrap-anywhere" data-selectable-text="true">
+      <span
+        className="tool-memory-legendary-meta min-w-0 whitespace-pre-wrap wrap-anywhere"
+        data-selectable-text="true"
+      >
         {receipt.text.replace(/^[^\p{L}\p{N}]+/u, '')}
       </span>
-      <time className="shrink-0 text-(--ui-text-quaternary)" dateTime={new Date(receipt.at).toISOString()}
-        title={new Date(receipt.at).toLocaleString()}>{relativeTime(receipt.at)}</time>
+      <time
+        className="shrink-0 text-(--ui-text-quaternary)"
+        dateTime={new Date(receipt.at).toISOString()}
+        title={new Date(receipt.at).toLocaleString()}
+      >
+        {relativeTime(receipt.at)}
+      </time>
     </div>
   )
 }

--- a/apps/desktop/src/plugins/hermes-bots/group-review-row.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-review-row.tsx
@@ -1,0 +1,18 @@
+import { Codicon, relativeTime } from '@hermes/plugin-sdk'
+
+import type { GroupReviewReceipt } from './types'
+
+/** Read-only audit line, not a bot reply: no reply button, mentions or model input. */
+export function GroupReviewRow({ receipt }: { receipt: GroupReviewReceipt }) {
+  return (
+    <div className="flex min-w-0 items-start gap-1.5 px-2 py-0.5 text-xs" data-review-receipt={receipt.id}>
+      <Codicon className="shrink-0 text-(--tool-memory-legendary-icon)" name="lightbulb" />
+      <span className="tool-memory-legendary-title shrink-0">{receipt.member}</span>
+      <span className="tool-memory-legendary-meta min-w-0 whitespace-pre-wrap wrap-anywhere" data-selectable-text="true">
+        {receipt.text.replace(/^[^\p{L}\p{N}]+/u, '')}
+      </span>
+      <time className="shrink-0 text-(--ui-text-quaternary)" dateTime={new Date(receipt.at).toISOString()}
+        title={new Date(receipt.at).toLocaleString()}>{relativeTime(receipt.at)}</time>
+    </div>
+  )
+}

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -235,6 +235,7 @@ export default {
                   // Pre-thread entries get synthetic thread ids on hydrate so
                   // every UI/engine path can assume entry.thread exists.
                   log: assignLegacyThreads(room.log),
+                  reviewReceipts: Array.isArray(room.reviewReceipts) ? room.reviewReceipts : [],
                   watermarks: room.watermarks && typeof room.watermarks === 'object' ? room.watermarks : {},
                   sessions: room.sessions && typeof room.sessions === 'object' ? room.sessions : {},
                   sessionOwners: room.sessionOwners && typeof room.sessionOwners === 'object' ? room.sessionOwners : {},

--- a/apps/desktop/src/plugins/hermes-bots/types.ts
+++ b/apps/desktop/src/plugins/hermes-bots/types.ts
@@ -152,6 +152,15 @@ export interface GroupMessage {
   thread?: string
 }
 
+/** Display cache only; never part of the room's model-facing log/watermarks. */
+export interface GroupReviewReceipt {
+  at: number
+  id: string
+  member: string
+  memberKey: string
+  text: string
+}
+
 export interface GroupHold {
   at?: number
   noted?: boolean
@@ -163,6 +172,7 @@ export interface GroupChat {
   holds?: Record<string, GroupHold>
   image?: null | string
   log: GroupMessage[]
+  reviewReceipts?: GroupReviewReceipt[]
   members?: GroupMember[]
   /** Immutable identity, so a rename doesn't fork the room. */
   roomId?: null | string

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -1396,6 +1396,25 @@ export const host = {
     })
   },
 
+  /** Read a session's review receipts from its explicit owning source. This
+   *  never resumes a hidden Group Chat runtime or changes the active profile. */
+  listReviewSummaries: async (
+    route: PluginProfileRoute,
+    sessionId: string
+  ): Promise<{ session_id: string; messages: unknown[] }> => {
+    if (!route.connectionId.trim() || !route.profile.trim() || !route.targetProfile.trim() || !sessionId.trim()) {
+      throw new Error('Review reads require an owning route and stored session id')
+    }
+
+    const query = new URLSearchParams({ profile: route.targetProfile })
+
+    return hermesApi<{ session_id: string; messages: unknown[] }>({
+      connectionId: route.connectionId,
+      path: `/api/sessions/${encodeURIComponent(sessionId)}/review-summaries?${query.toString()}`,
+      timeoutMs: 15_000
+    })
+  },
+
   /** Mutate the durable hidden flag through the source primary. Keeping the
    *  owner profile in the body (not request.profile) prevents Electron from
    *  starting a profile backend merely to reconcile persisted visibility. */

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -302,6 +302,24 @@ describe('connection-aware plugin host APIs', () => {
     expect(requestGatewayForProfile).not.toHaveBeenCalled()
   })
 
+  it('reads review receipts on the explicit owner without activating or resuming it', async () => {
+    const route = {
+      connectionId: 'source-a',
+      mode: 'remote' as const,
+      profile: 'desktop-alias',
+      targetProfile: 'backend-worker'
+    }
+    vi.mocked(hermesApi).mockResolvedValueOnce({ session_id: 'group/sid', messages: [] })
+    await host.listReviewSummaries(route, 'group/sid')
+    expect(hermesApi).toHaveBeenCalledWith({
+      connectionId: 'source-a',
+      path: '/api/sessions/group%2Fsid/review-summaries?profile=backend-worker',
+      timeoutMs: 15_000
+    })
+    expect(requestGatewayForAgent).not.toHaveBeenCalled()
+    await expect(host.listReviewSummaries({ ...route, connectionId: '' }, 'group/sid')).rejects.toThrow('owning route')
+  })
+
   it('reads and hides persisted sessions through the source primary without activating the profile', async () => {
     const route = {
       connectionId: 'source-a',

--- a/apps/desktop/src/store/session-unread.ts
+++ b/apps/desktop/src/store/session-unread.ts
@@ -161,10 +161,16 @@ const profileKeyForRow = (row: SessionInfo): string => normalizeProfileKey(row.p
  *  profile's backend is its own namespace, so two profiles can hold the same
  *  id; a tie breaks toward the live gateway, since both opening a session and
  *  running one swap the gateway onto that session's profile. */
-function resolveLoadedRow(storedSessionId: string): SessionInfo | undefined {
+function resolveLoadedRow(storedSessionId: string, profileHint?: null | string): SessionInfo | undefined {
   const matches = rowsFor([$sessions.get(), $cronSessions.get(), $messagingSessions.get()]).filter(row =>
     sessionMatchesStoredId(row, storedSessionId)
   )
+
+  // An explicit owner is stronger than an unrelated loaded row with the same
+  // id. In particular, a hidden B session must not adopt A's visible row.
+  if (profileHint?.trim()) {
+    return matches.find(row => profileKeyForRow(row) === normalizeProfileKey(profileHint))
+  }
 
   if (matches.length < 2) {
     return matches[0]
@@ -214,11 +220,16 @@ function setMarkerBucket(profile: string, ids: readonly string[]): void {
 export function markSessionUnreadFinished(storedSessionId: string, profileHint?: null | string): void {
   const current = $unreadFinishedSessionIds.get()
 
-  if (!current.includes(storedSessionId)) {
+  // The transient id list cannot represent same-id cross-profile sessions.
+  // Explicit foreign owners use the scoped durable marker below instead.
+  if (
+    (!profileHint || normalizeProfileKey(profileHint) === normalizeProfileKey($activeGatewayProfile.get())) &&
+    !current.includes(storedSessionId)
+  ) {
     $unreadFinishedSessionIds.set([...current, storedSessionId])
   }
 
-  const row = resolveLoadedRow(storedSessionId)
+  const row = resolveLoadedRow(storedSessionId, profileHint)
   const profile = row ? profileKeyForRow(row) : unlistedProfile(profileHint)
   const durableId = row ? sessionPinId(row) : storedSessionId
   const bucket = $unreadFinishedMarkers.get()[profile] ?? []

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -638,6 +638,7 @@ export interface SessionInfo {
 }
 
 export type TimelineDisplayMetadata =
+  | { review_id: string; source_session_id?: string }
   | { model: string; provider?: string }
   | {
       delegation_id: string

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -123,6 +123,9 @@ def _collect_resume_entries(display_history, disp: dict, clean_assistant):
         tool_calls = msg.get("tool_calls") or []
         if display_kind == "hidden":
             continue
+        if display_kind == "review_summary" and isinstance(content, str) and content.strip():
+            entries.append(("event", _sanitize_display_text(content)))
+            continue
         if display_kind in _RESUME_EVENT_TEXT:
             metadata = msg.get("display_metadata") or {}
             label = metadata.get("display_text") if display_kind == "async_delegation_complete" else None

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -489,6 +489,18 @@ async def get_session_detail(session_id: str, profile: Optional[str] = None):
     return _with_db(profile, _detail, read_only=True)
 
 
+@manage_router.get("/api/sessions/{session_id}/review-summaries")
+async def get_session_review_summaries(session_id: str, profile: Optional[str] = None):
+    """Display-only receipts. Read the owning profile without creating/resuming an agent."""
+    def _read(db):
+        sid = _resolve_session_id(db, session_id)
+        if not sid or not db.get_session(sid):
+            raise HTTPException(status_code=404, detail=_NOT_FOUND)
+        sid = db.resolve_resume_session_id(sid)
+        return {"session_id": sid, "messages": db.get_review_summaries(sid)}
+    return await asyncio.to_thread(_with_db, profile, _read, read_only=True)
+
+
 @manage_router.get("/api/sessions/{session_id}/latest-descendant")
 async def get_session_latest_descendant(session_id: str, profile: Optional[str] = None):
     latest, path = await asyncio.to_thread(

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -818,6 +818,25 @@ class SessionMessagesMixin:
                 rows.reverse()
         return [self._row_to_message_dict(row, warn_context="get_messages", summary_flag=True) for row in rows]
 
+    def get_review_summaries(self, session_id: str, limit: int = 50) -> List[Dict[str, Any]]:
+        """Recent display-only review receipts across compression, never sibling forks.
+
+        Filter before LIMIT so a long tool transcript cannot crowd out the receipts.
+        Compaction-archived receipts remain visible; explicit rewind rows do not.
+        """
+        ids = self.get_compression_lineage(session_id) or [session_id]
+        limit = min(50, max(0, int(limit)))
+        rows = []
+        for start in range(0, len(ids), 900):
+            chunk = ids[start:start + 900]
+            rows.extend(self._read_all(
+                f"SELECT * FROM messages WHERE session_id IN ({_placeholders(chunk)}) "
+                "AND display_kind = 'review_summary' AND (active = 1 OR compacted = 1) "
+                "ORDER BY id DESC LIMIT ?", [*chunk, limit]))
+        rows.sort(key=lambda row: row["id"], reverse=True)
+        return [self._row_to_message_dict(row, warn_context="get_review_summaries", summary_flag=True)
+                for row in reversed(rows[:limit])]
+
     def find_pr_url_messages(self, session_ids: List[str]) -> List[Dict[str, Any]]:
         """Tool results containing ``/pull/``: a deliberately loose scan, oldest-first so the caller takes the last."""
         ids = [s for s in session_ids if s]

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -606,7 +606,7 @@ class SessionMessagesMixin:
                 bound = watermark is not None
                 rewind_ids = [int(row["id"]) for row in conn.execute(
                     f"SELECT id FROM messages WHERE session_id = ? AND active = 1{' AND id <= ?' if bound else ''} "
-                    "ORDER BY id DESC LIMIT ?",
+                    "AND COALESCE(display_kind, '') != 'review_summary' ORDER BY id DESC LIMIT ?",
                     (session_id, *((int(watermark),) if bound else ()), int(tail_count))).fetchall()]
             rewind_ids += tail_ids
             if rewind_ids:
@@ -913,7 +913,7 @@ class SessionMessagesMixin:
             rows = self._dedupe_display_generations(rows)
         return self._rows_to_conversation(rows, session_id=session_id, include_ancestors=include_ancestors,
             repair_alternation=repair_alternation, include_row_ids=include_row_ids,
-            include_summary_markers=repair_alternation)
+            include_summary_markers=repair_alternation, include_display_events=include_compacted)
 
     def _dedupe_replayed_user(self, messages, msg, exact_user_clones) -> Tuple[bool, Any]:
         """Ancestor-lineage dedupe of one decoded user *msg* -> ``(skip, exact_clone_key)``. Rotation
@@ -939,7 +939,8 @@ class SessionMessagesMixin:
 
     def _rows_to_conversation(self, rows, *, session_id: str, include_ancestors: bool, repair_alternation: bool,
                               include_row_ids: bool = False,
-                              include_summary_markers: bool = False) -> List[Dict[str, Any]]:
+                              include_summary_markers: bool = False,
+                              include_display_events: bool = False) -> List[Dict[str, Any]]:
         """Decode fetched rows (ordered by id, pre-filtered) into OpenAI format, stable key order. Every dict is
         stamped ``_DB_PERSISTED_MARKER_KEY`` (born durable) so an identity-losing handoff never re-appends the
         transcript on flush. ``_row_id`` is opt-in (gateway reactions); reasoning restored on assistant rows
@@ -948,6 +949,9 @@ class SessionMessagesMixin:
         messages = []
         exact_user_clones: Dict[Tuple[Any, str], Dict[str, Any]] = {}
         for row in rows:
+            # Receipts describe completed writes; they are not instructions or model turns.
+            if row["display_kind"] == "review_summary" and not include_display_events:
+                continue
             content = self._decode_content(row["content"])
             if row["role"] in {"user", "assistant"} and isinstance(content, str):
                 content = sanitize_context(content).strip()
@@ -1020,7 +1024,7 @@ class SessionMessagesMixin:
             include_ancestors=False, repair_alternation=True, include_row_ids=True, include_summary_markers=True)
         display_history = self._rows_to_conversation(
             self._dedupe_display_generations(rows), session_id=session_id,
-            include_ancestors=True, repair_alternation=False, include_row_ids=True)
+            include_ancestors=True, repair_alternation=False, include_row_ids=True, include_display_events=True)
         return model_history, display_history
 
     def _resume_lineage_ids(self, session_id: str) -> List[str]:
@@ -1074,7 +1078,7 @@ class SessionMessagesMixin:
         if not ancestor_ids:
             return []
         lineage = self._rows_to_conversation(
-            rows, session_id=session_id, include_ancestors=True, repair_alternation=False, include_row_ids=True)
+            rows, session_id=session_id, include_ancestors=True, repair_alternation=False, include_row_ids=True, include_display_events=True)
         return [{k: v for k, v in message.items() if k != "_row_id"}
             for message in lineage if message.get("_row_id") in ancestor_ids]
 

--- a/tests/agent/test_review_summary_durability.py
+++ b/tests/agent/test_review_summary_durability.py
@@ -1,0 +1,83 @@
+"""Review receipts are display history, never new model instructions."""
+import json
+from types import SimpleNamespace
+
+from agent import background_review as review
+from hermes_state import SessionDB
+
+
+def parent(db, session_id):
+    return SimpleNamespace(
+        _session_db=db, session_id=session_id, _persist_disabled=False,
+        _safe_print=lambda text: None, background_review_callback=None,
+        background_review_event_callback=None, memory_notifications="on",
+        _emit_auxiliary_failure=lambda *args: None,
+    )
+
+
+def receipts(db, session_id):
+    return [m for m in db.get_resume_conversations(session_id)[1]
+            if m.get("display_kind") == "review_summary"]
+
+
+def test_confirmation_survives_reopen_and_compaction_without_changing_model_history(tmp_path):
+    path = tmp_path / "state.db"
+    db = SessionDB(path)
+    db.create_session("chat", source="desktop")
+    db.append_message("chat", "user", "Inspect this procedure")
+    db.append_message("chat", "assistant", "Done")
+    before = db.get_resume_conversations("chat")[0]
+    agent = parent(db, "chat")
+    events = []
+    agent.background_review_event_callback = events.append
+    review._publish_review_summary(agent, ["Skill 'canary' patched"])
+    rows = receipts(db, "chat")
+    assert len(rows) == 1, "the visible confirmation must be durable before delivery"
+    assert len(events) == 1
+    receipt = rows[0]
+    assert events[0]["review_id"] == receipt["display_metadata"]["review_id"]
+    assert events[0]["row_id"] == receipt["_row_id"]
+    assert events[0]["timestamp"] == receipt["timestamp"]
+    assert db.get_resume_conversations("chat")[0] == before
+    assert all(m.get("display_kind") != "review_summary"
+               for m in db.get_messages_as_conversation("chat", repair_alternation=True))
+    db.close()
+    db = SessionDB(path)
+    assert receipts(db, "chat") == rows
+    # A compacted model tail is shorter than the display history; the receipt
+    # cannot consume a verbatim-tail slot or be mistaken for model context.
+    db.archive_and_compact("chat", [{"role": "assistant", "content": "Done"}], tail_count=1)
+    assert len(receipts(db, "chat")) == 1
+    assert all(m.get("display_kind") != "review_summary"
+               for m in db.get_resume_conversations("chat")[0])
+    db.close()
+
+
+def test_completed_review_stays_with_its_origin_when_parent_moves_to_another_session(tmp_path, monkeypatch):
+    db = SessionDB(tmp_path / "state.db")
+    for sid in ("origin", "next-chat"):
+        db.create_session(sid, source="desktop")
+    agent = parent(db, "origin")
+    events = []
+    agent.background_review_event_callback = events.append
+
+    def finish_fork(agent, snapshot, prompt, config, run, state, review_memory, explicit):
+        agent.session_id = "next-chat"
+        state.review_messages = [
+            {"role": "assistant", "tool_calls": [{"id": "write-1", "type": "function", "function": {
+                "name": "skill_manage", "arguments": json.dumps({"action": "patch", "name": "canary"})}}]},
+            {"role": "tool", "tool_call_id": "write-1", "content": json.dumps({
+                "success": True, "message": "Skill 'canary' patched"})},
+        ]
+
+    monkeypatch.setattr(review, "_run_review_fork", finish_fork)
+    review._run_review_in_thread(agent, [], "Review")
+    assert len(receipts(db, "origin")) == 1
+    assert receipts(db, "next-chat") == []
+    assert events[0]["stored_session_id"] == "origin"
+    # Another profile with an identically named session sees none of the receipt.
+    other = SessionDB(tmp_path / "other-profile.db")
+    other.create_session("origin", source="desktop")
+    assert receipts(other, "origin") == []
+    other.close()
+    db.close()

--- a/tests/agent/test_review_summary_durability.py
+++ b/tests/agent/test_review_summary_durability.py
@@ -81,3 +81,64 @@ def test_completed_review_stays_with_its_origin_when_parent_moves_to_another_ses
     assert receipts(other, "origin") == []
     other.close()
     db.close()
+
+
+def test_idle_queue_freezes_origin_before_new_and_preserves_it_through_requeue(tmp_path, monkeypatch):
+    from agent.review_idle_queue import ReviewIdleQueue
+    import pytest
+
+    db = SessionDB(tmp_path / "queued.db")
+    for sid in ("origin", "next-chat"):
+        db.create_session(sid, source="desktop")
+    agent = parent(db, "origin")
+    queue = ReviewIdleQueue()
+    monkeypatch.setattr(queue, "_ensure_thread", lambda: None)
+    monkeypatch.setattr(queue, "_still_enabled", lambda item: True)
+    clock = [0.0]
+    queue._now = lambda: clock[0]
+    queue._server_idle = lambda: True
+    queue._quiet_since = -1000.0
+    calls = []
+
+    def finish_fork(agent, snapshot, prompt, config, run, state, review_memory, explicit):
+        state.review_messages = [
+            {"role": "assistant", "tool_calls": [{"id": "queued-write", "type": "function", "function": {
+                "name": "skill_manage", "arguments": json.dumps({"action": "patch", "name": "queued"})}}]},
+            {"role": "tool", "tool_call_id": "queued-write", "content": json.dumps({
+                "success": True, "message": "Skill 'queued' patched"})},
+        ]
+    monkeypatch.setattr(review, "_run_review_fork", finish_fork)
+
+    def dispatch(**kwargs):
+        run = review.prepare_background_review_run(agent)
+        assert run is not None
+        calls.append(run.source_session_id)
+        try:
+            if len(calls) == 1:
+                # A foreground preemption requeues while the worker still carries
+                # origin's Context; /new has already moved the reusable parent.
+                queue.enqueue(agent, "origin-key", kwargs)
+            else:
+                review._run_review_in_thread(agent, [], "Review", review_run=run)
+        finally:
+            review.finish_background_review_run(agent, run)
+            if hasattr(run, "worker_done"):
+                from agent.review_lifecycle import finish_review_worker
+                finish_review_worker(agent, run)
+    agent._spawn_background_review_now = dispatch
+    queue.enqueue(agent, "origin-key", {"task_cfg": {}})
+    agent.session_id = "next-chat"
+    clock[0] = 1000.0
+
+    class Done(BaseException):
+        pass
+    def wake():
+        if len(calls) >= 2:
+            raise Done
+    monkeypatch.setattr(queue._wake, "wait", wake)
+    with pytest.raises(Done):
+        queue._run()
+    assert calls == ["origin", "origin"]
+    assert len(receipts(db, "origin")) == 1
+    assert receipts(db, "next-chat") == []
+    db.close()

--- a/tests/hermes_cli/test_review_summary_surfaces.py
+++ b/tests/hermes_cli/test_review_summary_surfaces.py
@@ -1,0 +1,62 @@
+"""Read-only receipt queries and CLI rehydrate must not construct live agents."""
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agent.review_summary import publish_review_summary
+from hermes_state import SessionDB
+
+
+def test_receipt_query_pages_receipts_not_chat_and_never_crosses_profiles(tmp_path, monkeypatch):
+    from hermes_cli.web_routers import sessions
+    stores = {name: SessionDB(tmp_path / f"{name}.db") for name in ("room", "other")}
+    for name, db in stores.items():
+        db.create_session("group-sid", "desktop")
+        db.create_session("bot-chat", "desktop")
+        agent = SimpleNamespace(_session_db=db, session_id="group-sid", _persist_disabled=False,
+            _safe_print=lambda *_: None, background_review_callback=None)
+        publish_review_summary(agent, [f"Skill '{name}' patched"])
+        agent.session_id = "bot-chat"
+        publish_review_summary(agent, ["PRIVATE BOT CHAT"])
+        db.append_messages_batch("group-sid", [
+            {"role": "assistant", "content": f"ordinary message {i}"} for i in range(600)])
+    before = stores["room"].get_resume_conversations("group-sid")[0]
+    reads = []
+    def with_db(profile, fn, **kwargs):
+        reads.append((profile, kwargs))
+        return fn(stores[profile])
+    monkeypatch.setattr(sessions, "_with_db", with_db)
+    app = FastAPI()
+    app.include_router(sessions.manage_router)
+    with TestClient(app) as client:
+        for profile in stores:
+            result = client.get(f"/api/sessions/group-sid/review-summaries?profile={profile}")
+            assert result.status_code == 200
+            rows = result.json()["messages"]
+            assert len(rows) == 1
+            assert f"'{profile}'" in rows[0]["content"]
+            assert "PRIVATE" not in rows[0]["content"]
+        assert client.get("/api/sessions/missing/review-summaries?profile=room").status_code == 404
+    assert all(options == {"read_only": True} for _, options in reads)
+    assert stores["room"].get_resume_conversations("group-sid")[0] == before
+    # Archive in place: the read rail survives while the model tail stays small.
+    stores["room"].archive_and_compact("group-sid", [{"role": "assistant", "content": "summary"}], tail_count=1)
+    assert len(stores["room"].get_review_summaries("group-sid")) == 1
+    for db in stores.values():
+        db.close()
+
+
+def test_cli_resume_renders_receipts_as_events_without_replaying_in_model(tmp_path):
+    from hermes_cli.cli_agent_setup_mixin import _collect_resume_entries
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("chat", "cli")
+    db.append_message("chat", "user", "task")
+    agent = SimpleNamespace(_session_db=db, session_id="chat", _persist_disabled=False,
+        _safe_print=lambda *_: None, background_review_callback=None)
+    publish_review_summary(agent, ["Skill 'canary' patched"])
+    model, display = db.get_resume_conversations("chat")
+    entries, _, _ = _collect_resume_entries(display, {}, lambda s: s)
+    assert any(role == "event" and "canary" in text for role, text in entries)
+    assert not any("canary" in str(row.get("content", "")) for row in model)
+    db.close()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -934,6 +934,7 @@ def _wire_session_agent(sid: str, key: str, agent) -> bool:
     _wire_callbacks(sid)
     with contextlib.suppress(Exception):  # bare agents without the attribute must not break startup
         agent.background_review_callback = lambda message, _sid=sid: _emit("review.summary", _sid, {"text": str(message)})
+        agent.background_review_event_callback = lambda payload, _sid=sid: _emit("review.summary", _sid, payload)
         agent.memory_notifications = _load_memory_notifications()
     return notify_registered
 

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -309,6 +309,33 @@ describe('createGatewayEventHandler', () => {
     expect(ctx.system.sys).toHaveBeenCalledWith("💾 Self-improvement review: Skill 'hermes-release' patched")
   })
 
+  it('deduplicates a replayed durable review and retains its authored timestamp', async () => {
+    const { toTranscriptMessages } = await import('../domain/messages.js')
+
+    let history = toTranscriptMessages([
+      {
+        role: 'system',
+        text: 'Saved',
+        timestamp: 123,
+        display_kind: 'review_summary',
+        display_metadata: { review_id: 'one' }
+      }
+    ])
+
+    const ctx = buildCtx([])
+
+    ctx.transcript.setHistoryItems = (update: (rows: Msg[]) => Msg[]) => {
+      history = update(history)
+    }
+
+    const onEvent = createGatewayEventHandler(ctx)
+    onEvent({ type: 'review.summary', payload: { text: 'Saved', review_id: 'one', timestamp: 123 } })
+    onEvent({ type: 'review.summary', payload: { text: 'Another', review_id: 'two', timestamp: 456 } })
+    expect(history).toHaveLength(2)
+    expect(history.map(row => row.createdAt)).toEqual([123, 456])
+    expect(ctx.system.sys).not.toHaveBeenCalled()
+  })
+
   it('ignores review.summary events with empty or missing text', () => {
     const appended: Msg[] = []
     const ctx = buildCtx(appended)

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -1357,7 +1357,28 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         const text = String(ev.payload?.text ?? '').trim()
 
         if (text) {
-          sys(text)
+          const reviewId = ev.payload?.review_id
+          const timestamp = ev.payload?.timestamp
+
+          if (reviewId) {
+            setHistoryItems(previous =>
+              previous.some(message => message.reviewId === reviewId)
+                ? previous
+                : [
+                    ...previous,
+                    {
+                      role: 'system',
+                      text,
+                      reviewId,
+                      ...(typeof timestamp === 'number' &&
+                        Number.isFinite(timestamp) &&
+                        timestamp > 0 && { createdAt: timestamp })
+                    }
+                  ]
+            )
+          } else {
+            sys(text) // legacy backend without durable receipt identity
+          }
         }
 
         return

--- a/ui-tui/src/domain/messages.ts
+++ b/ui-tui/src/domain/messages.ts
@@ -50,6 +50,19 @@ export const toTranscriptMessages = (rows: unknown): Msg[] => {
       continue
     }
 
+    if (display_kind === 'review_summary') {
+      const reviewId = (row as TranscriptRow).display_metadata?.review_id
+      out.push({
+        role: 'system',
+        text,
+        ...(createdAt !== undefined && { createdAt }),
+        ...(typeof reviewId === 'string' && { reviewId })
+      })
+      pending = []
+
+      continue
+    }
+
     if (display_kind === 'model_switch') {
       out.push({ kind: 'event', role: 'system', text: 'model changed' })
       pending = []

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -779,7 +779,7 @@ export type GatewayEvent =
     }
   | { payload: { task_id: string; text: string }; session_id?: string; type: 'background.complete' }
   | { payload: { question?: string; task_id: string; text: string }; session_id?: string; type: 'btw.complete' }
-  | { payload?: { text?: string }; session_id?: string; type: 'review.summary' }
+  | { payload?: { text?: string; review_id?: string; timestamp?: number }; session_id?: string; type: 'review.summary' }
   | { payload: SubagentEventPayload; session_id?: string; type: 'subagent.spawn_requested' }
   | { payload: SubagentEventPayload; session_id?: string; type: 'subagent.start' }
   | { payload: SubagentEventPayload; session_id?: string; type: 'subagent.thinking' }

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -131,6 +131,7 @@ export interface ClarifyReq {
 }
 
 export interface Msg {
+  reviewId?: string
   info?: SessionInfo
   kind?: 'diff' | 'event' | 'intro' | 'panel' | 'slash' | 'trail'
   panelData?: PanelData


### PR DESCRIPTION
## Summary

Make **Self-improvement review** confirmations durable and visible across Desktop, canonical Bot Chat, Group Bot Chat, CLI and Ink TUI (including the Dashboard's embedded TUI).

This extends the original Desktop receipt fix rather than duplicating it. Runtime ownership and durable review cadence are handled by companion **#109474**. Related to **#109375**, not an automatic closing fix for the combined issue. **Cron / Bot Routines remain out of scope.**

The reporter previously requested P1 triage for disappearing confirmations; final classification belongs to maintainers.

## Durable receipts and ordinary Desktop/Bot Chat

- Persist parent-owned `display_kind="review_summary"` receipts in the existing messages/display-metadata store before structured live delivery. No new database, schema migration or tool.
- Capture the originating conversation and follow only its compression continuation. Preserve the existing text callback for legacy consumers; storage/delivery failure is logged rather than represented as durable success.
- Keep receipts out of model-history projection, raw-history turn setup, prompt cache and verbatim compaction-tail slots. Retain them in display history across compaction and reopening.
- Share stable `review_id` and backend timestamp between live delivery and history hydration. Replay is idempotent without collapsing different reviews with identical text.
- Preserve receipts arriving during an in-flight history read without overriding a later intentional rewind/reset. Keep the gradient row, display its timestamp, and mark off-focus receipts unread without stealing focus.

## Deferred review origin and unread scope

- Freeze the review's source session before idle-queue deferral. `ReviewIdleQueue` now captures a Context at enqueue, seeds the original session id into `REVIEW_SOURCE_SESSION_ID`, and dispatches/rechecks through that Context. A later `/new` on the reusable parent agent cannot retarget a queued receipt into the new chat.
- Carry the frozen source through bounded requeue and `prepare_background_review_run`, so the final receipt persists to the original conversation even when the worker starts after the active session changed.
- Scope unread handling by connection/profile as well as stored session id. Same-id profile collisions no longer make a background profile look focused, and hidden cross-profile receipts pass the profile hint to `markSessionUnreadFinished`.

## Group Bot Chat

- Add a bounded read-only receipt query for a member's **exact hidden room session**, explicitly scoped to connection and target profile. It reads receipt rows before applying the limit, so hundreds of ordinary messages cannot crowd out the receipt. It does not construct/resume an agent or activate a profile.
- Backfill on room open/reconnect and invalidate on relevant gateway events. Events are hints, not room content: a private Bot Chat's event text is never copied into a room. Stored session ownership is rechecked after asynchronous reads.
- Keep visible-room event subscriptions/route leases with balanced disposal. Backend lifetime ownership after the view closes belongs to #109474, not to this watcher.
- Cache/deduplicate the latest 50 receipts separately from `room.log`. Render member-attributed, timestamped rows in the room's timeline. **No review row enters bot prompts, advances dialogue watermarks, wakes a member or creates a round.**
- Follow room renames and discard stale reads on disband/same-name recreation. Missing endpoints/temporary disconnects preserve the existing cache; older shells feature-detect the new read API.

## CLI / TUI / Dashboard

- Restore display-only receipts as events in the interactive CLI's resume recap.
- Restore receipts as system rows in Ink TUI, preserve their original backend time, and deduplicate a replayed live event against hydrated rows using `review_id`.
- The web Dashboard embeds the same TUI, so it uses the shared terminal implementation. One-shot `-z` intentionally retains its final-answer-only stdout contract; its receipts remain available in stored history.

`display.memory_notifications`, write approval and protected-skill/provenance restrictions are unchanged. Historical confirmations that were never stored cannot be reconstructed. This is a completed-result rail, not a full queued/running/no-op/failure dashboard or independent filesystem verification of tool claims.

## Verification

**Latest reviewer-blocker proof:** https://github.com/Xipong/hermes-agent/actions/runs/34727923322

Published source head: **`30942dbb7319447cac28c033214a577c49957eac`**.

This run first demonstrates the intended failures on the pre-fix receipt branch:

- queued idle-review origin switches from `origin` to `next-chat` after `/new`;
- same stored-session-id cross-profile receipt events do not mark profile B unread.

Then it applies the production fix, publishes the commit, and verifies:

- **55 Python tests** across 6 isolated files: durable receipts, idle-queue origin freeze, read-only profile/session routing, CLI restoration, callback behavior, idle queue and review cache parity.
- **343 Desktop tests** across 15 files: Group receipt backfill/rendering, group lifecycle/rounds/turns, explicit SDK routing, Desktop receipt durability, profile-scoped unread marking and chat hydration.
- **125 TUI tests** across 2 files: transcript conversion and live event handling, including stable receipt identity and timestamp.
- Desktop renderer and TUI TypeScript checks passed. Targeted ESLint, Ruff, formatting of changed tracked files and `git diff --check` passed.

Original Desktop baseline proof remains at https://github.com/Xipong/hermes-agent/actions/runs/34717809118 : two backend and two Desktop assertions fail before the original production patch and pass afterward.

Receipt-surface expansion proof remains at https://github.com/Xipong/hermes-agent/actions/runs/34726146372 : receipt storage/read-only routing, Group Bot Chat, CLI/TUI and type-check coverage passed before the latest reviewer-blocker commit.

## Verification boundary / housekeeping

Tests use real temporary SQLite storage, the actual event/hydration/group stores and controlled provider/transport seams. No paid provider, production profile writes, packaged/native GUI, Windows or WAN end-to-end run is claimed. The full repository suite was not run.

The feature branch contains source and regression tests only; proof workflows and encoded payloads remain on a separate fork-only operations branch. No merge or deployment is performed.