### PR TITLE
security: state.db, snapshots and memory locks are owner-only regardless of umask (salvage #102878 + #59716, goose#11613)

### DIFF
--- a/contributors/emails/hermes-fleet-fix@localhost
+++ b/contributors/emails/hermes-fleet-fix@localhost
@@ -1,0 +1,1 @@
+rohitsabu

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -322,6 +322,21 @@ def _safe_copy_db(src: Path, dst: Path, *, timeout_seconds: float = 10.0) -> boo
     """
     conn = backup_conn = None
     try:
+        # sqlite3.connect() creates a missing destination with the process
+        # umask, which is commonly 0022 (0644).  Snapshot databases contain
+        # session and tool state, so create the inode owner-only before SQLite
+        # writes its first byte.  O_NOFOLLOW also refuses a planted symlink on
+        # platforms that support it.  Tighten an existing internal staging
+        # file as well (NamedTemporaryFile callers already create it 0600).
+        if os.name != "nt":
+            open_flags = os.O_WRONLY | os.O_CREAT
+            if hasattr(os, "O_NOFOLLOW"):
+                open_flags |= os.O_NOFOLLOW
+            secure_fd = os.open(dst, open_flags, 0o600)
+            try:
+                os.fchmod(secure_fd, 0o600)
+            finally:
+                os.close(secure_fd)
         # timeout=0.0 disables sqlite3's implicit busy wait so the progress callback owns the
         # full locked-source deadline instead of adding the default timeout before each callback.
         conn = sqlite3.connect(f"file:{src}?mode=ro", uri=True, timeout=0.0)
@@ -1182,6 +1197,25 @@ def _copy_quick_snapshot_files(
     return manifest, failed_dbs, oversized_skipped
 
 
+def _secure_quick_snapshot_tree(root: Path, snapshot_dir: Path) -> None:
+    """Make a staged quick snapshot owner-only before it is published.
+
+    The staging directory is private from creation, so copied source modes can
+    be normalized safely before the final atomic rename exposes the snapshot.
+    Permission failures are intentionally fatal: publishing a readable
+    recovery bundle is worse than reporting a failed snapshot.
+    """
+    if os.name == "nt":
+        return
+    os.chmod(root, 0o700)
+    os.chmod(snapshot_dir, 0o700)
+    for path in snapshot_dir.rglob("*"):
+        if path.is_dir():
+            os.chmod(path, 0o700)
+        elif path.is_file():
+            os.chmod(path, 0o600)
+
+
 def _create_quick_snapshot_locked(
     label: Optional[str], home: Path, keep: Optional[int], max_file_size: Optional[int]
 ) -> Optional[str]:
@@ -1199,7 +1233,10 @@ def _create_quick_snapshot_locked(
         suffix += 1
     staging_dir = root / f".{snap_id}.{os.getpid()}.partial"
     shutil.rmtree(staging_dir, ignore_errors=True)
-    staging_dir.mkdir(parents=True, exist_ok=False)
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if os.name != "nt":
+        os.chmod(root, 0o700)
+    staging_dir.mkdir(mode=0o700, exist_ok=False)
     logger.info("quick snapshot phase=copy status=started id=%s", snap_id)
     manifest, failed_dbs, oversized_skipped = _copy_quick_snapshot_files(home, staging_dir, max_file_size)
     if failed_dbs:
@@ -1221,6 +1258,7 @@ def _create_quick_snapshot_locked(
     }
     with open(staging_dir / "manifest.json", "w", encoding="utf-8") as f:
         json.dump(meta, f, indent=2)
+    _secure_quick_snapshot_tree(root, staging_dir)
     os.replace(staging_dir, root / snap_id)
     # Auto-prune (pre-update callers pass a smaller keep so state.db copies don't accumulate).
     # Skip when a DB failed to capture OR was skipped for size (#68805): the snapshot is

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -248,6 +248,10 @@ def _secure_state_db_files(db_path: Path, *, create_main: bool = False) -> None:
             fd = os.open(path, flags, 0o600)
         except FileNotFoundError:
             continue
+        except IsADirectoryError:
+            # Not a database file at all; sqlite3.connect() raises the
+            # canonical error for this, and a directory leaks no row data.
+            continue
         try:
             os.fchmod(fd, 0o600)
         finally:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -218,6 +218,42 @@ def _ensure_test_isolation(db_path: Path) -> None:
             )
 
 
+def _secure_state_db_files(db_path: Path, *, create_main: bool = False) -> None:
+    """Create/tighten a writable state database and its sidecars to 0600.
+
+    SQLite otherwise creates ``state.db``, ``-wal``, and ``-shm`` according to
+    the process umask (commonly 0644 under 0022). Use file descriptors so a
+    missing main database is private from its first byte and O_NOFOLLOW can
+    refuse a planted symlink. Read-only SessionDB attachments never call this
+    helper and remain observational.
+    """
+    if os.name == "nt":
+        return
+
+    for index, path in enumerate(
+        (
+            db_path,
+            db_path.with_name(db_path.name + "-wal"),
+            db_path.with_name(db_path.name + "-shm"),
+        )
+    ):
+        flags = os.O_RDONLY
+        if index == 0 and create_main:
+            flags = os.O_WRONLY | os.O_CREAT
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        if hasattr(os, "O_CLOEXEC"):
+            flags |= os.O_CLOEXEC
+        try:
+            fd = os.open(path, flags, 0o600)
+        except FileNotFoundError:
+            continue
+        try:
+            os.fchmod(fd, 0o600)
+        finally:
+            os.close(fd)
+
+
 # Openings of the background-review harness prompts (agent/background_review.py).
 _REVIEW_HARNESS_PREFIXES = (
     "Review the conversation above and update the skill library",
@@ -625,6 +661,9 @@ class SessionDB(
             # Unknown -> reads queue on the writer lock (slow but correct) instead of racing SQLITE_BUSY
             # on a file that may really be in rollback-journal mode.
             self._wal_active = mode == "wal" and _on_disk_journal_mode(conn) == "wal"
+            # Existing WAL/SHM files may predate the main-file hardening;
+            # normalize any sidecars that became visible during WAL setup.
+            _secure_state_db_files(self.db_path)
             apply_database_pragmas(conn, db_label="state.db")
             conn.execute("PRAGMA foreign_keys=ON")
             self._fts_cjk_loaded = load_fts5_cjk_extension(conn)
@@ -637,6 +676,9 @@ class SessionDB(
         # Refuse before sqlite3.connect (under the startup lock) so we cannot mint
         # a replacement WAL while a live writer still holds a deleted sidecar inode.
         refuse_deleted_wal_generation(self.db_path)
+        # Create/tighten the main database before sqlite3.connect() so a
+        # permissive process umask can never expose a fresh profile store.
+        _secure_state_db_files(self.db_path, create_main=True)
         self._conn = self._open_writer_conn()
         self._init_schema()
 

--- a/tests/hermes_cli/test_backup_stability.py
+++ b/tests/hermes_cli/test_backup_stability.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
+import sqlite3
+import stat
 from pathlib import Path
 
 import pytest
@@ -80,6 +83,39 @@ def test_quick_snapshot_is_published_with_manifest(tmp_path, monkeypatch) -> Non
     )
     assert manifest["id"] == snapshot_id
     assert manifest["files"] == {"config.yaml": 10}
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+def test_quick_snapshot_tree_is_owner_only_under_permissive_umask(tmp_path) -> None:
+    """Recovery snapshots must never inherit world-readable default modes.
+
+    A normal 0022 umask creates SQLite databases and JSON files as 0644 and
+    directories as 0755.  Quick snapshots contain session state, credentials,
+    pairing records, and cron data, so every published file must be 0600 and
+    every directory 0700 regardless of the caller's umask or source modes.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("model: {}\n", encoding="utf-8")
+    with sqlite3.connect(home / "state.db") as conn:
+        conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY)")
+
+    old_umask = os.umask(0o022)
+    try:
+        snapshot_id = create_quick_snapshot(hermes_home=home)
+    finally:
+        os.umask(old_umask)
+
+    assert snapshot_id is not None
+    root = home / "state-snapshots"
+    snapshot = root / snapshot_id
+    directories = [root, snapshot, *(p for p in snapshot.rglob("*") if p.is_dir())]
+    files = [p for p in snapshot.rglob("*") if p.is_file()]
+
+    assert directories
+    assert files
+    assert all(stat.S_IMODE(path.stat().st_mode) == 0o700 for path in directories)
+    assert all(stat.S_IMODE(path.stat().st_mode) == 0o600 for path in files)
 
 
 def test_quick_snapshot_listing_ignores_partial_directories(tmp_path) -> None:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -5,6 +5,8 @@ import re
 import sqlite3
 import time
 import json
+import os
+import stat
 import threading
 from pathlib import Path
 from unittest import mock
@@ -119,6 +121,49 @@ def _no_fts_rebuild_throttle(monkeypatch):
 
 
 class TestConnectionLifecycle:
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+    def test_writable_state_db_is_owner_only_under_permissive_umask(self, tmp_path):
+        """state.db and any live SQLite sidecars must not inherit 0644 modes."""
+        db_path = tmp_path / "state.db"
+
+        old_umask = os.umask(0o022)
+        try:
+            session_db = SessionDB(db_path=db_path)
+        finally:
+            os.umask(old_umask)
+
+        try:
+            state_files = [
+                path
+                for path in (
+                    db_path,
+                    db_path.with_name(db_path.name + "-wal"),
+                    db_path.with_name(db_path.name + "-shm"),
+                )
+                if path.exists()
+            ]
+            assert state_files
+            assert all(
+                stat.S_IMODE(path.stat().st_mode) == 0o600
+                for path in state_files
+            )
+        finally:
+            session_db.close()
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+    def test_writable_state_db_tightens_existing_loose_mode(self, tmp_path):
+        """Opening a legacy 0644 profile store repairs it in place."""
+        db_path = tmp_path / "state.db"
+        initial = SessionDB(db_path=db_path)
+        initial.close()
+        os.chmod(db_path, 0o644)
+
+        session_db = SessionDB(db_path=db_path)
+        try:
+            assert stat.S_IMODE(db_path.stat().st_mode) == 0o600
+        finally:
+            session_db.close()
+
     def test_failed_writable_open_does_not_leak_tracked_connection(
         self, tmp_path, monkeypatch
     ):

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -1126,3 +1126,27 @@ print(json.dumps(q.get_nowait(), sort_keys=True))
     assert by_index[1]["status"] == "unknown"
     assert "1/2 child results were recorded" in evt["error"]
     assert "done: fast member" in format_process_notification(evt)
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
+def test_connect_creates_state_db_0o600_under_permissive_umask(tmp_path, monkeypatch):
+    """``_connect`` shares state.db with hermes_state.SessionDB -- a fresh
+    HERMES_HOME must land the file (and its WAL sidecar, if created) at 0o600
+    even under a permissive process umask, not the SessionDB-only path."""
+    import stat
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    old_umask = os.umask(0o022)
+    try:
+        conn = ad._connect()
+        conn.close()
+    finally:
+        os.umask(old_umask)
+
+    db_path = tmp_path / "state.db"
+    assert stat.S_IMODE(db_path.stat().st_mode) == 0o600
+
+    for suffix in ("-wal", "-shm"):
+        sidecar = tmp_path / f"state.db{suffix}"
+        if sidecar.exists():
+            assert stat.S_IMODE(sidecar.stat().st_mode) == 0o600

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -1,6 +1,8 @@
 """Tests for tools/memory_tool.py — MemoryStore, security scanning, and tool dispatcher."""
 
 import json
+import os
+import stat
 import pytest
 from pathlib import Path
 
@@ -106,6 +108,45 @@ def store(tmp_path, monkeypatch):
     s = MemoryStore(memory_char_limit=500, user_char_limit=300)
     s.load_from_disk()
     return s
+
+
+class TestMemoryFileLockPermissions:
+    def test_new_lock_file_is_owner_only_under_permissive_umask(self, tmp_path):
+        memory_path = tmp_path / "MEMORY.md"
+        previous_umask = os.umask(0o002)
+        try:
+            with MemoryStore._file_lock(memory_path):
+                pass
+        finally:
+            os.umask(previous_umask)
+
+        lock_path = tmp_path / "MEMORY.md.lock"
+        assert stat.S_IMODE(lock_path.stat().st_mode) == 0o600
+
+    def test_existing_loose_lock_file_is_tightened(self, tmp_path):
+        memory_path = tmp_path / "MEMORY.md"
+        lock_path = tmp_path / "MEMORY.md.lock"
+        lock_path.write_text("", encoding="utf-8")
+        lock_path.chmod(0o664)
+
+        with MemoryStore._file_lock(memory_path):
+            pass
+
+        assert stat.S_IMODE(lock_path.stat().st_mode) == 0o600
+
+    @pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="O_NOFOLLOW unavailable")
+    def test_lock_file_symlink_is_refused(self, tmp_path):
+        memory_path = tmp_path / "MEMORY.md"
+        outside = tmp_path / "outside"
+        outside.write_text("do not touch", encoding="utf-8")
+        lock_path = tmp_path / "MEMORY.md.lock"
+        lock_path.symlink_to(outside)
+
+        with pytest.raises(OSError):
+            with MemoryStore._file_lock(memory_path):
+                pass
+
+        assert outside.read_text(encoding="utf-8") == "do not touch"
 
 
 class TestMemoryStoreAdd:

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -85,12 +85,18 @@ def _db_path():
 def _connect() -> sqlite3.Connection:
     path = _db_path()
     path.parent.mkdir(parents=True, exist_ok=True)
+    # Same state.db as hermes_state.SessionDB -- reuse its owner-only (0600)
+    # hardening so this writer doesn't create/leave the file (and its WAL
+    # sidecars) at the process umask. See hermes_state._secure_state_db_files.
+    from hermes_state import _secure_state_db_files
+    _secure_state_db_files(path, create_main=True)
     conn = sqlite3.connect(path, timeout=10)
     try:
         _initialize_schema(conn)
     except Exception:
         conn.close()  # don't leak the connection on PRAGMA/DDL failure
         raise
+    _secure_state_db_files(path)
     return conn
 
 

--- a/tools/memory_tool_store.py
+++ b/tools/memory_tool_store.py
@@ -4,6 +4,7 @@ Module state that tests monkeypatch (``get_memory_dir``, ``fcntl``/``msvcrt``) s
 in ``tools.memory_tool`` and is read lazily."""
 
 import logging
+import os
 import time
 from contextlib import contextmanager, suppress
 from pathlib import Path
@@ -151,7 +152,22 @@ class MemoryStore:
         if fcntl is None and msvcrt is None:
             yield
             return
-        with open(lock_path, "a+", encoding="utf-8") as fd:
+        flags = os.O_RDWR | os.O_CREAT
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        raw_fd = os.open(lock_path, flags, 0o600)
+        try:
+            # The creation mode is filtered through the process umask and does
+            # not repair a lock left loose by an older Hermes process. Tighten
+            # the opened inode before acquiring the lock so both cases are
+            # owner-only. Operating on the fd avoids a path-swap window.
+            if hasattr(os, "fchmod"):
+                os.fchmod(raw_fd, 0o600)
+            fd = os.fdopen(raw_fd, "r+", encoding="utf-8")
+        except Exception:
+            os.close(raw_fd)
+            raise
+        with fd:
             def _flock(unlock: bool):
                 if fcntl:
                     fcntl.flock(fd, fcntl.LOCK_UN if unlock else fcntl.LOCK_EX)


### PR DESCRIPTION
State databases, recovery snapshots, and memory lock files are now created and repaired owner-only (0600 files / 0700 dirs) regardless of the process umask.

## What changed
- `hermes_state.py`: new `_secure_state_db_files()` — before `sqlite3.connect()`, a missing `state.db` is pre-created 0600 via fd (`O_NOFOLLOW`/`O_CLOEXEC`), and after WAL setup any `-wal`/`-shm` sidecars (including legacy loose ones) are tightened via `fchmod`. Read-only attachments stay observational.
- `tools/async_delegation.py`: `_connect()` — the second direct `state.db` writer — reuses the same helper (this was the gap teknium1's sweeper review flagged on #59716).
- `hermes_cli/backup.py`: `_safe_copy_db` creates snapshot DB destinations 0600 before SQLite writes a byte (with `O_NOFOLLOW` against planted symlinks); quick-snapshot staging dirs are 0700 from creation and `_secure_quick_snapshot_tree` normalizes the whole tree before the atomic publish rename.
- `tools/memory_tool_store.py`: `_file_lock` opens `.lock` files via `os.open(..., 0o600)` + `fchmod` (repairs pre-existing loose locks) and refuses symlinked lock paths.

## Why
`sqlite3.connect()` and `open()` honor the process umask (0644 under the common 022). Today the 0700 `~/.hermes` directory is the only shield; it becomes load-bearing the moment `HERMES_HOME_MODE` is widened, a managed 0750 home is in play, or files are copied out by backup/snapshot paths. Full conversation history, tool state, and memory should never be group/world-readable. Upstream analog: aaif-goose/goose#11613 (session storage permissions) landed the same hardening this week.

## Provenance / credit
Salvage composing two open community PRs onto current `origin/main` (post-#102117 module split):
- #102878 by @rohitsabu — fd-based state.db/sidecar/snapshot/memory-lock hardening (both commits cherry-picked; memory-lock hunk relocated from the old `tools/memory_tool.py` inline code to its current home `tools/memory_tool_store.py::_file_lock`).
- #59716 by @JoaoMarcos44 — the async_delegation follow-up commit cherry-picked with authorship intact, adapted to reuse `_secure_state_db_files`.

## Validation
| Check | Result |
|---|---|
| Live before (origin/main, umask 022, fresh HERMES_HOME) | `state.db` 0644, `-wal`/`-shm` 0644, mem lock 0644, snapshot files 0644/dirs 0755 |
| Live after (this branch, same probe) | `state.db`/`-wal`/`-shm` 0600, `ad._connect()` path 0600, mem lock 0600, snapshot root+dirs 0700 / files 0600, symlinked lock refused (OSError) |
| `tests/tools/test_memory_tool.py` + `test_async_delegation.py` | 89 passed, 0 failed |
| `tests/test_hermes_state.py` + `tests/hermes_cli/test_backup_stability.py` | 282 passed, 1 failed — `TestFTS5Search::test_search_projection_skips_context_enrichment_queries` fails identically on pristine origin/main (pre-existing, unrelated) |
| ruff / windows-footguns / compat pointers / `git diff --check` | clean |

Windows is untouched (`os.name == "nt"` early return): POSIX mode bits are not the mechanism there, and the existing `_secure_file` ACL work covers it.

Closes #59706.

## Infographic

![Owner-Only State Storage](https://v3b.fal.media/files/b/0aaa32db/X8PWLQAbpJsjL4q0pDnhv_d3fQQcs0.png)
