### PR TITLE
fix: avoid BlueBubbles webhook bind on outbound sends

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -197,7 +197,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
     # --- Lifecycle ---
 
-    async def connect(self, *, is_reconnect: bool = False) -> bool:
+    async def connect(self, *, is_reconnect: bool = False, outbound_only: bool = False) -> bool:
         if not self.server_url or not self.password:
             logger.error("[bluebubbles] BLUEBUBBLES_SERVER_URL and BLUEBUBBLES_PASSWORD are required")
             return False
@@ -218,11 +218,15 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             logger.error("[bluebubbles] cannot reach server at %s: %s", self.server_url, exc)
             await self._close_client()
             return False
-        # client_max_size makes aiohttp enforce the cap on every read path, incl. chunked requests
-        # with no Content-Length.
-        # Explicit body cap: BlueBubbles webhook events are small JSON (or form-encoded) payloads.
-        # client_max_size makes aiohttp enforce the cap on every read path — including chunked requests that
-        # carry no Content-Length (same pattern as webhook.py / raft, #58536/#58902).
+        if outbound_only:
+            self._mark_connected()
+            self._wire_plugin_handlers(None)
+            return True
+
+        # Explicit body cap: BlueBubbles webhook events are small JSON (or
+        # form-encoded) payloads. client_max_size makes aiohttp enforce the
+        # cap on every read path — including chunked requests that carry no
+        # Content-Length (same pattern as webhook.py / raft, #58536/#58902).
         app = web.Application(client_max_size=_WEBHOOK_MAX_BODY_BYTES)
         app.router.add_get("/health", lambda _: web.Response(text="ok"))
         app.router.add_post(self.webhook_path, self._handle_webhook)
@@ -247,7 +251,11 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             self.client = None
 
     async def disconnect(self) -> None:
-        await self._unregister_webhook()
+        # Unregister only webhooks this adapter instance registered. Direct
+        # outbound sends use the REST API without owning a webhook listener;
+        # unregistering there could remove the live gateway's inbound webhook.
+        if self._runner:
+            await self._unregister_webhook()
         await self._close_client()
         if self._runner:
             await self._runner.cleanup()

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -74,6 +74,41 @@ class TestBlueBubblesHelpers:
         adapter = _make_adapter(monkeypatch, server_url="http://localhost:1234/")
         assert adapter.server_url == "http://localhost:1234"
 
+    @pytest.mark.asyncio
+    async def test_outbound_only_connect_does_not_start_or_unregister_webhook(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        calls = []
+
+        async def fake_api_get(path):
+            calls.append(("get", path))
+            if path == "/api/v1/server/info":
+                return {"data": {"private_api": True, "helper_connected": True}}
+            return {"data": {}}
+
+        async def fail_register():
+            raise AssertionError("outbound-only connect must not register a webhook")
+
+        async def fail_unregister():
+            raise AssertionError("outbound-only disconnect must not unregister a webhook")
+
+        class MockClient:
+            async def aclose(self):
+                calls.append(("close", None))
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda *args, **kwargs: MockClient())
+        monkeypatch.setattr(adapter, "_api_get", fake_api_get)
+        monkeypatch.setattr(adapter, "_register_webhook", fail_register)
+        monkeypatch.setattr(adapter, "_unregister_webhook", fail_unregister)
+
+        assert await adapter.connect(outbound_only=True) is True
+        assert adapter._runner is None
+        await adapter.disconnect()
+        assert calls == [
+            ("get", "/api/v1/ping"),
+            ("get", "/api/v1/server/info"),
+            ("close", None),
+        ]
+
 
 class _FakeBlueBubblesRequest:
     def __init__(self, payload, password="secret"):

--- a/tools/send_message_senders.py
+++ b/tools/send_message_senders.py
@@ -581,7 +581,7 @@ async def _send_bluebubbles(extra, chat_id, message):
     try:
         from gateway.config import PlatformConfig
         adapter = bb.BlueBubblesAdapter(PlatformConfig(extra=extra))
-        if not await adapter.connect():
+        if not await adapter.connect(outbound_only=True):
             return _error("BlueBubbles: failed to connect to server")
         try:
             result = await adapter.send(chat_id, message)


### PR DESCRIPTION
## Summary
- add an outbound-only BlueBubbles adapter connection path for direct sends
- use that path from send_message so cron/origin delivery does not try to bind the webhook port already owned by the gateway
- avoid unregistering a gateway webhook from outbound-only adapter instances

## Verification
- scripts/run_tests.sh tests/gateway/test_bluebubbles.py tests/gateway/test_aiohttp_body_caps.py -q