### PR TITLE
feat(agent): expose per-turn voice context to pre_llm_call hooks

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1433,6 +1433,7 @@ def _run_conversation_turn(
     persist_user_display_metadata: Optional[Dict[str, Any]] = None,
     persist_user_platform_id: Optional[str] = None,
     turn_author: Optional[Dict[str, Any]] = None,
+    voice_context: Optional[Dict[str, Any]] = None,
     moa_config: Optional[dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Run a complete conversation with tool calling until completion; returns the result dict.
@@ -1440,7 +1441,9 @@ def _run_conversation_turn(
     ``stream_callback``: per-text-delta callback (TTS). ``persist_user_message``: clean text to
     store when ``user_message`` carries API-only synthetic prefixes; timestamp / platform id are
     stored as metadata (platform id lets restart drain recovery dedup). ``persist_user_display_*``:
-    display-only event rendering; the model still receives the message unchanged."""
+    display-only event rendering; the model still receives the message unchanged. ``voice_context``:
+    trusted per-turn ``{input_modality, voice_session_active, client_surface}`` (#109455), never
+    persisted; reaches ``pre_llm_call`` hooks via ``agent._turn_voice_context``."""
     if moa_config is None:
         user_message, moa_config, persist_user_message = _decode_inline_moa_turn(
             user_message, persist_user_message
@@ -1468,6 +1471,7 @@ def _run_conversation_turn(
             persist_user_display_metadata=persist_user_display_metadata,
             persist_user_platform_id=persist_user_platform_id,
             turn_author=turn_author,
+            voice_context=voice_context,
             restore_or_build_system_prompt=_restore_or_build_system_prompt,
             install_safe_stdio=_install_safe_stdio,
             sanitize_surrogates=_sanitize_surrogates,
@@ -1584,6 +1588,7 @@ def run_conversation(
     persist_user_platform_id: Optional[str] = None,
     moa_config: Optional[dict[str, Any]] = None,
     turn_author: Optional[Dict[str, Any]] = None,
+    voice_context: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Run one turn (see ``_run_conversation_turn``) and export the current-turn boundary.
 
@@ -1608,6 +1613,7 @@ def run_conversation(
         persist_user_platform_id=persist_user_platform_id,
         moa_config=moa_config,
         turn_author=turn_author,
+        voice_context=voice_context,
     )
     return export_current_turn_boundary(agent, result, user_message)
 

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -26,6 +26,7 @@ from agent.model_metadata import estimate_messages_tokens_rough, estimate_reques
 from agent.image_token_cost import bind_image_token_cost
 from agent.usage_anchor import anchored_context_tokens, restore_usage_anchor
 from agent.turn_author import parse_turn_author
+from agent.turn_voice_context import parse_voice_context
 
 logger = logging.getLogger(__name__)
 
@@ -661,7 +662,8 @@ def _collect_pre_llm_call_context(
 ) -> str:
     """Run ``pre_llm_call`` plugins; their context is injected into the user message
     (never the system prompt). Oversized per-hook context is spilled to disk so a
-    runaway plugin can't inflate every subsequent turn's prompt."""
+    runaway plugin can't inflate every subsequent turn's prompt. Hooks also receive this
+    turn's ``voice_context`` (#109455) so a plugin can branch on it without core changes."""
     if getattr(agent, "_persist_disabled", False):
         return ""
     try:
@@ -678,6 +680,9 @@ def _collect_pre_llm_call_context(
             platform=getattr(agent, "platform", None) or "",
             parent_session_id=getattr(agent, "_parent_session_id", None) or "",
             sender_id=getattr(agent, "_user_id", None) or "",
+            # Trusted per-turn signal (#109455): {} on every non-voice turn, never the
+            # previous turn's value — see build_turn_context's reset-first comment.
+            voice_context=getattr(agent, "_turn_voice_context", None) or {},
         )
         try:
             # Spill oversized per-hook context to disk so a runaway plugin can't inflate every subsequent
@@ -855,6 +860,7 @@ def build_turn_context(
     persist_user_message: Optional[Any], persist_user_timestamp: Optional[float]=None,
     persist_user_platform_id: Optional[str]=None, *, persist_user_display_kind: Optional[str]=None,
     persist_user_display_metadata: Optional[Dict[str, Any]]=None, turn_author: Optional[Dict[str, Any]]=None,
+    voice_context: Optional[Dict[str, Any]]=None,
     restore_or_build_system_prompt,
     install_safe_stdio, sanitize_surrogates, summarize_user_message_for_log, set_session_context,
     set_current_write_origin, ra, moa_active: bool=False,
@@ -873,6 +879,10 @@ def build_turn_context(
     # Reset first: a cached gateway agent must never carry the previous turn's bot author into a human turn.
     turn_author = parse_turn_author(turn_author)
     agent._turn_author = turn_author
+    # Same reset-first rule for voice context (#109455): a typed turn on a cached gateway
+    # agent must never inherit a prior turn's voice signal, so this is rewritten every turn
+    # to {} rather than left alone when the caller passes nothing.
+    agent._turn_voice_context = parse_voice_context(voice_context)
 
     # Recover a rotated session before binding log/turn ids or copying client history so
     # everything in this turn belongs to the canonical child.

--- a/agent/turn_facade.py
+++ b/agent/turn_facade.py
@@ -27,6 +27,7 @@ class TurnFacadeMixin:
         persist_user_display_metadata: Optional[Dict[str, Any]]=None,
         persist_user_platform_id: Optional[str]=None, moa_config: Optional[dict[str, Any]]=None,
         turn_author: Optional[Dict[str, Any]] = None,
+        voice_context: Optional[Dict[str, Any]] = None,
         relay_metadata: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
@@ -136,7 +137,7 @@ class TurnFacadeMixin:
                         persist_user_display_kind=persist_user_display_kind,
                         persist_user_display_metadata=persist_user_display_metadata,
                         persist_user_platform_id=persist_user_platform_id, moa_config=moa_config,
-                        turn_author=turn_author,
+                        turn_author=turn_author, voice_context=voice_context,
                     )
                 finally:
                     # Post-loop relay/task finalization must not receive a late refresh interrupt;

--- a/agent/turn_voice_context.py
+++ b/agent/turn_voice_context.py
@@ -1,0 +1,54 @@
+"""Trusted per-turn voice/input-modality context, carried from a client entry point (CLI,
+TUI, Desktop-via-gateway) into the turn loop and on into ``pre_llm_call`` plugin/shell hooks.
+
+Ephemeral by construction: a cached gateway agent sees many turns over its lifetime, so this
+is read fresh per turn (mirrors ``agent/turn_author.py``) and never folded into the persisted
+user message, conversation history, or the cached system prompt — only the API-local copy of
+the current turn ever sees it. A turn that does not pass one clears whatever the previous turn
+set (#109455).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping
+
+_VALID_MODALITIES = frozenset({"voice", "text"})
+_MAX_SURFACE_LEN = 40
+
+
+def _clean_surface(value: Any) -> str:
+    """A short, trimmed surface label ("cli", "tui", "desktop", a platform name, ...); ``""``
+    for anything that isn't a non-empty string. No fixed enum — new surfaces need no code change."""
+    if not isinstance(value, str):
+        return ""
+    return value.strip()[:_MAX_SURFACE_LEN]
+
+
+def _truthy(value: Any) -> bool:
+    """Same coercion as ``turn_author._bot_flag``: a recognized truthy string, or a real
+    bool/int — never Python's own truthiness (``bool("false")`` is ``True``, which would be a
+    silent inversion of an explicit ``voice_session_active: "false"``)."""
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes"}
+    return isinstance(value, (bool, int)) and bool(value)
+
+
+def parse_voice_context(raw: Any) -> Dict[str, Any]:
+    """Normalize *raw* into ``{"input_modality", "voice_session_active", "client_surface"}``.
+
+    ``input_modality`` is this turn's input, ``voice_session_active`` is whether a voice
+    interaction is ongoing (independent — a user can type one message mid voice-session).
+    Anything that isn't a mapping, or a mapping asserting nothing (default modality, inactive,
+    no surface), normalizes to ``{}`` — falsy, so callers can treat "no signal" and "garbage
+    input" identically instead of special-casing either. Every field is normalized defensively
+    (an unhashable ``input_modality`` must not raise) since this can carry data from a client's
+    hook payload, not just Hermes' own trusted call sites."""
+    if not isinstance(raw, Mapping):
+        return {}
+    modality = raw.get("input_modality")
+    modality = modality if isinstance(modality, str) and modality in _VALID_MODALITIES else "text"
+    active = _truthy(raw.get("voice_session_active"))
+    surface = _clean_surface(raw.get("client_surface"))
+    if modality == "text" and not active and not surface:
+        return {}
+    return {"input_modality": modality, "voice_session_active": active, "client_surface": surface}

--- a/cli.py
+++ b/cli.py
@@ -2521,6 +2521,7 @@ class _ChatTurn:
     stop_event: Optional[threading.Event] = None
     tts_normal_exit: bool = False
     voice_prefix: str = ""
+    voice_context: Optional[dict] = None
 from hermes_cli.cli_chat_turn_mixin import CLIChatTurnMixin
 
 

--- a/hermes_cli/cli_chat_turn_mixin.py
+++ b/hermes_cli/cli_chat_turn_mixin.py
@@ -271,6 +271,13 @@ class CLIChatTurnMixin:
         if voice_input and isinstance(message, str):
             turn.voice_prefix = ("[Voice input — respond concisely and conversationally, "
                                  "2-3 sentences max. No code blocks or markdown.] ")
+        # Structured counterpart to the prose prefix above (#109455): lets a plugin's
+        # pre_llm_call hook branch on the signal instead of pattern-matching the prefix text.
+        if voice_input:
+            turn.voice_context = {
+                "input_modality": "voice", "voice_session_active": bool(self._voice_mode),
+                "client_surface": "cli",
+            }
 
     def _chat_run_agent(self, turn, message):
         """Agent-thread body: bind per-thread callbacks/approval key, prepend one-shot notes, run the turn."""
@@ -319,6 +326,7 @@ class CLIChatTurnMixin:
                 conversation_history=self.conversation_history[:-1],  # exclude the message just staged
                 stream_callback=turn.stream_callback, task_id=self.session_id,
                 persist_user_message=_persist_clean_user_message, moa_config=_moa_cfg,
+                voice_context=turn.voice_context,
             )
             if getattr(self, "_pending_moa_disable_after_turn", False):
                 _restore = getattr(self, "_pending_moa_restore_model", None) or {}

--- a/hermes_cli/hooks.py
+++ b/hermes_cli/hooks.py
@@ -116,6 +116,9 @@ _DEFAULT_PAYLOADS = {
     "pre_llm_call": {
         "session_id": "test-session", "user_message": "What is the weather?",
         "conversation_history": [], "is_first_turn": True, "model": "gpt-4", "platform": "cli",
+        # {} outside a voice turn (#109455) — non-empty only when the client marked this
+        # specific turn as voice input; see agent/turn_voice_context.py.
+        "voice_context": {},
     },
     "post_llm_call": {"session_id": "test-session", "model": "gpt-4", "platform": "cli"},
     "pre_verify": {

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -345,6 +345,88 @@ def test_turn_author_reaches_the_agent_through_the_real_facade(monkeypatch):
     assert agent._turn_author is None
 
 
+# ── Per-turn voice context (#109455) ─────────────────────────────────────────
+
+
+def test_voice_context_is_normalized_then_stashed_on_the_agent():
+    agent = _FakeAgent()
+
+    _build(agent, user_message="what's the weather",
+           voice_context={"input_modality": "voice", "voice_session_active": True,
+                          "client_surface": "desktop", "x": 1})
+
+    assert agent._turn_voice_context == {
+        "input_modality": "voice", "voice_session_active": True, "client_surface": "desktop",
+    }
+
+
+def test_turn_without_voice_context_clears_previous_turns_signal():
+    agent = _FakeAgent()
+    _build(agent, user_message="first turn", voice_context={"input_modality": "voice"})
+    assert agent._turn_voice_context["input_modality"] == "voice"
+
+    _build(agent, user_message="second turn")
+
+    assert agent._turn_voice_context == {}
+
+
+def test_garbage_voice_context_normalizes_to_empty_rather_than_raising():
+    agent = _FakeAgent()
+    _build(agent, user_message="hello", voice_context="not a dict")
+    assert agent._turn_voice_context == {}
+
+
+def test_voice_context_reaches_the_pre_llm_call_hook():
+    agent, _mm = _agent_with_memory_manager()
+    voice_context = {"input_modality": "voice", "voice_session_active": True, "client_surface": "cli"}
+
+    with patch("hermes_cli.lifecycle.invoke_hook", return_value=[]) as lifecycle_hook:
+        _build(agent, user_message="what did we decide?", voice_context=voice_context)
+
+    pre_llm_calls = [c for c in lifecycle_hook.call_args_list if c.args[:1] == ("pre_llm_call",)]
+    assert len(pre_llm_calls) == 1
+    assert pre_llm_calls[0].kwargs["voice_context"] == voice_context
+
+
+def test_absent_voice_context_reaches_the_pre_llm_call_hook_as_empty_dict():
+    agent, _mm = _agent_with_memory_manager()
+
+    with patch("hermes_cli.lifecycle.invoke_hook", return_value=[]) as lifecycle_hook:
+        _build(agent, user_message="what did we decide?")
+
+    pre_llm_calls = [c for c in lifecycle_hook.call_args_list if c.args[:1] == ("pre_llm_call",)]
+    assert len(pre_llm_calls) == 1
+    assert pre_llm_calls[0].kwargs["voice_context"] == {}
+
+
+def test_voice_context_reaches_the_agent_through_the_real_facade(monkeypatch):
+    """``AIAgent.run_conversation(voice_context=...)`` crosses the facade and the loop entry
+    point, not only ``build_turn_context``; a kwarg dropped at either hop raised TypeError on
+    every real turn (same regression shape as turn_author, above)."""
+    from types import SimpleNamespace
+    from run_agent import AIAgent
+
+    class _Completions:
+        def create(self, **_kw):
+            return SimpleNamespace(choices=[SimpleNamespace(
+                message=SimpleNamespace(content="ok", tool_calls=None, reasoning=None, reasoning_content=None),
+                finish_reason="stop")], usage=None, model="test-model")
+
+    monkeypatch.setattr("agent.process_bootstrap.OpenAI",
+                        lambda **_kw: SimpleNamespace(chat=SimpleNamespace(completions=_Completions())))
+    monkeypatch.setattr("model_tools.get_tool_definitions", lambda *a, **k: [])
+    agent = AIAgent(model="test-model", api_key="k", base_url="http://localhost:1/v1", platform="cli",
+                    max_iterations=2, quiet_mode=True, skip_memory=True)
+    agent._disable_streaming = True
+
+    agent.run_conversation("hi", voice_context={"input_modality": "voice", "voice_session_active": True})
+    assert agent._turn_voice_context == {
+        "input_modality": "voice", "voice_session_active": True, "client_surface": "",
+    }
+    agent.run_conversation("hi again")
+    assert agent._turn_voice_context == {}
+
+
 def test_turn_start_replaces_stale_parent_history_with_compression_child():
     agent = _FakeAgent()
     stale_history = [{"role": "user", "content": "stale parent"}]

--- a/tests/agent/test_turn_voice_context.py
+++ b/tests/agent/test_turn_voice_context.py
@@ -1,0 +1,73 @@
+"""Tests for agent.turn_voice_context: the trusted per-turn voice/input-modality signal (#109455)."""
+
+import pytest
+
+from agent.turn_voice_context import parse_voice_context
+
+
+class TestParseVoiceContext:
+    @pytest.mark.parametrize("raw", [None, "", "voice", 1, True, [], ["voice"]])
+    def test_non_mapping_input_returns_empty(self, raw):
+        assert parse_voice_context(raw) == {}
+
+    def test_empty_dict_returns_empty(self):
+        assert parse_voice_context({}) == {}
+
+    def test_dict_asserting_nothing_returns_empty(self):
+        # Default modality, inactive session, no surface — indistinguishable from "not provided".
+        assert parse_voice_context({"input_modality": "text", "voice_session_active": False}) == {}
+
+    def test_voice_modality_is_preserved(self):
+        result = parse_voice_context({"input_modality": "voice"})
+        assert result == {"input_modality": "voice", "voice_session_active": False, "client_surface": ""}
+
+    def test_active_session_alone_is_preserved(self):
+        # Typed message mid voice-session: modality is text, but the session flag still matters.
+        result = parse_voice_context({"voice_session_active": True})
+        assert result == {"input_modality": "text", "voice_session_active": True, "client_surface": ""}
+
+    def test_surface_alone_is_preserved(self):
+        result = parse_voice_context({"client_surface": "desktop"})
+        assert result == {"input_modality": "text", "voice_session_active": False, "client_surface": "desktop"}
+
+    def test_full_shape_round_trips(self):
+        raw = {"input_modality": "voice", "voice_session_active": True, "client_surface": "desktop"}
+        assert parse_voice_context(raw) == raw
+
+    def test_unknown_modality_falls_back_to_text(self):
+        result = parse_voice_context({"input_modality": "telepathy", "voice_session_active": True})
+        assert result["input_modality"] == "text"
+
+    def test_non_string_surface_is_dropped(self):
+        result = parse_voice_context({"input_modality": "voice", "client_surface": 12345})
+        assert result["client_surface"] == ""
+
+    def test_surface_is_trimmed_and_capped(self):
+        result = parse_voice_context({"input_modality": "voice", "client_surface": "  desktop  "})
+        assert result["client_surface"] == "desktop"
+        long_surface = "x" * 500
+        result = parse_voice_context({"input_modality": "voice", "client_surface": long_surface})
+        assert len(result["client_surface"]) == 40
+
+    def test_extra_keys_are_ignored(self):
+        result = parse_voice_context({"input_modality": "voice", "tts_provider": "elevenlabs"})
+        assert "tts_provider" not in result
+
+    @pytest.mark.parametrize("unhashable", [[], {}, ["voice"], {"nested": True}])
+    def test_unhashable_modality_normalizes_to_text_instead_of_raising(self, unhashable):
+        # Regression: `modality in _VALID_MODALITIES` on a list/dict raised TypeError
+        # (unhashable type), defeating this function's whole "never raise on garbage" contract.
+        result = parse_voice_context({"input_modality": unhashable, "voice_session_active": True})
+        assert result["input_modality"] == "text"
+
+    def test_string_false_does_not_mean_active(self):
+        # Regression: bool("false") is True in Python — a naive bool() cast would silently
+        # invert an explicit voice_session_active: "false" sent by a JSON-ish caller.
+        assert parse_voice_context({"voice_session_active": "false"}) == {}
+        result = parse_voice_context({"input_modality": "voice", "voice_session_active": "false"})
+        assert result["voice_session_active"] is False
+
+    @pytest.mark.parametrize("truthy_string", ["true", "True", "1", "yes"])
+    def test_recognized_truthy_strings_activate_the_session(self, truthy_string):
+        result = parse_voice_context({"voice_session_active": truthy_string})
+        assert result["voice_session_active"] is True

--- a/tests/hermes_cli/test_cli_voice_context_109455.py
+++ b/tests/hermes_cli/test_cli_voice_context_109455.py
@@ -1,0 +1,105 @@
+"""Structured voice_context wiring in CLIChatTurnMixin (#109455).
+
+The existing ``voice_prefix`` (issue #65827) bakes a prose note into the API-only message so
+the model speaks concisely; these tests cover the newer, structured counterpart that lets a
+``pre_llm_call`` hook branch on the signal instead of pattern-matching that prose.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cli import _ChatTurn
+from hermes_cli.cli_chat_turn_mixin import CLIChatTurnMixin
+
+
+class _VoiceAudioHost(CLIChatTurnMixin):
+    """Minimal stand-in covering only what ``_chat_setup_turn_audio`` touches."""
+
+    def __init__(self, *, voice_mode: bool):
+        self._voice_mode = voice_mode
+        self._voice_continuous = False
+        self._voice_tts = False
+
+
+class TestChatSetupTurnAudioVoiceContext:
+    def test_voice_input_sets_structured_voice_context(self):
+        host = _VoiceAudioHost(voice_mode=True)
+        turn = _ChatTurn()
+
+        host._chat_setup_turn_audio(turn, "what's the weather", voice_input=True)
+
+        assert turn.voice_context == {
+            "input_modality": "voice", "voice_session_active": True, "client_surface": "cli",
+        }
+        assert turn.voice_prefix  # existing #65827 prose behavior is untouched
+
+    def test_voice_input_outside_continuous_mode_reports_session_inactive(self):
+        # A one-off dictated utterance (push-to-talk), not standing voice mode.
+        host = _VoiceAudioHost(voice_mode=False)
+        turn = _ChatTurn()
+
+        host._chat_setup_turn_audio(turn, "hi", voice_input=True)
+
+        assert turn.voice_context["voice_session_active"] is False
+
+    def test_typed_input_leaves_voice_context_unset(self):
+        host = _VoiceAudioHost(voice_mode=False)
+        turn = _ChatTurn()
+
+        host._chat_setup_turn_audio(turn, "hello", voice_input=False)
+
+        assert turn.voice_context is None
+        assert turn.voice_prefix == ""
+
+
+class _RunAgentHost(CLIChatTurnMixin):
+    """Minimal stand-in covering only what ``_chat_run_agent`` touches."""
+
+    def __init__(self):
+        self.session_id = "sess-1"
+        self.conversation_history = [{"role": "user", "content": "hi"}]
+        self.agent = MagicMock()
+        self.agent.run_conversation.return_value = {
+            "final_response": "ok", "messages": [], "api_calls": 1, "completed": True,
+        }
+        for _cb in ("_sudo_password_callback", "_approval_callback", "_secret_capture_callback",
+                    "_vault_unlock_callback", "_vault_save_login_callback", "_vault_code_callback"):
+            setattr(self, _cb, MagicMock())
+        self._pending_model_switch_note = None
+        self._pending_skills_reload_note = None
+        self._pending_moa_config = None
+        self._pending_moa_disable_after_turn = False
+        self._pending_one_turn_model_restore = None
+        self._flush_credit_notices = MagicMock()
+
+
+@pytest.fixture(autouse=True)
+def _no_speech_interrupt():
+    with patch("tools.tts_streaming.take_speech_interrupted", return_value=False):
+        yield
+
+
+class TestChatRunAgentForwardsVoiceContext:
+    def test_voice_turn_context_reaches_run_conversation(self):
+        host = _RunAgentHost()
+        turn = _ChatTurn()
+        turn.voice_context = {
+            "input_modality": "voice", "voice_session_active": True, "client_surface": "cli",
+        }
+
+        host._chat_run_agent(turn, "what's the weather")
+
+        _, kwargs = host.agent.run_conversation.call_args
+        assert kwargs["voice_context"] == turn.voice_context
+
+    def test_typed_turn_forwards_none(self):
+        host = _RunAgentHost()
+        turn = _ChatTurn()  # voice_context defaults to None
+
+        host._chat_run_agent(turn, "hello")
+
+        _, kwargs = host.agent.run_conversation.call_args
+        assert kwargs["voice_context"] is None

--- a/tests/tui_gateway/test_voice_turn_context_109455.py
+++ b/tests/tui_gateway/test_voice_turn_context_109455.py
@@ -1,0 +1,192 @@
+"""Structured voice_context for TUI/Desktop gateway turns (#109455).
+
+Desktop's GPT-Live full-duplex mode already tags its turns with ``surface: "voice-live"``
+(see tools/voice_live.py, tests/tui_gateway/test_voice_live_delegation.py); these tests cover
+turning that existing signal into the same structured ``{input_modality, voice_session_active,
+client_surface}`` shape ``pre_llm_call`` hooks/plugins get for CLI voice input, and threading it
+into the actual turn via ``agent.run_conversation(voice_context=...)``.
+
+``voice_context`` is threaded as an explicit per-request argument end-to-end (``prompt.submit``
+-> ``_handle_busy_submit``/``_enqueue_prompt`` -> the queued-prompt dict -> ``_run_prompt_submit``
+-> ``_invoke_agent``), exactly like the existing ``turn_author`` — NOT stashed on the shared
+``session`` dict. An earlier version of this change stored it as ``session["voice_turn_context"]``
+and read it back in ``_invoke_agent``; two independent reviewers caught that a session dict is
+mutated on every submit, so a value stored there would misattribute to whichever turn next reads
+it — a queued prompt still waiting behind a busy turn, or an internal follow-up (auto-continue,
+goal continuation, a heartbeat/background notification) that calls ``_run_prompt_submit`` directly
+and never goes through ``prompt.submit`` at all. The tests below pin the explicit-threading fix
+and the state-bleed scenario it closes.
+"""
+
+from __future__ import annotations
+
+import threading
+import types
+
+import pytest
+
+from tui_gateway import server
+
+# ``_invoke_agent``/``_TurnRun``/etc. reference server.py globals (``_emit``, ``sys``, ...) as bare
+# names; they only resolve once ``method_ctx.bind_module`` rebinds them onto ``server`` at import
+# time (see prompt_turn.py's module docstring), so tests must call the rebound ``server.<name>``,
+# not the raw ``prompt_turn``/``session_auto_continue`` module attribute.
+_TurnRun = server._TurnRun
+_invoke_agent = server._invoke_agent
+_enqueue_prompt = server._enqueue_prompt
+_sanitize_queued_entry_vs_inflight_user = server._sanitize_queued_entry_vs_inflight_user
+
+
+def _session(**extra):
+    return {
+        "agent": types.SimpleNamespace(valid_tool_names=set()),
+        "session_key": "session-key",
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": True,
+        "transport": None,
+        "attached_images": [],
+        **extra,
+    }
+
+
+_VOICE_CONTEXT = {"input_modality": "voice", "voice_session_active": True, "client_surface": "voice-live"}
+
+
+class TestPromptSubmitComputesVoiceContextWithoutMutatingSession:
+    """``prompt.submit`` no longer stashes the signal on the session — it's a local, threaded
+    straight into the turn invocation for THIS request only."""
+
+    @pytest.fixture
+    def busy_session(self):
+        session = _session()
+        server._sessions["sid"] = session
+        yield session
+        server._sessions.pop("sid", None)
+
+    def test_live_surface_submit_leaves_no_trace_on_the_session(self, busy_session):
+        server._methods["prompt.submit"](
+            "r1", {"session_id": "sid", "text": "what's the weather", "queued": True, "surface": "voice-live"})
+
+        assert "voice_turn_context" not in busy_session
+
+    def test_hud_surface_submit_also_leaves_no_trace(self, busy_session):
+        server._methods["prompt.submit"](
+            "r1", {"session_id": "sid", "text": "x", "queued": True, "surface": "hud"})
+
+        assert "voice_turn_context" not in busy_session
+
+
+class _FakeAgentWithVoiceContext:
+    """A ``run_conversation`` whose signature actually declares ``voice_context`` (unlike a bare
+    ``MagicMock``, on which ``inspect.signature`` can't feature-detect the parameter) — mirrors
+    the real ``agent.turn_facade.TurnFacadeMixin.run_conversation`` contract closely enough for
+    ``_invoke_agent``'s ``"voice_context" in run_params`` guard to behave as it does in production.
+    """
+
+    def __init__(self):
+        self.valid_tool_names = set()
+        self.captured_kwargs: dict = {}
+
+    def run_conversation(self, run_message, *, conversation_history=None, stream_callback=None,
+                         persist_user_message=None, task_id=None, turn_author=None,
+                         voice_context=None, **_ignored):
+        self.captured_kwargs = dict(voice_context=voice_context, turn_author=turn_author)
+        return {"final_response": "ok", "messages": [], "completed": True}
+
+
+def _turn_run(agent):
+    return _TurnRun(agent=agent, one_turn_restore=None, terminal_callback=None, receipt_committed=False)
+
+
+class TestInvokeAgentThreadsVoiceContext:
+    def test_voice_context_reaches_run_conversation(self):
+        agent = _FakeAgentWithVoiceContext()
+        session = _session()
+        st = _turn_run(agent)
+
+        _invoke_agent("sid", session, st, "what's the weather", "what's the weather", None, [], None, None,
+                      None, _VOICE_CONTEXT)
+
+        assert agent.captured_kwargs["voice_context"] == _VOICE_CONTEXT
+
+    def test_typed_turn_omits_voice_context_kwarg(self):
+        agent = _FakeAgentWithVoiceContext()
+        session = _session()
+        st = _turn_run(agent)
+
+        _invoke_agent("sid", session, st, "hello", "hello", None, [], None, None)
+
+        assert agent.captured_kwargs["voice_context"] is None
+
+    def test_no_state_bleed_across_invocations_on_the_same_session(self):
+        """Regression: a prior design stored the signal on ``session["voice_turn_context"])``,
+        so a voice turn's flag survived on the shared dict and leaked into the NEXT turn on the
+        same session — including an internal follow-up that never passed voice_context at all.
+        Explicit-argument threading makes that structurally impossible: two calls sharing one
+        session dict must not influence each other."""
+        agent = _FakeAgentWithVoiceContext()
+        session = _session()
+        st = _turn_run(agent)
+
+        _invoke_agent("sid", session, st, "what's the weather", "what's the weather", None, [], None, None,
+                      None, _VOICE_CONTEXT)
+        assert agent.captured_kwargs["voice_context"] == _VOICE_CONTEXT
+
+        # A same-session follow-up (auto-continue, goal continuation, a heartbeat) that never
+        # passes voice_context must not inherit the previous turn's flag.
+        _invoke_agent("sid", session, st, "continuing...", "continuing...", None, [], None, None)
+        assert agent.captured_kwargs["voice_context"] is None
+
+
+class TestEnqueuePromptPreservesVoiceContext:
+    """The queued-prompt envelope (mirrors ``turn_author``'s existing handling)."""
+
+    def test_voice_tagged_prompt_is_queued_with_its_context(self):
+        session = _session()
+
+        _enqueue_prompt(session, "what's the weather", None, voice_context=_VOICE_CONTEXT)
+
+        assert session["queued_prompt"]["voice_context"] == _VOICE_CONTEXT
+
+    def test_voice_tagged_prompt_does_not_merge_with_a_plain_queued_slot(self):
+        session = _session()
+        _enqueue_prompt(session, "first", None)
+        assert "queued_prompts" not in session  # plain text-only queue: still just one slot
+
+        _enqueue_prompt(session, "second (voice)", None, voice_context=_VOICE_CONTEXT)
+
+        # A voice-tagged entry must stay a separate envelope, not get glued onto the plain one —
+        # merging would make the combined text's voice_context ambiguous.
+        assert session["queued_prompt"]["text"] == "first"
+        assert session["queued_prompts"][0]["text"] == "second (voice)"
+        assert session["queued_prompts"][0]["voice_context"] == _VOICE_CONTEXT
+
+    def test_plain_prompt_after_a_voice_tagged_one_does_not_merge_into_it(self):
+        session = _session()
+        _enqueue_prompt(session, "first (voice)", None, voice_context=_VOICE_CONTEXT)
+
+        _enqueue_prompt(session, "second", None)
+
+        assert session["queued_prompt"]["text"] == "first (voice)"
+        assert session["queued_prompts"][0]["text"] == "second"
+        assert "voice_context" not in session["queued_prompts"][0]
+
+
+class TestSanitizeQueuedEntryKeepsVoiceTaggedEnvelopes:
+    def test_voice_tagged_self_duplicate_text_is_not_dropped(self):
+        entry = {"text": "what's the weather", "voice_context": _VOICE_CONTEXT}
+
+        result = _sanitize_queued_entry_vs_inflight_user(entry, "what's the weather")
+
+        assert result == entry
+
+    def test_untagged_self_duplicate_text_is_still_droppable(self):
+        # Baseline: without a voice_context (or turn_author), the existing self-duplicate
+        # detection is untouched by this change.
+        entry = {"text": "what's the weather"}
+
+        result = _sanitize_queued_entry_vs_inflight_user(entry, "what's the weather")
+
+        assert result is None

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -471,7 +471,8 @@ def _persist_session_row_for_submit(rid, session):
     return error
 
 
-def _run_after_agent_ready(rid, sid, session, text, display_kind, hosted_terminal_callback, turn_author=None):
+def _run_after_agent_ready(rid, sid, session, text, display_kind, hosted_terminal_callback, turn_author=None,
+                           voice_context=None):
     """Turn thread body: patient wait for a deferred build (a slow build must not eat the
     accepted in-flight message), then run."""
     # The wait delivers the prompt when the still-running build completes, honors a cancel promptly, notices
@@ -501,7 +502,7 @@ def _run_after_agent_ready(rid, sid, session, text, display_kind, hosted_termina
             return
     _run_prompt_submit(
         rid, sid, session, text, display_kind=display_kind,
-        terminal_callback=hosted_terminal_callback, turn_author=turn_author)
+        terminal_callback=hosted_terminal_callback, turn_author=turn_author, voice_context=voice_context)
 
 
 _TRUNCATION_PARAMS = (
@@ -586,6 +587,16 @@ def _(rid, params: dict) -> dict:
     voice_context = params.get("voice_context")
     session["voice_live_context"] = (
         voice_context[:6000] if session["client_surface"] == "voice-live" and isinstance(voice_context, str) else "")
+    # Structured counterpart for pre_llm_call hooks/plugins (#109455). Distinct from
+    # voice_context above (that's the spoken transcript text on the wire; this is the trusted
+    # input_modality/client_surface signal threaded into agent._turn_voice_context). Threaded as
+    # an explicit per-request argument below (turn_voice_context), like turn_author — NOT stashed
+    # on the shared session dict: a session is mutated on every submit, so a value stored there
+    # would misattribute to whichever turn next reads it (a queued/auto-continue/goal-followup
+    # turn that never went through this handler at all).
+    turn_voice_context = (
+        {"input_modality": "voice", "voice_session_active": True, "client_surface": "voice-live"}
+        if session["client_surface"] == "voice-live" else None)
     has_truncation = any(params.get(k) is not None for k in _TRUNCATION_PARAMS)
     if has_truncation and isinstance(text, str):
         # A rewind replays what the transcript shows: re-expand a skill invocation or
@@ -615,7 +626,8 @@ def _(rid, params: dict) -> dict:
                 return _err(rid, 4091, "hosted room member session is busy")
             busy_transport = t or session.get("transport")
         busy_response = _handle_busy_submit(
-            rid, sid, session, text, busy_transport, queued=bool(params.get("queued")), turn_author=turn_author)
+            rid, sid, session, text, busy_transport, queued=bool(params.get("queued")), turn_author=turn_author,
+            voice_context=turn_voice_context)
         if busy_response is not None:
             return busy_response
     raw_rebind_ids = params.get("rebind_survivor_row_ids")
@@ -654,7 +666,7 @@ def _(rid, params: dict) -> dict:
         _start_agent_build(sid, session)
     run_thread = threading.Thread(
         target=lambda: _run_after_agent_ready(
-            rid, sid, session, text, display_kind, hosted_terminal_callback, turn_author),
+            rid, sid, session, text, display_kind, hosted_terminal_callback, turn_author, turn_voice_context),
         daemon=True)
     # Handle lets session.interrupt tell a live turn from a stuck `running` flag.
     session["_run_thread"] = run_thread

--- a/tui_gateway/prompt_turn.py
+++ b/tui_gateway/prompt_turn.py
@@ -511,7 +511,7 @@ def _prepare_turn_input(sid: str, session: dict, st: _TurnRun, text: Any, images
 def _invoke_agent(
     sid: str, session: dict, st: _TurnRun, prompt: Any, run_message: Any, streamer,
     images: list[str], display_kind: str | None, display_metadata: dict | None,
-    turn_author: dict | None = None) -> None:
+    turn_author: dict | None = None, voice_context: dict | None = None) -> None:
     """Wire the streaming callbacks and run the conversation into ``st.result``."""
     agent = st.agent
 
@@ -549,6 +549,8 @@ def _invoke_agent(
         run_kwargs["persist_user_display_metadata"] = display_metadata
     if turn_author and "turn_author" in run_params:
         run_kwargs["turn_author"] = turn_author
+    if voice_context and "voice_context" in run_params:
+        run_kwargs["voice_context"] = voice_context
     # Live-rename hook: auto-titling fires inside the turn prologue.
     _title_key = session.get("session_key") or sid
     agent._on_session_title = lambda t, _src, _k=_title_key: _emit(
@@ -793,7 +795,7 @@ def _run_prompt_submit(
     display_metadata: dict | None = None, image_paths: list[str] | None = None,
     queued_prompt_generation: int | None = None,
     terminal_callback: Callable[[dict[str, Any]], None] | None = None,
-    turn_author: dict | None = None) -> bool:
+    turn_author: dict | None = None, voice_context: dict | None = None) -> bool:
     admitted = _admit_prompt_turn(sid, session, text, image_paths, queued_prompt_generation)
     if admitted is None:
         return False
@@ -836,7 +838,7 @@ def _run_prompt_submit(
             prompt, run_message, cols, streamer = prepared
             _invoke_agent(
                 sid, session, st, prompt, run_message, streamer, images, display_kind,
-                display_metadata, turn_author)
+                display_metadata, turn_author, voice_context)
             status_note = _absorb_turn_result(
                 sid, session, st, text, display_kind, display_metadata)
             payload, raw, status = _complete_turn_payload(session, st, status_note, cols)

--- a/tui_gateway/session_auto_continue.py
+++ b/tui_gateway/session_auto_continue.py
@@ -126,25 +126,28 @@ def _ac_inflight_original(session: dict) -> str:
 
 
 def _enqueue_prompt(session: dict, text: Any, transport: Any, image_paths: list[str] | None = None,
-                    turn_author: dict | None = None) -> None:
+                    turn_author: dict | None = None, voice_context: dict | None = None) -> None:
     """Queue a message for the next turn. Text-only arrivals share a slot and merge losslessly (like the
-    consecutive-user merge in ``repair_message_sequence``); image-bearing and authored ones stay separate
-    envelopes so attachment chronology and the sender survive. ``transport`` is pinned so the drained turn
-    streams to its sender."""
+    consecutive-user merge in ``repair_message_sequence``); image-bearing, authored and voice-tagged ones
+    stay separate envelopes so attachment chronology, the sender and the voice signal (#109455) survive.
+    ``transport`` is pinned so the drained turn streams to its sender."""
     image_paths = list(image_paths or [])
     # Scrub live-turn self-duplicates first so the text merge below can't glue "{original}\n\n{later}" and re-fire the
     # original after a correction settles.
     # See #84417.
     _drop_queued_duplicates_of_inflight_user(session)
     text_only = not image_paths and isinstance(text, str)
-    # A text-only self-copy of the live prompt would restart it on drain; an authored copy is another sender's message.
-    if text_only and not turn_author and text.strip() == _ac_inflight_original(session) != "":
+    # A text-only self-copy of the live prompt would restart it on drain; an authored or voice-tagged copy
+    # is either another sender's message or carries a signal that must not be silently dropped.
+    if text_only and not turn_author and not voice_context and text.strip() == _ac_inflight_original(session) != "":
         return
     queued = {"text": text, "transport": transport, **({"image_paths": image_paths} if image_paths else {}),
-              **({"turn_author": turn_author} if turn_author else {})}
+              **({"turn_author": turn_author} if turn_author else {}),
+              **({"voice_context": voice_context} if voice_context else {})}
     existing = session.get("queued_prompt")
-    if (existing and text_only and not turn_author and isinstance(existing.get("text"), str)
+    if (existing and text_only and not turn_author and not voice_context and isinstance(existing.get("text"), str)
             and not existing.get("image_paths") and not existing.get("turn_author")
+            and not existing.get("voice_context")
             and not session.get("queued_prompts")):
         prev = existing["text"]
         existing["text"] = f"{prev}\n\n{text}" if prev and text else (prev or text)
@@ -156,8 +159,9 @@ def _enqueue_prompt(session: dict, text: Any, transport: Any, image_paths: list[
 
 def _sanitize_queued_entry_vs_inflight_user(entry: Any, original: str) -> dict | None:
     """Drop (``None``) a text-only self-duplicate of the live user text, or rewrite a merged slot
-    ``"{original}\\n\\n{later}"`` to ``later`` so the correction survives without re-firing the original. Image-bearing
-    and authored envelopes are left alone: chronology and the sender's own words are kept.
+    ``"{original}\\n\\n{later}"`` to ``later`` so the correction survives without re-firing the original. Image-bearing,
+    authored and voice-tagged envelopes are left alone: chronology, the sender's own words and the voice
+    signal (#109455) are kept.
 
     Returns ``None`` to drop the envelope, or a (possibly rewritten) dict to keep. A merged slot
     ``"{original}\\n\\n{later}"`` (from ``_enqueue_prompt``'s consecutive text merge) is rewritten to just
@@ -166,7 +170,8 @@ def _sanitize_queued_entry_vs_inflight_user(entry: Any, original: str) -> dict |
     if not isinstance(entry, dict):
         return None
     text = entry.get("text")
-    if not original or entry.get("image_paths") or entry.get("turn_author") or not isinstance(text, str):
+    if (not original or entry.get("image_paths") or entry.get("turn_author") or entry.get("voice_context")
+            or not isinstance(text, str)):
         return entry
     # A lossless text-merge may have glued the live original onto a later follow-up: keep the remainder.
     rest = next((text[len(original + sep):] for sep in ("\n\n", "\n") if text.startswith(original + sep)), text).strip()
@@ -238,7 +243,7 @@ def _ac_try_correction(rid, session: dict, agent: Any, method: str, plain_text: 
 
 
 def _handle_busy_submit(rid, sid: str, session: dict, text: Any, transport: Any, queued: bool = False,
-                        turn_author: dict | None = None) -> dict | None:
+                        turn_author: dict | None = None, voice_context: dict | None = None) -> dict | None:
     """Apply ``display.busy_input_mode`` to a mid-turn prompt instead of rejecting it (rejection made clients busy-retry
     and drop sends): ``interrupt`` (default) → redirect, falling back to hard interrupt + queue; ``queue`` → queue only;
     ``steer`` → inject after the current atomic action. ``queued=True`` (client queue drain) forces queue mode: a "run
@@ -269,7 +274,8 @@ def _handle_busy_submit(rid, sid: str, session: dict, text: Any, transport: Any,
             if image_paths:
                 session["attached_images"] = image_paths + list(session.get("attached_images", []))
             return None
-        _enqueue_prompt(session, text, transport, image_paths=image_paths, turn_author=turn_author)
+        _enqueue_prompt(session, text, transport, image_paths=image_paths, turn_author=turn_author,
+                        voice_context=voice_context)
         session["last_active"] = time.time()
     # Attachments need their own model invocation: queue without cancelling so the user gets both results in order.
     # ``steer`` must NEVER escalate to a hard interrupt: it would kill the live turn AND drop ``AIAgent._pending_steer``
@@ -312,12 +318,13 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
     kwargs: dict = {"queued_prompt_generation": queue_generation}
     if queued.get("image_paths"):
         kwargs["image_paths"] = queued["image_paths"]
-    # The compute-host frame has no author field, so only the inline runner receives it.
+    # The compute-host frame has no author (or voice) field, so only the inline runner receives them.
     author_kwargs = {"turn_author": queued["turn_author"]} if queued.get("turn_author") else {}
+    voice_kwargs = {"voice_context": queued["voice_context"]} if queued.get("voice_context") else {}
     dispatch_failed = False
     try:
         if not use_compute_host:
-            _run_prompt_submit(rid, sid, session, queued["text"], **kwargs, **author_kwargs)
+            _run_prompt_submit(rid, sid, session, queued["text"], **kwargs, **author_kwargs, **voice_kwargs)
         elif (resp := _submit_prompt_to_compute_host(rid, sid, session, queued["text"], **kwargs)).get("error"):
             with session["history_lock"]:
                 session["running"] = False


### PR DESCRIPTION
## What does this PR do?

Adds a trusted, ephemeral, per-turn `voice_context` signal — `{input_modality, voice_session_active, client_surface}` — that reaches `pre_llm_call` plugin/shell hooks, so a plugin can implement voice-aware behavior (e.g. shorter, more speakable replies) without patching core, per #109455.

Scoped to the backend primitive plus the two client paths verifiable end-to-end without a GUI:

1. **The primitive**: `agent/turn_voice_context.py` normalizes/validates the shape (never raises on garbage input — coerces unhashable/mistyped fields defensively; a JSON-ish `"false"` string is not `bool()`-coerced to `True`). `build_turn_context` stores it as `agent._turn_voice_context`, reset every turn (mirrors the existing `turn_author` reset-first pattern) so a cached gateway agent never carries a stale voice signal into a typed turn. `_collect_pre_llm_call_context` forwards it to the `pre_llm_call` hook — both Python plugin hooks and shell hooks (the latter get it for free via the existing generic `extra` payload field in `agent/shell_hooks.py`).
2. **CLI**: `voice_input=True` (the existing signal behind #65827's prose prefix) now also populates the structured `voice_context`, forwarded through `run_conversation`.
3. **TUI/Desktop gateway**: Desktop's GPT-Live full-duplex mode already tags a turn with `surface: "voice-live"` (merged in #108137), but that signal never reached hooks — only an internal prose note. This PR converts it into the same structured shape and threads it **as an explicit per-request argument** — `prompt.submit` → `_handle_busy_submit`/`_enqueue_prompt` → the queued-prompt envelope → `_drain_queued_prompt` → `_run_prompt_submit` → `_invoke_agent` → `agent.run_conversation(voice_context=...)` — mirroring exactly how `turn_author` is already threaded through this same pipeline, using the same `inspect.signature` feature-detection guard so nothing breaks for an older/different `run_conversation`.

**Never persisted, never shared-mutable-state**: like `turn_author`/the `api_content` sidecar pattern already documented in CONTRIBUTING.md ("Ephemeral injection... never persisted to the database or logs"), `voice_context` never touches `persist_user_message`, conversation history, or the cached system prompt. An earlier draft of this PR stored the TUI-side signal on the shared `session` dict; two reviewers (independent agent review, see below) caught that this leaks across turns that share a session — a queued prompt waiting behind a busy turn, or an internal follow-up (auto-continue, goal continuation, a heartbeat/background notification) that calls `_run_prompt_submit` directly and never goes through `prompt.submit` at all. Fixed by threading it as an explicit function argument end-to-end instead, exactly like `turn_author` — see the regression tests in `tests/tui_gateway/test_voice_turn_context_109455.py::TestInvokeAgentThreadsVoiceContext::test_no_state_bleed_across_invocations_on_the_same_session`.

**Reviewed by two other coding agents (codex, antigravity) against this diff before submission** — both independently caught the session-state-bleed bug above; after the fix, both re-verified the fix and found no new regressions. One further nuance codex flagged: the mid-turn `steer`/`redirect` correction path (`_ac_try_correction` in `session_auto_continue.py`) doesn't thread `voice_context` either — confirmed this is a **pre-existing parity gap shared identically with `turn_author`** (that function has no `turn_author` parameter at all), not a new regression from this change, since a steer/redirect injects into an already-built turn without re-invoking `build_turn_context`/`pre_llm_call`.

**Not in scope for this PR** (flagging rather than silently dropping, per the issue's own multi-surface ask):
- TUI's own push-to-talk dictation currently submits transcribed text indistinguishably from typed input — `ui-tui/src` has no existing wire field for it, and I didn't want to guess at a new RPC contract for a frontend I can't visually test or build in this environment.
- Messaging-platform voice input (e.g. a Telegram voice note transcribed to text) isn't wired — `gateway/run_turn_runner.py` already threads `turn_author` the same way; `voice_context` would follow the identical shape there as a natural next step.
- The isolated compute-worker path (`_submit_prompt_to_compute_host`) doesn't carry `turn_author` either today, so `voice_context` is consistently absent there too — not a new gap.

The backend primitive and the `prompt.submit` → `agent.run_conversation` plumbing (including the queueing envelope) are already in place, so each of the above is a small, additive follow-up whenever someone can verify it against the real frontend/platform.

## Related Issue

Addresses the core "let hooks/plugins see this turn's voice signal" ask in #109455 (backend primitive + CLI + the existing Desktop voice-live surface, with proper per-request isolation through the busy/queue path). Full multi-surface/gateway-platform coverage the issue also asks for is left for follow-up PRs, scoped to what can actually be verified.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/turn_voice_context.py` (new) — `parse_voice_context()`: normalizes/whitelists `{input_modality, voice_session_active, client_surface}`; `{}` for anything that isn't a mapping or asserts nothing; never raises on malformed fields.
- `agent/turn_context.py` — `build_turn_context(voice_context=...)` stores `agent._turn_voice_context` (reset every turn); `_collect_pre_llm_call_context` forwards it to the `pre_llm_call` hook.
- `agent/conversation_loop.py`, `agent/turn_facade.py` — thread `voice_context` through `run_conversation`/`_run_conversation_turn`/`AIAgent.run_conversation` (additive, defaults to `None`).
- `hermes_cli/cli_chat_turn_mixin.py`, `cli.py` — `_chat_setup_turn_audio` builds the structured `turn.voice_context` alongside the existing `voice_prefix`; `_chat_run_agent` forwards it; `_ChatTurn` gets the field.
- `hermes_cli/hooks.py` — `hermes hooks test`/`doctor`'s sample `pre_llm_call` payload now includes `voice_context: {}` for discoverability.
- `tui_gateway/methods_prompt.py` — computes the structured signal from `client_surface == "voice-live"` as a **local** (not session-stored), threaded into `_handle_busy_submit`/`_run_after_agent_ready`.
- `tui_gateway/session_auto_continue.py` — `_handle_busy_submit`, `_enqueue_prompt` (+ the queued-prompt envelope and its merge/self-duplicate exclusion rules), and `_drain_queued_prompt` thread `voice_context` exactly like the existing `turn_author`.
- `tui_gateway/prompt_turn.py` — `_run_prompt_submit`/`_invoke_agent` accept `voice_context` as an explicit parameter (not read from `session`), threaded into `run_kwargs["voice_context"]` when the target `run_conversation` declares it.
- Tests: `tests/agent/test_turn_voice_context.py` (normalizer unit tests, including regressions for the two bugs a reviewer's direct execution surfaced), additions to `tests/agent/test_turn_context.py` (reset-per-turn + hook exposure + real-facade end-to-end, mirroring the existing `turn_author` tests), `tests/hermes_cli/test_cli_voice_context_109455.py`, `tests/tui_gateway/test_voice_turn_context_109455.py` (including the same-session no-leak regression and queue-envelope preservation).

## How to Test

```
scripts/run_tests.sh tests/agent/test_turn_voice_context.py tests/agent/test_turn_context.py tests/hermes_cli/test_cli_voice_context_109455.py tests/tui_gateway/test_voice_turn_context_109455.py tests/tui_gateway/test_voice_live_delegation.py tests/tui_gateway/test_auto_continue.py
```
All new + existing tests pass. Also ran the full `tests/agent/`, `tests/hermes_cli/`, `tests/tui_gateway/` directories through `scripts/run_tests.sh` (the hermetic per-file runner CONTRIBUTING recommends) with no new failures relative to `main`.

Manual: a `pre_llm_call` plugin hook declaring `**kwargs` (or an explicit `voice_context` parameter) now receives `voice_context={"input_modality": "voice", "voice_session_active": True, "client_surface": "cli"}` on a CLI turn started with `voice_input=True`, and `{}`/absent on every typed turn.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(agent):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (no PR references #109455 as of this writing)
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` on the directly relevant test suites and directories, all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin), Python 3.11

### Documentation & Housekeeping

- [x] No user-facing config keys added — N/A for `cli-config.yaml.example`
- [x] No architecture/workflow change requiring `CONTRIBUTING.md`/`AGENTS.md` updates
- [x] Cross-platform: pure Python data plumbing, no OS/process/file/terminal calls; `scripts/check-windows-footguns.py` reports clean on this diff
- [x] No existing tool schema changed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsASVczrsCMPYT6AGq62bR
