### PR TITLE
fix(local-runtime): price SWA layers from the GGUF's own per-layer pattern, not just a name table

### DIFF
--- a/hermes_cli/local_runtime/estimator.py
+++ b/hermes_cli/local_runtime/estimator.py
@@ -76,22 +76,36 @@ class HardwareBudget:
 def profile_from_gguf(header: GGUFHeader) -> ModelProfile:
     kv_heads = header.head_counts_kv()
     dk, dv = header.head_dim_k, header.head_dim_v
+    dk_swa = header.key_length_swa or dk
+    dv_swa = header.value_length_swa or dv
+
+    # Priority ladder, highest first: (1) the file's own per-layer pattern — architecture-agnostic
+    # and exact; (2) a known-architecture fraction, for older files that declare `sliding_window`
+    # but no per-layer pattern; (3) no signal at all -> every layer priced as full attention
+    # (overestimate; safe).
+    pattern = header.sliding_window_pattern
+    has_pattern = (pattern is not None and header.sliding_window > 0
+                  and len(pattern) == len(kv_heads))
     swa_fraction = _SWA_LAYER_FRACTION.get(header.architecture, 0.0)
-    has_swa = header.sliding_window > 0 and swa_fraction > 0
+    has_fraction = not has_pattern and header.sliding_window > 0 and swa_fraction > 0
+    n_attn_total = sum(1 for h in kv_heads if h > 0)
+    n_swa = round(n_attn_total * swa_fraction) if has_fraction else 0
 
     layers: list[tuple[LayerKind, int]] = []
     n_attn_seen = 0
-    n_attn_total = sum(1 for h in kv_heads if h > 0)
-    n_swa = round(n_attn_total * swa_fraction) if has_swa else 0
-    for heads in kv_heads:
+    for i, heads in enumerate(kv_heads):
         if heads == 0:
             layers.append((LayerKind.RECURRENT, 0))
             continue
-        per_token = round(heads * (dk + dv) * _F16_BYTES_PER_ELEM)
-        # Distribute the SWA share across the first n_swa attention layers; only the full/SWA
-        # SPLIT matters to the totals, not which indexes.
-        kind = LayerKind.SWA if n_attn_seen < n_swa else LayerKind.FULL
-        layers.append((kind, per_token))
+        if has_pattern:
+            is_swa = bool(pattern[i])
+        else:
+            # Distribute the SWA share across the first n_swa attention layers; only the
+            # full/SWA split matters to the totals, not which indexes.
+            is_swa = n_attn_seen < n_swa
+        layer_dk, layer_dv = (dk_swa, dv_swa) if is_swa else (dk, dv)
+        per_token = round(heads * (layer_dk + layer_dv) * _F16_BYTES_PER_ELEM)
+        layers.append((LayerKind.SWA if is_swa else LayerKind.FULL, per_token))
         n_attn_seen += 1
 
     return ModelProfile(

--- a/hermes_cli/local_runtime/gguf.py
+++ b/hermes_cli/local_runtime/gguf.py
@@ -79,7 +79,24 @@ class GGUFHeader:
         "full_attention_interval",
         "GDN-hybrid discriminator (qwen35 family): every Nth layer is full attention, the rest "
         "are linear/recurrent. 0 = not present.")
+    key_length_swa = _arch_int(
+        "attention.key_length_swa",
+        "Per-token key size for sliding-window layers when it differs from the global "
+        "attention.key_length (e.g. gemma3/gemma4). 0 = not present.")
+    value_length_swa = _arch_int(
+        "attention.value_length_swa",
+        "Per-token value size for sliding-window layers when it differs from the global "
+        "attention.value_length. 0 = not present.")
     del _arch_int
+
+    @property
+    def sliding_window_pattern(self) -> list[int] | None:
+        """Per-layer SWA pattern declared by the file itself: a truthy entry marks a
+        sliding-window layer, falsy marks global. None when the file doesn't declare one (older
+        GGUFs, or architectures without per-layer SWA metadata) — callers should fall back to a
+        coarser signal."""
+        v = self._arch_key("attention.sliding_window_pattern")
+        return [int(x) for x in v] if isinstance(v, list) else None
 
     @property
     def n_vocab(self) -> int:

--- a/tests/hermes_cli/test_local_runtime_gguf_swa.py
+++ b/tests/hermes_cli/test_local_runtime_gguf_swa.py
@@ -1,0 +1,59 @@
+"""profile_from_gguf must trust the GGUF file's own per-layer SWA pattern over the hardcoded
+architecture-name table (#109551): an architecture absent from `_SWA_LAYER_FRACTION` that still
+declares `attention.sliding_window_pattern` should be priced from that pattern, not as fully
+global attention."""
+
+from __future__ import annotations
+
+from hermes_cli.local_runtime.estimator import LayerKind, ctx_bytes, profile_from_gguf
+from hermes_cli.local_runtime.gguf import GGUFHeader
+
+_ARCH = "gemma4"  # deliberately absent from _SWA_LAYER_FRACTION
+
+
+def _header(**extra_metadata) -> GGUFHeader:
+    metadata = {
+        "general.architecture": _ARCH,
+        f"{_ARCH}.block_count": 6,
+        f"{_ARCH}.context_length": 262144,
+        f"{_ARCH}.attention.head_count_kv": 8,
+        f"{_ARCH}.attention.sliding_window": 1024,
+        f"{_ARCH}.attention.key_length": 512,
+        f"{_ARCH}.attention.value_length": 512,
+        **extra_metadata,
+    }
+    return GGUFHeader(path="test.gguf", version=3, metadata=metadata,
+                      n_tensors=0, tensor_bytes=0, embd_table_bytes=0)
+
+
+def test_unknown_arch_without_pattern_falls_back_to_full_attention():
+    header = _header()
+    profile = profile_from_gguf(header)
+    assert all(kind == LayerKind.FULL for kind, _ in profile.layers)
+
+
+def test_unknown_arch_with_pattern_is_priced_per_layer():
+    header = _header(**{
+        # 5 SWA layers followed by 1 global layer, exactly as the GGUF declares it.
+        f"{_ARCH}.attention.sliding_window_pattern": [1, 1, 1, 1, 1, 0],
+        f"{_ARCH}.attention.key_length_swa": 256,
+        f"{_ARCH}.attention.value_length_swa": 256,
+    })
+    profile = profile_from_gguf(header)
+
+    kinds = [kind for kind, _ in profile.layers]
+    assert kinds == [LayerKind.SWA] * 5 + [LayerKind.FULL]
+
+    swa_layer_bytes = profile.layers[0][1]
+    full_layer_bytes = profile.layers[-1][1]
+    # SWA layers use the file's *_swa key/value dims (256+256), not the global ones (512+512).
+    assert swa_layer_bytes == round(8 * (256 + 256) * 2.0)
+    assert full_layer_bytes == round(8 * (512 + 512) * 2.0)
+
+    # At a window far beyond the 1024-token SWA cap, the per-layer pricing keeps the SWA share
+    # capped while only the single global layer keeps growing — the false-positive refusal from
+    # the issue came from every layer growing unbounded like this instead.
+    small = ctx_bytes(profile, window=2048, flash_attention=False)
+    large = ctx_bytes(profile, window=65536, flash_attention=False)
+    full_layer_only_growth = full_layer_bytes * (65536 - 2048)
+    assert large - small == full_layer_only_growth


### PR DESCRIPTION
## What does this PR do?

`hermes_cli/local_runtime/estimator.py::profile_from_gguf` decides how many of a GGUF model's
layers use sliding-window attention (SWA) by looking up the model's architecture name in a
hardcoded table (`_SWA_LAYER_FRACTION = {"gemma3": 5/6, "gemma2": 1/2}`). Any architecture absent
from that table (e.g. `gemma4`) falls through to pricing *every* layer as full attention, which
massively inflates the estimated KV cache at long context and causes the physics check to refuse
models that actually fit and run fine.

GGUF files that declare a per-layer SWA layout already carry that information directly in the
header — `{arch}.attention.sliding_window_pattern` (a per-layer 0/1 array) plus
`{arch}.attention.key_length_swa` / `value_length_swa` (the SWA layers' own K/V dimensions, smaller
than the global ones). `gguf.py` had no accessor for any of the three, so the estimator could not
see them.

This PR makes the file's own metadata authoritative, with the name table and current
all-global behavior kept as fallbacks, in priority order:

1. **Per-layer array, when present** — read `sliding_window_pattern` and classify each layer
   directly from it, using the `*_swa` key/value lengths for the SWA layers. Architecture-agnostic;
   no Hermes release needed when a new SWA family ships.
2. **Known-architecture fraction** — the existing `_SWA_LAYER_FRACTION` behavior, unchanged, for
   older files that declare `sliding_window` but no per-layer pattern.
3. **All layers global** — the existing worst-case fallback, only when neither of the above is
   present (unchanged for files/architectures with no SWA metadata at all).

## Related Issue

Fixes #109551

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/local_runtime/gguf.py`: add `GGUFHeader.sliding_window_pattern` (per-layer array
  accessor), `key_length_swa`, and `value_length_swa`.
- `hermes_cli/local_runtime/estimator.py`: `profile_from_gguf` prefers the per-layer pattern (using
  the SWA-specific K/V dims) over the architecture-name table, and still falls back to the table
  and then to all-global exactly as before when the file doesn't declare a pattern.
- `tests/hermes_cli/test_local_runtime_gguf_swa.py` (new): constructs a synthetic header for an
  architecture absent from `_SWA_LAYER_FRACTION` and asserts (a) with no declared pattern, behavior
  is unchanged (all layers priced full — regression guard for the existing fallback), and (b) with
  a declared `sliding_window_pattern` + `*_swa` dims, layers are classified and sized from the file,
  and the resulting context-memory growth beyond the SWA window comes only from the true global
  layers.

## How to Test

1. `python -m pytest tests/hermes_cli/test_local_runtime_gguf_swa.py -v`
2. Confirm the new test fails without the fix:
   `git checkout HEAD~1 -- hermes_cli/local_runtime/estimator.py hermes_cli/local_runtime/gguf.py`
   then rerun — `test_unknown_arch_with_pattern_is_priced_per_layer` fails because every layer is
   still classified `FULL`. Restore with
   `git checkout HEAD -- hermes_cli/local_runtime/estimator.py hermes_cli/local_runtime/gguf.py`.

Actual output, before the fix (`git checkout HEAD~1 -- ...` then rerun):
```
FAILED tests/hermes_cli/test_local_runtime_gguf_swa.py::test_unknown_arch_with_pattern_is_priced_per_layer
AssertionError: assert [<LayerKind.FULL...] == [<LayerKind.SWA...]
At index 0 diff: <LayerKind.FULL: 'full'> != <LayerKind.SWA: 'swa'>
```

After the fix:
```
tests/hermes_cli/test_local_runtime_gguf_swa.py::test_unknown_arch_without_pattern_falls_back_to_full_attention PASSED
tests/hermes_cli/test_local_runtime_gguf_swa.py::test_unknown_arch_with_pattern_is_priced_per_layer PASSED
2 passed in 0.47s
```

Also ran the existing estimator/preset/catalog/growth suites to check for regressions (all pass,
unmodified):
```
python -m pytest tests/hermes_cli/test_local_growth.py tests/hermes_cli/test_catalog_variants.py \
  tests/hermes_cli/test_local_preset_admission.py tests/hermes_cli/test_local_runtime_gguf_swa.py -q
28 passed
```

`ruff check` on the touched files passes clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` (targeted subset above; full suite requires optional deps not
  installed in this environment — fastapi/httpx2 for unrelated HTTP-route tests)
- [x] I've added tests for my changes
- [ ] I've tested on my platform (no access to a physical machine with the reported hardware;
  verified via unit tests against synthetic GGUF headers instead)

### Documentation & Housekeeping

- [x] N/A — no docs/config keys/architecture changed beyond the estimator internals described above

## AI assistance disclosure

This PR was prepared with the help of an AI coding agent (Claude), which read the issue, located
and modified the two files described above, and wrote the accompanying test. All changes were
reviewed and verified (test run before/after the fix, lint) before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
