### PR TITLE
fix(kanban): install the assignee's secret scope before scrubbing worker env

### DIFF
--- a/hermes_cli/kanban_db_dispatch.py
+++ b/hermes_cli/kanban_db_dispatch.py
@@ -2192,13 +2192,33 @@ def _default_spawn(task: Task, workspace: str, *, board: Optional[str] = None) -
 
     profile_arg = normalize_profile_name(task.assignee)
 
-    from agent.secret_scope import is_multiplex_active
+    from agent.secret_scope import (
+        build_profile_secret_scope, is_multiplex_active, reset_secret_scope, set_secret_scope)
     from tools.environments.local import build_subprocess_env, strip_launch_profile_env
 
-    env = build_subprocess_env(
-        scrub_secrets=is_multiplex_active(),
-        inherit_profile_home=True,
-    )
+    try:
+        profile_home = resolve_profile_env(profile_arg)
+    except FileNotFoundError:
+        # No profile dir (isolated test fixtures) — the CLI resolves it from
+        # HERMES_PROFILE (set below) instead.
+        profile_home = None
+
+    multiplex_active = is_multiplex_active()
+    # build_subprocess_env's secret scrub resolves terminal.env_passthrough vars
+    # through get_secret(), which raises UnscopedSecretError with no profile scope
+    # installed while multiplexing is on — mirrors _resolve_worker_cli_toolsets's
+    # own scope-then-read ordering a few functions up in this module.
+    secret_token = (
+        set_secret_scope(build_profile_secret_scope(Path(profile_home)))
+        if multiplex_active and profile_home else None)
+    try:
+        env = build_subprocess_env(
+            scrub_secrets=multiplex_active,
+            inherit_profile_home=True,
+        )
+    finally:
+        if secret_token is not None:
+            reset_secret_scope(secret_token)
     # The dispatcher is detached from every conversation; its worker must never
     # inherit routing mirrored by a previous gateway turn.
     from gateway.session_context import _VAR_MAP
@@ -2209,15 +2229,11 @@ def _default_spawn(task: Task, workspace: str, *, board: Optional[str] = None) -
     # without it the child's get_hermes_home() falls back to the DEFAULT
     # profile root because `hermes -p` applies its override before
     # hermes_constants is imported.
-    try:
-        env["HERMES_HOME"] = resolve_profile_env(profile_arg)
+    if profile_home:
+        env["HERMES_HOME"] = profile_home
         # A multiplexer dispatching for another profile must not hand it the launch
         # profile's .env settings / TERMINAL_* policy — a standalone dispatcher never would.
-        strip_launch_profile_env(env, env["HERMES_HOME"])
-    except FileNotFoundError:
-        # No profile dir (isolated test fixtures) — the CLI resolves it from
-        # HERMES_PROFILE (set below) instead.
-        pass
+        strip_launch_profile_env(env, profile_home)
     if task.tenant:
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -136,6 +136,60 @@ def test_default_spawn_model_override_survives_real_cli_parse(monkeypatch, tmp_p
     assert args.query == "work kanban task t_spawn_tools"
 
 
+def test_default_spawn_resolves_env_passthrough_under_multiplex(monkeypatch, tmp_path):
+    """Under multiplex, a worker spawn must not crash when ``terminal.env_passthrough``
+    is configured, and the forwarded value must come from the ASSIGNEE profile's own
+    secret scope, not the dispatcher's ambient os.environ.
+
+    Regression guard: ``_default_spawn`` built the worker env via
+    ``build_subprocess_env(scrub_secrets=True)`` with no profile secret scope
+    installed. Any registered ``env_passthrough`` var made
+    ``resolve_passthrough_value()`` call ``get_secret()`` with no scope while
+    multiplexing was active, which raises ``UnscopedSecretError`` and crashed the
+    spawn for every task, every profile, as soon as ``terminal.env_passthrough``
+    was configured anywhere.
+    """
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "elias"
+    profile.mkdir(parents=True)
+    root.joinpath("config.yaml").write_text(
+        "terminal:\n  env_passthrough:\n    - MY_PASSTHROUGH_VAR\n", encoding="utf-8")
+    profile.joinpath("config.yaml").write_text("{}\n", encoding="utf-8")
+    profile.joinpath(".env").write_text("MY_PASSTHROUGH_VAR=elias-value\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setenv("MY_PASSTHROUGH_VAR", "dispatcher-value")
+
+    from agent.secret_scope import set_multiplex_active
+    from hermes_cli import kanban_db as kb
+    from hermes_cli import kanban_db_dispatch as kbd
+
+    monkeypatch.setattr(kbd, "_resolve_hermes_argv", lambda: ["hermes"])
+
+    captured = {}
+
+    class FakeProc:
+        pid = 4243
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["env"] = dict(kwargs.get("env") or {})
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    set_multiplex_active(True)
+    try:
+        pid = kbd._default_spawn(_make_task(kb, assignee="elias"), str(workspace))
+    finally:
+        set_multiplex_active(False)
+
+    assert pid == 4243
+    # The assignee's own scoped value, not the dispatcher's ambient os.environ one.
+    assert captured["env"].get("MY_PASSTHROUGH_VAR") == "elias-value"
+
+
 def test_resolve_worker_cli_toolsets_uses_profile_home_not_parent_config(monkeypatch, tmp_path):
     root = tmp_path / ".hermes"
     profile = root / "profiles" / "elias"


### PR DESCRIPTION
## What does this PR do?

`_default_spawn()` (`hermes_cli/kanban_db_dispatch.py`) builds each Kanban worker's subprocess environment via:

```python
env = build_subprocess_env(
    scrub_secrets=is_multiplex_active(),
    inherit_profile_home=True,
)
```

with no profile secret scope installed around the call.

## The bug

Under `gateway.multiplex_profiles`, `build_subprocess_env(scrub_secrets=True)` → `_sanitize_subprocess_env` → `_filter_secret_env` calls `resolve_passthrough_value(key, value)` for any env var registered via `terminal.env_passthrough` in `config.yaml`. With no scope installed and multiplexing active, `resolve_passthrough_value` calls `agent.secret_scope.get_secret(name)`, which fails closed by design:

```python
if _MULTIPLEX_ACTIVE:
    raise UnscopedSecretError(...)
```

That exception propagates straight out of `_default_spawn`. In practice: **as soon as any `terminal.env_passthrough` var is configured (for any profile) and multiplex is active, every Kanban task, for every profile, fails to spawn** — the dispatcher's `_dispatch_lane_task` catches the exception and records `spawn_failed`, silently blocking the board once `failure_limit` is hit.

The fix mirrors an existing sibling in the same file: `_resolve_worker_cli_toolsets()` (a few functions up) already resolves the assignee's `HERMES_HOME`, installs `set_secret_scope(build_profile_secret_scope(...))` around its own credential-reading call, and tears it down in a `finally`. `_default_spawn()` never got the same treatment for its own `build_subprocess_env()` call.

## The fix

- Resolve `profile_home` via `resolve_profile_env(profile_arg)` *before* building the env (previously done only afterward, purely to set `env["HERMES_HOME"]`).
- Install `set_secret_scope(build_profile_secret_scope(Path(profile_home)))` around the `build_subprocess_env(...)` call when multiplexing is active, torn down in a `finally` — identical pattern to `_resolve_worker_cli_toolsets`.
- Reuse the already-resolved `profile_home` to set `env["HERMES_HOME"]` afterward instead of calling `resolve_profile_env()` a second time.

With the scope installed, a registered passthrough var now resolves to the **assignee profile's own** `.env` value (or is safely dropped if that profile doesn't define it) instead of raising.

## Testing

Added `test_default_spawn_resolves_env_passthrough_under_multiplex` (`tests/hermes_cli/test_kanban_worker_spawn_toolsets.py`), which:
- registers `MY_PASSTHROUGH_VAR` via `terminal.env_passthrough` in the root config,
- sets a *different* value for it in the dispatcher's ambient `os.environ` vs. the assignee profile's own `.env`,
- asserts the spawn succeeds and the worker receives the assignee's own value.

Mutation-verified: reverting the fix makes this test fail with the exact `UnscopedSecretError` described above, not a generic assertion failure. Ran the full Kanban + multiplex-parity test suites (`test_kanban_worker_spawn_toolsets.py`, `test_kanban_multiplex_served_profile_parity.py`, `test_cron_kanban_env_isolation.py`, plus every other `test_kanban_*` file) — all pass, no regressions.

## Scope note

Checked for competing fixes: open PRs #83007 and #55600 target the same general area but the pre-decomposition `hermes_cli/kanban_db.py` location and an older `hermes_subprocess_env`-based architecture (they address a broader, still-separate concern — arbitrary non-blocklisted "secret-shaped" values leaking from the dispatcher's ambient env, GH #82936) rather than the `terminal.env_passthrough` crash this PR fixes on the current `build_subprocess_env`/`resolve_passthrough_value` architecture. #107955/#57837 fix a different call site entirely (`gateway/kanban_watchers_dispatcher.py`'s auto-decompose tick). None of them touch `_default_spawn`'s current implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
