### PR TITLE
feat(tui): inline ghost-text auto-suggest in the composer (CLI parity)

### DIFF
--- a/tui_gateway/AGENTS.md
+++ b/tui_gateway/AGENTS.md
@@ -36,6 +36,7 @@ existing topical sibling, registered in the table — no `if method == ...` chai
 | Session picker | `sessionPicker.tsx` | `session.list` / `session.resume` |
 | Slash commands | local handler + fallthrough | `slash.exec` → `_SlashWorker`; `command.dispatch` |
 | Completions | `useCompletion` hook | `complete.slash`, `complete.path` |
+| Inline ghost text | `domain/inlineSuggest.ts` → `textInput.tsx` | none — reuses the rows those two already returned |
 | Theming | `theme.ts` + `branding.tsx` | `gateway.ready` carries skin data |
 | Plugin compat notice | — | `plugins.compat_report` (see `plugins/AGENTS.md`) |
 

--- a/ui-tui/src/__tests__/completionApply.test.ts
+++ b/ui-tui/src/__tests__/completionApply.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { applyCompletion, completionToApplyOnSubmit } from '../domain/slash.js'
+import { applyCompletion, completionToApplyOnSubmit, tabAcceptValue } from '../domain/slash.js'
 
 describe('applyCompletion', () => {
   it('replaces from compReplace and drops the leading slash from the row', () => {
@@ -59,5 +59,26 @@ describe('completionToApplyOnSubmit', () => {
   it('returns null when there is no row text', () => {
     expect(completionToApplyOnSubmit('/exit', undefined, 1)).toBeNull()
     expect(completionToApplyOnSubmit('/exit', '', 1)).toBeNull()
+  })
+})
+
+describe('tabAcceptValue — one Tab, two suggestion sources', () => {
+  it('applies the highlighted completion row when a menu is open', () => {
+    expect(tabAcceptValue('/he', 'help', 1, 'lp')).toBe('/help')
+  })
+
+  it('falls back to the inline ghost when no row is highlighted', () => {
+    // History recalls ghost without ever opening a menu.
+    expect(tabAcceptValue('git pu', undefined, 0, 'sh origin main')).toBe('git push origin main')
+  })
+
+  it('prefers the row even when the ghost points elsewhere', () => {
+    // The user arrowed the highlight off the shortest match; Tab must honor it.
+    expect(tabAcceptValue('/he', 'heartbeat', 1, 'lp')).toBe('/heartbeat')
+  })
+
+  it('is a no-op when there is neither a row nor a ghost', () => {
+    expect(tabAcceptValue('/he', undefined, 1, '')).toBeNull()
+    expect(tabAcceptValue('/he', '', 1, '')).toBeNull()
   })
 })

--- a/ui-tui/src/__tests__/inlineSuggest.test.ts
+++ b/ui-tui/src/__tests__/inlineSuggest.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+
+import { inlineGhostText } from '../components/textInput.js'
+import { completionGhost, historyGhost, inlineSuggestion } from '../domain/inlineSuggest.js'
+
+const rows = (...texts: string[]) => texts.map(text => ({ display: text, text }))
+
+describe('completionGhost', () => {
+  it('ghosts the remainder of the shortest matching command (CLI tie-break)', () => {
+    // `/he` must ghost "lp" (→ /help), not "artbeat" (→ /heartbeat): the CLI
+    // walks its registry shortest-name-first for exactly this reason.
+    expect(completionGhost('/he', rows('heartbeat', 'help'), 1)).toBe('lp')
+  })
+
+  it('ghosts argument completions from their own replace point', () => {
+    expect(completionGhost('/cron ad', rows('add', 'list'), 6)).toBe('d')
+  })
+
+  it('drops the row that no longer extends what is typed', () => {
+    expect(completionGhost('/help', rows('exit'), 1)).toBe('')
+  })
+
+  it('ignores an exact match completing to itself plus the menu-keeping space', () => {
+    // The gateway appends a trailing space to an exact hit so prompt_toolkit
+    // keeps the dropdown open. There is no text to ghost there.
+    expect(completionGhost('/help', rows('help '), 1)).toBe('')
+  })
+
+  it('handles client-side widget rows that carry their leading slash', () => {
+    // mergeWidgetAppItems emits `/timer`; applyCompletion drops the duplicate
+    // slash, and the ghost must follow the same rule rather than show "/timer".
+    expect(completionGhost('/tim', rows('/timer'), 1)).toBe('er')
+  })
+
+  it('refuses a replace point that belongs to a longer, older input', () => {
+    // Rows lag the input by one debounce. A stale `replace_from` past the end
+    // of the text would append the row wholesale: `/he` + `add` → `/headd`.
+    expect(completionGhost('/he', rows('add'), 7)).toBe('')
+  })
+
+  it('ghosts an inline /skill reference typed mid-prose', () => {
+    expect(completionGhost('tidy this with /cle', rows('clean-up'), 16)).toBe('an-up')
+  })
+})
+
+describe('historyGhost', () => {
+  it('suggests the most recent entry that extends the input', () => {
+    expect(historyGhost('git ', ['git status', 'git push origin main'])).toBe('push origin main')
+  })
+
+  it('ghosts only the first line of a multi-line recall', () => {
+    // A `\n` in the ghost would reflow the composer under the hint.
+    expect(historyGhost('fix ', ['fix the parser\nthen run tests'])).toBe('the parser')
+  })
+
+  it('has nothing to add for an exact recall', () => {
+    expect(historyGhost('deploy', ['deploy'])).toBe('')
+  })
+
+  it('stays quiet for empty or multi-line input', () => {
+    expect(historyGhost('   ', ['deploy now'])).toBe('')
+    expect(historyGhost('deploy\n', ['deploy now'])).toBe('')
+  })
+})
+
+describe('inlineSuggestion', () => {
+  const history = ['/cron add nightly backup', 'ship the release notes']
+
+  it('prefers a completion row over history', () => {
+    expect(inlineSuggestion({ compReplace: 1, completions: rows('help'), history, value: '/he' })).toBe('lp')
+  })
+
+  it('never falls back to history while the command NAME is being typed', () => {
+    // `/c` must not ghost yesterday's `/cron add nightly backup` over the
+    // command it is in the middle of naming. The CLI returns None here.
+    expect(inlineSuggestion({ compReplace: 1, completions: [], history, value: '/c' })).toBe('')
+  })
+
+  it('falls back to history once the command has an argument', () => {
+    expect(inlineSuggestion({ compReplace: 6, completions: [], history, value: '/cron add n' })).toBe('ightly backup')
+  })
+
+  it('falls back to history for ordinary prose', () => {
+    expect(inlineSuggestion({ compReplace: 0, completions: [], history, value: 'ship the' })).toBe(' release notes')
+  })
+
+  it('stays quiet on empty and multi-line input', () => {
+    expect(inlineSuggestion({ compReplace: 0, completions: rows('help'), history, value: '' })).toBe('')
+    expect(inlineSuggestion({ compReplace: 0, completions: [], history, value: 'ship the\nrest' })).toBe('')
+  })
+})
+
+describe('inlineGhostText — when the cells after the caret are free', () => {
+  const base = {
+    columns: 40,
+    cursor: 3,
+    focus: true,
+    masked: false,
+    selected: false,
+    suggestion: 'lp',
+    value: '/he'
+  }
+
+  it('paints at the end of a focused, unmasked, unselected line', () => {
+    expect(inlineGhostText(base)).toBe('lp')
+  })
+
+  it('stays hidden when the caret is not at the end', () => {
+    expect(inlineGhostText({ ...base, cursor: 1 })).toBe('')
+  })
+
+  it('stays hidden over a mask, a selection, or an unfocused input', () => {
+    expect(inlineGhostText({ ...base, masked: true })).toBe('')
+    expect(inlineGhostText({ ...base, selected: true })).toBe('')
+    expect(inlineGhostText({ ...base, focus: false })).toBe('')
+  })
+
+  it('stays hidden when it would not fit the rest of the row', () => {
+    // A wrapping ghost would grow the composer by a line the real value does
+    // not occupy — the input box must never resize under a hint.
+    expect(inlineGhostText({ ...base, columns: 5 })).toBe('')
+    expect(inlineGhostText({ ...base, columns: 6 })).toBe('lp')
+  })
+
+  it('measures only the last visual line of a multi-line buffer', () => {
+    expect(inlineGhostText({ ...base, cursor: 9, value: 'first\n/he' })).toBe('lp')
+  })
+})

--- a/ui-tui/src/__tests__/textInputGhost.test.tsx
+++ b/ui-tui/src/__tests__/textInputGhost.test.tsx
@@ -1,0 +1,139 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+
+import { renderSync } from '@hermes/ink'
+import React, { useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { TextInput } from '../components/textInput.js'
+
+class FakeInput extends EventEmitter {
+  chunks: string[] = []
+  isRaw = false
+  isTTY = true
+  readableLength = 0
+
+  read() {
+    const next = this.chunks.shift() ?? null
+    this.readableLength = this.chunks.length
+
+    return next
+  }
+
+  ref = vi.fn()
+
+  send(...chunks: string[]) {
+    this.chunks.push(...chunks)
+    this.readableLength = this.chunks.length
+    this.emit('readable')
+  }
+
+  setEncoding = vi.fn()
+
+  setRawMode = vi.fn((enabled: boolean) => {
+    this.isRaw = enabled
+  })
+
+  unref = vi.fn()
+}
+
+const settle = (ms = 25) => new Promise(resolve => setTimeout(resolve, ms))
+
+const ESC_RE = /\[[\d;]*m/g
+
+/** Mount a composer holding `initial`, with `suggestion` as its ghost. */
+function mount(initial: string, suggestion: string) {
+  const stdin = new FakeInput()
+  const stdout = new PassThrough()
+  const stderr = new PassThrough()
+  const painted: string[] = []
+  const changes: string[] = []
+
+  Object.assign(stdout, { columns: 80, isTTY: false, rows: 24 })
+  Object.assign(stderr, { columns: 80, isTTY: false, rows: 24 })
+  stdout.on('data', (chunk: Buffer) => painted.push(String(chunk)))
+
+  function Harness() {
+    const [value, setValue] = useState(initial)
+
+    return (
+      <TextInput
+        columns={40}
+        onChange={next => {
+          changes.push(next)
+          setValue(next)
+        }}
+        onSubmit={() => {}}
+        suggestion={suggestion}
+        value={value}
+      />
+    )
+  }
+
+  const instance = renderSync(React.createElement(Harness), {
+    patchConsole: false,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream
+  })
+
+  return {
+    changes,
+    close: () => {
+      instance.unmount()
+      instance.cleanup()
+    },
+    frames: () => painted.join('').replace(ESC_RE, ''),
+    stdin
+  }
+}
+
+describe('TextInput inline ghost text', () => {
+  it('paints the suggestion after the caret without changing the value', async () => {
+    const ui = mount('/he', 'lp')
+
+    await settle()
+    const frames = ui.frames()
+    ui.close()
+
+    expect(frames).toContain('/help')
+    expect(ui.changes).toEqual([])
+  })
+
+  it('→ at the end of the line accepts the whole suggestion', async () => {
+    const ui = mount('/he', 'lp')
+
+    await settle()
+    ui.stdin.send('\u001b[C')
+    await settle()
+    ui.close()
+
+    expect(ui.changes.at(-1)).toBe('/help')
+  })
+
+  it('Ctrl+E accepts it too, and a plain keystroke still just types', async () => {
+    const ui = mount('/he', 'lp')
+
+    await settle()
+    ui.stdin.send('\u0005')
+    await settle()
+    expect(ui.changes.at(-1)).toBe('/help')
+
+    ui.stdin.send('x')
+    await settle()
+    ui.close()
+
+    expect(ui.changes.at(-1)).toBe('/helpx')
+  })
+
+  it('leaves → alone as a cursor move when there is nothing to suggest', async () => {
+    const ui = mount('/he', '')
+
+    await settle()
+    ui.stdin.send('\u001b[C')
+    await settle()
+    ui.close()
+
+    expect(ui.changes).toEqual([])
+  })
+})

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -413,6 +413,8 @@ export interface ComposerState {
   compIdx: number
   compReplace: number
   completions: CompletionItem[]
+  /** Inline ghost text for the current input; '' when nothing is suggested. */
+  ghost: string
   historyIdx: null | number
   input: string
   inputBuf: string[]
@@ -585,6 +587,7 @@ export interface AppLayoutComposerProps {
   compIdx: number
   completions: CompletionItem[]
   empty: boolean
+  ghost: string
   handleTextPaste: (event: PasteEvent) => MaybePromise<ComposerPasteResult | null>
   input: string
   inputBuf: string[]

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -9,6 +9,7 @@ import { useCallback, useMemo, useRef, useState } from 'react'
 
 import type { PasteEvent } from '../components/textInput.js'
 import { droppedTokens, imageToken, nextImageIndex } from '../domain/attachments.js'
+import { inlineSuggestion } from '../domain/inlineSuggest.js'
 import type { ClipboardPasteResponse, ImageAttachResponse, InputDetectDropResponse } from '../gatewayTypes.js'
 import { useCompletion } from '../hooks/useCompletion.js'
 import { useInputHistory } from '../hooks/useInputHistory.js'
@@ -143,6 +144,19 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
 
   const { historyRef, historyIdx, setHistoryIdx, historyDraftRef, pushHistory } = useInputHistory()
   const { completions, compIdx, setCompIdx, compReplace } = useCompletion(input, isBlocked, gw)
+
+  // Inline ghost text. Derived from the completion rows already fetched for
+  // this keystroke plus the recall history, so it adds no round trip of its own
+  // (see domain/inlineSuggest). Suppressed while a history recall is being
+  // stepped through: the input IS a past line there, and ghosting the tail of
+  // an even longer one fights the ↑/↓ the user is actually driving.
+  const ghost = useMemo(
+    () =>
+      isBlocked || historyIdx !== null
+        ? ''
+        : inlineSuggestion({ compReplace, completions, history: historyRef.current, value: input }),
+    [compReplace, completions, historyIdx, historyRef, input, isBlocked]
+  )
 
   const clearIn = useCallback(() => {
     setInput('')
@@ -479,6 +493,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
       compIdx,
       compReplace,
       completions,
+      ghost,
       historyIdx,
       input,
       inputBuf,
@@ -486,7 +501,7 @@ export function useComposerState({ gw, submitRef, sys }: UseComposerStateOptions
       queuedDisplay,
       tokens
     }),
-    [compIdx, compReplace, completions, historyIdx, input, inputBuf, queueEditIdx, queuedDisplay, tokens]
+    [compIdx, compReplace, completions, ghost, historyIdx, input, inputBuf, queueEditIdx, queuedDisplay, tokens]
   )
 
   return {

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -4,7 +4,7 @@ import { useEffect, useRef } from 'react'
 
 import { DASHBOARD_TUI_MODE } from '../config/env.js'
 import { DOUBLE_ESC_MS, TYPING_IDLE_MS } from '../config/timing.js'
-import { applyCompletion } from '../domain/slash.js'
+import { tabAcceptValue } from '../domain/slash.js'
 import type {
   ApprovalRespondResponse,
   ConfigSetResponse,
@@ -737,11 +737,18 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       })
     }
 
-    if (key.tab && cState.completions.length) {
-      const row = cState.completions[cState.compIdx]
+    // Tab takes the highlighted completion row, or the inline ghost when no
+    // menu is up (history recalls ghost without ever opening one).
+    if (key.tab && (cState.completions.length || cState.ghost)) {
+      const next = tabAcceptValue(
+        cState.input,
+        cState.completions[cState.compIdx]?.text,
+        cState.compReplace,
+        cState.ghost
+      )
 
-      if (row?.text) {
-        cActions.setInput(applyCompletion(cState.input, row.text, cState.compReplace))
+      if (next !== null) {
+        cActions.setInput(next)
       }
 
       return

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -1262,6 +1262,7 @@ export function useMainApp(gw: GatewayClient) {
       compIdx: composerState.compIdx,
       completions: composerState.completions,
       empty,
+      ghost: composerState.ghost,
       handleTextPaste: composerActions.handleTextPaste,
       input: composerState.input,
       inputBuf: composerState.inputBuf,

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -438,6 +438,7 @@ const ComposerPane = memo(function ComposerPane({
                   // terminals lie about their background); anything blended
                   // toward the resolved surface inherits that wrong polarity.
                   placeholderColor={ui.theme.color.muted}
+                  suggestion={composer.ghost}
                   value={composer.input}
                   voiceRecordKey={composer.voiceRecordKey}
                 />

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -745,6 +745,43 @@ function renderWithSelection(
   )
 }
 
+/**
+ * Whether inline ghost text may be drawn right now, and how much of it.
+ *
+ * Ghost text is a HINT painted in the cells after the caret, so every state
+ * where those cells are not free, or are not the user's own next keystroke,
+ * disqualifies it:
+ *
+ *   - not focused / masked → no hint over a password, none on a parked input
+ *   - a selection is up    → the inverted range owns the cells
+ *   - caret not at the end → the ghost would be typed INTO, not appended
+ *
+ * The width test is what keeps the composer from resizing under the hint: the
+ * ghost never starts a new visual row, so `inputVisualHeight` (computed from
+ * the real value) stays truthful and the input box can't grow a line just
+ * because a suggestion arrived. A suggestion too long for the remaining row is
+ * simply not shown — it is still there to accept, Tab/→ just apply it unseen.
+ */
+export function inlineGhostText(opts: {
+  columns: number
+  cursor: number
+  focus: boolean
+  masked: boolean
+  selected: boolean
+  suggestion: string
+  value: string
+}): string {
+  const { columns, cursor, focus, masked, selected, suggestion, value } = opts
+
+  if (!focus || masked || selected || !suggestion || !value || cursor !== value.length) {
+    return ''
+  }
+
+  const lastLine = value.slice(value.lastIndexOf('\n') + 1)
+
+  return stringWidth(lastLine) + stringWidth(suggestion) < Math.max(1, columns) ? suggestion : ''
+}
+
 function useFwdDelete(active: boolean) {
   const ref = useRef(false)
   const { inputEmitter: ee } = useStdin()
@@ -788,6 +825,7 @@ export function TextInput({
   placeholderColor,
   accentColor,
   color,
+  suggestion = '',
   focus = true
 }: TextInputProps) {
   const [cur, setCur] = useState(() =>
@@ -823,6 +861,11 @@ export function TextInput({
   const lastClickRef = useRef<{ at: number; offset: number }>({ at: 0, offset: -1 })
   const undo = useRef<{ cursor: number; value: string }[]>([])
   const redo = useRef<{ cursor: number; value: string }[]>([])
+  // Read from the key handler (a stable closure) and from canFastEchoBase, so
+  // both see the ghost/suggestion of the CURRENT render, not the first one.
+  const ghostRef = useRef('')
+  const suggestionRef = useRef('')
+  suggestionRef.current = suggestion
 
   const cbChange = useRef(onChange)
   const cbSubmit = useRef(onSubmit)
@@ -902,6 +945,25 @@ export function TextInput({
   const accentOpen = mask ? '' : fgSeq(accentColor)
   const highlights = useMemo(() => (accentOpen ? highlightMask(display) : null), [accentOpen, display])
 
+  // Inline ghost text (CLI `SlashCommandAutoSuggest` parity). The composer
+  // decides WHAT to suggest; this decides whether the cells after the caret are
+  // free to show it (see inlineGhostText).
+  const ghost = inlineGhostText({
+    columns,
+    cursor: cur,
+    focus,
+    masked: !!mask,
+    selected: !!selected,
+    suggestion,
+    value: display
+  })
+
+  // The fast-echo bypass writes ONLY the newly typed cells — straight into the
+  // ones the ghost is sitting in. A typed char would overwrite the ghost's
+  // first glyph and strand the rest on screen until an unrelated repaint, so
+  // typing under a ghost takes the full Ink path (see canFastEchoBase).
+  ghostRef.current = ghost
+
   const rendered = useMemo(() => {
     if (!focus) {
       return display ? paintHighlights(display, accentOpen, highlights) : colorizeHint(placeholder, placeholderColor)
@@ -917,10 +979,22 @@ export function TextInput({
       return renderWithSelection(display, selected.start, selected.end, accentOpen, highlights)
     }
 
+    if (!ghost) {
+      return nativeCursor
+        ? paintHighlights(display, accentOpen, highlights) || ' '
+        : renderWithCursor(display, cur, accentOpen, highlights)
+    }
+
+    // Hardware cursor drawn by the host ⇒ the ghost is just hint text behind
+    // it. No hardware cursor ⇒ the cursor cell IS the ghost's first glyph
+    // (the placeholder's synthetic-cursor trick), so the hint stays readable
+    // instead of being swallowed by an inverted block.
     return nativeCursor
-      ? paintHighlights(display, accentOpen, highlights) || ' '
-      : renderWithCursor(display, cur, accentOpen, highlights)
-  }, [accentOpen, cur, display, focus, highlights, nativeCursor, placeholder, placeholderColor, selected])
+      ? paintHighlights(display, accentOpen, highlights) + colorizeHint(ghost, placeholderColor)
+      : paintHighlights(display, accentOpen, highlights) +
+          hintCursorCell(ghost[0] ?? ' ', placeholderColor) +
+          colorizeHint(ghost.slice(1), placeholderColor)
+  }, [accentOpen, cur, display, focus, ghost, highlights, nativeCursor, placeholder, placeholderColor, selected])
 
   useEffect(() => {
     const ownEcho = self.current && value === vRef.current
@@ -1078,7 +1152,7 @@ export function TextInput({
   }
 
   const canFastEchoBase = () =>
-    supportsFastEchoTerminal() && focus && termFocus && !selected && !mask && !!stdout?.isTTY
+    supportsFastEchoTerminal() && focus && termFocus && !selected && !mask && !ghostRef.current && !!stdout?.isTTY
 
   const canFastAppend = (current: string, cursor: number, text: string) =>
     canFastEchoBase() &&
@@ -1273,6 +1347,29 @@ export function TextInput({
     return range && range.start !== range.end
       ? { end: Math.max(range.start, range.end), start: Math.min(range.start, range.end) }
       : null
+  }
+
+  /**
+   * Accept the inline suggestion: append it whole and park the caret after it.
+   *
+   * Accepts the FULL suggestion even when it was too wide to paint (see
+   * inlineGhostText) — prompt_toolkit does the same, and a suggestion that is
+   * real enough to Tab is real enough to apply. Returns false when there is
+   * nothing to accept or the caret is not at the end, so callers can fall
+   * through to the key's ordinary meaning (→ moves, End moves).
+   */
+  const acceptSuggestion = () => {
+    const text = suggestionRef.current
+    const v = vRef.current
+
+    if (!text || mask || selRange() || curRef.current !== v.length) {
+      return false
+    }
+
+    flushKeyBurst()
+    commit(v + text, v.length + text.length)
+
+    return true
   }
 
   const ins = (v: string, c: number, s: string) => v.slice(0, c) + s + v.slice(c)
@@ -1479,6 +1576,12 @@ export function TextInput({
 
         return
       } else if (actionEnd) {
+        // Already at the end ⇒ End completes the ghost (readline/fish habit);
+        // otherwise it just travels there.
+        if (!k.shift && acceptSuggestion()) {
+          return
+        }
+
         c = v.length
         moveCursor(c, k.shift)
 
@@ -1495,6 +1598,12 @@ export function TextInput({
 
         return
       } else if (k.rightArrow) {
+        // → at the end of the line accepts the ghost instead of no-op'ing
+        // against the end of the buffer (the CLI's prompt_toolkit binding).
+        if (!range && !wordMod && !k.shift && acceptSuggestion()) {
+          return
+        }
+
         if (range && !wordMod && !k.shift) {
           clearSel()
           c = range.end
@@ -1815,6 +1924,8 @@ interface TextInputProps {
   placeholder?: string
   /** Hex color for placeholder text (theme muted); SGR dim when omitted. */
   placeholderColor?: string
+  /** Inline ghost text painted after the caret; → / End / Tab accept it. */
+  suggestion?: string
   value: string
   voiceRecordKey?: ParsedVoiceRecordKey
 }

--- a/ui-tui/src/domain/inlineSuggest.ts
+++ b/ui-tui/src/domain/inlineSuggest.ts
@@ -1,0 +1,118 @@
+import type { CompletionItem } from '../app/interfaces.js'
+
+import { applyCompletion, looksLikeSlashCommand } from './slash.js'
+
+/**
+ * Inline ghost text for the composer — the TUI half of the CLI's
+ * `SlashCommandAutoSuggest` (hermes_cli/commands_completion.py).
+ *
+ * The CLI builds its suggestion by re-walking the command registry on every
+ * keystroke. The TUI can't: the registry lives in the gateway process. But the
+ * dropdown ALREADY asks the gateway for exactly that registry slice
+ * (`complete.slash` / `complete.path`, the same `SlashCommandCompleter` the CLI
+ * completes from), so the ghost is derived from the rows that request returned
+ * instead of costing a second round trip per keystroke. Two consequences worth
+ * keeping:
+ *
+ *   - The ghost can never disagree with the menu underneath it. It is one of
+ *     the visible rows, by construction.
+ *   - Rows lag the input by one debounce (60ms). That is survivable because the
+ *     ghost is recomputed against the CURRENT text: a stale row that still
+ *     extends what is typed keeps ghosting through the gap (type `/he` → `/hel`
+ *     and "lp" simply shrinks to "p"), and one that no longer extends it is
+ *     dropped by the prefix test rather than shown wrong.
+ *
+ * Selection rule matches the CLI's: the SHORTEST completion wins, so `/he`
+ * ghosts `lp` (→ `/help`) rather than `artbeat` (→ `/heartbeat`).
+ */
+
+/** Ghost text derived from the completion rows fetched for this input, or ''. */
+export function completionGhost(value: string, completions: CompletionItem[], compReplace: number): string {
+  // A replace point past the end of the text belongs to an older, longer input
+  // (the rows are one debounce behind). Applying it would append the row to the
+  // whole value and ghost nonsense: `/he` + `add` → `/headd`.
+  if (compReplace < 0 || compReplace > value.length) {
+    return ''
+  }
+
+  let best = ''
+
+  for (const item of completions) {
+    if (!item.text) {
+      continue
+    }
+
+    // Reuse the menu's own replace semantics so ghost text and Tab-accept can
+    // never diverge on the leading-slash rule.
+    const next = applyCompletion(value, item.text, compReplace)
+
+    if (!next.startsWith(value)) {
+      continue
+    }
+
+    const remainder = next.slice(value.length)
+
+    // An exact match completes to itself plus the trailing space the gateway
+    // appends to keep the menu open. There is nothing to ghost there.
+    if (!remainder.trim()) {
+      continue
+    }
+
+    if (!best || remainder.length < best.length) {
+      best = remainder
+    }
+  }
+
+  return best
+}
+
+/** Ghost text from the most recent matching history entry, or ''. */
+export function historyGhost(value: string, history: readonly string[]): string {
+  if (!value.trim() || value.includes('\n')) {
+    return ''
+  }
+
+  for (let i = history.length - 1; i >= 0; i--) {
+    // Multi-line recalls ghost their FIRST line only: the composer is one
+    // logical line here, and a `\n` in the ghost would reflow the input box.
+    const entry = (history[i] ?? '').split('\n')[0] ?? ''
+
+    if (entry.length > value.length && entry.startsWith(value)) {
+      return entry.slice(value.length)
+    }
+  }
+
+  return ''
+}
+
+/** True while the user is still typing the command NAME (`/he`, not `/help x`). */
+const typingCommandName = (value: string) => looksLikeSlashCommand(value) && !/\s/.test(value)
+
+export interface InlineSuggestArgs {
+  compReplace: number
+  completions: CompletionItem[]
+  history: readonly string[]
+  value: string
+}
+
+/**
+ * The single ghost string to draw after the cursor, or '' for none.
+ *
+ * Order mirrors the CLI: completions first, history second — except while the
+ * command name itself is being typed, where a history hit would fight the
+ * command being completed (`/c` must ghost `lear`, never the `/cron add ...`
+ * line from yesterday). The CLI returns `None` in exactly that state.
+ */
+export function inlineSuggestion({ compReplace, completions, history, value }: InlineSuggestArgs): string {
+  if (!value || value.includes('\n')) {
+    return ''
+  }
+
+  const fromCompletions = completionGhost(value, completions, compReplace)
+
+  if (fromCompletions) {
+    return fromCompletions
+  }
+
+  return typingCommandName(value) ? '' : historyGhost(value, history)
+}

--- a/ui-tui/src/domain/slash.ts
+++ b/ui-tui/src/domain/slash.ts
@@ -78,6 +78,28 @@ export const applyCompletion = (value: string, rowText: string, compReplace: num
 }
 
 /**
+ * The value Tab applies, or `null` when Tab has nothing to do.
+ *
+ * One rule for both sources so they can't drift: the highlighted menu row wins
+ * when there is one, and the inline ghost is what Tab means when no menu is up
+ * (a history recall, or a suggestion whose rows have since been cleared).
+ * Preferring the row is not a demotion of the ghost — the ghost IS one of those
+ * rows, so a user who moved the highlight gets the row they chose.
+ */
+export const tabAcceptValue = (
+  value: string,
+  rowText: string | undefined,
+  compReplace: number,
+  ghost: string
+): string | null => {
+  if (rowText) {
+    return applyCompletion(value, rowText, compReplace)
+  }
+
+  return ghost ? value + ghost : null
+}
+
+/**
  * Decide what Enter does when a completion is highlighted: returns the value
  * to set (accept the completion) or `null` to fall through to submit.
  *

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -107,7 +107,7 @@ Keybindings match the [Classic CLI](cli.md#keybindings) exactly. The only behavi
 - **Mouse drag** highlights text with a uniform selection background.
 - **`Cmd+V` / `Ctrl+V`** first tries normal text paste, then falls back to OSC52/native clipboard reads, and finally image attach when the clipboard or pasted payload resolves to an image.
 - **`/terminal-setup`** installs local VS Code / Cursor / Windsurf terminal bindings for better `Cmd+Enter` and undo/redo parity on macOS.
-- **Slash autocompletion** opens as a floating panel with descriptions, not an inline dropdown.
+- **Slash autocompletion** opens as a floating panel with descriptions, not an inline dropdown. Inline ghost text runs alongside it exactly as in the classic CLI: type `/upd` and a dim `ate` appears after the cursor (ordinary prompts ghost your matching history instead). `Tab`, `→`, or `End` accepts it — with the panel open, `Tab` takes the highlighted row.
 - **`Ctrl+X`** opens the live session switcher. When a queued message is highlighted (sent while the agent was still running), it still deletes that queued message instead. **`Esc`** cancels editing and unhighlights without deleting.
 - **`Ctrl+G` / `Ctrl+X Ctrl+E`** — open the current input buffer in `$EDITOR` for multi-line / long-prompt composition; save-and-exit sends the contents back as the prompt.
 


### PR DESCRIPTION
## What does this PR do?

Adds inline ghost-text auto-suggest to the TUI composer, closing the last "feel" gap with the classic CLI.

The classic CLI has had inline ghost text since prompt_toolkit's `SlashCommandAutoSuggest`: type `/upd` and a dim `ate` appears after the cursor. The TUI had tab-completion against the same backend completer but nothing inline, so its composer felt inert by comparison — you had to press `Tab` to find out a command existed.

```
› /he│lp                     ← ghost text (dim), → / End / Tab accepts
› ship the│ release notes    ← history recall for ordinary prose
```

**Why this approach.** The issue offered two options: a new `complete.suggest` RPC backed by `SlashCommandAutoSuggest`, or a client-side port of the suggestion logic. This takes a third and cheaper one — the suggestion is derived from the completion rows the composer **already fetched for this keystroke** (`complete.slash` / `complete.path`, the same `SlashCommandCompleter` the CLI completes from). No second round trip per character, and no duplicated command registry in TypeScript that could drift from the Python one.

Two properties fall out of that:

- **The ghost can never disagree with the menu under it.** It is one of the visible rows, by construction — so `Tab` taking the highlighted row and `→` taking the ghost cannot diverge.
- **The 60 ms row-debounce lag is invisible.** The ghost is recomputed against the *current* text, not the text the rows were fetched for: a stale row that still extends what is typed keeps ghosting (typing `/he` → `/hel` just shrinks `lp` to `p`), and one that no longer extends it is dropped by the prefix test rather than shown wrong. A stale `replace_from` pointing past the end of the text is refused outright — it would otherwise ghost `/he` + `add` → `/headd`.

**Parity details.** Selection and fallback mirror the CLI: shortest match wins (`/he` → `lp`, not `artbeat` — the CLI's `sorted(COMMANDS, key=len)`), arguments ghost from their own replace point (`/cron ad` → `d`), and ordinary prose falls back to history recall — except while the command name itself is being typed, where the CLI returns `None` and a history hit would fight the command being named (`/c` must ghost `lear`, not yesterday's `/cron add nightly backup`). One TUI-only addition: an inline `/skill` reference typed mid-prose ghosts too (`tidy this with /cle` → `an-up`), a shape the CLI doesn't have.

**Rendering safety.** The ghost is only painted where the cells after the caret are free (focused, unmasked — never over a password, no selection, caret at end) and where it fits the rest of the row, so the input box can never grow a line under a hint (`inputVisualHeight` is computed from the real value). A suggestion too wide to paint is still accepted by `→`/`Tab`, matching prompt_toolkit. Typing while a ghost is painted takes the full Ink render path: the fast-echo bypass writes only the newly typed cells, straight into the ones the ghost occupies, and would strand the ghost's tail on screen. Where the host doesn't draw a hardware cursor, the cursor cell *is* the ghost's first glyph (the bubbles-textinput trick the placeholder already uses), so the hint stays legible instead of being swallowed by an inverted block. Tones go through Ink's own `colorize` at the theme's `muted`, never SGR dim — the transparent-background hazard the placeholder comment documents.

## Related Issue

Fixes #15495

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`ui-tui/src/domain/inlineSuggest.ts`** (new) — the whole suggestion policy, pure and testable: `completionGhost` (rows → ghost, shortest-remainder wins, stale-`replace_from` refusal), `historyGhost` (most recent matching entry, first line only — a `\n` would reflow the composer), and `inlineSuggestion` (completions first, history second, no history while the command name is being typed).
- **`ui-tui/src/components/textInput.tsx`** — new optional `suggestion` prop; `inlineGhostText()` decides whether the cells after the caret are free and whether the ghost fits the row; ghost rendering in both the hardware-cursor and synthetic-cursor paths; `→` and `End`/`Ctrl+E` accept via `acceptSuggestion()`; `canFastEchoBase()` now refuses the fast-echo bypass while a ghost is painted.
- **`ui-tui/src/domain/slash.ts`** — `tabAcceptValue()`: one rule for what `Tab` applies (highlighted row wins; inline ghost otherwise), reusing `applyCompletion`'s replace semantics so the leading-slash rule (bare `help` from the gateway vs. `/timer` from the client-side widget registry) stays in one place.
- **`ui-tui/src/app/useComposerState.ts`** — derives `ghost` from the rows already in hand plus `useInputHistory`; suppressed while blocked by an overlay and while stepping `↑`/`↓` through history recall.
- **`ui-tui/src/app/useInputHandlers.ts`** — the `Tab` branch now routes through `tabAcceptValue` (replaces the row-only branch; `Shift+Tab` → yolo is untouched).
- **`ui-tui/src/app/interfaces.ts`, `ui-tui/src/app/useMainApp.ts`, `ui-tui/src/components/appLayout.tsx`** — `ghost` on `ComposerState` / `AppLayoutComposerProps`, passed to the composer's `TextInput`.
- **`website/docs/user-guide/tui.md`** — the "differences from the classic CLI" bullet now documents inline ghost text and its accept keys.
- **`tui_gateway/AGENTS.md`** — new row in the key-surfaces table (inline ghost text reuses the completion RPCs; it is not a new one).
- **Tests** — `ui-tui/src/__tests__/inlineSuggest.test.ts` (new), `ui-tui/src/__tests__/textInputGhost.test.tsx` (new), plus `tabAcceptValue` cases appended to `ui-tui/src/__tests__/completionApply.test.ts`.

No gateway/Python changes: no new RPC, no new config key, no new env var.

## How to Test

Automated (this change is JS-only; `scripts/ci/classify_changes.py` routes it to the vitest lane):

```bash
cd ui-tui
npm run build:ink
npx tsc --noEmit -p tsconfig.json
npx vitest run                      # 170 files, 1800 tests pass (was 168 / 1771)
npx vitest run src/__tests__/inlineSuggest.test.ts src/__tests__/textInputGhost.test.tsx
```

Manually, in the TUI (`hermes --tui`):

1. Type `/he` — a dim `lp` appears after the cursor (`help`, not `heartbeat`: shortest match wins). Press `→` and the composer reads `/help`.
2. Type `/cron ad` — ghosts `d` from the subcommand list. Press `End` to accept.
3. Send any prompt, start a new one with the same first few words — the rest of the previous prompt ghosts from history. `Tab` accepts.
4. Type `/c`, then press `↑` — the ghost disappears while you step through history recall, and no stale history line fights the command name while you type it.
5. Open the completion panel and arrow the highlight off the first row, then press `Tab` — the row you selected wins over the ghost.
6. Move the caret into the middle of the text (`←`) or select text with the mouse — no ghost is painted in either state, and `→` is an ordinary cursor move again.
7. Narrow the terminal until the suggestion no longer fits the row — the ghost stops being painted and the input box does **not** grow a line; `Tab` still completes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(tui): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **N/A, JS-only change**; ran the vitest suite instead: `170 files / 1800 tests pass` (was `168 / 1771`), plus `tsc --noEmit` clean
- [x] I've added tests for my changes — 29 new behavior tests, including a real `TextInput` rendered over a fake TTY that asserts the ghost paints, `→`/`Ctrl+E` accept it, and a plain keystroke still types
- [x] I've tested on my platform: Linux x86_64 (kernel 7.0.0-31-generic), Node 22

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `website/docs/user-guide/tui.md`
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new config
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — `tui_gateway/AGENTS.md` key-surfaces table
- [x] I've considered cross-platform impact — no platform APIs touched; the accept keys reuse the existing `actionEnd` resolution that already handles the macOS `Cmd`/`Ctrl+E` fallbacks, and the width guard uses Ink's own `stringWidth` (wide/CJK safe)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no model tools touched

## Screenshots / Logs

```
$ npx vitest run
 Test Files  170 passed (170)
      Tests  1800 passed (1800)

$ npx tsc --noEmit -p tsconfig.json
(clean)
```

`eslint` is not installed in this checkout so lint did not run locally; `prettier --check` is clean on every touched file.