### PR TITLE
fix(egress): refresh Bitwarden credentials on setup restart

### DIFF
--- a/hermes_cli/proxy_cli.py
+++ b/hermes_cli/proxy_cli.py
@@ -103,7 +103,7 @@ def cmd_setup(args: argparse.Namespace) -> int:
     proxy_cfg = _setup_write_config(console, args, mappings, *ca)
     if proxy_cfg is None:
         return 1
-    _setup_restart_daemon(console, args, proxy_cfg)
+    _setup_restart_daemon(console, args)
     console.print()
     console.print("[green]✓ iron-proxy is configured.[/green]  Sandboxes will route outbound traffic through it.")
     console.print(
@@ -289,7 +289,7 @@ def _setup_write_config(console: Console, args: argparse.Namespace, mappings, ca
     return proxy_cfg
 
 
-def _setup_restart_daemon(console: Console, args: argparse.Namespace, proxy_cfg: dict) -> None:
+def _setup_restart_daemon(console: Console, args: argparse.Namespace) -> None:
     """Stop a running daemon and decide whether to (re)start it with the new config.
 
     --restart → always (re)start; --no-restart → never (print the manual hint); neither + tty →
@@ -312,18 +312,9 @@ def _setup_restart_daemon(console: Console, args: argparse.Namespace, proxy_cfg:
     else:
         do_restart = False
     if do_restart:
-        try:
-            new_status = ip.start_proxy(install_if_missing=bool(proxy_cfg.get("auto_install", True)))
-        except Exception as exc:  # noqa: BLE001 — user-facing funnel
-            console.print(f"  [yellow]⚠ could not start iron-proxy with the new config: {exc}[/yellow]")
+        # Setup restarts need the same credential refresh and refusal policy as explicit starts.
+        if cmd_start(args) != 0:
             console.print("  Run [cyan]hermes egress start[/cyan] manually before launching new Docker sandboxes.")
-        else:
-            listening = "listening" if new_status.listening else "not yet listening"
-            verb = "restarted" if was_running else "started"
-            console.print(
-                f"  [green]✓[/green] {verb} iron-proxy with the new config "
-                f"(pid={new_status.pid}, port={new_status.tunnel_port}, {listening})"
-            )
     elif was_running:
         console.print(
             "  [yellow]⚠ stopped the running iron-proxy; config or tokens "

--- a/tests/test_iron_proxy_cli.py
+++ b/tests/test_iron_proxy_cli.py
@@ -195,6 +195,102 @@ def test_cmd_restart_propagates_start_failure(hermes_home, monkeypatch):
     assert rc == 1
 
 
+@pytest.fixture
+def setup_bitwarden_runtime(hermes_home, monkeypatch):
+    from hermes_cli.config import load_config, save_config
+
+    cfg = load_config()
+    cfg["secrets"]["bitwarden"] = {
+        "enabled": True,
+        "project_id": "test-project",
+        "access_token_env": "BWS_ACCESS_TOKEN",
+    }
+    save_config(cfg)
+    monkeypatch.setenv("BWS_ACCESS_TOKEN", "test-access-token")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "stale-host-key")
+    monkeypatch.setenv("UNMAPPED_SECRET", "unrelated-host-key")
+    monkeypatch.setattr(ip, "find_iron_proxy", lambda **kw: hermes_home / "iron-proxy")
+    monkeypatch.setattr(ip, "iron_proxy_version", lambda binary: "test")
+    monkeypatch.setattr(ip, "ensure_ca_cert", lambda **kw: (hermes_home / "ca.crt", hermes_home / "ca.key"))
+    spawned = []
+
+    def capture_spawn(binary, config, env, log):
+        spawned.append(env)
+        raise RuntimeError("test stopped at the daemon process boundary")
+
+    monkeypatch.setattr(ip, "_spawn_daemon", capture_spawn)
+    return spawned
+
+
+@pytest.mark.parametrize("restart", [True, None])
+@pytest.mark.parametrize("allow_fallback", [False, True])
+def test_setup_restart_refreshes_bitwarden_before_spawning(
+    setup_bitwarden_runtime, monkeypatch, restart, allow_fallback,
+):
+    from agent.secret_sources import bitwarden as bw
+    from hermes_cli.config import load_config, save_config
+
+    cfg = load_config()
+    cfg["proxy"]["allow_env_fallback"] = allow_fallback
+    save_config(cfg)
+    monkeypatch.setattr(ip, "get_status", lambda: ip.ProxyStatus(pid=4242 if restart is None else None))
+    monkeypatch.setattr(proxy_cli.sys.stdin, "isatty", lambda: False)
+
+    fetches = []
+
+    def fetch(**kwargs):
+        fetches.append(kwargs)
+        if allow_fallback and len(fetches) > 1:
+            return {}, []
+        value = "discovery-key" if len(fetches) == 1 else "fresh-vault-key"
+        return {"OPENROUTER_API_KEY": value, "UNMAPPED_SECRET": "unrelated-vault-key"}, []
+
+    monkeypatch.setattr(bw, "fetch_bitwarden_secrets", fetch)
+
+    proxy_cli.cmd_setup(_args(from_bitwarden=True, restart=restart))
+
+    assert len(setup_bitwarden_runtime) == 1
+    env = setup_bitwarden_runtime[0]
+    assert env["OPENROUTER_API_KEY"] == ("stale-host-key" if allow_fallback else "fresh-vault-key")
+    assert "UNMAPPED_SECRET" not in env
+    assert "BWS_ACCESS_TOKEN" not in env
+    assert len(fetches) == 2
+    assert all(call["use_cache"] is False for call in fetches)
+
+
+@pytest.mark.parametrize("failure", ["missing-secret", "missing-token", "disabled-source"])
+@pytest.mark.parametrize("restart", [True, None])
+def test_setup_restart_refuses_broken_bitwarden_source(
+    setup_bitwarden_runtime, monkeypatch, failure, restart,
+):
+    from agent.secret_sources import bitwarden as bw
+    from hermes_cli.config import load_config, save_config
+
+    monkeypatch.setattr(ip, "get_status", lambda: ip.ProxyStatus(pid=4242 if restart is None else None))
+    monkeypatch.setattr(proxy_cli.sys.stdin, "isatty", lambda: False)
+
+    fetches = []
+
+    def fetch(**kwargs):
+        fetches.append(kwargs)
+        if len(fetches) > 1:
+            return {}, []
+        if failure == "missing-token":
+            monkeypatch.delenv("BWS_ACCESS_TOKEN")
+        if failure == "disabled-source":
+            cfg = load_config()
+            cfg["secrets"]["bitwarden"]["enabled"] = False
+            save_config(cfg)
+        return {"OPENROUTER_API_KEY": "discovery-key"}, []
+
+    monkeypatch.setattr(bw, "fetch_bitwarden_secrets", fetch)
+
+    proxy_cli.cmd_setup(_args(from_bitwarden=True, restart=restart))
+
+    assert setup_bitwarden_runtime == []
+    assert load_config()["proxy"]["credential_source"] == "bitwarden"
+
+
 # ---------------------------------------------------------------------------
 # _load_env_file_into_environ — setup discovers keys kept only in ~/.hermes/.env
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`hermes egress setup --from-bitwarden --restart` can start iron-proxy with a stale host credential even after setup successfully reads the vault. Its restart path calls `start_proxy` without the Bitwarden refresh configuration used by `egress start` and `egress restart`. Automatic restart during a flagless setup has the same problem.

Delegate setup restarts to `cmd_start` so they share credential refresh, missing-source refusal and the explicit environment fallback policy. Two parametrized regression tests exercise the real setup, saved configuration, mappings and daemon environment construction through the process boundary.

Related to #108598 and #108604. This fixes the existing setup path on main and complements the custom credential work in #108604; it does not implement or replace that feature.

Validation on macOS with Python 3.13:

* Reproduced stale credential delivery and missing-source refusal failures before the fix.
* `scripts/run_tests.sh tests/test_iron_proxy.py tests/test_iron_proxy_cli.py tests/tools/test_docker_environment.py -j 4 --file-retries 0`: 111 passed on the updated main base.
* Four additional isolated scenarios with the real iron-proxy binary passed on #108604 with this patch applied. Three also ran actual Docker containers through the generated proxy configuration, checking header token replacement, query-only denial and credential isolation. Vault responses used synthetic fixtures.
* Ruff and `git diff --check` passed.
