### PR TITLE
fix(approval): scope API runs to resolver capability

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1153,6 +1153,9 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         self._site: Optional["web.TCPSite"] = None
         self._response_store = ResponseStore()
         _api_runs._initialize_run_state(self, store_factory=RunIdempotencyStore)
+        # Serialize run terminal transitions against approval resolution. The resolver itself
+        # remains route/run-scoped; this lock only closes the lifecycle race at the adapter seam.
+        self._run_lifecycle_lock = threading.RLock()
         self._session_db: Optional[Any] = None  # explicit override (tests/manual wiring)
         self._session_dbs: Dict[str, Any] = {}  # per-profile-home SessionDB cache
         self._session_db_cache_lock = threading.Lock()
@@ -1192,6 +1195,15 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
     def interrupt_active_runs(self, reason: str) -> int:
         """Interrupt every adapter-owned agent during shutdown (they are not in
         ``GatewayRunner._running_agents``): exactly the set the drain waits on. Returns count."""
+        # Shutdown is a cancellation boundary for /v1/runs too. Revoke and wake each
+        # resolver before asking agents to stop, so no approval can win after shutdown begins.
+        with self._run_lifecycle_lock:
+            for run_id in tuple(self._run_approval_resolvers):
+                status = self._run_statuses.get(run_id, {})
+                if status.get("status") not in _api_runs.TERMINAL_STATUSES:
+                    self._set_run_status(run_id, "stopping", last_event="run.stopping")
+                    self._stopping_run_ids.add(run_id)
+                _api_runs._revoke_run_approval(self, run_id)
         # Dedupe by identity: an agent in both registries must be interrupted once.
         agents = {id(agent): agent for agent in (
             *self._active_run_agents.values(), *self._shutdown_interruptible_agents.values())

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -97,7 +97,8 @@ def _initialize_run_state(self, *, store_factory) -> None:
     (
         self._run_owners, self._run_streams, self._run_streams_created, self._active_run_agents,
         self._active_run_tasks, self._run_statuses, self._run_approval_sessions,
-    ) = ({} for _ in range(7))
+        self._run_approval_resolvers,
+    ) = ({} for _ in range(8))
 
 
 def _http_routes(self) -> list[tuple[str, str, Any]]:
@@ -354,8 +355,10 @@ def _forget_run(self, run_id: str, *tables) -> None:
 
 def _retire_live_run(self, run_id: str) -> None:
     """Retire agent/task/approval control state once the executor-backed task is done."""
-    _forget_run(self, run_id, self._active_run_agents, self._active_run_tasks, self._run_approval_sessions,
-                self._stopping_run_ids)
+    with self._run_lifecycle_lock:
+        _forget_run(
+            self, run_id, self._active_run_agents, self._active_run_tasks, self._run_approval_sessions,
+            self._run_approval_resolvers, self._stopping_run_ids)
 
 
 def _drop_run_transport(self, run_id: str) -> None:
@@ -502,6 +505,8 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
         browser_control_transport_family=_api_server._api_request_browser_control_transport_family.get(),
         turn_author=turn_author, approval_resolver=create_approval_resolver(run_id))
     self._activate_admitted_request()
+    with self._run_lifecycle_lock:
+        self._run_approval_resolvers[run_id] = launch.approval_resolver
     task = self._active_run_tasks[run_id] = asyncio.create_task(_execute_run(self, launch, _api_server=_api_server))
     with suppress(TypeError):
         self._background_tasks.add(task)  # tracked for shutdown drain
@@ -708,7 +713,7 @@ def _release_run_owner_if_forgotten(self, run_id: str) -> None:
     """Drop the owner stamp only once nothing keyed by *run_id* survives: ownership must
     outlive every surface it protects (retired on different clocks); ownerless = fail-closed."""
     live = (self._run_statuses, self._active_run_agents, self._active_run_tasks, self._run_streams,
-            self._run_approval_sessions)
+            self._run_approval_sessions, self._run_approval_resolvers)
     if not any(run_id in table for table in live):
         self._run_owners.pop(run_id, None)
 
@@ -809,6 +814,21 @@ def _mark_run_event(self, run_id: str, name: str, **fields: Any) -> None:
 _APPROVAL_CHOICE_ALIASES = {"approve": "once", "approved": "once", "allow": "once"}
 
 
+def _revoke_run_approval(self, run_id: str) -> None:
+    """Revoke one run's resolver and wake every approval waiter it owns.
+
+    Callers hold ``_run_lifecycle_lock`` so a stop/shutdown transition and a competing
+    HTTP approval resolution have one serialized winner.
+    """
+    resolver = self._run_approval_resolvers.get(run_id)
+    session_key = self._run_approval_sessions.get(run_id)
+    if session_key:
+        from tools.approval import unregister_gateway_notify
+        unregister_gateway_notify(session_key, resolver)
+    elif resolver is not None:
+        resolver.revoke()
+
+
 async def _handle_run_approval(self, request: "web.Request", *, _api_server) -> "web.Response":
     """POST /v1/runs/{run_id}/approval — resolve a pending run approval."""
     _openai_error = _api_server._openai_error
@@ -828,7 +848,6 @@ async def _handle_run_approval(self, request: "web.Request", *, _api_server) -> 
     # Room grants may resolve exactly one request and never widen to session/always.
     allowed = {"once", "deny"} if room_scoped else {"once", "session", "always", "deny"}
     resolve_all = any(_api_server._coerce_request_bool(body.get(k), default=False) for k in ("all", "resolve_all"))
-    approval_session_key = self._run_approval_sessions.get(run_id)
     for failed, message, code, status in (
         (raw_request_id is not None and (not request_id or len(request_id) > 256),
          "Approval request_id is invalid.", "invalid_approval_request", 400),
@@ -839,17 +858,29 @@ async def _handle_run_approval(self, request: "web.Request", *, _api_server) -> 
          "Room approvals can resolve only one exact request", "invalid_approval_scope", 400),
         (room_scoped and not request_id,
          "Room approvals require the exact request_id.", "approval_request_required", 400),
-        (not approval_session_key,
-         f"Run has no active approval session: {run_id}", "approval_not_active", 409)):
+    ):
         if failed:
             return _json_error(_openai_error, message, code=code, status=status)
-    try:
-        from tools.approval import resolve_gateway_approval
-        resolved = resolve_gateway_approval(
-            approval_session_key, choice, resolve_all=resolve_all, request_id=request_id or None)
-    except Exception as exc:
-        logger.exception("[api_server] approval resolution failed for run %s", run_id)
-        return _json_error(_openai_error, str(exc), status=500)
+    with self._run_lifecycle_lock:
+        status = self._run_statuses.get(run_id) or {}
+        if status.get("status") in TERMINAL_STATUSES or status.get("status") == "stopping":
+            return _json_error(
+                _openai_error, f"Run is no longer accepting approval: {run_id}",
+                code="approval_not_active", status=409)
+        approval_session_key = self._run_approval_sessions.get(run_id)
+        resolver = self._run_approval_resolvers.get(run_id)
+        if not approval_session_key or resolver is None:
+            return _json_error(
+                _openai_error, f"Run has no active approval session: {run_id}",
+                code="approval_not_active", status=409)
+        try:
+            from tools.approval import resolve_gateway_approval
+            resolved = resolve_gateway_approval(
+                approval_session_key, choice, resolve_all=resolve_all, request_id=request_id or None,
+                approval_resolver=resolver)
+        except Exception as exc:
+            logger.exception("[api_server] approval resolution failed for run %s", run_id)
+            return _json_error(_openai_error, str(exc), status=500)
     if resolved <= 0:
         return _json_error(
             _openai_error, f"Run has no pending approval: {run_id}", code="approval_not_pending", status=409)
@@ -901,14 +932,16 @@ async def _handle_stop_run(self, request: "web.Request", *, _api_server) -> "web
         self, request, _api_server=_api_server, permission="stop", active_fallback=True)
     if err is not None:
         return err
-    if status.get("status") in TERMINAL_STATUSES:
-        return web.json_response(status)
-    if agent is None and task is None:
-        return _json_error(
-            _openai_error, f"Run is not active in this gateway process: {run_id}",
-            code="run_not_active", status=409)
-    self._set_run_status(run_id, "stopping", last_event="run.stopping")
-    self._stopping_run_ids.add(run_id)
+    with self._run_lifecycle_lock:
+        if status.get("status") in TERMINAL_STATUSES:
+            return web.json_response(status)
+        if agent is None and task is None:
+            return _json_error(
+                _openai_error, f"Run is not active in this gateway process: {run_id}",
+                code="run_not_active", status=409)
+        self._set_run_status(run_id, "stopping", last_event="run.stopping")
+        self._stopping_run_ids.add(run_id)
+        _revoke_run_approval(self, run_id)
     if agent is not None:
         with suppress(Exception):
             _api_server.request_hard_interrupt(agent, "Stop requested via API")

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -567,9 +567,14 @@ def _run_agent_sync(self, run: _RunLaunch, agent, approval_notify, *, _api_serve
                 _api_server._publish_turn_process_ownership(agent, effective_task_id)
                 # Passed only when set: a human turn keeps today's call shape.
                 author_kwargs = {"turn_author": run.turn_author} if run.turn_author is not None else {}
-                r = agent.run_conversation(
-                    user_message=run.user_message, conversation_history=run.conversation_history,
-                    task_id=effective_task_id, **author_kwargs)
+                # Close the cancellation gap between capability activation and agent startup. Guards
+                # also re-check the capability, so a revoke after this read still fails closed.
+                if run.approval_resolver.is_active():
+                    r = agent.run_conversation(
+                        user_message=run.user_message, conversation_history=run.conversation_history,
+                        task_id=effective_task_id, **author_kwargs)
+                else:
+                    r = {"final_response": "", "messages": [], "interrupted": True}
             else:
                 # A cancellation can win between admission and executor startup. Do not run an
                 # agent after the owning approval capability has been permanently revoked.
@@ -596,21 +601,32 @@ def _make_approval_notify(self, run: _RunLaunch, *, _api_server) -> Callable[[Di
     run_id, q, loop = run.run_id, run.queue, asyncio.get_running_loop()
 
     def _approval_notify(approval_data: Dict[str, Any]) -> None:
-        event = dict(approval_data or {})
-        # Clients must never receive the raw flagged command: redact before it hits the stream.
-        # Redact credentials from the command before it enters the SSE/API event stream — same egress bug as
-        # #48456, second transport: API/desktop clients would otherwise receive the raw command Tirith
-        # flagged. Reuse the gateway seam.
-        if "command" in event:
-            from gateway.run import _redact_approval_command
-            event["command"] = _redact_approval_command(event.get("command"))
-        event.update(_run_event(run_id, "approval.request", choices=_api_server._approval_event_choices(
-            smart_denied=bool(event.get("smart_denied")),
-            allow_session=event.get("allow_session") is not False,
-            allow_permanent=event.get("allow_permanent") is not False)))
-        self._set_run_status(run_id, "waiting_for_approval", last_event="approval.request", approval=event)
-        with suppress(Exception):
-            loop.call_soon_threadsafe(q.put_nowait, event)
+        def _publish() -> None:
+            event = dict(approval_data or {})
+            # Clients must never receive the raw flagged command: redact before it hits the stream.
+            # Redact credentials from the command before it enters the SSE/API event stream — same egress bug as
+            # #48456, second transport: API/desktop clients would otherwise receive the raw command Tirith
+            # flagged. Reuse the gateway seam.
+            if "command" in event:
+                from gateway.run import _redact_approval_command
+                event["command"] = _redact_approval_command(event.get("command"))
+            event.update(_run_event(run_id, "approval.request", choices=_api_server._approval_event_choices(
+                smart_denied=bool(event.get("smart_denied")),
+                allow_session=event.get("allow_session") is not False,
+                allow_permanent=event.get("allow_permanent") is not False)))
+            self._set_run_status(run_id, "waiting_for_approval", last_event="approval.request", approval=event)
+            with suppress(Exception):
+                loop.call_soon_threadsafe(q.put_nowait, event)
+
+        resolver = getattr(run, "approval_resolver", None)
+        if resolver is None:
+            _publish()
+            return
+        # Teardown revokes the capability under the same lifecycle lock. Holding that lock across
+        # status publication makes a stale callback a no-op instead of resurrecting a stopped run.
+        with resolver.active_scope() as active:
+            if active:
+                _publish()
 
     return _approval_notify
 

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -332,6 +332,7 @@ class _RunLaunch:
     browser_control_principal: Any
     browser_control_transport_family: Any
     turn_author: Optional[Dict[str, Any]] = None  # memory-attribution label only; grants nothing
+    approval_resolver: Any = None
 
     @property
     def approval_session_key(self) -> str:
@@ -488,6 +489,7 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
                 self._run_statuses, self._run_owners)
             return _replay_or_conflict(self, request, outcome, record, gateway_session_key, _openai_error)
         self._run_idempotency_ids.add(run_id)
+    from tools.approval_context import create_approval_resolver
     launch = _RunLaunch(
         self, run_id, q, session_id, gateway_session_key, _declared_selected, user_message,
         conversation_history, session_history_delivery,
@@ -498,7 +500,7 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
         request_profile=_api_server._api_request_profile.get(),
         browser_control_principal=_api_server._api_request_browser_control_principal.get(),
         browser_control_transport_family=_api_server._api_request_browser_control_transport_family.get(),
-        turn_author=turn_author)
+        turn_author=turn_author, approval_resolver=create_approval_resolver(run_id))
     self._activate_admitted_request()
     task = self._active_run_tasks[run_id] = asyncio.create_task(_execute_run(self, launch, _api_server=_api_server))
     with suppress(TypeError):
@@ -520,7 +522,10 @@ def _run_agent_sync(self, run: _RunLaunch, agent, approval_notify, *, _api_serve
     # held by a live transport are never reaped, so with the desktop app open for days those fleets
     # accumulate until the OS refuses new process spawns.
     from tools.approval import register_gateway_notify, unregister_gateway_notify
-    from tools.approval_context import reset_current_session_key, set_current_session_key
+    from tools.approval_context import (
+        reset_current_approval_resolver, reset_current_session_key,
+        set_current_approval_resolver, set_current_session_key,
+    )
     session_id = run.session_id
     effective_task_id = session_id or run.run_id
     # (token, reset) pairs unwound in the finally block; bound only once each step succeeds.
@@ -552,14 +557,24 @@ def _run_agent_sync(self, run: _RunLaunch, agent, approval_notify, *, _api_serve
                 policy = RoomExecutionPolicy.from_mapping(run.agent_kwargs["room_execution_policy"] or {})
                 resets.append((bind_room_execution_policy(policy), reset_room_execution_policy))
             register_gateway_notify(run.approval_session_key, approval_notify)
-            # /v1/runs owns its agent lifecycle (no TurnRunner): record process ownership
-            # so stop/cancel reaps only the background processes this run created.
-            _api_server._publish_turn_process_ownership(agent, effective_task_id)
-            # Passed only when set: a human turn keeps today's call shape.
-            author_kwargs = {"turn_author": run.turn_author} if run.turn_author is not None else {}
-            r = agent.run_conversation(
-                user_message=run.user_message, conversation_history=run.conversation_history,
-                task_id=effective_task_id, **author_kwargs)
+            if run.approval_resolver.activate():
+                resets.append((
+                    set_current_approval_resolver(run.approval_resolver),
+                    reset_current_approval_resolver,
+                ))
+                # /v1/runs owns its agent lifecycle (no TurnRunner): record process ownership
+                # so stop/cancel reaps only the background processes this run created.
+                _api_server._publish_turn_process_ownership(agent, effective_task_id)
+                # Passed only when set: a human turn keeps today's call shape.
+                author_kwargs = {"turn_author": run.turn_author} if run.turn_author is not None else {}
+                r = agent.run_conversation(
+                    user_message=run.user_message, conversation_history=run.conversation_history,
+                    task_id=effective_task_id, **author_kwargs)
+            else:
+                # A cancellation can win between admission and executor startup. Do not run an
+                # agent after the owning approval capability has been permanently revoked.
+                unregister_gateway_notify(run.approval_session_key, run.approval_resolver)
+                r = {"final_response": "", "messages": [], "interrupted": True}
         finally:
             # Clear ownership now so a later stop can't reap work this run left running.
             _api_server._clear_turn_process_ownership(agent)
@@ -568,7 +583,7 @@ def _run_agent_sync(self, run: _RunLaunch, agent, approval_notify, *, _api_serve
                 self._bind_declared_conversation(
                     getattr(agent, "session_id", None) or session_id, run.gateway_session_key)
             try:
-                unregister_gateway_notify(run.approval_session_key)
+                unregister_gateway_notify(run.approval_session_key, run.approval_resolver)
             finally:
                 for token, reset in resets:
                     with suppress(Exception):
@@ -655,18 +670,22 @@ async def _execute_run(self, run: _RunLaunch, *, _api_server) -> None:
     finally:
         # On cancellation (/stop) the executor thread may still block on an approval
         # Event; unregistering releases it. Idempotent on normal completion.
-        _unregister_approval_notify(run.approval_session_key)
+        _unregister_approval_notify(run.approval_session_key, run.approval_resolver)
         with suppress(Exception):
             run.put_event(None)  # sentinel: close the SSE stream
         _retire_live_run(self, run_id)
 
 
-def _unregister_approval_notify(approval_session_key: Optional[str]) -> None:
-    """Best-effort release of a run's approval waiter (no-op without a key)."""
+def _unregister_approval_notify(
+    approval_session_key: Optional[str], approval_resolver: Any = None,
+) -> None:
+    """Revoke a run capability before releasing its approval waiter and notifier."""
     with suppress(Exception):
         from tools.approval import unregister_gateway_notify
         if approval_session_key:
-            unregister_gateway_notify(approval_session_key)
+            unregister_gateway_notify(approval_session_key, approval_resolver)
+        elif approval_resolver is not None:
+            approval_resolver.revoke()
 
 
 def _release_run_owner_if_forgotten(self, run_id: str) -> None:

--- a/tests/gateway/test_api_server_approval_scope.py
+++ b/tests/gateway/test_api_server_approval_scope.py
@@ -1,0 +1,295 @@
+"""Boundary tests for route-scoped approval on the API server.
+
+The durable ``/v1/runs`` route owns an authenticated approval resolver, while
+the OpenAI-compatible routes do not.  These tests call the real adapter
+lifecycle with a small agent double whose only work is the harmless
+``execute_code`` guard; no code is spawned.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    cors_middleware,
+    security_headers_middleware,
+)
+from tools import approval as approval_module
+from tools import approval_context
+
+
+class _GuardAgent:
+    """Agent double that exposes the real execute-code approval result."""
+
+    session_prompt_tokens = 0
+    session_completion_tokens = 0
+    session_total_tokens = 0
+
+    def __init__(self, seen: list[dict], *, calls: int = 1, hardline: bool = False):
+        self.seen = seen
+        self.calls = calls
+        self.hardline = hardline
+
+    def run_conversation(self, **_kwargs):
+        for _ in range(self.calls):
+            if self.hardline:
+                result = approval_module.check_all_command_guards("rm -rf /", "local")
+            else:
+                result = approval_module.check_execute_code_guard(
+                    "print('approval-probe')", "local"
+                )
+            self.seen.append(result)
+            if not result.get("approved"):
+                return {
+                    "final_response": result.get("message", "blocked"),
+                    "messages": [],
+                }
+        return {"final_response": "approval-probe continued", "messages": []}
+
+
+def _make_adapter() -> APIServerAdapter:
+    return APIServerAdapter(PlatformConfig(enabled=True, extra={}))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    middlewares = [
+        middleware
+        for middleware in (cors_middleware, security_headers_middleware)
+        if middleware is not None
+    ]
+    app = web.Application(middlewares=middlewares)
+    app["api_server_adapter"] = adapter
+    app.router.add_post("/v1/runs", adapter._handle_runs)
+    app.router.add_get("/v1/runs/{run_id}", adapter._handle_get_run)
+    app.router.add_post("/v1/runs/{run_id}/approval", adapter._handle_run_approval)
+    app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
+    app.router.add_post("/v1/responses", adapter._handle_responses)
+    return app
+
+
+async def _run_status(client: TestClient, run_id: str) -> dict:
+    response = await client.get(f"/v1/runs/{run_id}")
+    assert response.status == 200
+    return await response.json()
+
+
+async def _wait_for_status(
+    client: TestClient, run_id: str, expected: str, *, timeout: float = 4.0
+) -> dict:
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        last = await _run_status(client, run_id)
+        if last.get("status") == expected:
+            return last
+        await asyncio.sleep(0.02)
+    raise AssertionError(f"run {run_id} did not reach {expected!r}: {last!r}")
+
+
+def _isolated_approval(monkeypatch):
+    """Keep tests independent from the live host policy and approval state."""
+    monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
+    monkeypatch.setattr(approval_context, "_get_approval_mode", lambda: "manual")
+    monkeypatch.setattr(
+        approval_context, "_get_unattended_approval_mode", lambda: "deny"
+    )
+
+
+def _clear_run_approval(run_id: str) -> None:
+    approval_module.clear_session(run_id)
+    with approval_module._lock:
+        approval_module._gateway_queues.pop(run_id, None)
+        approval_module._gateway_notify_cbs.pop(run_id, None)
+
+
+@pytest.mark.asyncio
+async def test_runs_execute_code_approval_round_trip_once(monkeypatch):
+    """A real /v1/runs resolver must emit and resolve a one-shot approval."""
+    _isolated_approval(monkeypatch)
+    adapter = _make_adapter()
+    seen: list[dict] = []
+    agent = _GuardAgent(seen)
+
+    async with TestClient(TestServer(_create_app(adapter))) as client:
+        with patch.object(adapter, "_create_agent", return_value=agent):
+            response = await client.post(
+                "/v1/runs", json={"input": "safe approval control-flow probe"}
+            )
+        assert response.status == 202
+        run_id = (await response.json())["run_id"]
+
+        waiting = await _wait_for_status(client, run_id, "waiting_for_approval")
+        assert waiting["approval"]["event"] == "approval.request"
+        assert waiting["approval"]["run_id"] == run_id
+        assert seen == []
+        assert getattr(adapter, "_run_approval_sessions")[run_id] == run_id
+
+        approval_response = await client.post(
+            f"/v1/runs/{run_id}/approval", json={"choice": "once"}
+        )
+        assert approval_response.status == 200
+        assert (await approval_response.json())["resolved"] == 1
+
+        completed = await _wait_for_status(client, run_id, "completed")
+        assert completed["output"] == "approval-probe continued"
+        assert seen[0]["approved"] is True
+        assert seen[0].get("user_approved") is True
+
+    _clear_run_approval(run_id)
+
+
+@pytest.mark.asyncio
+async def test_runs_execute_code_explicit_deny_stops_before_continuation(monkeypatch):
+    """The same run-scoped transport must honor an explicit deny."""
+    _isolated_approval(monkeypatch)
+    adapter = _make_adapter()
+    seen: list[dict] = []
+    agent = _GuardAgent(seen)
+
+    async with TestClient(TestServer(_create_app(adapter))) as client:
+        with patch.object(adapter, "_create_agent", return_value=agent):
+            response = await client.post("/v1/runs", json={"input": "deny probe"})
+        run_id = (await response.json())["run_id"]
+        await _wait_for_status(client, run_id, "waiting_for_approval")
+
+        approval_response = await client.post(
+            f"/v1/runs/{run_id}/approval", json={"choice": "deny"}
+        )
+        assert approval_response.status == 200
+
+        completed = await _wait_for_status(client, run_id, "completed")
+        assert "BLOCKED" in completed["output"]
+        assert seen[0]["approved"] is False
+        assert seen[0]["outcome"] == "denied"
+
+    _clear_run_approval(run_id)
+
+
+@pytest.mark.asyncio
+async def test_runs_approval_isolated_between_simultaneous_runs(monkeypatch):
+    """Approving one run must not resolve another run's pending guard."""
+    _isolated_approval(monkeypatch)
+    adapter = _make_adapter()
+    seen_a: list[dict] = []
+    seen_b: list[dict] = []
+    agents = [_GuardAgent(seen_a), _GuardAgent(seen_b)]
+
+    async with TestClient(TestServer(_create_app(adapter))) as client:
+        with patch.object(adapter, "_create_agent", side_effect=agents):
+            first = await client.post("/v1/runs", json={"input": "run A"})
+            second = await client.post("/v1/runs", json={"input": "run B"})
+        run_a = (await first.json())["run_id"]
+        run_b = (await second.json())["run_id"]
+
+        await _wait_for_status(client, run_a, "waiting_for_approval")
+        await _wait_for_status(client, run_b, "waiting_for_approval")
+
+        approval_response = await client.post(
+            f"/v1/runs/{run_a}/approval", json={"choice": "once"}
+        )
+        assert approval_response.status == 200
+        await _wait_for_status(client, run_a, "completed")
+        still_waiting = await _run_status(client, run_b)
+        assert still_waiting["status"] == "waiting_for_approval"
+        assert seen_b == []
+
+        denial_response = await client.post(
+            f"/v1/runs/{run_b}/approval", json={"choice": "deny"}
+        )
+        assert denial_response.status == 200
+        await _wait_for_status(client, run_b, "completed")
+        assert seen_a[0]["approved"] is True
+        assert seen_b[0]["approved"] is False
+
+    _clear_run_approval(run_a)
+    _clear_run_approval(run_b)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("choice", ["session", "always"])
+async def test_runs_persistent_choice_applies_only_inside_that_run(monkeypatch, choice):
+    """Persistent approval choices stay local to the run's exact approval key."""
+    _isolated_approval(monkeypatch)
+    adapter = _make_adapter()
+    seen: list[dict] = []
+    agent = _GuardAgent(seen, calls=2)
+
+    async with TestClient(TestServer(_create_app(adapter))) as client:
+        with patch.object(adapter, "_create_agent", return_value=agent):
+            response = await client.post("/v1/runs", json={"input": "session probe"})
+        run_id = (await response.json())["run_id"]
+        await _wait_for_status(client, run_id, "waiting_for_approval")
+
+        approval_response = await client.post(
+            f"/v1/runs/{run_id}/approval", json={"choice": choice}
+        )
+        assert approval_response.status == 200
+        completed = await _wait_for_status(client, run_id, "completed")
+
+        assert completed["output"] == "approval-probe continued"
+        assert len(seen) == 2
+        assert all(result["approved"] is True for result in seen)
+
+    _clear_run_approval(run_id)
+    with approval_module._lock:
+        approval_module._permanent_approved.discard("execute_code")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("endpoint", "payload"),
+    [
+        (
+            "/v1/chat/completions",
+            {"messages": [{"role": "user", "content": "chat probe"}]},
+        ),
+        ("/v1/responses", {"input": "responses probe", "store": False}),
+    ],
+)
+async def test_listenerless_openai_routes_keep_execute_code_fail_closed(
+    monkeypatch, endpoint, payload
+):
+    """OpenAI routes have no approval responder and must not create a waiter."""
+    _isolated_approval(monkeypatch)
+    adapter = _make_adapter()
+    seen: list[dict] = []
+
+    async with TestClient(TestServer(_create_app(adapter))) as client:
+        with patch.object(adapter, "_create_agent", return_value=_GuardAgent(seen)):
+            response = await client.post(endpoint, json=payload)
+        assert response.status == 200
+        assert seen[0]["approved"] is False
+        assert seen[0]["outcome"] == "blocked"
+        assert not approval_module._gateway_queues
+        assert not approval_module._pending
+
+
+@pytest.mark.asyncio
+async def test_runs_resolver_does_not_bypass_hardline_floor(monkeypatch):
+    """A resolver-backed run still stops before ordinary human approval."""
+    _isolated_approval(monkeypatch)
+    adapter = _make_adapter()
+    seen: list[dict] = []
+
+    async with TestClient(TestServer(_create_app(adapter))) as client:
+        with patch.object(
+            adapter, "_create_agent", return_value=_GuardAgent(seen, hardline=True)
+        ):
+            response = await client.post("/v1/runs", json={"input": "floor probe"})
+        run_id = (await response.json())["run_id"]
+        completed = await _wait_for_status(client, run_id, "completed")
+
+        assert completed["output"]
+        assert seen[0]["approved"] is False
+        assert seen[0]["hardline"] is True
+        assert run_id not in approval_module._gateway_queues
+
+    _clear_run_approval(run_id)

--- a/tests/gateway/test_api_server_approval_scope.py
+++ b/tests/gateway/test_api_server_approval_scope.py
@@ -175,6 +175,10 @@ async def test_runs_execute_code_approval_round_trip_once(monkeypatch):
         assert seen[0]["approved"] is True
         assert seen[0].get("user_approved") is True
 
+        stop_after_approval = await client.post(f"/v1/runs/{run_id}/stop")
+        assert stop_after_approval.status == 200
+        assert (await stop_after_approval.json())["status"] == "completed"
+
     _clear_run_approval(run_id)
 
 

--- a/tests/gateway/test_api_server_approval_scope.py
+++ b/tests/gateway/test_api_server_approval_scope.py
@@ -9,6 +9,7 @@ lifecycle with a small agent double whose only work is the harmless
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -56,6 +57,35 @@ class _GuardAgent:
         return {"final_response": "approval-probe continued", "messages": []}
 
 
+class _InterruptibleGuardAgent(_GuardAgent):
+    """Guard agent whose worker-thread wait can be interrupted by lifecycle control."""
+
+    def __init__(self, seen: list[dict]):
+        super().__init__(seen)
+        self.worker_thread_id = None
+        self.continued = threading.Event()
+
+    def run_conversation(self, **kwargs):
+        from tools.interrupt import is_interrupted, set_interrupt
+
+        self.worker_thread_id = threading.get_ident()
+        set_interrupt(False)
+        try:
+            result = super().run_conversation(**kwargs)
+            if is_interrupted():
+                result["interrupted"] = True
+            if result.get("final_response") == "approval-probe continued":
+                self.continued.set()
+            return result
+        finally:
+            set_interrupt(False, self.worker_thread_id)
+
+    def interrupt(self, _message=None):
+        from tools.interrupt import set_interrupt
+
+        set_interrupt(True, self.worker_thread_id)
+
+
 def _make_adapter() -> APIServerAdapter:
     return APIServerAdapter(PlatformConfig(enabled=True, extra={}))
 
@@ -71,6 +101,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/v1/runs", adapter._handle_runs)
     app.router.add_get("/v1/runs/{run_id}", adapter._handle_get_run)
     app.router.add_post("/v1/runs/{run_id}/approval", adapter._handle_run_approval)
+    app.router.add_post("/v1/runs/{run_id}/stop", adapter._handle_stop_run)
     app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
     app.router.add_post("/v1/responses", adapter._handle_responses)
     return app
@@ -143,6 +174,68 @@ async def test_runs_execute_code_approval_round_trip_once(monkeypatch):
         assert completed["output"] == "approval-probe continued"
         assert seen[0]["approved"] is True
         assert seen[0].get("user_approved") is True
+
+    _clear_run_approval(run_id)
+
+
+@pytest.mark.asyncio
+async def test_pending_approval_stop_wins_over_racing_once(monkeypatch):
+    """A successful stop invalidates approval before a racing once can continue the tool."""
+    _isolated_approval(monkeypatch)
+    adapter = _make_adapter()
+    seen: list[dict] = []
+    agent = _InterruptibleGuardAgent(seen)
+
+    async with TestClient(TestServer(_create_app(adapter))) as client:
+        with patch.object(adapter, "_create_agent", return_value=agent):
+            response = await client.post("/v1/runs", json={"input": "stop race probe"})
+        run_id = (await response.json())["run_id"]
+        await _wait_for_status(client, run_id, "waiting_for_approval")
+
+        stop_response = await client.post(f"/v1/runs/{run_id}/stop")
+        assert stop_response.status == 200
+        assert (await stop_response.json())["status"] == "stopping"
+
+        racing_approval = await client.post(
+            f"/v1/runs/{run_id}/approval", json={"choice": "once"}
+        )
+        assert racing_approval.status == 409
+        assert (await racing_approval.json())["error"]["code"] == "approval_not_active"
+
+        cancelled = await _wait_for_status(client, run_id, "cancelled")
+        assert cancelled["status"] == "cancelled"
+        assert seen and seen[0]["approved"] is False
+        assert not agent.continued.is_set()
+
+    _clear_run_approval(run_id)
+
+
+@pytest.mark.asyncio
+async def test_pending_approval_gateway_shutdown_wins_over_racing_once(monkeypatch):
+    """Gateway shutdown invalidates every live run resolver before approval can continue it."""
+    _isolated_approval(monkeypatch)
+    adapter = _make_adapter()
+    seen: list[dict] = []
+    agent = _InterruptibleGuardAgent(seen)
+
+    async with TestClient(TestServer(_create_app(adapter))) as client:
+        with patch.object(adapter, "_create_agent", return_value=agent):
+            response = await client.post("/v1/runs", json={"input": "shutdown race probe"})
+        run_id = (await response.json())["run_id"]
+        await _wait_for_status(client, run_id, "waiting_for_approval")
+
+        assert adapter.interrupt_active_runs("gateway shutdown") == 1
+
+        racing_approval = await client.post(
+            f"/v1/runs/{run_id}/approval", json={"choice": "once"}
+        )
+        assert racing_approval.status == 409
+        assert (await racing_approval.json())["error"]["code"] == "approval_not_active"
+
+        cancelled = await _wait_for_status(client, run_id, "cancelled")
+        assert cancelled["status"] == "cancelled"
+        assert seen and seen[0]["approved"] is False
+        assert not agent.continued.is_set()
 
     _clear_run_approval(run_id)
 

--- a/tests/gateway/test_api_server_approval_scope.py
+++ b/tests/gateway/test_api_server_approval_scope.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -241,6 +242,41 @@ async def test_runs_persistent_choice_applies_only_inside_that_run(monkeypatch, 
     _clear_run_approval(run_id)
     with approval_module._lock:
         approval_module._permanent_approved.discard("execute_code")
+
+
+@pytest.mark.asyncio
+async def test_revoked_run_notifier_cannot_restore_waiting_status():
+    """A late approval callback cannot resurrect a run after resolver teardown."""
+    from gateway.platforms.api_server_runs import _make_approval_notify
+
+    class _StatusOwner:
+        def __init__(self):
+            self.statuses = {}
+
+        def _set_run_status(self, run_id, status, **fields):
+            self.statuses[run_id] = {"status": status, **fields}
+
+        @staticmethod
+        def _approval_event_choices(**_kwargs):
+            return ["once", "session", "always", "deny"]
+
+    owner = _StatusOwner()
+    run_id = "run_revoked_notifier"
+    resolver = approval_context.create_approval_resolver(run_id)
+    assert resolver.activate() is True
+    run = SimpleNamespace(
+        run_id=run_id,
+        queue=asyncio.Queue(),
+        approval_resolver=resolver,
+    )
+    notify = _make_approval_notify(owner, run, _api_server=owner)
+
+    resolver.revoke()
+    notify({"pattern_key": "execute_code", "description": "late approval"})
+    await asyncio.sleep(0)
+
+    assert owner.statuses == {}
+    assert run.queue.empty()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -1524,7 +1524,12 @@ class TestHostedRoomRuns:
             "request_id": "approval-B",
             "command": "rm -rf build-B",
         })
+        from tools.approval_context import create_approval_resolver
+
+        resolver = create_approval_resolver(run_id)
+        assert resolver.activate() is True
         auth_adapter._run_approval_sessions[run_id] = run_id
+        auth_adapter._run_approval_resolvers[run_id] = resolver
         auth_adapter._run_statuses[run_id] = {
             "run_id": run_id,
             "status": "waiting_for_approval",
@@ -1559,6 +1564,7 @@ class TestHostedRoomRuns:
                     exact_body = await exact.json()
         finally:
             approval_mod.unregister_gateway_notify(run_id)
+            auth_adapter._run_approval_resolvers.pop(run_id, None)
 
         assert missing.status == 400
         assert missing_body["error"]["code"] == "approval_request_required"

--- a/tests/gateway/test_api_server_runs_extraction.py
+++ b/tests/gateway/test_api_server_runs_extraction.py
@@ -138,6 +138,7 @@ def test_run_state_initialization_and_teardown_are_shard_owned():
     assert adapter._stopping_run_ids == set()
     assert adapter._run_statuses == {}
     assert adapter._run_approval_sessions == {}
+    assert adapter._run_approval_resolvers == {}
 
     api_server_runs._close_run_state(adapter)
     store.close.assert_called_once_with()

--- a/tests/tools/test_api_server_approval_scope.py
+++ b/tests/tools/test_api_server_approval_scope.py
@@ -1,0 +1,258 @@
+"""Unit witnesses for the resolver-backed approval boundary."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from gateway.session_context import clear_session_vars, set_session_vars
+from gateway.platforms.api_server_runs import _unregister_approval_notify
+from tools import approval as approval_module
+from tools import approval_context
+
+
+@pytest.fixture(autouse=True)
+def isolate_approval_state(monkeypatch):
+    monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
+    monkeypatch.setattr(approval_context, "_get_approval_mode", lambda: "manual")
+    monkeypatch.setattr(
+        approval_context, "_get_unattended_approval_mode", lambda: "deny"
+    )
+    yield
+    with approval_module._lock:
+        approval_module._gateway_queues.clear()
+        approval_module._gateway_notify_cbs.clear()
+        approval_module._pending.clear()
+
+
+@pytest.mark.parametrize("platform", ["webhook", "msgraph_webhook"])
+def test_notifier_only_unattended_platform_stays_fail_closed(platform):
+    """An outbound notifier does not prove that a client can resolve approval."""
+    key = f"notifier-only-{platform}"
+    tokens = set_session_vars(platform=platform, session_key=key)
+    session_token = approval_context.set_current_session_key(key)
+    notified: list[dict] = []
+    approval_module.register_gateway_notify(key, notified.append)
+    try:
+        result = approval_module.check_execute_code_guard(
+            "print('unattended probe')", "local"
+        )
+        assert approval_context._is_gateway_approval_context() is False
+        assert result["approved"] is False
+        assert result["outcome"] == "blocked"
+        assert notified == []
+        assert key not in approval_module._gateway_queues
+    finally:
+        approval_module.unregister_gateway_notify(key)
+        approval_context.reset_current_session_key(session_token)
+        clear_session_vars(tokens)
+
+
+def test_api_server_listenerless_execute_code_stays_fail_closed():
+    """An API session without the explicit run capability remains unattended."""
+    key = "listenerless-api"
+    tokens = set_session_vars(platform="api_server", session_key=key)
+    session_token = approval_context.set_current_session_key(key)
+    try:
+        result = approval_module.check_execute_code_guard(
+            "print('listenerless probe')", "local"
+        )
+        assert approval_context._is_gateway_approval_context() is False
+        assert result["approved"] is False
+        assert result["outcome"] == "blocked"
+        assert key not in approval_module._gateway_queues
+    finally:
+        approval_context.reset_current_session_key(session_token)
+        clear_session_vars(tokens)
+
+
+def test_api_server_notifier_only_does_not_grant_resolver_capability():
+    """The shared outbound callback registry is not an inbound run resolver."""
+    key = "notifier-only-api-server"
+    tokens = set_session_vars(platform="api_server", session_key=key)
+    session_token = approval_context.set_current_session_key(key)
+    notified: list[dict] = []
+    approval_module.register_gateway_notify(key, notified.append)
+    try:
+        result = approval_module.check_execute_code_guard(
+            "print('notifier-only probe')", "local"
+        )
+        assert approval_context._is_gateway_approval_context() is False
+        assert result["approved"] is False
+        assert result["outcome"] == "blocked"
+        assert notified == []
+        assert key not in approval_module._gateway_queues
+    finally:
+        approval_module.unregister_gateway_notify(key)
+        approval_context.reset_current_session_key(session_token)
+        clear_session_vars(tokens)
+
+
+def test_resolver_capability_requires_exact_api_session_key():
+    """The capability cannot bleed into a different concurrent session."""
+    key = "resolver-api-session"
+    tokens = set_session_vars(platform="api_server", session_key=key)
+    session_token = approval_context.set_current_session_key(key)
+    resolver = approval_context.create_approval_resolver(key)
+    resolver.activate()
+    resolver_token = approval_context.set_current_approval_resolver(resolver)
+    try:
+        assert approval_context._is_unattended_platform_approval_context() is False
+        assert approval_context._is_gateway_approval_context() is True
+
+        other_session_token = approval_context.set_current_session_key("other-session")
+        try:
+            assert approval_context._is_unattended_platform_approval_context() is True
+            assert approval_context._is_gateway_approval_context() is False
+        finally:
+            approval_context.reset_current_session_key(other_session_token)
+    finally:
+        resolver.revoke()
+        approval_context.reset_current_approval_resolver(resolver_token)
+        approval_context.reset_current_session_key(session_token)
+        clear_session_vars(tokens)
+
+
+def test_revoked_run_resolver_fails_closed_before_notifier_teardown(monkeypatch):
+    """A cancelled run cannot leave a late tool call with an unanswerable waiter."""
+    key = "revoked-api-run"
+    tokens = set_session_vars(platform="api_server", session_key=key)
+    session_token = approval_context.set_current_session_key(key)
+    resolver = approval_context.create_approval_resolver(key)
+    resolver.activate()
+    resolver_token = approval_context.set_current_approval_resolver(resolver)
+    notified: list[dict] = []
+    approval_module.register_gateway_notify(key, notified.append)
+    try:
+        _unregister_approval_notify(key, resolver)
+        # Model the race where the gate computed ``is_gateway=True`` just
+        # before cancellation revoked the capability and removed the notifier.
+        monkeypatch.setattr(
+            approval_module,
+            "_presence",
+            lambda *_args, **_kwargs: (None, False, True, False),
+        )
+        monkeypatch.setattr(approval_module, "_unattended_contexts", lambda: [])
+        result = approval_module.check_execute_code_guard(
+            "print('late cancellation probe')", "local"
+        )
+        assert result["approved"] is False
+        assert result["outcome"] == "blocked"
+        assert result.get("status") != "pending_approval"
+        assert notified == []
+        assert key not in approval_module._gateway_queues
+    finally:
+        approval_module.unregister_gateway_notify(key)
+        approval_context.reset_current_approval_resolver(resolver_token)
+        approval_context.reset_current_session_key(session_token)
+        clear_session_vars(tokens)
+
+
+def test_gateway_wait_rechecks_revocable_api_resolver_before_enqueuing(monkeypatch):
+    """A late guard must not enqueue after cancellation already released the resolver."""
+    from tools import approval_gateway_wait
+
+    key = "revoked-before-gateway-wait"
+    tokens = set_session_vars(platform="api_server", session_key=key)
+    session_token = approval_context.set_current_session_key(key)
+    resolver = approval_context.create_approval_resolver(key)
+    resolver.activate()
+    resolver_token = approval_context.set_current_approval_resolver(resolver)
+    notified: list[dict] = []
+    approval_module.register_gateway_notify(key, notified.append)
+    monkeypatch.setattr(
+        approval_gateway_wait, "_poll_event", lambda *_args, **_kwargs: "timeout"
+    )
+    try:
+        _unregister_approval_notify(key, resolver)
+        result = approval_gateway_wait._await_gateway_decision(
+            key,
+            notified.append,
+            {"command": "late", "description": "late", "pattern_key": "execute_code"},
+        )
+        assert result["resolved"] is False
+        assert result["reason"] == "approval resolver unavailable"
+        assert notified == []
+        assert key not in approval_module._gateway_queues
+    finally:
+        approval_module.unregister_gateway_notify(key)
+        approval_context.reset_current_approval_resolver(resolver_token)
+        approval_context.reset_current_session_key(session_token)
+        clear_session_vars(tokens)
+
+
+def test_execute_code_entrypoint_propagates_run_resolver_to_kernel_worker(monkeypatch):
+    """The real execute_code entry point retains the run capability across its worker hop."""
+    from tools import code_execution_tool, code_kernel, terminal_tool, terminal_scope
+    from tools import process_registry
+    from tools.thread_context import propagate_context_to_thread
+
+    key = "execute-code-worker-api-run"
+    tokens = set_session_vars(platform="api_server", session_key=key)
+    session_token = approval_context.set_current_session_key(key)
+    resolver = approval_context.create_approval_resolver(key)
+    resolver.activate()
+    resolver_token = approval_context.set_current_approval_resolver(resolver)
+    with approval_module._lock:
+        approval_module._permanent_approved.discard("execute_code")
+    seen: dict[str, bool] = {}
+
+    def resolve_once(data: dict):
+        approval_module.resolve_gateway_approval(
+            key, "once", request_id=data["request_id"]
+        )
+
+    approval_module.register_gateway_notify(key, resolve_once)
+    monkeypatch.setattr(code_execution_tool, "SANDBOX_AVAILABLE", True)
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: {"env_type": "local"})
+    monkeypatch.setattr(terminal_tool, "_docker_has_host_access", lambda _config: False)
+    monkeypatch.setattr(terminal_scope, "enforce_no_refusal", lambda: None)
+    monkeypatch.setattr(
+        process_registry, "_is_supervised_gateway_process", lambda: False
+    )
+    monkeypatch.setattr(
+        code_execution_tool, "_load_config", lambda: {"timeout": 1, "max_tool_calls": 1}
+    )
+    monkeypatch.setattr(code_execution_tool, "_get_execution_mode", lambda: "project")
+
+    def fake_kernel(_code, **_kwargs):
+        seen["resolver"] = approval_context._has_current_approval_resolver()
+        return "kernel-result"
+
+    monkeypatch.setattr(code_kernel, "execute_in_session_kernel", fake_kernel)
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            result = executor.submit(
+                propagate_context_to_thread(
+                    lambda: code_execution_tool.execute_code(
+                        "print('worker approval probe')", task_id=key
+                    )
+                )
+            ).result(timeout=5)
+        assert result == "kernel-result"
+        assert seen["resolver"] is True
+    finally:
+        approval_module.unregister_gateway_notify(key)
+        approval_context.reset_current_approval_resolver(resolver_token)
+        approval_context.reset_current_session_key(session_token)
+        clear_session_vars(tokens)
+
+
+def test_hardline_floor_precedes_any_approval_transport():
+    """A representative hardline command remains unconditionally blocked."""
+    key = "hardline-api"
+    tokens = set_session_vars(platform="api_server", session_key=key)
+    session_token = approval_context.set_current_session_key(key)
+    notified: list[dict] = []
+    approval_module.register_gateway_notify(key, notified.append)
+    try:
+        result = approval_module.check_all_command_guards("rm -rf /", "local")
+        assert result["approved"] is False
+        assert result["hardline"] is True
+        assert notified == []
+        assert key not in approval_module._gateway_queues
+    finally:
+        approval_module.unregister_gateway_notify(key)
+        approval_context.reset_current_session_key(session_token)
+        clear_session_vars(tokens)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -126,10 +126,13 @@ def register_gateway_notify(session_key: str, cb) -> None:
         _gateway_notify_cbs[session_key] = cb
 
 
-def unregister_gateway_notify(session_key: str) -> None:
+def unregister_gateway_notify(session_key: str, approval_resolver=None) -> None:
     """Unregister the callback and wake ALL blocked threads for this session so
-    they don't hang forever (agent run finished or interrupted)."""
+    they don't hang forever (agent run finished or interrupted). Revoke an
+    optional run resolver under the same lock as queue teardown."""
     with _lock:
+        if approval_resolver is not None:
+            approval_resolver.revoke()
         _gateway_notify_cbs.pop(session_key, None)
         entries = _gateway_queues.pop(session_key, [])
     for entry in entries:
@@ -728,6 +731,18 @@ def _human_decision(spec: _GateSpec, *, command: str, description: str,
         if spec.user_approved:
             return _user_approved(session_key, description)
         return _approved()
+
+    # A run cancellation can revoke the resolver after presence/unattended checks
+    # but before this shared decision engine reaches the gateway branch. Never
+    # create a pending approval once the exact API run can no longer receive a reply.
+    if is_gateway and not approval_context._api_approval_resolver_available(session_key):
+        return deny(
+            spec.gateway_refused,
+            "blocked",
+            reason="approval resolver unavailable",
+            reason_addendum="",
+            timeout_addendum="",
+        )
 
     if spec.transport:
         attempt = _present_with_selected_transport(

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -136,13 +136,18 @@ def unregister_gateway_notify(session_key: str, approval_resolver=None) -> None:
         _gateway_notify_cbs.pop(session_key, None)
         entries = _gateway_queues.pop(session_key, [])
     for entry in entries:
+        # A lifecycle teardown is a deny/cancel wake, not an approval. Preserve an
+        # already-recorded user choice if the approval endpoint won the queue race.
+        if entry.result is None:
+            entry.result = "deny"
         entry.event.set()
 
 
 def resolve_gateway_approval(session_key: str, choice: str,
                              resolve_all: bool = False,
                              reason: Optional[str] = None,
-                             request_id: Optional[str] = None) -> int:
+                             request_id: Optional[str] = None,
+                             approval_resolver=None) -> int:
     """Unblock waiting agent thread(s) from the gateway's /approve or /deny handler.
 
     *resolve_all* resolves every pending approval (``/approve all``); otherwise the oldest
@@ -150,6 +155,10 @@ def resolve_gateway_approval(session_key: str, choice: str,
     relayed to the agent in the BLOCKED message. Returns the number resolved.
     """
     with _lock:
+        # API-run lifecycle cancellation and approval resolution share this queue lock. Once
+        # the owning resolver is revoked, a stale endpoint must not release any waiter as approved.
+        if approval_resolver is not None and not approval_resolver.is_active():
+            return 0
         queue = _gateway_queues.get(session_key)
         if not queue:
             return 0

--- a/tools/approval_context.py
+++ b/tools/approval_context.py
@@ -9,6 +9,7 @@ import contextvars
 import logging
 import os
 import threading
+from contextlib import contextmanager
 from hermes_cli.config import cfg_get
 from utils import env_var_enabled, is_truthy_value
 
@@ -48,6 +49,12 @@ class ApprovalResolverCapability:
         """Return whether the owning run still has a live inbound resolver."""
         with self._lock:
             return self._active
+
+    @contextmanager
+    def active_scope(self):
+        """Hold the lifecycle lock while publishing one resolver-owned event."""
+        with self._lock:
+            yield self._active
 
 
 # Per-thread/per-task gateway session identity: gateway runs agent turns concurrently in executor threads, so a

--- a/tools/approval_context.py
+++ b/tools/approval_context.py
@@ -8,6 +8,7 @@ gate in :mod:`tools.approval`.
 import contextvars
 import logging
 import os
+import threading
 from hermes_cli.config import cfg_get
 from utils import env_var_enabled, is_truthy_value
 
@@ -16,6 +17,37 @@ logger = logging.getLogger("tools.approval")
 
 def _ctx(name: str, default: "str | None" = "") -> contextvars.ContextVar:
     return contextvars.ContextVar(name, default=default)
+
+
+class ApprovalResolverCapability:
+    """Revocable proof that one exact API run has an inbound approval resolver."""
+
+    __slots__ = ("session_key", "_lock", "_active", "_revoked")
+
+    def __init__(self, session_key: str):
+        self.session_key = session_key or ""
+        self._lock = threading.Lock()
+        self._active = False
+        self._revoked = False
+
+    def activate(self) -> bool:
+        """Mark the resolver usable unless its owning run was already revoked."""
+        with self._lock:
+            if self._revoked:
+                return False
+            self._active = True
+            return True
+
+    def revoke(self) -> None:
+        """Permanently disable this run's approval capability."""
+        with self._lock:
+            self._revoked = True
+            self._active = False
+
+    def is_active(self) -> bool:
+        """Return whether the owning run still has a live inbound resolver."""
+        with self._lock:
+            return self._active
 
 
 # Per-thread/per-task gateway session identity: gateway runs agent turns concurrently in executor threads, so a
@@ -82,6 +114,39 @@ def reset_current_session_key(token: contextvars.Token[str]) -> None:
     _approval_session_key.reset(token)
 
 
+_approval_resolver_session_key: contextvars.ContextVar[ApprovalResolverCapability | None] = _ctx(
+    "approval_resolver_session_key", None)
+
+
+def create_approval_resolver(session_key: str) -> ApprovalResolverCapability:
+    """Create an inactive capability for one API run before its resolver is registered."""
+    return ApprovalResolverCapability(session_key)
+
+
+def set_current_approval_resolver(
+    resolver: ApprovalResolverCapability,
+) -> contextvars.Token[ApprovalResolverCapability | None]:
+    """Bind the exact capability backed by a live inbound approval resolver."""
+    return _approval_resolver_session_key.set(resolver)
+
+
+def reset_current_approval_resolver(token: contextvars.Token[ApprovalResolverCapability | None]) -> None:
+    """Restore the prior resolver-backed approval capability."""
+    _approval_resolver_session_key.reset(token)
+
+
+def _has_current_approval_resolver() -> bool:
+    """Return true only for an API run whose exact approval key has an inbound resolver."""
+    resolver = _approval_resolver_session_key.get()
+    return (
+        _get_session_platform() == "api_server"
+        and resolver is not None
+        and resolver.is_active()
+        and bool(resolver.session_key)
+        and resolver.session_key == get_current_session_key(default="")
+    )
+
+
 _Tokens = tuple[contextvars.Token[str], contextvars.Token[str], contextvars.Token[str]]
 
 
@@ -105,6 +170,13 @@ def get_current_session_key(default: str = "default") -> str:
         return session_key
     from gateway.session_context import get_session_env
     return get_session_env("HERMES_SESSION_KEY", default)
+
+
+def _api_approval_resolver_available(session_key: str) -> bool:
+    """Return whether an API approval wait still has its exact live resolver."""
+    if _get_session_platform() != "api_server":
+        return True
+    return _has_current_approval_resolver() and get_current_session_key(default="") == session_key
 
 
 def _session_env(name: str) -> str:
@@ -138,11 +210,15 @@ def _is_unattended_platform_approval_context() -> bool:
     """True when the session platform is a programmatic/unattended surface.
 
     Webhook, msgraph_webhook, and api_server sessions bind ``HERMES_SESSION_PLATFORM`` like chat gateways
-    do, but there is no human who can resolve a pending approval. Treating them as gateway approval contexts
+    do, but there is no human who can resolve a pending approval unless the exact API run key is backed by
+    the ``/v1/runs/{run_id}/approval`` resolver. Treating listener-less sessions as gateway approval contexts
     blocks the session for the full approval timeout (60-300s) and then fails closed anyway — the deadlock
     in #37284/#87509.
     """
-    return _get_session_platform() in _UNATTENDED_APPROVAL_PLATFORMS
+    return (
+        _get_session_platform() in _UNATTENDED_APPROVAL_PLATFORMS
+        and not _has_current_approval_resolver()
+    )
 
 
 def _is_single_query_approval_context() -> bool:
@@ -163,8 +239,10 @@ def _is_gateway_approval_context() -> bool:
     delivery routing): falling through would submit a pending approval with no
     listener and block the job indefinitely; unattended platforms likewise.
 
-    Unattended programmatic platforms (webhook, msgraph_webhook, api_server) are excluded for the same
-    reason: those adapters have no ``send_exec_approval`` and no way to receive ``/approve`` replies.
+    Unattended programmatic platforms (webhook, msgraph_webhook, and listener-less api_server routes) are excluded
+    for the same reason: those adapters have no ``send_exec_approval`` and no way to receive ``/approve`` replies.
+    A ``/v1/runs`` turn is the narrow exception because its exact run key is bound to the authenticated approval
+    resolver for ``POST /v1/runs/{run_id}/approval``.
     Submitting a pending approval there blocks the session for the full approval timeout (60-300 s) with no
     human who can resolve it (#37284, 87509). Their dangerous-command handling is governed by
     ``approvals.unattended_mode`` config (default deny), mirroring cron.

--- a/tools/approval_gateway_wait.py
+++ b/tools/approval_gateway_wait.py
@@ -117,6 +117,12 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict, *,
     the leader, so the follower falls through to a fresh prompt."""
     from tools import approval as _approval
 
+    # A cancelled /v1/runs executor can outlive the request task. Re-check the
+    # revocable capability before adding a new queue entry, so a stale worker
+    # cannot create an approval nobody can resolve after teardown.
+    if not _ctx._api_approval_resolver_available(session_key):
+        return {"resolved": False, "choice": "deny", "reason": "approval resolver unavailable"}
+
     primary_key = approval_data.get("pattern_key", "")
     payload = {
         "command": approval_data.get("command", ""),
@@ -127,6 +133,8 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict, *,
     }
     keys = list(approval_data.get("pattern_keys") or [])
     with _approval._lock:
+        if not _ctx._api_approval_resolver_available(session_key):
+            return {"resolved": False, "choice": "deny", "reason": "approval resolver unavailable"}
         leader = next((e for e in _approval._gateway_queues.get(session_key, [])
                        if e.data.get("command") == approval_data.get("command")
                        and list(e.data.get("pattern_keys") or []) == keys), None)
@@ -137,6 +145,8 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict, *,
 
     entry = _ApprovalEntry(approval_data)
     with _approval._lock:
+        if not _ctx._api_approval_resolver_available(session_key):
+            return {"resolved": False, "choice": "deny", "reason": "approval resolver unavailable"}
         _approval._gateway_queues.setdefault(session_key, []).append(entry)
 
     def _drop_entry() -> None:

--- a/tools/approval_gateway_wait.py
+++ b/tools/approval_gateway_wait.py
@@ -36,7 +36,8 @@ class _ApprovalEntry:
         self.reason: str | None = None
 
 
-def _poll_event(event: threading.Event, session_key: str, *, interrupt_log: str) -> str:
+def _poll_event(event: threading.Event, session_key: str, *, interrupt_log: str,
+                wake_is_cancelled=None) -> str:
     """Wait on *event* until it fires, the turn is interrupted, or approvals.timeout
     elapses; returns ``"set"`` | ``"interrupted"`` | ``"timeout"``. Polls in ~1s
     slices so activity heartbeats reach the agent's inactivity tracker every ~10s —
@@ -63,6 +64,12 @@ def _poll_event(event: threading.Event, session_key: str, *, interrupt_log: str)
             if remaining <= 0:
                 return "timeout"
             if event.wait(timeout=min(1.0, remaining)):
+                # A lifecycle revoke wakes the same Event used by an approval response. Recheck
+                # cancellation after wake so that wakeup cannot be mistaken for approval.
+                cancelled = wake_is_cancelled() if wake_is_cancelled is not None else is_interrupted()
+                if cancelled:
+                    logger.info(interrupt_log, session_key)
+                    return "interrupted"
                 return "set"
             heartbeat()
 
@@ -85,9 +92,12 @@ def _await_coalesced_leader(session_key: str, leader, payload: dict):
     so the caller must issue a fresh prompt. Hooks fire with ``coalesced=True``
     so observers see the follower's lifecycle without a duplicate prompt."""
     _ctx._fire_approval_hook("pre_approval_request", **payload, coalesced=True)
-    state = _poll_event(leader.event, session_key,
-                        interrupt_log="Coalesced approval wait interrupted by user signal — "
-                                      "returning deny for session %s")
+    state = _poll_event(
+        leader.event, session_key,
+        interrupt_log="Coalesced approval wait interrupted by user signal — returning deny for session %s",
+        wake_is_cancelled=lambda: leader.result is None and (
+            is_interrupted() or not _ctx._api_approval_resolver_available(session_key)),
+    )
     if state == "interrupted":
         # Deny only OUR follower; the leader thread handles its own signal.
         choice, resolved = "deny", True
@@ -168,8 +178,12 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict, *,
         _ctx._fire_approval_hook("post_approval_response", **payload, choice="notify_failed")
         return {"resolved": False, "choice": None, "notify_failed": True}
 
-    state = _poll_event(entry.event, session_key,
-                        interrupt_log="Approval wait interrupted by user signal — returning deny for session %s")
+    state = _poll_event(
+        entry.event, session_key,
+        interrupt_log="Approval wait interrupted by user signal — returning deny for session %s",
+        wake_is_cancelled=lambda: entry.result is None and (
+            is_interrupted() or not _ctx._api_approval_resolver_available(session_key)),
+    )
     if state == "interrupted":
         entry.result = "deny"
         entry.event.set()


### PR DESCRIPTION
## Summary

- Add an explicit, revocable approval-resolver capability for each `/v1/runs` run.
- Activate it only after that run's approval callback is registered, require an exact run/session-key match, and revoke it during teardown.
- Keep listener-less `api_server` routes, `webhook`, and `msgraph_webhook` fail-closed under `approvals.unattended_mode`; hardline blocks remain before human approval.
- Close resolver teardown races so stale workers cannot enqueue or publish an unanswerable approval.

## Verification

- Initial regression tests reproduced the immediate unattended deny on `/v1/runs`; the resolver-backed tests now pass for `once`, `deny`, `session`, `always`, run isolation, listener-less OpenAI routes, unattended platforms, and hardline floor.
- Relevant suite: 78 files, 1198 passed, 3 Windows-only skips on Linux.
- Live gateway/WebUI runs-API bridge: `approval.request` reached the bridge, the exact `run_id` was resolved with `once`, and the harmless probe completed. Live `deny` and concurrent-run isolation also passed.
- `approvals.unattended_mode: deny` and existing configuration defaults are unchanged.

## Upstream context

Fixes #98728. Upstream PR #98735 was evaluated; this implementation uses an explicit resolver-backed capability because outbound notifier presence alone is not proof of an inbound approval resolver for webhook or other unattended transports.