### PR TITLE
fix(cli): warn when config get echoes an unrecognized key

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3498,6 +3498,8 @@ def set_config_value(key: str, value: str, force: bool = False):
 
 def get_config_value(key: str, *, as_json: bool = False):
     """Print a resolved configuration value."""
+    # Env keys live outside the YAML schema; only YAML paths are schema-checked below.
+    schema_known, suggestion = True, None
     if _is_env_config_key(key):
         env_value = get_env_value(key.upper())
         value = _MISSING if env_value is None else env_value
@@ -3506,9 +3508,22 @@ def get_config_value(key: str, *, as_json: bool = False):
         # See #71047.
         key, _ = _redirect_platform_display_key(key)
         value = _get_nested(load_config(), key)
+        schema_known, suggestion = _validate_config_key(key)
 
     if value is _MISSING:
         _exit_invalid(f"Config key not set: {key}")
+
+    # Unknown-key notice on the read path (#109443), mirroring the post-write notice in
+    # set_config_value (#34067): a hand-edited config.yaml can park a value at a plausible-but-
+    # wrong dotted path (``agent.tool_search.enabled`` vs ``tools.tool_search.enabled``). ``get``
+    # is the natural way to verify such an edit, so echo the value but say the runtime may never
+    # read it. stderr keeps ``--json`` stdout parseable and the exit code untouched.
+    if not schema_known:
+        print(color(
+            f"⚠ '{key}' is not a recognized config key — the value prints, "
+            "but Hermes may never read it.", Colors.YELLOW), file=sys.stderr)
+        if suggestion:
+            print(color(f"  Did you mean: {suggestion}", Colors.YELLOW), file=sys.stderr)
 
     print(_format_config_get_value(value, as_json=as_json))
 

--- a/tests/hermes_cli/test_config_get_unknown_key_notice.py
+++ b/tests/hermes_cli/test_config_get_unknown_key_notice.py
@@ -1,0 +1,92 @@
+"""Regression tests for #109443: `hermes config get` must notice unknown keys.
+
+A hand-edited config.yaml can park a value at a plausible-but-wrong dotted path
+(``agent.tool_search.enabled`` where the runtime reads ``tools.tool_search.enabled``).
+``hermes config get`` is the natural way to verify such an edit, and previously
+echoed the value back with no hint that the runtime would never read it.
+``set_config_value`` already prints a post-write unknown-key notice (#34067);
+the read path now mirrors it on stderr, leaving stdout (and ``--json``) intact.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    """Temp HERMES_HOME whose config.yaml carries the wrong-path edit from #109443."""
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(yaml.dump({
+        "agent": {"tool_search": {"enabled": False}},
+        "tools": {"tool_search": {"enabled": "off"}},
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def _get(key: str, *, as_json: bool = False):
+    from hermes_cli.config import get_config_value
+    get_config_value(key, as_json=as_json)
+
+
+class TestGetUnknownKeyNotice:
+    def test_wrong_nested_path_prints_notice_but_echoes_value(self, hermes_home, capsys):
+        """agent.tool_search.enabled prints its value AND warns the runtime never reads it."""
+        _get("agent.tool_search.enabled")
+
+        out = capsys.readouterr()
+        assert 'false' in out.out
+        assert "not a recognized config key" in out.err
+        assert "agent.tool_search.enabled" in out.err
+
+    def test_known_nested_path_no_notice(self, hermes_home, capsys):
+        """The real path tools.tool_search.enabled stays notice-free."""
+        _get("tools.tool_search.enabled")
+
+        out = capsys.readouterr()
+        assert "not a recognized config key" not in out.err
+
+    def test_json_stdout_stays_parseable(self, hermes_home, capsys):
+        """--json output must remain machine-parseable; the notice goes to stderr."""
+        _get("agent.tool_search.enabled", as_json=True)
+
+        out = capsys.readouterr()
+        assert yaml.safe_load(out.out) is False
+        assert "not a recognized config key" in out.err
+
+    def test_env_key_immune_to_schema_notice(self, hermes_home, monkeypatch, capsys):
+        """Env-routed keys live outside the YAML schema and must not be flagged."""
+        monkeypatch.setenv("HERMES_TEST_TOKEN", "tok")
+        _get("hermes_test_token")
+
+        out = capsys.readouterr()
+        assert "tok" in out.out
+        assert "not a recognized config key" not in out.err
+
+    def test_missing_key_still_errors(self, hermes_home, capsys):
+        """The pre-existing MISSING behavior (exit 1) is unchanged."""
+        with pytest.raises(SystemExit) as exc:
+            _get("agent.tool_search.does_not_exist")
+        assert exc.value.code == 1
+
+        out = capsys.readouterr()
+        assert "Config key not set" in out.err
+
+    def test_notice_suggests_typo_sibling_when_close(self, tmp_path, monkeypatch, capsys):
+        """A near-miss sub-key keeps the set-path did-you-mean behavior (gateway.discord.*)."""
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text(yaml.dump({
+            "gateway": {"strict": True, "trust_recent_file": False},
+        }))
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        _get("gateway.trust_recent_file")
+
+        out = capsys.readouterr()
+        assert 'false' in out.out
+        assert "not a recognized config key" in out.err
+        assert "trust_recent_files" in out.err


### PR DESCRIPTION
## What does this PR do?

`hermes config set` has printed a post-write unknown-key notice since #34067, but `hermes config get` echoed any stored value with no hint at all. That made `get` the perfect false-confidence machine for hand-edited config.yaml files: the #109443 report parks `agent.tool_search.enabled: false` at a plausible-but-wrong dotted path (the runtime reads `tools.tool_search.enabled`), then verifies the edit with `hermes config get agent.tool_search.enabled` — which echoes `false` back and looks exactly like a setting that took effect.

This mirrors the set-path notice on the read path. When the resolved value exists but `_validate_config_key` says the dotted path is outside the schema, `get` still prints the value (non-blocking, exit code untouched) and adds a stderr notice, including the existing did-you-mean sibling when one is close. Env-routed keys (`_is_env_config_key`) are exempt since they live outside the YAML schema. The notice goes to stderr so `--json` stdout stays machine-parseable.

## Related Issue

Fixes #109443

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config.py` — `get_config_value`: validate the YAML path via the existing `_validate_config_key` and print a #34067-style unknown-key notice to stderr (with suggestion when available); env-key branch and MISSING-path behavior unchanged
- `tests/hermes_cli/test_config_get_unknown_key_notice.py` — regression tests: notice fires for the wrong-path key while the value still echoes, known paths and env keys stay notice-free, `--json` stdout stays parseable, missing-key exit behavior unchanged, did-you-mean sibling appears for near-miss sub-keys

## How to Test

1. Put the wrong-path edit from the report into `~/.hermes/config.yaml`:
   ```yaml
   agent:
     tool_search:
       enabled: false
   ```
2. Run `hermes config get agent.tool_search.enabled` — should print `false` on stdout **and** `⚠ 'agent.tool_search.enabled' is not a recognized config key — the value prints, but Hermes may never read it.` on stderr (observed result: notice present, exit code 0)
3. Run `hermes config get tools.tool_search.enabled` — no notice (observed result: clean echo)
4. Run `hermes config get agent.tool_search.enabled --json` — stdout is pure JSON, notice stays on stderr (observed result: `false` on stdout, notice on stderr)
5. `pytest tests/hermes_cli/test_config_get_unknown_key_notice.py tests/hermes_cli/test_set_config_value.py tests/hermes_cli/test_config_set_platforms_redirect.py -q` — should pass (observed result: 103 passed)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ hermes config get agent.tool_search.enabled
⚠ 'agent.tool_search.enabled' is not a recognized config key — the value prints, but Hermes may never read it.
false
```