### PR TITLE
fix(errors): Anthropic credits_required 429 rotates the credential instead of retrying (omp#11333 port)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -107,8 +107,16 @@ _XAI_SPENDING_LIMIT_ERROR_CODE = "personal-team-blocked:spending-limit"
 _BILLING_ERROR_CODES = frozenset({
     "insufficient_quota", "billing_not_active", "payment_required", "insufficient_credits",
     "no_usable_credits", "balance_depleted", "model_not_supported_on_free_tier",
-    "member_spend_cap_exceeded", _XAI_SPENDING_LIMIT_ERROR_CODE,
+    "member_spend_cap_exceeded", "credits_required", _XAI_SPENDING_LIMIT_ERROR_CODE,
 })
+
+# Anthropic plan-entitlement exhaustion: asking a subscription for a model the plan is not
+# entitled to returns 429 with a ``rate_limit_error`` envelope whose ``details.error_code``
+# is ``credits_required`` ("Usage credits are required for this model."). The envelope type
+# trips _RATE_LIMIT_PATTERNS, so _status_429 must check these BEFORE the rate-limit
+# disambiguation — otherwise the verdict stays retryable and the session re-hits the same
+# account until the retry budget dies (port of can1357/oh-my-pi#11333).
+_CREDITS_REQUIRED_SIGNALS = ("credits_required", "usage credits are required")
 
 # Transient rate limiting. Bedrock "Throttling error: Too many tokens" also
 # contains an overflow phrase; rate limit is matched first so throttle wins.
@@ -734,6 +742,11 @@ def _status_429(c: _Ctx) -> Verdict:
         upstream = _extract_upstream_provider_name(c.body)
         ctx = {"upstream_provider": upstream} if upstream else {}
         return _v(_R.upstream_rate_limit, should_fallback=True, error_context=ctx)
+    # Anthropic ``credits_required`` (plan not entitled to the model) arrives inside a
+    # ``rate_limit_error`` envelope, so it must win before the explicit-rate-limit check:
+    # rotate to a sibling account instead of retrying the same one (#11333 upstream).
+    if any(p in c.msg for p in _CREDITS_REQUIRED_SIGNALS):
+        return _V_BILLING
     # Quota walls as 429 (Anthropic ``usage_limit_reached``, "quota", billing
     # phrases) are billing ONLY when the body is not itself a rate-limit phrase
     # ("Rate limit exceeded" contains "limit exceeded") and carries no reset/

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -295,6 +295,29 @@ class TestClassifyApiError:
         assert result.should_rotate_credential is True
         assert result.should_fallback is True
 
+    def test_anthropic_429_credits_required_is_billing(self):
+        """Plan-entitlement exhaustion inside a rate_limit_error envelope must rotate,
+        not retry (port of can1357/oh-my-pi#11333)."""
+        e = MockAPIError(
+            "Error code: 429 - rate_limit_error: Usage credits are required for this model.",
+            status_code=429,
+            body={
+                "type": "error",
+                "error": {
+                    "type": "rate_limit_error",
+                    "message": "Usage credits are required for this model.",
+                    "details": {"error_code": "credits_required", "model": "claude-fable-5"},
+                },
+            },
+        )
+
+        result = classify_api_error(e, provider="anthropic", model="claude-fable-5")
+
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
+
     def test_anthropic_429_usage_limit_without_reset_is_billing(self):
         e = MockAPIError(
             "usage limit reached",


### PR DESCRIPTION
Anthropic's `credits_required` 429 (a subscription asked for a model its plan is not entitled to) now rotates to a sibling credential immediately instead of retrying the same account until the retry budget dies.

Port of can1357/oh-my-pi#11333 (weekly omp PR scout).

## Root cause

The response arrives as HTTP 429 wrapped in a `rate_limit_error` envelope:

```json
{"type":"error","error":{"type":"rate_limit_error","message":"Usage credits are required for this model.","details":{"error_code":"credits_required","model":"claude-fable-5"}}}
```

The envelope's `rate_limit` wording matched `_RATE_LIMIT_PATTERNS`, so `_status_429` returned a retryable `rate_limit` verdict — the credential never rotated and no bench was written. Upstream saw the identical failure repeat 46× in one day on a multi-account pool.

## Changes

- `_status_429` checks `_CREDITS_REQUIRED_SIGNALS` (`credits_required` code + "usage credits are required" phrase) before the explicit-rate-limit disambiguation → `billing` (rotate immediately, non-retryable, fallback allowed).
- `credits_required` added to `_BILLING_ERROR_CODES` so the statusless structured-code stage agrees.

## Validation

| Case | Before | After |
|---|---|---|
| Exact wire body above (429, anthropic) | `rate_limit`, retryable | `billing`, rotate, non-retryable |
| Genuine 429 "try again in 30 seconds" | `rate_limit`, retryable | unchanged |
| 429 overloaded body | `overloaded` | unchanged |

**Live repro:** classified the exact wire body through `classify_api_error` on `origin/main` (→ `rate_limit`, retryable — bug fires) and on this branch (→ `billing`, rotate) in the same interpreter harness; negative cases unchanged.

Tests: `tests/agent/test_error_classifier.py` (full file green, incl. new `test_anthropic_429_credits_required_is_billing`).

## Infographic

![infographic](https://v3b.fal.media/files/b/0aaa3581/hPGdlAEtLG8Fgcj9t0-ZU_lrwx9IYc.png)
