### PR TITLE
fix(bot-screen): harden credentials and private viewer control

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/i18n.ts
+++ b/apps/desktop/src/plugins/hermes-bots/i18n.ts
@@ -263,8 +263,6 @@ type BotsMessages = {
     reconnect: string
     takeOver: string
     handBack: string
-    handBackForce: string
-    handBackForceHint: string
     openNeedsUpdate: string
     youControl: string
     otherControls: string
@@ -535,8 +533,6 @@ const en: BotsMessages = {
     reconnect: 'Reconnect',
     takeOver: 'Take over',
     handBack: 'Hand back',
-    handBackForce: 'Hand back (force)',
-    handBackForceHint: 'Release a lease held by a viewer that is no longer here, e.g. after a reload.',
     openNeedsUpdate: 'Update Hermes Desktop to open bot screens.',
     youControl: 'You are in control',
     otherControls: 'Another viewer is in control',
@@ -802,8 +798,6 @@ const ja: BotsMessages = {
     reconnect: '再接続',
     takeOver: '引き継ぐ',
     handBack: '戻す',
-    handBackForce: '強制的に戻す',
-    handBackForceHint: 'もう存在しないビューア（再読み込み後など）が保持しているリースを解放します。',
     openNeedsUpdate: 'ボットの画面を開くには Hermes Desktop を更新してください。',
     youControl: 'あなたが操作中',
     otherControls: '別のビューアが操作中',
@@ -1064,8 +1058,6 @@ const zh: BotsMessages = {
     reconnect: '重新连接',
     takeOver: '接管',
     handBack: '交还',
-    handBackForce: '强制交还',
-    handBackForceHint: '释放已不在场的查看者（例如重新加载后）持有的控制权。',
     openNeedsUpdate: '更新 Hermes Desktop 以打开机器人屏幕。',
     youControl: '你正在控制',
     otherControls: '另一位查看者正在控制',
@@ -1326,8 +1318,6 @@ const zhHant: BotsMessages = {
     reconnect: '重新連線',
     takeOver: '接手',
     handBack: '交還',
-    handBackForce: '強制交還',
-    handBackForceHint: '釋放已不在場的檢視者（例如重新載入後）持有的控制權。',
     openNeedsUpdate: '更新 Hermes Desktop 以開啟機器人螢幕。',
     youControl: '你正在控制',
     otherControls: '另一位檢視者正在控制',

--- a/apps/desktop/src/plugins/hermes-bots/screen-connection.ts
+++ b/apps/desktop/src/plugins/hermes-bots/screen-connection.ts
@@ -55,15 +55,52 @@ export interface DisplayObserveResult extends DisplayStatus {
   path: string
   /** Server-minted per attach: the only id the lease will ever be compared against. */
   viewer_id: string
+  /** Client-only capability that recovers this viewer after a renderer/WebSocket reload. */
+  resume_token: string
 }
 
 /** This window's identity for one attach: the minted id plus its lease-payload hash. */
 export interface ScreenViewer {
   id: string
   hash: string
+  resumeToken: string
 }
 
 const VIEWER_HASH_HEX = 12
+const VIEWER_CAPABILITY_PREFIX = 'hermes.desktop.bot-screen-viewer.v1:'
+
+function viewerCapabilityKey(bot: RosterRow): string {
+  const route = botConnectionRoute(bot)
+  const scope = route ? `${route.connectionId}\u0000${route.profile}` : `local\u0000${bot.name}`
+
+  return `${VIEWER_CAPABILITY_PREFIX}${encodeURIComponent(scope)}`
+}
+
+export function storedScreenViewerCapability(bot: RosterRow): { id: string; resumeToken: string } | null {
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(viewerCapabilityKey(bot)) ?? 'null') as unknown
+
+    if (!parsed || typeof parsed !== 'object') {
+      return null
+    }
+
+    const { id, resumeToken } = parsed as { id?: unknown; resumeToken?: unknown }
+
+    return typeof id === 'string' && id.length >= 16 && typeof resumeToken === 'string' && resumeToken.length >= 32
+      ? { id, resumeToken }
+      : null
+  } catch {
+    return null
+  }
+}
+
+export function rememberScreenViewerCapability(bot: RosterRow, viewer: Pick<ScreenViewer, 'id' | 'resumeToken'>): void {
+  try {
+    window.localStorage.setItem(viewerCapabilityKey(bot), JSON.stringify(viewer))
+  } catch {
+    // Recovery remains available in this renderer's screen state when storage is unavailable.
+  }
+}
 
 /** `viewer_hash` as the lease broadcasts it: first 12 hex of sha256(viewer_id). */
 export async function viewerHash(viewerId: string): Promise<string> {
@@ -159,9 +196,13 @@ export async function resolveScreenWsUrl(bot: RosterRow, ticket: string): Promis
   // the bridge authenticates on the ticket alone, so the gateway credential is
   // dropped rather than spending a second one-shot ticket.
   const url = new URL(
-    await resolveSiblingWsUrl({ connectionId: route?.connectionId ?? null, profile: route?.profile ?? bot.name }, '/api/display/ws', {
-      stripGatewayCredential: true
-    })
+    await resolveSiblingWsUrl(
+      { connectionId: route?.connectionId ?? null, profile: route?.profile ?? bot.name },
+      '/api/display/ws',
+      {
+        stripGatewayCredential: true
+      }
+    )
   )
 
   url.searchParams.set('display_ticket', ticket)

--- a/apps/desktop/src/plugins/hermes-bots/screen-pane-lifecycle.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/screen-pane-lifecycle.test.tsx
@@ -117,7 +117,12 @@ beforeEach(() => {
   retention.held = 0
   vi.mocked(displayRequest)
     .mockReset()
-    .mockResolvedValue({ ...status, ticket: 'test-ticket', viewer_id: 'this-viewer' })
+    .mockResolvedValue({
+      ...status,
+      ticket: 'test-ticket',
+      viewer_id: 'this-viewer',
+      resume_token: 'resume-token-with-at-least-thirty-two-characters'
+    })
   vi.stubGlobal(
     'WebSocket',
     class {

--- a/apps/desktop/src/plugins/hermes-bots/screen-pane.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/screen-pane.tsx
@@ -15,7 +15,20 @@ import type { RpcEvent } from '@hermes/plugin-sdk'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { useBots } from './i18n'
-import { type DisplayLease, type DisplayObserveResult, displayRequest, type DisplayStatus, isDisplayUnavailable, isEventForBotScreen, leaseHeldBy, resolveScreenWsUrl, retainBotScreen, viewerHash } from './screen-connection'
+import {
+  type DisplayLease,
+  type DisplayObserveResult,
+  displayRequest,
+  type DisplayStatus,
+  isDisplayUnavailable,
+  isEventForBotScreen,
+  leaseHeldBy,
+  rememberScreenViewerCapability,
+  resolveScreenWsUrl,
+  retainBotScreen,
+  storedScreenViewerCapability,
+  viewerHash
+} from './screen-connection'
 import { ScreenInstallCard } from './screen-install'
 import { $screenState, screenStateFor, setScreenLease, setScreenStatus, setScreenUnavailable, setScreenViewer } from './screen-state'
 import type { RosterRow } from './types'
@@ -131,8 +144,21 @@ export function BotScreenPane({ bot }: { bot: RosterRow }) {
       }
 
       retention.current = retain
-      const observe = await displayRequest<DisplayObserveResult>(bot, 'display.observe')
-      const minted = { id: observe.viewer_id, hash: await viewerHash(observe.viewer_id) }
+      const recovery = viewer ?? storedScreenViewerCapability(bot)
+
+      const observe = await displayRequest<DisplayObserveResult>(
+        bot,
+        'display.observe',
+        recovery ? { viewer_id: recovery.id, resume_token: recovery.resumeToken } : {}
+      )
+
+      const minted = {
+        id: observe.viewer_id,
+        hash: await viewerHash(observe.viewer_id),
+        resumeToken: observe.resume_token
+      }
+
+      rememberScreenViewerCapability(bot, minted)
       setScreenStatus(bot, observe)
       const url = await resolveScreenWsUrl(bot, observe.ticket)
 
@@ -194,7 +220,7 @@ export function BotScreenPane({ bot }: { bot: RosterRow }) {
         setError(err instanceof Error ? err.message : String(err))
       }
     }
-  }, [bot, detach, refresh, t.screen.streamLost])
+  }, [bot, detach, refresh, t.screen.streamLost, viewer])
 
   // Visibility is not lifecycle: the stream stays attached while the pane is
   // hidden; only unmount tears it down (and hands control back server-side).
@@ -234,7 +260,10 @@ export function BotScreenPane({ bot }: { bot: RosterRow }) {
     setBusy(true)
 
     try {
-      const result = await displayRequest<{ lease: DisplayLease }>(bot, 'display.lease.acquire', { viewer_id: viewer?.id })
+      const result = await displayRequest<{ lease: DisplayLease }>(bot, 'display.lease.acquire', {
+        viewer_id: viewer?.id
+      })
+
       setScreenLease(bot, result.lease)
 
       if (conn !== 'live') {
@@ -247,25 +276,21 @@ export function BotScreenPane({ bot }: { bot: RosterRow }) {
     }
   }, [attach, bot, conn, viewer?.id])
 
-  // `force` is the escape hatch for a lease this window no longer owns (a reload
-  // minted a fresh viewer id; the old one still holds): the server refuses a
-  // plain release from anyone but the holder.
-  const handBack = useCallback(
-    async (force = false) => {
-      setBusy(true)
+  const handBack = useCallback(async () => {
+    setBusy(true)
 
-      try {
-        const params = force ? { force: true } : { viewer_id: viewer?.id }
-        const result = await displayRequest<{ lease: DisplayLease }>(bot, 'display.lease.release', params)
-        setScreenLease(bot, result.lease)
-      } catch (err) {
-        setError(err instanceof Error ? err.message : String(err))
-      } finally {
-        setBusy(false)
-      }
-    },
-    [bot, viewer?.id]
-  )
+    try {
+      const result = await displayRequest<{ lease: DisplayLease }>(bot, 'display.lease.release', {
+        viewer_id: viewer?.id
+      })
+
+      setScreenLease(bot, result.lease)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBusy(false)
+    }
+  }, [bot, viewer?.id])
 
   if (state?.unavailable) {
     return <EmptyState description={t.screen.portalUnavailable} title={t.screen.unavailableTitle} />
@@ -325,13 +350,8 @@ export function BotScreenPane({ bot }: { bot: RosterRow }) {
           <Button disabled={busy} onClick={() => void handBack()} size="sm" variant="secondary">
             <Codicon name="debug-continue" /> {t.screen.handBack}
           </Button>
-        ) : (
+        ) : humanOther ? null : (
           <>
-            {humanOther ? (
-              <Button disabled={busy} onClick={() => void handBack(true)} size="sm" title={t.screen.handBackForceHint} variant="secondary">
-                <Codicon name="debug-continue" /> {t.screen.handBackForce}
-              </Button>
-            ) : null}
             <Button disabled={busy || conn === 'attaching'} onClick={() => void takeOver()} size="sm">
               <Codicon name="record-keys" /> {t.screen.takeOver}
             </Button>

--- a/apps/desktop/src/plugins/hermes-bots/screen-viewer-identity.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/screen-viewer-identity.test.tsx
@@ -35,8 +35,6 @@ vi.mock('./i18n', () => ({
       otherControls: 'Other controls',
       agentControls: 'Bot controls',
       handBack: 'Hand back',
-      handBackForce: 'Hand back (force)',
-      handBackForceHint: 'Force',
       takeOver: 'Take over',
       reconnect: 'Reconnect',
       streamLost: 'Stream lost'
@@ -61,12 +59,13 @@ vi.mock('@novnc/novnc', () => ({
 // eslint-disable-next-line no-restricted-imports
 import { emitGatewayEvent } from '../../contrib/events'
 
-import { displayRequest, viewerHash } from './screen-connection'
+import { displayRequest, rememberScreenViewerCapability, viewerHash } from './screen-connection'
 import { BotScreenPane } from './screen-pane'
 import { $screenState } from './screen-state'
 
 const bot: RosterRow = { name: 'default' }
-const MINTED = 'srv-viewer-0001'
+const MINTED = 'srv-viewer-00001'
+const RESUME_TOKEN = 'resume-token-with-at-least-thirty-two-characters'
 
 const status: DisplayStatus = {
   profile: 'default',
@@ -84,11 +83,14 @@ const status: DisplayStatus = {
 }
 
 beforeEach(() => {
+  window.localStorage.clear()
   $screenState.set({})
   vi.mocked(displayRequest)
     .mockReset()
     .mockImplementation(async (_bot, method) =>
-      method === 'display.observe' ? { ...status, ticket: 'test-ticket', viewer_id: MINTED } : status
+      method === 'display.observe'
+        ? { ...status, ticket: 'test-ticket', viewer_id: MINTED, resume_token: RESUME_TOKEN }
+        : status
     )
   vi.stubGlobal(
     'WebSocket',
@@ -111,7 +113,7 @@ const emitLease = (viewer_hash: string) =>
 
 it('holds control when the lease names the hash of the server-minted viewer id, not when it names another', async () => {
   const view = render(<BotScreenPane bot={bot} />)
-  await waitFor(() => expect(vi.mocked(displayRequest)).toHaveBeenCalledWith(bot, 'display.observe'))
+  await waitFor(() => expect(vi.mocked(displayRequest)).toHaveBeenCalledWith(bot, 'display.observe', {}))
   await act(async () => {})
 
   emitLease(await viewerHash('someone-else'))
@@ -125,7 +127,7 @@ it('holds control when the lease names the hash of the server-minted viewer id, 
 
 it('hands back with the minted id, never a client-generated one', async () => {
   const view = render(<BotScreenPane bot={bot} />)
-  await waitFor(() => expect(vi.mocked(displayRequest)).toHaveBeenCalledWith(bot, 'display.observe'))
+  await waitFor(() => expect(vi.mocked(displayRequest)).toHaveBeenCalledWith(bot, 'display.observe', {}))
   await act(async () => {})
   emitLease(await viewerHash(MINTED))
 
@@ -136,18 +138,26 @@ it('hands back with the minted id, never a client-generated one', async () => {
   view.unmount()
 })
 
-it('offers a forced hand-back for a human lease this window does not hold, sending {force: true} and no viewer id', async () => {
+it('does not offer takeover or forced release for a lease held by another viewer', async () => {
   const view = render(<BotScreenPane bot={bot} />)
-  await waitFor(() => expect(vi.mocked(displayRequest)).toHaveBeenCalledWith(bot, 'display.observe'))
+  await waitFor(() => expect(vi.mocked(displayRequest)).toHaveBeenCalledWith(bot, 'display.observe', {}))
   await act(async () => {})
 
-  emitLease(await viewerHash(MINTED))
-  expect(view.queryByText('Hand back (force)')).toBeNull()
-
   emitLease(await viewerHash('viewer-from-before-the-reload'))
-  await act(async () => {
-    view.getByText('Hand back (force)').click()
-  })
-  expect(vi.mocked(displayRequest)).toHaveBeenCalledWith(bot, 'display.lease.release', { force: true })
+  expect(view.queryByText('Hand back')).toBeNull()
+  expect(view.queryByText('Take over')).toBeNull()
+  view.unmount()
+})
+
+it('presents the client-only recovery capability after a renderer reload', async () => {
+  rememberScreenViewerCapability(bot, { id: MINTED, resumeToken: RESUME_TOKEN })
+  const view = render(<BotScreenPane bot={bot} />)
+
+  await waitFor(() =>
+    expect(vi.mocked(displayRequest)).toHaveBeenCalledWith(bot, 'display.observe', {
+      viewer_id: MINTED,
+      resume_token: RESUME_TOKEN
+    })
+  )
   view.unmount()
 })

--- a/hermes_cli/web_routers/display.py
+++ b/hermes_cli/web_routers/display.py
@@ -15,7 +15,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Optional
+import threading
+from typing import Callable, Optional
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
@@ -32,25 +33,38 @@ _CLOSE_BAD_TICKET = 4401
 _CLOSE_NOT_ALLOWED = 4403
 _CLOSE_PROTOCOL = 1003
 _LEASE_REFRESH_S = 0.25
+_active_viewers_lock = threading.Lock()
+_active_viewers: dict[str, tuple[object, Callable[[], None]]] = {}
 
 
-def _should_evict(held: dict, lease, viewer_id: str) -> bool:
-    """A viewer that held control during this connection and lost it to ANOTHER human is kicked so its
-    UI repaints; a plain hand-back to the agent, pure watchers and the new holder stay connected. The
-    hand-back also forgets that this viewer ever held: after it, they are a plain watcher again and a
-    later takeover by someone else must not evict them. ``held`` is the per-connection memory."""
+def _claim_active_viewer(profile_key: str, evict: Callable[[], None]) -> object:
+    """Claim the one stream slot for a profile and evict its stale viewer, if any."""
+    token = object()
+    with _active_viewers_lock:
+        previous = _active_viewers.get(profile_key)
+        _active_viewers[profile_key] = (token, evict)
+    if previous is not None:
+        previous[1]()
+    return token
+
+
+def _release_active_viewer(profile_key: str, token: object) -> None:
+    with _active_viewers_lock:
+        current = _active_viewers.get(profile_key)
+        if current is not None and current[0] is token:
+            _active_viewers.pop(profile_key, None)
+
+
+def _should_evict(lease, viewer_id: str) -> bool:
+    """While a human holds control, only that viewer may observe the framebuffer."""
     from tools.bot_desktop import lease as _lease
-    if lease.holder != _lease.HUMAN:
-        held["ever"] = False
-        return False
-    if lease.viewer_id == viewer_id:
-        held["ever"] = True
-        return False
-    return bool(held["ever"])
+
+    return lease.holder == _lease.HUMAN and lease.viewer_id != viewer_id
 
 
 def _consume_display_ticket(ws: WebSocket) -> Optional[dict]:
     from hermes_cli.dashboard_auth.ws_tickets import TicketInvalid, consume_ticket
+
     ticket = ws.query_params.get("display_ticket", "")
     if not ticket:
         return None
@@ -86,6 +100,12 @@ async def _bridge(ws: WebSocket, info: dict) -> None:
     profile_home = str(info["hermes_home"])
     profile_key = hermes_home_key(profile_home)
     viewer_id = str(info.get("viewer_id") or info.get("user_id") or "viewer")
+    # A login session can legitimately mint more than one single-use display ticket (reconnects),
+    # so authentication alone cannot make takeover private. Refuse every non-holder here before it
+    # receives an initial framebuffer; the listener/poller below closes connections already open.
+    if _should_evict(_lease.get(profile_key=profile_home), viewer_id):
+        await ws.close(code=_CLOSE_CONTROL_TAKEN, reason="control-taken")
+        return
     if not sock.exists():
         await ws.close(code=_CLOSE_DESKTOP_GONE, reason="Bot Desktop is not running")
         return
@@ -99,11 +119,11 @@ async def _bridge(ws: WebSocket, info: dict) -> None:
     await ws.accept()
     loop = asyncio.get_running_loop()
     evicted = asyncio.Event()
-    held = {"ever": _lease.viewer_may_send_input(viewer_id, profile_key=profile_home)}
+    initially_allowed = _lease.viewer_may_send_input(viewer_id, profile_key=profile_home)
     # Input gate cache: reading lease.json per client message (a stat + read on the event loop for
     # every pointer move) is replaced by a decision refreshed on this process's on_change callback
     # and by a file re-read at most every _LEASE_REFRESH_S, so another process's takeover still lands.
-    allowed = {"input": held["ever"], "at": loop.time()}
+    allowed = {"input": initially_allowed, "at": loop.time()}
 
     def _refresh_allowed(lease=None) -> None:
         if lease is None:
@@ -120,9 +140,20 @@ async def _bridge(ws: WebSocket, info: dict) -> None:
         if key != profile_key:
             return
         loop.call_soon_threadsafe(_refresh_allowed, lease)
-        if _should_evict(held, lease, viewer_id):
+        if _should_evict(lease, viewer_id):
             loop.call_soon_threadsafe(evicted.set)
+
     unsubscribe = _lease.on_change(_on_lease)
+
+    # Close the admission/listener race: takeover may have happened after the first lease read but
+    # before this connection subscribed. This also refreshes the input decision from the same read.
+    current_lease = _lease.get(profile_key=profile_home)
+    _refresh_allowed(current_lease)
+    if _should_evict(current_lease, viewer_id):
+        unsubscribe()
+        writer.close()
+        await ws.close(code=_CLOSE_CONTROL_TAKEN, reason="control-taken")
+        return
 
     rfb_filter = RfbClientFilter(_may_send_input)
 
@@ -157,11 +188,24 @@ async def _bridge(ws: WebSocket, info: dict) -> None:
                 await writer.drain()  # backpressure toward the browser
 
     async def watch_eviction() -> None:
-        await evicted.wait()
+        # on_change is process-local. Polling also catches a takeover written by a separate Hermes
+        # process, which must stop framebuffer delivery—not merely block that viewer's input.
+        while not evicted.is_set():
+            if _should_evict(_lease.get(profile_key=profile_home), viewer_id):
+                evicted.set()
+                break
+            try:
+                await asyncio.wait_for(evicted.wait(), timeout=_LEASE_REFRESH_S)
+            except asyncio.TimeoutError:
+                pass
         await ws.close(code=_CLOSE_CONTROL_TAKEN, reason="control-taken")
 
-    tasks = [asyncio.create_task(rfb_to_ws()), asyncio.create_task(ws_to_rfb()),
-             asyncio.create_task(watch_eviction())]
+    viewer_slot = _claim_active_viewer(profile_key, lambda: loop.call_soon_threadsafe(evicted.set))
+    tasks = [
+        asyncio.create_task(rfb_to_ws()),
+        asyncio.create_task(ws_to_rfb()),
+        asyncio.create_task(watch_eviction()),
+    ]
     try:
         done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
         for t in pending:
@@ -171,6 +215,7 @@ async def _bridge(ws: WebSocket, info: dict) -> None:
             if exc and not isinstance(exc, (WebSocketDisconnect, ConnectionError)):
                 _log.debug("display ws ended: %r", exc)
     finally:
+        _release_active_viewer(profile_key, viewer_slot)
         unsubscribe()
         writer.close()
         # Closing the viewer window hands control back. A DROPPED link (laptop lid, Wi-Fi, 1006)

--- a/hermes_cli/web_routers/display.py
+++ b/hermes_cli/web_routers/display.py
@@ -62,6 +62,25 @@ def _should_evict(lease, viewer_id: str) -> bool:
     return lease.holder == _lease.HUMAN and lease.viewer_id != viewer_id
 
 
+async def _admit_active_viewer(
+    profile_key: str,
+    profile_home: str,
+    viewer_id: str,
+    evict: Callable[[], None],
+) -> Optional[tuple[object, object]]:
+    """Atomically validate the lease and bind its epoch to the profile's one viewer slot."""
+    from tools.bot_desktop import lease as _lease
+
+    # acquire/release use this same file lock. A takeover that wins first is therefore observed
+    # before the slot changes; a viewer that wins first is authorized to begin its pumps at that
+    # lease epoch and subsequent transitions reach the subscribed eviction callback below.
+    with _lease.locked_snapshot(profile_key=profile_home) as current_lease:
+        if _should_evict(current_lease, viewer_id):
+            return None
+        slot = _claim_active_viewer(profile_key, evict)
+        return slot, current_lease
+
+
 def _consume_display_ticket(ws: WebSocket) -> Optional[dict]:
     from hermes_cli.dashboard_auth.ws_tickets import TicketInvalid, consume_ticket
 
@@ -119,11 +138,10 @@ async def _bridge(ws: WebSocket, info: dict) -> None:
     await ws.accept()
     loop = asyncio.get_running_loop()
     evicted = asyncio.Event()
-    initially_allowed = _lease.viewer_may_send_input(viewer_id, profile_key=profile_home)
     # Input gate cache: reading lease.json per client message (a stat + read on the event loop for
     # every pointer move) is replaced by a decision refreshed on this process's on_change callback
     # and by a file re-read at most every _LEASE_REFRESH_S, so another process's takeover still lands.
-    allowed = {"input": initially_allowed, "at": loop.time()}
+    allowed = {"input": False, "at": loop.time()}
 
     def _refresh_allowed(lease=None) -> None:
         if lease is None:
@@ -145,15 +163,19 @@ async def _bridge(ws: WebSocket, info: dict) -> None:
 
     unsubscribe = _lease.on_change(_on_lease)
 
-    # Close the admission/listener race: takeover may have happened after the first lease read but
-    # before this connection subscribed. This also refreshes the input decision from the same read.
-    current_lease = _lease.get(profile_key=profile_home)
-    _refresh_allowed(current_lease)
-    if _should_evict(current_lease, viewer_id):
+    admission = await _admit_active_viewer(
+        profile_key,
+        profile_home,
+        viewer_id,
+        lambda: loop.call_soon_threadsafe(evicted.set),
+    )
+    if admission is None:
         unsubscribe()
         writer.close()
         await ws.close(code=_CLOSE_CONTROL_TAKEN, reason="control-taken")
         return
+    viewer_slot, admitted_lease = admission
+    _refresh_allowed(admitted_lease)
 
     rfb_filter = RfbClientFilter(_may_send_input)
 
@@ -200,7 +222,6 @@ async def _bridge(ws: WebSocket, info: dict) -> None:
                 pass
         await ws.close(code=_CLOSE_CONTROL_TAKEN, reason="control-taken")
 
-    viewer_slot = _claim_active_viewer(profile_key, lambda: loop.call_soon_threadsafe(evicted.set))
     tasks = [
         asyncio.create_task(rfb_to_ws()),
         asyncio.create_task(ws_to_rfb()),

--- a/tests/hermes_cli/test_display_ws_drop_keeps_lease.py
+++ b/tests/hermes_cli/test_display_ws_drop_keeps_lease.py
@@ -18,10 +18,12 @@ class _Ws:
 
     def __init__(self, close_code: int):
         self._code = close_code
+        self.accepted = False
         self.closed = False
+        self.closed_code = None
 
     async def accept(self):
-        pass
+        self.accepted = True
 
     async def receive(self):
         await asyncio.sleep(0.05)
@@ -31,6 +33,8 @@ class _Ws:
         pass
 
     async def close(self, code=1000, reason=""):
+        if not self.closed:
+            self.closed_code = code
         self.closed = True
 
 
@@ -64,17 +68,39 @@ def test_only_a_clean_viewer_close_hands_the_screen_back(monkeypatch, close_code
     assert (after.holder == lease.HUMAN) is human_keeps_control, after
 
 
-def test_ex_holder_who_handed_back_is_not_evicted_by_a_later_takeover():
-    """desk-1 holds, hands back to the agent, then desk-2 takes over: desk-1 is a plain watcher again
-    and must stay connected; only a takeover WHILE desk-1 held (or believed it held) kicks it."""
-    held = {"ever": False}
-    assert display._should_evict(held, lease.Lease(holder=lease.HUMAN, viewer_id="desk-1"), "desk-1") is False
-    assert display._should_evict(held, lease.Lease(holder=lease.AGENT), "desk-1") is False
-    assert display._should_evict(held, lease.Lease(holder=lease.HUMAN, viewer_id="desk-2"), "desk-1") is False
+def test_every_nonholder_is_evicted_during_human_takeover():
+    assert display._should_evict(lease.Lease(holder=lease.HUMAN, viewer_id="desk-1"), "desk-1") is False
+    assert display._should_evict(lease.Lease(holder=lease.AGENT), "desk-1") is False
+    assert display._should_evict(lease.Lease(holder=lease.HUMAN, viewer_id="desk-2"), "desk-1") is True
 
-    held = {"ever": False}
-    display._should_evict(held, lease.Lease(holder=lease.HUMAN, viewer_id="desk-1"), "desk-1")
-    assert display._should_evict(held, lease.Lease(holder=lease.HUMAN, viewer_id="desk-2"), "desk-1") is True
+
+def test_single_viewer_slots_are_scoped_per_bot_profile():
+    evicted = []
+    a1 = display._claim_active_viewer("bot-a", lambda: evicted.append("a1"))
+    b1 = display._claim_active_viewer("bot-b", lambda: evicted.append("b1"))
+    a2 = display._claim_active_viewer("bot-a", lambda: evicted.append("a2"))
+    try:
+        assert evicted == ["a1"]
+    finally:
+        display._release_active_viewer("bot-a", a1)
+        display._release_active_viewer("bot-a", a2)
+        display._release_active_viewer("bot-b", b1)
+
+
+def test_authenticated_reconnect_during_takeover_receives_no_framebuffer():
+    """A reusable login may mint another one-shot ticket; its non-holder viewer is still refused."""
+
+    async def _run(home: str) -> _Ws:
+        ws = _Ws(1000)
+        await display._bridge(ws, {"hermes_home": home, "viewer_id": "desk-1"})
+        return ws
+
+    lease._reset_for_tests()
+    with tempfile.TemporaryDirectory() as home:
+        lease.acquire("desk-2", profile_key=home)
+        ws = asyncio.run(_run(home))
+    lease._reset_for_tests()
+    assert ws.closed_code == display._CLOSE_CONTROL_TAKEN
 
 
 class _OpenWs(_Ws):
@@ -89,22 +115,67 @@ class _OpenWs(_Ws):
         return {"type": "websocket.disconnect", "code": self._code}
 
 
-def test_a_takeover_made_by_another_process_stops_input_within_the_refresh_interval(monkeypatch):
+def test_new_viewer_replaces_the_existing_stream_for_one_profile():
+    async def _run(home: str) -> tuple[_OpenWs, _OpenWs]:
+        sock_dir = os.path.join(home, "bot-desktop")
+        os.makedirs(sock_dir, exist_ok=True)
+
+        async def _xvnc(reader, writer):
+            await asyncio.sleep(2)
+            writer.close()
+
+        server = await asyncio.start_unix_server(_xvnc, path=os.path.join(sock_dir, "rfb.sock"))
+        first, second = _OpenWs(), _OpenWs()
+        first_task = asyncio.create_task(display._bridge(first, {"hermes_home": home, "viewer_id": "desk-1"}))
+        second_task = None
+        try:
+            while not first.accepted:
+                await asyncio.sleep(0.01)
+            second_task = asyncio.create_task(display._bridge(second, {"hermes_home": home, "viewer_id": "desk-2"}))
+            await asyncio.wait_for(first_task, timeout=2.0)
+            assert first.closed_code == display._CLOSE_CONTROL_TAKEN
+            return first, second
+        finally:
+            second.finish.set()
+            if second_task is not None:
+                await second_task
+            if not first_task.done():
+                first.finish.set()
+                await first_task
+            server.close()
+
+    lease._reset_for_tests()
+    with tempfile.TemporaryDirectory() as home:
+        first, second = asyncio.run(_run(home))
+    lease._reset_for_tests()
+    assert first.closed and second.accepted
+
+
+def test_a_takeover_made_by_another_process_evicts_within_the_refresh_interval(
+    monkeypatch,
+):
     """The bridge caches the input decision instead of reading lease.json per message; a takeover
     written by ANOTHER process (no in-process listener fires) must still be seen quickly."""
     from tools.bot_desktop import rfb_filter
+
     captured = {}
 
     class _Filter(rfb_filter.RfbClientFilter):
         def __init__(self, allow_input):
             super().__init__(allow_input)
             captured["allow"] = allow_input
+
     monkeypatch.setattr(rfb_filter, "RfbClientFilter", _Filter)
 
     async def _run(home: str) -> float:
         sock_dir = os.path.join(home, "bot-desktop")
         os.makedirs(sock_dir, exist_ok=True)
-        server = await asyncio.start_unix_server(lambda r, w: None, path=os.path.join(sock_dir, "rfb.sock"))
+
+        async def _xvnc(reader, writer):
+            await asyncio.sleep(2)
+            writer.close()
+
+        server = await asyncio.start_unix_server(_xvnc, path=os.path.join(sock_dir, "rfb.sock"))
         ws = _OpenWs()
         task = asyncio.create_task(display._bridge(ws, {"hermes_home": home, "viewer_id": "desk-1"}))
         try:
@@ -112,14 +183,21 @@ def test_a_takeover_made_by_another_process_stops_input_within_the_refresh_inter
                 await asyncio.sleep(0.01)
             assert captured["allow"]() is True
             # Another process takes over: the file changes, no listener in this process is told.
-            lease._write(lease._path(home), lease.Lease(holder=lease.HUMAN, viewer_id="desk-2", epoch=2))
+            lease._write(
+                lease._path(home),
+                lease.Lease(holder=lease.HUMAN, viewer_id="desk-2", epoch=2),
+            )
             t0 = asyncio.get_running_loop().time()
             while captured["allow"]() and asyncio.get_running_loop().time() - t0 < 2.0:
                 await asyncio.sleep(0.02)
-            return asyncio.get_running_loop().time() - t0
+            elapsed = asyncio.get_running_loop().time() - t0
+            await asyncio.wait_for(task, timeout=2.0)
+            assert ws.closed_code == display._CLOSE_CONTROL_TAKEN
+            return elapsed
         finally:
-            ws.finish.set()
-            await task
+            if not task.done():
+                ws.finish.set()
+                await task
             server.close()
 
     lease._reset_for_tests()

--- a/tests/hermes_cli/test_display_ws_drop_keeps_lease.py
+++ b/tests/hermes_cli/test_display_ws_drop_keeps_lease.py
@@ -115,6 +115,15 @@ class _OpenWs(_Ws):
         return {"type": "websocket.disconnect", "code": self._code}
 
 
+class _RecordingWs(_OpenWs):
+    def __init__(self):
+        super().__init__()
+        self.frames = []
+
+    async def send_bytes(self, data):
+        self.frames.append(data)
+
+
 def test_new_viewer_replaces_the_existing_stream_for_one_profile():
     async def _run(home: str) -> tuple[_OpenWs, _OpenWs]:
         sock_dir = os.path.join(home, "bot-desktop")
@@ -149,6 +158,69 @@ def test_new_viewer_replaces_the_existing_stream_for_one_profile():
         first, second = asyncio.run(_run(home))
     lease._reset_for_tests()
     assert first.closed and second.accepted
+
+
+def test_takeover_before_atomic_admission_cannot_evict_holder_or_send_framebuffer(monkeypatch):
+    """A stale reconnect paused at final admission must lose to a takeover that linearizes first."""
+
+    async def _run(home: str) -> tuple[_RecordingWs, _RecordingWs]:
+        sock_dir = os.path.join(home, "bot-desktop")
+        os.makedirs(sock_dir, exist_ok=True)
+
+        async def _xvnc(reader, writer):
+            writer.write(b"frame")
+            await writer.drain()
+            await asyncio.sleep(2)
+            writer.close()
+
+        server = await asyncio.start_unix_server(_xvnc, path=os.path.join(sock_dir, "rfb.sock"))
+        holder, stale = _RecordingWs(), _RecordingWs()
+        holder_task = asyncio.create_task(
+            display._bridge(holder, {"hermes_home": home, "viewer_id": "desk-holder"})
+        )
+        stale_task = None
+        try:
+            while not holder.frames:
+                await asyncio.sleep(0.01)
+
+            real_admit = display._admit_active_viewer
+            admission_reached = asyncio.Event()
+            continue_admission = asyncio.Event()
+
+            async def _paused_admit(*args, **kwargs):
+                admission_reached.set()
+                await continue_admission.wait()
+                return await real_admit(*args, **kwargs)
+
+            monkeypatch.setattr(display, "_admit_active_viewer", _paused_admit)
+            stale_task = asyncio.create_task(
+                display._bridge(stale, {"hermes_home": home, "viewer_id": "desk-stale"})
+            )
+            await asyncio.wait_for(admission_reached.wait(), timeout=1.0)
+
+            lease.acquire("desk-holder", profile_key=home)
+            continue_admission.set()
+            await asyncio.wait_for(stale_task, timeout=1.0)
+
+            assert stale.frames == []
+            assert stale.closed_code == display._CLOSE_CONTROL_TAKEN
+            assert not holder_task.done(), "the rejected stale viewer must not evict the valid holder"
+            return holder, stale
+        finally:
+            holder.finish.set()
+            stale.finish.set()
+            if not holder_task.done():
+                await holder_task
+            if stale_task is not None and not stale_task.done():
+                await stale_task
+            server.close()
+
+    lease._reset_for_tests()
+    with tempfile.TemporaryDirectory() as home:
+        holder, stale = asyncio.run(_run(home))
+    lease._reset_for_tests()
+    assert holder.frames
+    assert stale.frames == []
 
 
 def test_a_takeover_made_by_another_process_evicts_within_the_refresh_interval(

--- a/tests/tools/test_bot_desktop_install.py
+++ b/tests/tools/test_bot_desktop_install.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import io
+import os
 import threading
 
 import pytest
@@ -12,9 +14,17 @@ from tools.bot_desktop import install, runtime
 @pytest.fixture(autouse=True)
 def _isolated_host(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setattr(install, "_sudo_nopasswd", lambda: False)
+    system_executables = {
+        "sudo": "/usr/bin/sudo",
+        "apt-get": "/usr/bin/apt-get",
+        "dnf": "/usr/bin/dnf",
+        "pacman": "/usr/bin/pacman",
+    }
+    monkeypatch.setattr(runtime, "_system_executable", system_executables.get)
+    monkeypatch.setattr(install, "_sudo_nopasswd", lambda _sudo: False)
     monkeypatch.setattr(runtime, "is_supported_host", lambda: True)
-    monkeypatch.setattr(runtime, "install_command", lambda: "sudo apt-get install -y tigervnc-standalone-server")
+    monkeypatch.setattr(runtime, "install_command",
+                        lambda: "/usr/bin/sudo /usr/bin/apt-get install -y tigervnc-standalone-server")
     yield
     install._running.clear()
 
@@ -60,6 +70,39 @@ def test_claim_is_atomic_and_refuses_a_second_claim():
     install.release(key)
 
 
+def test_install_uses_absolute_executables_and_a_scrubbed_environment(monkeypatch):
+    captured = {}
+
+    class FakeProcess:
+        def __init__(self):
+            self.pid = os.getpid()
+            self.stdin = io.StringIO()
+            self.stdout: list[str] = []
+
+        @staticmethod
+        def wait():
+            return 0
+
+    def fake_popen(argv, **kwargs):
+        captured["argv"] = argv
+        captured["env"] = kwargs["env"]
+        return FakeProcess()
+
+    monkeypatch.setenv("PATH", "/home/user/.local/bin:/usr/bin")
+    monkeypatch.setenv("OPENAI_API_KEY", "must-not-leak")
+    monkeypatch.setattr(install.subprocess, "Popen", fake_popen)
+
+    command = "/usr/bin/sudo /usr/bin/apt-get install -y package"
+    assert install._run(command, ask_password=lambda: "password", on_line=lambda _line: None,
+                        timeout_seconds=1) == 0
+    assert captured["argv"][:5] == ["/usr/bin/sudo", "-S", "-p", "", "/usr/bin/apt-get"]
+    assert captured["env"] == {
+        "PATH": runtime._SYSTEM_PATH,
+        "DEBIAN_FRONTEND": "noninteractive",
+        "LC_ALL": "C.UTF-8",
+    }
+
+
 @pytest.mark.linux_only
 def test_timeout_kills_the_package_managers_whole_process_group(monkeypatch):
     """sudo forks the package manager into the same (new) session; killing sudo alone leaves apt/dnf
@@ -67,9 +110,9 @@ def test_timeout_kills_the_package_managers_whole_process_group(monkeypatch):
     import subprocess
     import time
 
-    monkeypatch.setattr(install, "_sudo_nopasswd", lambda: True)
+    monkeypatch.setattr(install, "_sudo_nopasswd", lambda _sudo: True)
     # stand-in for `sudo apt-get ...`: a parent that spawns a child and waits, both in the new session
-    fake = ["sudo"]
+    fake = ["/usr/bin/sudo"]
     real_popen = subprocess.Popen
 
     def popen(argv, **kw):
@@ -79,7 +122,8 @@ def test_timeout_kills_the_package_managers_whole_process_group(monkeypatch):
 
     monkeypatch.setattr(install.subprocess, "Popen", popen)
     lines: list[str] = []
-    code = install._run("sudo apt-get install -y x", ask_password=lambda: "", on_line=lines.append, timeout_seconds=0.5)
+    code = install._run("/usr/bin/sudo /usr/bin/apt-get install -y x",
+                        ask_password=lambda: "", on_line=lines.append, timeout_seconds=0.5)
     assert code != 0
     child = next(int(line.split()[1]) for line in lines if line.startswith("child "))
     from pathlib import Path

--- a/tests/tools/test_bot_desktop_launcher_seed.py
+++ b/tests/tools/test_bot_desktop_launcher_seed.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import xml.etree.ElementTree as ET
@@ -14,13 +15,22 @@ LAUNCHER = Path(__file__).resolve().parents[2] / "tools" / "bot_desktop" / "laun
 pytestmark = pytest.mark.linux_only
 
 
-def _seed(tmp_path: Path, fake_bins: list[str], browser_exec: str = "") -> Path:
+def _seed(tmp_path: Path, fake_bins: list[str], browser_exec: str = "",
+          xauth_probe: tuple[Path, Path] | None = None) -> Path:
     bindir = tmp_path / "bin"
     bindir.mkdir()
     for name in fake_bins:
         exe = bindir / name
         exe.write_text("#!/bin/sh\n", encoding="utf-8")
         exe.chmod(0o755)
+    if xauth_probe:
+        argv_log, stdin_log = xauth_probe
+        xauth = bindir / "xauth"
+        xauth.write_text(
+            f'#!/bin/sh\nprintf "%s\\n" "$@" > "{argv_log}"\ncat > "{stdin_log}"\n',
+            encoding="utf-8",
+        )
+        xauth.chmod(0o755)
     # The script's own tooling (mkdir, sed, cat, awk...) symlinked in, so PATH need not contain the
     # host's /usr/bin where a real chrome/thunar would leak into the dock under test.
     for tool in ("mkdir", "sed", "cat", "printf", "dirname", "bash", "sh", "rm", "ln", "touch", "chmod", "xauth", "od", "tr", "awk"):
@@ -39,6 +49,18 @@ def _seed(tmp_path: Path, fake_bins: list[str], browser_exec: str = "") -> Path:
     }
     subprocess.run(["bash", str(LAUNCHER)], env=env, check=True, stdin=subprocess.DEVNULL, capture_output=True, timeout=30)
     return cfg
+
+
+def test_xauthority_cookie_is_sent_on_stdin_not_process_arguments(tmp_path):
+    argv_log, stdin_log = tmp_path / "xauth-argv", tmp_path / "xauth-stdin"
+    _seed(tmp_path, [], xauth_probe=(argv_log, stdin_log))
+
+    assert argv_log.read_text(encoding="utf-8").splitlines() == [
+        "-q", "-f", str(tmp_path / "Xauthority")
+    ]
+    command = stdin_log.read_text(encoding="utf-8").split()
+    assert command[:3] == ["add", ":99", "MIT-MAGIC-COOKIE-1"]
+    assert len(command) == 4 and re.fullmatch(r"[0-9a-f]{32}", command[3])
 
 
 def test_dock_lists_only_programs_present_on_path(tmp_path):

--- a/tests/tools/test_bot_desktop_lease.py
+++ b/tests/tools/test_bot_desktop_lease.py
@@ -11,12 +11,12 @@ from tools.bot_desktop import lease
 from tools.bot_desktop.rfb_filter import RfbClientFilter
 
 _HANDSHAKE = b"RFB 003.008\n" + b"\x01" + b"\x00"
-_KEY = b"\x04\x01\x00\x00\x00\x00\x00\x61"          # KeyEvent 'a' down
+_KEY = b"\x04\x01\x00\x00\x00\x00\x00\x61"  # KeyEvent 'a' down
 # QEMU Extended KeyEvent (type 255, sub 0): what noVNC sends once Xvnc advertises the pseudo-encoding.
 _QEMU_KEY = bytes([255, 0, 0, 1]) + (0x65).to_bytes(4, "big") + (0x12).to_bytes(4, "big")
-_POINTER = b"\x05\x01\x00\x10\x00\x10"              # PointerEvent, button 1
-_CUT = b"\x06\x00\x00\x00\x00\x00\x00\x02hi"        # ClientCutText "hi"
-_FBUR = b"\x03\x00" + b"\x00" * 8                   # FramebufferUpdateRequest
+_POINTER = b"\x05\x01\x00\x10\x00\x10"  # PointerEvent, button 1
+_CUT = b"\x06\x00\x00\x00\x00\x00\x00\x02hi"  # ClientCutText "hi"
+_FBUR = b"\x03\x00" + b"\x00" * 8  # FramebufferUpdateRequest
 _SETENC = b"\x02\x00\x00\x02" + b"\x00\x00\x00\x07" + b"\xff\xff\xff\x21"  # SetEncodings x2
 
 
@@ -34,16 +34,17 @@ def test_rfb_filter_forwards_input_only_from_the_lease_holder_across_arbitrary_c
 
     # Agent holds: read-only messages pass, input is dropped, even when split byte by byte.
     stream = _KEY + _FBUR + _POINTER + _SETENC + _CUT + _QEMU_KEY
-    out = b"".join(f.feed(stream[i:i + 1]) for i in range(len(stream)))
+    out = b"".join(f.feed(stream[i : i + 1]) for i in range(len(stream)))
     assert out == _FBUR + _SETENC
 
     lease.acquire("v1")
     assert f.feed(_KEY + _POINTER + _QEMU_KEY) == _KEY + _POINTER + _QEMU_KEY
 
-    lease.acquire("v2")  # last writer wins: v1 is evicted from input on the very next message
-    assert f.feed(_KEY) == b""
-    assert lease.release("v1").holder == lease.HUMAN, "a stale viewer's release must not yank control from v2"
-    assert lease.release("v2").holder == lease.AGENT
+    with pytest.raises(lease.ViewerLeaseHeld):
+        lease.acquire("v2")
+    assert f.feed(_KEY) == _KEY, "a second viewer cannot steal the private holder's input lease"
+    assert lease.release("v2").holder == lease.HUMAN, "a foreign viewer cannot release the holder"
+    assert lease.release("v1").holder == lease.AGENT
 
 
 def test_computer_use_refuses_every_action_while_a_human_holds_the_screen(monkeypatch):
@@ -75,13 +76,22 @@ def test_lease_authority_is_shared_across_processes(tmp_path):
     import sys
 
     lease.acquire("desktop-viewer")
-    probe = ("import sys; sys.path.insert(0, %r)\n"
-             "from tools.bot_desktop import lease\n"
-             "try:\n    lease.assert_agent_may_act(); print('AGENT')\n"
-             "except lease.HumanHasControl:\n    print('HUMAN')\n"
-             "lease.release('desktop-viewer')\n") % os.getcwd()
-    out = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True, encoding="utf-8", timeout=30,
-                         stdin=subprocess.DEVNULL, env={**os.environ, "HERMES_HOME": os.environ["HERMES_HOME"]})
+    probe = (
+        "import sys; sys.path.insert(0, %r)\n"
+        "from tools.bot_desktop import lease\n"
+        "try:\n    lease.assert_agent_may_act(); print('AGENT')\n"
+        "except lease.HumanHasControl:\n    print('HUMAN')\n"
+        "lease.release('desktop-viewer')\n"
+    ) % os.getcwd()
+    out = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=30,
+        stdin=subprocess.DEVNULL,
+        env={**os.environ, "HERMES_HOME": os.environ["HERMES_HOME"]},
+    )
     assert out.stdout.strip() == "HUMAN", out.stderr
     assert lease.get().holder == lease.AGENT, "the other process's release is visible here"
 
@@ -167,14 +177,23 @@ def test_lease_works_without_fcntl(tmp_path):
     import subprocess
     import sys
 
-    probe = ("import sys; sys.modules['fcntl'] = None; sys.path.insert(0, %r)\n"
-             "from tools.bot_desktop import lease\n"
-             "import tools.computer_use.handoff\n"
-             "assert lease.get().holder == lease.AGENT\n"
-             "assert lease.acquire('v1').holder == lease.HUMAN\n"
-             "assert lease.get().holder == lease.HUMAN\n"
-             "assert lease.release('v1').holder == lease.AGENT\n"
-             "print('OK')\n") % os.getcwd()
-    out = subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True, encoding="utf-8", timeout=60,
-                         stdin=subprocess.DEVNULL, env={**os.environ, "HERMES_HOME": str(tmp_path)})
+    probe = (
+        "import sys; sys.modules['fcntl'] = None; sys.path.insert(0, %r)\n"
+        "from tools.bot_desktop import lease\n"
+        "import tools.computer_use.handoff\n"
+        "assert lease.get().holder == lease.AGENT\n"
+        "assert lease.acquire('v1').holder == lease.HUMAN\n"
+        "assert lease.get().holder == lease.HUMAN\n"
+        "assert lease.release('v1').holder == lease.AGENT\n"
+        "print('OK')\n"
+    ) % os.getcwd()
+    out = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=60,
+        stdin=subprocess.DEVNULL,
+        env={**os.environ, "HERMES_HOME": str(tmp_path)},
+    )
     assert out.stdout.strip() == "OK", out.stderr

--- a/tests/tools/test_bot_desktop_runtime.py
+++ b/tests/tools/test_bot_desktop_runtime.py
@@ -21,6 +21,21 @@ def test_every_required_binary_maps_to_an_installed_package(pm):
     assert not {"xorg-x11-server-utils", "xorg-x11-utils"} & set(runtime.PACKAGES["dnf"]), "retired on Fedora"
 
 
+def test_privileged_executable_resolution_ignores_inherited_path(tmp_path, monkeypatch):
+    attacker = tmp_path / "attacker"
+    system = tmp_path / "system"
+    attacker.mkdir()
+    system.mkdir()
+    for directory in (attacker, system):
+        executable = directory / "sudo"
+        executable.write_text("#!/bin/sh\n", encoding="utf-8")
+        executable.chmod(0o755)
+    monkeypatch.setenv("PATH", str(attacker))
+    monkeypatch.setattr(runtime, "_SYSTEM_PATH", str(system))
+
+    assert runtime._system_executable("sudo") == str(system / "sudo")
+
+
 def test_no_running_screen_returns_none_without_grabbing(monkeypatch):
     monkeypatch.setattr(runtime, "published_env", lambda: {"DISPLAY": ":99"})
     monkeypatch.setattr(runtime, "_launcher_pid", lambda: None)

--- a/tests/tools/test_bot_desktop_runtime.py
+++ b/tests/tools/test_bot_desktop_runtime.py
@@ -61,6 +61,45 @@ def test_recorded_display_held_by_a_live_server_is_not_reused(tmp_path, monkeypa
     assert runtime._allocate_display() == 37, "a free recorded number is reclaimed"
 
 
+def test_desktop_launcher_does_not_inherit_credentials(tmp_path, monkeypatch):
+    """The graphical session keeps benign host settings but never receives Hermes credentials."""
+    import os
+
+    from tools.bot_desktop import browser
+
+    captured: dict[str, str] = {}
+
+    class FakeProcess:
+        pid = os.getpid()
+        returncode = None
+
+        @staticmethod
+        def poll():
+            return None
+
+    def fake_popen(*_args, **kwargs):
+        captured.update(kwargs["env"])
+        Path(captured["HERMES_BD_ENV_FILE"]).write_text("DISPLAY=:44\n", encoding="utf-8")
+        Path(captured["HERMES_BD_SOCKET"]).touch()
+        return FakeProcess()
+
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-secret")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-secret")
+    monkeypatch.setenv("GITHUB_TOKEN", "github-secret")
+    monkeypatch.setenv("BOT_DESKTOP_BENIGN", "keep-me")
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.setattr(runtime.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(runtime, "geometry", lambda: "800x600")
+    monkeypatch.setattr(runtime, "status", lambda: "ready")
+    monkeypatch.setattr(browser, "dock_launch", lambda: None)
+
+    assert runtime._spawn_and_wait(tmp_path, 44, 0.1) == "ready"
+    assert captured["BOT_DESKTOP_BENIGN"] == "keep-me"
+    assert "DISPLAY" not in captured
+    assert "OPENAI_API_KEY" not in captured
+    assert "ANTHROPIC_API_KEY" not in captured
+    assert "GITHUB_TOKEN" not in captured
+
 
 _FAKE_LAUNCHER = """#!/usr/bin/env bash
 # Stands in for launcher.sh + Xvnc: the X lock appears only after a delay (the TOCTOU window), then the

--- a/tests/tools/test_bot_desktop_runtime.py
+++ b/tests/tools/test_bot_desktop_runtime.py
@@ -101,6 +101,27 @@ def test_desktop_launcher_does_not_inherit_credentials(tmp_path, monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "openai-secret")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-secret")
     monkeypatch.setenv("GITHUB_TOKEN", "github-secret")
+    aws_credentials = {
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_SECURITY_TOKEN",
+        "AWS_PROFILE",
+        "AWS_DEFAULT_PROFILE",
+        "AWS_CONFIG_FILE",
+        "AWS_SHARED_CREDENTIALS_FILE",
+        "AWS_WEB_IDENTITY_TOKEN_FILE",
+        "AWS_ROLE_ARN",
+        "AWS_ROLE_SESSION_NAME",
+        "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+        "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+        "AWS_CONTAINER_AUTHORIZATION_TOKEN",
+        "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+    }
+    for key in aws_credentials:
+        monkeypatch.setenv(key, "aws-secret")
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-west-2")
     monkeypatch.setenv("BOT_DESKTOP_BENIGN", "keep-me")
     monkeypatch.setenv("DISPLAY", ":0")
     monkeypatch.setattr(runtime.subprocess, "Popen", fake_popen)
@@ -114,6 +135,9 @@ def test_desktop_launcher_does_not_inherit_credentials(tmp_path, monkeypatch):
     assert "OPENAI_API_KEY" not in captured
     assert "ANTHROPIC_API_KEY" not in captured
     assert "GITHUB_TOKEN" not in captured
+    assert aws_credentials.isdisjoint(captured)
+    assert captured["AWS_REGION"] == "us-east-1"
+    assert captured["AWS_DEFAULT_REGION"] == "us-west-2"
 
 
 _FAKE_LAUNCHER = """#!/usr/bin/env bash

--- a/tests/tui_gateway/test_display_methods.py
+++ b/tests/tui_gateway/test_display_methods.py
@@ -31,7 +31,12 @@ def test_install_worker_keeps_the_requested_profile_scope(tmp_path, monkeypatch)
 
     monkeypatch.setattr(install, "install_packages", fake_install)
     monkeypatch.setattr(server, "_broadcast_global_event", lambda *a, **k: None)
-    resp = server.handle_request({"jsonrpc": "2.0", "id": 1, "method": "display.install", "params": {"profile": "named"}})
+    resp = server.handle_request({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "display.install",
+        "params": {"profile": "named"},
+    })
     assert resp["result"]["started"], resp
     assert done.wait(5)
     assert seen["home"] == str(named)
@@ -40,13 +45,24 @@ def test_install_worker_keeps_the_requested_profile_scope(tmp_path, monkeypatch)
 @pytest.fixture
 def _fresh_lease():
     from tools.bot_desktop import lease
+    import tui_gateway.server as server
+
     lease._reset_for_tests()
+    server._minted_viewer_ids.clear()
+    server._stdio_minted_viewer_ids.clear()
     yield lease
     lease._reset_for_tests()
+    server._minted_viewer_ids.clear()
+    server._stdio_minted_viewer_ids.clear()
 
 
 def _call(server, method, params):
-    return server.handle_request({"jsonrpc": "2.0", "id": 7, "method": method, "params": params})
+    return server.handle_request({
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": method,
+        "params": params,
+    })
 
 
 def test_thumbnail_is_suppressed_while_a_human_holds_the_lease(monkeypatch, _fresh_lease):
@@ -56,7 +72,11 @@ def test_thumbnail_is_suppressed_while_a_human_holds_the_lease(monkeypatch, _fre
     from tools.bot_desktop import thumbnail
 
     grabs = []
-    monkeypatch.setattr(thumbnail, "thumbnail_data_url", lambda: grabs.append(1) or "data:image/jpeg;base64,SECRET")
+    monkeypatch.setattr(
+        thumbnail,
+        "thumbnail_data_url",
+        lambda: grabs.append(1) or "data:image/jpeg;base64,SECRET",
+    )
     _fresh_lease.acquire("viewer-1")
     result = _call(server, "display.thumbnail", {})["result"]
     assert result["data_url"] is None and result["suppressed"] == "human_has_control"
@@ -65,21 +85,80 @@ def test_thumbnail_is_suppressed_while_a_human_holds_the_lease(monkeypatch, _fre
     assert _call(server, "display.thumbnail", {})["result"]["data_url"].endswith("SECRET")
 
 
-def test_release_without_viewer_id_cannot_yank_another_viewers_lease(_fresh_lease):
-    """lease.release(None) skips the holder check, so a client that lost its viewer id (or a bare RPC)
-    must be refused unless it forces; a matching viewer id and force keep working."""
-    import tui_gateway.server as server
+class _Peer:
+    def write(self, obj):
+        return True
 
-    _fresh_lease.acquire("viewer-1")
-    refused = _call(server, "display.lease.release", {})
-    assert refused["error"]["data"]["code"] == "viewer_mismatch"
-    assert _fresh_lease.get().holder == _fresh_lease.HUMAN
-    assert _call(server, "display.lease.release", {"viewer_id": "viewer-1"})["result"]["lease"]["holder"] == _fresh_lease.AGENT
-    _fresh_lease.acquire("viewer-2")
-    assert _call(server, "display.lease.release", {"force": True})["result"]["lease"]["holder"] == _fresh_lease.AGENT
+
+def _peer_rpc(server, peer, method, params):
+    return server.dispatch({"jsonrpc": "2.0", "id": 7, "method": method, "params": params}, peer)
+
+
+def _observe(server, peer, **params):
+    return _peer_rpc(server, peer, "display.observe", params)["result"]
+
+
+def test_foreign_transport_cannot_take_or_release_private_control(monkeypatch, tmp_path, _fresh_lease):
+    """A second authenticated transport gets its own viewer id, but neither that id, a copied id,
+    nor the former force flag authorizes changing the current holder's lease."""
+    import tui_gateway.server as server
+    from tools.bot_desktop import runtime
+
+    monkeypatch.setattr(runtime, "rfb_socket_path", lambda: tmp_path / "rfb.sock")
+    holder_peer, foreign_peer = _Peer(), _Peer()
+    holder = _observe(server, holder_peer)
+    foreign = _observe(server, foreign_peer)
+
+    assert (
+        _peer_rpc(
+            server,
+            holder_peer,
+            "display.lease.acquire",
+            {"viewer_id": holder["viewer_id"]},
+        )["result"]["lease"]["holder"]
+        == _fresh_lease.HUMAN
+    )
+    assert (
+        _peer_rpc(
+            server,
+            foreign_peer,
+            "display.lease.acquire",
+            {"viewer_id": foreign["viewer_id"]},
+        )["error"]["data"]["code"]
+        == "lease_held"
+    )
+    assert (
+        _peer_rpc(
+            server,
+            foreign_peer,
+            "display.lease.release",
+            {"viewer_id": holder["viewer_id"]},
+        )["error"]["data"]["code"]
+        == "viewer_not_owned"
+    )
+    assert (
+        _peer_rpc(server, foreign_peer, "display.lease.release", {"force": True})["error"]["data"]["code"]
+        == "viewer_not_owned"
+    )
+    assert _fresh_lease.get().viewer_id == holder["viewer_id"]
+    assert (
+        _peer_rpc(
+            server,
+            holder_peer,
+            "display.lease.release",
+            {"viewer_id": holder["viewer_id"]},
+        )["result"]["lease"]["holder"]
+        == _fresh_lease.AGENT
+    )
+
 
 def _rpc(server, method, params):
-    return server.handle_request({"jsonrpc": "2.0", "id": 7, "method": method, "params": params})
+    return server.handle_request({
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": method,
+        "params": params,
+    })
 
 
 def test_observe_mints_the_viewer_id_and_status_never_discloses_the_holder(monkeypatch, tmp_path):
@@ -92,7 +171,11 @@ def test_observe_mints_the_viewer_id_and_status_never_discloses_the_holder(monke
     monkeypatch.setattr(runtime, "rfb_socket_path", lambda: tmp_path / "rfb.sock")
     lease._reset_for_tests()
     broadcasts = []
-    monkeypatch.setattr(server, "_broadcast_global_event", lambda ev, payload=None: broadcasts.append((ev, payload)))
+    monkeypatch.setattr(
+        server,
+        "_broadcast_global_event",
+        lambda ev, payload=None: broadcasts.append((ev, payload)),
+    )
     try:
         observed = _rpc(server, "display.observe", {"viewer_id": "victim"})["result"]
         assert observed["viewer_id"] != "victim"
@@ -100,17 +183,30 @@ def test_observe_mints_the_viewer_id_and_status_never_discloses_the_holder(monke
         assert ws_tickets.consume_ticket(observed["ticket"])["viewer_id"] == observed["viewer_id"]
         holder = observed["viewer_id"]
 
-        # Only the connection that minted an id may reuse it (a reconnecting pane keeps its lease).
-        class _Peer:
-            def write(self, obj):
-                return True
+        # Only the connection that minted an id may reuse it without a recovery capability.
         mine, other = _Peer(), _Peer()
-        with_mine = server.dispatch({"jsonrpc": "2.0", "id": 8, "method": "display.observe", "params": {}}, mine)["result"]
-        again = server.dispatch({"jsonrpc": "2.0", "id": 9, "method": "display.observe",
-                                 "params": {"viewer_id": with_mine["viewer_id"]}}, mine)["result"]
+        with_mine = server.dispatch({"jsonrpc": "2.0", "id": 8, "method": "display.observe", "params": {}}, mine)[
+            "result"
+        ]
+        again = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": 9,
+                "method": "display.observe",
+                "params": {"viewer_id": with_mine["viewer_id"]},
+            },
+            mine,
+        )["result"]
         assert again["viewer_id"] == with_mine["viewer_id"]
-        stolen = server.dispatch({"jsonrpc": "2.0", "id": 10, "method": "display.observe",
-                                  "params": {"viewer_id": with_mine["viewer_id"]}}, other)["result"]
+        stolen = server.dispatch(
+            {
+                "jsonrpc": "2.0",
+                "id": 10,
+                "method": "display.observe",
+                "params": {"viewer_id": with_mine["viewer_id"]},
+            },
+            other,
+        )["result"]
         assert stolen["viewer_id"] != with_mine["viewer_id"]
 
         _rpc(server, "display.status", {})  # installs the broadcast listener
@@ -123,3 +219,31 @@ def test_observe_mints_the_viewer_id_and_status_never_discloses_the_holder(monke
         assert lease_events and all(holder not in json.dumps(p) for p in lease_events)
     finally:
         lease._reset_for_tests()
+
+
+def test_holder_recovers_after_reload_only_with_client_capability(monkeypatch, tmp_path, _fresh_lease):
+    from tools.bot_desktop import runtime
+    import tui_gateway.server as server
+
+    monkeypatch.setattr(runtime, "rfb_socket_path", lambda: tmp_path / "rfb.sock")
+    original, reloaded = _Peer(), _Peer()
+    observed = _observe(server, original)
+    acquired = _peer_rpc(server, original, "display.lease.acquire", {"viewer_id": observed["viewer_id"]})
+    assert acquired["result"]["lease"]["holder"] == _fresh_lease.HUMAN
+
+    recovered = _observe(
+        server,
+        reloaded,
+        viewer_id="client-supplied-id-is-not-authority",
+        resume_token=observed["resume_token"],
+    )
+    assert recovered["viewer_id"] == observed["viewer_id"]
+    assert (
+        _peer_rpc(
+            server,
+            reloaded,
+            "display.lease.release",
+            {"viewer_id": recovered["viewer_id"]},
+        )["result"]["lease"]["holder"]
+        == _fresh_lease.AGENT
+    )

--- a/tools/bot_desktop/install.py
+++ b/tools/bot_desktop/install.py
@@ -77,9 +77,9 @@ def install_packages(*, ask_password: Callable[[], str], on_line: Callable[[str]
             release(key)
 
 
-def _sudo_nopasswd() -> bool:
+def _sudo_nopasswd(sudo: str) -> bool:
     try:
-        return subprocess.run(["sudo", "-n", "true"], capture_output=True, timeout=3,
+        return subprocess.run([sudo, "-n", "true"], capture_output=True, timeout=3,
                               stdin=subprocess.DEVNULL).returncode == 0
     except Exception:
         return False
@@ -88,21 +88,27 @@ def _sudo_nopasswd() -> bool:
 def _run(cmd: str, *, ask_password: Callable[[], str], on_line: Callable[[str], None],
          timeout_seconds: float) -> int:
     argv = shlex.split(cmd)
-    assert argv[0] == "sudo", cmd
+    sudo = runtime._system_executable("sudo")
+    package_managers = {
+        path for name in runtime._PACKAGE_MANAGER_BINARIES.values()
+        if (path := runtime._system_executable(name)) is not None
+    }
+    if sudo is None or len(argv) < 2 or argv[0] != sudo or argv[1] not in package_managers:
+        raise RuntimeError("refusing untrusted Bot Desktop install command")
     stdin_payload: Optional[str] = None
-    if not _sudo_nopasswd():
+    if not _sudo_nopasswd(sudo):
         password = ask_password() or ""
         if not password:
             on_line("install cancelled: no sudo password provided")
             return -1
         # -S: read the password from stdin; -p '': no prompt text mixed into the streamed output.
-        argv = ["sudo", "-S", "-p", "", *argv[1:]]
+        argv = [sudo, "-S", "-p", "", *argv[1:]]
         stdin_payload = password + "\n"
     on_line(f"$ {cmd}")
-    env = {"DEBIAN_FRONTEND": "noninteractive", "LC_ALL": "C.UTF-8"}
+    env = {"PATH": runtime._SYSTEM_PATH, "DEBIAN_FRONTEND": "noninteractive", "LC_ALL": "C.UTF-8"}
     proc = subprocess.Popen(  # windows-footgun: ok — Linux-only (is_supported_host)
         argv, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-        env={**os.environ, **env}, text=True, encoding="utf-8", errors="replace", start_new_session=True)
+        env=env, text=True, encoding="utf-8", errors="replace", start_new_session=True)
     try:
         if stdin_payload is not None:
             proc.stdin.write(stdin_payload)  # type: ignore[union-attr]

--- a/tools/bot_desktop/launcher.sh
+++ b/tools/bot_desktop/launcher.sh
@@ -49,7 +49,9 @@ if [[ -e "$xlock" ]] && ! kill -0 "$(tr -d ' ' < "$xlock" 2>/dev/null)" 2>/dev/n
   rm -f "$xlock" "/tmp/.X11-unix/X${HERMES_BD_DISPLAY_NUM}"
 fi
 : > "$XAUTHORITY"; chmod 600 "$XAUTHORITY"
-xauth -q -f "$XAUTHORITY" add "$DISPLAY" MIT-MAGIC-COOKIE-1 "$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
+cookie="$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
+printf 'add %s MIT-MAGIC-COOKIE-1 %s\n' "$DISPLAY" "$cookie" | xauth -q -f "$XAUTHORITY"
+unset cookie
 
 # ---- look: dark theme from whatever the host ships (first match wins), Hermes wallpaper ----
 pick_theme() { local d t; for t in "$@"; do for d in /usr/share/themes "$HOME/.themes"; do [[ -d "$d/$t" ]] && { echo "$t"; return; }; done; done; echo "$1"; }

--- a/tools/bot_desktop/lease.py
+++ b/tools/bot_desktop/lease.py
@@ -28,7 +28,7 @@ from hermes_constants import get_hermes_home, hermes_home_key
 try:
     import fcntl
 except ImportError:  # Windows/macOS without fcntl: computer_use imports this module on every call, and no
-    fcntl = None     # multi-process Bot Desktop exists there, so the cross-process lock degrades to a no-op.
+    fcntl = None  # multi-process Bot Desktop exists there, so the cross-process lock degrades to a no-op.
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +41,10 @@ class HumanHasControl(RuntimeError):
     """Raised by screen-driving tools while a human holds the lease."""
 
 
+class ViewerLeaseHeld(RuntimeError):
+    """Raised when another authenticated viewer session already holds this profile's screen."""
+
+
 @dataclass
 class Lease:
     holder: str = AGENT
@@ -48,6 +52,7 @@ class Lease:
     since: float = field(default_factory=time.time)
     reason: str = ""
     pending_handoff: Optional[str] = None  # agent's reason for asking, until the human takes over
+    resume_hash: str = ""  # hash of the holder's client-only recovery capability; never broadcast
     epoch: int = 0
 
     def as_dict(self) -> Dict[str, object]:
@@ -130,6 +135,7 @@ def on_change(listener: Callable[[str, Lease], None]) -> Callable[[], None]:
         with _lock:
             if listener in _listeners:
                 _listeners.remove(listener)
+
     return _off
 
 
@@ -142,7 +148,10 @@ def _notify(key: str, lease: Lease) -> None:
 
 
 def _transition(profile_key: Optional[str], mutate: Callable[[Lease], bool]) -> Lease:
-    key, path = hermes_home_key(profile_key) if profile_key else hermes_home_key(), _path(profile_key)
+    key, path = (
+        hermes_home_key(profile_key) if profile_key else hermes_home_key(),
+        _path(profile_key),
+    )
     with _locked(path):
         lease = _read(path)
         if not mutate(lease):
@@ -155,40 +164,60 @@ def _transition(profile_key: Optional[str], mutate: Callable[[Lease], bool]) -> 
     return lease
 
 
-def acquire(viewer_id: str, *, profile_key: Optional[str] = None, reason: str = "") -> Lease:
-    """Human ``viewer_id`` takes control. Last writer wins: a second viewer evicts the first, and the
-    RFB bridge closes the evicted socket so its UI drops to view-only."""
+def acquire(
+    viewer_id: str,
+    *,
+    profile_key: Optional[str] = None,
+    reason: str = "",
+    resume_hash: str = "",
+) -> Lease:
+    """Let ``viewer_id`` take control unless another authenticated viewer session holds it."""
+
     def _m(lease: Lease) -> bool:
+        if lease.holder == HUMAN and lease.viewer_id != viewer_id:
+            raise ViewerLeaseHeld("another viewer already holds private control")
         # The agent's ask ("please log in to X") stays as the takeover reason: the human needs it
         # on screen WHILE they act, not only before they clicked Take over.
         lease.holder, lease.viewer_id, lease.since = HUMAN, viewer_id, time.time()
         lease.reason = reason or lease.pending_handoff or ""
         lease.pending_handoff = None
+        lease.resume_hash = resume_hash
         return True
+
     return _transition(profile_key, _m)
 
 
 def release(viewer_id: Optional[str] = None, *, profile_key: Optional[str] = None) -> Lease:
     """Return control to the agent. With ``viewer_id`` only that holder may release (a stale viewer
     closing its window must not yank control from the one who took over after it)."""
+
     def _m(lease: Lease) -> bool:
         if viewer_id is not None and lease.holder == HUMAN and lease.viewer_id != viewer_id:
             # Ignored, not an error: the returned lease still shows the real holder. Logged so a
             # caller that never inspects the return value leaves a trace.
             logger.info("bot-desktop lease: release by %r ignored, another viewer holds", viewer_id)
             return False
-        lease.holder, lease.viewer_id, lease.since, lease.reason = AGENT, None, time.time(), ""
+        lease.holder, lease.viewer_id, lease.since, lease.reason = (
+            AGENT,
+            None,
+            time.time(),
+            "",
+        )
+        lease.resume_hash = ""
         lease.pending_handoff = None  # "hand back" answers an open request even if nobody formally took over
         return True
+
     return _transition(profile_key, _m)
 
 
 def request_handoff(reason: str, *, profile_key: Optional[str] = None) -> Lease:
     """Agent asks a human to take over (login, 2FA, CAPTCHA, payment). Recorded so the UI can show
     why and the bridge can page the user; control itself still flips only on ``acquire``."""
+
     def _m(lease: Lease) -> bool:
         lease.pending_handoff = reason
         return True
+
     return _transition(profile_key, _m)
 
 
@@ -196,12 +225,20 @@ def wait_for_release(*, timeout: float, profile_key: Optional[str] = None) -> bo
     """Block until the agent holds the lease (and no handoff is pending) or ``timeout`` elapses.
     True when control is back with the agent. Polls the file so a release made by another process
     is seen; the local Condition just shortens the wait for same-process transitions."""
-    return _wait_until(lambda lease: lease.holder == AGENT and lease.pending_handoff is None, timeout, profile_key)
+    return _wait_until(
+        lambda lease: lease.holder == AGENT and lease.pending_handoff is None,
+        timeout,
+        profile_key,
+    )
 
 
 def wait_for_takeover_or_release(*, timeout: float, profile_key: Optional[str] = None) -> bool:
     """False when, after ``timeout``, the agent still holds with a handoff pending: nobody answered."""
-    return _wait_until(lambda lease: lease.holder == HUMAN or lease.pending_handoff is None, timeout, profile_key)
+    return _wait_until(
+        lambda lease: lease.holder == HUMAN or lease.pending_handoff is None,
+        timeout,
+        profile_key,
+    )
 
 
 def _wait_until(done: Callable[[Lease], bool], timeout: float, profile_key: Optional[str]) -> bool:
@@ -234,7 +271,8 @@ def assert_agent_may_act(profile_key: Optional[str] = None) -> Lease:
         raise HumanHasControl(
             "A human has taken over this desktop (they may be entering a credential). Screen actions and "
             "captures are refused until they hand control back; call computer_use action='wait_for_human' "
-            "to block until then.")
+            "to block until then."
+        )
     return lease
 
 

--- a/tools/bot_desktop/lease.py
+++ b/tools/bot_desktop/lease.py
@@ -19,9 +19,10 @@ import logging
 import os
 import threading
 import time
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, Iterator, List, Optional
 
 from hermes_constants import get_hermes_home, hermes_home_key
 
@@ -123,6 +124,18 @@ class _locked:
 
 def get(profile_key: Optional[str] = None) -> Lease:
     return _read(_path(profile_key))
+
+
+@contextmanager
+def locked_snapshot(profile_key: Optional[str] = None) -> Iterator[Lease]:
+    """Yield one read-only lease snapshot while excluding cross-process transitions.
+
+    Admission code may bind other process-local state to this snapshot before releasing the lock;
+    callers must not mutate it because this context deliberately performs no write.
+    """
+    path = _path(profile_key)
+    with _locked(path):
+        yield _read(path)
 
 
 def on_change(listener: Callable[[str, Lease], None]) -> Callable[[], None]:

--- a/tools/bot_desktop/runtime.py
+++ b/tools/bot_desktop/runtime.py
@@ -316,8 +316,12 @@ def _spawn_and_wait(sd: Path, num: int, wait_seconds: float) -> DesktopStatus:
     env_file = sd / "env"
     env_file.unlink(missing_ok=True)
 
-    child_env = {k: v for k, v in os.environ.items() if k not in {
-        "DISPLAY", "XAUTHORITY", "WAYLAND_DISPLAY", "DBUS_SESSION_BUS_ADDRESS", "SESSION_MANAGER"}}
+    # Xfce, its terminal, and browser extensions are untrusted subprocess surfaces. Keep benign host
+    # settings, but do not expose provider, plugin, gateway, or internal Hermes credentials to them.
+    from tools.environments.local import hermes_subprocess_env
+    child_env = hermes_subprocess_env(inherit_credentials=False)
+    for key in ("DISPLAY", "XAUTHORITY", "WAYLAND_DISPLAY", "DBUS_SESSION_BUS_ADDRESS", "SESSION_MANAGER"):
+        child_env.pop(key, None)
     child_env.update({
         "HERMES_BD_PROFILE": _profile_name(),
         "HERMES_BD_DISPLAY_NUM": str(num),

--- a/tools/bot_desktop/runtime.py
+++ b/tools/bot_desktop/runtime.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
+import shlex
 import shutil
 import signal
 import subprocess
@@ -35,6 +36,11 @@ _LAUNCHER = Path(__file__).with_name("launcher.sh")
 # Display numbers below 10 collide with real seats and default Xvfb recipes (:99 is popular too); scan a
 # private band and record the choice so restarts reuse it.
 _DISPLAY_MIN, _DISPLAY_MAX = 20, 89
+
+# Package installation is privileged. Never resolve sudo or a package manager through the gateway's
+# inherited PATH, which commonly contains user-writable directories such as ~/.local/bin.
+_SYSTEM_PATH = "/usr/sbin:/usr/bin:/sbin:/bin"
+_PACKAGE_MANAGER_BINARIES = {"apt": "apt-get", "dnf": "dnf", "pacman": "pacman"}
 
 # Binaries the launcher execs; the package hint is per distro family.
 REQUIRED_BINARIES = ("Xvnc", "xfwm4", "xfce4-panel", "xfdesktop", "xfsettingsd", "dbus-run-session",
@@ -81,22 +87,32 @@ def missing_binaries() -> list[str]:
     return [b for b in REQUIRED_BINARIES if shutil.which(b) is None]
 
 
+def _system_executable(name: str) -> Optional[str]:
+    """Absolute executable resolved only from root-managed system directories."""
+    executable = shutil.which(name, path=_SYSTEM_PATH)
+    return str(Path(executable).resolve()) if executable else None
+
+
 def package_manager() -> Optional[str]:
-    for pm in ("apt-get", "dnf", "pacman"):
-        if shutil.which(pm):
-            return "apt" if pm == "apt-get" else pm
+    for pm, executable in _PACKAGE_MANAGER_BINARIES.items():
+        if _system_executable(executable):
+            return pm
     return None
 
 
 def install_command() -> Optional[str]:
     pm = package_manager()
-    if pm is None:
+    sudo = _system_executable("sudo")
+    package_manager_executable = _system_executable(_PACKAGE_MANAGER_BINARIES[pm]) if pm else None
+    if pm is None or sudo is None or package_manager_executable is None:
         return None
     pkgs = " ".join(PACKAGES[pm])
     return {
-        "apt": f"sudo apt-get install -y --no-install-recommends {pkgs}",
-        "dnf": f"sudo dnf install -y {pkgs}",
-        "pacman": f"sudo pacman -S --needed --noconfirm {pkgs}",
+        "apt": f"{shlex.quote(sudo)} {shlex.quote(package_manager_executable)} "
+               f"install -y --no-install-recommends {pkgs}",
+        "dnf": f"{shlex.quote(sudo)} {shlex.quote(package_manager_executable)} install -y {pkgs}",
+        "pacman": f"{shlex.quote(sudo)} {shlex.quote(package_manager_executable)} "
+                  f"-S --needed --noconfirm {pkgs}",
     }[pm]
 
 

--- a/tools/bot_desktop/runtime.py
+++ b/tools/bot_desktop/runtime.py
@@ -42,6 +42,27 @@ _DISPLAY_MIN, _DISPLAY_MAX = 20, 89
 _SYSTEM_PATH = "/usr/sbin:/usr/bin:/sbin:/bin"
 _PACKAGE_MANAGER_BINARIES = {"apt": "apt-get", "dnf": "dnf", "pacman": "pacman"}
 
+# ``hermes_subprocess_env(inherit_credentials=False)`` intentionally preserves the standard AWS
+# credential chain for ordinary terminal children. A graphical desktop is a less trusted boundary:
+# Xfce applications and browser extensions must not inherit credentials or paths to credential files.
+_DESKTOP_AWS_CREDENTIAL_ENV = frozenset({
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AWS_SECURITY_TOKEN",
+    "AWS_PROFILE",
+    "AWS_DEFAULT_PROFILE",
+    "AWS_CONFIG_FILE",
+    "AWS_SHARED_CREDENTIALS_FILE",
+    "AWS_WEB_IDENTITY_TOKEN_FILE",
+    "AWS_ROLE_ARN",
+    "AWS_ROLE_SESSION_NAME",
+    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+    "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+    "AWS_CONTAINER_AUTHORIZATION_TOKEN",
+    "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+})
+
 # Binaries the launcher execs; the package hint is per distro family.
 REQUIRED_BINARIES = ("Xvnc", "xfwm4", "xfce4-panel", "xfdesktop", "xfsettingsd", "dbus-run-session",
                      "xauth", "xdpyinfo", "setxkbmap", "xprop")
@@ -336,7 +357,9 @@ def _spawn_and_wait(sd: Path, num: int, wait_seconds: float) -> DesktopStatus:
     # settings, but do not expose provider, plugin, gateway, or internal Hermes credentials to them.
     from tools.environments.local import hermes_subprocess_env
     child_env = hermes_subprocess_env(inherit_credentials=False)
-    for key in ("DISPLAY", "XAUTHORITY", "WAYLAND_DISPLAY", "DBUS_SESSION_BUS_ADDRESS", "SESSION_MANAGER"):
+    for key in _DESKTOP_AWS_CREDENTIAL_ENV | {
+        "DISPLAY", "XAUTHORITY", "WAYLAND_DISPLAY", "DBUS_SESSION_BUS_ADDRESS", "SESSION_MANAGER",
+    }:
         child_env.pop(key, None)
     child_env.update({
         "HERMES_BD_PROFILE": _profile_name(),

--- a/tui_gateway/methods_display.py
+++ b/tui_gateway/methods_display.py
@@ -25,6 +25,7 @@ method = _registry.method
 _profile_scoped = _registry.profile_scoped
 
 _DISPLAY_ERR = 5300
+_DISPLAY_FORBIDDEN = 4403
 _lease_listener_installed = threading.Event()
 
 
@@ -33,8 +34,10 @@ def _lease_view(lease) -> dict:
     co-drives or releases the lease), so it is replaced by a short hash the holder can match against
     its own id to know it is the one in control."""
     import hashlib
+
     d = lease.as_dict()
     vid = d.pop("viewer_id")
+    d.pop("resume_hash", None)
     d["viewer_id"] = None
     d["viewer_hash"] = hashlib.sha256(vid.encode()).hexdigest()[:12] if vid else None
     return d
@@ -43,8 +46,13 @@ def _lease_view(lease) -> dict:
 def _display_snapshot() -> dict:
     from hermes_constants import hermes_home_key
     from tools.bot_desktop import lease as _bd_lease, runtime as _bd_runtime
+
     st = _bd_runtime.status()
-    return {**st.as_dict(), "lease": _lease_view(_bd_lease.get()), "profile_key": hermes_home_key()}
+    return {
+        **st.as_dict(),
+        "lease": _lease_view(_bd_lease.get()),
+        "profile_key": hermes_home_key(),
+    }
 
 
 def _install_lease_listener() -> None:
@@ -55,6 +63,7 @@ def _install_lease_listener() -> None:
 
     def _on_change(profile_key: str, lease) -> None:
         _broadcast_global_event("display.lease", {"profile_key": profile_key, "lease": _lease_view(lease)})
+
     _bd_lease.on_change(_on_change)
     _lease_listener_installed.set()  # only once the subscription exists, or a failed import would silence every client
 
@@ -76,9 +85,11 @@ def _(rid, params: dict) -> dict:
     Suppressed while a human holds the lease — the frame may show what they are typing."""
     try:
         from tools.bot_desktop import lease as _bd_lease
+
         if _bd_lease.human_holds():
             return _ok(rid, {"data_url": None, "suppressed": "human_has_control"})
         from tools.bot_desktop.thumbnail import thumbnail_data_url
+
         return _ok(rid, {"data_url": thumbnail_data_url()})
     except Exception as e:
         return _err(rid, _DISPLAY_ERR, str(e))
@@ -89,6 +100,7 @@ def _(rid, params: dict) -> dict:
 def _(rid, params: dict) -> dict:
     _install_lease_listener()
     from tools.bot_desktop import runtime as _bd_runtime
+
     try:
         _bd_runtime.start()
         return _ok(rid, _display_snapshot())
@@ -100,7 +112,14 @@ def _(rid, params: dict) -> dict:
 @_profile_scoped
 def _(rid, params: dict) -> dict:
     from tools.bot_desktop import lease as _bd_lease, runtime as _bd_runtime
+
     try:
+        if _bd_lease.human_holds():
+            return _err(
+                rid,
+                _DISPLAY_FORBIDDEN,
+                "private takeover is active; hand back from the holding viewer first",
+            )
         _bd_lease.release()
         stopped = _bd_runtime.stop()
         return _ok(rid, {**_display_snapshot(), "stopped": stopped})
@@ -108,24 +127,70 @@ def _(rid, params: dict) -> dict:
         return _err(rid, _DISPLAY_ERR, str(e))
 
 
-# viewer ids minted per connection (keyed by the transport that asked), so a reconnecting pane can
-# keep its identity — and its lease — while nobody can claim an id minted for another connection.
-_minted_viewer_ids: "weakref.WeakKeyDictionary[object, set[str]]" = weakref.WeakKeyDictionary()
+# Viewer ids and their recovery hashes are scoped to both the authenticated transport and profile
+# that minted them. The stdio transport cannot be weak-referenced; it is one process-local peer.
+_minted_viewer_ids: "weakref.WeakKeyDictionary[object, dict[str, dict[str, str]]]" = weakref.WeakKeyDictionary()
+_stdio_minted_viewer_ids: dict[str, dict[str, str]] = {}
 
 
-def _mint_viewer_id(requested: str) -> str:
-    """Server-minted viewer identity. ``requested`` is honoured only when THIS connection minted it
-    earlier; anything else (including a holder id read off display.status) gets a fresh id."""
-    import secrets
+def _current_transport_viewer_ids() -> dict[str, str] | None:
+    from hermes_constants import hermes_home_key
+
+    transport = current_transport()
+    if transport is None:
+        return None
     try:
-        mine = _minted_viewer_ids.setdefault(current_transport(), set())
-    except TypeError:  # stdio / slotted transports cannot be weakly referenced: always mint
-        mine = set()
-    if requested in mine:
-        return requested
-    viewer_id = secrets.token_urlsafe(16)
-    mine.add(viewer_id)
-    return viewer_id
+        by_profile = _minted_viewer_ids.setdefault(transport, {})
+    except TypeError:
+        if transport is not _stdio_transport:
+            return None
+        by_profile = _stdio_minted_viewer_ids
+    return by_profile.setdefault(hermes_home_key(), {})
+
+
+def _viewer_id_owned_by_current_transport(viewer_id: str) -> bool:
+    mine = _current_transport_viewer_ids()
+    return mine is not None and viewer_id in mine
+
+
+def _viewer_resume_hash(viewer_id: str) -> str:
+    mine = _current_transport_viewer_ids()
+    return mine.get(viewer_id, "") if mine is not None else ""
+
+
+def _capability_hash(value: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def _mint_viewer_identity(requested: str, resume_token: str) -> tuple[str, str]:
+    """Return a server-owned viewer id plus a client-only recovery capability.
+
+    A new transport may recover the current holder only by proving the random token whose hash is
+    stored in the lease. The raw viewer id remains identity, never authorization.
+    """
+    import secrets
+
+    mine = _current_transport_viewer_ids()
+    if mine is not None and resume_token:
+        from tools.bot_desktop import lease as _bd_lease
+
+        held = _bd_lease.get()
+        candidate_hash = _capability_hash(resume_token)
+        if (
+            held.holder == _bd_lease.HUMAN
+            and held.viewer_id
+            and held.resume_hash
+            and secrets.compare_digest(candidate_hash, held.resume_hash)
+        ):
+            mine[held.viewer_id] = held.resume_hash
+            return held.viewer_id, resume_token
+    viewer_id = requested if mine is not None and requested in mine else secrets.token_urlsafe(16)
+    resume_token = secrets.token_urlsafe(32)
+    if mine is not None:
+        mine[viewer_id] = _capability_hash(resume_token)
+    return viewer_id, resume_token
 
 
 @method("display.observe")
@@ -137,14 +202,33 @@ def _(rid, params: dict) -> dict:
     from hermes_constants import get_hermes_home
     from hermes_cli.dashboard_auth.ws_tickets import mint_ticket
     from tools.bot_desktop import runtime as _bd_runtime
+
     try:
         if _bd_runtime.rfb_socket_path() is None:
-            return _err(rid, _DISPLAY_ERR, "this profile's Bot Desktop is not running; call display.start first")
-        viewer_id = _mint_viewer_id(str(params.get("viewer_id") or "").strip())
-        ticket = mint_ticket(user_id=f"display:{viewer_id}", provider="bot-desktop",
-                             extra={"hermes_home": str(get_hermes_home()), "viewer_id": viewer_id})
-        return _ok(rid, {"ticket": ticket, "path": "/api/display/ws", "viewer_id": viewer_id,
-                         **_display_snapshot()})
+            return _err(
+                rid,
+                _DISPLAY_ERR,
+                "this profile's Bot Desktop is not running; call display.start first",
+            )
+        viewer_id, resume_token = _mint_viewer_identity(
+            str(params.get("viewer_id") or "").strip(),
+            str(params.get("resume_token") or "").strip(),
+        )
+        ticket = mint_ticket(
+            user_id=f"display:{viewer_id}",
+            provider="bot-desktop",
+            extra={"hermes_home": str(get_hermes_home()), "viewer_id": viewer_id},
+        )
+        return _ok(
+            rid,
+            {
+                "ticket": ticket,
+                "path": "/api/display/ws",
+                "viewer_id": viewer_id,
+                "resume_token": resume_token,
+                **_display_snapshot(),
+            },
+        )
     except Exception as e:
         return _err(rid, _DISPLAY_ERR, str(e))
 
@@ -156,15 +240,25 @@ def _(rid, params: dict) -> dict:
     ``display.install.done``. Refused while one is already running for this profile."""
     from hermes_constants import hermes_home_key
     from tools.bot_desktop import install as _bd_install, runtime as _bd_runtime
+
     if not _bd_runtime.is_supported_host():
         return _err(rid, _DISPLAY_ERR, "Bot Desktop runs on Linux gateway hosts only")
     if _bd_runtime.install_command() is None:
-        return _err(rid, _DISPLAY_ERR, "no supported package manager (apt-get, dnf, pacman) on this host")
+        return _err(
+            rid,
+            _DISPLAY_ERR,
+            "no supported package manager (apt-get, dnf, pacman) on this host",
+        )
     profile_key = hermes_home_key()
     sid = str(params.get("session_id") or "")
 
     def _ask_password() -> str:
-        return _block("display.install.sudo.request", sid, {"profile_key": profile_key}, timeout=300)
+        return _block(
+            "display.install.sudo.request",
+            sid,
+            {"profile_key": profile_key},
+            timeout=300,
+        )
 
     def _line(text: str) -> None:
         _broadcast_global_event("display.install.log", {"profile_key": profile_key, "line": text})
@@ -173,6 +267,7 @@ def _(rid, params: dict) -> dict:
     # CLIENT that clicked Install) and the profile scope `_profile_scoped` installed (so status, lock
     # and events all speak for the requested profile) are carried across with copy_context().
     import contextvars
+
     ctx = contextvars.copy_context()
 
     def _run() -> None:
@@ -181,25 +276,54 @@ def _(rid, params: dict) -> dict:
         except Exception as e:
             _line(f"install failed: {e}")
             code = 1
-        _broadcast_global_event("display.install.done", {"profile_key": profile_key, "code": code,
-                                                         "status": _display_snapshot()})
+        _broadcast_global_event(
+            "display.install.done",
+            {"profile_key": profile_key, "code": code, "status": _display_snapshot()},
+        )
 
     try:
         _bd_install.claim()  # atomic: two fast clicks cannot both start a package manager
     except _bd_install.InstallBusy as e:
         return _err(rid, _DISPLAY_ERR, str(e))
-    threading.Thread(target=ctx.run, args=(_run,), name=f"bot-desktop-install:{profile_key}", daemon=True).start()
-    return _ok(rid, {"started": True, "command": _bd_runtime.install_command(), "profile_key": profile_key})
+    threading.Thread(
+        target=ctx.run,
+        args=(_run,),
+        name=f"bot-desktop-install:{profile_key}",
+        daemon=True,
+    ).start()
+    return _ok(
+        rid,
+        {
+            "started": True,
+            "command": _bd_runtime.install_command(),
+            "profile_key": profile_key,
+        },
+    )
 
 
 @method("display.lease.acquire")
 @_profile_scoped
 def _(rid, params: dict) -> dict:
     from tools.bot_desktop import lease as _bd_lease
+
     viewer_id = str(params.get("viewer_id") or "").strip()
     if not viewer_id:
         return _err(rid, _DISPLAY_ERR, "viewer_id required")
-    lease = _bd_lease.acquire(viewer_id, reason=str(params.get("reason") or ""))
+    if not _viewer_id_owned_by_current_transport(viewer_id):
+        return _err(
+            rid,
+            _DISPLAY_FORBIDDEN,
+            "viewer_id is not owned by this connection",
+            data={"code": "viewer_not_owned"},
+        )
+    try:
+        lease = _bd_lease.acquire(
+            viewer_id,
+            reason=str(params.get("reason") or ""),
+            resume_hash=_viewer_resume_hash(viewer_id),
+        )
+    except _bd_lease.ViewerLeaseHeld as exc:
+        return _err(rid, _DISPLAY_FORBIDDEN, str(exc), data={"code": "lease_held"})
     return _ok(rid, {"lease": _lease_view(lease)})
 
 
@@ -207,13 +331,23 @@ def _(rid, params: dict) -> dict:
 @_profile_scoped
 def _(rid, params: dict) -> dict:
     from tools.bot_desktop import lease as _bd_lease
-    viewer_id = str(params.get("viewer_id") or "").strip() or None
-    # lease.release(None) skips the holder check; a client that lost its viewer id must not be able to
-    # yank control from whoever holds it unless it says so explicitly (force).
-    if viewer_id is None and not params.get("force") and _bd_lease.human_holds():
-        return _err(rid, _DISPLAY_ERR, "viewer_id required to release another viewer's lease (or pass force: true)",
-                    data={"code": "viewer_mismatch"})
+
+    viewer_id = str(params.get("viewer_id") or "").strip()
+    if not viewer_id or not _viewer_id_owned_by_current_transport(viewer_id):
+        return _err(
+            rid,
+            _DISPLAY_FORBIDDEN,
+            "viewer_id is not owned by this connection",
+            data={"code": "viewer_not_owned"},
+        )
     lease = _bd_lease.release(viewer_id)
+    if lease.holder == _bd_lease.HUMAN:
+        return _err(
+            rid,
+            _DISPLAY_FORBIDDEN,
+            "only the holding viewer may hand back control",
+            data={"code": "viewer_mismatch"},
+        )
     return _ok(rid, {"lease": _lease_view(lease)})
 
 

--- a/website/docs/user-guide/features/bot-screen.md
+++ b/website/docs/user-guide/features/bot-screen.md
@@ -77,8 +77,9 @@ Every bot's computer is one click away in three places of Hermes Desktop:
    connection is different: if your laptop lid closes or Wi-Fi drops while you
    hold control, you keep it — the bot stays locked out of a screen you may be
    mid-login on — until you reconnect and hand back. If you come back after a
-   reload and the pane still says a human holds control, a **Hand back (force)**
-   button appears to clear it.
+   reload, the pane uses a client-only recovery capability to reconnect as the
+   same viewer so you can hand control back normally. If that browser storage
+   was cleared, use the explicit CLI recovery command below.
 
 While you hold control, the bot's `computer_use` and browser tools are refused
 with `human_has_control`, captures included. This is a tool-level fence, not an
@@ -91,8 +92,9 @@ shows **Bot needs you**, the bot tells you in its reply what it needs (so the
 ask reaches you in whatever chat you are on), and it blocks in
 `action: "wait_for_human"` until you hand back.
 
-Two viewers on one screen: the most recent **Take over** wins; the previous
-controller drops back to watching.
+Only one viewer stream is kept per bot. A normal reconnect replaces the stale
+stream. Once a viewer has private control, a different session cannot watch,
+take over or force-release its lease.
 
 ## Browser sessions that survive the handoff
 
@@ -162,7 +164,7 @@ Xauthority, launcher log, per-profile xfconf).
 - **Typing produces wrong characters** — the screen uses a US keymap so RFB
   keysyms and cua-driver agree; change it with `setxkbmap` on that `DISPLAY`
   if you need another layout.
-- **Bot says `human_has_control` after you left** — click **Hand back** in the
-  pane (or **Hand back (force)** after a reload). From a shell,
+- **Bot says `human_has_control` after you left** — reconnect and click **Hand
+  back** in the pane. If the viewer recovery capability was lost, from a shell
   `hermes computer-use screen stop` releases the lease and stops the screen;
   `hermes computer-use screen start` brings it back with the bot in control.


### PR DESCRIPTION
## Summary

- keep Hermes and provider credentials out of desktop child-process environments
- harden the privileged package-install path with validated executables and a scrubbed environment
- pass the Xauthority cookie to xauth through stdin instead of exposing it in process arguments
- mint viewer identities server-side and bind lease acquire/release to the authenticated connection
- recover a private lease after reload only with a client-held capability whose hash is stored server-side
- allow one viewer stream per bot; reconnects replace stale streams, while private takeover rejects non-holders
- remove remote force-release and retain the explicit local CLI recovery path

## Security model

Hermes remains a single-user product. The authorization boundary here is between authenticated viewer sessions, not between intended human users. This prevents a second or replayed authenticated session from watching, taking over, or releasing a private bot screen.

## Validation

- focused Python security suite: 34 passed, 0 failed, 7 Linux-only skips on macOS
- desktop viewer lifecycle and identity tests: 8 passed
- renderer TypeScript check passed
- changed-file ESLint, Ruff, and diff checks passed

This draft targets the original Bot Screen contribution branch so the combined change can be reviewed before submission to main.
