### PR TITLE
fix(plugins): per-session hook single-flight + matcher gate before the flight window

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -341,6 +341,10 @@ def _make_callback(spec: ShellHookSpec) -> Callable[..., Optional[Dict[str, Any]
         return _evaluate_result(spec, _spawn(spec, _serialize_payload(spec.event, kwargs)))
 
     _callback.__name__ = _callback.__qualname__ = f"shell_hook[{spec.event}:{spec.command}]"
+    # Dispatcher contract: expose the tool matcher so invoke_hook can skip non-matching tools
+    # BEFORE the single-flight window — an unmatched callback must never contend for (nor be
+    # skipped because of) another session's in-flight run (upstream #105223).
+    _callback._hermes_matches_tool = spec.matches_tool
     return _callback
 
 

--- a/hermes_cli/plugins_dispatch.py
+++ b/hermes_cli/plugins_dispatch.py
@@ -189,6 +189,12 @@ class PluginDispatchMixin:
         fail_closed = hook_name in _HOOK_TIMEOUT_FAIL_CLOSED_HOOKS
         for cb in self._hooks.get(hook_name, []):
             try:
+                # Matcher gate BEFORE the single-flight window (upstream #105223): a shell-hook
+                # callback that doesn't match this tool must never acquire (nor be skipped for)
+                # the flight token of another session's in-flight run of the same callback.
+                matcher = getattr(cb, "_hermes_matches_tool", None)
+                if matcher is not None and not matcher(kwargs.get("tool_name")):
+                    continue
                 if use_timeout:
                     ret = self._run_hook_callback_bounded(hook_name, cb, kwargs, timeout)
                     if ret is _HOOK_SKIPPED:
@@ -211,7 +217,13 @@ class PluginDispatchMixin:
         suppressed, still running, timed out (worker abandoned, never joined), or the worker
         could not be started. Exceptions propagate."""
         callback_name = getattr(cb, "__name__", repr(cb))
-        callback_key = (hook_name, id(cb))
+        # Single-flight is scoped per (callback, session) — NOT per callback process-wide
+        # (upstream #105223): parallel sessions sharing this process each get their own flight
+        # token, so one session's in-flight hook can never skip (fail-close) another's.
+        # Same key composition as the shell-hook payload (agent/shell_hooks.py) so "" is the
+        # shared fallback when identity kwargs are absent.
+        session_key = kwargs.get("session_id") or kwargs.get("parent_session_id") or ""
+        callback_key = (hook_name, id(cb), session_key)
         token = object()
         with self._hook_timeout_lock:
             suppressed_until = self._hook_timeout_suppressed_until.get(callback_key)

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -2453,3 +2453,211 @@ class TestDispatchToolWithoutCliRef:
             assert calls[0][1].get("parent_agent") is None
         finally:
             registry.deregister("_test_dispatch_probe")
+
+
+class TestHookSingleFlightContentionUpstream105223:
+    """Polarity tests for cross-session single-flight contention (upstream #105223).
+
+    Before the fix, one session's in-flight ``pre_tool_call`` callback skipped (and,
+    because ``pre_tool_call`` fails closed, blocked) every other session's identical
+    callback process-wide. The fix has two halves: (1) the shell-hook tool matcher is
+    honored BEFORE the single-flight window, (2) flight/suppression keys are scoped
+    per (callback, session).
+    """
+
+    def _manager_with_hook(self, hook_name, cb):
+        from hermes_cli.plugins import PluginManager
+
+        mgr = PluginManager()
+        mgr._hooks[hook_name] = [cb]
+        return mgr
+
+    def test_polarity_a_non_matching_hook_never_contends(self, monkeypatch):
+        """A shell-hook matcher that doesn't match the tool must not even enter the
+        flight window — another session's in-flight run can never skip it."""
+        import time
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 5.0
+        )
+
+        hold = threading.Event()
+        started = threading.Event()
+        other_session_ran = threading.Event()
+
+        def _matches(tool_name):
+            return tool_name == "terminal"
+
+        def slow_terminal_hook(**_kwargs):
+            started.set()
+            hold.wait(timeout=10.0)
+            return None
+
+        slow_terminal_hook._hermes_matches_tool = _matches
+
+        mgr = self._manager_with_hook("pre_tool_call", slow_terminal_hook)
+
+        t = threading.Thread(
+            target=lambda: mgr.invoke_hook(
+                "pre_tool_call", tool_name="terminal", session_id="sess-A", args={}
+            )
+        )
+        t.start()
+        assert started.wait(timeout=2.0)
+
+        # Different tool + different session: must NOT be skipped (pre-patch: block).
+        def probe():
+            res = mgr.invoke_hook(
+                "pre_tool_call", tool_name="write_file", session_id="sess-B", args={}
+            )
+            assert res == [], f"non-matching hook contended: {res!r}"
+            other_session_ran.set()
+
+        probe()
+        hold.set()
+        t.join(timeout=5.0)
+        assert other_session_ran.is_set()
+
+    def test_polarity_b_same_session_single_flight_preserved(self, monkeypatch):
+        """Same session, same callback: the second fire while one runs must still skip
+        (and for pre_tool_call, fail closed) — hang protection is per session."""
+        import time
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 5.0
+        )
+
+        hold = threading.Event()
+        started = threading.Event()
+
+        def blocker(**_kwargs):
+            started.set()
+            hold.wait(timeout=10.0)
+            return None
+
+        mgr = self._manager_with_hook("pre_tool_call", blocker)
+
+        t = threading.Thread(
+            target=lambda: mgr.invoke_hook(
+                "pre_tool_call", tool_name="terminal", session_id="sess-A", args={}
+            )
+        )
+        t.start()
+        assert started.wait(timeout=2.0)
+
+        from hermes_cli.plugins import _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE
+
+        res = mgr.invoke_hook(
+            "pre_tool_call", tool_name="terminal", session_id="sess-A", args={}
+        )
+        assert res == [{"action": "block", "message": _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE}]
+        hold.set()
+        t.join(timeout=5.0)
+
+    def test_polarity_c_parallel_sessions_do_not_block_each_other(self, monkeypatch):
+        """Different sessions, same callback: neither fire may be skipped by the
+        other's in-flight run — the core contention fix."""
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 5.0
+        )
+
+        hold = threading.Event()
+        started = threading.Event()
+        calls = []
+        done = threading.Event()
+
+        def slow_hook(**kwargs):
+            calls.append(kwargs.get("session_id"))
+            if len(calls) == 1:
+                started.set()
+                hold.wait(timeout=10.0)  # first fire stays in flight
+            return None
+
+        mgr = self._manager_with_hook("pre_tool_call", slow_hook)
+
+        t = threading.Thread(
+            target=lambda: mgr.invoke_hook(
+                "pre_tool_call", tool_name="terminal", session_id="sess-A", args={}
+            )
+        )
+        t.start()
+        assert started.wait(timeout=2.0)
+
+        # Session B must run its own fire immediately, not be skipped.
+        res = mgr.invoke_hook(
+            "pre_tool_call", tool_name="terminal", session_id="sess-B", args={}
+        )
+        assert res == [], f"cross-session fire was skipped/blocked: {res!r}"
+        hold.set()
+        t.join(timeout=5.0)
+        assert sorted(calls) == ["sess-A", "sess-B"]
+
+    def test_polarity_d_matching_hook_still_dispatched_via_matcher_gate(self, monkeypatch):
+        """A matcher-exposed hook that DOES match the tool must still run (the gate
+        must not silently swallow matching hooks)."""
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 5.0
+        )
+
+        ran = threading.Event()
+
+        def _matches(tool_name):
+            return tool_name == "terminal"
+
+        def hook(**_kwargs):
+            ran.set()
+            return {"ok": True}
+
+        hook._hermes_matches_tool = _matches
+        mgr = self._manager_with_hook("pre_tool_call", hook)
+
+        res = mgr.invoke_hook(
+            "pre_tool_call", tool_name="terminal", session_id="sess-A", args={}
+        )
+        assert res == [{"ok": True}]
+        assert ran.is_set()
+
+    def test_polarity_e_real_shell_hook_matcher_gate_end_to_end(self, monkeypatch, tmp_path):
+        """E2E with a real parsed shell hook spec: the matcher attribute survives
+        _make_callback and the dispatcher gate honors it (non-matching tool never
+        spawns the script, matching tool does)."""
+        import agent.shell_hooks as shell_hooks_mod
+        from hermes_cli.plugins import PluginManager
+
+        script = tmp_path / "matcher_probe.sh"
+        script.write_text("#!/bin/sh\nexit 0\n")
+        script.chmod(0o755)
+
+        specs = shell_hooks_mod.iter_configured_hooks(
+            {"hooks": {"pre_tool_call": [{"command": str(script), "matcher": "terminal"}]}}
+        )
+        assert specs and specs[0].matcher == "terminal"
+
+        spawned = {"n": 0}
+        real_spawn = shell_hooks_mod._spawn
+
+        def counting_spawn(spec, stdin_json):
+            spawned["n"] += 1
+            return real_spawn(spec, stdin_json)
+
+        monkeypatch.setattr(shell_hooks_mod, "_spawn", counting_spawn)
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 5.0
+        )
+
+        cb = shell_hooks_mod._make_callback(specs[0])
+        assert callable(getattr(cb, "_hermes_matches_tool", None))
+
+        mgr = PluginManager()
+        mgr._hooks["pre_tool_call"] = [cb]
+
+        res = mgr.invoke_hook(
+            "pre_tool_call", tool_name="web_search", session_id="sess-A", args={}
+        )
+        assert res == []
+        assert spawned["n"] == 0, "non-matching tool spawned the hook script"
+
+        res = mgr.invoke_hook(
+            "pre_tool_call", tool_name="terminal", session_id="sess-A", args={}
+        )
+        assert spawned["n"] == 1, "matching tool did not spawn the hook script"


### PR DESCRIPTION
## Problem (upstream #105223)

`pre_tool_call` is a fail-closed policy hook: when its callback is skipped (still running for another fire, or in the 60s post-timeout suppression window), the tool call is **blocked**. Because single-flight is keyed per `(hook_name, callback)` process-wide, **parallel sessions sharing one process** (e.g. an API/webui server that imports AIAgent directly and runs many concurrent sessions) block each other's tool calls whenever their hook runs overlap — even though no callback ever actually hangs.

Two amplifiers make it routine rather than rare:
1. Shell-hook tool matchers are evaluated **inside** the callback — i.e. inside the single-flight window — so *every* configured `pre_tool_call` hook contends on *every* tool call of every session, matching or not.
2. Hooks dispatch sequentially per call, widening the overlap window.

Observed on a 10+ parallel-session host: 333 skip events in two days, all "skipped ... **or while still running**" — zero real timeouts. Sessions hit `same_tool_failure_halt` tool-guardrail halts from the resulting blocked-call streaks.

## Fix (two minimal, independent changes)

1. **Matcher gate before the flight window** (`hermes_cli/plugins_dispatch.py`): if a callback exposes `_hermes_matches_tool` (shell-hook callbacks do, `agent/shell_hooks.py`), non-matching tools `continue` *before* acquiring the flight token. A non-matching hook can never contend (nor be skipped because of) another session's in-flight run.
2. **Session-scoped flight keys** (`hermes_cli/plugins_dispatch.py`): `callback_key = (hook_name, id(cb), session_id)` — same composition as the shell-hook payload (falls back to `""` when identity kwargs are absent). Parallel sessions each get their own flight token + suppression window; same-session single-flight (hang protection, one stacked worker per session) is fully preserved.

## Tests

New `TestHookSingleFlightContentionUpstream105223` (5 polarity tests) + synthetic load test:
- non-matching hook across threads → never contends
- matching hook, same session → still single-flight (skip preserved)
- matching hook, different sessions → no skip, both run
- matching hook still dispatched; real shell-hook e2e matcher gate
- load: 8 parallel sessions × 6 sequential calls = 48 fires → 48 ran, **0 blocked** (pre-patch: same scenario produces the fail-closed storm); same-session polarity: 1 ran / 5 blocked (hang protection intact)

`tests/hermes_cli/test_plugins.py` 83/83 green on this branch (incl. existing timeout/fail-closed/suppression regression tests untouched).

## Notes

- `pre_tool_call` fail-closed semantics on *actual* timeout are unchanged — only cross-session false contention is removed.
- Python-plugin callbacks without `_hermes_matches_tool` behave exactly as before (the gate is opt-in via the attribute).