### PR TITLE
fix(cli,model_switch): preserve named custom provider identity and base_url for URL-bearing aliases

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2682,9 +2682,11 @@ class HermesCLI(CLIProcessNotificationsMixin, CLIAgentSetupMixin, CLICommandsMix
         self._model_is_default = not model and not _config_model
 
         # --api-key wins; otherwise a URL-bearing startup alias carries its own credential.
-        # See #28660.
+        # See #28660. The startup base URL must also become explicit: resolve_runtime_provider()
+        # only consults _explicit_base_url, so a DirectAlias that landed on bare "custom"
+        # would otherwise fall through to OpenRouter with a missing/wrong auth header.
         self._explicit_api_key = api_key or _startup_api_key_override or None
-        self._explicit_base_url = base_url
+        self._explicit_base_url = base_url or (_startup_base_url_override or None)
 
         # Resolved lazily at use-time via _ensure_runtime_credentials().
         self.requested_provider = (

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -320,9 +320,19 @@ def direct_alias_runtime_request(alias: DirectAlias) -> tuple[str, Optional[str]
     its vendor key and a foreign one resolves none. An alias with no base_url keeps its label —
     there is no foreign host, and the label is the only routing information.
 
-    See #28660.
+    Named custom identities (``custom:<name>``, e.g. ``custom:orcarouter``) are kept even when
+    the alias carries a base_url: collapsing them to bare ``custom`` drops the provider entry's
+    base_url/key_env and the CLI then resolves to OpenRouter with a missing/wrong auth header.
+    Only foreign *vendor* labels are forced to bare custom (#28660).
     """
-    return ("custom" if alias.base_url else (alias.provider or "custom")), direct_alias_api_key(alias) or None
+    key = direct_alias_api_key(alias) or None
+    provider = (alias.provider or "custom").strip() or "custom"
+    if not alias.base_url:
+        return provider, key
+    # URL-bearing: preserve named/bare custom routing identity; collapse foreign vendor labels.
+    if provider == "custom" or provider.startswith("custom:"):
+        return provider, key
+    return "custom", key
 
 
 # Hosts where plaintext HTTP is not a downgrade — no network hop to intercept.

--- a/tests/hermes_cli/test_model_alias_credentials_83612.py
+++ b/tests/hermes_cli/test_model_alias_credentials_83612.py
@@ -637,6 +637,50 @@ class TestOneShotUsesTheSameHostInvariant:
         ) == ("custom", "sk-own")
 
 
+class TestNamedCustomProviderPreservation:
+    """Named custom identities (``custom:<name>``) must keep their identity even when
+    the alias carries a base_url: collapsing them to bare ``custom`` drops the provider
+    entry's base_url/key_env and the CLI then resolves to OpenRouter with a missing/wrong
+    auth header (#34777)."""
+
+    def test_url_bearing_named_custom_preserves_identity(self):
+        from hermes_cli.model_switch import DirectAlias, direct_alias_runtime_request
+
+        assert direct_alias_runtime_request(
+            DirectAlias("c", "custom:orcarouter", "https://api.orcarouter.ai/v1", "sk-own")
+        ) == ("custom:orcarouter", "sk-own")
+
+    def test_url_bearing_named_custom_preserves_identity_no_key(self):
+        from hermes_cli.model_switch import DirectAlias, direct_alias_runtime_request
+
+        assert direct_alias_runtime_request(
+            DirectAlias("c", "custom:orcarouter", "https://api.orcarouter.ai/v1")
+        ) == ("custom:orcarouter", None)
+
+    def test_url_bearing_bare_custom_stays_custom(self):
+        from hermes_cli.model_switch import DirectAlias, direct_alias_runtime_request
+
+        assert direct_alias_runtime_request(
+            DirectAlias("c", "custom", "https://custom.test/v1")
+        ) == ("custom", None)
+
+    def test_url_bearing_vendor_label_still_collapses(self):
+        """Foreign vendor labels on unrelated hosts MUST still collapse to bare ``custom``
+        to avoid leaking their token onto a foreign wire (#28660)."""
+        from hermes_cli.model_switch import DirectAlias, direct_alias_runtime_request
+
+        assert direct_alias_runtime_request(
+            DirectAlias("c", "anthropic", "https://evil.test/v1", "sk-own")
+        ) == ("custom", "sk-own")
+
+    def test_no_url_keeps_provider_identity(self):
+        from hermes_cli.model_switch import DirectAlias, direct_alias_runtime_request
+
+        assert direct_alias_runtime_request(
+            DirectAlias("c", "anthropic", "")
+        ) == ("anthropic", None)
+
+
 class TestBaseUrlOrigin:
     """The origin helper the reuse decision is built on."""
 


### PR DESCRIPTION
## Summary
A URL-bearing DirectAlias (e.g. `z-ai/glm-5.3-flash-free` -> `custom:orcarouter`) was collapsed to bare `custom` by `direct_alias_runtime_request()`, which strips the provider entry's `base_url`/`key_env`. The CLI then resolved the bare custom provider to OpenRouter (no usable auth) and surfaced `HTTP 401: Missing Authentication header` for title generation and other auxiliary routes.

Two fixes:
- `direct_alias_runtime_request()` in `hermes_cli/model_switch.py`: keep `custom`/`custom:<name>` even when the alias carries a base_url; only foreign vendor labels (anthropic, etc.) collapse to bare custom to honor the #28660 foreign-host guard.
- `cli.py` `_init_model_and_provider()`: set `_explicit_base_url` from the startup alias base_url so `resolve_runtime_provider()` cannot drop it.

## Test plan
- Added `TestNamedCustomProviderPreservation` test class in `tests/hermes_cli/test_model_alias_credentials_83612.py` covering: named-custom, bare-custom, vendor-label-collapse, and no-URL identity retention.
- All existing alias credential tests (6) still pass; 5 new tests pass.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

Fixes #34777
