### PR TITLE
fix(kanban): resolve a new card's board from the store it lands in

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -493,6 +493,51 @@ def kanban_db_path(board: Optional[str] = None) -> Path:
     return _board_path("HERMES_KANBAN_DB", board, ("kanban.db",), "kanban.db")
 
 
+def board_for_db_path(path: "str | os.PathLike[str] | None") -> Optional[str]:
+    """Board slug whose canonical store is ``path`` — the inverse of
+    :func:`kanban_db_path`. ``None`` when ``path`` is not a board store in the
+    canonical layout: a copied, relative or in-memory store carries no board
+    identity, and callers must not attribute one to it."""
+    if not path:
+        return None
+    try:
+        candidate = Path(path).expanduser().resolve()
+        home_store = (kanban_home() / "kanban.db").resolve()
+    except (OSError, RuntimeError):
+        return None
+    if candidate == home_store:
+        return DEFAULT_BOARD
+    try:
+        rel = candidate.relative_to(boards_root().resolve())
+    except (OSError, RuntimeError, ValueError):
+        return None
+    parts = rel.parts
+    if len(parts) != 2 or parts[1] != "kanban.db":
+        return None
+    try:
+        return _normalize_board_slug(parts[0])
+    except ValueError:
+        return None
+
+
+def _board_for_connection(conn: sqlite3.Connection, declared: Optional[str] = None) -> Optional[str]:
+    """Board whose store ``conn`` opened, preferring it over ``declared``.
+
+    ``HERMES_KANBAN_DB`` pins the store and outranks the board slug in
+    :func:`_board_path`, so the store — not the board the caller named or the
+    session sits on — is the only reliable answer to "which board is this row
+    about to land on".
+    """
+    try:
+        rows = conn.execute("PRAGMA database_list").fetchall()
+    except sqlite3.Error:
+        return declared
+    for row in rows:
+        if row[1] == "main":
+            return board_for_db_path(row[2]) or declared
+    return declared
+
+
 def workspaces_root(board: Optional[str] = None) -> Path:
     """Per-board scratch workspace root (``HERMES_KANBAN_WORKSPACES_ROOT`` wins);
     ``default`` keeps the legacy ``<root>/kanban/workspaces/``."""
@@ -1259,6 +1304,13 @@ def create_task(
         raise ValueError("title is required")
     if initial_status not in VALID_INITIAL_STATUSES:
         raise ValueError(f"initial_status must be one of {sorted(VALID_INITIAL_STATUSES)}")
+    # The row lands in the store THIS connection opened, and ``HERMES_KANBAN_DB``
+    # (injected into every dispatcher-spawned worker) pins that store ahead of the
+    # board slug, so the store can belong to a different board than the one the
+    # session sits on. Board-derived columns must follow the store: reading the
+    # session's board here anchors the task to another board's project/workdir.
+    # An explicit ``board=`` stays the fallback for stores with no board identity.
+    board = _board_for_connection(conn, board)
     # A project-scoped board anchors every new task to its project's repo
     # (deterministic worktree + branch) without each surface repeating it.
     # An explicit ``scratch`` (or ``project_id=""``) is a request for no project:

--- a/tests/hermes_cli/test_kanban_board_project.py
+++ b/tests/hermes_cli/test_kanban_board_project.py
@@ -7,6 +7,7 @@ metadata round-trip and the create-time inheritance.
 
 from __future__ import annotations
 
+import sqlite3
 import sys
 from pathlib import Path
 
@@ -105,5 +106,70 @@ def test_create_task_explicit_scratch_beats_board(fresh_home, tmp_path):
         assert (scratch.workspace_kind, scratch.project_id) == ("scratch", None)
         default = kb.get_task(conn, kb.create_task(conn, title="default", board="scoped3"))
         assert (default.workspace_kind, default.project_id) == ("worktree", proj_id)
+    finally:
+        conn.close()
+
+
+def test_create_task_uses_the_store_board_not_the_session_board(fresh_home, tmp_path, monkeypatch):
+    """A pinned store must not leak the *session's* board scope into the row.
+
+    ``HERMES_KANBAN_DB`` is injected into every dispatcher-spawned worker and wins
+    over the board slug (``_board_path``), so the store a create lands in can differ
+    from the board the session sits on. The board-derived columns have to come from
+    the store that actually received the task, not from ``get_current_board()``.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    with pdb.connect_closing() as pconn:
+        proj_id = pdb.create_project(pconn, name="Widget", primary_path=str(repo))
+
+    kb.create_board("scoped", name="Scoped", project_id=proj_id, default_workdir=str(elsewhere))
+    kb.set_current_board("scoped")  # the session sits on the scoped board ...
+    # ... but the store in play is the default board's, as it is for a spawned worker.
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(kb.kanban_home() / "kanban.db"))
+
+    conn = kbc.connect()
+    try:
+        tid = kb.create_task(conn, title="pinned store")
+        task = kb.get_task(conn, tid)
+        assert (task.project_id, task.workspace_kind, task.branch_name) == (None, "scratch", None)
+
+        # The row really landed in the pinned store (default board), not the scoped one.
+        raw = sqlite3.connect(str(kb.kanban_db_path()))
+        try:
+            landed = raw.execute("SELECT count(*) FROM tasks WHERE id = ?", (tid,)).fetchone()[0]
+        finally:
+            raw.close()
+        assert landed == 1
+
+        # A persistent kind must not inherit the other board's default_workdir either.
+        dir_task = kb.get_task(
+            conn, kb.create_task(conn, title="pinned store dir", workspace_kind="dir"))
+        assert dir_task.workspace_path is None
+    finally:
+        conn.close()
+
+
+def test_create_task_inherits_from_the_store_board(fresh_home, tmp_path):
+    """The inverse direction: with no ``board=`` argument the store still decides.
+
+    A session whose active board is ``default`` must not strip the scope from a
+    create against the scoped board's store — the explicit-argument path above is
+    the only case where the caller gets to name the board.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    with pdb.connect_closing() as pconn:
+        proj_id = pdb.create_project(pconn, name="Widget", primary_path=str(repo))
+
+    kb.create_board("scoped2", name="Scoped2", project_id=proj_id)
+    kb.set_current_board("default")
+    conn = kbc.connect(board="scoped2")
+    try:
+        task = kb.get_task(conn, kb.create_task(conn, title="store decides"))
+        assert (task.workspace_kind, task.project_id) == ("worktree", proj_id)
+        assert task.branch_name
     finally:
         conn.close()


### PR DESCRIPTION
## What does this PR do?

`create_task()` decided where a new card belonged by asking the session which board was current, while the row itself went to whichever store the connection opened. Those two disagree whenever `HERMES_KANBAN_DB` is set, because the pin outranks the board slug (`hermes_cli/kanban_db.py:473-493`). The row could then land in one board's store stamped with another board's project, `workspace_kind=worktree`, and a `branch_name` resolving under that other board's repository, so a worker claiming the card would build and push in the wrong repo. That is the normal environment for a dispatcher-spawned worker, since the dispatcher injects the pin into every worker.

I hit this while filing cards onto another board from a session: the row landed in the pinned store and came out owned by the board the session sat on instead.

The store is the only reliable answer to which board a row is about to land in, so this makes the store the authority:

- `board_for_db_path()` (`:496`) is the inverse of `kanban_db_path()`: root store -> `default`, `<boards_root>/<slug>/kanban.db` -> `<slug>`, anything else -> no board identity.
- `_board_for_connection()` (`:523`) reads that back off the connection (`PRAGMA database_list`) and prefers it over the board the caller declared.
- `create_task()` (`:1313`) resolves the board that way before deriving any column, so the row's project follows the store it lands in.

Preferring the store over the declared board is deliberate: when the pin is set, the declared board is exactly the value `_board_path()` just discarded, and trusting it is what produced the bug. A store with no board identity (a copy, a relative path, `:memory:`) does not guess; it falls back to the declared board and behaves as before. An explicit `workspace_kind` or `project_id` still wins.

## Related Issue

Fixes #109435

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py`: added `board_for_db_path()` and `_board_for_connection()`; `create_task()` now resolves the board from the connection's store before deriving board-derived columns.
- `tests/hermes_cli/test_kanban_board_project.py`: two behaviour tests, red on main and green with the change.

118 insertions across those two files, nothing else touched.

## How to Test

1. `pytest tests/hermes_cli/test_kanban_board_project.py -q` -> `7 passed`. With the source change stashed, the two new tests fail: `test_create_task_uses_the_store_board_not_the_session_board` and `test_create_task_inherits_from_the_store_board`.
2. The repro from #109435, run against a hermetic `HERMES_HOME`, three creates in one pass: pin at the root store with the session on the project-scoped board, the same with `--workspace scratch`, and the inverse (pin at the scoped store, session on `default`). On main the first row comes out `<project>|worktree|scoped/<id>` and the inverse row loses the project; here the first is `None|scratch|` and the inverse row inherits the scoped project and its worktree.
3. `pytest tests/hermes_cli -q`, same tree both ways: 27 failed / 307 passed with the change, 29 failed / 305 passed without it. Apart from the two tests above the failure sets are identical, so nothing else regressed. Those 27 fail on a clean checkout too (they are tied to this machine's paths and notification setup).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(kanban): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate. Closest neighbours: #74395 (the dashboard's `POST /tasks` did not forward the resolved `board=` into `create_task()`), #70865 (create-time validation for un-dispatchable worktree cards, also inside `create_task`), and #29145 (rejecting a relative board `default_workdir`). None of them touches which board a create reads its project from.
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (see the note on the suite-wide box below)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2 (darwin/arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A: no docs needed, the two new helpers carry docstrings
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered [cross-platform impact](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A: pure `pathlib` and `sqlite3` work with no OS-specific calls, and a Windows store path still compares through `Path(...).parts`

Note on the suite-wide box: this checkout shows 27 failures in `tests/hermes_cli` on unmodified main, so "the whole suite passes" is not a true statement on this machine either way. What I can show is that the diff does not change the failure set, and step 3 above is that comparison.

## AI assistance

Authored with AI assistance (Hermes Agent); I ran the reproduction and the tests locally and read the diff over by hand.
