### PR TITLE
fix(kanban): dispatcher-presence probe checks the store home, not the profile home

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -104,15 +104,20 @@ def _check_dispatcher_presence(hermes_home: Optional[Path] = None) -> tuple[bool
 
     The dashboard plugin API passes it because the dashboard backend process can be running under a
     different HERMES_HOME than the profile the request targets, which otherwise produced a "no gateway is
-    running" warning against a perfectly healthy profile gateway (#71211). CLI callers leave it ``None`` and
-    keep the existing process-level behavior.
+    running" warning against a perfectly healthy profile gateway (#71211).
+
+    When ``hermes_home`` is ``None`` (the CLI), the probe resolves to the *kanban store's* home
+    (``kanban_home()``), not the active profile's ``HERMES_HOME``: the board is shared at the root home by
+    design (``kanban_db.kanban_home``), so a profile-scoped shell must not warn "no gateway" against a
+    healthy root gateway just because the profile's own ``gateway.pid`` is absent.
     """
     try:
         from gateway.status import resolve_gateway_liveness  # type: ignore
 
         # Same ladder as the dashboard status endpoints so PID-file-less / cross-container gateways
         # aren't misreported; use_cache=False because this one-shot probe must see the state now.
-        liveness = resolve_gateway_liveness(profile_dir=hermes_home, use_cache=False)
+        probe_dir = hermes_home if hermes_home is not None else kb.kanban_home()
+        liveness = resolve_gateway_liveness(profile_dir=probe_dir, use_cache=False)
     except Exception:
         return (True, "")  # can't probe — silent
     if liveness.probe_error:  # resolver swallows per-rung failures; "can't tell" != "no gateway"

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -967,6 +967,42 @@ def test_config_default_dispatch_in_gateway_is_true():
     )
 
 
+def test_dispatcher_presence_probe_scopes_to_kanban_home(monkeypatch, tmp_path):
+    """The CLI's "no gateway is running" warning must probe the kanban store's
+    home, not the active profile's HERMES_HOME. The board is shared at the root
+    home by design, so a profile-scoped shell must not warn against a healthy
+    root gateway just because the profile's own gateway.pid is absent."""
+    from gateway.status import GatewayLiveness
+    from hermes_cli import kanban as kb_cli
+    import hermes_cli.kanban_ops as kanban_ops
+
+    root = tmp_path / ".hermes"
+    profile_home = root / "profiles" / "secondary"
+    profile_home.mkdir(parents=True)
+
+    # The board is shared at the root home; the CLI's own HERMES_HOME is the
+    # profile dir (the exact scenario that previously mis-probed).
+    monkeypatch.setattr(kb, "kanban_home", lambda: root)
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    seen: dict[str, object] = {}
+
+    def fake_liveness(*, profile_dir=None, **kwargs):
+        seen["profile_dir"] = profile_dir
+        return GatewayLiveness(running=True, pid=4242, source="pid")
+
+    monkeypatch.setattr("gateway.status.resolve_gateway_liveness", fake_liveness)
+    monkeypatch.setattr(kanban_ops, "_kanban_config", lambda: {"dispatch_in_gateway": True})
+
+    running, message = kb_cli._check_dispatcher_presence()
+
+    assert running is True
+    assert "dispatch enabled" in message
+    assert seen.get("profile_dir") == root, (
+        f"probe should target the kanban store home {root}, got {seen.get('profile_dir')!r}"
+    )
+
+
 
 
 


### PR DESCRIPTION
## Problem

`hermes kanban create` warned **"No gateway is running"** against a healthy root gateway — the very gateway serving the board the card was written to — whenever it ran in a profile-scoped shell.

## Cause

`_check_dispatcher_presence` probed the gateway pid relative to the active profile's `HERMES_HOME`, while the kanban store resolves to the root home (shared by design). In a profile-scoped shell the probe therefore always missed.

## Fix

Resolve the probe against `kanban_home()` — the same home that resolves the store — so the warning reflects the gateway that is actually serving the board.

## Regression coverage

`test_dispatcher_presence_probe_scopes_to_kanban_home` covers the profile-`HERMES_HOME` case: the probe targets the kanban store home, not the profile home.

Red on the base revision (1 failed) and green with the fix (24 passed, 1 skipped) via `scripts/run_tests.sh tests/hermes_cli/test_kanban_core_functionality.py`.

Split out of #108831 to keep one concern per PR; that PR keeps the diagnostics-hint fix.
