### PR TITLE
fix(desktop): leftover npm/yarn config in a user's home no longer breaks the desktop build

### DIFF
--- a/apps/desktop/scripts/assert-root-install.mjs
+++ b/apps/desktop/scripts/assert-root-install.mjs
@@ -11,7 +11,7 @@
 // re-runs it for anyone invoking the build steps directly; the check is pure
 // filesystem lookups, so paying for it twice costs nothing.
 
-import { existsSync, readFileSync } from "fs"
+import { existsSync, readFileSync, realpathSync } from "fs"
 import { createRequire } from "module"
 import { resolve, join, dirname } from "path"
 import { isMain } from "./utils.mjs"
@@ -76,17 +76,19 @@ export function requiredPackages(appDir) {
   }
 }
 
-// esbuild switches to Yarn Plug'n'Play resolution when it finds a PnP manifest
-// in *any* ancestor directory — including ones above this repo, such as a stray
-// `~/.pnp.cjs` left by running `yarn` in a home directory. The manifest does not
-// list this workspace's packages, so `bundle-electron-main.mjs` then fails with
-// `Could not resolve "simple-git"` even though the npm install is complete, and
-// nothing in that error points at a file outside the repo. A fresh OS user has
-// no such file, which makes the failure look machine-specific and random.
+// esbuild adopts a Yarn Plug'n'Play manifest from any ancestor of its working
+// directory (the build runs from this app's directory) — including folders above
+// the repo, such as a stray `~/.pnp.cjs` left by running `yarn` in a home
+// directory. A real manifest that does not list this workspace makes every bare
+// import fail (`Could not resolve "simple-git"`) over a complete npm install, and
+// nothing in that error points outside the repo. An empty file, a directory, or an
+// unrelated file with the same name is ignored by esbuild, so the filename alone
+// must not fail the build: `findPnpManifest` is only a cheap pre-filter, and
+// `checkPnpResolution` asks esbuild itself.
 const PNP_MANIFESTS = [".pnp.cjs", ".pnp.js", ".pnp.data.json"]
 export { PNP_MANIFESTS }
 
-// First PnP manifest found walking from `fromDir` up to the filesystem root, or null.
+// First path named like a PnP manifest, walking from `fromDir` up to the filesystem root, or null.
 export function findPnpManifest(fromDir) {
   let dir = fromDir
   for (;;) {
@@ -100,22 +102,62 @@ export function findPnpManifest(fromDir) {
   }
 }
 
-// Pure check — returns { ok: true } or { ok: false, error: "..." }.
-// Kept side-effect-free so it can be unit tested without spawning a process.
-export function checkRootInstall(appDir, rootDir) {
-  const pnpManifest = findPnpManifest(appDir)
-  if (pnpManifest) {
+const PNP_PROBE_ENTRY = "assert-root-install-pnp-probe"
+
+// Resolves `probePackage` through esbuild from `appDir` — same working directory
+// as the real bundle — without writing or bundling anything: the probe module is
+// served from memory and every resolved file is stubbed. Fails only when esbuild
+// reports that a Plug'n'Play manifest blocked the import; any other esbuild error
+// is left for the build itself to report.
+export async function checkPnpResolution(requestedAppDir, probePackage = "vite") {
+  const candidate = findPnpManifest(requestedAppDir)
+  if (!candidate) return { ok: true }
+
+  // The build's working directory is always a real path; esbuild matches the
+  // manifest against real paths, so a symlinked spelling (macOS /var -> /private/var)
+  // would silently skip PnP and hide the failure this check exists to catch.
+  const appDir = realpathSync(requestedAppDir)
+  const probePath = join(appDir, `${PNP_PROBE_ENTRY}.js`)
+  const { build } = await import("esbuild")
+  try {
+    await build({
+      entryPoints: [PNP_PROBE_ENTRY],
+      absWorkingDir: appDir,
+      bundle: true,
+      write: false,
+      platform: "node",
+      logLevel: "silent",
+      plugins: [{
+        name: PNP_PROBE_ENTRY,
+        setup(pluginBuild) {
+          pluginBuild.onResolve({ filter: new RegExp(`^${PNP_PROBE_ENTRY}$`) }, () => ({ path: probePath }))
+          pluginBuild.onLoad({ filter: /.*/ }, args =>
+            args.path === probePath
+              ? { contents: `import ${JSON.stringify(probePackage)}`, loader: "js", resolveDir: appDir }
+              : { contents: "", loader: "js" })
+        }
+      }]
+    })
+    return { ok: true }
+  } catch (err) {
+    const note = (err.errors ?? []).flatMap(message => message.notes ?? [])
+      .find(n => n.text.includes("Plug'n'Play"))
+    if (!note) return { ok: true }
+    const manifest = note.location?.file ? resolve(appDir, note.location.file) : candidate
     return {
       ok: false,
       error:
-        `found a Yarn Plug'n'Play manifest at ${pnpManifest}. This workspace is ` +
-        `installed with npm, but esbuild honours PnP manifests in any parent ` +
-        `directory and will fail to resolve installed packages (e.g. ` +
-        `Could not resolve "simple-git"). Move or delete that file — it is ` +
-        `usually left over from running yarn in a parent folder — then rebuild.`
+        `esbuild is using the Yarn Plug'n'Play manifest at ${manifest}, which does not ` +
+        `list this npm workspace, so the build cannot resolve installed packages ` +
+        `(${note.text.replace(/:\s*$/, "")}). Move or delete that file — it is usually ` +
+        `left over from running yarn in a parent folder — then rebuild.`
     }
   }
+}
 
+// Pure check — returns { ok: true } or { ok: false, error: "..." }.
+// Kept side-effect-free so it can be unit tested without spawning a process.
+export function checkRootInstall(appDir, rootDir) {
   const wanted = [...new Set([...BUILD_CRITICAL_PACKAGES, ...requiredPackages(appDir)])]
   const missing = wanted.filter(pkg => !packageIsInstalled(pkg, appDir))
   if (missing.length > 0) {
@@ -167,17 +209,19 @@ export function checkRootInstall(appDir, rootDir) {
   return { ok: true }
 }
 
-function main() {
+async function main() {
   const app = resolve(import.meta.dirname, "..")
   const root = resolve(app, "..", "..")
-  const result = checkRootInstall(app, root)
-
-  if (!result.ok) {
-    console.error(`✗ assert-root-install: ${result.error}`)
-    process.exit(1)
+  // The PnP probe loads esbuild, so it only runs once the install check has
+  // confirmed the declared toolchain is present.
+  for (const result of [checkRootInstall(app, root), await checkPnpResolution(app)]) {
+    if (!result.ok) {
+      console.error(`✗ assert-root-install: ${result.error}`)
+      process.exit(1)
+    }
   }
 }
 
 if (isMain(import.meta.url)) {
-  main()
+  await main()
 }

--- a/apps/desktop/scripts/assert-root-install.mjs
+++ b/apps/desktop/scripts/assert-root-install.mjs
@@ -15,6 +15,7 @@ import { existsSync, readFileSync, realpathSync } from "fs"
 import { createRequire } from "module"
 import { resolve, join, dirname } from "path"
 import { isMain } from "./utils.mjs"
+import { electronBundleOptions } from "./electron-bundle-options.mjs"
 
 // Packages the build *consumes*, as opposed to merely declares. Each one is
 // load-bearing for a distinct build step, and each one has been observed
@@ -84,7 +85,7 @@ export function requiredPackages(appDir) {
 // nothing in that error points outside the repo. An empty file, a directory, or an
 // unrelated file with the same name is ignored by esbuild, so the filename alone
 // must not fail the build: `findPnpManifest` is only a cheap pre-filter, and
-// `checkPnpResolution` asks esbuild itself.
+// `checkPnpResolution` asks esbuild itself, using the real bundle options.
 const PNP_MANIFESTS = [".pnp.cjs", ".pnp.js", ".pnp.data.json"]
 export { PNP_MANIFESTS }
 
@@ -102,56 +103,51 @@ export function findPnpManifest(fromDir) {
   }
 }
 
-const PNP_PROBE_ENTRY = "assert-root-install-pnp-probe"
-
-// Resolves `probePackage` through esbuild from `appDir` — same working directory
-// as the real bundle — without writing or bundling anything: the probe module is
-// served from memory and every resolved file is stubbed. Fails only when esbuild
-// reports that a Plug'n'Play manifest blocked the import; any other esbuild error
-// is left for the build itself to report.
-export async function checkPnpResolution(requestedAppDir, probePackage = "vite") {
-  const candidate = findPnpManifest(requestedAppDir)
-  if (!candidate) return { ok: true }
+// Runs the real Electron bundles (electron-bundle-options.mjs) in memory from
+// `appDir` — the same working directory, entrypoints and externals as
+// bundle-electron-main.mjs, with nothing written — and collects every import that
+// esbuild says a Plug'n'Play manifest blocked. A manifest can list some of the
+// packages the bundles need and omit others, so probing a single package is not
+// enough. Any other esbuild error is left for the build itself to report.
+export async function checkPnpResolution(requestedAppDir, { bundleOptions } = {}) {
+  if (!findPnpManifest(requestedAppDir)) return { ok: true }
 
   // The build's working directory is always a real path; esbuild matches the
   // manifest against real paths, so a symlinked spelling (macOS /var -> /private/var)
   // would silently skip PnP and hide the failure this check exists to catch.
   const appDir = realpathSync(requestedAppDir)
-  const probePath = join(appDir, `${PNP_PROBE_ENTRY}.js`)
+  const realEntry = entry => (existsSync(entry) ? realpathSync(entry) : entry)
   const { build } = await import("esbuild")
-  try {
-    await build({
-      entryPoints: [PNP_PROBE_ENTRY],
-      absWorkingDir: appDir,
-      bundle: true,
-      write: false,
-      platform: "node",
-      logLevel: "silent",
-      plugins: [{
-        name: PNP_PROBE_ENTRY,
-        setup(pluginBuild) {
-          pluginBuild.onResolve({ filter: new RegExp(`^${PNP_PROBE_ENTRY}$`) }, () => ({ path: probePath }))
-          pluginBuild.onLoad({ filter: /.*/ }, args =>
-            args.path === probePath
-              ? { contents: `import ${JSON.stringify(probePackage)}`, loader: "js", resolveDir: appDir }
-              : { contents: "", loader: "js" })
-        }
-      }]
-    })
-    return { ok: true }
-  } catch (err) {
-    const note = (err.errors ?? []).flatMap(message => message.notes ?? [])
-      .find(n => n.text.includes("Plug'n'Play"))
-    if (!note) return { ok: true }
-    const manifest = note.location?.file ? resolve(appDir, note.location.file) : candidate
-    return {
-      ok: false,
-      error:
-        `esbuild is using the Yarn Plug'n'Play manifest at ${manifest}, which does not ` +
-        `list this npm workspace, so the build cannot resolve installed packages ` +
-        `(${note.text.replace(/:\s*$/, "")}). Move or delete that file — it is usually ` +
-        `left over from running yarn in a parent folder — then rebuild.`
+  const blocked = new Map() // package -> manifest esbuild used
+
+  for (const options of bundleOptions ?? electronBundleOptions(appDir)) {
+    try {
+      await build({
+        ...options,
+        entryPoints: options.entryPoints.map(realEntry),
+        absWorkingDir: appDir,
+        write: false,
+        logLevel: "silent"
+      })
+    } catch (err) {
+      for (const message of err.errors ?? []) {
+        const note = (message.notes ?? []).find(n => n.text.includes("Plug'n'Play"))
+        if (!note) continue
+        const pkg = note.text.match(/importing "([^"]+)"/)?.[1] ?? message.text
+        blocked.set(pkg, note.location?.file ? resolve(appDir, note.location.file) : findPnpManifest(appDir))
+      }
     }
+  }
+
+  if (blocked.size === 0) return { ok: true }
+  const packages = [...blocked.keys()].map(name => `"${name}"`).join(", ")
+  return {
+    ok: false,
+    error:
+      `esbuild is using the Yarn Plug'n'Play manifest at ${[...new Set(blocked.values())].join(", ")}, ` +
+      `which does not list ${packages} for this npm workspace, so the Electron bundle cannot ` +
+      `resolve them. Move or delete that file — it is usually left over from running yarn ` +
+      `in a parent folder — then rebuild.`
   }
 }
 

--- a/apps/desktop/scripts/assert-root-install.mjs
+++ b/apps/desktop/scripts/assert-root-install.mjs
@@ -76,9 +76,46 @@ export function requiredPackages(appDir) {
   }
 }
 
+// esbuild switches to Yarn Plug'n'Play resolution when it finds a PnP manifest
+// in *any* ancestor directory — including ones above this repo, such as a stray
+// `~/.pnp.cjs` left by running `yarn` in a home directory. The manifest does not
+// list this workspace's packages, so `bundle-electron-main.mjs` then fails with
+// `Could not resolve "simple-git"` even though the npm install is complete, and
+// nothing in that error points at a file outside the repo. A fresh OS user has
+// no such file, which makes the failure look machine-specific and random.
+const PNP_MANIFESTS = [".pnp.cjs", ".pnp.js", ".pnp.data.json"]
+export { PNP_MANIFESTS }
+
+// First PnP manifest found walking from `fromDir` up to the filesystem root, or null.
+export function findPnpManifest(fromDir) {
+  let dir = fromDir
+  for (;;) {
+    for (const name of PNP_MANIFESTS) {
+      const candidate = join(dir, name)
+      if (existsSync(candidate)) return candidate
+    }
+    const parent = dirname(dir)
+    if (parent === dir) return null
+    dir = parent
+  }
+}
+
 // Pure check — returns { ok: true } or { ok: false, error: "..." }.
 // Kept side-effect-free so it can be unit tested without spawning a process.
 export function checkRootInstall(appDir, rootDir) {
+  const pnpManifest = findPnpManifest(appDir)
+  if (pnpManifest) {
+    return {
+      ok: false,
+      error:
+        `found a Yarn Plug'n'Play manifest at ${pnpManifest}. This workspace is ` +
+        `installed with npm, but esbuild honours PnP manifests in any parent ` +
+        `directory and will fail to resolve installed packages (e.g. ` +
+        `Could not resolve "simple-git"). Move or delete that file — it is ` +
+        `usually left over from running yarn in a parent folder — then rebuild.`
+    }
+  }
+
   const wanted = [...new Set([...BUILD_CRITICAL_PACKAGES, ...requiredPackages(appDir)])]
   const missing = wanted.filter(pkg => !packageIsInstalled(pkg, appDir))
   if (missing.length > 0) {

--- a/apps/desktop/scripts/assert-root-install.test.mjs
+++ b/apps/desktop/scripts/assert-root-install.test.mjs
@@ -4,14 +4,26 @@ import os from 'node:os'
 import path from 'node:path'
 import { test } from 'vitest'
 
-import { BUILD_CRITICAL_PACKAGES as BUILD_CRITICAL, checkRootInstall, requiredPackages } from '../scripts/assert-root-install.mjs'
+import {
+  BUILD_CRITICAL_PACKAGES as BUILD_CRITICAL,
+  checkRootInstall,
+  findPnpManifest,
+  requiredPackages
+} from '../scripts/assert-root-install.mjs'
 
 // Build a throwaway repo shaped like this one: an app workspace whose
 // dependencies are hoisted to the repo root, which is what the guard walks.
 // `manifest` is merged into the app's package.json so tests can declare
-// dependencies the guard is expected to read.
-function makeTree({ rootPackages = BUILD_CRITICAL, react = '19.2.7', reactDom = '19.2.7', manifest = {} } = {}) {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-assert-root-'))
+// dependencies the guard is expected to read. `parentDir` places the repo
+// inside an existing directory so tests can plant files above the repo root.
+function makeTree({
+  rootPackages = BUILD_CRITICAL,
+  react = '19.2.7',
+  reactDom = '19.2.7',
+  manifest = {},
+  parentDir = os.tmpdir()
+} = {}) {
+  const tempRoot = fs.mkdtempSync(path.join(parentDir, 'hermes-assert-root-'))
   const appDir = path.join(tempRoot, 'apps', 'desktop')
   fs.mkdirSync(appDir, { recursive: true })
   fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify({ name: 'desktop', ...manifest }), 'utf8')
@@ -193,5 +205,38 @@ test('checkRootInstall keeps the floor when the manifest is unreadable', () => {
     assert.match(result.error, /katex/)
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+// esbuild adopts a Yarn PnP manifest from any ancestor directory, so a stray
+// `.pnp.cjs` above the repo (typically in a home directory) breaks
+// `bundle-electron-main.mjs` with `Could not resolve "simple-git"` over a
+// complete npm install. The guard must name the file instead.
+test('checkRootInstall fails when a PnP manifest sits above the repo root', () => {
+  const outer = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-assert-pnp-'))
+  fs.writeFileSync(path.join(outer, '.pnp.cjs'), '', 'utf8')
+  const { tempRoot, appDir } = makeTree({ parentDir: outer })
+  try {
+    const result = checkRootInstall(appDir, tempRoot)
+    assert.equal(result.ok, false)
+    assert.ok(result.error.includes(path.join(outer, '.pnp.cjs')))
+    assert.match(result.error, /Plug'n'Play/)
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true })
+  }
+})
+
+test('findPnpManifest detects every manifest name and returns null when absent', () => {
+  for (const name of ['.pnp.cjs', '.pnp.js', '.pnp.data.json']) {
+    const outer = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-assert-pnp-'))
+    const nested = path.join(outer, 'repo', 'apps', 'desktop')
+    fs.mkdirSync(nested, { recursive: true })
+    try {
+      assert.equal(findPnpManifest(nested), null)
+      fs.writeFileSync(path.join(outer, name), '', 'utf8')
+      assert.equal(findPnpManifest(nested), path.join(outer, name))
+    } finally {
+      fs.rmSync(outer, { recursive: true, force: true })
+    }
   }
 })

--- a/apps/desktop/scripts/assert-root-install.test.mjs
+++ b/apps/desktop/scripts/assert-root-install.test.mjs
@@ -6,6 +6,7 @@ import { test } from 'vitest'
 
 import {
   BUILD_CRITICAL_PACKAGES as BUILD_CRITICAL,
+  checkPnpResolution,
   checkRootInstall,
   findPnpManifest,
   requiredPackages
@@ -208,23 +209,92 @@ test('checkRootInstall keeps the floor when the manifest is unreadable', () => {
   }
 })
 
-// esbuild adopts a Yarn PnP manifest from any ancestor directory, so a stray
-// `.pnp.cjs` above the repo (typically in a home directory) breaks
-// `bundle-electron-main.mjs` with `Could not resolve "simple-git"` over a
-// complete npm install. The guard must name the file instead.
-test('checkRootInstall fails when a PnP manifest sits above the repo root', () => {
+// esbuild adopts a Yarn PnP manifest from any ancestor of its working directory,
+// so a real manifest above the repo (typically a stray one in a home directory)
+// breaks `bundle-electron-main.mjs` with `Could not resolve "..."` over a complete
+// npm install. Only a manifest esbuild actually loads may fail the check: an empty
+// file, a directory, an unrelated file or a corrupt manifest with the same name must
+// not block a build. These fixtures run the real esbuild resolver.
+
+// A minimal Yarn PnP state for a lone root workspace that declares no dependencies —
+// the shape `yarn` leaves behind when run in an otherwise empty folder.
+const PNP_STATE = JSON.stringify({
+  dependencyTreeRoots: [{ name: 'stray-root', reference: 'workspace:.' }],
+  enableTopLevelFallback: true,
+  fallbackExclusionList: [['stray-root', ['workspace:.']]],
+  fallbackPool: [],
+  ignorePatternData: null,
+  packageRegistryData: [
+    [null, [[null, { packageLocation: './', packageDependencies: [], linkType: 'SOFT' }]]],
+    ['stray-root', [['workspace:.', { packageLocation: './', packageDependencies: [['stray-root', 'workspace:.']], linkType: 'SOFT' }]]]
+  ]
+})
+
+const PNP_FIXTURES = {
+  'valid .pnp.data.json': outer => fs.writeFileSync(path.join(outer, '.pnp.data.json'), PNP_STATE),
+  'valid .pnp.cjs': outer => fs.writeFileSync(path.join(outer, '.pnp.cjs'), [
+    '"use strict";',
+    `const RAW_RUNTIME_STATE =\n'${PNP_STATE}';`,
+    'function $$SETUP_STATE(hydrateRuntimeState, basePath) {',
+    '  return hydrateRuntimeState(JSON.parse(RAW_RUNTIME_STATE), {basePath: basePath || __dirname});',
+    '}',
+    ''
+  ].join('\n')),
+  'empty .pnp.cjs': outer => fs.writeFileSync(path.join(outer, '.pnp.cjs'), ''),
+  '.pnp.cjs directory': outer => fs.mkdirSync(path.join(outer, '.pnp.cjs')),
+  'unrelated .pnp.js': outer => fs.writeFileSync(path.join(outer, '.pnp.js'), 'module.exports = {}\n'),
+  'corrupt .pnp.data.json': outer => fs.writeFileSync(path.join(outer, '.pnp.data.json'), '{"packageRegistryData": ['),
+}
+
+// An app workspace nested under `outer`, with one resolvable package hoisted to the repo root.
+function makePnpTree(fixture) {
   const outer = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-assert-pnp-'))
-  fs.writeFileSync(path.join(outer, '.pnp.cjs'), '', 'utf8')
-  const { tempRoot, appDir } = makeTree({ parentDir: outer })
+  const appDir = path.join(outer, 'repo', 'apps', 'desktop')
+  const pkgDir = path.join(outer, 'repo', 'node_modules', 'probe-pkg')
+  fs.mkdirSync(appDir, { recursive: true })
+  fs.mkdirSync(pkgDir, { recursive: true })
+  fs.writeFileSync(path.join(outer, 'repo', 'package.json'), JSON.stringify({ name: 'repo', private: true, workspaces: ['apps/*'] }))
+  fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify({ name: 'desktop', dependencies: { 'probe-pkg': '1.0.0' } }))
+  fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ name: 'probe-pkg', version: '1.0.0', main: 'index.js' }))
+  fs.writeFileSync(path.join(pkgDir, 'index.js'), 'module.exports = 1\n')
+  if (fixture) PNP_FIXTURES[fixture](outer)
+  return { outer, appDir }
+}
+
+test('checkPnpResolution passes without any PnP manifest', async () => {
+  const { outer, appDir } = makePnpTree(null)
   try {
-    const result = checkRootInstall(appDir, tempRoot)
-    assert.equal(result.ok, false)
-    assert.ok(result.error.includes(path.join(outer, '.pnp.cjs')))
-    assert.match(result.error, /Plug'n'Play/)
+    assert.deepEqual(await checkPnpResolution(appDir, 'probe-pkg'), { ok: true })
   } finally {
     fs.rmSync(outer, { recursive: true, force: true })
   }
 })
+
+for (const fixture of ['valid .pnp.data.json', 'valid .pnp.cjs']) {
+  test(`checkPnpResolution fails and names the manifest for a ${fixture} above the repo`, async () => {
+    const { outer, appDir } = makePnpTree(fixture)
+    try {
+      const result = await checkPnpResolution(appDir, 'probe-pkg')
+      assert.equal(result.ok, false)
+      assert.ok(result.error.includes(path.join(fs.realpathSync(outer), fixture.split(' ')[1])), result.error)
+      assert.match(result.error, /Plug'n'Play/)
+      assert.match(result.error, /probe-pkg/)
+    } finally {
+      fs.rmSync(outer, { recursive: true, force: true })
+    }
+  })
+}
+
+for (const fixture of ['empty .pnp.cjs', '.pnp.cjs directory', 'unrelated .pnp.js', 'corrupt .pnp.data.json']) {
+  test(`checkPnpResolution does not block the build for a stray ${fixture} above the repo`, async () => {
+    const { outer, appDir } = makePnpTree(fixture)
+    try {
+      assert.deepEqual(await checkPnpResolution(appDir, 'probe-pkg'), { ok: true })
+    } finally {
+      fs.rmSync(outer, { recursive: true, force: true })
+    }
+  })
+}
 
 test('findPnpManifest detects every manifest name and returns null when absent', () => {
   for (const name of ['.pnp.cjs', '.pnp.js', '.pnp.data.json']) {

--- a/apps/desktop/scripts/assert-root-install.test.mjs
+++ b/apps/desktop/scripts/assert-root-install.test.mjs
@@ -11,6 +11,7 @@ import {
   findPnpManifest,
   requiredPackages
 } from '../scripts/assert-root-install.mjs'
+import { electronBundleOptions } from '../scripts/electron-bundle-options.mjs'
 
 // Build a throwaway repo shaped like this one: an app workspace whose
 // dependencies are hoisted to the repo root, which is what the guard walks.
@@ -216,55 +217,68 @@ test('checkRootInstall keeps the floor when the manifest is unreadable', () => {
 // file, a directory, an unrelated file or a corrupt manifest with the same name must
 // not block a build. These fixtures run the real esbuild resolver.
 
-// A minimal Yarn PnP state for a lone root workspace that declares no dependencies —
-// the shape `yarn` leaves behind when run in an otherwise empty folder.
-const PNP_STATE = JSON.stringify({
-  dependencyTreeRoots: [{ name: 'stray-root', reference: 'workspace:.' }],
-  enableTopLevelFallback: true,
-  fallbackExclusionList: [['stray-root', ['workspace:.']]],
-  fallbackPool: [],
-  ignorePatternData: null,
-  packageRegistryData: [
-    [null, [[null, { packageLocation: './', packageDependencies: [], linkType: 'SOFT' }]]],
-    ['stray-root', [['workspace:.', { packageLocation: './', packageDependencies: [['stray-root', 'workspace:.']], linkType: 'SOFT' }]]]
-  ]
-})
+// A minimal Yarn PnP state for a lone root workspace, the shape `yarn` leaves
+// behind when run in a parent folder. `declared` lists packages the manifest maps
+// to this repo's hoisted node_modules; anything else is forbidden.
+function pnpState(declared = []) {
+  const hard = name => [name, [['npm:1.0.0', { packageLocation: `./repo/node_modules/${name}/`, packageDependencies: [[name, 'npm:1.0.0']], linkType: 'HARD' }]]]
+  const deps = declared.map(name => [name, 'npm:1.0.0'])
+  return JSON.stringify({
+    dependencyTreeRoots: [{ name: 'stray-root', reference: 'workspace:.' }],
+    enableTopLevelFallback: true,
+    fallbackExclusionList: [['stray-root', ['workspace:.']]],
+    fallbackPool: [],
+    ignorePatternData: null,
+    packageRegistryData: [
+      [null, [[null, { packageLocation: './', packageDependencies: deps, linkType: 'SOFT' }]]],
+      ['stray-root', [['workspace:.', { packageLocation: './', packageDependencies: [['stray-root', 'workspace:.'], ...deps], linkType: 'SOFT' }]]],
+      ...declared.map(hard)
+    ]
+  })
+}
 
 const PNP_FIXTURES = {
-  'valid .pnp.data.json': outer => fs.writeFileSync(path.join(outer, '.pnp.data.json'), PNP_STATE),
+  'valid .pnp.data.json': outer => fs.writeFileSync(path.join(outer, '.pnp.data.json'), pnpState()),
   'valid .pnp.cjs': outer => fs.writeFileSync(path.join(outer, '.pnp.cjs'), [
     '"use strict";',
-    `const RAW_RUNTIME_STATE =\n'${PNP_STATE}';`,
+    `const RAW_RUNTIME_STATE =\n'${pnpState()}';`,
     'function $$SETUP_STATE(hydrateRuntimeState, basePath) {',
     '  return hydrateRuntimeState(JSON.parse(RAW_RUNTIME_STATE), {basePath: basePath || __dirname});',
     '}',
     ''
   ].join('\n')),
+  'partial .pnp.data.json': outer => fs.writeFileSync(path.join(outer, '.pnp.data.json'), pnpState(['probe-pkg'])),
   'empty .pnp.cjs': outer => fs.writeFileSync(path.join(outer, '.pnp.cjs'), ''),
   '.pnp.cjs directory': outer => fs.mkdirSync(path.join(outer, '.pnp.cjs')),
   'unrelated .pnp.js': outer => fs.writeFileSync(path.join(outer, '.pnp.js'), 'module.exports = {}\n'),
   'corrupt .pnp.data.json': outer => fs.writeFileSync(path.join(outer, '.pnp.data.json'), '{"packageRegistryData": ['),
 }
 
-// An app workspace nested under `outer`, with one resolvable package hoisted to the repo root.
+// An app workspace nested under `outer` whose entry imports two packages hoisted
+// to the repo root, plus bundle options shaped like electron-bundle-options.mjs.
 function makePnpTree(fixture) {
   const outer = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-assert-pnp-'))
   const appDir = path.join(outer, 'repo', 'apps', 'desktop')
-  const pkgDir = path.join(outer, 'repo', 'node_modules', 'probe-pkg')
-  fs.mkdirSync(appDir, { recursive: true })
-  fs.mkdirSync(pkgDir, { recursive: true })
+  fs.mkdirSync(path.join(appDir, 'electron'), { recursive: true })
   fs.writeFileSync(path.join(outer, 'repo', 'package.json'), JSON.stringify({ name: 'repo', private: true, workspaces: ['apps/*'] }))
-  fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify({ name: 'desktop', dependencies: { 'probe-pkg': '1.0.0' } }))
-  fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ name: 'probe-pkg', version: '1.0.0', main: 'index.js' }))
-  fs.writeFileSync(path.join(pkgDir, 'index.js'), 'module.exports = 1\n')
+  fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify({ name: 'desktop', dependencies: { 'probe-pkg': '1.0.0', 'second-pkg': '1.0.0' } }))
+  for (const name of ['probe-pkg', 'second-pkg']) {
+    const pkgDir = path.join(outer, 'repo', 'node_modules', name)
+    fs.mkdirSync(pkgDir, { recursive: true })
+    fs.writeFileSync(path.join(pkgDir, 'package.json'), JSON.stringify({ name, version: '1.0.0', main: 'index.js' }))
+    fs.writeFileSync(path.join(pkgDir, 'index.js'), `module.exports = ${JSON.stringify(name)}\n`)
+  }
+  const entry = path.join(appDir, 'electron', 'main.ts')
+  fs.writeFileSync(entry, "import probe from 'probe-pkg'\nimport second from 'second-pkg'\nconsole.log(probe, second)\n")
   if (fixture) PNP_FIXTURES[fixture](outer)
-  return { outer, appDir }
+  const bundleOptions = [{ entryPoints: [entry], bundle: true, platform: 'node', format: 'esm', external: ['electron'] }]
+  return { outer, appDir, bundleOptions }
 }
 
 test('checkPnpResolution passes without any PnP manifest', async () => {
-  const { outer, appDir } = makePnpTree(null)
+  const { outer, appDir, bundleOptions } = makePnpTree(null)
   try {
-    assert.deepEqual(await checkPnpResolution(appDir, 'probe-pkg'), { ok: true })
+    assert.deepEqual(await checkPnpResolution(appDir, { bundleOptions }), { ok: true })
   } finally {
     fs.rmSync(outer, { recursive: true, force: true })
   }
@@ -272,29 +286,57 @@ test('checkPnpResolution passes without any PnP manifest', async () => {
 
 for (const fixture of ['valid .pnp.data.json', 'valid .pnp.cjs']) {
   test(`checkPnpResolution fails and names the manifest for a ${fixture} above the repo`, async () => {
-    const { outer, appDir } = makePnpTree(fixture)
+    const { outer, appDir, bundleOptions } = makePnpTree(fixture)
     try {
-      const result = await checkPnpResolution(appDir, 'probe-pkg')
+      const result = await checkPnpResolution(appDir, { bundleOptions })
       assert.equal(result.ok, false)
       assert.ok(result.error.includes(path.join(fs.realpathSync(outer), fixture.split(' ')[1])), result.error)
       assert.match(result.error, /Plug'n'Play/)
-      assert.match(result.error, /probe-pkg/)
+      assert.match(result.error, /"probe-pkg"/)
+      assert.match(result.error, /"second-pkg"/)
     } finally {
       fs.rmSync(outer, { recursive: true, force: true })
     }
   })
 }
 
+// A manifest can declare some bundle dependencies and omit others. Probing one
+// package would pass here while the real bundle still fails, so every import
+// reachable from the entrypoints must be resolved.
+test('checkPnpResolution names the omitted package when the manifest declares only some bundle dependencies', async () => {
+  const { outer, appDir, bundleOptions } = makePnpTree('partial .pnp.data.json')
+  try {
+    const result = await checkPnpResolution(appDir, { bundleOptions })
+    assert.equal(result.ok, false)
+    assert.match(result.error, /"second-pkg"/)
+    assert.doesNotMatch(result.error, /"probe-pkg"/)
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true })
+  }
+})
+
 for (const fixture of ['empty .pnp.cjs', '.pnp.cjs directory', 'unrelated .pnp.js', 'corrupt .pnp.data.json']) {
   test(`checkPnpResolution does not block the build for a stray ${fixture} above the repo`, async () => {
-    const { outer, appDir } = makePnpTree(fixture)
+    const { outer, appDir, bundleOptions } = makePnpTree(fixture)
     try {
-      assert.deepEqual(await checkPnpResolution(appDir, 'probe-pkg'), { ok: true })
+      assert.deepEqual(await checkPnpResolution(appDir, { bundleOptions }), { ok: true })
     } finally {
       fs.rmSync(outer, { recursive: true, force: true })
     }
   })
 }
+
+// Without explicit options the check resolves the real Electron bundles, so their
+// entrypoints must exist where bundle-electron-main.mjs builds them from.
+test('electronBundleOptions points at the real main and preload entrypoints', () => {
+  const desktopDir = path.resolve(import.meta.dirname, '..')
+  const options = electronBundleOptions(desktopDir)
+  assert.deepEqual(options.map(o => o.format), ['esm', 'cjs'])
+  for (const { entryPoints, external } of options) {
+    assert.ok(fs.existsSync(entryPoints[0]), entryPoints[0])
+    assert.ok(external.includes('electron'))
+  }
+})
 
 test('findPnpManifest detects every manifest name and returns null when absent', () => {
   for (const name of ['.pnp.cjs', '.pnp.js', '.pnp.data.json']) {

--- a/apps/desktop/scripts/bundle-electron-main.mjs
+++ b/apps/desktop/scripts/bundle-electron-main.mjs
@@ -7,59 +7,21 @@
 //   dist/electron-main.mjs    (MJS bundle — entry point for packaged app)
 //   dist/electron-preload.js (CJS bundle — loaded via BrowserWindow preload)
 //
-// `electron` and `node-pty` are external (provided by the runtime / staged
-// separately via stage-native-deps).
+// The esbuild options live in electron-bundle-options.mjs so the pre-build
+// check in assert-root-install.mjs resolves the same bundles.
 import { build } from 'esbuild'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { mkdirSync } from 'node:fs'
+import { electronBundleOptions } from './electron-bundle-options.mjs'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const root = resolve(here, '..')
-const distDir = resolve(root, 'dist')
-mkdirSync(distDir, { recursive: true })
+mkdirSync(resolve(root, 'dist'), { recursive: true })
 
-const mainEntry = resolve(root, 'electron/main.ts')
-const mainOut = resolve(distDir, 'electron-main.mjs')
-const preloadEntry = resolve(root, 'electron/preload.ts')
-const preloadOut = resolve(distDir, 'electron-preload.js')
-
-const external = ['electron', 'node-pty', 'get-windows', 'fs']
-// Production bundles bake packaged=true so unpackaged `electron .` still
-// behaves like a packaged build. Dev bundles (`--dev`) leave the env alone
-// so HERMES_DESKTOP_DEV_SERVER / source-tree resolution keep working.
 const isDev = process.argv.includes('--dev')
-const define = isDev
-  ? {}
-  : { 'process.env.HERMES_DESKTOP_IS_PACKAGED': JSON.stringify(true) }
 
-// Bundle main.ts → dist/electron-main.mjs
-await build({
-  entryPoints: [mainEntry],
-  bundle: true,
-  platform: 'node',
-  format: 'esm',
-  target: 'node20',
-  outfile: mainOut,
-  external,
-  banner: {
-    js: "import { createRequire } from 'module'; const require = createRequire(import.meta.url);",
-  },
-  define,
-  logLevel: 'info',
-})
-console.log(`bundled ${mainOut}${isDev ? ' (dev)' : ''}`)
-
-// Bundle preload.ts → dist/electron-preload.js
-await build({
-  entryPoints: [preloadEntry],
-  bundle: true,
-  platform: 'node',
-  format: 'cjs',
-  target: 'node20',
-  outfile: preloadOut,
-  external,
-  define,
-  logLevel: 'info',
-})
-console.log(`bundled ${preloadOut}${isDev ? ' (dev)' : ''}`)
+for (const options of electronBundleOptions(root, { isDev })) {
+  await build({ ...options, logLevel: 'info' })
+  console.log(`bundled ${options.outfile}${isDev ? ' (dev)' : ''}`)
+}

--- a/apps/desktop/scripts/electron-bundle-options.mjs
+++ b/apps/desktop/scripts/electron-bundle-options.mjs
@@ -1,0 +1,48 @@
+// electron-bundle-options.mjs — the esbuild options for the Electron main and
+// preload bundles, shared by bundle-electron-main.mjs (which writes them) and
+// assert-root-install.mjs (which resolves them in memory before a build), so the
+// pre-build check sees exactly the entrypoints, externals and settings the real
+// bundle uses.
+import { resolve } from 'node:path'
+
+// `electron` and `node-pty` are external (provided by the runtime / staged
+// separately via stage-native-deps).
+export const ELECTRON_EXTERNALS = ['electron', 'node-pty', 'get-windows', 'fs']
+
+export function electronBundleOptions(appDir, { isDev = false } = {}) {
+  const distDir = resolve(appDir, 'dist')
+  // Production bundles bake packaged=true so unpackaged `electron .` still
+  // behaves like a packaged build. Dev bundles (`--dev`) leave the env alone
+  // so HERMES_DESKTOP_DEV_SERVER / source-tree resolution keep working.
+  const define = isDev
+    ? {}
+    : { 'process.env.HERMES_DESKTOP_IS_PACKAGED': JSON.stringify(true) }
+
+  return [
+    // main.ts → dist/electron-main.mjs
+    {
+      entryPoints: [resolve(appDir, 'electron/main.ts')],
+      bundle: true,
+      platform: 'node',
+      format: 'esm',
+      target: 'node20',
+      outfile: resolve(distDir, 'electron-main.mjs'),
+      external: ELECTRON_EXTERNALS,
+      banner: {
+        js: "import { createRequire } from 'module'; const require = createRequire(import.meta.url);",
+      },
+      define,
+    },
+    // preload.ts → dist/electron-preload.js
+    {
+      entryPoints: [resolve(appDir, 'electron/preload.ts')],
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: 'node20',
+      outfile: resolve(distDir, 'electron-preload.js'),
+      external: ELECTRON_EXTERNALS,
+      define,
+    },
+  ]
+}

--- a/hermes_cli/main_web_build.py
+++ b/hermes_cli/main_web_build.py
@@ -325,6 +325,11 @@ def _run_npm_install_deterministic(
     ``package-lock.json``. Without it, an out-of-sync lockfile gets rewritten by the fallback, which drifts
     the committed lockfile and makes every future ``npm ci`` fail — a self-reinforcing cycle where web
     devDeps never install and a stale dist is served on every update (PR #65595).
+
+    ``npm ci`` also pins ``--legacy-peer-deps=false``. The lockfile already resolved every peer, but a
+    ``legacy-peer-deps=true`` left in the user's ``~/.npmrc`` (the usual ERESOLVE workaround, e.g. #75503)
+    makes ``npm ci`` skip those peers and exit 0 over a tree the desktop build cannot finish. Only the
+    lockfile path is pinned: the ``npm install`` fallback re-resolves, so it keeps honouring that workaround.
     """
     # CI=1 no-ops unicode-animations' postinstall that animates to /dev/tty.
     run_env = _npm_lifecycle_env(env)
@@ -335,7 +340,7 @@ def _run_npm_install_deterministic(
                 [npm_exe, *args, "--include=dev", *extra_args], cwd=cwd, env=run_env, capture_output=capture_output,
             )
         if (cwd / "package-lock.json").exists():
-            ci_result = _run(["ci"])
+            ci_result = _run(["ci", "--legacy-peer-deps=false"])
             if ci_result.returncode == 0:
                 return ci_result
         return _run(["install", "--no-save"])

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -146,10 +146,29 @@ class TestBuildWebUISkipsWhenFresh:
         args, kwargs = mock_run.call_args
         assert "--workspace" not in args[0]
         assert Path(args[0][0]).name in {"npm", "npm.cmd"}
-        assert args[0][1:] == ["ci", "--include=dev", "--silent", "--prefer-offline"]
+        assert args[0][1:] == ["ci", "--legacy-peer-deps=false", "--include=dev", "--silent", "--prefer-offline"]
         assert kwargs["cwd"] == web_dir
         assert "ESBUILD_BINARY_PATH" not in kwargs["env"]
         assert "ESBUILD_BINARY_PATH" not in mock_build.call_args.kwargs["env"]
+
+    def test_ci_pins_legacy_peer_deps_off_but_install_fallback_does_not(self, tmp_path):
+        """A ``legacy-peer-deps=true`` left in ~/.npmrc makes ``npm ci`` skip the peers the
+        lockfile resolved and exit 0 over a tree the build cannot finish, so ``ci`` pins it
+        off. The ``npm install`` fallback re-resolves and must keep honouring the user's
+        setting — it is the documented ERESOLVE workaround (#75503)."""
+        (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
+        failed = __import__("subprocess").CompletedProcess([], 1, stdout="", stderr="")
+        ok = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+        with patch(
+            "hermes_cli.main_web_build._run_npm_watching_for_engine_failure", side_effect=[failed, ok]
+        ) as mock_npm:
+            result = _run_npm_install_deterministic("npm", tmp_path)
+
+        assert result.returncode == 0
+        ci_argv, install_argv = (call.args[0] for call in mock_npm.call_args_list)
+        assert ci_argv[:3] == ["npm", "ci", "--legacy-peer-deps=false"]
+        assert install_argv[:3] == ["npm", "install", "--no-save"]
+        assert not any("legacy-peer-deps" in arg for arg in install_argv)
 
     def test_workspace_root_install_names_update_closure(self, tmp_path, monkeypatch):
         """From the workspace root, _build_web_ui must install the SAME


### PR DESCRIPTION
## What does this PR do?

Two pieces of leftover package-manager config in a user's home directory can break `hermes desktop` for that OS user only. A fresh OS user on the same machine installs fine, so the failure looks random. This PR makes the lockfile install ignore the first one and makes the build name the second.

1. **`legacy-peer-deps=true` in `~/.npmrc`.** This is the workaround suggested for ERESOLVE failures (e.g. #75503), and it tends to stay behind. `npm ci` honours it and skips peer dependencies that `package-lock.json` already resolved. On the current lockfile, a dry run with that setting would **remove 82 packages** from a complete install. The command still exits 0, so the missing packages only surface later in the build.
2. **A stray Yarn Plug'n'Play manifest above the repo** (e.g. `~/.pnp.cjs` left by running `yarn` in a home directory). esbuild switches to PnP resolution for any `.pnp.cjs` / `.pnp.js` / `.pnp.data.json` in *any* ancestor directory. `bundle-electron-main.mjs` then fails with `Could not resolve "simple-git"` over a complete npm install. The only hint is `../../../../.pnp.cjs` deep in the esbuild output. The CLI then suggests the Electron download may be blocked, which points people in the wrong direction.

## Related Issue

No existing issue covers this. #75503 is where the `legacy-peer-deps` workaround comes from. The user-facing symptom is "desktop install works under a fresh macOS user but fails under my main account".

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main_web_build.py`: `_run_npm_install_deterministic` runs `npm ci --legacy-peer-deps=false`. A CLI flag beats every npmrc level. Only the lockfile path is pinned: the `npm install --no-save` fallback re-resolves the tree, so it still honours a user's `legacy-peer-deps` workaround. The docstring explains the split.
- `apps/desktop/scripts/electron-bundle-options.mjs` (new): the esbuild options for the Electron main and preload bundles. `bundle-electron-main.mjs` now builds from it, and its `dist/` output is byte-identical to before (production and `--dev`).
- `apps/desktop/scripts/assert-root-install.mjs`: new `checkPnpResolution()`, run from `prebuild`/`build` after `checkRootInstall()`, before anything is cleaned or bundled.
  - `findPnpManifest()` is only a cheap pre-filter: it looks for any path named like a PnP manifest from the app directory upward. Builds without one skip the check.
  - When one exists, the check runs the real Electron bundles from those shared options in memory (`write: false`, `absWorkingDir` set to the app directory). This way a manifest that lists some bundle dependencies but omits others is still caught.
  - It fails only when esbuild reports a Plug'n'Play error, and names every blocked package plus the manifest esbuild used. Empty files, directories, unrelated same-name files and corrupt manifests pass through, and the build reports any other error itself.
- Tests:
  - `tests/hermes_cli/test_web_ui_build.py`:
    - `npm ci` carries the flag and the `npm install` fallback doesn't.
    - The existing exact-argv assertion is updated.
  - `apps/desktop/scripts/assert-root-install.test.mjs` runs the real esbuild resolver against a nested workspace with a hoisted package:
    - A valid `.pnp.data.json` and a valid `.pnp.cjs` above the repo fail, and the error includes the manifest path.
    - A partial manifest that declares one bundle dependency but omits another fails and names only the omitted package.
    - An empty `.pnp.cjs`, a `.pnp.cjs` directory, an unrelated `.pnp.js` and a corrupt `.pnp.data.json` do not block.
    - With no manifest at all, the check passes.
    - The real main/preload entrypoints in `electron-bundle-options.mjs` exist.

## How to Test

1. **legacy-peer-deps:** with a complete install, run `NPM_CONFIG_USERCONFIG=<file containing legacy-peer-deps=true> npm ci --dry-run` at the repo root. It reports `removed 82 packages`. `npm ci --legacy-peer-deps=false --dry-run` with the same userconfig reports `up to date`.
2. **PnP:** put a *real* PnP manifest in a parent folder of the checkout. For example, write the `PNP_STATE` JSON from `assert-root-install.test.mjs` to `../.pnp.data.json`, or run `yarn` (Berry) in an empty parent folder. Then `cd apps/desktop && npm run build`.
   - Before this change, esbuild fails with `Could not resolve "simple-git"`.
   - After, `assert-root-install` exits 1 immediately and names the manifest.
   - With an empty `.pnp.cjs`, a directory or an unrelated file of that name, the guard passes and the build succeeds, matching esbuild.
   - Remove the manifest and the build succeeds.
3. **Tests:** `scripts/run_tests.sh tests/hermes_cli/test_web_ui_build.py` and `cd apps/desktop && npx vitest run scripts/assert-root-install.test.mjs`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] Tests pass for the touched areas:
  - `tests/hermes_cli/test_web_ui_build.py`, `test_tui_npm_install.py`, `test_gui_command.py`, `test_cmd_update.py` and `test_desktop_exe_integrity.py` (see the How to Test commands).
  - `assert-root-install.test.mjs`: 22 passed.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26 (Apple Silicon). Reproduced both failures, and `hermes desktop --build-only` succeeds once they're addressed.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (docstring/comments updated in place)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact. The npm flag is platform-neutral; the PnP walk uses `path.dirname` up to the filesystem root, so it terminates on Windows drive roots too.


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
