### PR TITLE
fix(state): tolerate corrupt system prompt rows

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -406,6 +406,19 @@ class SessionDB(
         data = dict(row)
         if "_system_prompt_resolved" in data:
             resolved = data.pop("_system_prompt_resolved")
+            if "_system_prompt_legacy" in data:
+                candidates = (resolved, data.pop("_system_prompt_legacy"))
+                resolved = None
+                for candidate in candidates:
+                    if isinstance(candidate, str):
+                        resolved = candidate
+                        break
+                    if isinstance(candidate, bytes):
+                        try:
+                            resolved = candidate.decode("utf-8")
+                        except UnicodeDecodeError:
+                            continue
+                        break
             if "system_prompt" in data:
                 data["system_prompt"] = resolved
         return data

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -82,6 +82,15 @@ _PREVIEW_COL_SQL = f"""COALESCE(
                         ''
                     ) AS _preview_raw"""
 
+# Materialize prompt candidates as bytes so malformed UTF-8 cannot make
+# sqlite3 decode a row before _session_row_dict can apply the legacy fallback.
+_PROMPT_CANDIDATES_SQL = (
+    "CASE WHEN typeof(sp.prompt) = 'text' THEN CAST(sp.prompt AS BLOB) END "
+    "AS _system_prompt_resolved, "
+    "CASE WHEN typeof(s.system_prompt) = 'text' THEN CAST(s.system_prompt AS BLOB) END "
+    "AS _system_prompt_legacy"
+)
+
 
 def _where_sql(clauses: List[str], lead: str = "") -> str:
     """``WHERE a AND b`` (with *lead* prefix) or "" when there are no clauses."""
@@ -738,7 +747,7 @@ class SessionSessionsMixin:
         """Get a session by ID (drains queued token deltas first so cost readers see exact totals)."""
         self.flush_token_counts()
         row = self._read_one(
-            "SELECT s.*, COALESCE(sp.prompt, s.system_prompt) AS _system_prompt_resolved "
+            f"SELECT s.*, {_PROMPT_CANDIDATES_SQL} "
             "FROM sessions s LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash WHERE s.id = ?",
             (session_id,),
         )
@@ -1210,7 +1219,7 @@ class SessionSessionsMixin:
         # Shared projection head of the three list queries (whitespace is part of the SQL text).
         select_head = (
             f"SELECT {self._compact_session_cols() if compact_rows else 's.*'}"
-            + ("" if compact_rows else ", COALESCE(sp.prompt, s.system_prompt) AS _system_prompt_resolved")
+            + ("" if compact_rows else f", {_PROMPT_CANDIDATES_SQL}")
             + f",\n                    {_PREVIEW_COL_SQL},\n                    "
         )
         prompt_join = (
@@ -1376,7 +1385,7 @@ class SessionSessionsMixin:
             where_clauses.append(ws_clause)
             params.extend(ws_params)
         return [self._session_row_dict(row) for row in self._read_all(
-            "SELECT s.*, COALESCE(sp.prompt, s.system_prompt) AS _system_prompt_resolved, "
+            f"SELECT s.*, {_PROMPT_CANDIDATES_SQL}, "
             f"{_sql_session_last_active('s')} AS last_active "
             "FROM sessions s LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash "
             f"{_where_sql(where_clauses, ' ')} "

--- a/tests/test_session_system_prompt_dedup.py
+++ b/tests/test_session_system_prompt_dedup.py
@@ -25,6 +25,68 @@ def _prompt_count(db: SessionDB) -> int:
     )
 
 
+def _read_seeded_sessions(db: SessionDB, reader: str) -> dict[str, dict]:
+    if reader == "get_session":
+        rows = [db.get_session("fallback"), db.get_session("empty")]
+    else:
+        rows = getattr(db, reader)()
+    return {row["id"]: row for row in rows if row is not None}
+
+
+@pytest.mark.parametrize(
+    "reader",
+    ["get_session", "list_sessions_rich", "search_sessions"],
+)
+def test_session_readers_fail_open_for_corrupt_prompt_bytes(db, reader):
+    db.create_session("fallback", "cli", system_prompt="deduplicated fallback")
+    db.create_session("empty", "cli", system_prompt="deduplicated empty")
+    hashes = {
+        row["id"]: row["system_prompt_hash"]
+        for row in db._conn.execute(
+            "SELECT id, system_prompt_hash FROM sessions WHERE id IN ('fallback', 'empty')"
+        )
+    }
+    db._conn.execute(
+        "UPDATE system_prompts SET prompt = CAST(? AS TEXT) WHERE hash = ?",
+        (sqlite3.Binary(b"\xe2\x82"), hashes["fallback"]),
+    )
+    db._conn.execute(
+        "UPDATE system_prompts SET prompt = ? WHERE hash = ?",
+        (sqlite3.Binary(b"\xe2\x82"), hashes["empty"]),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET system_prompt = ? WHERE id = 'fallback'",
+        ("legacy fallback",),
+    )
+    db._conn.execute(
+        "UPDATE sessions SET system_prompt = ? WHERE id = 'empty'",
+        (sqlite3.Binary(b"\xff"),),
+    )
+    db._conn.commit()
+
+    rows = _read_seeded_sessions(db, reader)
+
+    assert rows["fallback"]["system_prompt"] == "legacy fallback"
+    assert rows["empty"]["system_prompt"] is None
+
+
+@pytest.mark.parametrize(
+    "reader",
+    ["get_session", "list_sessions_rich", "search_sessions"],
+)
+def test_session_readers_prefer_valid_deduplicated_prompt(db, reader):
+    db.create_session("fallback", "cli", system_prompt="preferred prompt")
+    db.create_session("empty", "cli", system_prompt="other prompt")
+    db._conn.execute(
+        "UPDATE sessions SET system_prompt = 'legacy prompt' WHERE id = 'fallback'"
+    )
+    db._conn.commit()
+
+    rows = _read_seeded_sessions(db, reader)
+
+    assert rows["fallback"]["system_prompt"] == "preferred prompt"
+
+
 def test_prompt_snapshots_are_deduplicated_and_hydrated_for_readers(db):
     prompt = "You are Hermes.\n" + ("Follow the profile policy.\n" * 5)
     db.create_session(


### PR DESCRIPTION
## What does this PR do?

Prevents a malformed UTF-8 value in `system_prompts.prompt` from aborting session load, list, and search queries during SQLite row materialization.

The affected projections now return prompt candidates as bytes, and the existing row hydration seam decodes them safely in precedence order. A valid deduplicated prompt is still preferred; an invalid or non-text deduplicated value falls back to a valid legacy `sessions.system_prompt`; if neither candidate is usable, the hydrated prompt is `None`. The database row is not modified.

## Related Issue

Fixes #109450

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state_sessions.py`: project deduplicated and legacy prompt candidates without asking SQLite's Python adapter to decode malformed text.
- `hermes_state.py`: decode candidates as UTF-8 and fail open to the legacy value or `None`.
- `tests/test_session_system_prompt_dedup.py`: cover corrupt prompt rows across direct load, rich list, and search readers, plus valid-prompt precedence.

## Proof Receipt

Base: `d595e636c83aa0b9606d4e914e1140ae9c796897`

Focused pre-fix RED:

```text
scripts/run_tests.sh tests/test_session_system_prompt_dedup.py -k 'session_readers_fail_open or session_readers_prefer_valid' -v
3 failed, 3 passed
sqlite3.OperationalError: Could not decode to UTF-8 column '_system_prompt_resolved'
```

Focused post-fix GREEN:

```text
scripts/run_tests.sh tests/test_session_system_prompt_dedup.py -k 'session_readers_fail_open or session_readers_prefer_valid' -v
6 passed, 0 failed

scripts/run_tests.sh tests/test_session_system_prompt_dedup.py
15 passed, 0 failed
```

Additional checks:

```text
ruff check hermes_state.py hermes_state_sessions.py tests/test_session_system_prompt_dedup.py
All checks passed!

git diff --check
passed
```

The broader `tests/test_hermes_state.py` run reported 272 passes and two unrelated local failures: a macOS holder probe blocked by sandboxed `sysctl`, and an FTS trace assertion observing a different pooled connection. Both reproduced when rerun and do not exercise prompt hydration.

## Review

- Developer self-review: P0 = 0.
- Independent P0-only review: P0 = 0.
- No schema migration, write-path change, row repair/deletion, or query filter/order change.

## Risks and Scope

This PR intentionally limits the change to `get_session`, `list_sessions_rich`, and `search_sessions`, matching the reported session panel/load failure. Other prompt projections are unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the focused affected tests locally
- [x] I've added regression tests for the change
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] Documentation update is N/A
- [x] Config example update is N/A
- [x] Architecture/workflow documentation update is N/A
- [x] Cross-platform impact was considered; the implementation uses standard SQLite/Python behavior
- [x] Tool description/schema update is N/A
