### PR TITLE
fix(gateway): format scoped MCP server names during reload

### DIFF
--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2338,6 +2338,7 @@ class GatewayTurnMixin:
             from tools.mcp_tool_discovery import discover_mcp_tools
             from tools.mcp_tool import _servers, _lock, _server_visible_in_scope
             from tools.mcp_tool_agent import reprobe_tool_availability
+            from tools.mcp_tool_scope import _key_name
             from tools.registry import registry
 
             reload_scope = registry.current_scope_key() if multiplex else None
@@ -2345,8 +2346,8 @@ class GatewayTurnMixin:
             def _scoped_server_names() -> set:
                 with _lock:
                     return {
-                        name for name in _servers
-                        if _server_visible_in_scope(name, reload_scope)
+                        _key_name(key) for key in _servers
+                        if _server_visible_in_scope(key, reload_scope)
                     }
 
             old_servers = _scoped_server_names()

--- a/tests/gateway/test_multiplex_mcp_discovery.py
+++ b/tests/gateway/test_multiplex_mcp_discovery.py
@@ -103,6 +103,54 @@ async def test_reload_mcp_only_touches_requesting_profile(
 
 
 @pytest.mark.asyncio
+async def test_reload_mcp_formats_scoped_connection_keys_before_refreshing_cached_agents(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Connection-ledger tuple keys are internal; reload reports server names and completes refresh."""
+    from gateway.run import GatewayRunner
+    from tools import mcp_tool
+    from tools import mcp_tool_discovery as _mcp_discovery
+    from tools import mcp_tool_lifecycle as _mcp_lifecycle
+
+    launch_scope = hermes_home_key(tmp_path / "default")
+    worker_home = tmp_path / "profiles" / "worker"
+    worker_home.mkdir(parents=True)
+    worker_scope = hermes_home_key(worker_home)
+    launch_key = (launch_scope, "default-srv")
+    worker_key = (worker_scope, "worker-srv")
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    runner._resolve_profile_home_for_source = MagicMock(return_value=worker_home)
+    runner._mcp_reload_refresh_cached_agents = MagicMock()
+    runner._async_session_store = SimpleNamespace(
+        get_or_create_session=MagicMock(side_effect=RuntimeError("skip transcript")),
+    )
+
+    monkeypatch.setattr(mcp_tool, "_servers", {launch_key: object(), worker_key: object()})
+    monkeypatch.setattr(
+        mcp_tool, "_server_scope_keys",
+        {launch_key: launch_scope, worker_key: worker_scope},
+    )
+    monkeypatch.setattr(_mcp_lifecycle, "shutdown_mcp_servers", lambda **_kwargs: None)
+    monkeypatch.setattr(_mcp_discovery, "discover_mcp_tools", lambda: [])
+
+    event = MessageEvent(
+        text="/reload-mcp", message_id="m1",
+        source=SessionSource(
+            platform=Platform.TELEGRAM, user_id="u1", chat_id="c1",
+            chat_type="dm", profile="worker",
+        ),
+    )
+    result = await runner._execute_mcp_reload(event)
+
+    assert "MCP reload failed" not in result
+    assert "worker-srv" in result
+    assert "default-srv" not in result
+    runner._mcp_reload_refresh_cached_agents.assert_called_once_with(True, "worker")
+
+
+@pytest.mark.asyncio
 async def test_reload_mcp_reports_a_shared_server_to_a_non_owner_profile(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway `/reload-mcp` crash when multiplexed MCP connections are keyed by `(profile_scope, server_name)` tuples.

`_execute_mcp_reload()` collects connection keys for its status summary, then passes them to `", ".join(...)`. With tuple keys, it returns `MCP reload failed: sequence item 0: expected str instance, tuple found` before reaching `_mcp_reload_refresh_cached_agents()`.

Use the existing `_key_name()` accessor for display names, after filtering the original keys through `_server_visible_in_scope()`. This preserves profile scoping without stringifying internal tuples or changing connection ownership, discovery, or cache-refresh policy.

## Related Issue

No separate issue found for this exact gateway crash. Follow-up to the composite connection keys introduced in #108352. The open reload-label PRs #94452 and #104051 concern configured-versus-connected diff semantics, not this tuple-formatting failure.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run_turn.py`: convert visible connection keys to server names through `_key_name()`.
- `tests/gateway/test_multiplex_mcp_discovery.py`: add one regression test using real tuple-shaped connection keys. Assert the requesting profile's name appears, a sibling profile's name does not, and cached-agent refresh is reached.

## How to Test

### Reproduction

1. Run a multiplexed gateway with an MCP connection belonging to a secondary profile.
2. Send `/reload-mcp` from that profile's gateway conversation.
3. Before this fix, the status-summary join fails with the tuple `TypeError`, preventing cached-agent refresh. After this fix, the summary reports plain server names and the refresh path completes.

The automated regression exercises the real gateway handler and scope predicate with temporary profile homes; network discovery/shutdown and the refresh call are mocked. It is not a claim of a live-network end-to-end test.

### Automated validation

Tested on macOS 15.7.7 against base `de2d6a1b93508463c31434c1ae067e204af81238`.

```bash
scripts/run_tests.sh tests/gateway/test_multiplex_mcp_discovery.py
# 9 passed
scripts/run_tests.sh tests/tools/test_mcp_multiplex_connection_keys.py
# 2 passed
scripts/run_tests.sh tests/tools/test_refresh_agent_mcp_tools.py
# 19 passed
python scripts/check-windows-footguns.py gateway/run_turn.py tests/gateway/test_multiplex_mcp_discovery.py
# No Windows footguns found
git diff --check
# Clean
```

The new regression was run before the production fix and failed with the exact reported error; it passes with the fix. All 30 focused tests pass using the canonical hermetic runner. The full repository suite and live-network manual reproduction have not been run for this PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing open and merged PRs and issues to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix, with no unrelated commits
- [ ] I've run `pytest tests/ -q` and all tests pass (full suite not run; focused canonical-runner results above)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.7.7

### Documentation & Housekeeping

- [x] Relevant documentation: N/A, restores existing behaviour
- [x] `cli-config.yaml.example`: N/A, no configuration changes
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A, no architecture or workflow changes
- [x] Cross-platform impact considered: no new OS-specific operations; Windows-footgun check passes
- [x] Tool descriptions/schemas: N/A, unchanged

## Screenshots / Logs

Before the production fix, the new regression reports:

```text
MCP reload failed: sequence item 0: expected str instance, tuple found
1 failed
```

After the fix, the focused canonical-runner files report 9, 2, and 19 tests passed respectively, with no failures.
