### PR TITLE
feat(gateway): opt-out for the post-upgrade auto-multiplex migration hook

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1955,6 +1955,13 @@ DEFAULT_CONFIG = {
         # served together — the duplicate adapter is parked; `hermes profile create --clone`
         # therefore leaves messaging channels behind unless --clone-channels is passed.
         "multiplex_profiles": False,
+        # May `hermes update` fold this install onto a multiplexed default gateway by itself?
+        # True (the default) keeps today's behaviour: a multi-profile install whose secondaries run
+        # their own gateways is migrated automatically after an update when nothing blocks it.
+        # Set to False to stay on per-profile gateways — a durable opt-out that survives updates, so
+        # the decision is not re-litigated on every release. Only the AUTOMATIC path reads this:
+        # `hermes gateway migrate --multiplex` is an explicit request and always proceeds.
+        "auto_migrate": True,
         # Route inbound chats of the default profile's bots to another profile
         # (gateway/profile_routing.py): [{profile, platform, chat_id|user_id|guild_id|...}].
         # Most-specific match wins; only read by the multiplexing default gateway.

--- a/hermes_cli/gateway_migrate.py
+++ b/hermes_cli/gateway_migrate.py
@@ -216,6 +216,25 @@ def _read_multiplex_flag(default_home: Path) -> bool:
     return bool(cfg.get("multiplex_profiles") or gateway_section.get("multiplex_profiles"))
 
 
+def _read_auto_migrate_flag(default_home: Path) -> bool:
+    """``gateway.auto_migrate`` in the DEFAULT profile's config.yaml: may ``hermes update`` fold
+    this install onto a multiplexed gateway on its own? Absent (the default) means yes; an explicit
+    ``false`` is a durable opt-out that survives updates, so an operator who wants to stay on
+    per-profile gateways does not have to re-decide after every release. Only the AUTO path reads
+    this — ``hermes gateway migrate --multiplex`` is an explicit request and always proceeds."""
+    cfg_path = default_home / "config.yaml"
+    if not cfg_path.exists():
+        return True
+    from hermes_cli.config import read_user_config_raw
+    cfg = read_user_config_raw(cfg_path) or {}
+    gateway_section = cfg.get("gateway") if isinstance(cfg.get("gateway"), dict) else {}
+    for source in (gateway_section, cfg):
+        value = source.get("auto_migrate")
+        if value is not None:
+            return bool(value)
+    return True
+
+
 def _write_multiplex_flag(default_home: Path, value: bool) -> None:
     """Set ``gateway.multiplex_profiles`` in the DEFAULT profile's config.yaml through the config API
     (same read-guard + nested-set + atomic write ``hermes config set`` uses; no raw YAML edits)."""
@@ -660,8 +679,11 @@ def cmd_migrate(args) -> None:
 
 def maybe_auto_migrate_after_update() -> None:
     """``hermes update`` hook: with >= 2 profiles, per-profile gateways present and multiplex off,
-    migrate automatically when unblocked (deterministic, never prompts) or print the blocker block."""
+    migrate automatically when unblocked (deterministic, never prompts) or print the blocker block.
+    ``gateway.auto_migrate: false`` on the default profile opts out durably."""
     if _host_supports_migration() is not None:
+        return
+    if not _read_auto_migrate_flag(_default_home()):
         return
     plan = build_migration_plan()
     if plan.already_multiplexed or len(plan.profiles) < 2 or not plan.standalone_secondaries:

--- a/tests/hermes_cli/test_gateway_migrate_multiplex.py
+++ b/tests/hermes_cli/test_gateway_migrate_multiplex.py
@@ -173,6 +173,37 @@ def test_update_hook_never_touches_single_profile_or_already_multiplexed(fleet, 
     assert capsys.readouterr().out == "" and _config_flag(fleet.root) is None
 
 
+def test_auto_migrate_false_opts_out_of_the_update_hook_but_not_the_explicit_command(fleet, capsys):
+    """``gateway.auto_migrate: false`` is a durable opt-out: an otherwise-eligible fleet is left
+    alone by ``hermes update``, while the operator typing ``migrate --multiplex`` still migrates."""
+    assert gm.build_migration_plan().eligible_for_migration()  # would migrate but for the flag
+    (fleet.root / "config.yaml").write_text(
+        "model:\n  default: x\ngateway:\n  auto_migrate: false\n", encoding="utf-8")
+
+    gm.maybe_auto_migrate_after_update()
+    assert capsys.readouterr().out == ""
+    assert fleet.ops == [] and _config_flag(fleet.root) is None
+    assert fleet.services == {"coder": ("systemd", False), "ops": ("systemd", False)}
+    assert fleet.pids == {"coder": 4101, "ops": 4102}
+    assert not (fleet.root / gm.MANIFEST_NAME).exists()
+
+    # Absent (the default) and an explicit true both keep today's automatic behaviour.
+    assert gm._read_auto_migrate_flag(fleet.root) is False
+    (fleet.root / "config.yaml").write_text(
+        "model:\n  default: x\ngateway:\n  auto_migrate: true\n", encoding="utf-8")
+    assert gm._read_auto_migrate_flag(fleet.root) is True
+    (fleet.root / "config.yaml").write_text("model:\n  default: x\n", encoding="utf-8")
+    assert gm._read_auto_migrate_flag(fleet.root) is True
+
+    # The opt-out governs the AUTOMATIC path only: an explicit --multiplex is an explicit request.
+    (fleet.root / "config.yaml").write_text(
+        "model:\n  default: x\ngateway:\n  auto_migrate: false\n", encoding="utf-8")
+    with pytest.raises(SystemExit) as exc:
+        gm.cmd_migrate(SimpleNamespace(multiplex=True, standalone=False, dry_run=False, yes=True))
+    assert exc.value.code == 0
+    assert _config_flag(fleet.root) is True and (fleet.root / gm.MANIFEST_NAME).exists()
+
+
 def test_explicit_migrate_with_no_standalone_secondaries_still_flips_flag_and_restarts_default(fleet, capsys, monkeypatch):
     """The user typed --multiplex: 'nothing to migrate' + flag left off was a no-op the user did not ask
     for. The update hook keeps its no-op (previous test); the explicit command proceeds."""

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -806,6 +806,23 @@ install that is already multiplexing is left alone. `hermes update` also does
 nothing when no secondary profile runs its own gateway — it never flips modes
 on an install where nothing was running.
 
+### Opting out of the automatic migration
+
+Set `gateway.auto_migrate: false` on the **default** profile to keep the
+automatic fold from ever running on this install:
+
+```bash
+hermes config set gateway.auto_migrate false
+```
+
+`hermes update` then leaves per-profile gateways exactly as they are, with no
+output and no changes, however eligible the install looks. The setting lives in
+config, so it survives updates — the decision is made once rather than
+re-litigated on every release. It governs the **automatic** path only:
+`hermes gateway migrate --multiplex` is an explicit request and still migrates
+(and is the supported way to opt back in). Absent or `true` keeps the default
+behaviour described above.
+
 The explicit command is different: `hermes gateway migrate --multiplex` with
 two or more profiles and **no** standalone secondary gateway still applies the
 one remaining step — it sets `gateway.multiplex_profiles: true`, (re)starts the


### PR DESCRIPTION
## What this changes

`hermes update` can fold an eligible multi-profile install onto a single multiplexed gateway by itself, and there is currently no way for an operator to say "not yet". This adds one: `gateway.auto_migrate`, a bool defaulting to `true`, read from the default profile's config.

- absent or `true` → today's behaviour exactly, byte for byte
- `false` → `maybe_auto_migrate_after_update()` returns before it builds a plan; no output, no changes, and the decision survives the next update

`hermes gateway migrate --multiplex` is an explicit request and still migrates regardless of the flag. The opt-out governs the automatic path only, which is also how the docs section frames it.

## Why the existing flag does not already do this

`gateway.multiplex_profiles: false` looks like the lever, but it is the default value: `_read_multiplex_flag()` returns `False` for "key absent" and for "operator wrote false" alike, so `plan.already_multiplexed` stays `False` and the migration proceeds either way. There is no state an operator can write down that means "I have considered this and I am staying on per-profile gateways."

## Why now

Two open upstream items say the automatic fold is ahead of its own schedule:

- #109417 (the multiplexing tracking issue) gates forced migration on a clean 24h soak plus a week of community "blocked" telemetry. Neither checklist item is ticked, but the update hook is already migrating installs without asking.
- #109473 (P1, open) documents that the way back is currently broken: `migrate --standalone` silently ignores `--dry-run`, the rollback can be SIGKILLed mid-flight by systemd `KillMode=mixed`, and a stale `served_profiles` entry then makes every `gateway install/start` exit 78. Until that is fixed, an automatic fold is closer to a one-way door than a reversible default.

An opt-out is the cheap thing that makes the soak safe rather than optional: installs that are not ready can hold, and the ones that do migrate become a cleaner data point.

## Our position, as one data point

This is a 6-profile macOS install. One process per profile means one crash takes one bot down rather than all six, and two of the profiles carry different local-model environment. We are not arguing against multiplexing — we would like to move when the rollback path in #109473 is fixed and the soak in #109417 has run. The ask is only: not automatically, and not before the soak.

## Scope

One early return, one schema entry with the reasoning inline as a comment, one invariant test, one docs section.

- `hermes_cli/gateway_migrate.py` — `_read_auto_migrate_flag()` alongside `_read_multiplex_flag()`, plus the early return in the update hook
- `hermes_cli/config_defaults.py` — `"auto_migrate": True`
- `tests/hermes_cli/test_gateway_migrate_multiplex.py` — `test_auto_migrate_false_opts_out_of_the_update_hook_but_not_the_explicit_command`: `false` blocks the hook, absent/`true` do not, and the explicit command still applies
- `website/docs/user-guide/multi-profile-gateways.md` — "Opting out of the automatic migration"

## Testing

`tests/hermes_cli/test_gateway_migrate_multiplex.py` + `tests/hermes_cli/test_update_multiplex_migration_hook.py`: 10 passed.

The new test was checked non-blind: with the early return deleted it fails; with it restored it passes.

Broader run of `tests/hermes_cli/ -k "config or gateway_migrate or multiplex"` gives 925 passed / 53 failed. The same selection on a clean tree at the same base commit gives 924 passed / 53 failed — the identical 53 failures (test-pollution under the broad selection; each file passes in isolation) and exactly one more pass, the new test. No failures are introduced by this change.
