### PR TITLE
fix(desktop): feed the ROUTES_AREA subscription snapshot into contributedRoutes (#109063)

### DIFF
--- a/apps/desktop/src/app/chat/route-tile-reactivity.test.tsx
+++ b/apps/desktop/src/app/chat/route-tile-reactivity.test.tsx
@@ -1,0 +1,78 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { registry } from '@/contrib/registry'
+
+import { RouteTilePane } from './route-tile'
+
+// #109063: route tiles subscribe to ROUTES_AREA but used to derive routes via
+// an independently-called `contributedRoutes()`, which React Compiler can keep
+// memoized across the delivered subscription update. These tests run through
+// the real registry, the real `useContributions` hook and the compiler-enabled
+// Vite config — mocking the route list would hide exactly this defect.
+
+afterEach(cleanup)
+
+/** Register (or hot-replace) the plugin route page mounted at `/resetwatch`. */
+function registerResetwatch(label: string) {
+  return registry.register({
+    id: 'resetwatch',
+    area: 'routes',
+    title: `Resetwatch ${label}`,
+    data: { path: '/resetwatch' },
+    render: () => <div>{`PLUGIN-PAGE-${label}`}</div>
+  })
+}
+
+describe('RouteTilePane route-contribution reactivity (#109063)', () => {
+  it('mounts a plugin page whose route registers after the pane', () => {
+    render(<RouteTilePane path="/resetwatch" />)
+    expect(screen.getByText(/no page at \/resetwatch/)).toBeTruthy()
+
+    let dispose = () => {}
+    act(() => {
+      dispose = registerResetwatch('A')
+    })
+    expect(screen.getByText('PLUGIN-PAGE-A')).toBeTruthy()
+
+    act(() => {
+      dispose()
+    })
+  })
+
+  it('hot-replaces the page when the same contribution id re-registers', () => {
+    let dispose = registerResetwatch('A')
+    render(<RouteTilePane path="/resetwatch" />)
+    expect(screen.getByText('PLUGIN-PAGE-A')).toBeTruthy()
+
+    act(() => {
+      dispose()
+      dispose = registerResetwatch('B')
+    })
+    expect(screen.getByText('PLUGIN-PAGE-B')).toBeTruthy()
+    expect(screen.queryByText('PLUGIN-PAGE-A')).toBeNull()
+
+    act(() => {
+      dispose()
+    })
+  })
+
+  it('returns to the fallback after dispose and mounts again on re-register', () => {
+    let dispose = registerResetwatch('A')
+    render(<RouteTilePane path="/resetwatch" />)
+
+    act(() => {
+      dispose()
+    })
+    expect(screen.getByText(/no page at \/resetwatch/)).toBeTruthy()
+
+    act(() => {
+      dispose = registerResetwatch('A')
+    })
+    expect(screen.getByText('PLUGIN-PAGE-A')).toBeTruthy()
+
+    act(() => {
+      dispose()
+    })
+  })
+})

--- a/apps/desktop/src/app/chat/route-tile.tsx
+++ b/apps/desktop/src/app/chat/route-tile.tsx
@@ -47,12 +47,14 @@ function routeTitle(path: string): string {
   return contributedRoutes().find(r => r.path === path)?.title ?? humanizePath(path)
 }
 
-function RouteTilePane({ path }: { path: string }) {
+export function RouteTilePane({ path }: { path: string }) {
   const builtin = BUILTIN_PAGES[path]
 
   // Subscribe so a plugin page tile appears the moment its route registers.
-  useContributions(ROUTES_AREA)
-  const contrib = builtin ? null : contributedRoutes().find(r => r.path === path)
+  // The snapshot feeds the lookup: under React Compiler an independently
+  // called contributedRoutes() can stay memoized across that registration.
+  const contributions = useContributions(ROUTES_AREA)
+  const contrib = builtin ? null : contributedRoutes(contributions).find(r => r.path === path)
 
   if (builtin) {
     return (

--- a/apps/desktop/src/app/contrib/surfaces-reactivity.test.tsx
+++ b/apps/desktop/src/app/contrib/surfaces-reactivity.test.tsx
@@ -1,0 +1,90 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { atom } from 'nanostores'
+import { MemoryRouter } from 'react-router'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { registry } from '@/contrib/registry'
+
+import { ChatRoutesSurface } from './surfaces'
+import type { WiringActions } from './types'
+
+// #109063: the workspace surface subscribes to ROUTES_AREA but used to derive
+// routes via an independently-called `contributedRoutes()`, which React
+// Compiler can keep memoized across the delivered subscription update. The
+// registry, `useContributions` and the routes module all stay REAL here — only
+// unrelated stores and heavy sibling views are stubbed, because mocking the
+// route list is exactly what hid the defect.
+
+vi.mock('@/store/connections', () => ({ $activeConnectionId: atom('local') }))
+vi.mock('@/store/gateway', () => ({ $gateway: atom<unknown>(null) }))
+vi.mock('@/store/profile', () => ({ $activeGatewayProfile: atom('default') }))
+vi.mock('@/store/session', () => ({
+  $freshDraftReady: atom(false),
+  $gatewayState: atom('open')
+}))
+vi.mock('../chat', () => ({ ChatView: () => <div data-testid="chat-view" /> }))
+vi.mock('../chat/sidebar', () => ({ ChatSidebar: () => null }))
+vi.mock('../right-sidebar/terminal/chrome', () => ({ TerminalPaneChrome: () => null }))
+vi.mock('../shell/hooks/use-status-snapshot', () => ({ useStatusSnapshot: () => ({}) }))
+vi.mock('../shell/hooks/use-statusbar-items', () => ({
+  useStatusbarItems: () => ({ leftStatusbarItems: [], statusbarItems: [] })
+}))
+vi.mock('../shell/statusbar-controls', () => ({ StatusbarControls: () => null }))
+vi.mock('../shell/model-menu-panel', () => ({ ModelMenuPanel: () => null }))
+vi.mock('./latest-actions', () => ({ latestChatActions: () => ({}), latestSidebarActions: () => ({}) }))
+vi.mock('./panes', () => ({ setStatusbarItemGroup: vi.fn(), useStatusbarContributions: () => [] }))
+
+afterEach(cleanup)
+
+/** Register (or hot-replace) the plugin route page mounted at `/resetwatch`. */
+function registerResetwatch(label: string) {
+  return registry.register({
+    id: 'resetwatch',
+    area: 'routes',
+    title: `Resetwatch ${label}`,
+    data: { path: '/resetwatch' },
+    render: () => <div>{`PLUGIN-PAGE-${label}`}</div>
+  })
+}
+
+describe('ChatRoutesSurface route-contribution reactivity (#109063)', () => {
+  it('mounts a plugin page registered after the surface, tracks replacement, and unmounts on dispose', () => {
+    const actions = { getGateway: () => null } as unknown as WiringActions
+
+    render(
+      <MemoryRouter initialEntries={['/resetwatch']}>
+        <ChatRoutesSurface actions={actions} />
+      </MemoryRouter>
+    )
+    // Unregistered path falls through the catch-all redirect to the chat view.
+    expect(screen.getByTestId('chat-view')).toBeTruthy()
+
+    let dispose = () => {}
+    act(() => {
+      // Late registration after the surface has mounted and settled.
+      dispose = registerResetwatch('A')
+    })
+    expect(screen.getByText('PLUGIN-PAGE-A')).toBeTruthy()
+    expect(screen.queryByTestId('chat-view')).toBeNull()
+
+    act(() => {
+      dispose()
+      dispose = registerResetwatch('B')
+    })
+    expect(screen.getByText('PLUGIN-PAGE-B')).toBeTruthy()
+
+    act(() => {
+      dispose()
+    })
+    expect(screen.getByTestId('chat-view')).toBeTruthy()
+
+    act(() => {
+      dispose = registerResetwatch('A')
+    })
+    expect(screen.getByText('PLUGIN-PAGE-A')).toBeTruthy()
+
+    act(() => {
+      dispose()
+    })
+  })
+})

--- a/apps/desktop/src/app/contrib/surfaces.tsx
+++ b/apps/desktop/src/app/contrib/surfaces.tsx
@@ -121,8 +121,8 @@ export const ChatRoutesSurface = memo(function ChatRoutesSurface({
   const activeGatewayProfile = useStore($activeGatewayProfile)
   const gateway = useStore($gateway)
   const gatewayState = useStore($gatewayState)
-  useContributions(ROUTES_AREA)
-  const routeContributions = contributedRoutes()
+  const routeSnapshot = useContributions(ROUTES_AREA)
+  const routeContributions = contributedRoutes(routeSnapshot)
 
   const modelMenuContent = useMemo(
     () =>

--- a/apps/desktop/src/app/routes.test.ts
+++ b/apps/desktop/src/app/routes.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
-import { NEW_CHAT_ROUTE, primaryRouteSelectedSessionId, sessionRoute, SETTINGS_ROUTE } from './routes'
+import { registry } from '@/contrib/registry'
+
+import { contributedRoutes, NEW_CHAT_ROUTE, primaryRouteSelectedSessionId, ROUTES_AREA, sessionRoute, SETTINGS_ROUTE } from './routes'
 
 const SESS_A = 'sess-a'
 const SESS_B = 'sess-b'
@@ -26,5 +28,39 @@ describe('primaryRouteSelectedSessionId', () => {
 
   it('returns null on a non-chat route with no store selection', () => {
     expect(primaryRouteSelectedSessionId(SETTINGS_ROUTE, null)).toBeNull()
+  })
+})
+
+describe('contributedRoutes', () => {
+  const page = (id: string, path: string) => ({
+    id,
+    area: ROUTES_AREA,
+    data: { path },
+    render: () => null
+  })
+
+  it('reads the registry when called with no arguments', () => {
+    const dispose = registry.register(page('helper-contract', '/helper-contract'))
+
+    try {
+      expect(contributedRoutes().some(route => route.path === '/helper-contract')).toBe(true)
+    } finally {
+      dispose()
+    }
+  })
+
+  it('uses an explicit snapshot instead of the registry (#109063)', () => {
+    // React consumers pass their useContributions(ROUTES_AREA) snapshot so the
+    // compiler-visible subscription stays a dependency of the derived routes.
+    // Pin the contract: the snapshot wins even when the registry disagrees.
+    const dispose = registry.register(page('helper-contract', '/helper-contract'))
+
+    try {
+      const routes = contributedRoutes([page('explicit', '/explicit')])
+
+      expect(routes.map(route => route.path)).toEqual(['/explicit'])
+    } finally {
+      dispose()
+    }
   })
 })

--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react'
 
 import { noteActiveTreeGroup, revealTreePane } from '@/components/pane-shell/tree/store'
 import { registry } from '@/contrib/registry'
+import type { Contribution } from '@/contrib/types'
 
 type NavigateLike = (to: string, options?: { replace?: boolean }) => void
 
@@ -91,9 +92,13 @@ export interface RouteContribution {
   path: string
 }
 
-export function contributedRoutes(): Array<{ key: string; path: string; title?: string; render: () => ReactNode }> {
-  return registry
-    .getArea(ROUTES_AREA)
+// React consumers must pass their `useContributions(ROUTES_AREA)` snapshot in:
+// with React Compiler enabled, an independently-called `contributedRoutes()`
+// can stay memoized across a late registration the subscription DID deliver.
+export function contributedRoutes(
+  contributions: readonly Contribution[] = registry.getArea(ROUTES_AREA)
+): Array<{ key: string; path: string; title?: string; render: () => ReactNode }> {
+  return contributions
     .map(c => ({
       key: `${c.source ?? 'core'}:${c.id}`,
       path: (c.data as RouteContribution | undefined)?.path ?? '',


### PR DESCRIPTION
## What does this PR do?

React route consumers (`ChatRoutesSurface`, `RouteTilePane`) subscribed to `useContributions(ROUTES_AREA)` but discarded its snapshot, then derived routes through an independent imperative `contributedRoutes()` call. With React Compiler enabled, the compiler-visible subscription update did not count as a dependency of that memoized call, so the derived route table could stay stale across a late plugin registration or hot replacement — an installed plugin showed its sidebar entry while its page never mounted ("no page at {path}").

`contributedRoutes()` now accepts an explicit contribution snapshot, defaulting to the registry read for imperative callers, and both React consumers pass their `useContributions(ROUTES_AREA)` snapshot through. This is the minimal repair validated in the issue report: the subscription stays a dependency of the derived routes, and the existing mapping/filtering behavior is unchanged.

## Related Issue

Fixes #109063

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/routes.ts` — `contributedRoutes()` takes an optional `contributions` snapshot parameter (default `registry.getArea(ROUTES_AREA)`), so React consumers can pass their subscription snapshot while imperative callers (`isContributedPath`, `routeTitle`) keep working unchanged.
- `apps/desktop/src/app/contrib/surfaces.tsx` — `ChatRoutesSurface` captures the `useContributions(ROUTES_AREA)` snapshot and passes it to `contributedRoutes()`.
- `apps/desktop/src/app/chat/route-tile.tsx` — `RouteTilePane` does the same; also exported for the new lifecycle test.
- `apps/desktop/src/app/routes.test.ts` — helper-contract tests: no-arg call reads the registry; an explicit snapshot wins over the registry.
- `apps/desktop/src/app/chat/route-tile-reactivity.test.tsx` — new: late registration, same-id hot replacement, dispose → fallback → re-register through the real registry, real `useContributions` hook and compiler-enabled Vite config.
- `apps/desktop/src/app/contrib/surfaces-reactivity.test.tsx` — new: same lifecycle for the workspace surface mounted at the plugin path in a `MemoryRouter`.

## How to Test

From `apps/desktop`:

1. `npm run test:ui -- src/app/contrib/surfaces.test.tsx src/app/contrib/surfaces-reactivity.test.tsx src/app/chat/route-tile-reactivity.test.tsx src/app/routes.test.ts`
2. `npm run typecheck && npm run lint`

Observed result: before the fix, the two new reactivity files fail on the late-registration/hot-replacement assertions (4 failures — the plugin page never mounts after registration, exactly the reported symptom); with the fix all 4 files pass (12 tests), plus 129 tests across the surrounding `src/app/contrib/` neighborhood. Typecheck passes; lint reports no findings on the changed files.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run the relevant suite: this is a pure `apps/desktop` TypeScript change, so `npm run test:ui` (142 tests across the touched neighborhoods), `npm run typecheck`, and `npm run lint` were run instead of `pytest tests/ -q`
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15.4 (arm64); the regression is compiler-level, covered by the compiler-enabled Vitest project

### Documentation & Housekeeping

- [ ] I have updated relevant documentation (README, `docs/`, docstrings) — N/A
- [ ] I have updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I have considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-availability) — pure React-layer fix, platform-independent
- [ ] I have updated tool descriptions/schemas if I changed tool behavior — N/A