### PR TITLE
fix(commandcode): /reasoning reaches the wire for DeepSeek models (#95232, salvage #95241)

### DIFF
--- a/plugins/model-providers/commandcode/__init__.py
+++ b/plugins/model-providers/commandcode/__init__.py
@@ -38,6 +38,23 @@ class CommandCodeProfile(ProviderProfile):
             return None
 
 
+    def build_api_kwargs_extras(
+        self, *, reasoning_config: dict | None = None, model: str | None = None, **context
+    ) -> tuple[dict, dict]:
+        """DeepSeek ids (``deepseek/deepseek-v4-flash``) get the native DeepSeek wire
+        controls: DeepSeek V4+ defaults to thinking when ``thinking`` is omitted, so
+        without them ``/reasoning`` never reaches the request (#95232). Other model
+        families stay a no-op — CommandCode declares no reasoning vocabulary for them."""
+        m = (model or "").strip()
+        if not m.lower().startswith("deepseek/") or len(m) <= len("deepseek/"):
+            return {}, {}
+        from plugins.model_providers.deepseek import deepseek as _deepseek_profile
+
+        return _deepseek_profile.build_api_kwargs_extras(
+            reasoning_config=reasoning_config, model=m.split("/", 1)[1], **context,
+        )
+
+
 class CommandCodeAnthropicProfile(CommandCodeProfile):
     """CommandCode — Anthropic Messages API-compatible endpoint."""
 
@@ -47,43 +64,6 @@ class CommandCodeAnthropicProfile(CommandCodeProfile):
         """Public /models endpoint, filtered to Anthropic-family models."""
         all_models = super().fetch_models(api_key=api_key, base_url=base_url, timeout=timeout)
         return None if all_models is None else [m for m in all_models if m.startswith("claude-")]
-
-    def build_api_kwargs_extras(
-        self, *, reasoning_config: dict | None = None, model: str | None = None, **context
-    ) -> tuple[dict, dict]:
-        """Apply the native DeepSeek reasoning controls for DeepSeek-family ids.
-
-        CommandCode fronts DeepSeek with vendor-prefixed ids
-        (``deepseek/deepseek-v4-flash``). DeepSeek V4+ defaults to thinking
-        mode when the ``thinking`` field is omitted, so without an explicit
-        wire control a Hermes ``/reasoning none`` changes the session state
-        but not the actual request — the turn sits in
-        ``reflecting.../brainstorming...`` for minutes (#95232). Strip the
-        vendor prefix and delegate to the native DeepSeek profile's logic
-        (extra_body.thinking + reasoning_effort mapping); other CommandCode
-        model families keep the base no-op behavior.
-        """
-        m = (model or "").strip()
-        if not m.lower().startswith("deepseek/") or len(m) <= len("deepseek/"):
-            return {}, {}
-        try:
-            from plugins.model_providers.deepseek import deepseek as _deepseek_profile
-        except ImportError:
-            # The bundled-plugin loader tolerates a plugin failing to load
-            # (it pops the half-registered module and continues), so the
-            # shim may be absent. Degrade to the pre-fix no-op instead of
-            # crashing every DeepSeek-routed CommandCode turn.
-            logger.warning(
-                "DeepSeek provider plugin unavailable; CommandCode cannot "
-                "forward reasoning controls (#95232)",
-                exc_info=True,
-            )
-            return {}, {}
-        return _deepseek_profile.build_api_kwargs_extras(
-            reasoning_config=reasoning_config,
-            model=m.split("/", 1)[1],
-            **context,
-        )
 
 
 commandcode = CommandCodeProfile(

--- a/plugins/model-providers/commandcode/__init__.py
+++ b/plugins/model-providers/commandcode/__init__.py
@@ -66,8 +66,19 @@ class CommandCodeAnthropicProfile(CommandCodeProfile):
         m = (model or "").strip()
         if not m.lower().startswith("deepseek/") or len(m) <= len("deepseek/"):
             return {}, {}
-        from plugins.model_providers.deepseek import deepseek as _deepseek_profile
-
+        try:
+            from plugins.model_providers.deepseek import deepseek as _deepseek_profile
+        except ImportError:
+            # The bundled-plugin loader tolerates a plugin failing to load
+            # (it pops the half-registered module and continues), so the
+            # shim may be absent. Degrade to the pre-fix no-op instead of
+            # crashing every DeepSeek-routed CommandCode turn.
+            logger.warning(
+                "DeepSeek provider plugin unavailable; CommandCode cannot "
+                "forward reasoning controls (#95232)",
+                exc_info=True,
+            )
+            return {}, {}
         return _deepseek_profile.build_api_kwargs_extras(
             reasoning_config=reasoning_config,
             model=m.split("/", 1)[1],

--- a/plugins/model-providers/commandcode/__init__.py
+++ b/plugins/model-providers/commandcode/__init__.py
@@ -48,6 +48,32 @@ class CommandCodeAnthropicProfile(CommandCodeProfile):
         all_models = super().fetch_models(api_key=api_key, base_url=base_url, timeout=timeout)
         return None if all_models is None else [m for m in all_models if m.startswith("claude-")]
 
+    def build_api_kwargs_extras(
+        self, *, reasoning_config: dict | None = None, model: str | None = None, **context
+    ) -> tuple[dict, dict]:
+        """Apply the native DeepSeek reasoning controls for DeepSeek-family ids.
+
+        CommandCode fronts DeepSeek with vendor-prefixed ids
+        (``deepseek/deepseek-v4-flash``). DeepSeek V4+ defaults to thinking
+        mode when the ``thinking`` field is omitted, so without an explicit
+        wire control a Hermes ``/reasoning none`` changes the session state
+        but not the actual request — the turn sits in
+        ``reflecting.../brainstorming...`` for minutes (#95232). Strip the
+        vendor prefix and delegate to the native DeepSeek profile's logic
+        (extra_body.thinking + reasoning_effort mapping); other CommandCode
+        model families keep the base no-op behavior.
+        """
+        m = (model or "").strip()
+        if not m.lower().startswith("deepseek/") or len(m) <= len("deepseek/"):
+            return {}, {}
+        from plugins.model_providers.deepseek import deepseek as _deepseek_profile
+
+        return _deepseek_profile.build_api_kwargs_extras(
+            reasoning_config=reasoning_config,
+            model=m.split("/", 1)[1],
+            **context,
+        )
+
 
 commandcode = CommandCodeProfile(
     name="commandcode", aliases=("commandcode-chat",), api_mode="chat_completions",

--- a/tests/plugins/model_providers/test_commandcode_profile.py
+++ b/tests/plugins/model_providers/test_commandcode_profile.py
@@ -86,28 +86,64 @@ class TestCommandCodeProfileIdentity:
 
 
 class TestCommandCodeProfileNoThinkingInterference:
-    """Chat completions profile is a no-op for thinking config — it delegates
-    to the underlying model's provider (DeepSeek, Qwen, etc.) for wire format.
+    """Reasoning wire controls for the chat-completions profile.
+
+    DeepSeek-family ids get the native DeepSeek controls (DeepSeek V4+
+    defaults to thinking when the field is omitted, so an explicit wire
+    control is required for ``/reasoning none`` to reach the request,
+    #95232); every other CommandCode model family keeps the base no-op.
     """
 
-    def test_passthrough_no_reasoning_config(self, commandcode_profile):
+    def test_deepseek_disabled_reasoning_sends_thinking_disabled(
+        self, commandcode_profile
+    ):
         extra_body, top_level = commandcode_profile.build_api_kwargs_extras(
-            reasoning_config=None, model="deepseek/deepseek-v4-pro"
+            reasoning_config={"enabled": False},
+            model="deepseek/deepseek-v4-flash",
         )
-        # Chat completions profile doesn't inject thinking params — that's
-        # the DeepSeek provider's job when routed through DeepSeek's own profile.
-        # When routed through CommandCode, the underlying model API handles it.
-        assert isinstance(extra_body, dict)
-        assert isinstance(top_level, dict)
-        # Default ProviderProfile returns ({}, {}).
+        assert extra_body.get("thinking") == {"type": "disabled"}
+        assert top_level == {}
 
-    def test_passthrough_with_reasoning_config(self, commandcode_profile):
+    def test_deepseek_enabled_reasoning_maps_effort(self, commandcode_profile):
         extra_body, top_level = commandcode_profile.build_api_kwargs_extras(
             reasoning_config={"enabled": True, "effort": "high"},
             model="deepseek/deepseek-v4-pro",
         )
-        assert isinstance(extra_body, dict)
-        assert isinstance(top_level, dict)
+        assert extra_body.get("thinking") == {"type": "enabled"}
+        assert top_level.get("reasoning_effort") == "high"
+
+    def test_deepseek_no_config_defaults_to_enabled(self, commandcode_profile):
+        # Matches DeepSeek's API default, applied explicitly so the field is
+        # never omitted for thinking-capable models.
+        extra_body, _ = commandcode_profile.build_api_kwargs_extras(
+            reasoning_config=None, model="deepseek/deepseek-v4-flash"
+        )
+        assert extra_body.get("thinking") == {"type": "enabled"}
+
+    def test_deepseek_v3_stays_noop(self, commandcode_profile):
+        extra_body, top_level = commandcode_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="deepseek/deepseek-v3",
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_passthrough_non_deepseek_family(self, commandcode_profile):
+        extra_body, top_level = commandcode_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "high"},
+            model="Qwen/Qwen3.7-Max",
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
+    def test_passthrough_no_reasoning_config_non_deepseek(
+        self, commandcode_profile
+    ):
+        extra_body, top_level = commandcode_profile.build_api_kwargs_extras(
+            reasoning_config=None, model="gpt-5.5"
+        )
+        assert extra_body == {}
+        assert top_level == {}
 
 
 # ── Anthropic Messages profile ────────────────────────────────────────────────

--- a/tests/plugins/model_providers/test_commandcode_profile.py
+++ b/tests/plugins/model_providers/test_commandcode_profile.py
@@ -145,6 +145,23 @@ class TestCommandCodeProfileNoThinkingInterference:
         assert extra_body == {}
         assert top_level == {}
 
+    def test_missing_deepseek_plugin_degrades_to_noop(
+        self, commandcode_profile, monkeypatch, caplog
+    ):
+        # The bundled-plugin loader pops half-registered modules when a
+        # plugin fails to load, so the deepseek shim can be absent at
+        # runtime; the delegation must degrade to the pre-fix no-op
+        # instead of crashing every DeepSeek-routed CommandCode turn.
+        import sys
+
+        monkeypatch.setitem(sys.modules, "plugins.model_providers.deepseek", None)
+        extra_body, top_level = commandcode_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+            model="deepseek/deepseek-v4-flash",
+        )
+        assert extra_body == {}
+        assert top_level == {}
+
 
 # ── Anthropic Messages profile ────────────────────────────────────────────────
 

--- a/tests/plugins/model_providers/test_commandcode_profile.py
+++ b/tests/plugins/model_providers/test_commandcode_profile.py
@@ -85,85 +85,28 @@ class TestCommandCodeProfileIdentity:
         assert commandcode_profile.get_hostname() == "api.commandcode.ai"
 
 
-class TestCommandCodeProfileNoThinkingInterference:
-    """Reasoning wire controls for the chat-completions profile.
+class TestCommandCodeReasoningWireControls:
+    """DeepSeek V4+ defaults to thinking when ``thinking`` is omitted, so the profile
+    must put the user's setting on the wire (#95232); other families stay a no-op."""
 
-    DeepSeek-family ids get the native DeepSeek controls (DeepSeek V4+
-    defaults to thinking when the field is omitted, so an explicit wire
-    control is required for ``/reasoning none`` to reach the request,
-    #95232); every other CommandCode model family keeps the base no-op.
-    """
-
-    def test_deepseek_disabled_reasoning_sends_thinking_disabled(
-        self, commandcode_profile
-    ):
+    def test_deepseek_disabled_reasoning_sends_thinking_disabled(self, commandcode_profile):
         extra_body, top_level = commandcode_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": False},
-            model="deepseek/deepseek-v4-flash",
+            reasoning_config={"enabled": False}, model="deepseek/deepseek-v4-flash",
         )
         assert extra_body.get("thinking") == {"type": "disabled"}
         assert top_level == {}
 
-    def test_deepseek_enabled_reasoning_maps_effort(self, commandcode_profile):
-        extra_body, top_level = commandcode_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": True, "effort": "high"},
-            model="deepseek/deepseek-v4-pro",
-        )
-        assert extra_body.get("thinking") == {"type": "enabled"}
-        assert top_level.get("reasoning_effort") == "high"
+    def test_deepseek_effort_matches_native_profile_and_others_noop(self, commandcode_profile):
+        from plugins.model_providers.deepseek import deepseek
 
-    def test_deepseek_no_config_defaults_to_enabled(self, commandcode_profile):
-        # Matches DeepSeek's API default, applied explicitly so the field is
-        # never omitted for thinking-capable models.
-        extra_body, _ = commandcode_profile.build_api_kwargs_extras(
-            reasoning_config=None, model="deepseek/deepseek-v4-flash"
-        )
-        assert extra_body.get("thinking") == {"type": "enabled"}
+        rc = {"enabled": True, "effort": "low"}
+        assert commandcode_profile.build_api_kwargs_extras(
+            reasoning_config=rc, model="deepseek/deepseek-v4.1-flash"
+        ) == deepseek.build_api_kwargs_extras(reasoning_config=rc, model="deepseek-v4.1-flash")
+        assert commandcode_profile.build_api_kwargs_extras(
+            reasoning_config=rc, model="Qwen/Qwen3.7-Max"
+        ) == ({}, {})
 
-    def test_deepseek_v3_stays_noop(self, commandcode_profile):
-        extra_body, top_level = commandcode_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": False},
-            model="deepseek/deepseek-v3",
-        )
-        assert extra_body == {}
-        assert top_level == {}
-
-    def test_passthrough_non_deepseek_family(self, commandcode_profile):
-        extra_body, top_level = commandcode_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": True, "effort": "high"},
-            model="Qwen/Qwen3.7-Max",
-        )
-        assert extra_body == {}
-        assert top_level == {}
-
-    def test_passthrough_no_reasoning_config_non_deepseek(
-        self, commandcode_profile
-    ):
-        extra_body, top_level = commandcode_profile.build_api_kwargs_extras(
-            reasoning_config=None, model="gpt-5.5"
-        )
-        assert extra_body == {}
-        assert top_level == {}
-
-    def test_missing_deepseek_plugin_degrades_to_noop(
-        self, commandcode_profile, monkeypatch, caplog
-    ):
-        # The bundled-plugin loader pops half-registered modules when a
-        # plugin fails to load, so the deepseek shim can be absent at
-        # runtime; the delegation must degrade to the pre-fix no-op
-        # instead of crashing every DeepSeek-routed CommandCode turn.
-        import sys
-
-        monkeypatch.setitem(sys.modules, "plugins.model_providers.deepseek", None)
-        extra_body, top_level = commandcode_profile.build_api_kwargs_extras(
-            reasoning_config={"enabled": False},
-            model="deepseek/deepseek-v4-flash",
-        )
-        assert extra_body == {}
-        assert top_level == {}
-
-
-# ── Anthropic Messages profile ────────────────────────────────────────────────
 
 class TestCommandCodeAnthropicProfileIdentity:
     """Anthropic-compatible profile metadata."""


### PR DESCRIPTION
`/reasoning` now reaches the wire for DeepSeek models routed through the `commandcode` provider (`deepseek/deepseek-v4-flash`, `deepseek/deepseek-v4.1-flash`, ...); every other CommandCode model family sends exactly what it sent before.

Salvage of #95241 by @liuhao1024 (cherry-picked, authorship preserved), with the parity approach also proposed in #95357 by @herman925. Fixes #95232. Reported again on Discord with a proxy capture showing `--reasoning low` and `--reasoning medium` producing byte-identical requests (same sha256).

## Changes

- `plugins/model-providers/commandcode/__init__.py::CommandCodeProfile.build_api_kwargs_extras` — for `deepseek/<id>` model ids, strip the vendor prefix and delegate to the native `DeepSeekProfile.build_api_kwargs_extras`, so CommandCode emits the same `extra_body.thinking` + top-level `reasoning_effort` the native DeepSeek provider does. Non-DeepSeek ids return the base `({}, {})`.
- Follow-up commit (ours): drops the `try/except ImportError` around the bundled-plugin import (it cannot fail) and trims tests to two invariants.

## Root cause

With a registered `ProviderProfile`, `chat_completions._build_kwargs_from_profile` only puts on the wire what `profile.build_api_kwargs_extras()` returns; `CommandCodeProfile` inherited the base no-op, so the reasoning config was dropped for every model, and DeepSeek V4+ fell back to its server default (thinking on).

## Validation

Through the real transport (`ChatCompletionsTransport.build_kwargs` with the registered profile), on this branch:

| model | reasoning_config | before (main) | after |
|---|---|---|---|
| `deepseek/deepseek-v4.1-flash` | `effort: low` | nothing | `reasoning_effort: low`, `thinking: enabled` |
| `deepseek/deepseek-v4.1-flash` | `effort: medium` | nothing | `reasoning_effort: medium`, `thinking: enabled` |
| `deepseek/deepseek-v4.1-flash` | `enabled: False` | nothing | `thinking: disabled` |
| `Qwen/Qwen3.7-Max` | `effort: low` | nothing | nothing (unchanged) |
| `deepseek/deepseek-v3` | `enabled: False` | nothing | nothing (unchanged) |

Tests: `tests/plugins/model_providers/test_commandcode_profile.py` + `test_deepseek_profile.py` — 62 passed; the two new tests go red with the source file reverted to main.

Not verified live against `api.commandcode.ai` (no key on this machine): that the proxy accepts top-level `reasoning_effort`. The `thinking` field is the one the #95232 reporter confirmed works direct-to-proxy, and the wire shape is identical to what the native DeepSeek provider already sends.

Known side effect (both original PRs share it): `auxiliary_client._profile_projection` detects "profile handles reasoning" by method identity, so aux calls (compression, titles) for non-DeepSeek CommandCode models no longer get the generic OpenRouter-vocabulary `extra_body.reasoning` fallback. The main path never sent it for CommandCode, so the two paths now agree.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aaa33f4/UGIuf6ODU_o0OUtu9O0Ig_Pk4hTqXU.png)
