### PR TITLE
fix(terminal): run local sudo outside Electron NoNewPrivs

### DIFF
--- a/tests/tools/test_sudo_no_new_privs.py
+++ b/tests/tools/test_sudo_no_new_privs.py
@@ -1,0 +1,71 @@
+"""Desktop Linux: sudo under Electron's inherited NoNewPrivs (#108595).
+
+Packaged Electron with a setuid chrome-sandbox latches PR_SET_NO_NEW_PRIVS on
+the main process; the spawned backend inherits it and kernel-refuses sudo's
+setuid bit (NOPASSWD and SUDO_PASSWORD both fail with "no new privileges").
+Escape hatch: systemd-run --user --pipe so the command runs in a fresh user
+unit outside that tree.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+import pytest
+
+import tools.terminal_tool_sudo as terminal_tool
+
+
+def test_wraps_sudo_in_systemd_run_pipe_when_no_new_privs(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_process_has_no_new_privs", lambda: True)
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/systemd-run" if name == "systemd-run" else None)
+
+    wrapped = terminal_tool._wrap_local_command_for_no_new_privs("sudo -n true")
+
+    assert wrapped != "sudo -n true"
+    assert "systemd-run" in wrapped
+    assert "--user" in wrapped
+    assert "--pipe" in wrapped
+    assert "--wait" in wrapped
+    assert "sudo -n true" in wrapped
+
+
+def test_does_not_wrap_when_no_new_privs_is_clear(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_process_has_no_new_privs", lambda: False)
+
+    assert terminal_tool._wrap_local_command_for_no_new_privs("sudo -n true") == "sudo -n true"
+
+
+def test_does_not_wrap_commands_without_sudo(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_process_has_no_new_privs", lambda: True)
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/systemd-run" if name == "systemd-run" else None)
+
+    assert terminal_tool._wrap_local_command_for_no_new_privs("id -un") == "id -un"
+
+
+@pytest.mark.skipif(
+    not shutil.which("setpriv") or not shutil.which("systemd-run"),
+    reason="setpriv + systemd-run required for the kernel-latch harness",
+)
+def test_wrapped_sudo_does_not_hit_kernel_no_new_privs_latch(monkeypatch):
+    """setpriv reproduces Electron's latch; the wrap must change the error."""
+    raw = subprocess.run(
+        ["setpriv", "--no-new-privs", "sudo", "-n", "true"],
+        capture_output=True,
+        text=True,
+        timeout=8,
+    )
+    assert raw.returncode != 0
+    assert "no new privileges" in (raw.stderr or "").lower()
+
+    monkeypatch.setattr(terminal_tool, "_process_has_no_new_privs", lambda: True)
+    wrapped = terminal_tool._wrap_local_command_for_no_new_privs("sudo -n true")
+    escaped = subprocess.run(
+        ["setpriv", "--no-new-privs", "bash", "-lc", wrapped],
+        capture_output=True,
+        text=True,
+        timeout=12,
+    )
+    combined = f"{escaped.stdout}\n{escaped.stderr}".lower()
+    assert "no new privileges" not in combined

--- a/tests/tools/test_sudo_no_new_privs.py
+++ b/tests/tools/test_sudo_no_new_privs.py
@@ -9,6 +9,7 @@ unit outside that tree.
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 
@@ -19,16 +20,24 @@ import tools.terminal_tool_sudo as terminal_tool
 
 def test_wraps_sudo_in_systemd_run_pipe_when_no_new_privs(monkeypatch):
     monkeypatch.setattr(terminal_tool, "_process_has_no_new_privs", lambda: True)
-    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/systemd-run" if name == "systemd-run" else None)
 
-    wrapped = terminal_tool._wrap_local_command_for_no_new_privs("sudo -n true")
+    wrapped = terminal_tool._wrap_local_command_for_no_new_privs("sudo -n true", cwd="/tmp")
 
-    assert wrapped != "sudo -n true"
-    assert "systemd-run" in wrapped
-    assert "--user" in wrapped
+    assert wrapped.startswith("/usr/bin/systemd-run")
+    assert " --user " in f" {wrapped} " or "--user" in wrapped
     assert "--pipe" in wrapped
     assert "--wait" in wrapped
+    assert "--unit=hermes-nnp-sudo-" in wrapped
+    assert "--working-directory=/tmp" in wrapped
     assert "sudo -n true" in wrapped
+    assert shutil.which("systemd-run") is not None or wrapped.startswith("/usr/bin/systemd-run")
+
+
+def test_wrap_units_are_unique(monkeypatch):
+    monkeypatch.setattr(terminal_tool, "_process_has_no_new_privs", lambda: True)
+    a = terminal_tool._wrap_local_command_for_no_new_privs("sudo -n true")
+    b = terminal_tool._wrap_local_command_for_no_new_privs("sudo -n true")
+    assert terminal_tool._nnp_sudo_unit_from_command(a) != terminal_tool._nnp_sudo_unit_from_command(b)
 
 
 def test_does_not_wrap_when_no_new_privs_is_clear(monkeypatch):
@@ -39,17 +48,27 @@ def test_does_not_wrap_when_no_new_privs_is_clear(monkeypatch):
 
 def test_does_not_wrap_commands_without_sudo(monkeypatch):
     monkeypatch.setattr(terminal_tool, "_process_has_no_new_privs", lambda: True)
-    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/systemd-run" if name == "systemd-run" else None)
 
     assert terminal_tool._wrap_local_command_for_no_new_privs("id -un") == "id -un"
 
 
+def test_does_not_use_untrusted_systemd_run_on_path(monkeypatch, tmp_path):
+    monkeypatch.setattr(terminal_tool, "_process_has_no_new_privs", lambda: True)
+    monkeypatch.setattr(terminal_tool, "_trusted_systemd_run_binary", lambda: None)
+    fake = tmp_path / "systemd-run"
+    fake.write_text("#!/bin/sh\nexit 0\n")
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", str(tmp_path) + os.pathsep + os.environ.get("PATH", ""))
+
+    assert terminal_tool._wrap_local_command_for_no_new_privs("sudo -n true") == "sudo -n true"
+
+
 @pytest.mark.skipif(
-    not shutil.which("setpriv") or not shutil.which("systemd-run"),
-    reason="setpriv + systemd-run required for the kernel-latch harness",
+    not shutil.which("setpriv") or not os.path.isfile("/usr/bin/systemd-run"),
+    reason="setpriv + /usr/bin/systemd-run required for the kernel-latch harness",
 )
 def test_wrapped_sudo_does_not_hit_kernel_no_new_privs_latch(monkeypatch):
-    """setpriv reproduces Electron's latch; the wrap must change the error."""
+    """setpriv reproduces Electron's latch; wrap must actually reach sudo."""
     raw = subprocess.run(
         ["setpriv", "--no-new-privs", "sudo", "-n", "true"],
         capture_output=True,
@@ -60,7 +79,7 @@ def test_wrapped_sudo_does_not_hit_kernel_no_new_privs_latch(monkeypatch):
     assert "no new privileges" in (raw.stderr or "").lower()
 
     monkeypatch.setattr(terminal_tool, "_process_has_no_new_privs", lambda: True)
-    wrapped = terminal_tool._wrap_local_command_for_no_new_privs("sudo -n true")
+    wrapped = terminal_tool._wrap_local_command_for_no_new_privs("sudo -n true", cwd="/tmp")
     escaped = subprocess.run(
         ["setpriv", "--no-new-privs", "bash", "-lc", wrapped],
         capture_output=True,
@@ -69,3 +88,13 @@ def test_wrapped_sudo_does_not_hit_kernel_no_new_privs_latch(monkeypatch):
     )
     combined = f"{escaped.stdout}\n{escaped.stderr}".lower()
     assert "no new privileges" not in combined
+    assert "failed to connect" not in combined
+    sudo_ran = escaped.returncode == 0 or "password is required" in combined
+    assert sudo_ran, combined
+    unit = terminal_tool._nnp_sudo_unit_from_command(wrapped)
+    assert unit
+    subprocess.run(
+        ["/usr/bin/systemctl", "--user", "stop", unit],
+        capture_output=True,
+        timeout=5,
+    )

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -713,13 +713,16 @@ class LocalEnvironment(BaseEnvironment):
     _sudo_nopasswd_probe_supported = True
     _profile_scoped_passthrough = True
 
-    def _prepare_command(self, command: str) -> tuple[str, str | None]:
-        from tools.terminal_tool_sudo import _wrap_local_command_for_no_new_privs
+    def _wrap_command(self, command: str, cwd: str) -> str:
+        from tools.terminal_tool_sudo import (
+            _nnp_sudo_unit_from_command,
+            _wrap_local_command_for_no_new_privs,
+        )
 
-        transformed, sudo_stdin = super()._prepare_command(command)
-        if transformed is None:
-            return transformed, sudo_stdin
-        return _wrap_local_command_for_no_new_privs(transformed), sudo_stdin
+        script = super()._wrap_command(command, cwd)
+        wrapped = _wrap_local_command_for_no_new_privs(script, cwd=cwd)
+        self._nnp_sudo_unit = _nnp_sudo_unit_from_command(wrapped)
+        return wrapped
 
     def _sudo_nopasswd_works(self) -> bool:
         """Probe ``sudo -n`` outside Electron's NoNewPrivs tree when latched."""
@@ -728,7 +731,7 @@ class LocalEnvironment(BaseEnvironment):
         if not self._sudo_nopasswd_probe_supported:
             return False
         try:
-            probe = _wrap_local_command_for_no_new_privs("sudo -n true")
+            probe = _wrap_local_command_for_no_new_privs("sudo -n true", cwd=self.cwd or None)
             proc = self._run_bash(probe, timeout=self._SUDO_PROBE_TIMEOUT_S)
             return self._wait_for_process(proc, timeout=self._SUDO_PROBE_TIMEOUT_S).get("returncode") == 0
         except Exception:
@@ -839,12 +842,18 @@ class LocalEnvironment(BaseEnvironment):
         return proc
 
     def _kill_process(self, proc):
-        """Kill the entire process group (all children)."""
+        """Kill the entire process group (all children) and any NNP sudo unit."""
+        from tools.terminal_tool_sudo import _stop_nnp_sudo_unit
+
         try:
             (_kill_process_windows if _IS_WINDOWS else _kill_process_group_posix)(proc)
         except OSError:  # ProcessLookupError / PermissionError included
             with contextlib.suppress(Exception):
                 proc.kill()
+        unit = getattr(self, "_nnp_sudo_unit", None)
+        if unit:
+            _stop_nnp_sudo_unit(unit)
+            self._nnp_sudo_unit = None
 
     def _extract_cwd_from_output(self, result: dict):
         """Base semantics plus: Git Bash ``pwd -P`` emits MSYS form on Windows —

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -712,6 +712,28 @@ class LocalEnvironment(BaseEnvironment):
 
     _sudo_nopasswd_probe_supported = True
     _profile_scoped_passthrough = True
+
+    def _prepare_command(self, command: str) -> tuple[str, str | None]:
+        from tools.terminal_tool_sudo import _wrap_local_command_for_no_new_privs
+
+        transformed, sudo_stdin = super()._prepare_command(command)
+        if transformed is None:
+            return transformed, sudo_stdin
+        return _wrap_local_command_for_no_new_privs(transformed), sudo_stdin
+
+    def _sudo_nopasswd_works(self) -> bool:
+        """Probe ``sudo -n`` outside Electron's NoNewPrivs tree when latched."""
+        from tools.terminal_tool_sudo import _wrap_local_command_for_no_new_privs
+
+        if not self._sudo_nopasswd_probe_supported:
+            return False
+        try:
+            probe = _wrap_local_command_for_no_new_privs("sudo -n true")
+            proc = self._run_bash(probe, timeout=self._SUDO_PROBE_TIMEOUT_S)
+            return self._wait_for_process(proc, timeout=self._SUDO_PROBE_TIMEOUT_S).get("returncode") == 0
+        except Exception:
+            return False
+
     # Commands run on the Hermes host itself — controller-side platform behavior
     # (macOS TCC pruning, etc.) legitimately applies here.
     is_local = True

--- a/tools/terminal_tool_sudo.py
+++ b/tools/terminal_tool_sudo.py
@@ -9,11 +9,12 @@ import os
 import platform
 import re
 import shlex
-import shutil
+import stat
 import subprocess
 import sys
 import threading
 import time
+import uuid
 from collections.abc import Callable, Iterator
 
 from utils import env_var_enabled
@@ -437,12 +438,53 @@ def _process_has_no_new_privs() -> bool:
     return False
 
 
-def _wrap_local_command_for_no_new_privs(command: str) -> str:
+_TRUSTED_SYSTEMD_RUN = "/usr/bin/systemd-run"
+_NNP_SUDO_UNIT_RE = re.compile(r"--unit=(hermes-nnp-sudo-[0-9]+-[0-9a-f]+\.service)")
+
+
+def _trusted_systemd_run_binary() -> str | None:
+    """``/usr/bin/systemd-run`` only — never PATH. Must be a root-owned regular file."""
+    path = _TRUSTED_SYSTEMD_RUN
+    try:
+        st = os.stat(path)
+    except OSError:
+        return None
+    if not stat.S_ISREG(st.st_mode) or st.st_uid != 0:
+        return None
+    if not os.access(path, os.X_OK):
+        return None
+    return path
+
+
+def _nnp_sudo_unit_from_command(command: str | None) -> str | None:
+    if not command:
+        return None
+    match = _NNP_SUDO_UNIT_RE.search(command)
+    return match.group(1) if match else None
+
+
+def _stop_nnp_sudo_unit(unit: str | None) -> None:
+    if not unit or not unit.startswith("hermes-nnp-sudo-"):
+        return
+    ctl = "/usr/bin/systemctl"
+    if not os.path.isfile(ctl):
+        return
+    for args in (
+        [ctl, "--user", "stop", "--quiet", unit],
+        [ctl, "--user", "reset-failed", "--quiet", unit],
+    ):
+        try:
+            subprocess.run(args, capture_output=True, timeout=5, check=False)
+        except (OSError, subprocess.TimeoutExpired):
+            return
+
+
+def _wrap_local_command_for_no_new_privs(command: str, *, cwd: str | None = None) -> str:
     """Run a local sudo-bearing command in a fresh systemd user unit.
 
     ``systemd-run --user --pipe`` is a sibling of the user manager, not a child
     of Electron, so it does not inherit NoNewPrivs. No-ops when the flag is
-    clear, systemd-run is missing, or the command has no real sudo invocation.
+    clear, the trusted binary is missing, or the command has no real sudo.
     """
     if not command or sys.platform == "win32":
         return command
@@ -450,15 +492,27 @@ def _wrap_local_command_for_no_new_privs(command: str) -> str:
         return command
     if _rewrite_real_sudo_invocations(command)[1] == 0:
         return command
-    binary = shutil.which("systemd-run")
+    binary = _trusted_systemd_run_binary()
     if not binary:
+        logger.warning(
+            "NoNewPrivs is set; local sudo cannot escape without /usr/bin/systemd-run "
+            "(root-owned). Command will fail with the kernel latch."
+        )
         return command
-    # --pipe: sudo -S password on our stdin reaches the unit.
-    # --wait/--collect: foreground, then drop the transient unit.
-    return (
-        f"{shlex.quote(binary)} --user --pipe --wait --quiet --collect -- "
-        f"/bin/bash -lc {shlex.quote(command)}"
-    )
+    unit = f"hermes-nnp-sudo-{os.getpid()}-{uuid.uuid4().hex[:8]}.service"
+    parts = [
+        shlex.quote(binary),
+        "--user",
+        "--pipe",
+        "--wait",
+        "--quiet",
+        "--collect",
+        f"--unit={unit}",
+    ]
+    if cwd and os.path.isabs(cwd) and os.path.isdir(cwd):
+        parts.append(f"--working-directory={shlex.quote(cwd)}")
+    parts.extend(["--", "/bin/bash", "-lc", shlex.quote(command)])
+    return " ".join(parts)
 
 
 def _transform_sudo_command(

--- a/tools/terminal_tool_sudo.py
+++ b/tools/terminal_tool_sudo.py
@@ -9,6 +9,7 @@ import os
 import platform
 import re
 import shlex
+import shutil
 import subprocess
 import sys
 import threading
@@ -415,6 +416,49 @@ def _rewrite_compound_background(command: str) -> str:
         separator = " ;" if needs_separator else ""
         result = result[:insert_pos] + "{ " + result[insert_pos:amp_pos] + "& }" + separator + suffix
     return result
+
+
+def _process_has_no_new_privs() -> bool:
+    """True when this process has PR_SET_NO_NEW_PRIVS latched (Linux /proc).
+
+    Packaged Electron with a setuid chrome-sandbox sets the flag on itself; the
+    spawned backend inherits it and cannot exec setuid sudo. The bit cannot be
+    cleared. Missing /proc (Windows, some containers) is treated as clear.
+    """
+    if sys.platform == "win32":
+        return False
+    try:
+        with open("/proc/self/status", encoding="utf-8") as status:
+            for line in status:
+                if line.startswith("NoNewPrivs:"):
+                    return line.split()[1] == "1"
+    except OSError:
+        return False
+    return False
+
+
+def _wrap_local_command_for_no_new_privs(command: str) -> str:
+    """Run a local sudo-bearing command in a fresh systemd user unit.
+
+    ``systemd-run --user --pipe`` is a sibling of the user manager, not a child
+    of Electron, so it does not inherit NoNewPrivs. No-ops when the flag is
+    clear, systemd-run is missing, or the command has no real sudo invocation.
+    """
+    if not command or sys.platform == "win32":
+        return command
+    if not _process_has_no_new_privs():
+        return command
+    if _rewrite_real_sudo_invocations(command)[1] == 0:
+        return command
+    binary = shutil.which("systemd-run")
+    if not binary:
+        return command
+    # --pipe: sudo -S password on our stdin reaches the unit.
+    # --wait/--collect: foreground, then drop the transient unit.
+    return (
+        f"{shlex.quote(binary)} --user --pipe --wait --quiet --collect -- "
+        f"/bin/bash -lc {shlex.quote(command)}"
+    )
 
 
 def _transform_sudo_command(


### PR DESCRIPTION
## Summary
- Packaged Hermes Desktop on Linux with a setuid `chrome-sandbox` latches `PR_SET_NO_NEW_PRIVS` on Electron; the spawned backend inherits it and kernel-refuses sudo's setuid bit (NOPASSWD and `SUDO_PASSWORD` both fail with \"no new privileges\").
- Local sudo-bearing commands, and the `sudo -n` NOPASSWD probe, now run via `systemd-run --user --pipe --wait` so they execute in a fresh user unit outside that tree.
- No-ops when the flag is clear, `systemd-run` is missing, or the command has no real `sudo` invocation. SSH/Docker backends unchanged.

Closes #108595

## Test plan
- [x] `pytest tests/tools/test_sudo_no_new_privs.py tests/tools/test_terminal_tool.py tests/tools/test_subagent_sudo_prompt.py tests/tools/test_terminal_none_command_guard.py` — 26 passed
- [x] `setpriv --no-new-privs sudo -n true` still prints the kernel latch; the wrapped command does not
- [ ] Packaged Desktop (`hermes desktop`, SUID `chrome-sandbox`) `sudo id -un` — this Omarchy box runs `--no-sandbox` so NNP=0 on the live backend; needs a SUID-sandbox install to reconfirm end-to-end

This Omarchy host: live `Hermes --no-sandbox`, `chrome-sandbox` is 0755 not 4755, backend `NoNewPrivs=0`. The kernel harness is `setpriv`, matching the issue thread.