### PR TITLE
fix(vault): default detected password managers to enabled (opt-out contract)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2195,14 +2195,15 @@ DEFAULT_CONFIG = {
     # headless sessions (cron, webhook, API) never prompt and see them as locked.
     "vault": {
         "onepassword": {
-            "enabled": False,       # `op` CLI: Login items with a website URL become fillable handles.
+            # Detected managers are login sources unless the user opts out (vault.<name>.enabled: false).
+            "enabled": True,        # `op` CLI: Login items with a website URL become fillable handles.
             "account": "",          # account shorthand for `op --account`; empty = default account.
             "binary_path": "",      # absolute path to op; empty = PATH.
             # Env var holding a service-account token (headless auth, no unlock prompt). Unset = prompt.
             "service_account_token_env": "OP_SERVICE_ACCOUNT_TOKEN",
         },
         "bitwarden": {
-            "enabled": False,       # `bw` CLI (Password Manager, not Secrets Manager); run `bw login` once first.
+            "enabled": True,        # `bw` CLI (Password Manager, not Secrets Manager); run `bw login` once first.
             "binary_path": "",      # absolute path to bw; empty = PATH.
         },
     },

--- a/tests/tui_gateway/test_vault_methods.py
+++ b/tests/tui_gateway/test_vault_methods.py
@@ -102,6 +102,45 @@ def test_add_validation_errors_are_clean(home):
     assert "s3cret-pw-9000" not in json.dumps(err)
 
 
+def _sources_rows(home):
+    out = _result(srv._methods["vault.sources"](90, {}))
+    return {row["name"]: row for row in out["sources"]}
+
+
+def test_enabling_a_detected_manager_reports_it_enabled(home, monkeypatch):
+    """The Settings toggle and `hermes vault sources --enable` both clear the opt-out override;
+    the shipped default must then agree with `is_enabled()`'s zero-config contract — an installed
+    manager becomes a login source instead of silently staying off (#109546)."""
+    monkeypatch.setattr(
+        "agent.vault_backends.base.is_installed", lambda name: name == "bitwarden"
+    )
+    _result(
+        srv._methods["vault.source.set"](80, {"name": "bitwarden", "enabled": True})
+    )
+    rows = _sources_rows(home)
+    assert rows["bitwarden"]["installed"] is True
+    assert rows["bitwarden"]["enabled"] is True
+
+
+def test_disabling_a_manager_persists_the_opt_out(home, monkeypatch):
+    monkeypatch.setattr(
+        "agent.vault_backends.base.is_installed", lambda name: name == "bitwarden"
+    )
+    _result(
+        srv._methods["vault.source.set"](81, {"name": "bitwarden", "enabled": False})
+    )
+    rows = _sources_rows(home)
+    assert rows["bitwarden"]["installed"] is True
+    assert rows["bitwarden"]["enabled"] is False
+
+
+def test_undetected_manager_stays_off(home, monkeypatch):
+    monkeypatch.setattr("agent.vault_backends.base.is_installed", lambda name: False)
+    rows = _sources_rows(home)
+    assert rows["bitwarden"]["installed"] is False
+    assert rows["bitwarden"]["enabled"] is False
+
+
 def test_remove_is_idempotent(home):
     item_id = _result(srv._methods["vault.add"](1, dict(_LOGIN_PARAMS)))["id"]
     assert _result(srv._methods["vault.remove"](2, {"id": item_id}))["removed"] is True


### PR DESCRIPTION
## Summary

The Settings toggle for a detected password manager was a silent no-op: `vault.source.set(enabled=true)` and `hermes vault sources --enable` both implement "enable" as *removing* the `vault.<name>.enabled` override (an opt-out by design), but the shipped default for that key was `False` — so removing the override fell back to "off" and the source stayed `Off` forever. The only workaround was `hermes config set vault.bitwarden.enabled true`.

Three contracts disagreed, and this fixes the odd one out:

| site | behavior on `main` |
|---|---|
| `agent/vault_backends/base.py::is_enabled()` | installed manager is a login source **unless** `enabled: false` ("zero-config on purpose", per docstring) |
| `tui_gateway/methods_vault.py` / `hermes_cli/vault.py` enable handlers | `section.pop("enabled")` — remove the opt-out |
| `hermes_cli/config_defaults.py` | `"enabled": False` ← the shipped default contradicted both |
| `website/docs/.../credential-vault.md` | already documents `# opt OUT of a detected manager (default: on when installed)` |

Fix: flip the shipped defaults for `vault.onepassword.enabled` and `vault.bitwarden.enabled` to `True` so they agree with the opt-out contract everything else (including the docs) already implements. No user-visible behavior change for anyone who explicitly opted out — their `enabled: false` still wins; an uninstalled manager still stays off because `is_enabled()` requires `is_installed()`.

The enable handlers are left as override-removal intentionally: that keeps "reset to default" meaningful and matches the documented contract.

## Testing

- RED first: with the fix reverted, `test_enabling_a_detected_manager_reports_it_enabled` fails (`assert False is True`) on current `main` behavior — the toggle no-ops.
- With the fix: `tests/tui_gateway/test_vault_methods.py` — 7 passed (3 new: enable-toggle, disable persists the opt-out, undetected manager stays off).
- Mutation check: removing the `is_installed` gate in `is_enabled()` turns `test_undetected_manager_stays_off` red (the tests bite).
- Neighbors: `tests/agent/test_vault_backends.py` (10 passed), `tests/hermes_cli/test_config.py` (124 passed, 4 skipped — golden config migrations unaffected).
- `ruff check` clean; `ruff format --diff` drift identical to `main` baseline on both files.

Fixes #109546
