### PR TITLE
fix(gateway): harden standalone migration recovery

### DIFF
--- a/hermes_cli/gateway_migrate.py
+++ b/hermes_cli/gateway_migrate.py
@@ -480,7 +480,8 @@ def _read_manifest(default_home: Path) -> Optional[dict]:
 
 
 def _write_manifest(default_home: Path, data: dict) -> None:
-    _manifest_path(default_home).write_text(json.dumps(data, indent=2), encoding="utf-8")
+    from utils import atomic_json_write
+    atomic_json_write(_manifest_path(default_home), data)
 
 
 def _wait_for_served(default_home: Path, expected: set[str], timeout: float) -> Optional[list[str]]:
@@ -531,6 +532,9 @@ def apply_migration(plan: MigrationPlan, *, served_wait: float = _SERVED_WAIT_SE
         "default": plan.default.to_dict(),
         "secondaries": [p.to_dict() for p in plan.standalone_secondaries],
     }
+    # Establish recovery metadata before the first destructive operation.  The
+    # atomic write keeps the previous valid manifest if the process is interrupted.
+    _write_manifest(plan.default_home, manifest)
     for p in plan.standalone_secondaries:
         if p.service is not None:
             kind, system = p.service
@@ -577,8 +581,6 @@ def rollback_migration(default_home: Optional[Path] = None) -> bool:
         "default", default_home, pid=_live_gateway_pid(default_home),
         service=(default_service["kind"], bool(default_service.get("system"))) if default_service else _installed_service(default_home),
     )
-    if default_gw.has_gateway:
-        print(f"  ✓ {_restart_default(default_gw, None, default_home)}")
     ok = True
     for rec in manifest.get("secondaries", []):
         home = Path(rec["home"])
@@ -599,6 +601,21 @@ def rollback_migration(default_home: Optional[Path] = None) -> bool:
         except Exception as exc:
             ok = False
             print(f"  ✗ {name}: {exc}")
+    # Restore secondary ownership before restarting the default.  A service-manager
+    # restart can terminate this command when it runs inside the default gateway's
+    # cgroup, so it must be the final lifecycle operation.
+    if ok and default_gw.has_gateway:
+        try:
+            # Clear this before the restart: a service-manager restart can
+            # terminate the migration process when it runs in the gateway's
+            # cgroup, so cleanup after restart is not reliable.
+            with _home_env(default_home):
+                from gateway.status import write_runtime_status
+                write_runtime_status(served_profiles=[])
+            print(f"  ✓ {_restart_default(default_gw, None, default_home)}")
+        except Exception as exc:
+            ok = False
+            print(f"  ✗ default: {exc}")
     if ok:
         _manifest_path(default_home).unlink(missing_ok=True)
         print("✓ Rolled back to per-profile gateways.")
@@ -622,6 +639,9 @@ def _host_supports_migration() -> Optional[str]:
 
 def cmd_migrate(args) -> None:
     """``hermes gateway migrate [--multiplex|--standalone] [--dry-run] [--yes]``."""
+    if getattr(args, "standalone", False) and getattr(args, "dry_run", False):
+        print("✗ --standalone --dry-run is not supported; no changes were made.")
+        return
     if getattr(args, "standalone", False):
         sys.exit(0 if rollback_migration() else 1)
     reason = _host_supports_migration()

--- a/tests/hermes_cli/test_gateway_migrate_multiplex.py
+++ b/tests/hermes_cli/test_gateway_migrate_multiplex.py
@@ -56,7 +56,7 @@ def fleet(tmp_path, monkeypatch):
             (root / "gateway.pid").write_text(json.dumps({"pid": os.getpid(), "hermes_home": str(root)}))
             (root / "gateway_state.json").write_text(json.dumps({
                 "pid": os.getpid(), "hermes_home": str(root), "gateway_state": "running",
-                "served_profiles": ["default", "coder", "ops"],
+                "served_profiles": ["default", "coder", "ops"] if _config_flag(root) else [],
             }))
 
     monkeypatch.setattr(gm, "_installed_service", lambda home: state.services.get(_name(home)))
@@ -117,6 +117,32 @@ def test_apply_records_manifest_flips_flag_and_rollback_restores(fleet, capsys):
     assert [op for op in fleet.ops if op[0] != "default"] == [
         ("coder", "install"), ("coder", "start"), ("ops", "install"), ("ops", "start")]
     assert not (fleet.root / gm.MANIFEST_NAME).exists()
+
+
+def test_standalone_dry_run_is_side_effect_free(fleet, capsys):
+    manifest = fleet.root / gm.MANIFEST_NAME
+    manifest.write_text('{"flag_was": true}', encoding="utf-8")
+    before = manifest.read_bytes()
+
+    gm.cmd_migrate(SimpleNamespace(multiplex=False, standalone=True, dry_run=True, yes=True))
+
+    assert manifest.read_bytes() == before
+    assert fleet.ops == []
+    assert _config_flag(fleet.root) is None
+    assert "no changes were made" in capsys.readouterr().out
+
+
+def test_rollback_restores_secondaries_before_restarting_default(fleet):
+    plan = gm.build_migration_plan()
+    assert gm.apply_migration(plan, served_wait=5.0) is True
+    fleet.ops.clear()
+
+    assert gm.rollback_migration(fleet.root) is True
+
+    default_restart = next(i for i, op in enumerate(fleet.ops) if op == ("default", "restart"))
+    assert all(i < default_restart for i, op in enumerate(fleet.ops) if op[0] != "default")
+    from hermes_cli.gateway_multiplex_served import recorded_served_profiles
+    assert not recorded_served_profiles(fleet.root)
 
 
 def test_secondary_port_binder_is_notice_with_ingress_and_blocker_without(fleet, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #109473.

This PR addresses the standalone rollback failure mode without changing normal multiplex migration behavior.

## Investigation

The issue is reproducible from the current migration implementation:

1. `cmd_migrate()` dispatched `--standalone` before reading `args.dry_run`, so `hermes gateway migrate --standalone --dry-run` entered the mutating rollback path.
2. Rollback restarted the default gateway before restoring secondary gateways. When invoked from the default gateway service cgroup, that restart can terminate the migration process before the remaining rollback steps execute.
3. Rollback did not explicitly invalidate the persisted multiplexer ownership projection. A stale `served_profiles` list could make CLI lifecycle guards treat a secondary profile as still served and refuse repair with exit 78.

The related open PR #109478 was reviewed as competing work and was not copied or cherry-picked. This branch contains an independent implementation focused on the verified root causes and invariant tests.

## Changes

- Reject the unsupported `--standalone --dry-run` combination before any state-changing operation, with an explicit no-changes message.
- Restore and start all recorded secondary gateways before restarting the default gateway, making the potentially self-terminating service restart the final lifecycle operation.
- Explicitly write an empty `served_profiles` record after successful standalone restoration so older gateway startup paths cannot preserve stale multiplexer ownership metadata.
- Add behavioral regression tests for dry-run immutability, rollback ordering, and stale served-profile invalidation.

## Verification

Command:

    scripts/run_tests.sh tests/hermes_cli/test_gateway_migrate_multiplex.py

Result: 8 tests passed.

Also verified `git diff --check` passed and the branch was created from `origin/main`.

## Scope and limitations

This PR does not alter the broader migration transaction model, service-manager APIs, Windows Scheduled Task behavior, or unrelated profile rename/reconciliation work. The stale-state fix is limited to the rollback boundary and preserves the live multiplexer record as authoritative while multiplex mode is active.

Security review found no demonstrated confidentiality or authorization bypass; the reported behavior is an availability and lifecycle-state consistency defect.
