### PR TITLE
fix(desktop): make collapsed HUD fully click-through (#108793)

### DIFF
--- a/apps/desktop/src/app/hud/click-through.ts
+++ b/apps/desktop/src/app/hud/click-through.ts
@@ -33,6 +33,21 @@ export function hudIgnoresMouse(
     return false
   }
 
+  // Collapsed HUD's resize frame must not keep the window solid. The frame's
+  // thin border strips are invisible chrome around the whole window — when the
+  // transcript is collapsed they hang in transparent space and would otherwise
+  // intercept clicks meant for the app underneath. (#108793)
+  const isResizeHandle = hit !== null && hit.closest('[data-hud-resize]') !== null
+  if (isResizeHandle) {
+    const hudIdle =
+      !root.hasAttribute('data-hud-recent') &&
+      !root.hasAttribute('data-hud-held') &&
+      root.querySelector('[data-slot="composer-rich-input"]:focus') === null
+    if (hudIdle) {
+      return true
+    }
+  }
+
   const overSomething = hit !== null && !hit.contains(root)
 
   const composerFocused =

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -3468,6 +3468,17 @@ button[data-slot='aui_msg-reactions'] svg {
   touch-action: none;
 }
 
+/* Collapsed HUD must be fully click-through except for the bar itself.
+   The resize frame is invisible chrome around the whole window — when the
+   transcript is collapsed (no recent activity, not held, not focused) it
+   hangs in transparent space and its thin border strips intercept clicks
+   meant for the app underneath. Gate the handles on the HUD being
+   interactive so only the bar remains hit-testable at rest. (#108793) */
+[data-hud-shell]:not([data-hud-recent]):not([data-hud-held]):not(:has([data-slot='composer-rich-input']:focus))
+  [data-hud-resize] {
+  pointer-events: none;
+}
+
 [data-hud-shell] [data-hud-resize='n'] {
   top: 0;
   right: 1.25rem;


### PR DESCRIPTION
Fixes #108793

**Problem:** After collapsing the HUD drawer to the mini bar/orb, the drawer content became click-through but a thin border/frame from the collapsed drawer (the invisible resize handles) remained active and intercepted mouse events meant for the underlying app.

**Root cause:** The resize frame (`[data-hud-resize]`) is invisible chrome around the whole window with `pointer-events: auto` and `hudIgnoresMouse` treated any hit on it as solid (`overSomething=true`). When the transcript was collapsed (no `data-hud-recent`/`data-hud-held`/focus), those strips hung in transparent space yet still kept the OS window solid.

**Fix:** Gate the resize handles on the HUD being interactive in both layers:
- **CSS:** Disable `pointer-events` on `[data-hud-resize]` when the shell is idle (`not recent, not held, not focused`), so hit-testing falls through to the scaffold.
- **JS:** Make `hudIgnoresMouse` return transparent for resize-handle hits when idle, so the OS-level click-through (`setIgnoreMouse`) also falls through. Dragging state (`data-hud-grabbing`) still pins solid.

Only the visible mini bar/orb remains interactive when collapsed.