### PR TITLE
fix(vault): discover and fill forms inside open shadow roots

### DIFF
--- a/agent/vault_login_classifier.py
+++ b/agent/vault_login_classifier.py
@@ -244,15 +244,16 @@ def build_otp_fills(otp_controls: List[ClassifiedLoginControl], code: str) -> Li
 # Open shadow roots belong to the same document/origin. Never traverse frames:
 # their origin would need a separate binding check at the mutation boundary.
 _QUERY_ALL_JS = """const queryAll = (selector) => {
-    const roots = [document], matches = [];
-    for (let i = 0; i < roots.length; i++) {
-      const root = roots[i];
-      matches.push(...root.querySelectorAll(selector));
+    const roots = new Set([document]), matches = new Set();
+    // Synthetic shadow DOM can expose a root or control through multiple paths.
+    // Stamp each control once: duplicate indices would overwrite its nonce binding.
+    for (const root of roots) {
+      for (const element of root.querySelectorAll(selector)) matches.add(element);
       for (const element of root.querySelectorAll('*')) {
-        if (element.shadowRoot) roots.push(element.shadowRoot);
+        if (element.shadowRoot) roots.add(element.shadowRoot);
       }
     }
-    return matches;
+    return Array.from(matches);
   };"""
 
 

--- a/agent/vault_login_classifier.py
+++ b/agent/vault_login_classifier.py
@@ -348,7 +348,7 @@ _FILL_JS_TEMPLATE = """(() => {
       const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value");
       // one-time-code split into single-character boxes: f.value is the slice for THIS box (see build_otp_fills)
       if (setter && setter.set) { setter.set.call(el, f.value); } else { el.value = f.value; }
-      el.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "insertText" }));
+      el.dispatchEvent(new InputEvent("input", { bubbles: true, composed: true, inputType: "insertText" }));
       el.dispatchEvent(new Event("change", { bubbles: true }));
       if (el.value.length > 0) filled += 1;
     } catch (e) { /* skip */ }

--- a/agent/vault_login_classifier.py
+++ b/agent/vault_login_classifier.py
@@ -241,14 +241,36 @@ def build_otp_fills(otp_controls: List[ClassifiedLoginControl], code: str) -> Li
     return [{"index": best.control.index, "token": "one-time-code", "value": code}]
 
 
+# Open shadow roots belong to the same document/origin. Never traverse frames:
+# their origin would need a separate binding check at the mutation boundary.
+_QUERY_ALL_JS = """const queryAll = (selector) => {
+    const roots = [document], matches = [];
+    for (let i = 0; i < roots.length; i++) {
+      const root = roots[i];
+      matches.push(...root.querySelectorAll(selector));
+      for (const element of root.querySelectorAll('*')) {
+        if (element.shadowRoot) roots.push(element.shadowRoot);
+      }
+    }
+    return matches;
+  };"""
+
+
+def build_form_probe_js(selector: str) -> str:
+    """Use the same DOM scope for tab discovery as inspection and injection."""
+    return "(() => {" + _QUERY_ALL_JS + "return queryAll(" + json.dumps(selector) + ").length > 0;})()"
+
+
 def build_inspection_js(nonce: str) -> str:
-    return _LOGIN_CONTROL_INSPECTION_JS_TEMPLATE.replace("__NONCE__", json.dumps(nonce))
+    return (_LOGIN_CONTROL_INSPECTION_JS_TEMPLATE.replace("__NONCE__", json.dumps(nonce))
+            .replace("__QUERY_ALL__", _QUERY_ALL_JS))
 
 
 _LOGIN_CONTROL_INSPECTION_JS_TEMPLATE = """(() => {
   const nonce = __NONCE__;
-  const elements = Array.from(document.querySelectorAll("input, select"));
-  const forms = Array.from(document.forms);
+  __QUERY_ALL__
+  const elements = queryAll("input, select");
+  const forms = queryAll("form");
   elements.forEach((element, index) => element.setAttribute("data-hermes-vault-slot", nonce + ":" + index));
   const out = elements.flatMap((element, index) => {
     if (element.disabled || element.readOnly) return [];
@@ -258,7 +280,7 @@ _LOGIN_CONTROL_INSPECTION_JS_TEMPLATE = """(() => {
     const labels = element.labels ? Array.from(element.labels, (l) => l.textContent || "") : [];
     const ariaText = (element.getAttribute("aria-labelledby") || "")
       .split(/\\s+/).filter(Boolean)
-      .map((id) => { const n = document.getElementById(id); return n ? (n.textContent || "") : ""; })
+      .map((id) => { const n = element.getRootNode().getElementById(id); return n ? (n.textContent || "") : ""; })
       .join(" ");
     const resolvedFormIndex = element.form ? forms.indexOf(element.form) : -1;
     return [{
@@ -297,6 +319,7 @@ def build_fill_js(fills: List[Dict[str, Any]], expected_origin: str, nonce: str 
         [{"index": f["index"], "token": f.get("token", "current-password"), "value": f["value"]} for f in fills]
     )
     return (_FILL_JS_TEMPLATE.replace("__EXPECTED_ORIGIN__", json.dumps(expected_origin))
+            .replace("__QUERY_ALL__", _QUERY_ALL_JS)
             .replace("__FILLS__", payload).replace("__NONCE__", json.dumps(nonce)))
 
 
@@ -307,10 +330,12 @@ _FILL_JS_TEMPLATE = """(() => {
   }
   const fills = __FILLS__;
   const nonce = __NONCE__;
+  __QUERY_ALL__
+  const stamped = queryAll("[data-hermes-vault-slot]");
   let filled = 0;
   const norm = (t) => String(t || "").trim().toLowerCase();
   for (const f of fills) {
-    const el = document.querySelector('[data-hermes-vault-slot="' + nonce + ':' + f.index + '"]');
+    const el = stamped.find((n) => n.getAttribute("data-hermes-vault-slot") === nonce + ':' + f.index);
     if (!el || (f.token === "current-password" && el.type !== "password")) continue;
     try {
       if (el.tagName === "SELECT") {
@@ -328,6 +353,6 @@ _FILL_JS_TEMPLATE = """(() => {
       if (el.value.length > 0) filled += 1;
     } catch (e) { /* skip */ }
   }
-  document.querySelectorAll("[data-hermes-vault-slot]").forEach((n) => n.removeAttribute("data-hermes-vault-slot"));
+  stamped.forEach((n) => n.removeAttribute("data-hermes-vault-slot"));
   return JSON.stringify({ filled });
 })()"""

--- a/tests/test_browser_vault.py
+++ b/tests/test_browser_vault.py
@@ -239,7 +239,7 @@ class TestClassifier:
         assert "vaultSecret" not in js
         assert "data-vault-secret" not in js
         assert "elements[f.index]" not in js
-        assert "[data-hermes-vault-slot=" in js and "nonce + ':' + f.index" in js
+        assert 'getAttribute("data-hermes-vault-slot")' in js and "nonce + ':' + f.index" in js
         assert 'f.token === "current-password" && el.type !== "password"' in js  # a password fill never lands in a text box
         assert js.index('removeAttribute("data-hermes-vault-slot")') > js.index("setter.set.call")
 

--- a/tests/tools/test_vault_shadow_dom_live.py
+++ b/tests/tools/test_vault_shadow_dom_live.py
@@ -1,0 +1,183 @@
+"""Real Chromium regression: tab discovery, inspection and fill share DOM scope.
+
+Runs when Chrome/Chromium is installed; uses only an isolated browser profile,
+loopback pages and a temporary local vault. No personal browser or manager.
+"""
+import http.server
+import json
+import shutil
+import subprocess
+import threading
+import time
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from agent.vault_login_classifier import build_fill_js, build_inspection_js
+from tools import browser_vault_tool as vault
+from tools.browser_supervisor import SUPERVISOR_REGISTRY
+from tools.browser_use_cli import _attach_vault_supervisor
+from tools.registry import registry
+
+
+@pytest.fixture
+def browser(tmp_path):
+    executable = next((shutil.which(n) for n in ("chromium", "chromium-browser", "google-chrome")
+                       if shutil.which(n)), None)
+    mac = Path('/Applications/Google Chrome.app/Contents/MacOS/Google Chrome')
+    if not executable and mac.exists():
+        executable = str(mac)
+    if not executable:
+        pytest.skip("Chrome/Chromium is required for the live DOM regression")
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(b"<!doctype html><title>vault regression</title><body></body>")
+
+        def log_message(self, *args):
+            pass
+
+    server = http.server.ThreadingHTTPServer(('127.0.0.1', 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    origin = f'http://127.0.0.1:{server.server_port}'
+    profile = tmp_path / 'chrome'
+    process = subprocess.Popen([executable, '--headless=new', '--no-sandbox',
+                                '--disable-dev-shm-usage', '--no-first-run',
+                                '--no-default-browser-check', '--remote-debugging-port=0',
+                                f'--user-data-dir={profile}', origin + '/unrelated'],
+                               stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    task = 'vault-shadow-regression'
+    try:
+        deadline = time.monotonic() + 20
+        active_port = profile / 'DevToolsActivePort'
+        address = []
+        while time.monotonic() < deadline and process.poll() is None:
+            if active_port.exists():
+                address = active_port.read_text().splitlines()
+                if len(address) >= 2 and address[0].isdigit() and address[1].startswith('/devtools/browser/'):
+                    break
+            time.sleep(.05)
+        assert len(address) >= 2, 'isolated Chrome did not publish its DevTools address'
+        port, ws_path = address[:2]
+        _attach_vault_supervisor({'BU_CDP_WS': f'ws://127.0.0.1:{port}{ws_path}'}, task)
+        sup = SUPERVISOR_REGISTRY.get(task)
+        assert sup is not None, 'browser_exec must attach the vault supervisor'
+        def wait_page(url):
+            from urllib.parse import urlsplit
+
+            parsed = urlsplit(url)
+            page_origin = f'{parsed.scheme}://{parsed.netloc}'
+            deadline = time.monotonic() + 30
+            while time.monotonic() < deadline:
+                if sup.focus_page(page_origin).get('ok'):
+                    ready = sup.evaluate_runtime(
+                        f'location.href === {json.dumps(url)} && document.readyState === "complete"')
+                    if ready.get('ok') and ready.get('result'):
+                        return
+                time.sleep(.05)
+            pytest.fail('test page did not finish loading')
+
+        wait_page(origin + '/unrelated')
+
+        def new_page(url):
+            request = urllib.request.Request(f'http://127.0.0.1:{port}/json/new?{url}', method='PUT')
+            with urllib.request.urlopen(request, timeout=5) as response:
+                json.load(response)
+            wait_page(url)
+        yield sup, task, origin, new_page
+    finally:
+        SUPERVISOR_REGISTRY.stop(task)
+        process.terminate()
+        process.wait(timeout=10)
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def evaluate(sup, expression):
+    result = sup.evaluate_runtime(expression)
+    assert result['ok'], result
+    return result['result']
+
+
+def shadow_form(sup):
+    evaluate(sup, """(() => {
+      const host = document.createElement('div'); document.body.append(host);
+      const outer = host.attachShadow({mode:'open'});
+      outer.innerHTML = '<div id="nested"></div>';
+      const inner = outer.querySelector('#nested').attachShadow({mode:'open'});
+      inner.innerHTML = '<form><label id="pw-label">Password</label>' +
+        '<input type="password" aria-labelledby="pw-label" autocomplete="current-password">' +
+        '<input autocomplete="cc-number"><input autocomplete="postal-code">' +
+        '<input autocomplete="one-time-code"></form>';
+      window.testRoot = inner;
+    })()""")
+
+
+def test_shadow_probe_inspection_and_nonce_fill_share_scope(browser):
+    sup, _, origin, _ = browser
+    shadow_form(sup)
+    for kind in ('login', 'payment', 'address', 'otp'):
+        assert evaluate(sup, vault._TAB_PROBES[kind]), kind
+    controls = json.loads(evaluate(sup, build_inspection_js('test-nonce')))
+    password = next(c for c in controls if c['type'] == 'password')
+    assert password['label'].strip() == 'Password'
+    assert password['formIndex'] >= 0
+    fills = [{'index': password['index'], 'token': 'current-password', 'value': 'dummy-live-value'}]
+    refused = json.loads(evaluate(sup, build_fill_js(fills, origin + '.invalid', 'test-nonce')))
+    assert refused['refused'] == 'origin_changed'
+    assert evaluate(sup, "testRoot.querySelector('input').value === ''")
+    assert json.loads(evaluate(sup, build_fill_js(fills, origin, 'wrong-nonce')))['filled'] == 0
+    # A stale nonce attempt clears stamps; inspect again before the authorized write.
+    evaluate(sup, build_inspection_js('test-nonce'))
+    assert json.loads(evaluate(sup, build_fill_js(fills, origin, 'test-nonce')))['filled'] == 1
+    assert evaluate(sup, "testRoot.querySelector('input').value === 'dummy-live-value'")
+    assert evaluate(sup, "testRoot.querySelectorAll('[data-hermes-vault-slot]').length") == 0
+    # Stamps alone do not authorize a password write into a field whose type changed.
+    evaluate(sup, build_inspection_js('test-nonce'))
+    evaluate(sup, "testRoot.querySelector('input').type = 'text'; testRoot.querySelector('input').value = ''")
+    assert json.loads(evaluate(sup, build_fill_js(fills, origin, 'test-nonce')))['filled'] == 0
+    # Shadow traversal must not widen mutation scope to embedded documents.
+    evaluate(sup, """document.body.innerHTML = '<iframe></iframe>';
+      document.querySelector('iframe').contentDocument.body.innerHTML = '<input type=password>'""")
+    assert not evaluate(sup, vault._TAB_PROBES['login'])
+    assert json.loads(evaluate(sup, build_inspection_js('frame-test'))) == []
+    # Ordinary light-DOM fields keep working too.
+    evaluate(sup, "document.body.innerHTML = '<input type=password>'")
+    assert evaluate(sup, vault._TAB_PROBES['login'])
+    controls = json.loads(evaluate(sup, build_inspection_js('light-test')))
+    fills[0]['index'] = controls[0]['index']
+    assert json.loads(evaluate(sup, build_fill_js(fills, origin, 'light-test')))['filled'] == 1
+
+
+def test_vault_fill_finds_shadow_login_not_unrelated_first_tab(browser):
+    from agent.vault_store import get_vault_store
+
+    sup, task, origin, new_page = browser
+    # A distinct exact origin on the same server, leaving the original tab intact.
+    login_origin = origin.replace('127.0.0.1', 'localhost')
+    new_page(login_origin + '/page')
+    shadow_form(sup)
+    assert sup.focus_page(origin)['ok']
+    item = get_vault_store().add_item('login', 'synthetic login',
+                                    {'identifier': 'test', 'identifier_type': 'username',
+                                     'password': 'dummy-live-value'}, origin=login_origin)
+    raw = registry.dispatch('browser_vault_fill', {'handle': item.id}, task_id=task)
+    result = json.loads(raw)
+    assert result['success'], result
+    assert result['filled_fields'] == 1 and result['origin'] == login_origin
+    assert 'dummy-live-value' not in raw
+    assert evaluate(sup, "testRoot.querySelector('input').value === 'dummy-live-value'")
+    assert sup.focus_page(origin)['ok']
+    assert evaluate(sup, "document.querySelectorAll('input').length") == 0
+    # No tab on the bound origin: never weaken origin matching to make progress.
+    other = get_vault_store().add_item('login', 'absent origin',
+                                     {'identifier': 'test', 'identifier_type': 'username',
+                                      'password': 'another-dummy'}, origin='https://absent.invalid')
+    refusal = json.loads(registry.dispatch('browser_vault_fill', {'handle': other.id}, task_id=task))
+    assert refusal['error_type'] == 'origin_mismatch'

--- a/tests/tools/test_vault_shadow_dom_live.py
+++ b/tests/tools/test_vault_shadow_dom_live.py
@@ -116,6 +116,13 @@ def shadow_form(sup):
         '<input autocomplete="cc-number"><input autocomplete="postal-code">' +
         '<input autocomplete="one-time-code"></form>';
       window.testRoot = inner;
+      window.testInputObservers = [];
+      for (const [name, target] of [['host', host], ['document', document]]) {
+        target.addEventListener('input', event => {
+          window.testInputObservers.push({observer: name, composed: event.composed,
+            retargeted: event.target === host, inputType: event.inputType});
+        });
+      }
     })()""")
 
 
@@ -173,6 +180,12 @@ def test_vault_fill_finds_shadow_login_not_unrelated_first_tab(browser):
     assert result['filled_fields'] == 1 and result['origin'] == login_origin
     assert 'dummy-live-value' not in raw
     assert evaluate(sup, "testRoot.querySelector('input').value === 'dummy-live-value'")
+    # Framework observers outside both shadow roots must see the input event,
+    # with normal shadow-DOM retargeting and without exposing the field value.
+    assert evaluate(sup, 'window.testInputObservers') == [
+        {'observer': observer, 'composed': True, 'retargeted': True, 'inputType': 'insertText'}
+        for observer in ('host', 'document')
+    ]
     assert sup.focus_page(origin)['ok']
     assert evaluate(sup, "document.querySelectorAll('input').length") == 0
     # No tab on the bound origin: never weaken origin matching to make progress.

--- a/tests/tools/test_vault_shadow_dom_live.py
+++ b/tests/tools/test_vault_shadow_dom_live.py
@@ -162,7 +162,8 @@ def test_shadow_probe_inspection_and_nonce_fill_share_scope(browser):
     assert json.loads(evaluate(sup, build_fill_js(fills, origin, 'light-test')))['filled'] == 1
 
 
-def test_vault_fill_finds_shadow_login_not_unrelated_first_tab(browser):
+@pytest.mark.parametrize('aliased_root', [False, True])
+def test_vault_fill_finds_shadow_login_not_unrelated_first_tab(browser, aliased_root):
     from agent.vault_store import get_vault_store
 
     sup, task, origin, new_page = browser
@@ -170,6 +171,15 @@ def test_vault_fill_finds_shadow_login_not_unrelated_first_tab(browser):
     login_origin = origin.replace('127.0.0.1', 'localhost')
     new_page(login_origin + '/page')
     shadow_form(sup)
+    if aliased_root:
+        # Synthetic-shadow adapters can expose the same root via multiple hosts.
+        # Repeated traversal must not overwrite a control's inspection stamp.
+        evaluate(sup, """(() => {
+          const alias = document.createElement('div');
+          const root = document.body.firstElementChild.shadowRoot;
+          Object.defineProperty(alias, 'shadowRoot', {get: () => root});
+          document.body.append(alias);
+        })()""")
     assert sup.focus_page(origin)['ok']
     item = get_vault_store().add_item('login', 'synthetic login',
                                     {'identifier': 'test', 'identifier_type': 'username',

--- a/tools/browser_vault_tool.py
+++ b/tools/browser_vault_tool.py
@@ -31,6 +31,8 @@ import secrets
 import logging
 from typing import Any, Dict, Optional
 
+from agent.vault_login_classifier import build_form_probe_js
+
 logger = logging.getLogger(__name__)
 
 
@@ -184,11 +186,13 @@ def _current_page_origin(task_id: str) -> Optional[str]:
 
 
 # Per kind: a JS probe that is truthy on a tab holding the form this kind fills.
-_TAB_PROBES = {
-    "login": "!!document.querySelector('input[type=password]')",
-    "payment": "!!document.querySelector('input[autocomplete^=cc-], [name*=card i], [placeholder*=card i], [name*=cvc i], [name*=cvv i]')",
-    "address": "!!document.querySelector('input[autocomplete^=address-], [autocomplete=postal-code], [name*=address i], [name*=zip i], [name*=postal i]')",
-}
+_TAB_PROBES = {kind: build_form_probe_js(selector) for kind, selector in {
+    "login": "input[type=password]",
+    "payment": "input[autocomplete^=cc-], [name*=card i], [placeholder*=card i], [name*=cvc i], [name*=cvv i]",
+    "address": "input[autocomplete^=address-], [autocomplete=postal-code], [name*=address i], [name*=zip i], [name*=postal i]",
+    "otp": "input[autocomplete=one-time-code], input[name*=otp i], input[name*=code i], "
+           "input[id*=otp i], input[id*=code i], input[name*=totp i], input[aria-label*=code i]",
+}.items()}
 
 
 def _focus_bound_origin(task_id: str, origin: str, kind: str) -> Optional[str]:
@@ -316,10 +320,6 @@ def browser_vault_save_login(label: str = "", task_id: Optional[str] = None) -> 
                        "identifier_type": id_type, "fill": filled,
                        "next": "Type the identifier into the username field if the form has one, then submit."},
                       ensure_ascii=False)
-
-
-_TAB_PROBES["otp"] = ("!!document.querySelector('input[autocomplete=one-time-code], input[name*=otp i], input[name*=code i], "
-                      "input[id*=otp i], input[id*=code i], input[name*=totp i], input[aria-label*=code i]')")
 
 
 def browser_vault_enter_code(handle: str = "", task_id: Optional[str] = None) -> str:


### PR DESCRIPTION
## Summary
Fix vault form discovery, inspection, and injection for controls inside nested open shadow roots. Previously the form probe used `document.querySelector`, so a login tab whose password control lived in shadow DOM was rejected and the supervisor remained attached to an unrelated tab. Exact-origin enforcement then correctly refused the fill.

- Share one shadow-aware query helper across login/payment/address/OTP tab probes, control inspection, and nonce-bound injection.
- Resolve ARIA labels within the control's own root and preserve shadow-local form associations.
- Keep exact-origin checks, nonce targeting, password-type checks, and stamp cleanup. Do not traverse frames or closed shadow roots.
- Add two real Chromium regression tests using an isolated profile, loopback pages, a temporary vault, Browser Use supervisor attachment, and registry dispatch. No personal accounts or browser profiles are used.

## Verification
- Before the fix, both Chromium regressions failed: the shadow password probe returned false and registry-dispatched fill refused with `origin_mismatch` while attached to the unrelated first tab.
- Final targeted run: **182 passed, 0 failed**, with file retries disabled:
  ```sh
  HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
    tests/tools/test_vault_shadow_dom_live.py tests/test_browser_vault.py \
    tests/agent/test_vault_backends.py tests/tui_gateway/test_vault_methods.py \
    tests/tools/test_browser_use_cli.py tests/tools/test_browser_use_session_expiry.py
  ```
- The two live Chromium tests additionally passed three consecutive runs with retries disabled. Fixtures wait for complete DevTools address publication and page readiness rather than assuming file existence means startup is complete.
- Coverage includes nested shadow roots, all four form probes, shadow-local labels/forms, real dummy-password injection, unrelated-tab isolation, absent-origin refusal, in-script origin-change refusal, stale nonce rejection, changed password-type rejection, stamp cleanup, iframe exclusion, light-DOM compatibility, and no dummy secret in tool output.
- `git diff --check` passed.
- Full-suite attempt was interrupted; **no full-suite pass is claimed**. Hosted CI is pending.

This is a source fix, not a deployment: no running gateway was restarted.
