### PR TITLE
fix(setup): configure shared tools once during first install

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -957,7 +957,7 @@ def _checklist_diff(new_enabled: Set[str], prev: Set[str], platform: str) -> tup
 
 
 def _first_install_flow(config: dict, enabled_platforms: List[str]) -> None:
-    """Fresh install: one checklist per platform, no menu, keys prompted for every enabled tool."""
+    """Fresh install: one checklist per platform, with shared tools configured once per invocation."""
     # Provider choices are shared by every platform in this profile.
     already_configured: Set[str] = set()
     for pkey in enabled_platforms:
@@ -965,18 +965,18 @@ def _first_install_flow(config: dict, enabled_platforms: List[str]) -> None:
         current_enabled = _current_platform_tools(config, pkey)
         new_enabled = _prompt_toolset_checklist(pinfo["label"], current_enabled - _DEFAULT_OFF_TOOLSETS, pkey)
         _print_toolset_diff(*_checklist_diff(new_enabled, current_enabled, pkey))
-        auto_configured = apply_nous_managed_defaults(config, enabled_toolsets=new_enabled, force_fresh=True)
+        pending_toolsets = new_enabled - already_configured
+        auto_configured = apply_nous_managed_defaults(config, enabled_toolsets=pending_toolsets, force_fresh=True)
         for ts_key in sorted(auto_configured):
             label = next((l for k, l, _ in CONFIGURABLE_TOOLSETS if k == ts_key), ts_key)
             print(color(f"  ✓ {label}: using your Nous subscription defaults", Colors.GREEN))
-        # Walk through ALL selected tools with provider options or key requirements, so browser (Local vs
-        # Browserbase), TTS (Edge vs OpenAI vs ElevenLabs), etc. are shown even when a free provider exists.
+        # Offer a provider choice even when a free default or API key already exists.
         to_configure = [
-            ts for ts in sorted(new_enabled)
-            if _is_configurable(ts) and ts not in auto_configured and ts not in already_configured
+            ts for ts in sorted(pending_toolsets)
+            if _is_configurable(ts) and ts not in auto_configured
         ]
         _configure_list(to_configure, config, selected=False)
-        already_configured.update(to_configure)
+        already_configured.update(new_enabled)
         _save_platform_tools(config, pkey, new_enabled)
         save_config(config)
         print(color(f"  ✓ Saved {pinfo['label']} tool configuration", Colors.GREEN))

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -958,6 +958,8 @@ def _checklist_diff(new_enabled: Set[str], prev: Set[str], platform: str) -> tup
 
 def _first_install_flow(config: dict, enabled_platforms: List[str]) -> None:
     """Fresh install: one checklist per platform, no menu, keys prompted for every enabled tool."""
+    # Provider choices are shared by every platform in this profile.
+    already_configured: Set[str] = set()
     for pkey in enabled_platforms:
         pinfo = PLATFORMS[pkey]
         current_enabled = _current_platform_tools(config, pkey)
@@ -969,9 +971,12 @@ def _first_install_flow(config: dict, enabled_platforms: List[str]) -> None:
             print(color(f"  ✓ {label}: using your Nous subscription defaults", Colors.GREEN))
         # Walk through ALL selected tools with provider options or key requirements, so browser (Local vs
         # Browserbase), TTS (Edge vs OpenAI vs ElevenLabs), etc. are shown even when a free provider exists.
-        _configure_list(
-            [ts for ts in sorted(new_enabled) if _is_configurable(ts) and ts not in auto_configured],
-            config, selected=False)
+        to_configure = [
+            ts for ts in sorted(new_enabled)
+            if _is_configurable(ts) and ts not in auto_configured and ts not in already_configured
+        ]
+        _configure_list(to_configure, config, selected=False)
+        already_configured.update(to_configure)
         _save_platform_tools(config, pkey, new_enabled)
         save_config(config)
         print(color(f"  ✓ Saved {pinfo['label']} tool configuration", Colors.GREEN))

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -286,6 +286,66 @@ def test_first_install_nous_auto_configures_video_gen(monkeypatch):
     # video_gen should NOT appear in the manual configure list — it's auto-configured
     assert "video_gen" not in configured
 
+
+def test_first_install_skips_already_configured_toolsets_across_platforms(monkeypatch):
+    """Toolsets with global config (browser, TTS, etc.) should only be
+    configured once during first_install, even when multiple platforms
+    are enabled (e.g. cli + slack).  Regression test for #24069."""
+    config: dict = {
+        "model": {"provider": "openrouter"},
+        "platform_toolsets": {},
+    }
+    # Clean env so no auto-detection adds extra platforms
+    for env_var in (
+        "TELEGRAM_BOT_TOKEN", "DISCORD_BOT_TOKEN", "SLACK_BOT_TOKEN",
+        "WHATSAPP_ENABLED", "QQ_APP_ID",
+        "VOICE_TOOLS_OPENAI_KEY", "OPENAI_API_KEY",
+        "ELEVENLABS_API_KEY", "FIRECRAWL_API_KEY", "FIRECRAWL_API_URL",
+        "TAVILY_API_KEY", "PARALLEL_API_KEY",
+        "BROWSERBASE_API_KEY", "BROWSERBASE_PROJECT_ID",
+        "BROWSER_USE_API_KEY", "FAL_KEY",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+
+    # Simulate two enabled platforms: cli and slack
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._get_enabled_platforms",
+        lambda: ["cli", "slack"],
+    )
+    # Both platforms select the same toolsets
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._prompt_toolset_checklist",
+        lambda *args, **kwargs: {"browser", "tts", "image_gen", "web"},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.tools_config.apply_nous_managed_defaults",
+        lambda config, enabled_toolsets, force_fresh: set(),
+    )
+    monkeypatch.setattr("hermes_cli.tools_config.save_config", lambda config: None)
+
+    configured: list[str] = []
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._configure_toolset",
+        lambda ts_key, cfg: configured.append(ts_key),
+    )
+
+    tools_command(first_install=True, config=config)
+
+    # Each toolset should be configured exactly once, not once per platform
+    assert len(configured) == len(set(configured)), (
+        f"Duplicate toolset configuration detected: {configured}"
+    )
+    assert len(configured) > 0, "Expected at least one toolset to be configured"
+    # Verify no duplicates — each toolset appears exactly once
+    from collections import Counter
+    counts = Counter(configured)
+    for ts_key, count in counts.items():
+        assert count == 1, (
+            f"Toolset {ts_key!r} was configured {count} times "
+            f"(expected 1 — tool settings are global, not per-platform)"
+        )
+
+
 # ── Platform / toolset consistency ────────────────────────────────────────────
 
 

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -287,63 +287,73 @@ def test_first_install_nous_auto_configures_video_gen(monkeypatch):
     assert "video_gen" not in configured
 
 
-def test_first_install_skips_already_configured_toolsets_across_platforms(monkeypatch):
-    """Toolsets with global config (browser, TTS, etc.) should only be
-    configured once during first_install, even when multiple platforms
-    are enabled (e.g. cli + slack).  Regression test for #24069."""
-    config: dict = {
-        "model": {"provider": "openrouter"},
-        "platform_toolsets": {},
+def test_first_install_configures_shared_tools_once_per_invocation(tmp_path, monkeypatch):
+    from hermes_cli import tools_config
+    from hermes_cli.config import load_config
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "test-slack-token")
+    monkeypatch.setenv("FAL_KEY", "test-existing-image-key")
+    selections = {
+        "cli": {"browser", "image_gen", "tts"},
+        "slack": {"browser", "tts", "web"},
     }
-    # Clean env so no auto-detection adds extra platforms
-    for env_var in (
-        "TELEGRAM_BOT_TOKEN", "DISCORD_BOT_TOKEN", "SLACK_BOT_TOKEN",
-        "WHATSAPP_ENABLED", "QQ_APP_ID",
-        "VOICE_TOOLS_OPENAI_KEY", "OPENAI_API_KEY",
-        "ELEVENLABS_API_KEY", "FIRECRAWL_API_KEY", "FIRECRAWL_API_URL",
-        "TAVILY_API_KEY", "PARALLEL_API_KEY",
-        "BROWSERBASE_API_KEY", "BROWSERBASE_PROJECT_ID",
-        "BROWSER_USE_API_KEY", "FAL_KEY",
-    ):
-        monkeypatch.delenv(env_var, raising=False)
+    config = {
+        "model": {"provider": "custom"},
+        "browser": {"cloud_provider": "local"},
+        "tts": {"provider": "edge"},
+        "platform_toolsets": {platform: [] for platform in selections},
+    }
+    prompted_platforms = []
+    configured = []
 
-    # Simulate two enabled platforms: cli and slack
-    monkeypatch.setattr(
-        "hermes_cli.tools_config._get_enabled_platforms",
-        lambda: ["cli", "slack"],
-    )
-    # Both platforms select the same toolsets
-    monkeypatch.setattr(
-        "hermes_cli.tools_config._prompt_toolset_checklist",
-        lambda *args, **kwargs: {"browser", "tts", "image_gen", "web"},
-    )
-    monkeypatch.setattr(
-        "hermes_cli.tools_config.apply_nous_managed_defaults",
-        lambda config, enabled_toolsets, force_fresh: set(),
-    )
-    monkeypatch.setattr("hermes_cli.tools_config.save_config", lambda config: None)
+    def choose_tools(_label, _enabled, platform="cli", **_kwargs):
+        prompted_platforms.append(platform)
+        return selections[platform]
 
-    configured: list[str] = []
+    monkeypatch.setattr(tools_config, "_prompt_toolset_checklist", choose_tools)
+    monkeypatch.setattr(tools_config, "_configure_toolset", lambda key, _config: configured.append(key))
+
+    for _ in range(2):
+        prompted_platforms.clear()
+        configured.clear()
+        tools_command(first_install=True, config=config)
+
+        assert prompted_platforms == list(selections)
+        # Existing keys and free defaults must still offer a provider choice on the first pass.
+        assert sorted(configured) == sorted(set().union(*selections.values()))
+        saved = load_config()["platform_toolsets"]
+        assert {platform: set(saved[platform]) for platform in selections} == selections
+
+
+def test_first_install_keeps_shared_nous_defaults_without_reopening_provider_setup(tmp_path, monkeypatch):
+    from hermes_cli import tools_config
+    from hermes_cli.config import load_config
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "test-slack-token")
     monkeypatch.setattr(
-        "hermes_cli.tools_config._configure_toolset",
-        lambda ts_key, cfg: configured.append(ts_key),
+        "hermes_cli.nous_subscription.get_nous_portal_account_info",
+        lambda *args, **kwargs: NousPortalAccountInfo(
+            logged_in=True, source="jwt", fresh=False, paid_service_access=True,
+        ),
     )
+    selections = {"cli": {"browser"}, "slack": {"browser", "video_gen"}}
+    config = {"model": {"provider": "nous"}, "platform_toolsets": {key: [] for key in selections}}
+    configured = []
+    monkeypatch.setattr(
+        tools_config, "_prompt_toolset_checklist",
+        lambda _label, _enabled, platform="cli", **_kwargs: selections[platform],
+    )
+    monkeypatch.setattr(tools_config, "_configure_toolset", lambda key, _config: configured.append(key))
 
     tools_command(first_install=True, config=config)
 
-    # Each toolset should be configured exactly once, not once per platform
-    assert len(configured) == len(set(configured)), (
-        f"Duplicate toolset configuration detected: {configured}"
-    )
-    assert len(configured) > 0, "Expected at least one toolset to be configured"
-    # Verify no duplicates — each toolset appears exactly once
-    from collections import Counter
-    counts = Counter(configured)
-    for ts_key, count in counts.items():
-        assert count == 1, (
-            f"Toolset {ts_key!r} was configured {count} times "
-            f"(expected 1 — tool settings are global, not per-platform)"
-        )
+    assert configured == []
+    saved = load_config()
+    assert saved["browser"]["cloud_provider"] == "nous"
+    assert saved["video_gen"]["provider"] == "nous"
+    assert {platform: set(saved["platform_toolsets"][platform]) for platform in selections} == selections
 
 
 # ── Platform / toolset consistency ────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

With CLI and Slack enabled during first install, selecting the same browser, image, TTS or web tools opens their shared provider setup twice. Track tools handled during this invocation so each provider is configured once, while each platform keeps its own tool selection. Tools first selected on a later platform still receive setup.

This salvages #24077 by @liuhao1024. The original commit was cherry-picked with authorship preserved and adapted to the current `_first_install_flow` helper. A follow-up also handles Nous defaults: an automatically configured browser must not reopen manual provider setup on the next platform.

## Related Issue

Fixes #24069

Salvages #24077.

## Type of Change

- [x] Bug fix

## Changes Made

- `hermes_cli/tools_config.py`: configure only toolsets not yet handled in this first-install run, including tools configured automatically through Nous.
- `tests/hermes_cli/test_tools_config.py`: replace the original mock-heavy regression with two behavior tests covering shared and platform-specific selections, repeat invocations, existing credentials, free defaults and Nous defaults.

## How to Test

Enable Slack during first install and select overlapping tools in the CLI and Slack checklists. Shared provider prompts should appear once, and the saved platform selections should match each checklist.

The new tests exercise the real tools command, platform detection, config writes and reloads under a temporary `HERMES_HOME`. Interactive answers and the Nous account lookup are stubbed.

Both tests fail on base `d595e636c8`. The Nous test also fails on the adapted original fix because browser setup reopens on Slack.

```bash
scripts/run_tests.sh \
  tests/hermes_cli/test_tools_config.py \
  tests/hermes_cli/test_nous_subscription.py \
  tests/hermes_cli/test_install_identity.py \
  tests/hermes_cli/test_setup_openclaw_migration.py \
  tests/hermes_cli/test_setup_reconfigure.py \
  tests/hermes_cli/test_mcp_tools_config.py \
  -j 4 --file-retries 0 --tb=short
```

Result on macOS with Python 3.13.12: **96 passed, 6 skipped, 0 failed**. Ruff and `git diff --check` also pass. The full repository suite was not run.

## Checklist

- [x] Read the contributing guide and searched existing PRs; this explicitly builds on #24077.
- [x] Conventional commits, focused changes and original contributor credit preserved.
- [x] Added regression tests and ran the affected setup/configuration suites.
- [x] Updated the affected docstring. No new config keys or dependencies.
- [x] Considered cross-platform behavior; the change uses invocation-local set bookkeeping.
