### PR TITLE
fix(skills): repair GitHub consolidation callers and persisted skill loading

### DIFF
--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2912,7 +2912,7 @@ export const en: Translations = {
     githubSuggestions: {
       label: 'Set up GitHub',
       tip: 'GitHub works through the gh CLI skills here — click to connect your account',
-      done: 'Added /github-auth',
+      done: 'Added /github',
       doneTip: 'Send the message and the agent walks you through GitHub sign-in'
     },
     repairSuggestions: {

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -2754,7 +2754,7 @@ export const ru = defineLocale({
     githubSuggestions: {
       label: 'Настроить GitHub',
       tip: 'GitHub работает через навыки gh CLI здесь — нажмите, чтобы подключить аккаунт',
-      done: 'Добавлено /github-auth',
+      done: 'Добавлено /github',
       doneTip: 'Отправьте сообщение, и агент проведёт вас через вход в GitHub'
     },
     repairSuggestions: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3068,7 +3068,7 @@ export const zh = defineLocale({
     githubSuggestions: {
       label: '设置 GitHub',
       tip: '这里通过 gh CLI 技能使用 GitHub — 点击连接你的账号',
-      done: '已添加 /github-auth',
+      done: '已添加 /github',
       doneTip: '发送消息后，agent 将引导你完成 GitHub 登录'
     },
     repairSuggestions: {

--- a/apps/desktop/src/lib/mcp-directory.ts
+++ b/apps/desktop/src/lib/mcp-directory.ts
@@ -15,9 +15,10 @@
  *
  * GitHub is intentionally absent (here AND in the catalog): its hosted MCP
  * requires each MCP host to provide its own OAuth app (generic Dynamic
- * Client Registration 404s at /register), and the bundled github/* skills
- * via the gh CLI are the more capable integration. The composer's github
- * suggestion provider offers the `github-auth` skill instead.
+ * Client Registration 404s at /register), and the bundled consolidated
+ * `github` skill via the gh CLI is the more capable integration. The
+ * composer's github suggestion provider offers the `github` skill
+ * (auth workflow) instead.
  */
 export interface McpDirectoryEntry {
   /** Server name as it will appear in mcp_servers config. */

--- a/apps/desktop/src/store/suggestion-providers/github.test.ts
+++ b/apps/desktop/src/store/suggestion-providers/github.test.ts
@@ -1,6 +1,36 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { githubHit } from './github'
+import type { DraftProvider } from '@/store/composer-suggestions'
+
+const mocks = vi.hoisted(() => ({
+  getGhAuthStatus: vi.fn(),
+  registerDraftProvider: vi.fn(),
+  requestComposerFocus: vi.fn(),
+  requestComposerInsert: vi.fn()
+}))
+
+vi.mock('@/hermes', () => ({ getGhAuthStatus: mocks.getGhAuthStatus }))
+vi.mock('@/store/composer-suggestions', () => ({ registerDraftProvider: mocks.registerDraftProvider }))
+vi.mock('@/app/chat/composer/focus', () => ({
+  requestComposerFocus: mocks.requestComposerFocus,
+  requestComposerInsert: mocks.requestComposerInsert
+}))
+
+import { githubHit, invalidateGithubSuggestionIndex } from './github'
+
+it('offers the consolidated GitHub skill for sign-in and inserts it only on invocation', async () => {
+  invalidateGithubSuggestionIndex()
+  mocks.getGhAuthStatus.mockResolvedValue({ authenticated: false })
+  const provider = mocks.registerDraftProvider.mock.calls.find(([name]) => name === 'github')?.[1] as DraftProvider
+
+  const suggestions = await provider({ sessionId: null, text: 'connect github please' })
+
+  expect(suggestions).toHaveLength(1)
+  expect(mocks.requestComposerInsert).not.toHaveBeenCalled()
+  await suggestions[0].invoke({ cancelled: () => false, sessionId: null })
+  expect(mocks.requestComposerInsert).toHaveBeenCalledExactlyOnceWith('/github ', { mode: 'prefix' })
+  expect(mocks.requestComposerFocus).toHaveBeenCalledOnce()
+})
 
 describe('githubHit', () => {
   it('matches a completed whole-word github mention', () => {

--- a/apps/desktop/src/store/suggestion-providers/github.ts
+++ b/apps/desktop/src/store/suggestion-providers/github.ts
@@ -9,17 +9,18 @@ import { type ComposerSuggestion, registerDraftProvider } from '@/store/composer
  * GitHub has no entry in the MCP catalog and never gets a connect pill: its
  * hosted MCP requires a per-host OAuth app (generic Dynamic Client
  * Registration 404s at /register), and more importantly the bundled
- * github/* skills driving the `gh` CLI are a strictly more capable
+ * consolidated `github` skill driving the `gh` CLI is a strictly more capable
  * integration (PRs, reviews, issues, releases, workflows) than the remote
  * MCP's tool surface. So when the draft signals GitHub intent, the right
- * offer is onboarding onto the skills:
+ * offer is onboarding onto the skill:
  *
- * - `gh` already authenticated → no pill. The skills just work; suggesting
+ * - `gh` already authenticated → no pill. The skill just works; suggesting
  *   setup at an already-set-up user is noise.
- * - not authenticated (or gh missing) → offer the `github-auth` skill. The
- *   invoke prefixes the draft with `/github-auth` (same reversible,
- *   never-sends-on-your-behalf contract as the skill provider) and the
- *   agent walks the user through `gh auth login` / install.
+ * - not authenticated (or gh missing) → offer the `github` skill (auth
+ *   workflow in references/auth.md). The invoke prefixes the draft with
+ *   `/github` (same reversible, never-sends-on-your-behalf contract as the
+ *   skill provider) and the agent walks the user through `gh auth login` /
+ *   install.
  *
  * The auth probe is served by `GET /api/git/gh-auth` (cached backend-side);
  * a probe failure (older backend, transient error) suggests nothing rather
@@ -27,7 +28,7 @@ import { type ComposerSuggestion, registerDraftProvider } from '@/store/composer
  */
 
 const AUTH_TTL_MS = 5 * 60_000
-const SKILL_NAME = 'github-auth'
+const SKILL_NAME = 'github'
 
 let needsSetup: boolean | null = null
 let checkedAt = 0
@@ -83,8 +84,8 @@ function toSuggestion(): ComposerSuggestion {
     id: SKILL_NAME,
     invoke: async () => {
       // Prefix, don't replace — and never send. The agent takes over when
-      // the user sends: the github-auth skill installs gh if needed and
-      // runs the device-code OAuth flow.
+      // the user sends: the github skill (auth reference) installs gh if
+      // needed and runs the device-code OAuth flow.
       requestComposerInsert(`/${SKILL_NAME} `, { mode: 'prefix' })
       requestComposerFocus()
     },

--- a/cli.py
+++ b/cli.py
@@ -4498,7 +4498,7 @@ def main(
     Examples:
         python cli.py                            # Start interactive mode
         python cli.py --toolsets web,terminal    # Use specific toolsets
-        python cli.py --skills hermes-agent-dev,github-auth
+        python cli.py --skills hermes-agent-dev,github
         python cli.py -q "What is Python?"       # Single query mode
         python cli.py -q "Describe this" --image ~/storage/shared/Pictures/cat.png
         python cli.py --list-tools               # List tools and exit

--- a/contributors/emails/yamatotamac@gmail.com
+++ b/contributors/emails/yamatotamac@gmail.com
@@ -1,0 +1,1 @@
+yukincom

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -84,7 +84,7 @@ Examples:
     hermes config edit            Edit config in $EDITOR
     hermes config set model gpt-4 Set a config value
     hermes gateway                Run messaging gateway
-    hermes -s hermes-agent-dev,github-auth
+    hermes -s github
     hermes -w                     Start in isolated git worktree
     hermes gateway install        Install gateway background service
     hermes sessions list          List past sessions

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1212,7 +1212,7 @@ def _normalize_task_skills(skills: Optional[Iterable[str]]) -> Optional[list[str
             f"{quoted} {noun}, not skill name(s). "
             "Put toolsets in the assignee profile's `toolsets:` config "
             "instead of per-task skills. Skills are named skill bundles "
-            "(e.g. `blogwatcher`, `github-code-review`); toolsets are runtime "
+            "(e.g. `blogwatcher`, `github`); toolsets are runtime "
             "capabilities (e.g. `web`, `browser`, `terminal`)."
         )
     return cleaned

--- a/hermes_cli/kanban_parser.py
+++ b/hermes_cli/kanban_parser.py
@@ -173,7 +173,7 @@ _SPECS = [
         _arg("--skill", action="append", default=[], dest="skills",
              help="Skill to force-load into the worker (repeatable). The kanban "
                   "lifecycle is already injected automatically. Example: --skill "
-                  "translation --skill github-code-review"),
+                  "translation --skill github"),
         _arg("--max-retries", type=int, metavar="N",
              help="Per-task override for the consecutive-failure "
                   f"circuit breaker. Trip on the Nth failure — e.g. --max-retries 1 blocks on the "

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -59,7 +59,7 @@ TIPS = [
     "hermes -w creates an isolated git worktree — perfect for parallel agent workflows.",
     "hermes -w -q \"Fix issue #42\" combines worktree isolation with a one-shot query.",
     "hermes chat -t web,terminal enables only specific toolsets for a focused session.",
-    "hermes chat -s github-pr-workflow preloads a skill at launch.",
+    "hermes chat -s github preloads a skill at launch.",
     "hermes chat -q \"query\" runs a single non-interactive query and exits.",
     "hermes chat --max-turns 1000 overrides the default 500-iteration limit per turn.",
     "hermes chat --checkpoints enables filesystem snapshots before every destructive file change.",

--- a/hermes_cli/web_routers/git.py
+++ b/hermes_cli/web_routers/git.py
@@ -52,7 +52,7 @@ async def git_status_route(path: str):
 
 # Cached `gh auth status` for the desktop composer's GitHub suggestion pill. GitHub
 # deliberately has NO MCP catalog entry (hosted MCP needs a per-host OAuth app; the
-# gh-CLI skills are the better integration), so the pill offers `/github-auth` —
+# gh-CLI skill is the better integration), so the pill offers `/github` (auth) —
 # only to users who aren't already authenticated.
 _GH_AUTH_TTL_S = 300.0
 _gh_auth_cache: Optional[tuple] = None  # (monotonic_ts, payload)

--- a/skills/autonomous-ai-agents/hermes-agent/references/webhooks.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/webhooks.md
@@ -134,7 +134,7 @@ Then in GitHub repo Settings → Webhooks → Add webhook:
 hermes webhook subscribe github-prs \
   --events "pull_request" \
   --prompt "PR #{pull_request.number} {action}: {pull_request.title}\nBy: {pull_request.user.login}\nBranch: {pull_request.head.ref}\n\n{pull_request.body}" \
-  --skills "github-code-review" \
+  --skills "github" \
   --deliver github_comment
 ```
 

--- a/skills/productivity/meeting-action-items/SKILL.md
+++ b/skills/productivity/meeting-action-items/SKILL.md
@@ -60,7 +60,7 @@ Done when every action has supported fields or visible unresolved values.
 
 ### 4. Reconcile existing records
 
-Load the user's tracker connector (`notion`, `github-issues`, or whichever system owns the work). Search for matching open items before creating anything — recurring meetings breed duplicate tickets. Preserve conflicts in owner/date/status for confirmation rather than silently overwriting. Done when proposed creates vs updates are distinguished.
+Load the user's tracker connector (`notion`, `github` (issues workflow), or whichever system owns the work). Search for matching open items before creating anything — recurring meetings breed duplicate tickets. Preserve conflicts in owner/date/status for confirmation rather than silently overwriting. Done when proposed creates vs updates are distinguished.
 
 ### 5. Prepare the follow-up package
 

--- a/skills/software-development/github/references/auth.md
+++ b/skills/software-development/github/references/auth.md
@@ -263,7 +263,7 @@ If git credentials are already configured (via credential.helper store), the tok
 
 ```bash
 # Read from git credential store
-uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py"
+uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/software-development/github/scripts/git-credential-token.py"
 ```
 
 ### Helper: Detect Auth Method
@@ -280,7 +280,7 @@ elif _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && 
   export GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
   echo "AUTH_METHOD=curl"
 elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
-  export GITHUB_TOKEN=$(uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
+  export GITHUB_TOKEN=$(uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/software-development/github/scripts/git-credential-token.py")
   echo "AUTH_METHOD=curl"
 else
   echo "AUTH_METHOD=none"

--- a/skills/software-development/github/references/code-review.md
+++ b/skills/software-development/github/references/code-review.md
@@ -4,7 +4,7 @@ Perform code reviews on local changes before pushing, or review open PRs on GitH
 
 ## Prerequisites
 
-- Authenticated with GitHub (see `github-auth` skill)
+- Authenticated with GitHub (see `references/auth.md` in the `github` skill)
 - Inside a git repository
 
 ### Setup (for PR interactions)
@@ -18,7 +18,7 @@ else
     if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
       GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
     elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
-      GITHUB_TOKEN=$(uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
+      GITHUB_TOKEN=$(uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/software-development/github/scripts/git-credential-token.py")
     fi
   fi
 fi
@@ -322,7 +322,7 @@ When the user asks you to "review PR #N", "look at this PR", or gives you a PR U
 ### Step 1: Set up environment
 
 ```bash
-source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"
+source "${HERMES_HOME:-$HOME/.hermes}/skills/software-development/github/scripts/gh-env.sh"
 # Or run the inline setup block from the top of this skill
 ```
 

--- a/skills/software-development/github/references/github-api-cheatsheet.md
+++ b/skills/software-development/github/references/github-api-cheatsheet.md
@@ -6,7 +6,7 @@ All requests need: `-H "Authorization: token $GITHUB_TOKEN"`
 
 Use the `gh-env.sh` helper to set `$GITHUB_TOKEN`, `$GH_OWNER`, `$GH_REPO` automatically:
 ```bash
-source "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/gh-env.sh"
+source "${HERMES_HOME:-$HOME/.hermes}/skills/software-development/github/scripts/gh-env.sh"
 ```
 
 ## Repositories

--- a/skills/software-development/github/references/issue-to-pr.md
+++ b/skills/software-development/github/references/issue-to-pr.md
@@ -38,7 +38,7 @@ Temporarily restore the old behavior of the exact function under test, run the n
 
 ### 7. Run repository quality gates, then open the PR immediately
 
-Run the formatter, lint, typecheck, and the repo's canonical test entrypoint on affected areas; use `requesting-code-review` on the diff. Then push and open the PR right away — the PR is what dispatches CI, and CI latency is the long pole; do not sit on finished work. Load `github-pr-workflow` for PR mechanics: conventional branch/commit, body linking the issue with problem, approach, tests, risk, and exclusions. Read the PR back and verify head SHA, base, title, and files. Done when the PR exists with the intended diff and CI is running.
+Run the formatter, lint, typecheck, and the repo's canonical test entrypoint on affected areas; use `requesting-code-review` on the diff. Then push and open the PR right away — the PR is what dispatches CI, and CI latency is the long pole; do not sit on finished work. Read `github` → `references/pr-workflow.md` for PR mechanics: conventional branch/commit, body linking the issue with problem, approach, tests, risk, and exclusions. Read the PR back and verify head SHA, base, title, and files. Done when the PR exists with the intended diff and CI is running.
 
 ### 8. Shepherd CI honestly and close the loop
 

--- a/skills/software-development/github/references/issues.md
+++ b/skills/software-development/github/references/issues.md
@@ -4,7 +4,7 @@ Create, search, triage, and manage GitHub issues. Each section shows `gh` first,
 
 ## Prerequisites
 
-- Authenticated with GitHub (see `github-auth` skill)
+- Authenticated with GitHub (see `references/auth.md` in the `github` skill)
 - Inside a git repo with a GitHub remote, or specify the repo explicitly
 
 ### Setup
@@ -18,7 +18,7 @@ else
     if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
       GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
     elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
-      GITHUB_TOKEN=$(uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
+      GITHUB_TOKEN=$(uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/software-development/github/scripts/git-credential-token.py")
     fi
   fi
 fi

--- a/skills/software-development/github/references/pr-workflow.md
+++ b/skills/software-development/github/references/pr-workflow.md
@@ -4,7 +4,7 @@ Complete guide for managing the PR lifecycle. Each section shows the `gh` way fi
 
 ## Prerequisites
 
-- Authenticated with GitHub (see `github-auth` skill)
+- Authenticated with GitHub (see `references/auth.md` in the `github` skill)
 - Inside a git repository with a GitHub remote
 
 ### Quick Auth Detection
@@ -20,7 +20,7 @@ else
     if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
       GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
     elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
-      GITHUB_TOKEN=$(uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
+      GITHUB_TOKEN=$(uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/software-development/github/scripts/git-credential-token.py")
     fi
   fi
 fi

--- a/skills/software-development/github/references/repo-management.md
+++ b/skills/software-development/github/references/repo-management.md
@@ -4,7 +4,7 @@ Create, clone, fork, configure, and manage GitHub repositories. Each section sho
 
 ## Prerequisites
 
-- Authenticated with GitHub (see `github-auth` skill)
+- Authenticated with GitHub (see `references/auth.md` in the `github` skill)
 
 ### Setup
 
@@ -17,7 +17,7 @@ else
     if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
       GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
     elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
-      GITHUB_TOKEN=$(uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
+      GITHUB_TOKEN=$(uv run python "${HERMES_HOME:-$HOME/.hermes}/skills/software-development/github/scripts/git-credential-token.py")
     fi
   fi
 fi

--- a/skills/software-development/github/scripts/gh-env.sh
+++ b/skills/software-development/github/scripts/gh-env.sh
@@ -2,7 +2,7 @@
 # GitHub environment detection helper for Hermes Agent skills.
 #
 # Usage (via terminal tool):
-#   source skills/github/github-auth/scripts/gh-env.sh
+#   source skills/software-development/github/scripts/gh-env.sh
 #
 # After sourcing, these variables are set:
 #   GH_AUTH_METHOD  - "gh", "curl", or "none"
@@ -29,7 +29,7 @@ elif _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && 
         GH_AUTH_METHOD="curl"
     fi
 elif [ -f "$HOME/.git-credentials" ]; then
-    GITHUB_TOKEN=$(uv run python3 "${HERMES_HOME:-$HOME/.hermes}/skills/github/github-auth/scripts/git-credential-token.py")
+    GITHUB_TOKEN=$(uv run python3 "${HERMES_HOME:-$HOME/.hermes}/skills/software-development/github/scripts/git-credential-token.py")
     if [ -n "$GITHUB_TOKEN" ]; then
         GH_AUTH_METHOD="curl"
     fi
@@ -61,6 +61,6 @@ unset _remote_url
 echo "GitHub Auth: $GH_AUTH_METHOD"
 [ -n "$GH_USER" ]       && echo "User: $GH_USER"
 [ -n "$GH_OWNER_REPO" ] && echo "Repo: $GH_OWNER_REPO"
-[ "$GH_AUTH_METHOD" = "none" ] && echo "⚠ Not authenticated — see github-auth skill"
+[ "$GH_AUTH_METHOD" = "none" ] && echo "⚠ Not authenticated — see github → references/auth.md"
 
 export GH_AUTH_METHOD GITHUB_TOKEN GH_USER GH_OWNER GH_REPO GH_OWNER_REPO

--- a/tests/skills/test_github_auth_environment.py
+++ b/tests/skills/test_github_auth_environment.py
@@ -1,0 +1,71 @@
+"""Exercise the bundled auth helper without any retired GitHub skills."""
+
+from pathlib import Path
+import os
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+
+def test_credential_store_fallback_works_with_only_consolidated_skill(tmp_path):
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("The bundled shell helper requires Bash")
+
+    user_home = tmp_path / "user"
+    user_home.mkdir()
+    (user_home / ".git-credentials").write_text(
+        "https://octocat:fixture-token@github.com\n", encoding="utf-8"
+    )
+    hermes_home = tmp_path / "hermes"
+    skill = hermes_home / "skills/software-development/github"
+    shutil.copytree(
+        Path(__file__).resolve().parents[2] / "skills/software-development/github",
+        skill,
+    )
+
+    # Stub only external services and the uv launcher. The shipped shell
+    # helper must discover and execute the real credential parser itself.
+    result = subprocess.run(
+        [
+            bash, "--noprofile", "--norc", "-c",
+            r'''
+gh() { return 1; }
+git() { return 1; }
+uv() {
+    [ "$1" = run ] || return 1
+    shift 2
+    "$TEST_PYTHON" "$@"
+}
+curl() {
+    [ "$1" = -s ] && [ "$2" = -H ] || return 1
+    [ "$3" = "Authorization: token fixture-token" ] || return 1
+    [ "$4" = https://api.github.com/user ] || return 1
+    printf '%s\n' '{"login":"octocat"}'
+}
+source "$1"
+[ "$GH_AUTH_METHOD" = curl ] &&
+[ "$GITHUB_TOKEN" = fixture-token ] &&
+[ "$GH_USER" = octocat ]
+''',
+            "github-auth-test", str(skill / "scripts/gh-env.sh"),
+        ],
+        cwd=tmp_path,
+        env={
+            "HOME": str(user_home),
+            "HERMES_HOME": str(hermes_home),
+            "PATH": str(Path(sys.executable).parent) + os.pathsep + os.defpath,
+            "TEST_PYTHON": sys.executable,
+        },
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "GitHub Auth: curl" in result.stdout
+    assert "User: octocat" in result.stdout
+    assert result.stderr == ""

--- a/tests/skills/test_github_compatibility.py
+++ b/tests/skills/test_github_compatibility.py
@@ -1,0 +1,81 @@
+"""Persisted GitHub skill names resolve through the real runtime loader."""
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+
+LEGACY_NAMES = (
+    "github-auth", "github-code-review", "github-issue-to-pr",
+    "github-issues", "github-pr-workflow", "github-repo-management",
+)
+
+
+@pytest.fixture
+def github_home(tmp_path, monkeypatch):
+    from agent import skill_utils
+    from tools import skills_tool
+
+    home = tmp_path / "hermes"
+    skills = home / "skills"
+    shutil.copytree(
+        Path(__file__).resolve().parents[2] / "skills/software-development/github",
+        skills / "software-development/github",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", skills)
+    monkeypatch.setattr(skill_utils, "get_project_skills_dirs", lambda: [])
+    monkeypatch.setattr(skill_utils, "get_external_skills_dirs", lambda: [])
+    return home
+
+
+@pytest.mark.parametrize("name", LEGACY_NAMES)
+@pytest.mark.parametrize("separator", ["", "/", ":"])
+def test_persisted_names_load_the_consolidated_workflow(github_home, name, separator):
+    from agent.skill_commands import build_preloaded_skills_prompt
+    from cron.scheduler_prompt import _load_cron_skill_parts
+    from tools.skills_tool import skill_view
+
+    identifier = f"github{separator}{name}" if separator else name
+    # Round-trip a stored task payload before dispatch, rather than just checking a map.
+    task_file = github_home / "saved-task.json"
+    task_file.write_text(json.dumps({"id": "fixture", "skills": [identifier]}))
+    task = json.loads(task_file.read_text())
+    loaded = json.loads(skill_view(task["skills"][0], preprocess=False))
+    assert loaded["success"], loaded
+    assert loaded["name"] == "github"
+    assert Path(loaded["skill_dir"]) == github_home / "skills/software-development/github"
+    for reference in loaded["linked_files"]["references"]:
+        resource = json.loads(skill_view(identifier, file_path=reference, preprocess=False))
+        assert resource["success"], resource
+        assert "skills/github/github-auth/" not in resource["content"]
+
+    prompt, names, missing = build_preloaded_skills_prompt(task["skills"])
+    assert names == ["github"]
+    assert missing == []
+    assert "references/pr-workflow.md" in prompt
+    assert "references/pr-workflow.md" in "\n".join(_load_cron_skill_parts(task, task["skills"]))
+
+
+@pytest.mark.parametrize("disabled", ["github", "github-auth"])
+def test_migration_respects_disabled_and_existing_custom_skills(github_home, disabled):
+    from tools.skills_tool import skill_view
+
+    config = github_home / "config.yaml"
+    config.write_text(f"skills:\n  disabled: [{disabled}]\n")
+    result = json.loads(skill_view("github-auth", preprocess=False))
+    assert not result["success"]
+    assert "disabled" in result["error"].lower()
+
+    config.write_text("skills:\n  disabled: []\n")
+    custom = github_home / "skills/custom/github-auth"
+    custom.mkdir(parents=True)
+    (custom / "SKILL.md").write_text(
+        "---\nname: github-auth\ndescription: Custom auth.\n---\nLocal workflow.\n"
+    )
+    result = json.loads(skill_view("github-auth", preprocess=False))
+    assert result["success"], result
+    assert result["name"] == "github-auth"
+    assert Path(result["skill_dir"]) == custom

--- a/tools/kanban_tools_schemas.py
+++ b/tools/kanban_tools_schemas.py
@@ -442,7 +442,7 @@ KANBAN_CREATE_SCHEMA = _schema(
                 "worker. The kanban lifecycle is already injected "
                 "automatically; use this to pin a task to a specialist "
                 "context — e.g. ['translation'] for a translation "
-                "task, ['github-code-review'] for a reviewer task. "
+                "task, ['github'] for a reviewer task. "
                 "The names must match skills installed on the "
                 "assignee's profile."
             ),

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -72,6 +72,17 @@ def _skills_dir() -> Path:
 _secret_capture_callback = None
 _LOOKUP_HINT = "Use a skill name or relative path within the skills directory."
 
+# Persisted cron/webhook/kanban/CLI references survive the bundled GitHub consolidation.
+# Only missing names migrate; installed user skills and collision checks keep precedence.
+_CONSOLIDATED_SKILLS = {
+    identifier: "software-development/github"
+    for old_name in (
+        "github-auth", "github-code-review", "github-issue-to-pr",
+        "github-issues", "github-pr-workflow", "github-repo-management",
+    )
+    for identifier in (old_name, f"github/{old_name}")
+}
+
 
 def _skill_lookup_path_error(name: str) -> Optional[str]:
     """Error if lookup *name* could escape the search roots it is joined onto. Windows drive
@@ -471,6 +482,11 @@ def _locate_skill(name: str, local_category_name: Optional[str], project_dirs: l
         return _fail(
             "Skills directory does not exist yet. It will be created on first install."), None, None
     candidates = _collect_skill_candidates(name, local_category_name, all_dirs)
+    legacy_name = local_category_name or name
+    if not candidates and (target := _CONSOLIDATED_SKILLS.get(legacy_name)):
+        if _is_skill_disabled(name) or _is_skill_disabled(legacy_name.rsplit("/", 1)[-1]):
+            return _fail(f"Skill '{name}' is disabled. Enable it with `hermes skills`."), None, None
+        candidates = _collect_skill_candidates(target, None, all_dirs)
     if len(candidates) > 1 and project_dirs:
         # A project skill intentionally overrides a same-named local/external skill;
         # ambiguity WITHIN the project tier still refuses.

--- a/web/src/i18n/af.ts
+++ b/web/src/i18n/af.ts
@@ -768,7 +768,7 @@ export const af: Translations = {
     assigneePlaceholder: "toegewysde",
     priority: "Prioriteit",
     skillsPlaceholder:
-      "vaardighede (opsioneel, kommageskei): translation, github-code-review",
+      "vaardighede (opsioneel, kommageskei): translation, github",
     noParent: "— geen ouer —",
     workspacePathDir: "werkruimtepad (verpligtend, bv. ~/projects/my-app)",
     workspacePathOptional:

--- a/web/src/i18n/ar.ts
+++ b/web/src/i18n/ar.ts
@@ -702,7 +702,7 @@ export const ar = defineLocale({
     assigneePlaceholder: "المكلَّف",
     priority: "الأولوية",
     skillsPlaceholder:
-      "مهارات (اختياري، مفصولة بفواصل): translation, github-code-review",
+      "مهارات (اختياري، مفصولة بفواصل): translation, github",
     noParent: "— لا يوجد أب —",
     workspacePathDir: "مسار مساحة العمل (مطلوب، مثال ~/projects/my-app)",
     workspacePathOptional:

--- a/web/src/i18n/de.ts
+++ b/web/src/i18n/de.ts
@@ -767,7 +767,7 @@ export const de: Translations = {
     assigneePlaceholder: "Zuständige Person",
     priority: "Priorität",
     skillsPlaceholder:
-      "Fähigkeiten (optional, kommagetrennt): translation, github-code-review",
+      "Fähigkeiten (optional, kommagetrennt): translation, github",
     noParent: "— keine übergeordnete Aufgabe —",
     workspacePathDir: "Arbeitsbereichs-Pfad (erforderlich, z. B. ~/projects/my-app)",
     workspacePathOptional:

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -860,7 +860,7 @@ export const en: Translations = {
     assigneePlaceholder: "assignee",
     priority: "Priority",
     skillsPlaceholder:
-      "skills (optional, comma-separated): translation, github-code-review",
+      "skills (optional, comma-separated): translation, github",
     noParent: "— no parent —",
     workspacePathDir: "workspace path (required, e.g. ~/projects/my-app)",
     workspacePathOptional:

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -768,7 +768,7 @@ export const es: Translations = {
     assigneePlaceholder: "asignado",
     priority: "Prioridad",
     skillsPlaceholder:
-      "habilidades (opcional, separadas por comas): translation, github-code-review",
+      "habilidades (opcional, separadas por comas): translation, github",
     noParent: "— sin padre —",
     workspacePathDir: "ruta del workspace (obligatoria, p. ej. ~/projects/my-app)",
     workspacePathOptional:

--- a/web/src/i18n/fr.ts
+++ b/web/src/i18n/fr.ts
@@ -768,7 +768,7 @@ export const fr: Translations = {
     assigneePlaceholder: "assigné",
     priority: "Priorité",
     skillsPlaceholder:
-      "compétences (facultatif, séparées par virgules): translation, github-code-review",
+      "compétences (facultatif, séparées par virgules): translation, github",
     noParent: "— aucun parent —",
     workspacePathDir: "chemin du workspace (requis, par ex. ~/projects/my-app)",
     workspacePathOptional:

--- a/web/src/i18n/ga.ts
+++ b/web/src/i18n/ga.ts
@@ -776,7 +776,7 @@ export const ga: Translations = {
     assigneePlaceholder: "sannaí",
     priority: "Tosaíocht",
     skillsPlaceholder:
-      "scileanna (roghnach, scartha le camóga): translation, github-code-review",
+      "scileanna (roghnach, scartha le camóga): translation, github",
     noParent: "— gan tuismitheoir —",
     workspacePathDir: "conair workspace (riachtanach, m.sh. ~/projects/my-app)",
     workspacePathOptional:

--- a/web/src/i18n/hu.ts
+++ b/web/src/i18n/hu.ts
@@ -768,7 +768,7 @@ export const hu: Translations = {
     assigneePlaceholder: "felelős",
     priority: "Prioritás",
     skillsPlaceholder:
-      "készségek (opcionális, vesszővel elválasztva): translation, github-code-review",
+      "készségek (opcionális, vesszővel elválasztva): translation, github",
     noParent: "— nincs szülő —",
     workspacePathDir: "munkaterület útvonala (kötelező, pl. ~/projects/my-app)",
     workspacePathOptional:

--- a/web/src/i18n/it.ts
+++ b/web/src/i18n/it.ts
@@ -767,7 +767,7 @@ export const it: Translations = {
     assigneePlaceholder: "assegnatario",
     priority: "Priorità",
     skillsPlaceholder:
-      "competenze (facoltative, separate da virgole): translation, github-code-review",
+      "competenze (facoltative, separate da virgole): translation, github",
     noParent: "— nessun padre —",
     workspacePathDir: "percorso del workspace (richiesto, ad es. ~/projects/my-app)",
     workspacePathOptional:

--- a/web/src/i18n/ja.ts
+++ b/web/src/i18n/ja.ts
@@ -767,7 +767,7 @@ export const ja: Translations = {
     assigneePlaceholder: "担当者",
     priority: "優先度",
     skillsPlaceholder:
-      "スキル（任意、カンマ区切り）: translation, github-code-review",
+      "スキル（任意、カンマ区切り）: translation, github",
     noParent: "— 親タスクなし —",
     workspacePathDir: "ワークスペースのパス（必須、例: ~/projects/my-app）",
     workspacePathOptional:

--- a/web/src/i18n/ko.ts
+++ b/web/src/i18n/ko.ts
@@ -767,7 +767,7 @@ export const ko: Translations = {
     assigneePlaceholder: "담당자",
     priority: "우선순위",
     skillsPlaceholder:
-      "스킬 (선택, 쉼표로 구분): translation, github-code-review",
+      "스킬 (선택, 쉼표로 구분): translation, github",
     noParent: "— 상위 작업 없음 —",
     workspacePathDir: "작업 공간 경로 (필수, 예: ~/projects/my-app)",
     workspacePathOptional:

--- a/web/src/i18n/pt.ts
+++ b/web/src/i18n/pt.ts
@@ -769,7 +769,7 @@ export const pt: Translations = {
     assigneePlaceholder: "responsável",
     priority: "Prioridade",
     skillsPlaceholder:
-      "competências (opcional, separadas por vírgulas): translation, github-code-review",
+      "competências (opcional, separadas por vírgulas): translation, github",
     noParent: "— sem pai —",
     workspacePathDir: "caminho do espaço de trabalho (obrigatório, p. ex. ~/projects/my-app)",
     workspacePathOptional:

--- a/web/src/i18n/ru.ts
+++ b/web/src/i18n/ru.ts
@@ -768,7 +768,7 @@ export const ru: Translations = {
     assigneePlaceholder: "исполнитель",
     priority: "Приоритет",
     skillsPlaceholder:
-      "навыки (необязательно, через запятую): translation, github-code-review",
+      "навыки (необязательно, через запятую): translation, github",
     noParent: "— без родителя —",
     workspacePathDir: "путь к рабочей области (обязательно, например ~/projects/my-app)",
     workspacePathOptional:

--- a/web/src/i18n/tr.ts
+++ b/web/src/i18n/tr.ts
@@ -768,7 +768,7 @@ export const tr: Translations = {
     assigneePlaceholder: "atanan",
     priority: "Öncelik",
     skillsPlaceholder:
-      "beceriler (isteğe bağlı, virgülle ayrılmış): translation, github-code-review",
+      "beceriler (isteğe bağlı, virgülle ayrılmış): translation, github",
     noParent: "— üst yok —",
     workspacePathDir: "workspace yolu (zorunlu, ör. ~/projects/my-app)",
     workspacePathOptional:

--- a/web/src/i18n/uk.ts
+++ b/web/src/i18n/uk.ts
@@ -769,7 +769,7 @@ export const uk: Translations = {
     assigneePlaceholder: "виконавець",
     priority: "Пріоритет",
     skillsPlaceholder:
-      "навички (необов'язково, через кому): translation, github-code-review",
+      "навички (необов'язково, через кому): translation, github",
     noParent: "— без батька —",
     workspacePathDir: "шлях робочої області (обов'язково, напр. ~/projects/my-app)",
     workspacePathOptional:

--- a/web/src/i18n/zh-hant.ts
+++ b/web/src/i18n/zh-hant.ts
@@ -767,7 +767,7 @@ export const zhHant: Translations = {
     assigneePlaceholder: "負責人",
     priority: "優先順序",
     skillsPlaceholder:
-      "技能（選填，以逗號分隔）：translation、github-code-review",
+      "技能（選填，以逗號分隔）：translation、github",
     noParent: "— 無上層任務 —",
     workspacePathDir: "工作區路徑（必填，例如 ~/projects/my-app）",
     workspacePathOptional:

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -763,7 +763,7 @@ export const zh: Translations = {
     assigneePlaceholder: "负责人",
     priority: "优先级",
     skillsPlaceholder:
-      "技能（可选，逗号分隔）：翻译、github-code-review",
+      "技能（可选，逗号分隔）：翻译、github",
     noParent: "— 无父任务 —",
     workspacePathDir: "工作区路径（必填，例如 ~/projects/my-app）",
     workspacePathOptional:

--- a/website/docs/guides/automation-blueprints.md
+++ b/website/docs/guides/automation-blueprints.md
@@ -76,7 +76,7 @@ Review for:
 - Missing tests for new behavior
 
 Post a concise review. If the PR is a trivial docs/typo change, say so briefly." \
-  --skills github-code-review \
+  --skills github \
   --deliver github_comment
 ```
 
@@ -99,7 +99,7 @@ platforms:
             Author: {pull_request.user.login}
             Diff URL: {pull_request.diff_url}
             Review for security, performance, and code quality.
-          skills: ["github-code-review"]
+          skills: ["github"]
           deliver: "github_comment"
           deliver_extra:
             repo: "{repository.full_name}"
@@ -432,7 +432,7 @@ If action is 'closed' and pull_request.merged is true:
 5. Reference the original PR in the new PR description
 
 If action is not 'closed' or not merged, respond with [SILENT]." \
-  --skills github-pr-workflow \
+  --skills github \
   --deliver log
 ```
 

--- a/website/docs/guides/tips.md
+++ b/website/docs/guides/tips.md
@@ -34,7 +34,7 @@ Don't try to hand-hold every step. Say "find and fix the failing test" rather th
 
 ### Use Skills for Complex Workflows
 
-Before writing a long prompt explaining how to do something, check if there's already a skill for it. Type `/skills` to browse available skills, or just invoke one directly like `/axolotl` or `/github-pr-workflow`.
+Before writing a long prompt explaining how to do something, check if there's already a skill for it. Type `/skills` to browse available skills, or just invoke one directly like `/axolotl` or `/github`.
 
 ## CLI Power User Tips
 

--- a/website/docs/guides/troubleshooting-agent-quality.md
+++ b/website/docs/guides/troubleshooting-agent-quality.md
@@ -111,7 +111,7 @@ You can also help directly: say "remember this for next time" after a productive
 - `/tools list` — see available tools; a tool disabled earlier with `/tools disable` stays out of the agent's toolset for the session.
 - `/context all` — per-skill and per-toolset cost listing, which doubles as an inventory of what's actually loaded.
 
-**What it means:** Skills are the agent's procedural knowledge — multi-step workflows and tool-specific instructions. If a skill is missing or a toolset was trimmed (e.g., a session started with `hermes chat -t "terminal"` to reduce prompt weight), the agent genuinely has less to work with in that session. Re-enable tools with `/tools enable`, or invoke the skill explicitly by name (`/github-pr-workflow`) to confirm it loads.
+**What it means:** Skills are the agent's procedural knowledge — multi-step workflows and tool-specific instructions. If a skill is missing or a toolset was trimmed (e.g., a session started with `hermes chat -t "terminal"` to reduce prompt weight), the agent genuinely has less to work with in that session. Re-enable tools with `/tools enable`, or invoke the skill explicitly by name (`/github`) to confirm it loads.
 
 ## 7. Compression side-effects
 

--- a/website/docs/guides/work-with-skills.md
+++ b/website/docs/guides/work-with-skills.md
@@ -29,7 +29,7 @@ This shows a compact list with names and descriptions:
 ```
 ascii-art         Generate ASCII art using pyfiglet, cowsay, boxes...
 arxiv             Search and retrieve academic papers from arXiv...
-github-pr-workflow Full PR lifecycle — create branches, commit...
+github            GitHub auth, PRs, issues, reviews, and repo management.
 plan              Plan mode — inspect context, write a markdown...
 excalidraw        Create hand-drawn style diagrams using Excalidraw...
 ```
@@ -64,7 +64,7 @@ Every installed skill is automatically a slash command. Just type its name:
 # Load a skill and give it a task
 /ascii-art Make a banner that says "HELLO WORLD"
 /plan Design a REST API for a todo app
-/github-pr-workflow Create a PR for the auth refactor
+/github Create a PR for the auth refactor
 
 # Just the skill name (no task) loads it and lets you describe what you need
 /excalidraw

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1317,9 +1317,8 @@ Examples:
 
 ```bash
 hermes bundles create backend-dev \
-  --skill github-code-review \
+  --skill github \
   --skill test-driven-development \
-  --skill github-pr-workflow \
   -d "Backend feature work"
 
 hermes bundles list

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -154,7 +154,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 
 | Command | Description |
 |---------|-------------|
-| `/<skill-name>` | Load any installed skill as an on-demand command. Example: `/gif-search`, `/github-pr-workflow`, `/excalidraw`. |
+| `/<skill-name>` | Load any installed skill as an on-demand command. Example: `/gif-search`, `/github`, `/excalidraw`. |
 | `/skills ...` | Search, browse, inspect, install, audit, publish, and configure skills from registries and the official optional-skills catalog. |
 
 ### Quick Commands

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -41,8 +41,8 @@ hermes chat --provider openrouter  # Force OpenRouter
 hermes chat --toolsets "web,terminal,skills"
 
 # Start with one or more skills preloaded
-hermes -s hermes-agent-dev,github-auth
-hermes chat -s github-pr-workflow -q "open a draft PR"
+hermes -s hermes-agent-dev,github
+hermes chat -s github -q "open a draft PR"
 
 # Resume previous sessions
 hermes --continue             # Resume the most recent CLI session (-c)
@@ -272,8 +272,8 @@ Then type `/status`, `/gpu`, or `/restart` in any chat. See the [Configuration g
 If you already know which skills you want active for the session, pass them at launch time:
 
 ```bash
-hermes -s hermes-agent-dev,github-auth
-hermes chat -s github-pr-workflow -s github-auth
+hermes -s hermes-agent-dev,github
+hermes chat -s github -s test-driven-development
 ```
 
 Hermes loads each named skill into the session prompt before the first turn. The same flag works in interactive mode and single-query mode.
@@ -285,7 +285,7 @@ Every installed skill in `~/.hermes/skills/` is automatically registered as a sl
 ```
 /gif-search funny cats
 /axolotl help me fine-tune Llama 3 on my dataset
-/github-pr-workflow create a PR for the auth refactor
+/github create a PR for the auth refactor
 
 # Just the skill name loads it and lets the agent ask what you need:
 /excalidraw

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -600,7 +600,7 @@ curl -N -X POST http://localhost:8642/api/sessions/$ID/chat/stream \
 ```bash
 curl http://localhost:8642/v1/skills \
   -H "Authorization: Bearer $API_SERVER_KEY"
-# → [{"name": "github-pr-workflow", "description": "...", "category": "..."}, ...]
+# → [{"name": "github", "description": "...", "category": "..."}, ...]
 
 curl http://localhost:8642/v1/toolsets \
   -H "Authorization: Bearer $API_SERVER_KEY"

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -504,7 +504,7 @@ The lifecycle plus the load-bearing reference details (workspace kinds, delivera
 
 ### Pinning extra skills to a specific task
 
-Sometimes a single task needs specialist context the assignee profile doesn't carry by default — a translation job that needs the `translation` skill, a review task that needs `github-code-review`, a security audit that needs `security-pr-audit`. Rather than editing the assignee's profile every time, attach the skills directly to the task.
+Sometimes a single task needs specialist context the assignee profile doesn't carry by default — a translation job that needs the `translation` skill, a review task that needs `github`, a security audit that needs `security-pr-audit`. Rather than editing the assignee's profile every time, attach the skills directly to the task.
 
 **From an orchestrator agent** (the usual case — one agent routing work to another), use the `kanban_create` tool's `skills` array:
 
@@ -518,7 +518,7 @@ kanban_create(
 kanban_create(
     title="audit auth flow",
     assignee="reviewer",
-    skills=["security-pr-audit", "github-code-review"],
+    skills=["security-pr-audit", "github"],
 )
 ```
 
@@ -532,7 +532,7 @@ hermes kanban create "translate README to Japanese" \
 hermes kanban create "audit auth flow" \
     --assignee reviewer \
     --skill security-pr-audit \
-    --skill github-code-review
+    --skill github
 ```
 
 **From the dashboard**, type the skills comma-separated into the **skills** field of the create-task dialog.

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -202,9 +202,9 @@ declare it.
 
 GitHub is deliberately **not** in the catalog: its hosted MCP requires each
 client to bring its own OAuth app (generic dynamic client registration is
-rejected), and Hermes's bundled `github/*` skills driving the `gh` CLI are a
+rejected), and Hermes's bundled `github` skill driving the `gh` CLI is a
 more capable integration. On Desktop, GitHub mentions instead offer the
-`github-auth` skill when `gh` isn't signed in yet.
+`github` skill when `gh` isn't signed in yet.
 
 ## Two kinds of MCP servers
 

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -55,7 +55,7 @@ Every installed skill is automatically available as a slash command:
 # In the CLI or any messaging platform:
 /gif-search funny cats
 /axolotl help me fine-tune Llama 3 on my dataset
-/github-pr-workflow create a PR for the auth refactor
+/github create a PR for the auth refactor
 /songsee analyze the frequency spread of this mix
 
 # Just the skill name loads it and lets the agent ask what you need:
@@ -69,7 +69,7 @@ at the start — every leading `/skill` token (up to 5) is loaded, and the rest
 becomes your instruction:
 
 ```bash
-/github-pr-workflow /test-driven-development fix issue #123 and open a PR
+/github /test-driven-development fix issue #123 and open a PR
 ```
 
 Parsing stops at the first token that isn't an installed skill, so arguments
@@ -474,6 +474,8 @@ Trust is a repo-level decision, but a repo's skill content changes with every `g
 
 Cron jobs and other non-interactive surfaces inherit your interactive trust decision — they never prompt and never auto-trust. The project root resolves from the surface's working directory (a cron job's `workdir`, via the same mechanism the terminal tool uses). A cron job whose `workdir` is inside a repo you previously trusted loads that repo's project skills; a job in an untrusted or undecided repo loads none.
 
+The six former GitHub skill IDs (`github-auth`, `github-code-review`, `github-issue-to-pr`, `github-issues`, `github-pr-workflow`, and `github-repo-management`) resolve to `software-development/github` when loaded through `skill_view`, preloaded with `-s`, or referenced by saved tasks and bundles. An installed skill with the original name takes precedence; disabled skills stay disabled. Use `/github` for new slash-command invocations and `github` in new configurations.
+
 ## Skill Bundles
 
 Skill bundles are tiny YAML files that group several skills under a single slash command. When you run `/<bundle-name>`, every skill listed in the bundle loads at once — useful when a particular task always benefits from the same set of skills together.
@@ -483,9 +485,8 @@ Skill bundles are tiny YAML files that group several skills under a single slash
 ```bash
 # Create a bundle for backend feature work
 hermes bundles create backend-dev \
-  --skill github-code-review \
+  --skill github \
   --skill test-driven-development \
-  --skill github-pr-workflow \
   -d "Backend feature work — review, test, PR workflow"
 ```
 
@@ -495,7 +496,7 @@ Then in the CLI or any gateway platform:
 /backend-dev refactor the auth middleware
 ```
 
-The agent receives all three skills loaded into one user message, with any text after the slash command attached as a user instruction.
+The agent receives both skills loaded into one user message, with any text after the slash command attached as a user instruction.
 
 ### YAML schema
 
@@ -505,9 +506,8 @@ Bundles live in **`~/.hermes/skill-bundles/<slug>.yaml`** and look like this:
 name: backend-dev
 description: Backend feature work — review, test, PR workflow.
 skills:
-  - github-code-review
+  - github
   - test-driven-development
-  - github-pr-workflow
 instruction: |
   Always start by writing failing tests, then implement.
   Open the PR through the standard workflow with co-author tags.

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -111,7 +111,7 @@ platforms:
             URL: {pull_request.html_url}
             Diff URL: {pull_request.diff_url}
             Action: {action}
-          skills: ["github-code-review"]
+          skills: ["github"]
           deliver: "github_comment"
           deliver_extra:
             repo: "{repository.full_name}"


### PR DESCRIPTION
## What does this PR do?

After the six GitHub skills were consolidated into `software-development/github`, Desktop onboarding still inserted `/github-auth`, saved tasks could fail to load retired IDs, and the consolidated workflows still referenced removed credential-helper paths.

This PR updates callers to `github`, fixes the shipped helper paths, and resolves missing legacy GitHub IDs through the existing skill loader. Installed skills with those names keep precedence, and collision, quarantine, platform, and disabled-skill checks remain in place. Desktop onboarding still only prefixes the draft; it does not send a message.

## Related Issue

Related to #106671 and review feedback on this PR. Includes the minimal credential-path fixes also proposed in the still-open #106695 and #106684 so this PR works independently. It does not include their broader authentication-policy changes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update Desktop onboarding/completion labels, CLI/kanban help, web translations, bundled workflow instructions, and hand-written usage examples to use `github`.
- Resolve the six retired GitHub IDs, including category-qualified forms, to the consolidated skill only when the original skill is absent. This covers `skill_view`, CLI preloading, saved task inputs, and skill bundles without rewriting user configuration. Use `/github` for new slash commands.
- Correct authentication script paths throughout the consolidated skill, including the real `.git-credentials` fallback in `gh-env.sh`.
- Add behavioral tests that load the shipped skill and references through the real resolver, exercise CLI and cron consumers, respect disabled/custom skills, and execute the auth helper with isolated fixture credentials and stubbed external services.
- Retain the contributor email mapping required by the repository's attribution check.

## How to Test

1. Run the targeted Python suite through the canonical entry point:
   ```sh
   scripts/run_tests.sh tests/skills/test_github_auth_environment.py tests/skills/test_github_compatibility.py tests/tools/test_skills_tool.py tests/tools/test_skills_tool_profile_scope.py tests/tools/test_skills_tool_discovery_cache.py tests/agent/test_skill_commands.py tests/agent/test_skill_bundles.py tests/cron/test_cron_prompt_injection_skill.py tests/skills/test_github_skill.py tests/skills/test_github_credential_token.py tests/hermes_cli/test_tips.py -j 2
   ```
2. From `apps/desktop`, run:
   ```sh
   npm run test:ui -- src/store/suggestion-providers/github.test.ts src/store/suggestion-providers/mcp.test.ts src/store/suggestion-providers/skill.test.ts
   ```
3. Run Desktop and web TypeScript checks, Ruff on the changed Python implementation/tests, ESLint on the changed suggestion/translation files, and Bash syntax checking for `gh-env.sh`.
4. For manual verification, use an unauthenticated Desktop profile, type `connect github please`, and invoke **Set up GitHub**. The draft should gain `/github ` and remain unsent. Live sign-in and packaged-app testing were not performed for this revision.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — targeted tests were run through `scripts/run_tests.sh`; the full suite is left to CI.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — workflows, help, and hand-written usage examples updated.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; resolution remains in the existing loader.
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no OS-specific behavior added.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — kanban examples and the legacy-ID resolution contract are documented.

## Screenshots / Logs

[Independent fork CI](https://github.com/yukincom/hermes-agent/actions/runs/34732507638) passed all three jobs: Python regressions on Linux and macOS, and Desktop/web checks. The CI branch is PR commit `8366ac4eb31aeb2b9fcfcf01ff54f2ccd1ff9361` plus a fork-only workflow; no application code differs.

```text
Python: 11 files, 167 tests passed (Linux and macOS)
Desktop: 3 files, 38 tests passed
Desktop/web TypeScript, targeted ESLint/Ruff, Bash syntax: passed
```

Before the resolver fix, the initial 14 regression cases failed on missing/disabled legacy skill loading. The original Desktop provider also fails the suggestion test by inserting `/github-auth` instead of `/github`.

This is targeted integration coverage, not a full-suite or live GitHub-authentication claim. Generated website skill catalogs are outside this caller/runtime fix. Upstream CI status is reported separately from the fork run.
