### PR TITLE
fix(skills): frame internal scan cache identity without changing bundle hashes

### DIFF
--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -27,6 +27,7 @@ from tools.skills_guard import (
     should_allow_install,
     format_scan_report,
     content_hash,
+    scan_skill_cached,
     _determine_verdict,
     _resolve_trust_level,
     _check_structure,
@@ -344,6 +345,60 @@ class TestContentHash:
         f.write_text("version2", encoding="utf-8")
         h2 = content_hash(tmp_path)
         assert h1 != h2
+
+
+class TestScanCacheIdentity:
+    payload = b"rm -rf /synthetic-fixture-never-executed\n"
+
+    def test_directory_record_boundaries_prevent_stale_verdict_reuse(self, tmp_path):
+        skill = tmp_path / "skill"
+        cache = tmp_path / "cache"
+        skill.mkdir()
+        (skill / "SKILL.md").write_text("# Inert cache fixture\n", encoding="utf-8")
+        (skill / "A.png").write_bytes(b"prefixB.sh\0" + self.payload)
+
+        before, before_meta = scan_skill_cached(skill, source="project-local", cache_dir=cache)
+        public_hash = content_hash(skill)
+        assert before.verdict == "safe"
+        assert before_meta["fresh"] is True
+
+        (skill / "A.png").write_bytes(b"prefix")
+        (skill / "B.sh").write_bytes(self.payload)
+
+        after, after_meta = scan_skill_cached(skill, source="project-local", cache_dir=cache)
+        cached, cached_meta = scan_skill_cached(skill, source="project-local", cache_dir=cache)
+        assert content_hash(skill) == public_hash  # Public bundle-hash compatibility is unchanged.
+        assert after.verdict == cached.verdict == "dangerous"
+        assert after_meta["fresh"] is True
+        assert cached_meta["fresh"] is False
+
+    def test_path_kind_and_single_file_name_are_cache_identity(self, tmp_path):
+        image = tmp_path / "payload.png"
+        shell = tmp_path / "payload.sh"
+        image.write_bytes(self.payload)
+        shell.write_bytes(self.payload)
+        assert content_hash(image) == content_hash(shell)
+
+        image_result, _ = scan_skill_cached(image, cache_dir=tmp_path / "name-cache")
+        shell_result, shell_meta = scan_skill_cached(shell, cache_dir=tmp_path / "name-cache")
+        shell_cached, shell_cached_meta = scan_skill_cached(shell, cache_dir=tmp_path / "name-cache")
+        assert image_result.verdict == "safe"
+        assert shell_result.verdict == shell_cached.verdict == "dangerous"
+        assert shell_meta["fresh"] is True
+        assert shell_cached_meta["fresh"] is False
+
+        directory = tmp_path / "directory"
+        directory.mkdir()
+        (directory / "payload.sh").write_bytes(self.payload)
+        single = tmp_path / "single.png"
+        single.write_bytes(b"payload.sh\0" + self.payload)
+        assert content_hash(single) == content_hash(directory)
+
+        single_result, _ = scan_skill_cached(single, cache_dir=tmp_path / "kind-cache")
+        directory_result, directory_meta = scan_skill_cached(directory, cache_dir=tmp_path / "kind-cache")
+        assert single_result.verdict == "safe"
+        assert directory_result.verdict == "dangerous"
+        assert directory_meta["fresh"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -19,6 +19,7 @@ from typing import List, Tuple
 
 
 SCANNER_VERSION = "skills-guard-v2"
+SCAN_CACHE_FINGERPRINT_VERSION = "skills-guard-cache-v1"
 
 # NVIDIA-verified skills each ship a signed `skill.oms.sig` + governance `skill-card.md`.
 TRUSTED_REPOS = {"openai/skills", "anthropics/skills", "huggingface/skills", "NVIDIA/skills"}
@@ -440,6 +441,14 @@ def scan_skill(skill_path: Path, source: str = "community") -> ScanResult:
                       _build_summary(name, source, trust, verdict, findings))
 
 
+def _update_hashes_from_file(path: Path, *hashes) -> None:
+    """Feed exact file bytes to each hash without buffering the whole file."""
+    with path.open("rb") as stream:
+        while chunk := stream.read(1024 * 1024):
+            for digest in hashes:
+                digest.update(chunk)
+
+
 def _content_digest(skill_path: Path) -> str:
     """Canonical SHA-256 over (POSIX relative path, file bytes) ORDERED by the rel-path STRING — Path sorting is
     case-insensitive on Windows and diverged from ``skills_hub.bundle_content_hash`` (every installed skill then
@@ -449,13 +458,37 @@ def _content_digest(skill_path: Path) -> str:
     case-insensitive there (normcase), while ``bundle_content_hash`` sorts plain strings — the same skill
     hashed to different digests and every installed skill reported ``update_available`` forever (#62310).
     """
+    digest = hashlib.sha256()
     if not skill_path.is_dir():
-        return hashlib.sha256(skill_path.read_bytes()).hexdigest()
-    h = hashlib.sha256()
-    for rel, p in sorted((p.relative_to(skill_path).as_posix(), p) for p in skill_path.rglob("*") if p.is_file()):
-        h.update(rel.encode("utf-8") + b"\x00")
-        h.update(p.read_bytes())
-    return h.hexdigest()
+        _update_hashes_from_file(skill_path, digest)
+        return digest.hexdigest()
+    for rel, path in sorted((p.relative_to(skill_path).as_posix(), p)
+                            for p in skill_path.rglob("*") if p.is_file()):
+        digest.update(rel.encode("utf-8") + b"\x00")
+        _update_hashes_from_file(path, digest)
+    return digest.hexdigest()
+
+
+def _scan_cache_identities(skill_path: Path) -> Tuple[str, str]:
+    """Return the public bundle digest and an unambiguous scan-cache identity in one read pass."""
+    directory = skill_path.is_dir()
+    files = (sorted((p.relative_to(skill_path).as_posix(), p)
+                    for p in skill_path.rglob("*") if p.is_file())
+             if directory else [(skill_path.name, skill_path)])
+    bundle_digest = hashlib.sha256()
+    fingerprint = hashlib.sha256(
+        SCAN_CACHE_FINGERPRINT_VERSION.encode("ascii") + b"\x00"
+        + (b"directory\x00" if directory else b"file\x00")
+    )
+    for relative_name, path in files:
+        name = relative_name.encode("utf-8")
+        if directory:
+            bundle_digest.update(name + b"\x00")
+        fingerprint.update(len(name).to_bytes(8, "big") + name)
+        file_digest = hashlib.sha256()
+        _update_hashes_from_file(path, bundle_digest, file_digest)
+        fingerprint.update(file_digest.digest())
+    return bundle_digest.hexdigest(), fingerprint.hexdigest()
 
 
 def content_hash(skill_path: Path) -> str:
@@ -466,14 +499,14 @@ def content_hash(skill_path: Path) -> str:
 
 def scan_skill_cached(skill_path: Path, source: str = "community", *, source_url: str = "",
                       cache_dir: Path | None = None) -> Tuple[ScanResult, dict]:
-    """Scan plus attestation dict; the cache (keyed by content digest + source identity) only serves exact
-    current content under the current scanner version."""
-    digest = _content_digest(skill_path)
+    """Scan plus attestation dict; a framed identity keys verdict reuse without changing the public bundle hash."""
+    digest, fingerprint = _scan_cache_identities(skill_path)
     cache_root = cache_dir or skill_path.parent / ".scan-cache"
     source_identity = hashlib.sha256(f"{source}\0{source_url}".encode("utf-8")).hexdigest()[:16]
-    cache_file = cache_root / f"{digest}-{source_identity}.json"
+    cache_file = cache_root / f"{fingerprint}-{source_identity}.json"
     expected = {"bundle_hash": f"sha256:{digest}", "scanner_version": SCANNER_VERSION, "source": source,
-                "source_url": source_url}
+                "source_url": source_url, "cache_fingerprint": f"sha256:{fingerprint}",
+                "cache_fingerprint_version": SCAN_CACHE_FINGERPRINT_VERSION}
     cached = None
     with suppress(OSError, json.JSONDecodeError):
         cached = json.loads(cache_file.read_text(encoding="utf-8"))


### PR DESCRIPTION
## What does this PR do?
Uses a separate, versioned internal fingerprint for Skills Guard verdict reuse. The public bundle digest remains byte-compatible, but it is not sufficient as scanner identity: single-file names/extensions and directory record boundaries can change what is scanned without changing that digest.

## Related Issue
Fixes #109512

Related: #98103 addresses the outer project-quarantine memo's freshness. This PR fixes the inner `scan_skill_cached` identity and does not implement that outer invalidation change.

## Type of Change
- [x] Bug fix (non-breaking)

## Changes Made
- `tools/skills_guard.py`: separate file/directory domains, length-frame relative names, and include fixed-size per-file digests in a versioned cache fingerprint. Keep source identity and scanner-version validation.
- Compute public and internal identities in one content-read pass, streaming 1 MiB chunks. This adds hashing CPU, not an additional content-read pass.
- `tests/tools/test_skills_guard.py`: two real cache-path invariants covering directory record boundaries, single-file extensions, and file/directory distinction. Fixtures are inert bytes and are never executed. A changed layout must produce a fresh corrected verdict, then reuse it on the next unchanged call.

Existing cache records miss naturally. Public bundle hashes and hub compatibility remain unchanged; old cache files are not proactively deleted.

## How to Test
Windows 11 / Python 3.11.15, canonical runner with isolated temporary homes:
- `scripts/run_tests.sh tests/tools/test_skills_guard.py -k 'stale_verdict or path_kind'` — the two regressions passed during implementation and independent review; both fail against unchanged current main `de2d6a1b93508463c31434c1ae067e204af81238`.
- Parent reran `scripts/run_tests.sh -j 4 tests/tools/test_skills_guard.py tests/tools/test_skills_guard_agent_config.py tests/tools/test_skill_bundle_provenance.py tests/agent/test_project_skills.py`:
  - candidate: **100 passed, 4 failed, 2 skipped**;
  - exact unchanged base, same runner/environment: **98 passed, the same 4 failed, 2 skipped**.
- Compared each failure: `test_symlink_escape` fails at fixture setup with WinError 1314; two provenance tests expect LF bytes but receive CRLF; `test_bundled_optional_source_still_includes_support_files` expects POSIX rather than Windows separators. No new failure was introduced; those four remain failing locally.
- `ruff check tools/skills_guard.py tests/tools/test_skills_guard.py` (0.15.10) and `git diff --check` — passed.

## Limits
Skills Guard remains a heuristic review aid, not an OS security boundary. This does not make filesystem inventory/hash/scan atomic or change symlink/permission policy. Warm lookup still reads the bundle; this is an identity correction, not a performance claim.

## Checklist
- [x] Read the applicable contribution guidance; Conventional Commit; focused diff.
- [x] Searched existing issues and PRs; related provenance, public-hash ordering, and quarantine-freshness work is distinct.
- [x] Added real producer/cache/consumer regressions and tested on Windows 11.
- [ ] Full repository test suite — not run; bounded results and baseline failures disclosed above.
- [x] Relevant internal docstrings updated. New configuration/tool schema/architecture: N/A.
- [x] Public hash compatibility and cross-platform path ordering considered. Other OS lanes left to CI.
