### PR TITLE
fix(compression): bound tail message floor by lean token budget (#108647)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -4252,10 +4252,40 @@ Write only the summary body. Do not include any preamble or prefix."""
             cut_idx, _ = self._walk_tail_budget(messages, head_end, token_budget, min_tail, cut_at_break=True)
 
         fallback_cut = n - min_tail
-        cut_idx = min(cut_idx, fallback_cut)
+        # Token-bounded floor: the min_tail message floor must not override the
+        # soft token ceiling unbounded (LEAN_TAIL 10k budget -> 15k ceiling grew
+        # to 63k / 6.3x in #108647). Only expand to fallback_cut when its tail
+        # fits soft_ceiling; otherwise keep the budget-respecting cut. Also
+        # compute a hard cap (floor=0) so even the budget walk's own min_tail
+        # inclusion cannot blow past soft_ceiling without bound.
+        hard_cap_cut, _ = self._walk_tail_budget(messages, head_end, soft_ceiling, 0, cut_at_break=False)
+        if hard_cap_cut > head_end:
+            # Budget-respecting cap exists (tail alone exceeds ceiling) — floor
+            # cannot move earlier than it.
+            if fallback_cut < cut_idx:
+                # Measure fallback tail tokens; only enforce floor if it fits.
+                charge_all = self._stale_thinking_on_wire()
+                newest_idx = _last_assistant_index(messages)
+                fallback_tokens = sum(
+                    _estimate_msg_budget_tokens(messages[i], charge_all or i == newest_idx)
+                    for i in range(fallback_cut, n)
+                )
+                if fallback_tokens <= soft_ceiling:
+                    cut_idx = fallback_cut
+                else:
+                    # Floor would blow the ceiling — keep budget cut, but still
+                    # respect the hard cap so walk's own floor overshoot is clipped.
+                    cut_idx = max(cut_idx, hard_cap_cut)
+            else:
+                cut_idx = max(min(cut_idx, fallback_cut), hard_cap_cut)
+        else:
+            cut_idx = min(cut_idx, fallback_cut)
         # Small conversations: force a cut after the head so compression still removes something.
         if cut_idx <= head_end:
             cut_idx = max(fallback_cut, head_end + 1)
+            # Re-apply hard cap if tail now exceeds ceiling (small convo path).
+            if hard_cap_cut > head_end:
+                cut_idx = max(cut_idx, hard_cap_cut)
         cut_idx = self._align_boundary_backward(messages, cut_idx)
         # Latest user message must stay in the tail (active task). Latest assistant reply must stay too;
         # anchors only walk backward, so chaining is monotonic.


### PR DESCRIPTION
Fixes #108647

**Problem:** `_find_tail_cut_by_tokens` walks backward against a token budget with a documented 1.5x overshoot allowance (`soft_ceiling = budget * 1.5`), then discards it via unconditional `cut_idx = min(cut_idx, n - min_tail)`. On lean mode (`LEAN_TAIL_FLOOR_TOKENS=10k`, `soft_ceiling=15k`) this returns a 63,081-token tail (6.3x budget) and 9 messages against an effective `min_tail=8` - neither bound holds. Tail is exempt from pre-pass tool-result prune, so those tokens are incompressible and consume the compression trigger.

**Root cause:** Two sources of unbounded tail:
1. `fallback_cut = n - min_tail` applied with `min()` unconditionally, no token check.
2. `_walk_tail_budget` itself can exceed `soft_ceiling` arbitrarily when the first `min_tail` messages already exceed it (early `return` is suppressed until `n-i >= min_tail`).

**Fix:** Token-bounded floor:
- Compute a hard token cap via `_walk_tail_budget(..., soft_ceiling, 0)` (no floor).
- Only expand to `fallback_cut` when its tail tokens fit `soft_ceiling`; otherwise keep the budget-respecting cut.
- Clip the walk's own floor overshoot via `max(cut_idx, hard_cap_cut)`.
- Re-apply cap on the small-conversation force-cut path.

Preserves the message-count floor when it fits (small-tail test keeps 8 messages), caps the unbounded case to ~8k/5 messages instead of 63k/9.

**Tests:** Deterministic tail reproduction (huge 32k-char tool outputs -> 8-message tail is capped to budget) + existing suite: `test_infinite_compaction_loop` (12), `test_compression_feasibility/budget_rearm/in_place_compaction` (27) all green. Import/compile ok.