### PR TITLE
fix(supermemory): read recall text from chunk so document hits reach recall

### DIFF
--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -171,6 +171,26 @@ def _memory_fields(item: Any, *keys: str) -> dict:
             for k in keys}
 
 
+def _result_text(item: Any) -> str:
+    """Recall text for a search/profile result, wherever the SDK put it.
+
+    ``memory`` holds extracted memories, but document and full-session hits carry
+    their text in ``chunk`` (with ``memory`` left as ``None``) and chunked hits in
+    ``chunks[].content``. Reading only ``memory`` makes every document-derived hit
+    look empty, and ``_format_prefetch_context`` then drops it (its dedupe key is
+    ``item.get("memory", "")``, and a falsy key filters the item out).
+    """
+    for attr in ("memory", "chunk", "context"):
+        value = getattr(item, attr, None)
+        if value:
+            return str(value)
+    chunks = getattr(item, "chunks", None) or []
+    if chunks:
+        first = chunks[0]
+        return str(first.get("content") or "") if isinstance(first, dict) else str(getattr(first, "content", "") or "")
+    return ""
+
+
 class _SupermemoryClient:
     def __init__(self, api_key: str, timeout: float, container_tag: str,
                  search_mode: str = "hybrid", base_url: str = ""):
@@ -206,7 +226,7 @@ class _SupermemoryClient:
         kwargs: dict[str, Any] = {"q": query, "container_tag": container_tag or self._container_tag, "limit": limit,
                                   **({"search_mode": mode} if mode in _VALID_SEARCH_MODES else {})}
         response = self._client.search.memories(**kwargs)
-        return [{**_memory_fields(item, "id", "memory", "similarity", "updated_at", "metadata"), "memory": getattr(item, "memory", "") or ""}
+        return [{**_memory_fields(item, "id", "similarity", "updated_at", "metadata"), "memory": _result_text(item)}
                 for item in (getattr(response, "results", None) or [])]
 
     def get_profile(self, query: Optional[str] = None, *, container_tag: Optional[str] = None) -> dict:
@@ -216,7 +236,8 @@ class _SupermemoryClient:
         raw_results = getattr(search_data, "results", None) or search_data or []
         return {
             **{k: (getattr(profile_data, k, []) or []) if profile_data else [] for k in ("static", "dynamic")},
-            "search_results": [item if isinstance(item, dict) else _memory_fields(item, "memory", "updated_at", "similarity")
+            "search_results": [item if isinstance(item, dict)
+                               else {**_memory_fields(item, "updated_at", "similarity"), "memory": _result_text(item)}
                                for item in raw_results] if isinstance(raw_results, list) else [],
         }
 

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -456,3 +456,85 @@ def test_save_config_sets_owner_only_permissions(tmp_path):
     assert config_file.exists()
     mode = stat.S_IMODE(config_file.stat().st_mode)
     assert mode == 0o600, f"Expected 0o600 (owner-only), got {oct(mode)}"
+
+# --- recall text for document / session hits -------------------------------
+# The SDK reports document and full-session hits with ``memory`` = None and the
+# text in ``chunk`` (or ``chunks[].content``). Reading only ``memory`` made those
+# hits look empty, and ``_format_prefetch_context`` then dropped them from recall
+# (its dedupe key is ``item.get("memory", "")``, and a falsy key filters the item).
+
+
+@pytest.fixture
+def sdk(monkeypatch):
+    """Stub the Supermemory SDK so canned search results can be injected."""
+    import sys
+    import types
+
+    class _Search:
+        def __init__(self):
+            self.results = []
+
+        def memories(self, **kwargs):
+            return types.SimpleNamespace(results=self.results)
+
+    class StubSupermemory:
+        def __init__(self, **kwargs):
+            self.search = _Search()
+
+    module = types.ModuleType("supermemory")
+    module.Supermemory = StubSupermemory
+    monkeypatch.setitem(sys.modules, "supermemory", module)
+    monkeypatch.setattr("tools.lazy_deps.ensure", lambda *a, **k: None)
+    return StubSupermemory
+
+
+class _Hit:
+    """Mimics an SDK search result; ``memory`` is None for document/session hits."""
+
+    def __init__(self, **kw):
+        self.id = kw.get("id", "hit-1")
+        self.memory = kw.get("memory")
+        self.chunk = kw.get("chunk")
+        self.chunks = kw.get("chunks", [])
+        self.context = kw.get("context")
+        self.similarity = 0.84
+        self.updated_at = "2026-09-13T00:00:00Z"
+        self.updatedAt = self.updated_at
+        self.metadata = kw.get("metadata", {})
+
+
+def _client(sdk, results):
+    from plugins.memory.supermemory import _SupermemoryClient
+
+    client = _SupermemoryClient(api_key="test-key", timeout=1.0, container_tag="hermes")
+    client._client.search.results = results
+    return client
+
+
+def test_document_hit_text_comes_from_chunk(sdk):
+    client = _client(sdk, [_Hit(chunk="gateway restart commands")])
+    assert client.search_memories("gateway")[0]["memory"] == "gateway restart commands"
+
+
+def test_chunked_hit_text_comes_from_chunks(sdk):
+    client = _client(sdk, [_Hit(chunks=[{"content": "from chunks"}])])
+    assert client.search_memories("anything")[0]["memory"] == "from chunks"
+
+
+def test_extracted_memory_still_used(sdk):
+    """Extracted memories keep reading ``memory`` — no regression on that path."""
+    client = _client(sdk, [_Hit(memory="likes short answers", chunk="ignored")])
+    assert client.search_memories("anything")[0]["memory"] == "likes short answers"
+
+
+def test_document_hit_reaches_the_recall_block(sdk):
+    """The user-visible symptom: chunk-only hits vanished from the recall block."""
+    client = _client(sdk, [_Hit(chunk="gateway restart commands")])
+    rendered = _format_prefetch_context([], [], client.search_memories("gateway"), max_results=10)
+    assert "Relevant Memories" in rendered
+    assert "gateway restart commands" in rendered
+
+
+def test_no_text_anywhere_yields_empty_string(sdk):
+    client = _client(sdk, [_Hit()])
+    assert client.search_memories("anything")[0]["memory"] == ""


### PR DESCRIPTION
## Bug Description

Auto-recall silently drops every document- and session-derived memory. The search
tool reports `count: 1` with a similarity score but an empty `content`, and the
`<supermemory-context>` block injected before each turn loses those hits entirely.

Extracted memories (`task_type='memory'`) are unaffected, which is why this hides
so well: search *looks* like it is working.

## Root Cause

The Supermemory SDK puts a result's text in different fields depending on the task
type:

| field | populated when |
|---|---|
| `memory` | extracted memory (`task_type='memory'`) |
| `chunk` | document / full-session chunk — **`memory` is `None`** |
| `chunks[].content` | chunked hits |
| `context` | aggregated context |

`_SupermemoryClient.search_memories()` reads only `memory`:

```python
return [{**_memory_fields(item, "id", "memory", "similarity", "updated_at", "metadata"),
         "memory": getattr(item, "memory", "") or ""}
        for item in (getattr(response, "results", None) or [])]
```

`get_profile()`'s `search_results` has the same problem via
`_memory_fields(item, "memory", ...)`.

It does not stop at an empty string. `_format_prefetch_context()` seeds its dedupe
with `key=lambda i: i.get("memory", "")` and the key doubles as a filter:

```python
return [i for i in items or [] if (k := key(i)) and k not in seen and not seen.add(k)][:max_results]
```

An empty key is falsy, so the item is dropped before it can be rendered.

## Fix

- Add `_result_text(item)`, which falls back `memory -> chunk -> context ->
  chunks[0].content`.
- Use it in `search_memories()` and in `get_profile()`'s `search_results` mapping.

No behaviour change for extracted memories: `memory` is still consulted first.

## How to Verify

1. Point the provider at a store holding at least one ingested session (these are
   stored as `full_session` documents).
2. Search for a phrase from that session:
   ```python
   client.search_memories("<phrase from a past session>", limit=3)
   ```
   Before: `[{'id': ..., 'memory': '', 'similarity': 0.84}]`
   After:  `[{'id': ..., 'memory': '<real text>', 'similarity': 0.84}]`
3. Render the recall block:
   ```python
   _format_prefetch_context([], [], hits, max_results=10)
   ```
   Before: `""` (no `Relevant Memories` section). After: a populated bullet.

Measured before/after against a live store (1 matching document hit):

```
BEFORE  hits=1  memory_len=0    recall bullets=0   recall block=""
AFTER   hits=1  memory_len=100  recall bullets=1   recall block="- [8h ago] [84%] [USER] hermes gateway start"
```

## Test Plan

- [x] Added regression test for this bug — 5 cases in
      `tests/plugins/memory/test_supermemory_provider.py`, covering `chunk`,
      `chunks[].content`, the `memory`-first precedence, the recall-block symptom,
      and the all-empty case.
- [x] Existing tests still pass.
- [x] Manual verification of the fix (before/after output above).

New tests against `main` (red) and with the patch (green):

```
RED   (upstream main) : 3 failed, 2 passed
GREEN (patched)       : 5 passed
```

## Risk Assessment

**Low.**

- Additive: `memory` is still the first field consulted, so the extracted-memory
  path is byte-for-byte unchanged. The two tests that pass on `main` cover exactly
  that path plus the empty-result case.
- The new fallbacks are read-only `getattr` lookups on fields already present on
  the SDK result objects; nothing is written back to the API.
- Blast radius is limited to recall text rendering: `search_memories()`,
  `get_profile()`, and everything downstream of them (`prefetch`,
  `_format_prefetch_context`, `forget_by_query`).
- `search_mode="memories"` still returns nothing for a document-only store — that
  is a separate SDK scoping behaviour, unchanged here. `hybrid` (the default)
  returns document hits.
