### PR TITLE
fix(kanban): classify zero-turn clean exits as route failures and reap before classifying

### DIFF
--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -685,16 +685,27 @@ _PROTOCOL_VIOLATION_FAILURE_LIMIT = 3
 # Closed runs to walk when counting the streak; it trips at a handful anyway.
 _PROTOCOL_VIOLATION_SCAN_LIMIT = 50
 
+# A route failure (clean exit, zero heartbeats — see ``_ROUTE_FAILURE_ERROR``)
+# gets its OWN bounded streak, independent of ``_PROTOCOL_VIOLATION_FAILURE_LIMIT``:
+# it is not a paperwork miss and must not share that budget. Below this many
+# trailing route failures the card is released streak-free (no
+# ``_record_task_failure`` call at all); at or above it, it trips the breaker
+# so a persistently unreachable route still blocks and surfaces.
+_ROUTE_FAILURE_FAILURE_LIMIT = 2
+
 
 def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     """Count the task's trailing run of clean-exit protocol violations.
 
     Walks closed runs newest-first (including the one ``detect_crashed_workers``
     just closed). ``rate_limited`` runs are neutral and skipped (a quota wall
-    says nothing about the task); any other closed run breaks the streak, so
-    the budget counts ONLY protocol violations. Violations are recognized by the
-    ``protocol_violation`` run-metadata marker, with the error text as fallback
-    for runs recorded before the marker existed.
+    says nothing about the task); a ``route_failure`` run is also neutral (it
+    never reached the model, so it says nothing about paperwork discipline)
+    and is skipped rather than breaking the streak. Any other closed run
+    breaks the streak, so the budget counts ONLY protocol violations.
+    Violations are recognized by the ``protocol_violation`` run-metadata
+    marker, with the error text as fallback for runs recorded before the
+    marker existed.
     """
     streak = 0
     rows = conn.execute(
@@ -705,12 +716,34 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     ).fetchall()
     for row in rows:
         outcome = row["outcome"] or ""
-        if outcome == "rate_limited":
+        if outcome == "rate_limited" or _kb._json_dict(row["metadata"]).get("route_failure"):
             continue
         if outcome == "crashed" and (
             _kb._json_dict(row["metadata"]).get("protocol_violation")
             or "protocol violation" in (row["error"] or "")
         ):
+            streak += 1
+            continue
+        break
+    return streak
+
+
+def _route_failure_streak(conn: sqlite3.Connection, task_id: str) -> int:
+    """Count the task's trailing run of route failures.
+
+    Mirrors ``_protocol_violation_streak`` but walks the ``route_failure``
+    marker instead — the two streaks are independent budgets over the same
+    closed-run history (see ``_ROUTE_FAILURE_FAILURE_LIMIT``).
+    """
+    streak = 0
+    rows = conn.execute(
+        "SELECT outcome, metadata FROM task_runs "
+        "WHERE task_id = ? AND ended_at IS NOT NULL "
+        "ORDER BY id DESC LIMIT ?",
+        (task_id, _PROTOCOL_VIOLATION_SCAN_LIMIT),
+    ).fetchall()
+    for row in rows:
+        if row["outcome"] == "crashed" and _kb._json_dict(row["metadata"]).get("route_failure"):
             streak += 1
             continue
         break
@@ -730,6 +763,19 @@ _PROTOCOL_VIOLATION_ERROR = (
     "matter what it did."
 )
 
+# Worker exited cleanly (rc=0) but its ``last_heartbeat_at`` never advanced —
+# no MCP tool call ever extended the claim, so classifying it as a paperwork-
+# miss protocol violation is wrong: the worker never got the chance to do or
+# skip anything. Overwhelmingly a routing/credential failure before the model
+# ever ran. Released via its own bounded streak (``_ROUTE_FAILURE_FAILURE_LIMIT``),
+# independent of the protocol-violation budget, and WITHOUT the ``rate_limited``
+# quota-wall deferral (reusing it suppressed the very next dispatch tick).
+_ROUTE_FAILURE_ERROR = (
+    "worker exited cleanly (rc=0) with zero recorded turns (no heartbeat "
+    "ever reached the claim) — treated as a route failure, not a protocol "
+    "violation."
+)
+
 
 @dataclass
 class _DeadWorker:
@@ -742,18 +788,57 @@ class _DeadWorker:
     event_payload: dict
     protocol_violation: bool = False
     rate_limited: bool = False
+    # Clean exit, zero heartbeats ever recorded — a route/credential failure
+    # before the model ever ran, not a paperwork miss. See ``_ROUTE_FAILURE_ERROR``.
+    route_failure: bool = False
 
     @property
     def run_outcome(self) -> str:
         # A rate-limited requeue is recorded as ``rate_limited`` so board history
-        # doesn't show a phantom crash for a quota wall.
+        # doesn't show a phantom crash for a quota wall. A route failure stays
+        # ``crashed`` — only the event kind and metadata marker distinguish it
+        # (reusing ``rate_limited`` here would suppress the next dispatch tick).
         return "rate_limited" if self.rate_limited else "crashed"
 
 
-def _classify_dead_worker(pid: int, claimer: Optional[str]) -> _DeadWorker:
+def _classify_dead_worker(
+    pid: int, claimer: Optional[str], *,
+    last_heartbeat_at: Optional[int] = None, elapsed: Optional[float] = None,
+) -> _DeadWorker:
     """Map a dead worker's reaped exit status to its reclaim bookkeeping."""
     kind, code = _classify_worker_exit(pid)
     if kind == "clean_exit":
+        if (
+            last_heartbeat_at is None
+            and elapsed is not None
+            and elapsed >= _kb._resolve_crash_grace_seconds()
+        ):
+            # Zero heartbeats ever recorded (column AND event both absent)
+            # and enough time passed that this isn't a spawn-race artifact:
+            # the worker never made a single MCP tool call, so it never had
+            # the chance to do (or skip) the work. Distinct from a protocol
+            # violation — do NOT set ``protocol_violation`` or ``rate_limited``.
+            return _DeadWorker(
+                kind, code, _ROUTE_FAILURE_ERROR, "route_failure",
+                {
+                    "pid": pid, "claimer": claimer, "exit_code": code,
+                    "exit_signal": "heartbeat_null", "elapsed": int(elapsed),
+                    # Durable marker for _protocol_violation_streak's neutral
+                    # skip and _account_crashes' route-failure branch: _end_run
+                    # copies this payload verbatim into the run metadata, so
+                    # without this key here neither the streak accounting nor
+                    # the breaker logic could recognize a route failure from
+                    # the closed run row.
+                    "route_failure": True,
+                    # This clean exit was actually reaped and classified by
+                    # this process (as opposed to the registry-miss
+                    # ``unknown`` branch below) — makes the two races
+                    # countable.
+                    "reap_status": "observed",
+                },
+                protocol_violation=False,
+                route_failure=True,
+            )
         # rc=0 while still ``running``: usually the work succeeded and only the
         # paperwork was skipped; the corrective sentence reaches the retry
         # worker via ``build_worker_context``.
@@ -762,7 +847,13 @@ def _classify_dead_worker(pid: int, claimer: Optional[str]) -> _DeadWorker:
             # ``protocol_violation`` is the durable marker for
             # _protocol_violation_streak: _end_run copies this payload into the
             # run metadata.
-            {"pid": pid, "claimer": claimer, "exit_code": code, "protocol_violation": True},
+            {
+                "pid": pid, "claimer": claimer, "exit_code": code,
+                "protocol_violation": True,
+                # See the route-failure branch above — this clean exit was
+                # also actually reaped and classified by this process.
+                "reap_status": "observed",
+            },
             protocol_violation=True,
         )
     if kind == "rate_limited":
@@ -785,6 +876,15 @@ def _classify_dead_worker(pid: int, claimer: Optional[str]) -> _DeadWorker:
     if code is not None and kind != "unknown":
         event_payload["exit_kind"] = kind
         event_payload["exit_code"] = code
+    if kind == "unknown":
+        # Registry miss: this pid was never recorded as reaped (either genuinely
+        # dead with no /proc entry, or a zombie the reaper hadn't yet reaped when
+        # this ran) — vs. ``reap_status="observed"`` for a status this process
+        # actually reaped. Makes the two races countable instead of inferred
+        # from a missing ``exit_code`` key.
+        event_payload["reap_status"] = "registry_miss"
+    else:
+        event_payload["reap_status"] = "observed"
     return _DeadWorker(kind, code, error_text, "crashed", event_payload)
 
 
@@ -794,9 +894,9 @@ class _CrashSweep:
 
     crashed: list[str] = field(default_factory=list)
     rate_limited: list[str] = field(default_factory=list)
-    # ``(task_id, pid, claimer, protocol_violation, error_text)``: accounted
-    # after the txn via ``_record_task_failure`` (needs its own write_txn).
-    crash_details: list[tuple[str, int, str, bool, str]] = field(default_factory=list)
+    # ``(task_id, pid, claimer, protocol_violation, error_text, route_failure)``:
+    # accounted after the txn via ``_record_task_failure`` (needs its own write_txn).
+    crash_details: list[tuple[str, int, str, bool, str, bool]] = field(default_factory=list)
     # Worker-exit observer payloads, fired only after every reclaim/accounting
     # txn has committed.
     exited_hook_payloads: list[dict] = field(default_factory=list)
@@ -804,6 +904,11 @@ class _CrashSweep:
 
 def _reclaim_dead_workers(conn: sqlite3.Connection) -> _CrashSweep:
     """Release every host-local ``running`` task whose worker PID is dead."""
+    # Reap first: a child that exited between the previous tick's reap and this
+    # classification would otherwise be seen as a registry miss (``unknown``)
+    # instead of its real exit status — the same failure booked two different
+    # ways depending on reap timing.
+    reap_worker_zombies()
     sweep = _CrashSweep()
     with _kb.write_txn(conn):
         rows = conn.execute(
@@ -825,7 +930,23 @@ def _reclaim_dead_workers(conn: sqlite3.Connection) -> _CrashSweep:
                 continue
 
             pid = int(row["worker_pid"])
-            dead = _classify_dead_worker(pid, row["claim_lock"])
+            # Read the closing run's heartbeat BEFORE ``_end_run`` overwrites
+            # the row below — it is the signal that distinguishes a route
+            # failure (no MCP tool call ever reached the claim) from a
+            # protocol violation (the worker did the work and only skipped
+            # the terminal call).
+            hb_row = conn.execute(
+                "SELECT last_heartbeat_at FROM task_runs "
+                "WHERE task_id = ? AND ended_at IS NULL "
+                "ORDER BY id DESC LIMIT 1",
+                (row["id"],),
+            ).fetchone()
+            last_heartbeat_at = hb_row["last_heartbeat_at"] if hb_row is not None else None
+            elapsed = time.time() - (started_at or 0)
+            dead = _classify_dead_worker(
+                pid, row["claim_lock"],
+                last_heartbeat_at=last_heartbeat_at, elapsed=elapsed,
+            )
             retry_status = _kb._retry_status_for_run(conn, row["id"])
             dead.event_payload["retry_status"] = retry_status
             cur = conn.execute(
@@ -854,12 +975,12 @@ def _reclaim_dead_workers(conn: sqlite3.Connection) -> _CrashSweep:
                 "outcome": dead.run_outcome,
                 "retry_status": retry_status,
             })
-            if dead.rate_limited or dead.protocol_violation:
+            if dead.rate_limited or dead.protocol_violation or dead.route_failure:
                 # Stamp last_failure_error WITHOUT touching ``consecutive_failures``:
                 # a rate-limited requeue must show ``check_respawn_guard`` a quota
-                # blocker; a below-budget protocol violation never reaches
-                # ``_record_task_failure`` (which stamps this column), yet the
-                # board UI and retry worker need the corrective message.
+                # blocker; a below-budget protocol violation or route failure never
+                # reaches ``_record_task_failure`` (which stamps this column), yet
+                # the board UI and retry worker need the corrective message.
                 conn.execute(
                     "UPDATE tasks SET last_failure_error = ? WHERE id = ?",
                     (dead.error_text[:500], row["id"]),
@@ -869,7 +990,7 @@ def _reclaim_dead_workers(conn: sqlite3.Connection) -> _CrashSweep:
             else:
                 sweep.crashed.append(row["id"])
                 sweep.crash_details.append(
-                    (row["id"], pid, row["claim_lock"], dead.protocol_violation, dead.error_text)
+                    (row["id"], pid, row["claim_lock"], dead.protocol_violation, dead.error_text, dead.route_failure)
                 )
     return sweep
 
@@ -879,16 +1000,38 @@ def _account_crashes(conn: sqlite3.Connection, crash_details: list) -> list[str]
 
     Protocol violations get a BOUNDED violation-only budget independent of
     ``consecutive_failures`` (per-task ``max_retries`` takes precedence);
-    systemic same-error crashes (>= 3 identical fingerprints this tick) trip
-    immediately.
+    route failures get their own separate bounded budget
+    (``_ROUTE_FAILURE_FAILURE_LIMIT``); systemic same-error crashes (>= 3
+    identical fingerprints this tick) trip immediately.
     """
     auto_blocked: list[str] = []
     fp_counts: dict[str, int] = {}
-    for _, _, _, _, err_text in crash_details:
+    for _, _, _, _, err_text, _ in crash_details:
         fp = _error_fingerprint(err_text)
         fp_counts[fp] = fp_counts.get(fp, 0) + 1
-    for tid, pid, claimer, protocol_violation, error_text in crash_details:
-        if protocol_violation:
+    for tid, pid, claimer, protocol_violation, error_text, route_failure in crash_details:
+        if route_failure:
+            streak = _route_failure_streak(conn, tid)
+            if streak < _ROUTE_FAILURE_FAILURE_LIMIT:
+                # Below budget: already back at ``ready`` with the error stamped.
+                # No ``_record_task_failure`` — streak-free release, must not
+                # consume the unified budget either.
+                continue
+            tripped = _record_task_failure(
+                conn, tid,
+                error=error_text,
+                outcome="crashed",
+                force_trip=True,
+                release_claim=False,
+                end_run=False,
+                event_payload_extra={
+                    "pid": pid,
+                    "claimer": claimer,
+                    "route_failures": streak,
+                    "route_failure_limit": _ROUTE_FAILURE_FAILURE_LIMIT,
+                },
+            )
+        elif protocol_violation:
             streak = _protocol_violation_streak(conn, tid)
             trow = conn.execute("SELECT max_retries FROM tasks WHERE id = ?", (tid,)).fetchone()
             if trow is None:
@@ -1633,7 +1776,6 @@ def _run_reclaim_phase(
     reconcile_orphans: bool,
 ) -> None:
     """Reclaim stale/orphaned/crashed/timed-out running tasks, then promote."""
-    reap_worker_zombies()
     result.reclaimed = _kb.release_stale_claims(conn)
     if reconcile_orphans:
         result.reconciled_orphans = reconcile_orphaned_running(conn)

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1588,8 +1588,9 @@ def test_route_failure_respects_crash_grace_window():
     fake_pid = 995001
     kbd._record_worker_exit(fake_pid, 0)  # os.W_EXITCODE(status=0, signal=0) == 0
     try:
+        host_prefix = kb._claimer_id().split(":", 1)[0]
         dead = kbd._classify_dead_worker(
-            fake_pid, "hermes01:mock",
+            fake_pid, f"{host_prefix}:mock",
             last_heartbeat_at=None, elapsed=5.0,
         )
         assert dead.event_kind != "route_failure", (
@@ -1621,15 +1622,16 @@ def test_reap_status_recorded_on_both_clean_exit_branches():
     kbd._record_worker_exit(route_pid, 0)
     kbd._record_worker_exit(pv_pid, 0)
     try:
+        host_prefix = kb._claimer_id().split(":", 1)[0]
         route_dead = kbd._classify_dead_worker(
-            route_pid, "hermes01:mock",
+            route_pid, f"{host_prefix}:mock",
             last_heartbeat_at=None, elapsed=9999.0,
         )
         assert route_dead.event_kind == "route_failure"
         assert route_dead.event_payload.get("reap_status") == "observed"
 
         pv_dead = kbd._classify_dead_worker(
-            pv_pid, "hermes01:mock",
+            pv_pid, f"{host_prefix}:mock",
             last_heartbeat_at=1234567, elapsed=9999.0,
         )
         assert pv_dead.event_kind == "protocol_violation"

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1285,7 +1285,7 @@ def test_reclaim_task_resets_running_to_ready(kanban_home, monkeypatch):
 
 
 
-def _drive_worker_exit(conn, tid, fake_pid, raw_status):
+def _drive_worker_exit(conn, tid, fake_pid, raw_status, *, heartbeat=False):
     """Claim ``tid``, record ``raw_status`` for its dead worker pid, and run
     one reaper pass.
 
@@ -1295,6 +1295,11 @@ def _drive_worker_exit(conn, tid, fake_pid, raw_status):
     the exit into one module object while reaping through another (stale)
     one makes ``_classify_worker_exit`` return ``unknown`` — silently turning
     a clean-exit protocol violation into a plain crash.
+
+    ``heartbeat=True`` records one heartbeat on the open run before the exit
+    is reaped, so a clean exit classifies as a genuine protocol violation
+    (the worker did reach the model) rather than a route failure (zero
+    heartbeats ever recorded).
     """
     import hermes_cli.kanban_db as _kb
     from hermes_cli import kanban_db_dispatch as _kbd
@@ -1302,6 +1307,10 @@ def _drive_worker_exit(conn, tid, fake_pid, raw_status):
     claimed = _kb.claim_task(conn, tid, claimer=f"{host_prefix}:mock")
     assert claimed is not None, "task was not claimable for the next attempt"
     _kbd._set_worker_pid(conn, tid, fake_pid)
+    if heartbeat:
+        assert _kbd.heartbeat_worker(
+            conn, tid, expected_run_id=claimed.current_run_id,
+        ), "heartbeat_worker must succeed on a freshly-claimed task"
     _kbd._record_worker_exit(fake_pid, raw_status)
     original_alive = _kb._pid_alive
     _kb._pid_alive = lambda p: False
@@ -1314,9 +1323,21 @@ def _drive_worker_exit(conn, tid, fake_pid, raw_status):
 def _drive_protocol_violation(conn, tid, fake_pid):
     """One clean-exit protocol violation reaper pass for ``tid``.
 
+    Heartbeats once before the exit so the worker is proven to have reached
+    the model — a genuine paperwork miss, not a route failure.
+
     os.W_EXITCODE(status=0, signal=0) == 0 on POSIX.
     """
-    return _drive_worker_exit(conn, tid, fake_pid, 0)
+    return _drive_worker_exit(conn, tid, fake_pid, 0, heartbeat=True)
+
+
+def _drive_route_failure(conn, tid, fake_pid):
+    """One clean-exit, zero-heartbeat reaper pass for ``tid`` — a route
+    failure: the worker exited cleanly without ever heartbeating.
+
+    os.W_EXITCODE(status=0, signal=0) == 0 on POSIX.
+    """
+    return _drive_worker_exit(conn, tid, fake_pid, 0, heartbeat=False)
 
 
 def _drive_nonzero_crash(conn, tid, fake_pid):
@@ -1414,5 +1435,208 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
         assert events == [], "historical events must not replay to a new sub"
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Route-failure classification — clean exit with zero heartbeats is a route
+# failure (routing/credential failure before the model ever ran), not a
+# protocol violation (worker did the work, forgot the terminal call).
+# ---------------------------------------------------------------------------
+
+
+def test_route_failure_does_not_consume_protocol_violation_streak(kanban_home):
+    """A clean exit with zero heartbeats is a ``route_failure`` event, is
+    released without consuming the protocol-violation streak, and the card
+    stays re-dispatchable (``ready``, not ``blocked``)."""
+    conn = kbc.connect()
+    try:
+        tid = kb.create_task(conn, title="route", assignee="worker")
+
+        crashed = _drive_route_failure(conn, tid, 992000)
+        assert tid in crashed, "a route failure is still a crashed-phase reclaim"
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready", "the card must stay re-dispatchable"
+        assert task.consecutive_failures == 0, (
+            "a below-budget route failure must not tick the unified counter"
+        )
+
+        events = kb.list_events(conn, tid)
+        route_events = [e for e in events if e.kind == "route_failure"]
+        assert len(route_events) == 1
+        payload = route_events[0].payload or {}
+        assert payload.get("pid") == 992000
+        assert payload.get("exit_signal") == "heartbeat_null"
+        assert payload.get("exit_code") == 0
+        assert "elapsed" in payload
+
+        # Protocol-violation streak must read 0: a route failure is neutral,
+        # not a violation.
+        assert kbd._protocol_violation_streak(conn, tid) == 0
+
+        run = kb.list_runs(conn, tid)[-1]
+        assert run.outcome == "crashed", "run_outcome stays crashed, not rate_limited"
+        assert (run.metadata or {}).get("route_failure") is True
+        assert "rate_limited" not in (run.outcome or "")
+    finally:
+        conn.close()
+
+
+def test_two_trailing_route_failures_trip_the_breaker(kanban_home):
+    """Two consecutive route failures hit ``_ROUTE_FAILURE_FAILURE_LIMIT=2``
+    and trip the breaker, with the limit recorded in the payload."""
+    conn = kbc.connect()
+    try:
+        tid = kb.create_task(conn, title="route-trip", assignee="worker")
+        assert kbd._ROUTE_FAILURE_FAILURE_LIMIT == 2
+
+        _drive_route_failure(conn, tid, 994001)
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready", "first route failure alone must not block"
+        assert task.consecutive_failures == 0
+
+        _drive_route_failure(conn, tid, 994002)
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked", (
+            "second trailing route failure must trip the breaker"
+        )
+        gave_up = [e for e in kb.list_events(conn, tid) if e.kind == "gave_up"]
+        assert len(gave_up) == 1
+        payload = gave_up[0].payload or {}
+        assert payload.get("route_failures") == 2
+        assert payload.get("route_failure_limit") == 2
+    finally:
+        conn.close()
+
+
+def test_reap_ordering_classifies_real_exit_status_not_unknown(kanban_home):
+    """A child that exits between two reaper passes must be classified from
+    its real exit status, not fall into the ``unknown``/``pid not alive``
+    branch — the ordering fix moves ``reap_worker_zombies()`` to the top of
+    ``_reclaim_dead_workers``.
+
+    Builds a genuine unreaped zombie (spawn + wait for Z state, no manual
+    reap) so this test is RED-capable for the ordering fix itself: recording
+    the exit via ``_record_worker_exit`` directly would start from the
+    POST-reap state and could never go red on a reverted ordering move.
+    """
+    import hermes_cli.kanban_db as _kb
+    conn = kbc.connect()
+    proc = None
+    try:
+        tid = kb.create_task(conn, title="reap-order", assignee="worker")
+        host_prefix = _kb._claimer_id().split(":", 1)[0]
+        claimed = kb.claim_task(conn, tid, claimer=f"{host_prefix}:mock")
+        assert claimed is not None
+
+        # Real child, real exit, deliberately NOT reaped by this test — a
+        # genuine unreaped zombie, the actual race the ordering fix targets.
+        proc = subprocess.Popen(["true"])
+        deadline = time.time() + 10
+        state = None
+        while time.time() < deadline:
+            try:
+                with open(f"/proc/{proc.pid}/stat") as fh:
+                    state = fh.read().rsplit(")", 1)[1].split()[0]
+            except FileNotFoundError:
+                break
+            if state == "Z":
+                break
+            time.sleep(0.05)
+        assert state == "Z", f"child pid {proc.pid} did not become a zombie in time"
+
+        kbd._set_worker_pid(conn, tid, proc.pid)
+        # Pre-condition proving the race is real: classified from this
+        # process's reap registry BEFORE any reap runs -> unknown.
+        assert kbd._classify_worker_exit(proc.pid) == ("unknown", None)
+
+        original_alive = _kb._pid_alive
+        _kb._pid_alive = lambda p: False
+        try:
+            crashed = kbd.detect_crashed_workers(conn)
+        finally:
+            _kb._pid_alive = original_alive
+
+        assert tid in crashed
+        run = kb.list_runs(conn, tid)[-1]
+        metadata = run.metadata or {}
+        # Classified from its real exit status (a route failure, zero
+        # heartbeats) — NOT the ``unknown``/"pid not alive" registry-miss
+        # branch, which would carry no ``exit_code`` and no route_failure
+        # marker. This is only possible because ``detect_crashed_workers``
+        # reaps the zombie BEFORE classifying it (the ordering fix); with the
+        # fix reverted, the pid is still unreaped at classification time and
+        # this assertion goes red.
+        assert metadata.get("exit_code") == 0
+        assert metadata.get("route_failure") is True
+        assert run.error != f"pid {proc.pid} not alive"
+    finally:
+        if proc is not None:
+            proc.wait()  # final cleanup reap so the test doesn't leak a zombie
+        conn.close()
+
+
+def test_route_failure_respects_crash_grace_window():
+    """A clean exit with zero heartbeats INSIDE the crash-grace window must
+    NOT be classified as a route failure — a freshly spawned worker whose
+    first heartbeat simply hasn't landed yet looks identical (clean exit,
+    ``last_heartbeat_at=None``) to a genuine routing failure until enough
+    time has actually passed. ``_classify_dead_worker`` only takes the
+    route-failure branch once ``elapsed >= _resolve_crash_grace_seconds()``;
+    below that it must fall through to its other clean-exit classification.
+    """
+    fake_pid = 995001
+    kbd._record_worker_exit(fake_pid, 0)  # os.W_EXITCODE(status=0, signal=0) == 0
+    try:
+        dead = kbd._classify_dead_worker(
+            fake_pid, "hermes01:mock",
+            last_heartbeat_at=None, elapsed=5.0,
+        )
+        assert dead.event_kind != "route_failure", (
+            f"elapsed=5s is inside the grace window (30s default); "
+            f"a fresh spawn must not be booked as a route failure, got "
+            f"{dead.event_kind!r}"
+        )
+        assert dead.event_kind == "protocol_violation"
+        assert dead.route_failure is False
+    finally:
+        # _record_worker_exit registers module-level reap state for fake_pid;
+        # nothing else in this process reads it once the test ends, but drop
+        # it explicitly rather than leaving a stray entry keyed on a pid that
+        # was never actually spawned.
+        kbd._recent_worker_exits.pop(fake_pid, None)
+
+
+def test_reap_status_recorded_on_both_clean_exit_branches():
+    """Both clean-exit branches of ``_classify_dead_worker`` (route_failure
+    and protocol_violation) must stamp ``reap_status: observed`` in their
+    event payload — the marker the commit message advertises as making the
+    two exit-status races countable. Without it, a route failure or a
+    protocol violation reaped by this process is indistinguishable in the
+    event/run metadata from the registry-miss (``unknown``) branch, which
+    stamps ``reap_status: registry_miss``.
+    """
+    route_pid = 995002
+    pv_pid = 995003
+    kbd._record_worker_exit(route_pid, 0)
+    kbd._record_worker_exit(pv_pid, 0)
+    try:
+        route_dead = kbd._classify_dead_worker(
+            route_pid, "hermes01:mock",
+            last_heartbeat_at=None, elapsed=9999.0,
+        )
+        assert route_dead.event_kind == "route_failure"
+        assert route_dead.event_payload.get("reap_status") == "observed"
+
+        pv_dead = kbd._classify_dead_worker(
+            pv_pid, "hermes01:mock",
+            last_heartbeat_at=1234567, elapsed=9999.0,
+        )
+        assert pv_dead.event_kind == "protocol_violation"
+        assert pv_dead.event_payload.get("reap_status") == "observed"
+    finally:
+        kbd._recent_worker_exits.pop(route_pid, None)
+        kbd._recent_worker_exits.pop(pv_pid, None)
+
 
 


### PR DESCRIPTION
What breaks: a worker that exits rc=0 having made no tool call at all, the shape a routing or credential failure takes before the model ever runs, is booked as a protocol violation and counted against the protocol-violation streak. With the common per-task `max_retries=1` that single misclassification blocks the card.

Repro: a card whose worker dies with zero heartbeats is closed as `crashed` with `pid <n> not alive` and counted against `_PROTOCOL_VIOLATION_FAILURE_LIMIT`.

Fix, three parts: `_classify_dead_worker` takes the closing run's last heartbeat and elapsed time and classifies a clean exit with no heartbeat past the crash grace as `route_failure`; `_reclaim_dead_workers` reaps the zombie before classifying so a child exiting between the two calls is classified from its real exit status; route failures do not consume the protocol-violation streak and carry their own budget of two trailing failures before the breaker trips.

Adjacent work: `#107886` classifies 429/quota exits as `capacity_failure` in the same function. Ours is the zero-turn rc=0 case; the labels stay distinct and the ordering between the two branches is explicit.

Tests: five invariant tests, each failing on the base commit, including the ordering classification, streak non-consumption, and the breaker payload.
