### PR TITLE
fix(desktop): resume authoritative snapshots after replay gaps

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
@@ -2,9 +2,15 @@ import { renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type * as HermesModule from '@/hermes'
-import { setSessionOwnerHint, setSessions } from '@/store/session'
+import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
+import { $activeSessionId, setSessionOwnerHint, setSessions } from '@/store/session'
 import { $sessionTiles, sessionTileDelegate } from '@/store/session-states'
 import type { SessionInfo } from '@/types/hermes'
+
+import {
+  clearSingleFlightSessionResumeState,
+  singleFlightSessionResume
+} from '../../session/hooks/use-prompt-actions/single-flight-resume'
 
 import { useSessionTileDelegate } from './use-session-tile-delegate'
 
@@ -63,11 +69,13 @@ function renderTile(
 
 describe('useSessionTileDelegate resumeTile', () => {
   beforeEach(() => {
+    clearSingleFlightSessionResumeState()
     setSessions([])
     vi.mocked(getLatestSessionMessages).mockClear()
   })
 
   afterEach(() => {
+    clearSingleFlightSessionResumeState()
     setSessions([])
   })
 
@@ -192,6 +200,164 @@ describe('useSessionTileDelegate resumeTile', () => {
     expect(runtimeId).toBe('runtime-a')
     expect(requestGateway).not.toHaveBeenCalled()
     expect(getLatestSessionMessages).not.toHaveBeenCalled()
+  })
+
+  it('forces an owner-routed message snapshot into a warm tile without touching foreground state', async () => {
+    const ownerRoute = { connectionId: 'remote-tile', profile: 'tile-profile', targetProfile: 'backend-tile' }
+
+    const pending = {
+      id: 'user-pending',
+      parts: [{ type: 'text', text: 'local pending prompt' }],
+      pending: true,
+      role: 'user'
+    }
+
+    const warm = { busy: false, messages: [pending], storedSessionId: 'stored-tile' }
+    const runtimeIdByStoredSessionIdRef = { current: new Map([['stored-tile', 'runtime-tile']]) }
+    const states = { current: new Map([['runtime-tile', warm]]) }
+
+    const update = vi.fn((id, updater) => {
+      const next = updater(states.current.get(id))
+      states.current.set(id, next)
+
+      return next
+    })
+
+    $activeSessionId.set('runtime-foreground')
+    $sessionTiles.set([{ ownerRoute, runtimeId: 'runtime-tile', storedSessionId: 'stored-tile' }] as never)
+    stashSessionDraft('stored-tile', 'unsent tile draft', [])
+    vi.mocked(requestGatewayForAgent).mockResolvedValueOnce({
+      info: { model: 'snapshot-model', yolo: true },
+      message_count: 2,
+      messages: [
+        { content: 'new prompt', role: 'user', timestamp: 1 },
+        { content: 'new answer', role: 'assistant', timestamp: 2 }
+      ],
+      resumed: 'stored-tile',
+      running: true,
+      session_id: 'runtime-tile'
+    } as never)
+
+    renderTile(vi.fn(), {
+      runtimeIdByStoredSessionIdRef,
+      sessionStateByRuntimeIdRef: states,
+      updateSessionState: update
+    })
+
+    await sessionTileDelegate()!.resumeTile('stored-tile', { authoritativeSnapshot: true })
+
+    expect(requestGatewayForAgent).toHaveBeenCalledWith('remote-tile', 'tile-profile', 'session.resume', {
+      cols: 96,
+      omit_messages: false,
+      profile: 'backend-tile',
+      session_id: 'stored-tile'
+    })
+    expect(getLatestSessionMessages).not.toHaveBeenCalled()
+    expect(states.current.get('runtime-tile')).toMatchObject({ busy: true, model: 'snapshot-model', yolo: true })
+    expect(JSON.stringify(states.current.get('runtime-tile')?.messages)).toContain('new answer')
+    expect(states.current.get('runtime-tile')?.messages).toContainEqual(pending)
+    expect($activeSessionId.get()).toBe('runtime-foreground')
+    expect(takeSessionDraft('stored-tile').text).toBe('unsent tile draft')
+
+    clearSessionDraft('stored-tile')
+    $activeSessionId.set(null)
+    $sessionTiles.set([])
+  })
+
+  it('serializes an authoritative gap snapshot after an omitted-message resume already in flight', async () => {
+    const ownerRoute = { connectionId: 'remote-tile', profile: 'tile-profile', targetProfile: 'backend-tile' }
+    const oldMessage = { id: 'old-user', parts: [{ type: 'text', text: 'old prompt' }], role: 'user' }
+
+    const pending = {
+      id: 'user-pending',
+      parts: [{ type: 'text', text: 'local pending prompt' }],
+      pending: true,
+      role: 'user'
+    }
+
+    const warm = { busy: false, messages: [oldMessage, pending], storedSessionId: 'stored-tile' }
+    const runtimeIdByStoredSessionIdRef = { current: new Map([['stored-tile', 'runtime-tile']]) }
+    const states = { current: new Map([['runtime-tile', warm]]) }
+
+    const update = vi.fn((id, updater) => {
+      const next = updater(states.current.get(id))
+      states.current.set(id, next)
+
+      return next
+    })
+
+    let resolveNormal!: (value: unknown) => void
+    let resolveAuthoritative!: (value: unknown) => void
+    const normalResponse = new Promise(resolve => (resolveNormal = resolve))
+    const authoritativeResponse = new Promise(resolve => (resolveAuthoritative = resolve))
+
+    vi.mocked(requestGatewayForAgent).mockReset()
+    vi.mocked(requestGatewayForAgent).mockImplementation(
+      async (_connectionId, _profile, _method, params) =>
+        (params?.omit_messages ? normalResponse : authoritativeResponse) as never
+    )
+
+    $activeSessionId.set('runtime-foreground')
+    $sessionTiles.set([{ ownerRoute, runtimeId: 'runtime-tile', storedSessionId: 'stored-tile' }] as never)
+    stashSessionDraft('stored-tile', 'unsent tile draft', [])
+    renderTile(vi.fn(), {
+      runtimeIdByStoredSessionIdRef,
+      sessionStateByRuntimeIdRef: states,
+      updateSessionState: update
+    })
+
+    const normal = singleFlightSessionResume('stored-tile', () =>
+      requestGatewayForAgent('remote-tile', 'tile-profile', 'session.resume', {
+        omit_messages: true,
+        profile: 'backend-tile',
+        session_id: 'stored-tile'
+      })
+    )
+
+    await vi.waitFor(() => expect(requestGatewayForAgent).toHaveBeenCalledTimes(1))
+
+    let authoritativeSettled = false
+
+    const authoritative = sessionTileDelegate()!
+      .resumeTile('stored-tile', { authoritativeSnapshot: true })
+      .finally(() => (authoritativeSettled = true))
+
+    await Promise.resolve()
+    expect(requestGatewayForAgent).toHaveBeenCalledTimes(1)
+
+    resolveNormal({ messages: [], resumed: 'stored-tile', session_id: 'runtime-tile' })
+    await normal
+    await Promise.resolve()
+    expect(authoritativeSettled).toBe(false)
+    expect(states.current.get('runtime-tile')?.messages).toEqual([oldMessage, pending])
+
+    await vi.waitFor(() => expect(requestGatewayForAgent).toHaveBeenCalledTimes(2))
+    expect(requestGatewayForAgent).toHaveBeenLastCalledWith('remote-tile', 'tile-profile', 'session.resume', {
+      cols: 96,
+      omit_messages: false,
+      profile: 'backend-tile',
+      session_id: 'stored-tile'
+    })
+
+    resolveAuthoritative({
+      info: { model: 'snapshot-model' },
+      messages: [
+        { content: 'new prompt', role: 'user', timestamp: 1 },
+        { content: 'new answer', role: 'assistant', timestamp: 2 }
+      ],
+      resumed: 'stored-tile',
+      session_id: 'runtime-tile'
+    })
+    await authoritative
+
+    expect(JSON.stringify(states.current.get('runtime-tile')?.messages)).toContain('new answer')
+    expect(states.current.get('runtime-tile')?.messages).toContainEqual(pending)
+    expect($activeSessionId.get()).toBe('runtime-foreground')
+    expect(takeSessionDraft('stored-tile').text).toBe('unsent tile draft')
+
+    clearSessionDraft('stored-tile')
+    $activeSessionId.set(null)
+    $sessionTiles.set([])
   })
 
   it('merges persisted messages into a warm tile on explicit reopen (#96183)', async () => {

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.test.ts
@@ -264,6 +264,69 @@ describe('useSessionTileDelegate resumeTile', () => {
     $sessionTiles.set([])
   })
 
+  it('preserves a newer completed tile turn when an older authoritative snapshot arrives late', async () => {
+    const ownerRoute = { connectionId: 'remote-tile', profile: 'tile-profile', targetProfile: 'backend-tile' }
+
+    const baseline = {
+      busy: false,
+      messages: [
+        { id: 'old-user', parts: [{ type: 'text', text: 'old prompt' }], role: 'user' },
+        { id: 'old-answer', parts: [{ type: 'text', text: 'old answer' }], role: 'assistant' }
+      ],
+      storedSessionId: 'stored-tile'
+    }
+
+    const runtimeIdByStoredSessionIdRef = { current: new Map([['stored-tile', 'runtime-tile']]) }
+    const states = { current: new Map([['runtime-tile', baseline]]) }
+
+    const update = vi.fn((id, updater) => {
+      const next = updater(states.current.get(id))
+      states.current.set(id, next)
+
+      return next
+    })
+
+    let resolveSnapshot!: (value: unknown) => void
+    const snapshot = new Promise(resolve => (resolveSnapshot = resolve))
+
+    vi.mocked(requestGatewayForAgent).mockReset()
+    vi.mocked(requestGatewayForAgent).mockReturnValueOnce(snapshot as never)
+    $sessionTiles.set([{ ownerRoute, runtimeId: 'runtime-tile', storedSessionId: 'stored-tile' }] as never)
+    renderTile(vi.fn(), {
+      runtimeIdByStoredSessionIdRef,
+      sessionStateByRuntimeIdRef: states,
+      updateSessionState: update
+    })
+
+    const refreshing = sessionTileDelegate()!.resumeTile('stored-tile', { authoritativeSnapshot: true })
+    await vi.waitFor(() => expect(requestGatewayForAgent).toHaveBeenCalledTimes(1))
+
+    const completed = {
+      ...baseline,
+      messages: [
+        ...baseline.messages,
+        { id: 'new-user', parts: [{ type: 'text', text: 'new prompt' }], role: 'user' },
+        { id: 'new-answer', parts: [{ type: 'text', text: 'new completed answer' }], role: 'assistant' }
+      ]
+    }
+
+    states.current.set('runtime-tile', completed as never)
+    resolveSnapshot({
+      messages: [
+        { content: 'old prompt', role: 'user', timestamp: 1 },
+        { content: 'old answer', role: 'assistant', timestamp: 2 }
+      ],
+      resumed: 'stored-tile',
+      running: false,
+      session_id: 'runtime-tile'
+    })
+    await refreshing
+
+    expect(states.current.get('runtime-tile')?.messages).toContainEqual(completed.messages[2])
+    expect(states.current.get('runtime-tile')?.messages).toContainEqual(completed.messages[3])
+    $sessionTiles.set([])
+  })
+
   it('serializes an authoritative gap snapshot after an omitted-message resume already in flight', async () => {
     const ownerRoute = { connectionId: 'remote-tile', profile: 'tile-profile', targetProfile: 'backend-tile' }
     const oldMessage = { id: 'old-user', parts: [{ type: 'text', text: 'old prompt' }], role: 'user' }

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -32,6 +32,7 @@ import {
   chatMessageArraysEquivalent,
   preserveLocalPendingTurnMessages,
   reconcileResumeMessages,
+  resolveResumedBusy,
   resolveSessionOwner
 } from '../../session/hooks/use-session-actions/utils'
 import type { useSessionStateCache } from '../../session/hooks/use-session-state-cache'
@@ -275,6 +276,7 @@ export function useSessionTileDelegate({
 
         const cached = existing ? sessionStateByRuntimeIdRef.current.get(existing) : undefined
         const refreshTranscript = options?.refreshTranscript === true
+        const authoritativeSnapshot = options?.authoritativeSnapshot === true
 
         // Warm path: reuse a live binding — but only when it still carries a
         // transcript (or is mid-turn, where messages legitimately stream in).
@@ -291,7 +293,8 @@ export function useSessionTileDelegate({
           existing &&
           cached?.storedSessionId === storedSessionId &&
           (cached.busy || cached.messages.length > 0) &&
-          !refreshTranscript
+          !refreshTranscript &&
+          !authoritativeSnapshot
         ) {
           publishSessionState(existing, cached)
 
@@ -310,9 +313,16 @@ export function useSessionTileDelegate({
             ? { connectionId: owner.connectionId, profile: owner.targetProfile || owner.profile }
             : owner
 
-        const prefetchPromise = getLatestSessionMessages(storedSessionId, restScope).catch(() => null)
+        const prefetchPromise = authoritativeSnapshot
+          ? Promise.resolve(null)
+          : getLatestSessionMessages(storedSessionId, restScope).catch(() => null)
 
-        if (existing && cached?.storedSessionId === storedSessionId && (cached.busy || cached.messages.length > 0)) {
+        if (
+          !authoritativeSnapshot &&
+          existing &&
+          cached?.storedSessionId === storedSessionId &&
+          (cached.busy || cached.messages.length > 0)
+        ) {
           const prefetch = await prefetchPromise
           // Deltas and completion may land while REST is in flight.
           updateSessionState(
@@ -338,17 +348,23 @@ export function useSessionTileDelegate({
           () => {
             assertSessionOwnerResolved(owner, { method: 'session.resume', sessionId: storedSessionId })
 
-            return singleFlightSessionResume(storedSessionId, () =>
-              requestForSessionProfile<SessionResumeResponse>(owner, requestGateway, 'session.resume', {
-                session_id: storedSessionId,
-                cols: 96,
-                omit_messages: true,
-                ...(owner ? { profile: typeof owner === 'string' ? owner : owner.profile } : {})
-              })
+            return singleFlightSessionResume(
+              storedSessionId,
+              () =>
+                requestForSessionProfile<SessionResumeResponse>(owner, requestGateway, 'session.resume', {
+                  session_id: storedSessionId,
+                  cols: 96,
+                  omit_messages: !authoritativeSnapshot,
+                  ...(owner ? { profile: typeof owner === 'string' ? owner : owner.profile } : {})
+                }),
+              { requiresMessages: authoritativeSnapshot }
             )
           },
           async () => {
-            const stored = (await prefetchPromise) ?? (await fetchStoredTranscriptAcrossBackends(storedSessionId))
+            const stored =
+              (await prefetchPromise) ??
+              (await getLatestSessionMessages(storedSessionId, restScope).catch(() => null)) ??
+              (await fetchStoredTranscriptAcrossBackends(storedSessionId))
 
             if (!stored) {
               throw new Error('stored transcript unavailable on every reachable backend')
@@ -395,18 +411,42 @@ export function useSessionTileDelegate({
 
         updateSessionState(
           runtimeId,
-          state => ({
-            ...state,
-            busy: Boolean(info?.running),
-            // Persist the session's own model/provider from resume so the tile
-            // pill does not wait on a chrome-scoped catalog read (#93892).
-            ...(typeof info?.model === 'string' ? { model: info.model } : {}),
-            ...(typeof info?.provider === 'string' ? { provider: info.provider } : {}),
-            ...(typeof info?.reasoning_effort === 'string' ? { reasoningEffort: info.reasoning_effort } : {}),
-            ...(typeof info?.fast === 'boolean' ? { fast: info.fast } : {}),
-            messages:
-              state.messages.length > 0 ? state.messages : toChatMessages(prefetch?.messages ?? resumed?.messages ?? [])
-          }),
+          state => {
+            const previousMessages = state.messages.length > 0 ? state.messages : (cached?.messages ?? [])
+
+            const messages = authoritativeSnapshot
+              ? resumed.messages.length > 0
+                ? mergeTileTranscript(previousMessages, resumed.messages, state.streamId ?? cached?.streamId)
+                : previousMessages
+              : previousMessages.length > 0
+                ? previousMessages
+                : toChatMessages(prefetch?.messages ?? resumed.messages ?? [])
+
+            const busyChangedWhileResuming = cached
+              ? Boolean(
+                  state.busy &&
+                    (state.turnStartedAt !== cached.turnStartedAt || (state.turnLive && !cached.turnLive))
+                )
+              : state.busy
+
+            const running = resolveResumedBusy(resumed.running ?? info?.running, busyChangedWhileResuming)
+
+            return {
+              ...state,
+              ...(typeof info?.branch === 'string' ? { branch: info.branch } : {}),
+              ...(typeof info?.cwd === 'string' ? { cwd: info.cwd } : {}),
+              ...(typeof info?.fast === 'boolean' ? { fast: info.fast } : {}),
+              ...(typeof info?.model === 'string' ? { model: info.model } : {}),
+              ...(typeof info?.personality === 'string' ? { personality: info.personality } : {}),
+              ...(typeof info?.provider === 'string' ? { provider: info.provider } : {}),
+              ...(typeof info?.reasoning_effort === 'string' ? { reasoningEffort: info.reasoning_effort } : {}),
+              ...(typeof info?.service_tier === 'string' ? { serviceTier: info.service_tier } : {}),
+              ...(typeof info?.yolo === 'boolean' ? { yolo: info.yolo } : {}),
+              awaitingResponse: running && !resumed.inflight?.assistant,
+              busy: running,
+              messages
+            }
+          },
           storedSessionId
         )
 

--- a/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-session-tile-delegate.ts
@@ -30,6 +30,7 @@ import { singleFlightSessionResume } from '../../session/hooks/use-prompt-action
 import { markSessionRecentlyInterrupted, withSessionNotFoundResume } from '../../session/hooks/use-prompt-actions/utils'
 import {
   chatMessageArraysEquivalent,
+  overlayConcurrentMessageChanges,
   preserveLocalPendingTurnMessages,
   reconcileResumeMessages,
   resolveResumedBusy,
@@ -275,6 +276,7 @@ export function useSessionTileDelegate({
           $sessionTiles.get().find(tile => tile.storedSessionId === storedSessionId)?.runtimeId
 
         const cached = existing ? sessionStateByRuntimeIdRef.current.get(existing) : undefined
+        const resumeRequestBaselineMessages = cached?.messages ?? []
         const refreshTranscript = options?.refreshTranscript === true
         const authoritativeSnapshot = options?.authoritativeSnapshot === true
 
@@ -357,7 +359,7 @@ export function useSessionTileDelegate({
                   omit_messages: !authoritativeSnapshot,
                   ...(owner ? { profile: typeof owner === 'string' ? owner : owner.profile } : {})
                 }),
-              { requiresMessages: authoritativeSnapshot }
+              { requiresMessages: authoritativeSnapshot, scope: owner }
             )
           },
           async () => {
@@ -407,16 +409,34 @@ export function useSessionTileDelegate({
           throw new Error('resume returned no session id')
         }
 
+        const currentBinding =
+          runtimeIdByStoredSessionIdRef.current.get(storedSessionId) ??
+          $sessionTiles.get().find(tile => tile.storedSessionId === storedSessionId)?.runtimeId
+
+        // Another resume/rebind won while this request was in flight. Do not
+        // publish the older response into the runtime the tile now owns.
+        if (currentBinding && currentBinding !== existing && currentBinding !== runtimeId) {
+          return currentBinding
+        }
+
         const info = resumed?.info
 
         updateSessionState(
           runtimeId,
           state => {
-            const previousMessages = state.messages.length > 0 ? state.messages : (cached?.messages ?? [])
+            const previousMessages = state.messages.length > 0 ? state.messages : resumeRequestBaselineMessages
 
             const messages = authoritativeSnapshot
               ? resumed.messages.length > 0
-                ? mergeTileTranscript(previousMessages, resumed.messages, state.streamId ?? cached?.streamId)
+                ? overlayConcurrentMessageChanges(
+                    mergeTileTranscript(
+                      resumeRequestBaselineMessages,
+                      resumed.messages,
+                      cached?.streamId
+                    ),
+                    resumeRequestBaselineMessages,
+                    previousMessages
+                  )
                 : previousMessages
               : previousMessages.length > 0
                 ? previousMessages

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/lifecycle.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/lifecycle.ts
@@ -11,7 +11,13 @@ import {
   setChangeEventsAvailable
 } from '@/store/live-sync'
 import { markRuntimeGone } from '@/store/runtime-gone'
-import { dropSessionState, unbindTileRuntime } from '@/store/session-states'
+import { getSessionOwnerHint, requestSessionResume } from '@/store/session'
+import {
+  $sessionTiles,
+  dropSessionState,
+  sessionTileDelegate,
+  unbindTileRuntime
+} from '@/store/session-states'
 // Leaf import (not the `@/themes` barrel) to avoid pulling the ThemeProvider
 // module graph into the gateway event hot path.
 import { ingestBackendSkin } from '@/themes/backend-sync'
@@ -112,6 +118,44 @@ export function handleLifecycleEvent(ctx: GatewayEventContext): boolean {
 
     // The row's ended_at moved, so refresh the lists that render it.
     notifySessionsChanged()
+
+    return true
+  }
+
+  if (event.type === 'session.replay_gap') {
+    const runtimeId = event.session_id || ''
+
+    const storedSessionId = runtimeId
+      ? deps.sessionStateByRuntimeIdRef.current.get(runtimeId)?.storedSessionId
+      : null
+
+    const eventMatchesOwner = (owner: { connectionId: string; profile: string } | undefined) =>
+      Boolean(
+        owner &&
+          event.connectionId === owner.connectionId &&
+          (event.profile?.trim() || 'default') === (owner.profile.trim() || 'default')
+      )
+
+    if (storedSessionId && runtimeId === deps.activeSessionIdRef.current) {
+      const ownerRoute = getSessionOwnerHint(storedSessionId, {
+        connectionId: event.connectionId || '',
+        profile: event.profile || 'default'
+      })
+
+      if (eventMatchesOwner(ownerRoute)) {
+        requestSessionResume(storedSessionId, ownerRoute, { authoritativeSnapshot: true })
+
+        return true
+      }
+    }
+
+    const tile = $sessionTiles
+      .get()
+      .find(candidate => candidate.runtimeId === runtimeId && eventMatchesOwner(candidate.ownerRoute))
+
+    if (tile) {
+      void sessionTileDelegate()?.resumeTile(tile.storedSessionId, { authoritativeSnapshot: true }).catch(() => undefined)
+    }
 
     return true
   }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/lifecycle.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/lifecycle.ts
@@ -11,7 +11,8 @@ import {
   setChangeEventsAvailable
 } from '@/store/live-sync'
 import { markRuntimeGone } from '@/store/runtime-gone'
-import { getSessionOwnerHint, requestSessionResume } from '@/store/session'
+import { getSessionOwnerHint, knownSessionOwner, ownerLookupSessionRows, requestSessionResume } from '@/store/session'
+import type { SessionOwnerScope } from '@/store/session-request-router'
 import {
   $sessionTiles,
   dropSessionState,
@@ -129,29 +130,49 @@ export function handleLifecycleEvent(ctx: GatewayEventContext): boolean {
       ? deps.sessionStateByRuntimeIdRef.current.get(runtimeId)?.storedSessionId
       : null
 
-    const eventMatchesOwner = (owner: { connectionId: string; profile: string } | undefined) =>
-      Boolean(
-        owner &&
-          event.connectionId === owner.connectionId &&
-          (event.profile?.trim() || 'default') === (owner.profile.trim() || 'default')
-      )
+    const eventProfile = event.profile?.trim() || 'default'
+    const eventConnectionId = event.connectionId?.trim() || ''
+
+    const eventMatchesOwner = (owner: SessionOwnerScope) => {
+      if (!owner) {
+        return false
+      }
+
+      if (typeof owner === 'string') {
+        // A profile-only owner is the legacy/local pool route. It is safe only
+        // for an untagged primary event; an explicitly tagged source must have
+        // an exact route so same-named remote profiles remain isolated.
+        return !eventConnectionId && eventProfile === (owner.trim() || 'default')
+      }
+
+      return eventConnectionId === owner.connectionId.trim() && eventProfile === (owner.profile.trim() || 'default')
+    }
+
+    const ownerForStoredSession = (id: string): SessionOwnerScope =>
+      getSessionOwnerHint(id, {
+        connectionId: eventConnectionId,
+        profile: eventProfile
+      }) ?? knownSessionOwner(ownerLookupSessionRows(), id)
 
     if (storedSessionId && runtimeId === deps.activeSessionIdRef.current) {
-      const ownerRoute = getSessionOwnerHint(storedSessionId, {
-        connectionId: event.connectionId || '',
-        profile: event.profile || 'default'
-      })
+      const ownerRoute = ownerForStoredSession(storedSessionId)
 
       if (eventMatchesOwner(ownerRoute)) {
-        requestSessionResume(storedSessionId, ownerRoute, { authoritativeSnapshot: true })
+        requestSessionResume(storedSessionId, ownerRoute && typeof ownerRoute === 'object' ? ownerRoute : undefined, {
+          authoritativeSnapshot: true
+        })
 
         return true
       }
     }
 
-    const tile = $sessionTiles
-      .get()
-      .find(candidate => candidate.runtimeId === runtimeId && eventMatchesOwner(candidate.ownerRoute))
+    const tile = $sessionTiles.get().find(candidate => {
+      if (candidate.runtimeId !== runtimeId) {
+        return false
+      }
+
+      return eventMatchesOwner(candidate.ownerRoute ?? ownerForStoredSession(candidate.storedSessionId))
+    })
 
     if (tile) {
       void sessionTileDelegate()?.resumeTile(tile.storedSessionId, { authoritativeSnapshot: true }).catch(() => undefined)

--- a/apps/desktop/src/app/session/hooks/use-message-stream/replay-gap.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/replay-gap.test.tsx
@@ -1,0 +1,143 @@
+import { act, cleanup, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/composer'
+import {
+  $sessionResumeRequest,
+  _resetSessionOwnerHintsForTests,
+  setSessionOwnerHint
+} from '@/store/session'
+import {
+  $sessionTiles,
+  sessionTileDelegate,
+  setSessionTileDelegate
+} from '@/store/session-states'
+import type { RpcEvent } from '@/types/hermes'
+
+import { renderMessageStream } from './test-harness'
+
+const replayGap = (
+  sessionId: string,
+  owner: { connectionId: string; profile: string }
+): RpcEvent => ({
+  ...owner,
+  payload: { latest_seq: 41, replay_epoch: 'epoch-next' },
+  session_id: sessionId,
+  type: 'session.replay_gap'
+}) as RpcEvent
+
+const inertDelegate = () => ({
+  archiveSession: vi.fn(async () => undefined),
+  branchSession: vi.fn(async () => undefined),
+  deleteSession: vi.fn(async () => undefined),
+  executeSlash: vi.fn(async () => undefined),
+  interruptSession: vi.fn(async () => undefined),
+  resumeTile: vi.fn(async () => 'runtime-unused'),
+  submitToSession: vi.fn(async () => undefined),
+  updateSession: vi.fn(state => state)
+})
+
+describe('session.replay_gap recovery', () => {
+  beforeEach(() => {
+    $sessionResumeRequest.set(null)
+    $sessionTiles.set([])
+    _resetSessionOwnerHintsForTests()
+    setSessionTileDelegate(inertDelegate() as never)
+  })
+
+  afterEach(() => {
+    cleanup()
+    clearSessionDraft('stored-active')
+    clearSessionDraft('stored-tile')
+    $sessionResumeRequest.set(null)
+    $sessionTiles.set([])
+    _resetSessionOwnerHintsForTests()
+  })
+
+  it('requests an authoritative resume for the affected active route without losing owner scope or its draft', () => {
+    const ownerRoute = {
+      connectionId: 'remote-a',
+      mode: 'remote' as const,
+      profile: 'desktop-profile',
+      targetProfile: 'backend-profile'
+    }
+
+    const state = createClientSessionState('stored-active')
+
+    setSessionOwnerHint('stored-active', ownerRoute)
+    stashSessionDraft('stored-active', 'keep typing', [])
+
+    const stream = renderMessageStream('runtime-active', {
+      states: new Map([['runtime-active', state]])
+    })
+
+    act(() => stream.handleEvent(replayGap('runtime-active', ownerRoute)))
+
+    expect($sessionResumeRequest.get()).toMatchObject({
+      authoritativeSnapshot: true,
+      ownerRoute,
+      sessionId: 'stored-active'
+    })
+    expect(takeSessionDraft('stored-active').text).toBe('keep typing')
+  })
+
+  it('re-resumes the affected mounted tile for a gateway snapshot while retaining its owner and draft', async () => {
+    const ownerRoute = {
+      connectionId: 'remote-b',
+      mode: 'remote' as const,
+      profile: 'tile-profile',
+      targetProfile: 'backend-tile-profile'
+    }
+
+    const resumeTile = vi.fn(async () => 'runtime-tile')
+    const delegate = { ...inertDelegate(), resumeTile }
+    const state = createClientSessionState('stored-tile')
+
+    state.messages = [{
+      id: 'pending-user',
+      parts: [{ type: 'text', text: 'local pending prompt' }],
+      pending: true,
+      role: 'user'
+    }]
+    $sessionTiles.set([{ ownerRoute, runtimeId: 'runtime-tile', storedSessionId: 'stored-tile' }] as never)
+    setSessionTileDelegate(delegate as never)
+    stashSessionDraft('stored-tile', 'unsent tile draft', [])
+
+    const stream = renderMessageStream('runtime-other', {
+      states: new Map([['runtime-tile', state]])
+    })
+
+    act(() => stream.handleEvent(replayGap('runtime-tile', ownerRoute)))
+
+    await waitFor(() =>
+      expect(resumeTile).toHaveBeenCalledWith('stored-tile', { authoritativeSnapshot: true })
+    )
+    expect($sessionTiles.get()[0]?.ownerRoute).toEqual(ownerRoute)
+    expect(takeSessionDraft('stored-tile').text).toBe('unsent tile draft')
+    expect(sessionTileDelegate()).toBe(delegate)
+  })
+
+  it('ignores a colliding runtime id delivered by a different exact owner', () => {
+    const ownerRoute = { connectionId: 'remote-a', profile: 'default' }
+    const state = createClientSessionState('stored-active')
+    const resumeTile = vi.fn(async () => 'runtime-collision')
+
+    setSessionOwnerHint('stored-active', ownerRoute)
+    $sessionTiles.set([
+      { ownerRoute, runtimeId: 'runtime-collision', storedSessionId: 'stored-tile' }
+    ] as never)
+    setSessionTileDelegate({ ...inertDelegate(), resumeTile } as never)
+
+    const stream = renderMessageStream('runtime-collision', {
+      states: new Map([['runtime-collision', state]])
+    })
+
+    act(() =>
+      stream.handleEvent(replayGap('runtime-collision', { connectionId: 'remote-b', profile: 'default' }))
+    )
+
+    expect($sessionResumeRequest.get()).toBeNull()
+    expect(resumeTile).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/replay-gap.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/replay-gap.test.tsx
@@ -6,7 +6,8 @@ import { clearSessionDraft, stashSessionDraft, takeSessionDraft } from '@/store/
 import {
   $sessionResumeRequest,
   _resetSessionOwnerHintsForTests,
-  setSessionOwnerHint
+  setSessionOwnerHint,
+  setSessions
 } from '@/store/session'
 import {
   $sessionTiles,
@@ -19,7 +20,7 @@ import { renderMessageStream } from './test-harness'
 
 const replayGap = (
   sessionId: string,
-  owner: { connectionId: string; profile: string }
+  owner: { connectionId?: string; profile?: string }
 ): RpcEvent => ({
   ...owner,
   payload: { latest_seq: 41, replay_epoch: 'epoch-next' },
@@ -42,6 +43,7 @@ describe('session.replay_gap recovery', () => {
   beforeEach(() => {
     $sessionResumeRequest.set(null)
     $sessionTiles.set([])
+    setSessions([])
     _resetSessionOwnerHintsForTests()
     setSessionTileDelegate(inertDelegate() as never)
   })
@@ -52,6 +54,7 @@ describe('session.replay_gap recovery', () => {
     clearSessionDraft('stored-tile')
     $sessionResumeRequest.set(null)
     $sessionTiles.set([])
+    setSessions([])
     _resetSessionOwnerHintsForTests()
   })
 
@@ -80,6 +83,23 @@ describe('session.replay_gap recovery', () => {
       sessionId: 'stored-active'
     })
     expect(takeSessionDraft('stored-active').text).toBe('keep typing')
+  })
+
+  it('accepts an untagged primary replay gap for its profile-only local session owner', () => {
+    setSessions([{ id: 'stored-active', profile: 'default' }] as never)
+    const state = createClientSessionState('stored-active')
+
+    const stream = renderMessageStream('runtime-active', {
+      states: new Map([['runtime-active', state]])
+    })
+
+    act(() => stream.handleEvent(replayGap('runtime-active', { profile: 'default' })))
+
+    expect($sessionResumeRequest.get()).toMatchObject({
+      authoritativeSnapshot: true,
+      sessionId: 'stored-active'
+    })
+    expect($sessionResumeRequest.get()?.ownerRoute).toBeUndefined()
   })
 
   it('re-resumes the affected mounted tile for a gateway snapshot while retaining its owner and draft', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/single-flight-resume.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/single-flight-resume.test.ts
@@ -54,6 +54,42 @@ describe('singleFlightSessionResume', () => {
     expect(requestGateway).toHaveBeenCalledTimes(2)
   })
 
+  it('does not coalesce the same stored id across backend owners', async () => {
+    let release!: () => void
+    const pending = new Promise<void>(resolve => (release = resolve))
+
+    const runA = vi.fn(async () => {
+      await pending
+
+      return { session_id: 'runtime-a' }
+    })
+
+    const runB = vi.fn(async () => {
+      await pending
+
+      return { session_id: 'runtime-b' }
+    })
+
+    const a = singleFlightSessionResume('stored-shared', runA, {
+      scope: { connectionId: 'backend-a', profile: 'default' }
+    })
+
+    const b = singleFlightSessionResume('stored-shared', runB, {
+      scope: { connectionId: 'backend-b', profile: 'default' }
+    })
+
+    await vi.waitFor(() => {
+      expect(runA).toHaveBeenCalledTimes(1)
+      expect(runB).toHaveBeenCalledTimes(1)
+    })
+    release()
+
+    await expect(Promise.all([a, b])).resolves.toEqual([
+      { session_id: 'runtime-a' },
+      { session_id: 'runtime-b' }
+    ])
+  })
+
   it('a rejected flight is not cached: the next caller retries', async () => {
     const run = vi
       .fn<() => Promise<{ session_id: string }>>()

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/single-flight-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/single-flight-resume.ts
@@ -13,19 +13,33 @@
  * `session_id`); joiners receive whatever the winning call returns.
  */
 
-const _inFlightResumeByStoredSessionId = new Map<string, Promise<unknown>>()
+interface SessionResumeFlight {
+  includesMessages: boolean
+  promise: Promise<unknown>
+}
 
-export function singleFlightSessionResume<T>(storedSessionId: string, run: () => Promise<T>): Promise<T> {
+const _inFlightResumeByStoredSessionId = new Map<string, SessionResumeFlight>()
+
+export function singleFlightSessionResume<T>(
+  storedSessionId: string,
+  run: () => Promise<T>,
+  options?: { requiresMessages?: boolean }
+): Promise<T> {
   const existing = _inFlightResumeByStoredSessionId.get(storedSessionId)
 
-  if (existing) {
-    return existing as Promise<T>
+  if (existing && (!options?.requiresMessages || existing.includesMessages)) {
+    return existing.promise as Promise<T>
   }
 
   // Promise.resolve().then(run) tolerates run() being synchronous, returning a
   // bare value, or throwing synchronously (test doubles and legacy callers do
   // all three) — a raw run().finally() would crash on a non-promise return.
-  const flight = Promise.resolve()
+  // A message-bearing caller cannot join an omitted-message flight. Queue one
+  // follow-up behind it instead: this preserves same-session ordering while
+  // still letting all later callers join the stronger queued snapshot.
+  const ready = existing ? existing.promise.then(() => undefined, () => undefined) : Promise.resolve()
+
+  const promise = ready
     .then(run)
     .finally(() => {
       if (_inFlightResumeByStoredSessionId.get(storedSessionId) === flight) {
@@ -33,9 +47,14 @@ export function singleFlightSessionResume<T>(storedSessionId: string, run: () =>
       }
     })
 
+  const flight: SessionResumeFlight = {
+    includesMessages: options?.requiresMessages === true,
+    promise
+  }
+
   _inFlightResumeByStoredSessionId.set(storedSessionId, flight)
 
-  return flight
+  return promise
 }
 
 /**

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/single-flight-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/single-flight-resume.ts
@@ -1,5 +1,7 @@
+import { type ProfileScope, profileScopeKey } from '@/api/client'
+
 /**
- * Single-flight guard for `session.resume`, keyed by STORED session id.
+ * Single-flight guard for `session.resume`, keyed by owner scope + STORED id.
  *
  * After sleep/wake or a reconnect, many independent surfaces discover the same
  * dead runtime at once — submit recovery, slash/rewind recovery, tile resumes,
@@ -23,9 +25,10 @@ const _inFlightResumeByStoredSessionId = new Map<string, SessionResumeFlight>()
 export function singleFlightSessionResume<T>(
   storedSessionId: string,
   run: () => Promise<T>,
-  options?: { requiresMessages?: boolean }
+  options?: { requiresMessages?: boolean; scope?: ProfileScope }
 ): Promise<T> {
-  const existing = _inFlightResumeByStoredSessionId.get(storedSessionId)
+  const flightKey = JSON.stringify([profileScopeKey(options?.scope), storedSessionId])
+  const existing = _inFlightResumeByStoredSessionId.get(flightKey)
 
   if (existing && (!options?.requiresMessages || existing.includesMessages)) {
     return existing.promise as Promise<T>
@@ -42,8 +45,8 @@ export function singleFlightSessionResume<T>(
   const promise = ready
     .then(run)
     .finally(() => {
-      if (_inFlightResumeByStoredSessionId.get(storedSessionId) === flight) {
-        _inFlightResumeByStoredSessionId.delete(storedSessionId)
+      if (_inFlightResumeByStoredSessionId.get(flightKey) === flight) {
+        _inFlightResumeByStoredSessionId.delete(flightKey)
       }
     })
 
@@ -52,7 +55,7 @@ export function singleFlightSessionResume<T>(
     promise
   }
 
-  _inFlightResumeByStoredSessionId.set(storedSessionId, flight)
+  _inFlightResumeByStoredSessionId.set(flightKey, flight)
 
   return promise
 }

--- a/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
@@ -21,10 +21,20 @@ interface HarnessProps {
   freshDraftReady: boolean
   gatewayState: string
   locationPathname: string
-  resumeSession: (sessionId: string, focus: boolean, ownerRoute?: SessionProfileRoute) => Promise<unknown>
+  resumeSession: (
+    sessionId: string,
+    focus: boolean,
+    ownerRoute?: SessionProfileRoute,
+    options?: { authoritativeSnapshot?: boolean }
+  ) => Promise<unknown>
   resumeFailedSessionId?: null | string
   resumeExhaustedSessionId?: null | string
-  sessionResumeRequest?: null | { ownerRoute?: SessionProfileRoute; sequence: number; sessionId: string }
+  sessionResumeRequest?: null | {
+    authoritativeSnapshot?: boolean
+    ownerRoute?: SessionProfileRoute
+    sequence: number
+    sessionId: string
+  }
   routedSessionId: null | string
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionId: null | string
@@ -138,6 +148,36 @@ describe('useRouteResume', () => {
     rerender(<RouteResumeHarness {...props} sessionResumeRequest={{ sequence: 1, sessionId: 'session-1' }} />)
 
     expect(resumeSession).toHaveBeenCalledWith('session-1', true)
+  })
+
+  it('forwards an authoritative snapshot request and its exact owner to resumeSession', () => {
+    const resumeSession = vi.fn(async () => undefined)
+    const ownerRoute = { connectionId: 'remote-a', profile: 'desktop', targetProfile: 'backend' }
+    const activeSessionIdRef = { current: 'runtime-1' }
+    const selectedStoredSessionIdRef = { current: 'session-1' }
+
+    render(
+      <RouteResumeHarness
+        activeSessionId="runtime-1"
+        activeSessionIdRef={activeSessionIdRef}
+        creatingSessionRef={{ current: false }}
+        currentView="chat"
+        freshDraftReady={false}
+        gatewayState="open"
+        locationPathname="/session-1"
+        resumeSession={resumeSession}
+        routedSessionId="session-1"
+        runtimeIdByStoredSessionIdRef={{ current: new Map([['session-1', 'runtime-1']]) }}
+        selectedStoredSessionId="session-1"
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        sessionResumeRequest={{ authoritativeSnapshot: true, ownerRoute, sequence: 1, sessionId: 'session-1' }}
+        startFreshSessionDraft={vi.fn()}
+      />
+    )
+
+    expect(resumeSession).toHaveBeenCalledWith('session-1', true, ownerRoute, {
+      authoritativeSnapshot: true
+    })
   })
 
   it('self-heals a stranded routed session (null selected/active, same pathname, not a fresh draft)', () => {

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -13,7 +13,12 @@ interface RouteResumeOptions {
   freshDraftReady: boolean
   gatewayState: string | undefined
   locationPathname: string
-  resumeSession: (sessionId: string, focus: boolean, ownerRoute?: SessionProfileRoute) => Promise<unknown>
+  resumeSession: (
+    sessionId: string,
+    focus: boolean,
+    ownerRoute?: SessionProfileRoute,
+    options?: { authoritativeSnapshot?: boolean }
+  ) => Promise<unknown>
   // Stored-session id whose most recent resume failed terminally (set by
   // useSessionActions, mirrored from $resumeFailedSessionId). While this equals
   // routedSessionId the window would otherwise latch on the loader forever, so
@@ -183,7 +188,9 @@ export function useRouteResume({
         const ownerRoute =
           sessionResumeRequest?.sessionId === routedSessionId ? sessionResumeRequest.ownerRoute : undefined
 
-        if (ownerRoute) {
+        if (explicitlyRequested && sessionResumeRequest.authoritativeSnapshot) {
+          void resumeSession(routedSessionId, true, ownerRoute, { authoritativeSnapshot: true })
+        } else if (ownerRoute) {
           void resumeSession(routedSessionId, true, ownerRoute)
         } else {
           void resumeSession(routedSessionId, true)

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -995,7 +995,12 @@ function ResumeHarness({
   onStateUpdate?: (sessionId: string, state: ClientSessionState) => void
   onViewSync?: (sessionId: string, state: ClientSessionState) => void
   onReady: (
-    resume: (storedSessionId: string, replaceRoute?: boolean, ownerRoute?: SessionProfileRoute) => Promise<unknown>
+    resume: (
+      storedSessionId: string,
+      replaceRoute?: boolean,
+      ownerRoute?: SessionProfileRoute,
+      options?: { authoritativeSnapshot?: boolean }
+    ) => Promise<unknown>
   ) => void
   requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>
   runtimeIdByStoredSessionIdRef?: MutableRefObject<Map<string, string>>
@@ -2861,6 +2866,84 @@ describe('resumeSession warm-cache mapping integrity', () => {
       expect.objectContaining({ omit_messages: true, session_id: 'rt-A' })
     )
     expect(runtimeIdByStoredSessionIdRef.current.get('stored-A')).toBe('rt-A')
+  })
+
+  it('forces a message-bearing resume over a warm cache for an authoritative replay-gap snapshot', async () => {
+    const pending = {
+      id: 'user-pending',
+      parts: [{ type: 'text' as const, text: 'local pending prompt' }],
+      pending: true,
+      role: 'user' as const
+    }
+
+    const warm = clientState('stored-A')
+    warm.messages = [
+      { id: 'old-user', parts: [{ type: 'text', text: 'old prompt' }], role: 'user' },
+      pending
+    ]
+    const runtimeIdByStoredSessionIdRef = { current: new Map([['stored-A', 'rt-A']]) }
+    const sessionStateByRuntimeIdRef = { current: new Map([['rt-A', warm]]) }
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method !== 'session.resume') {
+        throw new Error(`unexpected ${method}`)
+      }
+
+      expect(params).toMatchObject({
+        defer_history: false,
+        omit_messages: false,
+        session_id: 'stored-A'
+      })
+
+      return {
+        info: { model: 'snapshot-model', yolo: true },
+        message_count: 2,
+        messages: [
+          { content: 'new prompt', role: 'user', timestamp: 1 },
+          { content: 'new answer', role: 'assistant', timestamp: 2 }
+        ],
+        resumed: 'stored-A',
+        running: true,
+        session_id: 'rt-A'
+      } as never
+    })
+
+    setSessions([storedSession({ id: 'stored-A', message_count: 2 })])
+    setMessages(warm.messages)
+    stashSessionDraft('stored-A', 'keep typing', [])
+
+    let resume:
+      | ((
+          storedSessionId: string,
+          replaceRoute?: boolean,
+          ownerRoute?: SessionProfileRoute,
+          options?: { authoritativeSnapshot?: boolean }
+        ) => Promise<unknown>)
+      | undefined
+
+    render(
+      <ResumeHarness
+        onReady={value => (resume = value)}
+        requestGateway={requestGateway}
+        runtimeIdByStoredSessionIdRef={runtimeIdByStoredSessionIdRef}
+        selectedStoredSessionId="stored-A"
+        sessionStateByRuntimeIdRef={sessionStateByRuntimeIdRef}
+      />
+    )
+    await waitFor(() => expect(resume).toBeDefined())
+    await resume!('stored-A', true, undefined, { authoritativeSnapshot: true })
+
+    expect(requestGateway.mock.calls.map(([method]) => method)).toEqual(['session.resume'])
+    expect(getLatestSessionMessages).not.toHaveBeenCalled()
+    expect(JSON.stringify($messages.get())).toContain('new answer')
+    expect($messages.get()).toContainEqual(pending)
+    expect(sessionStateByRuntimeIdRef.current.get('rt-A')).toMatchObject({
+      busy: true,
+      model: 'snapshot-model',
+      yolo: true
+    })
+    expect(takeSessionDraft('stored-A').text).toBe('keep typing')
+    clearSessionDraft('stored-A')
   })
 
   it('re-arms a pending clarify in place on the warm session.activate path', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -885,7 +885,12 @@ export function useSessionActions({
   }, [navigate, selectedStoredSessionId])
 
   const resumeSession = useCallback(
-    async (storedSessionId: string, replaceRoute = false, capturedOwner?: SessionProfileRoute) => {
+    async (
+      storedSessionId: string,
+      replaceRoute = false,
+      capturedOwner?: SessionProfileRoute,
+      options?: { authoritativeSnapshot?: boolean }
+    ) => {
       // Delete/archive tombstones the durable id before the route flips, and
       // requestSessionResume already refuses to queue for a doomed id. This is
       // the actuator-side half of the same rule: a resume that was queued
@@ -1066,7 +1071,7 @@ export function useSessionActions({
       // purges a cross-wired mapping before we trust the fast-path.
       const warmHit = takeWarmCache()
 
-      if (warmHit) {
+      if (warmHit && !options?.authoritativeSnapshot) {
         const cachedRuntimeId = warmHit.runtimeId
         const cachedState = warmHit.state
 
@@ -1563,27 +1568,37 @@ export function useSessionActions({
         // max(prefetch, resume) instead of their sum. The prefetch paints the
         // transcript as soon as it lands; the RPC binds the runtime id.
         // Watch windows skip the prefetch — lazy resume attaches the live mirror.
-        const prefetchPromise = watchWindow ? null : getLatestSessionMessages(storedSessionId, sessionRestScope)
+        const prefetchPromise =
+          watchWindow || options?.authoritativeSnapshot
+            ? null
+            : getLatestSessionMessages(storedSessionId, sessionRestScope)
 
         let resumeRuntimeBaselineMessages: ChatMessage[] = []
         const resumeStartedAt = Date.now() / 1000
 
-        const resumePromise = singleFlightSessionResume(storedSessionId, () =>
-          requestForSession<SessionResumeResponse>('session.resume', {
-            session_id: storedSessionId,
-            cols: 96,
-            source: 'desktop',
-            defer_history: !watchWindow,
-            // REST is the transcript authority for Desktop. Avoid duplicating a
-            // potentially huge compression lineage in the WebSocket response.
-            // Watch windows attach lazily (live mirror). Every other cold resume
-            // gets the gateway's default deferred build: the RPC returns the
-            // transcript immediately instead of blocking the switch on _make_agent
-            // (MCP discovery / prompt build), and the agent pre-warms in the
-            // background while the prefetch above paints the transcript.
-            ...(watchWindow ? { lazy: true } : { omit_messages: true }),
-            ...(sessionProfile ? { profile: sessionProfile } : {})
-          })
+        const resumePromise = singleFlightSessionResume(
+          storedSessionId,
+          () =>
+            requestForSession<SessionResumeResponse>('session.resume', {
+              session_id: storedSessionId,
+              cols: 96,
+              source: 'desktop',
+              defer_history: options?.authoritativeSnapshot ? false : !watchWindow,
+              // REST is the transcript authority for Desktop. Avoid duplicating a
+              // potentially huge compression lineage in the WebSocket response.
+              // Watch windows attach lazily (live mirror). Every other cold resume
+              // gets the gateway's default deferred build: the RPC returns the
+              // transcript immediately instead of blocking the switch on _make_agent
+              // (MCP discovery / prompt build), and the agent pre-warms in the
+              // background while the prefetch above paints the transcript.
+              ...(options?.authoritativeSnapshot
+                ? { omit_messages: false }
+                : watchWindow
+                  ? { lazy: true }
+                  : { omit_messages: true }),
+              ...(sessionProfile ? { profile: sessionProfile } : {})
+            }),
+          { requiresMessages: options?.authoritativeSnapshot }
         ).then(resumed => {
           resumeRuntimeBaselineMessages =
             sessionStateByRuntimeIdRef.current.get(resumed.session_id)?.messages ?? resumeRuntimeBaselineMessages
@@ -1655,6 +1670,10 @@ export function useSessionActions({
         const hasLiveProjection = Boolean(resumed.inflight || resumed.queued)
 
         const preferredMessages = (() => {
+          if (options?.authoritativeSnapshot && resumed.messages.length === 0 && !hasLiveProjection) {
+            return currentMessages
+          }
+
           if (prefetchApplied && prefetchMatchesResumedSession) {
             if (hasLiveProjection && prefetchedTranscriptMessages) {
               const runtimeMessages = toChatMessages(resumed.messages)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -1598,7 +1598,7 @@ export function useSessionActions({
                   : { omit_messages: true }),
               ...(sessionProfile ? { profile: sessionProfile } : {})
             }),
-          { requiresMessages: options?.authoritativeSnapshot }
+          { requiresMessages: options?.authoritativeSnapshot, scope: sessionOwner }
         ).then(resumed => {
           resumeRuntimeBaselineMessages =
             sessionStateByRuntimeIdRef.current.get(resumed.session_id)?.messages ?? resumeRuntimeBaselineMessages

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1347,8 +1347,12 @@ export interface SessionTileDelegate {
    *  the main view). Returns the runtime id, or throws.
    *  `refreshTranscript` forces a REST merge even when a warm cached
    *  transcript already exists — reopen-after-idle must not paint the
-   *  snapshot that was current when the panel last had a socket. */
-  resumeTile(storedSessionId: string, options?: { refreshTranscript?: boolean }): Promise<string>
+   *  snapshot that was current when the panel last had a socket.
+   *  `authoritativeSnapshot` forces a message-bearing gateway resume. */
+  resumeTile(
+    storedSessionId: string,
+    options?: { authoritativeSnapshot?: boolean; refreshTranscript?: boolean }
+  ): Promise<string>
   /** Retire one runtime's busy/awaiting claim through the wiring cache
    *  (updateSessionState), so cache, focused view, busyRef, and tile mirrors
    *  settle together. Returns false when the cache holds no busy state for

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -871,6 +871,7 @@ export const $awaitingResponse = atom(false)
 // Null whenever the active route has a healthy (or in-flight) resume.
 export const $resumeFailedSessionId = atom<string | null>(null)
 export interface SessionResumeRequest {
+  authoritativeSnapshot?: boolean
   ownerRoute?: SessionOwnerRoute
   sequence: number
   sessionId: string
@@ -1287,7 +1288,11 @@ export const setMessages = (next: Updater<ChatMessage[]>) => updateAtom($message
 export const setFreshDraftReady = (next: Updater<boolean>) => updateAtom($freshDraftReady, next)
 export const setResumeFailedSessionId = (next: Updater<string | null>) => updateAtom($resumeFailedSessionId, next)
 
-export const requestSessionResume = (sessionId: string, ownerRoute?: SessionOwnerRoute) => {
+export const requestSessionResume = (
+  sessionId: string,
+  ownerRoute?: SessionOwnerRoute,
+  options?: { authoritativeSnapshot?: boolean }
+) => {
   const id = sessionId.trim()
 
   if (!id) {
@@ -1309,6 +1314,7 @@ export const requestSessionResume = (sessionId: string, ownerRoute?: SessionOwne
   }
 
   $sessionResumeRequest.set({
+    ...(options?.authoritativeSnapshot ? { authoritativeSnapshot: true } : {}),
     ...(ownerRoute ? { ownerRoute: { ...ownerRoute } } : {}),
     sequence: ++sessionResumeRequestSequence,
     sessionId: id


### PR DESCRIPTION
## Why
Follow-up to #106742, targeting `feat/unified-gateway-runtime`, not `main`. Implements the maintainer-requested consumer for `session.replay_gap` added on top of #108838.

The shared client now reports invalid replay windows, but Desktop did not consume that event. Reconnecting alone is not enough when a gap arrives after the connection opens.

## Change
- Re-resume the affected active route or mounted tile using its existing owner-scoped path.
- Force a message-bearing authoritative snapshot rather than warm activation or a REST-only refresh.
- Preserve drafts, pending input, foreground selection, and unrelated sessions.
- Serialize authoritative refresh behind an existing weaker resume, so an omit-messages response cannot masquerade as a complete snapshot.

No shared protocol changes or new recovery manager. Scope is active routes and mounted tiles, not a new unmounted-background replay system.

## Verification
Rebased to gateway head `9c2f624c7bf1279c1edcff846ef00e6e9b83e56a` before publication. Independently reran 142 Desktop tests across five files and all three Desktop TypeScript projects: passed. Behavioral RED/GREEN covers event routing, actual warm-path bypass, snapshot application, owner isolation, draft preservation, and single-flight races. Targeted lint and whitespace checks passed. Independent review found no remaining blockers.

No live Electron/cross-host E2E certification is claimed. This is independent of the detach and webhook fixes.
