### PR TITLE
refactor(secrets-io): one 0600-from-creation atomic writer for all credential files; 24 non-secret writers and the tar guard unified

### DIFF
--- a/agent/anthropic_credentials.py
+++ b/agent/anthropic_credentials.py
@@ -18,7 +18,6 @@ import logging
 import os
 import platform
 import secrets
-import stat
 import subprocess
 import threading
 import time
@@ -27,6 +26,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from hermes_constants import get_hermes_home
+from utils import atomic_json_write
 from agent.secret_scope import get_secret as _get_secret
 
 logger = logging.getLogger(__name__)
@@ -82,22 +82,9 @@ def _load_json_if_exists(path: Path, what: str) -> Optional[Any]:
 
 
 def _atomic_write_private_json(path: Path, payload: Any) -> None:
-    """Write *payload* via a 0o600 O_EXCL temp file + fsync + os.replace: the token is never briefly umask-readable
-    (write_text + chmod had a TOCTOU window); the random suffix avoids collisions with concurrent writers and
-    crashed leftovers. The parent dir's mode is left alone (~/.claude/ is owned by Claude Code)."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(f".tmp.{os.getpid()}.{secrets.token_hex(4)}")
-    try:
-        fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_EXCL, stat.S_IRUSR | stat.S_IWUSR)
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            json.dump(payload, fh, indent=2)
-            fh.flush()
-            os.fsync(fh.fileno())
-        os.replace(tmp, path)
-    except OSError:
-        with contextlib.suppress(OSError):
-            tmp.unlink(missing_ok=True)
-        raise
+    """0600-from-creation temp file + fsync + atomic replace (the token is never briefly umask-readable).
+    The parent dir's mode is left alone (~/.claude/ is owned by Claude Code)."""
+    atomic_json_write(path, payload, mode=0o600)
 
 
 def _commit_private_json(path: Path, payload: Any, what: str) -> None:

--- a/agent/proxy_sources/iron_proxy.py
+++ b/agent/proxy_sources/iron_proxy.py
@@ -29,6 +29,8 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from utils import atomic_json_write, atomic_write_text
+
 logger = logging.getLogger(__name__)
 
 # Pinned: never auto-resolve "latest" — the YAML schema may change between releases.
@@ -577,21 +579,15 @@ def ensure_audit_log(audit_path: Path) -> None:
         ) from exc
 
 
-def _write_state_file_atomic(state: Path, name: str, dump) -> Path:
-    """0600 temp file + atomic replace: the file holds proxy tokens; chmod-after-replace would be a world-readable TOCTOU window."""
-    tmp_path = state / f".{name}.tmp"
-    with open(tmp_path, "w", encoding="utf-8") as f:
-        dump(f)
-    os.chmod(tmp_path, 0o600)
-    os.replace(tmp_path, state / name)
-    return state / name
-
-
 def write_proxy_config(config: Dict) -> Path:
-    """Serialize the config dict to ``<hermes_home>/proxy/proxy.yaml`` (safe_dump, no Python tags)."""
+    """Serialize the config dict to ``<hermes_home>/proxy/proxy.yaml`` (safe_dump, no Python tags).
+
+    The file holds proxy tokens: written 0600 from creation, never at process umask."""
     if (yaml := _yaml()) is None:
         raise RuntimeError("PyYAML is required to write the iron-proxy config but is not installed.")
-    return _write_state_file_atomic(_proxy_state_dir(), "proxy.yaml", lambda f: yaml.safe_dump(config, f, default_flow_style=False, sort_keys=False))
+    path = _proxy_state_dir() / "proxy.yaml"
+    atomic_write_text(path, yaml.safe_dump(config, default_flow_style=False, sort_keys=False), mode=0o600)
+    return path
 
 
 def write_mappings(mappings: List[TokenMapping]) -> Path:
@@ -600,7 +596,9 @@ def write_mappings(mappings: List[TokenMapping]) -> Path:
         "proxy_token": m.proxy_token, "env_name": m.real_env_name, "upstream_hosts": list(m.upstream_hosts),
         "match_headers": list(m.match_headers), "alias_env_names": list(m.alias_env_names),
     } for m in mappings]}
-    return _write_state_file_atomic(_proxy_state_dir(), "mappings.json", lambda f: json.dump(payload, f, indent=2))
+    path = _proxy_state_dir() / "mappings.json"
+    atomic_json_write(path, payload, mode=0o600)
+    return path
 
 
 def load_mappings() -> List[TokenMapping]:

--- a/agent/secret_sources/_cache.py
+++ b/agent/secret_sources/_cache.py
@@ -12,11 +12,13 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Dict, Generic, Optional, TypeVar
+
+from hermes_constants import secure_parent_dir
+from utils import atomic_json_write
 
 __all__ = [
     "CachedFetch",
@@ -68,32 +70,13 @@ def entry_from_payload(payload: object) -> Optional[CachedFetch]:
     return CachedFetch(secrets=typed, fetched_at=float(fetched_at))
 
 
-def atomic_write_json(path: Path, payload: dict, *, tmp_prefix: str) -> None:
-    """Write ``payload`` to ``path`` via mkstemp → chmod 0600 → os.replace.
-
-    The containing dir is forced to ``0700`` (``mkdir``'s mode is umask-subject,
-    so the chmod is the reliable form). Raises ``OSError`` on failure; callers
-    decide whether that is best-effort.
-    """
-    cache_dir = path.parent
-    cache_dir.mkdir(parents=True, exist_ok=True)
-    try:
-        os.chmod(cache_dir, 0o700)
-    except OSError:
-        pass
-    # tempfile honours os.umask, so chmod 0600 explicitly before the rename.
-    fd, tmp = tempfile.mkstemp(prefix=tmp_prefix, suffix=".tmp", dir=str(cache_dir))
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            json.dump(payload, f)
-        os.chmod(tmp, 0o600)
-        os.replace(tmp, path)
-    except BaseException:
-        try:
-            os.unlink(tmp)
-        except OSError:
-            pass
-        raise
+def atomic_write_json(path: Path, payload: dict) -> None:
+    """Secret cache entry at 0600 from creation; the containing dir is tightened to 0700
+    (``secure_parent_dir`` refuses ``/``, top-level dirs and the install tree). Raises ``OSError``
+    on failure; callers decide whether that is best-effort."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    secure_parent_dir(path)
+    atomic_json_write(path, payload, indent=None, mode=0o600)
 
 
 K = TypeVar("K")
@@ -116,8 +99,6 @@ class DiskCache(Generic[K]):
     def __init__(self, basename: str, *, key_serializer: Callable[[K], str]) -> None:
         self._basename = basename
         self._key_serializer = key_serializer
-        # Per-backend temp prefix so concurrent writers in one dir never collide.
-        self._tmp_prefix = f".{basename.split('.', 1)[0]}_"
 
     def path(self, home_path: Optional[Path] = None) -> Path:
         return resolve_cache_home(home_path) / "cache" / self._basename
@@ -142,7 +123,7 @@ class DiskCache(Generic[K]):
             return
         payload = {"key": self._key_serializer(key), "secrets": entry.secrets, "fetched_at": entry.fetched_at}
         try:
-            atomic_write_json(self.path(home_path), payload, tmp_prefix=self._tmp_prefix)
+            atomic_write_json(self.path(home_path), payload)
         except OSError:
             pass  # best-effort — a disk-cache miss next invocation is fine
 

--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -268,7 +268,7 @@ def _write_encrypted_disk_cache(*, cache_key: _CacheKey, access_token: str, entr
         ciphertext = AESGCM(key).encrypt(nonce, plaintext, serialized_key.encode("utf-8"))
         payload = {"version": _ENCRYPTED_CACHE_VERSION, "key": serialized_key,
                    "salt": _b64e(salt), "nonce": _b64e(nonce), "ciphertext": _b64e(ciphertext)}
-        atomic_write_json(_encrypted_disk_cache_path(home_path), payload, tmp_prefix=".bws_cache_enc_")
+        atomic_write_json(_encrypted_disk_cache_path(home_path), payload)
         _STORE.disk.clear(home_path)
     except Exception:  # noqa: BLE001 — best-effort cache only
         return

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -13,7 +13,6 @@ import os
 import re
 import subprocess
 import sys
-import tempfile
 import threading
 import time
 from contextlib import ExitStack, contextmanager, suppress
@@ -31,7 +30,7 @@ except ImportError:  # pragma: no cover
     fcntl = None  # type: ignore[assignment]
 
 from hermes_constants import get_hermes_home
-from utils import atomic_replace
+from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
@@ -469,16 +468,7 @@ def save_allowlist(data: Dict[str, Any]) -> None:
     """Atomic write; on OSError log and keep the in-process approval."""
     p = allowlist_path()
     try:
-        p.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp_path = tempfile.mkstemp(prefix=f"{p.name}.", suffix=".tmp", dir=str(p.parent))
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as fh:
-                fh.write(json.dumps(data, indent=2, sort_keys=True))
-            atomic_replace(tmp_path, p)
-        except Exception:
-            with suppress(OSError):
-                os.unlink(tmp_path)
-            raise
+        atomic_json_write(p, data, sort_keys=True)
     except OSError as exc:
         logger.warning("Failed to persist shell hook allowlist to %s: %s. The approval is in-memory for this run, "
                        "but the next startup will re-prompt (or skip registration on non-TTY runs without "

--- a/agent/vault_store.py
+++ b/agent/vault_store.py
@@ -30,6 +30,7 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import urlsplit
 
 from hermes_constants import get_hermes_home
+from utils import atomic_write_bytes
 
 VAULT_KINDS = ("login", "payment", "address")
 
@@ -282,24 +283,8 @@ class VaultStore:
         self._ensure_dir()
         payload = json.dumps({"version": 1, "items": items}).encode("utf-8")
         blob = self._fernet().encrypt(payload)
-        tmp = self._vault_path.with_suffix(".enc.tmp")
-        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-        try:
-            os.write(fd, blob)
-            os.fsync(fd)  # the blob must be on disk before the rename makes it THE vault
-        finally:
-            os.close(fd)
-        os.replace(tmp, self._vault_path)
-        with suppress(OSError):  # directory entry durable too (power loss between rename and next sync)
-            dfd = os.open(self._base, os.O_RDONLY)
-            try:
-                os.fsync(dfd)
-            finally:
-                os.close(dfd)
-        try:
-            os.chmod(self._vault_path, 0o600)
-        except OSError:
-            pass
+        # fsync_dir: the directory entry must be durable too (power loss between rename and next sync).
+        atomic_write_bytes(self._vault_path, blob, mode=0o600, fsync_dir=True)
 
     # -- public API ----------------------------------------------------------
 

--- a/cron/suggestions.py
+++ b/cron/suggestions.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
-import tempfile
 import threading
 import uuid
 from pathlib import Path
@@ -21,7 +19,7 @@ from typing import Any, Dict, List, Optional
 
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
-from utils import atomic_replace
+from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
@@ -46,13 +44,6 @@ _STATUS_DISMISSED = "dismissed"
 
 def _current_suggestions_file() -> Path:
     return SUGGESTIONS_FILE or (get_hermes_home().resolve() / "cron" / "suggestions.json")
-
-
-def _secure_file(path: Path) -> None:
-    try:
-        os.chmod(path, 0o600)
-    except OSError:
-        pass
 
 
 def _ensure_dir() -> None:
@@ -81,22 +72,8 @@ def _load_raw() -> Dict[str, Any]:
 
 def _save_raw(suggestions: List[Dict[str, Any]]) -> None:
     _ensure_dir()
-    suggestions_file = _current_suggestions_file()
-    fd, tmp_path = tempfile.mkstemp(dir=str(suggestions_file.parent), suffix=".tmp", prefix=".sugg_")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            payload = {"suggestions": suggestions, "updated_at": _hermes_now().isoformat()}
-            json.dump(payload, f, indent=2)
-            f.flush()
-            os.fsync(f.fileno())
-        atomic_replace(tmp_path, suggestions_file)
-        _secure_file(suggestions_file)
-    except BaseException:
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
-        raise
+    payload = {"suggestions": suggestions, "updated_at": _hermes_now().isoformat()}
+    atomic_json_write(_current_suggestions_file(), payload, mode=0o600)
 
 
 def load_suggestions() -> List[Dict[str, Any]]:

--- a/gateway/hosted_room_peer.py
+++ b/gateway/hosted_room_peer.py
@@ -48,7 +48,7 @@ _ROOM_GRANT_SECRET_FILE = ".room-link-grant-secret"
 @lru_cache(maxsize=32)
 def _gateway_room_grant_secret_for_home(home_value: str) -> bytes:
     """Load one restart-scoped grant secret for an exact installation root."""
-    from hermes_cli.install_identity import _fsync_directory
+    from utils import fsync_directory
     (home := Path(home_value)).mkdir(parents=True, exist_ok=True)
     path = home / _ROOM_GRANT_SECRET_FILE
     def _read() -> bytes:
@@ -75,7 +75,7 @@ def _gateway_room_grant_secret_for_home(home_value: str) -> bytes:
             except FileExistsError:
                 material = _read()
             else:
-                _fsync_directory(home)
+                fsync_directory(home)
         finally:
             temporary.unlink(missing_ok=True)
     return hmac.new(material, b"hermes-hosted-room-installation-grant-v1", hashlib.sha256).digest()

--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -13,7 +13,6 @@ import json
 import logging
 import os
 import secrets
-import tempfile
 import threading
 import time
 from pathlib import Path
@@ -21,7 +20,7 @@ from typing import Optional
 
 from gateway.whatsapp_identity import expand_whatsapp_aliases, normalize_whatsapp_identifier
 from hermes_constants import get_default_hermes_root, get_hermes_dir, get_hermes_home
-from utils import atomic_replace
+from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
@@ -279,7 +278,7 @@ def _load_json_file(path: Path) -> dict:
 
 
 def _save_json_file(path: Path, data: dict) -> None:
-    _secure_write(path, json.dumps(data, indent=2, ensure_ascii=False))
+    atomic_json_write(path, data, mode=0o600)
 
 
 def _migrate_split_pairing_dirs(*, home: Optional[Path] = None, active: Optional[Path] = None) -> None:
@@ -303,24 +302,6 @@ def _migrate_split_pairing_dirs(*, home: Optional[Path] = None, active: Optional
         merged.update(current)
         if merged != current:
             _save_json_file(active / src.name, merged)
-
-
-def _secure_write(path: Path, data: str) -> None:
-    """Write 0600 via temp file + atomic rename so readers never see a partial file."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(data)
-            f.flush()
-            os.fsync(f.fileno())
-        atomic_replace(tmp_path, path)
-        with contextlib.suppress(OSError):  # Windows doesn't support chmod the same way
-            os.chmod(path, 0o600)
-    except BaseException:
-        with contextlib.suppress(OSError):
-            os.unlink(tmp_path)
-        raise
 
 
 def _is_hashed_entry(entry) -> bool:

--- a/gateway/rich_sent_store.py
+++ b/gateway/rich_sent_store.py
@@ -15,6 +15,7 @@ import json
 import os
 import time
 from typing import Optional
+from utils import atomic_json_write
 
 _MAX_ENTRIES = 1000
 _MAX_TEXT_CHARS = 2000
@@ -47,10 +48,7 @@ def _update(chat_id, message_id, fields: dict) -> None:
         if len(data) > _MAX_ENTRIES:  # trim oldest by timestamp
             for k, _ in sorted(data.items(), key=lambda kv: kv[1].get("ts", 0))[: len(data) - _MAX_ENTRIES]:
                 data.pop(k, None)
-        tmp = f"{path}.tmp.{os.getpid()}"
-        with open(tmp, "w", encoding="utf-8") as fh:
-            json.dump(data, fh, ensure_ascii=False)
-        os.replace(tmp, path)  # atomic; tolerates concurrent writers racing
+        atomic_json_write(path, data, indent=None)  # atomic; tolerates concurrent writers racing
     except Exception:
         return
 

--- a/gateway/session_persistence.py
+++ b/gateway/session_persistence.py
@@ -7,12 +7,10 @@ from __future__ import annotations
 import contextlib
 import logging
 import json
-import os
-import tempfile
 import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional
-from utils import atomic_replace
+from utils import atomic_json_write
 
 if TYPE_CHECKING:
     from gateway.session import SessionEntry
@@ -475,22 +473,7 @@ class SessionPersistenceMixin:
 
     def _save_sessions_json(self, data: Dict[str, Any]) -> None:
         """Write the legacy sessions.json mirror of the routing index (atomic + fsync)."""
-        self.sessions_dir.mkdir(parents=True, exist_ok=True)
-        sessions_file = self.sessions_dir / "sessions.json"
-        data = {"_README": _SESSIONS_JSON_README, **data}
-        fd, tmp_path = tempfile.mkstemp(dir=str(self.sessions_dir), suffix=".tmp", prefix=".sessions_")
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2)
-                f.flush()
-                os.fsync(f.fileno())
-            atomic_replace(tmp_path, sessions_file)
-        except BaseException:
-            try:
-                os.unlink(tmp_path)
-            except OSError as e:
-                logger.debug("Could not remove temp file %s: %s", tmp_path, e)
-            raise
+        atomic_json_write(self.sessions_dir / "sessions.json", {"_README": _SESSIONS_JSON_README, **data})
 
     def _save_entries(self) -> None:
         """Snapshot latest state under ``_lock`` and persist after releasing it."""

--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any, Iterator, Optional
 
 from hermes_constants import get_default_hermes_root, get_hermes_home
+from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
@@ -287,17 +288,7 @@ def _valid_process_start(v: Any) -> bool:
 
 
 def _write_entries(path: Path, entries: list[dict[str, Any]]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_name(f"{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
-    try:
-        with open(tmp, "w", encoding="utf-8") as fh:
-            json.dump({"entries": entries}, fh, sort_keys=True)
-        os.replace(tmp, path)
-    finally:
-        try:
-            tmp.unlink(missing_ok=True)
-        except OSError:
-            pass
+    atomic_json_write(path, {"entries": entries}, indent=None, sort_keys=True)
 
 
 def _process_start_time(pid: int) -> Optional[float]:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -16,10 +16,8 @@ import logging
 import os
 import shutil
 import shlex
-import stat
 import threading
 import time
-import uuid
 import webbrowser  # noqa: F401  (tests patch auth_mod.webbrowser.open; same module object)
 
 from contextlib import ExitStack, contextmanager
@@ -34,7 +32,7 @@ from hermes_cli.config import (
     get_hermes_home, get_config_path, read_raw_config, require_readable_config_before_write)
 from hermes_constants import OPENROUTER_BASE_URL, hermes_home_key, secure_parent_dir
 from agent.credential_persistence import sanitize_borrowed_credential_payload
-from utils import atomic_replace, atomic_yaml_write, env_float, is_truthy_value  # noqa: F401  (env_float: agent.credential_pool reads auth_mod.env_float)
+from utils import atomic_json_write, atomic_yaml_write, env_float, is_truthy_value  # noqa: F401  (env_float: agent.credential_pool reads auth_mod.env_float)
 from hermes_cli.auth_zai_kimi import (  # noqa: F401  re-exported
     KIMI_CODE_BASE_URL, ZAI_ENDPOINTS, _normalize_lmstudio_runtime_base_url, _resolve_kimi_base_url,
     _resolve_zai_base_url, detect_zai_endpoint)
@@ -696,61 +694,26 @@ def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
     return _empty_auth_store()
 
 
-def _write_private_file_atomic(
-    target: Path, payload: str, *, replace: Optional[Callable[[Any, Any], Any]] = None,
-    fsync_dir: bool = False) -> None:
-    """Write *payload* to *target* via a 0o600 temp file + atomic rename.
-
-    ``os.open(O_EXCL, 0o600)`` closes the TOCTOU window where ``write_text()`` + post-write
-    ``chmod`` briefly exposed tokens at process umask. The per-process random temp suffix avoids
-    collisions between concurrent writers and stale leftovers from a crashed prior write."""
+def _save_private_json(target: Path, data: Any, *, fsync_dir: bool = False, **dump_kwargs: Any) -> None:
+    """0600 credential JSON under a 0700 parent (``secure_parent_dir`` refuses ``/``, top-level dirs
+    and the install tree). ``atomic_json_write`` creates the temp file 0600 before any byte lands."""
     target.parent.mkdir(parents=True, exist_ok=True)
-    secure_parent_dir(target)  # refuses to chmod /, top-level dirs, or the install tree
-    tmp_path = target.with_name(f"{target.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
-    try:
-        fd = os.open(str(tmp_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, stat.S_IRUSR | stat.S_IWUSR)
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            handle.write(payload)
-            handle.flush()
-            os.fsync(handle.fileno())
-        (replace or atomic_replace)(tmp_path, target)
-        if fsync_dir:
-            try:
-                dir_fd = os.open(str(target.parent), os.O_RDONLY)
-            except OSError:
-                pass
-            else:
-                try:
-                    os.fsync(dir_fd)
-                finally:
-                    os.close(dir_fd)
-    finally:
-        try:
-            if tmp_path.exists():
-                tmp_path.unlink()
-        except OSError:
-            pass
+    secure_parent_dir(target)
+    atomic_json_write(target, data, mode=0o600, fsync_dir=fsync_dir, **dump_kwargs)
 
 
 def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = None) -> Path:
     """Atomically persist *auth_store* (0o600, parent tightened to 0o700) to the active store, or to
     an explicit *target_path* (e.g. the global-root write-through for rotating xAI OAuth grants)."""
     auth_file = target_path if target_path is not None else _auth_file_path()
-    # Tighten parent dir to 0o700 so siblings can't traverse to creds. No-op on Windows (POSIX mode bits not
-    # enforced); ignore failures. secure_parent_dir refuses to chmod /, top-level dirs, or the hermes-agent
-    # install tree (#25821, #93050).
     auth_store["version"] = AUTH_STORE_VERSION
     auth_store["updated_at"] = datetime.now(timezone.utc).isoformat()
-    _write_private_file_atomic(auth_file, json.dumps(auth_store, indent=2) + "\n", fsync_dir=True)
+    _save_private_json(auth_file, auth_store, fsync_dir=True)
     if target_path is not None:
         # A write-through to the global root must not be masked by the mtime memo: on coarse-mtime
         # filesystems a read-after-write in the same tick would keep serving the pre-write store.
         global _global_auth_store_cache
         _global_auth_store_cache = None
-    try:
-        auth_file.chmod(stat.S_IRUSR | stat.S_IWUSR)
-    except OSError:
-        pass
     return auth_file
 
 

--- a/hermes_cli/auth_nous.py
+++ b/hermes_cli/auth_nous.py
@@ -384,7 +384,7 @@ def _write_shared_nous_state(state: Dict[str, Any]) -> None:
 
     Best-effort: failures are logged and swallowed; per-profile auth.json stays the source of truth.
     """
-    from hermes_cli.auth import _nonempty_str, _write_private_file_atomic
+    from hermes_cli.auth import _nonempty_str, _save_private_json
     refresh_token = state.get("refresh_token")
     # Nothing worth sharing without refresh material: an OAuth refresh_token (with its access token),
     # or a guest's anon_ credential, which is the whole identity and may not have been exchanged yet.
@@ -397,8 +397,7 @@ def _write_shared_nous_state(state: Dict[str, Any]) -> None:
     try:
         with _nous_shared_store_lock():
             path = _nous_shared_store_path()
-            _write_private_file_atomic(
-                path, json.dumps(shared, indent=2, sort_keys=True), replace=os.replace)
+            _save_private_json(path, shared, sort_keys=True)
         _oauth_trace(
             "nous_shared_store_written", path=str(path),
             refresh_token_fp=_token_fingerprint(refresh_token))

--- a/hermes_cli/auth_qwen.py
+++ b/hermes_cli/auth_qwen.py
@@ -43,9 +43,9 @@ def _read_qwen_cli_tokens() -> Dict[str, Any]:
 
 
 def _save_qwen_cli_tokens(tokens: Dict[str, Any]) -> Path:
-    from hermes_cli.auth import _qwen_cli_auth_path, _write_private_file_atomic
+    from hermes_cli.auth import _qwen_cli_auth_path, _save_private_json
     auth_path = _qwen_cli_auth_path()
-    _write_private_file_atomic(auth_path, json.dumps(tokens, indent=2, sort_keys=True) + "\n")
+    _save_private_json(auth_path, tokens, sort_keys=True)
     return auth_path
 
 

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -681,13 +681,8 @@ def save_banner_snapshot(tools: List[dict], enabled_toolsets: List[str], availab
     }
 
     def _write():
-        import tempfile
-        path = _banner_snapshot_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".banner_snap.")
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            json.dump(payload, fh)
-        os.replace(tmp, path)
+        from utils import atomic_json_write
+        atomic_json_write(_banner_snapshot_path(), payload, indent=None)
     _quiet(_write)
 
 

--- a/hermes_cli/codex_runtime_plugin_migration.py
+++ b/hermes_cli/codex_runtime_plugin_migration.py
@@ -374,21 +374,9 @@ def _build_hermes_tools_mcp_entry() -> dict:
 
 
 def _write_atomic(target: Path, text: str) -> None:
-    """Write via a same-directory temp file + rename (atomic on POSIX, ReplaceFile on Windows) so a
-    crash mid-write never leaves a half-written config.toml that codex would refuse to load."""
-    import tempfile
-    tmp_fd, tmp_path_str = tempfile.mkstemp(prefix=".config.toml.", dir=str(target.parent))
-    tmp_path = Path(tmp_path_str)
-    try:
-        with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
-            fh.write(text)
-        tmp_path.replace(target)
-    except Exception:
-        try:
-            tmp_path.unlink(missing_ok=True)
-        except Exception:
-            pass
-        raise
+    """Atomic rewrite so a crash mid-write never leaves a half-written config.toml codex refuses to load."""
+    from utils import atomic_write_text
+    atomic_write_text(target, text, tmp_prefix=".config.toml.", preserve_mode=True)
 
 
 def migrate(

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Optional
 
 from hermes_cli._subprocess_compat import IS_WINDOWS, windows_hide_flags
+from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
@@ -270,15 +271,6 @@ def _read_jwt_store(path: Path) -> Optional[dict]:
         return None
 
 
-def _write_jwt_store(path: Path, store: dict) -> None:
-    """Atomically write the JWT store (tmp + os.replace), best-effort 0o600."""
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(json.dumps(store), encoding="utf-8")
-    with contextlib.suppress(Exception):
-        os.chmod(tmp, 0o600)
-    os.replace(tmp, path)
-
-
 def _jwt_disk_path() -> Optional[Path]:
     """Path to the on-disk exchanged-JWT cache (profile-aware), or None."""
     try:
@@ -313,7 +305,7 @@ def evict_cached_exchanged_token(raw_token: str) -> None:
     def _evict(path, store):
         if store is not None and fp in store:
             del store[fp]
-            _write_jwt_store(path, store)
+            atomic_json_write(path, store, indent=None, mode=0o600)
 
     _with_jwt_store("evict cached", _evict)
 
@@ -339,7 +331,7 @@ def _save_jwt_to_disk(fp: str, api_token: str, expires_at: float, base_url: Opti
             k: v for k, v in (store or {}).items()
             if isinstance(v, dict) and float(v.get("expires_at", 0) or 0) > now}
         kept[fp] = {"api_token": api_token, "expires_at": expires_at, "base_url": base_url}
-        _write_jwt_store(path, kept)
+        atomic_json_write(path, kept, indent=None, mode=0o600)
 
     _with_jwt_store("persist", _save)
 

--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -16,7 +16,7 @@ from types import SimpleNamespace
 from typing import Optional
 
 from hermes_constants import get_hermes_home
-from utils import atomic_replace
+from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
@@ -54,12 +54,8 @@ def _load_pending() -> list[dict]:
 
 
 def _save_pending(entries: list[dict]) -> None:
-    path = _pending_file()
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(".json.tmp")
-        tmp.write_text(json.dumps(entries, indent=2), encoding="utf-8")
-        atomic_replace(tmp, path)
+        atomic_json_write(_pending_file(), entries)
     except OSError:
         pass  # non-fatal — worst case the user runs ``hermes debug delete`` manually
 

--- a/hermes_cli/install_identity.py
+++ b/hermes_cli/install_identity.py
@@ -6,12 +6,12 @@ import contextlib
 import os
 from pathlib import Path
 import re
-import tempfile
 import threading
 from typing import Optional
 import uuid
 
 from hermes_constants import get_default_hermes_root
+from utils import atomic_write_text
 
 _INSTALL_ID_FILENAME = "install_id"
 _INSTALL_ID_RE = re.compile(r"^[0-9a-f]{32}$")
@@ -47,22 +47,6 @@ def _install_id_file_lock(root: Path):
             os.close(fd)
 
 
-def _fsync_directory(path: Path) -> None:
-    """Best-effort durability for the directory entry after replace."""
-    if os.name == "nt":
-        return
-    try:
-        fd = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
-    except OSError:
-        return
-    try:
-        os.fsync(fd)
-    except OSError:
-        pass
-    finally:
-        os.close(fd)
-
-
 def _read_existing(path: Path) -> tuple[Optional[str], bool]:
     """``(valid id or None, mint?)`` — mint on a missing or malformed file, never on a read failure."""
     try:
@@ -92,18 +76,7 @@ def read_or_create_install_id(root: Path | None = None) -> Optional[str]:
             existing, mint = _read_existing(path)
             if not mint:
                 return existing
-            fd, tmp_name = tempfile.mkstemp(dir=str(root), prefix=".install_id-")
-            try:
-                with os.fdopen(fd, "w", encoding="utf-8") as handle:
-                    handle.write(uuid.uuid4().hex + "\n")
-                    handle.flush()
-                    os.fsync(handle.fileno())
-                os.replace(tmp_name, path)
-                _fsync_directory(root)
-            except BaseException:
-                with contextlib.suppress(OSError):
-                    os.unlink(tmp_name)
-                raise
+            atomic_write_text(path, uuid.uuid4().hex + "\n", tmp_prefix=".install_id-", fsync_dir=True)
             committed = path.read_text(encoding="utf-8").strip().lower()
             return committed if _INSTALL_ID_RE.fullmatch(committed) else None
     except OSError:

--- a/hermes_cli/local_runtime/presets.py
+++ b/hermes_cli/local_runtime/presets.py
@@ -155,17 +155,8 @@ def generate_presets(models_dir: Path, budget: HardwareBudget, preset_path: Path
             body = "\n".join(f"{k} = {v}" for k, v in entry.keys.items())
             sections.append(f"[{entry.model_id}]\n{body}\n")
 
-    preset_path.parent.mkdir(parents=True, exist_ok=True)
-    import os
-    import tempfile
-
-    fd, tmp = tempfile.mkstemp(prefix=preset_path.name, suffix=".tmp", dir=preset_path.parent)
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as stream:
-            stream.write("\n".join(sections))
-        os.replace(tmp, preset_path)
-    finally:
-        Path(tmp).unlink(missing_ok=True)
+    from utils import atomic_write_text
+    atomic_write_text(preset_path, "\n".join(sections), tmp_prefix=f".{preset_path.name}_")
     logger.info("wrote %d preset sections to %s", sum(e.keys is not None for e in entries), preset_path)
     return entries
 

--- a/hermes_cli/model_catalog.py
+++ b/hermes_cli/model_catalog.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any
 
 from hermes_cli import __version__ as _HERMES_VERSION
-from utils import atomic_replace
+from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
@@ -154,14 +154,8 @@ def _read_disk_cache() -> tuple[dict[str, Any] | None, float]:
 
 
 def _write_disk_cache(data: dict[str, Any]) -> None:
-    path = _cache_path()
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(path.suffix + ".tmp")
-        with open(tmp, "w", encoding="utf-8") as fh:
-            json.dump(data, fh, indent=2)
-            fh.write("\n")
-        atomic_replace(tmp, path)
+        atomic_json_write(_cache_path(), data)
     except OSError as exc:
         logger.info("model catalog cache write failed: %s", exc)
 

--- a/hermes_cli/plugin_compat.py
+++ b/hermes_cli/plugin_compat.py
@@ -27,6 +27,7 @@ import warnings
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Tuple
+from utils import atomic_json_write
 
 COMPAT_REMOVAL_DATE = _dt.date(2026, 9, 14)
 COMPAT_REMOVAL = COMPAT_REMOVAL_DATE.isoformat()
@@ -247,10 +248,7 @@ def _write_report_file(report: Dict[str, List[Hit]]) -> None:
                    "written_at": _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds"),
                    "plugins": {k: [h.__dict__ for h in v] for k, v in report.items()},
                    "lines": summary_lines(report)}
-        p.parent.mkdir(parents=True, exist_ok=True)
-        tmp = p.with_suffix(".tmp")
-        tmp.write_text(json.dumps(payload, indent=1), encoding="utf-8")
-        os.replace(tmp, p)
+        atomic_json_write(p, payload, indent=1)
     except Exception:
         pass
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1617,18 +1617,13 @@ def _plugin_toolset_keys_cache_path() -> Path:
 def _persist_plugin_toolset_keys() -> None:
     """Persist discovered plugin toolset keys + portable MCP names (best-effort)."""
     try:
-        import tempfile
+        from utils import atomic_json_write
         keys = sorted({ts_key for ts_key, _, _ in get_plugin_toolsets()})
         try:
             portable = sorted(get_plugin_manager().get_portable_mcp_servers())
         except Exception:
             portable = []
-        path = _plugin_toolset_keys_cache_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".pt_keys.")
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            json.dump({"toolset_keys": keys, "portable_mcp": portable}, fh)
-        os.replace(tmp, path)
+        atomic_json_write(_plugin_toolset_keys_cache_path(), {"toolset_keys": keys, "portable_mcp": portable}, indent=None)
     except Exception:
         logger.debug("plugin toolset key persist failed", exc_info=True)
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1591,15 +1591,12 @@ def import_profile(archive_path: str, name: Optional[str] = None) -> Path:
 # Rename
 
 def _atomic_write_json(path: Path, data: dict) -> bool:
-    """Write *data* to *path* via a sibling ``.tmp`` + rename. Returns False (tmp cleaned) on OSError."""
-    tmp = path.with_suffix(path.suffix + ".tmp")
+    """Atomic rewrite of a third-party JSON config; False on OSError (nothing partially written)."""
+    from utils import atomic_json_write
     try:
-        tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
-        tmp.replace(path)
+        atomic_json_write(path, data)
         return True
     except OSError:
-        with contextlib.suppress(OSError):
-            tmp.unlink(missing_ok=True)
         return False
 
 

--- a/hermes_cli/psutil_android.py
+++ b/hermes_cli/psutil_android.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import shutil
-import tarfile
-from pathlib import Path, PurePosixPath
+from pathlib import Path
+
+from hermes_cli.archive_safe import safe_extract_targz
 
 # Pinned to a version whose marker line patches cleanly; bump when upstream changes its shape.
 PSUTIL_URL = (
@@ -20,40 +20,12 @@ class PsutilAndroidInstallError(RuntimeError):
     """Raised when the pinned psutil sdist is missing or unsafe."""
 
 
-def _normalize_member_parts(member_name: str) -> tuple[str, ...]:
-    path = PurePosixPath(member_name)
-    parts = tuple(part for part in path.parts if part not in ("", "."))
-    if path.is_absolute() or ".." in parts or not parts:
-        raise PsutilAndroidInstallError(f"Unsafe archive member path: {member_name!r}")
-    return parts
-
-
-def _safe_extract_tar_gz(archive: Path, destination: Path) -> None:
-    """Extract a tar.gz without allowing traversal or link members."""
-    with tarfile.open(archive, "r:gz") as tf:
-        for member in tf.getmembers():
-            parts = _normalize_member_parts(member.name)
-            target = destination.joinpath(*parts)
-            if member.isdir():
-                target.mkdir(parents=True, exist_ok=True)
-                continue
-            if not member.isfile():
-                raise PsutilAndroidInstallError(f"Unsupported archive member type: {member.name}")
-            target.parent.mkdir(parents=True, exist_ok=True)
-            extracted = tf.extractfile(member)
-            if extracted is None:
-                raise PsutilAndroidInstallError(f"Cannot read archive member: {member.name}")
-            with extracted, open(target, "wb") as dst:
-                shutil.copyfileobj(extracted, dst)
-            try:
-                target.chmod(member.mode & 0o777)
-            except OSError:
-                pass
-
-
 def prepare_patched_psutil_sdist(archive: Path, destination: Path) -> Path:
     """Safely extract the pinned psutil sdist and patch it for Android."""
-    _safe_extract_tar_gz(archive, destination)
+    try:
+        safe_extract_targz(archive, destination)  # rejects traversal, links and device nodes
+    except ValueError as exc:
+        raise PsutilAndroidInstallError(str(exc)) from exc
     src_roots = [path for path in destination.iterdir() if path.is_dir() and path.name.startswith("psutil-")]
     if not src_roots:
         raise PsutilAndroidInstallError("psutil sdist did not contain a psutil-* directory")

--- a/hermes_cli/terminal_breadcrumbs.py
+++ b/hermes_cli/terminal_breadcrumbs.py
@@ -11,6 +11,7 @@ import sys
 import time
 from pathlib import Path
 from typing import Optional
+from utils import atomic_json_write
 
 # Multiplexer / terminal-emulator identity env vars, checked in order when no real tty path is
 # available (e.g. stdin piped but stdout still a pty owned by a known terminal).
@@ -86,9 +87,7 @@ def write_breadcrumb(session_id: str, cwd: Optional[str] = None) -> None:
         directory.mkdir(parents=True, exist_ok=True)
         now = time.time()
         payload = {"session_id": session_id, "cwd": cwd or os.getcwd(), "ts": now}
-        tmp = directory / f".{terminal_id}.tmp"
-        tmp.write_text(json.dumps(payload), encoding="utf-8")
-        os.replace(tmp, directory / terminal_id)
+        atomic_json_write(directory / terminal_id, payload, indent=None)
         _prune_stale(directory, now)
     except Exception:
         pass

--- a/hermes_cli/web_server_lifecycle.py
+++ b/hermes_cli/web_server_lifecycle.py
@@ -4,15 +4,14 @@
 import asyncio
 import logging
 import ipaddress
-import json
 import os
 import subprocess
 import sys
-import tempfile
 import threading
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
+from utils import atomic_json_write
 
 if TYPE_CHECKING:  # pragma: no cover - annotation only
     import uvicorn
@@ -212,25 +211,9 @@ def _write_dashboard_ready_file(actual_port: int) -> None:
     if not target:
         return
 
-    tmp_name = ""
     try:
-        path = Path(target)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        payload = json.dumps({"port": int(actual_port)}, separators=(",", ":"))
-        with tempfile.NamedTemporaryFile(
-            "w", encoding="utf-8", dir=str(path.parent), prefix=f"{path.name}.", suffix=".tmp", delete=False
-        ) as fh:
-            fh.write(payload)
-            fh.flush()
-            os.fsync(fh.fileno())
-            tmp_name = fh.name
-        os.replace(tmp_name, path)
+        atomic_json_write(Path(target), {"port": int(actual_port)}, indent=None, separators=(",", ":"))
     except Exception as exc:
-        if tmp_name:
-            try:
-                Path(tmp_name).unlink(missing_ok=True)
-            except Exception:
-                pass
         _log.warning("Failed to write dashboard ready file %r: %s", target, exc)
 
 

--- a/hermes_cli/worktree_ops.py
+++ b/hermes_cli/worktree_ops.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Dict, Optional
 
 from hermes_constants import get_hermes_home
+from utils import atomic_json_write
 
 logger = logging.getLogger("cli")
 
@@ -458,21 +459,11 @@ def _load_worktree_merge_cache() -> Dict[str, bool]:
 
 def _save_worktree_merge_cache(verdicts: Dict[str, bool]) -> None:
     """Atomically persist the newest ``_WORKTREE_MERGE_CACHE_MAX`` verdicts. Never raises."""
-    path = _worktree_merge_cache_path()
-    tmp = None
     try:
         items = list(verdicts.items())[-_WORKTREE_MERGE_CACHE_MAX:]
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(f".{os.getpid()}.tmp")
-        tmp.write_text(json.dumps({"version": 1, "verdicts": dict(items)}), encoding="utf-8")
-        os.replace(str(tmp), str(path))
+        atomic_json_write(_worktree_merge_cache_path(), {"version": 1, "verdicts": dict(items)}, indent=None)
     except Exception as e:
         logger.debug("Could not persist worktree merge cache: %s", e)
-        if tmp is not None:
-            try:
-                tmp.unlink()
-            except Exception:
-                pass
 
 
 def _worktree_commits_all_merged_upstream(

--- a/plugins/google_meet/_jsonfile.py
+++ b/plugins/google_meet/_jsonfile.py
@@ -1,8 +1,7 @@
-"""Tiny JSON file helpers shared by the bot, process manager, node registry and node server."""
+"""Tiny JSON read helper shared by the bot, process manager, node registry and node server."""
 
 from __future__ import annotations
 
-import contextlib
 import json
 from pathlib import Path
 from typing import Any, Optional
@@ -16,15 +15,3 @@ def read_json(path: Path) -> Optional[Any]:
         return json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return None
-
-
-def write_json_atomic(path: Path, data: Any, mode: Optional[int] = None) -> None:
-    """Write ``json.dumps(data, indent=2)`` via a ``.json.tmp`` sibling + rename; *mode* (e.g.
-    ``0o600``) is applied to the temp file so the final file never exists with looser perms."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(".json.tmp")
-    tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
-    if mode is not None:
-        with contextlib.suppress(OSError, NotImplementedError):  # best-effort on non-POSIX filesystems
-            tmp.chmod(mode)
-    tmp.replace(path)

--- a/plugins/google_meet/meet_bot.py
+++ b/plugins/google_meet/meet_bot.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Optional
 
-from plugins.google_meet._jsonfile import write_json_atomic
+from utils import atomic_json_write
 
 # Short three-segment code, a lookup URL, or /new. Anything else is rejected.
 MEET_URL_RE = re.compile(
@@ -93,7 +93,7 @@ class _BotState:
     def _flush(self) -> None:
         data = {key: getattr(self, attr) if attr else None for key, attr, _ in _STATUS_FIELDS}
         data.update(transcriptPath=str(self.transcript_path), pid=os.getpid())  # keeps table key order
-        write_json_atomic(self.status_path, data)
+        atomic_json_write(self.status_path, data)
 
     def set(self, **kwargs) -> None:
         self.__dict__.update(kwargs)

--- a/plugins/google_meet/node/registry.py
+++ b/plugins/google_meet/node/registry.py
@@ -13,7 +13,8 @@ from typing import Any, Dict, List, Optional
 
 from hermes_constants import get_hermes_home
 
-from plugins.google_meet._jsonfile import read_json, write_json_atomic
+from plugins.google_meet._jsonfile import read_json
+from utils import atomic_json_write
 
 
 def _default_path() -> Path:
@@ -33,7 +34,7 @@ class NodeRegistry:
         return nodes if isinstance(nodes, dict) else {}
 
     def _save(self, nodes: Dict[str, Dict[str, Any]]) -> None:
-        write_json_atomic(self.path, {"nodes": nodes})
+        atomic_json_write(self.path, {"nodes": nodes})
 
     def get(self, name: str) -> Optional[Dict[str, Any]]:
         entry = self._load().get(name)

--- a/plugins/google_meet/node/server.py
+++ b/plugins/google_meet/node/server.py
@@ -17,7 +17,8 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from hermes_constants import get_hermes_home
-from plugins.google_meet._jsonfile import read_json, write_json_atomic
+from plugins.google_meet._jsonfile import read_json
+from utils import atomic_json_write
 from plugins.google_meet.node import protocol as _proto
 
 _START_BOT_KEYS = ("url", "guest_name", "duration", "headed", "auth_state", "session_id", "out_dir")
@@ -80,7 +81,7 @@ class NodeServer:
         if not (isinstance(tok, str) and tok):
             tok = secrets.token_hex(16)  # 32 hex chars
             # Owner-only: the token grants full RPC access to the meet bot.
-            write_json_atomic(self.token_path, {"token": tok, "generated_at": time.time()}, mode=0o600)
+            atomic_json_write(self.token_path, {"token": tok, "generated_at": time.time()}, mode=0o600)
         self._token = tok
         return tok
 

--- a/plugins/google_meet/process_manager.py
+++ b/plugins/google_meet/process_manager.py
@@ -21,7 +21,8 @@ from typing import Any, Dict, Optional
 
 from hermes_constants import get_hermes_home
 
-from plugins.google_meet._jsonfile import read_json, write_json_atomic
+from plugins.google_meet._jsonfile import read_json
+from utils import atomic_json_write
 
 
 def _root() -> Path:
@@ -33,7 +34,7 @@ def _read_active() -> Optional[Dict[str, Any]]:
 
 
 def _write_active(data: Dict[str, Any]) -> None:
-    write_json_atomic(_root() / ".active.json", data)
+    atomic_json_write(_root() / ".active.json", data)
 
 
 def _pid_alive(pid: int) -> bool:

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -41,6 +41,7 @@ from gateway.platforms._shared import get_scoped_secret as _get_scoped_secret
 from gateway.platforms.base import BasePlatformAdapter, SendResult
 from gateway.platforms.event import MessageEvent, MessageType
 from gateway.platforms.helpers import compile_mention_patterns, strip_markdown
+from utils import atomic_json_write
 
 from .auth import load_project_credentials
 # Sidecar dir resolution is lazy (never at import): it probes the filesystem and may
@@ -89,22 +90,9 @@ def _runtime_record_path() -> Path:
 
 
 def _write_runtime_record(port: int, token: str, pid: int) -> None:
-    """Atomically persist ``{port, token, pid}`` with owner-only perms (best-effort)."""
-    import tempfile
+    """Atomically persist ``{port, token, pid}`` 0600 from creation (best-effort)."""
     try:
-        path = _runtime_record_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".photon-sidecar.", suffix=".tmp")
-        try:
-            with contextlib.suppress(OSError):  # perms BEFORE the token hits disk (Windows / odd fs)
-                os.chmod(tmp, 0o600)
-            with os.fdopen(fd, "w", encoding="utf-8") as fh:
-                json.dump({"port": port, "token": token, "pid": pid}, fh)
-            os.replace(tmp, path)
-        except BaseException:
-            with contextlib.suppress(OSError):
-                os.unlink(tmp)
-            raise
+        atomic_json_write(_runtime_record_path(), {"port": port, "token": token, "pid": pid}, indent=None, mode=0o600)
     except Exception as e:
         logger.warning("[photon] failed to write sidecar runtime record: %s", e)
 

--- a/scripts/docker_rebootstrap_nous_session.py
+++ b/scripts/docker_rebootstrap_nous_session.py
@@ -187,14 +187,22 @@ def reseed_if_terminal(auth_path: str, seed_raw: str) -> str:
     # Surgical replacement: swap ONLY providers.nous, preserve everything else.
     providers["nous"] = seed_nous
 
-    tmp_path = f"{auth_path}.rebootstrap.tmp"
-    with open(tmp_path, "w", encoding="utf-8") as fh:
-        json.dump(store, fh)
-    os.replace(tmp_path, auth_path)
+    # 0600 from creation: the seed holds a refresh token and must never sit at umask, even briefly.
+    # (stdlib only by design — see module docstring — so this mirrors utils.atomic_json_write by hand.)
+    tmp_path = f"{auth_path}.rebootstrap.{os.getpid()}.tmp"
+    fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     try:
-        os.chmod(auth_path, 0o600)
-    except OSError:
-        pass
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(store, fh)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, auth_path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
     return "reseeded" if terminal else "reseeded_newer"
 
 

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -452,14 +452,15 @@ class TestAllowlistConcurrency:
         p.parent.mkdir(parents=True, exist_ok=True)
 
         tmp_paths_seen: list = []
-        real_mkstemp = shell_hooks.tempfile.mkstemp
+        import utils
+        real_mkstemp = utils.tempfile.mkstemp
 
         def spying_mkstemp(*args, **kwargs):
             fd, path = real_mkstemp(*args, **kwargs)
             tmp_paths_seen.append(path)
             return fd, path
 
-        monkeypatch.setattr(shell_hooks.tempfile, "mkstemp", spying_mkstemp)
+        monkeypatch.setattr(utils.tempfile, "mkstemp", spying_mkstemp)
 
         shell_hooks.save_allowlist({"approvals": [{"event": "a", "command": "x"}]})
         shell_hooks.save_allowlist({"approvals": [{"event": "b", "command": "y"}]})

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -17,7 +17,7 @@ from gateway.pairing import (
     RATE_LIMIT_SECONDS,
     MAX_PENDING_PER_PLATFORM,
     MAX_FAILED_ATTEMPTS,
-    _secure_write,
+    _save_json_file,
 )
 
 
@@ -82,11 +82,11 @@ class TestProfileScopedDiscovery:
 
 
 # ---------------------------------------------------------------------------
-# _secure_write
+# _save_json_file
 # ---------------------------------------------------------------------------
 
 
-class TestSecureWrite:
+class TestSaveJsonFile:
 
     @pytest.mark.skipif(
         sys.platform.startswith("win"),
@@ -94,7 +94,7 @@ class TestSecureWrite:
     )
     def test_sets_file_permissions(self, tmp_path):
         target = tmp_path / "secret.json"
-        _secure_write(target, "data")
+        _save_json_file(target, {"data": 1})
         mode = oct(target.stat().st_mode & 0o777)
         assert mode == "0o600"
 

--- a/tests/hermes_cli/test_auth_toctou_file_modes.py
+++ b/tests/hermes_cli/test_auth_toctou_file_modes.py
@@ -6,10 +6,9 @@ The three writers below used to create a temp file via ``Path.write_text`` /
 ``Path.open('w')`` and only ``chmod``'d it to ``0o600`` afterward. Between
 create and chmod the file existed at the process umask (typically ``0o644``),
 briefly exposing OAuth tokens to other local users on multi-user hosts. The
-fix switches them to ``os.open(O_EXCL, mode=0o600)`` + ``os.fdopen`` +
-``fsync`` so the file is atomic at ``0o600`` on creation. Mirrors the fixes
-shipped for ``agent/google_oauth.py`` (#19673) and ``tools/mcp_oauth.py``
-(#21148).
+writers now go through ``utils.atomic_json_write(mode=0o600)`` whose mkstemp temp
+file is ``O_EXCL`` at 0600 on creation (the cross-writer invariant lives in
+``tests/test_private_credential_writers.py``).
 
 These tests stay green only while the token file and its parent directory
 end up at ``0o600`` / ``0o700`` after every write. POSIX-only — the mode-bit
@@ -22,7 +21,6 @@ import json
 import os
 import stat
 import sys
-from unittest.mock import patch
 
 import pytest
 
@@ -153,50 +151,3 @@ def test_shared_nous_store_writes_0o600_with_0o700_parent(tmp_path, monkeypatch)
 
     data = json.loads(path.read_text())
     assert data["refresh_token"] == "nous-refresh-xxx"
-
-
-# ---------------------------------------------------------------------------
-# Atomicity: verify ``os.open`` is called with an explicit 0o600 mode.
-# ---------------------------------------------------------------------------
-
-
-def test_save_auth_store_uses_os_open_with_0o600_mode(tmp_path, monkeypatch):
-    """Regression: the writer must call ``os.open`` with an explicit restricted
-    mode so the file is created at 0o600 atomically — closing the TOCTOU
-    window the previous ``Path.open('w')`` left open (fd inherited process
-    umask and was briefly 0o644 before post-write chmod)."""
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-
-    observed_opens: list[tuple[str, int, int]] = []
-    real_os_open = os.open
-
-    def spying_os_open(path, flags, mode=0o777, *args, **kwargs):
-        observed_opens.append((str(path), flags, mode))
-        return real_os_open(path, flags, mode, *args, **kwargs)
-
-    with patch.object(os, "open", spying_os_open):
-        from hermes_cli import auth as auth_mod
-
-        auth_mod._save_auth_store(
-            {"version": auth_mod.AUTH_STORE_VERSION, "providers": {}}
-        )
-
-    auth_tmp_opens = [
-        (p, fl, m) for (p, fl, m) in observed_opens if "auth.json.tmp" in p
-    ]
-    assert auth_tmp_opens, (
-        f"os.open was never called for the auth.json temp file; "
-        f"observed={observed_opens!r}"
-    )
-    for path, flags, mode in auth_tmp_opens:
-        assert flags & os.O_CREAT, f"auth.json temp open missing O_CREAT: path={path}"
-        assert flags & os.O_EXCL, (
-            f"auth.json temp open missing O_EXCL — TOCTOU-safe pattern regressed: "
-            f"path={path}, flags={flags}"
-        )
-        # Must be exactly S_IRUSR | S_IWUSR (0o600) — no group/other bits.
-        expected = stat.S_IRUSR | stat.S_IWUSR
-        assert mode == expected, (
-            f"auth.json temp open mode 0o{mode:o} != 0o{expected:o} — "
-            f"umask would apply and potentially expose tokens"
-        )

--- a/tests/hermes_cli/test_codex_runtime_plugin_migration.py
+++ b/tests/hermes_cli/test_codex_runtime_plugin_migration.py
@@ -79,13 +79,12 @@ class TestTomlValueFormatter:
         """If rename fails partway through (out of disk, permissions,
         crash), the temp file must be cleaned up. Otherwise repeated
         failed migrations would pile up .config.toml.* files."""
-        from pathlib import Path as _Path
-        original_replace = _Path.replace
+        import utils
 
-        def failing_replace(self, target):
+        def failing_replace(tmp, target):
             raise OSError("simulated disk full")
 
-        monkeypatch.setattr(_Path, "replace", failing_replace)
+        monkeypatch.setattr(utils, "atomic_replace", failing_replace)
         report = migrate(
             {"mcp_servers": {"x": {"command": "y"}}},
             codex_home=tmp_path,

--- a/tests/hermes_cli/test_install_identity.py
+++ b/tests/hermes_cli/test_install_identity.py
@@ -21,14 +21,15 @@ def _race_first_install_id(
     if start_barrier is not None:
         start_barrier.wait(timeout=10)
     if writer_entered is not None:
-        original_mkstemp = install_identity.tempfile.mkstemp
+        import utils
+        original_mkstemp = utils.tempfile.mkstemp
 
         def held_mkstemp(*args, **kwargs):
             writer_entered.set()
             assert release_writer.wait(timeout=10)
             return original_mkstemp(*args, **kwargs)
 
-        install_identity.tempfile.mkstemp = held_mkstemp
+        utils.tempfile.mkstemp = held_mkstemp
     results.put(read_or_create_install_id(root))
 
 

--- a/tests/hermes_cli/test_psutil_android_extract.py
+++ b/tests/hermes_cli/test_psutil_android_extract.py
@@ -64,6 +64,20 @@ def test_prepare_patched_psutil_sdist_rejects_symlink_member(tmp_path):
     assert not (tmp_path / "outside" / "_common.py").exists()
 
 
+def test_prepare_patched_psutil_sdist_rejects_traversal_member(tmp_path):
+    """A ``..`` member must be refused the same way the shared archive guard refuses it
+    (one traversal check for every tar.gz we extract), surfaced as the installer's own error."""
+    archive = tmp_path / "evil.tar.gz"
+    with tarfile.open(archive, "w:gz") as tf:
+        _add_dir(tf, "psutil-7.2.2")
+        _add_file(tf, "psutil-7.2.2/../escaped.py", "x")
+
+    with pytest.raises(PsutilAndroidInstallError, match="Unsafe archive member path"):
+        prepare_patched_psutil_sdist(archive, tmp_path / "extract")
+
+    assert not (tmp_path / "escaped.py").exists()
+
+
 def test_install_psutil_android_compat_uses_patched_tree(tmp_path):
     """Updater path should install from the patched temporary sdist tree."""
     archive = tmp_path / "psutil.tar.gz"

--- a/tests/test_atomic_json_writers_unified.py
+++ b/tests/test_atomic_json_writers_unified.py
@@ -1,0 +1,69 @@
+"""Invariant for the non-secret atomic JSON writers that used to inline ``utils._atomic_write``.
+
+Contract under test for ``gateway/session_persistence``, ``cron/suggestions`` and
+``agent/shell_hooks``: a failed replace leaves the previous file byte-identical AND leaves no temp
+file behind (the interrupt-safe cleanup only the canonical helper guarantees). A hand-rolled copy
+that skips the cleanup, or writes through the target instead of a sibling temp, fails this.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _failing_replace(tmp, target):
+    raise OSError("simulated disk full")
+
+
+def _leftovers(directory: Path, keep: str) -> list[str]:
+    return sorted(p.name for p in directory.iterdir() if p.name != keep)
+
+
+@pytest.fixture
+def broken_replace(monkeypatch):
+    import utils
+
+    monkeypatch.setattr(utils, "atomic_replace", _failing_replace)
+
+
+def test_sessions_json_failed_replace_keeps_old_bytes_and_no_temp(tmp_path, monkeypatch, broken_replace):
+    from gateway.session_persistence import SessionPersistenceMixin
+
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    target = sessions_dir / "sessions.json"
+    target.write_text('{"old": true}', encoding="utf-8")
+    store = SessionPersistenceMixin()
+    store.sessions_dir = sessions_dir
+    with pytest.raises(OSError):
+        store._save_sessions_json({"k": "v"})
+    assert target.read_text(encoding="utf-8") == '{"old": true}'
+    assert _leftovers(sessions_dir, "sessions.json") == []
+
+
+def test_suggestions_failed_replace_keeps_old_bytes_and_no_temp(tmp_path, monkeypatch, broken_replace):
+    from cron import suggestions
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    target = suggestions._current_suggestions_file()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text('{"old": true}', encoding="utf-8")
+    with pytest.raises(OSError):
+        suggestions._save_raw([{"id": 1}])
+    assert target.read_text(encoding="utf-8") == '{"old": true}'
+    assert _leftovers(target.parent, target.name) == []
+
+
+def test_shell_hooks_allowlist_survives_failed_replace_without_temp(tmp_path, monkeypatch, broken_replace):
+    from agent import shell_hooks
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    target = shell_hooks.allowlist_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps({"approvals": []}), encoding="utf-8")
+    shell_hooks.save_allowlist({"approvals": [{"event": "a", "command": "x"}]})  # logs, never raises
+    assert json.loads(target.read_text(encoding="utf-8")) == {"approvals": []}
+    assert _leftovers(target.parent, target.name) == []

--- a/tests/test_private_credential_writers.py
+++ b/tests/test_private_credential_writers.py
@@ -1,0 +1,113 @@
+"""Cross-writer invariant: every private-credential file is 0600 from the moment its temp file exists.
+
+The credential writers (auth.json, MCP OAuth tokens, secret-source cache, iron-proxy state, the
+exchanged-JWT store, the Photon sidecar record, pairing data, the vault blob, the third-party
+credential file) all funnel through ``utils.atomic_json_write`` / ``atomic_write_text`` /
+``atomic_write_bytes`` with ``mode=0o600``. The contract under test: the *temp* file is created
+with mode 0600 (``O_EXCL``) BEFORE any byte lands and the final file carries 0600 — never
+"open at umask, then chmod" (the #19673 window). POSIX-only: mode bits are not enforced on Windows.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX mode bits not enforced on Windows")
+
+_PRIVATE = stat.S_IRUSR | stat.S_IWUSR
+
+
+@pytest.fixture
+def opens_spy(monkeypatch):
+    """Record every ``os.open`` create (path, flags, mode) issued through ``utils``."""
+    import utils
+
+    observed: list[tuple[str, int, int]] = []
+    real_open = os.open
+
+    def spying(path, flags, mode=0o777, *args, **kwargs):
+        if flags & os.O_CREAT:
+            observed.append((os.fspath(path), flags, mode))
+        return real_open(path, flags, mode, *args, **kwargs)
+
+    # mkstemp resolves ``os.open`` at call time from the ``tempfile`` module namespace.
+    monkeypatch.setattr(utils.tempfile._os, "open", spying)
+    return observed
+
+
+def _writers(home: Path, monkeypatch):
+    """``(label, callable, target_path)`` for every private-credential writer."""
+    from agent import anthropic_credentials
+    from agent.secret_sources._cache import CachedFetch, DiskCache
+    from agent.proxy_sources import iron_proxy
+    from agent.vault_store import VaultStore
+    from gateway import pairing
+    from hermes_cli import auth as auth_mod, copilot_auth
+    from tools import mcp_oauth
+    from plugins.platforms.photon import adapter as photon_adapter
+
+    photon_record = home / "runtime" / "photon.json"
+    monkeypatch.setattr(photon_adapter, "_runtime_record_path", lambda: photon_record)
+    cache = DiskCache("probe.json", key_serializer=str)
+    vault = VaultStore(home / "vault")
+    return [
+        ("auth.json", lambda: auth_mod._save_auth_store({"version": auth_mod.AUTH_STORE_VERSION, "providers": {}}),
+         auth_mod._auth_file_path()),
+        ("third-party credentials", lambda: anthropic_credentials._atomic_write_private_json(
+            home / "cc" / ".credentials.json", {"tok": 1}), home / "cc" / ".credentials.json"),
+        ("mcp oauth tokens", lambda: mcp_oauth._write_json(home / "mcp" / "probe.tokens.json", {"access_token": "x"}),
+         home / "mcp" / "probe.tokens.json"),
+        ("secret-source cache", lambda: cache.write("k", CachedFetch(secrets={"A": "b"}, fetched_at=1.0), 60, home),
+         cache.path(home)),
+        ("iron-proxy mappings", lambda: iron_proxy.write_mappings([]), home / "proxy" / "mappings.json"),
+        ("exchanged JWT store", lambda: copilot_auth._save_jwt_to_disk("fp", "jwt", 9e12, None),
+         copilot_auth._jwt_disk_path()),
+        ("photon sidecar record", lambda: photon_adapter._write_runtime_record(1, "tok", 2), photon_record),
+        ("pairing", lambda: pairing._save_json_file(home / "pairing" / "p.json", {"a": 1}), home / "pairing" / "p.json"),
+        ("vault blob", lambda: vault._write_all([]), vault._vault_path),
+    ]
+
+
+def test_every_credential_writer_creates_its_temp_file_at_0600(tmp_path, monkeypatch, opens_spy):
+    pytest.importorskip("cryptography")
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    old_umask = os.umask(0o022)  # a "write then chmod" regression would surface as 0o644
+    try:
+        for label, write, target in _writers(home, monkeypatch):
+            del opens_spy[:]
+            write()
+            assert target.exists(), f"{label}: nothing written at {target}"
+            assert stat.S_IMODE(target.stat().st_mode) == _PRIVATE, f"{label}: final file not 0600"
+            creates = [(p, m) for p, fl, m in opens_spy if Path(p).parent == target.parent]
+            assert creates, f"{label}: no temp file created in {target.parent}; opens={opens_spy!r}"
+            for path, mode in creates:
+                assert mode == _PRIVATE, f"{label}: temp file {path} created 0o{mode:o}, not 0600"
+    finally:
+        os.umask(old_umask)
+
+
+def test_canonical_private_writers_round_trip_json_text_and_bytes(tmp_path):
+    from utils import atomic_json_write, atomic_write_bytes, atomic_write_text
+
+    target = tmp_path / "nested" / "creds.json"
+    payload = {"token": "sk-\u00e9\u2603", "n": [1, 2]}
+    atomic_json_write(target, payload, mode=0o600, fsync_dir=True)
+    assert json.loads(target.read_text(encoding="utf-8")) == payload
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+    atomic_write_text(target, "plain\n", mode=0o600)
+    assert target.read_text(encoding="utf-8") == "plain\n"
+
+    blob = bytes(range(256)) * 3
+    atomic_write_bytes(target, blob, mode=0o600, fsync_dir=True)
+    assert target.read_bytes() == blob
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert [p.name for p in target.parent.iterdir()] == ["creds.json"], "temp files must not survive"

--- a/tools/bot_live_delivery.py
+++ b/tools/bot_live_delivery.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 import json
 import os
 import re
-import tempfile
 import time
 import uuid
 from contextlib import contextmanager
+
+from utils import atomic_json_write, fsync_directory
 from pathlib import Path
 from typing import Any
 
@@ -73,25 +74,14 @@ def _root(home: Path | str) -> Path:
     return Path(home).resolve() / "runtime" / DELIVERY_DIR_NAME
 
 
-def _fsync_dir(path: Path) -> None:
-    # Windows cannot open directories with os.open; file fsync still applies.
-    if os.name == "nt":
-        return
-    fd = os.open(path, os.O_RDONLY)
-    try:
-        os.fsync(fd)
-    finally:
-        os.close(fd)
-
-
 @contextmanager
 def _locked(home: Path | str):
     root = _root(home)
     root.parent.mkdir(parents=True, exist_ok=True)
     root.mkdir(mode=0o700, exist_ok=True)
     root.chmod(0o700)
-    _fsync_dir(root.parent)
-    _fsync_dir(root.parent.parent)
+    fsync_directory(root.parent)
+    fsync_directory(root.parent.parent)
     lock = root / ".lock"
     fd = os.open(lock, os.O_CREAT | os.O_WRONLY, 0o600)
     os.close(fd)
@@ -107,16 +97,7 @@ def _read(path: Path) -> dict[str, Any] | None:
 
 
 def _write(path: Path, record: dict[str, Any]) -> None:
-    fd, temporary = tempfile.mkstemp(dir=path.parent, prefix=".delivery-")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as stream:
-            json.dump(record, stream, ensure_ascii=False, sort_keys=True)
-            stream.flush()
-            os.fsync(stream.fileno())
-        os.replace(temporary, path)
-        _fsync_dir(path.parent)
-    finally:
-        Path(temporary).unlink(missing_ok=True)
+    atomic_json_write(path, record, indent=None, sort_keys=True, fsync_dir=True)
 
 
 def deliver_to_live_owner(

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -407,9 +407,8 @@ def _run_local_turn(argv: list[str], dm_file: str, *, env: Optional[dict[str, st
 
 def _admit_live_dm(profile_home: Path | None, dm_file: str, author: Optional[dict] = None) -> dict | None:
     """Pin intent before admission; retries may inspect, never change transport."""
-    from tools.bot_live_delivery import (
-        _fsync_dir, deliver_to_live_owner, find_canonical_live_owner, read_delivery_result,
-    )
+    from tools.bot_live_delivery import deliver_to_live_owner, find_canonical_live_owner, read_delivery_result
+    from utils import fsync_directory
 
     intent: dict[str, Any]
     intent_path = Path(dm_file + ".live.json")
@@ -432,7 +431,7 @@ def _admit_live_dm(profile_home: Path | None, dm_file: str, author: Optional[dic
                 json.dump(intent, stream)
                 stream.flush()
                 os.fsync(stream.fileno())
-            _fsync_dir(intent_path.parent)
+            fsync_directory(intent_path.parent)
     home = intent["owner"]["profile_home"]
     record = read_delivery_result(home, intent["delivery_id"])
     if record is None:

--- a/tools/bot_relay.py
+++ b/tools/bot_relay.py
@@ -21,13 +21,13 @@ import re
 import shlex
 import shutil
 import sys
-import tempfile
 import time
 import uuid
 from pathlib import Path
 from typing import Any, Iterator, Optional
 
 from tools.bot_mode_probe import _default_home, _hermes_root
+from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
@@ -90,17 +90,8 @@ def _ensure_dirs(root: Path | str) -> Path:
     return base
 
 
-def _atomic_write_json(target: Path, payload: Any, *, prefix: str, sort_keys: bool = False) -> None:
-    """tempfile + os.replace so readers never see a partial file; tempfile removed on failure."""
-    fd, tmp = tempfile.mkstemp(dir=str(target.parent), prefix=prefix, suffix=".tmp")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            json.dump(payload, f, ensure_ascii=False, sort_keys=sort_keys)
-        os.replace(tmp, target)
-    except Exception:
-        with contextlib.suppress(OSError):
-            os.unlink(tmp)
-        raise
+def _atomic_write_json(target: Path, payload: Any, *, sort_keys: bool = False) -> None:
+    atomic_json_write(target, payload, indent=None, sort_keys=sort_keys)
 
 
 def _bot_mode_cfg(key: str, *, loader: str) -> Any:
@@ -145,8 +136,7 @@ def write_remote_roster(root: Path | str, rows: Any) -> int:
     for norm in filter(None, map(_normalize_roster_row, rows if isinstance(rows, list) else [])):
         by_key.setdefault((norm["connection_id"], norm["profile"]), norm)
     cleaned = [by_key[k] for k in sorted(by_key)]
-    _atomic_write_json(base / ROSTER_FILE, {"updated_at": int(time.time()), "agents": cleaned},
-                       prefix=".roster-", sort_keys=True)
+    _atomic_write_json(base / ROSTER_FILE, {"updated_at": int(time.time()), "agents": cleaned}, sort_keys=True)
     return len(cleaned)
 
 
@@ -229,7 +219,7 @@ def enqueue_envelope(root: Path | str, *, target: dict, message: str, sender_pro
         "target_connection": target["connection_id"], "target_profile": target["profile"],
         "target_handle": target["handle"], "message": message,
     }
-    _atomic_write_json(base / OUTBOX_DIR / f"{envelope['id']}.json", envelope, prefix=".env-")
+    _atomic_write_json(base / OUTBOX_DIR / f"{envelope['id']}.json", envelope)
     return envelope
 
 
@@ -289,8 +279,7 @@ def write_reply(root: Path | str, envelope_id: str, *, reply: str = "", error: s
 
         code = classify_agent_error(err)
     path = base / REPLIES_DIR / f"{safe}.json"
-    _atomic_write_json(path, {"id": safe, "at": int(time.time()), "reply": str(reply or ""), "error": err, "reason": code},
-                       prefix=".rep-")
+    _atomic_write_json(path, {"id": safe, "at": int(time.time()), "reply": str(reply or ""), "error": err, "reason": code})
     return path
 
 

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -16,7 +16,6 @@ import json
 import logging
 import os
 import re
-import secrets
 import socket
 import stat
 import sys
@@ -30,6 +29,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import parse_qs, urlparse
 
 from hermes_constants import secure_parent_dir
+from utils import atomic_json_write
 from tools.mcp_dashboard_oauth import contextvar_set as _contextvar_set, get_dashboard_oauth_flow
 
 if TYPE_CHECKING:  # annotations only; the SDK is imported lazily at runtime
@@ -236,33 +236,11 @@ def _read_json(path: Path) -> dict | None:
 
 
 def _write_json(path: Path, data: dict) -> None:
-    """Atomically write *data* as JSON created at 0o600 (``O_EXCL`` + mode avoids the write-then-chmod
-    window where the file inherits a world-readable umask); parent dir tightened to 0o700. The random
-    per-process tmp suffix avoids clashes with concurrent writers/crash leftovers.
-
-    The previous ``write_text`` + post-write ``chmod`` opened a TOCTOU window where the temp file briefly
-    inherited the process umask (commonly 0o644 = world-readable), exposing OAuth tokens to other local
-    users between create and chmod. Mirrors the fix in ``agent/google_oauth.py`` (#19673).
-    """
+    """OAuth tokens/client info at 0600 from creation, parent tightened to 0700 (``secure_parent_dir``
+    refuses ``/``, top-level dirs and the install tree — #25821, #93050)."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    # secure_parent_dir refuses to chmod /, top-level dirs, or the hermes-agent install tree (#25821,
-    # #93050).
-    # Tighten parent dir to 0o700 so siblings can't traverse to the creds. No-op on Windows (POSIX mode bits
-    # aren't enforced); ignore failures. secure_parent_dir refuses to chmod /, top-level dirs, or the
-    # hermes-agent install tree (#25821, #93050).
     secure_parent_dir(path)
-    tmp = path.with_suffix(f".tmp.{os.getpid()}.{secrets.token_hex(4)}")
-    try:
-        fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_EXCL, stat.S_IRUSR | stat.S_IWUSR)
-        with os.fdopen(fd, "w", encoding="utf-8") as fh:
-            json.dump(data, fh, indent=2, default=str)
-            fh.flush()
-            os.fsync(fh.fileno())
-        os.replace(tmp, path)
-    except OSError:
-        with contextlib.suppress(OSError):
-            tmp.unlink(missing_ok=True)
-        raise
+    atomic_json_write(path, data, mode=0o600, default=str)
 
 
 def _model_json(model: Any) -> dict:

--- a/tools/web_result_cache.py
+++ b/tools/web_result_cache.py
@@ -10,7 +10,6 @@ Lives here, not in tool dispatch, so hits sit *after* every safety check and ski
 import hashlib
 import json
 import logging
-import os
 import re
 import threading
 import time
@@ -18,6 +17,7 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Dict, Optional, Tuple
 from urllib.parse import urlparse
+from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
@@ -183,11 +183,9 @@ def _save_index(index: dict) -> None:
         if len(index) > _INDEX_MAX_ENTRIES:
             newest = sorted(index.items(), key=lambda kv: kv[1].get("fetched_at", 0), reverse=True)
             index = dict(newest[:_INDEX_MAX_ENTRIES])
-        # Per-process tmp name: CLI, gateway, cron, and subagents all write this index; a shared tmp name
-        # would let concurrent writers truncate each other. os.replace is atomic: worst case is a lost insert.
-        tmp = path.with_suffix(f".tmp.{os.getpid()}")
-        tmp.write_text(json.dumps(index), encoding="utf-8")
-        tmp.replace(path)
+        # CLI, gateway, cron, and subagents all write this index; the replace is atomic, so the worst case
+        # under concurrent writers is a lost insert, never a truncated index.
+        atomic_json_write(path, index, indent=None)
     except Exception as exc:  # noqa: BLE001
         logger.debug("Failed to save web extract cache index: %s", exc)
 

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import difflib
 import json
 import logging
-import os
 import re
 import time
 import uuid
@@ -24,6 +23,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from hermes_constants import get_hermes_home
+from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
@@ -82,11 +82,7 @@ def stage_write(subsystem: str, payload: Dict[str, Any], *, summary: str, origin
         "created_at": time.time(), "payload": payload,
     }
     try:
-        path = _pending_path(subsystem, pid)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(".json.tmp")
-        tmp.write_text(json.dumps(record, ensure_ascii=False, indent=2), encoding="utf-8")
-        os.replace(tmp, path)
+        atomic_json_write(_pending_path(subsystem, pid), record)
     except Exception as e:  # pragma: no cover - disk failure path
         logger.error("Failed to stage pending %s write: %s", subsystem, e, exc_info=True)
     return record

--- a/tui_gateway/turn_marker.py
+++ b/tui_gateway/turn_marker.py
@@ -8,15 +8,13 @@ marker" instead of raising."""
 
 from __future__ import annotations
 
-import contextlib
 import json
 import logging
-import os
-import tempfile
 import threading
 import time
 from pathlib import Path
 from typing import Any
+from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
@@ -59,16 +57,7 @@ def _store(path: Path, entries: dict[str, dict]) -> None:
     if not entries:
         path.unlink(missing_ok=True)
         return
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=".turn-marker-")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            json.dump(entries, f)
-        os.replace(tmp, path)
-    except Exception:
-        with contextlib.suppress(OSError):
-            os.unlink(tmp)
-        raise
+    atomic_json_write(path, entries, indent=None)
 
 
 def _update(home: Path | str, session_key: str, mutate, what: str) -> None:

--- a/utils.py
+++ b/utils.py
@@ -174,25 +174,51 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     return real_path
 
 
-def _atomic_write(path: Path, write, *, prefix: str, encoding: str = "utf-8", mode: "int | None" = None, preserve_owner: bool = True) -> None:
+def fsync_directory(path: Union[str, Path]) -> None:
+    """Best-effort fsync of a directory entry so a just-renamed file survives power loss.
+
+    No-op on Windows (directories can't be opened with ``os.open``; the file fsync still applies)
+    and on any OSError — durability of the directory entry is never worth failing a write that
+    has already been replaced into place.
+    """
+    if os.name == "nt":
+        return
+    try:
+        fd = os.open(path, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    except OSError:
+        return
+    try:
+        with suppress(OSError):
+            os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _atomic_write(path: Path, write, *, prefix: str, encoding: str = "utf-8", mode: "int | None" = None,
+                  preserve_owner: bool = True, binary: bool = False, fsync_dir: bool = False) -> None:
     """Temp file + fsync + :func:`atomic_replace`, then re-apply owner/mode.
 
-    *write(f)* emits the payload into the open text handle. *mode* is fchmod'd onto the temp fd
-    BEFORE the replace so the target never transits through mkstemp's 0600 (fchmod is Unix-only;
-    the post-replace chmod is the sole path on Windows). The temp file is removed on any failure —
+    *write(f)* emits the payload into the open handle (text, or bytes when *binary*). The temp file
+    is created by ``mkstemp`` — ``O_CREAT|O_EXCL`` at 0600 regardless of umask — so a secret is
+    never readable at process umask, not even between create and chmod. *mode* is fchmod'd onto
+    the temp fd BEFORE the replace so the target never transits through mkstemp's 0600 (fchmod is
+    Unix-only; the post-replace chmod is the sole path on Windows). *fsync_dir* also fsyncs the
+    parent so the rename itself is durable. The temp file is removed on any failure —
     ``BaseException`` on purpose, so KeyboardInterrupt / SystemExit still clean up.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     original_owner = _preserve_file_owner(path) if preserve_owner else None
     fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), prefix=prefix, suffix=".tmp")
     try:
-        with os.fdopen(fd, "w", encoding=encoding) as f:
+        with os.fdopen(fd, "wb" if binary else "w", encoding=None if binary else encoding) as f:
             if mode is not None and hasattr(os, "fchmod"):
                 os.fchmod(f.fileno(), mode)
             write(f)
             f.flush()
             os.fsync(f.fileno())
         _restore_file_metadata(Path(atomic_replace(tmp_path, path)), original_owner, mode)  # symlink-preserving
+        if fsync_dir:
+            fsync_directory(path.parent)
     except BaseException:
         with suppress(OSError):
             os.unlink(tmp_path)
@@ -206,29 +232,44 @@ def _mode_for_write(path: Path, create_mode: "int | None", preserve: bool = True
 
 
 def atomic_write_text(path: Union[str, Path], content: str, *, encoding: str = "utf-8", tmp_prefix: str = ".tmp_",
-                      preserve_mode: bool = False, create_mode: "int | None" = None) -> None:
+                      preserve_mode: bool = False, create_mode: "int | None" = None, mode: "int | None" = None,
+                      fsync_dir: bool = False) -> None:
     """Write *content* to *path* via temp file + fsync + atomic rename.
 
     The target is never left partially written on crash/interrupt. Shared by every destructive
-    file rewrite (memory store, skill manager, agent importer, ...).
+    file rewrite (memory store, skill manager, agent importer, ...). *mode* forces the final
+    permission bits (secret files: ``0o600``) regardless of what exists; *create_mode* applies only
+    when the target is new and *preserve_mode* carries an existing file's bits and owner across.
     """
     path = Path(path)
     _atomic_write(path, lambda f: f.write(content), prefix=tmp_prefix, encoding=encoding,
-                  mode=_mode_for_write(path, create_mode, preserve=preserve_mode), preserve_owner=preserve_mode)
+                  mode=mode if mode is not None else _mode_for_write(path, create_mode, preserve=preserve_mode),
+                  preserve_owner=preserve_mode, fsync_dir=fsync_dir)
+
+
+def atomic_write_bytes(path: Union[str, Path], content: bytes, *, tmp_prefix: str = ".tmp_",
+                       mode: "int | None" = None, fsync_dir: bool = False) -> None:
+    """Bytes variant of :func:`atomic_write_text` (encrypted blobs, key material)."""
+    path = Path(path)
+    _atomic_write(path, lambda f: f.write(content), prefix=tmp_prefix, binary=True, preserve_owner=False,
+                  mode=mode if mode is not None else _preserve_file_mode(path), fsync_dir=fsync_dir)
 
 
 def atomic_json_write(
     path: Union[str, Path], data: Any, *, indent: int = 2, mode: int | None = None,
-    ensure_ascii: bool = False, **dump_kwargs: Any,
+    ensure_ascii: bool = False, fsync_dir: bool = False, **dump_kwargs: Any,
 ) -> None:
     """Write JSON to *path* atomically (temp file + fsync + replace).
 
     ``ensure_ascii=True`` lets callers persist surrogate-escaped strings (non-UTF-8 argv/paths)
-    that a utf-8 text handle would otherwise reject with ``UnicodeEncodeError``.
+    that a utf-8 text handle would otherwise reject with ``UnicodeEncodeError``. ``mode=0o600``
+    is the private-credential form: the temp file is 0600 from creation (mkstemp), so the payload
+    is never umask-readable.
     """
     path = Path(path)
     _atomic_write(path, lambda f: json.dump(data, f, indent=indent, ensure_ascii=ensure_ascii, **dump_kwargs),
-                  prefix=f".{path.stem}_", mode=mode if mode is not None else _preserve_file_mode(path))
+                  prefix=f".{path.stem}_", mode=mode if mode is not None else _preserve_file_mode(path),
+                  fsync_dir=fsync_dir)
 
 
 def warn_if_credential_file_broadly_readable(path: Union[str, Path], *, label: str = "", log: logging.Logger | None = None) -> bool:


### PR DESCRIPTION
Every private-credential file and every non-secret atomic JSON/text writer now goes through one implementation in `utils.py`, and the psutil Android installer uses the shared safe-tar guard.

## Changes

- `utils.py`: `_atomic_write` gains `binary=` and `fsync_dir=`; new `atomic_write_bytes` and `fsync_directory`; `atomic_write_text` gains `mode=`; `atomic_json_write` gains `fsync_dir=`. mkstemp already creates the temp file `O_EXCL` at 0600 regardless of umask, so `mode=0o600` is the private-credential form.
- 10 private-credential writers become 1–3 line callers of `atomic_json_write(mode=0o600)` / `atomic_write_text(mode=0o600)` / `atomic_write_bytes(mode=0o600)`. `hermes_cli/auth.py::_write_private_file_atomic` is replaced by `_save_private_json` (secure_parent_dir + canonical); `_secure_write`, `_write_jwt_store`, `_write_state_file_atomic`, secret_sources' `tmp_prefix=` are deleted.
- 24 non-secret writers repointed onto `atomic_json_write` / `atomic_write_text`; `tools/bot_live_delivery._fsync_dir` and `hermes_cli/install_identity._fsync_directory` collapse into `utils.fsync_directory`; `plugins/google_meet/_jsonfile.write_json_atomic` deleted.
- `hermes_cli/psutil_android.py` extracts via `archive_safe.safe_extract_targz` (own `_normalize_member_parts` / `_safe_extract_tar_gz` deleted), re-raising as `PsutilAndroidInstallError` so callers are unchanged.
- `scripts/docker_rebootstrap_nous_session.py` (stdlib-only by design) closes its own open-at-umask window with `os.open(O_EXCL, 0o600)` + fsync.

## Sites

### Private credential writers (all → `utils.atomic_json_write(mode=0o600)` unless noted)

| path::symbol | now |
|---|---|
| `hermes_cli/auth.py::_write_private_file_atomic` (auth.json, Qwen tokens, Nous shared store) | `_save_private_json` → secure_parent_dir + canonical, `fsync_dir=True` for auth.json |
| `agent/anthropic_credentials.py::_atomic_write_private_json` | 1-line forwarder |
| `tools/mcp_oauth.py::_write_json` | secure_parent_dir + canonical (`default=str`) |
| `agent/secret_sources/_cache.py::atomic_write_json` (+ bitwarden caller) | secure_parent_dir + canonical; `tmp_prefix` param dropped |
| `agent/proxy_sources/iron_proxy.py::_write_state_file_atomic` | deleted; `write_proxy_config` → `atomic_write_text(mode=0o600)`, `write_mappings` → canonical |
| `hermes_cli/copilot_auth.py::_write_jwt_store` | deleted; 2 callers use canonical |
| `plugins/platforms/photon/adapter.py::_write_runtime_record` | canonical |
| `gateway/pairing.py::_secure_write` | deleted; `_save_json_file` → canonical |
| `agent/vault_store.py::_write_all` | `atomic_write_bytes(mode=0o600, fsync_dir=True)` |
| `scripts/docker_rebootstrap_nous_session.py::reseed_if_terminal` | stdlib O_EXCL 0600 (script cannot import utils) |

### Non-secret writers (→ `atomic_json_write` / `atomic_write_text`)

`tools/bot_relay._atomic_write_json`, `hermes_cli/profiles._atomic_write_json`, `hermes_cli/active_sessions._write_entries`, `gateway/rich_sent_store._update`, `hermes_cli/banner.save_banner_snapshot._write`, `hermes_cli/plugins._persist_plugin_toolset_keys`, `hermes_cli/terminal_breadcrumbs.write_breadcrumb`, `hermes_cli/worktree_ops._save_worktree_merge_cache`, `tools/web_result_cache._save_index`, `tools/write_approval.stage_write`, `tui_gateway/turn_marker._store`, `tools/bot_live_delivery._write` + `_fsync_dir`, `hermes_cli/model_catalog._write_disk_cache`, `hermes_cli/debug._save_pending`, `hermes_cli/plugin_compat._write_report_file`, `hermes_cli/web_server_lifecycle._write_dashboard_ready_file`, `plugins/google_meet/_jsonfile.write_json_atomic` (deleted, 4 callers), `gateway/session_persistence._save_sessions_json`, `cron/suggestions._save_raw` (+ dead `_secure_file`), `agent/shell_hooks.save_allowlist`, `hermes_cli/install_identity.read_or_create_install_id` + `_fsync_directory`, `hermes_cli/codex_runtime_plugin_migration._write_atomic`, `hermes_cli/local_runtime/presets.generate_presets`, `tools/bot_mode_dm` + `gateway/hosted_room_peer` (fsync helper callers).

Left alone on purpose: `cron/jobs._stage_jobs_payload` (two-phase staging), `gateway/status._write_json_excl` (create-only lock), `hermes_cli/kanban_transfer._write_json` (staging dir, not atomic), `tools/skill_usage._write_suppressed_names` (inside a PLUGIN-COMPAT block).

### Tar guard

| path::symbol | now |
|---|---|
| `hermes_cli/psutil_android.py::_safe_extract_tar_gz` + `_normalize_member_parts` | deleted → `hermes_cli/archive_safe.safe_extract_targz` |

### Not changed: `managed_gateway_auth_headers` duplicate

`tools/managed_tool_gateway.py::managed_gateway_auth_headers` / `is_managed_nous_gateway_url` / `build_managed_media_uploader` all live inside the file's `PLUGIN-COMPAT` block (`# ---- BEGIN PLUGIN-COMPAT` at L185 through EOF) and are listed in `compat_manifest.json` as restored compat pointers. That block is scheduled for deletion by reverting its commit on 2026-09-14 and is off-limits in-tree; the only in-tree production caller (`tools/tool_gateway/client.py`) already imports the `tools/managed_gateway_auth.py` copy. The two-origin set (`tool` + `connector`) in `managed_gateway_auth.py` is the one that survives the revert; no in-tree caller uses the one-origin variant.

## Behavior change

- `iron_proxy` `proxy.yaml`/`mappings.json` and the exchanged-JWT store are 0600 **from creation** (previously opened at process umask, then chmod'ed — the #19673 window) and are fsync'd.
- Every credential write goes through `atomic_replace` (symlink-preserving; Windows winerror 5/32/33 retry; EXDEV/bind-mount copy fallback) instead of bare `os.replace`. `auth_nous` shared store no longer forces `os.replace` (no recorded reason; its own test passes).
- secret_sources cache tightens its parent through the guarded `secure_parent_dir` instead of an unguarded `chmod 0700`.
- Non-secret writers now fsync, preserve an existing target's mode, and clean the temp file on `BaseException`. `cron/suggestions.json` is 0600 from creation instead of chmod-after-replace.
- psutil installer also rejects Windows-absolute / backslash-smuggled member names.

## Validation

| | before | after |
|---|---|---|
| `write_mappings` temp file mode under umask 022 | 0644 until chmod | 0600 from `mkstemp` |
| `_save_jwt_to_disk` temp file mode | 0644 until chmod | 0600 from `mkstemp` |
| `atomic_json_write` onto a symlinked credential file | n/a (callers used bare `os.replace`, symlink replaced by a regular file) | symlink preserved, real file rewritten |
| Hand-rolled writer definitions | 10 private + 24 non-secret + 2 fsync helpers + 1 tar guard | 0 |
| `scripts/run_tests.sh` on every touched mirror dir | — | 35901 passed / 8 failed, all 8 pre-existing on `origin/main` (lazy-install / timing) |

E2E (worktree at `sys.path[0]`, temp `HERMES_HOME`, real I/O, umask 022): auth.json 0600 under 0700 parent + round-trip + no temp; symlinked target preserved; mappings/JWT/vault 0600 + reload; failing `atomic_replace` leaves the old bytes intact with no temp; a pre-existing 0644 non-secret file keeps 0644.

## Tests

- `tests/test_private_credential_writers.py::test_every_credential_writer_creates_its_temp_file_at_0600` — spies `os.open` through the mkstemp seam and asserts every one of the 9 in-tree writers creates its temp file at exactly 0600 and lands the target at 0600. Sabotage: reverting `copilot_auth` to write-then-chmod → red (`no temp file created`); making the canonical create at `0o666` → red (`created 0o666, not 0600`).
- `tests/test_private_credential_writers.py::test_canonical_private_writers_round_trip_json_text_and_bytes` — JSON/text/bytes round-trip with `fsync_dir`, no temp survivors. Sabotage: `binary=False` in `atomic_write_bytes` → `TypeError`.
- `tests/test_atomic_json_writers_unified.py` (3 tests) — session_persistence / suggestions / shell_hooks: a failing replace leaves the old bytes and no temp file. Sabotage: inline `write_text + os.replace` in `_save_raw` → `DID NOT RAISE`.
- `tests/hermes_cli/test_psutil_android_extract.py::test_prepare_patched_psutil_sdist_rejects_traversal_member` — `..` member refused, nothing written. Sabotage: `tf.extractall(filter="fully_trusted")` → 2 red.
- Repointed: `test_pairing` (`_secure_write` → `_save_json_file`), `test_auth_toctou_file_modes` (dropped the temp-name-shape spy, kept the three mode tests), `test_install_identity` / `test_shell_hooks` (mkstemp spy → `utils.tempfile`), `test_codex_runtime_plugin_migration` (`Path.replace` → `utils.atomic_replace`).

## Review follow-ups

- `d40544c11e03` fix(utils): `atomic_json_write` escapes lone surrogates instead of raising `UnicodeEncodeError`. Sites repointed onto the canonical (breadcrumbs, shell-hook allowlist, active sessions, debug, model catalog, credential writers) previously had json's `ensure_ascii=True`; a surrogate-escaped cwd/argv now raised a `ValueError` past their `except OSError`. The writer serializes to a str first and retries with `ensure_ascii=True` on `UnicodeEncodeError` (round-trips via `json.loads`; `surrogateescape` would emit a raw 0xFF byte the reader rejects). Test: `tests/test_atomic_json_writers_unified.py::test_surrogate_escaped_strings_round_trip_through_atomic_json_write`; sabotage (retry removed) → red with `UnicodeEncodeError`.
- `0dfb42342e96` fix(utils): NEW non-secret atomic writes follow the process umask again. `_atomic_write` applies `default_new_file_mode()` (`0o666 & ~umask`; `hermes_cli/backup._default_new_file_mode` moved into `utils` and reused) when `mode is None` and the target is new; secret writers and existing files unchanged; `None` on non-POSIX so Windows is untouched. Test: `::test_new_non_secret_file_follows_umask_while_secret_and_existing_modes_hold` (`linux_only`); sabotage (chmod dropped) → red `0o600 != 0o644`.
- `b218dae71355` fix(docker): `reseed_if_terminal` uses `tempfile.mkstemp` (random name, 0600, stdlib only) instead of a PID-named `O_EXCL` temp, so a temp left by a SIGKILL'd boot hook can no longer make every later re-seed die in `main()`'s swallowed exception. Test: `tests/tools/test_docker_rebootstrap_nous_session.py::test_stale_temp_from_a_killed_prior_run_does_not_block_reseed`; sabotage (PID name restored) → red `FileExistsError`.
- `637f11a0e7be` chore: spawn ledger (`hermes_cli/process_identity`) and meet-node token (`plugins/google_meet/node/server.ensure_token`) added to `test_private_credential_writers::_writers` (11 writers now); unused `import os` dropped from `agent/secret_sources/_cache.py`.

Behavior change (follow-ups + review NITs):
- Surrogate-escaped strings are written as `\udcff` JSON escapes and round-trip; on-disk bytes for normal content are unchanged (raw UTF-8).
- NEW non-secret files follow the process umask again (0644 under 022); existing files keep their mode; credential files stay 0600 before, during and after the write.
- Docker rebootstrap temp is randomly named; a stale temp never blocks recovery.
- Trailing newline dropped on `auth.json` / `model_catalog` cache / `profiles._atomic_write_json` (Honcho config) JSON; readers unaffected.
- Credential writers now `chown` the target back to its prior owner after the replace (root rewriting a user-owned `auth.json`).
- `tools/bot_live_delivery` directory-fsync errors are now swallowed (previously aborted delivery).

Follow-up validation: `scripts/run_tests.sh` on the 19 touched/adjacent files (credential writers, atomic writers, utils, docker rebootstrap, process_identity, suggestions, breadcrumbs, shell_hooks, backup, weixin, debug, model_catalog, active_sessions, atomic_write_text_metadata, atomic_replace_symlinks) → 389 passed, 0 failed, 4 skipped; the 54 test files asserting mode bits → 1652 passed, 0 failed. E2E from the worktree under umask 022: `{'cwd': 'a\udcffb'}` round-trips, new non-secret file 0644, `mode=0o600` file 0600, existing 0640 preserved.

## Infographic

![secrets-io-atomic-writers](https://v3b.fal.media/files/b/0aaa3571/2Ivko1UCUj1yhDanfRzrT_3DnlKsKA.png)

