### PR TITLE
fix(models): allow Priority Processing on the SuperGrok OAuth route

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1096,7 +1096,11 @@ def _fast_mode_route_supported(
     if _is_anthropic_fast_model(model_id):
         allowed = {"anthropic": "api.anthropic.com"}
     elif is_grok_46_family(str(model_id or "")):
-        allowed = {"xai": "api.x.ai"}
+        # BOTH first-party xAI routes bill Priority Processing. ``xai-oauth`` is its own provider
+        # id — normalize_provider folds grok-oauth / x-ai-oauth / xai-grok-oauth into it, never
+        # into ``xai`` — so listing only ``xai`` withheld /fast from every SuperGrok OAuth
+        # session while model_supports_fast_mode still reported the model as fast-capable.
+        allowed = {"xai": "api.x.ai", "xai-oauth": "api.x.ai"}
     else:
         allowed = {"openai": "api.openai.com", "openai-codex": "chatgpt.com"}
     if provider and normalize_provider(provider) not in allowed:

--- a/tests/agent/test_fast_mode_auto.py
+++ b/tests/agent/test_fast_mode_auto.py
@@ -141,3 +141,39 @@ def test_fast_auto_and_cold_parse_and_slash_command(monkeypatch):
     route_stub.base_url = "https://openrouter.ai/api/v1"
     route_stub.provider = "openrouter"
     assert cli_mod.HermesCLI._resolve_turn_agent_config(route_stub, "hi")["request_overrides"] is None
+
+
+def test_grok_46_priority_covers_the_supergrok_oauth_route():
+    """``xai-oauth`` is a distinct provider id from ``xai``; both are first-party api.x.ai.
+
+    ``normalize_provider`` folds ``grok-oauth`` / ``x-ai-oauth`` / ``xai-grok-oauth`` into
+    ``xai-oauth`` — never into ``xai`` — so allow-listing only ``xai`` withholds Priority
+    Processing from every SuperGrok OAuth session while ``model_supports_fast_mode`` still
+    reports the model as fast-capable. The toggle is then offered and silently does nothing.
+    """
+    from hermes_cli.models import normalize_provider, resolve_fast_mode_overrides
+
+    oauth_ids = ("xai-oauth", "grok-oauth", "x-ai-oauth", "xai-grok-oauth")
+    assert [normalize_provider(p) for p in oauth_ids] == ["xai-oauth"] * len(oauth_ids)
+
+    for provider in ("xai", *oauth_ids):
+        assert resolve_fast_mode_overrides(
+            "grok-4.6", provider=provider, base_url="https://api.x.ai/v1"
+        ) == {"service_tier": "priority"}, provider
+
+
+def test_grok_46_priority_stays_closed_off_the_first_party_host():
+    """Widening the provider allow-list must not widen the host check."""
+    from hermes_cli.models import resolve_fast_mode_overrides
+
+    for provider, base_url in (
+        ("xai-oauth", "http://127.0.0.1:8000/v1"),
+        ("xai-oauth", "https://proxy.example.com/v1"),
+        ("openrouter", "https://openrouter.ai/api/v1"),
+    ):
+        assert resolve_fast_mode_overrides("grok-4.6", provider=provider, base_url=base_url) is None, (
+            provider, base_url)
+
+    # Only the Grok 4.6 family bills Priority Processing.
+    assert resolve_fast_mode_overrides(
+        "grok-4.5", provider="xai-oauth", base_url="https://api.x.ai/v1") is None


### PR DESCRIPTION
## What does this PR do?

`_fast_mode_route_supported` is the single route gate behind `/fast`, `agent.service_tier`, and the desktop/TUI Fast toggle. It allow-lists the Grok 4.6 family at `api.x.ai` — but it named only the `xai` provider id.

`xai-oauth` (SuperGrok / Premium+) is a **distinct** provider id: `normalize_provider` folds `grok-oauth`, `x-ai-oauth` and `xai-grok-oauth` into `xai-oauth`, never into `xai`. So every first-party OAuth session fell through the allow-list and got no fast-mode override, while the model-level check still reported the model as fast-capable:

```python
model_supports_fast_mode("grok-4.6")                                          # True
resolve_fast_mode_overrides("grok-4.6", provider="xai-oauth",
                            base_url="https://api.x.ai/v1")
# before: None                     after: {"service_tier": "priority"}
```

What the user actually hits, because the two checks disagree:

- **Desktop** — flipping Fast in the composer errors out: `config.set key=fast` returns `"fast mode is not available for this model"` (`tui_gateway/methods_config_set.py`). The toggle is visible and unusable.
- **CLI / gateway** — `/fast` and `agent.service_tier: priority` are accepted, then the param is dropped at the turn route: the request goes out at the standard tier, at standard pricing, with no warning.

`c7e2e0b779` salvaged #89960, whose own allow-list was described as "xAI (`xai`/`xai-oauth` @ `api.x.ai`)". The OAuth entry was lost in the salvage and has never appeared in that dict anywhere in the repo's history (`git log -S 'xai-oauth": "api.x.ai' -- hermes_cli/models.py` → empty). This restores the documented intent.

Scope: the host check is untouched, so aggregators (OpenRouter, Nous, Copilot, Azure, Bedrock) and self-hosted proxies still fail closed, and older Grok ids still do not bill flex/priority.

## Related Issue

Fixes #89440

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/models.py` — `_fast_mode_route_supported`: the Grok 4.6 family allow-list is now `{"xai": "api.x.ai", "xai-oauth": "api.x.ai"}` (was `{"xai": "api.x.ai"}`), plus a comment recording why the two ids are not interchangeable.
- `tests/agent/test_fast_mode_auto.py` — two invariants:
  - `test_grok_46_priority_covers_the_supergrok_oauth_route` — pins the `normalize_provider` identity (`grok-oauth`/`x-ai-oauth`/`xai-grok-oauth` → `xai-oauth`) and asserts all five first-party ids resolve to `{"service_tier": "priority"}`.
  - `test_grok_46_priority_stays_closed_off_the_first_party_host` — widening the provider list must not widen the host check: `xai-oauth` @ a loopback/proxy host, `openrouter`, and `grok-4.5` all stay `None`.

## How to Test

The first test is proven **red on base** (`d595e636c8`) and green with the fix:

```text
# base, test only
tests/agent/test_fast_mode_auto.py::test_grok_46_priority_covers_the_supergrok_oauth_route
E   AssertionError: xai-oauth
E   assert None == {'service_tier': 'priority'}
1 failed, 3 passed

# base + fix
bash scripts/run_tests.sh tests/agent/test_fast_mode_auto.py tests/cli/test_fast_command.py   tests/gateway/test_fast_command.py tests/gateway/test_turn_request_overrides.py   tests/gateway/test_custom_provider_request_overrides.py   tests/tui_gateway/test_fast_session_scope.py            ->  45 passed
```

Repro on a live SuperGrok OAuth account (the affected route):

```python
from hermes_cli.models import resolve_fast_mode_overrides
resolve_fast_mode_overrides("grok-4.6", provider="xai-oauth", base_url="https://api.x.ai/v1")
# main: None   -> the desktop Fast toggle errors, /fast is a no-op
# here: {'service_tier': 'priority'}
```

Note on the model id: there is no `grok-4.6-fast` slug (404 on both the API-key and OAuth routes). xAI's "fast" is Priority Processing — the `service_tier: "priority"` request field at 2x token rates, echoed back as `"service_tier": "priority"` when honoured. So this PR fixes the route gate only; the request field and the `xhigh` xAI reasoning ceiling were already landed with #84799.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run**: the full suite was not executed locally on Windows 11; the six fast-mode-adjacent files above pass (45/45). CI is the first full run.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (git-bash), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behaviour contract unchanged; the comment records the why)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure resolution logic, no OS-specific paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ python -c "from hermes_cli.models import resolve_fast_mode_overrides as r; print(r('grok-4.6', provider='xai-oauth', base_url='https://api.x.ai/v1'))"
{'service_tier': 'priority'}      # main returns None
```

Related: #107357 (opt-in trusted endpoints for self-hosted proxies) touches the same gate from the other direction — that work stays fail-closed here.
