### PR TITLE
fix(a2a): carry the inbound task id into the session source

### DIFF
--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -521,7 +521,8 @@ class A2AAdapter(BasePlatformAdapter):
             return self._end_task(rec, protocol.STATE_FAILED, "Agent gateway not ready to accept A2A tasks.")
         fut = self._add_pending(task_id, context_id)
         event = MessageEvent(text=framed, message_type=MessageType.TEXT, message_id=task_id,
-                             source=self.build_source(chat_id=context_id, chat_name=f"a2a:{peer}", chat_type="dm", user_id=peer, user_name=peer))
+                             source=self.build_source(chat_id=context_id, chat_name=f"a2a:{peer}", chat_type="dm", user_id=peer, user_name=peer,
+                                                       message_id=task_id))
         try:
             asyncio.run_coroutine_threadsafe(self.handle_message(event), self._loop)
         except Exception as e:

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -1393,6 +1393,49 @@ class TestMultiAgentRouting:
         assert protocol.extract_text(terminal["artifacts"][0]) == "dev reply"
         assert adapter.tasks.get(terminal["id"])["state"] == protocol.STATE_COMPLETED
 
+    def test_local_dispatch_carries_task_id_into_session_source(self):
+        """The local (non-forwarded) dispatch path already put ``task_id`` on the
+        MessageEvent but never passed it to ``build_source()``, so
+        ``event.source.message_id`` stayed None for every A2A turn even though
+        the id was already in scope -- the same bug class #719cb67bdb fixed for
+        buzz/dingtalk/email/google_chat/line/ntfy/photon/sms/teams/wecom/whatsapp,
+        just not for a2a.
+        """
+        from plugins.platforms.a2a.adapter import A2AAdapter
+        from gateway.config import PlatformConfig
+
+        adapter = A2AAdapter(PlatformConfig(enabled=True))
+        captured = {}
+
+        async def _completed():
+            return None
+
+        def fake_handle_message(event):
+            # A plain (non-async) stub: captures ``event`` at call time, i.e.
+            # exactly when _prepare_task builds it -- before it's wrapped into a
+            # coroutine and handed to asyncio.run_coroutine_threadsafe, so this
+            # assertion does not depend on the loop ever actually running it.
+            captured["event"] = event
+            return _completed()
+
+        adapter.handle_message = fake_handle_message  # type: ignore
+        adapter._message_handler = object()  # non-None so dispatch proceeds
+        adapter._loop = asyncio.new_event_loop()
+        try:
+            terminal, pending = adapter._prepare_task(
+                {"message": protocol.text_message(protocol.ROLE_USER, "hello", context_id="ctx-1")},
+                "peer-1",
+            )
+            adapter._loop.run_until_complete(asyncio.sleep(0))
+        finally:
+            adapter._loop.close()
+
+        assert terminal is None
+        assert pending is not None
+        event = captured["event"]
+        assert event.message_id == pending["task_id"]
+        assert event.source.message_id == pending["task_id"]
+
 
 class TestClientTenantAndDiscovery:
     def test_rpc_body_echoes_tenant_from_agent_card(self, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

`A2AAdapter._prepare_task()` builds the inbound `MessageEvent` for a locally-handled task with:

```python
event = MessageEvent(text=framed, message_type=MessageType.TEXT, message_id=task_id,
                     source=self.build_source(chat_id=context_id, chat_name=f"a2a:{peer}", chat_type="dm", user_id=peer, user_name=peer))
```

`task_id` is passed to `MessageEvent.message_id` but never to `build_source(...)`, so `event.source.message_id` was always `None` for every A2A turn — even though `task_id` was already in scope right there.

## Why this matters

This is the exact same bug class `719cb67bdb` ("carry the inbound message id into the session source everywhere") fixed for buzz, dingtalk, email, google_chat, line, ntfy, photon, sms, teams, wecom and whatsapp — that commit's own message says "only sites where the id variable was already in scope are widened," and `plugins/platforms/a2a/adapter.py` wasn't among them.

`gateway/run.py` reads `context.source.message_id` (not `event.message_id`) to populate `HERMES_SESSION_MESSAGE_ID` for the turn. Consumers of that contextvar are cross-platform, not A2A-specific: `tools/kanban_tools.py`, `tools/terminal_tool_background.py`, `tools/cronjob_job_args.py`. All of them saw an empty value for A2A turns instead of the real task id.

## The fix

One-line addition mirroring `719cb67bdb`'s pattern exactly: pass `message_id=task_id` to `build_source(...)` as well.

## Testing

Added `test_local_dispatch_carries_task_id_into_session_source` (`tests/plugins/test_a2a_plugin.py`), which drives `_prepare_task()` through the local (non-forwarded) dispatch path with a stubbed `handle_message` and asserts `event.source.message_id == pending["task_id"]`.

Mutation-verified: reverting the one-line fix makes the new assertion fail with `event.source.message_id` being `None` instead of the task id, confirming the test catches the exact regression. Ran the full A2A test suite (`test_a2a_plugin.py`, `test_a2a_phase23.py`, `test_a2a_tools_gate.py`, `test_a2a_schema_registration.py`, `test_a2a_reason_roundtrip.py`, `test_a2a_sessions.py`) — 176 passed, no regressions.

## Scope note

Checked for competing fixes with several keyword searches (`a2a message_id`, `a2a build_source`, `a2a task_id source`, `a2a session source`) — the only directly related merged PR, #109162, fixed Slack/Feishu's inbound-message-id gap, not A2A's. No open or merged PR touches this call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
