### PR TITLE
fix(skills): distinguish unknown and empty availability in index cache

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1352,8 +1352,8 @@ def _build_skills_system_prompt_inner(
     project_dirs = project_dirs or []
     cache_key = (
         str(skills_dir), tuple(str(d) for d in external_dirs), tuple(str(d) for d in project_dirs),
-        tuple(sorted(str(t) for t in (available_tools or set()))),
-        tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
+        (available_tools is None, tuple(sorted(str(t) for t in (available_tools or set())))),
+        (available_toolsets is None, tuple(sorted(str(ts) for ts in (available_toolsets or set())))),
         _platform_hint, tuple(sorted(disabled)), tuple(sorted(compact_categories or ())),
     )
     with _SKILLS_PROMPT_CACHE_LOCK:

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1058,6 +1058,58 @@ class TestBuildSkillsSystemPromptConditional:
         result = build_skills_system_prompt()
         assert "duckduckgo" in result
 
+    @pytest.mark.parametrize("unknown_first", [True, False])
+    def test_unknown_and_explicitly_empty_toolsets_cache_separately(
+        self, monkeypatch, tmp_path, unknown_first
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "iot" / "terminal-only"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: terminal-only\ndescription: Needs terminal\nmetadata:\n  hermes:\n"
+            "    requires_toolsets: [terminal]\n---\n"
+        )
+        calls = (
+            [(None, None), (None, set())]
+            if unknown_first
+            else [(None, set()), (None, None)]
+        )
+
+        prompts = [
+            build_skills_system_prompt(available_tools=tools, available_toolsets=toolsets)
+            for tools, toolsets in calls
+        ]
+        unknown_prompt, empty_prompt = prompts if unknown_first else reversed(prompts)
+
+        assert "terminal-only" in unknown_prompt
+        assert "terminal-only" not in empty_prompt
+
+    @pytest.mark.parametrize("unknown_first", [True, False])
+    def test_unknown_and_explicitly_empty_tools_cache_separately(
+        self, monkeypatch, tmp_path, unknown_first
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "general" / "needs-terminal"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: needs-terminal\ndescription: Needs terminal\nmetadata:\n  hermes:\n"
+            "    requires_tools: [terminal]\n---\n"
+        )
+        calls = (
+            [(None, None), (set(), None)]
+            if unknown_first
+            else [(set(), None), (None, None)]
+        )
+
+        prompts = [
+            build_skills_system_prompt(available_tools=tools, available_toolsets=toolsets)
+            for tools, toolsets in calls
+        ]
+        unknown_prompt, empty_prompt = prompts if unknown_first else reversed(prompts)
+
+        assert "needs-terminal" in unknown_prompt
+        assert "needs-terminal" not in empty_prompt
+
 
 
 


### PR DESCRIPTION
## What does this PR do?
Keeps unknown tool availability distinct from an explicitly empty set in the rendered skill-index cache. Otherwise, whichever context builds the index first determines whether a conditional skill is shown to the next context.

## Related Issue
Fixes #109511

## Type of Change
- [x] Bug fix (non-breaking)

## Changes Made
- `agent/prompt_builder.py`: preserve the `None` state independently for tools and toolsets in the cache key; retain sorted values.
- `tests/agent/test_prompt_builder.py`: two behavioral invariants, each tested in both cache-population orders through the production entry point and real temporary skill files.

No conditional-predicate, disk-snapshot, filesystem-refresh, or active-conversation prompt policy changes.

## How to Test
Using the canonical runner and a Python environment with the repository's test dependencies:
- `scripts/run_tests.sh tests/agent/test_prompt_builder.py` — **80 passed, 1 skipped** on Windows 11 / Python 3.11.15.
- The four new cases all fail with unchanged production code at current main `de2d6a1b93508463c31434c1ae067e204af81238`. They assert actual skill visibility, not prompt advice text.
- `ruff check agent/prompt_builder.py tests/agent/test_prompt_builder.py` — passed with Ruff 0.15.10.
- `git diff --check` — passed.

## Checklist
- [x] Read the applicable contribution guidance; Conventional Commit; focused diff.
- [x] Searched existing issues and PRs; nearby CLI-list parity and filesystem-freshness proposals do not fix this cache equivalence.
- [x] Added regression tests and tested on Windows 11.
- [ ] Full repository test suite — not run; results above are the bounded local verification.
- [x] Documentation/config/schema/architecture changes: N/A for this internal key correction.
- [x] Considered cross-platform behavior; no platform-specific branch added. Other OS lanes left to CI.
