### PR TITLE
Profile clones no longer carry messaging bot credentials (--clone-channels opts in); gateway.multiplex_profiles registered; explicit migrate --multiplex flips the flag

### DIFF
--- a/hermes_cli/AGENTS.md
+++ b/hermes_cli/AGENTS.md
@@ -128,7 +128,9 @@ matchers; parser-derived flag sets; never blanket-exclude gateway ancestors, #87
 
 `_apply_profile_override()` in `hermes_cli/main.py` sets `HERMES_HOME` before any module import, so
 every `get_hermes_home()` scopes to the active profile (rules in root). Profiles are independent
-islands by design — no live config inheritance; `--clone` copies at creation. Multiplex
+islands by design — no live config inheritance; `--clone` copies at creation, minus messaging
+channels (`profile_channels.py` derives the token/allowlist/platform-section key set from the adapter
+registry + `gateway/config_env._ENV_STEPS`, never a hand list; `--clone-channels` opts in). Multiplex
 (`gateway.multiplex_profiles`) secret-scope rules: `gateway/AGENTS.md`. The served set is
 `profiles.py::profiles_to_serve(multiplex=True)` = default + every live (non-tombstoned) dir under
 `profiles/` — there is no allowlist (`gateway.multiplex_profile_allowlist` was retired in config v43).

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1946,6 +1946,19 @@ DEFAULT_CONFIG = {
         # (primary copy: state.db gateway_routing table). True for external tooling and downgrade
         # safety; False stops producing the file.
         "write_sessions_json": True,
+        # One gateway for every profile on this host: the DEFAULT profile's gateway also connects
+        # each named profile's bots (their own .env / config.yaml, per-profile secret scope) and
+        # stamps the profile into session keys. Flip with `hermes gateway migrate --multiplex`
+        # (records a rollback manifest; `--standalone` undoes it) or `hermes config set
+        # gateway.multiplex_profiles true` + `hermes gateway restart`. GATEWAY_MULTIPLEX_PROFILES
+        # in the environment overrides. Two profiles configuring the same bot token cannot be
+        # served together — the duplicate adapter is parked; `hermes profile create --clone`
+        # therefore leaves messaging channels behind unless --clone-channels is passed.
+        "multiplex_profiles": False,
+        # Route inbound chats of the default profile's bots to another profile
+        # (gateway/profile_routing.py): [{profile, platform, chat_id|user_id|guild_id|...}].
+        # Most-specific match wins; only read by the multiplexing default gateway.
+        "profile_routes": [],
         # Scale-to-zero idle TIMEOUT only. When an instance is opted in via the NAS "Labs" toggle
         # (HERMES_SCALE_TO_ZERO env stamp) AND messaging is relay-only/absent AND a wakeUrl is
         # registered, the relay transport goes dormant so the platform (e.g. Fly autostop) can

--- a/hermes_cli/gateway_migrate.py
+++ b/hermes_cli/gateway_migrate.py
@@ -109,7 +109,9 @@ class MigrationPlan:
         }
 
     def eligible_for_migration(self) -> bool:
-        """>= 2 profiles, at least one secondary with its own gateway, multiplex off, no blockers."""
+        """>= 2 profiles, at least one secondary with its own gateway, multiplex off, no blockers.
+        This is the AUTO-migration (``hermes update``) bar; the explicit command also proceeds with
+        zero standalone secondaries (see :func:`cmd_migrate`)."""
         return (
             len(self.profiles) >= 2 and bool(self.standalone_secondaries)
             and not self.already_multiplexed and not self.blocked
@@ -434,14 +436,22 @@ def format_plan(plan: MigrationPlan, *, dry_run: bool) -> list[str]:
     for p in plan.standalone_secondaries:
         what = " + ".join(x for x in (f"stop pid {p.pid}" if p.pid else "", f"uninstall {p.service_label()}" if p.service else "") if x)
         steps.append(f"  - {p.name}: {what}")
+    if len(plan.profiles) < 2:  # the notice already says "only one profile exists"
+        return lines + _plan_tail(plan)
     if not steps:
-        lines.append("  No secondary profile runs its own gateway; nothing to migrate.")
+        lines.append("  No secondary profile runs its own gateway; the only step is turning the flag on:")
     else:
-        lines += ["  Steps:", *steps, f"  - default: set gateway.multiplex_profiles: true in {plan.default_home / 'config.yaml'}"]
-        target = plan.target_service_kind()
-        lines.append(f"  - default: {'restart' if plan.default.has_gateway else 'start'} the gateway"
-                     + (f" via {target[0]}" if target else " (detached)") + f", verify it serves {len(plan.profiles)} profiles")
-        lines.append(f"  - record removed services in {plan.default_home / MANIFEST_NAME} (rollback: hermes gateway migrate --standalone)")
+        lines += ["  Steps:", *steps]
+    lines.append(f"  - default: set gateway.multiplex_profiles: true in {plan.default_home / 'config.yaml'}")
+    target = plan.target_service_kind()
+    lines.append(f"  - default: {'restart' if plan.default.has_gateway else 'start'} the gateway"
+                 + (f" via {target[0]}" if target else " (detached)") + f", verify it serves {len(plan.profiles)} profiles")
+    lines.append(f"  - record the previous state in {plan.default_home / MANIFEST_NAME} (rollback: hermes gateway migrate --standalone)")
+    return lines + _plan_tail(plan)
+
+
+def _plan_tail(plan: MigrationPlan) -> list[str]:
+    lines: list[str] = []
     if plan.blockers:
         lines += ["", "  ✗ Blockers (fix these first, nothing will be changed):"]
         lines += [f"    • {b}" for b in plan.blockers]
@@ -635,10 +645,10 @@ def cmd_migrate(args) -> None:
         return
     if plan.already_multiplexed:
         return
-    if plan.blocked:
-        sys.exit(1)
-    if not plan.standalone_secondaries:
-        return
+    if plan.blocked or len(plan.profiles) < 2:
+        sys.exit(1 if plan.blocked else 0)
+    # Zero standalone secondaries is still a migration when the user asks for it explicitly: the flag
+    # goes on and the default gateway restarts (the update hook keeps treating that case as a no-op).
     if not getattr(args, "yes", False) and sys.stdin.isatty():
         from hermes_cli.setup import prompt_yes_no
         if not prompt_yes_no("Apply this migration now?", True):

--- a/hermes_cli/profile_channels.py
+++ b/hermes_cli/profile_channels.py
@@ -1,0 +1,354 @@
+"""Messaging-channel settings a profile clone must NOT inherit.
+
+A ``--clone``d profile that keeps the source's bot tokens, allowlists and platform state makes two
+gateways fight over one bot (standalone) or blocks ``hermes gateway migrate --multiplex`` with a
+duplicate-credential finding per platform. The key set is DERIVED from the platform adapters — the
+``Platform`` enum + plugin registry (``required_env``, allowlist/allow-all/home-channel env names),
+the gateway env-override table (``gateway.config_env._ENV_STEPS`` / ``_ENV_ENABLE_CREDENTIALS``) and
+the ``<PLATFORM>_`` env prefix every adapter's keys share — so a new adapter is covered without a
+hand-written list. Model/provider keys, tool keys, memory and general config are never touched.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import re
+from functools import partial
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Set, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Platforms whose env names do not share the ``<PLATFORM>_`` prefix of their config id. The
+# dashboard Channels page uses the same table to decide which Keys-page fields a card owns.
+_PLATFORM_ENV_PREFIX_ALIASES: dict[str, tuple[str, ...]] = {
+    "email": ("EMAIL_",),
+    "homeassistant": ("HASS_",),
+    "qqbot": ("QQ_", "QQBOT_"),
+    "sms": ("TWILIO_",),
+    "wecom": ("WECOM_BOT_", "WECOM_SECRET"),
+    "wecom_callback": ("WECOM_CALLBACK_",),
+}
+
+# Multiplexer-owner settings: a clone of the default that inherits them and is then started
+# standalone tries to be a second multiplexer for every profile on the host.
+_GATEWAY_OWNER_KEYS = ("multiplex_profiles", "profile_routes")
+
+_ENV_LINE_RE = re.compile(r"^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=")
+
+
+def platform_env_prefixes(platform_id: str) -> tuple[str, ...]:
+    """Env-var prefixes owned by one messaging platform."""
+    return _PLATFORM_ENV_PREFIX_ALIASES.get(platform_id, (platform_id.upper().replace("-", "_") + "_",))
+
+
+def platform_ids() -> List[str]:
+    """Every messaging platform id: built-in ``Platform`` members plus registered plugin adapters."""
+    from gateway.config import Platform
+    ids = {m.value for m in Platform.__members__.values() if m.value != "local"}
+    with contextlib.suppress(Exception):
+        from hermes_cli.plugins import discover_plugins
+        discover_plugins()  # idempotent
+        from gateway.platform_registry import platform_registry
+        ids.update(entry.name for entry in platform_registry.all_entries())
+    return sorted(ids)
+
+
+def _cred_row_envs(row) -> Set[str]:
+    """Every env name a ``gateway.config_env._Cred`` row reads."""
+    names: Set[str] = set()
+
+    def _flatten(spec) -> None:
+        if isinstance(spec, str):
+            names.add(spec)
+        elif isinstance(spec, (tuple, list)):
+            for item in spec:
+                _flatten(item)
+
+    _flatten(row.creds)
+    if row.token:
+        names.add(row.token)
+    for key_env in (*row.fixed, *row.optional, *row.optional_stripped):
+        _flatten(key_env[1])
+    if row.warn_missing:
+        names.add(row.warn_missing[0])
+    if row.home:
+        names.update({row.home, f"{row.home}_NAME", f"{row.home}_THREAD_ID"})
+    return names
+
+
+def declared_channel_env_keys() -> Dict[str, str]:
+    """``{ENV_KEY: platform_id}`` for every env name an adapter declares outright (registry entry
+    fields, the gateway env-override table). Prefix matching covers the rest."""
+    keys: Dict[str, str] = {}
+    with contextlib.suppress(Exception):
+        from hermes_cli.plugins import discover_plugins
+        discover_plugins()
+        from gateway.platform_registry import platform_registry
+        for entry in platform_registry.all_entries():
+            for name in (*entry.required_env, entry.allowed_users_env, entry.allow_all_env, entry.cron_deliver_env_var):
+                if name:
+                    keys[name] = entry.name
+    with contextlib.suppress(Exception):
+        from gateway import config_env
+        for platform, names in config_env._ENV_ENABLE_CREDENTIALS.items():
+            keys.update(dict.fromkeys(names, platform.value))
+        for step in config_env._ENV_STEPS:
+            if isinstance(step, config_env._Cred):
+                keys.update(dict.fromkeys(_cred_row_envs(step), step.platform.value))
+            elif isinstance(step, partial):
+                platform = step.keywords.get("platform")
+                for kw in ("env", "env_base"):
+                    if step.keywords.get(kw) and platform is not None:
+                        keys[step.keywords[kw]] = platform.value
+    return keys
+
+
+_CREDENTIAL_SUFFIXES = (
+    "_TOKEN", "_SECRET", "_KEY", "_PASSWORD", "_APP_ID", "_CLIENT_ID", "_BOT_ID", "_ACCOUNT_SID",
+    "_SERVICE_ACCOUNT_JSON", "_PROJECT_ID",
+)
+
+
+def credential_env_keys() -> Dict[str, str]:
+    """``{ENV_KEY: platform_id}`` for the keys that make an adapter CONNECT AS a bot (token / app id /
+    client id / secret — the shape ``GatewayRunner._adapter_credential_fingerprint`` hashes). Enable
+    flags, URLs and hosts are excluded: two profiles pointing at one Mattermost server collide only
+    when they also share the token."""
+    keys: Dict[str, str] = {}
+    with contextlib.suppress(Exception):
+        from hermes_cli.plugins import discover_plugins
+        discover_plugins()
+        from gateway.platform_registry import platform_registry
+        for entry in platform_registry.all_entries():
+            keys.update(dict.fromkeys(entry.required_env, entry.name))
+    with contextlib.suppress(Exception):
+        from gateway import config_env
+        for platform, names in config_env._ENV_ENABLE_CREDENTIALS.items():
+            keys.update(dict.fromkeys(names, platform.value))
+        for step in config_env._ENV_STEPS:
+            if isinstance(step, config_env._Cred):
+                creds: Set[str] = set()
+                for group in step.creds:
+                    creds.update((group,) if isinstance(group, str) else group)
+                if step.token:
+                    creds.add(step.token)
+                keys.update(dict.fromkeys(creds, step.platform.value))
+    return {key: pid for key, pid in keys.items() if key.endswith(_CREDENTIAL_SUFFIXES)}
+
+
+class ChannelKeyIndex:
+    """Resolves an env key to the messaging platform that owns it (``None`` = not a channel key)."""
+
+    def __init__(self) -> None:
+        self.platforms = platform_ids()
+        self.declared = declared_channel_env_keys()
+        self._prefixes: List[Tuple[str, str]] = sorted(
+            ((prefix, pid) for pid in self.platforms for prefix in platform_env_prefixes(pid)),
+            key=lambda item: -len(item[0]),  # longest prefix wins: WECOM_CALLBACK_ before WECOM_
+        )
+
+    def platform_for(self, key: str) -> Optional[str]:
+        if key in self.declared:
+            return self.declared[key]
+        return next((pid for prefix, pid in self._prefixes if key.startswith(prefix)), None)
+
+
+def _env_key_of_line(line: str) -> Optional[str]:
+    match = _ENV_LINE_RE.match(line)
+    return match.group(1) if match else None
+
+
+def strip_channel_env_file(env_path: Path, index: Optional[ChannelKeyIndex] = None) -> Dict[str, List[str]]:
+    """Drop every messaging-channel assignment from ``env_path`` in place; comments, blank lines and
+    every other key survive verbatim. Returns ``{platform: [keys removed]}``."""
+    if not env_path.is_file():
+        return {}
+    index = index or ChannelKeyIndex()
+    removed: Dict[str, List[str]] = {}
+    kept: List[str] = []
+    text = env_path.read_text(encoding="utf-8-sig", errors="replace")
+    for line in text.splitlines():
+        key = _env_key_of_line(line)
+        platform = index.platform_for(key) if key else None
+        if key is None or platform is None:
+            kept.append(line)
+        else:
+            removed.setdefault(platform, []).append(key)
+    if removed:
+        env_path.write_text("\n".join(kept) + ("\n" if text.endswith("\n") or kept else ""), encoding="utf-8")
+    return removed
+
+
+def _channel_config_paths(raw: dict, platforms: Iterable[str]) -> List[Tuple[str, ...]]:
+    """Dotted paths in a raw config.yaml mapping that hold platform identity: ``platforms``, every
+    top-level ``<platform>:`` block, ``gateway.platforms`` / ``gateway.<platform>``, and the
+    multiplexer-owner keys (both spellings the gateway loader accepts)."""
+    paths: List[Tuple[str, ...]] = []
+    gateway: dict = raw["gateway"] if isinstance(raw.get("gateway"), dict) else {}
+    if "platforms" in raw:
+        paths.append(("platforms",))
+    if "platforms" in gateway:
+        paths.append(("gateway", "platforms"))
+    for key in _GATEWAY_OWNER_KEYS:
+        if key in raw:
+            paths.append((key,))
+        if key in gateway:
+            paths.append(("gateway", key))
+    for pid in platforms:
+        if pid in raw:
+            paths.append((pid,))
+        if pid in gateway:
+            paths.append(("gateway", pid))
+    return paths
+
+
+def strip_channel_config(config_path: Path, index: Optional[ChannelKeyIndex] = None) -> List[str]:
+    """Remove platform sections from a raw ``config.yaml`` in place. Returns the dotted paths removed."""
+    if not config_path.is_file():
+        return []
+    from hermes_cli.config import read_user_config_raw
+    from utils import atomic_yaml_write
+    index = index or ChannelKeyIndex()
+    raw = read_user_config_raw(config_path)
+    paths = _channel_config_paths(raw, index.platforms)
+    if not paths:
+        return []
+    for path in paths:
+        node = raw
+        for seg in path[:-1]:
+            node = node[seg]
+        node.pop(path[-1], None)
+    if isinstance(raw.get("gateway"), dict) and not raw["gateway"]:
+        raw.pop("gateway")
+    atomic_yaml_write(config_path, raw, sort_keys=False)
+    return [".".join(path) for path in paths]
+
+
+def channel_state_entries(root: Path, index: Optional[ChannelKeyIndex] = None) -> List[Path]:
+    """Root entries of a profile that hold per-bot runtime identity: pairing approvals and the
+    WhatsApp device session (``platforms/`` + legacy dirs), the gateway's per-platform ledgers,
+    channel directories and every ``<platform>_*`` state file an adapter writes beside config.yaml."""
+    if not root.is_dir():
+        return []
+    index = index or ChannelKeyIndex()
+    fixed = {"platforms", "pairing", "whatsapp", "gateway", "channel_directory.json", "channel_aliases.json"}
+    prefixes = tuple(f"{pid}_" for pid in index.platforms)
+    return sorted(
+        entry for entry in root.iterdir()
+        if entry.name in fixed or (entry.is_file() and entry.name.startswith(prefixes))
+    )
+
+
+def strip_channel_settings(profile_dir: Path, *, include_state: bool) -> Dict[str, List[str]]:
+    """Strip channel credentials/identity from a freshly cloned profile. ``include_state`` also
+    drops the runtime state ``--clone-all`` copied. Returns ``{platform|"config"|"state": [what]}``."""
+    import shutil
+    index = ChannelKeyIndex()
+    stripped: Dict[str, List[str]] = dict(strip_channel_env_file(profile_dir / ".env", index))
+    config_paths = strip_channel_config(profile_dir / "config.yaml", index)
+    if config_paths:
+        stripped["config"] = config_paths
+    if include_state:
+        dropped = []
+        for entry in channel_state_entries(profile_dir, index):
+            shutil.rmtree(entry, ignore_errors=True) if entry.is_dir() else entry.unlink(missing_ok=True)
+            dropped.append(entry.name)
+        if dropped:
+            stripped["state"] = dropped
+    return stripped
+
+
+def channel_platforms_configured(profile_dir: Path) -> List[str]:
+    """Platform ids with any channel setting in ``profile_dir`` (.env keys or config.yaml sections) —
+    what a channel-less clone of it leaves behind. Pure read."""
+    index = ChannelKeyIndex()
+    found: Set[str] = set()
+    env_path = profile_dir / ".env"
+    if env_path.is_file():
+        for line in env_path.read_text(encoding="utf-8-sig", errors="replace").splitlines():
+            key = _env_key_of_line(line)
+            platform = index.platform_for(key) if key else None
+            if platform:
+                found.add(platform)
+    config_path = profile_dir / "config.yaml"
+    if config_path.is_file():
+        from hermes_cli.config import read_user_config_raw
+        raw = read_user_config_raw(config_path)
+        for path in _channel_config_paths(raw, index.platforms):
+            node = raw
+            for seg in path:
+                node = node[seg]
+            if path[-1] == "platforms" and isinstance(node, dict):
+                found.update(str(k) for k in node)
+            elif path[-1] in index.platforms:
+                found.add(path[-1])
+    return sorted(found)
+
+
+def _env_values(env_path: Path, wanted: Dict[str, str]) -> Dict[str, str]:
+    values: Dict[str, str] = {}
+    if not env_path.is_file():
+        return values
+    from dotenv import dotenv_values
+    with contextlib.suppress(Exception):
+        for key, value in (dotenv_values(env_path, encoding="utf-8-sig") or {}).items():
+            if key in wanted and value and value.strip():
+                values[key] = value.strip()
+    return values
+
+
+def _config_platform_tokens(config_path: Path) -> Dict[str, str]:
+    """``{platform: token}`` from ``platforms.<p>.token|api_key`` (both nesting spellings)."""
+    tokens: Dict[str, str] = {}
+    if not config_path.is_file():
+        return tokens
+    from hermes_cli.config import read_user_config_raw
+    raw = read_user_config_raw(config_path)
+    gateway: dict = raw["gateway"] if isinstance(raw.get("gateway"), dict) else {}
+    for section in (raw.get("platforms"), gateway.get("platforms")):
+        if not isinstance(section, dict):
+            continue
+        for pid, block in section.items():
+            if isinstance(block, dict):
+                token = block.get("token") or block.get("api_key")
+                if isinstance(token, str) and token.strip():
+                    tokens[str(pid)] = token.strip()
+    return tokens
+
+
+def shared_channel_credentials(profile_dir: Path, source_dir: Path) -> List[str]:
+    """Platforms whose CONNECTING credential (bot token / app id / account) in ``profile_dir`` is
+    byte-identical to ``source_dir``'s — the bots that will collide. Pure file reads: no secret
+    manager, no gateway config load, so ``hermes profile list`` can afford it per profile."""
+    wanted = credential_env_keys()
+    mine = _env_values(profile_dir / ".env", wanted)
+    theirs = _env_values(source_dir / ".env", wanted)
+    shared = {wanted[key] for key in mine if theirs.get(key) == mine[key]}
+    mine_cfg = _config_platform_tokens(profile_dir / "config.yaml")
+    theirs_cfg = _config_platform_tokens(source_dir / "config.yaml")
+    shared.update(pid for pid, token in mine_cfg.items() if theirs_cfg.get(pid) == token)
+    return sorted(shared)
+
+
+def shared_credential_warning(profile: str, platforms: List[str], source: str = "default") -> str:
+    return (
+        f"⚠ Profile '{profile}' shares its {', '.join(platforms)} credential with {source}: the bot can "
+        f"only belong to one profile. Give '{profile}' its own bot (hermes -p {profile} setup, or the "
+        f"dashboard Messaging page) or remove the token from '{profile}'; a multiplexed gateway parks "
+        f"the duplicate and `hermes gateway migrate --multiplex` refuses until it is gone."
+    )
+
+
+def format_stripped_notice(profile: str, platforms: List[str], clone_flag: str = "--clone") -> List[str]:
+    """Lines printed after a channel-less clone so the user knows what was left behind and how to
+    configure the new profile's own bots."""
+    if not platforms:
+        return []
+    return [
+        f"Messaging channels were NOT cloned ({', '.join(platforms)}): a copied bot token or allowlist "
+        "would make two gateways fight over one bot.",
+        f"  Configure this profile's own bots:  hermes -p {profile} setup   (or the dashboard Messaging page)",
+        f"  To copy the source's channels anyway:  hermes profile create {profile} {clone_flag} --clone-channels",
+    ]

--- a/hermes_cli/profile_cmd.py
+++ b/hermes_cli/profile_cmd.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 import os
 import sys
+from typing import Optional
 
 
 def _die(msg: str, code: int = 1, *, err: bool = False) -> None:
@@ -132,6 +133,29 @@ def _profile_list(args):
         dist = f"{p.distribution_name}@{p.distribution_version or '?'}"[:30] if p.distribution_name else "—"
         print(f"{marker}{name:<15} {model:<28} {gw:<12} {alias:<12} {dist}")
     print()
+    for line in _shared_credential_warnings(profiles):
+        print(line)
+
+
+def _shared_credential_warnings(profiles) -> list:
+    """One warning per named profile whose bot credential is byte-identical to the default's
+    (typically an old ``--clone`` that copied .env): the collision that parks a multiplexed
+    adapter or makes two standalone gateways fight over one bot."""
+    from hermes_cli.profile_channels import shared_channel_credentials, shared_credential_warning
+    default = next((p for p in profiles if p.is_default), None)
+    if default is None:
+        return []
+    lines = []
+    for p in profiles:
+        if p.is_default:
+            continue
+        try:
+            shared = shared_channel_credentials(p.path, default.path)
+        except Exception:
+            continue
+        if shared:
+            lines.append(shared_credential_warning(p.name, shared))
+    return lines + ([""] if lines else [])
 
 
 def _profile_use(args):
@@ -142,6 +166,58 @@ def _profile_use(args):
         print("Switched to: default (~/.hermes)" if name == "default" else f"Switched to: {name}")
     except (ValueError, FileNotFoundError) as e:
         _die(f"Error: {e}")
+
+
+def _source_profile_dir(source_label: str) -> Path:
+    from hermes_cli.profiles import get_profile_dir
+    source_dir = get_profile_dir(source_label)
+    if not source_dir.is_dir():
+        raise FileNotFoundError(source_dir)
+    return source_dir
+
+
+def _clone_channels_refusal(source_label: str) -> Optional[str]:
+    """``--clone-channels`` is refused when a live multiplexer already serves the source: the
+    duplicate adapter would be parked at once (same explanation the migrate preflight gives)."""
+    from hermes_cli.gateway_multiplex_served import recorded_served_profiles
+    from hermes_cli.profile_channels import channel_platforms_configured
+    from hermes_cli.profiles import normalize_profile_name
+    served = recorded_served_profiles()
+    if not served or len(served) < 2 or normalize_profile_name(source_label) not in {
+        normalize_profile_name(p) for p in served
+    }:
+        return None
+    try:
+        platforms = channel_platforms_configured(_source_profile_dir(source_label))
+    except FileNotFoundError:
+        return None
+    if not platforms:
+        return None
+    return (
+        f"Error: --clone-channels would copy {', '.join(platforms)} from '{source_label}', which the running "
+        "multiplexed gateway already serves: the bot can only belong to one profile, so the copy would be "
+        "parked as a duplicate credential. Clone without --clone-channels and give the new profile its own bot "
+        "(hermes -p <name> setup), or route its chats with gateway.profile_routes instead."
+    )
+
+
+def _print_channel_clone_notice(name: str, source_label: str, clone_channels: bool, clone_flag: str) -> None:
+    from hermes_cli.profile_channels import (
+        channel_platforms_configured, format_stripped_notice, shared_channel_credentials,
+        shared_credential_warning,
+    )
+    from hermes_cli.profiles import get_profile_dir
+    try:
+        source_dir = _source_profile_dir(source_label)
+    except FileNotFoundError:
+        return
+    if not clone_channels:
+        for line in format_stripped_notice(name, channel_platforms_configured(source_dir), clone_flag):
+            print(line)
+        return
+    shared = shared_channel_credentials(get_profile_dir(name), source_dir)
+    if shared:
+        print(shared_credential_warning(name, shared, source_label))
 
 
 def _profile_create(args):
@@ -155,22 +231,29 @@ def _profile_create(args):
     no_alias = getattr(args, "no_alias", False)
     no_skills = getattr(args, "no_skills", False)
     clone_from = getattr(args, "clone_from", None)
+    clone_channels = getattr(args, "clone_channels", False)
     clone_config = clone or clone_from is not None
     cloned = clone_config or clone_all
+    source_label = clone_from or get_active_profile_name()
+    if clone_channels and cloned:
+        refusal = _clone_channels_refusal(source_label)
+        if refusal:
+            _die(refusal)
     try:
         profile_dir = create_profile(
             name=name, clone_from=clone_from, clone_all=clone_all, clone_config=clone_config,
             no_alias=no_alias, no_skills=no_skills, description=getattr(args, "description", None),
+            clone_channels=clone_channels,
         )
     except (ValueError, FileExistsError, FileNotFoundError) as e:
         _die(f"Error: {e}")
     print(f"\nProfile '{name}' created at {profile_dir}")
     if cloned:
-        source_label = clone_from or get_active_profile_name()
         if clone_all:
             print(f"Full copy from {source_label} (excluding session history, cron jobs, backups, and snapshots).")
         else:
             print(f"Cloned config, .env, SOUL.md, and skills from {source_label}.")
+        _print_channel_clone_notice(name, source_label, clone_channels, "--clone-all" if clone_all else "--clone")
         # Auto-clone Honcho config for the new profile (only with clone operations)
         try:
             from plugins.memory.honcho.cli import clone_honcho_for_profile

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -800,11 +800,16 @@ def _bootstrap_profile_dir(profile_dir: Path, source_dir: Optional[Path]) -> Non
 def create_profile(
     name: str, clone_from: Optional[str] = None, clone_all: bool = False, clone_config: bool = False,
     no_alias: bool = False, no_skills: bool = False, description: Optional[str] = None,
+    clone_channels: bool = False,
 ) -> Path:
     """Create a new profile directory and return its path.
 
     ``clone_from`` defaults to the active profile when cloning. ``clone_all`` copies all state;
     ``clone_config`` copies config.yaml/.env/SOUL.md, installed skills, and identity files.
+    Either clone strips the source's messaging channels — bot tokens, allowlists, platform
+    sections, pairing/session state — unless ``clone_channels`` opts in: a copied bot credential
+    makes two gateways fight over one bot (``hermes_cli.profile_channels``; callers list what
+    was left behind with ``channel_platforms_configured(source_dir)``).
     ``no_skills`` creates an empty profile and writes a marker so ``hermes update`` skips
     re-seeding its skills; it is mutually exclusive with the clone options, which copy skills."""
     if no_skills and (clone_from is not None or clone_config or clone_all):
@@ -832,6 +837,11 @@ def create_profile(
         _clone_all_into(source_dir, profile_dir, canon)
     else:
         _bootstrap_profile_dir(profile_dir, source_dir)
+    if source_dir is not None and not clone_channels:
+        from hermes_cli.profile_channels import strip_channel_settings
+        stripped = strip_channel_settings(profile_dir, include_state=clone_all)
+        if stripped:
+            logger.info("profile %s: cloned without messaging channels %s", canon, stripped)
 
     # Seed an empty .env so the profile owns a credentials file from day one. Without it,
     # profile-scoped env writes (dashboard Channels/Keys pages, `hermes -p <name> auth add`)

--- a/hermes_cli/subcommands/profile.py
+++ b/hermes_cli/subcommands/profile.py
@@ -19,13 +19,19 @@ def build_profile_parser(subparsers, *, cmd_profile: Callable) -> None:
     profile_create.add_argument("profile_name", help="Profile name (lowercase, alphanumeric)")
     profile_create.add_argument(
         "--clone", action="store_true",
-        help="Copy config.yaml, .env, SOUL.md, and skills from active profile")
+        help="Copy config.yaml, .env, SOUL.md, and skills from active profile "
+             "(messaging bot tokens/allowlists are left behind; see --clone-channels)")
     profile_create.add_argument(
         "--clone-all", action="store_true",
-        help="Full copy of active profile (all state, excluding per-profile history)")
+        help="Full copy of active profile (all state, excluding per-profile history and messaging channels)")
     profile_create.add_argument(
         "--clone-from", metavar="SOURCE",
         help="Source profile to clone from; implies --clone unless --clone-all is set")
+    profile_create.add_argument(
+        "--clone-channels", action="store_true",
+        help="Also copy the source's messaging channels (bot tokens, allowlists, platform sections). "
+             "Two profiles holding one bot token collide; refused when the source is served by a live "
+             "multiplexed gateway.")
     profile_create.add_argument(
         "--no-alias", action="store_true", help="Skip wrapper script creation")
     profile_create.add_argument(

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -407,6 +407,9 @@ class ProfileCreate(BaseModel):
     clone_from: Optional[str] = None
     clone_from_default: bool = False  # legacy clients; new ones send clone_from explicitly
     clone_all: bool = False
+    # Opt-in: also copy the source's messaging channels (bot tokens, allowlists, platform sections).
+    # Default False — a copied bot credential makes two profiles collide over one bot.
+    clone_channels: bool = False
     no_skills: bool = False
     description: Optional[str] = None
     provider: Optional[str] = None

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -667,7 +667,8 @@ async def create_profile_endpoint(body: ProfileCreate):
                          bad_request=(ValueError, FileExistsError, FileNotFoundError)):
         path = profiles_mod.create_profile(
             name=body.name, clone_from=clone_from, clone_all=body.clone_all,
-            clone_config=clone_config, no_skills=body.no_skills, description=body.description)
+            clone_config=clone_config, no_skills=body.no_skills, description=body.description,
+            clone_channels=body.clone_channels)
         # Match the CLI flow: fresh named profiles get the bundled skills (cloning already
         # copied the source's; no_skills wrote the opt-out marker so seeding no-ops) and a
         # ~/.local/bin wrapper when the alias is safe.

--- a/hermes_cli/web_server_messaging.py
+++ b/hermes_cli/web_server_messaging.py
@@ -281,18 +281,11 @@ _MESSAGING_KEYS_PAGE_KEYS = frozenset({
     "GATEWAY_ALLOW_ALL_USERS", "GATEWAY_PROXY_KEY", "GATEWAY_PROXY_URL"})
 
 
-_PLATFORM_ENV_PREFIX_ALIASES: dict[str, tuple[str, ...]] = {
-    "email": ("EMAIL_",),
-    "homeassistant": ("HASS_",),
-    "qqbot": ("QQ_", "QQBOT_"),
-    "sms": ("TWILIO_",),
-    "wecom": ("WECOM_BOT_", "WECOM_SECRET"),
-    "wecom_callback": ("WECOM_CALLBACK_",)}
-
-
 def _platform_env_prefixes(platform_id: str) -> tuple[str, ...]:
-    """Env-var prefixes owned by a messaging platform card."""
-    return _PLATFORM_ENV_PREFIX_ALIASES.get(platform_id, (platform_id.upper().replace("-", "_") + "_",))
+    """Env-var prefixes owned by a messaging platform card (shared with the profile-clone
+    channel stripper so a card and a clone agree on which keys belong to a platform)."""
+    from hermes_cli.profile_channels import platform_env_prefixes
+    return platform_env_prefixes(platform_id)
 
 
 def _discover_platform_env_vars(platform_id: str) -> tuple[str, ...]:

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1910,3 +1910,13 @@ class TestConfigCommandFailClosedSurface:
         assert excinfo.value.code == 1
         assert "not valid YAML" in capsys.readouterr().err
         assert config_path.read_text(encoding="utf-8") == original
+
+
+def test_gateway_multiplex_keys_are_recognized_config_keys():
+    """``hermes config set gateway.multiplex_profiles true`` used to warn 'not a recognized config
+    key' although gateway/config.py reads it; the key (and profile_routes) live in DEFAULT_CONFIG."""
+    from hermes_cli.config import _validate_config_key
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+    assert DEFAULT_CONFIG["gateway"]["multiplex_profiles"] is False
+    assert _validate_config_key("gateway.multiplex_profiles") == (True, None)
+    assert _validate_config_key("gateway.profile_routes") == (True, None)

--- a/tests/hermes_cli/test_gateway_migrate_multiplex.py
+++ b/tests/hermes_cli/test_gateway_migrate_multiplex.py
@@ -171,3 +171,31 @@ def test_update_hook_never_touches_single_profile_or_already_multiplexed(fleet, 
     fleet.services.clear(); fleet.pids.clear()  # secondaries exist but run no gateway of their own
     gm.maybe_auto_migrate_after_update()
     assert capsys.readouterr().out == "" and _config_flag(fleet.root) is None
+
+
+def test_explicit_migrate_with_no_standalone_secondaries_still_flips_flag_and_restarts_default(fleet, capsys, monkeypatch):
+    """The user typed --multiplex: 'nothing to migrate' + flag left off was a no-op the user did not ask
+    for. The update hook keeps its no-op (previous test); the explicit command proceeds."""
+    fleet.services.clear(); fleet.pids.clear()
+
+    def _detached(home):  # no service manager anywhere -> detached start writes the served record
+        fleet.services["default-detached"] = True
+        (fleet.root / "gateway.pid").write_text(json.dumps({"pid": os.getpid(), "hermes_home": str(fleet.root)}))
+        (fleet.root / "gateway_state.json").write_text(json.dumps({
+            "pid": os.getpid(), "hermes_home": str(fleet.root), "gateway_state": "running",
+            "served_profiles": ["default", "coder", "ops"]}))
+        return True
+    monkeypatch.setattr(gm, "_spawn_detached_gateway", _detached)
+    assert not gm.build_migration_plan().standalone_secondaries
+    with pytest.raises(SystemExit) as exc:
+        gm.cmd_migrate(SimpleNamespace(multiplex=True, standalone=False, dry_run=False, yes=True))
+    assert exc.value.code == 0
+    assert fleet.services.pop("default-detached") is True
+    assert _config_flag(fleet.root) is True
+    manifest = json.loads((fleet.root / gm.MANIFEST_NAME).read_text(encoding="utf-8"))
+    assert manifest["secondaries"] == [] and manifest["flag_was"] is False
+    assert ("default", "install") not in fleet.ops
+    out = capsys.readouterr().out
+    assert "serves 3 profiles" in out
+    # The same manifest rolls it back: flag restored, nothing to reinstall.
+    assert gm.rollback_migration(fleet.root) is True and _config_flag(fleet.root) is False

--- a/tests/hermes_cli/test_profile_clone_channels.py
+++ b/tests/hermes_cli/test_profile_clone_channels.py
@@ -1,0 +1,122 @@
+"""``hermes profile create --clone`` leaves messaging channels behind (``hermes_cli.profile_channels``).
+
+Invariant, not snapshot: the clone's credential fingerprint set — computed by the gateway's own
+``_adapter_credential_fingerprint`` through the migrate preflight — is DISJOINT from the source's,
+while provider/tool keys and general config survive; ``--clone-channels`` restores the copy.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+import hermes_constants
+from hermes_cli import gateway_migrate as gm
+from hermes_cli.profile_channels import (
+    channel_platforms_configured, shared_channel_credentials, strip_channel_env_file,
+)
+from hermes_cli.profiles import create_profile
+
+_SOURCE_ENV = (
+    "OPENAI_API_KEY=sk-model-key\n"
+    "FIRECRAWL_API_KEY=fc-tool-key\n"
+    "# telegram\n"
+    "TELEGRAM_BOT_TOKEN=111111:default-telegram-token\n"
+    "TELEGRAM_ALLOWED_USERS=12345\n"
+    "TELEGRAM_GROUP_ALLOWED_CHATS=-100999\n"
+    "DISCORD_BOT_TOKEN=default-discord-token-abcdef\n"
+    "DISCORD_ALLOWED_USERS=777\n"
+    "WHATSAPP_ENABLED=true\n"
+    "API_SERVER_KEY=default-api-server-key-0123456789\n"
+)
+_SOURCE_CONFIG = {
+    "model": {"default": "gpt-5", "provider": "openai"},
+    "memory": {"provider": "builtin"},
+    "platforms": {"telegram": {"enabled": True, "token": "111111:default-telegram-token"},
+                  "discord": {"enabled": True}},
+    "telegram": {"reactions": True, "allowed_chats": "-100999"},
+    "discord": {"require_mention": False, "dm_role_auth_guild": "42"},
+    "gateway": {"multiplex_profiles": True, "profile_routes": [{"profile": "x", "platform": "telegram"}],
+                "platform_connect_timeout": 45},
+}
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    root = tmp_path / ".hermes"
+    root.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setattr(hermes_constants, "_default_hermes_root_memo", None)
+    for name in ("TELEGRAM_BOT_TOKEN", "DISCORD_BOT_TOKEN", "API_SERVER_KEY", "WHATSAPP_ENABLED",
+                 "GATEWAY_MULTIPLEX_PROFILES", "TELEGRAM_ALLOWED_USERS"):
+        monkeypatch.delenv(name, raising=False)
+    (root / ".env").write_text(_SOURCE_ENV, encoding="utf-8")
+    (root / "config.yaml").write_text(yaml.safe_dump(_SOURCE_CONFIG), encoding="utf-8")
+    (root / "SOUL.md").write_text("Be helpful.", encoding="utf-8")
+    monkeypatch.setattr(gm, "_installed_service", lambda home: None)
+    monkeypatch.setattr(gm, "_live_gateway_pid", lambda home: None)
+    return root
+
+
+def _fingerprints(profile_home: Path) -> set:
+    """``(platform, fingerprint)`` claims exactly as the migrate preflight / multiplexer see them."""
+    with gm._multiplex_read_mode():
+        return set(gm._credential_claims(gm._profile_gateway_config(profile_home)))
+
+
+def test_clone_strips_every_channel_credential_but_keeps_model_and_tool_keys(home):
+    source_claims = _fingerprints(home)
+    assert {p for p, _ in source_claims} >= {"telegram", "discord"}
+
+    profile_dir = create_profile("bot2", clone_config=True, no_alias=True)
+
+    assert _fingerprints(profile_dir).isdisjoint(source_claims)
+    assert shared_channel_credentials(profile_dir, home) == []
+    env_text = (profile_dir / ".env").read_text(encoding="utf-8")
+    assert "OPENAI_API_KEY=sk-model-key" in env_text and "FIRECRAWL_API_KEY=fc-tool-key" in env_text
+    assert "TELEGRAM" not in env_text and "DISCORD" not in env_text
+    assert "WHATSAPP_ENABLED" not in env_text and "API_SERVER_KEY" not in env_text
+    cfg = yaml.safe_load((profile_dir / "config.yaml").read_text(encoding="utf-8"))
+    assert cfg["model"] == _SOURCE_CONFIG["model"] and cfg["memory"] == _SOURCE_CONFIG["memory"]
+    assert (profile_dir / "SOUL.md").read_text(encoding="utf-8") == "Be helpful."
+    for section in ("platforms", "telegram", "discord"):
+        assert section not in cfg
+    # The clone must not think it is the host's multiplexer, but unrelated gateway knobs survive.
+    assert "multiplex_profiles" not in cfg["gateway"] and "profile_routes" not in cfg["gateway"]
+    assert cfg["gateway"]["platform_connect_timeout"] == 45
+    # The migrate preflight, which blocked with a duplicate finding per platform, is now clean.
+    plan = gm.build_migration_plan()
+    assert not plan.blocked, plan.blockers
+
+
+def test_clone_channels_opt_in_keeps_the_source_channels(home):
+    profile_dir = create_profile("twin", clone_config=True, no_alias=True, clone_channels=True)
+    assert _fingerprints(profile_dir) == _fingerprints(home)
+    assert set(shared_channel_credentials(profile_dir, home)) >= {"telegram", "discord"}
+    assert set(channel_platforms_configured(profile_dir)) >= {"telegram", "discord", "whatsapp", "api_server"}
+    assert gm.build_migration_plan().blocked
+
+
+def test_clone_all_drops_pairing_and_platform_state(home):
+    (home / "platforms" / "pairing").mkdir(parents=True)
+    (home / "platforms" / "pairing" / "telegram_approved.json").write_text("{}", encoding="utf-8")
+    (home / "discord_threads.json").write_text("{}", encoding="utf-8")
+    (home / "memories").mkdir()
+    (home / "memories" / "MEMORY.md").write_text("remember", encoding="utf-8")
+
+    profile_dir = create_profile("full", clone_all=True, no_alias=True)
+
+    assert not (profile_dir / "platforms").exists() and not (profile_dir / "discord_threads.json").exists()
+    assert (profile_dir / "memories" / "MEMORY.md").read_text(encoding="utf-8") == "remember"
+    assert _fingerprints(profile_dir) == set()
+
+
+def test_strip_env_file_keeps_comments_and_unknown_keys_verbatim(tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("# header\nexport OPENAI_API_KEY=abc\n\nTELEGRAM_BOT_TOKEN=1:x\nMY_CUSTOM_THING=1\n", encoding="utf-8")
+    removed = strip_channel_env_file(env)
+    assert removed == {"telegram": ["TELEGRAM_BOT_TOKEN"]}
+    assert env.read_text(encoding="utf-8") == "# header\nexport OPENAI_API_KEY=abc\n\nMY_CUSTOM_THING=1\n"

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -323,6 +323,10 @@ def _mirror_launch_credentials(path, params: dict) -> dict:
     # .env: only over the seeded comment-only stub (never a clone's secrets).
     mirrored["env"] = _try(lambda: _mirror_secret(path, launch_home, ".env", lambda src, dst: (
         _env_has_content(src) and not _try(lambda: _env_has_content(dst), False))), False)
+    if mirrored["env"] and not is_truthy_value(params.get("clone_channels", False)):
+        # Provider/tool keys are what "mirror credentials" means; the launch profile's bot tokens
+        # and allowlists would make the new bot collide with it over one Telegram/Discord bot.
+        _best_effort(lambda: _lazy("hermes_cli.profile_channels", "strip_channel_env_file")(path / ".env"))
     if not share_auth:  # a copy forks token state: the first refresh in either store strands the other
         mirrored["auth"] = _try(lambda: _mirror_secret(path, launch_home, "auth.json",
                                                        lambda src, dst: not dst.exists()), False)
@@ -337,7 +341,8 @@ def _mirror_launch_credentials(path, params: dict) -> dict:
 @method("profiles.create")
 def _(rid, params: dict) -> dict:
     """Create a profile (ws twin of POST /api/profiles). Params: ``name``, ``description``,
-    ``clone_from`` (omitted = fresh + bundled skills), ``clone_all``, ``no_skills``, ``soul``,
+    ``clone_from`` (omitted = fresh + bundled skills), ``clone_all``, ``clone_channels`` (opt-in: keep the
+    source's bot tokens/allowlists — default strips them so two profiles never hold one bot), ``no_skills``, ``soul``,
     ``model`` + ``provider``, ``share_auth``, ``no_alias``, ``mirror_credentials`` (default true: a bare
     ``create_profile()`` seeds a comment-only .env and no auth.json = NO provider headless)."""
     name = str(params.get("name") or "").strip()
@@ -351,7 +356,8 @@ def _(rid, params: dict) -> dict:
             name=name, clone_from=clone_from, clone_all=clone_all,
             clone_config=bool(clone_from) and not clone_all,
             no_skills=is_truthy_value(params.get("no_skills", False)),
-            description=str(params.get("description") or "").strip() or None)
+            description=str(params.get("description") or "").strip() or None,
+            clone_channels=is_truthy_value(params.get("clone_channels", False)))
     except (ValueError, FileExistsError, FileNotFoundError) as e:
         return _err(rid, 4062, str(e))
     except Exception as e:

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -802,7 +802,23 @@ preflight:
   fix and the one-liner to run later. Nothing is changed.
 
 Single-profile installs are never migrated (there is nothing to gain), and an
-install that is already multiplexing is left alone.
+install that is already multiplexing is left alone. `hermes update` also does
+nothing when no secondary profile runs its own gateway — it never flips modes
+on an install where nothing was running.
+
+The explicit command is different: `hermes gateway migrate --multiplex` with
+two or more profiles and **no** standalone secondary gateway still applies the
+one remaining step — it sets `gateway.multiplex_profiles: true`, (re)starts the
+default gateway and writes the same rollback manifest (with an empty
+`secondaries` list), so `--standalone` undoes it. You asked for multiplex; you
+get multiplex.
+
+:::tip Clones do not carry channels
+`hermes profile create --clone` leaves the source's bot tokens and allowlists
+behind (see [Profiles → messaging channels are never cloned](./profiles.md#messaging-channels-are-never-cloned---clone-channels-to-opt-in)),
+so a fleet of clones no longer trips the duplicate-credential blocker below.
+Older clones that still carry them are flagged by `hermes profile list`.
+:::
 
 ### What the migration does
 

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -80,6 +80,34 @@ hermes profile create work --clone-from coder
 hermes profile create work-backup --clone-from coder --clone-all
 ```
 
+### Messaging channels are never cloned (`--clone-channels` to opt in)
+
+Every clone — `--clone`, `--clone-from`, `--clone-all`, and the dashboard / Desktop / TUI
+"clone from profile" option — copies the source **without its messaging channels**: bot tokens
+and allowlists (`TELEGRAM_BOT_TOKEN`, `DISCORD_ALLOWED_USERS`, `WHATSAPP_ENABLED`,
+`API_SERVER_KEY`, `WEBHOOK_SECRET`, …), the `platforms:` / `telegram:` / `discord:` sections of
+`config.yaml`, `gateway.multiplex_profiles` / `profile_routes`, and (for `--clone-all`) the
+pairing store, WhatsApp session and other per-bot state. Provider and tool API keys, the model
+block, memory settings, skills and `SOUL.md` are copied as before. The command prints which
+platforms were left behind.
+
+The reason is that a bot can only belong to one profile: two standalone gateways holding the
+same token fight over its long-poll, and a [multiplexed gateway](./multi-profile-gateways.md)
+parks the duplicate adapter (and `hermes gateway migrate --multiplex` refuses with one
+duplicate-credential blocker per platform). Configure the new profile's own bots with
+`hermes -p <name> setup` or the dashboard Messaging page.
+
+```bash
+hermes profile create twin --clone --clone-channels   # keep the source's bots anyway
+```
+
+`--clone-channels` is refused when a running multiplexed gateway already serves the source
+(the copy would be parked immediately) and otherwise prints a warning naming the platforms
+now shared with the source. `hermes profile list` prints the same warning for any existing
+profile whose bot credential is byte-identical to the default's, so older clones surface
+before they bite. The key set is derived from the platform adapters themselves (registry
+entries and the gateway's env table), so a newly added platform is covered automatically.
+
 :::tip Honcho memory + profiles
 When Honcho is enabled, clone operations automatically create a dedicated AI peer for the new profile while sharing the same user workspace. Each profile builds its own observations and identity. See [Honcho -- Multi-agent / Profiles](./features/memory-providers.md#honcho) for details.
 :::


### PR DESCRIPTION
`hermes profile create --clone` (every entry point) now leaves the source's messaging channels behind, so a cloned profile never collides with the original's Telegram/Discord/WhatsApp/API-server bot; `--clone-channels` opts back in, `gateway.multiplex_profiles` is a recognized config key, and an explicit `hermes gateway migrate --multiplex` turns multiplex on even when no secondary runs its own gateway.

## Root cause

`_CLONE_CONFIG_FILES = ["config.yaml", ".env", "SOUL.md"]` copied `.env` and `config.yaml` verbatim, so every clone carried `TELEGRAM_BOT_TOKEN`, `DISCORD_BOT_TOKEN`, allowlists, `WHATSAPP_ENABLED`, `API_SERVER_KEY` and the `platforms:`/`telegram:`/`discord:` sections byte-for-byte (`--clone-all` also copied the pairing store and WhatsApp session). Standalone, two gateways fought over one bot's long-poll; under multiplex the migrate preflight blocked with one duplicate-credential finding per platform per clone — 18 on a real 10-profile install where 9 profiles had been `--clone`d from default. Separately, `DEFAULT_CONFIG["gateway"]` never listed `multiplex_profiles`/`profile_routes` (read only by the raw gateway loader), and `cmd_migrate` returned early on `not plan.standalone_secondaries`.

## Changes

- **`hermes_cli/profile_channels.py`** (new): derives the channel key set from the adapters — `Platform` enum + plugin registry (`required_env`, `allowed_users_env`, `allow_all_env`, `cron_deliver_env_var`), the gateway env table (`gateway.config_env._ENV_STEPS` / `_ENV_ENABLE_CREDENTIALS`) and each platform's env prefix — so a new adapter is covered with no hand list. Strips `.env` keys (comments/other keys verbatim), the `platforms` / `<platform>:` / `gateway.platforms` / `gateway.<platform>` config sections plus `multiplex_profiles`/`profile_routes` (a clone must not think it is the host's multiplexer), and for `--clone-all` the `platforms/` (pairing, WhatsApp session), `gateway/`, `channel_directory.json`, `<platform>_*.json` state.
- **`create_profile(..., clone_channels=False)`** strips after the copy on both the `--clone` and `--clone-all` paths. Wired through the CLI (`--clone-channels`, consistent with `--clone`/`--clone-all`/`--clone-from`), dashboard `POST /api/profiles` (`clone_channels`), and TUI/Desktop `profiles.create` (`clone_channels`) — including its `mirror_credentials` `.env` copy for fresh bots, which was a second door for the same collision.
- CLI notice after a clone lists the platforms left behind and how to configure the new bot (`hermes -p X setup` / dashboard Messaging page). `--clone-channels` is refused when a live multiplexer already serves the source (same explanation the migrate preflight gives) and otherwise warns which platforms are now shared. `hermes profile list` prints `⚠ Profile 'X' shares its telegram, discord credential with default …` for existing clones (byte-identical connecting credential in `.env` or `platforms.<p>.token`; pure file reads).
- The dashboard's `_PLATFORM_ENV_PREFIX_ALIASES` moves into `profile_channels` so Channels-page cards and the stripper share one definition.
- **`DEFAULT_CONFIG["gateway"]`** registers `multiplex_profiles: false` and `profile_routes: []` with doc comments; no `_config_version` bump (new keys deep-merge).
- **`gateway_migrate.cmd_migrate`**: with ≥2 profiles and zero standalone secondaries the explicit command applies the one remaining step (flag on, default gateway (re)started, same manifest with empty `secondaries` for `--standalone`). `maybe_auto_migrate_after_update` is unchanged and still treats that case as a no-op — `hermes update` never flips modes when nothing was running (`test_update_hook_never_touches_single_profile_or_already_multiplexed` still pins it).
- Docs: `profiles.md` (new "Messaging channels are never cloned" section), `multi-profile-gateways.md` (explicit-vs-update behaviour, clone tip), `hermes_cli/AGENTS.md`.

## Validation

| Check | Before (origin/main `de2d6a1b`) | After |
|---|---|---|
| `hermes profile create bot2 --clone` from a default with TG+Discord+WhatsApp+API-server creds in `.env` **and** `config.yaml` | bot2 `.env` has all 10 keys; `platforms:`/`telegram:`/`discord:` sections copied | bot2 `.env` = `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `FIRECRAWL_API_KEY` only; no platform sections; notice: `Messaging channels were NOT cloned (api_server, discord, telegram, whatsapp)` |
| `hermes gateway migrate --multiplex --dry-run` on that pair | `✗ Blockers: … both configure telegram …`, `… both configure discord …` | zero blockers; plan lists the flag flip + default start |
| `--clone-channels` | n/a | keeps all keys; prints `⚠ Profile 'bot2' shares its discord, telegram, whatsapp credential with default` |
| `hermes profile list` with a duplicate clone | table only | table + the same shared-credential warning |
| `hermes config set gateway.multiplex_profiles true` | `⚠ … not a recognized config key` | `✓ Set …`, no warning |
| `migrate --multiplex`, 3 profiles, none standalone | `No secondary profile runs its own gateway; nothing to migrate.` — flag stays off | flag `true`, default started, manifest written, `--standalone` restores |
| Dashboard `POST /api/profiles {clone_from: default}` / TUI `profiles.create` (clone and fresh+mirror) | `.env` carried `TELEGRAM_BOT_TOKEN` | stripped; `clone_channels: true` keeps it (E2E with real `TestClient` / RPC handler against a temp `HERMES_HOME`) |
| `--clone-all` | copied `platforms/pairing`, `discord_threads.json` | dropped; `memories/MEMORY.md` kept |

**Live repro:** `/tmp/clone-fix/live_repro.sh` — scratch `HOME`, fake tokens; base shows the two duplicate-credential blockers and the unrecognized-key warning, fixed tree shows none (values redacted in the transcript).

Tests (red on base by `git show origin/main:<file>` swap, green after): `tests/hermes_cli/test_profile_clone_channels.py` (fingerprint set via the gateway's own `_adapter_credential_fingerprint` is disjoint from the source while model/tool keys survive; `--clone-channels` restores it; `--clone-all` drops pairing state; `.env` comments/unknown keys verbatim), `test_gateway_migrate_multiplex.py::test_explicit_migrate_with_no_standalone_secondaries_still_flips_flag_and_restarts_default`, `test_config.py::test_gateway_multiplex_keys_are_recognized_config_keys`. `tests/hermes_cli/ + tests/tui_gateway/`: 10741 passed; the one failure (`test_update_head_moved_gate.py::test_update_success_when_head_moves`) fails identically on the untouched main checkout at the same SHA (managed-uv install path), unrelated.

## Infographic

![profile clone leaves the bots behind](https://v3b.fal.media/files/b/0aaa324e/Ehg5SBoKoSOOIoUxw5dnD_h7jW6uFf.png)
