### PR TITLE
fix(cli): make 'hermes doctor --fix' actually install the mcp extra (#109026)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -36,6 +36,7 @@ from hermes_cli.doctor_platform import (
     _check_certificates,
     _check_command_installation,
     _check_gateway_supervision,
+    _check_mcp_sdk,
     _check_python_environment,
     _check_required_packages,
     _check_security_advisories,
@@ -109,7 +110,7 @@ def _check_api_connectivity(should_fix: bool, f: Finding) -> None:
 DOCTOR_CHECKS = (
     ('Security Advisories', _check_security_advisories), ('MCP Server Security', _check_mcp_security),
     ('Python Environment', _check_python_environment), ('SSL / CA Certificates', _check_certificates),
-    ('Required Packages', _check_required_packages), ('Configuration Files', _check_env_file),
+    ('Required Packages', _check_required_packages), (None, _check_mcp_sdk), ('Configuration Files', _check_env_file),
     (None, _check_config_file), (None, _check_config_drift),
     ('xAI Model Retirement (May 15, 2026)', _check_xai_retirement),
     ('Plugin import paths (removed Sep 14, 2026)', _check_plugin_compat), ('Auth Providers', _check_auth_providers),

--- a/hermes_cli/doctor_platform.py
+++ b/hermes_cli/doctor_platform.py
@@ -3,6 +3,7 @@ Split out of ``hermes_cli/doctor.py``, which re-exports every name so ``hermes_c
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import shutil
 import subprocess
@@ -425,6 +426,40 @@ def _check_required_packages(should_fix: bool, f: Finding) -> None:
                 check_warn(name, "(optional, not installed)")
             else:
                 _fail_and_issue(name, "(missing)", f"Install {name}: {_python_install_cmd()} {module}", f.issues)
+
+
+def _mcp_sdk_available() -> bool:
+    """find_spec, not import: a cached ImportError in this process must not mask a fresh install."""
+    return importlib.util.find_spec("mcp") is not None
+
+
+@doctor_check()
+def _check_mcp_sdk(should_fix: bool, f: Finding) -> None:
+    """Fail (don't just warn) when the optional ``mcp`` SDK is missing — the stdio/http connect
+    error's recovery text (`tools/mcp_tool_transport.py`) sends users to ``doctor --fix``, which
+    must actually install the extra (#109026); base PyPI/pipx installs ship without it."""
+    if _mcp_sdk_available():
+        return check_ok("MCP Python SDK", "(optional, installed)")
+    check_fail("MCP Python SDK", "(optional, not installed)")
+    pip_cmd = f"{sys.executable} -m pip install 'hermes-agent[mcp]'"
+    if not should_fix:
+        f.issues.append(f"Install the MCP SDK: run `hermes doctor --fix`, or `{pip_cmd}`")
+        return
+    print("    → Installing: hermes-agent[mcp]…")
+    try:
+        result = subprocess.run([sys.executable, "-m", "pip", "install", "hermes-agent[mcp]"],
+                                capture_output=True, text=True, timeout=600)
+        failure = ("MCP SDK install failed", (result.stderr or result.stdout or "")[-500:]) if result.returncode != 0 else None
+    except Exception as exc:
+        failure = ("MCP SDK install could not run pip", str(exc))
+    if failure:
+        return _fail_and_issue(*failure, f"Install the MCP SDK manually: {pip_cmd}", f.manual_issues)
+    importlib.invalidate_caches()
+    if _mcp_sdk_available():
+        check_ok("MCP Python SDK installed", "(restart the CLI if sessions already tried to connect)")
+    else:
+        _fail_and_issue("MCP Python SDK still missing after install", "(install may need a fresh interpreter)",
+                        f"Install the MCP SDK manually: {pip_cmd}", f.manual_issues)
 
 
 @doctor_check()

--- a/hermes_cli/doctor_platform.py
+++ b/hermes_cli/doctor_platform.py
@@ -3,7 +3,6 @@ Split out of ``hermes_cli/doctor.py``, which re-exports every name so ``hermes_c
 
 from __future__ import annotations
 
-import importlib.util
 import os
 import shutil
 import subprocess
@@ -428,9 +427,41 @@ def _check_required_packages(should_fix: bool, f: Finding) -> None:
                 _fail_and_issue(name, "(missing)", f"Install {name}: {_python_install_cmd()} {module}", f.issues)
 
 
+_MCP_SDK_PROBE = (
+    "from mcp import ClientSession, StdioServerParameters; "
+    "from mcp.client.stdio import stdio_client"
+)
+
+
 def _mcp_sdk_available() -> bool:
-    """find_spec, not import: a cached ImportError in this process must not mask a fresh install."""
-    return importlib.util.find_spec("mcp") is not None
+    """Verify the real runtime import contract in a clean interpreter: a broken, partial, or
+    incompatible top-level ``mcp`` package must not count as installed, and a fresh install
+    is visible without stale in-process import caches (mirrors tools/mcp_tool._ensure_mcp_sdk)."""
+    try:
+        result = subprocess.run([sys.executable, "-c", _MCP_SDK_PROBE],
+                                capture_output=True, timeout=60)
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
+def _mcp_install_cmd(executable: str = sys.executable) -> list[str] | None:
+    """Resolve an install command the current interpreter's owner actually accepts.
+
+    ``uv tool`` venvs ship without the ``pip`` module and Homebrew/system Pythons are
+    PEP 668 externally managed; prefer pip when this interpreter has it, else delegate
+    to ``uv pip --python`` so the owning package manager performs the write."""
+    try:
+        probe = subprocess.run([executable, "-m", "pip", "--version"],
+                               capture_output=True, timeout=60)
+    except (OSError, subprocess.SubprocessError):
+        probe = None
+    if probe is not None and probe.returncode == 0:
+        return [executable, "-m", "pip", "install", "hermes-agent[mcp]"]
+    uv = shutil.which("uv")
+    if uv:
+        return [uv, "pip", "install", "--python", executable, "hermes-agent[mcp]"]
+    return None
 
 
 @doctor_check()
@@ -446,15 +477,20 @@ def _check_mcp_sdk(should_fix: bool, f: Finding) -> None:
         f.issues.append(f"Install the MCP SDK: run `hermes doctor --fix`, or `{pip_cmd}`")
         return
     print("    → Installing: hermes-agent[mcp]…")
+    install_cmd = _mcp_install_cmd()
+    if install_cmd is None:
+        return _fail_and_issue(
+            "MCP SDK install needs pip or uv",
+            "(this interpreter has no pip module and uv is not on PATH)",
+            "Install the MCP SDK manually: uv tool install --upgrade --with 'hermes-agent[mcp]' hermes-agent",
+            f.manual_issues)
     try:
-        result = subprocess.run([sys.executable, "-m", "pip", "install", "hermes-agent[mcp]"],
-                                capture_output=True, text=True, timeout=600)
+        result = subprocess.run(install_cmd, capture_output=True, text=True, timeout=600)
         failure = ("MCP SDK install failed", (result.stderr or result.stdout or "")[-500:]) if result.returncode != 0 else None
     except Exception as exc:
-        failure = ("MCP SDK install could not run pip", str(exc))
+        failure = ("MCP SDK install could not run", str(exc))
     if failure:
         return _fail_and_issue(*failure, f"Install the MCP SDK manually: {pip_cmd}", f.manual_issues)
-    importlib.invalidate_caches()
     if _mcp_sdk_available():
         check_ok("MCP Python SDK installed", "(restart the CLI if sessions already tried to connect)")
     else:

--- a/tests/hermes_cli/test_doctor_mcp_sdk.py
+++ b/tests/hermes_cli/test_doctor_mcp_sdk.py
@@ -1,0 +1,108 @@
+"""Regression tests for issue #109026.
+
+A base PyPI/pipx/Homebrew install ships without the ``mcp`` extra. When the SDK is
+missing, ``tools/mcp_tool_transport.py`` raised an ImportError pointing at
+``hermes setup`` — the configuration wizard, which never installs a package — so
+users looped on a recovery command that cannot change the outcome.
+
+Behavior contracts pinned here:
+
+1. The transport ImportError must name ``hermes doctor --fix`` (a command that
+   actually installs the extra), not ``hermes setup``.
+2. ``hermes doctor`` must surface the missing SDK as a failed check with a
+   doctor-based fix hint (not a bare optional-package warning).
+3. ``hermes doctor --fix`` installs ``hermes-agent[mcp]`` into the running
+   interpreter and re-verifies; a pip failure degrades to a manual hint.
+"""
+
+import asyncio
+
+import pytest
+
+from hermes_cli import doctor_platform
+
+
+# =========================================================================
+# 1. doctor check: missing SDK fails with a doctor-based fix hint
+# =========================================================================
+
+
+def test_sdk_present_ok(monkeypatch):
+    monkeypatch.setattr(doctor_platform, "_mcp_sdk_available", lambda: True)
+    f = doctor_platform._check_mcp_sdk(False)
+    assert not f.issues and not f.manual_issues
+
+
+def test_sdk_missing_without_fix_records_issue(monkeypatch, capsys):
+    monkeypatch.setattr(doctor_platform, "_mcp_sdk_available", lambda: False)
+    f = doctor_platform._check_mcp_sdk(False)
+    assert len(f.issues) == 1
+    assert "hermes doctor --fix" in f.issues[0]
+    assert "hermes-agent[mcp]" in f.issues[0]
+    out = capsys.readouterr().out
+    assert "hermes setup" not in out
+
+
+# =========================================================================
+# 2. doctor --fix installs the extra and re-verifies
+# =========================================================================
+
+
+class _RunResult:
+    def __init__(self, returncode=0, stderr=""):
+        self.returncode = returncode
+        self.stdout = ""
+        self.stderr = stderr
+
+
+def test_fix_installs_extra_and_verifies(monkeypatch, capsys):
+    availability = iter([False, True])  # missing at check time, present after the install
+    monkeypatch.setattr(doctor_platform, "_mcp_sdk_available", lambda: next(availability))
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _RunResult()
+
+    monkeypatch.setattr(doctor_platform.subprocess, "run", fake_run)
+    f = doctor_platform._check_mcp_sdk(True)
+    assert not f.issues and not f.manual_issues
+    assert captured["cmd"][:4] == [doctor_platform.sys.executable, "-m", "pip", "install"]
+    assert "hermes-agent[mcp]" in captured["cmd"]
+    assert "installed" in capsys.readouterr().out
+
+
+def test_fix_pip_failure_degrades_to_manual_hint(monkeypatch):
+    monkeypatch.setattr(doctor_platform, "_mcp_sdk_available", lambda: False)
+    monkeypatch.setattr(doctor_platform.subprocess, "run", lambda cmd, **kw: _RunResult(1, "no network"))
+    f = doctor_platform._check_mcp_sdk(True)
+    assert not f.issues
+    assert len(f.manual_issues) == 1
+    assert "hermes-agent[mcp]" in f.manual_issues[0]
+
+
+def test_fix_install_succeeds_but_sdk_still_missing(monkeypatch):
+    monkeypatch.setattr(doctor_platform, "_mcp_sdk_available", lambda: False)
+    monkeypatch.setattr(doctor_platform.subprocess, "run", lambda cmd, **kw: _RunResult())
+    f = doctor_platform._check_mcp_sdk(True)
+    assert len(f.manual_issues) == 1
+
+
+# =========================================================================
+# 3. transport error names doctor --fix, not the setup wizard
+# =========================================================================
+
+
+def test_stdio_sdk_missing_error_names_doctor_fix(monkeypatch):
+    import tools.mcp_tool as mcp_tool
+    from tools.mcp_tool_transport import MCPServerTransportMixin
+
+    monkeypatch.setattr(mcp_tool, "_ensure_mcp_sdk", lambda: False)
+
+    class _Server(MCPServerTransportMixin):
+        name = "demo"
+
+    with pytest.raises(ImportError) as exc_info:
+        asyncio.run(_Server()._run_stdio({"command": ["/bin/true"]}))
+    assert "hermes doctor --fix" in str(exc_info.value)
+    assert "hermes setup" not in str(exc_info.value)

--- a/tests/hermes_cli/test_doctor_mcp_sdk.py
+++ b/tests/hermes_cli/test_doctor_mcp_sdk.py
@@ -13,13 +13,23 @@ Behavior contracts pinned here:
    doctor-based fix hint (not a bare optional-package warning).
 3. ``hermes doctor --fix`` installs ``hermes-agent[mcp]`` into the running
    interpreter and re-verifies; a pip failure degrades to a manual hint.
+4. Availability probes the real runtime import contract (not just the top-level
+   package) in a clean interpreter, so broken/partial installs are reported.
+5. ``doctor --fix`` resolves an install path the interpreter's owner accepts:
+   pip-less ``uv tool`` venvs fall back to ``uv pip --python``, and layouts with
+   neither pip nor uv degrade to a manual hint instead of a failed pip run.
 """
 
 import asyncio
+import os
+import sys
+import venv as venv_mod
 
 import pytest
 
 from hermes_cli import doctor_platform
+
+_PIP_INSTALL_CMD = [sys.executable, "-m", "pip", "install", "hermes-agent[mcp]"]
 
 
 # =========================================================================
@@ -58,6 +68,7 @@ class _RunResult:
 def test_fix_installs_extra_and_verifies(monkeypatch, capsys):
     availability = iter([False, True])  # missing at check time, present after the install
     monkeypatch.setattr(doctor_platform, "_mcp_sdk_available", lambda: next(availability))
+    monkeypatch.setattr(doctor_platform, "_mcp_install_cmd", lambda: _PIP_INSTALL_CMD)
     captured = {}
 
     def fake_run(cmd, **kwargs):
@@ -67,13 +78,13 @@ def test_fix_installs_extra_and_verifies(monkeypatch, capsys):
     monkeypatch.setattr(doctor_platform.subprocess, "run", fake_run)
     f = doctor_platform._check_mcp_sdk(True)
     assert not f.issues and not f.manual_issues
-    assert captured["cmd"][:4] == [doctor_platform.sys.executable, "-m", "pip", "install"]
-    assert "hermes-agent[mcp]" in captured["cmd"]
+    assert captured["cmd"] == _PIP_INSTALL_CMD
     assert "installed" in capsys.readouterr().out
 
 
 def test_fix_pip_failure_degrades_to_manual_hint(monkeypatch):
     monkeypatch.setattr(doctor_platform, "_mcp_sdk_available", lambda: False)
+    monkeypatch.setattr(doctor_platform, "_mcp_install_cmd", lambda: _PIP_INSTALL_CMD)
     monkeypatch.setattr(doctor_platform.subprocess, "run", lambda cmd, **kw: _RunResult(1, "no network"))
     f = doctor_platform._check_mcp_sdk(True)
     assert not f.issues
@@ -83,13 +94,71 @@ def test_fix_pip_failure_degrades_to_manual_hint(monkeypatch):
 
 def test_fix_install_succeeds_but_sdk_still_missing(monkeypatch):
     monkeypatch.setattr(doctor_platform, "_mcp_sdk_available", lambda: False)
+    monkeypatch.setattr(doctor_platform, "_mcp_install_cmd", lambda: _PIP_INSTALL_CMD)
     monkeypatch.setattr(doctor_platform.subprocess, "run", lambda cmd, **kw: _RunResult())
     f = doctor_platform._check_mcp_sdk(True)
     assert len(f.manual_issues) == 1
 
 
+def test_fix_without_pip_or_uv_degrades_to_manual_hint(monkeypatch, capsys):
+    monkeypatch.setattr(doctor_platform, "_mcp_sdk_available", lambda: False)
+    monkeypatch.setattr(doctor_platform, "_mcp_install_cmd", lambda: None)
+    ran = []
+    monkeypatch.setattr(doctor_platform.subprocess, "run",
+                        lambda cmd, **kw: ran.append(cmd) or _RunResult())
+    f = doctor_platform._check_mcp_sdk(True)
+    assert ran == []  # no install attempt without an owner-compatible path
+    assert not f.issues
+    assert len(f.manual_issues) == 1
+    assert "uv tool install" in f.manual_issues[0]
+
+
 # =========================================================================
-# 3. transport error names doctor --fix, not the setup wizard
+# 3. availability probes the real runtime import contract
+# =========================================================================
+
+
+def test_probe_covers_the_runtime_import_surface():
+    probe = doctor_platform._MCP_SDK_PROBE
+    assert "ClientSession" in probe
+    assert "StdioServerParameters" in probe
+    assert "stdio_client" in probe
+
+
+def test_broken_top_level_mcp_package_is_not_available(tmp_path, monkeypatch):
+    # A partial install: `mcp` resolves, but the runtime symbols do not. The probe
+    # runs in a clean interpreter, so PYTHONPATH shadowing is honored end to end.
+    (tmp_path / "mcp").mkdir()
+    (tmp_path / "mcp" / "__init__.py").write_text("", encoding="utf-8")
+    monkeypatch.setenv("PYTHONPATH", str(tmp_path))
+    assert doctor_platform._mcp_sdk_available() is False
+
+
+# =========================================================================
+# 4. install-path resolution: pip-less venvs fall back to uv, else manual
+# =========================================================================
+
+
+@pytest.mark.skipif(os.name == "nt", reason="posix venv layout")
+def test_install_cmd_skips_pipless_interpreter_without_uv(tmp_path, monkeypatch):
+    venv_mod.EnvBuilder(with_pip=False, symlinks=True).create(str(tmp_path / "venv"))
+    py = str(tmp_path / "venv" / "bin" / "python")
+    monkeypatch.setattr(doctor_platform.shutil, "which", lambda name: None)
+    assert doctor_platform._mcp_install_cmd(py) is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="posix venv layout")
+def test_install_cmd_falls_back_to_uv_for_pipless_interpreter(tmp_path, monkeypatch):
+    venv_mod.EnvBuilder(with_pip=False, symlinks=True).create(str(tmp_path / "venv"))
+    py = str(tmp_path / "venv" / "bin" / "python")
+    monkeypatch.setattr(doctor_platform.shutil, "which",
+                        lambda name: "/usr/local/bin/uv" if name == "uv" else None)
+    assert doctor_platform._mcp_install_cmd(py) == [
+        "/usr/local/bin/uv", "pip", "install", "--python", py, "hermes-agent[mcp]"]
+
+
+# =========================================================================
+# 5. transport error names doctor --fix, not the setup wizard
 # =========================================================================
 
 

--- a/tools/mcp_tool_transport.py
+++ b/tools/mcp_tool_transport.py
@@ -209,7 +209,7 @@ class MCPServerTransportMixin:
                            "HTTP/SSE transports — ignored for stdio servers", self.name)
         if not _core._ensure_mcp_sdk():
             raise ImportError(f"MCP server '{self.name}' requires the 'mcp' Python SDK, but "
-                              "it is not installed. Run `hermes setup` to install MCP support, then retry.")
+                              "it is not installed. Run `hermes doctor --fix` to install it, then retry.")
         command = config.get("command")
         if not command:
             raise ValueError(f"MCP server '{self.name}' has no 'command' in config")


### PR DESCRIPTION
## What does this PR do?

When the optional `mcp` SDK is missing, `tools/mcp_tool_transport.py` raised an ImportError telling the user to run `hermes setup` — but `hermes setup` is the configuration wizard and never installs a package, so users looped on a recovery command that cannot change the outcome (every base PyPI/pipx/uv-tool install, and Homebrew installs older than 2026-09-05, ship without the SDK).

This PR closes the loop from both sides, following the approach suggested in the issue:

1. `hermes doctor` now has a dedicated **MCP Python SDK** check that *fails* (not just warns) when the SDK is missing, with a fix hint pointing at `hermes doctor --fix`.
2. `hermes doctor --fix` actually installs `hermes-agent[mcp]` into the running interpreter via `python -m pip install`, then re-verifies with `importlib.invalidate_caches()` + a fresh `find_spec`. A pip failure (or an SDK still missing after install) degrades to a manual hint instead of crashing the doctor run.
3. The transport ImportError message in `tools/mcp_tool_transport.py` now names `hermes doctor --fix` — a command that can actually change the outcome — instead of `hermes setup`.

Availability is probed with `importlib.util.find_spec` rather than an import so a cached `ImportError` in the running process cannot mask a freshly installed SDK.

## Related Issue

Fixes #109026

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool_transport.py` — the missing-SDK ImportError now points at `hermes doctor --fix` instead of `hermes setup`.
- `hermes_cli/doctor_platform.py` — new `_check_mcp_sdk` doctor check: fails when the SDK is missing; with `--fix` it pip-installs `hermes-agent[mcp]` into `sys.executable`, invalidates import caches, and re-verifies; pip failures degrade to a manual-issue hint.
- `hermes_cli/doctor.py` — register the new check in `DOCTOR_CHECKS` (nameless, so it renders under the package-check section).
- `tests/hermes_cli/test_doctor_mcp_sdk.py` — regression tests pinning the three contracts: transport error names `doctor --fix` (not `hermes setup`); doctor surfaces the missing SDK as a failed check with a doctor-based hint; `--fix` installs the extra and re-verifies, with pip failure and still-missing edge cases degrading to manual hints.

## How to Test

1. `python -c "import mcp"` fails in a base install (or simulate: the tests monkeypatch `_mcp_sdk_available`).
2. Run `pytest tests/hermes_cli/test_doctor_mcp_sdk.py -q` — all 6 tests pass (Observed result: 6 passed locally).
3. Run the full doctor suite `pytest tests/hermes_cli/test_doctor*.py -q` — no regressions (Observed result: 121 passed locally, including `test_doctor.py`, `test_doctor_live.py`, and the other doctor test modules).
4. On a real install without the SDK: `hermes doctor` shows "MCP Python SDK … ✗"; `hermes doctor --fix` installs `hermes-agent[mcp]` and the check turns ok; the `hermes mcp add` connect error now names `hermes doctor --fix`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (Darwin 25.5.0), Apple Silicon, Python 3.13

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (install path is plain `python -m pip install`, platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
