### PR TITLE
fix(computer_use): fall back to input schema properties when MCP SDK drops capabilities (#108846)

### DIFF
--- a/tests/tools/test_computer_use_cua_backend_linux.py
+++ b/tests/tools/test_computer_use_cua_backend_linux.py
@@ -142,3 +142,30 @@ def test_explicit_app_capture_preserves_filtered_target_order():
     chrome = _normalized_windows(LINUX_LIST_WINDOWS)[1]
 
     assert _select_capture_target([chrome], app_requested=True) == chrome
+
+def test_supports_capability_falls_back_to_tool_schema_property():
+    """Verify #108846: when MCP SDK drops the non-spec capabilities array from tools/list,
+    supports_capability falls back to detecting unambiguous inputSchema properties."""
+    from tools.computer_use.cua_backend_session import _CuaDriverSession, _AsyncBridge
+
+    session = _CuaDriverSession(_AsyncBridge())
+    # Simulate empty _capabilities due to MCP SDK drop
+    session._capabilities = {}
+    session._tool_schemas = {
+        "click": {
+            "type": "object",
+            "properties": {
+                "element_token": {"type": "string"},
+                "delivery_mode": {"type": "string"},
+            },
+        }
+    }
+
+    # Should detect accessibility.element_tokens via element_token property
+    assert session.supports_capability("accessibility.element_tokens", tool="click") is True
+    # Should detect input.delivery_mode via delivery_mode property
+    assert session.supports_capability("input.delivery_mode", tool="click") is True
+    # Unmapped or absent capability returns False
+    assert session.supports_capability("nonexistent.capability", tool="click") is False
+    # Check across any tool when tool=None
+    assert session.supports_capability("accessibility.element_tokens") is True

--- a/tools/computer_use/cua_backend_session.py
+++ b/tools/computer_use/cua_backend_session.py
@@ -158,6 +158,18 @@ def _logical_error_text(result: Dict[str, Any]) -> str:
             chunks.append(str(value))
     return "\n".join(chunks)
 
+# The MCP Python SDK's ``Tool`` model has no ``capabilities`` field, so the non-spec per-tool
+# `capabilities[]` array (trycua/cua#1961) is silently dropped on the round-trip through
+# `tools/list`, even when the driver genuinely advertises it (#108846). ``inputSchema``, being
+# part of the spec, always survives — so a schema property that could ONLY exist to serve a given
+# capability is itself proof the driver supports that capability. Kept intentionally small: only
+# properties that are an unambiguous 1:1 stand-in for the capability token belong here.
+_CAPABILITY_SCHEMA_PROPERTIES = {
+    "accessibility.element_tokens": "element_token",
+    "input.delivery_mode": "delivery_mode",
+}
+
+
 def _is_ended_session_result(result: Any) -> bool:
     """Recognise cua-driver's explicit recoverable ended-session result."""
     if not isinstance(result, dict) or result.get("isError") is not True:
@@ -357,10 +369,19 @@ class _CuaDriverSession:
     def supports_capability(self, capability: str, tool: Optional[str] = None) -> bool:
         """Driver advertises *capability* for *tool* (or ANY tool). False before start.
 
-        capability token (trycua/cua#1961 capability vocabulary).
+        capability token (trycua/cua#1961 capability vocabulary). Falls back to
+        ``_CAPABILITY_SCHEMA_PROPERTIES`` when ``_capabilities`` doesn't have it: the MCP SDK
+        drops the non-spec ``capabilities`` field from ``tools/list``, but ``inputSchema`` (spec)
+        survives, so a matching input property still proves the capability (#108846).
         """
         caps = [self._capabilities.get(tool, set())] if tool is not None else self._capabilities.values()
-        return any(capability in c for c in caps)
+        if any(capability in c for c in caps):
+            return True
+        schema_property = _CAPABILITY_SCHEMA_PROPERTIES.get(capability)
+        if schema_property is None:
+            return False
+        tools = [tool] if tool is not None else list(self._tool_schemas)
+        return any(self.supports_input_property(t, schema_property) for t in tools)
 
     def _has_tool(self, name: str) -> bool:
         """``tools/list`` advertised *name*. Routes capture() (PNG capture moved into ``get_window_state``).


### PR DESCRIPTION
Closes #108846

### Summary
Fixes a silent failure where `computer_use` on Linux with cua-driver 0.28+ refuses `element` clicks with `click: bare element_index is not accepted; pass element_token`.

### Root Cause
The MCP Python SDK's Pydantic `Tool` model drops non-spec attributes, silently stripping cua-driver's `capabilities` field during `tools/list` parsing. Because `self._capabilities` was empty, `supports_capability("accessibility.element_tokens")` returned `False`, and the agent never attached the captured `element_token`.

### Changes
1. Added `_CAPABILITY_SCHEMA_PROPERTIES` mapping in `cua_backend_session.py` for capabilities with unambiguous 1:1 input schema properties (`accessibility.element_tokens` -> `element_token`, `input.delivery_mode` -> `delivery_mode`).
2. Updated `supports_capability()` to fall back to checking `self.supports_input_property()` against the tool's `inputSchema` (which survives the MCP SDK round-trip) when `self._capabilities` has no match.
3. Added regression unit test in `tests/tools/test_computer_use_cua_backend_linux.py` verifying schema fallback for both single tool and global discovery.

Tested locally: 6/6 tests pass in `test_computer_use_cua_backend_linux.py`.