### PR TITLE
fix(memory): reject malformed single-store batches before approval

### DIFF
--- a/tests/tools/test_memory_batch_contract.py
+++ b/tests/tools/test_memory_batch_contract.py
@@ -1,0 +1,94 @@
+"""Batch shape is validated before staging and during native-store replay."""
+
+import copy
+import json
+
+import pytest
+
+from hermes_cli.config import load_config, save_config
+from tools import memory_tool as mt
+from tools import write_approval as wa
+from tools.skill_provenance import reset_current_write_origin, set_current_write_origin
+
+
+@pytest.fixture
+def store():
+    result = mt.MemoryStore(memory_char_limit=60, user_char_limit=60)
+    result.load_from_disk()
+    assert result.add("memory", "Project uses Python")["success"]
+    assert result.add("user", "User prefers concise replies")["success"]
+    result.load_from_disk()
+    return result
+
+
+@pytest.mark.parametrize("route", ["direct", "foreground", "background", "store", "replay"])
+@pytest.mark.parametrize("operations", [
+    [], {}, "add", 0, [None], [[]], ["add"], [{}],
+    [{"action": []}], [{"action": "delete"}],
+    [{"action": "add", "content": "New fact", "target": "memory"}],
+    [{"action": "add", "content": "New fact", "target": "user"}],
+    [{"action": "add", "content": "New fact", "typo": True}],
+    [{"action": "add", "content": 1}],
+    [{"action": "add", "new_text": ["New fact"]}],
+    [{"action": "remove", "old_text": False}],
+    [{"action": "add", "content": " "}],
+    [{"action": "replace", "content": "New fact"}],
+])
+def test_malformed_batch_neither_stages_nor_changes_either_store(store, route, operations):
+    before = {target: store._path_for(target).read_bytes() for target in ("memory", "user")}
+    original = copy.deepcopy(operations)
+    config = load_config()
+    config.setdefault("memory", {})["write_approval"] = route in {"foreground", "background"}
+    save_config(config)
+    token = set_current_write_origin("background_review" if route == "background" else "foreground")
+    try:
+        if route == "store":
+            result = store.apply_batch("memory", operations)
+        elif route == "replay":
+            result = mt.apply_memory_pending(
+                {"action": "batch", "target": "memory", "operations": operations}, store)
+        else:
+            # An explicit malformed operations value must not fall back to the single action.
+            result = json.loads(mt.memory_tool(
+                action="add", target="memory", content="Fallback must not be written",
+                operations=operations, store=store))
+    finally:
+        reset_current_write_origin(token)
+    assert result["success"] is False, result
+    assert result.get("error")
+    assert not result.get("staged")
+    assert wa.list_pending(wa.MEMORY) == []
+    assert operations == original
+    assert {target: store._path_for(target).read_bytes() for target in before} == before
+
+
+@pytest.mark.parametrize("target", ["memory", "user"])
+@pytest.mark.parametrize("route", ["direct", "approved"])
+def test_valid_single_store_batch_preserves_gate_final_budget_and_prompt(store, target, route):
+    config = load_config()
+    config.setdefault("memory", {})["write_approval"] = route == "approved"
+    save_config(config)
+    other = "user" if target == "memory" else "memory"
+    other_before = store._path_for(other).read_bytes()
+    before = store._path_for(target).read_bytes()
+    snapshot = store.format_for_system_prompt(target)
+    content = "Keep notes short and use focused changes"
+    operations = [
+        {"action": "add", "content": None, "new_text": content},
+        {"action": "remove", "old_text": store._entries_for(target)[0]},
+    ]
+    result = json.loads(mt.memory_tool(target=target, operations=operations, store=store))
+    assert result["success"], result
+    if route == "approved":
+        assert result["staged"]
+        assert store._path_for(target).read_bytes() == before
+        from hermes_cli.write_approval_commands import handle_pending_subcommand
+        reply = handle_pending_subcommand(
+            wa.MEMORY, ["approve", result["pending_id"]], memory_store=store)
+        assert "Approved 1" in reply, reply
+    assert wa.list_pending(wa.MEMORY) == []
+    fresh = mt.MemoryStore(memory_char_limit=60, user_char_limit=60)
+    fresh.load_from_disk()
+    assert fresh._entries_for(target) == [content]
+    assert store._path_for(other).read_bytes() == other_before
+    assert store.format_for_system_prompt(target) == snapshot

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -42,6 +42,7 @@ def get_memory_dir() -> Path:
 
 from tools.memory_tool_store import (  # noqa: E402,F401  (re-exports)
     ENTRY_DELIMITER, MEMORY_BLOCK_HEADERS, MemoryStore, _scan_memory_content)
+from tools.memory_tool_store import validate_memory_batch
 
 
 def load_on_disk_store() -> "MemoryStore":
@@ -181,12 +182,13 @@ def memory_tool(action: str = None, target: str = "memory", content: str = None,
         content = new_text
     # Strict providers send JSON null for optional fields; treat as omitted.
     target = "memory" if target is None else target
+    if operations is not None:
+        if invalid := validate_memory_batch(target, operations):
+            return tool_error(invalid, success=False)
     target_error = _memory_target_error(store, target)
     if target_error is not None:
         return json.dumps(target_error)
-    if operations:
-        if not isinstance(operations, list):
-            return tool_error("operations must be a list of {action, content?, old_text?} objects.", success=False)
+    if operations is not None:
         denied = _background_delete_gate(action, operations, target)
         if denied is not None:
             return denied
@@ -236,7 +238,7 @@ def check_memory_requirements() -> bool:
 
 def _memory_target_error(store: "MemoryStore", target: str) -> Optional[Dict[str, Any]]:
     """Return a shared validation error for an invalid or disabled target."""
-    if target not in {"memory", "user"}:
+    if not isinstance(target, str) or target not in {"memory", "user"}:
         from tools.registry import _bound_error_text
         return {"success": False,
                 "error": _bound_error_text(f"Invalid memory target '{target}'. Use 'memory' or 'user'.")}
@@ -253,7 +255,7 @@ def apply_memory_pending(payload: Dict[str, Any], store: "MemoryStore") -> Dict[
     if target_error is not None:
         return target_error
     if action == "batch":
-        return store.apply_batch(target, payload.get("operations") or [])
+        return store.apply_batch(target, payload.get("operations"))
     if action not in _STORE_ACTIONS:
         return {"success": False, "error": f"Unknown staged action '{action}'."}
     return _STORE_ACTIONS[action][0](store, target, payload.get("content") or "", payload.get("old_text") or "")
@@ -264,8 +266,10 @@ MEMORY_SCHEMA = {
     "description": (
         "Save durable facts to persistent memory that survive across sessions. Memory is "
         "injected into every future turn, so keep entries compact and high-signal.\n\n"
-        "HOW: make ALL your changes in ONE call via an 'operations' array (each item: "
-        "{action, content?, old_text?}). The batch applies atomically and the char limit is "
+        "HOW: make your changes in ONE call PER STORE via an 'operations' array (each item: "
+        "{action, content?, old_text?}). Set target once at the top level; never put target "
+        "inside an operation. Use separate calls for 'memory' and 'user'. Each batch applies "
+        "atomically to its one store and the char limit is "
         "checked only on the FINAL result — so a single call can remove/replace stale entries "
         "to free room AND add new ones, even when an add alone would overflow. The response "
         "reports current/limit chars and confirms completion; one batch call finishes the "
@@ -296,7 +300,7 @@ MEMORY_SCHEMA = {
             "target": {
                 "type": "string",
                 "enum": ["memory", "user"],
-                "description": "Which memory store: 'memory' for personal notes, 'user' for user profile."
+                "description": "Top-level store shared by every operation (defaults to memory): 'memory' for personal notes, 'user' for user profile. Use separate calls for different stores."
             },
             "content": {
                 "type": "string",
@@ -315,7 +319,8 @@ MEMORY_SCHEMA = {
                 "description": (
                     "Batch shape: a list of operations applied atomically in one call "
                     "against the final char budget. Preferred when making multiple changes "
-                    "or consolidating to make room. Each item is {action, content?, old_text?}."
+                    "or consolidating to make room in ONE store. Each item is {action, content?, "
+                    "old_text?}; target belongs only at the top level."
                 ),
                 "items": {
                     "type": "object",
@@ -326,6 +331,7 @@ MEMORY_SCHEMA = {
                         "old_text": {"type": "string", "description": "Substring identifying the entry for replace/remove."},
                     },
                     "required": ["action"],
+                    "additionalProperties": False,
                 },
             },
         },

--- a/tools/memory_tool_store.py
+++ b/tools/memory_tool_store.py
@@ -63,6 +63,41 @@ def _find_unique_match(entries: List[str], old_text: str) -> Tuple[Optional[int]
     return (matches[0] if matches else None), False
 
 
+def validate_memory_batch(target: str, operations: Any) -> Optional[str]:
+    """Reject malformed batches before approval or disk access; never reinterpret their targets."""
+    if not isinstance(target, str) or target not in {"memory", "user"}:
+        return "A memory batch target must be 'memory' or 'user'."
+    if not isinstance(operations, list):
+        return "operations must be a list of {action, content?, new_text?, old_text?} objects."
+    if not operations:
+        return "operations list is empty."
+    allowed = {"action", "content", "new_text", "old_text"}
+    for index, op in enumerate(operations, 1):
+        prefix = f"Operation {index}"
+        if not isinstance(op, dict):
+            return f"{prefix} must be an object."
+        if "target" in op:
+            return (f"{prefix}: target is allowed only at the top level, never inside operations. "
+                    "Each batch applies to one store. Split changes into separate calls with "
+                    "target='memory' and target='user'.")
+        if unknown := set(op) - allowed:
+            return f"{prefix}: unknown field(s): {', '.join(sorted(map(str, unknown)))}."
+        action = op.get("action")
+        if not isinstance(action, str) or action not in {"add", "replace", "remove"}:
+            return f"{prefix}: action must be 'add', 'replace', or 'remove'."
+        for field in ("content", "new_text", "old_text"):
+            value = op.get(field)
+            if value is not None and not isinstance(value, str):
+                return f"{prefix}: {field} must be a string or null."
+        content = (op.get("content") or op.get("new_text") or "").strip()
+        old_text = (op.get("old_text") or "").strip()
+        if action in {"add", "replace"} and not content:
+            return f"{prefix} ({action}): content or new_text is required."
+        if action in {"replace", "remove"} and not old_text:
+            return f"{prefix} ({action}): old_text is required."
+    return None
+
+
 class MemoryStore:
     """Bounded curated memory with file persistence; one instance per AIAgent.
     ``_system_prompt_snapshot`` is frozen at load time (prefix-cache stable);
@@ -307,9 +342,9 @@ class MemoryStore:
         """Apply add/replace/remove ops atomically against the FINAL budget, so one call
         can free space and add entries. All-or-nothing: any malformed / unmatched op or
         an over-limit result writes NOTHING and returns the first failure plus live state."""
-        if not operations:
-            return _error("operations list is empty.")
-        ops = [op or {} for op in operations]
+        if invalid := validate_memory_batch(target, operations):
+            return _error(invalid)
+        ops = operations
         # Scan every add/replace content BEFORE touching disk -- one poisoned op rejects the batch.
         for i, op in enumerate(ops):
             scan_error = op.get("action") in {"add", "replace"} and op.get("content") and _scan_memory_content(op["content"])

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -66,6 +66,28 @@ The agent uses the `memory` tool with these actions:
 
 There is no `read` action — memory content is automatically injected into the system prompt at session start. The agent sees its memories as part of its conversation context.
 
+### Batch operations use one target
+
+Use one top-level `target` for the entire `operations` array. To change both
+`memory` and `user`, make separate calls; do not put `target` inside an operation.
+Each batch is atomic within its selected store, with the character limit checked
+against the final result.
+
+```python
+memory(target="user", operations=[
+    {"action": "replace", "old_text": "prefers detailed replies",
+     "content": "User prefers concise replies"},
+    {"action": "add", "content": "User prefers metric units"},
+])
+```
+
+Malformed batches return an error before they can be staged for approval or
+written. This includes empty arrays, unknown operation fields, and nested
+`target` fields. Correct the proposal and submit it again. Existing pending
+batches are validated again when approved; they are never silently redirected
+to another store. Optional `operations: null` still selects the single-action
+form.
+
 ### Substring Matching
 
 The `replace` and `remove` actions use short unique substring matching — you don't need the full entry text. The `old_text` parameter just needs to be a unique substring that identifies exactly one entry:


### PR DESCRIPTION
## What does this PR do?

Reject malformed native-memory batches before either approval gate, and enforce the same structural contract during direct store calls and approval replay. A batch addresses exactly one top-level store; an operation-level `target` must not be silently ignored.

For example, `memory(target="memory", operations=[{"action": "add", "target": "user", "content": "User prefers concise replies"}])` currently writes the entry to MEMORY.md when approval is off, despite the nested user target. With approval enabled it can stage that misleading payload. This change returns an actionable error, leaves both files unchanged, and creates no pending request. Callers must submit separate batches for the two stores.

## Related Issue

Related to #109215; this addresses malformed batch structure, not the entire invalid-proposal lifecycle.

Reviewed open PRs #109227 (fresh-state semantic preflight) and #109280 (failed-approval disposition). This PR does not copy, replace, supersede, or depend on either. Missing/ambiguous anchors, drift before approval, repeated rejection history, and crash-recovery decisions remain separate work. The change was extracted from a larger local integration to keep those independent concerns out of this diff.

Searched open and closed PRs for memory approval, batch target, operations/target, and malformed batch; no equivalent structural-validation fix was found.

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tools/memory_tool_store.py`: share a small structural validator for nonempty operation arrays, operation objects, supported actions/fields, string values, required content/anchors, and one top-level target. Run it before store I/O.
- `tools/memory_tool.py`: validate before foreground/background approval routing; distinguish an explicitly malformed empty/falsey batch from omitted or null operations; preserve the original payload during replay validation. Clarify the schema and disallow unknown operation properties.
- `tests/tools/test_memory_batch_contract.py`: two parameterized behavior contracts exercise real config, gates, queue files, store writes, and the shared approval command. They verify malformed input does not stage or mutate either file, while valid add-then-remove batches preserve final-budget semantics, approval requirements, the other store, and the frozen prompt snapshot.
- Update the memory guide with the single-store batch format and recovery instructions.

No dependencies, config keys, pending-record formats, permission changes, or external-provider behavior are added. Optional `operations: null` keeps the existing single-action meaning; existing content/new_text aliases remain supported. Previously ignored nested targets and unknown operation keys now produce errors intentionally. Old malformed pending records are not rewritten or deleted; replay rejects them for explicit user review/rejection.

## How to Test

Run from a checkout with test dependencies:

```sh
scripts/run_tests.sh -j 3 --file-retries 0 \
  tests/tools/test_memory_batch_contract.py \
  tests/tools/test_memory_tool.py \
  tests/tools/test_write_approval.py \
  tests/tools/test_memory_tool_schema.py \
  tests/agent/test_background_review_memory_scope.py \
  tests/agent/test_builtin_memory_disabled_surface.py -q
```

- RED on upstream `de2d6a1b93508463c31434c1ae067e204af81238`: new test file gives 60 failures and 34 passes, including ignored nested targets, malformed-input exceptions/staging, and empty-array fallback writes.
- GREEN on macOS: 193 tests passed across the six files, no retries.
- Linux: the same 193 tests passed, no retries, using one worker in a disposable source copy with a temporary test home, private network, read-only production runtime dependencies, and a 240 MiB memory limit.
- Ruff on changed Python files and `git diff --check`: passed.

The integration tests use temporary HERMES_HOME, synthetic entries and actual imports/file I/O. No live memory, credentials, conversation logs, deployment scripts, or local verification artifacts are included. No LLM/network calls are needed by these tests. Windows and the full repository suite have not been run; the patch adds no platform-specific locking or filesystem primitives.

## Checklist

- [x] Read CONTRIBUTING.md and applicable AGENTS.md instructions.
- [x] Conventional Commit message.
- [x] Searched existing PRs; scope is distinct from related open work.
- [x] Diff contains only this batch-contract fix, tests and documentation.
- [ ] Full repository test suite passes (not run; targeted results above).
- [x] Added regression tests, demonstrated RED on the upstream base.
- [x] Tested on macOS and Linux; results above.
- [x] Updated relevant user documentation and tool schema descriptions.
- [x] Considered cross-platform impact; Windows execution remains unverified.
- [x] Config/architecture changes: N/A.

AI-assisted implementation and testing; validation results are scoped to the commands above.
