### PR TITLE
fix(mcp): isolate OAuth connections by profile (fixes #109422)

### DIFF
--- a/tests/tools/test_mcp_multiplex_connection_keys.py
+++ b/tests/tools/test_mcp_multiplex_connection_keys.py
@@ -89,6 +89,26 @@ def test_same_named_server_with_other_credentials_is_a_separate_connection(two_p
     assert handlers._check_circuit_breaker("x") is None
 
 
+def test_oauth_server_is_not_adopted_across_profiles(two_profiles):
+    from tools import mcp_tool_discovery as disc
+    from tools import mcp_tool_registration as reg
+    from tools.registry import registry
+
+    cfg = {"url": "https://mcp.example/x", "auth": "oauth"}
+
+    two_profiles("a")
+    srv_a = _server("x", cfg)
+    disc._adopt_server("x", srv_a)
+    srv_a._registered_tool_names = reg._register_server_tools("x", srv_a, cfg)
+    assert reg.register_connected_into_current_scope({"x": dict(cfg)}) == 0
+    assert registry.get_tool_names_for_toolset("mcp-x") == ["mcp__x__t"]
+
+    two_profiles("b")
+    assert reg.register_connected_into_current_scope({"x": dict(cfg)}) == 0
+    assert registry.get_tool_names_for_toolset("mcp-x") == []
+    assert "x" in disc._select_new_servers({"x": dict(cfg)})
+
+
 def test_owner_reload_reregisters_profiles_that_adopted_its_connection(two_profiles):
     import tools.mcp_tool as core
     from tools import mcp_tool_discovery as disc, mcp_tool_lifecycle as lifecycle

--- a/tools/mcp_tool_registration.py
+++ b/tools/mcp_tool_registration.py
@@ -413,8 +413,19 @@ def _connection_identity(config: dict) -> tuple:
             (config.get("auth") or "").lower().strip())
 
 
-def _same_server_route(server: Any, config: dict) -> bool:
-    return _connection_identity(getattr(server, "_config", {}) or {}) == _connection_identity(config)
+def _same_server_route(server: Any, config: dict, *, cross_profile: bool = False) -> bool:
+    """Whether *server* matches *config*, with OAuth connections never reusable across profiles.
+
+    OAuth credentials live in the owning profile's token storage rather than the static config,
+    so identical OAuth configs cannot prove that two profiles authenticate as the same account.
+    """
+    server_config = getattr(server, "_config", {}) or {}
+    if cross_profile and any(
+        (candidate.get("auth") or "").lower().strip() == "oauth"
+        for candidate in (server_config, config)
+    ):
+        return False
+    return _connection_identity(server_config) == _connection_identity(config)
 
 
 def register_connected_into_current_scope(servers: dict) -> int:
@@ -447,8 +458,10 @@ def _register_connected_into_current_scope(servers: dict) -> int:
                 continue
             server = _core._servers.get(key)
             config = servers.get(_key_name(key))
+            cross_profile = key != _server_key(_key_name(key), scope, current=False)
             if (config is None or not _server_enabled(config) or server is None
-                    or getattr(server, "session", None) is None or not _same_server_route(server, config)):
+                    or getattr(server, "session", None) is None
+                    or not _same_server_route(server, config, cross_profile=cross_profile)):
                 stale.append(key)
     for key in stale:
         _remove_server_scope(key, scope)
@@ -463,7 +476,7 @@ def _register_connected_into_current_scope(servers: dict) -> int:
             # Any other profile's live connection with the same route AND credentials is shareable.
             shared = [(key, live) for key, live in _core._servers.items()
                       if _key_name(key) == name and getattr(live, "session", None) is not None
-                      and _same_server_route(live, config)]
+                      and _same_server_route(live, config, cross_profile=True)]
         if not shared:
             continue
         key, server = shared[0]


### PR DESCRIPTION
Fixes #109422.

## Bug

Under `gateway.multiplex_profiles`, two profiles configuring the SAME hosted per-user OAuth MCP
server URL (e.g. a self-hosted Google Calendar/Workspace MCP supporting many Google accounts)
could have one profile's tool calls silently served by the OTHER profile's already-authenticated
live connection — because `_connection_identity()` never considered the actual OAuth-authenticated
identity, only static config (url/transport/headers/env/auth-type-string).

Reproduced live: two Hermes profiles each completed their own independent OAuth login against the
same hosted Google Calendar MCP. The SAME `whoami` tool call, in one profile's long-running
session, returned two different Google account emails a few minutes apart with no config change or
reconnection in between - the live connection object being served was flipping between the two
profiles' adopted/owned states.

## Fix

`_same_server_route()` now takes a `cross_profile` flag. When true (i.e. the candidate connection
is owned by a different profile scope than the caller), any config on either side with
`auth: oauth` is refused as a match - an OAuth connection is never adopted across profile scopes,
full stop. This is deliberately fail-closed rather than trying to compare actual token identities,
since OAuth credentials live in per-profile token storage (`~/.hermes/profiles/<name>/mcp-tokens/`)
rather than the static config dict that `config_fingerprint`/`_connection_identity` hash, and no
provider is guaranteed to expose a stable subject/account identifier.

Non-OAuth connection sharing (stdio, header-authenticated, env-authenticated servers) is
unaffected - the pre-existing identity comparison is unchanged for those, and the existing tests
proving that sharing still pass.

## Testing

- New regression test `test_oauth_server_is_not_adopted_across_profiles` in
  `tests/tools/test_mcp_multiplex_connection_keys.py`: profile A registers a live OAuth connection;
  profile B, with a byte-identical config, must NOT adopt it (0 registered, empty tool overlay, and
  the server remains a new-connect candidate for B).
- Verified this test fails on pre-fix code (`assert 1 == 0`) via a clean `git archive` export of
  the base commit with only the new test file copied in - confirms the test exercises the actual
  vulnerable path, not something adjacent.
- Full targeted run: `scripts/run_tests.sh tests/tools/ -k mcp` -> 761 passed, 0 failed, 4 skipped.
  (Two unrelated wall-clock timing tests flaked once under 24-way parallel load and passed on
  retry - not touched by this change.)

## Review

Independently reviewed (read-only) by a second agent, which traced every cross-profile
connection-adoption path in `tools/mcp_tool_registration.py`/`mcp_tool_discovery.py`/
`mcp_tool_lifecycle.py` to confirm no path bypasses the new guard, attempted several falsifications
of the new test (auth-string casing, missing `_config`, asymmetric oauth/non-oauth pairing, orphan
re-registration, reversed scope ordering) without finding a gap, and reproduced all test runs
itself rather than trusting the author's report. Verdict: ready for PR, no blocking or major issues
in the changed code.

One adjacent, pre-existing, NOT-introduced-by-this-diff gap was flagged during review: mTLS
`client_cert`/`client_key` are also static config excluded from `_connection_identity`, so two
profiles with the same URL/headers but different client certs would still wrongly share a
connection today. Filed separately as a follow-up rather than scope-creeping this PR.

## Non-goals / out of scope for this PR

- mTLS client-cert identity (separate, same-bug-class, pre-existing issue - filed separately).
- Comparing actual resolved OAuth subject/account identifiers (would allow re-sharing once both
  sides are known to be the same account, but adds complexity and provider-dependent risk for
  marginal benefit over fail-closed isolation).
