### PR TITLE
fix(desktop): close the queue-drain switchback gap in $primaryBusy

### DIFF
--- a/apps/desktop/src/app/chat/composer/queue-switchback-busy.test.ts
+++ b/apps/desktop/src/app/chat/composer/queue-switchback-busy.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { PRIMARY_SESSION_VIEW } from '@/app/chat/session-view'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { shouldAutoDrain } from '@/store/composer-queue'
+import { $activeSessionId, $busy, $selectedStoredSessionId, $sessions } from '@/store/session'
+import { $workingSessionIds, clearAllSessionStates, publishSessionState } from '@/store/session-states'
+
+/**
+ * Queue a prompt in session A while A is mid-turn, switch to B, switch back to
+ * A: the queued prompt must still wait for A's in-flight turn.
+ *
+ * `PRIMARY_SESSION_VIEW.$busy` is what the composer's auto-drain gate consumes,
+ * and `$workingSessionIds` is the authoritative per-session truth the sidebar
+ * arc paints from. Any window where those two disagree about A is a window
+ * where the queue drains into a still-running session.
+ *
+ * The gap these cover: selection moves to A immediately while `$activeSessionId`
+ * still points at B (the runtime rebind is awaited behind `session.activate`),
+ * so the pane would otherwise read B's idle flag for A.
+ */
+describe('composer busy gate across a session switch-back', () => {
+  // nanostores computed atoms are lazy — they only recompute while subscribed.
+  // Hold a subscription for the duration of each test so reads are live.
+  const subscribeAtoms = () => {
+    const unsubscribes = [PRIMARY_SESSION_VIEW.$busy.subscribe(() => {}), $workingSessionIds.subscribe(() => {})]
+
+    return () => {
+      for (const unsubscribe of unsubscribes) {
+        unsubscribe()
+      }
+    }
+  }
+
+  afterEach(() => {
+    clearAllSessionStates()
+    $sessions.set([])
+    $activeSessionId.set(null)
+    $selectedStoredSessionId.set(null)
+    $busy.set(false)
+  })
+
+  it('reports session A as working while its turn is in flight', () => {
+    const stop = subscribeAtoms()
+
+    $sessions.set([{ id: 'stored-a' }, { id: 'stored-b' }] as never)
+    publishSessionState('runtime-a', { ...createClientSessionState('stored-a'), busy: true })
+
+    expect($workingSessionIds.get()).toContain('stored-a')
+    stop()
+  })
+
+  it('keeps the composer busy gate asserted across a switch away and back', () => {
+    const stop = subscribeAtoms()
+
+    $sessions.set([{ id: 'stored-a' }, { id: 'stored-b' }] as never)
+
+    // A is mid-turn and focused.
+    publishSessionState('runtime-a', { ...createClientSessionState('stored-a'), busy: true })
+    $selectedStoredSessionId.set('stored-a')
+    $activeSessionId.set('runtime-a')
+
+    expect(PRIMARY_SESSION_VIEW.$busy.get()).toBe(true)
+
+    // Switch to B (idle).
+    publishSessionState('runtime-b', { ...createClientSessionState('stored-b'), busy: false })
+    $selectedStoredSessionId.set('stored-b')
+    $activeSessionId.set('runtime-b')
+
+    expect(PRIMARY_SESSION_VIEW.$busy.get()).toBe(false)
+
+    // Switch BACK to A. Selection lands immediately; the runtime rebind is
+    // awaited behind session.activate, so $activeSessionId still points at B.
+    // This is the real ordering in use-session-actions.
+    $selectedStoredSessionId.set('stored-a')
+
+    // A is STILL busy per the authoritative projection...
+    expect($workingSessionIds.get()).toContain('stored-a')
+
+    // ...so the composer's gate must not report idle in this window.
+    const busyDuringSwitchBack = PRIMARY_SESSION_VIEW.$busy.get()
+
+    expect(
+      shouldAutoDrain({ isBusy: busyDuringSwitchBack, parked: false, queueLength: 1 })
+    ).toBe(false)
+
+    // And once the runtime rebinds, the slice takes over and still says busy.
+    $activeSessionId.set('runtime-a')
+    expect(PRIMARY_SESSION_VIEW.$busy.get()).toBe(true)
+
+    stop()
+  })
+
+  it('goes idle once session A actually finishes its turn', () => {
+    const stop = subscribeAtoms()
+
+    $sessions.set([{ id: 'stored-a' }] as never)
+    publishSessionState('runtime-a', { ...createClientSessionState('stored-a'), busy: true })
+    $selectedStoredSessionId.set('stored-a')
+    $activeSessionId.set('runtime-a')
+
+    expect(PRIMARY_SESSION_VIEW.$busy.get()).toBe(true)
+
+    publishSessionState('runtime-a', { ...createClientSessionState('stored-a'), busy: false })
+
+    expect(PRIMARY_SESSION_VIEW.$busy.get()).toBe(false)
+    expect(shouldAutoDrain({ isBusy: false, parked: false, queueLength: 1 })).toBe(true)
+
+    stop()
+  })
+
+  it('does not let a busy session A leak onto an idle session B', () => {
+    const stop = subscribeAtoms()
+
+    $sessions.set([{ id: 'stored-a' }, { id: 'stored-b' }] as never)
+
+    publishSessionState('runtime-a', { ...createClientSessionState('stored-a'), busy: true })
+    publishSessionState('runtime-b', { ...createClientSessionState('stored-b'), busy: false })
+
+    // Focus B while A runs. B must read idle even though A is busy.
+    $selectedStoredSessionId.set('stored-b')
+    $activeSessionId.set('runtime-b')
+
+    expect(PRIMARY_SESSION_VIEW.$busy.get()).toBe(false)
+
+    // And in B's own pre-rebind window (active id still A, selection B).
+    $activeSessionId.set('runtime-a')
+    expect(PRIMARY_SESSION_VIEW.$busy.get()).toBe(false)
+
+    stop()
+  })
+
+  it('keeps the draft busy latch for a brand-new chat with no stored id', () => {
+    const stop = subscribeAtoms()
+
+    $selectedStoredSessionId.set(null)
+    $activeSessionId.set(null)
+    $busy.set(true)
+
+    expect(PRIMARY_SESSION_VIEW.$busy.get()).toBe(true)
+
+    stop()
+  })
+})

--- a/apps/desktop/src/app/chat/session-view.tsx
+++ b/apps/desktop/src/app/chat/session-view.tsx
@@ -14,9 +14,11 @@ import {
   $currentReasoningEffort,
   $messages,
   $selectedStoredSessionId,
-  $turnStartedAt
+  $sessions,
+  $turnStartedAt,
+  idsShareLineage
 } from '@/store/session'
-import { $sessionStates } from '@/store/session-states'
+import { $sessionStates, $workingSessionIds } from '@/store/session-states'
 
 import { lastVisibleMessageIsUser } from './thread-loading'
 
@@ -82,14 +84,39 @@ function primaryField<T>(select: (state: ClientSessionState) => T, $draft: Reada
 const $primaryMessages = primaryField<ChatMessage[]>(state => state.messages, $messages)
 
 /**
- * Turn-busy for the workspace pane. A selected stored session that has no
- * slice yet (cold resume) must stay idle — the global `$busy` atom is a
- * leftover from whichever session last published, and inheriting it is how
- * focusing B while A runs marked B busy. The draft atom is only for a true
- * new chat (no stored id) so the first-send optimistic lock still paints.
+ * Turn-busy for the workspace pane.
+ *
+ * The slice is authoritative only for the session the pane actually SHOWS.
+ * `$primaryState` keys on `$activeSessionId` (the bound runtime) while the
+ * composer and its queue key on the selected/routed STORED id, and a switch
+ * moves those at different times: selection lands at once, the runtime rebinds
+ * a beat later behind an awaited `session.activate`. In that window the slice
+ * still describes the session the user just LEFT.
+ *
+ * That gap is the queued-prompt bug: queue a turn in A while A runs, switch to
+ * idle B, switch back. Selection is A, the runtime is still B, so the pane
+ * inherits B's `busy: false` — and `shouldAutoDrain` reads exactly this atom,
+ * firing A's queued prompts into A's live turn. Treating "no slice yet" (cold
+ * resume) as idle had the same effect.
+ *
+ * So trust the slice only when it belongs to the selected conversation, else
+ * fall back to `$workingSessionIds`: the per-session projection the sidebar arc
+ * paints from, published under every lineage alias, so it survives both the
+ * slice gap and compression tip rotation. `$busy` stays DRAFT-only (no stored
+ * id) for the first-send optimistic lock — it mirrors whichever session last
+ * published and must never be inherited by a stored session.
  */
-const $primaryBusy = computed([$primaryState, $busy, $selectedStoredSessionId], (state, draftBusy, selected) =>
-  state ? state.busy : selected ? false : draftBusy
+const $primaryBusy = computed(
+  [$primaryState, $busy, $selectedStoredSessionId, $workingSessionIds, $sessions],
+  (state, draftBusy, selected, working, sessions) => {
+    if (!selected) {
+      return state ? state.busy : draftBusy
+    }
+
+    return state?.storedSessionId && idsShareLineage(state.storedSessionId, selected, sessions)
+      ? state.busy
+      : working.includes(selected)
+  }
 )
 
 export const PRIMARY_SESSION_VIEW: SessionView = {


### PR DESCRIPTION
## Summary

Second layer of the queued-prompt session-switch bug. #98944 stopped the queue draining into a still-running session; this closes the window that fix couldn't cover.

## The gap

Queue a turn in A while A runs, switch to idle B, switch back to A. Selection (`$selectedStoredSessionId`) lands immediately, but the runtime rebind is awaited behind `session.activate` — so for a beat the pane's slice (``, keyed on ``) still describes **B**. The pane inherits B's `busy: false` for A, and `shouldAutoDrain` reads exactly that atom → A's queued prompts fire into A's live turn.

Same effect when a cold-resume session has no slice yet: treated as idle.

## Fix

`$primaryBusy` trusts the slice only when it belongs to the selected conversation (`idsShareLineage(state.storedSessionId, selected, sessions)`); otherwise it falls back to `` — the authoritative per-session projection the sidebar arc already paints from, published under every lineage alias (survives slice gaps and compression tip rotation). `` stays draft-only (no stored id) for the first-send optimistic lock.

## Evidence

`queue-switchback-busy.test.ts`: A-busy projection, the B-idle switch-back window (selection moved, runtime still on B — gate must stay asserted), and lineage-mismatch fallback.