### PR TITLE
docs(mcp): document per-profile OAuth identity isolation under multiplexing (#109422)

### DIFF
--- a/tests/tools/test_mcp_oauth_identity_isolation.py
+++ b/tests/tools/test_mcp_oauth_identity_isolation.py
@@ -1,0 +1,254 @@
+"""Two profiles that share an OAuth MCP server URL keep distinct identity state (#109422):
+
+a profile NEVER adopts another profile's live connection when the two authenticate as
+different users (different on-disk OAuth token files). Profiles with identical token
+state, or non-OAuth routes, still share as before.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_constants import hermes_home_key, reset_hermes_home_override, set_hermes_home_override
+
+OAUTH_CFG = {
+    "url": "https://mcp.example/cal",
+    "auth": "oauth",
+    "enabled": True,
+    "oauth": {"client_id": "shared-client", "scope": "calendar.events"},
+}
+
+
+def _tool():
+    return SimpleNamespace(name="whoami", description="d",
+                           inputSchema={"type": "object", "properties": {}}, annotations=None)
+
+
+def _server(name, cfg):
+    return SimpleNamespace(name=name, session=object(), _config=cfg, _tools=[_tool()],
+                           tool_timeout=30, initialize_result=None,
+                           _registered_tool_names=[], _sampling=None)
+
+
+def _seed_tokens(home: Path, owner: str) -> None:
+    """Pre-seed a completed OAuth flow for profile *owner* (what `hermes mcp login` would leave)."""
+    tok = home / "mcp-tokens"
+    tok.mkdir(parents=True, exist_ok=True)
+    (tok / "cal.json").write_text(json.dumps({
+        "access_token": f"tok-{owner}", "token_type": "Bearer",
+        "expires_in": 3600, "expires_at": time.time() + 3600,
+        "refresh_token": f"rt-{owner}", "scope": "calendar.events"}))
+    (tok / "cal.client.json").write_text(json.dumps({
+        "client_id": "shared-client",
+        "redirect_uris": ["http://127.0.0.1:8377/oauth/callback"],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "none"}))
+    (tok / "cal.meta.json").write_text(json.dumps({
+        "issuer": "https://accounts.example", "token_endpoint": "https://accounts.example/token"}))
+
+
+def _sync_token_files(src_home: Path, dst_home: Path) -> None:
+    dst = dst_home / "mcp-tokens"
+    dst.mkdir(parents=True, exist_ok=True)
+    for f in ("cal.json", "cal.client.json", "cal.meta.json"):
+        shutil.copy(src_home / "mcp-tokens" / f, dst / f)
+
+
+@pytest.fixture
+def two_profiles(tmp_path, monkeypatch):
+    """Multiplex on, clean MCP ledgers, a scope switcher for homes A and B; restores everything."""
+    import tools.mcp_tool as core
+    from tools import mcp_tool_config as _config
+    from tools.registry import registry
+
+    homes = {k: tmp_path / "profiles" / k for k in ("a", "b")}
+    for home in homes.values():
+        home.mkdir(parents=True)
+    monkeypatch.setattr("agent.secret_scope.is_multiplex_active", lambda: True)
+    monkeypatch.setattr(core, "_ensure_mcp_sdk", lambda: True)
+    monkeypatch.setattr(_config, "_filter_suspicious_mcp_servers", lambda servers: servers)
+    ledgers = ("_servers", "_server_scope_keys", "_server_tool_scopes", "_server_connecting",
+               "_server_connect_errors", "_server_connect_retry_after", "_server_connect_failures",
+               "_server_error_counts", "_server_breaker_opened_at", "_lazy_server_configs",
+               "_mcp_tool_server_names", "_orphaned_adopters")
+    saved = {n: type(getattr(core, n))(getattr(core, n)) for n in ledgers}
+    for n in ledgers:
+        getattr(core, n).clear()
+    tokens = []
+
+    def enter(which, seed=True):
+        home = homes[which]
+        if seed:
+            _seed_tokens(home, which.upper())
+        tokens.append(set_hermes_home_override(home))
+        return hermes_home_key(home)
+
+    yield enter, homes
+    for tool_name in ("mcp__cal__whoami", "mcp__x__whoami"):
+        for home in homes.values():
+            registry.deregister(tool_name, scope=hermes_home_key(home))
+    for token in reversed(tokens):
+        reset_hermes_home_override(token)
+    for n in ledgers:
+        getattr(core, n).clear()
+        getattr(core, n).update(saved[n])
+
+
+def test_oauth_profiles_with_distinct_tokens_do_not_cross_adopt(two_profiles):
+    """The #109422 acceptance case: two profiles, identical OAuth config, different token
+    files. B's discovery must NOT adopt A's live connection — B stays a connect candidate
+    so it opens its OWN connection authenticated as B's user."""
+    import tools.mcp_tool as core
+    from tools import mcp_tool_discovery as disc, mcp_tool_registration as reg
+    from tools.registry import registry
+
+    enter, _ = two_profiles
+    scope_a = enter("a")
+    srv_a = _server("cal", OAUTH_CFG)
+    disc._adopt_server("cal", srv_a)
+    srv_a._registered_tool_names = reg._register_server_tools("cal", srv_a, OAUTH_CFG)
+    assert registry.snapshot_registration("mcp__cal__whoami", scope=scope_a) is not None
+
+    scope_b = enter("b")
+    # B must not record itself into A's scope and must not be healed onto A's connection.
+    assert reg.register_connected_into_current_scope({"cal": OAUTH_CFG}) == 0
+    with core._lock:
+        assert scope_b not in core._server_tool_scopes.get((scope_a, "cal"), ())
+        assert (scope_b, "cal") not in core._servers
+    # B's own key stays a connect candidate: B will open its OWN connection (not shadowed by A).
+    assert "cal" in disc._select_new_servers({"cal": OAUTH_CFG})
+    assert registry.snapshot_registration("mcp__cal__whoami", scope=scope_b) is None
+
+
+def test_oauth_profiles_with_identical_token_state_still_share(two_profiles):
+    """Same token state on both sides is one identity: adoption still works — no regression
+    on the sharing fast path."""
+    import tools.mcp_tool as core
+    from tools import mcp_tool_discovery as disc, mcp_tool_registration as reg
+    from tools.registry import registry
+
+    enter, homes = two_profiles
+    scope_a = enter("a")
+    srv_a = _server("cal", OAUTH_CFG)
+    disc._adopt_server("cal", srv_a)
+    srv_a._registered_tool_names = reg._register_server_tools("cal", srv_a, OAUTH_CFG)
+
+    _sync_token_files(homes["a"], homes["b"])
+    scope_b = enter("b", seed=False)
+    assert reg.register_connected_into_current_scope({"cal": OAUTH_CFG}) == 1
+    assert registry.snapshot_registration("mcp__cal__whoami", scope=scope_b) is not None
+    with core._lock:
+        assert scope_b in core._server_tool_scopes.get((scope_a, "cal"), ())
+
+
+def test_non_oauth_shared_route_is_unchanged(two_profiles):
+    """No ``auth: oauth``: header/static routes keep the legacy credential-free sharing."""
+    import tools.mcp_tool as core
+    from tools import mcp_tool_discovery as disc, mcp_tool_registration as reg
+    from tools.registry import registry
+
+    cfg = {"url": "https://mcp.example/x", "headers": {"Authorization": "Bearer shared"}}
+    enter, _ = two_profiles
+    scope_a = enter("a", seed=False)
+    srv_a = _server("x", cfg)
+    disc._adopt_server("x", srv_a)
+    srv_a._registered_tool_names = reg._register_server_tools("x", srv_a, cfg)
+
+    scope_b = enter("b", seed=False)
+    assert reg.register_connected_into_current_scope({"x": cfg}) == 1
+    assert registry.snapshot_registration("mcp__x__whoami", scope=scope_b) is not None
+    with core._lock:
+        assert scope_b in core._server_tool_scopes.get((scope_a, "x"), ())
+
+
+def test_oauth_caller_without_token_file_still_adopts(two_profiles):
+    """Caller has ``auth: oauth`` but no token file yet (first-use profile): no identity to
+    compare, so the shared route is still adoptable — the pending flow behaves as before."""
+    import tools.mcp_tool as core
+    from tools import mcp_tool_discovery as disc, mcp_tool_registration as reg
+    from tools.registry import registry
+
+    enter, _ = two_profiles
+    scope_a = enter("a")
+    srv_a = _server("cal", OAUTH_CFG)
+    disc._adopt_server("cal", srv_a)
+    srv_a._registered_tool_names = reg._register_server_tools("cal", srv_a, OAUTH_CFG)
+
+    scope_b = enter("b", seed=False)  # B has NO mcp-tokens at all
+    assert reg.register_connected_into_current_scope({"cal": OAUTH_CFG}) == 1
+    assert registry.snapshot_registration("mcp__cal__whoami", scope=scope_b) is not None
+
+
+def test_oauth_credential_fingerprint_distinct_per_home(two_profiles):
+    """Direct check: token material under different homes produces different fingerprints,
+    and the same home compares stably (no per-call nonce)."""
+    from tools import mcp_tool_registration as reg
+
+    enter, homes = two_profiles
+    home_a = enter("a")   # seeds A's mcp-tokens
+    home_b = enter("b")   # seeds B's mcp-tokens (distinct token values)
+    assert home_b != home_a
+    fp_a = reg._oauth_credential_fingerprint("cal", "oauth", hermes_home=home_a)
+    fp_b = reg._oauth_credential_fingerprint("cal", "oauth", hermes_home=home_b)
+    assert fp_a and fp_b and fp_a != fp_b
+    assert fp_a == reg._oauth_credential_fingerprint("cal", "oauth", hermes_home=home_a)
+    # No auth method -> no fingerprint.
+    assert reg._oauth_credential_fingerprint("cal", "", hermes_home=home_a) is None
+
+
+def test_same_server_route_oauth_distinct_tokens(two_profiles):
+    """Predicate-level check of the adoption gate itself."""
+    from tools import mcp_tool_registration as reg
+
+    enter, homes = two_profiles
+    scope_a = enter("a")
+    srv_a = _server("cal", OAUTH_CFG)
+    enter("b")
+    # Different token files on both sides -> not the same route (the #109422 blocker).
+    assert reg._same_server_route(srv_a, OAUTH_CFG, "cal", owner_home=str(homes["a"])) is False
+    # Identical token content on both sides -> shareable.
+    _sync_token_files(homes["a"], homes["b"])
+    assert reg._same_server_route(srv_a, OAUTH_CFG, "cal", owner_home=str(homes["a"])) is True
+    # Different static route -> never shareable, regardless of token state.
+    other_route = dict(OAUTH_CFG, url="https://mcp.example/other")
+    assert reg._same_server_route(srv_a, other_route, "cal", owner_home=str(homes["a"])) is False
+    # Deliberately drop the owner hint: caller-without-token-files case still shares.
+    homes_b = homes["b"]
+    for f in ("cal.json", "cal.client.json", "cal.meta.json"):
+        (homes_b / "mcp-tokens" / f).unlink(missing_ok=True)
+    assert reg._same_server_route(srv_a, OAUTH_CFG, "cal") is True
+
+
+def test_single_profile_behavior_unchanged(tmp_path, monkeypatch):
+    """No multiplexer: bare name keys, self-comparison of the identity always passes, and
+    scoped no-ops stay no-ops — the legacy single-profile behavior, unchanged."""
+    import tools.mcp_tool as core
+    from tools import mcp_tool_discovery as disc, mcp_tool_registration as reg
+    from hermes_constants import get_hermes_home
+
+    home = tmp_path / "home"
+    home.mkdir()
+    _seed_tokens(home, "A")
+    monkeypatch.setattr("agent.secret_scope.is_multiplex_active", lambda: False)
+    tokens = [set_hermes_home_override(home)]
+    try:
+        srv = _server("cal", OAUTH_CFG)
+        assert core._mcp_registry_scope() is None
+        disc._adopt_server("cal", srv)
+        assert "cal" in core._servers  # bare name key, not (scope, name)
+        assert reg._same_server_route(srv, OAUTH_CFG, "cal") is True  # self-compare under own home
+        assert reg.register_connected_into_current_scope({"cal": OAUTH_CFG}) == 0  # no scope: no-op
+        assert str(get_hermes_home()) == str(home)
+    finally:
+        for token in reversed(tokens):
+            reset_hermes_home_override(token)
+        for key in ("cal", ("a", "cal"), ("b", "cal")):
+            core._servers.pop(key, None)
+            core._server_scope_keys.pop(key, None)

--- a/tools/mcp_tool_registration.py
+++ b/tools/mcp_tool_registration.py
@@ -3,6 +3,7 @@ include/exclude filtering, trust-tier metadata capture, utility-tool selection, 
 resolution and the schema-cache write-through. Both entry points (``_register_server_tools``
 live, ``_register_from_cache_sync`` lazy) build ``_Candidate`` records for ``_register_candidates``."""
 
+import hashlib
 import json
 import logging
 import threading
@@ -399,11 +400,36 @@ def _server_enabled(config: dict) -> bool:
     return _parse_boolish(config.get("enabled", True), default=True)
 
 
+def _oauth_credential_fingerprint(name: str, auth_method: str, hermes_home: Optional[str] = None) -> Optional[str]:
+    """Fingerprint of the profile identified by *hermes_home*'s on-disk OAuth token material for
+    *name* — the identity half that ``config_fingerprint`` deliberately omits. ``None`` when the
+    server is not OAuth-authenticated (with no per-profile credential material, two profiles on the
+    same route are one identity and sharing is safe) or when that profile has no token file yet
+    (a pending flow still rides the legacy shareable route)."""
+    if not (auth_method or "").lower().strip():
+        return None
+    from tools.mcp_oauth import _get_token_dir, _safe_filename
+
+    token_dir = _get_token_dir(hermes_home)
+    stem = _safe_filename(name)
+    material = []
+    for suffix in (".json", ".client.json", ".meta.json"):
+        path = token_dir / f"{stem}{suffix}"
+        data = path.read_bytes() if path.exists() else None
+        material.append(f"{suffix}:{hashlib.sha256(data).hexdigest() if data is not None else '-'}")
+    if ".json:-" in material:
+        return None
+    return hashlib.sha256("".join(material).encode("utf-8")).hexdigest()[:16]
+
+
 def _connection_identity(config: dict) -> tuple:
     """What makes one live connection reusable for another profile: the route fingerprint PLUS
     everything that authenticates it (``config_fingerprint`` deliberately excludes credentials so
     the schema cache survives a token rotation). Two profiles pointing at the same URL with different
-    headers/env/auth are two identities; borrowing across them would call tools as the other user."""
+    headers/env/auth are two identities; borrowing across them would call tools as the other user.
+    The per-profile OAuth token files are compared separately in ``_same_server_route``: two
+    profiles with their OWN token files are two identities even with identical static config, so
+    a profile never adopts a live connection authenticated as a different user (#109422)."""
     from tools.mcp_schema_cache import config_fingerprint
 
     def _frozen(value):
@@ -413,8 +439,24 @@ def _connection_identity(config: dict) -> tuple:
             (config.get("auth") or "").lower().strip())
 
 
-def _same_server_route(server: Any, config: dict) -> bool:
-    return _connection_identity(getattr(server, "_config", {}) or {}) == _connection_identity(config)
+def _same_server_route(server: Any, config: dict, server_name: str = "", *,
+                       owner_home: Optional[str] = None) -> bool:
+    """Adoption predicate: may the CALLING profile ride a live connection opened under
+    *owner_home*? The route + static-credential portion must match AND, when the server is
+    OAuth-authenticated, the owner's and caller's on-disk token state must be the same identity —
+    different users' token files are different identities even for the identical config block."""
+    server_identity = _connection_identity(getattr(server, "_config", {}) or {})
+    caller_identity = _connection_identity(config)
+    if server_identity != caller_identity:
+        return False
+    auth_method = caller_identity[3]
+    if not auth_method:
+        return True
+    owner_creds = _oauth_credential_fingerprint(server_name, auth_method, owner_home)
+    caller_creds = _oauth_credential_fingerprint(server_name, auth_method)
+    if owner_creds is None or caller_creds is None:
+        return True
+    return owner_creds == caller_creds
 
 
 def register_connected_into_current_scope(servers: dict) -> int:
@@ -448,7 +490,9 @@ def _register_connected_into_current_scope(servers: dict) -> int:
             server = _core._servers.get(key)
             config = servers.get(_key_name(key))
             if (config is None or not _server_enabled(config) or server is None
-                    or getattr(server, "session", None) is None or not _same_server_route(server, config)):
+                    or getattr(server, "session", None) is None
+                    or not _same_server_route(server, config, _key_name(key),
+                                              owner_home=_core._server_registry_scope(key))):
                 stale.append(key)
     for key in stale:
         _remove_server_scope(key, scope)
@@ -463,7 +507,8 @@ def _register_connected_into_current_scope(servers: dict) -> int:
             # Any other profile's live connection with the same route AND credentials is shareable.
             shared = [(key, live) for key, live in _core._servers.items()
                       if _key_name(key) == name and getattr(live, "session", None) is not None
-                      and _same_server_route(live, config)]
+                      and _same_server_route(live, config, name,
+                                             owner_home=_core._server_registry_scope(key))]
         if not shared:
             continue
         key, server = shared[0]

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -337,6 +337,27 @@ Behavior:
 - Token refresh is automatic; re-authorization only happens when refresh fails
 - Only applies to HTTP/StreamableHTTP transport (`url`-based servers)
 
+:::note Per-profile OAuth identity (multiplexed gateways)
+Token files live under the **active profile's** home: `~/.hermes/mcp-tokens/`
+for the default profile, `~/.hermes/profiles/<name>/mcp-tokens/` for a named
+profile. In a [multiplexed gateway](/user-guide/multi-profile-gateways#4-mcp-oauth-identity-is-per-profile)
+(`gateway.multiplex_profiles: true`), two profiles on the same server route
+share one live connection only when they present the same OAuth identity:
+identical configuration **and** identical on-disk token state. If profile A
+logged in as user A and profile B as user B, B gets its own connection and its
+tool calls run as B — a sibling profile can never ride A's Bearer token.
+:::
+
+:::warning Previous behavior: cross-profile identity adoption (fixed)
+Earlier builds shared a live connection across profiles as soon as the static
+configuration (URL, transport, headers, auth method) matched, ignoring the
+on-disk tokens — so two profiles with an identical `mcp_servers` block
+silently executed the second profile's calls under the first profile's OAuth
+account ([issue #109422](https://github.com/NousResearch/hermes-agent/issues/109422)).
+The fix is now in; pending first-logins (no token file yet) and non-OAuth
+routes still share as before.
+:::
+
 ### Device-code login (RFC 8628)
 
 For an authorization server advertising `device_authorization_endpoint`, explicitly choose

--- a/website/docs/user-guide/multi-profile-gateways.md
+++ b/website/docs/user-guide/multi-profile-gateways.md
@@ -284,7 +284,79 @@ adapter is always the secondary's (see
 [Token-conflict safety](#token-conflict-safety) — the rule is unchanged, it's
 just enforced inside the one process now).
 
-#### 4. Session keys are namespaced by profile
+#### 4. MCP OAuth identity is per profile
+
+MCP servers connected over HTTP/SSE with `auth: oauth` keep their token files
+in each profile's **own** home — `~/.hermes/mcp-tokens/<server>.json` for the
+default profile, `~/.hermes/profiles/<name>/mcp-tokens/<server>.json` for a
+named one (0o600; client registration and issuer metadata sit next to it as
+`<server>.client.json` / `<server>.meta.json`). Under multiplexing, two
+profiles on the same server route share one live connection only when they
+present the **same** OAuth identity:
+
+- **Same route, same account** — e.g. you logged every profile into the same
+  Portal org — share one connection. That is the efficient path: one
+  handshake, one token refresh, and an owner's `/reload-mcp` re-registers the
+  tools for the sharing profiles without them reloading.
+- **Same route, different accounts** (profile A signed in as user A, profile B
+  signed in as user B) each keep their own connection, and every tool call
+  under B's turn runs on B's OAuth account — never on A's.
+
+:::warning Previous behavior: cross-profile identity adoption (fixed)
+Before the fix shipped for [issue #109422](https://github.com/NousResearch/hermes-agent/issues/109422),
+the route-reuse check compared only the *static* configuration (URL,
+transport, headers, auth method) and deliberately ignored on-disk credentials —
+that design kept the schema cache alive across token rotation, but it meant
+two profiles with an **identical** `mcp_servers` block silently shared one
+live connection regardless of who had logged in on each side. Whichever
+profile ran discovery first won: the second profile's calls rode the first
+profile's Bearer token, so tool calls under profile B were executed **as A's
+OAuth account**, with no error and no config change to stop it. After the fix,
+a profile with its own token file for that route is treated as a distinct
+identity and opens its own connection; a profile with *no* token file yet
+(still mid-login) and non-OAuth routes still share as before, so
+single-profile behavior is byte-for-byte unchanged.
+:::
+
+Example — two profiles, one server route, two accounts:
+
+```yaml
+# ~/.hermes/config.yaml — default profile, user alice's org login
+mcp_servers:
+  team_api:
+    url: "https://mcp.team.example.com/mcp"
+    auth: oauth
+
+# ~/.hermes/profiles/coder/config.yaml — same server, bob's org login
+mcp_servers:
+  team_api:
+    url: "https://mcp.team.example.com/mcp"
+    auth: oauth
+```
+
+Each profile keeps its own login under its own `mcp-tokens/` directory and its
+turns authenticate as that profile's account. If both profiles log into the
+*same* OAuth account instead, they present one identity and share a single
+live connection as described above.
+
+:::info Caveats
+- Isolation follows the on-disk token state. Re-login a profile's
+  `mcp-tokens/<server>.json` with a different account and the route is
+  re-evaluated on the next connection — no restart is required, but an
+  already-established connection keeps its current identity until reloaded
+  (or the process restarts).
+- When neither profile has a token file yet (both first-time), the legacy
+  shareable route still applies: one profile can finish the browser login and
+  the sibling can adopt the resulting connection. This is the pending-flow
+  case, not a leak of an existing account.
+- This only affects multiplexed gateways (`gateway.multiplex_profiles: true`)
+  and other single-process, multi-profile setups. One gateway per profile —
+  the default — already isolates connections process-by-process.
+- Static-credential routes (custom `headers`, `identity_header`, mTLS) were
+  never shared across differing configs and are unaffected.
+:::
+
+#### 5. Session keys are namespaced by profile
 
 Each profile's sessions live under an `agent:<profile>:…` namespace so two
 profiles on the same platform/chat never collide in the shared session store.
@@ -303,7 +375,7 @@ The Desktop/TUI backend's own store is likewise pinned to the home it launched
 under, and a Bot Chat's side agents (`prompt.background`) persist next to their
 parent conversation.
 
-#### 5. One PID/lock and one status surface
+#### 6. One PID/lock and one status surface
 
 There is a single process-level PID and lock (the multiplexer, under the default
 home). `hermes status` on the default profile reports the multiplexer and lists


### PR DESCRIPTION
Document the per-profile OAuth identity isolation for shared MCP routes under multiplexing.

## Background

Issue #109422: with `gateway.multiplex_profiles: true`, two profiles with an
identical `mcp_servers` block (same URL, `auth: oauth`) silently shared one
live connection — the profile that ran discovery first won, and the sibling's
tool calls rode the first profile's Bearer token (executed as the other
user's OAuth account), with no error and no config change to stop it.

## This PR

The code fix (`9317655671`, included in this branch so the PR is testable end
to end) adds an OAuth-credential fingerprint to the route-adoption predicate
in `tools/mcp_tool_registration.py`: two profiles with **distinct** on-disk
token files are two identities and each keeps its own connection; pending
first-logins (no token file yet) and non-OAuth routes still share, keeping
single-profile behavior byte-for-byte unchanged.

This commit adds the user-facing documentation:

- `website/docs/user-guide/multi-profile-gateways.md` — new "What changes when
  multiplexing is on" section "MCP OAuth identity is per profile" with a
  warning about the previous cross-profile adoption behavior, a two-profile /
  two-account example, and caveats (token-state re-evaluation, pending-flow
  sharing, static-credential routes unaffected). Subsequent sections
  renumbered (session keys → 5, PID/lock → 6).
- `website/docs/reference/mcp-config-reference.md` — per-profile note plus a
  warning about the previous behavior in the OAuth 2.1 section.

## Caveats / review notes

- Branch is based on the fix commit `9317655671` (parent `de2d6a1b93`), which
  predates current upstream main; a rebase onto main before merge may be
  needed if upstream has touched the same docs sections.
- The code fix itself has open competing PRs (#109428, #109430, #109434);
  this PR's diff against those should be reviewed as the docs addendum that
  whichever code fix lands needs.
