### PR TITLE
feat(voice): support GPT Live through Codex subscription

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1120,10 +1120,11 @@ DEFAULT_CONFIG = {
         #   chained  — STT → Hermes turn → TTS (the stt.* / tts.* providers below)
         #   gpt-live — one full-duplex voice model (OpenAI GPT-Live) owns the mic and speaker and
         #              DELEGATES every real request to Hermes (any model / provider you have
-        #              selected); needs an OpenAI API key. $0.05/min voice layer billing.
+        #              selected); gpt-live-1 needs an OpenAI API key, while
+        #              gpt-live-1-codex uses the existing ChatGPT/Codex subscription login.
         "voice_chat_mode": "chained",
         "gpt_live": {
-            "model": "gpt-live-1",
+            "model": "gpt-live-1",  # or gpt-live-1-codex for ChatGPT subscription OAuth
             "voice": "marin",  # marin | quartz | ripple | vesper | willow | stone | gleam | meridian | ...
             # Extra sentences appended to the live model's conversation persona (tone, pacing, language).
             "instructions": "",

--- a/tests/tui_gateway/test_voice_live_delegation.py
+++ b/tests/tui_gateway/test_voice_live_delegation.py
@@ -12,6 +12,7 @@ matter and are pinned here:
   HUD note it sits beside.
 """
 
+import base64
 import json
 import threading
 import types
@@ -78,6 +79,78 @@ class TestSessionCreation:
         assert session["input"][0]["role"] == "user"
         assert captured["body"]["transport"] == {"type": "webrtc", "sdp": "v=0 offer"}
         assert "sk-test" not in json.dumps(result)
+
+    def test_codex_model_uses_subscription_oauth_call(self, monkeypatch):
+        """The Codex-only model uses the ChatGPT subscription endpoint and account
+        header while preserving the renderer's existing normalized answer shape."""
+        captured = {}
+
+        class _Headers(dict):
+            def get(self, key, default=None):
+                return super().get(key, default)
+
+        class _Resp:
+            headers = _Headers({"Location": "/backend-api/codex/realtime/calls/rtc_live_123"})
+
+            def read(self):
+                return b"v=0 answer\r\n"
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+        def fake_urlopen(req, timeout=0):
+            captured["url"] = req.full_url
+            captured["headers"] = {key.lower(): value for key, value in req.header_items()}
+            captured["body"] = json.loads(req.data)
+            return _Resp()
+
+        claims = {"https://api.openai.com/auth": {"chatgpt_account_id": "acct-test"}}
+        payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+        token = f"header.{payload}.signature"
+        monkeypatch.setattr(voice_live.urllib.request, "urlopen", fake_urlopen)
+        monkeypatch.setattr(
+            voice_live, "_live_section",
+            lambda voice=None: {"model": "gpt-live-1-codex", "voice": "cove"})
+        monkeypatch.setattr(
+            "hermes_cli.auth.resolve_codex_runtime_credentials",
+            lambda: {"api_key": token})
+
+        result = voice_live.create_webrtc_session("v=0 offer")
+
+        assert captured["url"] == voice_live.CODEX_LIVE_CALL_URL
+        assert captured["headers"]["authorization"] == f"Bearer {token}"
+        assert captured["headers"]["chatgpt-account-id"] == "acct-test"
+        assert captured["headers"]["originator"] == "hermes-agent"
+        assert captured["headers"]["openai-alpha"] == "quicksilver=v2"
+        assert captured["headers"]["session-id"]
+        assert captured["headers"]["thread-id"]
+        assert captured["headers"]["x-session-id"]
+        assert captured["body"]["sdp"] == "v=0 offer"
+        assert captured["body"]["session"]["model"] == "gpt-live-1-codex"
+        assert captured["body"]["session"]["delegation"] == {"type": "client"}
+        assert result == {
+            "session": {"id": "rtc_live_123"},
+            "transport": {"type": "webrtc", "sdp": "v=0 answer\r\n"},
+        }
+        assert token not in json.dumps(result)
+
+    def test_codex_model_requires_subscription_login_before_network(self, monkeypatch):
+        monkeypatch.setattr(
+            voice_live, "_live_section", lambda voice=None: {"model": "gpt-live-1-codex"})
+        monkeypatch.setattr(
+            voice_live, "_resolve_codex_subscription_credentials", lambda: ("", ""))
+        monkeypatch.setattr(
+            voice_live.urllib.request, "urlopen",
+            lambda *a, **k: pytest.fail("must not call the vendor"))
+
+        with pytest.raises(ValueError, match="hermes auth add openai-codex"):
+            voice_live.create_webrtc_session("v=0 offer")
+        status = voice_live.resolve_gpt_live_status()
+        assert status["available"] is False
+        assert "openai-codex" in status["reason"]
 
     def test_missing_key_refuses_before_any_network(self, monkeypatch):
         monkeypatch.setattr(voice_live, "_resolve_credentials", lambda live: ("", voice_live.DEFAULT_LIVE_BASE_URL))

--- a/tools/voice_live.py
+++ b/tools/voice_live.py
@@ -1,23 +1,23 @@
 """GPT-Live voice chat mode: the full-duplex voice frontend that delegates to Hermes.
 
 ``voice.voice_chat_mode: gpt-live`` replaces the chained STT → turn → TTS loop with ONE
-full-duplex voice model (OpenAI ``gpt-live-1``) that owns the microphone and the speaker and
-delegates every real request to Hermes as its *client-delegation* backend. Hermes stays the
-agent: whatever model/provider the session has selected answers, with the full toolset.
+full-duplex voice model that owns the microphone and the speaker and delegates every real request
+to Hermes as its *client-delegation* backend. Hermes stays the agent: whatever model/provider the
+session has selected answers, with the full toolset.
 
 Division of labour (the Live API has no tools of its own in client mode):
 
 * the desktop renderer holds the WebRTC media session (mic in, speech out) and the data channel;
 * this module resolves WHICH credentials/voice/persona to use and performs the one server-side
-  step the API requires — exchanging the browser's SDP offer for an answer with the project key
-  (``POST /v1/live/sessions``), so the key never reaches the client;
+  step the API requires — exchanging the browser's SDP offer for an answer using either an OpenAI
+  API key (``gpt-live-1``) or the existing ChatGPT/Codex OAuth login
+  (``gpt-live-1-codex``), so credentials never reach the client;
 * the renderer turns each ``session.delegation.created`` into a normal ``prompt.submit`` on the
   active session (surface ``voice-live``) and streams the reply back as
   ``session.commentary.append`` — Hermes' answer is what the voice speaks.
 
-Vendor contract: https://developers.openai.com/api/docs/guides/live (+ live-delegation,
-voice-webrtc). Billing is $0.05/min of session time on the OpenAI key, separate from the
-Hermes turn.
+Public API contract: https://developers.openai.com/api/docs/guides/live (+ live-delegation,
+voice-webrtc). Public API billing is separate from the delegated Hermes turn.
 """
 
 from __future__ import annotations
@@ -26,7 +26,9 @@ import json
 import logging
 import urllib.error
 import urllib.request
+import uuid
 from typing import Any, Dict, Optional
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +37,11 @@ CHAINED_MODE = "chained"
 DEFAULT_LIVE_MODEL = "gpt-live-1"
 DEFAULT_LIVE_VOICE = "marin"
 DEFAULT_LIVE_BASE_URL = "https://api.openai.com/v1"
+CODEX_LIVE_MODEL = "gpt-live-1-codex"
+CODEX_LIVE_CALL_URL = (
+    "https://chatgpt.com/backend-api/codex/realtime/calls"
+    "?intent=quicksilver&architecture=avas"
+)
 # Voices the vendor lists for gpt-live-1 (live-conversations guide) plus the realtime defaults it
 # accepts; free text stays allowed for custom voices.
 GPT_LIVE_VOICES = (
@@ -123,6 +130,106 @@ def _resolve_credentials(live: Dict[str, Any]) -> tuple[str, str]:
     return api_key, base_url
 
 
+def _resolve_codex_subscription_credentials() -> tuple[str, str]:
+    """Return ``(access_token, chatgpt_account_id)`` for the user's existing
+    ``openai-codex`` login. Refresh and profile/pool fallback stay owned by the
+    canonical Codex auth resolver; this module never reads ``auth.json`` itself.
+    """
+    try:
+        from hermes_cli.auth import resolve_codex_runtime_credentials
+
+        resolved = resolve_codex_runtime_credentials()
+        access_token = str(resolved.get("api_key") or "").strip()
+        headers = _codex_identity_headers(access_token)
+        account_id = str(headers.get("ChatGPT-Account-ID") or "").strip()
+        return access_token, account_id
+    except Exception as exc:
+        logger.debug("Could not resolve OpenAI Codex OAuth for GPT-Live: %s", exc)
+        return "", ""
+
+
+def _codex_identity_headers(access_token: str) -> Dict[str, str]:
+    from agent.codex_headers import codex_cloudflare_headers
+
+    return codex_cloudflare_headers(access_token, base_url=CODEX_LIVE_CALL_URL)
+
+
+def _configured_model(live: Dict[str, Any]) -> str:
+    return str(live.get("model") or DEFAULT_LIVE_MODEL).strip()
+
+
+def _uses_codex_subscription(live: Dict[str, Any]) -> bool:
+    return _configured_model(live).lower() == CODEX_LIVE_MODEL
+
+
+def _redact_vendor_detail(detail: str, *secrets: str) -> str:
+    redacted = detail
+    for secret in secrets:
+        if secret:
+            redacted = redacted.replace(secret, "[redacted]")
+    return redacted
+
+
+def _codex_call_id(headers: Any) -> str:
+    """Best-effort public call id for the existing renderer response shape."""
+    session_id = str(headers.get("openai-session-id") or "").strip()
+    location = str(headers.get("Location") or "").strip()
+    if location:
+        for part in reversed([part for part in urlparse(location).path.split("/") if part]):
+            if part.startswith("rtc_") or (len(part) == 36 and part.count("-") == 4):
+                return part
+    return session_id
+
+
+def _create_codex_webrtc_session(
+    sdp_offer: str, history: Optional[list], live: Dict[str, Any]
+) -> Dict[str, Any]:
+    access_token, account_id = _resolve_codex_subscription_credentials()
+    if not access_token or not account_id:
+        raise ValueError(
+            "GPT-Live Codex needs a ChatGPT subscription login "
+            "(run `hermes auth add openai-codex`)"
+        )
+
+    request_id = str(uuid.uuid4())
+    body = json.dumps({
+        "sdp": sdp_offer,
+        "session": build_session_config(history, live=live),
+    }).encode("utf-8")
+    req = urllib.request.Request(
+        CODEX_LIVE_CALL_URL,
+        data=body,
+        method="POST",
+        headers={
+            **_codex_identity_headers(access_token),
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+            "OpenAI-Alpha": "quicksilver=v2",
+            "chatgpt-account-id": account_id,
+            "session-id": str(uuid.uuid4()),
+            "thread-id": str(uuid.uuid4()),
+            "x-session-id": request_id,
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            answer = resp.read().decode("utf-8")
+            if not answer.strip():
+                raise RuntimeError("GPT-Live session creation returned an empty SDP answer")
+            call_id = _codex_call_id(resp.headers)
+            return {
+                "session": {"id": call_id} if call_id else {},
+                "transport": {"type": "webrtc", "sdp": answer},
+            }
+    except urllib.error.HTTPError as exc:
+        detail = _redact_vendor_detail(
+            exc.read().decode("utf-8", "replace")[:600], access_token, account_id)
+        logger.warning("GPT-Live Codex session creation failed: %s %s", exc.code, detail)
+        raise RuntimeError(
+            f"GPT-Live Codex session creation failed ({exc.code}): {detail}"
+        ) from exc
+
+
 def live_instructions(live: Optional[Dict[str, Any]] = None) -> str:
     extra = str((live if live is not None else _live_section()).get("instructions") or "").strip()
     return f"{LIVE_PERSONA}\n\n{extra}" if extra else LIVE_PERSONA
@@ -134,20 +241,33 @@ def resolve_gpt_live_status() -> Dict[str, Any]:
     voice = _voice_section()
     mode = voice_chat_mode(voice)
     live = _live_section(voice)
-    api_key, _base = _resolve_credentials(live)
+    if _uses_codex_subscription(live):
+        access_token, account_id = _resolve_codex_subscription_credentials()
+        available = bool(access_token and account_id)
+        reason = None if available else (
+            "no ChatGPT subscription login (run `hermes auth add openai-codex`)"
+        )
+    else:
+        api_key, _base = _resolve_credentials(live)
+        available = bool(api_key)
+        reason = None if available else (
+            "no OpenAI API key (set OPENAI_API_KEY or voice.gpt_live.api_key)"
+        )
     return {
         "mode": mode,
-        "available": bool(api_key),
-        "reason": None if api_key else "no OpenAI API key (set OPENAI_API_KEY or voice.gpt_live.api_key)",
-        "model": str(live.get("model") or DEFAULT_LIVE_MODEL),
+        "available": available,
+        "reason": reason,
+        "model": _configured_model(live),
         "voice": str(live.get("voice") or DEFAULT_LIVE_VOICE),
     }
 
 
-def build_session_config(history: Optional[list] = None) -> Dict[str, Any]:
+def build_session_config(
+    history: Optional[list] = None, *, live: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
     """The ``session`` object for ``POST /v1/live/sessions`` (client delegation, WebRTC — the
     transport negotiates the audio format, so none is set)."""
-    live = _live_section()
+    live = live if live is not None else _live_section()
     config: Dict[str, Any] = {
         "model": str(live.get("model") or DEFAULT_LIVE_MODEL),
         "instructions": live_instructions(live),
@@ -167,11 +287,13 @@ def create_webrtc_session(sdp_offer: str, history: Optional[list] = None) -> Dic
     status/detail) for a rejected request.
     """
     live = _live_section()
+    if _uses_codex_subscription(live):
+        return _create_codex_webrtc_session(sdp_offer, history, live)
     api_key, base_url = _resolve_credentials(live)
     if not api_key:
         raise ValueError("GPT-Live needs an OpenAI API key (OPENAI_API_KEY or voice.gpt_live.api_key)")
     body = json.dumps({
-        "session": build_session_config(history),
+        "session": build_session_config(history, live=live),
         "transport": {"type": "webrtc", "sdp": sdp_offer},
     }).encode("utf-8")
     req = urllib.request.Request(

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -201,15 +201,21 @@ The chained loop above is one of two voice chat modes in the desktop app. The ot
 voice:
   voice_chat_mode: gpt-live     # chained (default) | gpt-live
   gpt_live:
+    model: gpt-live-1
     voice: marin                # marin, cedar, quartz, ripple, vesper, willow, stone, gleam, meridian, …
     instructions: ""            # optional extra persona sentences (tone, pace, language)
 ```
 
-Requirements: an OpenAI API key (`OPENAI_API_KEY`, `VOICE_TOOLS_OPENAI_KEY`, or `voice.gpt_live.api_key`). The voice layer is billed by OpenAI at **$0.05 per minute of session time** (idle time counts); the Hermes turn is billed on its own provider as always. The mode is also in Settings → Voice → *Voice Chat Mode*.
+Authentication depends on the selected model:
+
+- `gpt-live-1` uses an OpenAI API key (`OPENAI_API_KEY`, `VOICE_TOOLS_OPENAI_KEY`, or `voice.gpt_live.api_key`). The voice layer is billed by OpenAI at **$0.05 per minute of session time** (idle time counts).
+- `gpt-live-1-codex` uses the existing ChatGPT/Codex subscription login. Run `hermes auth add openai-codex`, then set `model: gpt-live-1-codex` and a supported voice such as `voice: cove`; the OAuth token and ChatGPT account ID stay on the gateway host.
+
+The delegated Hermes turn is billed on its own provider as always. The mode is also in Settings → Voice → *Voice Chat Mode*.
 
 How it works: pressing the voice button opens a WebRTC session from the desktop to GPT-Live; the desktop only ever receives a session id and an SDP answer — the key stays on the gateway host, which performs the session creation (`POST /api/audio/voice-live/session`). Each `session.delegation.created` becomes a normal turn on the open chat (the bubble shows what you said; the recent spoken exchange rides the model input as a per-turn note, never the system prompt, so the reply is speakable prose). Tool activity is fed to the voice as quiet context ("Hermes is working: terminal") so it can tell you what is happening if you ask; the final answer is streamed back sentence by sentence. Saying the stop phrase ends the conversation. If `gpt-live` is selected but no key resolves, the button falls back to the chained mode with a notice.
 
-Not supported in this mode: the Nous-managed audio proxy (direct key only), the CLI/TUI (`/voice` keeps the chained loop), and the `tts` tool (it keeps using `tts.provider`).
+Not supported in this mode: the Nous-managed audio proxy, the CLI/TUI (`/voice` keeps the chained loop), and the `tts` tool (it keeps using `tts.provider`).
 
 ### Barge-in
 


### PR DESCRIPTION
## Summary

- add `gpt-live-1-codex` as an opt-in GPT Live model backed by the existing `openai-codex` subscription login
- keep the SDP exchange and OAuth credentials on the gateway while forwarding the canonical Hermes identity and ChatGPT account headers
- preserve the existing API-key path for `gpt-live-1` and document both authentication modes

## Validation

- `python -m ruff check tools/voice_live.py hermes_cli/config_defaults.py tests/tui_gateway/test_voice_live_delegation.py`
- `HERMES_PYTHON=... bash scripts/run_tests.sh tests/tui_gateway/test_voice_live_delegation.py` (7 passed)

A live vendor handshake was not run because it requires an authenticated ChatGPT subscription and consumes account quota.