### PR TITLE
fix(cron): decode script stdout lossily so one bad byte can't fail a good run

### DIFF
--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -756,7 +756,8 @@ def _deliver_to_bot_chat(job: dict, content: str, profile: str) -> Optional[str]
             "-Q", "--query-file", query_file,
         ]
         result = subprocess.run(
-            argv, capture_output=True, text=True, timeout=_get_bot_chat_delivery_timeout(), env=env,
+            argv, capture_output=True, text=True, errors="replace",
+            timeout=_get_bot_chat_delivery_timeout(), env=env,
             creationflags=windows_hide_flags())
         if result.returncode != 0:
             tail = (result.stderr or result.stdout or "").strip()[-500:]

--- a/cron/scheduler_script.py
+++ b/cron/scheduler_script.py
@@ -338,7 +338,14 @@ def _run_job_script(
 
     try:
         from tools.environments.local import build_subprocess_env
-        popen_kwargs: dict[str, Any] = {"start_new_session": True}
+        # errors="replace" on POSIX too: the ambient locale still decodes the script's output
+        # (no forced utf-8), but a SINGLE undecodable byte must not abort the read. Strict
+        # decoding turns a script that exited 0 into "Script execution failed: 'utf-8' codec
+        # can't decode byte ...", which reports a successful run as a failure and drops the
+        # delivery — a stray byte from a child process sharing the pipe is enough to trigger it.
+        # Only affects bytes that are already undecodable; valid output in any locale is
+        # unchanged. Windows already pins this (see the branch below, #39029).
+        popen_kwargs: dict[str, Any] = {"start_new_session": True, "errors": "replace"}
         if sys.platform == "win32":
             popen_kwargs = {
                 "creationflags": windows_hide_flags()

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -321,7 +321,9 @@ class TestRunJobScript:
         assert captured["kwargs"]["text"] is True
         assert "creationflags" not in captured["kwargs"]
         assert "encoding" not in captured["kwargs"]
-        assert "errors" not in captured["kwargs"]
+        # Undecodable bytes degrade instead of aborting the read: the locale still decodes
+        # (no forced utf-8), but a stray byte must not turn a successful run into a failure.
+        assert captured["kwargs"]["errors"] == "replace"
 
     def test_non_overlay_branch_keeps_plain_argv(self, cron_env, monkeypatch):
         """When the Windows uv-venv overlay is NOT active, the invocation must
@@ -383,8 +385,9 @@ class TestRunJobScript:
     def test_invalid_utf8_stdout_does_not_raise(self, cron_env):
         """Truncated/invalid UTF-8 in script stdout must never escape as an
         exception (#47393) — a raised UnicodeDecodeError higher up would
-        silently drop the whole delivery (#42384). The run may fail, but it
-        must fail as a (False, message) result the scheduler can deliver.
+        silently drop the whole delivery (#42384). It must also not rewrite a
+        successful run as a failure: the script exited 0, so the run *is* a
+        success and the undecodable byte is replaced in the delivered text.
         """
         from cron.scheduler_script import _run_job_script
 
@@ -399,9 +402,8 @@ class TestRunJobScript:
 
         success, output = _run_job_script("bad_bytes.py")  # must not raise
 
-        assert isinstance(success, bool)
-        assert isinstance(output, str)
-        assert output  # a message is always produced, never a silent drop
+        assert success is True, "an exit-0 script with one bad byte is still a success"
+        assert output == "partial \ufffd"
 
 
 class TestBuildJobPromptWithScript:


### PR DESCRIPTION
# fix(cron): decode script stdout lossily so one bad byte can't fail a good run

## What happens

A `no_agent` cron job whose script exits **0** is reported as a failure whenever a single
undecodable byte reaches its stdout:

```
# Cron Job: DSH 每周自动升级
**Status:** script failed
Script execution failed: 'utf-8' codec can't decode byte 0xe2 in position 64: invalid continuation byte
```

The script's own work had completed: the version was upgraded, native modules rebuilt,
service restarted (`/tmp/dsh-upgrade.log` confirmed every step). Only the read of the script's
output failed — and the run was labelled failed, with the delivered message truncated to that
codec error.

## Reproduction (on current `main`, POSIX)

```bash
cat > ~/.hermes/scripts/bad_byte.sh <<'EOF'
#!/bin/bash
echo "normal line"
printf '\xe2\x28\xa1 croaked\n'
EOF
chmod +x ~/.hermes/scripts/bad_byte.sh

cd ~/.hermes/hermes-agent && venv/bin/python -c "
from cron.scheduler_script import _run_job_script
print(_run_job_script('bad_byte.sh'))"
# (False, "Script execution failed: 'utf-8' codec can't decode byte 0xe2 in position 14: invalid continuation byte")
```

The byte does not have to be written by the script itself — any child process that inherited
the same pipe (a package manager, a service restart helper) interleaving a partial multi-byte
write is enough.

## Cause

`cron/scheduler_script.py::_run_job_script` reads the script's output with `text=True` and no
`errors`, so the ambient locale decodes it **strictly**. The Windows branch of the same
function already pins `encoding="utf-8", errors="replace"` for exactly this failure class
(#39029, #42384); POSIX was left strict.

## Fix

- `cron/scheduler_script.py`: `popen_kwargs` gains `errors="replace"` on the POSIX path.
- `cron/scheduler_delivery.py`: the bot-chat delivery subprocess reads its child's output the
  same way (into the failure diagnostics) — same one-liner.

The POSIX locale decision is preserved: no `encoding` is forced, so valid output still decodes
through the locale exactly as before. `errors="replace"` only affects bytes that are *already*
undecodable — they become U+FFFD instead of aborting the read and turning a successful run
into a reported failure.

## Tests

`tests/cron/test_cron_script.py`:

- `test_invalid_utf8_stdout_does_not_raise` — strengthened to the contract that matters
  (script exits 0 + one bad byte ⇒ `success is True`, decodable text preserved with U+FFFD).
  Fails on the previous behaviour (verified red before the fix).
- `test_non_windows_script_preserves_default_text_decoding` — still pins "no forced encoding
  on POSIX"; now requires `errors="replace"` instead of asserting its absence.

`pytest tests/cron/` green after the change.
