### PR TITLE
fix(gateway): detach canonical subscriptions without stopping sessions

### DIFF
--- a/gateway/session_controls.py
+++ b/gateway/session_controls.py
@@ -39,6 +39,9 @@ class AuthorityConnection:
         rid = request.get('id')
         method = request.get('method')
         params = request.get('params') or {}
+        if method == 'session.detach' and not isinstance(params, dict):
+            return {'jsonrpc': '2.0', 'id': rid, 'error': {
+                'code': 4001, 'message': 'invalid_params', 'data': {'reason': 'invalid_params'}}}
         ref = SessionRef(self.actor.profile_id, params.get('session_id', ''))
         handlers = {'session.create': self.create, 'ping': self.ping, 'runtime.describe': self.describe,
                     'commands.catalog': self.command_catalog, 'complete.slash': self.slash_completions,
@@ -53,7 +56,8 @@ class AuthorityConnection:
                     'worker.register': self.worker_register, 'worker.adopt': self.worker_adopt,
                     'worker.persist': self.worker_persist,
                     'setup.status': self.setup_status, 'setup.runtime_check': self.setup_runtime_check,
-                    'session.resume': self.resume, 'prompt.submit': self.submit,
+                    'session.resume': self.resume, 'session.detach': self.detach,
+                    'prompt.submit': self.submit,
                     'prompt.receipt': self.receipt, 'prompt.cancel': self.cancel,
                     'prompt.resolve_unknown': self.resolve_unknown,
                     'session.interrupt': self.interrupt, 'session.events.since': self.events_since,
@@ -255,6 +259,24 @@ class AuthorityConnection:
                 'execution_generation': snapshot.handle.execution_generation,
                 'pending': [asdict(r) for r in snapshot.pending],
                 'prompts': list(snapshot.prompts), 'info': info}
+
+    async def detach(self, ref, params):
+        if set(params) != {'session_id', 'subscription_id'}:
+            raise RuntimeStoreError('invalid_params')
+        session_id = params['session_id']
+        subscription_id = params['subscription_id']
+        if (not isinstance(session_id, str) or not session_id
+                or not isinstance(subscription_id, str) or not subscription_id):
+            raise RuntimeStoreError('invalid_params')
+        result = {'session_id': session_id, 'subscription_id': subscription_id,
+                  'detached': False}
+        if self.subscriptions.get(session_id) != subscription_id:
+            return result
+        await self.authority.detach(self.actor, subscription_id)
+        if self.subscriptions.get(session_id) == subscription_id:
+            del self.subscriptions[session_id]
+        result['detached'] = True
+        return result
 
     async def events_since(self, ref, params):
         self.authority.authorize(self.actor, ref, 'session:read')

--- a/tests/gateway/test_authority_connection.py
+++ b/tests/gateway/test_authority_connection.py
@@ -1,4 +1,5 @@
 """Connection membership against the real authority and temporary SQLite."""
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -70,4 +71,134 @@ async def test_close_after_a_subscribed_session_was_deleted_releases_every_membe
         assert not viewer.subscriptions
         assert viewer.actor.transport_id not in authority.events
     finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_detach_releases_only_the_paired_subscription_without_stopping_execution(tmp_path):
+    db = SessionDB(db_path=tmp_path / 'state.db')
+    running = None
+    viewer = observer = None
+    try:
+        for sid in ('a', 'b'):
+            db.create_session(sid, source='test')
+        epoch = begin_runtime_epoch(db, instance_id='test')
+        authority = SessionAuthority(SimpleNamespace(), profile_id='test',
+                                     instance_id='test', db=db, epoch=epoch)
+        for sid in ('a', 'b'):
+            authority.sessions[sid] = LiveSession(None, sid + '-route')
+        running = asyncio.create_task(asyncio.Event().wait())
+        authority.sessions['a'].task = running
+        viewer = AuthorityConnection(authority, object(), {
+            'user_id': 'human', 'capabilities': ['session:read']})
+        observer = AuthorityConnection(authority, object(), {
+            'user_id': 'peer', 'capabilities': ['session:read']})
+
+        a = (await viewer.dispatch({'id': 1, 'method': 'session.resume',
+                                    'params': {'session_id': 'a'}}))['result']
+        peer_a = (await observer.dispatch({'id': 1, 'method': 'session.resume',
+                                           'params': {'session_id': 'a'}}))['result']
+        b = (await viewer.dispatch({'id': 2, 'method': 'session.resume',
+                                    'params': {'session_id': 'b'}}))['result']
+        request = {'id': 3, 'method': 'session.detach', 'params': {
+            'session_id': 'a', 'subscription_id': a['subscription_id']}}
+
+        detached = await viewer.dispatch(request)
+
+        assert detached['result'] == {
+            'session_id': 'a', 'subscription_id': a['subscription_id'], 'detached': True}
+        assert authority.sessions['a'].task is running and not running.done()
+        assert list(authority.sessions['a'].subscribers) == [peer_a['subscription_id']]
+        assert list(authority.sessions['b'].subscribers) == [b['subscription_id']]
+        assert viewer.subscriptions == {'b': b['subscription_id']}
+
+        duplicate = await viewer.dispatch(request)
+        stale_pair = await viewer.dispatch({'id': 4, 'method': 'session.detach', 'params': {
+            'session_id': 'b', 'subscription_id': a['subscription_id']}})
+        caller_mismatch = await viewer.dispatch({'id': 5, 'method': 'session.detach', 'params': {
+            'session_id': 'a', 'subscription_id': peer_a['subscription_id']}})
+        assert duplicate['result'] == {
+            'session_id': 'a', 'subscription_id': a['subscription_id'], 'detached': False}
+        assert stale_pair['result'] == {
+            'session_id': 'b', 'subscription_id': a['subscription_id'], 'detached': False}
+        assert caller_mismatch['result'] == {
+            'session_id': 'a', 'subscription_id': peer_a['subscription_id'], 'detached': False}
+        assert list(authority.sessions['a'].subscribers) == [peer_a['subscription_id']]
+        assert list(authority.sessions['b'].subscribers) == [b['subscription_id']]
+    finally:
+        if viewer is not None:
+            await viewer.close()
+        if observer is not None:
+            await observer.close()
+        if running is not None:
+            running.cancel()
+            await asyncio.gather(running, return_exceptions=True)
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_detach_rejects_malformed_params_through_dispatcher(tmp_path):
+    db = SessionDB(db_path=tmp_path / 'state.db')
+    viewer = None
+    try:
+        db.create_session('s', source='test')
+        epoch = begin_runtime_epoch(db, instance_id='test')
+        authority = SessionAuthority(SimpleNamespace(), profile_id='test',
+                                     instance_id='test', db=db, epoch=epoch)
+        authority.sessions['s'] = LiveSession(None, 'route')
+        viewer = AuthorityConnection(authority, object(), {'user_id': 'human'})
+
+        malformed = [
+            ['unexpected'],
+            'unexpected',
+            1,
+            {},
+            {'session_id': 's'},
+            {'session_id': '', 'subscription_id': 'token'},
+            {'session_id': 's', 'subscription_id': ''},
+            {'session_id': 1, 'subscription_id': 'token'},
+            {'session_id': 's', 'subscription_id': 1},
+            {'session_id': 's', 'subscription_id': 'token', 'extra': True},
+        ]
+        for index, params in enumerate(malformed):
+            reply = await viewer.dispatch({
+                'id': index, 'method': 'session.detach', 'params': params})
+            assert reply['error']['data']['reason'] == 'invalid_params', reply
+    finally:
+        if viewer is not None:
+            await viewer.close()
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_stale_same_session_token_cannot_detach_newer_subscription(tmp_path):
+    db = SessionDB(db_path=tmp_path / 'state.db')
+    viewer = None
+    try:
+        db.create_session('s', source='test')
+        epoch = begin_runtime_epoch(db, instance_id='test')
+        authority = SessionAuthority(SimpleNamespace(), profile_id='test',
+                                     instance_id='test', db=db, epoch=epoch)
+        authority.sessions['s'] = LiveSession(None, 'route')
+        viewer = AuthorityConnection(authority, object(), {'user_id': 'human'})
+
+        first = (await viewer.dispatch({'id': 1, 'method': 'session.resume',
+                                        'params': {'session_id': 's'}}))['result']
+        # Model an already-retired attachment before the same connection resumes S.
+        await authority.detach(viewer.actor, first['subscription_id'])
+        second = (await viewer.dispatch({'id': 2, 'method': 'session.resume',
+                                         'params': {'session_id': 's'}}))['result']
+        assert second['subscription_id'] != first['subscription_id']
+
+        stale = await viewer.dispatch({'id': 3, 'method': 'session.detach', 'params': {
+            'session_id': 's', 'subscription_id': first['subscription_id']}})
+        duplicate_stale = await viewer.dispatch({'id': 4, 'method': 'session.detach', 'params': {
+            'session_id': 's', 'subscription_id': first['subscription_id']}})
+        assert stale['result']['detached'] is False
+        assert duplicate_stale['result']['detached'] is False
+        assert viewer.subscriptions == {'s': second['subscription_id']}
+        assert list(authority.sessions['s'].subscribers) == [second['subscription_id']]
+    finally:
+        if viewer is not None:
+            await viewer.close()
         db.close()

--- a/ui-tui/src/__tests__/resumeEpochRenderer.test.tsx
+++ b/ui-tui/src/__tests__/resumeEpochRenderer.test.tsx
@@ -110,3 +110,189 @@ it('resumes a successor with a reset epoch while retaining original attempted ad
     rmSync(home, { recursive: true, force: true })
   }
 })
+
+it('detaches the prior canonical subscription only after the replacement attaches', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'ink-session-detach-'))
+  vi.stubEnv('HERMES_HOME', home)
+  resetUiState()
+  const pending: Array<{ method: string; params: any; resolve: (value: any) => void }> = []
+
+  const request = vi.fn((method: string, params: any) =>
+    new Promise(resolve => pending.push({ method, params, resolve })))
+
+  let lifecycle!: ReturnType<typeof useSessionLifecycle>
+
+  function Harness() {
+    lifecycle = useSessionLifecycle({ colsRef: { current: 80 }, composerActions: { setComposerTokens: vi.fn() },
+      gw: { isCanonical: true, request }, rpc: request, scrollRef: { current: null }, panel: vi.fn(), sys: vi.fn(),
+      setHistoryItems: vi.fn(), setLastUserMsg: vi.fn(), setSessionStartedAt: vi.fn(), setStickyPrompt: vi.fn(),
+      setVoiceProcessing: vi.fn(), setVoiceRecording: vi.fn() } as any)
+
+    return <Text>detach</Text>
+  }
+
+  const instance = renderSync(<Harness />, { stdin: new PassThrough() as any,
+    stdout: Object.assign(new PassThrough(), { columns: 80, rows: 20, isTTY: false }) as any,
+    stderr: new PassThrough() as any, patchConsole: false })
+
+  const result = (sid: string, subscriptionId: string) => ({
+    session_id: sid, subscription_id: subscriptionId, messages: [], running: false,
+    info: { model: 'test', tools: {}, skills: {}, stored_session_id: sid,
+      execution_epoch: sid, execution_generation: 0 }
+  })
+
+  try {
+    lifecycle.resumeById('a')
+    await vi.waitFor(() => expect(pending).toHaveLength(1))
+    pending.shift()!.resolve(result('a', 'sub-a'))
+    await vi.waitFor(() => expect(getUiState().sid).toBe('a'))
+
+    lifecycle.resumeById('b')
+    await vi.waitFor(() => expect(pending).toHaveLength(1))
+    expect(pending).toMatchObject([{ method: 'session.resume', params: { session_id: 'b' } }])
+    expect(request).not.toHaveBeenCalledWith('session.detach', expect.anything())
+
+    pending.shift()!.resolve(result('b', 'sub-b'))
+    await vi.waitFor(() => expect(getUiState().sid).toBe('b'))
+    expect(request).toHaveBeenCalledWith('session.detach', {
+      session_id: 'a', subscription_id: 'sub-a'
+    })
+    pending.find(call => call.method === 'session.detach')!.resolve({
+      session_id: 'a', subscription_id: 'sub-a', detached: true
+    })
+    pending.splice(pending.findIndex(call => call.method === 'session.detach'), 1)
+    await new Promise(resolve => setImmediate(resolve))
+
+    // A newer switch may win before an older response arrives. Adopt D first,
+    // then release C's stale reply and clean up exactly C's returned token.
+    lifecycle.resumeById('c')
+    await vi.waitFor(() => expect(pending.some(call => call.params.session_id === 'c')).toBe(true))
+    lifecycle.resumeById('d')
+    await vi.waitFor(() => expect(pending.filter(call => call.method === 'session.resume')).toHaveLength(2))
+    const cResume = pending.find(call => call.params.session_id === 'c')!
+    const dResume = pending.find(call => call.params.session_id === 'd')!
+    pending.splice(pending.indexOf(dResume), 1)
+    dResume.resolve(result('d', 'sub-d'))
+    await vi.waitFor(() => expect(getUiState().sid).toBe('d'))
+    pending.splice(pending.indexOf(cResume), 1)
+    cResume.resolve(result('c', 'sub-c-stale'))
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith('session.detach', {
+      session_id: 'c', subscription_id: 'sub-c-stale'
+    }))
+
+    // Repeated same-session replies can return the same current token. A stale
+    // duplicate must never detach the token adopted by the newer flight.
+    pending.splice(0, pending.length)
+    lifecycle.resumeById('d')
+    await vi.waitFor(() => expect(pending).toHaveLength(1))
+    lifecycle.resumeById('d')
+    await vi.waitFor(() => expect(pending).toHaveLength(2))
+    const staleD = pending.shift()!
+    const currentD = pending.shift()!
+    currentD.resolve(result('d', 'sub-d-new'))
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith('session.detach', {
+      session_id: 'd', subscription_id: 'sub-d'
+    }))
+    staleD.resolve(result('d', 'sub-d-new'))
+    await new Promise(resolve => setImmediate(resolve))
+    expect(request).not.toHaveBeenCalledWith('session.detach', {
+      session_id: 'd', subscription_id: 'sub-d-new'
+    })
+  } finally {
+    instance.unmount()
+    resetUiState()
+    vi.unstubAllEnvs()
+    rmSync(home, { recursive: true, force: true })
+  }
+})
+
+it('waits for a delayed detach before reattaching the same canonical session', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'ink-session-switchback-'))
+  vi.stubEnv('HERMES_HOME', home)
+  resetUiState()
+  const subscriptions = new Map<string, string>()
+  const delivered: string[] = []
+  let nextSubscription = 0
+  let releaseFirstADetach: undefined | (() => void)
+
+  const result = (sid: string, subscriptionId: string) => ({
+    session_id: sid, subscription_id: subscriptionId, messages: [], running: false,
+    info: { model: 'test', tools: {}, skills: {}, stored_session_id: sid,
+      execution_epoch: sid, execution_generation: 0 }
+  })
+  const request = vi.fn((method: string, params: any) => {
+    if (method === 'session.resume') {
+      // Match SessionAuthority.attach: the actor's existing token is reused
+      // until its detach has actually reached the server.
+      const subscriptionId = subscriptions.get(params.session_id)
+        ?? `sub-${params.session_id}-${++nextSubscription}`
+      subscriptions.set(params.session_id, subscriptionId)
+
+      return Promise.resolve(result(params.session_id, subscriptionId))
+    }
+
+    if (method === 'session.detach') {
+      const detach = () => {
+        if (subscriptions.get(params.session_id) === params.subscription_id) {
+          subscriptions.delete(params.session_id)
+        }
+      }
+      if (params.session_id === 'a' && !releaseFirstADetach) {
+        return new Promise(resolve => {
+          releaseFirstADetach = () => {
+            detach()
+            resolve({ ...params, detached: true })
+          }
+        })
+      }
+      detach()
+
+      return Promise.resolve({ ...params, detached: true })
+    }
+
+    return Promise.resolve(null)
+  })
+  const emit = (sessionId: string, text: string) => {
+    if (subscriptions.has(sessionId)) {delivered.push(text)}
+  }
+  let lifecycle!: ReturnType<typeof useSessionLifecycle>
+
+  function Harness() {
+    lifecycle = useSessionLifecycle({ colsRef: { current: 80 }, composerActions: { setComposerTokens: vi.fn() },
+      gw: { isCanonical: true, request }, rpc: request, scrollRef: { current: null }, panel: vi.fn(), sys: vi.fn(),
+      setHistoryItems: vi.fn(), setLastUserMsg: vi.fn(), setSessionStartedAt: vi.fn(), setStickyPrompt: vi.fn(),
+      setVoiceProcessing: vi.fn(), setVoiceRecording: vi.fn() } as any)
+
+    return <Text>switchback</Text>
+  }
+
+  const instance = renderSync(<Harness />, { stdin: new PassThrough() as any,
+    stdout: Object.assign(new PassThrough(), { columns: 80, rows: 20, isTTY: false }) as any,
+    stderr: new PassThrough() as any, patchConsole: false })
+
+  try {
+    lifecycle.resumeById('a')
+    await vi.waitFor(() => expect(getUiState().sid).toBe('a'))
+    lifecycle.resumeById('b')
+    await vi.waitFor(() => expect(getUiState().sid).toBe('b'))
+    await vi.waitFor(() => expect(releaseFirstADetach).toBeTypeOf('function'))
+
+    lifecycle.resumeById('a')
+    await new Promise(resolve => setImmediate(resolve))
+    expect(request.mock.calls.filter(
+      ([method, params]) => method === 'session.resume' && params.session_id === 'a')).toHaveLength(1)
+    releaseFirstADetach!()
+    await vi.waitFor(() => expect(request.mock.calls.filter(
+      ([method, params]) => method === 'session.resume' && params.session_id === 'a')).toHaveLength(2))
+    await vi.waitFor(() => expect(getUiState().sid).toBe('a'))
+
+    emit('a', 'after switchback')
+    expect(subscriptions.has('a')).toBe(true)
+    expect(delivered).toEqual(['after switchback'])
+  } finally {
+    instance.unmount()
+    resetUiState()
+    vi.unstubAllEnvs()
+    rmSync(home, { recursive: true, force: true })
+  }
+})

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -14,6 +14,7 @@ import type {
   SessionActivateResponse,
   SessionCloseResponse,
   SessionCreateResponse,
+  SessionDetachResponse,
   SessionInflightTurn,
   SessionResumeResponse,
   SessionTitleResponse,
@@ -141,11 +142,62 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
   const closeSession = useCallback(
     (targetSid?: null | string) =>
       targetSid && !gw.isCanonical ? rpc<SessionCloseResponse>('session.close', { session_id: targetSid }) : Promise.resolve(null),
-    [rpc]
+    [gw.isCanonical, rpc]
   )
 
   const cancelResumeScrollRef = useRef<null | (() => void)>(null)
   const attachmentFlight = useRef(0)
+  const canonicalSubscriptions = useRef(new Map<string, string>())
+  const canonicalDetachFlights = useRef(new Map<string, Promise<void>>())
+
+  const detachCanonical = useCallback((sessionId?: null | string, subscriptionId?: null | string) => {
+    if (!gw.isCanonical || !sessionId || !subscriptionId) {
+      return
+    }
+
+    const detach = () => rpc<SessionDetachResponse>('session.detach', {
+      session_id: sessionId,
+      subscription_id: subscriptionId
+    }).then(result => {
+      if (result?.detached && canonicalSubscriptions.current.get(sessionId) === subscriptionId) {
+        canonicalSubscriptions.current.delete(sessionId)
+      }
+    }).catch(() => undefined)
+    const previous = canonicalDetachFlights.current.get(sessionId)
+    const pending = previous ? previous.then(detach) : detach()
+
+    canonicalDetachFlights.current.set(sessionId, pending)
+    void pending.then(() => {
+      if (canonicalDetachFlights.current.get(sessionId) === pending) {
+        canonicalDetachFlights.current.delete(sessionId)
+      }
+    })
+  }, [gw.isCanonical, rpc])
+
+  const discardStaleAttachment = useCallback((result?: null | { session_id: string; subscription_id?: string }) => {
+    const subscriptionId = result?.subscription_id
+
+    if (result && subscriptionId && canonicalSubscriptions.current.get(result.session_id) !== subscriptionId) {
+      detachCanonical(result.session_id, subscriptionId)
+    }
+  }, [detachCanonical])
+
+  const adoptAttachment = useCallback((
+    result: { session_id: string; subscription_id?: string },
+    previousSid?: null | string,
+    previousSubscription?: null | string
+  ) => {
+    if (!gw.isCanonical || !result.subscription_id) {
+      return
+    }
+
+    canonicalSubscriptions.current.set(result.session_id, result.subscription_id)
+
+    if (previousSid && previousSubscription
+        && (previousSid !== result.session_id || previousSubscription !== result.subscription_id)) {
+      detachCanonical(previousSid, previousSubscription)
+    }
+  }, [detachCanonical, gw.isCanonical])
 
   const resetSession = useCallback(() => {
     cancelResumeScrollRef.current?.()
@@ -193,6 +245,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
     async (msg?: string, title?: string, keepCurrent = false) => {
       const flight = ++attachmentFlight.current
       const previousSid = getUiState().sid
+      const previousSubscription = previousSid ? canonicalSubscriptions.current.get(previousSid) : undefined
       const setup = gw.isCanonical ? null : await rpc<SetupStatusResponse>('setup.status', {})
 
       if (flight !== attachmentFlight.current) {return null}
@@ -213,7 +266,11 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
       const r = await rpc<SessionCreateResponse>('session.create', gw.isCanonical
         ? { request_id: randomUUID(), ...localCreationOptions() } : { cols: colsRef.current })
 
-      if (flight !== attachmentFlight.current) {return null}
+      if (flight !== attachmentFlight.current) {
+        discardStaleAttachment(r)
+
+        return null
+      }
 
       if (!r) {
         patchUiState({ status: 'ready' })
@@ -277,10 +334,12 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
       }
 
       signalFreshSessionBoundary(previousSid, r.session_id, onFreshSessionStarted)
+      adoptAttachment(r, previousSid, previousSubscription)
 
       return r.session_id
     },
-    [closeSession, colsRef, onFreshSessionStarted, panel, resetSession, rpc, setHistoryItems, setSessionStartedAt, sys]
+    [adoptAttachment, closeSession, colsRef, discardStaleAttachment, gw.isCanonical, onFreshSessionStarted, panel,
+      resetSession, rpc, setHistoryItems, setSessionStartedAt, sys]
   )
 
   const newSession = useCallback(
@@ -300,13 +359,26 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
   const activateLiveSession = useCallback(
     (id: string) => {
       const flight = ++attachmentFlight.current
+      const previousSid = getUiState().sid
+      const previousSubscription = previousSid ? canonicalSubscriptions.current.get(previousSid) : undefined
       patchOverlayState({ sessions: false })
       patchUiState({ status: 'switching session…' })
 
-      gw.request<SessionActivateResponse>('session.activate', { session_id: id })
+      const pendingDetach = canonicalDetachFlights.current.get(id)
+      const request = pendingDetach
+        ? pendingDetach.then(() => flight === attachmentFlight.current
+          ? gw.request<SessionActivateResponse>('session.activate', { session_id: id }) : null)
+        : gw.request<SessionActivateResponse>('session.activate', { session_id: id })
+
+      request
         .then(raw => {
-          if (flight !== attachmentFlight.current) {return}
           const r = asRpcResult<SessionActivateResponse>(raw)
+
+          if (flight !== attachmentFlight.current) {
+            discardStaleAttachment(r)
+
+            return
+          }
 
           if (!r) {
             sys('error: invalid response: session.activate')
@@ -334,6 +406,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
           hydrateLiveSessionInflight(r.inflight)
           cancelResumeScrollRef.current?.()
           cancelResumeScrollRef.current = scheduleResumeScrollToBottom(scrollRef)
+          adoptAttachment(r, previousSid, previousSubscription)
         })
         .catch((e: Error) => {
           if (flight !== attachmentFlight.current) {return}
@@ -341,7 +414,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
           patchUiState({ status: 'ready' })
         })
     },
-    [gw, resetSession, scrollRef, setHistoryItems, setSessionStartedAt, sys]
+    [adoptAttachment, discardStaleAttachment, gw, resetSession, scrollRef, setHistoryItems, setSessionStartedAt, sys]
   )
 
   const resumeById = useCallback(
@@ -349,6 +422,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
       const flight = ++attachmentFlight.current
       const current = captureDestination()
       const previousSid = current.sid
+      const previousSubscription = previousSid ? canonicalSubscriptions.current.get(previousSid) : undefined
 
       const destination = current.sid === id || current.storedSid === id
         ? current : { ...current, sid: id, storedSid: id }
@@ -366,10 +440,21 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
           return
         }
 
-        gw.request<SessionResumeResponse>('session.resume', { cols: colsRef.current, session_id: id })
+        const pendingDetach = canonicalDetachFlights.current.get(id)
+        const request = pendingDetach
+          ? pendingDetach.then(() => flight === attachmentFlight.current
+            ? gw.request<SessionResumeResponse>('session.resume', { cols: colsRef.current, session_id: id }) : null)
+          : gw.request<SessionResumeResponse>('session.resume', { cols: colsRef.current, session_id: id })
+
+        request
           .then(raw => {
-            if (flight !== attachmentFlight.current) {return}
             const r = asRpcResult<SessionResumeResponse>(raw)
+
+            if (flight !== attachmentFlight.current) {
+              discardStaleAttachment(r)
+
+              return
+            }
 
             if (!r) {
               sys('error: invalid response: session.resume')
@@ -408,6 +493,8 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
             if (previousSid && previousSid !== r.session_id) {
               void closeSession(previousSid)
             }
+
+            adoptAttachment(r, previousSid, previousSubscription)
           })
           .catch((e: Error) => {
             if (flight !== attachmentFlight.current) {return}
@@ -416,7 +503,8 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
           })
       })
     },
-    [closeSession, colsRef, gw, panel, resetSession, rpc, scrollRef, setHistoryItems, setSessionStartedAt, sys]
+    [adoptAttachment, closeSession, colsRef, discardStaleAttachment, gw, panel, resetSession, rpc, scrollRef,
+      setHistoryItems, setSessionStartedAt, sys]
   )
 
   const guardBusySessionSwitch = useCallback(
@@ -452,8 +540,7 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
       newSession,
       resetSession,
       resetVisibleHistory,
-      resumeById,
-      trimTail
+      resumeById
     ]
   )
 }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -185,6 +185,7 @@ export interface SessionCreateResponse {
   stored_session_id?: string
   info?: SessionInfo & { config_warning?: string; credential_warning?: string }
   session_id: string
+  subscription_id?: string
 }
 
 export interface SessionResumeResponse {
@@ -199,6 +200,7 @@ export interface SessionResumeResponse {
   session_id: string
   started_at?: number
   status?: LiveSessionStatus
+  subscription_id?: string
 }
 
 export type LiveSessionStatus = 'idle' | 'starting' | 'waiting' | 'working'
@@ -237,6 +239,13 @@ export interface SessionActivateResponse {
   session_key?: string
   started_at?: number
   status?: LiveSessionStatus
+  subscription_id?: string
+}
+
+export interface SessionDetachResponse {
+  detached: boolean
+  session_id: string
+  subscription_id: string
 }
 
 export interface SessionListItem {


### PR DESCRIPTION
## Why
Follow-up to #106742, targeting `feat/unified-gateway-runtime`, not `main`.

The authority already supports subscription detach, but clients could only release all subscriptions by closing the socket. Ink session switches retained obsolete subscriptions. A client should be able to leave one conversation without stopping its execution or losing its other attachments.

## Change
- Expose `session.detach` with an exact connection-local `session_id` / `subscription_id` pair.
- Malformed parameters are refused; stale, duplicate, or mismatched pairs are harmless `detached:false` results.
- Reuse the existing authority detach operation: no cancellation, deletion, or new permissions.
- Ink attaches its destination before detaching the previous subscription. Per-session coordination prevents a delayed A→B detach from removing the replacement A subscription after switching back.

Five files: one server adapter, two Ink files, and two behavioral test files. No Desktop or authority-runtime changes.

## Verification
Rebased to gateway head `9c2f624c7bf1279c1edcff846ef00e6e9b83e56a`. Independently reran all 1,832 Ink tests across 187 files, Ink typecheck, and eight authority tests: passed. RED/GREEN coverage includes exact pairing, other observers, continued execution, attach-first ordering, and delayed A→B→A token reuse. Targeted lint and whitespace checks pass; independent review found no remaining blockers.

Tests use the real authority dispatcher and Ink renderer fixtures; no live cross-host UI certification is claimed. Independent of the other follow-up fixes.
