### PR TITLE
fix(auth): recognize custom and openrouter in _config_model_provider for bootstrap (#109397)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1392,16 +1392,19 @@ def _logged_in_oauth_active_provider(*, skip_free_tier: bool = False) -> Optiona
 
 
 def _config_model_provider() -> Tuple[Any, Optional[str]]:
-    """``(model_cfg, provider)`` from config.yaml when ``model.provider`` names a registry provider.
+    """``(model_cfg, provider)`` from config.yaml when ``model.provider`` names a known provider.
 
     The normal chat/gateway path resolves config.provider upstream in resolve_requested_provider();
-    this is the safety net for the lone direct caller (main.py resolve_provider("auto"))."""
+    this is the safety net for the lone direct caller (main.py resolve_provider("auto")). Custom
+    and OpenRouter are not in PROVIDER_REGISTRY but are first-class OpenAI-compatible providers
+    and must be recognised here, otherwise free_tier_bootstrap wrongly reports no provider configured
+    for `provider: custom` installs (see #109397)."""
     try:
         from hermes_cli.config import load_config
         model_cfg = (load_config() or {}).get("model")
         provider = model_cfg.get("provider") if isinstance(model_cfg, dict) else None
         provider = provider.strip().lower() if isinstance(provider, str) else ""
-        return model_cfg, (provider if provider in PROVIDER_REGISTRY else None)
+        return model_cfg, (provider if provider in PROVIDER_REGISTRY or provider in ("custom", "openrouter") else None)
     except Exception as e:
         logger.debug("Could not read config.yaml model.provider for auto-resolution: %s", e)
         return None, None


### PR DESCRIPTION
Fixes #109397

**Problem:** After 0.21.2, dashboard TUI showed "Hermes needs a model provider before the TUI can start a session" for `model.provider: custom` (and openrouter) installs even though CLI/gateway worked. `_config_model_provider()` only recognized providers in `PROVIDER_REGISTRY`; `custom`/"openrouter" are pseudo-providers not in the registry, so `resolve_provider(auto)` raised `AuthError(no_provider_configured)` and `free_tier_bootstrap` set `provider_configured=False`.

**Fix:** Include `custom` and `openrouter` as known providers in `_config_model_provider()`. This restores `resolve_provider(auto)` → `custom` and makes bootstrap correctly report a configured provider.

**Verification:** 
- `_config_model_provider` now returns `custom`/`openrouter` (including case-insensitive)
- `resolve_provider(auto)` with custom config returns `custom`
- `_inventory_other_providers()` returns True and `_resolve_inference()` returns `custom`
- `tests/hermes_cli/test_provider_precedence.py` 11 passed