### PR TITLE
fix(telegram): decode JSON-encoded allowlist strings before comma-split

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -32,6 +32,23 @@ def _redact_telegram_error_text(error: object) -> str:
         return "<telegram error redacted>"
 
 
+def _decode_json_list_literal(raw):
+    """Decode a JSON-encoded allowlist written by ``hermes config set``.
+
+    String-typed defaults keep list literals verbatim on write (``allowed_chats`` is
+    declared as ``""``), so the config can hold ``'["-100","-200"]'`` as a string.
+    Malformed JSON passes through unchanged and keeps the legacy comma-split path.
+    """
+    if isinstance(raw, str) and raw.lstrip()[:1] == "[":
+        try:
+            loaded = json.loads(raw)
+        except ValueError:
+            return raw
+        if isinstance(loaded, list):
+            return loaded
+    return raw
+
+
 def _scoped_gate_env(name: str, default: str = "") -> str:
     """Per-profile TELEGRAM_*/GATEWAY_* gate env read (multiplex env is first-writer-wins).
 
@@ -5034,6 +5051,7 @@ class TelegramAdapter(BasePlatformAdapter):
         raw = self.config.extra.get(key)
         if raw is None:
             raw = _scoped_gate_env(env_name)
+        raw = _decode_json_list_literal(raw)
         if isinstance(raw, list):
             return {str(part).strip() for part in raw if str(part).strip()}
         return {part.strip() for part in str(raw).split(",") if part.strip()}
@@ -5107,6 +5125,7 @@ class TelegramAdapter(BasePlatformAdapter):
         raw = self.config.extra.get("ignored_threads")
         if raw is None:
             raw = _scoped_gate_env("TELEGRAM_IGNORED_THREADS")
+        raw = _decode_json_list_literal(raw)
         ignored: set[int] = set()
         for value in (raw if isinstance(raw, list) else str(raw).split(",")):
             text = str(value).strip()

--- a/tests/gateway/test_telegram_allowlist_json.py
+++ b/tests/gateway/test_telegram_allowlist_json.py
@@ -1,0 +1,83 @@
+import json
+from types import SimpleNamespace
+
+from gateway.config import Platform, PlatformConfig
+
+
+def _make_json_adapter(allowed_chats):
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    extra = {
+        "allowed_chats": allowed_chats,
+        "allowed_topics": [],
+        "group_allowed_chats": [],
+    }
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(enabled=True, token="***", extra=extra)
+    adapter._bot = SimpleNamespace(id=999, username="hermes_bot")
+    return adapter
+
+
+def _group_msg(chat_id=-100):
+    return SimpleNamespace(
+        message_id=42,
+        text="hello",
+        caption=None,
+        entities=[],
+        caption_entities=[],
+        message_thread_id=None,
+        chat=SimpleNamespace(id=chat_id, type="group", title="G", is_forum=False),
+        from_user=SimpleNamespace(id=111, full_name="A B", first_name="A"),
+        reply_to_message=None,
+        date=None,
+    )
+
+
+def test_allowed_chats_json_string_parses_as_allowlist():
+    adapter = _make_json_adapter('["-100","-200"]')
+    assert adapter._telegram_allowed_chats() == {"-100", "-200"}
+
+
+def test_allowed_chats_json_string_end_to_end_gating():
+    adapter = _make_json_adapter(json.dumps(["-100"]))
+    assert adapter._should_process_message(_group_msg(chat_id=-100)) is True
+    assert adapter._should_process_message(_group_msg(chat_id=-300)) is False
+
+
+def test_allowed_chats_comma_string_still_works():
+    adapter = _make_json_adapter("-100,-200")
+    assert adapter._telegram_allowed_chats() == {"-100", "-200"}
+
+
+def test_allowed_chats_native_list_still_works():
+    adapter = _make_json_adapter(["-100", "-200"])
+    assert adapter._telegram_allowed_chats() == {"-100", "-200"}
+
+
+def test_allowed_chats_malformed_json_falls_back_to_comma_split():
+    adapter = _make_json_adapter('["-100", "-200')
+    assert adapter._telegram_allowed_chats() == {'["-100"', '"-200'}
+
+
+def test_ignored_threads_json_string_parses():
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    extra = {"ignored_threads": '["7", "9"]'}
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(enabled=True, token="***", extra=extra)
+    adapter._bot = SimpleNamespace(id=999, username="hermes_bot")
+    assert adapter._telegram_ignored_threads() == {7, 9}
+
+
+def test_all_allowlist_keys_decode_json_string():
+    adapter = _make_json_adapter('["-100"]')
+    adapter.config.extra["group_allowed_chats"] = '["-300"]'
+    adapter.config.extra["allowed_topics"] = '["5"]'
+    adapter.config.extra["free_response_chats"] = '["-400"]'
+    adapter.config.extra["free_response_topics"] = '["-100:3"]'
+    assert adapter._telegram_group_allowed_chats() == {"-300"}
+    assert adapter._telegram_allowed_topics() == {"5"}
+    assert adapter._telegram_free_response_chats() == {"-400"}
+    assert adapter._telegram_free_response_topics() == {"-100:3"}


### PR DESCRIPTION
## What does this PR do?

`hermes config set telegram.allowed_chats '["id1","id2"]'` stores the value as the literal JSON-encoded **string** `'["id1","id2"]'`. I verified this end-to-end on current `main` with an isolated `HERMES_HOME`: `config set` resolves the default for `telegram.allowed_chats` to `""` (a string-typed leaf in `DEFAULT_CONFIG`), so `_coerce_config_set_value` preserves the list literal verbatim as a string.

The Telegram adapter's `_extra_str_set()` then splits every non-list value on commas with no JSON awareness, producing `{'["id1"', '"id2"]'}`. `_should_process_message` treats that non-empty garbage set as a hard group whitelist → no real chat id can ever match → group messages silently dropped while DMs keep working.

Fixes #109423

## Change

- Add `_decode_json_list_literal()`: when the raw allowlist value is a string that starts with `[`, try `json.loads`; if it yields a list, feed it through the same string-normalization as native lists. Malformed JSON passes through unchanged and keeps the legacy comma-split path.
- Apply it in `_extra_str_set` (covers `allowed_chats`, `group_allowed_chats`, `allowed_topics`, `free_response_chats`, `free_response_topics` — all five flow through this one helper).
- Apply it in `_telegram_ignored_threads()` — the integer-sibling allowlist in the same file suffers the identical corruption (`'["7","9"]'` → the split loop warns on every entry and the ignore-set ends up empty of nothing usable).
- New `tests/gateway/test_telegram_allowlist_json.py`: JSON string parse, end-to-end `_should_process_message` gating for both an allowed and a non-allowed chat, CSV fallback, native list, malformed-JSON fallback, `ignored_threads`, and a per-key check that all five allowlists decode JSON strings.

## Proof

On pristine `main` (fix reverted), the new suite is red on exactly the JSON-string cases:

```text
$ venv/.venv/bin/python -m pytest tests/gateway/test_telegram_allowlist_json.py -q
4 failed, 3 passed
```

With the fix:

```text
7 passed
tests/gateway/test_telegram_group_gating.py: 25 passed (neighbours)
ruff check: clean; ruff format: 0 new complaints vs main baseline (3540→3540 diff lines)
```

End-to-end CLI repro on `main` (isolated `HERMES_HOME`):

```text
$ hermes config set telegram.allowed_chats '["908231529","-1004472823051"]'
✓ Set telegram.allowed_chats = ["908231529","-1004472823051"] in .../config.yaml
# config.yaml: telegram.allowed_chats: '["908231529","-1004472823051"]'  ← string, not list
```

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

### Code
- [x] Commit messages follow Conventional Commits (`fix(scope):`)
- [x] Searched for existing PRs addressing the same issue — found #109427 posted ~4 min after my claim comment; comparison table posted on this PR, happy to defer to maintainers

### Tests
- [x] Added regression tests (new file, 7 tests)
- [x] All tests pass locally; RED verified on pristine main before applying the fix


### Pre-existing note (verified, not this diff)

Running `test_telegram_group_gating.py` and `test_allowed_channels_widening.py` in one pytest invocation makes `TestTelegramAllowedChats::test_empty_is_no_restriction` fail via cross-file state leakage — reproduced identically on **pristine `main`** with this diff reverted (33 passed / 1 failed both with and without the fix); each file is green in isolation. Flagging so a batched CI lane doesn't pin it on this PR.
