### PR TITLE
fix(desktop): pause the thinking-preview growth pin while the user scrolls away

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
@@ -125,6 +125,11 @@ const ChainToolFallback: FC<TimelineToolCallProps> = props => {
 
 type TimelineTextPartProps = TextMessagePartProps & { completedAt?: number; timestamp?: number }
 
+// Near-bottom slack for re-arming the live thinking preview's growth pin, matching the
+// outer transcript's RUN_START_SNAP_THRESHOLD_PX semantics: a reader a line or two off
+// the bottom still tracks, a reader in history must not be yanked back down (#109510).
+const THINKING_PIN_RESUME_THRESHOLD_PX = 64
+
 const TimelineMarkdownText: FC<TimelineTextPartProps> = ({ completedAt, timestamp }) => (
   <>
     <TimelineTimestamp className="mb-0.5 block" completedAt={completedAt} timestamp={timestamp} />
@@ -205,12 +210,28 @@ const ThinkingDisclosure: FC<{
     // growth needs the pin; the height rides the RO entry, reflow-free.
     let lastHeight = -1
 
+    // Follow/escape gate, mirroring the semantics the outer transcript gets
+    // from use-stick-to-bottom (RUN_START_SNAP_THRESHOLD_PX): a reader a line
+    // or two off the bottom still tracks new tokens, but once they scroll
+    // further up the growth pin must stop yanking them back — re-arming only
+    // when they return near the bottom. Derived from the user's own scrolls,
+    // not from geometry at growth time: right after content grows everyone is
+    // "off the bottom", so the position alone cannot tell follower from
+    // escapee.
+    let following = true
+
+    const onScroll = () => {
+      following = el.scrollHeight - el.scrollTop - el.clientHeight < THINKING_PIN_RESUME_THRESHOLD_PX
+    }
+
+    el.addEventListener('scroll', onScroll, { passive: true })
+
     const pin = (entries: readonly ResizeObserverEntry[]) => {
       const height = entries[entries.length - 1]?.borderBoxSize?.[0]?.blockSize ?? -1
       const grew = height < 0 || height > lastHeight
       lastHeight = height
 
-      if (grew) {
+      if (grew && following) {
         el.scrollTop = el.scrollHeight
       }
     }
@@ -220,7 +241,10 @@ const ThinkingDisclosure: FC<{
     const observer = new ResizeObserver(pin)
     observer.observe(content)
 
-    return () => observer.disconnect()
+    return () => {
+      el.removeEventListener('scroll', onScroll)
+      observer.disconnect()
+    }
     // Re-run when the disclosure toggles so the observer attaches to the new
     // DOM after expand/collapse (refs are conditionally rendered on `open`).
   }, [isPreview, open])

--- a/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
@@ -30,6 +30,10 @@ class TestResizeObserver {
     resizeObservers.delete(this)
   }
 
+  get observed(): Element | null {
+    return this.target
+  }
+
   trigger(height: number) {
     if (!this.target) {
       return
@@ -641,6 +645,43 @@ describe('assistant-ui streaming renderer', () => {
     expect(settled).toContain('max-h-40')
     expect(settled).toMatch(/\boverflow-auto\b/)
     expect(settled).not.toMatch(/\boverflow-hidden\b/)
+  })
+
+  it('stops pinning the live thinking preview when the user scrolls it up, re-arms near the bottom', async () => {
+    const { container } = render(<RunningReasoningHarness />)
+
+    const body = container.querySelector<HTMLElement>('[data-slot="aui_thinking-body"]')
+    expect(body).toBeTruthy()
+
+    // jsdom has no layout: give the capped body a scrollable geometry.
+    Object.defineProperty(body, 'scrollHeight', { value: 1000, configurable: true })
+    Object.defineProperty(body, 'clientHeight', { value: 160, configurable: true })
+
+    const growThinkingContent = (height: number) => {
+      act(() => {
+        for (const observer of resizeObservers) {
+          if (body.contains(observer.observed)) {
+            observer.trigger(height)
+          }
+        }
+      })
+    }
+
+    // No user scroll yet: content growth pins the preview to the bottom.
+    growThinkingContent(50)
+    expect(body.scrollTop).toBe(1000)
+
+    // The reader scrolls up to re-read: the next growth must not yank them back.
+    body.scrollTop = 200
+    fireEvent.scroll(body)
+    growThinkingContent(60)
+    expect(body.scrollTop).toBe(200)
+
+    // Returning near the bottom (within the 64px slack) re-arms the pin.
+    body.scrollTop = 1000 - 160 - 40
+    fireEvent.scroll(body)
+    growThinkingContent(70)
+    expect(body.scrollTop).toBe(1000)
   })
 
   it('does not collapse a live thinking preview when the turn settles', async () => {


### PR DESCRIPTION
## What does this PR do?

While a live thinking preview streams, the `ResizeObserver` pin in `ThinkingDisclosure` writes `el.scrollTop = el.scrollHeight` on every content growth (~30×/s during token streaming) without checking whether the user is still following. A user's upward scroll is reverted on the next growth, so trackpad/wheel scrolling over the transcript reads as dead — only scrollbar-thumb dragging survives (#109510).

This gates the pin on a `following` flag driven by the user's own `scroll` events, mirroring the escape semantics the outer transcript already gets from `use-stick-to-bottom` (`RUN_START_SNAP_THRESHOLD_PX`): readers within 64px of the bottom keep tracking new tokens, readers in history are never yanked back, and returning near the bottom re-arms the pin. The flag is deliberately not derived from geometry at growth time — right after content grows, everyone is "off the bottom", so the position alone cannot tell a follower from an escapee.

The wheel-capture half of the report (overscroll-contain on the capped body) is a separate mechanism and is not touched here.

## Related Issue

Fixes #109510

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/components/assistant-ui/thread/message-parts.tsx` — added `THINKING_PIN_RESUME_THRESHOLD_PX = 64` (matches the outer transcript's `RUN_START_SNAP_THRESHOLD_PX` slack); the pin effect now tracks a `following` flag updated by a passive `scroll` listener (near-bottom ⇒ following, scrolled-away ⇒ escaped) and only applies the growth pin while following; the listener is removed on cleanup.
- `apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx` — new regression test driving the pin through the existing `TestResizeObserver` harness with a mocked scrollable body (scrollHeight=1000, clientHeight=160): growth pins while untouched, stops pinning after the user scrolls up, re-arms after returning within the 64px slack. Also exposes an `observed` getter on `TestResizeObserver` so the test can trigger only the preview's observer.

## How to Test

1. `cd apps/desktop && npx vitest run src/components/assistant-ui/thread/streaming.test.tsx` — Observed result: 21 passed (including the new `stops pinning the live thinking preview when the user scrolls it up, re-arms near the bottom`). The full `src/components/assistant-ui/thread/` directory passes 193 tests; eslint is clean on both changed files. Reverting the gate makes the new test fail with `expected 1000 to be 200` (the yank-back symptom), confirming it pins the regression.
2. Manual (desktop app): start a chat, expand the thinking preview of a streaming turn, scroll up with trackpad/wheel — the view should stay where you put it while tokens keep arriving, and resume following once you scroll back to the bottom.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A for this change: it only touches `apps/desktop` TypeScript; the desktop suites above all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64); reproduction report was Windows 11 — the changed code is platform-neutral renderer logic

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A (scroll behavior; see the test in How to Test)