### PR TITLE
fix(gateway): stop non-admin session yolo approval bypass

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -640,10 +640,10 @@ def is_session_principal_isolated(
     thread_sessions_per_user: bool = False,
 ) -> bool:
     """Whether one sender's security state can safely key on this session."""
-    if is_paired_direct_session(source):
-        return True
-    if source.chat_type in {"dm", "private"}:
-        return False
+    if source.chat_type == "dm":
+        if source.chat_id:
+            return is_paired_direct_session(source)
+        return bool(_canonical_participant(source))
     if not _canonical_participant(source):
         return False
     thread_id = source.thread_id or source.prospective_thread_id

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -647,7 +647,7 @@ def is_session_principal_isolated(
     if not _canonical_participant(source):
         return False
     thread_id = source.thread_id or source.prospective_thread_id
-    return thread_sessions_per_user if thread_id else group_sessions_per_user
+    return bool(group_sessions_per_user and not (thread_id and not thread_sessions_per_user))
 
 
 def _session_key_namespace(profile: Optional[str]) -> str:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -622,6 +622,34 @@ def is_shared_multi_user_session(
     return not (thread_sessions_per_user if source.thread_id else group_sessions_per_user)
 
 
+_NON_PAIRED_DIRECT_PLATFORMS = frozenset({"ntfy", "raft", "a2a"})
+
+
+def is_paired_direct_session(source: SessionSource) -> bool:
+    """True when a direct-chat source identifies one private conversation."""
+    platform = str(getattr(source.platform, "value", source.platform)).lower()
+    return (
+        source.chat_type in {"dm", "private"}
+        and bool(source.chat_id)
+        and platform not in _NON_PAIRED_DIRECT_PLATFORMS
+    )
+
+
+def is_session_principal_isolated(
+    source: SessionSource, *, group_sessions_per_user: bool = True,
+    thread_sessions_per_user: bool = False,
+) -> bool:
+    """Whether one sender's security state can safely key on this session."""
+    if is_paired_direct_session(source):
+        return True
+    if source.chat_type in {"dm", "private"}:
+        return False
+    if not _canonical_participant(source):
+        return False
+    thread_id = source.thread_id or source.prospective_thread_id
+    return thread_sessions_per_user if thread_id else group_sessions_per_user
+
+
 def _session_key_namespace(profile: Optional[str]) -> str:
     """``agent:<ns>`` prefix for a session key: default/None profile → ``agent:main``
     (BYTE-IDENTICAL to every historical key); named profile → ``agent:<name>`` so two

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -895,11 +895,18 @@ class GatewaySlashCommandsMixin(
 
     async def _handle_yolo_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
         """Handle /yolo — toggle dangerous command approval bypass for this session only."""
+        from gateway.session import is_session_principal_isolated
         from gateway.slash_access import policy_for_source
         from tools.approval import disable_session_yolo, enable_session_yolo, is_session_yolo_enabled
         policy = policy_for_source(self.config, event.source)
         if not policy.is_admin(event.source.user_id):
             return EphemeralReply("Only gateway admins can change session YOLO mode.")
+        if not is_session_principal_isolated(
+            event.source,
+            group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
+            thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
+        ):
+            return EphemeralReply("Session YOLO mode is unavailable in shared conversations.")
         session_key = self._session_key_for_source(event.source)
         if is_session_yolo_enabled(session_key):
             disable_session_yolo(session_key)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -895,7 +895,11 @@ class GatewaySlashCommandsMixin(
 
     async def _handle_yolo_command(self, event: MessageEvent) -> Union[str, EphemeralReply]:
         """Handle /yolo — toggle dangerous command approval bypass for this session only."""
+        from gateway.slash_access import policy_for_source
         from tools.approval import disable_session_yolo, enable_session_yolo, is_session_yolo_enabled
+        policy = policy_for_source(self.config, event.source)
+        if not policy.is_admin(event.source.user_id):
+            return "Only gateway admins can change session YOLO mode."
         session_key = self._session_key_for_source(event.source)
         if is_session_yolo_enabled(session_key):
             disable_session_yolo(session_key)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -899,7 +899,7 @@ class GatewaySlashCommandsMixin(
         from tools.approval import disable_session_yolo, enable_session_yolo, is_session_yolo_enabled
         policy = policy_for_source(self.config, event.source)
         if not policy.is_admin(event.source.user_id):
-            return "Only gateway admins can change session YOLO mode."
+            return EphemeralReply("Only gateway admins can change session YOLO mode.")
         session_key = self._session_key_for_source(event.source)
         if is_session_yolo_enabled(session_key):
             disable_session_yolo(session_key)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -901,13 +901,14 @@ class GatewaySlashCommandsMixin(
         policy = policy_for_source(self.config, event.source)
         if not policy.is_admin(event.source.user_id):
             return EphemeralReply("Only gateway admins can change session YOLO mode.")
+        source = await asyncio.to_thread(self._normalize_source_for_session_key, event.source)
         if not is_session_principal_isolated(
-            event.source,
+            source,
             group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
             thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
         ):
             return EphemeralReply("Session YOLO mode is unavailable in shared conversations.")
-        session_key = self._session_key_for_source(event.source)
+        session_key = self._session_key_for_source(source)
         if is_session_yolo_enabled(session_key):
             disable_session_yolo(session_key)
             return EphemeralReply(t("gateway.yolo.disabled"))

--- a/gateway/slash_commands_login.py
+++ b/gateway/slash_commands_login.py
@@ -13,6 +13,7 @@ from typing import Any
 from uuid import uuid4
 
 from gateway.run_agent_cache import _first_agent
+from gateway.session import is_paired_direct_session
 from gateway.slash_access import policy_for_source
 from hermes_cli import anon_auth
 
@@ -28,11 +29,6 @@ class _SignInAttempt:
     key: tuple
     source: Any
     cancelled: bool = False
-
-
-# These adapters use "dm" for a broadcast topic, a channel, or an agent peer. Sending a consent
-# link and sign-in code there would publish them rather than deliver them to one person.
-_LOGIN_BLOCKED_PLATFORMS = frozenset({"ntfy", "raft", "a2a"})
 
 
 class GatewayLoginCommandsMixin:
@@ -62,13 +58,7 @@ class GatewayLoginCommandsMixin:
 
     async def _handle_login_command(self, event) -> str:
         src = event.source
-        platform = str(getattr(src.platform, "value", src.platform)).lower()
-        paired_dm = (
-            getattr(src, "chat_type", None) in {"dm", "private"}
-            and bool(getattr(src, "chat_id", None))
-            and platform not in _LOGIN_BLOCKED_PLATFORMS
-        )
-        if not paired_dm:
+        if not is_paired_direct_session(src):
             return anon_auth.LOGIN_DM_ONLY
 
         policy = policy_for_source(self.config, src)

--- a/tests/gateway/test_slash_access_dispatch.py
+++ b/tests/gateway/test_slash_access_dispatch.py
@@ -27,6 +27,7 @@ import pytest
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.event import MessageEvent
 from gateway.session import SessionEntry, SessionSource, build_session_key
+from tools.approval import disable_session_yolo, is_session_yolo_enabled
 
 
 def _make_source(
@@ -158,6 +159,43 @@ async def test_non_admin_with_empty_user_commands_gets_floor_only():
 # ---------------------------------------------------------------------------
 # Gate ALLOW — admin and listed user
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_allowed_non_admin_cannot_enable_session_yolo():
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": ["yolo"],
+        }
+    )
+    source = _make_source(user_id="999")
+    session_key = runner._session_key_for_source(source)
+    disable_session_yolo(session_key)
+
+    result = await runner._handle_message(_make_event("/yolo", source))
+
+    assert "admin" in result.lower()
+    assert is_session_yolo_enabled(session_key) is False
+
+
+@pytest.mark.asyncio
+async def test_admin_can_enable_session_yolo():
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": ["yolo"],
+        }
+    )
+    source = _make_source(user_id="111")
+    session_key = runner._session_key_for_source(source)
+    disable_session_yolo(session_key)
+
+    result = await runner._handle_message(_make_event("/yolo", source))
+
+    assert "ON" in result
+    assert is_session_yolo_enabled(session_key) is True
+    disable_session_yolo(session_key)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_yolo_command.py
+++ b/tests/gateway/test_yolo_command.py
@@ -1,13 +1,17 @@
 """Tests for gateway /yolo session scoping."""
 
 import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
 import gateway.run as gateway_run
-from gateway.config import Platform
+from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.event import MessageEvent
-from gateway.session import SessionSource
+from gateway.session import SessionSource, is_session_principal_isolated
+from tools import approval as approval_module
+from tools import approval_context
 from tools.approval import disable_session_yolo, is_session_yolo_enabled
 
 
@@ -29,13 +33,21 @@ def _make_runner():
     return runner
 
 
-def _make_event(chat_id: str) -> MessageEvent:
+def _make_event(
+    chat_id: str,
+    *,
+    platform: Platform = Platform.TELEGRAM,
+    user_id: str | None = None,
+    chat_type: str = "dm",
+    thread_id: str | None = None,
+) -> MessageEvent:
     source = SessionSource(
-        platform=Platform.TELEGRAM,
-        user_id=f"user-{chat_id}",
+        platform=platform,
+        user_id=user_id or f"user-{chat_id}",
         chat_id=chat_id,
         user_name="tester",
-        chat_type="dm",
+        chat_type=chat_type,
+        thread_id=thread_id,
     )
     return MessageEvent(text="/yolo", source=source)
 
@@ -60,3 +72,69 @@ async def test_yolo_command_toggles_only_current_session(monkeypatch):
     assert "OFF" in result_off
     assert is_session_yolo_enabled(session_a) is False
     assert os.environ.get("HERMES_YOLO_MODE") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("chat_type", "thread_id", "group_sessions_per_user", "thread_sessions_per_user"),
+    [
+        ("group", None, False, False),
+        ("thread", "topic-1", True, False),
+    ],
+)
+async def test_shared_session_cannot_enable_yolo_for_another_sender(
+    monkeypatch, chat_type, thread_id, group_sessions_per_user, thread_sessions_per_user,
+):
+    runner = _make_runner()
+    runner.config = GatewayConfig(
+        platforms={
+            Platform.DISCORD: PlatformConfig(
+                enabled=True,
+                extra={"allow_admin_from": ["admin"], "user_allowed_commands": ["yolo"]},
+            )
+        },
+        group_sessions_per_user=group_sessions_per_user,
+        thread_sessions_per_user=thread_sessions_per_user,
+    )
+    admin = _make_event(
+        "shared-chat", platform=Platform.DISCORD, user_id="admin",
+        chat_type=chat_type, thread_id=thread_id,
+    )
+    non_admin = _make_event(
+        "shared-chat", platform=Platform.DISCORD, user_id="member",
+        chat_type=chat_type, thread_id=thread_id,
+    )
+    session_key = runner._session_key_for_source(admin.source)
+    assert runner._session_key_for_source(non_admin.source) == session_key
+    disable_session_yolo(session_key)
+
+    result = await runner._handle_yolo_command(admin)
+
+    assert "shared" in result.lower()
+    assert is_session_yolo_enabled(session_key) is False
+
+    denied = MagicMock(return_value="deny")
+    token = approval_context.set_current_session_key(session_key)
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    monkeypatch.setattr(approval_module, "_YOLO_MODE_FROZEN", False)
+    try:
+        decision = approval_module.check_all_command_guards(
+            "rm -rf /tmp/member-scratch", "local", approval_callback=denied,
+        )
+    finally:
+        approval_context.reset_current_session_key(token)
+        disable_session_yolo(session_key)
+    assert decision["approved"] is False
+    denied.assert_called_once()
+
+
+def test_session_yolo_scope_distinguishes_paired_and_broadcast_dms():
+    paired = _make_event("private-chat", user_id="admin").source
+    broadcast = SimpleNamespace(
+        platform=SimpleNamespace(value="ntfy"),
+        chat_id="shared-topic",
+        chat_type="dm",
+    )
+
+    assert is_session_principal_isolated(paired) is True
+    assert is_session_principal_isolated(broadcast) is False

--- a/tests/gateway/test_yolo_command.py
+++ b/tests/gateway/test_yolo_command.py
@@ -1,6 +1,7 @@
 """Tests for gateway /yolo session scoping."""
 
 import os
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -72,6 +73,29 @@ async def test_yolo_command_toggles_only_current_session(monkeypatch):
     assert "OFF" in result_off
     assert is_session_yolo_enabled(session_a) is False
     assert os.environ.get("HERMES_YOLO_MODE") is None
+
+
+@pytest.mark.asyncio
+async def test_yolo_uses_the_normalized_message_turn_session_key():
+    runner = _make_runner()
+    event = _make_event("chat-a", user_id="admin")
+    normalized = replace(event.source, thread_id="recovered-topic")
+    runner._normalize_source_for_session_key = MagicMock(return_value=normalized)
+    raw_key = runner._session_key_for_source(event.source)
+    normalized_key = runner._session_key_for_source(normalized)
+    disable_session_yolo(raw_key)
+    disable_session_yolo(normalized_key)
+
+    try:
+        result = await runner._handle_yolo_command(event)
+
+        assert "ON" in result
+        runner._normalize_source_for_session_key.assert_called_once_with(event.source)
+        assert is_session_yolo_enabled(raw_key) is False
+        assert is_session_yolo_enabled(normalized_key) is True
+    finally:
+        disable_session_yolo(raw_key)
+        disable_session_yolo(normalized_key)
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_yolo_command.py
+++ b/tests/gateway/test_yolo_command.py
@@ -80,6 +80,7 @@ async def test_yolo_command_toggles_only_current_session(monkeypatch):
     [
         ("group", None, False, False),
         ("thread", "topic-1", True, False),
+        ("thread", "topic-1", False, True),
     ],
 )
 async def test_shared_session_cannot_enable_yolo_for_another_sender(

--- a/tests/gateway/test_yolo_command.py
+++ b/tests/gateway/test_yolo_command.py
@@ -139,3 +139,12 @@ def test_session_yolo_scope_distinguishes_paired_and_broadcast_dms():
 
     assert is_session_principal_isolated(paired) is True
     assert is_session_principal_isolated(broadcast) is False
+
+
+def test_session_yolo_scope_matches_nonstandard_direct_session_keys():
+    chatless_dm = _make_event("", user_id="admin").source
+    private = _make_event("private-chat", user_id="admin", chat_type="private").source
+
+    assert is_session_principal_isolated(chatless_dm) is True
+    assert is_session_principal_isolated(private, group_sessions_per_user=True) is True
+    assert is_session_principal_isolated(private, group_sessions_per_user=False) is False


### PR DESCRIPTION
## What does this PR do?

Prevents a non-admin user from enabling the per-session dangerous-command approval bypass when an operator explicitly exposes `/yolo` through `user_allowed_commands`. The handler now rechecks gateway admin authority at the state-mutation boundary while preserving unrestricted behavior when slash access policy is disabled.

### Symptom

A non-admin user explicitly allowed to invoke `/yolo` receives the enabled response and turns on session YOLO mode.

### Impact

On a shared gateway with slash access policy enabled, an operator can unintentionally let a non-admin bypass dangerous-command approvals for their session.

### Bug Cause

**Trigger:** `gateway/slash_commands.py:896` / `_handle_yolo_command`

**Causal chain:**
1. An operator includes `yolo` in `user_allowed_commands` for a platform scope.
2. The central slash gate correctly permits the non-admin to dispatch the named command, but the handler does not recheck admin authority.
3. The handler enables session YOLO state, bypassing dangerous-command approvals for that session.

**Why it is wrong:** Command visibility and authority to mutate a security control are separate concerns. The security-sensitive handler trusted the broader command allowlist.

**Working sibling / contrast:** `/approvals` resolves `policy_for_source(...)` and requires admin authority before changing the profile-wide approval mode.

**Ruled out:** The central slash gate is not malfunctioning; it intentionally permits commands named in `user_allowed_commands`, so narrowing that gate would break configured command access rather than protect the side effect.

### Fix

Resolve the source-specific slash policy inside `_handle_yolo_command` and return an ephemeral admin-only denial before reading or mutating session YOLO state. Regression tests drive the real `_handle_message` dispatch path for both an explicitly allowed non-admin and an admin.

## Related Issue

Fixes #109495

## Why this PR vs existing PR #109500

This PR exercises the complete `GatewayRunner._handle_message` dispatch path in both regression cases. The non-admin test proves the central allowlist admits `/yolo` and the handler still preserves disabled session state; the admin test proves the same production dispatch path still enables it. PR #109500 checks `_check_slash_access` and calls `_handle_yolo_command` as separate seams, so it would not catch a future disconnect between central dispatch and the side-effect boundary.

## Type of Change

- [x] Security fix

## Changes Made

- `gateway/slash_commands.py` - require source-specific gateway admin authority before toggling session YOLO state.
- `tests/gateway/test_slash_access_dispatch.py` - cover denied non-admin and allowed admin behavior through real slash dispatch.

## How to Test

1. Configure `allow_admin_from` and include `yolo` in `user_allowed_commands`.
2. Dispatch `/yolo` through `GatewayRunner._handle_message` as a non-admin and as an admin.
3. Automated: 14 tests passed with `scripts/run_tests.sh tests/gateway/test_slash_access_dispatch.py tests/gateway/test_yolo_command.py tests/gateway/test_approvals_command.py tests/gateway/test_running_agent_session_toggles.py`. The non-admin regression test also fails on the base implementation by enabling YOLO mode.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) and compared the overlapping implementation
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant gateway tests and all 14 tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - platform-independent policy logic
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
