### PR TITLE
test(update): stub the Windows gateway cold-start so update tests don't spawn a real gateway

### DIFF
--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -57,6 +57,14 @@ def _patch_gateway_discovery():
     phase's fresh ``from hermes_cli.gateway import ...`` then loads an
     UNPATCHED copy of the module — silently discarding every mock here and
     letting real gateway discovery (and real ``os.kill``) run on the dev box.
+
+    ``_cold_start_windows_gateway_after_update`` is stubbed for the same
+    reason on Windows: it re-reads the ``find_gateway_pids`` patched to ``[]``
+    above, interprets "no gateway running" as "cold-start one", and spawns a
+    REAL detached gateway. That trips the conftest live-system guard and fails
+    every success-path test in this file on a Windows box (it returns early on
+    POSIX, which is why CI never saw it). Returning ``True`` gives the
+    "already running, nothing to do" outcome the tests want.
     """
     with patch("hermes_cli.gateway.find_gateway_pids", return_value=[]), \
          patch("hermes_cli.gateway.supports_systemd_services", return_value=False), \
@@ -65,6 +73,7 @@ def _patch_gateway_discovery():
          patch("hermes_cli.update_inventory.report_unaccounted_runtimes", return_value=False), \
          patch.object(hermes_main, "_fleet_probe_expected_runtimes", lambda *a, **kw: False), \
          patch.object(hermes_main, "_purge_stale_hermes_modules", lambda *a, **kw: None), \
+         patch.object(hermes_main, "_cold_start_windows_gateway_after_update", lambda *a, **kw: True), \
          patch("hermes_cli.update_receipt.collect_fleet_versions", return_value=[]):
         yield
 


### PR DESCRIPTION
## Problem

`tests/hermes_cli/test_update_autostash.py` has an autouse fixture (`_patch_gateway_discovery`) whose stated job is to keep `cmd_update`'s gateway-restart phase off the developer's machine. It patches `hermes_cli.gateway.find_gateway_pids` to return `[]`.

The Windows cold-start path (`update_cmd_windows._cold_start_windows_gateway_after_update`) re-reads that **same** probe:

```python
from hermes_cli.gateway import find_gateway_pids
if list(find_gateway_pids(all_profiles=True)):
    return True          # already running -> nothing to do
...
pid = gateway_windows._spawn_detached()   # <-- [] falls through to here
```

So the fixture's `[]` reads as *"no gateway running, cold-start one"* and the test spawns a **real detached gateway**. That trips `tests/conftest.py`'s live-system guard, which turns into `SystemExit` and fails every success-path test in the file.

The cold-start returns early on POSIX (`if not _m()._is_windows(): return True`), which is why CI never caught this — it only reproduces on a Windows dev box with a live gateway.

## Fix

Stub `_cold_start_windows_gateway_after_update` in the same fixture, returning `True` (the "already running, nothing to do" outcome the tests want). `_m()` resolves to `hermes_cli.main`, which is already the module the fixture patches (`_fleet_probe_expected_runtimes`, `_purge_stale_hermes_modules`), so no new import is needed.

## Verification (Windows 11, live gateway running)

```
before: 7 failed, 22 passed, 1 skipped
after:  1 failed, 28 passed, 1 skipped
```

## Not addressed here

One test still fails: `test_cmd_update_orphan_guard_skips_rescue_ref_when_pre_pull_sha_missing`, now at a **different, later phase** — the update dependency-sync tries to quarantine the real `hermes.exe` and raises `ShimQuarantineError` → exit 2. That is a separate test-isolation gap (no `scripts_dir` / dep-sync stub in `_setup_update_mocks`), pre-existing and independent of the gateway issue, so it is left for its own change rather than widened into this one.
