### PR TITLE
fix: exclude cron/subagent sessions from default sessions list

### DIFF
--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -244,8 +244,15 @@ def _cmd_import(args):
 # -- handlers that receive an open SessionDB ----------------------------------
 
 def _default_exclude(args):
-    """Hide third-party tool sessions by default, but honour explicit --source."""
-    return None if getattr(args, "source", None) else ["tool"]
+    """Hide automation/third-party sessions by default, but honour explicit --source.
+
+    ``cron`` and ``subagent`` are not user conversations: every cron fire and every
+    delegate_task subagent run creates an untitled session row that would otherwise
+    flood ``sessions list`` (and the desktop session panel). They stay queryable via
+    ``--source cron`` / ``--source subagent``; ``session_search_tool`` already treats
+    them as hidden sources (see ``_HIDDEN_SESSION_SOURCES``).
+    """
+    return None if getattr(args, "source", None) else ["tool", "cron", "subagent"]
 
 
 def _cmd_list(db, args):

--- a/tests/hermes_cli/test_sessions_default_exclude.py
+++ b/tests/hermes_cli/test_sessions_default_exclude.py
@@ -1,0 +1,29 @@
+"""Behavior contract: `sessions list` hides automation sources by default.
+
+Every cron fire and every delegate_task subagent run creates an untitled session
+row in the store. Listing them alongside real user conversations floods
+`hermes sessions list` (and the desktop session panel that consumes it). The
+default exclusion covers ``tool``, ``cron`` and ``subagent``; an explicit
+``--source`` opts back into any of them.
+"""
+
+from argparse import Namespace
+
+from hermes_cli.sessions_cmd import _default_exclude
+
+
+def _args(**kw):
+    base = dict(sessions_action="list", source=None)
+    base.update(kw)
+    return Namespace(**base)
+
+
+def test_default_excludes_automation_sources():
+    excluded = _default_exclude(_args())
+    assert excluded is not None
+    assert set(excluded) == {"tool", "cron", "subagent"}
+
+
+def test_explicit_source_honored_no_exclusion():
+    assert _default_exclude(_args(source="cron")) is None
+    assert _default_exclude(_args(source="subagent")) is None


### PR DESCRIPTION
## Problem

Every cron fire and every delegate_task subagent run creates an untitled session row in the session store. `hermes sessions list` only excluded `tool` by default, so automation sessions flooded the output — on a machine with a worker team + scheduled jobs this is tens of thousands of rows (e.g. Project Follow-up every 30min, health checks hourly), drowning real user conversations in the CLI and in the desktop session panel that consumes `hermes sessions list`.

## Fix

Extend `_default_exclude` in `hermes_cli/sessions_cmd.py` to also exclude `cron` and `subagent` sources by default. Explicit `--source cron` / `--source subagent` still opts back in (`_default_exclude` returns `None` when `--source` is given), so the sessions remain fully queryable.

This aligns `sessions list` with existing intent elsewhere in the codebase: `session_search_tool._HIDDEN_SESSION_SOURCES = ("kanban", "subagent", "tool")` and `turn_context._UNTITLED_PLATFORMS = {"cron", "subagent"}` already treat these as non-user, deliberately-untitled sessions.

`hermes sessions browse` shares `_default_exclude`, so it inherits the same default.

## Test

New `tests/hermes_cli/test_sessions_default_exclude.py` pins the default exclusion set and the `--source` opt-out. Verified on a live store: default list went from ~1 real conversation visible (rest drowned by cron rows) to 15 real conversations; `--source cron` still returns the team job runs.