### PR TITLE
feat(state): honor HERMES_DISABLE_FTS_TRIGRAM to skip the fragile FTS5 trigram index

### DIFF
--- a/hermes_state_fts.py
+++ b/hermes_state_fts.py
@@ -325,6 +325,14 @@ class SessionFtsSetupMixin:
                 pass
 
     def _ensure_fts_schema(self, cursor: sqlite3.Cursor, table_name: str, ddl: str) -> bool:
+        # The hermes_state_search.optimize_fts docstring mentions an
+        # HERMES_DISABLE_FTS_TRIGRAM flag, but upstream never implemented it.
+        # The FTS5 trigram index is fragile under continuous writes and has
+        # corrupted state.db in production ("database disk image is malformed").
+        # The base messages_fts index remains active and covers word search;
+        # only the trigram index is skipped when the flag is set.
+        if table_name.endswith("_trigram") and os.getenv("HERMES_DISABLE_FTS_TRIGRAM"):
+            return False
         status = self._fts_table_probe(cursor, table_name)
         if status is None:
             return False

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -29,6 +29,25 @@ def _activity_snapshot(db, session_id):
     )
 
 
+def test_disable_fts_trigram_keeps_base_fts(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_DISABLE_FTS_TRIGRAM", "1")
+    db = SessionDB(db_path=tmp_path / "test_state.db")
+    try:
+        names = {
+            row[0]
+            for row in db._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+        assert "messages_fts" in names
+        assert "messages_fts_trigram" not in names
+        assert db._fts_enabled is True
+        assert db._trigram_available is False
+        db._conn.execute("SELECT rowid FROM messages_fts LIMIT 1").fetchall()
+    finally:
+        db.close()
+
+
 class _NoFtsCursor(sqlite3.Cursor):
     """Simulate a SQLite build without the fts5 module."""
 


### PR DESCRIPTION
`hermes_state_search.optimize_fts` documents an `HERMES_DISABLE_FTS_TRIGRAM` flag that was never implemented. On a long-running gateway deployment the FTS5 trigram index corrupted `state.db` repeatedly under continuous writes (`database disk image is malformed`), while the base `messages_fts` index was fine.

This implements the flag in `_ensure_fts_schema`: when set, tables ending in `_trigram` are skipped; `messages_fts` stays active and still covers word search. Default behaviour is unchanged.

Test: `tests/test_hermes_state.py::test_disable_fts_trigram_keeps_base_fts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmLjbCKsznnuaj4D7AqRBG
