### PR TITLE
refactor(config): one effective-user-config loader serves gateway, TUI, cron, send, doctor and bootstrap; HERMES_HOME path sites honor profiles

### DIFF
--- a/agent/onboarding.py
+++ b/agent/onboarding.py
@@ -153,16 +153,12 @@ def is_seen(config: Mapping[str, Any], flag: str) -> bool:
 def mark_seen(config_path: Path, flag: str) -> bool:
     """Persist ``onboarding.seen.<flag> = True`` atomically; False on any error (best-effort)."""
     try:
-        import yaml
-        from hermes_cli.config import atomic_config_write
+        from hermes_cli.config import atomic_config_write, read_user_config_raw
     except Exception as e:  # pragma: no cover — dependency issue
-        logger.debug("onboarding: failed to import yaml/utils: %s", e)
+        logger.debug("onboarding: failed to import config helpers: %s", e)
         return False
     try:
-        cfg: dict = {}
-        if config_path.exists():
-            with open(config_path, encoding="utf-8") as f:
-                cfg = yaml.safe_load(f) or {}
+        cfg: dict = read_user_config_raw(config_path)
         if not isinstance(cfg.get("onboarding"), dict):
             cfg["onboarding"] = {}
         seen = cfg["onboarding"].get("seen")

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1497,16 +1497,12 @@ def _resolve_default_model_snapshot() -> Optional[str]:
     """Default model resolved as the ticker's ``run_job`` does, so unpinned jobs can snapshot it and
     keep running on it after a later swap. ``None`` on missing config or failure ("no snapshot")."""
     try:
-        from hermes_cli.config import _expand_env_vars, read_user_config_raw
+        from hermes_cli.config_effective import load_user_config_effective
 
         cfg_path = get_hermes_home() / "config.yaml"
         if not cfg_path.exists():
             return None
-        cfg = read_user_config_raw(cfg_path)
-        with contextlib.suppress(Exception):
-            from hermes_cli import managed_scope
-            cfg = managed_scope.apply_managed_overlay(cfg)
-        cfg = _expand_env_vars(cfg)
+        cfg = load_user_config_effective(cfg_path)
         cron_cfg = cfg.get("cron") or {}
         if isinstance(cron_cfg, dict):
             cron_model = cron_cfg.get("model")

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -39,7 +39,7 @@ from hermes_constants import get_hermes_home
 from cron.env_settings import cron_env_setting
 from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import (
-    _expand_env_vars, load_config, load_config_readonly, resolve_cron_model_drift_defaults)
+    load_config, load_config_readonly, resolve_cron_model_drift_defaults)
 from hermes_cli.fallback_config import get_fallback_chain
 from hermes_time import now as _hermes_now
 from agent.interrupt_compat import request_hard_interrupt
@@ -1361,15 +1361,10 @@ def _load_cron_job_config(job: dict, job_id: str, job_name: str) -> _CronJobConf
     _cfg: dict = {}
     _model_cfg: Any = {}
     try:
-        from hermes_cli.config import read_user_config_raw
+        from hermes_cli.config_effective import load_user_config_effective
         _cfg_path = str(_get_hermes_home() / "config.yaml")
         if os.path.exists(_cfg_path):
-            _cfg = read_user_config_raw(Path(_cfg_path))
-            # Honor administrator-pinned managed scope (fail-open; no-op without managed scope).
-            with contextlib.suppress(Exception):
-                from hermes_cli import managed_scope
-                _cfg = managed_scope.apply_managed_overlay(_cfg)
-            _cfg = _expand_env_vars(_cfg)
+            _cfg = load_user_config_effective(Path(_cfg_path))
             # Coerce null to {} so a falsy default never clobbers a resolved env value.
             _model_cfg = _cfg.get("model") or {}
             _cron_cfg_for_model = _cfg.get("cron") or {}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2044,19 +2044,10 @@ def _bridge_config_to_env(_cfg: dict) -> None:
 
 
 def _load_bridge_config(config_path: Path) -> dict:
-    """Raw config read for the presence-sensitive env bridge, with the managed overlay applied. Raw (not
-    defaults-merged) so only keys the user wrote are bridged, else all of DEFAULT_CONFIG would be
-    exported; the overlay applies BEFORE bridging so pinned values win in env too."""
-    from hermes_cli.config import _expand_env_vars, read_user_config_raw
-    cfg = _expand_env_vars(read_user_config_raw(config_path))
-    if not isinstance(cfg, dict):
-        cfg = {}
-    try:
-        from hermes_cli import managed_scope
-        cfg = managed_scope.apply_managed_overlay(cfg)
-    except Exception:
-        pass
-    return cfg
+    """Effective USER config (no defaults) for the presence-sensitive env bridge: only keys the user
+    or the managed layer wrote get bridged, else all of DEFAULT_CONFIG would be exported."""
+    from hermes_cli.config_effective import load_user_config_effective
+    return load_user_config_effective(config_path)
 
 
 _config_path = _hermes_home / 'config.yaml'
@@ -2408,8 +2399,7 @@ def _try_resolve_fallback_provider() -> dict | None:
     """Attempt to resolve credentials from the fallback_model/fallback_providers config."""
     from hermes_cli.runtime_provider import resolve_runtime_provider
     try:
-        # Canonical loader so managed overlay / ${VAR} expansion reach the fallback chain.
-        cfg = _load_gateway_runtime_config()
+        cfg = _load_gateway_config()
         fb_list = get_fallback_chain(cfg)
         if not fb_list:
             return None
@@ -2814,51 +2804,18 @@ def _gateway_config_home() -> Path:
 
 
 def _load_gateway_config(config_path: "Path | None" = None) -> dict:
-    """Load and parse a gateway config.yaml, returning {} on any error (fail-open).
-    Defaults to the active gateway home (``_hermes_home`` monkeypatches apply); multiplexers pass a path.
+    """The effective user config.yaml (managed overlay, ``${VAR}`` expansion, model-key canon; no
+    DEFAULT_CONFIG merge) — ``{}`` on any error (fail-open). Defaults to the active gateway home
+    (``_hermes_home`` monkeypatches apply); multiplexers pass a path.
     """
     if config_path is None:
         config_path = _gateway_config_home() / 'config.yaml'
-    raw: dict = {}
-    used_canonical = False
     try:
-        from hermes_cli.config import get_config_path, read_raw_config
-        # Fast path via shared cache when the path is canonical; else direct read (test monkeypatches).
-        if config_path == get_config_path():
-            raw = read_raw_config()
-            used_canonical = True
+        from hermes_cli.config_effective import load_user_config_effective
+        return load_user_config_effective(config_path)
     except Exception:
-        pass
-
-    if not used_canonical:
-        try:
-            if config_path.exists():
-                import yaml
-                with open(config_path, 'r', encoding='utf-8') as f:
-                    raw = yaml.safe_load(f) or {}
-        except Exception:
-            logger.debug("Could not load gateway config from %s", config_path)
-            raw = {}
-
-    # Neither read_raw_config() nor yaml.safe_load carries the managed merge; overlay on both paths.
-    try:
-        from hermes_cli import managed_scope
-        raw = managed_scope.apply_managed_overlay(raw if isinstance(raw, dict) else {})
-    except Exception:
-        pass
-    if not isinstance(raw, dict):
+        logger.debug("Could not load gateway config from %s", config_path, exc_info=True)
         return {}
-    # Canonicalize model-id aliases (model.name/model.model → model.default) and migrate stale root
-    # provider/base_url: the gateway bypasses load_config(), else ``model: {name: <id>}`` is empty.
-    try:
-        # The gateway bypasses load_config() (it reads raw YAML for speed), so the normalization that
-        # load_config() applies must be replayed here or the gateway would resolve an empty model for
-        # ``model: {name: <id>}`` configs while the CLI resolves it correctly. See issue #34500. Fail-open.
-        from hermes_cli.config import _normalize_root_model_keys
-        raw = _normalize_root_model_keys(raw)
-    except Exception:
-        pass
-    return raw
 
 
 def _checkpoint_agent_kwargs(config: dict | None) -> dict:
@@ -2876,18 +2833,6 @@ def _checkpoint_agent_kwargs(config: dict | None) -> dict:
         "checkpoint_max_snapshots": cp_cfg.get("max_snapshots", defaults["max_snapshots"]),
         "checkpoint_max_total_size_mb": cp_cfg.get("max_total_size_mb", defaults["max_total_size_mb"]),
         "checkpoint_max_file_size_mb": cp_cfg.get("max_file_size_mb", defaults["max_file_size_mb"])}
-
-
-def _load_gateway_runtime_config() -> dict:
-    """Load gateway config for runtime reads, expanding supported ``${VAR}`` refs.
-    Expansion failures are deliberately NOT swallowed: an unexpanded dict would mask the bug fixed here.
-    """
-    cfg = _load_gateway_config()
-    if not isinstance(cfg, dict) or not cfg:
-        return {}
-    from hermes_cli.config import _expand_env_vars
-    expanded = _expand_env_vars(cfg)
-    return expanded if isinstance(expanded, dict) else {}
 
 
 def _resolve_gateway_model(config: dict | None = None) -> str:

--- a/gateway/run_adapters.py
+++ b/gateway/run_adapters.py
@@ -887,7 +887,7 @@ class GatewayAdapterLifecycleMixin:
         default profile owns the single shared listener and a secondary's port-binders are built in
         shared-listener mode (``/p/<profile>/...``) by ``_start_one_profile_adapters``."""
         from gateway.run import (
-            MultiplexConfigError, _load_gateway_runtime_config,
+            MultiplexConfigError, _load_gateway_config,
             _own_policy_open_startup_violation, _profile_runtime_scope,
         )
         from gateway.config import load_gateway_config
@@ -895,7 +895,7 @@ class GatewayAdapterLifecycleMixin:
         # Hydrate external secret sources off-loop ONCE: sync hydration would stall every heartbeat.
         await asyncio.to_thread(hydrate_profile_secret_sources, profile_home)
         with _profile_runtime_scope(profile_home, hydrate_secrets=False):
-            profile_runtime_cfg = _load_gateway_runtime_config()
+            profile_runtime_cfg = _load_gateway_config()
             from hermes_cli.plugins import discover_plugins
             discover_plugins()
             # This profile's `hooks:` block: start() registered before any profile scope existed.

--- a/gateway/run_config_loaders.py
+++ b/gateway/run_config_loaders.py
@@ -45,8 +45,8 @@ class GatewayConfigLoadersMixin:
     @staticmethod
     def _cfg_str(section: str, key: str) -> str:
         """``<section>.<key>`` from the gateway runtime config as a stripped string ("" when unset)."""
-        from gateway.run import _load_gateway_runtime_config
-        return str(cfg_get(_load_gateway_runtime_config(), section, key, default="") or "").strip()
+        from gateway.run import _load_gateway_config
+        return str(cfg_get(_load_gateway_config(), section, key, default="") or "").strip()
 
     @classmethod
     def _env_or_cfg_str(cls, env_var: str, section: str, key: str) -> str:
@@ -60,10 +60,10 @@ class GatewayConfigLoadersMixin:
         HERMES_PREFILL_MESSAGES_FILE env wins, then top-level prefill_messages_file in config.yaml,
         then legacy agent.prefill_messages_file. Relative paths resolve from ~/.hermes/.
         """
-        from gateway.run import _gateway_config_home, _load_gateway_runtime_config
+        from gateway.run import _gateway_config_home, _load_gateway_config
         file_path = os.getenv("HERMES_PREFILL_MESSAGES_FILE", "")
         if not file_path:
-            cfg = _load_gateway_runtime_config()
+            cfg = _load_gateway_config()
             file_path = str(
                 cfg.get("prefill_messages_file", "") or cfg_get(cfg, "agent", "prefill_messages_file", default="") or ""
             )
@@ -89,11 +89,11 @@ class GatewayConfigLoadersMixin:
     @staticmethod
     def _load_ephemeral_system_prompt() -> str:
         """HERMES_EPHEMERAL_SYSTEM_PROMPT env first, then ``display.personality`` / ``agent.system_prompt``."""
-        from gateway.run import _load_gateway_runtime_config
+        from gateway.run import _load_gateway_config
         prompt = os.getenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", "")
         if prompt:
             return prompt
-        return resolve_ephemeral_system_prompt_from_config(_load_gateway_runtime_config())
+        return resolve_ephemeral_system_prompt_from_config(_load_gateway_config())
 
     def _channel_override(self, platform: Platform, chat_id: str, thread_id, parent_id):
         """``channel_overrides`` entry for this channel/thread, or None (also when no config is bound)."""
@@ -151,9 +151,9 @@ class GatewayConfigLoadersMixin:
 
         Closes #21256.
         """
-        from gateway.run import _load_gateway_runtime_config
+        from gateway.run import _load_gateway_config
         from hermes_constants import resolve_reasoning_config
-        return resolve_reasoning_config(_load_gateway_runtime_config(), model)
+        return resolve_reasoning_config(_load_gateway_config(), model)
 
     @staticmethod
     def _parse_reasoning_command_args(raw_args: str) -> tuple[str, bool]:
@@ -234,8 +234,8 @@ class GatewayConfigLoadersMixin:
     @staticmethod
     def _load_show_reasoning() -> bool:
         """``display.show_reasoning`` toggle."""
-        from gateway.run import _load_gateway_runtime_config
-        return is_truthy_value(cfg_get(_load_gateway_runtime_config(), "display", "show_reasoning"), default=False)
+        from gateway.run import _load_gateway_config
+        return is_truthy_value(cfg_get(_load_gateway_config(), "display", "show_reasoning"), default=False)
 
     @classmethod
     def _load_busy_input_mode(cls) -> str:
@@ -330,12 +330,12 @@ class GatewayConfigLoadersMixin:
         """Env var (non-empty) else ``agent.<cfg_key>``; warn once when a supplied value fails to parse.
 
         ``0`` is a valid value; the parser falls back to ``default`` on garbage."""
-        from gateway.run import _load_gateway_runtime_config
+        from gateway.run import _load_gateway_config
         env_raw = os.getenv(env_var)
         if env_raw is not None and str(env_raw).strip() != "":
             raw: object = env_raw
         else:
-            raw = cfg_get(_load_gateway_runtime_config(), "agent", cfg_key, default=None)
+            raw = cfg_get(_load_gateway_config(), "agent", cfg_key, default=None)
         value = parse(raw)
         if raw is not None and str(raw).strip() != "":
             cls._warn_unparsable_timeout(cfg_key, raw, default)
@@ -363,8 +363,8 @@ class GatewayConfigLoadersMixin:
     @classmethod
     def _load_signal_interrupt_grace_timeout(cls) -> float:
         """``gateway.signal_interrupt_grace_timeout``: unexpected-signal post-interrupt grace in seconds."""
-        from gateway.run import _load_gateway_runtime_config
-        raw = cfg_get(_load_gateway_runtime_config(), "gateway", "signal_interrupt_grace_timeout", default=None)
+        from gateway.run import _load_gateway_config
+        raw = cfg_get(_load_gateway_config(), "gateway", "signal_interrupt_grace_timeout", default=None)
         value = parse_signal_interrupt_grace_timeout(raw)
         if raw is not None and raw != "":
             cls._warn_unparsable_timeout(
@@ -385,11 +385,11 @@ class GatewayConfigLoadersMixin:
         the AMBIENT profile — callers deciding for another profile's event enter its scope first
         (``_completion_event_scope``). The env override reads through the secret scope so a served
         secondary sees its own ``.env`` value, not the launch profile's ``os.environ``."""
-        from gateway.run import _load_gateway_runtime_config
+        from gateway.run import _load_gateway_config
         from gateway.authz_mixin import _platform_gate_env
         mode = _platform_gate_env("HERMES_BACKGROUND_NOTIFICATIONS")
         if not mode:
-            raw = cfg_get(_load_gateway_runtime_config(), "display", "background_process_notifications")
+            raw = cfg_get(_load_gateway_config(), "display", "background_process_notifications")
             if raw is False:
                 mode = "off"
             elif raw not in {None, ""}:
@@ -403,19 +403,19 @@ class GatewayConfigLoadersMixin:
     @staticmethod
     def _load_provider_routing() -> dict:
         """OpenRouter provider routing preferences (canonical fail-open loader: managed overlay + ${VAR})."""
-        from gateway.run import _load_gateway_runtime_config
+        from gateway.run import _load_gateway_config
         try:
-            return _load_gateway_runtime_config().get("provider_routing", {}) or {}
+            return _load_gateway_config().get("provider_routing", {}) or {}
         except Exception:
             return {}
 
     @staticmethod
     def _load_fallback_model() -> list | None:
         """Fallback chain: ``fallback_providers`` (kept first) merged with legacy ``fallback_model``."""
-        from gateway.run import _load_gateway_runtime_config
+        from gateway.run import _load_gateway_config
         try:
             # Canonical gateway loader (fail-open): managed overlay + ${VAR} expansion apply here too.
-            return get_fallback_chain(_load_gateway_runtime_config()) or None
+            return get_fallback_chain(_load_gateway_config()) or None
         except Exception:
             return None
 
@@ -443,23 +443,14 @@ class GatewayConfigLoadersMixin:
             by_home = self._fallback_model_by_home = {}
         home_key = hermes_home_key(home)
         try:
-            from hermes_cli.config import read_user_config_raw
+            from hermes_cli.config_effective import load_user_config_effective
             cfg_path = home / "config.yaml"
             if not cfg_path.exists():
                 by_home[home_key] = self._fallback_model = None
                 return self._fallback_model
-            # Raw primitive (raises on parse failure) is required here: the canonical fail-open
-            # loader would return {} on a torn mid-edit write and WIPE the last known-good chain.
-            # The overlay/expansion below fixes the managed-scope/${VAR} drift without losing that.
-            cfg = read_user_config_raw(cfg_path)
-            with suppress(Exception):
-                from hermes_cli import managed_scope
-                cfg = managed_scope.apply_managed_overlay(cfg)
-            with suppress(Exception):
-                from hermes_cli.config import _expand_env_vars
-                expanded = _expand_env_vars(cfg)
-                if isinstance(expanded, dict):
-                    cfg = expanded
+            # fail_closed: a torn mid-edit write must raise so the per-home last known-good chain
+            # below survives, instead of being WIPED by an empty fail-open result.
+            cfg = load_user_config_effective(cfg_path, fail_closed=True)
         except Exception:
             logger.debug("fallback_providers refresh: config.yaml read failed; keeping last known-good chain", exc_info=True)
             self._fallback_model = by_home.get(home_key, self._fallback_model)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -950,8 +950,8 @@ class GatewaySlashCommandsMixin(
             return EphemeralReply("Busy input mode could not be saved to config. Mode unchanged.")
         profile_name = self._busy_profile_name_for_source(event.source)
         if profile_name:
-            from gateway.run import _load_gateway_runtime_config
-            self._snapshot_profile_busy_modes(profile_name, _load_gateway_runtime_config())
+            from gateway.run import _load_gateway_config
+            self._snapshot_profile_busy_modes(profile_name, _load_gateway_config())
         else:
             self._busy_input_mode = arg
             # busy_input_mode is also the source of truth for the text mode — re-derive it so the

--- a/hermes_cli/AGENTS.md
+++ b/hermes_cli/AGENTS.md
@@ -67,9 +67,13 @@ Do not add a surface-specific goal parser. ACP has no goal command or goal loop 
   (`gateway_timeout`; `terminal.cwd` → `TERMINAL_CWD`). `MESSAGING_CWD` is removed and `TERMINAL_CWD`
   in `.env` is deprecated — the loader warns; canonical is `terminal.cwd`.
 - **Three loaders — know which you're in:** `load_cli_config()` (CLI, `cli.py`); `load_config()`
-  (`hermes tools/setup`, most subcommands, `hermes_cli/config.py`, merges `DEFAULT_CONFIG`); raw
-  YAML (gateway runtime, `gateway/run.py` + `gateway/config.py`). If the CLI sees a key and the
-  gateway doesn't (or vice versa), you're on the wrong loader — check `DEFAULT_CONFIG` coverage.
+  (`hermes tools/setup`, most subcommands, `hermes_cli/config.py`, merges `DEFAULT_CONFIG`);
+  `hermes_cli/config_effective.py::load_user_config_effective()` (gateway runtime via
+  `gateway/run.py::_load_gateway_config`, TUI gateway `_load_cfg`, cron, `hermes send`, doctor,
+  `hermes_time`/`hermes_logging`: user file + managed overlay + `${VAR}` expansion + model-key
+  canon, NO defaults — for presence-sensitive readers). If the CLI sees a key and the gateway
+  doesn't (or vice versa), you're on the wrong loader — check `DEFAULT_CONFIG` coverage. Never
+  hand-roll raw-read → overlay → expand; `read_user_config_raw` is for write-back round-trips only.
 - **Working directory:** CLI uses `os.getcwd()`; messaging uses `terminal.cwd`, bridged to
   `TERMINAL_CWD` for child tools.
 

--- a/hermes_cli/config_effective.py
+++ b/hermes_cli/config_effective.py
@@ -1,0 +1,105 @@
+"""The effective USER config: config.yaml + managed overlay + ``${VAR}`` expansion, no defaults.
+
+``load_config()`` merges ``DEFAULT_CONFIG`` first, which is wrong for readers that treat a
+missing key as "unset" (the gateway's presence-sensitive env bridge, ``cfg == {}`` sentinels,
+cron model pinning) — so nine surfaces used to hand-roll raw-read → overlay → expand in
+differing orders and none of them replayed the model-key canonicalization or the last-known-good
+recovery ``load_config()`` gained. This module is that one primitive.
+
+Order matches ``_load_config_impl``: the user layer is expanded BEFORE the managed overlay so a
+managed ``${VAR}`` resolves against the process environment only (``apply_managed_overlay``
+expands it) and can never be re-resolved through a profile's secret scope
+(docs/design/managed-scope.md §4.1). ``read_user_config_raw`` stays the write-back primitive.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+from hermes_cli import config as _config
+from hermes_cli import managed_scope
+from utils import fast_safe_load
+
+# path -> raw user mapping from the last successful parse in this process; served (through the
+# normal pipeline) when the file is later found mid-edit as broken YAML.
+_LAST_GOOD_USER_RAW: Dict[str, Dict[str, Any]] = {}
+# path -> (user_mtime_ns, user_size, managed_mtime_ns, managed_size, effective, env_snapshot).
+_EFFECTIVE_CACHE: Dict[str, Tuple[int, int, int, int, Dict[str, Any], Dict[str, Optional[str]]]] = {}
+
+
+def _effective(raw: Dict[str, Any]) -> Dict[str, Any]:
+    expanded = _config._expand_env_vars(raw)
+    merged = managed_scope.apply_managed_overlay(expanded if isinstance(expanded, dict) else {})
+    return _config._normalize_root_model_keys(merged if isinstance(merged, dict) else {})
+
+
+def _recover_user_raw(config_path: Path, path_key: str, exc: Exception) -> Dict[str, Any]:
+    """Last-known-good raw user mapping after a parse failure: this process's last good parse,
+    else the newest ``good`` copy in backups/config/, else ``{}`` (warned as defaults)."""
+    raw = _LAST_GOOD_USER_RAW.get(path_key)
+    fallback = "last-known-good"
+    if raw is None:
+        from hermes_cli.config_backups import load_newest_good_backup
+        raw = load_newest_good_backup(config_path)
+        fallback = "last-known-good-backup"
+    _config._warn_config_parse_failure(config_path, exc, fallback=fallback if raw is not None else "defaults")
+    return copy.deepcopy(raw) if raw is not None else {}
+
+
+def load_user_config_effective(config_path: Optional[Path] = None, *, fail_closed: bool = False) -> Dict[str, Any]:
+    """User ``config.yaml`` → ``${VAR}`` expansion → managed overlay → model-key canonicalization.
+    NO ``DEFAULT_CONFIG`` merge: a key absent from the file (and from the managed layer) is absent
+    here, so ``{}`` sentinels and presence-sensitive bridges keep working. An absent file is an
+    empty user layer (the managed layer still applies). Returns a fresh deepcopy.
+
+    Broken YAML: ``fail_closed=True`` raises the parse error (for callers that keep their own
+    last-good state); otherwise the last successfully parsed user file — in-process first, then
+    the newest ``backups/config/*.good.*`` copy — is served through the same pipeline, so a
+    mid-edit torn write never silently drops user overrides (same contract as ``load_config``).
+    Cached on the user + managed file signatures and the values of every referenced env var."""
+    if config_path is None:
+        config_path = _config.get_config_path()
+    path_key = str(config_path)
+    with _config._CONFIG_LOCK:
+        user_sig, cache_sig = _config._load_config_cache_sig(config_path)
+        cached = _EFFECTIVE_CACHE.get(path_key)
+        if cached is not None and cache_sig is not None and cached[:4] == cache_sig:
+            if all(_config._env_ref_lookup(k) == v for k, v in cached[5].items()):
+                return copy.deepcopy(cached[4])
+
+        raw: Dict[str, Any] = {}
+        recovered = False
+        raw_hit = _config._RAW_CONFIG_CACHE.get(path_key)
+        if user_sig is not None and raw_hit is not None and raw_hit[:2] == user_sig:
+            raw = copy.deepcopy(raw_hit[2])  # one parse per process, shared with read_raw_config()
+            _LAST_GOOD_USER_RAW.setdefault(path_key, copy.deepcopy(raw))
+        elif user_sig is not None:
+            try:
+                with open(config_path, encoding="utf-8") as f:
+                    loaded = fast_safe_load(f)
+            except Exception as exc:
+                if fail_closed:
+                    raise
+                raw, recovered = _recover_user_raw(config_path, path_key, exc), True
+            else:
+                raw = loaded if isinstance(loaded, dict) else {}
+                _config._RAW_CONFIG_CACHE[path_key] = (*user_sig, copy.deepcopy(raw))
+                _LAST_GOOD_USER_RAW[path_key] = copy.deepcopy(raw)
+                # Same copy load_config keeps: a fresh process recovers from it (see _recover_user_raw).
+                from hermes_cli.config_backups import backup_config
+                backup_config(config_path, "good")
+
+        env_snapshot = _config._env_ref_snapshot(raw)
+        managed = managed_scope.load_managed_config()
+        if managed:
+            _config._env_ref_snapshot(managed, env_snapshot)
+        effective = _effective(raw)
+        # A recovered result is never cached under the corrupt file's signature: a later
+        # ``fail_closed`` caller must still see the parse error, not a cache hit.
+        if cache_sig is not None and not recovered:
+            _EFFECTIVE_CACHE[path_key] = (*cache_sig, copy.deepcopy(effective), env_snapshot)
+        else:
+            _EFFECTIVE_CACHE.pop(path_key, None)
+        return effective

--- a/hermes_cli/credential_lifecycle.py
+++ b/hermes_cli/credential_lifecycle.py
@@ -87,19 +87,18 @@ def _scrub_config_yaml_mirrors(old_value: str, new_value: str | None) -> List[st
     """
     if not old_value:
         return []
-    from utils import atomic_yaml_write, fast_safe_load
+    from utils import atomic_yaml_write
 
-    from hermes_cli.config import get_config_path, require_readable_config_before_write
+    from hermes_cli.config import get_config_path, read_user_config_raw, require_readable_config_before_write
 
     config_path = get_config_path()
     if not config_path.exists():
         return []
     try:
-        with open(config_path, encoding="utf-8") as f:
-            user_config = fast_safe_load(f) or {}
+        user_config = read_user_config_raw(config_path)
     except Exception:
         return []
-    if not isinstance(user_config, dict):
+    if not user_config:
         return []
 
     touched: List[str] = []

--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -524,9 +524,10 @@ _HEX32 = set("0123456789abcdef")
 
 
 def _hermes_home_dir() -> Path:
-    """Resolved Hermes home (HERMES_HOME override or ~/.hermes)."""
-    override = os.environ.get("HERMES_HOME", "").strip()
-    return Path(override).expanduser() if override else Path.home() / ".hermes"
+    """The process's Hermes home: remote-backend locks are a process-level asset, so a request scoped
+    to another profile must still see the same lock dir."""
+    from hermes_constants import get_process_hermes_home
+    return get_process_hermes_home()
 
 
 def _is_hex(value: object, length: int) -> bool:

--- a/hermes_cli/doctor_live.py
+++ b/hermes_cli/doctor_live.py
@@ -40,14 +40,6 @@ class ProbeResult:
 
 # ── Small seams (monkeypatchable in tests, and single points of control) ──
 
-def _load_config() -> dict:
-    try:
-        from hermes_cli.config import load_config
-        return load_config() or {}
-    except Exception:
-        return {}
-
-
 def _http_get(url: str, headers: Optional[dict] = None, timeout: Optional[float] = None):
     """Single HTTP GET seam for all metadata probes."""
     import httpx
@@ -175,7 +167,8 @@ def _run_one(name: str, fn: Callable[[], ProbeResult], issues: List[str]) -> Pro
 def run_live_checks(issues: List[str]) -> List[ProbeResult]:
     """Run one bounded, read-only probe per configured tool backend — sequential by design (predictable output
     ordering). Appends a remediation line to ``issues`` per failed probe; skipped backends never append."""
-    config = _load_config()
+    from hermes_cli.config import load_config_readonly
+    config = load_config_readonly()
     try:
         timeout = float((config.get("doctor") or {}).get("live_probe_timeout", DEFAULT_PROBE_TIMEOUT))
     except (TypeError, ValueError):

--- a/hermes_cli/doctor_state.py
+++ b/hermes_cli/doctor_state.py
@@ -27,15 +27,11 @@ def _doctor_memory_config(hermes_home: Path | None = None) -> dict:
     """Return the effective memory section used by doctor diagnostics."""
     from hermes_cli.doctor import HERMES_HOME
     try:
-        from hermes_cli.config import _expand_env_vars, read_user_config_raw
+        from hermes_cli.config_effective import load_user_config_effective
         config_path = (hermes_home if hermes_home is not None else HERMES_HOME) / "config.yaml"
         if not config_path.exists():
             return {}
-        config = _expand_env_vars(read_user_config_raw(config_path))
-        with warn_on_error(""):
-            from hermes_cli import managed_scope
-            config = managed_scope.apply_managed_overlay(config)
-        section = config.get("memory") if isinstance(config, dict) else None
+        section = load_user_config_effective(config_path).get("memory")
         return section if isinstance(section, dict) else {}
     except Exception:
         return {}

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -332,7 +332,10 @@ def load_hermes_dotenv(
 ) -> list[Path]:
     """Load Hermes env files: ``~/.hermes/.env`` overrides stale shell exports; project ``.env`` is a dev
     fallback that only fills gaps when the user env exists (and overrides shell vars when it does not)."""
-    home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+    # Process home on purpose (never the per-turn override): a startup .env load must not follow a routed
+    # profile — see the multiplex guard below.
+    from hermes_constants import get_process_hermes_home
+    home_path = Path(hermes_home) if hermes_home else get_process_hermes_home()
 
     # Multiplex gateway: while a routed profile-home override is active, copying that profile's .env
     # into os.environ would expose its credentials to sibling turns and every spawned child. Unscoped

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -126,14 +126,6 @@ def _profile_author() -> str:
     return _specify_author("decomposer")
 
 
-def _load_config() -> dict:
-    try:
-        from hermes_cli.config import load_config
-        return load_config() or {}
-    except Exception:
-        return {}
-
-
 def _resolve_profile_from_cfg(cfg: dict, key: str) -> str:
     """``kanban.<key>`` if it names an existing profile, else the active
     default profile — so a task is never stranded for lack of an owner.
@@ -202,7 +194,8 @@ class _Routing:
 
 
 def _load_routing() -> _Routing:
-    cfg = _load_config()
+    from hermes_cli.config import load_config_readonly
+    cfg = load_config_readonly()
     kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
     roster, valid_names = _build_roster()
     return _Routing(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -604,20 +604,14 @@ load_hermes_dotenv(
 # is read from the same parse to avoid a second full load_config() (~17ms).
 _FORCE_IPV4_EARLY = False
 try:
-    # read_raw_config()'s (mtime, size)-keyed cache means this SAME parse serves
-    # hermes_logging and later raw reads: 3-4 config.yaml parses become one.
-    from hermes_cli.config import read_raw_config as _read_raw_early
+    # The effective-config cache (shared raw parse with read_raw_config()) means this SAME parse
+    # serves hermes_logging, hermes_time and later raw reads: 3-4 config.yaml parses become one.
+    # Managed overlay included: administrator-pinned redact_secrets / force_ipv4 win here too.
+    from hermes_cli.config_effective import load_user_config_effective as _load_effective_early
 
     _cfg_path = get_hermes_home() / "config.yaml"
     if _cfg_path.exists():
-        _early_cfg_raw = _read_raw_early() or {}
-        # Managed scope overlay: administrator-pinned redact_secrets /
-        # force_ipv4 must win here too (load_config isn't usable yet). Fail-open.
-        try:
-            from hermes_cli import managed_scope
-            _early_cfg_raw = managed_scope.apply_managed_overlay(_early_cfg_raw)
-        except Exception:
-            pass
+        _early_cfg_raw = _load_effective_early(_cfg_path)
         if "HERMES_REDACT_SECRETS" not in os.environ:
             _early_sec_cfg = _early_cfg_raw.get("security", {})
             if isinstance(_early_sec_cfg, dict):

--- a/hermes_cli/send_cmd.py
+++ b/hermes_cli/send_cmd.py
@@ -134,58 +134,31 @@ def _list_targets(platform_filter: Optional[str], *, json_mode: bool) -> int:
 def _load_hermes_env() -> None:
     """Populate ``os.environ`` from ``~/.hermes/.env`` AND bridge top-level ``config.yaml`` keys into
     the environment so the gateway config loader sees platform credentials and home channels."""
-    try:
-        from dotenv import load_dotenv
-    except Exception:
-        load_dotenv = None  # type: ignore[assignment]
+    import os
     try:
         from hermes_cli.config import get_hermes_home
         home = get_hermes_home()
     except Exception:
         return
     env_path = home / ".env"
-    if load_dotenv and env_path.exists():
+    if env_path.exists():
         try:
-            # utf-8-sig strips a leading BOM (PowerShell 5.1 / Notepad); plain "utf-8" would keep
-            # U+FEFF on the first key name and silently drop it from os.environ.
-            load_dotenv(str(env_path), override=True, encoding="utf-8-sig")
-        except UnicodeDecodeError:
-            try:  # utf-8-sig can't strip a BOM once we fall back to latin-1.
-                import codecs
-                import io
-                raw = env_path.read_bytes().removeprefix(codecs.BOM_UTF8)
-                load_dotenv(stream=io.StringIO(raw.decode("latin-1")), override=True)
-            except Exception:
-                pass
+            from hermes_cli.env_loader import _load_dotenv_with_fallback
+            _load_dotenv_with_fallback(env_path, override=True)
         except Exception:
             pass
 
-    # Bridge top-level config.yaml scalars into the environment (never overriding existing values).
-    import os
+    # Bridge top-level scalars the user (or the managed layer) actually wrote — never DEFAULT_CONFIG —
+    # into the environment, without overriding existing values.
     config_path = home / "config.yaml"
     if not config_path.exists():
         return
     try:
-        # Raw read is deliberate — only keys the user actually wrote get bridged.
-        from hermes_cli.config import read_user_config_raw
-        raw = read_user_config_raw(config_path)
+        from hermes_cli.config_effective import load_user_config_effective
+        cfg = load_user_config_effective(config_path)
     except Exception:
         return
-    try:
-        from hermes_cli.config import _expand_env_vars
-        raw = _expand_env_vars(raw)
-    except Exception:
-        pass
-
-    # Managed scope: administrator-pinned values win here too (fail-open via the helper).
-    try:
-        from hermes_cli import managed_scope
-        raw = managed_scope.apply_managed_overlay(raw if isinstance(raw, dict) else {})
-    except Exception:
-        pass
-    if not isinstance(raw, dict):
-        return
-    for key, val in raw.items():
+    for key, val in cfg.items():
         if isinstance(val, (str, int, float, bool)) and key not in os.environ:
             os.environ[key] = str(val)
 

--- a/hermes_cli/web_routers/local_models.py
+++ b/hermes_cli/web_routers/local_models.py
@@ -190,12 +190,8 @@ def _router_request(endpoint: Dict[str, Any], path: str, *, timeout: float, payl
         return None if payload is not None else json.loads(r.read())
 
 
-def _load_config() -> dict:
-    return _quiet(config_mod.load_config, {})
-
-
 def _runtime_section() -> dict:
-    return (_load_config() or {}).get("local_runtime") or {}
+    return (config_mod.load_config_readonly() or {}).get("local_runtime") or {}
 
 
 def _set_runtime_enabled(enabled: bool) -> dict:
@@ -445,7 +441,7 @@ def _active_llamacpp_model_id() -> str | None:
     """The active main model when it is one of ours (config authority: the model.provider + model.default
     that /api/model/set writes)."""
     def read() -> str | None:
-        model_section = (_load_config() or {}).get("model") or {}
+        model_section = (config_mod.load_config_readonly() or {}).get("model") or {}
         if str(model_section.get("provider", "")).strip().lower() in _LLAMACPP_PROVIDERS:
             return str(model_section.get("default") or model_section.get("name") or "").strip() or None
         return None
@@ -635,7 +631,7 @@ def _restart_on_new_tag(job: Dict[str, Any], tag: str, previous: list) -> bool:
         return False
     _step(job, "restarting", "Switching the running server to the new build")
     bootstrap.shutdown_local_runtime()
-    bootstrap.ensure_local_runtime(_load_config(), force=True)
+    bootstrap.ensure_local_runtime(config_mod.load_config_readonly(), force=True)
     return True
 
 

--- a/hermes_cli/worktree_gc.py
+++ b/hermes_cli/worktree_gc.py
@@ -91,7 +91,8 @@ def _dirty_split(path: str) -> tuple[bool, List[str]]:
 def _archive_untracked(tree: Path, untracked: List[str]) -> Optional[Path]:
     """Copy untracked files out of a doomed tree; None on any failure (caller must then keep)."""
     stamp = time.strftime("%Y%m%d-%H%M%S")
-    dest = Path.home() / ".hermes" / "archive" / "worktree-prune" / f"{tree.name}-{stamp}"
+    from hermes_constants import get_hermes_home
+    dest = get_hermes_home() / "archive" / "worktree-prune" / f"{tree.name}-{stamp}"
     try:
         for rel in untracked:
             src = tree / rel

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -604,12 +604,12 @@ def _add_rotating_handler(
 def _read_logging_config():
     """Best-effort read of ``logging.*`` from config.yaml."""
     try:
-        # Prefer the shared (mtime, size)-keyed raw-config cache so this reuses
-        # hermes_cli.main's early parse (one config.yaml parse per process);
-        # fall back to a direct parse for bare hermes_logging consumers.
+        # Prefer the shared effective-config cache (managed overlay included, so an administrator
+        # can pin logging.*) so this reuses hermes_cli.main's early parse (one config.yaml parse
+        # per process); fall back to a direct parse for bare hermes_logging consumers.
         try:
-            from hermes_cli.config import read_raw_config as _rrc
-            cfg = _rrc() or {}
+            from hermes_cli.config_effective import load_user_config_effective
+            cfg = load_user_config_effective(get_config_path())
         except Exception:
             from utils import fast_safe_load
             config_path = get_config_path()
@@ -619,12 +619,6 @@ def _read_logging_config():
                     cfg = fast_safe_load(f) or {}
         if not cfg:
             return (None, None, None)
-        # Managed scope: an administrator can pin logging.* too (fail-open overlay).
-        try:
-            from hermes_cli import managed_scope
-            cfg = managed_scope.apply_managed_overlay(cfg)
-        except Exception:
-            pass
         log_cfg = cfg.get("logging", {})
         if isinstance(log_cfg, dict):
             return (log_cfg.get("level"), log_cfg.get("max_size_mb"), log_cfg.get("backup_count"))

--- a/hermes_time.py
+++ b/hermes_time.py
@@ -48,22 +48,18 @@ def _resolve_timezone_name() -> str:
     if tz_env:
         return tz_env
     try:
-        # Prefer the shared cached raw-config reader (mtime-keyed + libyaml): a direct safe_load of
-        # a large config.yaml costs ~100 ms and this ran inside the FIRST system prompt build.
+        # Prefer the shared cached effective-config loader (mtime-keyed + libyaml, managed overlay
+        # included so an administrator can pin ``timezone``): a direct safe_load of a large
+        # config.yaml costs ~100 ms and this ran inside the FIRST system prompt build. The bare
+        # parse is the stdlib-safe fallback for bootstrap consumers without hermes_cli importable.
         try:
-            from hermes_cli.config import read_raw_config
-            cfg = read_raw_config() or {}
+            from hermes_cli.config_effective import load_user_config_effective
+            cfg = load_user_config_effective(get_config_path())
         except Exception:
             import yaml
             config_path = get_config_path()
             cfg = (yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}) if config_path.exists() else {}
         if cfg:
-            # Managed scope: an administrator can pin ``timezone`` too (fail-open overlay).
-            try:
-                from hermes_cli import managed_scope
-                cfg = managed_scope.apply_managed_overlay(cfg)
-            except Exception:
-                pass
             tz_cfg = cfg.get("timezone", "")
             if isinstance(tz_cfg, str) and tz_cfg.strip():
                 return tz_cfg.strip()

--- a/tests/agent/test_fast_mode_auto.py
+++ b/tests/agent/test_fast_mode_auto.py
@@ -104,7 +104,7 @@ def test_fast_auto_and_cold_parse_and_slash_command(monkeypatch):
     for raw, expected in (("auto", "auto"), ("COLD", "cold"), ("fast", "priority"), ("", None), ("bogus", None)):
         assert cli_mod._parse_service_tier_config(raw) == expected
         monkeypatch.setattr(
-            "gateway.run._load_gateway_runtime_config", lambda: {"agent": {"service_tier": raw}}
+            "gateway.run._load_gateway_config", lambda: {"agent": {"service_tier": raw}}
         )
         assert GatewayRunner._load_service_tier() == expected
     assert DEFAULT_CONFIG["agent"]["service_tier"] == ""

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1087,7 +1087,8 @@ class TestRunJobConfigLogging:
     """Verify that config.yaml parse failures are logged, not silently swallowed."""
 
     def test_bad_config_yaml_is_logged(self, caplog, tmp_path):
-        """When config.yaml is malformed, a warning should be logged."""
+        """When config.yaml is malformed, the shared config loader warns loudly (and serves the
+        last known-good copy instead of silently dropping the user's overrides)."""
         bad_yaml = tmp_path / "config.yaml"
         bad_yaml.write_text("invalid: yaml: [[[bad")
 
@@ -1116,11 +1117,11 @@ class TestRunJobConfigLogging:
             mock_agent.run_conversation.return_value = {"final_response": "ok"}
             mock_agent_cls.return_value = mock_agent
 
-            with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+            with caplog.at_level(logging.WARNING):
                 run_job(job)
 
-        assert any("failed to load config.yaml" in r.message for r in caplog.records), \
-            f"Expected 'failed to load config.yaml' warning in logs, got: {[r.message for r in caplog.records]}"
+        assert any("Failed to parse" in r.message and "config.yaml" in r.message for r in caplog.records), \
+            f"Expected a config.yaml parse warning in logs, got: {[r.message for r in caplog.records]}"
 
 
 class TestRunJobConfigEnvVarExpansion:

--- a/tests/gateway/test_busy_command.py
+++ b/tests/gateway/test_busy_command.py
@@ -75,7 +75,7 @@ class TestBusyCommandPersistence:
         # emulate the write that the mocked save_config_value skipped.
         monkeypatch.setattr(
             gateway_run,
-            "_load_gateway_runtime_config",
+            "_load_gateway_config",
             lambda: {"display": {"busy_input_mode": new_mode}},
         )
         monkeypatch.delenv("HERMES_GATEWAY_BUSY_TEXT_MODE", raising=False)

--- a/tests/gateway/test_custom_provider_request_overrides.py
+++ b/tests/gateway/test_custom_provider_request_overrides.py
@@ -172,7 +172,7 @@ def test_turn_route_merges_fast_mode_with_provider_request_overrides():
 @pytest.mark.asyncio
 async def test_run_agent_preserves_provider_request_overrides_on_gateway_path(monkeypatch):
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
-    monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
     monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
     monkeypatch.setattr(
         gateway_run,
@@ -228,7 +228,7 @@ async def test_reused_agent_turn_merges_request_overrides_not_overwrite(monkeypa
     fast-mode key while the provider extra_body survives.
     """
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
-    monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
     monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
     monkeypatch.setattr(
         gateway_run,

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -157,7 +157,7 @@ async def test_session_fast_override_beats_config_default(monkeypatch, tmp_path)
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
     monkeypatch.setattr(
         gateway_run,
-        "_load_gateway_runtime_config",
+        "_load_gateway_config",
         lambda: {"agent": {"service_tier": "fast"}},
     )
     monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -301,7 +301,7 @@ class TestSecondaryProfileFatalRecovery:
         )
         monkeypatch.setattr(runner, "_connect_adapter_with_timeout", connect)
         monkeypatch.setattr(runner, "_connect_initial_adapter_with_timeout", connect)
-        monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: {})
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
         monkeypatch.setattr(runner, "_snapshot_profile_busy_modes", lambda *a, **k: None)
         monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
         if entry == "startup":
@@ -335,7 +335,7 @@ class TestSecondaryProfileFatalRecovery:
         synced = []
         runner._sync_voice_mode_state_to_adapter = synced.append
         monkeypatch.setattr("hermes_cli.env_loader.hydrate_profile_secret_sources", lambda h: {})
-        monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: {})
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
         monkeypatch.setattr(runner, "_snapshot_profile_busy_modes", lambda *a, **k: None)
         monkeypatch.setattr("hermes_cli.plugins.discover_plugins", lambda: None)
 

--- a/tests/gateway/test_multiplex_busy_input_mode.py
+++ b/tests/gateway/test_multiplex_busy_input_mode.py
@@ -444,7 +444,7 @@ async def test_effective_mode_uses_startup_snapshot_without_rereading_config(
     def fail_config_read():
         raise AssertionError("busy-mode lookup reread config after startup")
 
-    monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", fail_config_read)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", fail_config_read)
     monkeypatch.setattr(gateway_run, "_load_gateway_config", fail_config_read)
 
     assert runner._effective_busy_input_mode(source) == "steer"

--- a/tests/gateway/test_reasoning_config_per_model.py
+++ b/tests/gateway/test_reasoning_config_per_model.py
@@ -21,7 +21,7 @@ class TestGatewayPerModelReasoningConfig:
                 },
             },
         }
-        monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: fake_cfg)
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: fake_cfg)
 
         result = gateway_run.GatewayRunner._load_reasoning_config()
         assert result is not None
@@ -42,7 +42,7 @@ class TestGatewayPerModelReasoningConfig:
                 "reasoning_effort": False,  # YAML boolean, not string
             },
         }
-        monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: fake_cfg)
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: fake_cfg)
 
         result = gateway_run.GatewayRunner._load_reasoning_config()
         assert result is not None
@@ -69,7 +69,7 @@ class TestGatewaySessionEffectiveModel:
                 },
             },
         }
-        monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: fake_cfg)
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: fake_cfg)
 
         # Session switched (session-only) to claude-opus-4.5 — its override
         # must win over the config default model's override.
@@ -111,7 +111,7 @@ class TestApiServerPerModelReasoning:
         from gateway.platforms.api_server import APIServerAdapter
 
         monkeypatch.setattr(
-            gateway_run, "_load_gateway_runtime_config", lambda: self._cfg(),
+            gateway_run, "_load_gateway_config", lambda: self._cfg(),
         )
         adapter = APIServerAdapter(PlatformConfig())
 

--- a/tests/gateway/test_streaming_tts_gateway_regression.py
+++ b/tests/gateway/test_streaming_tts_gateway_regression.py
@@ -100,7 +100,7 @@ def _setup_monkeypatches(monkeypatch, tmp_path):
     monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
     monkeypatch.setattr(
         gateway_run,
-        "_load_gateway_runtime_config",
+        "_load_gateway_config",
         lambda: {"agent": {"model": "test-model"}},
     )
     monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "test-model")

--- a/tests/hermes_cli/test_config_effective.py
+++ b/tests/hermes_cli/test_config_effective.py
@@ -1,0 +1,110 @@
+"""Invariants for ``hermes_cli.config_effective.load_user_config_effective`` — the one loader every
+defaults-free config reader (gateway runtime, TUI gateway, cron, ``hermes send`` bridge, doctor,
+bootstrap modules) goes through."""
+import textwrap
+
+import pytest
+
+
+@pytest.fixture
+def homes(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    managed = tmp_path / "managed"
+    managed.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_MANAGED_DIR", str(managed))
+    monkeypatch.setenv("FIXTURE_USER_KEY", "user-secret")
+    monkeypatch.setenv("FIXTURE_MANAGED_URL", "https://managed.example")
+    _reset_caches()
+    return home, managed
+
+
+def _reset_caches():
+    import hermes_cli.config as cfg
+    from hermes_cli import config_effective, managed_scope
+
+    cfg._LOAD_CONFIG_CACHE.clear()
+    cfg._RAW_CONFIG_CACHE.clear()
+    config_effective._EFFECTIVE_CACHE.clear()
+    config_effective._LAST_GOOD_USER_RAW.clear()
+    managed_scope.invalidate_managed_cache()
+
+
+def _write(path, body):
+    path.write_text(textwrap.dedent(body), encoding="utf-8")
+    _reset_caches()
+
+
+USER_YAML = """
+    model:
+      name: user/model
+      api_key: ${FIXTURE_USER_KEY}
+    provider: custom
+    display:
+      skin: user-skin
+    """
+MANAGED_YAML = """
+    model:
+      base_url: ${FIXTURE_MANAGED_URL}
+    display:
+      skin: managed-skin
+    """
+
+
+def _legacy_gateway_pipeline(config_path):
+    """The pre-unification gateway sequence (raw read → overlay → model-key canon → ${VAR} expansion)."""
+    from hermes_cli import managed_scope
+    from hermes_cli.config import _expand_env_vars, _normalize_root_model_keys, read_user_config_raw
+
+    raw = managed_scope.apply_managed_overlay(read_user_config_raw(config_path))
+    return _expand_env_vars(_normalize_root_model_keys(raw))
+
+
+def test_effective_equals_legacy_gateway_pipeline_and_carries_no_defaults(homes):
+    """Contract: the shared loader returns byte-for-byte what the gateway's hand-rolled pipeline did
+    for a user file with a managed overlay and ``${VAR}`` refs on both layers — so per-message
+    gateway config reads (and the system prompt built from them) do not change — while never
+    merging DEFAULT_CONFIG (a missing key stays missing)."""
+    from hermes_cli.config import DEFAULT_CONFIG
+    from hermes_cli.config_effective import load_user_config_effective
+
+    home, managed = homes
+    _write(home / "config.yaml", USER_YAML)
+    _write(managed / "config.yaml", MANAGED_YAML)
+
+    effective = load_user_config_effective(home / "config.yaml")
+
+    assert effective == _legacy_gateway_pipeline(home / "config.yaml")
+    assert effective["model"] == {
+        "default": "user/model", "provider": "custom", "api_key": "user-secret",
+        "base_url": "https://managed.example"}
+    assert effective["display"]["skin"] == "managed-skin"
+    assert "provider" not in effective  # root key migrated under ``model`` (canonicalization applied)
+    assert "agent" not in effective and "agent" in DEFAULT_CONFIG  # no DEFAULT_CONFIG merge
+
+
+def test_broken_yaml_serves_last_good_and_fail_closed_raises(homes):
+    """A torn mid-edit write must not silently drop user overrides: the fail-open path serves the last
+    successfully parsed user file through the same pipeline; ``fail_closed`` surfaces the error to
+    callers that keep their own last-good state."""
+    from hermes_cli.config_effective import load_user_config_effective
+
+    home, _ = homes
+    _write(home / "config.yaml", USER_YAML)
+    good = load_user_config_effective(home / "config.yaml")
+
+    (home / "config.yaml").write_text("model: [unterminated", encoding="utf-8")
+    _reset_caches_keep_last_good()
+
+    assert load_user_config_effective(home / "config.yaml") == good
+    with pytest.raises(Exception):
+        load_user_config_effective(home / "config.yaml", fail_closed=True)
+
+
+def _reset_caches_keep_last_good():
+    import hermes_cli.config as cfg
+    from hermes_cli import config_effective
+
+    cfg._RAW_CONFIG_CACHE.clear()
+    config_effective._EFFECTIVE_CACHE.clear()

--- a/tests/hermes_cli/test_doctor_live.py
+++ b/tests/hermes_cli/test_doctor_live.py
@@ -34,7 +34,7 @@ def _clean_env(monkeypatch):
                 "ELEVENLABS_API_KEY", "GROQ_API_KEY"):
         monkeypatch.delenv(var, raising=False)
     # Default: empty config, no MCP servers, local tts/stt.
-    monkeypatch.setattr(doctor_live, "_load_config", lambda: {})
+    monkeypatch.setattr("hermes_cli.config.load_config_readonly", lambda: {})
     # Default: browser not installed.
     monkeypatch.setattr(doctor_live, "_browser_available", lambda: False)
 
@@ -134,7 +134,7 @@ class TestConfiguredOnlySelection:
 
     def test_mcp_servers_probed_per_configured_server(self, monkeypatch):
         monkeypatch.setattr(
-            doctor_live, "_load_config",
+            "hermes_cli.config.load_config_readonly",
             lambda: {"mcp_servers": {"alpha": {"url": "https://x"},
                                      "beta": {"command": "foo"}}})
         probed = []
@@ -148,7 +148,7 @@ class TestConfiguredOnlySelection:
 
     def test_tts_local_provider_skipped(self, monkeypatch):
         monkeypatch.setattr(
-            doctor_live, "_load_config",
+            "hermes_cli.config.load_config_readonly",
             lambda: {"tts": {"provider": "edge"}})
         results = {r.name: r for r in run_live_checks([])}
         assert results["TTS"].status == "skip"
@@ -156,7 +156,7 @@ class TestConfiguredOnlySelection:
     def test_tts_openai_probed_with_key(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         monkeypatch.setattr(
-            doctor_live, "_load_config",
+            "hermes_cli.config.load_config_readonly",
             lambda: {"tts": {"provider": "openai"}})
         monkeypatch.setattr(
             doctor_live, "_http_get",
@@ -167,7 +167,7 @@ class TestConfiguredOnlySelection:
     def test_stt_groq_probed_with_key(self, monkeypatch):
         monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
         monkeypatch.setattr(
-            doctor_live, "_load_config",
+            "hermes_cli.config.load_config_readonly",
             lambda: {"stt": {"provider": "groq"}})
         monkeypatch.setattr(
             doctor_live, "_http_get",
@@ -177,7 +177,7 @@ class TestConfiguredOnlySelection:
 
     def test_stt_provider_configured_but_key_missing_warns(self, monkeypatch):
         monkeypatch.setattr(
-            doctor_live, "_load_config",
+            "hermes_cli.config.load_config_readonly",
             lambda: {"stt": {"provider": "groq"}})
         results = {r.name: r for r in run_live_checks([])}
         assert results["STT"].status == "warn"
@@ -248,7 +248,7 @@ class TestFailureIsolation:
 
     def test_mcp_probe_failure_isolated_per_server(self, monkeypatch):
         monkeypatch.setattr(
-            doctor_live, "_load_config",
+            "hermes_cli.config.load_config_readonly",
             lambda: {"mcp_servers": {"bad": {"url": "https://x"},
                                      "good": {"url": "https://y"}}})
 
@@ -278,7 +278,7 @@ class TestTimeoutHandling:
     def test_probe_timeout_bounded_and_configurable(self, monkeypatch):
         monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test")
         monkeypatch.setattr(
-            doctor_live, "_load_config",
+            "hermes_cli.config.load_config_readonly",
             lambda: {"doctor": {"live_probe_timeout": 3}})
         seen = {}
 

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -131,7 +131,7 @@ def test_decompose_fanout_false_invalid_llm_assignee_uses_default(kanban_home):
         p.start()
     try:
         with _patch_aux_client(llm_payload), _patch_extra_body(), patch(
-            "hermes_cli.kanban_decompose._load_config",
+            "hermes_cli.config.load_config_readonly",
             return_value={"kanban": {"default_assignee": "fallback"}},
         ):
             outcome = decomp.decompose_task(tid, author="me")

--- a/tests/hermes_cli/test_send_cmd.py
+++ b/tests/hermes_cli/test_send_cmd.py
@@ -313,16 +313,17 @@ def test_load_hermes_env_latin1_fallback_still_loads(tmp_path, monkeypatch):
 
 def test_load_hermes_env_latin1_fallback_overrides_shell(tmp_path, monkeypatch):
     """The stream-based latin-1 fallback must keep override=True semantics:
-    the .env value wins over a stale shell export, same as the primary path."""
+    the .env value wins over a stale shell export, same as the primary path. (A non-credential
+    key name: ``*_TOKEN`` values are ASCII-sanitized by the shared loader, by design.)"""
     import os
 
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()
     # 0xE9 forces the UnicodeDecodeError \u2192 latin-1 stream fallback.
-    (hermes_home / ".env").write_bytes(b"SEND_OVR_TOKEN=caf\xe9-file\n")
+    (hermes_home / ".env").write_bytes(b"SEND_OVR_LABEL=caf\xe9-file\n")
 
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-    monkeypatch.setenv("SEND_OVR_TOKEN", "stale-shell-value")
+    monkeypatch.setenv("SEND_OVR_LABEL", "stale-shell-value")
 
     from importlib import reload
     import hermes_cli.config as _hc_config
@@ -330,7 +331,7 @@ def test_load_hermes_env_latin1_fallback_overrides_shell(tmp_path, monkeypatch):
 
     send_cmd._load_hermes_env()
 
-    assert os.environ.get("SEND_OVR_TOKEN") == "caf\xe9-file"
+    assert os.environ.get("SEND_OVR_LABEL") == "caf\xe9-file"
 
 def test_load_hermes_env_fallback_read_error_is_swallowed(tmp_path, monkeypatch):
     """An I/O error inside the latin-1 fallback must not escape \u2014 the send

--- a/tests/hermes_cli/test_worktree_gc.py
+++ b/tests/hermes_cli/test_worktree_gc.py
@@ -153,16 +153,22 @@ class TestReclaim:
         )
         assert probe.returncode != 0, "branch should be gone with its tree"
 
-    def test_untracked_files_archived_before_removal(self, repo):
+    def test_untracked_files_archived_under_the_active_profile_home(self, repo, tmp_path, monkeypatch):
+        """The archive follows the active Hermes home (a named profile here), never ~/.hermes."""
+        native_home = tmp_path / "native"
+        profile_home = tmp_path / "root" / "profiles" / "work"
+        profile_home.mkdir(parents=True)
+        monkeypatch.setattr(Path, "home", lambda: native_home)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
         tree, _ = _add_worktree(repo, "hermes-scratch")
         (tree / "NOTES.md").write_text("important scribbles\n")
         records = worktree_gc.audit_worktrees(str(repo), with_sizes=False)
         worktree_gc.reclaim_worktrees(str(repo), records=records)
         assert not tree.exists()
-        archive_root = Path.home() / ".hermes" / "archive" / "worktree-prune"
-        archived = list(archive_root.rglob("NOTES.md"))
-        assert archived, "untracked file must be archived, not destroyed"
+        archived = list((profile_home / "archive" / "worktree-prune").rglob("NOTES.md"))
+        assert archived, "untracked file must be archived under the profile home, not destroyed"
         assert archived[0].read_text() == "important scribbles\n"
+        assert not (native_home / ".hermes").exists()
 
     def test_dry_run_changes_nothing(self, repo):
         tree, _ = _add_worktree(repo, "hermes-clean")

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -715,7 +715,7 @@ class TestLoadConfig(unittest.TestCase):
         mock_cli = MagicMock()
         mock_cli.CLI_CONFIG = {"code_execution": {"timeout": 999}}
         with patch.dict("sys.modules", {"cli": mock_cli}), \
-             patch("hermes_cli.config.read_raw_config", return_value={}):
+             patch("hermes_cli.config.load_config_readonly", return_value={}):
             result = _load_config()
         self.assertEqual(result, {})
 

--- a/tests/tui_gateway/test_reasoning_config_per_model.py
+++ b/tests/tui_gateway/test_reasoning_config_per_model.py
@@ -74,7 +74,7 @@ class TestTUIPerModelReasoningConfig:
             },
         }
         monkeypatch.setattr(tui_server, "_load_cfg", lambda: fake_cfg)
-        monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: fake_cfg)
+        monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: fake_cfg)
 
         tui_result = tui_server._load_reasoning_config()
         gw_result = gateway_run.GatewayRunner._load_reasoning_config()

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -53,7 +53,8 @@ _LOCAL_TARGET_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$")
 
 
 def _default_home() -> str:
-    return os.getenv("HERMES_HOME") or os.path.expanduser("~/.hermes")
+    from hermes_constants import get_process_hermes_home
+    return str(get_process_hermes_home())
 
 
 def message_agent_tool_schema() -> dict:

--- a/tools/bot_mode_probe.py
+++ b/tools/bot_mode_probe.py
@@ -38,8 +38,9 @@ _cached: dict[str, str] = {}
 
 
 def _default_home() -> str:
-    """Ambient HERMES_HOME (env, else ~/.hermes) as a string."""
-    return os.getenv("HERMES_HOME") or os.path.expanduser("~/.hermes")
+    """Ambient process HERMES_HOME (env, else the platform default) as a string."""
+    from hermes_constants import get_process_hermes_home
+    return str(get_process_hermes_home())
 
 
 def _resolve_home(home: str | os.PathLike | None) -> Path:

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -758,11 +758,11 @@ def _kill_process_group(proc, escalate: bool = False):
 
 
 def _load_config() -> dict:
-    """``code_execution`` config section via the lightweight raw reader — runs while the
+    """Effective ``code_execution`` section (defaults + user file + managed overlay) — runs while the
     module-level schema is built at tool discovery, so it must not import ``cli``."""
     try:
-        from hermes_cli.config import read_raw_config
-        cfg = read_raw_config().get("code_execution", {})
+        from hermes_cli.config import load_config_readonly
+        cfg = load_config_readonly().get("code_execution", {})
         return cfg if isinstance(cfg, dict) else {}
     except Exception:
         return {}

--- a/tui_gateway/methods_bot_relay.py
+++ b/tui_gateway/methods_bot_relay.py
@@ -21,8 +21,8 @@ method = _registry.method
 
 def _relay_root() -> Path:
     """Install root shared by every profile (relay state is install-wide)."""
-    home = Path(os.getenv("HERMES_HOME") or os.path.expanduser("~/.hermes"))
-    return home.parent.parent if home.parent.name == "profiles" else home
+    from hermes_constants import get_default_hermes_root
+    return get_default_hermes_root()
 
 
 def _run_delivery(profile: str, tmp: str, env: dict | None = None) -> subprocess.CompletedProcess:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -541,7 +541,7 @@ def _configured_cwd_from_cfg(cfg: dict | None) -> str | None:
 def _profile_configured_cwd(profile_home: Path | None) -> str | None:
     """A non-launch profile's ``terminal.cwd`` from ITS config.yaml (fail-open → None): the process-global
     ``TERMINAL_CWD`` belongs to the *launch* profile, and load_config() resolves the ACTIVE profile, so
-    read the file directly through the _load_cfg pipeline.
+    read that file through the same effective-config pipeline as ``_load_cfg``.
 
     A new session bound to another profile must take its workspace from THAT profile's config, not the stale
     env var (issue #40334). Returns an absolute, existing directory, or None for placeholders / missing /
@@ -550,9 +550,9 @@ def _profile_configured_cwd(profile_home: Path | None) -> str | None:
     if profile_home is None:
         return None
     with contextlib.suppress(Exception):
-        from hermes_cli.config import read_user_config_raw
+        from hermes_cli.config_effective import load_user_config_effective
         p = Path(profile_home) / "config.yaml"
-        return _configured_cwd_from_cfg(_expand_cfg(_apply_managed(read_user_config_raw(p)))) if p.exists() else None
+        return _configured_cwd_from_cfg(load_user_config_effective(p)) if p.exists() else None
     return None
 
 
@@ -1159,31 +1159,15 @@ def _load_cfg_raw() -> dict:
     return {}
 
 
-def _expand_cfg(cfg: dict) -> dict:
-    """``${ENV_VAR}`` expansion (same as ``load_config_readonly``); non-dict results keep the input."""
-    from hermes_cli.config import _expand_env_vars
-    expanded = _expand_env_vars(cfg)
-    return expanded if isinstance(expanded, dict) else cfg
-
-
 def _load_cfg() -> dict:
-    """Behavioral config read: raw user file + managed overlay + ${VAR} expansion — ``load_config_readonly``
-    minus the DEFAULT_CONFIG merge (callers treat a missing key as "unset"; merging would break
-    ``_load_cfg() == {}`` sentinels). Never pass the result to ``_save_cfg`` (use ``_load_cfg_raw()``)."""
-    cfg = _apply_managed(_load_cfg_raw())
+    """Behavioral config read: the effective USER config (managed overlay, ``${VAR}`` expansion, model-key
+    canon) minus the DEFAULT_CONFIG merge — callers treat a missing key as "unset", so merging would break
+    ``_load_cfg() == {}`` sentinels. Fail-open to ``{}``. Never pass the result to ``_save_cfg`` (use
+    ``_load_cfg_raw()``)."""
     with contextlib.suppress(Exception):
-        cfg = _expand_cfg(cfg)
-    return cfg
-
-
-def _apply_managed(cfg: dict) -> dict:
-    """Overlay administrator-pinned managed-scope values (read-side only, fail-open): this backend builds
-    config independently of load_config, so managed skin/reasoning_effort/service_tier/provider_routing
-    would otherwise be silently ignored."""
-    with contextlib.suppress(Exception):
-        from hermes_cli import managed_scope
-        return managed_scope.apply_managed_overlay(cfg if isinstance(cfg, dict) else {})
-    return cfg
+        from hermes_cli.config_effective import load_user_config_effective
+        return load_user_config_effective(_active_config_path())
+    return {}
 
 
 def _save_cfg(cfg: dict):


### PR DESCRIPTION
One `load_user_config_effective()` (user config.yaml → `${VAR}` → managed overlay → model-key canon, no defaults) replaces nine hand-rolled copies across gateway, TUI gateway, cron, `hermes send`, doctor and the bootstrap modules; six HERMES_HOME-blind path sites now resolve through `hermes_constants`; six thin `_load_config`/bare-`safe_load` copies collapse onto the canonical readers.

## Changes

- **New** `hermes_cli/config_effective.py::load_user_config_effective(path=None, *, fail_closed=False)`: shares `read_raw_config`'s parse cache (one parse per process), caches on user+managed file signatures and the referenced env values, serves the last known-good user file (in-process, then `backups/config/*.good.*`) on torn YAML — the same recovery `load_config()` got in de2d6a1b — or raises with `fail_closed=True`.
- `gateway/run.py::_load_gateway_config` is now a 5-line forwarder; `_load_gateway_runtime_config` (= `_load_gateway_config` + expansion) is **deleted**, 20 source sites + 9 test files repointed.
- `tui_gateway/server.py`: `_load_cfg` forwards; `_expand_cfg` / `_apply_managed` deleted; `_load_cfg_raw` stays (write-back primitive for `_save_cfg`).
- `hermes_cli/send_cmd.py::_load_hermes_env`: `.env` now read via `env_loader._load_dotenv_with_fallback` (credential sanitizer runs); config bridge via the shared loader.
- `hermes_cli/main.py` early parse, `hermes_time.py`, `hermes_logging.py`: normal path through the shared loader (managed overlay included); the stdlib/`fast_safe_load` bootstrap fallbacks stay for bare consumers.
- HERMES_HOME: `worktree_gc._archive_untracked` → `get_hermes_home()`; `dashboard_procs._hermes_home_dir`, `bot_mode_dm/_probe._default_home`, `env_loader.load_hermes_dotenv` default → `get_process_hermes_home()`; `methods_bot_relay._relay_root` → `get_default_hermes_root()`.
- Thin copies: `doctor_live`/`kanban_decompose` `_load_config` deleted (inline `load_config_readonly`); `local_models._load_config` deleted; `code_execution_tool._load_config` → `load_config_readonly`; `onboarding.mark_seen` + `credential_lifecycle` mirror scrub → `read_user_config_raw`.
- `hermes_cli/AGENTS.md` "Three loaders" entry names the new loader.

## Sites

| path::symbol | → canonical |
|---|---|
| `gateway/run.py::_load_gateway_config` | forwarder → `load_user_config_effective(path)` |
| `gateway/run.py::_load_bridge_config` | forwarder (expand order fixed) |
| `gateway/run.py::_load_gateway_runtime_config` | **deleted** → `_load_gateway_config` |
| `gateway/run_config_loaders.py::_refresh_fallback_model` | `load_user_config_effective(path, fail_closed=True)` |
| `tui_gateway/server.py::_load_cfg` / `_expand_cfg` / `_apply_managed` / `_profile_configured_cwd` | forwarder / deleted / deleted / forwarder |
| `hermes_cli/send_cmd.py::_load_hermes_env` | `_load_dotenv_with_fallback` + shared loader |
| `cron/scheduler.py::run_job` model resolution | shared loader |
| `cron/jobs.py::_resolve_default_model_snapshot` | shared loader |
| `hermes_cli/doctor_state.py::_doctor_memory_config` | shared loader (expand order fixed) |
| `hermes_cli/main.py` early parse | shared loader |
| `hermes_time.py::_resolve_timezone_name`, `hermes_logging.py::_read_logging_config` | shared loader, bootstrap fallback kept |
| `hermes_cli/worktree_gc.py::_archive_untracked` | `get_hermes_home()` |
| `hermes_cli/dashboard_procs.py::_hermes_home_dir` | `get_process_hermes_home()` |
| `hermes_cli/env_loader.py::load_hermes_dotenv` default home | `get_process_hermes_home()` |
| `tools/bot_mode_dm.py::_default_home`, `tools/bot_mode_probe.py::_default_home` | `get_process_hermes_home()` |
| `tui_gateway/methods_bot_relay.py::_relay_root` | `get_default_hermes_root()` |
| `hermes_cli/doctor_live.py::_load_config`, `hermes_cli/kanban_decompose.py::_load_config`, `hermes_cli/web_routers/local_models.py::_load_config` | deleted → `load_config_readonly()` |
| `tools/code_execution_tool.py::_load_config` | `load_config_readonly()` |
| `agent/onboarding.py::mark_seen`, `hermes_cli/credential_lifecycle.py::_scrub_config_yaml_mirrors` | `read_user_config_raw()` |

Not changed (documented-legit): `hermes_startup_watchdog._process_hermes_home` (stdlib bootstrap replica), `hermes_cli/gateway._hermes_home_for_target_user` (sudo remap), `main_dashboard:556` (desktop-ssh anchor), `codex_app_server:84` (child env), `gateway/config_loader.read_yaml_layers` + `terminal_scope` + `readiness` (raise-on-malformed by contract). `plugins/` and `dashboard_procs.py`'s serve predicate belong to other lanes.

## Behavior change

- `_load_bridge_config`, `send_cmd._load_hermes_env`, `doctor_state._doctor_memory_config` expanded `${VAR}` **before** the managed overlay; they now expand the user layer first and the managed layer against the process env only, like `load_config()`. A managed `api_key: ${FOO}` now expands on every surface.
- All nine sites gain `_normalize_root_model_keys` (`model: {name: x}` / root `provider:` resolve everywhere, not only in the gateway) and last-known-good recovery on torn YAML (previously `{}` → all overrides dropped for that read).
- `execute_code`'s `code_execution.*` reads now see `DEFAULT_CONFIG` and a managed-pinned `mode`.
- `hermes send` sanitizes non-ASCII from `*_TOKEN`/`*_KEY` values like every other entrypoint.
- `hermes worktree` archives land under the active `HERMES_HOME` (profile) instead of `~/.hermes`.
- Gateway per-message config reads: same dict as before for the same files (invariant test below), so system-prompt bytes are unchanged.

## Validation

| | before | after |
|---|---|---|
| `${VAR}` in managed config, `hermes send` bridge | literal `${VAR}` exported | expanded |
| `model: {name: x}` in cron / TUI gateway | empty model | `x` |
| torn config.yaml during a gateway turn | `{}` → every override dropped for that read | last good config served, loud warning |
| worktree archive under `HERMES_HOME=<root>/profiles/work` | `~/.hermes/archive/...` | `<profile>/archive/...` |

Tests: `tests/hermes_cli/test_config_effective.py` — (1) `load_user_config_effective` == the legacy gateway raw→overlay→canon→expand pipeline for a fixture with managed overlay + `${VAR}` on both layers, and carries no `DEFAULT_CONFIG` keys; (2) torn YAML serves the last good result / `fail_closed` raises. `tests/hermes_cli/test_worktree_gc.py::test_untracked_files_archived_under_the_active_profile_home` (patches `Path.home` AND `HERMES_HOME`). Sabotage: skipping the overlay → red; skipping the canon → red; reverting `worktree_gc` → red.

E2E (temp `HERMES_HOME` + `HERMES_MANAGED_DIR`, real files): gateway `_load_gateway_config()` == TUI `_load_cfg()` == `load_user_config_effective()`; cron snapshot, `hermes_time`, `hermes_logging` read the managed-pinned values; torn YAML → gateway keeps the last good dict, `fail_closed` raises; absent user file → managed layer still applies; `hermes send` bridge exports the effective scalars.

`scripts/run_tests.sh tests/hermes_cli tests/cron tests/tui_gateway tests/gateway tests/tools/test_code_execution*.py …`: green except `tests/hermes_cli/test_update_head_moved_gate.py::test_update_success_when_head_moves`, which fails identically on `origin/main` (pre-existing, unrelated).

## Infographic

![effective-config-loader](https://v3b.fal.media/files/b/0aaa35a5/gHoNaKfAiM36M2RomlxzJ_8iAwa94R.png)


## Review follow-ups

Fixes for the review findings, one commit each (head `4644d417880a`):

- **Relay root split (SHOULD-FIX)** — `tui_gateway/methods_bot_relay._relay_root` had moved to `get_default_hermes_root()` while the writers (`tools/bot_relay::cleanup_bot_relay_artifacts`, `tools/bot_mode_dm::message_agent_tool` / turn-lock / roster lookups) still use `bot_mode_probe._hermes_root`. For `HERMES_HOME=~/.hermes/<non-profiles-subdir>` the two disagreed → silent non-delivery. `_relay_root` now uses the same writer formula. Invariant test `tests/tui_gateway/test_bot_relay_methods.py::test_gateway_drains_the_mailbox_the_tools_write_to[profiles/ops|dev]` enqueues through the writer root and drains through the gateway handler. Sabotage (revert `_relay_root`): the `dev` case FAILS.
- **Fail-open guards restored (SHOULD-FIX)** — `hermes_cli/kanban_decompose._load_routing` and `hermes_cli/web_routers/local_models` (`_runtime_section`, `_active_llamacpp_model_id`, `_restart_on_new_tag`) catch `Exception` → `{}` again, matching the pre-PR `_load_config` copies (`load_config_readonly` can raise `FileNotFoundError` / `HomeInitializationError` via `ensure_hermes_home`). Tests: `test_kanban_decompose.py::test_load_routing_falls_back_to_defaults_when_config_unreadable`, `test_local_models_routes.py::test_status_renders_degraded_when_config_cannot_be_read`. Sabotage: both FAIL without the guards.
- **Good-config backup only for the active home (NIT)** — `load_user_config_effective` now calls `backup_config(..., "good")` only when `config_path == get_config_path()`, so a read of another profile's file (doctor, TUI `_profile_configured_cwd`) no longer creates `<other-profile>/backups/config/`. Test `test_config_effective.py::test_good_backup_is_written_only_for_the_active_home` (FAILS on revert).
- **Mirror test rewritten (NIT)** — `_legacy_gateway_pipeline` is gone; `test_effective_is_user_plus_managed_plus_env_with_no_defaults` pins a literal expected dict for user file + managed overlay + env. `fail_closed` now asserts `yaml.YAMLError`.
- **Duplicate `setattr` lines (NIT)** — deduped in `test_custom_provider_request_overrides.py`, `test_multiplex_busy_input_mode.py`, `test_fast_command.py`, `test_streaming_tts_gateway_regression.py` (the intended runtime dict is kept).

**Behavior change (declared):** on Windows the default `.env` location for `load_hermes_dotenv` (and `bot_mode_dm/_probe._default_home`, `dashboard_procs._hermes_home_dir`, `worktree_gc._archive_untracked`) is now the profile-aware `%LOCALAPPDATA%\hermes` — where `config.yaml` already lives — instead of `%USERPROFILE%\.hermes`. Also: `_normalize_root_model_keys` runs before the env bridge in `gateway/run._load_bridge_config` / `send_cmd._load_hermes_env`, so legacy root `provider`/`base_url`/`context_length`/`api_base` scalars are no longer exported as env vars (no reader exists).

Tests: `scripts/run_tests.sh` over `test_config_effective.py test_kanban_decompose*.py test_local_models_routes.py tests/tools/test_bot_mode*.py tests/tools/test_bot_relay*.py tests/tui_gateway/test_bot_relay_methods.py tests/tui_gateway/test_relay_live_author.py tests/test_tui_gateway_server.py test_worktree_gc.py` → 13 files, 803 passed, 0 failed, 1 skipped; the 4 deduped gateway test files → 30 passed. ruff, `check-windows-footguns --all`, `check_compat_pointers`, `git diff --check` clean.
