### PR TITLE
fix(mcp): isolate OAuth connections by profile

### DIFF
--- a/tests/tools/test_mcp_multiplex_connection_keys.py
+++ b/tests/tools/test_mcp_multiplex_connection_keys.py
@@ -89,6 +89,50 @@ def test_same_named_server_with_other_credentials_is_a_separate_connection(two_p
     assert handlers._check_circuit_breaker("x") is None
 
 
+@pytest.mark.parametrize(("auth", "expected_connections"), [
+    pytest.param(" OAuth ", 2, id="oauth-isolated"),
+    pytest.param(None, 1, id="non-oauth-shared-control"),
+])
+def test_identical_config_connection_sharing_respects_oauth_profile_ownership(
+    two_profiles, auth, expected_connections,
+):
+    import tools.mcp_tool as core
+    from tools import mcp_tool_discovery as disc
+    from tools import mcp_tool_registration as reg
+
+    cfg = {"url": "https://mcp.example/x"}
+    if auth is not None:
+        cfg["auth"] = auth
+
+    scope_a = two_profiles("a")
+    srv_a = _server("x", cfg)
+    disc._adopt_server("x", srv_a)
+    srv_a._registered_tool_names = reg._register_server_tools("x", srv_a, cfg)
+
+    scope_b = two_profiles("b")
+    connected = []
+
+    def fake_pass(new_servers):
+        for name, config in new_servers.items():
+            server = _server(name, config)
+            connected.append(server)
+            disc._adopt_server(name, server)
+            server._registered_tool_names = reg._register_server_tools(name, server, config)
+
+    with patch.object(disc, "_run_discovery_pass", fake_pass), \
+            patch.object(disc._loop, "_ensure_mcp_loop", lambda: None):
+        disc.register_mcp_servers({"x": dict(cfg)})
+
+    assert len(core._servers) == expected_connections
+    assert core._servers[(scope_a, "x")] is srv_a
+    if auth is not None:
+        assert len(connected) == 1
+        assert core._servers[(scope_b, "x")] is connected[0]
+    else:
+        assert connected == []
+        assert scope_b in core._server_tool_scopes[(scope_a, "x")]
+
+
 def test_owner_reload_reregisters_profiles_that_adopted_its_connection(two_profiles):
     import tools.mcp_tool as core
     from tools import mcp_tool_discovery as disc, mcp_tool_lifecycle as lifecycle

--- a/tools/mcp_tool_registration.py
+++ b/tools/mcp_tool_registration.py
@@ -399,22 +399,29 @@ def _server_enabled(config: dict) -> bool:
     return _parse_boolish(config.get("enabled", True), default=True)
 
 
-def _connection_identity(config: dict) -> tuple:
+def _connection_identity(config: dict, *, profile_scope: Optional[str] = None) -> tuple:
     """What makes one live connection reusable for another profile: the route fingerprint PLUS
     everything that authenticates it (``config_fingerprint`` deliberately excludes credentials so
     the schema cache survives a token rotation). Two profiles pointing at the same URL with different
-    headers/env/auth are two identities; borrowing across them would call tools as the other user."""
+    headers/env/auth are two identities; borrowing across them would call tools as the other user.
+    OAuth tokens live outside config, so their live connection identity also includes profile scope."""
     from tools.mcp_schema_cache import config_fingerprint
 
     def _frozen(value):
         return json.dumps(value or {}, sort_keys=True, default=str)
 
+    auth_mode = (config.get("auth") or "").lower().strip()
+    oauth_scope = profile_scope if auth_mode == "oauth" else None
     return (config_fingerprint(config), _frozen(config.get("env")), _frozen(config.get("headers")),
-            (config.get("auth") or "").lower().strip())
+            auth_mode, oauth_scope)
 
 
-def _same_server_route(server: Any, config: dict) -> bool:
-    return _connection_identity(getattr(server, "_config", {}) or {}) == _connection_identity(config)
+def _same_server_route(server: Any, config: dict, *, key=None) -> bool:
+    owner_scope = _core._server_registry_scope(key if key is not None else _server_key_for_task(server))
+    current_scope = _core._mcp_registry_scope()
+    return _connection_identity(
+        getattr(server, "_config", {}) or {}, profile_scope=owner_scope,
+    ) == _connection_identity(config, profile_scope=current_scope)
 
 
 def register_connected_into_current_scope(servers: dict) -> int:
@@ -448,7 +455,7 @@ def _register_connected_into_current_scope(servers: dict) -> int:
             server = _core._servers.get(key)
             config = servers.get(_key_name(key))
             if (config is None or not _server_enabled(config) or server is None
-                    or getattr(server, "session", None) is None or not _same_server_route(server, config)):
+                    or getattr(server, "session", None) is None or not _same_server_route(server, config, key=key)):
                 stale.append(key)
     for key in stale:
         _remove_server_scope(key, scope)
@@ -463,7 +470,7 @@ def _register_connected_into_current_scope(servers: dict) -> int:
             # Any other profile's live connection with the same route AND credentials is shareable.
             shared = [(key, live) for key, live in _core._servers.items()
                       if _key_name(key) == name and getattr(live, "session", None) is not None
-                      and _same_server_route(live, config)]
+                      and _same_server_route(live, config, key=key)]
         if not shared:
             continue
         key, server = shared[0]


### PR DESCRIPTION
## What does this PR do?

Prevents multiplexed profiles from adopting another profile's live OAuth MCP connection when both profiles use the same server name and URL.

OAuth tokens are stored under each profile rather than in the MCP config, so static config equality cannot prove that two OAuth connections represent the same authenticated identity. This change includes the owning profile scope in the live connection identity only for normalized `auth: oauth` configurations. Existing sharing remains unchanged for identical non-OAuth connections.

## Related Issue

Fixes #109422

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Scope OAuth live-connection identity to the profile that owns the connection.
- Pass the known connection key through adoption and stale-scope comparisons, avoiding nested MCP ledger locking.
- Add a multiplex regression test proving identical OAuth configs create separate profile-owned connections.
- Add a control proving identical non-OAuth configs still share one live connection.

## How to Test

1. On unmodified `d595e636c83a`, run the focused regression test. The OAuth case fails with one live connection instead of two, while the non-OAuth control passes.
2. Apply this patch and rerun the same probe; both parameterized cases pass.
3. Run the focused multiplex suites listed below.

```bash
env HERMES_PYTHON=/path/to/python scripts/run_tests.sh \
  tests/tools/test_mcp_multiplex_connection_keys.py \
  -k identical_config_connection_sharing_respects_oauth_profile_ownership

env HERMES_PYTHON=/path/to/python scripts/run_tests.sh \
  tests/tools/test_mcp_multiplex_connection_keys.py

env HERMES_PYTHON=/path/to/python scripts/run_tests.sh \
  tests/gateway/test_multiplex_mcp_discovery.py
```

Results:

- Focused regression: 2 passed
- MCP multiplex connection keys: 4 passed
- Gateway multiplex MCP discovery: 8 passed
- Independent P0 review: 0 findings

## Checklist

### Code

- [x] I've read the Contributing Guide and repository instructions
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs and found no competing PR for #109422
- [x] My PR contains only changes related to this fix
- [ ] I've run the full `pytest tests/ -q` suite
- [x] I've added tests for the bug fix
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] Documentation update: N/A; the behavior is documented in the affected helper docstring
- [x] `cli-config.yaml.example`: N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no workflow or architecture change
- [x] Cross-platform impact considered; the change is platform-independent Python logic
- [x] Tool descriptions/schemas: N/A; no tool schema changed

## Risk

The identity tuple gains a trailing scope component, but it is used internally for equality comparison and remains `None` for every non-OAuth mode. OAuth connections are intentionally no longer shared across multiplexed profiles; token files and schema-cache fingerprints are untouched.
