### PR TITLE
feat(feishu): scan-to-create onboarding from the dashboard

### DIFF
--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -68,6 +68,14 @@ class WhatsAppOnboardingApply(BaseModel):
     allowed_users: Optional[str] = None
     profile: Optional[str] = None
 
+class FeishuOnboardingStart(BaseModel):
+    # 域名决定找哪个品牌建应用：feishu（中国版）或 lark（国际版）。
+    domain: Optional[str] = None
+    profile: Optional[str] = None
+
+class FeishuOnboardingApply(BaseModel):
+    profile: Optional[str] = None
+
 class AudioTranscriptionRequest(BaseModel):
     data_url: str
     mime_type: Optional[str] = None

--- a/hermes_cli/web_routers/messaging.py
+++ b/hermes_cli/web_routers/messaging.py
@@ -29,11 +29,13 @@ from hermes_constants import get_process_hermes_home
 from hermes_cli.web_deps import LateState, late
 from hermes_cli.web_server_gateway import _restart_gateway_after
 from hermes_cli.web_server_messaging import (
-    _TelegramOnboardingPairing, _WhatsAppOnboardingSession, _messaging_platform_catalog, _telegram_onboarding_error_message, _telegram_onboarding_lock, _telegram_onboarding_pairings, _whatsapp_onboarding_payload, _whatsapp_onboarding_sessions,
+    _FeishuOnboardingSession, _TelegramOnboardingPairing, _WhatsAppOnboardingSession, _feishu_onboarding_lock, _feishu_onboarding_payload,
+    _feishu_onboarding_sessions, _messaging_platform_catalog, _prune_feishu_onboarding_sessions, _telegram_onboarding_error_message,
+    _telegram_onboarding_lock, _telegram_onboarding_pairings, _whatsapp_onboarding_payload, _whatsapp_onboarding_sessions,
 )
 from hermes_cli.web_routers._common import http_failure
 from hermes_cli.web_models import (
-    MessagingPlatformUpdate, TelegramOnboardingApply, TelegramOnboardingStart,
+    FeishuOnboardingApply, FeishuOnboardingStart, MessagingPlatformUpdate, TelegramOnboardingApply, TelegramOnboardingStart,
     WhatsAppOnboardingApply, WhatsAppOnboardingStart,
 )
 
@@ -45,6 +47,7 @@ _config_profile_scope = late("_config_profile_scope", "hermes_cli.web_server_pro
 _profile_scope = late("_profile_scope", "hermes_cli.web_server_profiles")
 _resolve_profile_dir = late("_resolve_profile_dir", "hermes_cli.web_server_profiles")
 _restart_gateway_after_whatsapp_onboarding = late("_restart_gateway_after_whatsapp_onboarding", "hermes_cli.web_server_messaging")
+_restart_gateway_after_feishu_onboarding = late("_restart_gateway_after_feishu_onboarding", "hermes_cli.web_server_messaging")
 _telegram_onboarding_request_sync = late("_telegram_onboarding_request_sync", "hermes_cli.web_server_messaging")
 _whatsapp_session_path = late("_whatsapp_session_path", "hermes_cli.web_server_messaging")
 _write_platform_enabled = late("_write_platform_enabled", "hermes_cli.web_server_messaging")
@@ -52,6 +55,7 @@ load_env = late("load_env", "hermes_cli.config")
 load_config = late("load_config", "hermes_cli.config")
 read_runtime_status = late("read_runtime_status", "gateway.status")
 remove_env_value = late("remove_env_value", "hermes_cli.config")
+get_env_value = late("get_env_value", "hermes_cli.config")
 save_env_value = late("save_env_value", "hermes_cli.config")
 _gateway_subcommand = late("_gateway_subcommand", "hermes_cli.web_server_gateway")
 _probe_gateway_health = late("_probe_gateway_health", "hermes_cli.web_server_gateway")
@@ -774,6 +778,171 @@ async def apply_telegram_onboarding(pairing_id: str, body: TelegramOnboardingApp
 async def cancel_telegram_onboarding(pairing_id: str):
     with _telegram_onboarding_lock:
         _telegram_onboarding_pairings.pop(pairing_id, None)
+    return {"ok": True}
+
+
+# ── Feishu / Lark scan-to-create onboarding ───────────────────
+#
+# 与 WhatsApp（本地子进程扫 QR）/ Telegram（走中转服务配对）都不同：飞书这条**完全在本地**完成 ——
+# 授权就是飞书账号域的设备码流程（init → begin 拿到授权链接 → 轮询 poll 取凭据），
+# 不依赖第三方服务、也不需要子进程。前端语义与前两者保持一致：start / status / apply / cancel。
+
+
+def _feishu_adapter():
+    """飞书适配器模块（延迟导入：没装飞书依赖的机器不该因为打开面板就报错）。"""
+    from plugins.platforms.feishu import adapter
+    return adapter
+
+
+def _normalize_feishu_domain(value: Optional[str]) -> str:
+    domain = (value or "feishu").strip().lower()
+    return domain if domain in {"feishu", "lark"} else "feishu"
+
+
+def _feishu_begin(domain: str) -> dict:
+    """init + begin（两次 HTTP）。放线程里跑 —— 它们会同步等网络。"""
+    adapter = _feishu_adapter()
+    adapter._init_registration(domain)
+    return adapter._begin_registration(domain)
+
+
+def _feishu_poll_into(record: _FeishuOnboardingSession) -> None:
+    """问平台一次并把结果写回 record（**只问一次**；节流由调用方按 record.interval 控制）。
+
+    与适配器里那条终端流程保持同一套判据：域名可能被平台纠正为 lark（企业品牌为 lark 时），
+    凭据出现的标志是 client_id + client_secret，access_denied / expired_token 是终态。
+    """
+    adapter = _feishu_adapter()
+    res = adapter._post_registration(adapter._accounts_base_url(record.domain), {
+        "action": "poll", "device_code": record.device_code, "tp": "ob_app",
+    })
+    user_info = res.get("user_info") or {}
+    # 用平台给的企业品牌纠正域名：国际版企业扫出来的凭据必须配 lark 域，否则连不上。
+    if user_info.get("tenant_brand") == "lark" and record.domain != "lark":
+        record.domain = "lark"
+    if res.get("client_id") and res.get("client_secret"):
+        record.app_id = str(res["client_id"])
+        record.app_secret = str(res["client_secret"])
+        record.open_id = user_info.get("open_id")
+        record.status = "ready"
+        return
+    error = str(res.get("error") or "")
+    if error == "access_denied":
+        record.status = "denied"
+        record.error = "Feishu / Lark authorization was denied. Start a new setup."
+    elif error == "expired_token":
+        record.status = "expired"
+        record.error = "Feishu / Lark setup expired. Start a new setup."
+    # 其余（authorization_pending 等）保持 pending，等下一次轮询。
+
+
+def _feishu_record_or_404(pairing_id: str) -> _FeishuOnboardingSession:
+    """Call with ``_feishu_onboarding_lock`` held."""
+    _prune_feishu_onboarding_sessions()
+    record = _feishu_onboarding_sessions.get(pairing_id)
+    if not record:
+        raise HTTPException(status_code=404, detail="Feishu / Lark setup session not found. Start a new setup.")
+    return record
+
+
+@router.post("/api/messaging/feishu/onboarding/start")
+async def start_feishu_onboarding(body: FeishuOnboardingStart):
+    domain = _normalize_feishu_domain(body.domain)
+    try:
+        begin = await asyncio.to_thread(_feishu_begin, domain)
+    except Exception as exc:  # noqa: BLE001 — 归一到可读错误，别把内部异常抛给前端
+        _log.warning("Feishu onboarding start failed: %s", exc)
+        raise HTTPException(
+            status_code=502,
+            detail="Could not reach Feishu / Lark. Check the network and try again.",
+        ) from exc
+
+    device_code = str(begin.get("device_code") or "").strip()
+    if not device_code:
+        raise HTTPException(status_code=502, detail="Feishu / Lark did not return a setup session. Try again.")
+
+    expires_in = int(begin.get("expire_in") or 600)
+    record = _FeishuOnboardingSession(
+        device_code=device_code, domain=domain, interval=max(1, int(begin.get("interval") or 5)),
+        expires_at_ts=time.time() + expires_in, profile=body.profile,
+        user_code=str(begin.get("user_code") or ""), qr_url=str(begin.get("qr_url") or ""),
+    )
+    pairing_id = secrets.token_urlsafe(16)
+    with _feishu_onboarding_lock:
+        _prune_feishu_onboarding_sessions()
+        _feishu_onboarding_sessions[pairing_id] = record
+        return _feishu_onboarding_payload(pairing_id, record)
+
+
+@router.get("/api/messaging/feishu/onboarding/{pairing_id}")
+async def get_feishu_onboarding_status(pairing_id: str):
+    with _feishu_onboarding_lock:
+        record = _feishu_record_or_404(pairing_id)
+        terminal = record.status in {"ready", "expired", "denied", "cancelled", "error"}
+        # 节流：平台给的 interval 是它对轮询频率的要求（飞书是 5s），问得更勤没有意义，
+        # 还可能被限流。间隔未到就把上次的状态原样回给前端。
+        due = (time.time() - record.last_poll_ts) >= record.interval
+        poll_now = (not terminal) and due
+        if poll_now:
+            record.last_poll_ts = time.time()
+
+    if poll_now:
+        try:
+            await asyncio.to_thread(_feishu_poll_into, record)
+        except Exception as exc:  # noqa: BLE001 — 网络抖动不该把会话判死，下次轮询再试
+            _log.debug("Feishu onboarding poll failed (will retry): %s", exc)
+
+    with _feishu_onboarding_lock:
+        record = _feishu_record_or_404(pairing_id)
+        if record.status in {"expired", "denied"}:
+            # 410：终态，前端据此停止轮询并提示重新开始（与 WhatsApp 同一约定）。
+            raise HTTPException(status_code=410, detail=record.error or "Feishu / Lark setup ended.")
+        return _feishu_onboarding_payload(pairing_id, record)
+
+
+@router.post("/api/messaging/feishu/onboarding/{pairing_id}/apply")
+async def apply_feishu_onboarding(pairing_id: str, body: FeishuOnboardingApply, profile: Optional[str] = None):
+    with _feishu_onboarding_lock:
+        record = _feishu_record_or_404(pairing_id)
+        if record.status != "ready" or not record.app_id or not record.app_secret:
+            raise HTTPException(status_code=409, detail="Feishu / Lark setup is not ready yet.")
+        app_id, app_secret, domain = record.app_id, record.app_secret, record.domain
+        record_profile = record.profile
+
+    effective_profile = body.profile or profile or record_profile
+
+    def _apply():
+        with _config_profile_scope(effective_profile):
+            save_env_value("FEISHU_APP_ID", app_id)
+            save_env_value("FEISHU_APP_SECRET", app_secret)
+            save_env_value("FEISHU_DOMAIN", domain)
+            # ★ 扫码建出来的应用只能走长连接（没有公网回调地址），所以默认写 websocket；
+            #   但**不覆盖**用户已经显式选的 webhook —— 那说明他自己配了回调，别替他改回去。
+            if not (get_env_value("FEISHU_CONNECTION_MODE") or "").strip():
+                save_env_value("FEISHU_CONNECTION_MODE", "websocket")
+            _write_platform_enabled("feishu", True)
+
+    with _onboarding_save_errors("Feishu onboarding apply failed", "Failed to save Feishu / Lark setup."):
+        await asyncio.to_thread(_apply)
+
+    with _feishu_onboarding_lock:
+        _feishu_onboarding_sessions.pop(pairing_id, None)
+
+    restart_result = _restart_gateway_after_feishu_onboarding(effective_profile)
+    return {
+        "ok": True, "platform": "feishu", "app_id": app_id,
+        "needs_restart": not restart_result["restart_started"], **restart_result,
+    }
+
+
+@router.delete("/api/messaging/feishu/onboarding/{pairing_id}")
+async def cancel_feishu_onboarding(pairing_id: str):
+    with _feishu_onboarding_lock:
+        record = _feishu_onboarding_sessions.pop(pairing_id, None)
+    if record:
+        record.status = "cancelled"
+        # 取消就把凭据从内存里抹掉（这是一次真实可用的 bot 密钥，不该留在进程里等 GC）。
+        record.app_secret = None
     return {"ok": True}
 
 

--- a/hermes_cli/web_server_messaging.py
+++ b/hermes_cli/web_server_messaging.py
@@ -6,6 +6,7 @@ import logging
 import os
 import subprocess
 import threading
+import time
 from dataclasses import dataclass
 from fastapi import HTTPException
 from pathlib import Path
@@ -371,6 +372,71 @@ def _whatsapp_onboarding_payload(pairing_id: str, record: _WhatsAppOnboardingSes
 def _restart_gateway_after_whatsapp_onboarding(profile: Optional[str] = None) -> dict[str, Any]:
     from hermes_cli.web_server_gateway import _restart_gateway_after
     return _restart_gateway_after(profile, what="WhatsApp onboarding", label="WhatsApp onboarding")
+
+
+# ── Feishu / Lark scan-to-create onboarding ────────────────────────────────
+#
+# 与 WhatsApp/Telegram 两套不同：飞书这边**没有子进程、也不依赖第三方中转服务** ——
+# 授权就是飞书账号域的设备码流程（本地发三次 HTTP：init → begin → poll），
+# 所以状态全在这一条 record 里，由前端轮询我们的 GET 端点来推动（每次最多问平台一次）。
+
+_FEISHU_TERMINAL_STATUSES = frozenset({"ready", "expired", "denied", "cancelled", "error"})
+
+# 终态在内存里留多久：让界面还能显示「已过期/已拒绝」，超过就回收（防内存里攒垃圾）。
+_FEISHU_SESSION_GRACE_SECONDS = 300.0
+
+
+@dataclass
+class _FeishuOnboardingSession:
+    device_code: str
+    domain: str
+    interval: int
+    expires_at_ts: float
+    profile: str | None = None
+    user_code: str = ""
+    qr_url: str = ""
+    status: str = "pending"
+    # ★ app_id/app_secret 只在这里**短暂**停留，用于「保存并启用」那一步；
+    #   它们不进 `_feishu_onboarding_payload`（见下面的字段白名单）——
+    #   设备码流程拿到的凭据是客户飞书里的真密钥，泄露一次就等于把 bot 交出去。
+    app_id: str | None = None
+    app_secret: str | None = None
+    open_id: str | None = None
+    bot_name: str | None = None
+    last_poll_ts: float = 0.0
+    error: str | None = None
+
+
+_feishu_onboarding_sessions: dict[str, _FeishuOnboardingSession] = {}
+_feishu_onboarding_lock = threading.RLock()
+
+# 对外只暴露这些字段（白名单，不是黑名单）—— 加字段时若忘了分类，默认就是「不暴露」。
+_FEISHU_PAYLOAD_FIELDS = (
+    "status", "qr_url", "user_code", "domain", "interval", "app_id", "bot_name", "error",
+)
+
+
+def _feishu_onboarding_payload(pairing_id: str, record: _FeishuOnboardingSession) -> dict[str, Any]:
+    payload = {"pairing_id": pairing_id, **{f: getattr(record, f) for f in _FEISHU_PAYLOAD_FIELDS}}
+    payload["expires_in"] = max(0, int(record.expires_at_ts - time.time()))
+    return payload
+
+
+def _prune_feishu_onboarding_sessions() -> None:
+    """清掉过期的会话；终态再多留一会儿（界面要能显示为什么结束）。"""
+    now = time.time()
+    for pairing_id, record in list(_feishu_onboarding_sessions.items()):
+        if record.status not in _FEISHU_TERMINAL_STATUSES and record.expires_at_ts <= now:
+            record.status = "expired"
+            record.error = "Feishu / Lark setup expired. Start a new setup."
+            record.app_secret = None
+        if record.status in _FEISHU_TERMINAL_STATUSES and record.expires_at_ts + _FEISHU_SESSION_GRACE_SECONDS <= now:
+            _feishu_onboarding_sessions.pop(pairing_id, None)
+
+
+def _restart_gateway_after_feishu_onboarding(profile: Optional[str] = None) -> dict[str, Any]:
+    from hermes_cli.web_server_gateway import _restart_gateway_after
+    return _restart_gateway_after(profile, what="Feishu onboarding", label="Feishu onboarding")
 
 
 _TELEGRAM_ONBOARDING_DEFAULT_URL = "https://setup.hermes-agent.nousresearch.com"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2428,6 +2428,170 @@ class TestWebServerEndpoints:
         assert payload["messages"][-1]["content"] == "msg 500"
         assert calls == [(500, 0), (500, 500)]
 
+    # ── 飞书扫码接入（面板里的第二步）─────────────────────────────
+    #
+    # 这几条盯的是**对外契约**：凭据只进不出（响应里永远没有 app_secret）、
+    # 轮询频率听平台的、终态用 410 表达、apply 之后 env 真的落盘并触发重启。
+
+    _FEISHU_FAKE_QR_URL = "https://open.feishu.cn/page/launcher?user_code=ABCD-1234&from=hermes&tp=hermes"
+
+    def _patch_feishu_adapter(self, monkeypatch, *, polls, begin_expire_in=3600):
+        """把适配器里的设备码原语换成可控的假实现，返回「被问了几次」的计数器。"""
+        from plugins.platforms.feishu import adapter
+
+        state = {"polls": 0}
+
+        def fake_begin(domain):
+            return {
+                "device_code": "dev-code-1", "qr_url": self._FEISHU_FAKE_QR_URL,
+                "user_code": "ABCD-1234", "interval": 5, "expire_in": begin_expire_in,
+            }
+
+        def fake_post(base_url, body):
+            assert body["action"] == "poll"
+            state["polls"] += 1
+            return polls[min(state["polls"], len(polls)) - 1]
+
+        monkeypatch.setattr(adapter, "_init_registration", lambda domain: None)
+        monkeypatch.setattr(adapter, "_begin_registration", fake_begin)
+        monkeypatch.setattr(adapter, "_post_registration", fake_post)
+        return state
+
+    @staticmethod
+    def _clear_feishu_sessions():
+        with _web_server_messaging._feishu_onboarding_lock:
+            _web_server_messaging._feishu_onboarding_sessions.clear()
+
+    def test_feishu_onboarding_start_returns_link_without_credentials(self, monkeypatch):
+        self._clear_feishu_sessions()
+        self._patch_feishu_adapter(monkeypatch, polls=[{"error": "authorization_pending"}])
+
+        resp = self.client.post("/api/messaging/feishu/onboarding/start", json={"domain": "feishu"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "pending"
+        assert data["qr_url"] == self._FEISHU_FAKE_QR_URL
+        assert data["user_code"] == "ABCD-1234"
+        assert data["domain"] == "feishu"
+        # 窗口来自适配器读到的 expires_in（3600），不是被砍过的 600。
+        assert data["expires_in"] > 600
+        # ★ 还没授权，凭据一个都不该出现；app_secret 更是任何响应里都不许有。
+        assert "app_secret" not in json.dumps(data)
+        assert not data.get("app_id")
+
+    def test_feishu_onboarding_unknown_domain_falls_back_to_feishu(self, monkeypatch):
+        self._clear_feishu_sessions()
+        self._patch_feishu_adapter(monkeypatch, polls=[{"error": "authorization_pending"}])
+
+        resp = self.client.post("/api/messaging/feishu/onboarding/start", json={"domain": "not-a-brand"})
+        assert resp.status_code == 200
+        assert resp.json()["domain"] == "feishu"
+
+    def test_feishu_onboarding_poll_is_throttled_by_platform_interval(self, monkeypatch):
+        """平台给的 interval 是对轮询频率的要求：连问两次也只该问平台一次。"""
+        self._clear_feishu_sessions()
+        state = self._patch_feishu_adapter(monkeypatch, polls=[{"error": "authorization_pending"}])
+
+        started = self.client.post("/api/messaging/feishu/onboarding/start", json={})
+        pairing_id = started.json()["pairing_id"]
+
+        first = self.client.get(f"/api/messaging/feishu/onboarding/{pairing_id}")
+        second = self.client.get(f"/api/messaging/feishu/onboarding/{pairing_id}")
+        assert first.status_code == 200 and second.status_code == 200
+        assert first.json()["status"] == "pending"
+        assert state["polls"] == 1, "间隔未到时不应再打平台接口"
+
+    def test_feishu_onboarding_becomes_ready_and_keeps_secret_off_the_wire(self, monkeypatch):
+        self._clear_feishu_sessions()
+        self._patch_feishu_adapter(monkeypatch, polls=[
+            {"error": "authorization_pending"},
+            {"client_id": "cli_from_scan", "client_secret": "sec_from_scan",
+             "user_info": {"open_id": "ou_scanner", "tenant_brand": "lark"}},
+        ])
+
+        started = self.client.post("/api/messaging/feishu/onboarding/start", json={})
+        pairing_id = started.json()["pairing_id"]
+
+        # 第一次轮询：还是 pending（并把它从 5s 节流里放出来）
+        self.client.get(f"/api/messaging/feishu/onboarding/{pairing_id}")
+        with _web_server_messaging._feishu_onboarding_lock:
+            _web_server_messaging._feishu_onboarding_sessions[pairing_id].last_poll_ts = 0
+
+        ready = self.client.get(f"/api/messaging/feishu/onboarding/{pairing_id}")
+        assert ready.status_code == 200
+        data = ready.json()
+        assert data["status"] == "ready"
+        assert data["app_id"] == "cli_from_scan"
+        # 平台说这是国际版企业 → 域名要跟着纠正，否则拿 lark 的凭据去连飞书域必然失败
+        assert data["domain"] == "lark"
+        assert "sec_from_scan" not in json.dumps(data)
+
+    def test_feishu_onboarding_apply_writes_env_and_restarts(self, monkeypatch):
+        self._clear_feishu_sessions()
+        self._patch_feishu_adapter(monkeypatch, polls=[
+            {"client_id": "cli_apply", "client_secret": "sec_apply", "user_info": {"open_id": "ou_x"}},
+        ])
+        from hermes_cli.config import load_config, load_env
+
+        restarts = []
+        monkeypatch.setattr(
+            _web_server_messaging, "_restart_gateway_after_feishu_onboarding",
+            lambda profile=None: restarts.append(profile) or {"restart_started": True, "restart_error": None},
+        )
+        # 未落盘任何 FEISHU_CONNECTION_MODE：apply 应补上 websocket（扫码建的应用只能走长连接）
+        import hermes_cli.config as config_mod
+        monkeypatch.setattr(config_mod, "get_env_value", lambda key: "")
+
+        started = self.client.post("/api/messaging/feishu/onboarding/start", json={})
+        pairing_id = started.json()["pairing_id"]
+        self.client.get(f"/api/messaging/feishu/onboarding/{pairing_id}")
+
+        applied = self.client.post(f"/api/messaging/feishu/onboarding/{pairing_id}/apply", json={})
+        assert applied.status_code == 200
+        body = applied.json()
+        assert body["ok"] is True and body["app_id"] == "cli_apply"
+        assert body["needs_restart"] is False
+        assert "sec_apply" not in json.dumps(body)
+        assert restarts == [None], "保存后必须触发一次重启（否则用户看到已开通、实际没生效）"
+
+        env = load_env()
+        assert env["FEISHU_APP_ID"] == "cli_apply"
+        assert env["FEISHU_APP_SECRET"] == "sec_apply"
+        assert env["FEISHU_DOMAIN"] == "feishu"
+        assert env["FEISHU_CONNECTION_MODE"] == "websocket"
+        assert load_config()["platforms"]["feishu"]["enabled"] is True
+
+        # 会话用完即弃：再查应是 404（凭据不该留在内存里）
+        assert self.client.get(f"/api/messaging/feishu/onboarding/{pairing_id}").status_code == 404
+
+    def test_feishu_onboarding_apply_requires_ready(self, monkeypatch):
+        self._clear_feishu_sessions()
+        self._patch_feishu_adapter(monkeypatch, polls=[{"error": "authorization_pending"}])
+
+        started = self.client.post("/api/messaging/feishu/onboarding/start", json={})
+        pairing_id = started.json()["pairing_id"]
+        resp = self.client.post(f"/api/messaging/feishu/onboarding/{pairing_id}/apply", json={})
+        assert resp.status_code == 409
+
+    def test_feishu_onboarding_denial_is_terminal_410(self, monkeypatch):
+        self._clear_feishu_sessions()
+        self._patch_feishu_adapter(monkeypatch, polls=[{"error": "access_denied"}])
+
+        started = self.client.post("/api/messaging/feishu/onboarding/start", json={})
+        pairing_id = started.json()["pairing_id"]
+        resp = self.client.get(f"/api/messaging/feishu/onboarding/{pairing_id}")
+        assert resp.status_code == 410
+        assert "denied" in resp.json()["detail"].lower()
+
+    def test_feishu_onboarding_cancel_drops_the_session(self, monkeypatch):
+        self._clear_feishu_sessions()
+        self._patch_feishu_adapter(monkeypatch, polls=[{"error": "authorization_pending"}])
+
+        started = self.client.post("/api/messaging/feishu/onboarding/start", json={})
+        pairing_id = started.json()["pairing_id"]
+        assert self.client.delete(f"/api/messaging/feishu/onboarding/{pairing_id}").status_code == 200
+        assert self.client.get(f"/api/messaging/feishu/onboarding/{pairing_id}").status_code == 404
+
 
 
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -79,6 +79,7 @@ const PROFILE_SCOPED_PREFIXES = [
   "/api/messaging/platforms",
   "/api/messaging/telegram/onboarding",
   "/api/messaging/whatsapp/onboarding",
+  "/api/messaging/feishu/onboarding",
   // OAuth/account state is profile-owned too: status, login sessions, polling,
   // cancellation, and disconnect must all follow the selected management
   // profile rather than silently targeting the dashboard process's profile.
@@ -952,6 +953,36 @@ export const api = {
   cancelWhatsAppOnboarding: (pairingId: string) =>
     fetchJSON<{ ok: boolean }>(
       `/api/messaging/whatsapp/onboarding/${encodeURIComponent(pairingId)}`,
+      { method: "DELETE" },
+    ),
+  startFeishuOnboarding: (body: {
+    domain?: "feishu" | "lark" | null;
+    profile?: string | null;
+  }) =>
+    fetchJSON<FeishuOnboardingStartResponse>(
+      "/api/messaging/feishu/onboarding/start",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    ),
+  getFeishuOnboardingStatus: (bindId: string) =>
+    fetchJSON<FeishuOnboardingStatusResponse>(
+      `/api/messaging/feishu/onboarding/${encodeURIComponent(bindId)}`,
+    ),
+  applyFeishuOnboarding: (bindId: string, body: { profile?: string | null }) =>
+    fetchJSON<FeishuOnboardingApplyResponse>(
+      `/api/messaging/feishu/onboarding/${encodeURIComponent(bindId)}/apply`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    ),
+  cancelFeishuOnboarding: (bindId: string) =>
+    fetchJSON<{ ok: boolean }>(
+      `/api/messaging/feishu/onboarding/${encodeURIComponent(bindId)}`,
       { method: "DELETE" },
     ),
 
@@ -2060,6 +2091,45 @@ export type WhatsAppOnboardingStatusResponse = WhatsAppOnboardingStartResponse;
 export interface WhatsAppOnboardingApplyResponse {
   ok: boolean;
   platform: "whatsapp";
+  needs_restart: boolean;
+  restart_started?: boolean;
+  restart_action?: string;
+  restart_pid?: number | null;
+  restart_error?: string;
+}
+
+export interface FeishuOnboardingStartResponse {
+  // Start and status serialize the same payload (the WhatsApp convention
+  // above). The backend names the session id `pairing_id`; the written
+  // contract called it `bind_id` — read whichever is present.
+  pairing_id?: string;
+  bind_id?: string;
+  // The payload carries the session's full vocabulary; GET only returns 200
+  // for the non-terminal ones (expired/denied come back as 410).
+  status:
+    | "pending"
+    | "waiting"
+    | "ready"
+    | "expired"
+    | "denied"
+    | "cancelled"
+    | "error";
+  qr_url: string;
+  user_code: string;
+  domain: "feishu" | "lark";
+  interval: number;
+  expires_in: number;
+  app_id?: string | null;
+  bot_name?: string | null;
+  error?: string | null;
+}
+
+export type FeishuOnboardingStatusResponse = FeishuOnboardingStartResponse;
+
+export interface FeishuOnboardingApplyResponse {
+  ok: boolean;
+  platform: "feishu";
+  app_id: string;
   needs_restart: boolean;
   restart_started?: boolean;
   restart_action?: string;

--- a/web/src/pages/ChannelsPage.tsx
+++ b/web/src/pages/ChannelsPage.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
   AlertTriangle,
   Bot,
   Check,
   CheckCircle2,
+  Copy,
   ExternalLink,
   Info,
   PlugZap,
@@ -26,7 +27,9 @@ import { Switch } from "@nous-research/ui/ui/components/switch";
 import { Toast } from "@nous-research/ui/ui/components/toast";
 import { useToast } from "@nous-research/ui/hooks/use-toast";
 import { api } from "@/lib/api";
+import { copyTextToClipboard } from "@/lib/clipboard";
 import type {
+  FeishuOnboardingStartResponse,
   MessagingPlatform,
   MessagingPlatformEnvVar,
   MessagingPlatformUpdate,
@@ -123,6 +126,20 @@ function isTerminalTelegramOnboardingError(error: unknown): boolean {
 function isTerminalWhatsAppOnboardingError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return /\b410\b/.test(message) && /\b(expired|gone)\b/i.test(message);
+}
+
+// Feishu authorization is terminal on 410 (expired, or the other side declined
+// the grant) and on 404 (the bind id is gone — e.g. the backend restarted and
+// dropped the in-memory session). Both mean: stop polling, start over.
+function isTerminalFeishuOnboardingError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /\b(410|404)\b/.test(message);
+}
+
+// The backend's payload names the session id `pairing_id`; the contract called
+// it `bind_id`. Read either so the panel works against both.
+function feishuBindId(setup: FeishuOnboardingStartResponse): string {
+  return setup.pairing_id ?? setup.bind_id ?? "";
 }
 
 function normalizeWhatsAppMode(mode: unknown): "bot" | "self-chat" | null {
@@ -634,6 +651,15 @@ export default function ChannelsPage() {
                 )}
                 {platform.id === "whatsapp" && (
                   <WhatsAppOnboardingPanel
+                    onChanged={load}
+                    onRestartNeeded={() => setRestartNeeded(true)}
+                    platform={platform}
+                    setRestartNeeded={setRestartNeeded}
+                    showToast={showToast}
+                  />
+                )}
+                {platform.id === "feishu" && (
+                  <FeishuOnboardingPanel
                     onChanged={load}
                     onRestartNeeded={() => setRestartNeeded(true)}
                     platform={platform}
@@ -1454,6 +1480,390 @@ function TelegramOnboardingPanel({
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+function FeishuOnboardingPanel({
+  onChanged,
+  onRestartNeeded,
+  platform,
+  setRestartNeeded,
+  showToast,
+}: {
+  onChanged: () => Promise<void>;
+  onRestartNeeded: () => void;
+  platform: MessagingPlatform;
+  setRestartNeeded: (needed: boolean) => void;
+  showToast: (message: string, type: "success" | "error") => void;
+}) {
+  const [setup, setSetup] = useState<FeishuOnboardingStartResponse | null>(null);
+  const [qrDataUrl, setQrDataUrl] = useState("");
+  const [phase, setPhase] = useState<
+    "idle" | "starting" | "waiting" | "ready" | "applying"
+  >("idle");
+  const [domain, setDomain] = useState<"feishu" | "lark">("feishu");
+  const [appId, setAppId] = useState("");
+  const [botName, setBotName] = useState("");
+  const [expiresAt, setExpiresAt] = useState("");
+  const [error, setError] = useState("");
+  const [tick, setTick] = useState(0);
+  // Absolute deadline derived from the backend's expires_in. Held in a ref so a
+  // refreshed value never restarts the polling effect.
+  const deadlineRef = useRef(0);
+
+  const updateQr = useCallback(async (payload?: string) => {
+    if (!payload) return;
+    try {
+      const dataUrl = await QRCode.toDataURL(payload, {
+        errorCorrectionLevel: "M",
+        margin: 2,
+        width: 240,
+      });
+      setQrDataUrl(dataUrl);
+    } catch {
+      // The QR image is a convenience; the authorization link below stays the
+      // source of truth and is rendered in full either way.
+      setQrDataUrl("");
+    }
+  }, []);
+
+  const resetSetup = useCallback(() => {
+    setSetup(null);
+    setQrDataUrl("");
+    setPhase("idle");
+    setAppId("");
+    setBotName("");
+    setExpiresAt("");
+    setError("");
+    deadlineRef.current = 0;
+  }, []);
+
+  useEffect(() => {
+    if (!setup || phase !== "waiting") return;
+    const bindId = feishuBindId(setup);
+    let cancelled = false;
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    const intervalMs = Math.max(1, setup.interval) * 1000;
+
+    const poll = async () => {
+      try {
+        const status = await api.getFeishuOnboardingStatus(bindId);
+        if (cancelled) return;
+        if (status.status === "ready") {
+          setPhase("ready");
+          setAppId(status.app_id ?? "");
+          setBotName(status.bot_name ?? "");
+          setError("");
+          return;
+        }
+        if (status.status === "error" || status.status === "cancelled") {
+          resetSetup();
+          setError(status.error || "飞书授权已结束，请重新开始。");
+          return;
+        }
+        if (typeof status.expires_in === "number") {
+          deadlineRef.current = Date.now() + status.expires_in * 1000;
+        }
+        setError("");
+        timeout = setTimeout(poll, intervalMs);
+      } catch (pollError) {
+        if (cancelled) return;
+        const expired =
+          deadlineRef.current > 0 && Date.now() >= deadlineRef.current;
+        if (isTerminalFeishuOnboardingError(pollError) || expired) {
+          resetSetup();
+          setError("飞书授权已过期或已被拒绝，请重新开始扫码授权。");
+          return;
+        }
+        setError(`仍在等待飞书授权，稍后重试：${pollError}`);
+        timeout = setTimeout(poll, Math.max(2, setup.interval) * 1000);
+      }
+    };
+
+    timeout = setTimeout(poll, 1000);
+    return () => {
+      cancelled = true;
+      if (timeout) clearTimeout(timeout);
+    };
+  }, [phase, resetSetup, setup]);
+
+  useEffect(() => {
+    if (!setup) return;
+    const timer = setInterval(() => setTick((value) => value + 1), 1000);
+    return () => clearInterval(timer);
+  }, [setup]);
+
+  const start = async () => {
+    setPhase("starting");
+    setError("");
+    setQrDataUrl("");
+    setAppId("");
+    setBotName("");
+    try {
+      const res = await api.startFeishuOnboarding({ domain, profile: null });
+      if (!feishuBindId(res)) {
+        setPhase("idle");
+        setError("飞书接入会话没有返回会话 ID，请重试。");
+        return;
+      }
+      const deadline = Date.now() + res.expires_in * 1000;
+      deadlineRef.current = deadline;
+      setSetup(res);
+      setExpiresAt(new Date(deadline).toISOString());
+      await updateQr(res.qr_url);
+      setPhase("waiting");
+    } catch (startError) {
+      setPhase("idle");
+      setError(String(startError));
+    }
+  };
+
+  const cancel = async () => {
+    if (setup) {
+      try {
+        await api.cancelFeishuOnboarding(feishuBindId(setup));
+      } catch {
+        /* local cleanup still wins */
+      }
+    }
+    resetSetup();
+  };
+
+  const copyLink = async () => {
+    if (!setup) return;
+    if (await copyTextToClipboard(setup.qr_url)) {
+      showToast("授权链接已复制", "success");
+    } else {
+      showToast("复制失败，请手动选中链接复制", "error");
+    }
+  };
+
+  // restart_started only means the `hermes gateway restart` child spawned — not
+  // that the restart will succeed. Poll the action status briefly and surface a
+  // non-zero exit via the manual-restart banner.
+  const watchRestartOutcome = async () => {
+    for (let i = 0; i < 20; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+      try {
+        const st = await api.getActionStatus("gateway-restart", 5);
+        if (st.running) continue;
+        if (st.exit_code !== 0 && st.exit_code !== null) {
+          onRestartNeeded();
+          showToast(`网关重启失败（退出码 ${st.exit_code}），请手动重启`, "error");
+        }
+        return;
+      } catch {
+        // transient fetch error; keep polling
+      }
+    }
+  };
+
+  const apply = async () => {
+    if (!setup) return;
+    setPhase("applying");
+    setError("");
+    try {
+      const result = await api.applyFeishuOnboarding(feishuBindId(setup), {
+        profile: null,
+      });
+      resetSetup();
+      // The backend always attempts the restart and reports `restart_started`
+      // plus `needs_restart` (= !restart_started) — same shape as WhatsApp.
+      if (result.restart_started) {
+        showToast("飞书凭据已保存，网关正在重启…", "success");
+        setRestartNeeded(false);
+        setTimeout(() => void onChanged(), 4000);
+        void watchRestartOutcome();
+      } else {
+        onRestartNeeded();
+        const detail = result.restart_error ? `：${result.restart_error}` : "";
+        showToast(`飞书凭据已保存，网关重启失败${detail}`, "error");
+      }
+      await onChanged();
+    } catch (applyError) {
+      setPhase("ready");
+      setError(String(applyError));
+    }
+  };
+
+  const expiresIn = useMemo(
+    () => (expiresAt ? formatExpiry(expiresAt) : ""),
+    // tick keeps the memo fresh without recalculating on every render branch.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [expiresAt, tick],
+  );
+  const setupHelp =
+    phase === "ready" || phase === "applying"
+      ? "已取得飞书应用凭据。保存并启用后重启网关即可生效。"
+      : "在飞书中打开授权链接并确认授权，页面会自动检测结果。";
+
+  return (
+    <div className="rounded-sm border border-border bg-background/35 p-4">
+      <div className="grid gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            size="sm"
+            className="uppercase"
+            onClick={() => void start()}
+            disabled={phase !== "idle"}
+            prefix={phase === "starting" ? <Spinner /> : <QrCode className="h-4 w-4" />}
+          >
+            {phase === "starting" ? "正在开始…" : "扫码授权接入"}
+          </Button>
+          <span className="text-xs text-muted-foreground">
+            在飞书中打开授权链接并确认，Hermes 会自动获取应用凭据并写入当前配置。
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end">
+          <div className="grid gap-1.5">
+            <span className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+              授权域名
+            </span>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                size="sm"
+                outlined={domain !== "feishu"}
+                onClick={() => setDomain("feishu")}
+                disabled={phase !== "idle"}
+              >
+                飞书
+              </Button>
+              <Button
+                size="sm"
+                outlined={domain !== "lark"}
+                onClick={() => setDomain("lark")}
+                disabled={phase !== "idle"}
+              >
+                Lark
+              </Button>
+            </div>
+          </div>
+          {platform.configured && (
+            <span className="text-xs text-muted-foreground">
+              飞书凭据已配置，保存新的授权会覆盖当前凭据。
+            </span>
+          )}
+        </div>
+
+        {error && (
+          <div className="border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {error}
+          </div>
+        )}
+
+        {setup && (
+          <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_260px]">
+            <div className="grid gap-3">
+              <div className="flex flex-wrap items-center gap-2">
+                {phase === "ready" || phase === "applying" ? (
+                  <Badge tone="success">已授权</Badge>
+                ) : (
+                  <Badge tone="warning">等待确认</Badge>
+                )}
+                <Badge tone={expiresIn === "expired" ? "destructive" : "outline"}>
+                  {expiresIn}
+                </Badge>
+                {botName && (
+                  <span className="font-courier text-sm text-muted-foreground">
+                    {botName}
+                  </span>
+                )}
+              </div>
+
+              <div className="text-sm text-muted-foreground">{setupHelp}</div>
+
+              <div className="grid gap-2">
+                <span className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                  授权链接
+                </span>
+                <code className="block select-all break-all border border-border bg-background/45 p-2 font-courier text-xs text-foreground">
+                  {setup.qr_url}
+                </code>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    size="sm"
+                    outlined
+                    onClick={() => void copyLink()}
+                    prefix={<Copy className="h-4 w-4" />}
+                  >
+                    复制链接
+                  </Button>
+                  <a
+                    className="inline-flex h-8 items-center gap-1 border border-border px-3 text-xs uppercase text-foreground hover:border-foreground/40"
+                    href={setup.qr_url}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    <ExternalLink className="h-4 w-4" />
+                    打开链接
+                  </a>
+                </div>
+              </div>
+
+              <div className="text-xs text-muted-foreground">
+                授权码{" "}
+                <span className="font-courier text-sm text-foreground">
+                  {setup.user_code}
+                </span>
+              </div>
+
+              {(phase === "ready" || phase === "applying") && (
+                <div className="grid gap-3">
+                  <div className="border border-border bg-background/45 p-3 text-sm">
+                    <div className="font-medium">
+                      {appId ? `应用凭据 ${appId}` : "飞书应用已授权"}
+                    </div>
+                    <div className="mt-1 text-muted-foreground">
+                      凭据只写入当前的 Hermes 配置。保存并启用后重启网关，飞书渠道即可生效。
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      size="sm"
+                      className="uppercase"
+                      onClick={() => void apply()}
+                      disabled={phase === "applying"}
+                      prefix={phase === "applying" ? <Spinner /> : <Save className="h-4 w-4" />}
+                    >
+                      {phase === "applying" ? "保存中…" : "保存并启用"}
+                    </Button>
+                    <Button size="sm" ghost onClick={() => void cancel()}>
+                      取消
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div className="flex flex-col items-center justify-center gap-3">
+              {qrDataUrl ? (
+                <img
+                  src={qrDataUrl}
+                  alt="飞书授权二维码"
+                  className="h-60 w-60 bg-white p-2"
+                />
+              ) : (
+                <div className="flex h-60 w-60 flex-col items-center justify-center gap-3 border border-border bg-background/50 p-4 text-center">
+                  <Spinner className="text-2xl" />
+                  <div className="text-xs text-muted-foreground">
+                    正在生成二维码…
+                  </div>
+                </div>
+              )}
+              <span className="text-center text-xs text-muted-foreground">
+                用飞书扫一扫二维码，或直接在浏览器打开这条授权链接。
+              </span>
+              {phase === "waiting" && (
+                <Button size="sm" ghost onClick={() => void cancel()}>
+                  取消
+                </Button>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Add scan-to-create onboarding for the **Feishu / Lark** channel to the dashboard's Channels page, matching the WhatsApp and Telegram panels that already exist there.
- Four REST endpoints under `/api/messaging/feishu/onboarding/*`: `start`, `status`, `apply`, `cancel`.
- Drives the adapter's existing device-code flow, so the CLI and the dashboard speak the same protocol.

## Motivation

Feishu is the only interactive-chat platform with no dashboard onboarding: `hermes gateway setup` renders the QR code as **ASCII art in the terminal**, so the operator screenshots it and sends it to whoever owns the bot. Two problems with that:

1. The credentials are only collected while that terminal poll is still alive, so a scan that arrives late times out — and the terminal only says it timed out, not why.
2. There is no way to onboard without either that CLI flow or hand-creating a Feishu app and pasting `FEISHU_APP_ID` / `FEISHU_APP_SECRET`.

This makes it self-service for the person who actually owns the Feishu account: the operator opens the panel and copies the authorization link, the owner approves it in Feishu, and the dashboard picks up the credentials and enables the channel. Nothing to screenshot.

## Changes

**Backend**
- `hermes_cli/web_models.py` — `FeishuOnboardingStart` / `FeishuOnboardingApply` request models.
- `hermes_cli/web_server_messaging.py` — `_FeishuOnboardingSession` + registry, an allow-list payload builder, TTL pruning (expired sessions are finalized, terminal ones are kept briefly so the UI can explain what happened), and a gateway-restart helper.
- `hermes_cli/web_routers/messaging.py` — the four endpoints.
  - `start` runs the two blocking registration calls in a thread and returns the link + user code.
  - `status` polls **at most once per the platform-supplied `interval`**, so a fast-polling UI cannot hammer the registration endpoint. It also adopts the brand the platform reports (`tenant_brand == "lark"`), otherwise an international tenant's credentials get paired with the wrong domain.
  - `apply` writes the credentials **and** restarts the gateway as a single step, so there is no state where the config is written but the channel is not running.
  - `cancel` drops the session; terminal states answer `410`.

**Frontend**
- `web/src/lib/api.ts` — client calls + response types; the path prefix is added to `PROFILE_SCOPED_PREFIXES` so credentials land in the profile the operator is scoped to rather than the dashboard process's default.
- `web/src/pages/ChannelsPage.tsx` — `FeishuOnboardingPanel`: brand toggle (Feishu / Lark), copy link, open link, QR render (reuses the already-vendored `qrcode`), poll, "save and enable", cancel.

## Security notes for reviewers

The credentials obtained here are **real production app credentials for the user's own tenant**, so:

- `app_secret` lives only in the server-side session record and is **never serialized to the client**. `_feishu_onboarding_payload` is an allow-list (`_FEISHU_PAYLOAD_FIELDS`), so a field added to the dataclass later is not exposed by default.
- The secret is nulled out as soon as the session reaches a terminal state or expires.
- The panel never displays a secret; the only things it shows are the authorization link and the user code.

## Test Plan

- [x] `tests/hermes_cli/test_web_server.py` — **197 passed**
  `uv run --with pytest==9.1.1 --with pytest-asyncio==1.3.0 pytest tests/hermes_cli/test_web_server.py -q`
- [x] 8 new tests: link is returned without credentials · unknown domain falls back to feishu · poll throttled by the platform interval · becomes ready while the secret stays off the wire · `apply` writes env and restarts · `apply` before ready is rejected · denial is terminal (`410`) · cancel drops the session.
- [x] Frontend typecheck clean: `tsc -p . --noEmit`
- [x] Manual end-to-end against the live registration endpoint (Feishu brand): real authorization link issued, QR rendered and readable in a headless browser, credentials absent from every response body.

## Scope, and related work

The panel consumes whatever `_begin_registration` returns. For the **Lark international** brand that is the legacy `/page/launcher` URL, which Lark rejects immediately — that is the pre-existing adapter bug in #100048, and #100066 addresses it (along with the `expire_in` / `expires_in` field-name mismatch). **This PR deliberately does not touch `adapter.py`**, so it does not conflict with #100066; once that lands, this panel inherits the correct brand URL and the full window with no change here.

Until #100066 lands, the session window the panel reports reflects the adapter's current 600 s default.

## Notes for Reviewers

- The four endpoints intentionally mirror the existing `whatsapp/onboarding/*` shape (same session-registry pattern, same restart-on-apply behaviour), so the three panels stay reviewable side by side.
- Panel copy is currently Chinese while the surrounding dashboard shell is English; happy to move it onto the i18n layer if you'd rather not merge hardcoded strings.
