### PR TITLE
fix(curator): advertise absorbed_into fork-locally and surface refused consolidation deletes (#97959)

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -697,6 +697,7 @@ def _write_run_report(
     tool_calls = llm_meta.get("tool_calls", []) or []
     after_by_name, before_by_name = _by_name(after_report), _by_name(before_report)
     diff = _diff_and_classify(before_names, set(after_by_name), tool_calls, llm_meta.get("final", "") or "")
+    refused_deletes = _refused_consolidation_deletes(before_names, set(after_by_name), tool_calls)
     states = ((n, (before_by_name.get(n) or {}).get("state"), (after_by_name.get(n) or {}).get("state")) for n in sorted(diff.after_names & before_names))
     transitions = [{"name": n, "from": b, "to": a} for n, b, a in states if b and a and b != a]
     tc_counts: Dict[str, int] = dict(Counter(tc.get("name", "unknown") for tc in tool_calls))
@@ -710,8 +711,10 @@ def _write_run_report(
             "archived_this_run": len(diff.removed), "added_this_run": len(diff.added),
             "consolidated_this_run": len(diff.consolidated), "pruned_this_run": len(diff.pruned),
             "state_transitions": len(transitions), "cron_jobs_rewritten": jobs_updated, "tool_calls_total": sum(tc_counts.values()),
+            "refused_consolidation_deletes": len(refused_deletes),
         },
         "tool_call_counts": tc_counts, "archived": diff.removed, "consolidated": diff.consolidated, "pruned": diff.pruned,
+        "refused_consolidation_delete_names": sorted(refused_deletes),
         "pruned_names": [p["name"] for p in diff.pruned], "added": diff.added, "state_transitions": transitions, "cron_rewrites": cron_rewrites,
         "llm_final": llm_meta.get("final", ""), "llm_summary": llm_meta.get("summary", ""),
         "llm_error": llm_meta.get("error"), "tool_calls": llm_meta.get("tool_calls", []),
@@ -787,6 +790,10 @@ def _render_report_markdown(p: Dict[str, Any]) -> str:
         f"- consolidated into umbrellas: **{counts.get('consolidated_this_run', 0)}**",
         f"- pruned (archived for staleness): **{counts.get('pruned_this_run', 0)}**", f"- new skills this run: **{counts.get('added_this_run', 0)}**",
         f"- state transitions (active ↔ stale ↔ archived): **{counts.get('state_transitions', 0)}**", "",
+        *([f"> ⚠ Refused consolidation deletes: **{counts.get('refused_consolidation_deletes', 0)}** — the review fork "
+           f"asked to delete {', '.join(f'`{n}`' for n in (p.get('refused_consolidation_delete_names') or [])[:10])} but every delete was "
+           "refused (guard fail-closed: missing `absorbed_into`?). Consolidation did NOT complete.\n"]
+          if counts.get("refused_consolidation_deletes") else []),
     ]
     for key, title, intro, render, show, hint in _REPORT_SECTIONS:
         items = p.get(key) or []
@@ -858,6 +865,17 @@ def _consolidation_pass(prefix: str, auto_summary: str, dry_run: bool, before_na
                 prompt = f"{CURATOR_DRY_RUN_BANNER}\n\n{prompt}"
             llm_meta = _run_llm_review(prompt)
             final_summary = f"{prefix}{auto_summary}; llm: {llm_meta.get('summary', 'no change')}"
+            # A pass whose consolidation deletes were ALL refused still reads as
+            # success in the LLM's own summary — surface the refusal count so
+            # `hermes curator status` can't look healthy while consolidation
+            # silently never completes (#97959).
+            refused = _refused_consolidation_deletes(
+                before_names, {r.get("name") for r in skill_usage.curated_report()},
+                llm_meta.get("tool_calls", []) or [])
+            if refused:
+                names_preview = ", ".join(sorted(refused)[:5])
+                final_summary = (f"{final_summary}; ⚠ {len(refused)} consolidation delete(s) refused "
+                                 f"({names_preview}) — see run report")
     except Exception as e:
         logger.debug("Curator LLM pass failed: %s", e, exc_info=True)
         final_summary = f"{prefix}{auto_summary}; llm: error ({e})"
@@ -1010,6 +1028,112 @@ def _resolve_review_provider() -> tuple:
     return rp, model_name, provider, overrides
 
 
+_ABSORBED_INTO_PROP = {
+    "type": "string",
+    "description": (
+        "delete only: the umbrella skill that absorbs this skill's "
+        "content. The consolidation delete guard refuses a delete "
+        "without it — the umbrella must already exist."),
+}
+
+
+def _with_absorbed_into(function: Dict[str, Any]) -> Dict[str, Any]:
+    """A copy of a ``skill_manage`` function schema advertising ``absorbed_into``.
+
+    Every container on the path is copied: entries in ``get_tool_definitions``'s
+    memoized result are shared process-wide and must never be edited in place.
+    """
+    params = function["parameters"]
+    properties = params["properties"]
+    operations = properties["operations"]
+    items = operations["items"]
+    return {
+        **function,
+        "parameters": {
+            **params,
+            "properties": {
+                **properties,
+                "operations": {
+                    **operations,
+                    "items": {
+                        **items,
+                        "properties": {
+                            **items["properties"],
+                            "absorbed_into": _ABSORBED_INTO_PROP,
+                        },
+                    },
+                },
+            },
+        },
+    }
+
+
+def _advertise_absorbed_into(enabled_toolsets):
+    """The fork's ``tools[]`` with ``skill_manage`` advertising ``absorbed_into``.
+
+    The handler has always accepted ``absorbed_into`` on delete and the
+    curator's delete guard REFUSES deletes that omit it (#97959), yet the
+    shared schema deliberately omits the parameter (token cost on every call
+    of every other session). The consolidation pass — the only caller that
+    needs it — therefore gets it fork-locally: the shared
+    ``SKILL_MANAGE_SCHEMA`` stays byte-identical, and a fresh list is built
+    here so the memoized ``get_tool_definitions`` cache is never mutated.
+    Returns the list unchanged when ``skill_manage`` is absent.
+    """
+    from model_tools import get_tool_definitions
+    tools = get_tool_definitions(enabled_toolsets=enabled_toolsets, quiet_mode=True) or []
+    out = []
+    for tool in tools:
+        function = tool.get("function") if isinstance(tool, dict) else None
+        try:
+            if function and function.get("name") == "skill_manage":
+                tool = {**tool, "function": _with_absorbed_into(function)}
+        except (KeyError, TypeError):
+            pass  # unexpected schema shape — advertise the shared one as-is
+        out.append(tool)
+    return out
+
+
+def _refused_consolidation_deletes(before_names, after_names, tool_calls):
+    """Names the fork tried to delete but are still present after the run.
+
+    A refused consolidation delete leaves the skill on disk (the guard is
+    fail-closed), so a delete-targeted skill in both snapshots was refused.
+    Counts distinct skills, not calls — model retries on the same refusal must
+    not inflate the number. Unparseable/truncated arguments are skipped (the
+    llm_meta tool_calls list caps arguments at 400 chars).
+    """
+    if not before_names or not tool_calls:
+        return set()
+    still_present = {n for n in before_names if n in after_names}
+    if not still_present:
+        return set()
+    refused = set()
+    for call in tool_calls:
+        if not isinstance(call, dict) or call.get("name") != "skill_manage":
+            continue
+        args = call.get("arguments")
+        if isinstance(args, str):
+            try:
+                args = json.loads(args)
+            except Exception:
+                continue  # truncated/garbage — never guess
+        if not isinstance(args, dict):
+            continue
+        if isinstance(args.get("operations"), list):
+            targets = [op for op in args["operations"]
+                       if isinstance(op, dict) and op.get("action") == "delete"]
+        elif args.get("action") == "delete":
+            targets = [args]
+        else:
+            continue
+        for op in targets:
+            name = op.get("name")
+            if isinstance(name, str) and name in still_present:
+                refused.add(name)
+    return refused
+
+
 def _run_llm_review(prompt: str) -> Dict[str, Any]:
     """Spawn an AIAgent fork on the review prompt. Returns ``final`` (untruncated response), ``summary`` (240-char cap),
     ``model``/``provider`` (what ran), ``tool_calls`` ([{name, arguments}], truncated) and ``error``. Never raises."""
@@ -1047,6 +1171,14 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         # write guards (external/bundled/hub) fire; turn_context binds this onto
         # the write-origin ContextVar at turn start.
         review_agent._memory_write_origin = "background_review"
+        # The fork's sole delete is a consolidation delete, which the guard only
+        # accepts with absorbed_into — advertise it fork-locally (#97959). Built
+        # fresh (never edits the memoized get_tool_definitions result), and pinned:
+        # a between-turns MCP refresh would rebuild tools[] from the registry and
+        # silently drop the augmentation.
+        review_agent.tools = _advertise_absorbed_into(["skills"])
+        review_agent.valid_tool_names = {t["function"]["name"] for t in review_agent.tools} if review_agent.tools else set()
+        review_agent._skip_mcp_refresh = True
         # Silence the fork's tool-call chatter (CLI synchronous foreground runs).
         with open(os.devnull, "w", encoding="utf-8") as devnull, \
              contextlib.redirect_stdout(devnull), contextlib.redirect_stderr(devnull):

--- a/tests/agent/test_curator_absorbed_into.py
+++ b/tests/agent/test_curator_absorbed_into.py
@@ -1,0 +1,256 @@
+"""Regression tests for #97959: curator consolidation can never complete.
+
+The skill_manage handler accepts ``absorbed_into`` on delete (flat and batch
+sole-op shapes) and the fail-closed curator delete guard REFUSES deletes that
+omit it — but the advertised schema never mentions the parameter. A
+schema-strict review model therefore cannot emit it, every consolidation
+delete is refused, and the run still reports success.
+
+Layers covered (see LAYERS.md at the branch root):
+1. The curator review fork must advertise ``absorbed_into`` in ITS OWN
+   ``tools[]`` (fork-local; the shared schema stays lean for every other
+   session).
+2. (Prompt wording is covered by competitor PR #88892 — excluded here.)
+3. A run whose deletes were all refused must surface that (run.json counts +
+   REPORT.md + status summary), not report silent success.
+4. The shared-schema comment must point at the fork-local advertisement.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — fork-local schema advertisement
+# ---------------------------------------------------------------------------
+
+def test_curator_fork_advertises_absorbed_into(tmp_path, monkeypatch):
+    """L1 RED: the curator review fork's skill_manage schema must include an
+    ``absorbed_into`` property — the guard refuses deletes without it, so a
+    schema that omits it makes consolidation structurally unable to complete."""
+    home = tmp_path / ".hermes"
+    (home / "skills").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import importlib
+    import agent.curator as curator
+    importlib.reload(curator)
+
+    monkeypatch.setattr(curator, "_resolve_review_provider", lambda: ({}, "", "", {}))
+
+    tools = curator._advertise_absorbed_into(["skills"])
+    sm = next(t for t in tools if t["function"]["name"] == "skill_manage")
+    props = sm["function"]["parameters"]["properties"]["operations"]["items"]["properties"]
+    assert "absorbed_into" in props, (
+        "curator fork's skill_manage schema must advertise absorbed_into: the "
+        "consolidation delete guard refuses deletes that omit it (#97959)")
+
+
+def test_shared_schema_stays_lean(tmp_path, monkeypatch):
+    """L1 guard: the shared SKILL_MANAGE_SCHEMA must NOT advertise
+    ``absorbed_into`` — the omission is deliberate token-saving for every
+    non-curator session; only the fork augments."""
+    from tools.skill_manager_tool import SKILL_MANAGE_SCHEMA
+    props = SKILL_MANAGE_SCHEMA["parameters"]["properties"]["operations"]["items"]["properties"]
+    assert "absorbed_into" not in props
+
+
+def test_fork_advertisement_does_not_poison_shared_cache(tmp_path, monkeypatch):
+    """L1 guard: the fork's augmented schema must not leak into the memoized
+    get_tool_definitions cache other sessions share."""
+    home = tmp_path / ".hermes"
+    (home / "skills").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import importlib
+    import agent.curator as curator
+    importlib.reload(curator)
+
+    fork_tools = curator._advertise_absorbed_into(["skills"])
+    fork_entry = next(t for t in fork_tools if t["function"]["name"] == "skill_manage")
+    fork_props = fork_entry["function"]["parameters"]["properties"]["operations"]["items"]["properties"]
+    assert "absorbed_into" in fork_props
+
+    from model_tools import get_tool_definitions
+    plain = get_tool_definitions(enabled_toolsets=["skills"], quiet_mode=True)
+    plain_entry = next(t for t in plain if t["function"]["name"] == "skill_manage")
+    plain_props = plain_entry["function"]["parameters"]["properties"]["operations"]["items"]["properties"]
+    assert "absorbed_into" not in plain_props, (
+        "fork-local augmentation leaked into the shared memoized schema cache")
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 — refused-deletes observability
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def curator_env(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    (home / "skills").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import importlib
+    import tools.skill_usage as usage
+    importlib.reload(usage)
+    import agent.curator as curator
+    importlib.reload(curator)
+
+    monkeypatch.setattr(curator, "_run_llm_review", lambda prompt: {
+        "final": "", "summary": "stub", "model": "", "provider": "",
+        "tool_calls": [], "error": None})
+    monkeypatch.setattr(curator, "_load_config", lambda: {"consolidate": True})
+    yield {"home": home, "curator": curator, "usage": usage}
+
+
+def _write_agent_skill(curator_env, name):
+    usage = curator_env["usage"]
+    skills_dir = curator_env["home"] / "skills"
+    d = skills_dir / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: x\n---\n", encoding="utf-8")
+    usage.mark_agent_created(name)
+    return d
+
+
+def test_refused_consolidation_deletes_counted(tmp_path, monkeypatch, curator_env):
+    """L3 RED: deletes the guard refused (skill still present after the run)
+    must be counted, not silently reported as success."""
+    curator = curator_env["curator"]
+    _write_agent_skill(curator_env, "alpha")
+    _write_agent_skill(curator_env, "beta")
+
+    before = {"alpha", "beta"}
+    after = {"alpha", "beta"}  # guard refused every delete
+    tool_calls = [
+        {"name": "skill_manage", "arguments": json.dumps({"action": "delete", "name": "alpha"})},
+        {"name": "skill_manage", "arguments": json.dumps({"action": "delete", "name": "beta"})},
+    ]
+    refused = curator._refused_consolidation_deletes(before, after, tool_calls)
+    assert refused == {"alpha", "beta"}
+
+
+def test_refused_consolidation_deletes_zero_when_deletes_landed(tmp_path, monkeypatch, curator_env):
+    """L3 companion: successful consolidations must not be flagged."""
+    curator = curator_env["curator"]
+    _write_agent_skill(curator_env, "alpha")
+    _write_agent_skill(curator_env, "umbrella")
+
+    before = {"alpha", "umbrella"}
+    after = {"umbrella"}  # alpha absorbed
+    tool_calls = [
+        {"name": "skill_manage", "arguments": json.dumps(
+            {"action": "delete", "name": "alpha", "absorbed_into": "umbrella"})},
+    ]
+    assert curator._refused_consolidation_deletes(before, after, tool_calls) == set()
+
+
+def test_refused_consolidation_deletes_robust_to_truncated_args(curator_env):
+    """L3 edge: truncated/garbage tool-call arguments must be skipped, never
+    crash or overcount."""
+    curator = curator_env["curator"]
+    before, after = {"alpha"}, {"alpha"}
+    tool_calls = [
+        {"name": "skill_manage", "arguments": '{"action": "delete", "name": "alp'},  # truncated
+        {"name": "skill_manage", "arguments": None},  # missing
+        {"name": "skill_manage", "arguments": json.dumps({"action": "patch", "name": "alpha"})},  # not a delete
+        {"name": "skills_list", "arguments": "{}"},  # other tool
+    ]
+    assert curator._refused_consolidation_deletes(before, after, tool_calls) == set()
+
+
+def test_refused_consolidation_deletes_counts_distinct_not_retries(curator_env):
+    """L3 edge: model retries on the same refused skill count once."""
+    curator = curator_env["curator"]
+    before, after = {"alpha", "beta"}, {"alpha", "beta"}
+    tool_calls = [
+        {"name": "skill_manage", "arguments": json.dumps({"action": "delete", "name": "alpha"})},
+        {"name": "skill_manage", "arguments": json.dumps({"action": "delete", "name": "alpha"})},  # retry
+        {"name": "skill_manage", "arguments": json.dumps({"action": "delete", "name": "beta"})},
+    ]
+    assert curator._refused_consolidation_deletes(before, after, tool_calls) == {"alpha", "beta"}
+
+
+def test_refused_consolidation_deletes_batch_shape(curator_env):
+    """L3 edge: a delete inside operations[] (sole-op batch) is detected."""
+    curator = curator_env["curator"]
+    before, after = {"alpha"}, {"alpha"}
+    tool_calls = [
+        {"name": "skill_manage", "arguments": json.dumps(
+            {"operations": [{"action": "delete", "name": "alpha"}]})},
+    ]
+    assert curator._refused_consolidation_deletes(before, after, tool_calls) == {"alpha"}
+
+
+def test_refused_consolidation_deletes_ignores_unknown_targets(curator_env):
+    """L3 edge: a delete aimed at a skill absent from before_names (already
+    gone, hallucinated) is not counted as refused."""
+    curator = curator_env["curator"]
+    before, after = {"alpha"}, {"alpha"}
+    tool_calls = [
+        {"name": "skill_manage", "arguments": json.dumps({"action": "delete", "name": "ghost"})},
+    ]
+    assert curator._refused_consolidation_deletes(before, after, tool_calls) == set()
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 integration — run.json / REPORT.md / status summary
+# ---------------------------------------------------------------------------
+
+def test_run_report_surfaces_refused_deletes(curator_env):
+    """L3 RED→GREEN: a refused-deletes run must carry the count in run.json
+    counts and a warning line in REPORT.md — not report silent success."""
+    import json as _json
+    curator = curator_env["curator"]
+    _write_agent_skill(curator_env, "alpha")
+    _write_agent_skill(curator_env, "umbrella")
+
+    from datetime import datetime, timezone as _tz
+    llm_meta = {
+        "final": "", "summary": "completed the pass", "model": "m", "provider": "p",
+        "tool_calls": [
+            {"name": "skill_manage", "arguments": _json.dumps({"action": "delete", "name": "alpha"})},
+        ], "error": None}
+    report_path = curator._write_run_report(
+        started_at=datetime.now(_tz.utc), elapsed_seconds=1.0,
+        auto_counts={"checked": 2, "marked_stale": 0, "archived": 0, "reactivated": 0},
+        auto_summary="no changes",
+        before_report=curator_env["usage"].curated_report(),
+        before_names={"alpha", "umbrella"},
+        after_report=curator_env["usage"].curated_report(),  # alpha still present
+        llm_meta=llm_meta)
+    assert report_path is not None
+    run_json = _json.loads((report_path / "run.json").read_text())
+    assert run_json["counts"]["refused_consolidation_deletes"] == 1
+    assert run_json["refused_consolidation_delete_names"] == ["alpha"]
+    report_md = (report_path / "REPORT.md").read_text()
+    assert "Refused consolidation deletes" in report_md
+
+
+def test_consolidation_pass_summary_flags_refused(curator_env, monkeypatch):
+    """L3 RED→GREEN: last_run_summary (what `hermes curator status` shows) must
+    flag refused consolidation deletes instead of the LLM's self-reported
+    success."""
+    import json as _json
+    curator = curator_env["curator"]
+    _write_agent_skill(curator_env, "alpha")
+    _write_agent_skill(curator_env, "umbrella")
+
+    monkeypatch.setattr(curator, "_run_llm_review", lambda prompt: {
+        "final": "", "summary": "Completed the pass and verified the catalog.",
+        "model": "m", "provider": "p",
+        "tool_calls": [
+            {"name": "skill_manage", "arguments": _json.dumps({"action": "delete", "name": "alpha"})},
+        ], "error": None})
+
+    final_summary, llm_meta = curator._consolidation_pass("auto: ", "no changes", False, {"alpha", "umbrella"})
+    assert "refused" in final_summary
+    assert "alpha" in final_summary

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -887,6 +887,11 @@ SKILL_MANAGE_SCHEMA = {
             # Also accepted, never advertised: the legacy flat single-op fields, and
             # `absorbed_into` on delete ops (curator-only vocabulary; the curator's
             # prompt documents it and the delete guard's error re-teaches it).
+            # EXCEPTION: the curator consolidation fork advertises `absorbed_into`
+            # fork-locally (agent/curator.py::_advertise_absorbed_into, #97959) —
+            # its delete guard refuses deletes without it, so the fork is the one
+            # context that MUST see the parameter. Every other session keeps the
+            # lean shared schema.
         },
         "required": ["operations"],
     },


### PR DESCRIPTION
## What

Fixes the curator consolidation deadlock from #97959: the `skill_manage` handler accepts `absorbed_into` on delete and the fail-closed consolidation delete guard refuses any delete without it, yet the advertised schema never mentioned the parameter — schema-strict review models could never emit it, every consolidation delete was refused (19 consecutive refusals in the reporter's run), and the run still reported success.

## How

- **Fork-local schema advertisement** (`agent/curator.py::_advertise_absorbed_into`): the curator review fork's own `tools[]` advertises `absorbed_into` on delete operations inside `operations[]`. The shared `SKILL_MANAGE_SCHEMA` stays byte-identical for every other session, preserving the deliberate token-saving omission (the fork is the only context that needs it — per the issue's option 1). Fresh dicts on every container level; the memoized `get_tool_definitions` cache is never mutated (test-proven). The fork pins `_skip_mcp_refresh` so a between-turns rebuild can't silently drop the augmentation — same pattern as the `background_review` fork.
- **Refused-deletes observability** (`_refused_consolidation_deletes`): a delete-targeted skill still present after the run = a refused delete (the guard is fail-closed). Surfaced in `run.json` `counts.refused_consolidation_deletes` + `refused_consolidation_delete_names`, a ⚠ warning block in `REPORT.md`, and a suffix on `last_run_summary` visible in `hermes curator status`. Counts distinct skills, not call retries; skips truncated/garbage arguments; ignores targets absent from `before_names`.
- **Comment honesty** (`tools/skill_manager_tool.py`): the shared-schema "never advertised" comment now points at the fork-local exception.

The prompt-wording layer of the issue is deliberately not touched here — #88892 covers the prompt contract.

## Verification

Fail-without-fix reproduced during review: production files reverted to `upstream/main`, 11 new tests kept → **10 failed / 1 passed** (the passing one is the shared-schema-stays-lean invariant, correct on both sides).

With the fix, on the rebased head (upstream `c6f87deb`):
- `tests/agent/test_curator_absorbed_into.py` — 11 passed
- `tests/agent/test_curator_reports.py` + `test_curator_classification.py` — 16 passed
- `tests/agent/test_curator.py` + `test_curator_activity.py` — 31 passed
- `tests/tools/test_skill_manager_tool.py` — 63 passed

## Competitor analysis

- #98538 (Aug 30, +8/−0): adds `absorbed_into` to the **shared** schema, no tests, no observability — this reverses the deliberate token-saving omission documented in the code comment and fixes only the schema layer. This PR keeps the shared schema lean and fixes all layers (schema + observability) with regression coverage.
- #98605: audit normalization for nested `operations[]` — explicitly does not duplicate the schema advertisement; complementary.

Closes #97959

Auto-published by Moonsong via Path B automated pipeline.
