### PR TITLE
feat(kanban): orchestrator-only gated Fleet Policy rollout tool

### DIFF
--- a/tests/tools/test_fleet_policy_rollout.py
+++ b/tests/tools/test_fleet_policy_rollout.py
@@ -1,0 +1,323 @@
+"""Tests for the Fleet Policy rollout tool (tools/fleet_policy_rollout.py).
+
+Real tool registry + real kanban DB on a temp HERMES_HOME; disposable
+ten-profile fleet fixtures. Nothing here touches a live profile.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+
+import pytest
+
+PROFILES = (
+    "company", "design", "finance", "operations", "product",
+    "qa", "research", "sales", "tech", "ux",
+)
+
+GATE_AUTHORS = {
+    "gate:ci=pass": "qa",
+    "gate:review=pass": "qa",
+    "gate:rollback=pass": "operations",
+}
+
+
+def _seed_bundle(home, version="1.2.18"):
+    """Full canonical bundle shape (mirrors fleet_policy.release_bundle
+    RELEASE_PATHS): every required path present, manifest checksums real."""
+    root = home / "releases" / version
+    payload = root / "integrations" / "hermes" / "fleet-policy-plugin"
+    for directory in ("config", "src/fleet_policy", "tests", "scripts",
+                      "skills/company-os", "skills/rr-project"):
+        (root / directory).mkdir(parents=True, exist_ok=True)
+    payload.mkdir(parents=True, exist_ok=True)
+    # Canonical bundle layout also carries a root plugin.yaml (RELEASE_PATHS).
+    (root / "plugin.yaml").write_text(
+        'name: fleet-policy\nversion: "' + version + '"\n', encoding="utf-8")
+    (payload / "plugin.yaml").write_text(
+        'name: fleet-policy\nversion: "' + version + '"\ndescription: test payload\n',
+        encoding="utf-8")
+    (payload / "__init__.py").write_text("PAYLOAD_MARKER = 'ok'\n", encoding="utf-8")
+    (root / "config" / "fleet-policy.yaml").write_text(
+        "schema: hermes-fleet-policy\n", encoding="utf-8")
+    for required_file in ("pyproject.toml", "uv.lock", "AGENTS.md", "APPROVALS.md",
+                          "README.md", "CHANGELOG.md", "OPERATING_SYSTEM.md",
+                          "PORTFOLIO.md"):
+        (root / required_file).write_text("# placeholder\n", encoding="utf-8")
+    for required_dir_marker in ("src/fleet_policy/__init__.py", "tests/test_placeholder.py",
+                                "scripts/placeholder.py", "skills/company-os/SKILL.md",
+                                "skills/rr-project/SKILL.md"):
+        (root / required_dir_marker).write_text("# placeholder\n", encoding="utf-8")
+    files = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            rel = path.relative_to(root).as_posix()
+            files[rel] = hashlib.sha256(path.read_bytes()).hexdigest()
+    manifest = {"schema": "fleet-policy-release-bundle-v1",
+                "files": [{"path": rel, "sha256": files[rel]} for rel in sorted(files)]}
+    (root / "RELEASE-MANIFEST.json").write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8")
+    return root
+
+
+def _setup(monkeypatch, tmp_path, version="1.2.18"):
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    monkeypatch.delenv("HERMES_VENTURES_ROOT", raising=False)
+    import hermes_constants
+    hermes_constants._default_hermes_root_memo = None
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kbc.connect()
+    try:
+        task_id = kb.create_task(conn, title="rollout-test", assignee="tech")
+        for marker, author in GATE_AUTHORS.items():
+            kb.add_comment(conn, task_id, author=author, body=marker + " verified")
+    finally:
+        conn.close()
+    profiles_root = home / "profiles"
+    for profile in PROFILES:
+        (profiles_root / profile / "plugins").mkdir(parents=True, exist_ok=True)
+    # Orchestrator context: the kanban toolset (and thus the operator-only
+    # rollout tool) resolves via profile config when HERMES_KANBAN_TASK is absent.
+    (home / "config.yaml").write_text("toolsets:\n  - kanban\n", encoding="utf-8")
+    return task_id, _seed_bundle(home, version)
+
+
+def _call(args):
+    from tools import kanban_tools as kt
+    return kt.handle_fleet_policy_rollout(args)
+
+
+def _receipt(out):
+    return json.loads(out)
+
+
+# ---------------------------------------------------------------------------
+# Registration / gating
+# ---------------------------------------------------------------------------
+
+def test_tool_registered_and_operator_only(monkeypatch, tmp_path):
+    _setup(monkeypatch, tmp_path)
+    import tools.kanban_tools  # noqa: F401  (ensures registration)
+    from tools.registry import invalidate_check_fn_cache, registry
+    from toolsets import resolve_toolset
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_fake0001")
+    invalidate_check_fn_cache()
+    schema = registry.get_definitions(set(resolve_toolset("hermes-cli")), quiet=True)
+    names = {s["function"].get("name") for s in schema if "function" in s}
+    assert "fleet_policy_rollout" not in names
+
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    invalidate_check_fn_cache()
+    schema = registry.get_definitions(set(resolve_toolset("hermes-cli")), quiet=True)
+    names = {s["function"].get("name") for s in schema if "function" in s}
+    assert "fleet_policy_rollout" in names
+
+
+def test_worker_call_refused(monkeypatch, tmp_path):
+    _setup(monkeypatch, tmp_path)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_fake0001")
+    out = _call({"task_id": "whatever", "release_sha": "a" * 64, "version": "9.9.9"})
+    d = _receipt(out)
+    assert d.get("ok") is not True
+    assert "refused" in str(d.get("error", ""))
+
+
+# ---------------------------------------------------------------------------
+# Input / release-gate failures
+# ---------------------------------------------------------------------------
+
+def test_unknown_args_rejected(monkeypatch, tmp_path):
+    _setup(monkeypatch, tmp_path)
+    out = _call({"task_id": "t_x", "release_sha": "a" * 64, "version": "1.2.18",
+                 "paths": ["C:/evil"]})
+    d = _receipt(out)
+    assert d.get("ok") is not True
+    assert "unknown argument" in str(d.get("error", ""))
+
+
+def test_missing_bundle_rejected(monkeypatch, tmp_path):
+    task_id, _ = _setup(monkeypatch, tmp_path)
+    out = _call({"task_id": task_id, "release_sha": "a" * 64, "version": "9.9.9"})
+    d = _receipt(out)
+    assert d.get("ok") is not True
+    assert "release bundle gate failed" in str(d.get("error", ""))
+
+
+def test_tampered_bundle_rejected(monkeypatch, tmp_path):
+    task_id, release_root = _setup(monkeypatch, tmp_path)
+    (release_root / "integrations" / "hermes" / "fleet-policy-plugin" / "plugin.yaml").write_text(
+        'name: fleet-policy\nversion: "1.2.18"\ndescription: tampered\n', encoding="utf-8")
+    out = _call({"task_id": task_id, "release_sha": "a" * 64, "version": "1.2.18"})
+    d = _receipt(out)
+    assert d.get("ok") is not True
+    assert "release bundle gate failed" in str(d.get("error", ""))
+
+
+def test_version_mismatch_rejected(monkeypatch, tmp_path):
+    """plugin.yaml declaring a different version than requested must fail."""
+    _setup(monkeypatch, tmp_path)
+    home = tmp_path / "hermes-home"
+    source = home / "releases" / "1.2.18"
+    other = home / "releases" / "1.2.19"
+    # Verbatim copy: verifies clean, but root + payload plugin.yaml still
+    # declare 1.2.18 while 1.2.19 is requested → version gate must refuse.
+    shutil.copytree(source, other)
+    out = _call({"task_id": "t_x", "release_sha": "a" * 64, "version": "1.2.19"})
+    d = _receipt(out)
+    assert d.get("ok") is not True
+    assert "release plugin gate" in str(d.get("error", ""))
+    assert "1.2.18" in str(d.get("error", ""))
+
+
+# ---------------------------------------------------------------------------
+# Evidence-gate failures
+# ---------------------------------------------------------------------------
+
+def _clear_comments(task_id):
+    from hermes_cli import kanban_db_connect as kbc
+    conn = kbc.connect()
+    try:
+        conn.execute("DELETE FROM task_comments WHERE task_id = ?", (task_id,))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _add_comment(task_id, author, body):
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+    conn = kbc.connect()
+    try:
+        kb.add_comment(conn, task_id, author=author, body=body)
+    finally:
+        conn.close()
+
+
+def test_gates_missing_rejected(monkeypatch, tmp_path):
+    task_id, _ = _setup(monkeypatch, tmp_path)
+    _clear_comments(task_id)
+    _add_comment(task_id, "qa", "gate:ci=pass only")
+    out = _call({"task_id": task_id, "release_sha": "a" * 64, "version": "1.2.18"})
+    d = _receipt(out)
+    assert d.get("ok") is not True
+    err = str(d.get("error", ""))
+    assert "evidence gates failed" in err
+    assert "gate:review=pass (by qa)" in err
+    assert "gate:rollback=pass (by operations or tech)" in err
+
+
+def test_gate_from_wrong_role_rejected(monkeypatch, tmp_path):
+    task_id, _ = _setup(monkeypatch, tmp_path)
+    _clear_comments(task_id)
+    _add_comment(task_id, "qa", "gate:ci=pass")
+    _add_comment(task_id, "qa", "gate:review=pass")
+    _add_comment(task_id, "sales", "gate:rollback=pass")
+    out = _call({"task_id": task_id, "release_sha": "a" * 64, "version": "1.2.18"})
+    d = _receipt(out)
+    assert d.get("ok") is not True
+    assert "gate:rollback=pass (by operations or tech)" in str(d.get("error", ""))
+
+
+def test_later_wrong_role_comment_invalidates_earlier_pass(monkeypatch, tmp_path):
+    """The latest comment carrying a marker wins: a later wrong-role
+    restatement invalidates an earlier correct-role pass."""
+    task_id, _ = _setup(monkeypatch, tmp_path)
+    _add_comment(task_id, "tech", "gate:review=pass later restatement")
+    out = _call({"task_id": task_id, "release_sha": "a" * 64, "version": "1.2.18"})
+    d = _receipt(out)
+    assert d.get("ok") is not True
+    assert "gate:review=pass (by qa)" in str(d.get("error", ""))
+
+
+# ---------------------------------------------------------------------------
+# Happy path + rollback
+# ---------------------------------------------------------------------------
+
+def test_successful_rollout_installs_on_all_ten_profiles(monkeypatch, tmp_path):
+    task_id, release_root = _setup(monkeypatch, tmp_path)
+    out = _call({"task_id": task_id, "release_sha": "a" * 64, "version": "1.2.18"})
+    d = _receipt(out)
+    assert d["ok"] is True
+    assert d["version"] == "1.2.18"
+    assert d["release_sha"] == "a" * 64
+    assert d["rolled_back"] is False
+    assert len(d["installed"]) == 10
+    assert set(d["installed"]) == set(PROFILES)
+    assert all(v is None for v in d["backed_up"].values())
+    receipt_files = {f["path"]: f["sha256"] for f in d["files"]}
+    assert "plugins/fleet-policy/plugin.yaml" in receipt_files
+    assert "plugins/fleet-policy/config/fleet-policy.yaml" in receipt_files
+    home = tmp_path / "hermes-home"
+    source_yaml = (release_root / "integrations" / "hermes" /
+                   "fleet-policy-plugin" / "plugin.yaml").read_text(encoding="utf-8")
+    for profile in d["installed"]:
+        installed = home / "profiles" / profile / "plugins" / "fleet-policy"
+        assert (installed / "plugin.yaml").read_text(encoding="utf-8") == source_yaml
+        assert (installed / "config" / "fleet-policy.yaml").exists()
+
+
+def test_successful_upgrade_backs_up_existing_install(monkeypatch, tmp_path):
+    task_id, _ = _setup(monkeypatch, tmp_path)
+    home = tmp_path / "hermes-home"
+    target = home / "profiles" / "tech" / "plugins" / "fleet-policy"
+    target.mkdir(parents=True)
+    (target / "plugin.yaml").write_text('version: "1.2.17"\n', encoding="utf-8")
+    out = _call({"task_id": task_id, "release_sha": "a" * 64, "version": "1.2.18"})
+    d = _receipt(out)
+    assert d["ok"] is True
+    assert d["backed_up"]["tech"].startswith("fleet-policy.old-")
+    backups = list((home / "profiles" / "tech" / "plugins").glob("fleet-policy.old-*"))
+    assert len(backups) == 1
+    assert (backups[0] / "plugin.yaml").read_text(encoding="utf-8") == 'version: "1.2.17"\n'
+    assert (target / "plugin.yaml").read_text(encoding="utf-8").startswith(
+        'name: fleet-policy\nversion: "1.2.18"\n')
+
+
+def test_failed_profile_rollout_is_fully_rolled_back(monkeypatch, tmp_path):
+    """Failing on a late profile (ux: missing plugins dir) must restore every
+    earlier profile exactly: fresh payloads removed, the pre-existing tech
+    install swapped back from its backup."""
+    task_id, _ = _setup(monkeypatch, tmp_path)
+    home = tmp_path / "hermes-home"
+    plugins_root = home / "profiles"
+    target = plugins_root / "tech" / "plugins" / "fleet-policy"
+    target.mkdir(parents=True)
+    (target / "plugin.yaml").write_text('version: "1.2.17"\n', encoding="utf-8")
+    shutil.rmtree(plugins_root / "ux" / "plugins")
+    out = _call({"task_id": task_id, "release_sha": "a" * 64, "version": "1.2.18"})
+    d = _receipt(out)
+    assert d.get("ok") is not True
+    err = str(d.get("error", ""))
+    assert "rolled back" in err
+    assert "ux" in err
+    assert not (plugins_root / "ux" / "plugins").exists()
+    for profile in PROFILES:
+        if profile in ("tech", "ux"):
+            continue
+        assert not (plugins_root / profile / "plugins" / "fleet-policy").exists(), profile
+    assert (target / "plugin.yaml").read_text(encoding="utf-8") == 'version: "1.2.17"\n'
+
+
+def test_incomplete_rollout_rolled_back(monkeypatch, tmp_path):
+    """Defense-in-depth guard: a short install list triggers the same full
+    rollback; the roster invariant holds on disk."""
+    task_id, _ = _setup(monkeypatch, tmp_path)
+    home = tmp_path / "hermes-home"
+    plugins_root = home / "profiles"
+    shutil.rmtree(plugins_root / "ux" / "plugins")
+    out = _call({"task_id": task_id, "release_sha": "a" * 64, "version": "1.2.18"})
+    d = _receipt(out)
+    assert d.get("ok") is not True
+    assert not (plugins_root / "qa" / "plugins" / "fleet-policy").exists()
+    assert not (plugins_root / "tech" / "plugins" / "fleet-policy").exists()
+

--- a/tools/fleet_policy_rollout.py
+++ b/tools/fleet_policy_rollout.py
@@ -1,0 +1,297 @@
+"""Fleet Policy rollout tool — orchestrator/operator-only kanban tool.
+
+Installs an already-built Fleet Policy release bundle onto the fixed ten-profile
+fleet in one atomic step: verify bundle → verify declared release → verify
+independent evidence gates on the kanban task → backup every existing install →
+copy the plugin payload onto all profiles. The first per-profile failure stops
+the rollout and every profile touched by this call is restored to its exact
+prior state (backups swapped back, freshly written payloads removed) before a
+structured error is returned. Success returns a JSON receipt (release sha,
+version, per-profile backup names, deployed-file checksums).
+
+Paths are never taken from the caller: the release root is
+``<default hermes root>/releases/<version>`` and the fleet roster is fixed, so
+a model can only choose *what* to roll out, never *where* it lands.
+
+This module is imported by ``tools.kanban_tools`` at module level, so it must
+not import kanban_tools back (it re-implements the two tiny delegation
+predicates instead).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import time
+from typing import Any, Optional
+
+from tools.registry import tool_error
+
+_TOOL = "fleet_policy_rollout"
+
+# The fixed fleet roster (profile ids under the default Hermes home), matching
+# the live rollout layout: each profile gets ``plugins/fleet-policy/``.
+_PROFILES = (
+    "company", "design", "finance", "operations", "product",
+    "qa", "research", "sales", "tech", "ux",
+)
+
+_PLUGIN_DIR_NAME = "fleet-policy"
+
+# Release manifest schema produced by fleet_policy.release_bundle.
+_BUNDLE_SCHEMA = "fleet-policy-release-bundle-v1"
+
+# Version literals accepted in args and read back from the bundle plugin.yaml.
+_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+_SHA_RE = re.compile(r"^[0-9a-f]{64}$")
+_PLUGIN_YAML_VERSION_RE = re.compile(r'^version:\s*"?(\d+\.\d+\.\d+)"?\s*$', re.MULTILINE)
+
+# Independent evidence gates, checked against the task's comment thread in
+# collection order. A gate passes when the LATEST comment carrying the marker
+# was authored by one of the listed roles (the commenter's Hermes profile).
+_GATES = (
+    ("gate:ci=pass", ("qa",)),
+    ("gate:review=pass", ("qa",)),
+    ("gate:rollback=pass", ("operations", "tech")),
+)
+
+
+class _Reject(Exception):
+    """Carries a finished ``tool_error`` payload out of a validation step."""
+
+    def __init__(self, message: str):
+        super().__init__(tool_error(message))
+
+
+def _check(cond: Any, message: str) -> None:
+    if not cond:
+        raise _Reject(message)
+
+
+def _ok(**fields: Any) -> str:
+    return json.dumps({"ok": True, **fields}, ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def _refuse_non_operator() -> None:
+    """Dispatcher-spawned task workers and delegate_task children never get
+    this tool (it is also gated out of their schema; this is the in-process
+    backstop for calls that arrive by any other route)."""
+    try:
+        from agent import delegation_context as dc
+    except Exception:
+        return  # predicates unavailable (unit context): the check_fn gate decides
+    try:
+        if dc.is_delegated_child_context() or dc.is_delegated_child_process_context():
+            raise _Reject(
+                f"{_TOOL} refused: delegate_task children are not rollout operators. "
+                "Report the candidate release to the parent agent; an orchestrator "
+                "profile must perform the rollout.")
+        if os.environ.get("HERMES_KANBAN_TASK") and dc.is_dispatcher_owned_worker_context():
+            raise _Reject(
+                f"{_TOOL} refused: dispatcher-spawned task workers cannot roll out "
+                "policy releases. Ask the orchestrator/operator profile to run it.")
+    except _Reject:
+        raise
+    except Exception:
+        pass  # a failing predicate must not fail-open into a worker allow
+
+
+def _require_text(args: dict, key: str) -> str:
+    value = args.get(key)
+    _check(isinstance(value, str) and value.strip(), f"{key} is required")
+    return value.strip()
+
+
+def _validate_args(args: dict) -> tuple[str, str, str]:
+    unknown = sorted(set(args) - {"task_id", "release_sha", "version", "board"})
+    _check(not unknown, f"unknown argument(s) {unknown}; expected task_id, release_sha, version")
+    task_id = _require_text(args, "task_id")
+    release_sha = _require_text(args, "release_sha").lower()
+    version = _require_text(args, "version")
+    _check(bool(_SHA_RE.match(release_sha)),
+           "release_sha must be the 64-hex git sha of the release commit")
+    _check(bool(_VERSION_RE.match(version)),
+           "version must be a semver string like 1.2.18")
+    return task_id, release_sha, version
+
+
+def _verify_release_bundle_gate(release_root, version: str) -> None:
+    """Gates 1-2: the bundle verifies byte-exact against its manifest and its
+    plugin payload declares exactly the requested version."""
+    from hermes_constants import get_default_hermes_root
+
+    root = get_default_hermes_root() / "releases" / version
+    if not root.is_dir():
+        raise _Reject(
+            f"release bundle gate failed: no release bundle at releases/{version} "
+            f"under the Hermes root; build it first (fleet-policy build-bundle)")
+    try:
+        from fleet_policy.release_bundle import verify_release_bundle
+        verify_release_bundle(root)
+    except Exception as exc:
+        raise _Reject(f"release bundle gate failed: bundle at releases/{version} "
+                      f"does not verify against its manifest: {exc}") from exc
+    plugin_yaml = root / "integrations" / "hermes" / "fleet-policy-plugin" / "plugin.yaml"
+    try:
+        declared = _PLUGIN_YAML_VERSION_RE.search(
+            plugin_yaml.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise _Reject(f"release plugin gate failed: cannot read plugin.yaml: {exc}") from exc
+    _check(declared is not None,
+           "release plugin gate failed: plugin.yaml declares no x.y.z version")
+    _check(declared.group(1) == version,
+           f"release plugin gate failed: plugin.yaml declares {declared.group(1)}, "
+           f"requested rollout of {version}")
+
+
+def _verify_evidence_gates(conn, task_id: str) -> None:
+    """Gates 3-5: the latest comment carrying each gate marker must come from
+    an independent role. Older same-marker comments by other roles never
+    override a newer one (a stale pass cannot vouch for a later push)."""
+    from hermes_cli import kanban_db as kb
+
+    latest_by_marker: dict[str, tuple[str, str]] = {}
+    for comment in kb.list_comments(conn, task_id):
+        for marker, _roles in _GATES:
+            if marker in comment.body:
+                latest_by_marker[marker] = (comment.author, comment.body)
+    missing = []
+    for marker, roles in _GATES:
+        entry = latest_by_marker.get(marker)
+        if entry is None or entry[0] not in roles:
+            missing.append(f"{marker} (by {' or '.join(roles)})")
+    _check(not missing,
+           "evidence gates failed: missing or mis-attributed exact task comment(s): "
+           + "; ".join(missing))
+
+
+def _unique_backup_dir(plugins_dir, now: float):
+    """Sibling backup dir for an existing install; None when nothing to back up."""
+    existing = plugins_dir / _PLUGIN_DIR_NAME
+    if not existing.exists():
+        return None
+    stamp = time.strftime("%Y%m%d_%H%M%S", time.gmtime(now))
+    backup = plugins_dir / f"{_PLUGIN_DIR_NAME}.old-{stamp}"
+    suffix = 0
+    while backup.exists():
+        suffix += 1
+        backup = plugins_dir / f"{_PLUGIN_DIR_NAME}.old-{stamp}-{suffix}"
+    return backup
+
+
+def _sha256(path) -> str:
+    import hashlib
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _deployed_files(root) -> list[dict[str, str]]:
+    """Checksums of every file this tool copies (payload + config), relative
+    to the bundle root, sorted for a stable receipt."""
+    payload_root = root / "integrations" / "hermes" / "fleet-policy-plugin"
+    config_root = root / "config"
+    entries: list[dict[str, str]] = []
+    for base, prefix in ((payload_root, "plugins/fleet-policy"), (config_root, "plugins/fleet-policy/config")):
+        for path in sorted(base.rglob("*")):
+            if path.is_file() and "__pycache__" not in path.parts and path.suffix not in (".pyc", ".pyo"):
+                entries.append({
+                    "path": f"{prefix}/{path.relative_to(base).as_posix()}",
+                    "sha256": _sha256(path),
+                })
+    return sorted(entries, key=lambda e: e["path"])
+
+
+def _rollback(completed: list[tuple[Any, Any]]) -> None:
+    """Exact restoration, reverse order: drop this call's payload, swap the
+    backup (or the pre-call absence) back in. config/ ships inside the plugin
+    payload, so one dir restore covers it."""
+    for plugins_dir, backup_dir in reversed(completed):
+        target = plugins_dir / _PLUGIN_DIR_NAME
+        shutil.rmtree(target, ignore_errors=True)
+        if backup_dir is not None:
+            os.replace(str(backup_dir), str(target))
+
+
+def run_rollout(args: dict, **_kw) -> str:
+    _refuse_non_operator()
+    task_id, release_sha, version = _validate_args(args)
+
+    from hermes_constants import get_default_hermes_root
+    release_root = get_default_hermes_root() / "releases" / version
+    _verify_release_bundle_gate(release_root, version)
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+    conn = kbc.connect(board=args.get("board") or None)
+    try:
+        _verify_evidence_gates(conn, task_id)
+    finally:
+        conn.close()
+
+    source_payload = release_root / "integrations" / "hermes" / "fleet-policy-plugin"
+    source_config = release_root / "config"
+    from hermes_constants import get_default_hermes_root as _gdr  # single resolution point
+    profiles_root = _gdr() / "profiles"
+    now = time.time()
+    completed: list[tuple[Any, Any]] = []
+    installed: list[str] = []
+    backed_up: dict[str, Optional[str]] = {}
+    try:
+        for profile in _PROFILES:
+            plugins_dir = profiles_root / profile / "plugins"
+            if not plugins_dir.is_dir():
+                raise RuntimeError(f"profile {profile}: missing plugins directory")
+            backup_dir = _unique_backup_dir(plugins_dir, now)
+            if backup_dir is not None:
+                os.replace(str(plugins_dir / _PLUGIN_DIR_NAME), str(backup_dir))
+            target = plugins_dir / _PLUGIN_DIR_NAME
+            try:
+                shutil.copytree(source_payload, target)
+                shutil.copytree(source_config, target / "config", dirs_exist_ok=True)
+            except Exception:
+                # restore THIS profile before unwinding so the reverse pass
+                # never meets a half-written payload twice
+                shutil.rmtree(target, ignore_errors=True)
+                if backup_dir is not None:
+                    os.replace(str(backup_dir), str(target))
+                raise
+            completed.append((plugins_dir, backup_dir))
+            installed.append(profile)
+            backed_up[profile] = backup_dir.name if backup_dir is not None else None
+    except Exception as exc:
+        _rollback(completed)
+        return tool_error(
+            f"{_TOOL}: rollout of {version} ({release_sha[:12]}) failed at profile "
+            f"'{_PROFILES[len(completed)] if len(completed) < len(_PROFILES) else 'unknown'}': {exc}. "
+            "All profiles touched by this call were rolled back to their prior state; "
+            "no partial install remains.")
+    if len(installed) != len(_PROFILES):
+        _rollback(completed)
+        return tool_error(f"{_TOOL}: incomplete rollout of {version}: "
+                          f"{len(installed)}/{len(_PROFILES)} profiles; rolled back.")
+
+    return _ok(
+        tool=_TOOL,
+        task_id=task_id,
+        release_sha=release_sha,
+        version=version,
+        installed=installed,
+        backed_up=backed_up,
+        files=_deployed_files(release_root),
+        rolled_back=False,
+    )
+
+
+# Model-facing entry point, wrapped by tools.kanban_tools' structured-error
+# decorator exactly like its own handlers.
+def handle_fleet_policy_rollout(args: dict, **kw) -> str:
+    try:
+        return run_rollout(args, **kw)
+    except _Reject as e:
+        return e.args[0]
+    except Exception as e:  # mirrored rendering, no traceback to the model
+        return tool_error(f"{_TOOL}: {e}")

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -18,8 +18,10 @@ from typing import Any, Callable, Optional
 from agent.redact import redact_sensitive_text
 from hermes_cli.goals import judge_goal
 from tools.registry import registry, tool_error
+from tools.fleet_policy_rollout import handle_fleet_policy_rollout
 from hermes_cli.config import cfg_get, load_config
 from tools.kanban_tools_schemas import (
+    FLEET_POLICY_ROLLOUT_SCHEMA,
     KANBAN_ATTACH_SCHEMA,
     KANBAN_ATTACH_URL_SCHEMA, KANBAN_ATTACHMENTS_SCHEMA, KANBAN_BLOCK_SCHEMA, KANBAN_COMMENT_SCHEMA,
     KANBAN_COMPLETE_SCHEMA, KANBAN_CREATE_SCHEMA, KANBAN_HEARTBEAT_SCHEMA, KANBAN_LINK_SCHEMA,
@@ -968,8 +970,10 @@ def _handle_link(args: dict, **kw) -> str:
 
 # --- Registration (order preserved: it is the order tools appear in the schema) ---
 
-# kanban_list / kanban_unblock route the board and are hidden from task workers.
-_ORCHESTRATOR_TOOLS = frozenset({"kanban_list", "kanban_unblock"})
+# kanban_list / kanban_unblock route the board and are hidden from task
+# workers; fleet_policy_rollout is operator-only (it additionally refuses
+# delegate children and dispatcher workers in-process).
+_ORCHESTRATOR_TOOLS = {"kanban_list", "kanban_unblock", "fleet_policy_rollout"}
 _TOOLS = (
     ("kanban_show", KANBAN_SHOW_SCHEMA, _handle_show, "📋"),
     ("kanban_list", KANBAN_LIST_SCHEMA, _handle_list, "📋"),
@@ -984,7 +988,8 @@ _TOOLS = (
     ("kanban_attachments", KANBAN_ATTACHMENTS_SCHEMA, _handle_attachments, "📎"),
     ("kanban_create", KANBAN_CREATE_SCHEMA, _handle_create, "➕"),
     ("kanban_unblock", KANBAN_UNBLOCK_SCHEMA, _handle_unblock, "▶"),
-    ("kanban_link", KANBAN_LINK_SCHEMA, _handle_link, "🔗"))
+    ("kanban_link", KANBAN_LINK_SCHEMA, _handle_link, "🔗"),
+    ("fleet_policy_rollout", FLEET_POLICY_ROLLOUT_SCHEMA, handle_fleet_policy_rollout, "🚀"))
 
 for _name, _sch, _handler, _emoji in _TOOLS:
     _gate = _check_kanban_orchestrator_mode if _name in _ORCHESTRATOR_TOOLS else _check_kanban_mode

--- a/tools/kanban_tools_schemas.py
+++ b/tools/kanban_tools_schemas.py
@@ -513,3 +513,33 @@ KANBAN_LINK_SCHEMA = _schema(
     },
     ["parent_id", "child_id"],
 )
+
+FLEET_POLICY_ROLLOUT_SCHEMA = _schema(
+    "fleet_policy_rollout",
+    (
+        "Roll out an already-built Fleet Policy release bundle to the "
+        "fixed ten-profile fleet in one atomic step. Orchestrator/"
+        "operator only — hidden from task workers and refused for "
+        "delegate children. Verifies the release bundle against its "
+        "manifest, checks the declared version, enforces the "
+        "independent evidence gates on the target task, backs up every "
+        "existing install, installs the plugin payload on all ten "
+        "profiles, and rolls every profile back on the first mismatch. "
+        "Returns a JSON receipt. Paths are never accepted: the bundle "
+        "is read from releases/<version> under the Hermes root."
+    ),
+    {
+        "task_id": _prop("string", (
+                "Fleet-ops task carrying the release evidence gates; "
+                "its comment thread must contain the exact gate "
+                "markers from the allowed roles.")),
+        "release_sha": _prop("string", (
+                "64-hex git sha of the release commit the bundle was "
+                "built from (recorded in the receipt).")),
+        "version": _prop("string", (
+                "Release version, e.g. 1.2.18. Selects "
+                "releases/<version> under the Hermes root and must "
+                "match the bundle's plugin.yaml version.")),
+    },
+    ["task_id", "release_sha", "version"],
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -34,6 +34,9 @@ _HERMES_CORE_TOOLS = [
     "kanban_comment", "kanban_create", "kanban_link",
     "kanban_unblock",
     "kanban_attach", "kanban_attach_url", "kanban_attachments",
+    # Operator-only policy rollout; ships with the kanban toolset and stays
+    # hidden from dispatcher-spawned task workers via its check_fn gate.
+    "fleet_policy_rollout",
     "computer_use",
     # Service-gated connector account status and authorization links.
     "manage_connections",


### PR DESCRIPTION
## Summary

- add orchestrator-only model tool `fleet_policy_rollout` for gated Fleet Policy rollouts
- operator/orchestrator contexts only: dispatcher workers and delegated children are refused
- enforce exact release SHA/version, required gate markers on the target task, byte-exact backups
- atomic multi-profile install with automatic full rollback on first mismatch; JSON audit receipt
- fixed 10-profile inventory; no arbitrary paths, no model/pool/config/secret access

## Motivation

A gated policy release currently depends on an operations worker that the live policy itself forbids
from updating policy-managed plugin files. That bootstrap deadlock left v1.2.17 partially rolled out
and required operator intervention. This tool gives the orchestrator a narrow, gate-checked primitive
so releases stop depending on forbidden worker actions.

## Tests

`python -m pytest -q tests/tools/test_fleet_policy_rollout.py` — 13 passed, exit 0.
