### PR TITLE
refactor(secrets): agent/redact.py is the only secret-pattern source (A2A, gateway chat, monitoring); one .env tokenizer; scope-aware env shims removed

### DIFF
--- a/agent/monitoring/redaction.py
+++ b/agent/monitoring/redaction.py
@@ -1,9 +1,9 @@
 """Redaction applied to monitoring data before egress.
 
 One unconditional scrub, no modes, no knobs. Every string that leaves the process passes
-through ``redact_for_export``: secrets first (``agent/redact.py::redact_sensitive_text(force=True)``
-plus bearer/token shapes, failing CLOSED so a broken redactor never emits the raw string), then
-PII (e-mail, phone, UUID-shaped ids -> ``[email]`` / ``[phone]`` / ``[id]``).
+through ``redact_for_export``: secrets via ``agent/redact.py::redact_for_egress`` (the single
+pattern source; fails CLOSED so a broken redactor never emits the raw string), then PII
+(e-mail, phone, UUID-shaped ids -> ``[email]`` / ``[phone]`` / ``[id]``).
 """
 
 from __future__ import annotations
@@ -11,11 +11,7 @@ from __future__ import annotations
 import re
 from typing import Any, Optional
 
-# ── secret shapes (belt-and-suspenders on top of agent/redact.py) ───────────
-_BEARER_RE = re.compile(r"\bBearer\s+[A-Za-z0-9._~+\-/]+=*", re.IGNORECASE)
-_TOKEN_RE = re.compile(r"\b(xox[baprs]-[A-Za-z0-9-]+|sk-[A-Za-z0-9_-]{8,}|gh[pousr]_[A-Za-z0-9_]{8,})\b")
-_SECRET_LITERAL_RE = re.compile(r"\*{3,}")
-_BEARER_RESIDUE_RE = re.compile(r"\bBearer\s+\[[^\]]+\]", re.IGNORECASE)
+from agent.redact import REDACTION_UNAVAILABLE as UNAVAILABLE, redact_for_egress
 
 # ── PII shapes ───────────────────────────────────────────────────────────────
 _EMAIL_RE = re.compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}")
@@ -25,27 +21,12 @@ _PHONE_RE = re.compile(
 )
 _UUID_RE = re.compile(r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b")
 
-UNAVAILABLE = "[redaction-unavailable]"
-
-
-def _secret_redact(text: str) -> str:
-    """Always-on secret redaction. force=True so user config can't disable it."""
-    try:
-        from agent.redact import redact_sensitive_text
-        out = redact_sensitive_text(text, force=True)
-    except Exception:
-        # Fail CLOSED: if the redactor can't run, do not emit the raw string.
-        return UNAVAILABLE
-    for pattern in (_BEARER_RE, _TOKEN_RE, _SECRET_LITERAL_RE, _BEARER_RESIDUE_RE):
-        out = pattern.sub("[redacted]", out)
-    return out
-
 
 def redact_for_export(text: Optional[str]) -> Optional[str]:
     """Scrub a string for egress: secrets, then PII. Unconditional."""
     if text is None:
         return None
-    out = _secret_redact(str(text))
+    out = redact_for_egress(str(text))
     out = _EMAIL_RE.sub("[email]", out)
     out = _UUID_RE.sub("[id]", out)
     out = _PHONE_RE.sub("[phone]", out)

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -797,6 +797,25 @@ def is_env_dump_command(command: str | None) -> bool:
     return False
 
 
+REDACTION_UNAVAILABLE = "[redaction-unavailable]"
+_BEARER_RESIDUE_RE = re.compile(r"\bBearer\s+(?:\[[^\]]+\]|[A-Za-z0-9._~+/-]+=*)", re.IGNORECASE)
+
+
+def redact_for_egress(text: str) -> str:
+    """The one scrub for text leaving the process for a remote reader (chat platforms, A2A peers,
+    telemetry). ``redact_sensitive_text(force=True)`` — the only secret-pattern list — plus a bearer
+    sweep, because a ``Bearer <opaque>`` value with no vendor prefix carries no shape the prefix
+    matcher can key on. Fails CLOSED: if the redactor raises, the raw text is never returned."""
+    text = str(text or "")
+    try:
+        text = redact_sensitive_text(text, force=True)
+    except Exception:
+        return REDACTION_UNAVAILABLE
+    if "earer" in text:
+        text = _BEARER_RESIDUE_RE.sub("Bearer [redacted]", text)
+    return text
+
+
 def redact_terminal_output(output: str, command: str | None = None, *, force: bool = False) -> str:
     """Single redaction policy for ALL terminal-output surfaces: the ENV-assignment
     pass runs only when ``command`` is an env dump or reads a ``.env`` file

--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -11,6 +11,7 @@ falling back to ``os.environ``. Design: ``docs/design/multiplexing-gateway.md``.
 """
 from __future__ import annotations
 
+import codecs
 import os
 import re
 from contextvars import ContextVar, Token
@@ -137,6 +138,13 @@ def get_secret(name: str, default: Optional[str] = None) -> Optional[str]:
     return _environ_or(name, default)
 
 
+def get_secret_str(name: str, default: str = "") -> str:
+    """``get_secret`` for callers that want a ``str``: ``default`` only when the secret is genuinely
+    unset. Still raises ``UnscopedSecretError`` — swallowing it hides a spawn-site bug."""
+    val = get_secret(name, default)
+    return default if val is None else val
+
+
 def _strip_inline_comment(value: str) -> str:
     """Strip a dotenv-style inline comment (python-dotenv semantics): quoted values
     scan to the matching close quote (backslash-aware for double quotes) and drop a
@@ -160,17 +168,42 @@ def _strip_inline_comment(value: str) -> str:
     return re.split(r"\s+#", value, maxsplit=1)[0].strip()
 
 
+def _parse_env_value(raw_value: str) -> str:
+    """Parse the small .env value subset Hermes writes itself (bare, 'single', or "double" with
+    ``\\"`` / ``\\\\`` escapes)."""
+    value = raw_value.strip()
+    if len(value) >= 2 and value[0] == value[-1] == '"':
+        quoted = value[1:-1]
+        parsed: list[str] = []
+        i = 0
+        while i < len(quoted):
+            escaped = quoted[i] == "\\" and quoted[i + 1:i + 2] in ('"', "\\")
+            parsed.append(quoted[i + 1] if escaped else quoted[i])
+            i += 2 if escaped else 1
+        return "".join(parsed)
+    if len(value) >= 2 and value[0] == value[-1] == "'":
+        return value[1:-1]
+    return value
+
+
 def load_env_file(env_path: Path) -> Dict[str, str]:
-    """Parse a ``.env`` file into a dict WITHOUT touching ``os.environ``: ``export``
-    prefix, ``#`` comments, and the writer's quote escapes reversed via the canonical
-    ``_parse_env_value``. ``utf-8-sig`` so a BOM doesn't prefix the first key."""
+    """THE ``.env`` tokenizer: every reader (profile scope, ``hermes_cli.config.load_env``, the dashboard
+    scrub, skill secret capture, managed .env, setup prompts) parses through here so no two boundaries
+    disagree on which keys/values a file defines. Dict only — never touches ``os.environ``. ``export``
+    prefix, ``#`` comments, quote escapes reversed; ``utf-8-sig`` so a BOM doesn't prefix the first key.
+    Invalid UTF-8 decodes as latin-1, exactly like ``env_loader._load_dotenv_with_fallback`` installs it
+    into ``os.environ``. Absent/unreadable → ``{}``."""
     secrets: Dict[str, str] = {}
     try:
-        text = env_path.read_text(encoding="utf-8-sig")
-    except (FileNotFoundError, OSError, UnicodeDecodeError):
+        raw = env_path.read_bytes()
+    except OSError:
         return secrets
-
-    from hermes_cli.config import _parse_env_value
+    if raw.startswith(codecs.BOM_UTF8):
+        raw = raw[len(codecs.BOM_UTF8):]
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        text = raw.decode("latin-1")
 
     for raw in text.splitlines():
         line = raw.strip()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -392,14 +392,6 @@ _CONNECTION_ERROR_MARKERS = (
     r"cannot\s+connect", r"failed\s+to\s+establish", r"could\s+not\s+connect")
 _GATEWAY_CONNECTION_ERROR_RE = re.compile("(" + "|".join(_CONNECTION_ERROR_MARKERS) + ")", re.IGNORECASE)
 
-_GATEWAY_SECRET_PATTERNS = (
-    re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_\-]{12,}\b"),
-    re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"), re.compile(r"\bxapp-\d+-[A-Za-z0-9\-]{20,}\b"),
-    re.compile(r"\bxox[baprs]-[A-Za-z0-9\-]{20,}\b"), re.compile(r"\bhf_[A-Za-z0-9]{20,}\b"),
-    re.compile(r"\bglpat-[A-Za-z0-9_\-]{20,}\b"),
-    re.compile(r"(?i)\b(Bearer\s+)[A-Za-z0-9._\-]{20,}\b"))
-
-
 def _ensure_windows_gateway_venv_imports() -> None:
     """Make detached Windows gateway runs see the Hermes venv packages.
 
@@ -544,26 +536,11 @@ def _gateway_loop_exception_handler(
 
 
 def _redact_gateway_user_facing_secrets(text: str) -> str:
-    """Secret redaction before text can leave the gateway.
+    """Secret redaction before text can leave the gateway for a chat platform: the shared egress scrub
+    (``force=True`` holds even when ``security.redact_secrets`` is off; fails closed). See #23810."""
+    from agent.redact import redact_for_egress
 
-    Shared ``redact_sensitive_text`` with ``force=True`` (holds even when ``security.redact_secrets`` is off);
-    ``_GATEWAY_SECRET_PATTERNS`` is a second pass so redaction degrades gracefully if that import fails.
-
-    Delegates to the authoritative ``agent.redact.redact_sensitive_text`` — the same Tirith-grade redactor
-    already applied to logs, tool output, and approval-command prompts — so the outbound chat path masks the
-    full credential set the startup banner promises ("chat responses are scrubbed before delivery"), not a
-    divergent subset. See #23810.
-    """
-    redacted = str(text or "")
-    try:
-        from agent.redact import redact_sensitive_text
-
-        redacted = redact_sensitive_text(redacted, force=True)
-    except Exception:
-        pass  # fail-soft: the local pattern pass below still runs rather than leaking raw text to chat
-    for pattern in _GATEWAY_SECRET_PATTERNS:
-        redacted = pattern.sub(lambda m: (m.group(1) if m.lastindex else "") + "[REDACTED]", redacted)
-    return redacted
+    return redact_for_egress(text)
 
 
 def _redact_approval_command(cmd: "str | None") -> str:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2352,24 +2352,6 @@ def save_config(
         _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)
 
 
-def _parse_env_value(raw_value: str) -> str:
-    """Parse the small .env value subset Hermes writes itself (bare, 'single', or "double" with
-    ``\\"`` / ``\\\\`` escapes)."""
-    value = raw_value.strip()
-    if len(value) >= 2 and value[0] == value[-1] == '"':
-        quoted = value[1:-1]
-        parsed: list[str] = []
-        i = 0
-        while i < len(quoted):
-            escaped = quoted[i] == "\\" and quoted[i + 1:i + 2] in ('"', "\\")
-            parsed.append(quoted[i + 1] if escaped else quoted[i])
-            i += 2 if escaped else 1
-        return "".join(parsed)
-    if len(value) >= 2 and value[0] == value[-1] == "'":
-        return value[1:-1]
-    return value
-
-
 # load_env() memo keyed on (path, mtime, size). Editing .env bumps mtime -> rebuild;
 # invalidate_env_cache() is the explicit knob for writers on coarse-mtime filesystems.
 _env_cache: Optional[Tuple[Tuple[str, Optional[float], Optional[int]], Dict[str, str]]] = None
@@ -2391,13 +2373,9 @@ def load_env() -> Dict[str, str]:
     if cache_key is not None and _env_cache is not None and _env_cache[0] == cache_key:
         return dict(_env_cache[1])
 
-    env_vars: Dict[str, str] = {}
-    for line in _read_env_lines(env_path) if env_path.exists() else ():
-        line = line.strip()
-        if line and not line.startswith('#') and '=' in line:
-            # Bash-compatible ``export KEY=...`` parses as ``KEY``.
-            key, _, value = line.removeprefix('export ').partition('=')
-            env_vars[key.strip()] = _parse_env_value(value)
+    from agent.secret_scope import load_env_file  # the one .env tokenizer; also installs profile scopes
+
+    env_vars = load_env_file(env_path)
     if cache_key is not None:
         _env_cache = (cache_key, dict(env_vars))
     return env_vars

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -47,24 +47,11 @@ _PROFILE_MANAGED_ENV_KEYS: frozenset[str] = frozenset({
 
 
 def _env_keys_defined_in_dotenv(path: Path) -> set[str]:
-    """KEY names assigned in a dotenv file (including empty ``KEY=``). A fast line scanner (works in early
-    bootstrap without python-dotenv); decode errors fall back to latin-1 like ``_load_dotenv_with_fallback``."""
-    keys: set[str] = set()
-    try:
-        text = path.read_text(encoding="utf-8", errors="replace")
-    except Exception:
-        try:
-            text = path.read_text(encoding="latin-1", errors="replace")
-        except Exception:
-            return keys
-    for line in text.splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        key = line.removeprefix("export ").split("=", 1)[0].strip()
-        if key:
-            keys.add(key)
-    return keys
+    """KEY names assigned in a dotenv file (including empty ``KEY=``), via the same tokenizer that installs
+    profile scopes — a key the installer sees is a key the dashboard scrub sees (BOM'd first line included)."""
+    from agent.secret_scope import load_env_file
+
+    return set(load_env_file(path))
 
 
 def _clear_known_keys_missing_from_dotenv(path: Path) -> None:

--- a/hermes_cli/managed_scope.py
+++ b/hermes_cli/managed_scope.py
@@ -76,8 +76,7 @@ def _cached_read(path: Path, cache: Dict[str, tuple], parse):
         if hit is not None and hit[:2] == key:
             return copy.deepcopy(hit[2])
     try:
-        with open(path, encoding="utf-8") as f:
-            parsed = parse(f)
+        parsed = parse(path)
     except Exception as exc:  # noqa: BLE001 — fail-open, but LOUD
         logger.warning(
             "managed scope: failed to parse %s: %s — IGNORING this managed file. "
@@ -99,12 +98,19 @@ def _load_managed_file(name: str, cache: Dict[str, tuple], parse) -> dict:
 
 def load_managed_config() -> dict:
     """Parsed managed config.yaml, or {} when absent/malformed (fail-open)."""
-    return _load_managed_file("config.yaml", _CONFIG_CACHE, lambda f: yaml.safe_load(f) or {})
+    return _load_managed_file("config.yaml", _CONFIG_CACHE, lambda p: yaml.safe_load(p.read_text(encoding="utf-8")) or {})
 
 
 def load_managed_env() -> Dict[str, str]:
     """Parsed managed .env (KEY=VALUE), or {} when absent (fail-open)."""
-    return _load_managed_file(".env", _ENV_CACHE, _parse_env)
+    return _load_managed_file(".env", _ENV_CACHE, _parse_managed_env)
+
+
+def _parse_managed_env(path: Path) -> Dict[str, str]:
+    from agent.secret_scope import load_env_file
+
+    path.read_text(encoding="utf-8-sig")  # load_env_file swallows decode errors; an admin file must fail LOUD
+    return load_env_file(path)
 
 
 def apply_managed_overlay(config: dict) -> dict:
@@ -133,15 +139,6 @@ def apply_managed_overlay(config: dict) -> dict:
     except Exception:  # noqa: BLE001 — overlay must never break a caller
         logger.warning("managed scope: failed to apply config overlay", exc_info=True)
         return config
-
-
-def _parse_env(f) -> Dict[str, str]:
-    out: Dict[str, str] = {}
-    for line in map(str.strip, f):
-        if line and not line.startswith("#") and "=" in line:
-            key, _, value = line.partition("=")
-            out[key.strip()] = value.strip().strip("\"'")
-    return out
 
 
 def _flatten_keys(d: dict, prefix: str = "") -> set:

--- a/hermes_cli/profile_cmd.py
+++ b/hermes_cli/profile_cmd.py
@@ -31,21 +31,10 @@ def _is_active(p, active: str) -> bool:
 
 
 def _env_file_has_key(env_path: Path, key: str) -> bool:
-    """True when *key* is assigned in *env_path*. Read as utf-8-sig: a Notepad-edited .env can
-    carry a BOM that would hide the first key behind U+FEFF. A mis-encoded file (UnicodeDecodeError
-    is a ValueError, not OSError) must not abort the install preview — skip the pre-check."""
-    if not env_path.is_file():
-        return False
-    try:
-        # .env is written as UTF-8 everywhere in the codebase, but a Notepad-edited file can carry a BOM —
-        # read as utf-8-sig so the first key isn't hidden behind U+FEFF (#62617).
-        for raw in env_path.read_text(encoding="utf-8-sig").splitlines():
-            line = raw.strip()
-            if line and not line.startswith("#") and line.split("=", 1)[0].strip() == key:
-                return True
-    except (OSError, UnicodeDecodeError):
-        pass
-    return False
+    """True when *key* is assigned in *env_path* (unreadable/mis-encoded file → False, never aborts)."""
+    from agent.secret_scope import load_env_file
+
+    return key in load_env_file(env_path)
 
 
 def _render_distribution_plan(plan) -> None:

--- a/hermes_cli/proxy_cli.py
+++ b/hermes_cli/proxy_cli.py
@@ -14,6 +14,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from agent.proxy_sources import iron_proxy as ip
+from agent.redact import mask_secret
 from hermes_cli.config import load_config, load_env, save_config
 
 
@@ -457,7 +458,7 @@ def format_status_text(*, show_tokens: bool = False) -> str:
     if mappings:
         lines.extend(["", "Token mappings:"])
         for m in mappings:
-            tok = m.proxy_token if show_tokens else _redact_token(m.proxy_token)
+            tok = m.proxy_token if show_tokens else mask_secret(m.proxy_token)
             lines.append(f"  - {m.real_env_name}: {tok} ({', '.join(m.upstream_hosts)})")
     uncovered = ip.discover_uncovered_providers()
     if uncovered:
@@ -594,7 +595,7 @@ def _mappings_table(mappings, env_header: str, hosts_header: str, *, show_tokens
     table.add_column(hosts_header, style="dim")
     table.add_column("Proxy token", style="green")
     for m in mappings:
-        tok = m.proxy_token if show_tokens else _redact_token(m.proxy_token)
+        tok = m.proxy_token if show_tokens else mask_secret(m.proxy_token)
         table.add_row(m.real_env_name, ", ".join(m.upstream_hosts), tok)
     return table
 
@@ -638,9 +639,3 @@ def _status_rows(proxy_cfg: dict, status, *, yn, dim) -> list[tuple[str, str]]:
         ("Credential src", str(proxy_cfg.get("credential_source", "env"))),
         ("Docker enforce", yn(bool(proxy_cfg.get("enforce_on_docker", True)))),
     ]
-
-
-def _redact_token(token: str) -> str:
-    if len(token) < 16:
-        return token
-    return f"{token[:12]}…{token[-4:]}"

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -20,7 +20,7 @@ from agent.credential_pool import (  # custom_provider_pool_key_candidates is re
     CredentialPool, PooledCredential, credential_pool_matches_provider, custom_provider_pool_key_candidates,  # noqa: F401
     load_pool,
 )
-from agent.secret_scope import get_secret as _get_secret
+from agent.secret_scope import get_secret_str
 from hermes_cli.auth import (  # resolve_external_process_provider_credentials is read via origin by runtime_provider_backends
     ACTUAL_LOCAL_NOAUTH_PLACEHOLDER, AuthError, DEFAULT_CODEX_BASE_URL, DEFAULT_QWEN_BASE_URL, DEFAULT_XAI_OAUTH_BASE_URL,
     PROVIDER_REGISTRY, _agent_key_is_usable, _nous_inference_env_override, format_auth_error, resolve_provider,
@@ -49,13 +49,6 @@ def get_compatible_custom_providers(config=None):
 
 def normalize_extra_headers(value):
     return _config_mod.normalize_extra_headers(value)
-
-
-def _getenv(name: str, default: str = "") -> str:
-    """Profile-scoped ``os.getenv`` for credential/provider reads: identical to ``os.getenv`` when
-    multiplexing is off; scope-aware (fail-closed on an unscoped read) when on."""
-    val = _get_secret(name, default)
-    return val if val is not None else default
 
 
 def _loopback_hostname(host: str) -> bool:
@@ -309,7 +302,7 @@ def _host_derived_api_key(base_url: str) -> str:
     sanitized = "".join(ch if ch.isalnum() else "_" for ch in labels[-2]).upper() if len(labels) >= 2 else ""
     if not sanitized or not sanitized[0].isalpha() or sanitized in ("OPENAI", "OPENROUTER", "OLLAMA"):
         return ""
-    return (_getenv(f"{sanitized}_API_KEY", "") or "").strip()
+    return (get_secret_str(f"{sanitized}_API_KEY", "") or "").strip()
 
 
 def _host_gated_env_key_candidates(base_url: str, *, ollama: bool) -> list:
@@ -318,9 +311,9 @@ def _host_gated_env_key_candidates(base_url: str, *, ollama: bool) -> list:
     (GHSA-76xc-57q6-vm5m); match on HOST, not substring. ``_host_derived_api_key`` skips OLLAMA, so
     callers that want it opt in via ``ollama``."""
     is_openai = base_url_host_matches(base_url, "openai.com") or base_url_host_matches(base_url, "openai.azure.com")
-    candidates = [_getenv("OLLAMA_API_KEY", "").strip() if base_url_host_matches(base_url, "ollama.com") else ""] if ollama else []
-    return candidates + [_getenv("OPENAI_API_KEY", "").strip() if is_openai else "",
-                         _getenv("OPENROUTER_API_KEY", "").strip() if base_url_host_matches(base_url, "openrouter.ai") else "",
+    candidates = [get_secret_str("OLLAMA_API_KEY", "").strip() if base_url_host_matches(base_url, "ollama.com") else ""] if ollama else []
+    return candidates + [get_secret_str("OPENAI_API_KEY", "").strip() if is_openai else "",
+                         get_secret_str("OPENROUTER_API_KEY", "").strip() if base_url_host_matches(base_url, "openrouter.ai") else "",
                          _host_derived_api_key(base_url)]
 
 
@@ -341,7 +334,7 @@ def _nous_min_key_ttl() -> int:
 
 
 def _resolve_nous_creds() -> Dict[str, Any]:
-    return resolve_nous_runtime_credentials(timeout_seconds=float(_getenv("HERMES_NOUS_TIMEOUT_SECONDS", "15")))
+    return resolve_nous_runtime_credentials(timeout_seconds=float(get_secret_str("HERMES_NOUS_TIMEOUT_SECONDS", "15")))
 
 
 def _finalize_base_url(provider: str, api_mode: str, base_url: str) -> str:
@@ -414,7 +407,7 @@ def resolve_requested_provider(requested: Optional[str] = None) -> str:
     cfg_provider = _get_model_config().get("provider")
     if isinstance(cfg_provider, str) and cfg_provider.strip():
         return cfg_provider.strip().lower()
-    return _getenv("HERMES_INFERENCE_PROVIDER", "").strip().lower() or "auto"
+    return get_secret_str("HERMES_INFERENCE_PROVIDER", "").strip().lower() or "auto"
 
 
 # ── extracted collaborators (re-exported; see module docstring) ────────────────────────────
@@ -490,7 +483,7 @@ def _resolve_runtime_from_pool_entry(*, provider: str, entry: PooledCredential, 
 def _openrouter_should_use_pool(requested_provider, model_cfg, explicit_api_key, explicit_base_url) -> bool:
     """OpenRouter pool only for a plain openrouter/auto request with no custom endpoint or override."""
     cfg_base_url = str(model_cfg.get("base_url") or "").strip()
-    env_base_urls = _getenv("OPENAI_BASE_URL", "").strip() or _getenv("OPENROUTER_BASE_URL", "").strip()
+    env_base_urls = get_secret_str("OPENAI_BASE_URL", "").strip() or get_secret_str("OPENROUTER_BASE_URL", "").strip()
     # A config base_url under provider: openrouter is a mirror only when it is NOT the canonical
     # OpenRouter host — `hermes setup` persists https://openrouter.ai/api/v1 for plain installs,
     # and treating that as custom would drop the auth.json pool (empty key).
@@ -602,7 +595,7 @@ def _explicit_api_key_provider(provider, pconfig, requested_provider, model_cfg,
         elif provider in {"kimi-coding", "kimi-coding-cn"}:
             base_url = resolve_api_key_provider_credentials(provider).get("base_url", "").rstrip("/")
         else:
-            env_url = _getenv(pconfig.base_url_env_var, "").strip().rstrip("/") if pconfig.base_url_env_var else ""
+            env_url = get_secret_str(pconfig.base_url_env_var, "").strip().rstrip("/") if pconfig.base_url_env_var else ""
             base_url = env_url or pconfig.inference_base_url
     base_url = _actual_url(provider, base_url)
     if not api_key:
@@ -705,10 +698,10 @@ def _azure_anthropic_env_key(model_cfg: Dict[str, Any]) -> str:
     api_key (multi-profile setups), then the historical fixed names."""
     for hint_key in ("key_env", "api_key_env"):
         env_var = str(model_cfg.get(hint_key) or "").strip()
-        if env_var and (token := _getenv(env_var, "").strip()):
+        if env_var and (token := get_secret_str(env_var, "").strip()):
             return token
-    return (str(model_cfg.get("api_key") or "").strip() or _getenv("AZURE_ANTHROPIC_KEY", "").strip()
-            or _getenv("ANTHROPIC_API_KEY", "").strip())
+    return (str(model_cfg.get("api_key") or "").strip() or get_secret_str("AZURE_ANTHROPIC_KEY", "").strip()
+            or get_secret_str("ANTHROPIC_API_KEY", "").strip())
 
 
 def _anthropic_env_runtime(requested_provider: str, model_cfg: Dict[str, Any]) -> Dict[str, Any]:

--- a/hermes_cli/runtime_provider_backends.py
+++ b/hermes_cli/runtime_provider_backends.py
@@ -10,6 +10,7 @@ import os
 import re
 from typing import Any, Dict, Optional
 
+from agent.secret_scope import get_secret_str
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches
 
@@ -49,7 +50,7 @@ def _azure_foundry_api_key(rp, explicit_api_key: str) -> str:
         api_key = get_env_value("AZURE_FOUNDRY_API_KEY") or ""
     except Exception:
         api_key = ""
-    api_key = api_key or rp._getenv("AZURE_FOUNDRY_API_KEY", "").strip()
+    api_key = api_key or get_secret_str("AZURE_FOUNDRY_API_KEY", "").strip()
     if not api_key:
         raise rp.AuthError(
             "Azure Foundry requires an API key. Set AZURE_FOUNDRY_API_KEY in "
@@ -80,7 +81,7 @@ def _resolve_azure_foundry_runtime(*, requested_provider: str, model_cfg: Dict[s
     # GPT-5.x / codex / o1-o4 deployments are Responses-API-only on Foundry.
     effective_model = str(target_model or model_cfg.get("default") or "").strip()
     cfg_api_mode = rp._azure_inferred_api_mode(effective_model, cfg_api_mode)
-    env_base_url = rp._getenv("AZURE_FOUNDRY_BASE_URL", "").strip().rstrip("/")
+    env_base_url = get_secret_str("AZURE_FOUNDRY_BASE_URL", "").strip().rstrip("/")
     base_url = explicit_base_url_clean or cfg_base_url or env_base_url
     if not base_url:
         raise rp.AuthError(
@@ -126,8 +127,8 @@ def _resolve_openrouter_runtime(
     # Aliases resolving to "custom" (ollama, vllm, …) follow bare-custom trust + routing rules.
     if requested_norm and requested_norm != "custom" and rp._resolves_to_custom(requested_norm):
         requested_norm = "custom"
-    env_openrouter_base_url = rp._getenv("OPENROUTER_BASE_URL", "").strip()
-    env_custom_base_url = rp._getenv("CUSTOM_BASE_URL", "").strip()
+    env_openrouter_base_url = get_secret_str("OPENROUTER_BASE_URL", "").strip()
+    env_custom_base_url = get_secret_str("CUSTOM_BASE_URL", "").strip()
     use_config_base_url = bool(cfg_base_url.strip()) and not explicit_base_url and (
         (requested_norm == "auto" and cfg_provider in ("", "auto"))
         or (requested_norm == "custom" and rp._config_base_url_trustworthy_for_bare_custom(cfg_base_url, cfg_provider))
@@ -152,7 +153,7 @@ def _resolve_openrouter_runtime(
         )
     )
     if is_openrouter_context:
-        candidates = [explicit_api_key, rp._getenv("OPENROUTER_API_KEY"), rp._getenv("OPENAI_API_KEY")]
+        candidates = [explicit_api_key, get_secret_str("OPENROUTER_API_KEY"), get_secret_str("OPENAI_API_KEY")]
     else:
         candidates = [explicit_api_key, (cfg_api_key if use_config_base_url else ""),
                       *rp._host_gated_env_key_candidates(base_url, ollama=True)]

--- a/hermes_cli/runtime_provider_custom.py
+++ b/hermes_cli/runtime_provider_custom.py
@@ -12,6 +12,7 @@ import os
 from typing import Any, Callable, Dict, Optional
 
 from hermes_cli.providers import custom_provider_aliases, custom_provider_slug
+from agent.secret_scope import get_secret_str
 from utils import base_url_hostname
 
 logger = logging.getLogger("hermes_cli.runtime_provider")
@@ -116,9 +117,9 @@ def _match_new_style_provider(requested_norm: str, providers: Dict[str, Any]) ->
         if not isinstance(entry, dict) or not is_provider_enabled(entry):
             continue
         # API key from the env var named by key_env, else the inline api_key. Read BEFORE the
-        # alias match (scope-aware ``_getenv`` fails closed identically for every entry).
+        # alias match (scope-aware ``get_secret_str`` fails closed identically for every entry).
         key_env = _clean(entry.get("key_env") or entry.get("api_key_env"))
-        api_key = rp._getenv(key_env, "").strip() if key_env else ""
+        api_key = get_secret_str(key_env, "").strip() if key_env else ""
         if requested_norm not in custom_provider_aliases(str(entry.get("name", "") or ep_name), str(ep_name)):
             continue
         base_url = _entry_url(entry)
@@ -487,7 +488,7 @@ def _resolve_named_custom_runtime(*, requested_provider: str, explicit_api_key: 
     candidates = [
         explicit_key,
         _clean(custom_provider.get("api_key", "")),
-        rp._getenv(_clean(custom_provider.get("key_env", "")), "").strip(),
+        get_secret_str(_clean(custom_provider.get("key_env", "")), "").strip(),
         *rp._host_gated_env_key_candidates(base_url, ollama=False),
     ]
     api_key: Any = next((c for c in candidates if rp.has_usable_secret(c)), "")

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -109,12 +109,8 @@ def _xai_credentials_present() -> bool:
         return True
     except Exception:
         pass
-    try:
-        from tools.xai_http import get_env_value as _xai_get_env_value
-        if str(_xai_get_env_value("XAI_API_KEY") or "").strip():
-            return True
-    except Exception:
-        pass
+    if str(get_env_value("XAI_API_KEY") or "").strip():
+        return True
     try:
         from agent.secret_scope import get_secret
     except ImportError:  # pragma: no cover — secret_scope is in-repo

--- a/hermes_cli/web_server_cron.py
+++ b/hermes_cli/web_server_cron.py
@@ -297,21 +297,10 @@ def _fire_cron_job_for_profile(profile: str, job_id: str, *, force: bool = False
 
 
 def _profile_env_value(home: Path, key: str) -> str:
-    """Best-effort read of one KEY=VALUE line from a profile's .env file."""
-    try:
-        env_path = home / ".env"
-        if not env_path.is_file():
-            return ""
-        for line in env_path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if not line or line.startswith("#") or "=" not in line:
-                continue
-            k, v = line.split("=", 1)
-            if k.strip() == key:
-                return v.strip().strip('"').strip("'")
-    except Exception:
-        pass
-    return ""
+    """One value from a profile's .env (``""`` when absent/unreadable)."""
+    from agent.secret_scope import load_env_file
+
+    return load_env_file(home / ".env").get(key, "")
 
 
 def _gateway_fire_endpoint(profile: str, home: Path) -> str:

--- a/plugins/memory/honcho/oauth.py
+++ b/plugins/memory/honcho/oauth.py
@@ -21,6 +21,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from agent.redact import redact_sensitive_text, register_redaction_patterns
+
 logger = logging.getLogger(__name__)
 
 ACCESS_TOKEN_PREFIX = "hch-at-"
@@ -36,12 +38,10 @@ _REFRESH_TOTAL_BUDGET_SECONDS = 20.0
 _REFRESH_FAILURE_COOLDOWN_SECONDS = 30.0
 # OAuth error codes a retry can never fix — the grant itself is dead.
 _PERMANENT_OAUTH_ERRORS = frozenset({"invalid_grant", "invalid_client", "unauthorized_client"})
-# Derived from the canonical prefixes so a prefix change can't silently break redaction.
-_TOKEN_VALUE_RE = re.compile(rf"({re.escape(ACCESS_TOKEN_PREFIX)}|{re.escape(REFRESH_TOKEN_PREFIX)})[A-Za-z0-9._~+/=-]+")
-
-def redact_tokens(text: str) -> str:
-    """Replace any embedded token values with their prefix plus a placeholder."""
-    return _TOKEN_VALUE_RE.sub(lambda m: f"{m.group(1)}[redacted]", text)
+# Registered with the shared redactor so EVERY log/tool-output surface masks Honcho tokens, not only
+# this module's own error strings. Built from the constants so a prefix rename can't split them.
+register_redaction_patterns([f"{p}[A-Za-z0-9._~+/=-]{{8,}}" for p in (ACCESS_TOKEN_PREFIX, REFRESH_TOKEN_PREFIX)],
+                            source="plugin:honcho")
 
 class OAuthRefreshError(Exception):
     """Token endpoint rejected the refresh. ``permanent`` means re-login is required."""
@@ -229,7 +229,7 @@ def _exchange_refresh_token(
     if status >= 400:
         error, description = str(body.get("error") or ""), str(body.get("error_description") or "")
         detail = " — ".join(p for p in (error, description) if p) or "no error body"
-        message = redact_tokens(f"token endpoint returned HTTP {status}: {detail}")
+        message = redact_sensitive_text(f"token endpoint returned HTTP {status}: {detail}", force=True)
         raise OAuthRefreshError(message, error=error, permanent=error in _PERMANENT_OAUTH_ERRORS)
     return OAuthCredential.from_token_response(
         body, now=now, client_id=cred.client_id, token_endpoint=cred.token_endpoint,
@@ -249,7 +249,7 @@ def _exchange_with_retry(cred: OAuthCredential, *, now: float) -> OAuthCredentia
     remaining = deadline - time.monotonic() - _REFRESH_RETRY_DELAY_SECONDS
     if remaining <= 0:
         raise first
-    logger.warning("Honcho OAuth token exchange failed, retrying once: %s", redact_tokens(str(first)))
+    logger.warning("Honcho OAuth token exchange failed, retrying once: %s", redact_sensitive_text(str(first), force=True))
     time.sleep(_REFRESH_RETRY_DELAY_SECONDS)
     return _exchange_refresh_token(cred, now=now, timeout=min(remaining, _REFRESH_TIMEOUT_SECONDS))
 
@@ -267,7 +267,7 @@ def _rotate_and_persist(
                          "run 'hermes honcho setup' to re-authenticate", host, exc)
             return None
         _refresh_failure_at[key] = time.monotonic()
-        logger.warning("Honcho OAuth %s failed for host %s: %s", op_label, host, redact_tokens(str(exc)))
+        logger.warning("Honcho OAuth %s failed for host %s: %s", op_label, host, redact_sensitive_text(str(exc), force=True))
         return None
     _persist_credential(path, host, rotated)
     return rotated

--- a/plugins/memory/honcho/session_auth.py
+++ b/plugins/memory/honcho/session_auth.py
@@ -7,7 +7,7 @@ import re
 from pathlib import Path
 from typing import Any, Callable
 
-from plugins.memory.honcho.oauth import redact_tokens as _redact_tokens
+from agent.redact import redact_sensitive_text as _redact_sensitive_text
 
 logger = logging.getLogger("plugins.memory.honcho.session")
 
@@ -48,7 +48,7 @@ _REAUTH_REQUIRED_MESSAGE = (
 
 
 def _auth_error_message(exc: BaseException) -> str:
-    return (f"Honcho rejected our credentials and a forced token refresh did not recover: {_redact_tokens(str(exc))}. "
+    return (f"Honcho rejected our credentials and a forced token refresh did not recover: {_redact_sensitive_text(str(exc), force=True)}. "
             "Re-authenticate with 'hermes honcho setup'.")
 
 
@@ -56,7 +56,7 @@ class SessionAuthMixin:
     """Auth state + ``_authed_call`` for HonchoSessionManager (state lives in __init__)."""
 
     def _record_auth_failure(self, exc: BaseException) -> None:
-        detail = _redact_tokens(str(exc))
+        detail = _redact_sensitive_text(str(exc), force=True)
         if self._auth_failure is None:
             logger.error("Honcho authentication failed and token refresh did not recover; "
                          "memory sync and recall are paused until the user re-authenticates: %s", detail)
@@ -135,7 +135,7 @@ class SessionAuthMixin:
             if not _is_auth_error(e):
                 raise
             logger.warning("Honcho %s hit an auth error; forcing token refresh and retrying once: %s",
-                           op_name, _redact_tokens(str(e)))
+                           op_name, _redact_sensitive_text(str(e), force=True))
             if not self._force_reauth():
                 self._record_auth_failure(e)
                 raise HonchoAuthError(_auth_error_message(e)) from e

--- a/plugins/memory/mem0/_setup.py
+++ b/plugins/memory/mem0/_setup.py
@@ -52,10 +52,10 @@ def _http_get(url: str, path: str, timeout: int):
 def _prompt_api_key(label: str, env_var: str, hermes_home: str) -> str:
     """Prompt for API key, showing masked existing value if found."""
     existing = os.environ.get(env_var, "")
-    env_path = Path(hermes_home) / ".env"
-    if not existing and env_path.exists():  # utf-8-sig: a Notepad BOM on line 1 would otherwise defeat the key match
-        lines = env_path.read_text(encoding="utf-8-sig", errors="replace").splitlines()
-        existing = next((line.split("=", 1)[1].strip() for line in lines if line.startswith(f"{env_var}=")), "")
+    if not existing:
+        from agent.secret_scope import load_env_file
+
+        existing = load_env_file(Path(hermes_home) / ".env").get(env_var, "")
     hint = f" (current: {_masked(existing)}, blank to keep)" if existing else ""
     return getpass.getpass(f"  {label} API key{hint}: ").strip()
 

--- a/plugins/platforms/a2a/security.py
+++ b/plugins/platforms/a2a/security.py
@@ -139,17 +139,8 @@ PRIVACY_PREFIX = (
     "colleague's request.]\n\n"
 )
 
-# Credential-shaped strings we never want to ship to a peer in a task body.
-_REDACTION_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
-    (re.compile(r"sk-[A-Za-z0-9_\-]{16,}"), "sk-[redacted]"),
-    (re.compile(r"sk-ant-[A-Za-z0-9_\-]{16,}"), "sk-ant-[redacted]"),
-    (re.compile(r"ghp_[A-Za-z0-9]{20,}"), "ghp_[redacted]"),
-    (re.compile(r"xox[bap]-[A-Za-z0-9\-]{10,}"), "xox-[redacted]"),
-    (re.compile(r"AKIA[0-9A-Z]{16}"), "AKIA[redacted]"),
-    (re.compile(r"eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}"), "[redacted-jwt]"),
-    (re.compile(r"(?i)bearer\s+[A-Za-z0-9._\-]{20,}"), "Bearer [redacted]"),
-    (re.compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}"), "[redacted-email]"),
-)
+# PII the canonical secret redactor deliberately leaves alone; a peer is a third party.
+_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}")
 
 
 def filter_inbound(text: str) -> str:
@@ -166,10 +157,13 @@ def wrap_inbound(peer: str, text: str) -> str:
 
 
 def redact_outbound(text: str) -> str:
-    """Scrub credential-shaped substrings before sending text to a peer."""
-    for pat, repl in _REDACTION_PATTERNS if text else ():
-        text = pat.sub(repl, text)
-    return text
+    """Scrub credentials (the shared egress scrub — every pattern ``agent/redact.py`` knows, fail-closed)
+    and e-mail addresses before text ships to a remote peer."""
+    if not text:
+        return text
+    from agent.redact import redact_for_egress
+
+    return _EMAIL_RE.sub("[redacted-email]", redact_for_egress(text))
 
 
 # Blocked even in localhost-only mode — a remote peer must not make us probe internal services

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -1185,3 +1185,19 @@ class TestValueAwareGatingCorpus:
         result = redact_sensitive_text(block, force=True)
         assert prose_line in result
         assert "A9f3kZq7Lm2Xw8Rt4Yv6" not in result
+
+
+class TestRedactForEgress:
+    """``redact_for_egress`` is the single scrub every remote-reader surface (gateway chat, A2A, monitoring)
+    calls; there is no second pattern list to keep in sync."""
+
+    def test_opaque_bearer_without_vendor_prefix_is_masked(self):
+        from agent.redact import redact_for_egress
+        out = redact_for_egress("curl -H 'Authorization: Bearer opaque0123456789abcdef' https://x.example")
+        assert "opaque0123456789abcdef" not in out
+        assert "https://x.example" in out
+
+    def test_fails_closed_when_the_redactor_raises(self, monkeypatch):
+        from agent import redact as R
+        monkeypatch.setattr(R, "redact_sensitive_text", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+        assert R.redact_for_egress("sk-live-0123456789abcdef") == R.REDACTION_UNAVAILABLE

--- a/tests/gateway/test_multiplex_credential_isolation.py
+++ b/tests/gateway/test_multiplex_credential_isolation.py
@@ -20,11 +20,10 @@ def _reset(monkeypatch):
 
 
 class TestRuntimeProviderUsesScope:
-    """hermes_cli.runtime_provider._getenv resolves through the secret scope."""
-
+    """runtime_provider's credential reads (agent.secret_scope.get_secret_str) resolve through the scope."""
 
     def test_getenv_two_profiles_isolated(self, monkeypatch):
-        from hermes_cli.runtime_provider import _getenv
+        from agent.secret_scope import get_secret_str as _getenv
         ss.set_multiplex_active(True)
 
         tok_a = ss.set_secret_scope({"OPENAI_API_KEY": "sk-A"})

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -57,6 +57,36 @@ def test_utf8_bom_does_not_mangle_first_key(tmp_path, monkeypatch):
     assert os.environ.get("\ufeffFIRST_KEY") is None
 
 
+def test_bom_first_key_is_seen_by_installer_and_scrub_alike(tmp_path, monkeypatch):
+    """Invariant: the key set the dashboard/profile scrub computes (``_env_keys_defined_in_dotenv``) equals
+    the key set the installers define (``load_hermes_dotenv`` into os.environ, ``load_env_file`` into a
+    profile scope). A BOM'd first line, ``export``, quotes and inline comments must not split them —
+    a key one side sees and the other doesn't is a scrub miss."""
+    from hermes_cli.env_loader import _env_keys_defined_in_dotenv
+    from agent.secret_scope import load_env_file
+
+    home = tmp_path / "hermes"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_bytes(
+        b"\xef\xbb\xbfFIRST_KEY=first-value\n"
+        b"export EXPORTED_KEY='quoted # not a comment'\n"
+        b"COMMENTED_KEY=value # trailing comment\n"
+        b"EMPTY_KEY=\n"
+    )
+    for key in ("FIRST_KEY", "EXPORTED_KEY", "COMMENTED_KEY", "EMPTY_KEY", "\ufeffFIRST_KEY"):
+        monkeypatch.delenv(key, raising=False)
+
+    load_hermes_dotenv(hermes_home=home)
+    installed = {k for k in ("FIRST_KEY", "EXPORTED_KEY", "COMMENTED_KEY", "EMPTY_KEY") if k in os.environ}
+    scoped = load_env_file(env_file)
+
+    assert _env_keys_defined_in_dotenv(env_file) == installed == set(scoped)
+    assert "\ufeffFIRST_KEY" not in _env_keys_defined_in_dotenv(env_file)
+    assert scoped["EXPORTED_KEY"] == os.environ["EXPORTED_KEY"] == "quoted # not a comment"
+    assert scoped["COMMENTED_KEY"] == os.environ["COMMENTED_KEY"] == "value"
+
+
 def test_bomless_utf8_env_still_loads(tmp_path, monkeypatch):
     """BOM-less UTF-8 .env files must keep loading after utf-8-sig."""
     home = tmp_path / "hermes"

--- a/tests/honcho_plugin/test_auth_recovery.py
+++ b/tests/honcho_plugin/test_auth_recovery.py
@@ -153,14 +153,16 @@ class TestExchangeRetry:
         assert "invalid_grant" in caplog.text
         assert "grant revoked" in caplog.text
 
-    def test_redaction_strips_token_values(self):
-        redacted = oauth.redact_tokens(
-            "exchange failed for hch-rt-supersecret123 got hch-at-alsosecret456"
+    def test_honcho_token_prefixes_are_registered_with_the_shared_redactor(self):
+        """Importing the plugin registers hch-at-/hch-rt- with agent.redact, so every surface that
+        runs the shared redactor (logs, tool output, chat egress) masks Honcho tokens, not only
+        this module's own error strings."""
+        from agent.redact import redact_sensitive_text
+        redacted = redact_sensitive_text(
+            "exchange failed for hch-rt-supersecret123 got hch-at-alsosecret456", force=True
         )
         assert "supersecret123" not in redacted
         assert "alsosecret456" not in redacted
-        assert "hch-rt-[redacted]" in redacted
-        assert "hch-at-[redacted]" in redacted
 
 
 class TestForceRefreshToken:
@@ -537,7 +539,6 @@ class TestAuthNotice:
         mgr._record_auth_failure(Exception("rejected token hch-at-secretvalue99"))
         notice = mgr.pop_auth_notice()
         assert "secretvalue99" not in notice
-        assert "hch-at-[redacted]" in notice
 
     def test_provider_prefetch_injects_notice_once(self):
         class _FakeManager:

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -13,6 +13,7 @@ import asyncio
 import hashlib
 import hmac
 import json
+import re
 import os
 import socket
 import threading
@@ -176,17 +177,31 @@ class TestInjectionFilter:
 
 
 class TestOutboundRedaction:
-    def test_openai_key_redacted(self):
-        out = security.redact_outbound("my key is sk-abcdefghij1234567890XYZ")
-        assert "sk-abcdefghij" not in out
-        assert "[redacted]" in out
+    def test_every_canonical_credential_class_is_scrubbed(self):
+        """Invariant: redact_outbound masks everything redact_sensitive_text masks. A2A ships text to a
+        REMOTE peer, so a private subset here silently drops every prefix later added to agent/redact.py.
+        Corpus: one synthetic token per registered prefix pattern, built from the pattern's literal prefix."""
+        from agent import redact as R
 
-    def test_github_token_redacted(self):
-        out = security.redact_outbound("token ghp_0123456789abcdefghij0123")
-        assert "ghp_0123456789" not in out
+        bodies = ("Qq7zP2mX9vLk4nRt8wYb1cDf6gHj3sA0", "QQ7ZP2MX9VLK4NRT", "b-Qq7zP2mX9vLk4nRt8wYb1cDf6gHj3sA0",
+                  ".Qq7zP2mX9vLk4nRt8wYb1cDf6gHj3sA0", "1-Qq7zP2mX9vLk4nRt8wYb1cDf6gHj3sA0",
+                  "Qq7zP2mX9vLk4nRt8wYb1cDf6gHj3sA0.Qq7zP2mX9vLk4nRt8wYb1cDf6gHj3sA0")
+        tokens = []
+        for pattern in R._PREFIX_PATTERNS + R._plugin_patterns():
+            prefix = R._extract_literal_prefix(pattern)
+            token = next((prefix + body for body in bodies if re.fullmatch(pattern, prefix + body)), None)
+            assert token, f"could not synthesize a token for {pattern!r}"
+            tokens.append(token)
+        for token in tokens:
+            leaked = R.redact_sensitive_text(f"peer, here: {token}", force=True)
+            if token in leaked:
+                continue  # the canonical redactor itself passes it (word-boundary/shape rule); not our contract
+            assert token not in security.redact_outbound(f"peer, here: {token}"), token
+        assert len(tokens) >= 50
 
-    def test_email_redacted(self):
-        out = security.redact_outbound("contact me at alice@example.com")
+    def test_bearer_and_email_redacted(self):
+        out = security.redact_outbound("Authorization: Bearer opaque0123456789abcdef; contact me at alice@example.com")
+        assert "opaque0123456789abcdef" not in out
         assert "alice@example.com" not in out
         assert "[redacted-email]" in out
 

--- a/tests/tools/test_transcription_dotenv_fallback.py
+++ b/tests/tools/test_transcription_dotenv_fallback.py
@@ -41,56 +41,6 @@ class TestProviderSelectionGate:
     configure ``{"enabled": True, "provider": ...}`` for explicit tests.
     """
 
-    def test_import_after_config_env_patch_uses_restored_dotenv_loader(self):
-        """Importing STT while hermes_cli.config.get_env_value is patched must
-        not freeze that temporary helper into this module forever.
-        """
-        import importlib
-        import hermes_cli.config as config_mod
-        from tools import transcription_tools as tt
-
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(config_mod, "get_env_value", lambda name, default=None: "")
-            tt = importlib.reload(tt)
-
-        try:
-            with patch.object(tt, "_HAS_FASTER_WHISPER", False), \
-                 patch.object(tt, "_HAS_OPENAI", True), \
-                 patch.object(tt, "_has_local_command", return_value=False), \
-                 patch("hermes_cli.config.load_env",
-                       return_value={"GROQ_API_KEY": "dotenv-secret"}):
-                assert tt._get_provider({"enabled": True, "provider": "groq"}) == "groq"
-        finally:
-            importlib.reload(tt)
-
-    def test_xai_resolver_import_after_config_env_patch_uses_restored_dotenv_loader(self):
-        """xAI HTTP auth must not cache a temporarily patched env helper."""
-        import importlib
-        import hermes_cli.config as config_mod
-        from tools import xai_http
-
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(config_mod, "get_env_value", lambda name, default=None: "")
-            xai_http = importlib.reload(xai_http)
-
-        try:
-            with patch(
-                "hermes_cli.runtime_provider.resolve_runtime_provider",
-                side_effect=RuntimeError("no oauth"),
-            ), patch(
-                "hermes_cli.auth.resolve_xai_oauth_runtime_credentials",
-                return_value={},
-            ), patch(
-                "hermes_cli.config.load_env",
-                return_value={"XAI_API_KEY": "dotenv-secret"},
-            ):
-                creds = xai_http.resolve_xai_http_credentials()
-        finally:
-            importlib.reload(xai_http)
-
-        assert creds["api_key"] == "dotenv-secret"
-
-
     def test_auto_detect_sees_dotenv_groq(self):
         """No local backend, no explicit provider — auto-detect should fall
         through to Groq when its key lives in dotenv only. Before the fix
@@ -132,7 +82,7 @@ class TestTranscribeCallSitesReadDotenv:
         fake_openai_module.APIConnectionError = Exception
         fake_openai_module.APITimeoutError = Exception
 
-        with patch.object(tt, "get_env_value", return_value="groq-dotenv-key"), \
+        with patch("hermes_cli.config.get_env_value", return_value="groq-dotenv-key"), \
              patch.object(tt, "_HAS_OPENAI", True), \
              patch.dict("sys.modules", {"openai": fake_openai_module}), \
              patch("builtins.open", MagicMock()):
@@ -163,7 +113,7 @@ class TestTranscribeCallSitesReadDotenv:
                 return "xai-dotenv-key"
             return None
 
-        with patch.object(tt, "get_env_value", side_effect=fake_get_env_value), \
+        with patch("hermes_cli.config.get_env_value", side_effect=fake_get_env_value), \
              patch.object(xai_http, "resolve_xai_http_credentials", return_value={
                  "provider": "xai-oauth",
                  "api_key": "subscription-oauth-token",
@@ -194,7 +144,7 @@ class TestTranscribeCallSitesReadDotenv:
                 return "elevenlabs-dotenv-key"
             return None
 
-        with patch.object(tt, "get_env_value", side_effect=fake_get_env_value), \
+        with patch("hermes_cli.config.get_env_value", side_effect=fake_get_env_value), \
              patch.object(tt, "_load_stt_config", return_value={}), \
              patch("requests.post", side_effect=fake_post), \
              patch("builtins.open", MagicMock()):

--- a/tests/tools/test_tts_dotenv_fallback.py
+++ b/tests/tools/test_tts_dotenv_fallback.py
@@ -35,7 +35,7 @@ def isolate_env(monkeypatch):
 class TestDotenvFallbackPerProvider:
     """For each affected provider, when only ``~/.hermes/.env`` carries the
     key, the provider must find it. These per-provider tests model that
-    dotenv-backed lookup by mocking ``tools.tts_tool.get_env_value`` directly;
+    dotenv-backed lookup by mocking ``hermes_cli.config.get_env_value`` directly;
     the separate regression-guard tests cover the lower-level
     ``hermes_cli.config.load_env`` integration. Before the fix, ``os.getenv``
     returned ``None`` and the provider raised
@@ -45,7 +45,7 @@ class TestDotenvFallbackPerProvider:
     def test_elevenlabs_reads_dotenv_key(self, tmp_path):
         from tools import tts_tool
 
-        with patch.object(tts_tool, "get_env_value", return_value="el-dotenv-key"), \
+        with patch("hermes_cli.config.get_env_value", return_value="el-dotenv-key"), \
              patch.object(tts_tool, "_import_elevenlabs") as mock_import:
             mock_client = MagicMock()
             mock_client.text_to_speech.convert.return_value = iter([b"audio"])
@@ -57,12 +57,10 @@ class TestDotenvFallbackPerProvider:
             mock_import.return_value.assert_called_once_with(api_key="el-dotenv-key")
 
     def test_xai_reads_dotenv_key(self, tmp_path):
-        """xAI TTS now resolves credentials through ``tools.xai_http``; the
-        dotenv fallback contract from #17140 is preserved by patching the
-        resolver's ``get_env_value`` rather than ``tts_tool.get_env_value``.
+        """xAI TTS resolves credentials through ``tools.xai_http``, which reads the
+        canonical ``hermes_cli.config.get_env_value`` — the dotenv contract from #17140.
         """
         from tools import tts_tool
-        from tools import xai_http
 
         captured: dict = {}
 
@@ -74,7 +72,7 @@ class TestDotenvFallbackPerProvider:
             response.raise_for_status = MagicMock()
             return response
 
-        with patch.object(xai_http, "get_env_value", return_value="xai-dotenv-key"), \
+        with patch("hermes_cli.config.get_env_value", return_value="xai-dotenv-key"), \
              patch("requests.post", side_effect=fake_post):
             tts_tool._generate_xai_tts("hi", str(tmp_path / "out.mp3"), {})
 
@@ -120,7 +118,7 @@ class TestDotenvFallbackPerProvider:
                 return "gemini-dotenv-key"
             return None
 
-        with patch.object(tts_tool, "get_env_value", side_effect=fake_get_env_value), \
+        with patch("hermes_cli.config.get_env_value", side_effect=fake_get_env_value), \
              patch("requests.post", side_effect=fake_post):
             tts_tool._generate_gemini_tts("hi", str(tmp_path / "out.wav"), {})
 
@@ -135,45 +133,6 @@ class TestRegressionGuard:
     ``hermes_cli.config.load_env`` to simulate ``~/.hermes/.env`` carrying the
     key while ``os.environ`` does not.
     """
-
-    def test_import_after_config_env_patch_uses_restored_dotenv_loader(self, tmp_path, monkeypatch):
-        """Importing TTS while hermes_cli.config.get_env_value is patched must
-        not freeze that temporary helper into this module forever.
-        """
-        import importlib
-        import hermes_cli.config as config_mod
-        from tools import tts_tool
-
-        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
-
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(config_mod, "get_env_value", lambda name: "")
-            tts_tool = importlib.reload(tts_tool)
-
-        try:
-            captured: dict = {}
-
-            def fake_post(url, **kwargs):
-                captured["headers"] = kwargs.get("headers", {})
-                response = MagicMock()
-                response.json.return_value = {
-                    "data": {"audio": b"\x00".hex()},
-                    "base_resp": {"status_code": 0},
-                }
-                response.raise_for_status = MagicMock()
-                return response
-
-            with patch(
-                "hermes_cli.config.load_env",
-                return_value={"MINIMAX_API_KEY": "dotenv-secret"},
-            ), patch("requests.post", side_effect=fake_post):
-                tts_tool._generate_minimax_tts(
-                    "hi", str(tmp_path / "out.mp3"), {}
-                )
-
-            assert captured["headers"]["Authorization"] == "Bearer dotenv-secret"
-        finally:
-            importlib.reload(tts_tool)
 
     def test_minimax_missing_when_only_in_dotenv_before_fix(self, tmp_path, monkeypatch):
         from tools import tts_tool

--- a/tests/tools/test_tts_macos_output.py
+++ b/tests/tools/test_tts_macos_output.py
@@ -35,7 +35,7 @@ def _run_stream(monkeypatch):
     """
     from tools.tts_tool_speaker import stream_tts_to_speaker
 
-    monkeypatch.setattr("tools.tts_tool.get_env_value",
+    monkeypatch.setattr("hermes_cli.config.get_env_value",
                         lambda name, default=None: "fake-key"
                         if name == "ELEVENLABS_API_KEY" else default)
     monkeypatch.setattr("tools.tts_tool._load_tts_config", lambda: {})

--- a/tests/tools/test_tts_minimax_region.py
+++ b/tests/tools/test_tts_minimax_region.py
@@ -20,7 +20,7 @@ CN_CREDENTIAL_SENTINEL = "FAKE_CN_CREDENTIAL"
 def _fake_minimax_credentials(monkeypatch):
     values = {}
     monkeypatch.setattr(
-        "tools.tts_tool.get_env_value",
+        "hermes_cli.config.get_env_value",
         lambda name, default=None: values.get(name, default),
     )
     return values

--- a/tests/tools/test_tts_provider_base_urls.py
+++ b/tests/tools/test_tts_provider_base_urls.py
@@ -62,7 +62,7 @@ def test_mistral_no_base_url_omits_server_url(tmp_path):
 
     out = tmp_path / "out.mp3"
     with patch.object(tts, "_import_mistral_client", return_value=_FakeMistral), \
-         patch.object(tts, "get_env_value", lambda k, *a: "key" if k == "MISTRAL_API_KEY" else None):
+         patch("hermes_cli.config.get_env_value", lambda k, *a: "key" if k == "MISTRAL_API_KEY" else None):
         tts._generate_mistral_tts("hi", str(out), {"mistral": {}})
 
     assert "server_url" not in captured

--- a/tests/tools/test_tts_pythonpath_fallback.py
+++ b/tests/tools/test_tts_pythonpath_fallback.py
@@ -139,7 +139,7 @@ class TestMistralSttPythonpathFallback:
             "mistralai.client": mock_mistralai,
         }), patch("tools.lazy_deps.ensure",
                   side_effect=FeatureUnavailable("stt.mistral", (), "test")), \
-             patch("tools.transcription_tools.get_env_value",
+             patch("hermes_cli.config.get_env_value",
                    return_value="test-key"):
             result = _transcribe_mistral(str(audio_file), "mistral-large-latest")
 

--- a/tests/tools/test_tts_streaming.py
+++ b/tests/tools/test_tts_streaming.py
@@ -141,7 +141,7 @@ def test_openai_streamer_prefers_configured_api_key(monkeypatch):
             self.audio.speech.with_streaming_response = _StreamingCreate()
 
     monkeypatch.setattr(ts, "resolve_openai_audio_api_key", lambda: "env-key")
-    monkeypatch.setattr(ts, "get_env_value", lambda key, *args: None)
+    monkeypatch.setattr("hermes_cli.config.get_env_value", lambda key, *args: None)
     monkeypatch.setattr("openai.OpenAI", _OpenAI)
 
     config = {

--- a/tests/tools/test_tts_xai_speech_tags.py
+++ b/tests/tools/test_tts_xai_speech_tags.py
@@ -201,7 +201,7 @@ def test_generate_xai_tts_prefers_explicit_api_key_over_oauth(tmp_path, monkeypa
     )
     monkeypatch.delenv("XAI_API_KEY", raising=False)
     monkeypatch.setattr(
-        "tools.xai_http.get_env_value",
+        "hermes_cli.config.get_env_value",
         lambda name, default=None: {
             "XAI_API_KEY": "paid-api-key",
             "XAI_BASE_URL": "https://staging.x.ai/v1/",

--- a/tests/tools/test_x_search_tool.py
+++ b/tests/tools/test_x_search_tool.py
@@ -365,7 +365,7 @@ def test_x_search_prefers_explicit_api_key_over_oauth(monkeypatch):
 
     monkeypatch.delenv("XAI_API_KEY", raising=False)
     monkeypatch.setattr(
-        "tools.xai_http.get_env_value",
+        "hermes_cli.config.get_env_value",
         lambda name, default=None: {
             "XAI_API_KEY": paid_key,
         }.get(name, default),
@@ -396,7 +396,7 @@ def test_x_search_bearer_helper_falls_back_to_oauth_without_api_key(monkeypatch)
 
     monkeypatch.delenv("XAI_API_KEY", raising=False)
     monkeypatch.setattr(
-        "tools.xai_http.get_env_value",
+        "hermes_cli.config.get_env_value",
         lambda name, default=None: default,
     )
     _install_fake_oauth_pool(monkeypatch, oauth_token)

--- a/tests/tools/test_xai_http_credentials.py
+++ b/tests/tools/test_xai_http_credentials.py
@@ -95,7 +95,7 @@ def test_prefer_api_key_wins_over_available_oauth(monkeypatch):
 
     monkeypatch.delenv("XAI_API_KEY", raising=False)
     monkeypatch.setattr(
-        "tools.xai_http.get_env_value",
+        "hermes_cli.config.get_env_value",
         lambda name, default=None: {"XAI_API_KEY": "paid-key-x1"}.get(name, default),
     )
     _install_fake_oauth_pool(monkeypatch, "oauth-token-x1")
@@ -118,7 +118,7 @@ def test_prefer_api_key_falls_back_to_oauth_without_explicit_key(monkeypatch):
 
     monkeypatch.delenv("XAI_API_KEY", raising=False)
     monkeypatch.setattr(
-        "tools.xai_http.get_env_value", lambda name, default=None: default
+        "hermes_cli.config.get_env_value", lambda name, default=None: default
     )
     _install_fake_oauth_pool(monkeypatch, "oauth-token-x1")
 
@@ -136,7 +136,7 @@ def test_prefer_api_key_honors_hermes_xai_base_url_with_validation(monkeypatch):
 
     monkeypatch.delenv("XAI_API_KEY", raising=False)
     monkeypatch.setattr(
-        "tools.xai_http.get_env_value",
+        "hermes_cli.config.get_env_value",
         lambda name, default=None: {
             "XAI_API_KEY": "paid-key-x1",
             "HERMES_XAI_BASE_URL": "https://staging.x.ai/v1",
@@ -149,7 +149,7 @@ def test_prefer_api_key_honors_hermes_xai_base_url_with_validation(monkeypatch):
     assert creds["base_url"] == "https://staging.x.ai/v1"
 
     monkeypatch.setattr(
-        "tools.xai_http.get_env_value",
+        "hermes_cli.config.get_env_value",
         lambda name, default=None: {
             "XAI_API_KEY": "paid-key-x1",
             "XAI_BASE_URL": "https://attacker.example/v1",

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -88,17 +88,11 @@ def _skill_lookup_path_error(name: str) -> Optional[str]:
 
 
 def load_env() -> Dict[str, str]:
-    """Load profile-scoped environment variables from HERMES_HOME/.env."""
-    env_path = get_hermes_home() / ".env"
-    env_vars: Dict[str, str] = {}
-    if env_path.exists():
-        # utf-8-sig: a Notepad BOM would otherwise glue U+FEFF onto the first key.
-        with env_path.open(encoding="utf-8-sig", errors="replace") as f:
-            for line in map(str.strip, f):
-                if line and not line.startswith("#") and "=" in line:
-                    key, _, value = line.removeprefix("export ").partition("=")
-                    env_vars[key.strip()] = value.strip().strip("\"'")
-    return env_vars
+    """Snapshot of HERMES_HOME/.env for the post-skill secret-capture diff (same tokenizer that
+    installs the profile scope, so a captured value never differs from the served one)."""
+    from agent.secret_scope import load_env_file
+
+    return load_env_file(get_hermes_home() / ".env")
 
 
 def set_secret_capture_callback(callback) -> None:

--- a/tools/transcription_cloud.py
+++ b/tools/transcription_cloud.py
@@ -3,8 +3,8 @@
 OpenAI-SDK-shaped backends (groq, openai, deepinfra), Mistral Voxtral, REST multipart
 backends (xAI, ElevenLabs), and OpenAI audio credential resolution (config > keyless
 local server > env > managed Nous gateway). Facade-owned state and helpers
-(``_HAS_OPENAI``, ``_resolve_provider_key``, ``_resolve_stt_language``, ``_load_stt_config``,
-``get_env_value``) are read lazily from ``tools.transcription_tools``.
+(``_HAS_OPENAI``, ``_resolve_provider_key``, ``_resolve_stt_language``, ``_load_stt_config``)
+are read lazily from ``tools.transcription_tools``.
 """
 
 from __future__ import annotations
@@ -227,7 +227,8 @@ def _transcribe_xai(
     file_path: str, model_name: str, *, language: Optional[str] = None, prompt: Optional[str] = None
 ) -> Dict[str, Any]:
     """Transcribe via xAI ``POST /v1/stt`` (multipart). Supports ITN, diarization, word timestamps."""
-    from tools.transcription_tools import _load_stt_config, _resolve_stt_language, get_env_value
+    from hermes_cli.config import get_env_value
+    from tools.transcription_tools import _load_stt_config, _resolve_stt_language
     from tools.xai_http import resolve_xai_http_credentials
     if prompt:
         _log_prompt_unsupported("STT provider 'xai'")
@@ -295,7 +296,8 @@ def _transcribe_elevenlabs(
     file_path: str, model_name: str, *, language: Optional[str] = None, prompt: Optional[str] = None
 ) -> Dict[str, Any]:
     """Transcribe using ElevenLabs Scribe STT API."""
-    from tools.transcription_tools import _load_stt_config, _resolve_provider_key, _resolve_stt_language, get_env_value
+    from hermes_cli.config import get_env_value
+    from tools.transcription_tools import _load_stt_config, _resolve_provider_key, _resolve_stt_language
     if prompt:
         _log_prompt_unsupported("STT provider 'elevenlabs'")
     api_key = _resolve_provider_key("ELEVENLABS_API_KEY", "elevenlabs")

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -43,23 +43,10 @@ from tools.transcription_command import (
 logger = logging.getLogger(__name__)
 
 
-def get_env_value(name, default=None):
-    """Read env values through the live config module (resolved per call: tests monkeypatch it around import)."""
-    try:
-        from hermes_cli.config import get_env_value as _get_env_value
-    except ImportError:
-        return os.getenv(name, default)
-    value = _get_env_value(name)
-    return default if value is None else value
-
-
 def _resolve_provider_key(env_var: str, provider_id: str) -> str:
     """STT API key via the shared voice-key resolver (config > env/.env > credential pool); resolved per call."""
-    try:
-        from tools.tool_backend_helpers import resolve_provider_secret
-    except ImportError:  # pragma: no cover — helpers are in-repo
-        return str(get_env_value(env_var) or "").strip()
-    return resolve_provider_secret(env_var, provider_id, env_getter=get_env_value)
+    from tools.tool_backend_helpers import resolve_provider_secret
+    return resolve_provider_secret(env_var, provider_id)
 
 
 def _safe_find_spec(module_name: str) -> bool:

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -17,7 +17,7 @@ from abc import ABC, abstractmethod
 from typing import Callable, Dict, Iterator, List, Optional
 
 from tools.tool_backend_helpers import resolve_openai_audio_api_key
-from tools.tts_tool import _get_provider, _load_tts_config, get_env_value
+from tools.tts_tool import _get_provider, _load_tts_config
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +32,7 @@ def _resolve_key(env_var: str, provider_id: str) -> str:
         from tools.tts_tool import _resolve_provider_key
         return _resolve_provider_key(env_var, provider_id) or ""
     except Exception:
+        from hermes_cli.config import get_env_value
         return get_env_value(env_var) or ""
 
 
@@ -210,6 +211,7 @@ class OpenAIStreamer(StreamingTTSProvider):
 
     def stream(self, text: str) -> Iterator[bytes]:
         from openai import OpenAI
+        from hermes_cli.config import get_env_value
         client = OpenAI(
             api_key=(self.section.get("api_key") or resolve_openai_audio_api_key()),
             base_url=(self.section.get("base_url") or get_env_value("OPENAI_BASE_URL") or None))
@@ -238,6 +240,7 @@ class GeminiStreamer(StreamingTTSProvider):
         import requests
         from tools.tts_tool_providers import (
             DEFAULT_GEMINI_TTS_BASE_URL, DEFAULT_GEMINI_TTS_MODEL, DEFAULT_GEMINI_TTS_VOICE)
+        from hermes_cli.config import get_env_value
         api_key = _gemini_key()
         model = str(self.section.get("model", DEFAULT_GEMINI_TTS_MODEL)).strip() or DEFAULT_GEMINI_TTS_MODEL
         voice = str(self.section.get("voice", DEFAULT_GEMINI_TTS_VOICE)).strip() or DEFAULT_GEMINI_TTS_VOICE

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -26,23 +26,10 @@ from hermes_constants import display_hermes_home
 logger = logging.getLogger(__name__)
 
 
-def get_env_value(name, default=None):
-    """Read env values through the live config module (resolved per call so test patches apply)."""
-    try:
-        from hermes_cli.config import get_env_value as _get_env_value
-    except ImportError:
-        return os.getenv(name, default)
-    value = _get_env_value(name)
-    return default if value is None else value
-
-
 def _resolve_provider_key(env_var: str, provider_id: str) -> str:
     """Resolve a TTS provider API key via the shared voice-key resolver (config > env/.env > pool)."""
-    try:
-        from tools.tool_backend_helpers import resolve_provider_secret
-    except ImportError:  # pragma: no cover — helpers are in-repo
-        return str(get_env_value(env_var) or "").strip()
-    return resolve_provider_secret(env_var, provider_id, env_getter=get_env_value)
+    from tools.tool_backend_helpers import resolve_provider_secret
+    return resolve_provider_secret(env_var, provider_id)
 
 
 from tools.tts_command_provider import (

--- a/tools/tts_tool_providers.py
+++ b/tools/tts_tool_providers.py
@@ -3,7 +3,7 @@
 Each ``_generate_<provider>(text, output_path, tts_config) -> path`` writes one final-encoded
 file. Shared here: bounded upstream response reading (16 MiB cap so a hostile endpoint can't
 feed unbounded audio) and the auxiliary-model speech-tag rewrites. OpenAI/DeepInfra live in
-``tts_tool_openai``. Origin seams (``get_env_value``, ``_resolve_provider_key``, ``_import_*``)
+``tts_tool_openai``. Origin seams (``_resolve_provider_key``, ``_import_*``)
 are resolved through :func:`_origin` at call time.
 """
 
@@ -314,7 +314,8 @@ def _generate_xai_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -
     if creds.get("provider") == "xai-oauth":
         base_url = creds.get("base_url")
     else:
-        base_url = xai_config.get("base_url") or creds.get("base_url") or _origin().get_env_value("XAI_BASE_URL")
+        from hermes_cli.config import get_env_value
+        base_url = xai_config.get("base_url") or creds.get("base_url") or get_env_value("XAI_BASE_URL")
     base_url = str(base_url or DEFAULT_XAI_BASE_URL).strip().rstrip("/")
 
     # Documented minimal POST /v1/tts shape; optional fields only when they differ from defaults.
@@ -399,8 +400,9 @@ def _generate_minimax_tts(text: str, output_path: str, tts_config: Dict[str, Any
     base_url = runtime.endpoint
     # MiniMax scopes TTS requests by GroupId (``?GroupId=<id>`` on the t2a_v2 URL): config or
     # MINIMAX_GROUP_ID, attached only when absent from the URL.
+    from hermes_cli.config import get_env_value
     group_id = (str(mm_config.get("group_id") or "").strip()
-                or (_origin().get_env_value("MINIMAX_GROUP_ID") or "").strip())
+                or (get_env_value("MINIMAX_GROUP_ID") or "").strip())
     if group_id and "GroupId=" not in base_url:
         base_url = f"{base_url}{'&' if '?' in base_url else '?'}GroupId={group_id}"
     is_t2a_v2 = "t2a_v2" in base_url
@@ -565,7 +567,8 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     gemini_config = _section(tts_config, "gemini")
     model = str(gemini_config.get("model", DEFAULT_GEMINI_TTS_MODEL)).strip() or DEFAULT_GEMINI_TTS_MODEL
     voice = str(gemini_config.get("voice", DEFAULT_GEMINI_TTS_VOICE)).strip() or DEFAULT_GEMINI_TTS_VOICE
-    base_url = str(gemini_config.get("base_url") or origin.get_env_value("GEMINI_BASE_URL")
+    from hermes_cli.config import get_env_value
+    base_url = str(gemini_config.get("base_url") or get_env_value("GEMINI_BASE_URL")
                    or DEFAULT_GEMINI_TTS_BASE_URL).strip().rstrip("/")
     persona_prompt = _read_gemini_persona_prompt(gemini_config)
     tts_script = text

--- a/tools/voice_client_config.py
+++ b/tools/voice_client_config.py
@@ -100,7 +100,8 @@ def _resolve_stt_client_config() -> Dict[str, Any]:
         return _direct(wire, provider, base_url, api_key, model, language=language)
 
     def env_base_url(env_var: str, default: str) -> str:
-        return str(section.get("base_url") or tt.get_env_value(env_var) or default).strip().rstrip("/")
+        from hermes_cli.config import get_env_value
+        return str(section.get("base_url") or get_env_value(env_var) or default).strip().rstrip("/")
 
     if provider in _STT_KEYED:
         env_var, default_model, base = _STT_KEYED[provider]
@@ -120,7 +121,8 @@ def _resolve_stt_client_config() -> Dict[str, Any]:
     if provider == "xai":
         # API key only: an xAI OAuth bearer refreshes server-side mid-session and
         # would strand the client on the first 401.
-        api_key = str(tt.get_env_value("XAI_API_KEY") or "").strip()
+        from hermes_cli.config import get_env_value
+        api_key = str(get_env_value("XAI_API_KEY") or "").strip()
         if not api_key:
             return _relay("xai oauth (server-managed) or no credentials")
         return direct(STT_WIRE_XAI, env_base_url("XAI_STT_BASE_URL", tc.XAI_STT_BASE_URL), api_key, None)

--- a/tools/xai_http.py
+++ b/tools/xai_http.py
@@ -49,19 +49,6 @@ def has_xai_credentials() -> bool:
         return False
 
 
-def get_env_value(name: str, default=None):
-    """Read ``name`` from ``~/.hermes/.env`` first, then ``os.environ``.
-
-    Wraps :func:`hermes_cli.config.get_env_value` so tests can patch ``tools.xai_http.get_env_value``.
-    """
-    try:
-        from hermes_cli.config import get_env_value as _hermes_get_env_value
-    except ImportError:
-        return os.environ.get(name, default)
-    value = _hermes_get_env_value(name)
-    return value if value is not None else default
-
-
 def hermes_xai_user_agent() -> str:
     """Return a stable Hermes-specific User-Agent for xAI HTTP calls."""
     try:
@@ -178,11 +165,12 @@ def _resolve_explicit_xai_api_key() -> str:
     (incl. failing closed in a multiplexed gateway turn) is never re-implemented per caller.
     """
     from tools.tool_backend_helpers import resolve_provider_secret
-    return resolve_provider_secret("XAI_API_KEY", "xai", env_getter=get_env_value)
+    return resolve_provider_secret("XAI_API_KEY", "xai")
 
 
 def _xai_base_url_override() -> str:
     """``HERMES_XAI_BASE_URL`` then ``XAI_BASE_URL``, stripped; '' when unset."""
+    from hermes_cli.config import get_env_value
     return str(get_env_value("HERMES_XAI_BASE_URL") or get_env_value("XAI_BASE_URL") or "").strip().rstrip("/")
 
 
@@ -235,6 +223,7 @@ def resolve_xai_http_credentials(
     except Exception:
         pass
 
+    from hermes_cli.config import get_env_value
     api_key = _resolve_explicit_xai_api_key()
     base_url = str(get_env_value("XAI_BASE_URL") or DEFAULT_XAI_BASE_URL).strip().rstrip("/")
     return {"provider": "xai", "api_key": api_key, "base_url": base_url}


### PR DESCRIPTION
`agent/redact.py` is now the only secret-pattern source (A2A peers, gateway chat and monitoring export all scrub through one `redact_for_egress`), `agent/secret_scope.load_env_file` is the only `.env` tokenizer, and the non-plugin scope-aware env shims are gone.

## Changes

**Redaction (one pattern list)**
- New `agent/redact.py::redact_for_egress(text)`: `redact_sensitive_text(force=True)` + a bearer sweep for prefix-less opaque tokens, fail-closed (`[redaction-unavailable]`). `REDACTION_UNAVAILABLE` is exported for callers that surface the sentinel.
- `plugins/platforms/a2a/security.py::redact_outbound` called none of the canonical redactor: 8 private regexes (`ghp_` only, `xox[bap]` only, no `hf_`/`glpat-`/`xapp-`/private keys/DB URLs/env assignments/auth headers/plugin patterns) on text shipped to a **remote peer**. Now `redact_for_egress` + its e-mail pass.
- `gateway/run.py::_GATEWAY_SECRET_PATTERNS` and `agent/monitoring/redaction.py::_TOKEN_RE/_BEARER_RE/_SECRET_LITERAL_RE/_BEARER_RESIDUE_RE` (two additive "fallback" lists) deleted; both call `redact_for_egress`.
- `plugins/memory/honcho/oauth.py` registers `hch-at-`/`hch-rt-` via `register_redaction_patterns` at import, so every log/tool-output/chat surface masks Honcho tokens; its private `redact_tokens` is deleted (callers use `redact_sensitive_text(force=True)`).
- `hermes_cli/proxy_cli.py::_redact_token` → `mask_secret`.

**`.env` parsing (one tokenizer)**
- `hermes_cli/config.load_env` is memo over `load_env_file` (public signature unchanged); `_parse_env_value` moves next to its only caller in `agent/secret_scope.py`.
- `load_env_file` gains the latin-1 fallback `env_loader._load_dotenv_with_fallback` uses when installing into `os.environ`, so a mis-encoded file yields the same key set on both sides.
- Managed `.env` keeps its fail-LOUD contract (decode error logs "IGNORING this managed file" and returns `{}`).

**Scope-aware getter shims**
- New `agent/secret_scope.get_secret_str(name, default="")` — `default` only when genuinely unset, still raises `UnscopedSecretError`. `hermes_cli/runtime_provider._getenv` deleted; `runtime_provider`, `_backends`, `_custom` call it directly.
- `tools/tts_tool`, `tools/transcription_tools`, `tools/xai_http` `get_env_value` re-exports deleted; production reads `hermes_cli.config.get_env_value` lazily; tests patch the canonical.

## Sites

| path::symbol | → canonical |
|---|---|
| `plugins/platforms/a2a/security.py::redact_outbound` (+ `_REDACTION_PATTERNS`) | `agent.redact.redact_for_egress` + local e-mail regex |
| `gateway/run.py::_redact_gateway_user_facing_secrets` (+ `_GATEWAY_SECRET_PATTERNS`) | `agent.redact.redact_for_egress` |
| `agent/monitoring/redaction.py::_secret_redact` (+ 4 private regexes) | `agent.redact.redact_for_egress` |
| `plugins/memory/honcho/oauth.py::redact_tokens` (+ `_TOKEN_VALUE_RE`) | `register_redaction_patterns` + `redact_sensitive_text(force=True)` (also `session_auth.py`) |
| `hermes_cli/proxy_cli.py::_redact_token` | `agent.redact.mask_secret` |
| `hermes_cli/config.py::load_env` | memo over `agent.secret_scope.load_env_file` |
| `tools/skills_tool.py::load_env` | `load_env_file(get_hermes_home()/".env")` |
| `hermes_cli/managed_scope.py::_parse_env` | `_parse_managed_env` → `load_env_file` (fail-loud decode check kept) |
| `hermes_cli/web_server_cron.py::_profile_env_value` | `load_env_file(home/".env").get(key, "")` |
| `hermes_cli/profile_cmd.py::_env_file_has_key` | `key in load_env_file(path)` |
| `hermes_cli/env_loader.py::_env_keys_defined_in_dotenv` | `set(load_env_file(path))` |
| `plugins/memory/mem0/_setup.py::_prompt_api_key` | `load_env_file(...).get(env_var, "")` |
| `hermes_cli/runtime_provider.py::_getenv` (+ 8 `rp._getenv` sibling calls) | `agent.secret_scope.get_secret_str` |
| `tools/tts_tool.py`, `tools/transcription_tools.py`, `tools/xai_http.py` `::get_env_value` (+ callers in `tts_streaming`, `tts_tool_providers`, `transcription_cloud`, `voice_client_config`, `hermes_cli/tools_config`) | `hermes_cli.config.get_env_value` (lazy) |

Verified thin wrappers (call `redact_sensitive_text(force=True)` / `mask_secret` / `redact_cdp_url`, no private list; untouched): `agent/trace_upload._redact`, `hermes_cli/debug._redact_log_text`, `hermes_cli/dump._redact`, `plugins/observability/langfuse._redact_secrets`, `tools/browser_supervisor*`, `tools/browser_tool_snapshot`, `tools/delegation_live_log`, `tui_gateway/tool_progress`, `tools/terminal_tool`, `gateway/platforms/api_server`, `plugins/platforms/telegram/adapter`, `agent/context_compressor`, `hermes_cli/_scan_venv_blockers`, `hermes_cli/web_server_mcp`. `cron/incidents._redact_error` is not forced (user toggle honoured) — left as-is, noted for the persistence lane.

## Validation

| | before | after |
|---|---|---|
| A2A outbound `hf_…` / `glpat-…` / plugin-registered token / opaque `Bearer …` | shipped verbatim to the peer | masked |
| Gateway chat when the redactor raises | raw text (fail-soft second pass) | `[redaction-unavailable]` |
| `.env` with BOM on line 1: dashboard profile scrub key set vs installed keys | scrub saw `\ufeffFIRST_KEY`, installer saw `FIRST_KEY` (scrub miss) | identical sets |
| `export KEY='a # b'` via skills secret capture / managed .env / mem0 prompt | `a # b` with quotes stripped inconsistently, `export KEY` as key in managed | same value as the profile scope |
| `hermes proxy status` token column | 12 visible prefix chars | 4 (`mask_secret`) |

E2E (`execute_code`, worktree at `sys.path[0]`, `tools*/hermes*/agent*/gateway*` purged, temp `HERMES_HOME`): a `.env` with BOM, `export`, single/double quotes with escapes, inline comments, `foo#bar`, empty value — `load_env_file`, `config.load_env`, `skills_tool.load_env`, `managed_scope.load_managed_env`, `_env_keys_defined_in_dotenv`, `_env_file_has_key`, `_profile_env_value`, mem0 `_prompt_api_key` all agree; latin-1 file and missing file negative cases; UTF-16 managed file logs and is ignored; a plugin-registered pattern is masked on all three egress paths.

**Behavior change:** A2A egress masks the full canonical set; gateway chat returns the fail-closed sentinel instead of raw text when the redactor raises; Honcho token mask is the shared head/tail form (`hch-at...t456`) instead of `hch-at-[redacted]`, and applies on every surface; proxy token display shows 4 prefix chars instead of 12; managed `.env`, skills secret capture and mem0 setup now honour `export`/quote escapes/inline comments like the profile scope; dashboard scrub and cron profile port tolerate a BOM. `get_secret_str` was staged with the `.env` commit (same file), listed here for accuracy.

## Tests

- `tests/plugins/test_a2a_plugin.py::TestOutboundRedaction::test_every_canonical_credential_class_is_scrubbed` — synthesizes one token per registered prefix pattern (56 built-in + plugin) and asserts none survive `redact_outbound`. Sabotage: restored the old private-list `redact_outbound` → FAILS; restored fix → passes.
- `tests/hermes_cli/test_env_loader.py::test_bom_first_key_is_seen_by_installer_and_scrub_alike` — key set from `load_hermes_dotenv` (installer) == `load_env_file` (scope) == `_env_keys_defined_in_dotenv` (scrub) for a BOM/export/quoted/commented file. Sabotage: restored the old `_env_keys_defined_in_dotenv` → FAILS on `\ufeffFIRST_KEY`.
- `tests/agent/test_redact.py::TestRedactForEgress` — opaque bearer masked; fail-closed sentinel when the redactor raises.
- Repointed: honcho `test_auth_recovery` (registry, not private helper), `test_multiplex_credential_isolation` (`get_secret_str`), 10 `tests/tools/*` files (patch `hermes_cli.config.get_env_value`); two shim-forwarding tautologies deleted.

`scripts/run_tests.sh tests/hermes_cli/ tests/agent/ tests/plugins/ tests/tools/ tests/monitoring/ tests/honcho_plugin/ tests/gateway/test_multiplex_credential_isolation.py tests/gateway/test_telegram_noise_filter.py tests/test_iron_proxy_cli.py tests/test_redaction_registry.py tests/test_secret_scope*.py tests/test_env_loader_*.py` — 18,368 + 9,157 + 748 passed; the only failures (`test_update_head_moved_gate`, `test_modal_snapshot_isolation`, `test_web_tools_config` parallel client, `test_execution_flag_detection`) fail identically on a clean `origin/main` checkout.

## Infographic

![one-secret-pattern-source](https://v3b.fal.media/files/b/0aaa35df/MfRHNArGdpOxnv-cvBy9A_87n0KL3W.png)


## Review follow-ups

- `3c40fde3dad3` — `redact_for_egress`'s bearer sweep regains the 20-char token floor the gateway/A2A sweeps always had; prose like "the bearer of bad news" passes through, `Bearer eyJ…` / opaque 20+ tokens still mask. Invariant test `tests/agent/test_redact.py::TestRedactForEgress::test_bearer_sweep_masks_real_tokens_not_the_english_word` (red with the floor-less regex). Two monitoring fixtures used a 16-char `Bearer top-secret-token`; lengthened to a real-shaped 27-char value.
- `03e336477fbc` — `test_every_canonical_credential_class_is_scrubbed` no longer skips tokens the canonical redactor passes: every synthesized class (56 built-in + plugins) must scrub, and the count is exactly `len(_PREFIX_PATTERNS) + len(_plugin_patterns())`. `test_chat_gateways_redact_secret_in_non_error_body` asserts the canonical `***` mask only (dead `[REDACTED]` branch + stale comment removed). Unused `import re` dropped from `plugins/memory/honcho/oauth.py`.
- `4ffa1b8e741f` — `tests/hermes_cli/test_config.py::TestLoadEnvInlineComments` pins `load_env`'s dotenv inline-comment rule (see below).

**Behavior change:** the bearer floor is restored at 20 chars — `redact_for_egress("I'm the bearer of bad news")` is unchanged; `Bearer <20+ token chars>` masks (the same floor `gateway/run.py::_GATEWAY_SECRET_PATTERNS` and the old A2A list used).

**Behavior change:** monitoring export (`redact_for_export`) no longer masks 8–9 char `sk-`/`gh[pousr]_` bodies — the canonical prefix floor is `{10,}`. No real key format is that short (OpenAI `sk-` keys are 40+ chars, GitHub `ghp_/gho_/ghu_/ghs_/ghr_` tokens are 36+), so nothing real is lost; the floor was not lowered.

**Behavior change:** A2A outbound uses the canonical boundary guard `(?<![A-Za-z0-9_-])…(?![A-Za-z0-9_-])` (introduced with `_PREFIX_RE` in the OAuth redaction commit as a false-positive guard for identifiers that merely contain a prefix). The old boundary-less A2A list masked a prefix glued into a longer identifier — `xsk-abcdefghij123456` and `x-sk-abcdefghij123456` now ship verbatim. This is deliberate: the realistic leak shapes still mask (`token=sk-…`, `Bearer sk-…`, `/v1/sk-…`, `"key":"sk-…"` — `=`, `/`, `"`, `:` and whitespace are not in the boundary set); the only loss is a token fused to a preceding alphanumeric/`-`/`_`, which is not how a credential appears in prose, headers, URLs or JSON. No boundary-less variant added.

**Behavior change:** `hermes_cli.config.load_env` (the `get_env_value` reader) now strips unquoted dotenv inline comments, matching the profile secret scope and python-dotenv: `PASSWORD=abc #123` → `abc` (origin/main gave `abc #123`); `PASSWORD="abc #123"` → `abc #123` (quoted hash kept). `foo#bar` (no whitespace before `#`) is untouched. Hermes' own `.env` writer `hermes_cli/config._quote_env_value` (used by `save_env_value`/`save_env_value_secure`, dashboard register, auth) quotes any value containing `#`, so saved secrets round-trip; only a hand-edited unquoted ` #…` tail changes meaning. The mem0/hindsight/openviking plugin `_write_env` helpers write raw `KEY=VALUE` (values are provider API keys, none of which contain ` #`).
