### PR TITLE
fix(plugin): identify critical findings in install blocks

### DIFF
--- a/tests/tools/test_plugin_guard_block_reason.py
+++ b/tests/tools/test_plugin_guard_block_reason.py
@@ -1,0 +1,34 @@
+"""Behavior contracts for plugin-guard dangerous-install diagnostics."""
+
+from tools.plugin_guard import should_allow_plugin_install
+from tools.skills_guard import Finding, ScanResult
+
+
+def test_dangerous_reason_counts_and_names_blocking_findings():
+    result = ScanResult(
+        skill_name="fixture-plugin",
+        source="owner/repo",
+        trust_level="community",
+        verdict="dangerous",
+        findings=[
+            Finding(
+                "hermes_config_mod_shell", "critical", "persistence",
+                "runtime/setup.sh", 4, "echo x > config.yaml", "writes config",
+            ),
+            Finding(
+                "unpinned_pip_install", "medium", "supply_chain",
+                "README.md", 8, "pip install example", "unpinned dependency",
+            ),
+            Finding(
+                "remote_fetch", "medium", "supply_chain",
+                "README.md", 9, "curl https://example.test", "remote fetch",
+            ),
+        ],
+    )
+
+    allowed, reason = should_allow_plugin_install(result)
+
+    assert allowed is False
+    assert "1 critical of 3 findings" in reason
+    assert "hermes_config_mod_shell" in reason
+    assert "unpinned_pip_install" not in reason

--- a/tests/tools/test_plugin_guard_block_reason.py
+++ b/tests/tools/test_plugin_guard_block_reason.py
@@ -12,8 +12,16 @@ def test_dangerous_reason_counts_and_names_blocking_findings():
         verdict="dangerous",
         findings=[
             Finding(
-                "hermes_config_mod_shell", "critical", "persistence",
+                "zeta_critical", "critical", "persistence",
                 "runtime/setup.sh", 4, "echo x > config.yaml", "writes config",
+            ),
+            Finding(
+                "alpha_critical", "critical", "persistence",
+                "runtime/other.sh", 5, "echo y > config.yaml", "writes config",
+            ),
+            Finding(
+                "zeta_critical", "critical", "persistence",
+                "runtime/again.sh", 6, "echo z > config.yaml", "writes config",
             ),
             Finding(
                 "unpinned_pip_install", "medium", "supply_chain",
@@ -29,11 +37,13 @@ def test_dangerous_reason_counts_and_names_blocking_findings():
     allowed, reason = should_allow_plugin_install(result)
 
     assert allowed is False
-    assert "1 critical of 3 findings" in reason
-    assert "hermes_config_mod_shell" in reason
+    assert "3 critical of 5 findings (alpha_critical, zeta_critical)" in reason
     assert "unpinned_pip_install" not in reason
+    forced_allowed, forced_reason = should_allow_plugin_install(result, force=True)
+    assert forced_allowed is False
+    assert "3 critical of 5 findings (alpha_critical, zeta_critical)" in forced_reason
     assert (
-        "Decision: BLOCKED — Blocked (dangerous verdict, 1 critical of 3 findings"
+        "Decision: BLOCKED — Blocked (dangerous verdict, 3 critical of 5 findings"
         in format_scan_report(result)
     )
 

--- a/tests/tools/test_plugin_guard_block_reason.py
+++ b/tests/tools/test_plugin_guard_block_reason.py
@@ -1,6 +1,6 @@
 """Behavior contracts for plugin-guard dangerous-install diagnostics."""
 
-from tools.plugin_guard import should_allow_plugin_install
+from tools.plugin_guard import format_scan_report, should_allow_plugin_install
 from tools.skills_guard import Finding, ScanResult
 
 
@@ -32,3 +32,29 @@ def test_dangerous_reason_counts_and_names_blocking_findings():
     assert "1 critical of 3 findings" in reason
     assert "hermes_config_mod_shell" in reason
     assert "unpinned_pip_install" not in reason
+    assert (
+        "Decision: BLOCKED — Blocked (dangerous verdict, 1 critical of 3 findings"
+        in format_scan_report(result)
+    )
+
+
+def test_plugin_report_uses_plugin_caution_policy():
+    result = ScanResult(
+        skill_name="fixture-plugin",
+        source="owner/repo",
+        trust_level="community",
+        verdict="caution",
+        findings=[
+            Finding(
+                "eval_string", "high", "obfuscation",
+                "runtime/helper.py", 2, "eval('x')", "evaluates a string",
+            ),
+        ],
+    )
+
+    report = format_scan_report(result)
+
+    assert (
+        "Decision: NEEDS CONFIRMATION — Requires confirmation (caution verdict, 1 findings)"
+        in report
+    )

--- a/tools/plugin_guard.py
+++ b/tools/plugin_guard.py
@@ -78,6 +78,14 @@ def _filter_findings(findings: List[Finding], rel_path: str) -> List[Finding]:
     return out
 
 
+def _dangerous_findings_summary(findings: List[Finding]) -> str:
+    """Describe the critical findings that made a plugin install dangerous."""
+    critical = [finding for finding in findings if finding.severity == "critical"]
+    pattern_ids = sorted({finding.pattern_id for finding in critical})
+    names = f" ({', '.join(pattern_ids)})" if pattern_ids else ""
+    return f"{len(critical)} critical of {len(findings)} findings{names}"
+
+
 def _check_plugin_structure(plugin_dir: Path) -> List[Finding]:
     """Structural checks sized for plugin repositories."""
     findings: List[Finding] = []
@@ -155,7 +163,7 @@ def should_allow_plugin_install(
             return True, f"Force-installed despite caution verdict ({n} findings)"
         return None, f"Requires confirmation (caution verdict, {n} findings)"
     return False, (
-        f"Blocked (dangerous verdict, {n} findings). "
+        f"Blocked (dangerous verdict, {_dangerous_findings_summary(result.findings)}). "
         f"--force does not override a dangerous verdict.")
 
 

--- a/tools/plugin_guard.py
+++ b/tools/plugin_guard.py
@@ -15,7 +15,8 @@ from pathlib import Path
 from typing import Iterator, List, Optional, Tuple
 
 from tools.skills_guard import (
-    Finding, ScanResult, SUSPICIOUS_BINARY_EXTENSIONS, _determine_verdict, format_scan_report,
+    Finding, ScanResult, SUSPICIOUS_BINARY_EXTENSIONS, _determine_verdict,
+    format_scan_report as _format_scan_report,
     scan_file)
 
 PLUGIN_SCANNER_VERSION = "plugin-guard-v1"
@@ -165,6 +166,11 @@ def should_allow_plugin_install(
     return False, (
         f"Blocked (dangerous verdict, {_dangerous_findings_summary(result.findings)}). "
         f"--force does not override a dangerous verdict.")
+
+
+def format_scan_report(result: ScanResult, force: bool = False) -> str:
+    """Format a plugin report using the plugin-specific install policy."""
+    return _format_scan_report(result, decision_fn=should_allow_plugin_install, force=force)
 
 
 __all__ = [

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -15,7 +15,7 @@ from contextlib import suppress
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List, Tuple
+from typing import Callable, List, Tuple
 
 
 SCANNER_VERSION = "skills-guard-v2"
@@ -511,8 +511,14 @@ def should_allow_install(result: ScanResult, force: bool = False) -> Tuple[bool,
     return False, blocked + ("--force does not override a dangerous verdict." if hard_block else "Use --force to override.")
 
 
-def format_scan_report(result: ScanResult) -> str:
-    """Compact multi-line report for CLI/chat display; findings sorted critical → low."""
+def format_scan_report(
+    result: ScanResult, *, decision_fn: Callable | None = None, force: bool = False,
+) -> str:
+    """Compact multi-line report for CLI/chat display; findings sorted critical → low.
+
+    ``decision_fn`` lets a scanner keep its own install policy while reusing this
+    formatter; the skills policy remains the default.
+    """
     lines = [f"Scan: {result.skill_name} ({result.source}/{result.trust_level})  Verdict: {result.verdict.upper()}"]
     if result.findings:
         order = {"critical": 0, "high": 1, "medium": 2, "low": 3}
@@ -520,7 +526,7 @@ def format_scan_report(result: ScanResult) -> str:
             lines.append(f"  {f.severity.upper().ljust(8)} {f.category.ljust(14)} "
                          f"{f'{f.file}:{f.line}'.ljust(30)} \"{f.match[:60]}\"")
         lines.append("")
-    allowed, reason = should_allow_install(result)
+    allowed, reason = (decision_fn or should_allow_install)(result, force=force)
     status = "ALLOWED" if allowed is True else "NEEDS CONFIRMATION" if allowed is None else "BLOCKED"
     return "\n".join(lines + [f"Decision: {status} — {reason}"])
 


### PR DESCRIPTION
## What does this PR do?

This is a complementary follow-up for #109391, not a replacement for or a copy of the existing test-tree fix in #109395.

The plugin guard correctly keeps a `dangerous` verdict fail-closed, but its install reason previously reported only the total number of findings. A plugin with one blocking `critical` finding and a large amount of non-blocking medium/high noise was therefore presented as a generic `N findings` block. The operator could see the full report, but the decision line did not identify which severity tier and rule caused the hard block.

This change makes the dangerous-plugin decision diagnostic: it reports the number of critical findings out of the total and the deterministic set of critical rule IDs. It also makes the embedded report use the plugin-specific install policy, so a caution result is displayed as requiring confirmation instead of being mislabeled as blocked by the generic skills policy. The scan verdict, severity policy, `--force` behavior, and scan scope are unchanged.

## Related Issue

Depends on #109395 for the canonical test-tree scan-scope fix.

Related to #109391 (this PR supplies the complementary diagnostic fix).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Investigation and root cause

Issue #109391 was reproduced against the current pre-fix code with a temporary plugin containing a critical Hermes-config write under `tests/fixture.sh`:

```text
verdict= dangerous
findings= [('hermes_config_mod_shell', 'critical', 'tests/fixture.sh', 1),
           ('hermes_config_ref', 'low', 'tests/fixture.sh', 1)]
```

The line-level path is:

- `tools/plugin_guard.py:132-152` scans the tree and passes all findings to `_determine_verdict`.
- `tools/skills_guard.py:629-632` maps any `critical` finding to `dangerous`.
- `tools/plugin_guard.py:156-168` maps that verdict to an unconditional install block because `--force` must not override dangerous plugin content.
- `hermes_cli/plugins_cmd.py:128-159` uses that reason for the CLI install path; the same scanner policy is also used by the update and dashboard paths.

Before this change, the dangerous branch said only:

```text
Blocked (dangerous verdict, 2 findings). --force does not override a dangerous verdict.
```

That wording loses the fact that the hard block was caused by one critical finding rather than the non-blocking findings.

## Changes Made

- `tools/plugin_guard.py:81-86`
  - Added `_dangerous_findings_summary()`.
  - Counts only findings whose final severity is `critical`.
  - Reports the critical count relative to the total finding count.
  - Names unique critical `pattern_id` values in sorted order for deterministic output.
- `tools/plugin_guard.py:156-168`
  - Uses the summary only in the dangerous install reason.
  - Leaves safe/caution behavior, the hard block, and `--force` semantics unchanged.
- `tools/skills_guard.py:514-531` and `tools/plugin_guard.py:171-173`
  - Adds policy injection to the shared report formatter without changing its default skills behavior.
  - Wraps the formatter for plugin callers so the displayed Decision line and the install gate use the same plugin policy.
- `tests/tools/test_plugin_guard_block_reason.py`
  - Adds behavior-contract tests through the public plugin decision and report functions.
  - Verifies that three critical findings among five findings, including duplicate and out-of-order IDs, are counted and rendered as the deterministic `3 critical of 5 findings (alpha_critical, zeta_critical)` summary.
  - Verifies that the `force=True` dangerous path remains blocked and retains the same critical summary; medium-only rule IDs are not presented as blockers.
  - Verifies that a community caution report says `NEEDS CONFIRMATION`, matching the plugin install policy.

## Why this is complementary

PR #109395 owns the core scan-scope correction: excluding exact `test/` and `tests/` directory components from the shared plugin walker so test fixtures cannot decide the install verdict. Its implementation also deliberately keeps documentation and ambiguous test-like paths scanned.

This PR does not touch `_walk()`, `EXCLUDED_DIRS`, test-tree policy, scanner severities, or any code from #109395. It improves the remaining operator-facing diagnostic requested in #109391 and applies automatically to every caller of `should_allow_plugin_install()` and the plugin report formatter.

The repository contains older open proposals #89613 and #97686 covering test-directory exclusion, and #103383/#108811 covering other scanner false positives. None of those proposals owns this critical-count/rule-ID decision diagnostic; no commit was copied or cherry-picked.

## Alternative solutions considered

1. Exclude all documentation: rejected. The original plugin-guard design intentionally scans documentation because agent-facing prompt injection can be delivered through plugin documentation such as `after-install.md`; the existing regression contract requires that content to remain dangerous.
2. Add a plugin-controlled ignore file: rejected for this fix. An untrusted plugin must not be able to declare its own runtime payload unscannable. The skill ignore-file semantics are not automatically safe for plugin installation.
3. Add a per-finding waiver or make `--force` override critical findings: rejected for this complementary change. That would weaken the fail-closed security boundary and would turn a broad scanner bypass into an operator-facing escape hatch. The targeted test-tree scope fix is safer for the reported false positive; this PR makes any remaining hard block actionable without changing that boundary.
4. Downgrade all findings in tests/docs: rejected. It would overlap the existing test-tree work and could demote real runtime threats if path classification is wrong. Runtime critical findings remain critical.
5. Change the verdict threshold: rejected. A critical finding must continue to produce `dangerous`; only the explanation is changed here.

## Algorithm and performance

The new summary performs one linear pass over the already-materialized finding list and one set construction over critical rule IDs: O(n) filtering/set-building time, followed by O(k log k) sorting and O(k) joining, where `n` is the total number of findings and `k` is the number of distinct critical rule IDs. Its auxiliary space is O(n + k) because the critical subset and ID set are materialized. The formatter policy injection is a constant-time function selection and call; it adds no filesystem traversal, regex scan, network I/O, or mutation. The summary runs only after the more expensive `scan_plugin()` work and only on the dangerous branch, so it does not add cost to safe/caution decisions. The existing scanner remains the dominant cost: filesystem traversal plus per-file regex matching over the plugin contents.

## How to Test

Focused regression test, using the canonical runner:

```text
HERMES_PYTHON=/c/Users/Nitro/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe \
  scripts/run_tests.sh tests/tools/test_plugin_guard_block_reason.py
# 1 file, 2 tests passed
```

Plugin-guard controls after the change:

```text
HERMES_PYTHON=/c/Users/Nitro/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe \
  scripts/run_tests.sh tests/tools/test_plugin_guard.py \
  tests/tools/test_plugin_guard_block_reason.py tests/tools/test_skills_guard.py \
  -k 'not symlink_escape'
# 3 files, 52 tests passed, 0 failed, 2 skipped
```

The excluded test name is an existing Windows-only environment limitation: this host does not grant the privilege required by `Path.symlink_to()`. The full baseline run independently reproduced that pre-existing limitation before the code change: 16 passed, 1 failed with `WinError 1314` at `tests/tools/test_plugin_guard.py:122`.

Shared scanner controls:

```text
HERMES_PYTHON=/c/Users/Nitro/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe \
  scripts/run_tests.sh tests/tools/test_skills_guard.py -k 'not symlink_escape'
# 1 file, 34 tests passed, 0 failed, 2 skipped
```

The unfiltered shared-suite run had the same pre-existing Windows symlink-privilege failure at `tests/tools/test_skills_guard.py:260` (`WinError 1314`).

Related plugin CLI checks were also exercised. `test_plugins_cmd_catalog.py` passed 2 tests. The broader plugin CLI files exposed unrelated/pre-existing Windows filesystem failures: `test_plugins_cmd.py` passed 44 and failed 2 (one symlink privilege failure and one existing autostash expectation), while `test_plugin_install_ref.py` passed 20 and failed 2 because Windows denied cleanup of Git object files. No failure was in the changed code or the new test.

Additional checks:

```text
python -m compileall -q tools/skills_guard.py tools/plugin_guard.py \
  tests/tools/test_plugin_guard_block_reason.py
# passed

git diff --check origin/main...HEAD
# passed

python -m ruff check tools/skills_guard.py tools/plugin_guard.py \
  tests/tools/test_plugin_guard_block_reason.py
# not run successfully: the available pytest environment does not install ruff
```

## Security considerations

- This patch does not add a waiver, ignore file, trust exception, or `--force` bypass.
- A critical finding still produces `dangerous` and still blocks community plugin installation.
- Only static rule IDs are added to the reason; source matches, paths, credentials, and environment values are not copied into the new summary.
- The change is diagnostic-only and does not alter the scanner's treatment of documentation or runtime code.
- The shared formatter retains the skills policy by default; only plugin_guard's additive wrapper selects the plugin policy.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs and issues, including #109395, #89613, #97686, #103383, and #108811
- [x] My PR contains only changes related to this diagnostic fix
- [ ] I've run the full repository suite; focused and related suites are recorded above, with Windows environmental failures documented
- [x] I've added a regression test for the changed behavior
- [x] I've tested on Windows 11 with Python 3.11.16 and pytest 9.1.1

### Documentation & Housekeeping

- [x] No configuration key, dependency, tool schema, or architecture workflow changed; relevant documentation update is N/A
- [x] Cross-platform impact considered: the implementation uses only standard Python collections and deterministic sorting

## Graphify receipt

- Pre-edit `graphify query "plugin_guard"` succeeded against `graphify-out/graph.json` and located `scan_plugin()`, `_walk()`, `_filter_findings()`, `should_allow_plugin_install()`, and `_determine_verdict()`.
- Post-edit `graphify update . --no-cluster` was executed as required. Its AST phase reached `3314/3314` files; the graph-writing phase did not finish within the configured wait window, produced no `graphify-out/graph.json`, and was stopped after the timeout. The command reported four pre-existing syntax-warning files outside this change. This did not affect the code/test results above.

## Publication receipt

- Local branch: `fix/issue-109391-plugin-guard-complementary`
- Base verified against current local `origin/main`: `d595e636c8`
- Commits: `0abb63e7addc607abb875622db81db1e3f8c6ce4`, `5281173358ec96fd6a3265b7bc0315160227aab2` (head)
- Pushed to: `JoaoMarcos44/hermes-agent:fix/issue-109391-plugin-guard-complementary`
- Remote branch read-back matched the local commit SHA after each push
- Pull request: `https://github.com/NousResearch/hermes-agent/pull/109420`
- Post-publication read-back: PR is OPEN, non-draft, head SHA matches, and GitHub currently reports no checks for this fork branch; merge state is BLOCKED pending repository review/check handling
- Issue read-back: #109391 remains OPEN and lists #109395 and #109420 in its development/closing references

Fixes https://github.com/NousResearch/hermes-agent/issues/109391.
