### PR TITLE
docs(browser): document the macOS Chrome identity collision and recovery

### DIFF
--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -242,6 +242,22 @@ losing unsaved tabs), then retries. If the profile is still locked after that
 to fully quit the browser — it won't loop or kill again on its own.
 :::
 
+:::warning macOS: the snapshot browser can block opening Chrome
+While a snapshot browser is alive, macOS sees it as a running Chrome instance
+(it uses your real Chrome binary — above), and LaunchServices can't tell it
+apart from your visible Chrome. Clicking Chrome in the Dock, or opening a Chrome
+link from another app, can then be a **silent no-op** — no window, no dialog,
+no error. To get a visible window right away, force a separate instance:
+
+```bash
+open -na "Google Chrome"
+```
+
+This macOS Chrome bundle-identity collision is tracked in
+[#33155](https://github.com/NousResearch/hermes-agent/issues/33155) and
+[#108387](https://github.com/NousResearch/hermes-agent/issues/108387).
+:::
+
 - **Supported browsers:** Chrome, Edge, Brave, Brave Origin, Chromium (whichever is your OS
   default). A non-Chromium default (e.g. Firefox) fails closed with a clear
   message rather than guessing.


### PR DESCRIPTION
## What does this PR do?

Documents the macOS Chrome bundle-identity collision that a real-profile session
can trigger, with the immediate recovery, so users who hit it have a next step
instead of a dead end.

While a real-profile snapshot browser is alive it runs the user's real
`Google Chrome.app` bundle headless; macOS LaunchServices then treats "Google
Chrome" as running and routes Dock clicks / external link-opens into the
invisible instance — a silent no-op: no window, no error. The structural fix is
a pending maintainer decision (see #33155); this PR implements the
guardrail/docs direction requested in #108387 ("a short warning + recovery line
would cover most users").

## Related Issue

Refs #108387 (guardrail direction) and #33155 (canonical needs-decision thread).
Deliberately not "Fixes": the collision itself stays open pending the
guardrail-vs-structural decision, and the lifecycle leaks are covered by the
open browser PRs (#100998 / #103595 / #104010).

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `website/docs/user-guide/features/browser.md` — adds a `:::warning` block to
  the "Real profile browsing" section (next to the existing Windows lock note):
  the symptom (silent Dock no-op / blocked link-open while a snapshot browser
  runs), the `open -na "Google Chrome"` recovery, and links to #33155 / #108387.

## How to Test

1. Open `website/docs/user-guide/features/browser.md` → "Real profile browsing
   (use your own logins)": the new warning reads between the Windows `:::note`
   block and the bullets. The site builds cleanly (`npm run build:fast` in
   `website/`, covered in CI by `docs-site-checks.yml`).
2. Content check against the referenced issues: the silent no-op on Dock click /
   link open and the `open -na` recovery are exactly what #108387 verifies live
   on macOS.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — no other PR documents this collision; the open browser PRs cover adjacent defects only (#108402 close-profile false-success, #100998 / #103595 / #104010 lifecycle)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] N/A — docs-only change; no code paths touched, so no pytest run applies
- [x] N/A — docs-only change (no tests to add)
- [x] I've tested on my platform: macOS 26.6.2 / Chrome 152 — the silent no-op was reproduced there (real-profile snapshot browser alive → clicking Chrome opens no window) and normal opening returns once the snapshot browser is stopped; `open -na "Google Chrome"` is the verified recovery

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — this PR *is* the documentation update
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — the note is explicitly macOS-scoped and sits next to the existing Windows note
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
