### PR TITLE
fix(gateway): long-running heartbeat says what is running, not just which tool

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -561,6 +561,10 @@ _TURN_STATE: Dict[str, Any] = {
     "_last_activity_provenance": ActivityProvenance.UNKNOWN,
     "_session_activity_last_persist_mono": 0.0,  # rate-limits durable SessionDB stamps
     "_current_tool": None,
+    # What the running tool is doing (short redacted arg preview) and since when, for the gateway
+    # heartbeat's "what is it doing right now" line. Both cleared when the tool completes.
+    "_current_tool_detail": None,
+    "_current_tool_started": None,
     "_api_call_count": 0,
     # Opt-out for the between-turns MCP refresh; set on forks that need byte-identical tools[].
     "_skip_mcp_refresh": False,

--- a/agent/session_activity.py
+++ b/agent/session_activity.py
@@ -12,6 +12,10 @@ from typing import Any, Mapping, Optional
 
 ACTIVITY_DESCRIPTION_MAX = 120
 
+# Below this a step timer is noise, not information: short tool calls are done before the next
+# heartbeat lands anyway, so the heartbeat stays terse instead of stamping every fast call.
+_STEP_TIMER_MIN_SECONDS = 5.0
+
 # Durable SessionDB heartbeat cadence. Contract: MUST stay >= 30s — the SessionDB write path is contended and
 # this observation-only projection never justifies extra write pressure. A code constant on purpose (no config
 # can make it a high-frequency writer); matches the kanban auto-heartbeat. force_persist (terminal stamps) is the only bypass.
@@ -59,6 +63,54 @@ def format_iteration_progress(api_call_count: Any, max_iterations: Any) -> str:
     if cap >= sys.maxsize:
         return f"iteration {api_call_count}"
     return f"iteration {api_call_count}/{cap}"
+
+
+def format_step_duration(seconds: Any) -> str:
+    """``45s`` / ``2m 10s`` / ``1h 03m`` — compact duration for a single step timer."""
+    try:
+        total = int(max(0.0, float(seconds)))
+    except (TypeError, ValueError):
+        return ""
+    hours, rest = divmod(total, 3600)
+    minutes, secs = divmod(rest, 60)
+    if hours:
+        return f"{hours}h {minutes:02d}m"
+    if minutes:
+        return f"{minutes}m {secs:02d}s"
+    return f"{secs}s"
+
+
+def format_current_step(activity: Mapping[str, Any], *, now: Optional[float] = None) -> str:
+    """One line of "what is it doing right now" for the gateway long-running heartbeat.
+
+    The running tool with its short argument preview and how long that step has taken, else the last
+    activity description with how long ago it was stamped. Returns "" when nothing is worth showing,
+    so a caller keeps its own terse fallback. The bare tool name is deliberately not returned on its
+    own: it is what made the heartbeat uninformative (#102806 follow-up).
+    """
+    clock = float(now if now is not None else time.time())
+    tool = activity.get("current_tool")
+    if tool:
+        detail = str(activity.get("current_tool_detail") or "").strip()
+        text = f"{tool}: {detail}" if detail else str(tool)
+        try:
+            started = activity.get("current_tool_started_at")
+            step_secs = clock - float(started) if started is not None else None
+        except (TypeError, ValueError):
+            step_secs = None
+        if step_secs is not None and step_secs >= _STEP_TIMER_MIN_SECONDS:
+            text += f" ({format_step_duration(step_secs)})"
+        return text
+    desc = str(activity.get("last_activity_desc") or "").strip()
+    if not desc or desc == "initializing":
+        return ""
+    try:
+        idle_secs = float(activity.get("seconds_since_activity"))
+    except (TypeError, ValueError):
+        idle_secs = None
+    if idle_secs is not None and idle_secs >= _STEP_TIMER_MIN_SECONDS:
+        return f"{desc} ({format_step_duration(idle_secs)} ago)"
+    return desc
 
 
 def reset_session_activity_persist_window(agent: Any) -> None:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -906,6 +906,23 @@ def _safe_callback(callback, label: str, *args, **kwargs) -> None:
         logging.debug("%s callback error: %s", label, callback_error)
 
 
+# Bound for the argument preview carried into the gateway heartbeat. Long commands/args are the
+# point of the field, but a status line is not a log: past this it stops being scannable.
+_CURRENT_TOOL_DETAIL_MAX = 120
+
+
+def _current_tool_detail(function_name: str, display_args: dict) -> str | None:
+    """Short, redacted argument preview for the running tool, or ``None`` when there is nothing to show.
+
+    ``display_args`` is the already-redacted dict, so this never puts a secret into a status line.
+    """
+    try:
+        return _build_tool_preview(function_name, display_args, _CURRENT_TOOL_DETAIL_MAX) or None
+    except Exception as preview_error:
+        logging.debug("Tool detail preview error: %s", preview_error)
+        return None
+
+
 def _begin_tool_execution(agent, ref: _ToolCallRef, display_index: int | None) -> None:
     """Run user-visible and checkpoint preflight on final tool arguments."""
     function_name, function_args, effective_task_id, tool_call_id = ref.name, ref.args, ref.task_id, ref.call_id
@@ -919,6 +936,8 @@ def _begin_tool_execution(agent, ref: _ToolCallRef, display_index: int | None) -
             print(f"  📞 {prefix}: {function_name}({list(function_args.keys())}) - {_preview(json.dumps(display_args, ensure_ascii=False), agent.log_prefix_chars)}")
 
     agent._current_tool = function_name
+    agent._current_tool_started = time.time()
+    agent._current_tool_detail = _current_tool_detail(function_name, display_args)
     agent._touch_activity(f"executing tool: {function_name}")
     _set_worker_activity_callback(agent)
 
@@ -1005,6 +1024,8 @@ def _commit_tool_result(
             logging.debug("Tool result (%d chars): %s", len(_log_result), _log_result)
 
     agent._current_tool = None
+    agent._current_tool_started = None
+    agent._current_tool_detail = None
     _status_suffix = " (error)" if is_error else ""
     agent._touch_activity(f"tool completed: {function_name} ({tool_duration:.1f}s){_status_suffix}")
 
@@ -1430,6 +1451,8 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     timeout_s = _resolve_concurrent_tool_timeout()
     batch = _ConcurrentBatch(agent, messages, effective_task_id, parsed_calls, timeout_s)
     agent._current_tool = tool_names_str
+    agent._current_tool_started = time.time()
+    agent._current_tool_detail = None
     agent._touch_activity(f"executing {num_tools} tools concurrently: {tool_names_str}")
 
     spinner = _start_quiet_tool_spinner(agent, "", {}, label=f"⚡ running {num_tools} tools concurrently")

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -16,7 +16,7 @@ import queue
 import threading
 import time
 from agent.i18n import t
-from agent.session_activity import format_iteration_progress
+from agent.session_activity import format_current_step, format_iteration_progress
 from contextlib import nullcontext, suppress
 from contextvars import copy_context
 from gateway.config import Platform
@@ -3835,9 +3835,9 @@ class GatewayTurnMixin:
                     _parts = []
                     if _want_iteration_detail:
                         _parts.append(format_iteration_progress(_a["api_call_count"], _a["max_iterations"]))
-                    _action = _a.get("current_tool") or _a.get("last_activity_desc")
+                    _action = format_current_step(_a)
                     if _action:
-                        _parts.append(str(_action))
+                        _parts.append(_action)
                     if _parts:
                         _status_detail = " — " + ", ".join(_parts)
             _heartbeat_text = (

--- a/run_agent.py
+++ b/run_agent.py
@@ -848,6 +848,8 @@ class AIAgent(
                 "current_tool": self._current_tool, "api_call_count": self._api_call_count,
                 "max_iterations": self.max_iterations, "budget_used": self.iteration_budget.used,
                 "budget_max": self.iteration_budget.max_total,
+                "current_tool_detail": getattr(self, "_current_tool_detail", None),
+                "current_tool_started_at": getattr(self, "_current_tool_started", None),
             },
         )
 

--- a/tests/agent/test_tool_executor_activity_detail.py
+++ b/tests/agent/test_tool_executor_activity_detail.py
@@ -1,0 +1,47 @@
+"""Invariant: the running tool's preview and start time are recorded for the heartbeat.
+
+``_begin_tool_execution`` already knows the tool's redacted display args (it builds the progress
+preview from them). The heartbeat reads ``_current_tool_detail`` / ``_current_tool_started`` off the
+agent, so the recording has to happen there — a heartbeat that silently loses its detail is the
+regression this covers.
+"""
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _agent():
+    agent = MagicMock()
+    agent.quiet_mode = True          # skip the printed progress lines
+    agent.verbose_logging = False
+    agent.tool_progress_callback = None
+    agent.log_prefix_chars = 80
+    agent._checkpoint_mgr.enabled = False
+    return agent
+
+
+def test_begin_tool_execution_records_preview_and_start_time():
+    from agent.tool_executor import _ToolCallRef, _begin_tool_execution
+
+    agent = _agent()
+    ref = _ToolCallRef("terminal", {"command": "git status --short"}, "task-1", "call-1", None)
+    before = time.time()
+    _begin_tool_execution(agent, ref, None)
+
+    assert agent._current_tool == "terminal"
+    assert "git status" in (agent._current_tool_detail or "")
+    assert before <= agent._current_tool_started <= time.time()
+
+
+def test_begin_tool_execution_records_no_detail_for_unpreviewable_args():
+    """A custom tool with no previewable argument must record ``None``, never ``"None"`` text."""
+    from agent.tool_executor import _ToolCallRef, _begin_tool_execution
+
+    agent = _agent()
+    ref = _ToolCallRef("some_custom_tool", {}, "task-1", "call-2", None)
+    _begin_tool_execution(agent, ref, None)
+
+    assert agent._current_tool == "some_custom_tool"
+    assert agent._current_tool_detail is None

--- a/tests/gateway/test_heartbeat_activity_detail.py
+++ b/tests/gateway/test_heartbeat_activity_detail.py
@@ -1,0 +1,138 @@
+"""Invariant: the long-running heartbeat says WHAT is running and FOR HOW LONG.
+
+The heartbeat used to render ``⏳ Working — N min — iteration I/M, terminal``: a bare tool name,
+no argument, no step timer. That reads as activity without information — it cannot tell a user
+whether the agent is fetching a page or running a 20-minute build. The line now carries the
+running tool's short argument preview plus how long that step has taken, and falls back to the
+last activity description with its age when no tool is running.
+
+Rendered through the real ``_run_agent_notify_long_running`` heartbeat path with a capturing
+adapter, so this asserts what a user actually receives.
+"""
+
+import asyncio
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from agent.session_activity import format_current_step, format_step_duration
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+
+class HeartbeatCaptureAdapter(BasePlatformAdapter):
+    """Adapter that records heartbeat sends instead of hitting a platform API."""
+
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
+        self.sent = []
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append(content)
+        return SendResult(success=True, message_id=f"hb{len(self.sent)}")
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        return SendResult(success=True, message_id=message_id)
+
+    async def send_typing(self, chat_id, metadata=None) -> None:
+        return None
+
+    async def stop_typing(self, chat_id) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+
+def _activity(**overrides):
+    activity = {
+        "current_tool": None, "current_tool_detail": None, "current_tool_started_at": None,
+        "api_call_count": 19, "max_iterations": 150,
+        "last_activity_desc": "executing tool: terminal", "seconds_since_activity": 1.0,
+    }
+    activity.update(overrides)
+    return activity
+
+
+async def _heartbeat_text(activity, monkeypatch) -> str:
+    """Drive the real long-running heartbeat once and return the text it sent."""
+    from gateway.run_turn import GatewayTurnMixin
+    from gateway.turn_context import TurnContext
+
+    monkeypatch.setenv("HERMES_AGENT_NOTIFY_INTERVAL", "0.01")
+    mixin = GatewayTurnMixin()
+    adapter = HeartbeatCaptureAdapter()
+    mixin._adapter_for_source = lambda source: adapter
+    # Called once per loop turn, once again before the pre-send guard, then the loop must exit.
+    answers = iter([True, True, False])
+    mixin._should_emit_long_running_notification = lambda *a, **k: next(answers, False)
+    disp = SimpleNamespace(
+        user_config={}, platform_key="telegram",
+        _display_surface_mode=lambda setting, **kwargs: "raw",
+        resolve_display_setting=lambda *a, **k: True,
+    )
+    ctx = TurnContext(
+        source=SimpleNamespace(chat_id="c1", platform="telegram"), session_key="s1",
+        agent_holder=[SimpleNamespace(get_activity_summary=lambda: activity)],
+    )
+    await mixin._run_agent_notify_long_running(disp, ctx, [None])
+    assert adapter.sent, "heartbeat never sent"
+    return adapter.sent[0]
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_reports_running_tool_detail_and_step_timer(monkeypatch):
+    activity = _activity(
+        current_tool="terminal", current_tool_detail="git status --short",
+        current_tool_started_at=time.time() - 72,
+    )
+    text = await _heartbeat_text(activity, monkeypatch)
+    assert "iteration 19/150" in text
+    assert "terminal: git status --short" in text
+    assert "(1m 12s)" in text
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_falls_back_to_activity_age_without_a_running_tool(monkeypatch):
+    activity = _activity(
+        last_activity_desc="waiting for non-streaming API response", seconds_since_activity=42.0,
+    )
+    text = await _heartbeat_text(activity, monkeypatch)
+    assert "waiting for non-streaming API response (42s ago)" in text
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_stays_terse_for_a_bare_tool_name(monkeypatch):
+    """No detail and no step timer of at least the minimum: just the tool, never a fake ``(0s)``."""
+    activity = _activity(current_tool="terminal", current_tool_started_at=time.time() - 1)
+    text = await _heartbeat_text(activity, monkeypatch)
+    assert text.endswith("terminal")
+    assert "terminal (" not in text
+
+
+def test_format_current_step_prefers_the_running_tool():
+    step = format_current_step(_activity(
+        current_tool="read_file", current_tool_detail="~/.hermes/config.yaml",
+        current_tool_started_at=1000.0,
+    ), now=1205.0)
+    assert step == "read_file: ~/.hermes/config.yaml (3m 25s)"
+
+
+def test_format_current_step_skips_unset_and_initializing_labels():
+    assert format_current_step(_activity()) == "executing tool: terminal"
+    assert format_current_step(_activity(last_activity_desc="initializing")) == ""
+    assert format_current_step(_activity(last_activity_desc="")) == ""
+
+
+def test_format_step_duration_units():
+    assert format_step_duration(9) == "9s"
+    assert format_step_duration(72) == "1m 12s"
+    assert format_step_duration(3660) == "1h 01m"
+    assert format_step_duration("nonsense") == ""


### PR DESCRIPTION
## Problem

The long-running heartbeat renders `⏳ Working — N min — iteration I/M, terminal`. The tool name
carries no argument and there is no step timer, so on a long turn the line reports activity
without information: the reader cannot tell whether the agent is running a 5-second `git status`
or a 20-minute build, and nothing shows how long the current step has taken.

The richer text already exists on the agent (`_last_activity_desc` carries entries like
`sequential tool running (45s): terminal`), but the heartbeat only falls back to it when no tool
name is set — which is almost never while tools are running.

## Change

```
⏳ Working — 24 min — iteration 19/150, terminal: git status --short (1m 12s)
⏳ Working — 24 min — iteration 19/150, waiting for non-streaming API response (42s ago)
```

- `agent/tool_executor.py` records `_current_tool_detail` (bounded, redacted preview built from
  the `display_args` already computed at that site) and `_current_tool_started` wherever
  `_current_tool` is set, and clears both with it — single-tool execution and the concurrent
  batch path.
- `agent/agent_init.py` declares the two fields next to `_current_tool`.
- `run_agent.py` exposes both in `get_activity_summary()`.
- `agent/session_activity.py` gains `format_current_step()` and `format_step_duration()`, next to
  the existing `format_iteration_progress()`, so the heartbeat line stays a rendering concern and
  `gateway/run_turn.py` only joins the parts.

Deliberately terse: step timers under 5s are suppressed, and when there is no previewable
argument the line stays a bare tool name rather than growing `tool: None`.

## Tests

- `tests/gateway/test_heartbeat_activity_detail.py` drives the real
  `_run_agent_notify_long_running` path with a capturing adapter and asserts the text a user
  receives (tool + preview + step timer, activity-age fallback, terse bare-tool case), plus the
  two pure formatting functions.
- `tests/agent/test_tool_executor_activity_detail.py` covers the recording at
  `_begin_tool_execution`, including the unpresentable-args case.

## Verification

On `d595e63`: both new files green (8 tests), plus `tests/agent/test_session_activity.py`,
`tests/gateway/test_gateway_inactivity_timeout.py`, `tests/gateway/test_run_cleanup_progress.py`,
`tests/gateway/test_busy_session_ack.py`, `tests/gateway/test_interim_send_lanes.py` and
`tests/run_agent/test_wait_state_visibility.py` (35 tests, no failures).

Behaviour contract only: no config keys, no new env var, no change to what the model sees. The
`busy_ack_detail` gate on the iteration counter is untouched.
