### PR TITLE
fix(desktop): pause thinking preview pin while the reader is scrolled up (#109510)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/message-parts.tsx
@@ -123,6 +123,10 @@ const ChainToolFallback: FC<TimelineToolCallProps> = props => {
   return <ToolFallback {...props} />
 }
 
+// How close to the preview's bottom a scroll must land before the live pin
+// re-engages. Sub-pixel rests and rounding don't count as "reading up".
+const PREVIEW_RELOCK_THRESHOLD_PX = 8
+
 type TimelineTextPartProps = TextMessagePartProps & { completedAt?: number; timestamp?: number }
 
 const TimelineMarkdownText: FC<TimelineTextPartProps> = ({ completedAt, timestamp }) => (
@@ -186,7 +190,10 @@ const ThinkingDisclosure: FC<{
   }
 
   // While the preview is live, pin the scroll container to the bottom on
-  // every content growth so the latest tokens are always visible.
+  // every content growth so the latest tokens are always visible. A reader
+  // who scrolls the preview up pauses the pin until they return to the
+  // bottom — the same escape/re-lock semantics the transcript's stick-to-
+  // bottom gives the outer viewport, applied to the preview scroller.
   useEffect(() => {
     if (!isPreview) {
       return
@@ -197,6 +204,14 @@ const ThinkingDisclosure: FC<{
 
     if (!el || !content) {
       return
+    }
+
+    let pinned = true
+
+    const distanceFromBottom = () => el.scrollHeight - el.scrollTop - el.clientHeight
+
+    const onScroll = () => {
+      pinned = distanceFromBottom() <= PREVIEW_RELOCK_THRESHOLD_PX
     }
 
     // Height-gated: the observer also fires when the container's WIDTH changes
@@ -210,17 +225,22 @@ const ThinkingDisclosure: FC<{
       const grew = height < 0 || height > lastHeight
       lastHeight = height
 
-      if (grew) {
+      if (grew && pinned) {
         el.scrollTop = el.scrollHeight
       }
     }
+
+    el.addEventListener('scroll', onScroll, { passive: true })
 
     // No sync pin(): the observer's guaranteed initial delivery runs it with
     // layout already clean (still before paint), avoiding a forced reflow.
     const observer = new ResizeObserver(pin)
     observer.observe(content)
 
-    return () => observer.disconnect()
+    return () => {
+      el.removeEventListener('scroll', onScroll)
+      observer.disconnect()
+    }
     // Re-run when the disclosure toggles so the observer attaches to the new
     // DOM after expand/collapse (refs are conditionally rendered on `open`).
   }, [isPreview, open])
@@ -250,8 +270,12 @@ const ThinkingDisclosure: FC<{
             // Body sits flush with the "Thinking" header — no left indent —
             // and inherits the disclosure-level opacity fade defined in
             // styles.css (~0.67 at rest, 1 on hover/focus). overflow-auto so
-            // the max-h-40 preview is a real scroller, not a clip.
-            'mt-0.5 w-full min-w-0 max-w-full overflow-auto overscroll-contain wrap-anywhere pb-1',
+            // the max-h-40 preview is a real scroller, not a clip. While live,
+            // the body must chain wheel/trackpad to the transcript instead of
+            // swallowing it — the reader hovers the streaming preview to
+            // scroll the conversation, not the capped box.
+            'mt-0.5 w-full min-w-0 max-w-full overflow-auto wrap-anywhere pb-1',
+            !isPreview && 'overscroll-contain',
             isPreview && 'max-h-40'
           )}
           data-slot="aui_thinking-body"

--- a/apps/desktop/src/components/assistant-ui/thread/thinking-preview-scroll.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/thinking-preview-scroll.test.tsx
@@ -1,0 +1,193 @@
+import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
+import { act, render } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { stubThreadEnvironment, stubThreadViewportSize } from '../test-utils'
+
+import { Thread } from '.'
+
+stubThreadEnvironment()
+stubThreadViewportSize()
+
+// stubThreadEnvironment installs an inert observer; the pin effect needs one
+// that actually delivers growth entries, like streaming.test.tsx.
+const resizeObservers = new Set<TestResizeObserver>()
+
+class TestResizeObserver {
+  private target: Element | null = null
+
+  constructor(private readonly callback: ResizeObserverCallback) {
+    resizeObservers.add(this)
+  }
+
+  observe(target: Element) {
+    this.target = target
+  }
+
+  unobserve() {}
+
+  disconnect() {
+    resizeObservers.delete(this)
+  }
+
+  trigger(height: number) {
+    if (!this.target) {
+      return
+    }
+
+    this.callback(
+      [
+        {
+          borderBoxSize: [{ blockSize: height }] as unknown as ResizeObserverEntry['borderBoxSize'],
+          contentRect: { height } as DOMRectReadOnly,
+          target: this.target
+        } as ResizeObserverEntry
+      ],
+      this as unknown as ResizeObserver
+    )
+  }
+}
+
+vi.stubGlobal('ResizeObserver', TestResizeObserver)
+
+const createdAt = new Date('2026-09-01T00:00:00.000Z')
+
+// The thinking preview body is a real scroller while streaming: jsdom has no
+// layout, so the distances the pin/re-lock logic reads are stubbed on the
+// prototype and moved per scenario below.
+let scrollHeight = 1000
+let clientHeight = 160
+let observedHeight = 0
+
+Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+  configurable: true,
+  get: () => scrollHeight
+})
+Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+  configurable: true,
+  get: () => clientHeight
+})
+
+beforeEach(() => {
+  window.localStorage.clear()
+  resizeObservers.clear()
+  scrollHeight = 1000
+  clientHeight = 160
+  observedHeight = 0
+})
+
+function streamingReasoningMessage(): ThreadMessage {
+  return {
+    id: 'assistant-reasoning-stream',
+    role: 'assistant',
+    content: [{ type: 'reasoning', text: ' Working through the problem step by step.', status: { type: 'running' } }],
+    status: { type: 'running' },
+    createdAt,
+    metadata: { unstable_state: null, unstable_annotations: [], unstable_data: [], steps: [], custom: {} }
+  } as unknown as ThreadMessage
+}
+
+function Harness() {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages: [streamingReasoningMessage()],
+    isRunning: true,
+    onNew: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  )
+}
+
+function previewBody(container: HTMLElement): HTMLElement {
+  const body = container.querySelector<HTMLElement>('[data-slot="aui_thinking-body"]')
+  expect(body).toBeTruthy()
+
+  return body!
+}
+
+function growthFrame() {
+  // Streamed tokens land: the observer reports a taller content box and the
+  // pin handler runs with the grown scrollHeight already visible to it.
+  scrollHeight += 200
+  observedHeight += 100
+
+  for (const observer of resizeObservers) {
+    observer.trigger(observedHeight)
+  }
+}
+
+async function settle(ticks = 8) {
+  await act(async () => {
+    for (let tick = 0; tick < ticks; tick += 1) {
+      await new Promise<void>(resolve => window.setTimeout(resolve, 0))
+    }
+  })
+}
+
+describe('streaming thinking preview scroll', () => {
+  it('pins the live preview to its bottom while the reader has not scrolled away', async () => {
+    const { container } = render(<Harness />)
+    await settle()
+
+    const body = previewBody(container)
+    expect(body.className).toContain('max-h-40')
+    expect(body.className).not.toMatch(/overscroll-contain/)
+
+    // Reading at the bottom: growth keeps the newest tokens visible.
+    body.scrollTop = scrollHeight - clientHeight
+    await act(async () => {
+      growthFrame()
+    })
+    // jsdom performs no layout, so the assigned value is not clamped.
+    expect(body.scrollTop).toBe(scrollHeight)
+  })
+
+  it('pauses the pin while the reader has scrolled the preview up', async () => {
+    const { container } = render(<Harness />)
+    await settle()
+
+    const body = previewBody(container)
+
+    // The reader scrolls up inside the streaming preview.
+    body.scrollTop = 120
+    await act(async () => {
+      body.dispatchEvent(new Event('scroll'))
+    })
+
+    const held = body.scrollTop
+    await act(async () => {
+      growthFrame()
+    })
+    // Growth no longer yanks the reader back down.
+    expect(body.scrollTop).toBe(held)
+  })
+
+  it('re-locks the pin once the reader returns to the bottom', async () => {
+    const { container } = render(<Harness />)
+    await settle()
+
+    const body = previewBody(container)
+
+    body.scrollTop = 120
+    await act(async () => {
+      body.dispatchEvent(new Event('scroll'))
+    })
+    await act(async () => {
+      growthFrame()
+    })
+    expect(body.scrollTop).toBe(120)
+
+    // Back to the bottom: follow resumes on the next growth.
+    body.scrollTop = scrollHeight - clientHeight
+    await act(async () => {
+      body.dispatchEvent(new Event('scroll'))
+    })
+    await act(async () => {
+      growthFrame()
+    })
+    expect(body.scrollTop).toBe(scrollHeight)
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Fixes #109510 — while a thinking preview is streaming (expanded, live tokens), scrolling the transcript with trackpad/wheel was dead: only dragging the scrollbar thumb worked.

Two compounding layers in `ThinkingDisclosure` (`apps/desktop/src/components/assistant-ui/thread/message-parts.tsx`):

1. **The pin had no user-intent awareness.** While live, a `ResizeObserver` set `el.scrollTop = el.scrollHeight` on every content growth. Every streamed delta re-snapped the preview to its bottom, overriding whatever a wheel/trackpad gesture had just done — the "pulled back toward the bottom" symptom.
2. **`overscroll-contain` on the live body** swallowed wheel events at the preview's edges instead of chaining them to the transcript viewport.

## Changes

- The pin now pauses while the reader has scrolled the preview up (distance-from-bottom > `PREVIEW_RELOCK_THRESHOLD_PX`, set on the preview's own `scroll` event) and re-locks once they return to the bottom — the same escape/re-lock semantics `useStickToBottom` gives the outer transcript, applied to the preview scroller.
- The live preview body (`isPreview`) drops `overscroll-contain` so wheel/trackpad chains to the transcript; a body the user expanded manually (settled) keeps its current behaviour.

## Relation to #96096

Complements rather than competes: #96096 removes `overscroll-contain` unconditionally (including the static expanded case) but leaves the streaming pin untouched — with the pin still active, a streaming preview would keep re-snapping even with chaining restored. This PR fixes the pin (streaming case only) and scopes its own `overscroll` change to the live preview, so the two changes compose.

## Testing

New spec `thinking-preview-scroll.test.tsx` (3 tests): pin follows while at bottom, pin pauses while scrolled up, pin re-locks on return to bottom. Mutation-checked (`grew && pinned` → `grew` reddens 2 of 3).

Local gates: `vitest` 3/3 new + 23/23 neighboring specs (`streaming`, `list-auto-show-earlier`, `list-session-scroll`), `tsc --build` clean, `eslint` clean.