### PR TITLE
fix(state): degrade undecodable UTF-8 cells instead of aborting session queries

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -74,6 +74,20 @@ logger = logging.getLogger(__name__)
 _MAX_SAFE_MESSAGES = 20_000  # resume/export guard default
 
 
+def _tolerant_text_factory(data: bytes) -> str:
+    """Decode a TEXT cell strictly when possible; undecodable bytes (e.g. a multi-byte
+    character truncated by a mid-write process death) degrade to U+FFFD in that one cell
+    instead of aborting every session-list/load query with OperationalError (#109450)."""
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        logger.warning(
+            "state.db: undecodable UTF-8 stored text (len=%d, head=%r) degraded to U+FFFD",
+            len(data), bytes(data[:32]),
+        )
+        return data.decode("utf-8", errors="replace")
+
+
 def _configured_transcript_limit(key: str, fallback: int = _MAX_SAFE_MESSAGES) -> int:
     """``sessions.<key>`` from config.yaml (lazy import: circular at load), else *fallback*; 0 disables."""
     try:
@@ -585,6 +599,7 @@ class SessionDB(
             check_same_thread=False, timeout=timeout, isolation_level=None,
         )
         conn.row_factory = sqlite3.Row
+        conn.text_factory = _tolerant_text_factory
         return conn
 
     def _handle_quarantine_if_invalid(self, already_locked: bool = False) -> None:
@@ -619,6 +634,7 @@ class SessionDB(
         )
         try:
             conn.row_factory = sqlite3.Row
+            conn.text_factory = _tolerant_text_factory
             mode = apply_wal_with_fallback(conn, db_label="state.db")
             # "wal" is also the *assumed* mode when the on-disk probe was blocked by a concurrent opener
             # (#86515): the lock-free mode=ro read pool needs a confirmed WAL header, so confirm it here.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -73,18 +73,32 @@ logger = logging.getLogger(__name__)
 
 _MAX_SAFE_MESSAGES = 20_000  # resume/export guard default
 
+# One warning per distinct corrupt value per process: repeated reads of the same bad cell stay silent.
+_corruption_warned_fingerprints: set = set()
+
 
 def _tolerant_text_factory(data: bytes) -> str:
     """Decode a TEXT cell strictly when possible; undecodable bytes (e.g. a multi-byte
     character truncated by a mid-write process death) degrade to U+FFFD in that one cell
-    instead of aborting every session-list/load query with OperationalError (#109450)."""
+    instead of aborting every session-list/load query with OperationalError (#109450).
+
+    Read/display surfaces stay tolerant on every connection (the read pool and the writer,
+    which _read_ctx degrades display queries onto when WAL is off or the pool is exhausted).
+    Read-modify-write seams instead decode strictly at the seam via BLOB casts
+    (_merge_model_config_json), so a malformed cell aborts the mutation instead of being
+    U+FFFD-rewritten over the original data. The warning is content-free (length + sha256
+    fingerprint, comparable against suspect cells via python) and fires once per distinct
+    bad value per process."""
     try:
         return data.decode("utf-8")
     except UnicodeDecodeError:
-        logger.warning(
-            "state.db: undecodable UTF-8 stored text (len=%d, head=%r) degraded to U+FFFD",
-            len(data), bytes(data[:32]),
-        )
+        fingerprint = hashlib.sha256(data).hexdigest()[:16]
+        if fingerprint not in _corruption_warned_fingerprints:
+            _corruption_warned_fingerprints.add(fingerprint)
+            logger.warning(
+                "state.db: undecodable UTF-8 stored text (len=%d, sha256[:16]=%s) degraded to U+FFFD on read",
+                len(data), fingerprint,
+            )
         return data.decode("utf-8", errors="replace")
 
 
@@ -635,6 +649,11 @@ class SessionDB(
         try:
             conn.row_factory = sqlite3.Row
             conn.text_factory = _tolerant_text_factory
+            # Tolerant here too (not just the read pool): _read_ctx degrades display/list queries
+            # onto the writer when WAL is off, the pool is exhausted, or a pooled open failed
+            # (slower beats EMFILE) — those surfaces must survive a corrupt cell (#109450).
+            # Read-modify-write seams stay fail-closed via strict BLOB casts at the seam itself
+            # (see _merge_model_config_json), not via connection-wide strict decoding.
             mode = apply_wal_with_fallback(conn, db_label="state.db")
             # "wal" is also the *assumed* mode when the on-disk probe was blocked by a concurrent opener
             # (#86515): the lock-free mode=ro read pool needs a confirmed WAL header, so confirm it here.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -438,6 +438,14 @@ class SessionDB(
         return data
 
     @staticmethod
+    def _public_cell(value: Any) -> Any:
+        """Scalar twin of ``_session_row_dict``: a corrupt BLOB-stored cell crossing a public
+        scalar or manually assembled projection (single-column reads like titles/roles, or
+        hand-built dicts like handoff/routing/cwd rollups) degrades to str here, so both
+        storage classes stay JSON-serializable on every read surface (#109465 review)."""
+        return _tolerant_decode_bytes(value) if isinstance(value, bytes) else value
+
+    @staticmethod
     def _close_connection_quietly(conn: Optional[sqlite3.Connection]) -> None:
         """Close a partially initialized connection without masking its error."""
         if conn is None:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -27,7 +27,12 @@ from agent.message_sanitization import _sanitize_surrogates
 from hermes_constants import get_hermes_home, mkdir_under_hermes_home
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, TypeVar, cast
 
-from hermes_state_common import escape_like as _escape_like, stat_db_file_identity as _stat_db_file_identity
+from hermes_state_common import (
+    _corruption_warned_fingerprints,  # noqa: F401  (re-export: tests reset the per-process dedupe)
+    escape_like as _escape_like,
+    stat_db_file_identity as _stat_db_file_identity,
+    tolerant_decode_bytes as _tolerant_decode_bytes,
+)
 from hermes_state_errors import (
     _DELETED_WAL_GENERATION_MSG, _DISK_IO_ERROR_MARKER, _STATE_DB_CORRUPT_MSG, _STATE_DB_GENERATION_KEY,
     _STATE_DB_REPLACED_MSG, DeletedWalGenerationError, SessionCompressionInProgressError, StateDbCorruptError,
@@ -73,9 +78,6 @@ logger = logging.getLogger(__name__)
 
 _MAX_SAFE_MESSAGES = 20_000  # resume/export guard default
 
-# One warning per distinct corrupt value per process: repeated reads of the same bad cell stay silent.
-_corruption_warned_fingerprints: set = set()
-
 
 def _tolerant_text_factory(data: bytes) -> str:
     """Decode a TEXT cell strictly when possible; undecodable bytes (e.g. a multi-byte
@@ -85,21 +87,11 @@ def _tolerant_text_factory(data: bytes) -> str:
     Read/display surfaces stay tolerant on every connection (the read pool and the writer,
     which _read_ctx degrades display queries onto when WAL is off or the pool is exhausted).
     Read-modify-write seams instead decode strictly at the seam via BLOB casts
-    (_merge_model_config_json), so a malformed cell aborts the mutation instead of being
-    U+FFFD-rewritten over the original data. The warning is content-free (length + sha256
-    fingerprint, comparable against suspect cells via python) and fires once per distinct
-    bad value per process."""
-    try:
-        return data.decode("utf-8")
-    except UnicodeDecodeError:
-        fingerprint = hashlib.sha256(data).hexdigest()[:16]
-        if fingerprint not in _corruption_warned_fingerprints:
-            _corruption_warned_fingerprints.add(fingerprint)
-            logger.warning(
-                "state.db: undecodable UTF-8 stored text (len=%d, sha256[:16]=%s) degraded to U+FFFD on read",
-                len(data), fingerprint,
-            )
-        return data.decode("utf-8", errors="replace")
+    (_merge_model_config_json, set_message_reaction), so a malformed cell aborts the mutation
+    instead of being U+FFFD-rewritten over the original data. The warning is content-free
+    (length + sha256 fingerprint, comparable against suspect cells via python), bounded, and
+    thread-safe — see hermes_state_common.tolerant_decode_bytes."""
+    return _tolerant_decode_bytes(data)
 
 
 def _configured_transcript_limit(key: str, fallback: int = _MAX_SAFE_MESSAGES) -> int:
@@ -436,6 +428,10 @@ class SessionDB(
             resolved = data.pop("_system_prompt_resolved")
             if "system_prompt" in data:
                 data["system_prompt"] = resolved
+        if isinstance(data.get("system_prompt"), bytes):
+            # BLOB storage bypasses text_factory (sqlite3 contract): degrade here so the public
+            # session dict stays a serializable str for BOTH storage classes (#109465 review).
+            data["system_prompt"] = _tolerant_decode_bytes(data["system_prompt"])
         return data
 
     @staticmethod

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -428,10 +428,13 @@ class SessionDB(
             resolved = data.pop("_system_prompt_resolved")
             if "system_prompt" in data:
                 data["system_prompt"] = resolved
-        if isinstance(data.get("system_prompt"), bytes):
-            # BLOB storage bypasses text_factory (sqlite3 contract): degrade here so the public
-            # session dict stays a serializable str for BOTH storage classes (#109465 review).
-            data["system_prompt"] = _tolerant_decode_bytes(data["system_prompt"])
+        # sessions has no legitimate BLOB column: any bytes is a corrupt cell that landed in BLOB
+        # storage and bypassed text_factory (sqlite3 contract). Normalize every field centrally so
+        # the public session dict stays serializable str for BOTH storage classes — not just
+        # system_prompt but also title, model, end_reason, ... (#109465 review, completeness gap 2).
+        for key, value in data.items():
+            if isinstance(value, bytes):
+                data[key] = _tolerant_decode_bytes(value)
         return data
 
     @staticmethod

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -3,11 +3,14 @@ the mixin modules can import it without a cycle."""
 
 import contextlib
 import errno
+import hashlib
 import json
 import logging
 import os
 import sys
+import threading
 import time
+from collections import OrderedDict
 from typing import Any
 
 from agent.skill_commands import SKILL_EXCERPT_JOINT, SKILL_SCAFFOLD_SQL_LIKE, describe_skill_invocation
@@ -981,6 +984,42 @@ _LOCK_BREAK_REACQUIRE_SECONDS = 5.0
 # "Another process holds the lock": flock → EWOULDBLOCK/EAGAIN, msvcrt.locking → EACCES (EDEADLK when its retry
 # gives up).  Anything else (ESTALE, ENOTSUP, ENOLCK, EIO) is a persistent failure polling cannot fix.
 _LOCK_CONTENTION_ERRNOS = {errno.EAGAIN, errno.EACCES, errno.EWOULDBLOCK, errno.EDEADLK}
+
+# One warning per distinct corrupt value per process, bounded and thread-safe (#109465 review: an
+# unbounded plain set retained one fingerprint per distinct bad cell — 10k malformed cells kept
+# 10k entries — and check/add raced across reader threads). Oldest fingerprint falls out at the
+# cap and may warn again on a later read: bounded memory beats a silent unbounded leak.
+_CORRUPTION_WARN_FINGERPRINT_CAP = 256
+_corruption_warned_fingerprints: "OrderedDict[str, None]" = OrderedDict()
+_corruption_warned_lock = threading.Lock()
+
+
+def warn_corrupt_cell(data: bytes) -> None:
+    """Content-free corrupt-cell warning: length + sha256[:16] fingerprint, never the raw bytes
+    (cells can hold prompts or accidentally persisted credentials)."""
+    fingerprint = hashlib.sha256(data).hexdigest()[:16]
+    with _corruption_warned_lock:
+        if fingerprint in _corruption_warned_fingerprints:
+            return
+        _corruption_warned_fingerprints[fingerprint] = None
+        if len(_corruption_warned_fingerprints) > _CORRUPTION_WARN_FINGERPRINT_CAP:
+            _corruption_warned_fingerprints.popitem(last=False)
+    logger.warning(
+        "state.db: undecodable UTF-8 stored text (len=%d, sha256[:16]=%s) degraded to U+FFFD on read",
+        len(data), fingerprint)
+
+
+def tolerant_decode_bytes(data: bytes) -> str:
+    """Decode a stored cell strictly when possible; undecodable bytes (e.g. a multi-byte character
+    truncated by a mid-write process death) degrade to U+FFFD in that one cell instead of aborting
+    every session-list/load query with OperationalError (#109450). Shared by ``text_factory``
+    (TEXT storage) and the BLOB hydration seams (BLOB storage bypasses ``text_factory``), so both
+    storage classes degrade identically and no public read surface ever hands out ``bytes``."""
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        warn_corrupt_cell(data)
+        return data.decode("utf-8", errors="replace")
 
 
 def is_advisory_lock_contention(exc: BaseException) -> bool:

--- a/hermes_state_gateway.py
+++ b/hermes_state_gateway.py
@@ -613,7 +613,7 @@ class SessionGatewayMixin:
         rows = self._read_all(
             "SELECT backend_id, pid, started_at, last_heartbeat, profile, host FROM gateway_heartbeats"
             " ORDER BY last_heartbeat DESC")
-        return [dict(r) for r in rows]
+        return [self._session_row_dict(r) for r in rows]
 
     def request_handoff(self, session_id: str, platform: str) -> bool:
         """Mark a session pending handoff to *platform*; False if a handoff is already in flight."""

--- a/hermes_state_gateway.py
+++ b/hermes_state_gateway.py
@@ -311,7 +311,9 @@ class SessionGatewayMixin:
             """,
             (cutoff,),
         )
-        return [dict(r) for r in rows]
+        # Same normalization boundary as the other public session projections: a corrupt cell
+        # stored in BLOB storage bypasses text_factory and must not escape as bytes (#109465 review).
+        return [self._session_row_dict(r) for r in rows]
 
     def _delete_routing_entries_for_sessions(self, session_ids: Set[str]) -> int:
         """Drop ``gateway_routing`` rows pointing at any of *session_ids*; the target id

--- a/hermes_state_gateway.py
+++ b/hermes_state_gateway.py
@@ -274,7 +274,7 @@ class SessionGatewayMixin:
     def load_gateway_routing_entries(self, *, scope: str = "") -> Dict[str, str]:
         """Load routing entries for *scope* as {session_key: entry_json}."""
         rows = self._read_all("SELECT session_key, entry_json FROM gateway_routing WHERE scope = ?", (scope,))
-        return {r["session_key"]: r["entry_json"] for r in rows}
+        return {self._public_cell(r["session_key"]): self._public_cell(r["entry_json"]) for r in rows}
 
     def list_never_active_keyed_sessions(self, *, older_than_days: float) -> List[Dict[str, Any]]:
         """Keyed, still-open rows with no evidence of a single turn (no messages, tokens, tool/API calls,
@@ -632,8 +632,9 @@ class SessionGatewayMixin:
                 (session_id,))
             if not row:
                 return None
-            return {"state": row["handoff_state"], "platform": row["handoff_platform"],
-                    "error": row["handoff_error"]}
+            return {"state": self._public_cell(row["handoff_state"]),
+                    "platform": self._public_cell(row["handoff_platform"]),
+                    "error": self._public_cell(row["handoff_error"])}
         except Exception:
             return None
 

--- a/hermes_state_maintenance.py
+++ b/hermes_state_maintenance.py
@@ -214,7 +214,9 @@ class SessionMaintenanceMixin:
         """Dry-run: sessions a matching prune/archive would touch, oldest first (``older_than_days``
         = inactivity threshold: latest message, else ``started_at``)."""
         where, params = self._prune_where(older_than_days, source, filters)
-        return [dict(row) for row in self._read_all(
+        # Shared normalization boundary so a BLOB-stored cell never escapes the public
+        # projection as bytes (#109465 review).
+        return [self._session_row_dict(row) for row in self._read_all(
             f"""SELECT s.id, s.source, s.title, s.model, s.started_at,
                            COALESCE(
                                (SELECT MAX(m.timestamp) FROM messages m

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -475,6 +475,12 @@ class SessionMessagesMixin:
             for row in conn.execute("SELECT id, role, content, CAST(display_metadata AS BLOB) AS display_metadata "
                     "FROM messages WHERE session_id = ? AND active = 1 AND display_metadata IS NOT NULL ORDER BY id",
                     (session_id,)).fetchall():
+                # A BLOB-stored role bypasses text_factory (sqlite3 contract) and would escape the
+                # take payload as bytes; same normalize-every-field contract as _row_to_message_dict
+                # (#109465 review, completeness gap 3).
+                role = row["role"]
+                if isinstance(role, bytes):
+                    role = tolerant_decode_bytes(role)
                 meta = self._strict_display_metadata_cell(row["display_metadata"], row["id"])
                 reactions = meta.get(self.REACTIONS_METADATA_KEY) if meta else None
                 if not isinstance(reactions, list):
@@ -487,7 +493,7 @@ class SessionMessagesMixin:
                     changed = True
                     content = self._decode_content(row["content"])
                     pending.append({
-                        "row_id": row["id"], "role": row["role"], "emoji": reaction.get("emoji") or "",
+                        "row_id": row["id"], "role": role, "emoji": reaction.get("emoji") or "",
                         "text": content if isinstance(content, str) else ""})
                 if changed:
                     conn.execute(_SET_DISPLAY_META_SQL, (self._encode_display_metadata(meta), row["id"]))

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -519,14 +519,14 @@ class SessionMessagesMixin:
         row = self._read_one(
             "SELECT role FROM messages WHERE session_id = ? AND active = 1 "
             "AND role NOT IN ('session_meta', 'system') ORDER BY id DESC LIMIT 1", (session_id,))
-        return row[0] if row else None
+        return self._public_cell(row[0]) if row else None
 
     def get_message_role(self, session_id: str, row_id: int) -> Optional[str]:
         """Role of the active message at *row_id* in *session_id*, or ``None``."""
         if not session_id:
             return None
         row = self._read_one("SELECT role FROM messages WHERE id = ? AND session_id = ? AND active = 1", (int(row_id), session_id))
-        return row[0] if row else None
+        return self._public_cell(row[0]) if row else None
 
     def _insert_message_rows(self, conn, session_id: str, messages: List[Dict[str, Any]]) -> tuple[int, int]:
         """Insert *messages* as fresh active rows in the caller's txn -> ``(inserted, tool_call_count)``.

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import sqlite3
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -15,7 +16,7 @@ from agent.message_sanitization import _sanitize_surrogates
 from hermes_cli.timefmt import coerce_epoch
 from hermes_state_common import (
     _COMPRESSION_LOCK_ROW_SQL, _ENDED_ROW_SQL, _RESET_END_REASONS, _RESET_END_REASONS_SQL, _ended_by_compression,
-    _legacy_reset_child_sql, _placeholders, _sql_json_extract)
+    _legacy_reset_child_sql, _placeholders, _sql_json_extract, tolerant_decode_bytes)
 
 logger = logging.getLogger("hermes_state")  # caplog tests pin the origin module's name
 
@@ -37,6 +38,10 @@ _TURN_LEASE_ROW_SQL = "SELECT holder, expires_at FROM session_turn_leases WHERE 
 _DELETE_COMPRESSION_LOCK_SQL = "DELETE FROM compression_locks WHERE session_id = ? AND holder = ?"
 _DISPLAY_ACTIVE_CLAUSE = " AND (active = 1 OR compacted = 1)"
 _DISPLAY_META_ROW_SQL = "SELECT display_metadata FROM messages WHERE id = ? AND session_id = ?"
+# Read-modify-write seam (set_message_reaction) reads the raw BLOB: CAST defeats the connection's
+# tolerant text_factory so an undecodable cell fails AT THE SEAM instead of degrading to U+FFFD,
+# parsing away to {} and letting the write drop the row's unrelated metadata (#109465 review).
+_DISPLAY_META_ROW_BLOB_SQL = "SELECT CAST(display_metadata AS BLOB) FROM messages WHERE id = ? AND session_id = ?"
 _ACTIVE_IDS_SQL = "SELECT id FROM messages WHERE session_id = ? AND active = 1 ORDER BY id"
 _SET_COUNTERS_SQL = "UPDATE sessions SET message_count = ?, tool_call_count = ?"
 _RESET_COUNTERS_SQL = "UPDATE sessions SET message_count = 0, tool_call_count = 0 WHERE id = ?"
@@ -130,7 +135,12 @@ class SessionMessagesMixin:
 
     @classmethod
     def _decode_content(cls, content: Any) -> Any:
-        """Reverse :meth:`_encode_content`; returns scalars unchanged."""
+        """Reverse :meth:`_encode_content`; returns scalars unchanged. A BLOB-stored value decodes
+        to ``str`` (U+FFFD on undecodable bytes) so public message dicts stay JSON-serializable
+        regardless of which storage class a corrupt cell landed in (#109465 review: BLOB bytes
+        made ``json.dumps(message)`` raise TypeError)."""
+        if isinstance(content, bytes):
+            return tolerant_decode_bytes(content)
         if isinstance(content, str) and content.startswith(cls._CONTENT_JSON_PREFIX):
             return _json_or(content[len(cls._CONTENT_JSON_PREFIX):], content,
                 "Failed to decode JSON-encoded message content; returning raw string")
@@ -169,6 +179,40 @@ class SessionMessagesMixin:
         if not isinstance(meta, dict):
             logger.warning("Ignoring non-object display metadata on message row")
             return None
+        return meta
+
+    @staticmethod
+    def _strict_display_metadata_cell(raw: Any, message_row_id: int) -> Optional[Dict[str, Any]]:
+        """Fail-closed decode+parse for the display_metadata read-modify-write seam
+        (#109465 review): a malformed cell — undecodable UTF-8, broken JSON, or a non-object
+        value — aborts the write with OperationalError instead of parsing away to ``{}`` and
+        letting the reaction update drop the row's unrelated metadata. Mirrors the model_config
+        seam (``_merge_model_config_json``); ``None`` (no metadata) stays a legal empty cell.
+        Same two-layer unwrap as :meth:`_decode_display_metadata` for pre-guard rows."""
+        if raw is None or raw == b"" or raw == "":
+            return None
+        meta: Any = raw
+        for _ in range(2):  # pre-guard rows carry a second string layer
+            if isinstance(meta, bytes):
+                try:
+                    meta = meta.decode("utf-8")
+                except UnicodeDecodeError as exc:
+                    raise sqlite3.OperationalError(
+                        f"message row {message_row_id}: display_metadata is not valid UTF-8; aborting "
+                        f"the metadata write so the stored field is not rewritten (fail closed): {exc}"
+                    ) from exc
+            if isinstance(meta, str):
+                try:
+                    meta = json.loads(meta)
+                except (json.JSONDecodeError, TypeError) as exc:
+                    raise sqlite3.OperationalError(
+                        f"message row {message_row_id}: display_metadata is not valid JSON; aborting "
+                        f"the metadata write so the stored field is not rewritten (fail closed): {exc}"
+                    ) from exc
+        if not isinstance(meta, dict):
+            raise sqlite3.OperationalError(
+                f"message row {message_row_id}: display_metadata is not a JSON object; aborting the "
+                f"metadata write so the stored field is not rewritten (fail closed)")
         return meta
 
     @staticmethod
@@ -393,10 +437,11 @@ class SessionMessagesMixin:
         if not session_id or message_row_id is None:
             return None
         def _do(conn):
-            row = conn.execute(_DISPLAY_META_ROW_SQL, (message_row_id, session_id)).fetchone()
+            row = conn.execute(_DISPLAY_META_ROW_BLOB_SQL, (message_row_id, session_id)).fetchone()
             if row is None:
                 return None
-            meta = self._decode_display_metadata(row[0]) or {}
+            # Fail-closed seam: a malformed cell aborts here; only a legal empty cell starts from {}.
+            meta = self._strict_display_metadata_cell(row[0], message_row_id) or {}
             existing = self._reaction_list(meta)
             reactions = [r for r in existing if r.get("author") != author]
             previous = next((r for r in existing if r.get("author") == author), None)

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -469,10 +469,13 @@ class SessionMessagesMixin:
             return []
         def _do(conn):
             pending = []
-            for row in conn.execute("SELECT id, role, content, display_metadata FROM messages "
-                    "WHERE session_id = ? AND active = 1 AND display_metadata IS NOT NULL ORDER BY id",
+            # CAST defeats the tolerant text_factory (same seam contract as set_message_reaction):
+            # an undecodable cell aborts the take instead of being rewritten as U+FFFD soup that
+            # silently destroys the row's unrelated metadata (#109465 review, completeness gap 1).
+            for row in conn.execute("SELECT id, role, content, CAST(display_metadata AS BLOB) AS display_metadata "
+                    "FROM messages WHERE session_id = ? AND active = 1 AND display_metadata IS NOT NULL ORDER BY id",
                     (session_id,)).fetchall():
-                meta = self._decode_display_metadata(row["display_metadata"])
+                meta = self._strict_display_metadata_cell(row["display_metadata"], row["id"])
                 reactions = meta.get(self.REACTIONS_METADATA_KEY) if meta else None
                 if not isinstance(reactions, list):
                     continue
@@ -801,6 +804,13 @@ class SessionMessagesMixin:
         msg = dict(row)
         msg.pop("display_identity", None)
         msg.pop("display_order", None)
+        # display_identity (popped above) is the messages table's only legitimate BLOB column, so
+        # any surviving bytes is a corrupt cell that landed in BLOB storage and bypassed text_factory
+        # (sqlite3 contract). Normalize centrally: NO public read surface may hand out bytes, or
+        # json.dumps(message) raises TypeError on e.g. a BLOB-stored reasoning cell (#109465 review).
+        for key, value in msg.items():
+            if isinstance(value, bytes):
+                msg[key] = tolerant_decode_bytes(value)
         if summary_flag and msg.pop("_compressed_summary", 0):
             msg["_compressed_summary"] = True
         msg["content"] = self._decode_content(msg["content"])

--- a/hermes_state_portability.py
+++ b/hermes_state_portability.py
@@ -164,7 +164,8 @@ class SessionPortabilityMixin:
             "SELECT cwd AS cwd, COUNT(*) AS sessions, MAX(COALESCE(ended_at, started_at, 0)) AS last_active "
             f"FROM sessions WHERE {where} GROUP BY cwd"
         )
-        return [{"cwd": r["cwd"], "sessions": int(r["sessions"] or 0), "last_active": float(r["last_active"] or 0)}
+        return [{"cwd": self._public_cell(r["cwd"]), "sessions": int(r["sessions"] or 0),
+                 "last_active": float(r["last_active"] or 0)}
                 for r in rows]
 
     def list_cron_job_runs(self, job_id: str, limit: int = 20, offset: int = 0) -> List[Dict[str, Any]]:

--- a/hermes_state_portability.py
+++ b/hermes_state_portability.py
@@ -230,7 +230,9 @@ class SessionPortabilityMixin:
                 ORDER BY s.started_at DESC
                 LIMIT ?
                 """, (SKILL_SCAFFOLD_SQL_LIKE, int(limit)))
-        return [dict(row) for row in rows]
+        # Shared normalization boundary: a BLOB-stored title/content cell bypasses text_factory
+        # and must not escape the public projection as bytes (#109465 review).
+        return [self._session_row_dict(row) for row in rows]
 
     # ── Export ─────────────────────────────────────────────────────────────
 

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -896,7 +896,9 @@ class SessionSearchMixin:
         search never runs the unbounded rebuild. Other ``DatabaseError``s propagate."""
         sql, params = self._fts_match_sql(table, match_query, order_by_sql, **kwargs)
         try:
-            return [dict(row) for row in self._read_all(sql, params)]
+            # Shared normalization boundary so a BLOB-stored cell never escapes the public
+            # search rows as bytes (#109465 review).
+            return [self._session_row_dict(row) for row in self._read_all(sql, params)]
         except sqlite3.OperationalError:
             if operational_debug:
                 logger.debug(operational_debug, exc_info=True)
@@ -912,7 +914,7 @@ class SessionSearchMixin:
     def _like_rows(self, where: List[str], params: list, *, order_by: str, limit_sql: str) -> List[Dict[str, Any]]:
         """Canonical-table LIKE scan; ``params[0]`` is the snippet anchor term."""
         sql = _search_select_sql(_LIKE_SNIPPET_SQL, "messages m", where, order_by, limit_sql)
-        return [dict(row) for row in self._read_all(sql, params)]
+        return [self._session_row_dict(row) for row in self._read_all(sql, params)]
 
     @staticmethod
     def _compile_like_boolean_query(query: str) -> Tuple[str, List[Any], Optional[str]]:
@@ -1070,7 +1072,7 @@ class SessionSearchMixin:
         else:
             sql, params = self._fts_match_sql("messages_fts", query, **route)
             try:
-                matches = [dict(row) for row in self._read_all(sql, params)]
+                matches = [self._session_row_dict(row) for row in self._read_all(sql, params)]
             except sqlite3.OperationalError:
                 return []  # FTS5 syntax error despite sanitization
             except sqlite3.DatabaseError as exc:

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -996,7 +996,8 @@ class SessionSearchMixin:
                 for match in batch:
                     try:
                         match["context"] = [
-                            {"role": row["role"], "content": _flatten_text(self._decode_content(row["content"]))[:200]}
+                            {"role": self._public_cell(row["role"]),
+                             "content": _flatten_text(self._decode_content(row["content"]))[:200]}
                             for row in contexts.get(match["id"], [])]
                     except Exception:
                         match["context"] = []

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -798,7 +798,7 @@ class SessionSessionsMixin:
                 LIMIT 1""",
             (session_id,),
         )
-        return dict(row) if row else None
+        return self._session_row_dict(row) if row else None
 
     def resolve_session_id(self, session_id_or_prefix: str) -> Optional[str]:
         """Exact id, else the single unambiguous prefix match, else None."""

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -49,6 +49,22 @@ def _parse_model_config(raw: Any) -> Dict[str, Any]:
     return dict(raw) if isinstance(raw, dict) else {}
 
 
+def _strict_model_config_text(raw: Any, session_id: str) -> Any:
+    """Fail-closed decode for the read-modify-write seam: a malformed model_config cell must
+    abort the mutation with OperationalError (sqlite3's strict-decode failure type) instead of
+    degrading to U+FFFD, parsing away to {} and letting the patch overwrite the stored field
+    (#109450 review: a `{"keep":"yes"}\\xff` cell patched to only `{"new":1}` under a tolerant factory)."""
+    if isinstance(raw, bytes):
+        try:
+            return raw.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise sqlite3.OperationalError(
+                f"session '{session_id}': model_config is not valid UTF-8; aborting the config "
+                f"patch so the stored field is not rewritten (fail closed): {exc}"
+            ) from exc
+    return raw
+
+
 def _cwd_prefix_clause(cwd_prefix: str) -> Tuple[str, List[str]]:
     prefix = cwd_prefix.rstrip("/\\") or cwd_prefix
     # ``_``/``%`` are LIKE wildcards but ordinary path characters: unescaped, a
@@ -676,12 +692,14 @@ class SessionSessionsMixin:
         """SELECT + tolerant-parse + merge ``patch`` into model_config (the one place that keeps
         ``_branched_from``/``_delegate_from`` alive); ``None`` deletes a key. Returns serialized JSON
         (``None`` when empty) or ``_MODEL_CONFIG_ROW_MISSING`` (``on_missing="raise"`` → ValueError)."""
-        row = conn.execute("SELECT model_config FROM sessions WHERE id = ?", (session_id,)).fetchone()
+        row = conn.execute(
+            "SELECT CAST(model_config AS BLOB) FROM sessions WHERE id = ?", (session_id,)
+        ).fetchone()
         if row is None:
             if on_missing == "raise":
                 raise ValueError(f"Session not found: {session_id}")
             return _MODEL_CONFIG_ROW_MISSING
-        config = _parse_model_config(row[0])
+        config = _parse_model_config(_strict_model_config_text(row[0], session_id))
         for key, value in patch.items():
             if value is None:
                 config.pop(key, None)

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -49,6 +49,23 @@ def _parse_model_config(raw: Any) -> Dict[str, Any]:
     return dict(raw) if isinstance(raw, dict) else {}
 
 
+def _parse_model_config_strict(raw: Any, session_id: str) -> Dict[str, Any]:
+    """Fail-closed parse for the read-modify-write seam: a syntactically malformed JSON cell
+    that strict-decoded fine (valid UTF-8) must still abort the patch instead of parsing away
+    to {} and letting the patch overwrite the stored field (#109465 review: a
+    `{"keep":"yes" BROKEN` cell patched to only `{"new":1}`). Legal emptiness (NULL/blank)
+    stays {}, same as the tolerant read path."""
+    if isinstance(raw, str) and raw.strip():
+        try:
+            raw = json.loads(raw)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise sqlite3.OperationalError(
+                f"session '{session_id}': model_config is not valid JSON; aborting the config "
+                f"patch so the stored field is not rewritten (fail closed): {exc}"
+            ) from exc
+    return dict(raw) if isinstance(raw, dict) else {}
+
+
 def _strict_model_config_text(raw: Any, session_id: str) -> Any:
     """Fail-closed decode for the read-modify-write seam: a malformed model_config cell must
     abort the mutation with OperationalError (sqlite3's strict-decode failure type) instead of
@@ -699,7 +716,7 @@ class SessionSessionsMixin:
             if on_missing == "raise":
                 raise ValueError(f"Session not found: {session_id}")
             return _MODEL_CONFIG_ROW_MISSING
-        config = _parse_model_config(_strict_model_config_text(row[0], session_id))
+        config = _parse_model_config_strict(_strict_model_config_text(row[0], session_id), session_id)
         for key, value in patch.items():
             if value is None:
                 config.pop(key, None)

--- a/hermes_state_telegram.py
+++ b/hermes_state_telegram.py
@@ -221,7 +221,7 @@ class SessionTelegramTopicsMixin:
                     SELECT * FROM telegram_dm_topic_bindings
                     WHERE profile_name = ? AND chat_id = ? AND thread_id = ?
                     """, (profile_name, str(chat_id), str(thread_id)))
-        return dict(row) if row else None
+        return self._session_row_dict(row) if row else None
 
     def list_telegram_topic_bindings_for_chat(
         self, *, chat_id: str, profile_name: str = "default"
@@ -235,7 +235,8 @@ class SessionTelegramTopicsMixin:
             )
         except sqlite3.OperationalError:
             return []
-        return [dict(row) for row in rows]
+        # Same normalization boundary as every other public projection (#109465 review).
+        return [self._session_row_dict(row) for row in rows]
 
     def get_telegram_topic_binding_by_session(self, *, session_id: str) -> Optional[Dict[str, Any]]:
         """Reverse lookup via the UNIQUE INDEX on session_id; None when unbound."""
@@ -243,7 +244,7 @@ class SessionTelegramTopicsMixin:
                     SELECT * FROM telegram_dm_topic_bindings
                     WHERE session_id = ?
                     """, (str(session_id),))
-        return dict(row) if row else None
+        return self._session_row_dict(row) if row else None
 
     def delete_telegram_topic_binding(self, *, chat_id: str, thread_id: str, profile_name: str = "default") -> int:
         """Remove the binding row for one (chat, thread) pair. Called when the Bot API confirms

--- a/hermes_state_titles.py
+++ b/hermes_state_titles.py
@@ -130,12 +130,12 @@ class SessionTitlesMixin:
     def get_session_title(self, session_id: str) -> Optional[str]:
         """Get the title for a session, or None."""
         row = self._read_one("SELECT title FROM sessions WHERE id = ?", (session_id,))
-        return row["title"] if row else None
+        return self._public_cell(row["title"]) if row else None
 
     def get_session_title_source(self, session_id: str) -> Optional[str]:
         """Get the provenance of a session's title, or None when untitled."""
         row = self._read_one("SELECT title, title_source FROM sessions WHERE id = ?", (session_id,))
-        return row["title_source"] if row and row["title"] is not None else None
+        return self._public_cell(row["title_source"]) if row and row["title"] is not None else None
 
     def set_session_title_source(self, session_id: str, source: str) -> bool:
         """Overwrite a title's provenance without touching the text (a title copied across a

--- a/tests/hermes_state/test_corrupt_row_robustness.py
+++ b/tests/hermes_state/test_corrupt_row_robustness.py
@@ -57,6 +57,54 @@ def test_list_export_and_insights_survive_corrupt_timestamp_rows(corrupt_db, cap
     assert any("bad-huge" in rec.getMessage() for rec in caplog.records)
 
 
+def test_corrupt_prompt_row_degrades_instead_of_killing_session_queries(tmp_path, caplog):
+    """One truncated-UTF-8 system_prompts row must degrade to U+FFFD in that one cell, never
+    abort every session-list/load query (#109450: one bad row made the desktop session panel
+    unable to list or open ANY session)."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        good_prompt = "You are Hermes ✓ 中文 round-trip"
+        db.create_session("good", "cli", system_prompt=good_prompt)
+        db.create_session("bad", "cli", system_prompt="You are Hermes truncated tail")
+
+        def _corrupt(conn):
+            row = conn.execute(
+                "SELECT hash FROM system_prompts WHERE prompt LIKE '%truncated tail%'"
+            ).fetchone()
+            # A mid-write process death left the 3-byte ✓ (e2 9c 93) missing its last byte;
+            # CAST keeps the bad value in TEXT storage so the strict decode path is exercised.
+            conn.execute(
+                "UPDATE system_prompts SET prompt = CAST(? AS TEXT) WHERE hash = ?",
+                (b"You are Hermes \xe2\x9c", row["hash"]),
+            )
+
+        db._execute_write(_corrupt)
+        kind = db._conn.execute(
+            "SELECT typeof(sp.prompt) FROM system_prompts sp"
+            " JOIN sessions s ON s.system_prompt_hash = sp.hash WHERE s.id = 'bad'"
+        ).fetchone()[0]
+        assert kind == "text"
+
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            rich = {s["id"]: s["system_prompt"] for s in db.list_sessions_rich()}
+            loaded_bad = db.get_session("bad")["system_prompt"]
+            searched = {s["id"]: s["system_prompt"] for s in db.search_sessions()}
+
+        # Every session still loads on every surface; only the corrupt cell degrades.
+        assert set(rich) == {"good", "bad"}
+        assert rich["good"] == good_prompt  # valid multi-byte text round-trips exactly
+        assert rich["bad"] == "You are Hermes \ufffd"
+        assert loaded_bad == rich["bad"]
+        assert searched == rich
+        # The warning carries the raw byte head so the corrupt row can be located on disk.
+        assert any(
+            "degraded to U+FFFD" in rec.getMessage() and "\\xe2\\x9c" in rec.getMessage()
+            for rec in caplog.records
+        )
+    finally:
+        db.close()
+
+
 def test_writers_never_persist_an_out_of_window_timestamp(tmp_path):
     db = SessionDB(db_path=tmp_path / "state.db")
     try:

--- a/tests/hermes_state/test_corrupt_row_robustness.py
+++ b/tests/hermes_state/test_corrupt_row_robustness.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import logging
 import sqlite3
+import time
 
 import pytest
 
@@ -414,5 +415,64 @@ def test_blob_stored_title_and_reasoning_stay_serializable(tmp_path):
         assert json.dumps(session) and json.dumps(messages)
         # The listing surface shares the same normalization boundary.
         assert all(json.dumps(s) for s in db.list_recent_sessions_bounded())
+    finally:
+        db.close()
+
+
+def test_take_unseen_reactions_normalizes_blob_stored_role(tmp_path):
+    """A BLOB-stored role bypasses text_factory (sqlite3 contract) and used to escape the
+    take_unseen_reactions payload as bytes, so json.dumps(result) raised TypeError. It must
+    degrade to str exactly like every other public read surface (#109465 review, gap 3)."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("s", "cli")
+        db.append_message("s", "user", "react to me")
+        row_id = db.latest_message_row_id("s", role="user")
+        db.set_message_reaction("s", row_id, "\U0001f44d", author="user")
+        db._execute_write(lambda conn: conn.execute(
+            "UPDATE messages SET role = ? WHERE id = ?", (b"user \xe2\x9c", row_id)))
+        assert db._conn.execute(
+            "SELECT typeof(role) FROM messages WHERE id = ?", (row_id,)).fetchone()[0] == "blob"
+
+        result = db.take_unseen_reactions("s", author="user")
+        assert result == [{
+            "row_id": row_id, "role": "user \ufffd", "emoji": "\U0001f44d", "text": "react to me"}]
+        assert json.dumps(result)
+    finally:
+        db.close()
+
+
+def test_partial_projection_apis_normalize_blob_stored_cells(tmp_path):
+    """list_never_active_keyed_sessions/list_skill_scaffolded_sessions used to hand out
+    dict(row) directly, letting a corrupt BLOB-stored cell escape the public projection as
+    bytes. They share the _session_row_dict normalization boundary now, so both payloads
+    stay JSON-serializable (#109465 review, gap 3)."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db._conn.execute(
+            "INSERT INTO sessions (id, source, session_key, chat_id, chat_type, user_id, "
+            "started_at, message_count, tool_call_count, api_call_count, input_tokens, "
+            "output_tokens, archived, pinned) VALUES (?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 0, 0, 0, 0)",
+            ("junk", "telegram", b"agent:main:telegram:dm:junk\xe2\x9c", "chat-1", "dm",
+             "user-1", time.time() - 45 * 86400.0))
+        db._conn.commit()
+        keyed = db.list_never_active_keyed_sessions(older_than_days=30)
+        assert [r["id"] for r in keyed] == ["junk"]
+        assert keyed[0]["session_key"] == "agent:main:telegram:dm:junk\ufffd"
+        assert json.dumps(keyed)
+
+        # Content stays TEXT: the selector's LIKE only matches TEXT storage. The BLOB damage
+        # lands on title, which the selector only checks for IS NOT NULL.
+        db.create_session("titled", "cli")
+        db.append_message("titled", "user", '[IMPORTANT: The user has invoked the "work" skill')
+        db.set_session_title("titled", "placeholder title")
+        db._execute_write(lambda conn: conn.execute(
+            "UPDATE sessions SET title = ? WHERE id = 'titled'", (b"Setup \xe2\x9c",)))
+        assert db._conn.execute(
+            "SELECT typeof(title) FROM sessions WHERE id = 'titled'").fetchone()[0] == "blob"
+        scaffolded = db.list_skill_scaffolded_sessions()
+        assert [r["id"] for r in scaffolded] == ["titled"]
+        assert scaffolded[0]["title"] == "Setup \ufffd"
+        assert json.dumps(scaffolded)
     finally:
         db.close()

--- a/tests/hermes_state/test_corrupt_row_robustness.py
+++ b/tests/hermes_state/test_corrupt_row_robustness.py
@@ -5,6 +5,7 @@ timestamp column (#102399, #102352, #99959). Never monkeypatch the coercion help
 """
 
 import argparse
+import hashlib
 import logging
 import sqlite3
 
@@ -15,7 +16,7 @@ from hermes_cli.session_export import iter_user_prompt_records
 from hermes_cli.session_export_html import generate_multi_session_html_export
 from hermes_cli.session_export_md import _iso_timestamp
 from hermes_cli.sessions_cmd import _cmd_list
-from hermes_state import SessionDB
+from hermes_state import SessionDB, _corruption_warned_fingerprints
 
 
 @pytest.fixture
@@ -85,6 +86,7 @@ def test_corrupt_prompt_row_degrades_instead_of_killing_session_queries(tmp_path
         ).fetchone()[0]
         assert kind == "text"
 
+        _corruption_warned_fingerprints.clear()  # module-level dedup: start from a known state
         with caplog.at_level(logging.WARNING, logger="hermes_state"):
             rich = {s["id"]: s["system_prompt"] for s in db.list_sessions_rich()}
             loaded_bad = db.get_session("bad")["system_prompt"]
@@ -96,11 +98,72 @@ def test_corrupt_prompt_row_degrades_instead_of_killing_session_queries(tmp_path
         assert rich["bad"] == "You are Hermes \ufffd"
         assert loaded_bad == rich["bad"]
         assert searched == rich
-        # The warning carries the raw byte head so the corrupt row can be located on disk.
-        assert any(
-            "degraded to U+FFFD" in rec.getMessage() and "\\xe2\\x9c" in rec.getMessage()
-            for rec in caplog.records
-        )
+        # The warning is content-free: sha256 fingerprint (no raw bytes — cells can hold secrets),
+        # and it fires once per distinct bad value — a second read pass stays silent.
+        fingerprint = hashlib.sha256(b"You are Hermes \xe2\x9c").hexdigest()[:16]
+        warned = [r for r in caplog.records if "degraded to U+FFFD" in r.getMessage()]
+        assert warned and fingerprint in warned[0].getMessage()
+        assert not any("\\xe2\\x9c" in r.getMessage() for r in caplog.records)
+        caplog.clear()
+        db.list_sessions_rich()
+        assert not [r for r in caplog.records if "degraded to U+FFFD" in r.getMessage()]
+    finally:
+        db.close()
+
+
+def test_corrupt_model_config_aborts_mutation_instead_of_rewriting(tmp_path):
+    """A malformed model_config cell must abort a read-modify-write (the writer connection stays
+    strict), never tolerate-decode to a JSON parse failure that turns into {} and lets the patch
+    overwrite the original field (#109450 review: `{"keep":"yes"}\\xff` became only `{"new":1}`)."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("bad", "cli")
+        raw = b'{"keep": "yes"}\xff'
+
+        def _corrupt(conn):
+            conn.execute(
+                "UPDATE sessions SET model_config = CAST(? AS TEXT) WHERE id = 'bad'", (raw,)
+            )
+
+        db._execute_write(_corrupt)
+        assert db._conn.execute(
+            "SELECT typeof(model_config) FROM sessions WHERE id = 'bad'"
+        ).fetchone()[0] == "text"
+
+        with pytest.raises(sqlite3.OperationalError):
+            db.patch_session_model_config("bad", {"new": 1})
+
+        # Fail closed: the mutation aborted, the malformed cell is byte-identical, "keep" survived.
+        stored = db._read_one(
+            "SELECT CAST(model_config AS BLOB) FROM sessions WHERE id = 'bad'"
+        )[0]
+        assert bytes(stored) == raw
+    finally:
+        db.close()
+
+
+def test_blob_stored_prompt_reads_back_as_bytes(tmp_path):
+    """BLOB storage bypasses text_factory by sqlite3 contract: a value stored as BLOB reads back
+    as ``bytes`` (pre-existing behavior, unchanged by this fix), unlike malformed TEXT which
+    degrades to U+FFFD on read."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("bad", "cli", system_prompt="placeholder tail")
+        raw = b"You are Hermes \xe2\x9c"
+
+        def _store_blob(conn):
+            row = conn.execute(
+                "SELECT hash FROM system_prompts WHERE prompt LIKE '%placeholder tail%'"
+            ).fetchone()
+            # No CAST: binding bytes stores a BLOB, which text_factory never sees.
+            conn.execute("UPDATE system_prompts SET prompt = ? WHERE hash = ?", (raw, row["hash"]))
+
+        db._execute_write(_store_blob)
+        assert db._conn.execute(
+            "SELECT typeof(sp.prompt) FROM system_prompts sp"
+            " JOIN sessions s ON s.system_prompt_hash = sp.hash WHERE s.id = 'bad'"
+        ).fetchone()[0] == "blob"
+        assert db.get_session("bad")["system_prompt"] == raw  # bytes in, bytes out
     finally:
         db.close()
 

--- a/tests/hermes_state/test_corrupt_row_robustness.py
+++ b/tests/hermes_state/test_corrupt_row_robustness.py
@@ -476,3 +476,107 @@ def test_partial_projection_apis_normalize_blob_stored_cells(tmp_path):
         assert json.dumps(scaffolded)
     finally:
         db.close()
+
+
+def _assert_no_bytes(node):
+    """Recursively fail on any bytes that escaped a public projection."""
+    if isinstance(node, bytes):
+        raise AssertionError(f"bytes escaped a public projection: {node!r}")
+    if isinstance(node, dict):
+        for key, value in node.items():
+            _assert_no_bytes(key)
+            _assert_no_bytes(value)
+    elif isinstance(node, (list, tuple)):
+        for item in node:
+            _assert_no_bytes(item)
+
+
+def test_public_projection_contract_table_serializes_blob_cells(tmp_path):
+    """Table-driven public API contract (#109465 review, gap 4): every public read surface —
+    the scalar single-column projections and manually assembled dicts named in review, plus
+    the dict(row) projections converted earlier in this PR — degrades a corrupt BLOB-stored
+    cell to str, so json.dumps(result) never raises TypeError. Each case seeds a malformed
+    (undecodable) BLOB in a column the API projects, then asserts the serialized payload
+    carries U+FFFD and no raw bytes anywhere."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("s", "cli")
+        db.append_message("s", "user", "hello needle")
+        db.append_message("s", "assistant", "answer")
+        db.append_message("s", "tool", "tool needle", tool_name="terminal")
+        # Second tool row so the two BLOB targets don't fight: the LIKE fallback's
+        # role_filter matches on TEXT role, so row A keeps role='tool' (its tool_name is
+        # corrupted instead) while the newest row B carries the BLOB role.
+        db.append_message("s", "tool", "tail needle", tool_name="browser")
+        search_row_id = db._read_one("SELECT id FROM messages WHERE session_id = 's' AND role = 'tool'")[0]
+        blob_row_id = db._read_one(
+            "SELECT id FROM messages WHERE session_id = 's' AND role = 'tool' ORDER BY id DESC")[0]
+        db.set_session_title("s", "placeholder title")
+        db.request_handoff("s", "telegram")
+        db.bind_telegram_topic(chat_id="chat-1", thread_id="77", user_id="user-1",
+                               session_key="agent:main:telegram:dm:chat-1_77", session_id="s")
+        db._execute_write(lambda conn: conn.execute(
+            "INSERT INTO gateway_routing (scope, session_key, entry_json, updated_at) "
+            "VALUES ('', 'agent:main:routed', '{}', 1.0)"))
+        db._execute_write(lambda conn: conn.execute(
+            "INSERT INTO gateway_heartbeats (backend_id, pid, started_at, last_heartbeat, profile, host) "
+            "VALUES ('srv-1', 42, 1.0, 1.0, 'default', 'box')"))
+        old_ts = time.time() - 45 * 86400.0
+        db._conn.execute(
+            "INSERT INTO sessions (id, source, title, started_at, ended_at, message_count, "
+            "tool_call_count, api_call_count, input_tokens, output_tokens, archived, pinned) "
+            "VALUES ('old', 'cli', 'placeholder old title', ?, ?, 0, 0, 0, 0, 0, 0, 0)",
+            (old_ts, old_ts))
+        db._conn.commit()
+
+        undecodable = b"corrupt \xe2\x9c"
+
+        def _store_blobs(conn):
+            # sessions: feeds get_session*, get_handoff_state, prune candidates, cwd rollup
+            conn.execute("UPDATE sessions SET title = ?, title_source = ?, handoff_error = ?, cwd = ? "
+                         "WHERE id = 's'", (undecodable, undecodable, undecodable, undecodable))
+            conn.execute("UPDATE sessions SET title = ? WHERE id = 'old'", (b"old corrupt \xe2\x9c",))
+            # messages: the newest row's role feeds latest_conversation_role/get_message_role;
+            # row A's tool_name feeds the LIKE-fallback search projection (content and role
+            # must stay TEXT so the search's WHERE still matches).
+            conn.execute("UPDATE messages SET role = ? WHERE id = ?", (undecodable, blob_row_id))
+            conn.execute("UPDATE messages SET tool_name = ? WHERE id = ?", (undecodable, search_row_id))
+            # gateway_routing / heartbeats / telegram bindings: manual dict assemblies
+            conn.execute("UPDATE gateway_routing SET session_key = ?, entry_json = ? "
+                         "WHERE session_key = 'agent:main:routed'", (undecodable, undecodable))
+            conn.execute("UPDATE gateway_heartbeats SET profile = ? WHERE backend_id = 'srv-1'",
+                         (undecodable,))
+            conn.execute("UPDATE telegram_dm_topic_bindings SET session_key = ? "
+                         "WHERE session_id = 's'", (undecodable,))
+
+        db._execute_write(_store_blobs)
+
+        cases = [
+            # Scalar projections named in review.
+            ("get_session_title", lambda: db.get_session_title("s")),
+            ("get_session_title_source", lambda: db.get_session_title_source("s")),
+            ("get_handoff_state", lambda: db.get_handoff_state("s")),
+            ("load_gateway_routing_entries", lambda: db.load_gateway_routing_entries()),
+            ("latest_conversation_role", lambda: db.latest_conversation_role("s")),
+            ("get_message_role", lambda: db.get_message_role("s", blob_row_id)),
+            ("distinct_session_cwds", lambda: db.distinct_session_cwds()),
+            # Dict(row) projections converted earlier in this PR.
+            ("get_session", lambda: db.get_session("s")),
+            ("list_prune_candidates", lambda: db.list_prune_candidates(older_than_days=30)),
+            ("list_backend_heartbeats", lambda: db.list_backend_heartbeats()),
+            ("list_telegram_topic_bindings_for_chat",
+             lambda: db.list_telegram_topic_bindings_for_chat(chat_id="chat-1")),
+            ("get_telegram_topic_binding_by_session",
+             lambda: db.get_telegram_topic_binding_by_session(session_id="s")),
+            # LIKE-fallback search rows (role_filter=['tool'] bypasses the trigram index).
+            ("search_messages_like_fallback",
+             lambda: db.search_messages("needle", role_filter=["tool"])),
+        ]
+        for name, factory in cases:
+            payload = factory()
+            assert payload, f"{name} lost its seeded row"
+            _assert_no_bytes(payload)
+            serialized = json.dumps(payload, ensure_ascii=False)
+            assert "\ufffd" in serialized, f"{name} did not degrade the BLOB cell"
+    finally:
+        db.close()

--- a/tests/hermes_state/test_corrupt_row_robustness.py
+++ b/tests/hermes_state/test_corrupt_row_robustness.py
@@ -335,3 +335,84 @@ def test_corruption_warning_dedupe_is_bounded_and_thread_safe(caplog):
         thread.join()
     assert not errors
     assert len(_corruption_warned_fingerprints) <= _CORRUPTION_WARN_FINGERPRINT_CAP
+
+
+def test_take_unseen_reactions_fails_closed_on_undecodable_metadata(tmp_path):
+    """The take_unseen_reactions read-modify-write seam must abort byte-identically on an
+    undecodable display_metadata cell — for BOTH storage classes — instead of parsing the
+    tolerant U+FFFD text, marking the reaction seen, and rewriting the row's private fields
+    as replacement soup (#109465 review, completeness gap 1)."""
+    for storage in ("blob", "text"):
+        db = SessionDB(db_path=tmp_path / f"state-{storage}.db")
+        try:
+            db.create_session("s", "cli")
+            db.append_message("s", "user", "react to me")
+            row_id = db.latest_message_row_id("s", role="user")
+            db.set_message_reaction("s", row_id, "\U0001f44d", author="user")
+            good_meta = db._conn.execute(
+                "SELECT CAST(display_metadata AS BLOB) FROM messages WHERE id = ?", (row_id,)
+            ).fetchone()[0]
+            assert json.loads(good_meta.decode("utf-8"))["reactions"][0]["emoji"] == "\U0001f44d"
+
+            # One private field carries undecodable bytes; the reaction itself stays valid.
+            undecodable_meta = json.dumps({
+                "private": "secret", "reactions": [
+                    {"emoji": "\U0001f44d", "author": "user", "at": 1.0, "seen": False}],
+            }).encode("utf-8").replace(b"secret", b"secret\xe2\x9c")
+
+            def _damage(conn):
+                if storage == "blob":
+                    conn.execute("UPDATE messages SET display_metadata = ? WHERE id = ?",
+                                 (undecodable_meta, row_id))
+                else:  # TEXT storage: the tolerant text_factory would hide the raw bytes on read
+                    conn.execute("UPDATE messages SET display_metadata = CAST(? AS TEXT) WHERE id = ?",
+                                 (undecodable_meta, row_id))
+
+            db._execute_write(_damage)
+            stored = db._conn.execute(
+                "SELECT CAST(display_metadata AS BLOB) FROM messages WHERE id = ?", (row_id,)
+            ).fetchone()[0]
+            assert stored == undecodable_meta
+
+            # Fail closed: the whole take aborts; the stored cell is byte-identical afterwards.
+            with pytest.raises(sqlite3.OperationalError, match="not valid UTF-8"):
+                db.take_unseen_reactions("s", author="user")
+            assert db._conn.execute(
+                "SELECT CAST(display_metadata AS BLOB) FROM messages WHERE id = ?", (row_id,)
+            ).fetchone()[0] == undecodable_meta
+
+            # With the damaged cell healed, the same take surfaces the reaction exactly once.
+            db._execute_write(lambda conn: conn.execute(
+                "UPDATE messages SET display_metadata = ? WHERE id = ?", (good_meta, row_id)))
+            assert db.take_unseen_reactions("s", author="user") == [{
+                "row_id": row_id, "role": "user", "emoji": "\U0001f44d", "text": "react to me"}]
+            assert db.take_unseen_reactions("s", author="user") == []
+        finally:
+            db.close()
+
+
+def test_blob_stored_title_and_reasoning_stay_serializable(tmp_path):
+    """BLOB-stored sessions.title and messages.reasoning must degrade to str in the public
+    dicts too, not just system_prompt/content: json.dumps(get_session(...)) and
+    json.dumps(get_messages(...)) keep working for BOTH storage classes (#109465 review,
+    completeness gap 2)."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("s", "cli")
+        db.append_message("s", "assistant", "answer placeholder head", reasoning="think placeholder head")
+        undecodable = b"why so serious \xe2\x9c"
+
+        def _store_blobs(conn):
+            conn.execute("UPDATE sessions SET title = ? WHERE id = 's'", (undecodable,))
+            conn.execute("UPDATE messages SET reasoning = ? WHERE session_id = 's'", (undecodable,))
+
+        db._execute_write(_store_blobs)
+        session = db.get_session("s")
+        messages = db.get_messages("s")
+        assert session["title"] == "why so serious \ufffd"
+        assert messages[0]["reasoning"] == "why so serious \ufffd"
+        assert json.dumps(session) and json.dumps(messages)
+        # The listing surface shares the same normalization boundary.
+        assert all(json.dumps(s) for s in db.list_recent_sessions_bounded())
+    finally:
+        db.close()

--- a/tests/hermes_state/test_corrupt_row_robustness.py
+++ b/tests/hermes_state/test_corrupt_row_robustness.py
@@ -6,6 +6,7 @@ timestamp column (#102399, #102352, #99959). Never monkeypatch the coercion help
 
 import argparse
 import hashlib
+import json
 import logging
 import sqlite3
 
@@ -17,6 +18,8 @@ from hermes_cli.session_export_html import generate_multi_session_html_export
 from hermes_cli.session_export_md import _iso_timestamp
 from hermes_cli.sessions_cmd import _cmd_list
 from hermes_state import SessionDB, _corruption_warned_fingerprints
+from hermes_state_common import (
+    _CORRUPTION_WARN_FINGERPRINT_CAP, warn_corrupt_cell as _warn_corrupt_cell)
 
 
 @pytest.fixture
@@ -142,28 +145,47 @@ def test_corrupt_model_config_aborts_mutation_instead_of_rewriting(tmp_path):
         db.close()
 
 
-def test_blob_stored_prompt_reads_back_as_bytes(tmp_path):
-    """BLOB storage bypasses text_factory by sqlite3 contract: a value stored as BLOB reads back
-    as ``bytes`` (pre-existing behavior, unchanged by this fix), unlike malformed TEXT which
-    degrades to U+FFFD on read."""
+def test_blob_stored_cells_degrade_to_str_never_escape_as_bytes(tmp_path, caplog):
+    """BLOB storage bypasses text_factory by sqlite3 contract, but NO public read surface may
+    hand out bytes: a BLOB system_prompt/message-content decodes to str (U+FFFD on undecodable
+    bytes), so session dicts and message dicts stay JSON-serializable for BOTH storage classes
+    (#109465 review: bytes escaped the public session API and json.dumps(message) raised
+    TypeError)."""
     db = SessionDB(db_path=tmp_path / "state.db")
     try:
         db.create_session("bad", "cli", system_prompt="placeholder tail")
-        raw = b"You are Hermes \xe2\x9c"
+        db.append_message("bad", "user", "msg placeholder tail")
+        undecodable = b"You are Hermes \xe2\x9c"
 
-        def _store_blob(conn):
+        def _store_blobs(conn):
             row = conn.execute(
                 "SELECT hash FROM system_prompts WHERE prompt LIKE '%placeholder tail%'"
             ).fetchone()
             # No CAST: binding bytes stores a BLOB, which text_factory never sees.
-            conn.execute("UPDATE system_prompts SET prompt = ? WHERE hash = ?", (raw, row["hash"]))
+            conn.execute("UPDATE system_prompts SET prompt = ? WHERE hash = ?", (undecodable, row["hash"]))
+            conn.execute("UPDATE messages SET content = ? WHERE session_id = 'bad'", (undecodable,))
 
-        db._execute_write(_store_blob)
+        db._execute_write(_store_blobs)
         assert db._conn.execute(
             "SELECT typeof(sp.prompt) FROM system_prompts sp"
             " JOIN sessions s ON s.system_prompt_hash = sp.hash WHERE s.id = 'bad'"
         ).fetchone()[0] == "blob"
-        assert db.get_session("bad")["system_prompt"] == raw  # bytes in, bytes out
+
+        _corruption_warned_fingerprints.clear()  # module-level dedup: start from a known state
+        with caplog.at_level(logging.WARNING, logger="hermes_state"):
+            session = db.get_session("bad")
+            messages = db.get_messages("bad")
+
+        # Both storage classes degrade identically: str with U+FFFD, never bytes.
+        assert session["system_prompt"] == "You are Hermes \ufffd"
+        assert isinstance(messages[0]["content"], str)
+        assert messages[0]["content"] == "You are Hermes \ufffd"
+        # Stable serializable output contract: json.dumps works on every public dict.
+        assert json.dumps(session) and json.dumps(messages)
+        # The BLOB degrade path shares the content-free fingerprint warning with text_factory.
+        fingerprint = hashlib.sha256(undecodable).hexdigest()[:16]
+        warned = [r for r in caplog.records if "degraded to U+FFFD" in r.getMessage()]
+        assert fingerprint in warned[0].getMessage()
     finally:
         db.close()
 
@@ -201,3 +223,115 @@ def test_bulk_delete_and_prune_stay_below_sqlite_variable_limit(tmp_path):
         assert db._read_one("SELECT COUNT(*) FROM messages WHERE session_id NOT IN (SELECT id FROM sessions)")[0] == 0
     finally:
         db.close()
+
+
+def test_broken_json_model_config_aborts_mutation_instead_of_rewriting(tmp_path):
+    """A syntactically malformed but valid-UTF-8 model_config cell aborts the patch too, not
+    just undecodable bytes: the strict decode alone left `{"keep":"yes" BROKEN` parsing away
+    to {} and letting the patch overwrite the stored field (#109465 review follow-up)."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("bad", "cli")
+        raw = '{"keep": "yes" BROKEN'  # decodes fine, parses to nothing
+
+        def _corrupt(conn):
+            conn.execute("UPDATE sessions SET model_config = ? WHERE id = 'bad'", (raw,))
+
+        db._execute_write(_corrupt)
+
+        with pytest.raises(sqlite3.OperationalError):
+            db.patch_session_model_config("bad", {"new": 1})
+
+        stored = db._read_one("SELECT CAST(model_config AS BLOB) FROM sessions WHERE id = 'bad'")[0]
+        assert bytes(stored) == raw.encode("utf-8")  # fail closed: byte-identical, "keep" survived
+    finally:
+        db.close()
+
+
+def test_reaction_write_never_drops_unrelated_display_metadata(tmp_path):
+    """set_message_reaction is a display_metadata read-modify-write seam: a malformed cell
+    (undecodable UTF-8, broken JSON, or a non-object value) aborts the reaction write with
+    OperationalError and the cell is preserved byte-identical; a healthy cell keeps its
+    unrelated keys through the rewrite (#109465 review: the {}-fallback dropped them)."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("s", "cli")
+        db.append_message("s", "user", "hello")
+        row_id = db.latest_message_row_id("s", role="user")
+
+        def _undecodable(conn):
+            conn.execute("UPDATE messages SET display_metadata = CAST(? AS TEXT) WHERE id = ?",
+                         (b'{"task_count": 3}\xff', row_id))
+
+        def _broken_json(conn):
+            conn.execute("UPDATE messages SET display_metadata = ? WHERE id = ?",
+                         ('{"task_count": 3 BROKEN', row_id))
+
+        def _non_object(conn):
+            conn.execute("UPDATE messages SET display_metadata = ? WHERE id = ?",
+                         ('["not", "an", "object"]', row_id))
+
+        for label, corrupt, expected in (
+            ("undecodable UTF-8", _undecodable, b'{"task_count": 3}\xff'),
+            ("broken JSON", _broken_json, b'{"task_count": 3 BROKEN'),
+            ("non-object JSON", _non_object, b'["not", "an", "object"]'),
+        ):
+            db._execute_write(corrupt)
+            with pytest.raises(sqlite3.OperationalError):
+                db.set_message_reaction("s", row_id, "\U0001f44d", author="user")
+            stored = db._read_one(
+                "SELECT CAST(display_metadata AS BLOB) FROM messages WHERE id = ?", (row_id,))[0]
+            assert bytes(stored) == expected, f"{label}: cell must stay byte-identical, not rewritten"
+
+        # Healthy cell: the reaction merges and the unrelated key survives the rewrite.
+        db._execute_write(lambda conn: conn.execute(
+            "UPDATE messages SET display_metadata = ? WHERE id = ?",
+            ('{"task_count": 3}', row_id)))
+        reactions = db.set_message_reaction("s", row_id, "\U0001f44d", author="user")
+        assert [r["emoji"] for r in reactions] == ["\U0001f44d"]
+        meta = json.loads(db._read_one(
+            "SELECT display_metadata FROM messages WHERE id = ?", (row_id,))[0])
+        assert meta["task_count"] == 3  # unrelated metadata preserved through the seam
+    finally:
+        db.close()
+
+
+def test_corruption_warning_dedupe_is_bounded_and_thread_safe(caplog):
+    """The per-process fingerprint dedupe is bounded and thread-safe: N distinct malformed cells
+    keep at most _CORRUPTION_WARN_FINGERPRINT_CAP entries (#109465 review: an unbounded plain
+    set retained one fingerprint per distinct bad cell and check/add raced across reader
+    threads); the oldest entry falls out at the cap and may warn again on a later read."""
+    import threading
+
+    _corruption_warned_fingerprints.clear()
+    with caplog.at_level(logging.WARNING, logger="hermes_state"):
+        for i in range(_CORRUPTION_WARN_FINGERPRINT_CAP + 50):
+            _warn_corrupt_cell(b"distinct-bad-cell-%d-\xff" % i)
+    assert len(_corruption_warned_fingerprints) == _CORRUPTION_WARN_FINGERPRINT_CAP
+
+    # The oldest fingerprint fell out (warns again on a later read); a retained one stays silent.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="hermes_state"):
+        _warn_corrupt_cell(b"distinct-bad-cell-0-\xff")
+        _warn_corrupt_cell(b"distinct-bad-cell-%d-\xff" % (_CORRUPTION_WARN_FINGERPRINT_CAP + 49))
+    warns = [r for r in caplog.records if "degraded to U+FFFD" in r.getMessage()]
+    assert len(warns) == 1
+
+    # Concurrent warners: no exception, and the set never exceeds the cap.
+    errors: list = []
+
+    def _hammer(worker: int) -> None:
+        try:
+            for i in range(200):
+                _warn_corrupt_cell(b"worker-%d-cell-%d-\xff" % (worker, i))
+        except Exception as exc:  # pragma: no cover - only on a locking regression
+            errors.append(exc)
+
+    _corruption_warned_fingerprints.clear()
+    threads = [threading.Thread(target=_hammer, args=(w,)) for w in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    assert not errors
+    assert len(_corruption_warned_fingerprints) <= _CORRUPTION_WARN_FINGERPRINT_CAP


### PR DESCRIPTION
## What does this PR do?

A single corrupt `system_prompts` row — a prompt truncated mid multi-byte character (e.g. a process killed mid-write left a 3650-byte value ending in `e2 9c`, one byte short of `✓`) — made **every** query that materializes `_system_prompt_resolved` raise `sqlite3.OperationalError: Could not decode to UTF-8`, because Python's sqlite3 decodes TEXT cells strictly and one bad cell aborts the whole result set. On the reporter's install the desktop session panel fired this 392 times and could not list or open **any** session.

This PR installs a tolerant `text_factory` on both SessionDB connection paths (the `mode=ro` read pool and the writer — the writer needs it too because `_read_ctx` degrades display/list queries onto it when WAL is off, the read pool is exhausted, or a pooled open failed):

- valid TEXT decodes strictly and round-trips **exactly** as before (the strict decode is just retried inside the factory);
- an undecodable cell degrades to U+FFFD for that one value, logs a **content-free** warning (length + sha256[:16] fingerprint — no raw bytes, since cells can hold prompts or accidentally persisted credentials; deduplicated per distinct bad value per process), and the query returns every row.

Review follow-up (fail-closed mutations): the writer can't simply go back to strict decoding without re-crashing non-WAL installs, so the read-modify-write seam itself now fails closed — `_merge_model_config_json` (the one place `model_config` is read-modify-written) selects `CAST(model_config AS BLOB)` and decodes strictly, so a malformed cell aborts the patch with `OperationalError` instead of parsing away to `{}` and letting the patch overwrite the stored field. Values stored as BLOB keep reading back as `bytes` (sqlite3 contract, unchanged).

This is the sqlite3-documented mechanism for fault-tolerant TEXT decoding, set at the single choke point both connections share, so it covers all ~10 query sites that project `COALESCE(sp.prompt, s.system_prompt) AS _system_prompt_resolved` across the state layer without touching their (pinned) SQL text. Repair/salvage connections in the repair module keep the strict decoder — those paths are diagnostics and should still surface corruption loudly.

Deliberately out of scope: the write path itself (a Python `str` is always valid Unicode at hand-off; the truncation happens at the storage layer, so it cannot be prevented from the application write side) and the offline salvage walk tracked in #98050.

## Related Issue

Fixes #109450

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`: added module-level `_tolerant_text_factory` (strict decode; on `UnicodeDecodeError` log a content-free warning — length + sha256[:16] fingerprint, deduplicated per distinct bad value — and decode with `errors="replace"`).
- `hermes_state.py`: set `conn.text_factory = _tolerant_text_factory` in `_connect_read_only` (read pool) and `_open_writer_conn` (writer) — the two places `conn.row_factory = sqlite3.Row` is already configured.
- `hermes_state_sessions.py`: `_merge_model_config_json` now selects `CAST(model_config AS BLOB)` and decodes strictly via `_strict_model_config_text`, so a malformed cell aborts a model_config patch with `OperationalError` (fail closed) instead of being U+FFFD-decoded, parsed away to `{}` and overwritten by the patch.
- `tests/hermes_state/test_corrupt_row_robustness.py`: regression tests in the existing corrupt-row family — seeds a TEXT-storage cell ending in the truncated `✓` bytes via `CAST(? AS TEXT)` and asserts every surface (list/rich/get/search) survives, the good multi-byte prompt round-trips exactly, the bad cell degrades to U+FFFD, the warning is content-free (sha256 fingerprint, no raw bytes) and fires only once per distinct bad value; a malformed `model_config` cell aborts `patch_session_model_config` with the stored bytes untouched; a BLOB-stored value reads back as `bytes` (contract pin).

## How to Test

1. `PYTHONPATH=. .venv/bin/python -m pytest tests/hermes_state/test_corrupt_row_robustness.py -q` — Observed result: 6 passed (the new tests fail on the pre-fix code: the crash surfaces raise `OperationalError: Could not decode to UTF-8 column '_system_prompt_resolved'` on unpatched `main`, and the fail-closed mutation test was verified red on the tolerant-seam variant).
2. Wider state-layer regression (hermes_state dir plus the state-related root test files) — Observed result: 330 passed + 1191 passed, 27 skipped, 0 failed.
3. `ruff check` on the changed files — Observed result: All checks passed.
4. Manual repro of the issue scenario (create good+bad sessions, corrupt the bad row's stored prompt to end in `e2 9c` via `CAST(? AS TEXT)`, then `list_sessions_rich()` / `get_session()` / `search_sessions()`): before the fix all three raise `OperationalError`; after the fix all three return both sessions, the good prompt reads back byte-exact and the corrupt one renders with a U+FFFD replacement character.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (Apple Silicon), Python 3.11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

