### PR TITLE
fix(cron): preserve elapsed durations across DST changes

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -25,7 +25,7 @@ try:
     import msvcrt
 except ImportError:  # pragma: no cover - non-Windows
     msvcrt = None
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from cron.env_settings import cron_env_setting
@@ -790,7 +790,9 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
         except ValueError:
             raise ValueError(
                 f"Invalid duration '{duration_str}' after 'in '. Use e.g. 'in 30m', 'in 2h'.")
-        run_at = _hermes_now() + timedelta(minutes=minutes)
+        now = _hermes_now()
+        # Durations measure elapsed time, not wall-clock hours across a DST transition.
+        run_at = (now.astimezone(timezone.utc) + timedelta(minutes=minutes)).astimezone(now.tzinfo)
         return {"kind": "once", "run_at": run_at.isoformat(), "display": f"once in {duration_str}"}
     with contextlib.suppress(ValueError):
         return _interval_schedule(parse_duration(schedule))
@@ -1108,7 +1110,9 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
         minutes = schedule.get("minutes")
         if minutes is None:
             return None
-        return (base_time + timedelta(minutes=minutes)).isoformat()
+        # Add in UTC so an interval keeps its duration when the profile's UTC offset changes.
+        next_run = base_time.astimezone(timezone.utc) + timedelta(minutes=minutes)
+        return next_run.astimezone(base_time.tzinfo).isoformat()
     if kind == "cron":
         expr = schedule.get("expr")
         if not expr:

--- a/tests/cron/test_duration_dst.py
+++ b/tests/cron/test_duration_dst.py
@@ -1,0 +1,45 @@
+"""Duration schedules measure elapsed time, including across UTC offset changes."""
+
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from cron import jobs
+
+
+@pytest.fixture(params=[
+    ("America/Toronto", "2026-03-08T01:30:00", 0),
+    ("America/Toronto", "2026-11-01T00:30:00", 0),
+    ("America/Toronto", "2026-11-01T01:30:00", 1),
+    ("Australia/Lord_Howe", "2026-04-05T01:45:00", 0),
+    ("Australia/Lord_Howe", "2026-10-04T01:45:00", 0),
+    ("UTC", "2026-03-08T01:30:00", 0),
+])
+def start(request):
+    zone, wall_time, fold = request.param
+    return datetime.fromisoformat(wall_time).replace(tzinfo=ZoneInfo(zone), fold=fold)
+
+
+def test_one_shot_delay_preserves_elapsed_duration(monkeypatch, start):
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: start)
+
+    schedule = jobs.parse_schedule("in 2h")
+    run_at = datetime.fromisoformat(schedule["run_at"])
+
+    assert run_at.astimezone(timezone.utc) - start.astimezone(timezone.utc) == timedelta(hours=2)
+    assert run_at.utcoffset() == run_at.astimezone(start.tzinfo).utcoffset()
+
+
+@pytest.mark.parametrize("resume", [False, True])
+def test_interval_preserves_elapsed_duration(monkeypatch, start, resume):
+    now = start + timedelta(days=2) if resume else start
+    monkeypatch.setattr(jobs, "_hermes_now", lambda: now)
+
+    schedule = jobs.parse_schedule("every 2h")
+    run_at = datetime.fromisoformat(jobs.compute_next_run(
+        schedule, last_run_at=start.isoformat() if resume else None,
+    ))
+
+    assert run_at.astimezone(timezone.utc) - start.astimezone(timezone.utc) == timedelta(hours=2)
+    assert run_at.utcoffset() == run_at.astimezone(start.tzinfo).utcoffset()


### PR DESCRIPTION
## What does this PR do?

Fixes next-run calculation for duration schedules across daylight-saving transitions. In `America/Toronto`, creating `in 2h` or `every 2h` at `2026-03-08 01:30 -05:00` currently stores a next run only **one elapsed hour** later; creating it at `2026-11-01 00:30 -04:00` stores **three elapsed hours** later.

Add the duration in UTC and convert back to the profile timezone. Both paths now preserve the requested elapsed interval and emit the correct local offset. Recurring schedules still anchor on `last_run_at` when provided.

## Related Issue

Fixes #109411.

I checked #66436 / #66456: they address the `croniter` branch for fixed wall-clock expressions. This PR changes only one-shot delays and recurring duration calculations; it does not change cron-expression semantics or audit the dispatch loop's separate DST comparisons.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/jobs.py`: perform elapsed arithmetic in UTC in `parse_schedule("in …")` and the interval branch of `compute_next_run()`.
- `tests/cron/test_duration_dst.py`: two invariant tests, parametrized across spring/fall transitions, the repeated hour, half-hour transitions in Lord Howe, UTC, and `last_run_at` restoration. Assertions compare elapsed UTC time and require a valid offset for the resulting local instant.

## How to Test

1. Run the reproduction in #109411. On the unfixed base, the new regression file reports **12 failed, 6 passed**.
2. Run the canonical hermetic runner with the project dev environment:

   ```sh
   scripts/run_tests.sh \
     tests/cron/test_duration_dst.py \
     tests/cron/test_jobs.py \
     tests/cron/test_compute_next_run_last_run_at.py \
     tests/cron/test_cron_next_run_profile_timezone.py \
     tests/cron/test_cron_timezone_migration_catchup.py \
     tests/cron/test_scheduled_occurrence.py --file-retries 0 -q
   ```

   Final branch rebased onto `c6f87deb2c38d75518c793790f1cc9afa37f0695`: **6 files, 146 passed, 0 failed**.
3. Exercise `hermes cron create 'in 2h' 'Duration test' --deliver local` and the `every 2h` variant through the real CLI entry point with an isolated temporary `HERMES_HOME` and the clock frozen at each Toronto transition. Reload `jobs.json` and compare `next_run_at` with `created_at` in UTC: all four runs persist **7200 elapsed seconds**. No live gateway/model call was used; this verifies CLI creation and persistence, not end-to-end message delivery.

`ruff check cron/jobs.py tests/cron/test_duration_dst.py` and `git diff --check` also pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits
- [x] I searched existing open and closed PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — full repository suite not run locally; the canonical runner's focused results are above
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS, Python 3.11.15

### Documentation & Housekeeping

- [x] Relevant documentation/docstrings — intent documented beside both arithmetic paths; no user configuration changes
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered: stdlib datetime/ZoneInfo arithmetic; tests do not spoof the host OS
- [x] Tool descriptions/schemas — N/A; existing duration semantics preserved

## Screenshots / Logs

```text
Before: in 2h / every 2h, spring transition -> elapsed_hours=1.0
Before: in 2h / every 2h, fall transition   -> elapsed_hours=3.0
After:  all four CLI-created records       -> elapsed_seconds=7200.0
```

Prepared with Codex assistance; validation limitations are stated above.
