### PR TITLE
fix(plugins): validate model-providers via register_provider(), not register(ctx)

### DIFF
--- a/hermes_cli/plugin_validate.py
+++ b/hermes_cli/plugin_validate.py
@@ -262,23 +262,89 @@ except Exception as exc:
 emit(recorded)
 """
 
+# kind: model-provider is loaded by providers._discover_providers() via
+# import-time register_provider(), not PluginManager.register(ctx).
+# Spy on the real register_provider during import; a no-op register(ctx)
+# must not pass.
+_MP_PROBE_SCRIPT = r"""
+import importlib.util
+import json
+import sys
 
-def _run_capability_probe(plugin_dir: Path) -> Tuple[Optional[dict], str]:
+plugin_dir = sys.argv[1]
+sentinel = sys.argv[2]
+
+def emit(payload):
+    print(sentinel + json.dumps(payload))
+
+try:
+    import providers as providers_mod
+except Exception as exc:
+    emit({"error": "model-provider probe could not import providers: %s" % exc})
+    sys.exit(0)
+
+calls = []
+_orig = providers_mod.register_provider
+
+def _spy(profile):
+    name = getattr(profile, "name", None)
+    calls.append(str(name) if name is not None else "")
+    return _orig(profile)
+
+providers_mod.register_provider = _spy
+
+try:
+    spec = importlib.util.spec_from_file_location(
+        "hermes_validate_probe_plugin",
+        plugin_dir + "/__init__.py",
+        submodule_search_locations=[plugin_dir],
+    )
+    module = importlib.util.module_from_spec(spec)
+    module.__path__ = [plugin_dir]
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+except Exception as exc:
+    emit({"error": "import failed: %s" % exc})
+    sys.exit(0)
+
+if not calls:
+    emit({"error": "model-provider did not call register_provider()"})
+    sys.exit(0)
+
+emit({"providers": calls, "tools": [], "hooks": [], "middleware": [], "commands": []})
+"""
+
+
+def _probe_child_env(scratch: str, *, kind: str) -> dict:
+    """Throwaway HERMES_HOME. Prepend this tree to PYTHONPATH only for the
+    model-provider spy so a generic probe still sees the original env."""
+    env = dict(os.environ)
+    env["HERMES_HOME"] = scratch
+    if kind == "model-provider":
+        root = str(Path(__file__).resolve().parent.parent)
+        existing = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = root if not existing else root + os.pathsep + existing
+    return env
+
+
+def _run_capability_probe(
+    plugin_dir: Path, *, kind: str = "standalone"
+) -> Tuple[Optional[dict], str]:
     """Run the recording probe in a scratch subprocess.
 
     Returns ``(recorded, error)`` — exactly one is meaningful: *recorded*
     is the ``{tools, hooks, middleware, commands}`` dict on success, and
     *error* is a human-readable failure description otherwise.
     """
+    script = _MP_PROBE_SCRIPT if kind == "model-provider" else _PROBE_SCRIPT
     with tempfile.TemporaryDirectory(prefix="hermes-validate-") as scratch:
-        env = dict(os.environ)
-        env["HERMES_HOME"] = scratch
+        env = _probe_child_env(scratch, kind=kind)
         try:
             result = subprocess.run(
                 [
                     sys.executable,
                     "-c",
-                    _PROBE_SCRIPT,
+                    script,
                     str(plugin_dir),
                     _PROBE_SENTINEL,
                 ],
@@ -324,37 +390,56 @@ def _check_capabilities(
     Returns the recorded dict (for the built-in collision check) or None
     when the probe failed / was skipped.
     """
+    # Exact match: providers._declares_model_provider_kind compares strip() ==
+    # "model-provider" (no case-fold). PluginManager lowercases unknown kinds to
+    # standalone for its own loader, so a mis-cased value is not a live MP.
+    kind = str(manifest.get("kind") or "standalone").strip()
     if not (plugin_dir / "__init__.py").is_file():
+        if kind == "model-provider":
+            report.add(
+                "capability probe",
+                False,
+                "kind: model-provider requires __init__.py that calls register_provider()",
+            )
+            return None
         report.warn(
             "no __init__.py — capability probe skipped (manifest-only plugin)"
         )
         report.add("capability probe", True, "skipped (no __init__.py)")
         return None
 
-    recorded, error = _run_capability_probe(plugin_dir)
+    recorded, error = _run_capability_probe(plugin_dir, kind=kind)
     if recorded is None:
         report.add("capability probe", False, error)
         return None
-    report.add("capability probe", True, "register() ran in isolation")
+    if kind == "model-provider":
+        names = [n for n in (recorded.get("providers") or []) if n]
+        report.add(
+            "capability probe",
+            True,
+            "register_provider() ran at import (%s)" % (", ".join(names) or "unnamed"),
+        )
+    else:
+        report.add("capability probe", True, "register() ran in isolation")
 
-    for kind, manifest_key in (
+    for cap_kind, manifest_key in (
         ("tools", "provides_tools"),
         ("hooks", "provides_hooks"),
         ("middleware", "provides_middleware"),
     ):
         declared = set(_declared_list(manifest, manifest_key))
-        actual = set(recorded.get(kind) or [])
+        actual = set(recorded.get(cap_kind) or [])
         undeclared = sorted(actual - declared)
         unregistered = sorted(declared - actual)
         if undeclared:
             report.add(
-                f"declared {kind}",
+                f"declared {cap_kind}",
                 False,
-                f"undeclared {kind} registered (not in {manifest_key}): "
+                f"undeclared {cap_kind} registered (not in {manifest_key}): "
                 f"{', '.join(undeclared)}",
             )
         else:
-            report.add(f"declared {kind}", True, "matches registrations")
+            report.add(f"declared {cap_kind}", True, "matches registrations")
         if unregistered:
             report.warn(
                 f"{manifest_key} declares {', '.join(unregistered)} "

--- a/hermes_cli/plugin_validate.py
+++ b/hermes_cli/plugin_validate.py
@@ -287,9 +287,10 @@ calls = []
 _orig = providers_mod.register_provider
 
 def _spy(profile):
+    result = _orig(profile)
     name = getattr(profile, "name", None)
     calls.append(str(name) if name is not None else "")
-    return _orig(profile)
+    return result
 
 providers_mod.register_provider = _spy
 

--- a/tests/hermes_cli/test_plugin_validate.py
+++ b/tests/hermes_cli/test_plugin_validate.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 import yaml
 
 from hermes_cli.plugin_validate import validate_plugin_dir
@@ -17,12 +18,13 @@ def _make_plugin(
     tmp_path: Path,
     *,
     manifest: dict,
-    init_py: str = "def register(ctx):\n    pass\n",
+    init_py: str | None = "def register(ctx):\n    pass\n",
 ) -> Path:
     d = tmp_path / manifest.get("name", "fixture-plugin")
     d.mkdir(parents=True, exist_ok=True)
     (d / "plugin.yaml").write_text(yaml.safe_dump(manifest), encoding="utf-8")
-    (d / "__init__.py").write_text(init_py, encoding="utf-8")
+    if init_py is not None:
+        (d / "__init__.py").write_text(init_py, encoding="utf-8")
     return d
 
 
@@ -136,4 +138,86 @@ class TestRequiresHermesSpec:
         assert any(
             "requires_hermes" in f and "does not parse" in f for f in report.failures
         ), report.failures
+
+
+_MP_MANIFEST = {
+    "name": "fixture-model-provider",
+    "kind": "model-provider",
+    "version": "1.0.0",
+    "description": "A fixture model provider.",
+}
+
+_MP_REGISTERING_INIT = """\
+from providers import register_provider
+from providers.base import ProviderProfile
+
+register_provider(ProviderProfile(
+    name="fixture-mp",
+    env_vars=("FIXTURE_MP_KEY",),
+    base_url="https://example.invalid/v1",
+    auth_type="api_key",
+    api_mode="chat_completions",
+))
+"""
+
+
+class TestModelProviderProbe:
+    """kind: model-provider must prove import-time register_provider(), not register(ctx)."""
+
+    @pytest.mark.parametrize(
+        "manifest, init_py, expect_ok, fail_contains, fail_excludes, probe_ok_contains",
+        [
+            pytest.param(
+                _MP_MANIFEST, _MP_REGISTERING_INIT, True, None, None, "register_provider",
+                id="import_register_provider",
+            ),
+            pytest.param(
+                _MP_MANIFEST, "def register(ctx):\n    pass\n", False,
+                "register_provider", "no register() function", None,
+                id="shell_register_ctx",
+            ),
+            pytest.param(
+                _MP_MANIFEST, None, False, "__init__.py", None, None,
+                id="missing_init",
+            ),
+            pytest.param(
+                {**_MP_MANIFEST, "kind": "Model-Provider"}, _MP_REGISTERING_INIT, False,
+                "no register() function", None, None,
+                id="wrong_case_kind",
+            ),
+        ],
+    )
+    def test_model_provider_admission(
+        self, tmp_path, manifest, init_py, expect_ok, fail_contains, fail_excludes,
+        probe_ok_contains,
+    ):
+        report = validate_plugin_dir(
+            _make_plugin(tmp_path, manifest=dict(manifest), init_py=init_py)
+        )
+        if expect_ok:
+            assert report.ok, report.failures
+        else:
+            assert not report.ok
+        joined = " ".join(report.failures)
+        if fail_contains:
+            assert fail_contains in joined, report.failures
+        if fail_excludes:
+            assert fail_excludes not in joined, report.failures
+        if probe_ok_contains:
+            assert any(
+                name == "capability probe" and ok and probe_ok_contains in detail
+                for name, ok, detail in report.checks
+            ), report.checks
+        else:
+            assert not any(
+                name == "capability probe" and ok and "register_provider" in detail
+                for name, ok, detail in report.checks
+            ), report.checks
+
+    def test_generic_plugin_still_requires_register_ctx(self, tmp_path):
+        report = validate_plugin_dir(
+            _make_plugin(tmp_path, manifest=dict(BASE_MANIFEST), init_py="# no register()\n")
+        )
+        assert not report.ok
+        assert any("no register() function" in f for f in report.failures), report.failures
 

--- a/tests/hermes_cli/test_plugin_validate.py
+++ b/tests/hermes_cli/test_plugin_validate.py
@@ -185,6 +185,18 @@ class TestModelProviderProbe:
                 "no register() function", None, None,
                 id="wrong_case_kind",
             ),
+            pytest.param(
+                _MP_MANIFEST,
+                (
+                    "from providers import register_provider\n"
+                    "try:\n"
+                    "    register_provider(object())\n"
+                    "except AttributeError:\n"
+                    "    pass\n"
+                ),
+                False, "register_provider", "no register() function", None,
+                id="swallowed_failed_register_provider",
+            ),
         ],
     )
     def test_model_provider_admission(


### PR DESCRIPTION
## What does this PR do?

`hermes plugins validate` (catalog CI and `.github/actions/plugin-validate`) required `register(ctx)` for every plugin with `__init__.py`. `kind: model-provider` is loaded by `providers._discover_providers()` via import-time `register_provider()`; PluginManager skips that kind so it does not double-instantiate. Result: bundled OpenRouter and any third-party model-provider fail admission with `no register() function`. A no-op `register(ctx)` would green the gate without proving a live provider.

This patch spies the real `register_provider()` during an isolated import for exact `kind: model-provider` (same `strip()` equality as `_declares_model_provider_kind`; no case-fold). After a successful spy it still diffs `provides_tools` / `provides_hooks` / `provides_middleware`. Missing `__init__.py` on a model-provider fails. Generic plugins still use `register(ctx)` with the original child env (PYTHONPATH prepend is model-provider-only).

Related but different: #86153 (`hermes plugins doctor`, same missing-`register()` mismatch). This PR does not change doctor.

This is a community contribution. It is not an official catalog listing, partnership, or endorsement.

## Before / after

Baseline: `de2d6a1b93508463c31434c1ae067e204af81238` (`origin/main` at PR time).

**Before:** `hermes plugins validate plugins/model-providers/openrouter` → exit 1, `capability probe: no register() function`.

**After:** same command → exit 0, `register_provider() ran at import (openrouter)`, plus declared tools/hooks/middleware match. A third-party model-provider (Vancine, public SHA) also exits 0.

## Tests

```
scripts/run_tests.sh tests/hermes_cli/test_plugin_validate.py
```

15 passed, 0 failed.

Contract coverage: import-time `register_provider()` passes; a no-op `register(ctx)` fails; missing `__init__.py` fails; mis-cased `kind` is not treated as a model-provider; generic plugins still require `register(ctx)`.