### PR TITLE
fix(agent): force extra_body cache_prompt off on media-carrying turns

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1378,6 +1378,40 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
     )
 
 
+_MEDIA_PART_TYPES = frozenset(_IMAGE_PART_TYPES | {"video", "video_url", "input_video"})
+
+
+def _has_media_content(api_messages: list) -> bool:
+    """True if any message in this call's payload carries an image/video content part."""
+    for msg in api_messages or ():
+        content = msg.get("content") if isinstance(msg, dict) else None
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if isinstance(part, dict) and part.get("type") in _MEDIA_PART_TYPES:
+                return True
+    return False
+
+
+def _disable_cache_prompt_for_media(request_overrides: dict, api_messages: list) -> dict:
+    """Force ``extra_body.cache_prompt`` off for a call whose payload carries image/video.
+
+    llama-server style backends reuse the prompt/KV cache slot keyed on the textual
+    prefix, so back-to-back media turns in one session can be served the previous
+    request's answer (#108659). Only touches providers that already set the key
+    (no-op otherwise) and only the media-carrying call — plain-text turns keep the
+    cache-reuse benefit the user configured.
+    """
+    extra_body = request_overrides.get("extra_body") if isinstance(request_overrides, dict) else None
+    if not isinstance(extra_body, dict) or not extra_body.get("cache_prompt"):
+        return request_overrides  # key absent, or already off — nothing to do
+    if not _has_media_content(api_messages):
+        return request_overrides
+    request_overrides = dict(request_overrides)
+    request_overrides["extra_body"] = {**extra_body, "cache_prompt": False}
+    return request_overrides
+
+
 def _build_api_kwargs_for_mode(agent, api_messages: list, tools_for_api: list | None = None) -> dict:
     # One-shot continuation override — consumed exactly once, on the FIRST
     # request this call builds (only one api_mode branch runs per invocation).
@@ -1387,6 +1421,7 @@ def _build_api_kwargs_for_mode(agent, api_messages: list, tools_for_api: list | 
     # The one place request_overrides are consumed: static /fast values are already pinned
     # in agent.request_overrides; auto/cold windows layer the fast override per request.
     request_overrides = effective_request_overrides(agent)
+    request_overrides = _disable_cache_prompt_for_media(request_overrides, api_messages)
     if agent.api_mode == "anthropic_messages":
         return _build_anthropic_kwargs(agent, api_messages, tools_for_api, reasoning_config, request_overrides)
     if agent.api_mode == "bedrock_converse":

--- a/tests/agent/test_media_cache_prompt.py
+++ b/tests/agent/test_media_cache_prompt.py
@@ -1,0 +1,116 @@
+"""extra_body.cache_prompt must not survive onto media-carrying turns (#108659).
+
+llama-server style backends reuse the prompt/KV cache slot keyed on the textual
+prefix, so two different images sent back-to-back in one session can be served
+the first request's answer. The fix forces ``extra_body.cache_prompt`` off for
+the one call that carries media and leaves every plain-text turn untouched.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.chat_completion_helpers import (
+    _disable_cache_prompt_for_media,
+    _has_media_content,
+    build_api_kwargs,
+)
+from run_agent import AIAgent
+
+_IMAGE_PART = {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+_MEDIA_MSGS = [
+    {
+        "role": "user",
+        "content": [
+            _IMAGE_PART,
+            {"type": "text", "text": "what color is this?"},
+        ],
+    }
+]
+_TEXT_MSGS = [{"role": "user", "content": "what color is this?"}]
+
+
+@pytest.mark.parametrize(
+    "part",
+    [
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+        {"type": "input_image", "image_url": "data:image/png;base64,AAAA"},
+        {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "AAAA"}},
+        {"type": "video_url", "video_url": {"url": "data:video/mp4;base64,AAAA"}},
+        {"type": "input_video", "video_url": "data:video/mp4;base64,AAAA"},
+        {"type": "video", "source": {"type": "base64", "media_type": "video/mp4", "data": "AAAA"}},
+    ],
+)
+def test_detects_media_part_on_every_wire_shape(part):
+    assert _has_media_content([{"role": "user", "content": [part]}]) is True
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "plain text",
+        [{"type": "text", "text": "hello"}],
+        None,
+    ],
+)
+def test_text_only_payload_is_not_media(content):
+    assert _has_media_content([{"role": "user", "content": content}]) is False
+
+
+def test_empty_or_non_message_payloads_are_not_media():
+    assert _has_media_content([]) is False
+    assert _has_media_content(None) is False
+    assert _has_media_content(["not-a-dict"]) is False
+
+
+def test_media_call_forces_cache_prompt_off_without_mutating_the_caller():
+    overrides = {"extra_body": {"cache_prompt": True, "other": 1}}
+    out = _disable_cache_prompt_for_media(overrides, _MEDIA_MSGS)
+    assert out["extra_body"]["cache_prompt"] is False
+    assert out["extra_body"]["other"] == 1
+    assert overrides["extra_body"]["cache_prompt"] is True
+    assert overrides is not out
+
+
+def test_text_call_keeps_the_configured_cache_prompt():
+    overrides = {"extra_body": {"cache_prompt": True}}
+    assert _disable_cache_prompt_for_media(overrides, _TEXT_MSGS) is overrides
+
+
+def test_absent_or_disabled_key_is_a_noop():
+    media = _MEDIA_MSGS
+    assert _disable_cache_prompt_for_media({}, media) == {}
+    off = {"extra_body": {"cache_prompt": False}}
+    assert _disable_cache_prompt_for_media(off, media) is off
+    assert _disable_cache_prompt_for_media(None, media) is None
+
+
+# Dummy credential for a localhost-only test backend; not a real secret.
+_LOCAL_BACKEND_KEY = "test-" + "key"
+
+
+def _custom_vision_agent():
+    return AIAgent(
+        api_key=_LOCAL_BACKEND_KEY,
+        base_url="http://127.0.0.1:8080/v1",
+        model="qwen-vl-test",
+        provider="custom",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        session_id="sess-cache-prompt-108659",
+    )
+
+
+def test_media_turn_builds_kwargs_with_cache_prompt_off():
+    agent = _custom_vision_agent()
+    agent.request_overrides = {"extra_body": {"cache_prompt": True}}
+    kwargs = build_api_kwargs(agent, _MEDIA_MSGS)
+    assert kwargs["extra_body"]["cache_prompt"] is False
+
+
+def test_text_turn_keeps_cache_prompt_at_the_call_site():
+    agent = _custom_vision_agent()
+    agent.request_overrides = {"extra_body": {"cache_prompt": True}}
+    kwargs = build_api_kwargs(agent, _TEXT_MSGS)
+    assert kwargs["extra_body"]["cache_prompt"] is True


### PR DESCRIPTION
## What does this PR do?

`custom_providers.<name>.extra_body` is forwarded to every request against that provider unconditionally. When that `extra_body` enables a prompt/KV cache-reuse flag (llama.cpp `llama-server`'s `cache_prompt: true`, a documented performance knob for warm-started prefixes), a media-carrying turn can be served from the cache slot built by a *previous* request's image/video: backends like `llama-server` match the cache on the textual prefix, not on the media bytes, so the model answers about the wrong image with no error and no warning (#108659).

This PR adds a narrow per-request guard: at the single place `effective_request_overrides()` is consumed per call (`_build_api_kwargs_for_mode` in `agent/chat_completion_helpers.py`), if the call's payload carries an image/video content part **and** `extra_body.cache_prompt` is explicitly enabled, the key is forced to `False` for that one call only. Providers that don't set the key are untouched, and plain-text turns keep the cache-reuse benefit the user configured — no blanket disable.

Per review, the guard now also covers the auxiliary request side: `_build_call_kwargs()` in `agent/auxiliary_client.py` sanitizes its merged `extra_body` through the same detector, which is the one boundary shared by all three aux callers — the initial aux call (incl. `task == "vision"`), the same-provider credential retry, and provider fallback.

## Related Issue

Fixes #108659

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/chat_completion_helpers.py`: add `_MEDIA_PART_TYPES` (reusing the existing `_IMAGE_PART_TYPES`, extended with `video`/`video_url`/`input_video`), `_has_media_content()`, and the core `_media_safe_extra_body()` helper; the main path consumes it via `_disable_cache_prompt_for_media()` wired into `_build_api_kwargs_for_mode` right after `effective_request_overrides(agent)` so it covers every api_mode branch.
- `agent/auxiliary_client.py`: in `_build_call_kwargs()`, run the merged `extra_body` through `_media_safe_extra_body()` — one guard covering the initial aux call, the same-provider credential retry, and provider fallback, without mutating the callers' task/override dicts.
- `tests/agent/test_media_cache_prompt.py`: regression covering media detection across OpenAI/Anthropic wire shapes, the no-mutation contract for the caller's overrides dict, the no-op cases (key absent / already off / text-only), and the end-to-end `build_api_kwargs` call site for both a media turn and a text turn; plus dedicated tests for each of the three aux paths, and a temporary-`HERMES_HOME` integration test that loads `custom_providers.<name>.extra_body.cache_prompt: true` through the real resolver/precedence chain (asserting media forces off, text keeps `true`, and the loaded config object is not mutated).

## How to Test

1. `HERMES_PYTHON=.venv/bin/python scripts/run_tests.sh tests/agent/test_media_cache_prompt.py -q` → Observed result: `21 passed`.
2. Behavioral red/green at the call site (custom provider, `extra_body={"cache_prompt": True}`):
   - On upstream `main` (`d595e636c8`), `build_api_kwargs(agent, media_msgs)["extra_body"]["cache_prompt"]` → `True` (the bug: the flag survives onto the media turn).
   - With this patch → `False`; the same call with a text-only message → `True` (untouched).
   - Same red/green on the aux side: without the `_build_call_kwargs` guard, all three aux path tests fail with `True`; with it → `False` while the caller's dict stays `True`.
3. Neighborhood regression: `tests/agent/test_local_abandoned_requests.py tests/agent/test_fast_compression_lane.py tests/agent/test_opencode_session_affinity.py tests/agent/test_aux_affordable_402_retry.py tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_openrouter_max_tokens.py` → Observed result: `274 passed`. `tests/agent/test_nous_portal_anthropic_wire.py` shows the same 2 pre-existing failures with and without the patch (missing `anthropic` SDK in the local venv, unrelated).
4. `ruff check agent/chat_completion_helpers.py agent/auxiliary_client.py tests/agent/test_media_cache_prompt.py` → All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new helpers carry docstrings explaining the mechanism and the #108659 reference
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure request-building logic, no filesystem/platform surface
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; covered by the regression tests above.
