### PR TITLE
fix(vault): resolve 1Password vaults from fresh item metadata

### DIFF
--- a/agent/vault_backends/onepassword.py
+++ b/agent/vault_backends/onepassword.py
@@ -4,7 +4,8 @@ Unlock: ``op signin --raw`` with the master password on stdin (desktop-app
 integration or account-level auth) mints an ``OP_SESSION_<account>`` token.
 A configured service-account token skips the prompt entirely (headless).
 List: ``op item list --categories Login --format json`` → title, urls,
-username. Resolve: ``op item get <id> --fields label=password --reveal``.
+username. Resolve: ``op item get <id> --vault <vault-id> ...``, selecting the
+item's vault from fresh listing metadata (required for service accounts).
 """
 
 from __future__ import annotations
@@ -118,14 +119,38 @@ class OnePasswordLoginBackend(LoginBackend):
     def get_meta(self, handle: str) -> Optional[VaultItemMeta]:
         return next((m for m in self.list_items() if m.id == handle), None)
 
-    def resolve_password(self, handle: str) -> str:
+    def _item_selector(self, handle: str) -> List[str]:
+        # Keep existing op:<item-id> handles valid, including across backend instances.
+        # Resolve from fresh metadata rather than caching a vault or guessing the first one.
+        if not handle.startswith(self.prefix):
+            raise ValueError("Invalid 1Password login handle")
         item_id = handle[len(self.prefix):]
-        return self._run("item", "get", item_id, "--fields", "label=password", "--reveal").rstrip("\r\n")
+        if not item_id or not item_id[0].isalnum() or not all(
+            c.isascii() and (c.isalnum() or c == "-") for c in item_id
+        ):
+            raise ValueError("Invalid 1Password login handle")
+        raw = json.loads(self._run("item", "list", "--categories", "Login", "--format", "json") or "[]")
+        if not isinstance(raw, list):
+            raise RuntimeError("Invalid 1Password login metadata")
+        matches = [item for item in raw if isinstance(item, dict) and item.get("id") == item_id]
+        if len(matches) != 1:
+            raise RuntimeError("1Password login is missing or ambiguous; list logins again")
+        vault = matches[0].get("vault")
+        vault_id = vault.get("id") if isinstance(vault, dict) else None
+        if isinstance(vault_id, str) and vault_id:
+            return [item_id, "--vault", vault_id]
+        if self._service_token:
+            raise RuntimeError("1Password login metadata is missing its vault ID; list logins again")
+        return [item_id]
+
+    def resolve_password(self, handle: str) -> str:
+        return self._run("item", "get", *self._item_selector(handle),
+                         "--fields", "label=password", "--reveal").rstrip("\r\n")
 
     def resolve_otp(self, handle: str) -> Optional[str]:
         # `--otp` mints the current TOTP from the item's one-time-password field; items without one error out.
         try:
-            code = self._run("item", "get", handle[len(self.prefix):], "--otp").strip()
+            code = self._run("item", "get", *self._item_selector(handle), "--otp").strip()
         except Exception:
             return None
         return code if code.isdigit() else None

--- a/tests/agent/test_vault_onepassword_selector.py
+++ b/tests/agent/test_vault_onepassword_selector.py
@@ -1,0 +1,92 @@
+"""Metadata-only selector regressions; no real password manager is invoked."""
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+
+from agent.vault_backends.onepassword import OnePasswordLoginBackend
+
+
+def item(item_id="item-a", vault: object = "vault-a"):
+    return {"id": item_id, "title": "Example", "vault": {"id": vault},
+            "urls": [{"href": "https://example.com/login"}]}
+
+
+@pytest.fixture
+def backend():
+    with patch("agent.secret_scope.get_secret", return_value="dummy-service-token"):
+        backend = OnePasswordLoginBackend()
+    backend._run = Mock()
+    return backend
+
+
+@pytest.mark.parametrize("method,flags,value", [
+    ("resolve_password", ("--fields", "label=password", "--reveal"), "dummy-password"),
+    ("resolve_otp", ("--otp",), "123456"),
+])
+def test_legacy_handles_resolve_each_items_vault(backend, method, flags, value):
+    records = [item(), item("item-b", "vault-b")]
+    backend._run.return_value = json.dumps(records)
+    assert [m.id for m in backend.list_items()] == ["op:item-a", "op:item-b"]
+    assert backend.get_meta("op:item-b").origin == "https://example.com"
+    for item_id, vault_id in [("item-a", "vault-a"), ("item-b", "vault-b")]:
+        backend._run.reset_mock()
+        backend._run.side_effect = [json.dumps(records), value + "\r\n"]
+        assert getattr(backend, method)("op:" + item_id) == value
+        assert backend._run.call_args_list[0].args == (
+            "item", "list", "--categories", "Login", "--format", "json")
+        assert backend._run.call_args_list[1].args == (
+            "item", "get", item_id, "--vault", vault_id, *flags)
+
+
+@pytest.mark.parametrize("records", [
+    [], [item("other")], [item(vault="")], [item(vault=None)],
+    [dict(item(), vault=None)], [dict(item(), vault="not-a-record")],
+    [item(), item(vault="vault-b")], {"error": "not-a-list"},
+])
+@pytest.mark.parametrize("method", ["resolve_password", "resolve_otp"])
+def test_missing_or_ambiguous_metadata_never_reads_secret(backend, records, method):
+    backend._run.return_value = json.dumps(records)
+    if method == "resolve_password":
+        with pytest.raises(RuntimeError):
+            backend.resolve_password("op:item-a")
+    else:
+        assert backend.resolve_otp("op:item-a") is None
+    assert all(c.args[:2] != ("item", "get") for c in backend._run.call_args_list)
+
+
+@pytest.mark.parametrize("method", ["resolve_password", "resolve_otp"])
+@pytest.mark.parametrize("failure", [RuntimeError("metadata unavailable"), "not-json", "[]"])
+def test_refresh_failure_does_not_reuse_old_vault(backend, method, failure):
+    backend._run.return_value = json.dumps([item()])
+    backend.list_items()
+    backend._run.reset_mock()
+    backend._run.side_effect = [failure]
+    if method == "resolve_password":
+        with pytest.raises((RuntimeError, ValueError)):
+            backend.resolve_password("op:item-a")
+    else:
+        assert backend.resolve_otp("op:item-a") is None
+    assert all(c.args[:2] != ("item", "get") for c in backend._run.call_args_list)
+
+
+@pytest.mark.parametrize("handle", ["bw:item-a", "op:", "op:--help", "op:vault-a:item-a"])
+def test_invalid_handles_fail_before_cli(backend, handle):
+    with pytest.raises(ValueError):
+        backend.resolve_password(handle)
+    assert backend.resolve_otp(handle) is None
+    backend._run.assert_not_called()
+
+
+def test_personal_session_without_vault_keeps_unscoped_read(backend):
+    backend._service_token = ""
+    backend._run.side_effect = [json.dumps([item(vault="")]), "dummy-password\n"]
+    assert backend.resolve_password("op:item-a") == "dummy-password"
+    assert backend._run.call_args.args == (
+        "item", "get", "item-a", "--fields", "label=password", "--reveal")
+
+
+def test_fresh_backend_does_not_depend_on_listing_cache(backend):
+    backend._run.side_effect = [json.dumps([item(vault="vault-new")]), "dummy-password\n"]
+    assert backend.resolve_password("op:item-a") == "dummy-password"
+    assert backend._run.call_args.args[3:5] == ("--vault", "vault-new")

--- a/tests/agent/test_vault_onepassword_subprocess.py
+++ b/tests/agent/test_vault_onepassword_subprocess.py
@@ -1,0 +1,184 @@
+"""Exercise the login backend through run_cli and an offline executable, not mocks."""
+import json
+import logging
+import os
+from contextlib import contextmanager
+from pathlib import Path
+import sys
+
+import pytest
+
+from agent import secret_scope
+from agent.vault_backends.base import UnlockRequired
+from agent.vault_backends.onepassword import OnePasswordLoginBackend
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+@pytest.fixture
+def fake_op(tmp_path, monkeypatch, caplog):
+    # Pin the executable and all home paths: never discover a developer's real op.
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    for key in list(os.environ):
+        if key.startswith("OP_"):
+            monkeypatch.delenv(key)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-a"))
+    monkeypatch.setenv("OP_SERVICE_ACCOUNT_TOKEN", "dummy-launch-token")
+    monkeypatch.setenv("OP_CONNECT_TOKEN", "dummy-launch-connect-token")
+    monkeypatch.setenv("OP_CONNECT_HOST", "https://invalid.example")
+    monkeypatch.setenv("OP_SESSION_other", "dummy-launch-session")
+    monkeypatch.setenv("UNRELATED_API_KEY", "dummy-unrelated-key")
+    profiles = {}
+    for name in ("a", "b", "empty"):
+        home = tmp_path / f"profile-{name}"
+        home.mkdir()
+        home.joinpath(".env").write_text(
+            "" if name == "empty" else f"OP_SERVICE_ACCOUNT_TOKEN=dummy-profile-{name}-token\n"
+        )
+        profiles[name] = home
+    state = tmp_path / "state.json"
+    state.write_text(json.dumps({"mode": "ok", "vault": "vault-b"}))
+    audit = tmp_path / "audit.jsonl"
+    executable = tmp_path / "op"
+    executable.write_text(f"#!{sys.executable}\n" + r'''
+import json
+import os
+from pathlib import Path
+import sys
+
+root = Path(__file__).parent
+state = json.loads((root / "state.json").read_text())
+args = sys.argv[1:]
+token = os.environ.get("OP_SERVICE_ACCOUNT_TOKEN")
+identity = next((name for name in ("a", "b")
+                 if token == "dummy-profile-" + name + "-token"), None)
+record = {"argv": args, "identity": identity, "stdin_eof": sys.stdin.read() == "",
+          "unexpected_env": sorted(k for k in os.environ
+              if k.startswith("OP_CONNECT_") or k.startswith("OP_SESSION")
+              or k == "UNRELATED_API_KEY")}
+with (root / "audit.jsonl").open("a") as stream:
+    stream.write(json.dumps(record) + "\n")
+if identity is None or record["unexpected_env"]:
+    print("authentication rejected", file=sys.stderr)
+    sys.exit(1)
+if args == ["item", "list", "--categories", "Login", "--format", "json"]:
+    records = [{"id": "item-a", "title": "First", "vault": {"id": "vault-a"},
+                "urls": [{"href": "https://first.example/login"}]},
+               {"id": "item-b", "title": "Second", "vault": {"id": state["vault"]},
+                "urls": [{"href": "https://second.example/login"}]}]
+    if state["mode"] == "ambiguous":
+        records.append(dict(records[1], vault={"id": "wrong-vault"}))
+    print(json.dumps(records))
+elif args[:3] == ["item", "get", "item-b"] and args[3:5] == ["--vault", state["vault"]]:
+    if state["mode"] == "error":
+        # Secret-bearing stdout from a failed command must not become diagnostics.
+        print(token + " dummy-password")
+        print("synthetic read failure", file=sys.stderr)
+        sys.exit(1)
+    if args[5:] == ["--fields", "label=password", "--reveal"]:
+        print("dummy-password")
+    elif args[5:] == ["--otp"]:
+        print("123456")
+    else:
+        sys.exit(2)
+else:
+    print("unexpected selector", file=sys.stderr)
+    sys.exit(2)
+''')
+    executable.chmod(0o700)
+    caplog.set_level(logging.DEBUG)
+    previous = secret_scope.is_multiplex_active()
+    secret_scope.set_multiplex_active(True)
+
+    @contextmanager
+    def profile(name):
+        home_token = set_hermes_home_override(profiles[name])
+        scope_token = secret_scope.set_secret_scope(
+            secret_scope.load_env_file(profiles[name] / ".env")
+        )
+        try:
+            yield OnePasswordLoginBackend({"binary_path": str(executable)})
+        finally:
+            secret_scope.reset_secret_scope(scope_token)
+            reset_hermes_home_override(home_token)
+
+    def calls():
+        return [json.loads(line) for line in audit.read_text().splitlines()] if audit.exists() else []
+
+    try:
+        yield profile, calls, state
+    finally:
+        secret_scope.set_multiplex_active(previous)
+
+
+def assert_no_secret_diagnostics(capfd, caplog, *diagnostics):
+    captured = capfd.readouterr()
+    text = captured.out + captured.err + caplog.text + repr(diagnostics)
+    for secret in ("dummy-profile-a-token", "dummy-profile-b-token", "dummy-launch-token",
+                   "dummy-launch-connect-token", "dummy-launch-session", "dummy-password"):
+        assert secret not in text
+
+
+@pytest.mark.parametrize("fake_op", [
+    pytest.param(None, marks=pytest.mark.linux_only, id="linux"),
+    pytest.param(None, marks=pytest.mark.macos_only, id="macos"),
+], indirect=True)
+def test_real_subprocess_selects_fresh_vault_and_keeps_secrets_private(fake_op, capfd, caplog):
+    profile, calls, state = fake_op
+    with profile("a") as backend:
+        metadata = backend.list_items()
+        assert [item.id for item in metadata] == ["op:item-a", "op:item-b"]
+        assert backend.get_meta("op:item-b").origin == "https://second.example"
+        assert backend.resolve_password("op:item-b") == "dummy-password"
+        # An already-issued handle must use newly listed metadata, not a cached vault.
+        state.write_text(json.dumps({"mode": "ok", "vault": "vault-moved"}))
+        assert backend.resolve_otp("op:item-b") == "123456"
+        state.write_text(json.dumps({"mode": "error", "vault": "vault-moved"}))
+        with pytest.raises(RuntimeError, match="synthetic read failure") as error:
+            backend.resolve_password("op:item-b")
+        assert backend.resolve_otp("op:item-b") is None
+        before = len(calls())
+        state.write_text(json.dumps({"mode": "ambiguous", "vault": "vault-moved"}))
+        with pytest.raises(RuntimeError, match="missing or ambiguous") as ambiguous:
+            backend.resolve_password("op:item-b")
+        assert backend.resolve_otp("op:item-b") is None
+        assert all(row["argv"][1] == "list" for row in calls()[before:])
+    rows = calls()
+    gets = [row["argv"] for row in rows if row["argv"][1] == "get"]
+    assert gets == [
+        ["item", "get", "item-b", "--vault", "vault-b", "--fields", "label=password", "--reveal"],
+        ["item", "get", "item-b", "--vault", "vault-moved", "--otp"],
+        ["item", "get", "item-b", "--vault", "vault-moved", "--fields", "label=password", "--reveal"],
+        ["item", "get", "item-b", "--vault", "vault-moved", "--otp"],
+    ]
+    assert all(row["identity"] == "a" and row["stdin_eof"] and not row["unexpected_env"] for row in rows)
+    assert_no_secret_diagnostics(capfd, caplog, metadata, str(error.value), str(ambiguous.value), rows)
+
+
+@pytest.mark.parametrize("fake_op", [
+    pytest.param(None, marks=pytest.mark.linux_only, id="linux"),
+    pytest.param(None, marks=pytest.mark.macos_only, id="macos"),
+], indirect=True)
+def test_real_subprocess_auth_is_scoped_and_empty_profile_fails_closed(fake_op, capfd, caplog):
+    profile, calls, _ = fake_op
+    for name in ("a", "b", "a"):
+        with profile(name) as backend:
+            assert backend.resolve_password("op:item-b") == "dummy-password"
+        assert [row["identity"] for row in calls()[-2:]] == [name, name]
+    before = calls()
+    with profile("empty") as backend:
+        assert not backend.is_unlocked()
+        assert backend.list_items() == []
+        with pytest.raises(UnlockRequired) as error:
+            backend.resolve_password("op:item-b")
+        assert backend.resolve_otp("op:item-b") is None
+    assert calls() == before  # No fallback to launch credentials or another profile.
+    token = secret_scope.set_secret_scope(None)
+    try:
+        with pytest.raises(secret_scope.UnscopedSecretError) as unscoped:
+            OnePasswordLoginBackend()
+    finally:
+        secret_scope.reset_secret_scope(token)
+    assert calls() == before
+    assert all(row["stdin_eof"] and not row["unexpected_env"] for row in before)
+    assert_no_secret_diagnostics(capfd, caplog, str(error.value), str(unscoped.value), before)


### PR DESCRIPTION
## Summary
Fix service-account password and OTP reads by looking up the requested item's vault ID from fresh `op item list` metadata and supplying `--vault` to `op item get`.

- Keep existing `op:<item-id>` handles unchanged, including `get_meta` lookup and newly constructed backend instances.
- Support items from multiple accessible vaults without a global vault configuration.
- Refuse secret reads when fresh metadata fails, the item is missing/ambiguous, or service-account metadata lacks a vault ID. No cached selector or arbitrary first-vault fallback.
- Share the selector between password and OTP resolution. Existing OTP failure-to-None behavior is preserved.
- Preserve session-token compatibility when older metadata lacks a vault ID. Browser exact-origin checks and secret injection paths are unchanged.

## Relationship to existing work
Related to #108335; alternative to #108339 and #108343. Those PRs were reviewed before preparing this change. #108339 requires a global selector and cannot select each listed item's vault automatically. #108343 encodes vault IDs into new handles; previously issued handles do not match `get_meta`, and its legacy read path still omits `--vault`. This version keeps the deployed handle contract and revalidates metadata at resolution time. It is separate from the unrelated shadow-DOM fix #109425.

## Verification
- Red: all 30 new regression cases failed against the unchanged backend (including missing selector, unguarded reads, and invalid handles).
- Green: **99 passed, 0 failed**, using the canonical isolated runner with file retries disabled:
  ```sh
  HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
    tests/agent/test_vault_onepassword_selector.py \
    tests/agent/test_vault_backends.py tests/test_browser_vault.py \
    tests/test_onepassword_secrets.py tests/tui_gateway/test_vault_methods.py
  ```
- `git diff --check` passed.
- A full-suite attempt was stopped at a 45-second timebox; no full-suite pass is claimed.
- Tests use mocked metadata and dummy secrets only. No real password or OTP was read during implementation/testing.
- The tested production delta was applied to the local active installation and verified byte-for-byte against the commit; no gateway restart or actual-site login verification is claimed.

AI-assisted implementation and testing.
