### PR TITLE
fix(bot-screen): clean up failed desktop starts

### DIFF
--- a/tests/tools/test_bot_desktop_runtime.py
+++ b/tests/tools/test_bot_desktop_runtime.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from tools.bot_desktop import runtime, thumbnail
+from tools.bot_desktop import browser, runtime, thumbnail
 
 
 @pytest.mark.parametrize("pm", sorted(runtime.PACKAGES))
@@ -144,3 +144,49 @@ def test_concurrent_starts_of_one_profile_spawn_one_launcher(tmp_path, start_in_
     out = _collect([start_in_fresh_process(tmp_path / "a"), start_in_fresh_process(tmp_path / "a")])
     assert len({o["pid"] for o in out}) == 1, out
     assert len(list((tmp_path / "xlocks").glob("spawned.*"))) == 1
+
+
+@pytest.mark.linux_only
+@pytest.mark.parametrize(("launcher_body", "error"), [
+    ("""sleep 30 &
+child=$!
+printf '%s %s\\n' "$$" "$child" > "${HERMES_BD_ENV_FILE}.pids"
+exit 0
+""", "launcher exited"),
+    ("""sh -c 'trap "" TERM; exec sleep 30' &
+child=$!
+printf '%s %s\\n' "$$" "$child" > "${HERMES_BD_ENV_FILE}.pids"
+: > "$HERMES_BD_SOCKET"
+wait
+""", "did not publish its display"),
+], ids=["launcher-exited-first", "child-ignores-term"])
+def test_failed_start_kills_residual_process_group_and_clears_state(
+        tmp_path, monkeypatch, launcher_body, error):
+    """Failure cleanup kills children even after their launcher exits or when they ignore TERM."""
+    import psutil
+    import time
+
+    launcher = tmp_path / "failed-launcher.sh"
+    launcher.write_text("#!/usr/bin/env bash\n" + launcher_body, encoding="utf-8")
+    monkeypatch.setattr(runtime, "_LAUNCHER", launcher)
+    monkeypatch.setattr(runtime, "geometry", lambda: "800x600")
+    monkeypatch.setattr(browser, "dock_launch", lambda: None)
+
+    with pytest.raises(RuntimeError, match=error):
+        runtime._spawn_and_wait(tmp_path, 42, 0.5)
+
+    launcher_pid, child_pid = map(int, (tmp_path / "env.pids").read_text(encoding="utf-8").split())
+
+    def alive(pid):
+        try:
+            return psutil.Process(pid).status() != psutil.STATUS_ZOMBIE
+        except psutil.NoSuchProcess:
+            return False
+
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline and any(alive(pid) for pid in (launcher_pid, child_pid)):
+        time.sleep(0.02)
+    assert not any(alive(pid) for pid in (launcher_pid, child_pid))
+    assert not (tmp_path / "launcher.pid").exists()
+    assert not (tmp_path / "env").exists()
+    assert not (tmp_path / "rfb.sock").exists()

--- a/tools/bot_desktop/runtime.py
+++ b/tools/bot_desktop/runtime.py
@@ -287,6 +287,39 @@ def _profile_name() -> str:
         return "default"
 
 
+def _cleanup_failed_start(proc: subprocess.Popen, sd: Path, env_file: Path, pid_record: str) -> None:
+    """Stop and reap this launch attempt without deleting state published by another attempt."""
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)  # windows-footgun: ok — Linux-only start cleanup
+    except ProcessLookupError:
+        pass
+    except OSError as exc:
+        logger.warning("Could not terminate Bot Desktop launcher process group %s: %s", proc.pid, exc)
+    try:
+        proc.wait(timeout=5)
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+
+    # Kill residual group members even when the launcher exited or handled TERM. An existence probe before
+    # killpg would only add a check/use race; ESRCH is the atomic "there is no group left" result.
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)  # windows-footgun: ok — Linux-only start cleanup
+    except ProcessLookupError:
+        pass
+    except OSError as exc:
+        logger.warning("Could not kill residual Bot Desktop process group %s: %s", proc.pid, exc)
+    try:
+        proc.wait(timeout=5)
+    except (subprocess.TimeoutExpired, OSError):
+        logger.warning("Bot Desktop launcher process group %s survived cleanup", proc.pid)
+
+    pid_file = sd / "launcher.pid"
+    if proc.poll() is not None and _read(pid_file) == pid_record:
+        pid_file.unlink(missing_ok=True)
+        env_file.unlink(missing_ok=True)
+        (sd / "rfb.sock").unlink(missing_ok=True)
+
+
 def start(*, wait_seconds: float = 15.0) -> DesktopStatus:
     """Start this profile's desktop (idempotent). Blocks until the launcher publishes its env file or
     ``wait_seconds`` pass; raises ``RuntimeError`` naming the blocker.
@@ -332,23 +365,30 @@ def _spawn_and_wait(sd: Path, num: int, wait_seconds: float) -> DesktopStatus:
         child_env["HERMES_BD_BROWSER_EXEC"] = dock_command(*browser)
     # Truncated per start: the log is a diagnostic for THIS launch, and nothing rotates it otherwise.
     log = open(sd / "launcher.log", "wb")  # noqa: SIM115 — handed to the child, closed by it
-    proc = subprocess.Popen(  # windows-footgun: ok — Linux-only runtime (is_supported_host)
-        ["bash", str(_LAUNCHER)], env=child_env, stdin=subprocess.DEVNULL, stdout=log, stderr=log,
-        start_new_session=True, close_fds=True)
-    log.close()
+    try:
+        proc = subprocess.Popen(  # windows-footgun: ok — Linux-only runtime (is_supported_host)
+            ["bash", str(_LAUNCHER)], env=child_env, stdin=subprocess.DEVNULL, stdout=log, stderr=log,
+            start_new_session=True, close_fds=True)
+    finally:
+        log.close()
     born = _create_time(proc.pid)
-    (sd / "launcher.pid").write_text(f"{proc.pid} {born if born is not None else 0}", encoding="utf-8")
-
-    deadline = time.monotonic() + wait_seconds
-    while time.monotonic() < deadline:
-        if proc.poll() is not None:
-            tail = (sd / "launcher.log").read_bytes()[-2000:].decode("utf-8", "replace")
-            raise RuntimeError(f"Bot Desktop launcher exited with {proc.returncode}:\n{tail}")
-        if env_file.exists() and (sd / "rfb.sock").exists():
-            logger.info("Bot Desktop for profile %s up on :%s", _profile_name(), num)
-            return status()
-        time.sleep(0.1)
-    raise RuntimeError(f"Bot Desktop did not publish its display within {wait_seconds:.0f}s (see {sd / 'launcher.log'})")
+    pid_record = f"{proc.pid} {born if born is not None else 0}"
+    try:
+        (sd / "launcher.pid").write_text(pid_record, encoding="utf-8")
+        deadline = time.monotonic() + wait_seconds
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                tail = (sd / "launcher.log").read_bytes()[-2000:].decode("utf-8", "replace")
+                raise RuntimeError(f"Bot Desktop launcher exited with {proc.returncode}:\n{tail}")
+            if env_file.exists() and (sd / "rfb.sock").exists():
+                logger.info("Bot Desktop for profile %s up on :%s", _profile_name(), num)
+                return status()
+            time.sleep(0.1)
+        raise RuntimeError(
+            f"Bot Desktop did not publish its display within {wait_seconds:.0f}s (see {sd / 'launcher.log'})")
+    except BaseException:
+        _cleanup_failed_start(proc, sd, env_file, pid_record)
+        raise
 
 
 def stop() -> bool:


### PR DESCRIPTION
## Summary

A Bot Screen launcher that misses the readiness deadline currently survives after `_spawn_and_wait()` raises. The caller sees a failed start, but the launcher/Xvnc process group and partial profile state can remain active.

This change makes every post-spawn failure path:

- terminate the exact process group created by that attempt;
- wait for the launcher, escalating from `SIGTERM` to `SIGKILL` when needed;
- avoid masking the original failure when cleanup itself encounters an OS/wait error;
- remove `launcher.pid`, `env`, and `rfb.sock` only while the persisted PID + create-time record still belongs to that attempt;
- close the launcher log even if `Popen` fails.

The patch is rebased on Bot Screen head `bc36ddb5f9696c25acc5d51cf29a961710e2d5a3`, which already adds PID create-time validation and lifecycle/display-allocation locks.

## Why

Without cleanup, a timed-out start can leave a desktop process running while status reports it as stopped. A retry can then interact with stale process/socket state.

## Tests

Added a real Linux process-group regression test. It launches a Bash supervisor with a child process, forces readiness timeout, and verifies that:

- launcher and child are no longer live;
- `launcher.pid` is removed;
- partial `env` is removed;
- partial `rfb.sock` is removed.

Validated locally:

```text
scripts/run_tests.sh tests/tools/test_bot_desktop_runtime.py
10 tests passed

python scripts/check-windows-footguns.py --all
No Windows footguns found (1551 files scanned)

uv run ruff check tools/bot_desktop/runtime.py tests/tools/test_bot_desktop_runtime.py
All checks passed

git diff --check
clean
```
