### PR TITLE
fix(kanban): preserve event identity in show output

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -13,6 +13,7 @@ import os
 import shlex
 import sys
 import time
+from dataclasses import asdict
 from pathlib import Path
 from typing import Optional
 
@@ -494,7 +495,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
         _print_json({
             "task": _task_to_dict(task), "latest_summary": latest_summary, "parents": parents, "children": children,
             "comments": [_obj_dict(c, ("author", "body", "created_at")) for c in comments],
-            "events": [_obj_dict(e, ("kind", "payload", "created_at", "run_id")) for e in events],
+            "events": [asdict(e) for e in events],
             "runs": [_obj_dict(r, _SHOW_RUN_FIELDS) for r in runs],
         })
         return 0

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -13,7 +13,6 @@ import os
 import shlex
 import sys
 import time
-from dataclasses import asdict
 from pathlib import Path
 from typing import Optional
 
@@ -495,7 +494,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
         _print_json({
             "task": _task_to_dict(task), "latest_summary": latest_summary, "parents": parents, "children": children,
             "comments": [_obj_dict(c, ("author", "body", "created_at")) for c in comments],
-            "events": [asdict(e) for e in events],
+            "events": [kb.event_to_dict(e) for e in events],
             "runs": [_obj_dict(r, _SHOW_RUN_FIELDS) for r in runs],
         })
         return 0

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -846,6 +846,18 @@ class Event:
         )
 
 
+def event_to_dict(event: Event) -> dict[str, Any]:
+    """Keep the public event schema independent of internal dataclass fields."""
+    return {
+        "id": event.id,
+        "task_id": event.task_id,
+        "kind": event.kind,
+        "payload": event.payload,
+        "created_at": event.created_at,
+        "run_id": event.run_id,
+    }
+
+
 # --- Schema ---
 
 SCHEMA_SQL = """

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -359,7 +359,7 @@ def get_task(
         return {
             "task": task_d,
             "comments": [asdict(c) for c in kanban_db.list_comments(conn, task_id)],
-            "events": [asdict(e) for e in kanban_db.list_events(conn, task_id)],
+            "events": [kanban_db.event_to_dict(e) for e in kanban_db.list_events(conn, task_id)],
             "attachments": [_attachment_dict(a) for a in kanban_db.list_attachments(conn, task_id)],
             "links": links,
             "child_results": [

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import threading
+from dataclasses import asdict
 from pathlib import Path
 
 import pytest
@@ -57,6 +58,25 @@ def test_kanban_list_json_includes_session_id(kanban_home):
         and row.get("session_id") == "acp-x"
         for row in payload
     )
+
+
+def test_kanban_show_json_preserves_canonical_events(kanban_home):
+    with kbc.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="event identity")
+        other_id = kb.create_task(conn, title="unrelated events")
+        kb.add_comment(conn, task_id, author="alice", body="first")
+        kb.add_comment(conn, other_id, author="alice", body="interleaved")
+        kb.claim_task(conn, task_id)
+        kb.add_comment(conn, task_id, author="bob", body="second")
+        # Timestamp ties must retain the database identities and their order.
+        conn.execute("UPDATE task_events SET created_at = ?", (1_700_000_000,))
+        conn.commit()
+        events = kb.list_events(conn, task_id)
+
+    output = json.loads(kc.run_slash(f"show {task_id} --json"))
+
+    assert output["events"] == [asdict(event) for event in events]
+    assert [event["id"] for event in output["events"]] == [event.id for event in events]
 
 
 def test_kanban_show_text_renders_graph_with_open_connection(kanban_home):

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -6,7 +6,6 @@ import argparse
 import json
 import os
 import threading
-from dataclasses import asdict
 from pathlib import Path
 
 import pytest
@@ -58,25 +57,6 @@ def test_kanban_list_json_includes_session_id(kanban_home):
         and row.get("session_id") == "acp-x"
         for row in payload
     )
-
-
-def test_kanban_show_json_preserves_canonical_events(kanban_home):
-    with kbc.connect_closing() as conn:
-        task_id = kb.create_task(conn, title="event identity")
-        other_id = kb.create_task(conn, title="unrelated events")
-        kb.add_comment(conn, task_id, author="alice", body="first")
-        kb.add_comment(conn, other_id, author="alice", body="interleaved")
-        kb.claim_task(conn, task_id)
-        kb.add_comment(conn, task_id, author="bob", body="second")
-        # Timestamp ties must retain the database identities and their order.
-        conn.execute("UPDATE task_events SET created_at = ?", (1_700_000_000,))
-        conn.commit()
-        events = kb.list_events(conn, task_id)
-
-    output = json.loads(kc.run_slash(f"show {task_id} --json"))
-
-    assert output["events"] == [asdict(event) for event in events]
-    assert [event["id"] for event in output["events"]] == [event.id for event in events]
 
 
 def test_kanban_show_text_renders_graph_with_open_connection(kanban_home):

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -13,6 +13,7 @@ import os
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -60,6 +61,70 @@ def client(kanban_home):
     app = FastAPI()
     app.include_router(_load_plugin_router(), prefix="/api/plugins/kanban")
     return TestClient(app)
+
+
+@pytest.mark.parametrize("internal_field", [False, True])
+def test_public_event_schema_and_surface_parity(client, monkeypatch, internal_field):
+    from hermes_cli import kanban as kc
+    import tools.kanban_tools  # register the real tool handler
+    from tools.registry import registry
+
+    if internal_field:
+        @dataclass
+        class InternalEvent(kb.Event):
+            internal_metadata: str = "not public"
+
+        monkeypatch.setattr(kb, "Event", InternalEvent)
+
+    with kbc.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="public event contract")
+        other_id = kb.create_task(conn, title="interleaved events")
+        kb.claim_task(conn, task_id)
+        run = kb.latest_run(conn, task_id)
+        assert run is not None
+        for index in range(55):
+            kb.add_comment(conn, task_id, author="worker", body=f"progress {index}")
+            kb.add_comment(conn, other_id, author="other", body="interleaved")
+        kb._append_event(conn, task_id, "heartbeat", run_id=run.id)
+        # Reverse timestamp groups relative to insertion order, retaining ties.
+        conn.execute("UPDATE task_events SET created_at = ? - (id % 3)", (1_700_000_000,))
+        conn.commit()
+        rows = conn.execute(
+            "SELECT id, task_id, kind, payload, created_at, run_id FROM task_events "
+            "WHERE task_id = ? ORDER BY created_at, id", (task_id,),
+        ).fetchall()
+
+    expected = [
+        {"id": row["id"], "task_id": row["task_id"], "kind": row["kind"],
+         "payload": json.loads(row["payload"]) if row["payload"] is not None else None,
+         "created_at": row["created_at"], "run_id": row["run_id"]}
+        for row in rows
+    ]
+    assert len(expected) > 50
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    cli_events = json.loads(kc.run_slash(f"show {task_id} --json"))["events"]
+    tool_output = registry.dispatch("kanban_show", {})
+    assert isinstance(tool_output, str)
+    tool_events = json.loads(tool_output)["events"]
+    response = client.get(f"/api/plugins/kanban/tasks/{task_id}")
+    assert response.status_code == 200, response.text
+    dashboard_events = response.json()["events"]
+
+    keys = {"id", "task_id", "kind", "payload", "created_at", "run_id"}
+    assert {
+        surface: [set(event) for event in events]
+        for surface, events in (
+            ("cli", cli_events), ("tool", tool_events), ("dashboard", dashboard_events),
+        )
+    } == {"cli": [keys] * len(expected), "tool": [keys] * 50,
+          "dashboard": [keys] * len(expected)}
+    assert cli_events == dashboard_events == expected
+    assert tool_events == cli_events[-50:]
+    assert all(
+        type(event["id"]) is int
+        for events in (cli_events, tool_events, dashboard_events)
+        for event in events
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import json
 import os
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import asdict
 
 import pytest
 
@@ -93,18 +92,30 @@ def test_show_preserves_canonical_last_50_events(worker_env):
         for index in range(55):
             kb.add_comment(conn, worker_env, author="worker", body=f"progress {index}")
             kb.add_comment(conn, other_id, author="other", body="interleaved")
-        kb._append_event(conn, worker_env, "heartbeat", run_id=kb.latest_run(conn, worker_env).id)
+        run = kb.latest_run(conn, worker_env)
+        assert run is not None
+        kb._append_event(conn, worker_env, "heartbeat", run_id=run.id)
         conn.execute("UPDATE task_events SET created_at = ?", (1_700_000_000,))
         conn.commit()
-        events = kb.list_events(conn, worker_env)
+        rows = conn.execute(
+            "SELECT id, task_id, kind, payload, created_at, run_id FROM task_events "
+            "WHERE task_id = ? ORDER BY created_at, id", (worker_env,),
+        ).fetchall()
 
-    assert len(events) > 50
-    expected = [asdict(event) for event in events[-50:]]
+    assert len(rows) > 50
+    expected = [
+        {"id": row["id"], "task_id": row["task_id"], "kind": row["kind"],
+         "payload": json.loads(row["payload"]) if row["payload"] is not None else None,
+         "created_at": row["created_at"], "run_id": row["run_id"]}
+        for row in rows[-50:]
+    ]
     output = json.loads(kt._handle_show({}))
 
     assert output["events"] == expected
-    assert [event["id"] for event in output["events"]] == [event.id for event in events[-50:]]
-    assert json.loads(registry.dispatch("kanban_show", {}))["events"] == expected
+    assert all(type(event["id"]) is int for event in output["events"])
+    dispatched = registry.dispatch("kanban_show", {})
+    assert isinstance(dispatched, str)
+    assert json.loads(dispatched)["events"] == expected
 
 
 def test_list_filters_tasks(monkeypatch, worker_env):

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import os
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict
 
 import pytest
 
@@ -79,6 +80,31 @@ def test_show_defaults_to_env_task_id(worker_env):
     assert d["task"]["status"] == "running"
     assert "worker_context" in d
     assert "runs" in d
+
+
+def test_show_preserves_canonical_last_50_events(worker_env):
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_connect as kbc
+    from tools import kanban_tools as kt
+    from tools.registry import registry
+
+    with kbc.connect_closing() as conn:
+        other_id = kb.create_task(conn, title="unrelated events")
+        for index in range(55):
+            kb.add_comment(conn, worker_env, author="worker", body=f"progress {index}")
+            kb.add_comment(conn, other_id, author="other", body="interleaved")
+        kb._append_event(conn, worker_env, "heartbeat", run_id=kb.latest_run(conn, worker_env).id)
+        conn.execute("UPDATE task_events SET created_at = ?", (1_700_000_000,))
+        conn.commit()
+        events = kb.list_events(conn, worker_env)
+
+    assert len(events) > 50
+    expected = [asdict(event) for event in events[-50:]]
+    output = json.loads(kt._handle_show({}))
+
+    assert output["events"] == expected
+    assert [event["id"] for event in output["events"]] == [event.id for event in events[-50:]]
+    assert json.loads(registry.dispatch("kanban_show", {}))["events"] == expected
 
 
 def test_list_filters_tasks(monkeypatch, worker_env):

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -13,6 +13,7 @@ import logging
 import os
 import time
 from contextlib import contextmanager
+from dataclasses import asdict
 from typing import Any, Callable, Optional
 
 from agent.redact import redact_sensitive_text
@@ -336,7 +337,6 @@ _TASK_SUMMARY_FIELDS = tuple(
     "created_at started_at completed_at current_run_id model_override provider_override".split())
 _RUN_FIELDS = tuple("id profile status outcome summary error metadata started_at ended_at".split())
 _COMMENT_FIELDS = ("author", "body", "created_at")
-_EVENT_FIELDS = ("kind", "payload", "created_at", "run_id")
 _ATTACHMENT_FIELDS = tuple(
     "id filename content_type size uploaded_by stored_path created_at".split())
 _CREATED_FIELDS = ("status", "workspace_kind", "workspace_path", "project_id")
@@ -523,7 +523,7 @@ def _handle_show(args: dict, **kw) -> str:
             "children": kb.child_ids(conn, tid),
             "comments": [_fields(c, _COMMENT_FIELDS) for c in kb.list_comments(conn, tid)],
             # Capped; full log via CLI.
-            "events": [_fields(e, _EVENT_FIELDS) for e in kb.list_events(conn, tid)[-50:]],
+            "events": [asdict(e) for e in kb.list_events(conn, tid)[-50:]],
             "runs": [_fields(r, _RUN_FIELDS) for r in kb.list_runs(conn, tid)],
             # Same string build_worker_context hands the dispatcher at spawn time.
             "worker_context": kb.build_worker_context(conn, tid)})

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -13,7 +13,6 @@ import logging
 import os
 import time
 from contextlib import contextmanager
-from dataclasses import asdict
 from typing import Any, Callable, Optional
 
 from agent.redact import redact_sensitive_text
@@ -523,7 +522,7 @@ def _handle_show(args: dict, **kw) -> str:
             "children": kb.child_ids(conn, tid),
             "comments": [_fields(c, _COMMENT_FIELDS) for c in kb.list_comments(conn, tid)],
             # Capped; full log via CLI.
-            "events": [asdict(e) for e in kb.list_events(conn, tid)[-50:]],
+            "events": [kb.event_to_dict(e) for e in kb.list_events(conn, tid)[-50:]],
             "runs": [_fields(r, _RUN_FIELDS) for r in kb.list_runs(conn, tid)],
             # Same string build_worker_context hands the dispatcher at spawn time.
             "worker_context": kb.build_worker_context(conn, tid)})


### PR DESCRIPTION
## Summary

- preserve canonical `task_events.id` and `task_id` in `hermes kanban show --json`
- expose the same explicit six-field event contract through the in-agent `kanban_show` tool and dashboard task-detail API
- centralize that allowlist in `kanban_db.event_to_dict()` so future internal `Event` fields cannot leak into public JSON
- retain the tool's existing last-50-event cap and the history ordering defined by `list_events()`

## Contract

Public events contain exactly:

- `id`
- `task_id`
- `kind`
- `run_id`
- `payload`
- `created_at`

`id` is opaque event identity only. This PR does not promise ID-order cursor semantics and does not change timestamp-first history ordering or tool windowing.

## Review remediation

- The cursor concern is resolved by documenting identity-only semantics and removing the stale monotonic-cursor claim from this PR description; ordering/windowing remain intentionally unchanged.
- The `asdict(Event)` concern is fixed with one shared explicit serializer used by CLI, tool, and dashboard paths.
- Literal parity coverage now creates multiple equal-timestamp, interleaved-task events and proves exact values/order across all three public surfaces. A synthetic internal dataclass field proves that internal fields cannot leak.

## Testing

Strict TDD remediation evidence:

- the new cross-surface contract test failed first because the old `asdict(Event)` paths leaked a synthetic `internal_note` field
- the strengthened tool assertion failed first because expected data was still derived via `asdict()`
- both passed after routing all three surfaces through the explicit serializer

Final verification:

```text
scripts/run_tests.sh tests/hermes_cli/test_kanban_cli.py tests/tools/test_kanban_tools.py tests/plugins/test_kanban_dashboard_plugin.py tests/hermes_cli/test_kanban_db.py --file-retries 0
114 passed, 0 failed

scripts/run_tests.sh tests/hermes_cli/test_kanban*.py tests/tools/test_kanban*.py tests/plugins/test_kanban_dashboard_plugin.py --file-retries 0
433 passed, 0 failed

ruff check hermes_cli/kanban_db.py hermes_cli/kanban.py tools/kanban_tools.py plugins/kanban/dashboard/plugin_api.py tests/hermes_cli/test_kanban_cli.py tests/tools/test_kanban_tools.py tests/plugins/test_kanban_dashboard_plugin.py
All checks passed

python -m compileall -q hermes_cli tools plugins tests
passed

git diff --check
passed
```

Targeted `ty` diagnostics improved from 63 baseline errors to 61; both removed diagnostics were the expected `dataclasses.asdict()` static-type failures in the CLI and tool handlers. The remaining diagnostics are pre-existing in the touched modules.

## Checklist

- [x] Read the contribution and area-specific development guides
- [x] Added tests for the changed behavior
- [x] Preserved existing ordering and tool cap
- [x] Kept IDs opaque rather than adding cursor semantics
- [x] Used one explicit serializer across all public surfaces

## Disclosure

This change was developed with AI assistance (Codex CLI), then independently re-run through the repository's focused tests and static checks before submission.
