### PR TITLE
fix(slack): keep rich_blocks/feedback semantics on native streams and drop the redundant post-stream chat_update

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2391,16 +2391,6 @@ class SlackAdapter(BasePlatformAdapter):
         if not ok:
             # Stop failed — post normally; the dangling stream times out on Slack's side.
             return None
-        # Streams render markdown natively; rich blocks are applied via
-        # chat_update on the sealed message (mirrors edit_message finalize).
-        blocks = self._maybe_blocks(text)
-        if blocks:
-            try:
-                await self._get_client(chat_id).chat_update(
-                    channel=chat_id, ts=ts, text=self.format_message(text), blocks=blocks)
-            except Exception as e:
-                logger.debug(
-                    "[Slack] Post-stream Block Kit update failed (markdown fallback stands): %s", e)
         await self.stop_typing(chat_id)
         return SendResult(success=True, message_id=ts)
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2263,6 +2263,12 @@ class SlackAdapter(BasePlatformAdapter):
         """Return whether Slack's native stream can preserve configured behavior."""
         if self._native_stream_unsupported:
             return False
+        # Native streams accept appended markdown text, but cannot preserve
+        # the structural fallback semantics of rich_blocks. This also wins
+        # when markdown_blocks is enabled so an unrenderable markdown block
+        # can still fall through to the rich renderer on the edit path.
+        if self._extra_flag("rich_blocks"):
+            return False
         # chat.*Stream has no unfurl controls; configured unfurl behavior needs
         # the edit-based transport whose chat.postMessage carries them.
         if _slack_unfurl_kwargs(self.config.extra):
@@ -2387,7 +2393,15 @@ class SlackAdapter(BasePlatformAdapter):
             return None
         self._active_streams.pop(chat_id, None)
         ts = stream["ts"]
-        ok = await self._seal_stream(chat_id, stream, final_text=text)
+        blocks = (
+            [self._feedback_block()] if self._extra_flag("feedback_buttons") else None
+        )
+        ok = await self._seal_stream(
+            chat_id,
+            stream,
+            final_text=text,
+            blocks=blocks,
+        )
         if not ok:
             # Stop failed — post normally; the dangling stream times out on Slack's side.
             return None

--- a/tests/gateway/test_slack_native_streaming.py
+++ b/tests/gateway/test_slack_native_streaming.py
@@ -208,14 +208,18 @@ class TestSendFinalization:
         client.chat_postMessage.assert_awaited()
 
     @pytest.mark.asyncio
-    async def test_rich_blocks_applied_after_seal(self):
-        adapter, client = _make_adapter({"rich_blocks": True})
+    @pytest.mark.parametrize("blocks_setting", ["markdown_blocks", "rich_blocks"])
+    async def test_streamed_text_is_not_reapplied_as_blocks_after_seal(
+        self, blocks_setting
+    ):
+        adapter, client = _make_adapter({blocks_setting: True})
         rich = "# Title\n\nbody text"
         await adapter.send_draft("D1", 7, rich[:5], metadata=META)
         result = await adapter.send("D1", rich, metadata=META)
         assert result.success
-        client.chat_update.assert_awaited()
-        assert client.chat_update.await_args.kwargs["blocks"]
+        client.chat_stopStream.assert_awaited_once()
+        client.chat_update.assert_not_awaited()
+        client.chat_postMessage.assert_not_awaited()
 
 
 class TestDisconnectCleanup:

--- a/tests/gateway/test_slack_native_streaming.py
+++ b/tests/gateway/test_slack_native_streaming.py
@@ -76,6 +76,18 @@ class TestSupportsDraftStreaming:
         adapter._native_stream_unsupported = True
         assert adapter.supports_draft_streaming() is False
 
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            {"rich_blocks": True},
+            {"rich_blocks": True, "markdown_blocks": True},
+        ],
+    )
+    def test_rich_blocks_disable_native_streaming(self, extra):
+        adapter, _ = _make_adapter(extra)
+
+        assert adapter.supports_draft_streaming(chat_type="dm") is False
+
 
 class TestSendDraft:
     @pytest.mark.asyncio
@@ -208,16 +220,32 @@ class TestSendFinalization:
         client.chat_postMessage.assert_awaited()
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("blocks_setting", ["markdown_blocks", "rich_blocks"])
-    async def test_streamed_text_is_not_reapplied_as_blocks_after_seal(
-        self, blocks_setting
-    ):
-        adapter, client = _make_adapter({blocks_setting: True})
+    async def test_streamed_markdown_is_not_reapplied_as_blocks_after_seal(self):
+        adapter, client = _make_adapter({"markdown_blocks": True})
         rich = "# Title\n\nbody text"
         await adapter.send_draft("D1", 7, rich[:5], metadata=META)
         result = await adapter.send("D1", rich, metadata=META)
         assert result.success
         client.chat_stopStream.assert_awaited_once()
+        assert "blocks" not in client.chat_stopStream.await_args.kwargs
+        client.chat_update.assert_not_awaited()
+        client.chat_postMessage.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_native_stream_seals_with_feedback_controls_only(self):
+        adapter, client = _make_adapter(
+            {"markdown_blocks": True, "feedback_buttons": True}
+        )
+        rich = "# Title\n\nbody text"
+        await adapter.send_draft("D1", 7, rich[:5], metadata=META)
+        result = await adapter.send("D1", rich, metadata=META)
+        assert result.success
+        client.chat_stopStream.assert_awaited_once()
+        blocks = client.chat_stopStream.await_args.kwargs["blocks"]
+        assert len(blocks) == 1
+        assert blocks[0]["type"] == "context_actions"
+        assert blocks[0]["elements"][0]["type"] == "feedback_buttons"
+        assert not any(block["type"] == "markdown" for block in blocks)
         client.chat_update.assert_not_awaited()
         client.chat_postMessage.assert_not_awaited()
 


### PR DESCRIPTION
Two small fixes to the Slack adapter's native streaming path, carried as local patches on a production deployment (13 bot profiles on one Slack workspace) since v0.21.0 and rebased onto current `main`.

**1. `rich_blocks` disables native streaming.** `chat.*Stream` accepts appended markdown but cannot preserve the structural fallback semantics of `rich_blocks`; when the flag is on we now fall back to the edit-based transport, so an unrenderable markdown block can still fall through to the rich renderer. Same applies when `markdown_blocks` is enabled.

**2. Feedback buttons survive the seal, and the post-stream `chat_update` goes away.** The sealed message now carries the feedback block directly through `_seal_stream(..., blocks=...)`, instead of a second `chat_update` after the stream. That second update duplicated the streamed text in blocks on the sealed message and could race with the stream's own final render.

Tests: `tests/gateway/test_slack_native_streaming.py` gains cases for both behaviours; `pytest tests/gateway/test_slack.py tests/gateway/test_slack_native_streaming.py` → 259 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmLjbCKsznnuaj4D7AqRBG
