### PR TITLE
fix(security): unlock 1Password via app Touch ID, never the master password

### DIFF
--- a/agent/vault_backends/__init__.py
+++ b/agent/vault_backends/__init__.py
@@ -8,9 +8,9 @@ the password server-side at fill time only. Handles are namespaced by backend
 change to route to the right one.
 
 External managers are locked until the user unlocks them for the current
-session (``agent/vault_backends/unlock.py``); the master password is typed
-into a masked prompt owned by the surface (CLI panel, Desktop dialog) and is
-never a tool argument, never argv, never persisted.
+session (``agent/vault_backends/unlock.py``). 1Password unlocks through the
+1Password app (Touch ID); Bitwarden uses a masked Hermes prompt. The master
+password is never a tool argument, never argv, never persisted.
 """
 
 from agent.vault_backends.base import LoginBackend, UnlockRequired, backend_for_handle, enabled_backends

--- a/agent/vault_backends/base.py
+++ b/agent/vault_backends/base.py
@@ -30,6 +30,9 @@ class LoginBackend(ABC):
     display_name: str        # user-facing
     prefix: str              # handle prefix ("vault_", "op:", "bw:")
     needs_unlock: bool = False
+    # True: unlock is the manager's own UI (1Password app / Touch ID). Hermes must not
+    # collect a master password. False: Hermes shows a masked prompt (Bitwarden).
+    app_unlock: bool = False
 
     def owns(self, handle: str) -> bool:
         return handle.startswith(self.prefix)

--- a/agent/vault_backends/onepassword.py
+++ b/agent/vault_backends/onepassword.py
@@ -1,10 +1,8 @@
 """1Password Login items as a vault backend (``op`` CLI).
 
-Unlock: ``op signin --raw`` with the master password on stdin (desktop-app
-integration or account-level auth) mints an ``OP_SESSION_<account>`` token.
-A configured service-account token skips the prompt entirely (headless).
-List: ``op item list --categories Login --format json`` → title, urls,
-username. Resolve: ``op item get <id> --fields label=password --reveal``.
+Unlock: ``op signin`` (no ``--raw``) so 1Password.app can do Touch ID, then
+``op account get`` to confirm (``op whoami`` lies under app integration).
+Hermes never collects the master password. A service-account token skips unlock.
 """
 
 from __future__ import annotations
@@ -18,13 +16,20 @@ from typing import Dict, List, Optional
 
 from agent.secret_sources.base import run_cli
 from agent.secret_sources.onepassword import _OP_ENV_ALLOWLIST, _scrub, find_op
-from agent.vault_backends.base import LoginBackend, UnlockRequired, run_with_stdin_secret
+from agent.vault_backends.base import LoginBackend, UnlockRequired
 from agent.vault_backends import unlock as _unlock
 from agent.vault_store import VaultItemMeta, normalize_origin
 
 logger = logging.getLogger(__name__)
 
 _TIMEOUT = 30.0
+# In-memory marker: this process may call `op` with desktop-app integration (no OP_SESSION).
+# Never passed to the child as an env value.
+_APP_SESSION = "__hermes_op_app__"
+_UNLOCK_HINT = (
+    "Unlock 1Password with Touch ID (Settings → Security), and turn on "
+    "Settings → Developer → Integrate with 1Password CLI. Hermes does not take your master password."
+)
 
 
 class OnePasswordLoginBackend(LoginBackend):
@@ -32,6 +37,7 @@ class OnePasswordLoginBackend(LoginBackend):
     display_name = "1Password"
     prefix = "op:"
     needs_unlock = True
+    app_unlock = True
 
     def __init__(self, cfg: Optional[Dict] = None):
         self.cfg = cfg or {}
@@ -61,26 +67,36 @@ class OnePasswordLoginBackend(LoginBackend):
             env["OP_ACCOUNT"] = account
         if self._service_token:
             env["OP_SERVICE_ACCOUNT_TOKEN"] = self._service_token
-        elif session_token:
-            # op signin --raw prints the bare token; the env var name carries the account shorthand,
-            # which op also accepts as plain OP_SESSION for the default account.
+        elif session_token and session_token != _APP_SESSION:
             env[f"OP_SESSION_{account}" if account else "OP_SESSION"] = session_token
         return env
 
     def is_unlocked(self) -> bool:
         return bool(self._service_token) or _unlock.is_unlocked(self.name)
 
-    def unlock(self, master_password: str) -> None:
-        """Mint a session token from the master password (consumed on stdin, never argv)."""
+    def unlock(self, master_password: str = "") -> None:
+        """Unlock via the 1Password app (Touch ID). Never collect the master password."""
+        _ = master_password  # old Settings UI may still send one; never hand it to `op`
         generation = _unlock.begin_unlock(self.name)
-        cmd = [str(self._op()), "signin", "--raw"]
-        if account := str(self.cfg.get("account") or ""):
-            cmd += ["--account", account]
-        proc = run_with_stdin_secret(cmd, env=self._env(None), secret=master_password, timeout=_TIMEOUT, label="op")
-        token = (proc.stdout or "").strip()
-        if proc.returncode != 0 or not token:
-            raise RuntimeError(f"1Password unlock failed: {_scrub(proc.stderr or '')[:200] or 'no session token'}")
-        if not _unlock.store_session_token(self.name, token, generation):
+        op = str(self._op())
+        env = self._env(None)
+        # Documented app-integration path: `op signin` with no --raw. 1Password.app
+        # does Touch ID. stdin is /dev/null so a classic password prompt cannot run.
+        try:
+            proc = run_cli(
+                [op, "signin"], env=env, timeout=_TIMEOUT, label="op",
+                timeout_message="op timed out waiting for 1Password Touch ID", stdin=subprocess.DEVNULL)
+        except RuntimeError as exc:
+            raise RuntimeError(_UNLOCK_HINT) from exc
+        # `op whoami` reports "not signed in" even when app-integration sessions work
+        # (`op account get` / item list succeed). Do not use whoami as the probe.
+        probe = run_cli(
+            [op, "account", "get"], env=env, timeout=_TIMEOUT, label="op",
+            timeout_message="op timed out waiting for 1Password", stdin=subprocess.DEVNULL)
+        if probe.returncode != 0:
+            err = _scrub((proc.stderr or "") + "\n" + (probe.stderr or ""))[:160]
+            raise RuntimeError(f"{_UNLOCK_HINT} ({err or 'not signed in'})")
+        if not _unlock.store_session_token(self.name, _APP_SESSION, generation):
             raise RuntimeError("1Password was locked while unlocking; try again")
 
     def _run(self, *args: str) -> str:

--- a/agent/vault_backends/unlock.py
+++ b/agent/vault_backends/unlock.py
@@ -1,10 +1,11 @@
 """Per-process unlock state for external password managers.
 
-An unlock is a session token minted by the manager's CLI from the master
-password (``op signin --raw`` / ``bw unlock --raw``). The token lives in
-process memory only, keyed by backend, and expires after an idle TTL or an
-explicit lock. The master password itself is consumed by the CLI call and
-dropped; nothing is written to disk or env.
+An unlock is a session token minted by the manager's CLI, or for 1Password
+a marker that the desktop app session is live (``op whoami``). The token
+lives in process memory only, keyed by backend, and expires after an idle
+TTL or an explicit lock. 1Password's master password is never collected;
+Bitwarden's is consumed by the CLI call and dropped. Nothing is written to
+disk or env.
 
 The surface owns the prompt: ``set_unlock_prompt_callback`` is installed by
 the CLI panel / TUI gateway bridge for the current thread, exactly like the

--- a/apps/desktop/src/app/settings/vault-settings.test.tsx
+++ b/apps/desktop/src/app/settings/vault-settings.test.tsx
@@ -141,7 +141,7 @@ describe('VaultSettings', () => {
     await waitFor(() => expect(requestGateway).toHaveBeenCalledWith('vault.remove', { id: 'vault_abc123' }))
   })
 
-  it('unlocks a password manager from Settings; the master password leaves only via vault.unlock', async () => {
+  it('unlocks 1Password from Settings without collecting a master password', async () => {
     const sources = [
       {
         name: 'onepassword',
@@ -149,7 +149,8 @@ describe('VaultSettings', () => {
         enabled: true,
         needs_unlock: true,
         unlocked: false,
-        installed: true
+        installed: true,
+        app_unlock: true
       },
       {
         name: 'bitwarden',
@@ -187,18 +188,13 @@ describe('VaultSettings', () => {
     expect(screen.queryByRole('switch', { name: 'Bitwarden' })).toBeNull()
     expect(screen.getByRole('switch', { name: '1Password' })).toBeTruthy()
     fireEvent.click(screen.getByRole('button', { name: 'Unlock' }))
-    await waitFor(() => expect(screen.getByText('Unlock 1Password')).toBeTruthy())
-
-    fireEvent.change(screen.getByPlaceholderText('Master password'), { target: { value: 'correct horse' } })
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Unlock' }).closest('form')!.querySelector('button[type=submit]')!
-    )
 
     await waitFor(() =>
-      expect(requestGateway).toHaveBeenCalledWith('vault.unlock', { name: 'onepassword', password: 'correct horse' })
+      expect(requestGateway).toHaveBeenCalledWith('vault.unlock', { name: 'onepassword' })
     )
     await waitFor(() => expect(screen.getByText('Unlocked')).toBeTruthy())
     expect(screen.queryByPlaceholderText('Master password')).toBeNull()
+    expect(screen.queryByText('Unlock 1Password')).toBeNull()
     expect(screen.getByRole('button', { name: 'Lock' })).toBeTruthy()
   })
 })

--- a/apps/desktop/src/app/settings/vault-settings.tsx
+++ b/apps/desktop/src/app/settings/vault-settings.tsx
@@ -46,6 +46,7 @@ export interface VaultSource {
   needs_unlock: boolean
   unlocked: boolean
   installed: boolean
+  app_unlock?: boolean
 }
 
 export type VaultKind = 'address' | 'login' | 'payment'
@@ -223,11 +224,15 @@ export function VaultSettings() {
   }, [])
 
   const unlockSource = useMutation({
-    mutationFn: ({ name }: { name: VaultSourceName }) => {
-      const password = pendingMasterPassword.current
+    mutationFn: ({ name, password }: { name: VaultSourceName; password?: string }) => {
+      const secret = password ?? pendingMasterPassword.current
       pendingMasterPassword.current = ''
+      const params: { name: VaultSourceName; password?: string } = { name }
+      if (secret) {
+        params.password = secret
+      }
 
-      return requestGateway<{ unlocked: boolean }>('vault.unlock', { name, password })
+      return requestGateway<{ unlocked: boolean }>('vault.unlock', params)
     },
     onSuccess: (_result, { name }) => {
       triggerHaptic('submit')
@@ -236,9 +241,12 @@ export function VaultSettings() {
       closeUnlock()
       invalidateVault()
     },
-    onError: err => {
+    onError: (err, vars) => {
       setMasterPassword('')
       setUnlockError(err instanceof Error ? err.message : String(err))
+      if (!vars.password) {
+        notifyError(err, v.sources.toggleFailed)
+      }
     }
   })
 
@@ -470,7 +478,14 @@ export function VaultSettings() {
                 ) : (
                   <Button
                     className="gap-1.5"
-                    onClick={() => setUnlockTarget(source)}
+                    disabled={unlockSource.isPending}
+                    onClick={() => {
+                      if (source.app_unlock) {
+                        unlockSource.mutate({ name: source.name })
+                      } else {
+                        setUnlockTarget(source)
+                      }
+                    }}
                     size="sm"
                     type="button"
                     variant="outline"
@@ -532,9 +547,10 @@ export function VaultSettings() {
               e.preventDefault()
 
               if (unlockTarget && masterPassword) {
-                pendingMasterPassword.current = masterPassword
+                pendingMasterPassword.current = ''
+                const password = masterPassword
                 setMasterPassword('')
-                unlockSource.mutate({ name: unlockTarget.name })
+                unlockSource.mutate({ name: unlockTarget.name, password })
               }
             }}
           >

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -603,12 +603,12 @@ export const en: Translations = {
       sources: {
         title: 'Password managers',
         blurb:
-          'Installed password managers are picked up automatically. The agent asks you to unlock one the first time it needs a login from it (once per session); only a session token stays in memory, and the agent never sees your master password or any login.',
+          'Installed password managers are picked up automatically. 1Password unlocks through the 1Password app (Touch ID). Bitwarden asks for your master password in Hermes once per session. The agent never sees your master password or any login.',
         toggleFailed: 'Could not update password manager',
         notInstalled: name =>
           `Not detected. Install the ${name} command-line tool and sign in to it; Hermes picks it up automatically.`,
         disabledDesc: 'Detected but turned off for Hermes.',
-        lockedDesc: 'Detected. The agent will ask you to unlock it when it needs a login, or unlock now.',
+        lockedDesc: 'Detected. Unlock 1Password in the 1Password app, or Bitwarden here, when a login is needed.',
         unlockedDesc: 'Unlocked for this session. Locks automatically after 30 minutes idle or when Hermes closes.',
         statusLocked: 'Locked',
         statusNotDetected: 'Not detected',

--- a/contributors/emails/sulaiman.ghori@outlook.com
+++ b/contributors/emails/sulaiman.ghori@outlook.com
@@ -1,0 +1,1 @@
+djmango

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2182,7 +2182,7 @@ DEFAULT_CONFIG = {
     # headless sessions (cron, webhook, API) never prompt and see them as locked.
     "vault": {
         "onepassword": {
-            "enabled": False,       # `op` CLI: Login items with a website URL become fillable handles.
+            "enabled": False,       # `op` CLI via the 1Password app (Touch ID). Hermes never takes the master password.
             "account": "",          # account shorthand for `op --account`; empty = default account.
             "binary_path": "",      # absolute path to op; empty = PATH.
             # Env var holding a service-account token (headless auth, no unlock prompt). Unset = prompt.

--- a/tests/agent/test_vault_backends.py
+++ b/tests/agent/test_vault_backends.py
@@ -20,6 +20,7 @@ import pytest
 
 from agent.vault_backends import unlock as unlock_mod
 from agent.vault_backends.bitwarden import BitwardenLoginBackend
+from agent.vault_backends.onepassword import OnePasswordLoginBackend
 
 # A stand-in `bw` that mimics the three commands the backend uses and the real CLI's password contract
 # (bw 2026.x rejects a piped password: "Master password is required"; it reads --passwordenv <VAR>).
@@ -168,3 +169,131 @@ def test_lock_during_unlock_wins_and_only_the_owning_session_release_drops_a_tok
         unlock_mod.release_session("sess-A")
         assert not backend.is_unlocked()
         unlock_mod.set_current_session_id(None)
+
+
+# ── 1Password: desktop-app session, never a master password in Hermes ─────────
+
+# A stand-in `op` that mimics app integration: `signin` (no --raw) and `whoami`
+# succeed when the app is unlocked. `signin --raw` is the master-password path and is a tripwire.
+_FAKE_OP = r'''#!/usr/bin/env python3
+import json, os, sys
+here = os.path.dirname(os.path.abspath(__file__))
+log = open(os.path.join(here, "op.log"), "a")
+argv = sys.argv[1:]
+stdin = sys.stdin.read() if not sys.stdin.isatty() else ""
+log.write(json.dumps({"argv": argv, "stdin": stdin,
+                      "OP_SESSION": os.environ.get("OP_SESSION"),
+                      "has_service_token": bool(os.environ.get("OP_SERVICE_ACCOUNT_TOKEN"))}) + "\n")
+locked = os.path.exists(os.path.join(here, "op.locked"))
+if argv[:1] == ["whoami"]:
+    # Real op whoami is broken with app integration; Hermes must not depend on it.
+    sys.stderr.write("not signed in\n"); sys.exit(1)
+if argv[:2] == ["account", "get"]:
+    if locked:
+        sys.stderr.write("not signed in\n"); sys.exit(1)
+    print("ID: dummy"); sys.exit(0)
+if argv[:1] == ["signin"]:
+    if "--raw" in argv:
+        sys.stderr.write("signin --raw is the master-password path and must not run\n"); sys.exit(99)
+    if locked:
+        sys.stderr.write("not signed in\n"); sys.exit(1)
+    sys.exit(0)
+if argv[:2] == ["item", "list"]:
+    print(json.dumps([{"id": "iid", "title": "Example", "created_at": "2026-01-01T00:00:00Z",
+                       "urls": [{"href": "https://example.com/login"}],
+                       "additional_information": "jane@example.com"}])); sys.exit(0)
+if argv[:2] == ["item", "get"] and "--otp" not in argv:
+    print("plain sentence nobody would flag 7"); sys.exit(0)
+sys.exit(2)
+'''
+
+
+@pytest.fixture
+def fake_op(tmp_path, monkeypatch):
+    exe = tmp_path / "op"
+    exe.write_text(_FAKE_OP, encoding="utf-8")
+    exe.chmod(exe.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    unlock_mod.lock()
+    yield exe, tmp_path / "op.log"
+    unlock_mod.lock()
+
+
+def _enabled_op(exe):
+    backend = OnePasswordLoginBackend({"enabled": True, "binary_path": str(exe)})
+    return patch("agent.vault_backends.base.enabled_backends", return_value=[backend]), backend
+
+
+def test_onepassword_unlocks_via_app_session_and_never_sends_a_master_password(fake_op):
+    """1Password on a desktop uses `op whoami` (app integration). A master password must never
+    reach argv, stdin, or env — even if a caller still hands one to unlock()."""
+    exe, log = fake_op
+    patcher, backend = _enabled_op(exe)
+    from tools.browser_vault_tool import browser_vault_fill, browser_vault_list, browser_vault_unlock
+
+    prompts = []
+    unlock_mod.set_unlock_prompt_callback(lambda name, display: prompts.append((name, display)) or "correct horse")
+    try:
+        with patcher, patch("agent.vault_backends.enabled_backends", return_value=[backend]), \
+             patch("tools.browser_vault_tool._current_page_origin", return_value="https://example.com"), \
+             patch("tools.browser_vault_tool._eval_js", return_value={"success": True, "result": json.dumps([
+                 {"tag": "input", "type": "password", "name": "password", "id": "pw", "autocomplete": "current-password",
+                  "visible": True}])}), \
+             patch("tools.browser_vault_tool._eval_js_secret", return_value={"success": True, "result": json.dumps(
+                 {"filled": 1})}):
+            unlocked = json.loads(browser_vault_unlock("onepassword"))
+            assert unlocked == {"success": True, "backend": "onepassword"}
+            assert prompts == [], "1Password must not ask Hermes for a master password"
+            listed = json.loads(browser_vault_list())
+            assert listed["items"][0]["handle"] == "op:iid"
+            assert listed["items"][0]["identifier"] == "jane@example.com"
+            filled = json.loads(browser_vault_fill("op:iid", task_id="t"))
+            filled.pop("next", None)
+            assert filled["success"] is True and filled["backend"] == "onepassword"
+    finally:
+        unlock_mod.set_unlock_prompt_callback(None)
+
+    calls = [json.loads(line) for line in log.read_text(encoding="utf-8").splitlines()]
+    assert any(c["argv"][:1] == ["signin"] and "--raw" not in c["argv"] for c in calls)
+    assert all("--raw" not in c["argv"] for c in calls), "op signin --raw is the master-password path; it must not run"
+    assert all(c["stdin"] == "" for c in calls)
+    assert all("correct horse" not in json.dumps(c) for c in calls)
+    assert all(c.get("OP_SESSION") in (None, "") for c in calls), "app integration must not mint OP_SESSION"
+
+
+def test_onepassword_unlock_ignores_a_supplied_master_password(fake_op):
+    exe, log = fake_op
+    backend = OnePasswordLoginBackend({"binary_path": str(exe)})
+    backend.unlock("correct horse")
+    assert backend.is_unlocked()
+    calls = [json.loads(line) for line in log.read_text(encoding="utf-8").splitlines()]
+    assert all("--raw" not in c["argv"] for c in calls)
+    assert all(c["stdin"] == "" for c in calls)
+
+
+def test_onepassword_locked_app_fails_closed_without_signin(fake_op):
+    exe, log = fake_op
+    (exe.parent / "op.locked").write_text("1", encoding="utf-8")
+    backend = OnePasswordLoginBackend({"binary_path": str(exe)})
+    with pytest.raises(RuntimeError, match="1Password"):
+        backend.unlock("")
+    assert not backend.is_unlocked()
+    calls = [json.loads(line) for line in log.read_text(encoding="utf-8").splitlines()]
+    assert all("--raw" not in c["argv"] for c in calls)
+
+
+def test_onepassword_headless_does_not_probe_the_app(fake_op, monkeypatch):
+    exe, log = fake_op
+    from tools.browser_vault_tool import browser_vault_unlock
+
+    patcher, backend = _enabled_op(exe)
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+    unlock_mod.set_unlock_prompt_callback(lambda *_: "correct horse")
+    try:
+        with patcher, patch("agent.vault_backends.enabled_backends", return_value=[backend]):
+            out = json.loads(browser_vault_unlock("onepassword"))
+            assert out["success"] is False and out["error_type"] == "unlock_unavailable"
+    finally:
+        unlock_mod.set_unlock_prompt_callback(None)
+    assert not log.exists(), "op must not be invoked from a headless session"
+    assert not backend.is_unlocked()

--- a/tools/browser_vault_tool.py
+++ b/tools/browser_vault_tool.py
@@ -264,6 +264,12 @@ def browser_vault_unlock(backend_name: str) -> str:
                            "error": (f"{backend.display_name} is locked and this session cannot prompt for the "
                                      "master password (headless/cron/API). Unlock it from an interactive Hermes "
                                      "session or the Desktop app first.")})
+    if getattr(backend, "app_unlock", False):
+        try:
+            backend.unlock("")  # type: ignore[attr-defined]
+        except Exception as exc:
+            return json.dumps({"success": False, "error_type": "unlock_failed", "error": str(exc)[:300]})
+        return json.dumps({"success": True, "backend": backend.name})
     prompt = get_unlock_prompt_callback()
     master = prompt(backend.name, backend.display_name) if prompt else ""
     if not master:
@@ -575,7 +581,7 @@ BROWSER_VAULT_LIST_SCHEMA = {
         "carry identifier + identifier_type so you can type the username yourself with the browser's input tool). "
         "Secret values are NEVER returned. Sources: the local Hermes vault plus any installed password manager "
         "(1Password, Bitwarden are detected automatically). A locked manager appears under `locked`; call "
-        "browser_vault_unlock (the user is prompted for their master password, you never see it) or, when it says "
+        "browser_vault_unlock (1Password unlocks via the 1Password app; Bitwarden prompts in Hermes, you never see a password) or, when it says "
         "unavailable_in_this_session, tell the user to unlock it from an interactive session. Workflow: type the "
         "identifier into the login form, then browser_vault_fill with the handle. No item for this origin: call "
         "browser_vault_save_login. Passwords are typed ONLY by these tools, never by you with the browser's input "
@@ -587,8 +593,9 @@ BROWSER_VAULT_LIST_SCHEMA = {
 BROWSER_VAULT_UNLOCK_SCHEMA = {
     "name": "browser_vault_unlock",
     "description": (
-        "Ask the user to unlock a password manager (1Password or Bitwarden) for this session. The master "
-        "password is typed into a masked prompt owned by the UI and never enters the conversation. "
+        "Ask the user to unlock a password manager (1Password or Bitwarden) for this session. "
+        "1Password unlocks through the 1Password app (Touch ID / app lock); never type that master "
+        "password into Hermes. Bitwarden uses a masked prompt owned by the UI. "
         "Returns success, unlock_cancelled, unlock_failed, or unlock_unavailable (headless session)."
     ),
     "parameters": {

--- a/tui_gateway/methods_vault.py
+++ b/tui_gateway/methods_vault.py
@@ -80,7 +80,8 @@ def _(rid, params: dict) -> dict:
         live = enabled.get(cls.name)
         rows.append({"name": cls.name, "display_name": cls.display_name, "enabled": live is not None,
                      "needs_unlock": True, "unlocked": bool(live and live.is_unlocked()),
-                     "installed": is_installed(cls.name)})
+                     "installed": is_installed(cls.name),
+                     "app_unlock": bool(getattr(cls, "app_unlock", False))})
     return _ok(rid, {"sources": rows})
 
 
@@ -109,7 +110,7 @@ def _(rid, params: dict) -> dict:
 
 @method("vault.unlock")
 def _(rid, params: dict) -> dict:
-    """Unlock a manager with the master password typed in the Settings dialog (consumed by the CLI on stdin)."""
+    """Unlock a manager. 1Password uses the app session (no password). Bitwarden still takes a master password."""
     from agent.vault_backends import enabled_backends
 
     name = str(params.get("name") or "")
@@ -117,12 +118,16 @@ def _(rid, params: dict) -> dict:
     backend = next((b for b in enabled_backends() if b.name == name and b.needs_unlock), None)
     if backend is None:
         return _err(rid, 5095, f"{name} is not an enabled password manager")
-    if not password:
+    app_unlock = bool(getattr(backend, "app_unlock", False))
+    if not app_unlock and not password:
         return _err(rid, 5095, "master password is required")
     try:
-        backend.unlock(password)  # type: ignore[attr-defined]
+        backend.unlock("" if app_unlock else password)  # type: ignore[attr-defined]
     except Exception as e:
-        return _err(rid, 5095, str(e).replace(password, "[REDACTED]"))
+        msg = str(e)
+        if password:
+            msg = msg.replace(password, "[REDACTED]")
+        return _err(rid, 5095, msg)
     finally:
         del password
     return _ok(rid, {"name": name, "unlocked": True})


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop Settings and `browser_vault_unlock` collected the 1Password **master password** and fed it to `op signin --raw`. That is the wrong unlock path on a Mac with app integration: 1Password.app should do Touch ID, and Hermes should never see the master password.

This PR:

- Calls `op signin` **without** `--raw`, stdin `/dev/null` (so a classic password prompt cannot run).
- Confirms the session with `op account get`. **`op whoami` is not used**: with app integration it reports `account is not signed in` while `op account get` / `op item list` succeed.
- Stores an in-memory app-session marker (`__hermes_op_app__`) that is never exported as `OP_SESSION`.
- Skips the Hermes master-password prompt for 1Password (`app_unlock`). Bitwarden is unchanged.
- Settings Unlock for 1Password no longer opens the password dialog.

## Related Issue

Fixes #107998

Not a duplicate of #108010. That PR still runs `op signin --raw` and treats empty stdout as success. This PR never takes the master password and does not trust `whoami`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/vault_backends/onepassword.py` — Touch ID / app `signin`, `account get` probe, ignore any supplied master password
- `agent/vault_backends/base.py` — `app_unlock` flag
- `tools/browser_vault_tool.py` — skip Hermes password prompt for app-unlock backends; headless still refused
- `tui_gateway/methods_vault.py` — password optional when `app_unlock`
- `apps/desktop/src/app/settings/vault-settings.tsx` — 1Password Unlock does not collect a password
- `tests/agent/test_vault_backends.py` — fake `op`: `--raw` is a tripwire; Bitwarden suite still passes

## How to Test

1. `scripts/run_tests.sh tests/agent/test_vault_backends.py`
   - Before: 1Password cases fail (`signin --raw` / master password).
   - After: 7 passed (Bitwarden + 1Password).
2. From `apps/desktop`: `npx vitest run src/app/settings/vault-settings.test.tsx src/app/settings/vault-settings.owner.test.tsx`
3. Manual (macOS): 1Password Settings → Security → Touch ID; Developer → Integrate with 1Password CLI. Restart Hermes. Settings → Password managers → 1Password → Unlock. Expect a 1Password/Touch ID prompt, not a Hermes master-password field.

Platforms tested: macOS (Apple Silicon). Fake `op` coverage is host-agnostic (POSIX shebang; existing Bitwarden tests already skip Windows).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/agent/test_vault_backends.py` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Settings UI is covered by vitest (no master-password field for `app_unlock: true`). Packaged desktop builds pick up the TSX on the next desktop release; the Python backend takes effect on Hermes restart.