### PR TITLE
fix(kanban): clear last_failure_error when a task is (re)claimed

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2092,7 +2092,8 @@ def _claim_and_open_run(
            SET status        = 'running',
                claim_lock    = ?,
                claim_expires = ?,
-               started_at    = COALESCE(started_at, ?)
+               started_at    = COALESCE(started_at, ?),
+               last_failure_error = NULL
          WHERE id = ?
            AND status = '{source_status}'
            AND claim_lock IS NULL

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -496,6 +496,7 @@ def enforce_max_runtime(conn: sqlite3.Connection, *, signal_fn=None) -> list[str
                 outcome="timed_out",
                 release_claim=False,
                 end_run=False,
+                reclaimed_run_id=run_id,
                 event_payload_extra={"pid": pid, "sigkill": killed, "retry_status": retry_status},
             )
     return timed_out
@@ -794,9 +795,11 @@ class _CrashSweep:
 
     crashed: list[str] = field(default_factory=list)
     rate_limited: list[str] = field(default_factory=list)
-    # ``(task_id, pid, claimer, protocol_violation, error_text)``: accounted
-    # after the txn via ``_record_task_failure`` (needs its own write_txn).
-    crash_details: list[tuple[str, int, str, bool, str]] = field(default_factory=list)
+    # ``(task_id, pid, claimer, protocol_violation, error_text, run_id)``:
+    # accounted after the txn via ``_record_task_failure`` (needs its own
+    # write_txn). ``run_id`` is the now-closed run being accounted for, used
+    # to CAS accounting against a later reclaim/re-claim of the same task.
+    crash_details: list[tuple[str, int, str, bool, str, int]] = field(default_factory=list)
     # Worker-exit observer payloads, fired only after every reclaim/accounting
     # txn has committed.
     exited_hook_payloads: list[dict] = field(default_factory=list)
@@ -869,7 +872,7 @@ def _reclaim_dead_workers(conn: sqlite3.Connection) -> _CrashSweep:
             else:
                 sweep.crashed.append(row["id"])
                 sweep.crash_details.append(
-                    (row["id"], pid, row["claim_lock"], dead.protocol_violation, dead.error_text)
+                    (row["id"], pid, row["claim_lock"], dead.protocol_violation, dead.error_text, run_id)
                 )
     return sweep
 
@@ -884,10 +887,10 @@ def _account_crashes(conn: sqlite3.Connection, crash_details: list) -> list[str]
     """
     auto_blocked: list[str] = []
     fp_counts: dict[str, int] = {}
-    for _, _, _, _, err_text in crash_details:
+    for _, _, _, _, err_text, _ in crash_details:
         fp = _error_fingerprint(err_text)
         fp_counts[fp] = fp_counts.get(fp, 0) + 1
-    for tid, pid, claimer, protocol_violation, error_text in crash_details:
+    for tid, pid, claimer, protocol_violation, error_text, run_id in crash_details:
         if protocol_violation:
             streak = _protocol_violation_streak(conn, tid)
             trow = conn.execute("SELECT max_retries FROM tasks WHERE id = ?", (tid,)).fetchone()
@@ -911,6 +914,7 @@ def _account_crashes(conn: sqlite3.Connection, crash_details: list) -> list[str]
                 force_trip=True,
                 release_claim=False,
                 end_run=False,
+                reclaimed_run_id=run_id,
                 event_payload_extra={
                     "pid": pid,
                     "claimer": claimer,
@@ -927,6 +931,7 @@ def _account_crashes(conn: sqlite3.Connection, crash_details: list) -> list[str]
                 failure_limit=1 if is_systemic else None,
                 release_claim=False,
                 end_run=False,
+                reclaimed_run_id=run_id,
                 event_payload_extra={"pid": pid, "claimer": claimer},
             )
         if tripped:
@@ -993,6 +998,7 @@ def _record_task_failure(
     force_trip: bool = False,
     release_claim: bool = False,
     end_run: bool = False,
+    reclaimed_run_id: Optional[int] = None,
     event_payload_extra: Optional[dict] = None,
 ) -> bool:
     """Record a non-success outcome and maybe trip the circuit breaker; every
@@ -1006,6 +1012,15 @@ def _record_task_failure(
     ``blocked`` + ``gave_up``). Threshold: per-task ``max_retries`` >
     ``failure_limit`` > ``DEFAULT_FAILURE_LIMIT``. ``force_trip`` trips
     unconditionally (caller applied its own bounded-retry policy).
+
+    ``reclaimed_run_id`` (crash/timeout path only) is the now-closed run this
+    call is accounting for. It CASes against ``MAX(task_runs.id)`` for the
+    task rather than ``tasks.current_run_id`` nullity: a higher id means a
+    later run has since been claimed, whether that run is still active or has
+    itself already finished (the plain nullity check is an ABA hazard in that
+    second case). When stale, the failure still counts toward the unified
+    ``consecutive_failures`` budget — it happened — but must not stamp status,
+    claim state, or ``last_failure_error`` onto the unrelated later run.
     """
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT
@@ -1017,12 +1032,19 @@ def _record_task_failure(
         ).fetchone()
         if row is None:
             return False
-        if not release_claim and row["current_run_id"] is not None:
-            # Crash/timeout path: the run being accounted for already ended
-            # (its reclaim/timeout txn nulled current_run_id). A non-null
-            # value here means a new run has since been claimed on this task
-            # — the stale error/counter must not land on that unrelated run.
-            # Historical data already written to task_runs/events stands.
+        stale = False
+        if not release_claim and reclaimed_run_id is not None:
+            latest = conn.execute(
+                "SELECT MAX(id) AS max_id FROM task_runs WHERE task_id = ?", (task_id,),
+            ).fetchone()
+            latest_id = _kb._row_get(latest, "max_id")
+            stale = latest_id is not None and int(latest_id) != int(reclaimed_run_id)
+        if stale:
+            conn.execute(
+                "UPDATE tasks SET consecutive_failures = consecutive_failures + 1 "
+                "WHERE id = ?",
+                (task_id,),
+            )
             return False
         retry_status = (
             _kb._retry_status_for_run(conn, task_id, row["current_run_id"])

--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -1017,6 +1017,13 @@ def _record_task_failure(
         ).fetchone()
         if row is None:
             return False
+        if not release_claim and row["current_run_id"] is not None:
+            # Crash/timeout path: the run being accounted for already ended
+            # (its reclaim/timeout txn nulled current_run_id). A non-null
+            # value here means a new run has since been claimed on this task
+            # — the stale error/counter must not land on that unrelated run.
+            # Historical data already written to task_runs/events stands.
+            return False
         retry_status = (
             _kb._retry_status_for_run(conn, task_id, row["current_run_id"])
             if release_claim

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -210,6 +210,52 @@ def test_schedule_task_parks_time_delay_without_dispatching(kanban_home):
 
 
 
+def test_claim_clears_stale_last_failure_error(kanban_home, monkeypatch):
+    """A crashed run's ``last_failure_error`` must not leak into a later run's
+    claim. In the native review lane a card cycles through several runs in
+    minutes; if a crash's stamped error text (e.g. "pid N not alive") survives
+    onto the next claim, a later run's unrelated ``kanban_complete``/
+    ``kanban_block`` failure gets misreported using a long-dead run's pid,
+    reading like a claim race instead of the real (and different) failure
+    (#109454)."""
+    import hermes_cli.kanban_db as _kb
+    from hermes_cli import kanban_db_dispatch as _kbd
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+
+    with kbc.connect() as conn:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="native-review-lane", assignee="impl")
+
+        # Implementer claims and requests review.
+        claimed = kb.claim_task(conn, tid, claimer=f"{host}:impl")
+        kb.request_review(
+            conn, tid, summary="done", expected_run_id=claimed.current_run_id,
+        )
+
+        # Reviewer claims the review lane, then crashes.
+        reviewed = kb.claim_review_task(conn, tid, claimer=f"{host}:reviewer")
+        assert reviewed is not None
+        _kbd._set_worker_pid(conn, tid, 266182)
+        crashed = _kbd.detect_crashed_workers(conn)
+        assert tid in crashed
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "review"
+        assert task.last_failure_error and "266182" in task.last_failure_error
+
+        # A fresh reviewer run claims the same card moments later — its own
+        # run must not inherit run 1's stale crash text.
+        reclaimed = kb.claim_review_task(conn, tid, claimer=f"{host}:reviewer2")
+        assert reclaimed is not None
+        task = kb.get_task(conn, tid)
+        assert task.last_failure_error is None, (
+            "a later run's claim must clear a prior run's stale "
+            f"last_failure_error, got {task.last_failure_error!r}"
+        )
+
+
 def test_stale_claim_reclaim_event_records_diagnostic_payload(
     kanban_home, monkeypatch,
 ):

--- a/tests/hermes_cli/test_kanban_reclaim_claim_lock_guard.py
+++ b/tests/hermes_cli/test_kanban_reclaim_claim_lock_guard.py
@@ -16,6 +16,7 @@ computed for.
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -115,27 +116,35 @@ def test_genuine_crash_still_reclaims(conn):
     assert final["status"] in ("ready", "blocked", "todo")
 
 
+def _dead_pid() -> int:
+    """A pid that has already exited, portable across platforms (no ``true``)."""
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    proc.wait()
+    return proc.pid
+
+
 def test_account_crashes_rejects_task_reclaimed_between_reclaim_and_accounting(conn):
     """``_reclaim_dead_workers`` commits its reclaim txn, then
     ``_account_crashes`` runs failure accounting in a SEPARATE txn. A new
     worker that claims the task in between must not have its run's task row
-    clobbered by the old crash's stale error/counter."""
+    clobbered by the old crash's stale error/status — but the crash must
+    still count toward the unified consecutive-failures budget."""
     host = kb._claimer_id().split(":", 1)[0]
     tid = kb.create_task(conn, title="race", assignee="w")
 
     kb.claim_task(conn, tid, claimer=f"{host}:A")
-    dead = subprocess.Popen(["true"])
-    dead.wait()
-    kbd._set_worker_pid(conn, tid, dead.pid)
+    dead_pid = _dead_pid()
+    kbd._set_worker_pid(conn, tid, dead_pid)
     conn.execute("UPDATE tasks SET started_at = started_at - 9999 WHERE id=?", (tid,))
     conn.execute("UPDATE task_runs SET started_at = started_at - 9999 WHERE task_id=?", (tid,))
     conn.commit()
-    kbd._record_worker_exit(dead.pid, 1 << 8)  # nonzero exit → crash
+    kbd._record_worker_exit(dead_pid, 1 << 8)  # nonzero exit → crash
 
     sweep = kbd._reclaim_dead_workers(conn)
     assert tid in sweep.crashed
 
-    # A new worker claims the task before the crash is accounted for.
+    # A new worker claims the task before the crash is accounted for, and is
+    # still running when accounting runs.
     kb.claim_task(conn, tid, claimer=f"{host}:B")
 
     kbd._account_crashes(conn, sweep.crash_details)
@@ -148,4 +157,112 @@ def test_account_crashes_rejects_task_reclaimed_between_reclaim_and_accounting(c
     assert final["last_failure_error"] is None, (
         "old run's crash accounting must not clobber the new run's task row"
     )
-    assert final["consecutive_failures"] == 0
+    assert final["consecutive_failures"] == 1, (
+        "the old crash must still count toward the unified failure budget"
+    )
+
+
+def test_account_crashes_still_counts_after_replacement_run_already_finished(conn):
+    """ABA case: the replacement run claimed between reclaim and accounting has
+    ALSO already finished (so ``current_run_id`` is NULL again) by the time
+    late accounting runs. A nullity check on ``current_run_id`` would treat
+    this as safe to overwrite; accounting must instead detect the later run
+    via ``task_runs`` and still only bump the counter."""
+    host = kb._claimer_id().split(":", 1)[0]
+    tid = kb.create_task(conn, title="aba", assignee="w")
+
+    kb.claim_task(conn, tid, claimer=f"{host}:A")
+    dead_pid = _dead_pid()
+    kbd._set_worker_pid(conn, tid, dead_pid)
+    conn.execute("UPDATE tasks SET started_at = started_at - 9999 WHERE id=?", (tid,))
+    conn.execute("UPDATE task_runs SET started_at = started_at - 9999 WHERE task_id=?", (tid,))
+    conn.commit()
+    kbd._record_worker_exit(dead_pid, 1 << 8)  # nonzero exit → crash
+
+    sweep = kbd._reclaim_dead_workers(conn)
+    assert tid in sweep.crashed
+
+    # A new worker claims the task and finishes it before the old crash is
+    # accounted for — ``current_run_id`` is NULL again, same as right after
+    # the original reclaim.
+    kb.claim_task(conn, tid, claimer=f"{host}:B")
+    kb.complete_task(conn, tid, summary="done")
+
+    kbd._account_crashes(conn, sweep.crash_details)
+
+    final = conn.execute(
+        "SELECT last_failure_error, consecutive_failures, status FROM tasks WHERE id=?",
+        (tid,),
+    ).fetchone()
+    assert final["status"] == "done", "late accounting must not reopen the completed task"
+    assert final["last_failure_error"] is None
+    assert final["consecutive_failures"] == 1
+
+
+def test_record_task_failure_timeout_still_running_counts_without_clobbering(conn):
+    """Same CAS protection, exercised via the ``timed_out`` outcome that
+    ``enforce_max_runtime`` passes to ``_record_task_failure``."""
+    host = kb._claimer_id().split(":", 1)[0]
+    tid = kb.create_task(conn, title="timeout-race", assignee="w")
+
+    kb.claim_task(conn, tid, claimer=f"{host}:A")
+    old_run_id = kb._end_run(
+        conn, tid, outcome="timed_out", status="timed_out", error="elapsed 99s > limit 1s"
+    )
+    conn.execute(
+        "UPDATE tasks SET status='ready', claim_lock=NULL, claim_expires=NULL, "
+        "worker_pid=NULL WHERE id=?",
+        (tid,),
+    )
+    conn.commit()
+
+    # A new worker claims the task before the timeout is accounted for, and
+    # is still running when accounting runs.
+    kb.claim_task(conn, tid, claimer=f"{host}:B")
+
+    kbd._record_task_failure(
+        conn, tid, error="elapsed 99s > limit 1s", outcome="timed_out",
+        release_claim=False, end_run=False, reclaimed_run_id=old_run_id,
+    )
+
+    final = conn.execute(
+        "SELECT last_failure_error, consecutive_failures, status FROM tasks WHERE id=?",
+        (tid,),
+    ).fetchone()
+    assert final["status"] == "running"
+    assert final["last_failure_error"] is None
+    assert final["consecutive_failures"] == 1
+
+
+def test_record_task_failure_timeout_still_counts_after_replacement_run_already_finished(conn):
+    """ABA case for the timeout path: the replacement run has also already
+    finished by the time late accounting runs."""
+    host = kb._claimer_id().split(":", 1)[0]
+    tid = kb.create_task(conn, title="timeout-aba", assignee="w")
+
+    kb.claim_task(conn, tid, claimer=f"{host}:A")
+    old_run_id = kb._end_run(
+        conn, tid, outcome="timed_out", status="timed_out", error="elapsed 99s > limit 1s"
+    )
+    conn.execute(
+        "UPDATE tasks SET status='ready', claim_lock=NULL, claim_expires=NULL, "
+        "worker_pid=NULL WHERE id=?",
+        (tid,),
+    )
+    conn.commit()
+
+    kb.claim_task(conn, tid, claimer=f"{host}:B")
+    kb.complete_task(conn, tid, summary="done")
+
+    kbd._record_task_failure(
+        conn, tid, error="elapsed 99s > limit 1s", outcome="timed_out",
+        release_claim=False, end_run=False, reclaimed_run_id=old_run_id,
+    )
+
+    final = conn.execute(
+        "SELECT last_failure_error, consecutive_failures, status FROM tasks WHERE id=?",
+        (tid,),
+    ).fetchone()
+    assert final["status"] == "done"
+    assert final["last_failure_error"] is None
+    assert final["consecutive_failures"] == 1

--- a/tests/hermes_cli/test_kanban_reclaim_claim_lock_guard.py
+++ b/tests/hermes_cli/test_kanban_reclaim_claim_lock_guard.py
@@ -113,3 +113,39 @@ def test_genuine_crash_still_reclaims(conn):
     assert tid in crashed
     final = conn.execute("SELECT status FROM tasks WHERE id=?", (tid,)).fetchone()
     assert final["status"] in ("ready", "blocked", "todo")
+
+
+def test_account_crashes_rejects_task_reclaimed_between_reclaim_and_accounting(conn):
+    """``_reclaim_dead_workers`` commits its reclaim txn, then
+    ``_account_crashes`` runs failure accounting in a SEPARATE txn. A new
+    worker that claims the task in between must not have its run's task row
+    clobbered by the old crash's stale error/counter."""
+    host = kb._claimer_id().split(":", 1)[0]
+    tid = kb.create_task(conn, title="race", assignee="w")
+
+    kb.claim_task(conn, tid, claimer=f"{host}:A")
+    dead = subprocess.Popen(["true"])
+    dead.wait()
+    kbd._set_worker_pid(conn, tid, dead.pid)
+    conn.execute("UPDATE tasks SET started_at = started_at - 9999 WHERE id=?", (tid,))
+    conn.execute("UPDATE task_runs SET started_at = started_at - 9999 WHERE task_id=?", (tid,))
+    conn.commit()
+    kbd._record_worker_exit(dead.pid, 1 << 8)  # nonzero exit → crash
+
+    sweep = kbd._reclaim_dead_workers(conn)
+    assert tid in sweep.crashed
+
+    # A new worker claims the task before the crash is accounted for.
+    kb.claim_task(conn, tid, claimer=f"{host}:B")
+
+    kbd._account_crashes(conn, sweep.crash_details)
+
+    final = conn.execute(
+        "SELECT last_failure_error, consecutive_failures, status FROM tasks WHERE id=?",
+        (tid,),
+    ).fetchone()
+    assert final["status"] == "running"
+    assert final["last_failure_error"] is None, (
+        "old run's crash accounting must not clobber the new run's task row"
+    )
+    assert final["consecutive_failures"] == 0


### PR DESCRIPTION
Fixes #109454.

## Root cause

In the native review lane (`review_lane=native`) a card cycles through
several runs and profiles (implementer → reviewer → implementer …) within
minutes, all sharing one card. `hermes_cli/kanban_db_dispatch.py`'s
`detect_crashed_workers()` → `_account_crashes()` → `_record_task_failure()`
stamps `tasks.last_failure_error` with the crashed run's text (e.g.
`"pid 266182 not alive"`) whenever a worker dies unexpectedly.

That column is only ever cleared by `complete_task()`'s success path
(`_clear_failure_counter`). Every legitimate mid-lane transition
(`kanban_request_review`, `kanban_request_changes`, a fresh claim) leaves it
untouched, so a crash from three runs ago survives on the row indefinitely.

`tools/kanban_tools.py::_handle_complete` falls back to reporting
`task.last_failure_error` as the failure reason whenever `complete_task`
returns `False` for *any* reason:

```python
_check(ok, (task.last_failure_error if task else None) or
       f"could not complete {tid} (unknown id, stale run, or already terminal)")
```

So a live, current run's own (unrelated) `kanban_complete`/`kanban_block`
failure gets misreported using a long-dead run's pid and error text — read
by the model as a claim race it should retry, when the run that actually
owned that pid ended minutes earlier. This matches the issue's observed
sequence exactly: run 84 (reviewer) crashes with pid 266182 at 11:49; runs
85–87 transition the card normally; run 88 (implementer) still sees
`"stale worker pid 266182 not alive"` at 12:07, three runs later.

## Fix

`_claim_and_open_run()` (the single choke point shared by both
`claim_task()` (ready→running) and `claim_review_task()` (review→running))
now clears `last_failure_error` as part of the same atomic claim UPDATE.
Every fresh run therefore starts with a clean slate — a prior run's crash
text can no longer leak into a later, unrelated run's error surface.

`consecutive_failures` is deliberately left untouched: the circuit breaker
still needs failures to accumulate across spawn boundaries (per the
existing `_clear_failure_counter` docstring), and `check_respawn_guard()` is
always called *before* the claim (confirmed in
`kanban_db_dispatch.py:1525` vs. the claim at `:1550`), so clearing the
message at claim time cannot hide a real quota/auth blocker from the guard
that already inspected it.

## Test

Added `test_claim_clears_stale_last_failure_error` in
`tests/hermes_cli/test_kanban_db.py`, reproducing the native review lane
scenario: implementer claims → requests review → reviewer claims → reviewer
crashes (dead pid) → a fresh reviewer run claims the same card moments
later. Asserts the second claim's task no longer carries the first run's
stale `last_failure_error`.

**Before the fix** (`git checkout HEAD~1 -- hermes_cli/kanban_db.py`, ran
against the unmodified source):

```
FAILED tests/hermes_cli/test_kanban_db.py::test_claim_clears_stale_last_failure_error
AssertionError: a later run's claim must clear a prior run's stale last_failure_error, got 'pid 266182 not alive'
```

**After the fix:**

```
$ python -m pytest tests/hermes_cli/test_kanban_db.py -k test_claim_clears_stale_last_failure_error -q
1 passed, 32 deselected in 1.65s
```

Full regression sweep (kanban DB/core/dispatch/tools):

```
$ python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py \
    tests/hermes_cli/test_kanban_dispatch_lock.py tests/hermes_cli/test_kanban_dispatch_tick_hook.py \
    tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py tests/tools/test_kanban_tools.py -q
102 passed, 1 skipped
```

`tests/hermes_cli/ -k kanban` (the full sweep) shows the same 28
pre-existing failures both with and without this change (missing
`pytest-asyncio`/`acp` optional deps and unrelated test-isolation issues
when the whole directory runs in one process) — confirmed identical on
unmodified `upstream/main`.

`ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py` →
all checks passed.

## AI assistance disclosure

This change was authored with AI assistance (Claude Code).
