### PR TITLE
feat(dashboard): allow allowlisted custom-scheme redirect URIs for the native OAuth flow

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -961,6 +961,15 @@ DEFAULT_CONFIG = {
             "client_id": "",  # agent:{instance_id} — Portal provisions this
             "portal_url": "",
         },
+        # Allowlisted custom URL schemes (RFC 8252 §7.1) for the native OAuth redirect, for
+        # mobile clients that cannot bind a loopback HTTP listener. Empty by default: loopback
+        # (127.0.0.1 / ::1) stays the only accepted native redirect_uri until an operator opts a
+        # scheme in. Each entry must be an exact scheme the client presents as
+        # "<scheme>://oauth" or "<scheme>://oauth/callback" (no query/fragment); a reverse-DNS
+        # private-use scheme (e.g. "com.example.myapp") is recommended so it can't collide with a
+        # scheme another installed app registered, but the allowlist itself is the security
+        # boundary — being listed here is what's trusted, not the scheme's shape.
+        "native_redirect_schemes": [],
         # Username/password gate (dashboard_auth/basic plugin, no OAuth IDP). Active when username
         # plus password_hash (preferred) or password (hashed in-memory) are set; empty username =
         # no-op. Env HERMES_DASHBOARD_BASIC_AUTH_USERNAME / _PASSWORD_HASH / _PASSWORD / _SECRET /

--- a/hermes_cli/dashboard_auth/prefix.py
+++ b/hermes_cli/dashboard_auth/prefix.py
@@ -128,3 +128,15 @@ def resolve_public_url() -> str:
     if not cfg_clean:
         _warn_if_malformed("dashboard.public_url in config.yaml", cfg_raw)
     return cfg_clean
+
+
+# --- dashboard.native_redirect_schemes --------------------------------------
+
+def native_redirect_schemes() -> list:
+    """Allowlisted custom URL schemes (``dashboard.native_redirect_schemes``) for the native
+    RFC 8252 redirect, lower-cased. Empty by default: loopback-only behaviour is unchanged
+    when the operator has not opted in."""
+    raw = _load_dashboard_section().get("native_redirect_schemes", [])
+    if not isinstance(raw, list):
+        return []
+    return [s.strip().lower() for s in raw if isinstance(s, str) and s.strip()]

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -227,6 +227,44 @@ def _validate_loopback_redirect_uri(raw: str) -> str:
     return raw
 
 
+def _validate_custom_scheme_redirect_uri(raw: str, parsed) -> str:
+    """Accept ``<scheme>://oauth`` or ``<scheme>://oauth/callback`` when ``<scheme>`` is in the
+    operator-configured ``dashboard.native_redirect_schemes`` allowlist. This is the mobile-app
+    analogue of the loopback redirect: an iOS/Android client cannot bind a loopback HTTP listener,
+    so RFC 8252 §7.1 names a private-use custom scheme as its alternative. The allowlist is the
+    security boundary here (same reasoning as loopback): the route is public, so accepting an
+    arbitrary scheme would make the callback an open redirect for whatever app registered that
+    scheme on the device. Query/fragment are rejected outright — the code and state only ever
+    belong in the path form the client asked for, never smuggled in extra parameters."""
+    allowed = _prefix_mod.native_redirect_schemes()
+    scheme = parsed.scheme.lower()
+    if not allowed or scheme not in allowed:
+        raise _http(
+            400,
+            "native redirect_uri must be http:// on the loopback interface, or a custom scheme "
+            "listed in dashboard.native_redirect_schemes")
+    if parsed.query or parsed.fragment:
+        raise _http(400, "native redirect_uri must not include a query string or fragment")
+    if parsed.netloc.lower() != "oauth" or parsed.path not in ("", "/callback"):
+        raise _http(
+            400,
+            f"native redirect_uri for scheme {scheme!r} must be '{scheme}://oauth' or "
+            f"'{scheme}://oauth/callback'")
+    return raw
+
+
+def _validate_native_redirect_uri(raw: str) -> str:
+    """Accept the loopback form, or an allowlisted custom-scheme form for native mobile clients
+    that cannot bind a loopback HTTP listener. Dispatches on scheme so the loopback path (and its
+    error strings) is unchanged when ``dashboard.native_redirect_schemes`` is empty."""
+    if not raw:
+        raise _http(400, "redirect_uri required")
+    parsed = urlparse(raw)
+    if parsed.scheme == "http":
+        return _validate_loopback_redirect_uri(raw)
+    return _validate_custom_scheme_redirect_uri(raw, parsed)
+
+
 def _select_native_provider(provider: str):
     """Resolve the provider for a native authorize request. An empty ``provider`` auto-selects
     the ONLY interactive session provider (password providers included — native sign-in brokers
@@ -249,7 +287,7 @@ async def auth_native_authorize(
         raise _http(400, "code_challenge_method must be S256")
     if not code_challenge:
         raise _http(400, "code_challenge required")
-    _validate_loopback_redirect_uri(redirect_uri)
+    _validate_native_redirect_uri(redirect_uri)
     p = _select_native_provider(provider)
     if p is None and not provider:
         candidates = list_session_providers()

--- a/tests/hermes_cli/test_dashboard_auth_native_flow.py
+++ b/tests/hermes_cli/test_dashboard_auth_native_flow.py
@@ -210,6 +210,163 @@ def test_native_authorize_rejects_non_loopback_redirect(gated_client):
 
 
 # ---------------------------------------------------------------------------
+# Allowlisted custom-scheme redirect_uri (dashboard.native_redirect_schemes) —
+# the mobile-app analogue of the loopback redirect for clients that cannot
+# bind a loopback HTTP listener (RFC 8252 §7.1).
+# ---------------------------------------------------------------------------
+
+
+def _set_native_redirect_schemes(monkeypatch, schemes):
+    cfg = {"dashboard": {"native_redirect_schemes": schemes}}
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+
+
+def _custom_scheme_params(challenge, redirect_uri, **overrides):
+    params = {
+        "provider": "stub",
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "redirect_uri": redirect_uri,
+        "state": "s",
+    }
+    params.update(overrides)
+    return params
+
+
+def test_native_authorize_accepts_allowlisted_custom_scheme(gated_client, monkeypatch):
+    """An operator who allowlisted a scheme can redirect a native (iOS/Android) client that has
+    no loopback listener, using the ``<scheme>://oauth`` form."""
+    _set_native_redirect_schemes(monkeypatch, ["com.stephenthorn.herald"])
+    _verifier, challenge = _make_pkce()
+    r = gated_client.get(
+        "/auth/native/authorize",
+        params=_custom_scheme_params(challenge, "com.stephenthorn.herald://oauth"),
+    )
+    assert r.status_code == 302, r.text
+    assert "code=stub_code" in r.headers["location"]
+
+
+def test_native_authorize_accepts_allowlisted_custom_scheme_callback_path(
+    gated_client, monkeypatch,
+):
+    _set_native_redirect_schemes(monkeypatch, ["com.stephenthorn.herald"])
+    _verifier, challenge = _make_pkce()
+    r = gated_client.get(
+        "/auth/native/authorize",
+        params=_custom_scheme_params(challenge, "com.stephenthorn.herald://oauth/callback"),
+    )
+    assert r.status_code == 302, r.text
+
+
+def test_native_authorize_rejects_non_allowlisted_custom_scheme(gated_client, monkeypatch):
+    """Empty allowlist (the default): a custom scheme is rejected exactly like any other
+    non-loopback redirect_uri — loopback behaviour is unchanged when the operator opts into
+    nothing."""
+    _set_native_redirect_schemes(monkeypatch, [])
+    _verifier, challenge = _make_pkce()
+    r = gated_client.get(
+        "/auth/native/authorize",
+        params=_custom_scheme_params(challenge, "com.stephenthorn.herald://oauth"),
+    )
+    assert r.status_code == 400
+    assert "native_redirect_schemes" in r.json()["detail"]
+
+
+def test_native_authorize_rejects_custom_scheme_not_in_allowlist(gated_client, monkeypatch):
+    """A scheme configured for a different app must not let an unrelated scheme ride along."""
+    _set_native_redirect_schemes(monkeypatch, ["com.stephenthorn.herald"])
+    _verifier, challenge = _make_pkce()
+    r = gated_client.get(
+        "/auth/native/authorize",
+        params=_custom_scheme_params(challenge, "com.other.app://oauth"),
+    )
+    assert r.status_code == 400
+    assert "native_redirect_schemes" in r.json()["detail"]
+
+
+def test_native_authorize_rejects_allowlisted_scheme_with_query(gated_client, monkeypatch):
+    _set_native_redirect_schemes(monkeypatch, ["com.stephenthorn.herald"])
+    _verifier, challenge = _make_pkce()
+    r = gated_client.get(
+        "/auth/native/authorize",
+        params=_custom_scheme_params(
+            challenge, "com.stephenthorn.herald://oauth?evil=1"),
+    )
+    assert r.status_code == 400
+    assert "query" in r.json()["detail"].lower()
+
+
+def test_native_authorize_rejects_allowlisted_scheme_with_fragment(gated_client, monkeypatch):
+    _set_native_redirect_schemes(monkeypatch, ["com.stephenthorn.herald"])
+    _verifier, challenge = _make_pkce()
+    r = gated_client.get(
+        "/auth/native/authorize",
+        params=_custom_scheme_params(
+            challenge, "com.stephenthorn.herald://oauth#evil"),
+    )
+    assert r.status_code == 400
+    assert "query" in r.json()["detail"].lower()
+
+
+def test_native_authorize_rejects_allowlisted_scheme_wrong_path(gated_client, monkeypatch):
+    """Only ``<scheme>://oauth`` or ``<scheme>://oauth/callback`` are accepted — an allowlisted
+    scheme does not grant an arbitrary path."""
+    _set_native_redirect_schemes(monkeypatch, ["com.stephenthorn.herald"])
+    _verifier, challenge = _make_pkce()
+    r = gated_client.get(
+        "/auth/native/authorize",
+        params=_custom_scheme_params(
+            challenge, "com.stephenthorn.herald://oauth/steal"),
+    )
+    assert r.status_code == 400
+
+
+def test_native_authorize_loopback_unaffected_by_configured_schemes(gated_client, monkeypatch):
+    """Configuring custom schemes must not change loopback validation — both forms stay
+    independently valid."""
+    _set_native_redirect_schemes(monkeypatch, ["com.stephenthorn.herald"])
+    _verifier, challenge = _make_pkce()
+    r = gated_client.get(
+        "/auth/native/authorize",
+        params=_custom_scheme_params(challenge, "http://127.0.0.1:53999/cb"),
+    )
+    assert r.status_code == 302, r.text
+    assert "code=stub_code" in r.headers["location"]
+
+
+def test_native_custom_scheme_full_roundtrip(gated_client, monkeypatch):
+    """authorize -> callback -> loopback-equivalent app redirect -> token exchange, using an
+    allowlisted custom scheme end to end."""
+    _set_native_redirect_schemes(monkeypatch, ["com.stephenthorn.herald"])
+    verifier, challenge = _make_pkce()
+    redirect_uri = "com.stephenthorn.herald://oauth"
+    r = gated_client.get(
+        "/auth/native/authorize",
+        params=_custom_scheme_params(challenge, redirect_uri),
+    )
+    assert r.status_code == 302, r.text
+    loc = r.headers["location"]
+    cb_qs = parse_qs(urlparse(loc).query)
+    cookies = r.cookies
+    r2 = gated_client.get(
+        "/auth/callback",
+        params={"code": cb_qs["code"][0], "state": cb_qs["state"][0]},
+        cookies=cookies,
+    )
+    assert r2.status_code == 302, r2.text
+    assert r2.headers["location"].startswith(f"{redirect_uri}?")
+    set_cookie = r2.headers.get("set-cookie", "")
+    assert "hermes_session_at" not in set_cookie
+
+    loop_qs = parse_qs(urlparse(r2.headers["location"]).query)
+    tokens = gated_client.post(
+        "/auth/native/token",
+        json={"code": loop_qs["code"][0], "code_verifier": verifier},
+    ).json()
+    assert tokens["access_token"]
+
+
+# ---------------------------------------------------------------------------
 # Empty-provider auto-select (the desktop omits ``provider``; the gateway
 # picks when there is exactly one brokerable candidate) — regression #78906
 # ---------------------------------------------------------------------------

--- a/website/docs/guides/desktop-native-signin.md
+++ b/website/docs/guides/desktop-native-signin.md
@@ -118,6 +118,11 @@ The relevant endpoints (all public, pre-auth bootstrap, same as the existing
 - `POST /auth/native/token` — exchanges the loopback code + verifier for tokens
 - `POST /auth/native/refresh` — rotates tokens from the app's refresh token
 
+By default `/auth/native/authorize` only accepts a loopback `redirect_uri`, which a mobile
+client (iOS/Android) can't provide. Operators who want to support a native mobile client can
+allowlist a custom URL scheme via `dashboard.native_redirect_schemes` — see [Native apps with
+custom URL schemes](../user-guide/features/web-dashboard.md#native-apps-with-custom-url-schemes).
+
 ## See also
 
 - [OAuth over SSH / Remote Hosts](./oauth-over-ssh.md) — the loopback-callback

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -717,6 +717,24 @@ curl -s http://<host>:9119/api/status | jq '.auth_required, .auth_providers'
 
 `GET /api/auth/me` then returns the verified session (`provider: nous`). For an internet-facing host, register with `--redirect-uri https://hermes.example.com/auth/callback` and set `HERMES_DASHBOARD_PUBLIC_URL` so the OAuth callback resolves to your public URL (see [Public URL override](#public-url-override)).
 
+### Native apps with custom URL schemes
+
+The [RFC 8252 native sign-in flow](../../guides/desktop-native-signin.md) redirects back to the client via a **loopback** HTTP listener (`http://127.0.0.1:<port>/…`) by default — the right choice for a desktop app, which can bind one. A native **mobile** client (iOS, Android) has no equivalent: it cannot bind a loopback HTTP listener, so it needs the other redirect form RFC 8252 §7.1 names for native apps, a **private-use custom URL scheme** (e.g. `com.example.myapp://oauth`).
+
+This is opt-in and off by default. Set `dashboard.native_redirect_schemes` in `config.yaml`:
+
+```yaml
+dashboard:
+  native_redirect_schemes:
+    - com.example.myapp
+```
+
+With a scheme allowlisted, `/auth/native/authorize` also accepts a `redirect_uri` of `<scheme>://oauth` or `<scheme>://oauth/callback` for any `<scheme>` in the list — with no query string or fragment. Everything else about the flow (PKCE, one-time code, single-use, short TTLs) is unchanged, and it stays mandatory here too: a custom scheme is not a substitute for PKCE, it's a substitute for the loopback listener.
+
+**Why the allowlist, and why it's the whole security boundary.** `/auth/native/authorize` is a public, pre-auth route — a redirect target that isn't scrutinized there is an open redirect that hands a live authorization code to whatever app registered a scheme on the device. Restricting accepted redirects to schemes the operator explicitly configured closes that off: a scheme not on the list is rejected exactly like any other non-loopback `redirect_uri`. Prefer a reverse-DNS ("private-use") scheme such as `com.example.myapp` — it's namespaced to your app the way a package or bundle ID is, so it's very unlikely to collide with a scheme some other installed app registered — but note that the *allowlist* is what's actually trusted here, not the scheme's shape; listing a plain word like `myapp` works exactly the same way if that's what your app is registered for.
+
+Loopback redirects keep working unchanged whether or not `native_redirect_schemes` is set — this only adds a second accepted form, it doesn't touch the first.
+
 ### Username/password provider (no OAuth IDP)
 
 If you don't want to wire up an OAuth identity provider — a self-hosted "just put a password on my dashboard" deployment — the bundled `plugins/dashboard_auth/basic` plugin registers a `DashboardAuthProvider` named `basic` that authenticates with a **username and password** instead of an OAuth redirect.


### PR DESCRIPTION
## What changed and why

`/auth/native/authorize` (the RFC 8252 native sign-in flow) only accepted a loopback `http://127.0.0.1[:port]/...` redirect_uri. A native mobile client (iOS or Android) cannot bind a loopback HTTP listener, so it has no way to complete this flow today, even though RFC 8252 section 7.1 names a private-use custom URL scheme as the standard alternative for exactly this case.

This adds an opt-in `dashboard.native_redirect_schemes` config list, empty by default so existing loopback-only behavior is unchanged. When a scheme is allowlisted, the route also accepts `<scheme>://oauth` or `<scheme>://oauth/callback` for that scheme, with no query string or fragment. PKCE stays mandatory; the allowlist is the security boundary, the same reasoning as the existing loopback check (the route is public, so an unscrutinized redirect target is an open redirect for a live authorization code).

Motivated by a native iOS Hermes client (iHermes) that needs to complete dashboard OAuth sign-in without an embedded webview.

## How to test

Set `dashboard.native_redirect_schemes: [com.example.myapp]` in config.yaml, then hit `/auth/native/authorize` with `redirect_uri=com.example.myapp://oauth` and complete the round trip through `/auth/callback` and `/auth/native/token`. New tests cover accept and reject cases in `tests/hermes_cli/test_dashboard_auth_native_flow.py`.

## Platforms tested

macOS, via the project's own pytest suite (`scripts/run_tests.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
