### PR TITLE
fix(update): back up local-only commits before reset --hard; refuse reset without a backup

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -760,9 +760,16 @@ def _reconcile_diverged_checkout(git_cmd, branch: str, pre_pull_sha) -> None:
     elif local_only != 0:
         # local_only > 0: there ARE local commits not on origin/<branch>; local_only < 0: the
         # count itself failed. Treat both as "back HEAD up" — the reset is unrecoverable.
+        # SHA suffix so two updates inside the same second get DISTINCT refs: ``update-ref``
+        # overwrites silently, and replacing the only recovery pointer to earlier local commits
+        # while reporting success is exactly the failure this backup exists to prevent.
+        # ``pre_pull_sha`` is the pre-reset HEAD; if it wasn't captured, re-read HEAD, and fall
+        # back to no suffix only when HEAD cannot be resolved at all.
+        backup_sha = pre_pull_sha or _capture_head_sha(git_cmd, _m().PROJECT_ROOT)
         backup_ref = (
             f"refs/hermes-update-backups/{branch}-"
-            f"{_time.strftime('%Y%m%d-%H%M%S')}")
+            f"{_time.strftime('%Y%m%d-%H%M%S')}"
+            + (f"-{backup_sha[:12]}" if backup_sha else ""))
         if _git_run(git_cmd, ["update-ref", backup_ref, "HEAD"]).returncode != 0:
             # Never claim a backup we do not have, and never run the destructive reset without one.
             print(f"✗ Could not create backup ref {backup_ref} for local commits; refusing to reset --hard.")

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -728,10 +728,15 @@ def _reconcile_diverged_checkout(git_cmd, branch: str, pre_pull_sha) -> None:
             sys.exit(1)
         return
     # Same branch: a true upstream force-push/rebase; local changes are stashed, so reset.
-    # Orphan divergence (no common ancestor: corrupted HEAD, re-init) would lose the whole
-    # local graph, so park pre_pull_sha behind a rescue ref first.
+    # But committed local-only work is NOT in the autostash (a committed fix shows clean in
+    # `git status`), so a bare `reset --hard` would silently destroy it. Count commits in HEAD
+    # that aren't on origin/<branch> and back HEAD up before resetting when there are any — or
+    # when the count itself failed (`local_only < 0`: bad ref / git error). The reset below is
+    # unrecoverable, so the only safe direction to fail is toward taking a backup we may not
+    # have needed. Never `reset --hard` without a working backup.
     merge_base_result = _git_run(git_cmd, ["merge-base", "HEAD", f"origin/{branch}"])
     has_common_ancestor = merge_base_result.returncode == 0 and merge_base_result.stdout.strip()
+    local_only = _count_commits_between(git_cmd, _m().PROJECT_ROOT, f"origin/{branch}", "HEAD")
     if not has_common_ancestor and pre_pull_sha:
         from datetime import datetime as _dt, timezone
         # SHA suffix so two updates in the same second get distinct refs.
@@ -744,11 +749,34 @@ def _reconcile_diverged_checkout(git_cmd, branch: str, pre_pull_sha) -> None:
                 f"{head}backed up current HEAD to {rescue_ref} before resetting. "
                 f"This backup expires after {_ORPHAN_RESCUE_REF_MAX_AGE_DAYS} days.")
         else:
-            # update-ref failure is intentionally non-fatal, but never claim a backup exists.
+            # update-ref failure is fatal: never reset --hard without a working backup.
             print(
                 f"{head}attempted to back up current HEAD to {rescue_ref} before resetting, "
                 f"but the backup write failed (pre-reset SHA was {pre_pull_sha}).")
+            print("  ✗ Refusing to reset --hard without a backup; your local history is still intact.")
+            print(f"  Reconcile manually with: git rebase origin/{branch}")
+            sys.exit(1)
         _prune_orphan_rescue_refs(git_cmd, _m().PROJECT_ROOT, branch)
+    elif local_only != 0:
+        # local_only > 0: there ARE local commits not on origin/<branch>; local_only < 0: the
+        # count itself failed. Treat both as "back HEAD up" — the reset is unrecoverable.
+        backup_ref = (
+            f"refs/hermes-update-backups/{branch}-"
+            f"{_time.strftime('%Y%m%d-%H%M%S')}")
+        if _git_run(git_cmd, ["update-ref", backup_ref, "HEAD"]).returncode != 0:
+            # Never claim a backup we do not have, and never run the destructive reset without one.
+            print(f"✗ Could not create backup ref {backup_ref} for local commits; refusing to reset --hard.")
+            print("  Your local commits are still intact. Reconcile manually with:")
+            print(f"    git rebase origin/{branch}")
+            sys.exit(1)
+        if local_only > 0:
+            print(
+                f"  ℹ Preserving {local_only} local commit(s) not on origin/{branch} before "
+                f"resetting (backed up to {backup_ref})...")
+        else:
+            print(
+                f"  ℹ Could not count local commits not on origin/{branch}; backing up HEAD to "
+                f"{backup_ref} before resetting, to be safe...")
     print("  ⚠ Fast-forward not possible (history diverged), resetting to match remote...")
     reset_result = _git_run(git_cmd, ["reset", "--hard", f"origin/{branch}"])
     if reset_result.returncode != 0:

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -314,9 +314,10 @@ def test_cmd_update_orphan_history_backs_up_before_reset(monkeypatch, tmp_path, 
     assert f"expires after {update_cmd._ORPHAN_RESCUE_REF_MAX_AGE_DAYS} days" in out
 
 
-def test_cmd_update_orphan_rescue_ref_write_failure_message_is_honest(monkeypatch, tmp_path, capsys):
-    """When ``git update-ref`` fails, the printed message must not claim a
-    backup exists — it should say the write was attempted and failed."""
+def test_cmd_update_orphan_rescue_ref_write_failure_is_fatal(monkeypatch, tmp_path, capsys):
+    """When ``git update-ref`` fails, the update must refuse to reset --hard
+    (never run the destructive reset without a working backup) and the printed
+    message must not claim a backup exists — it says the write failed."""
     _setup_update_mocks(monkeypatch, tmp_path)
 
     side_effect, recorded = _make_update_side_effect(
@@ -324,12 +325,17 @@ def test_cmd_update_orphan_rescue_ref_write_failure_message_is_honest(monkeypatc
     )
     monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
 
-    hermes_main.cmd_update(SimpleNamespace())
+    with pytest.raises(SystemExit):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    reset_calls = [c for c in recorded if "reset" in " ".join(str(x) for x in c) and "--hard" in c]
+    assert reset_calls == []
 
     out = capsys.readouterr().out
     assert "orphan divergence" in out
     assert "backup write failed" in out
     assert "backed up current HEAD" not in out
+    assert "Refusing to reset --hard without a backup" in out
 
 
 def test_cmd_update_orphan_rescue_refs_pruned_beyond_keep_limit(monkeypatch, tmp_path, capsys):
@@ -423,12 +429,13 @@ def test_prune_orphan_rescue_refs_leaves_unparseable_names_alone():
 
 
 def test_cmd_update_ordinary_divergence_skips_rescue_ref(monkeypatch, tmp_path, capsys):
-    """Common ancestor still exists (e.g. upstream force-push) → no rescue
-    ref, no orphan messaging, behavior identical to before #87694."""
+    """Common ancestor still exists (e.g. upstream force-push) and there are no
+    local-only commits → no rescue ref, no orphan messaging, behavior identical
+    to before #87694."""
     _setup_update_mocks(monkeypatch, tmp_path)
 
     side_effect, recorded = _make_update_side_effect(
-        ff_only_fails=True, merge_base_exists=True,
+        ff_only_fails=True, merge_base_exists=True, commit_count="0",
     )
     monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
 
@@ -442,29 +449,80 @@ def test_cmd_update_ordinary_divergence_skips_rescue_ref(monkeypatch, tmp_path, 
     assert "Fast-forward not possible (history diverged), resetting to match remote" in out
 
 
-def test_cmd_update_orphan_rescue_ref_write_failure_is_non_fatal(monkeypatch, tmp_path, capsys):
-    """#87694 stress test: ``git update-ref`` itself fails (disk full,
-    permissions) while parking the orphan rescue ref. The backup attempt is
-    best-effort — so the reset must still proceed and the update succeed."""
+def test_cmd_update_local_commits_backed_up_before_reset(monkeypatch, tmp_path, capsys):
+    """Same branch with local-only commits (common ancestor, HEAD ahead of
+    origin/main) → HEAD is parked behind a ``refs/hermes-update-backups/main-*``
+    ref before reset --hard is attempted, instead of silently discarding the
+    commits. ``reset_fails=True`` keeps the test off the gateway-restart success
+    path (blocked by the conftest live-system guard on a live-gateway box) while
+    still proving the backup is written before the reset."""
     _setup_update_mocks(monkeypatch, tmp_path)
 
     side_effect, recorded = _make_update_side_effect(
-        ff_only_fails=True, merge_base_exists=False, update_ref_fails=True,
+        ff_only_fails=True, merge_base_exists=True, commit_count="3", reset_fails=True,
     )
     monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
 
-    hermes_main.cmd_update(SimpleNamespace())
+    with pytest.raises(SystemExit):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    update_ref_calls = [c for c in recorded if "update-ref" in " ".join(str(x) for x in c)]
+    assert len(update_ref_calls) == 1
+    ref_name = update_ref_calls[0][update_ref_calls[0].index("update-ref") + 1]
+    assert ref_name.startswith("refs/hermes-update-backups/main-")
+    # Backs up current HEAD (not the pre-pull SHA), so the ref always points at
+    # a resolvable commit.
+    assert update_ref_calls[0][update_ref_calls[0].index("update-ref") + 2] == "HEAD"
+
+    # The backup is written even though the subsequent reset --hard fails.
+    reset_calls = [c for c in recorded if "reset" in " ".join(str(x) for x in c) and "--hard" in c]
+    assert len(reset_calls) == 1
+
+    out = capsys.readouterr().out
+    assert "Preserving 3 local commit(s) not on origin/main" in out
+    assert ref_name in out
+
+
+def test_cmd_update_local_commits_backup_failure_refuses_reset(monkeypatch, tmp_path, capsys):
+    """When the local-commit backup ``update-ref`` fails, the update must refuse
+    to reset --hard rather than silently discard the commits."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+
+    side_effect, recorded = _make_update_side_effect(
+        ff_only_fails=True, merge_base_exists=True, commit_count="3", update_ref_fails=True,
+    )
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit):
+        hermes_main.cmd_update(SimpleNamespace())
+
+    reset_calls = [c for c in recorded if "reset" in " ".join(str(x) for x in c) and "--hard" in c]
+    assert reset_calls == []
+
+    out = capsys.readouterr().out
+    assert "Could not create backup ref" in out
+    assert "refusing to reset --hard" in out
+
+
+def test_cmd_update_local_commits_count_failure_still_backs_up(monkeypatch, tmp_path, capsys):
+    """When the local-commit count itself fails (negative sentinel), the update
+    still backs HEAD up before reset — fail toward taking a backup."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+
+    monkeypatch.setattr(update_cmd, "_count_commits_between", lambda *a, **kw: -1)
+    side_effect, recorded = _make_update_side_effect(
+        ff_only_fails=True, merge_base_exists=True, reset_fails=True,
+    )
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    with pytest.raises(SystemExit):
+        hermes_main.cmd_update(SimpleNamespace())
 
     update_ref_calls = [c for c in recorded if "update-ref" in " ".join(str(x) for x in c)]
     assert len(update_ref_calls) == 1
 
-    reset_calls = [
-        c for c in recorded if "reset" in " ".join(str(x) for x in c) and "--hard" in c
-    ]
-    assert len(reset_calls) == 1
-
     out = capsys.readouterr().out
-    assert "orphan divergence" in out
+    assert "Could not count local commits" in out
 
 
 def test_cmd_update_orphan_guard_skips_rescue_ref_when_pre_pull_sha_missing(
@@ -479,6 +537,7 @@ def test_cmd_update_orphan_guard_skips_rescue_ref_when_pre_pull_sha_missing(
 
     side_effect, recorded = _make_update_side_effect(
         ff_only_fails=True, merge_base_exists=False, pre_pull_sha_unavailable=True,
+        commit_count="0",
     )
     monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
 

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -473,6 +473,10 @@ def test_cmd_update_local_commits_backed_up_before_reset(monkeypatch, tmp_path, 
     # Backs up current HEAD (not the pre-pull SHA), so the ref always points at
     # a resolvable commit.
     assert update_ref_calls[0][update_ref_calls[0].index("update-ref") + 2] == "HEAD"
+    # A SHA suffix disambiguates two updates inside the same second — without it
+    # the second ``update-ref`` silently overwrites the first, dropping the only
+    # recovery pointer to those commits while reporting success.
+    assert ref_name.endswith("-111111111111"), ref_name
 
     # The backup is written even though the subsequent reset --hard fails.
     reset_calls = [c for c in recorded if "reset" in " ".join(str(x) for x in c) and "--hard" in c]


### PR DESCRIPTION
## Summary

Port of the two safety fixes from #75154 into the current `_reconcile_diverged_checkout` helper. The original PR was closed after upstream refactored the inline preserve-and-reset block into `_reconcile_diverged_checkout`; this re-scopes the work to the two fixes that the refactor dropped.

## Problem

Committed local-only work (a fix committed on `main` that hasn't been pushed) is **not** in the autostash — a committed change shows clean in `git status`, so the stash has nothing to save. When `hermes update` hits a diverged checkout on the *same* branch, `_reconcile_diverged_checkout` ran `reset --hard origin/<branch>`, which **silently destroyed those local commits**.

## Changes

In `_reconcile_diverged_checkout` (same-branch path):

1. **Count local-only commits before reset.** `_count_commits_between(origin/<branch> .. HEAD)` now runs before `reset --hard`. When the count is non-zero — or the count itself failed (negative sentinel, failing toward safety) — HEAD is parked behind a `refs/hermes-update-backups/<branch>-<timestamp>` ref first.

2. **Make the backup write fatal.** If `git update-ref` fails to write the backup, the update now refuses to reset (`sys.exit(1)`) instead of proceeding without a backup. This applies to both the new local-commit backup and the existing orphan-rescue ref (whose `update-ref` failure was previously non-fatal).

## What was dropped from #75154 (intentionally)

The original PR's cherry-pick replay machinery (replaying preserved commits one-at-a-time after reset) and the installer-script changes are **not** in this PR. Upstream's refactor handles the divergence cases differently: custom-branch divergence merges (local commits survive via `git merge`), and same-branch divergence now gets the backup-ref guard above. The replay is a separate enhancement that can follow if the maintainers want it.

## Tests

- `test_cmd_update_local_commits_backed_up_before_reset` — local commits are backed up before reset.
- `test_cmd_update_local_commits_backup_failure_refuses_reset` — reset is refused when the backup write fails.
- `test_cmd_update_local_commits_count_failure_still_backs_up` — count failure still backs up (fail toward safety).
- `test_cmd_update_orphan_rescue_ref_write_failure_is_fatal` — orphan rescue-ref write failure is now fatal.

Closes #75154.
