### PR TITLE
fix(gateway): make standalone rollback recoverable

### DIFF
--- a/gateway/run_adapters.py
+++ b/gateway/run_adapters.py
@@ -828,6 +828,11 @@ class GatewayAdapterLifecycleMixin:
         are refused here — the only point seeing every profile's credentials together."""
         from gateway.run import MultiplexConfigError, _multiplex_profile_homes
         if not self._multiplex_on():
+            # gateway_state.json outlives its writer. A standalone process must invalidate the
+            # previous multiplexer's served set or profile lifecycle commands keep exiting 78.
+            with _log_suppressed(logging.DEBUG, "could not clear served_profiles", exc_info=True):
+                from gateway.status import write_runtime_status
+                write_runtime_status(served_profiles=[])
             return 0
         try:
             from hermes_cli.profiles import get_active_profile_name

--- a/hermes_cli/gateway_migrate.py
+++ b/hermes_cli/gateway_migrate.py
@@ -451,6 +451,32 @@ def format_plan(plan: MigrationPlan, *, dry_run: bool) -> list[str]:
     return lines
 
 
+def format_rollback_plan(default_home: Path) -> list[str]:
+    """Describe the recorded standalone rollback without changing persistent state."""
+    path = _manifest_path(default_home)
+    manifest = _read_manifest(default_home)
+    lines = [
+        "Rollback plan (dry run — nothing changed)",
+        f"  default home: {default_home}",
+        "",
+    ]
+    if manifest is None:
+        return [*lines, f"  ✗ No migration manifest at {path}; nothing to roll back."]
+    lines.append("  Steps:")
+    for rec in manifest.get("secondaries", []):
+        service = rec.get("service") or {}
+        if service:
+            lines.append(f"  - {rec['profile']}: reinstall and start its {service['kind']} service")
+        elif rec.get("pid"):
+            lines.append(f"  - {rec['profile']}: start its standalone gateway (detached)")
+    lines.extend([
+        "  - default: restore gateway.multiplex_profiles",
+        "  - default: restart the gateway after secondary services are restored",
+        f"  - remove {path} after every step succeeds",
+    ])
+    return lines
+
+
 def format_update_warning(plan: MigrationPlan) -> list[str]:
     return [
         "⚠ Your profiles each run their own gateway. A single multiplexed gateway is the recommended",
@@ -516,6 +542,16 @@ def _restart_default(plan_default: ProfileGateway, target: Optional[tuple[str, b
     return f"{verb} the default gateway (detached; no service manager was in use)"
 
 
+def _restart_default_after_rollback(default_gw: ProfileGateway, default_home: Path) -> str:
+    """Restart last, asking a managed live gateway to drain itself so it cannot kill this CLI."""
+    if default_gw.service is not None and default_gw.pid is not None:
+        from gateway.control_socket import pause_gateway_for_update
+        response = pause_gateway_for_update(default_home)
+        if response and (response.get("pausing") or response.get("already_stopping")):
+            return "requested a graceful default gateway restart via its control socket"
+    return _restart_default(default_gw, None, default_home)
+
+
 def apply_migration(plan: MigrationPlan, *, served_wait: float = _SERVED_WAIT_SECONDS) -> bool:
     """Stop/uninstall every secondary gateway, flip the flag, bring up the multiplexer, verify.
     Returns True when the multiplexer verifiably serves every profile."""
@@ -577,8 +613,6 @@ def rollback_migration(default_home: Optional[Path] = None) -> bool:
         "default", default_home, pid=_live_gateway_pid(default_home),
         service=(default_service["kind"], bool(default_service.get("system"))) if default_service else _installed_service(default_home),
     )
-    if default_gw.has_gateway:
-        print(f"  ✓ {_restart_default(default_gw, None, default_home)}")
     ok = True
     for rec in manifest.get("secondaries", []):
         home = Path(rec["home"])
@@ -599,6 +633,12 @@ def rollback_migration(default_home: Optional[Path] = None) -> bool:
         except Exception as exc:
             ok = False
             print(f"  ✗ {name}: {exc}")
+    if ok and default_gw.has_gateway:
+        try:
+            print(f"  ✓ {_restart_default_after_rollback(default_gw, default_home)}")
+        except Exception as exc:
+            ok = False
+            print(f"  ✗ default: {exc}")
     if ok:
         _manifest_path(default_home).unlink(missing_ok=True)
         print("✓ Rolled back to per-profile gateways.")
@@ -623,6 +663,9 @@ def _host_supports_migration() -> Optional[str]:
 def cmd_migrate(args) -> None:
     """``hermes gateway migrate [--multiplex|--standalone] [--dry-run] [--yes]``."""
     if getattr(args, "standalone", False):
+        if getattr(args, "dry_run", False):
+            _print(format_rollback_plan(_default_home()))
+            return
         sys.exit(0 if rollback_migration() else 1)
     reason = _host_supports_migration()
     if reason:

--- a/tests/hermes_cli/test_gateway_migrate_multiplex.py
+++ b/tests/hermes_cli/test_gateway_migrate_multiplex.py
@@ -8,12 +8,14 @@ fingerprint and port-binding predicates, so the tests assert verdict → effect,
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+import yaml
 
 import hermes_constants
 from hermes_cli import gateway_migrate as gm
@@ -52,11 +54,15 @@ def fleet(tmp_path, monkeypatch):
         elif verb == "install":
             state.services[name] = (kind, system)
         elif verb in ("start", "restart") and name == "default":
-            # What the real multiplexer does at startup: record the served set in the default home.
+            # Startup always replaces the prior process's served set, including standalone mode.
             (root / "gateway.pid").write_text(json.dumps({"pid": os.getpid(), "hermes_home": str(root)}))
             (root / "gateway_state.json").write_text(json.dumps({
                 "pid": os.getpid(), "hermes_home": str(root), "gateway_state": "running",
-                "served_profiles": ["default", "coder", "ops"],
+                "served_profiles": (
+                    ["default", "coder", "ops"]
+                    if (yaml.safe_load((root / "config.yaml").read_text()) or {}).get("gateway", {}).get("multiplex_profiles")
+                    else []
+                ),
             }))
 
     monkeypatch.setattr(gm, "_installed_service", lambda home: state.services.get(_name(home)))
@@ -94,7 +100,27 @@ def test_dry_run_and_blocked_preflight_change_nothing(fleet, capsys):
     assert "nothing will be changed" in capsys.readouterr().out
 
 
-def test_apply_records_manifest_flips_flag_and_rollback_restores(fleet, capsys):
+def test_standalone_dry_run_previews_manifest_without_changes(fleet, capsys):
+    manifest = {
+        "version": 1,
+        "flag_was": False,
+        "default": {"profile": "default", "home": str(fleet.root), "service": None},
+        "secondaries": [{
+            "profile": "coder", "home": str(fleet.root / "profiles/coder"),
+            "pid": 4101, "service": {"kind": "systemd", "system": False},
+        }],
+    }
+    gm._write_manifest(fleet.root, manifest)
+    before = (fleet.root / gm.MANIFEST_NAME).read_bytes()
+
+    gm.cmd_migrate(SimpleNamespace(standalone=True, dry_run=True))
+
+    assert "Rollback plan (dry run" in capsys.readouterr().out
+    assert (fleet.root / gm.MANIFEST_NAME).read_bytes() == before
+    assert fleet.ops == [] and _config_flag(fleet.root) is None
+
+
+def test_apply_records_manifest_flips_flag_and_rollback_restores(fleet, capsys, monkeypatch):
     plan = gm.build_migration_plan()
     assert gm.apply_migration(plan, served_wait=5.0) is True
     manifest = json.loads((fleet.root / gm.MANIFEST_NAME).read_text(encoding="utf-8"))
@@ -111,11 +137,27 @@ def test_apply_records_manifest_flips_flag_and_rollback_restores(fleet, capsys):
     assert again.already_multiplexed and gm.apply_migration(again) is True
 
     fleet.ops.clear()
+
+    def _graceful_restart(home):
+        # The managed gateway accepts its own deferred restart only after every secondary is restored.
+        assert [op for op in fleet.ops if op[0] != "default"] == [
+            ("coder", "install"), ("coder", "start"), ("ops", "install"), ("ops", "start")]
+        fleet.ops.append(("default", "restart-request"))
+        return {"pausing": True}
+
+    monkeypatch.setattr("gateway.control_socket.pause_gateway_for_update", _graceful_restart)
     assert gm.rollback_migration(fleet.root) is True
     assert _config_flag(fleet.root) is False
     assert fleet.services == {"default": ("systemd", False), "coder": ("systemd", False), "ops": ("systemd", False)}
     assert [op for op in fleet.ops if op[0] != "default"] == [
         ("coder", "install"), ("coder", "start"), ("ops", "install"), ("ops", "start")]
+    assert fleet.ops[-1] == ("default", "restart-request")
+
+    from gateway.run_adapters import GatewayAdapterLifecycleMixin
+    standalone = object.__new__(GatewayAdapterLifecycleMixin)
+    standalone._multiplex_on = lambda: False
+    asyncio.run(standalone._start_secondary_profile_adapters())
+    assert json.loads((fleet.root / "gateway_state.json").read_text())["served_profiles"] == []
     assert not (fleet.root / gm.MANIFEST_NAME).exists()
 
 

--- a/tests/hermes_cli/test_gateway_migrate_multiplex.py
+++ b/tests/hermes_cli/test_gateway_migrate_multiplex.py
@@ -137,6 +137,7 @@ def test_apply_records_manifest_flips_flag_and_rollback_restores(fleet, capsys, 
     assert again.already_multiplexed and gm.apply_migration(again) is True
 
     fleet.ops.clear()
+    fleet.pids["default"] = os.getpid()
 
     def _graceful_restart(home):
         # The managed gateway accepts its own deferred restart only after every secondary is restored.


### PR DESCRIPTION
## Summary

- make `gateway migrate --standalone --dry-run` print the recorded rollback plan without mutating configuration, services, or the manifest
- restore secondary profile gateways before restarting the default gateway
- request a managed gateway's graceful self-restart over its control socket so an in-gateway migration process is not killed by `KillMode=mixed`
- clear stale `served_profiles` whenever a standalone gateway starts

## Root Cause

The standalone branch entered `rollback_migration()` before reading `dry_run`. Rollback then restarted the default service before restoring secondaries, so a migration launched from the gateway's cgroup could be terminated midway. Finally, standalone startup preserved the old multiplexer-owned `served_profiles` value in `gateway_state.json`, causing profile lifecycle commands to keep refusing repairs with exit 78.

## Why this PR vs existing PR #109478

PR #109478 still calls the synchronous default-service restart in `hermes_cli/gateway_migrate.py`, so a migration process inside the gateway's `KillMode=mixed` cgroup can still be killed. This PR uses the live gateway control socket to request a graceful supervisor restart and return an acknowledgement before the gateway exits. It also invalidates `served_profiles` in `gateway/run_adapters.py` on every standalone startup, fixing stale records beyond the one rollback call while keeping the live multiplexer record authoritative until shutdown.

## Testing

- `scripts/run_tests.sh tests/hermes_cli/test_gateway_migrate_multiplex.py` (7 passed)
- `scripts/run_tests.sh tests/hermes_cli/test_gateway_multiplex_served_record.py tests/gateway/test_multiplex_adapter_registry.py` (43 passed)

## Related Issue

N/A
