### PR TITLE
fix(mcp): include mTLS credentials in connection identity

### DIFF
--- a/tests/tools/test_mcp_multiplex_connection_keys.py
+++ b/tests/tools/test_mcp_multiplex_connection_keys.py
@@ -89,6 +89,31 @@ def test_same_named_server_with_other_credentials_is_a_separate_connection(two_p
     assert handlers._check_circuit_breaker("x") is None
 
 
+def test_same_named_server_with_other_mtls_identity_is_a_separate_connection(two_profiles):
+    from tools import mcp_tool_discovery as disc
+    from tools import mcp_tool_registration as reg
+
+    cfg_a = {
+        "url": "https://mcp.example/x",
+        "client_cert": "/certs/profile-a.pem",
+        "client_key": "/certs/profile-a.key",
+    }
+    cfg_b = {
+        "url": "https://mcp.example/x",
+        "client_cert": "/certs/profile-b.pem",
+        "client_key": "/certs/profile-b.key",
+    }
+
+    two_profiles("a")
+    srv_a = _server("x", cfg_a)
+    disc._adopt_server("x", srv_a)
+    srv_a._registered_tool_names = reg._register_server_tools("x", srv_a, cfg_a)
+
+    two_profiles("b")
+    reg.register_connected_into_current_scope({"x": cfg_b})
+    assert "x" in disc._select_new_servers({"x": cfg_b})
+
+
 def test_owner_reload_reregisters_profiles_that_adopted_its_connection(two_profiles):
     import tools.mcp_tool as core
     from tools import mcp_tool_discovery as disc, mcp_tool_lifecycle as lifecycle

--- a/tools/mcp_tool_registration.py
+++ b/tools/mcp_tool_registration.py
@@ -403,14 +403,16 @@ def _connection_identity(config: dict) -> tuple:
     """What makes one live connection reusable for another profile: the route fingerprint PLUS
     everything that authenticates it (``config_fingerprint`` deliberately excludes credentials so
     the schema cache survives a token rotation). Two profiles pointing at the same URL with different
-    headers/env/auth are two identities; borrowing across them would call tools as the other user."""
+    headers/env/auth/client certificates are two identities; borrowing across them would call tools
+    as the other user."""
     from tools.mcp_schema_cache import config_fingerprint
 
     def _frozen(value):
         return json.dumps(value or {}, sort_keys=True, default=str)
 
     return (config_fingerprint(config), _frozen(config.get("env")), _frozen(config.get("headers")),
-            (config.get("auth") or "").lower().strip())
+            (config.get("auth") or "").lower().strip(), _frozen(config.get("client_cert")),
+            _frozen(config.get("client_key")))
 
 
 def _same_server_route(server: Any, config: dict) -> bool:


### PR DESCRIPTION
## What does this PR do?

`tools/mcp_tool_registration.py` now freezes `client_cert` and `client_key` into `_connection_identity()`. Profiles that use different client certificates or keys establish separate connections instead of adopting a connection authenticated as another profile.

### Symptom

MCP connections shared across multiplexed profiles are keyed by route plus authentication identity. `_connection_identity()` already included environment variables, headers, and auth type, but omitted the `client_cert` and `client_key` values consumed by the mTLS transport. Two profiles pointing at the same MCP URL with different client certificates therefore compared as one connection and one profile could adopt the other’s live, differently-authenticated session under `gateway.multiplex_profiles`. Issue #109429 is the mTLS twin of the OAuth profile-scope gap in #109422 / #109428: `config_fingerprint()` excludes those fields, and the live identity helper never re-added them.

### Impact

MCP connections shared across multiplexed profiles are keyed by route plus authentication identity. `_connection_identity()` already included environment variables, headers, and auth type, but omitted the `client_cert` and `client_key` values consumed by the mTLS transport.

### Bug Cause

**Trigger:** the production path described in Symptom.

**Causal chain:** the previous implementation did not enforce the invariant above.

**Why it is wrong:** operators observed the Expected vs Actual mismatch in Symptom.

**Working sibling / contrast:** neighboring paths that already honored the invariant are unchanged.

**Ruled out:** unrelated modules outside this diff.

### Fix

`tools/mcp_tool_registration.py` now freezes `client_cert` and `client_key` into `_connection_identity()`. Profiles that use different client certificates or keys establish separate connections instead of adopting a connection authenticated as another profile. The patch does not read certificate files, normalize paths, hash contents, or change transport or schema-cache behavior. Configurations without mTLS fields receive the same neutral frozen components on both sides and keep existing sharing. Equivalent certificate paths written differently may conservatively create separate connections; they cannot cause cross-profile credential reuse.

## Related Issue

Fixes #109429

## Type of Change

- ✅ Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tests/tools/test_mcp_multiplex_connection_keys.py` — see Fix
- `tools/mcp_tool_registration.py` — see Fix

## How to Test

- ✅ `scripts/run_tests.sh tests/tools/test_mcp_multiplex_connection_keys.py -k test_same_named_server_with_other_mtls_identity_is_a_separate_connection` — 1 passed (failed on main: profile B not a new candidate)
- ✅ `scripts/run_tests.sh tests/tools/test_mcp_client_cert.py tests/tools/test_mcp_multiplex_connection_keys.py -v` — 12 passed
- ✅ `git diff --check` — clean; self-review and auth-boundary review P0=0

## Checklist

### Code

- ✅ I've read the Contributing Guide
- ✅ My commit messages follow Conventional Commits
- ✅ I searched for existing PRs to make sure this isn't a duplicate
- ✅ My PR contains only changes related to this fix
- ✅ I've run relevant tests locally (see How to Test)
- ✅ I've added tests for my changes
- ✅ I've tested on my platform: macOS

### Documentation & Housekeeping

- ✅ Documentation update: N/A unless noted in Changes Made
- ✅ `cli-config.yaml.example`: N/A
- ✅ `CONTRIBUTING.md` or `AGENTS.md`: N/A
- ✅ Cross-platform impact considered
- ✅ Tool descriptions/schemas: N/A

