### PR TITLE
fix(vault): align config defaults with opt-out design for detected managers (#109546)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2193,16 +2193,15 @@ DEFAULT_CONFIG = {
     # encrypted vault (`hermes vault add`, Desktop → Settings → Credential Vault) is always on.
     # External password managers are unlocked per session with a masked master-password prompt;
     # headless sessions (cron, webhook, API) never prompt and see them as locked.
+    # Detected managers are enabled automatically when installed; users opt out via enabled: false.
     "vault": {
         "onepassword": {
-            "enabled": False,       # `op` CLI: Login items with a website URL become fillable handles.
             "account": "",          # account shorthand for `op --account`; empty = default account.
             "binary_path": "",      # absolute path to op; empty = PATH.
             # Env var holding a service-account token (headless auth, no unlock prompt). Unset = prompt.
             "service_account_token_env": "OP_SERVICE_ACCOUNT_TOKEN",
         },
         "bitwarden": {
-            "enabled": False,       # `bw` CLI (Password Manager, not Secrets Manager); run `bw login` once first.
             "binary_path": "",      # absolute path to bw; empty = PATH.
         },
     },

--- a/hermes_cli/vault.py
+++ b/hermes_cli/vault.py
@@ -154,7 +154,7 @@ def _cmd_sources(args) -> None:
         cfg = load_config()
         section = cfg.setdefault("vault", {}).setdefault(name, {})
         if args.enable:
-            section.pop("enabled", None)  # detected managers are on by default; drop the opt-out
+            section["enabled"] = True
         else:
             section["enabled"] = False
         save_config(cfg)

--- a/tests/tui_gateway/test_vault_methods.py
+++ b/tests/tui_gateway/test_vault_methods.py
@@ -112,3 +112,30 @@ def test_remove_is_idempotent(home):
 def test_remove_requires_id(home):
     err = _error(srv._methods["vault.remove"](1, {}))
     assert err["code"] == 5095
+
+
+def test_sources_detected_by_default_and_toggleable(home, monkeypatch):
+    from agent.vault_backends import base
+
+    monkeypatch.setattr(base, "is_installed", lambda name: True)
+
+    # By default without opt-out, an installed manager reports enabled
+    res = _result(srv._methods["vault.sources"](1, {}))
+    bw = next(s for s in res["sources"] if s["name"] == "bitwarden")
+    assert bw["installed"] is True
+    assert bw["enabled"] is True
+
+    # Disable via vault.source.set
+    set_res = _result(srv._methods["vault.source.set"](2, {"name": "bitwarden", "enabled": False}))
+    assert set_res["enabled"] is False
+    res = _result(srv._methods["vault.sources"](3, {}))
+    bw = next(s for s in res["sources"] if s["name"] == "bitwarden")
+    assert bw["enabled"] is False
+
+    # Enable via vault.source.set persists enabled state
+    set_res = _result(srv._methods["vault.source.set"](4, {"name": "bitwarden", "enabled": True}))
+    assert set_res["enabled"] is True
+    res = _result(srv._methods["vault.sources"](5, {}))
+    bw = next(s for s in res["sources"] if s["name"] == "bitwarden")
+    assert bw["enabled"] is True
+

--- a/tui_gateway/methods_vault.py
+++ b/tui_gateway/methods_vault.py
@@ -98,7 +98,7 @@ def _(rid, params: dict) -> dict:
     cfg = load_config()
     section = cfg.setdefault("vault", {}).setdefault(name, {})
     if enabled:
-        section.pop("enabled", None)  # detected managers are on by default; this removes the opt-out
+        section["enabled"] = True
     else:
         section["enabled"] = False
     if not enabled:


### PR DESCRIPTION
## Summary

Fixes #109546.

Detected password managers (`op` for 1Password, `bw` for Bitwarden) follow an opt-out contract where an installed CLI is enabled automatically unless `vault.<name>.enabled: false` is configured.

However, `DEFAULT_CONFIG` in `hermes_cli/config_defaults.py` included `"enabled": False` under `vault.onepassword` and `vault.bitwarden`. Consequently:
1. `load_config()` / `load_config_readonly()` merged user config with `DEFAULT_CONFIG`, falling back to `enabled: False`.
2. Enabling a manager via Desktop Settings (`vault.source.set`) or CLI (`hermes vault sources --enable`) popped the `enabled` key expecting default opt-out behavior, but the merged config retained `enabled: False`, leaving the manager stuck in `turned off`.

## Changes

1. **`hermes_cli/config_defaults.py`**: Remove `"enabled": False` from `DEFAULT_CONFIG["vault"]` for `onepassword` and `bitwarden`, aligning defaults with the documented opt-out design.
2. **`tui_gateway/methods_vault.py` & `hermes_cli/vault.py`**: Explicitly set `section["enabled"] = True` when enabled through `vault.source.set` or CLI `--enable`.
3. **`tests/tui_gateway/test_vault_methods.py`**: Add regression test `test_sources_detected_by_default_and_toggleable` verifying detected managers are enabled by default and properly respond to disable and re-enable toggles.

## Verification

- `pytest tests/tui_gateway/test_vault_methods.py` passes (5/5).
- `pytest tests/test_browser_vault.py` passes.
