### PR TITLE
fix(skills): stop nested support docs from shadowing real skills

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -76,17 +76,25 @@ def is_excluded_skill_path(path, *, root: Optional[Path] = None) -> bool:
 
 
 def is_skill_support_path(path, *, root: Optional[Path] = None) -> bool:
-    """True if *path* is under a support dir sitting directly inside a skill root
-    (``skills/scripts/foo`` stays discoverable: no ``SKILL.md`` above ``scripts``)."""
+    """True if *path* is under a support dir owned by an ancestor skill root.
+
+    Topic directories may sit between ``SKILL.md`` and the support directory;
+    top-level support-named categories remain discoverable because they have no
+    owning skill above them.
+    """
     path_obj = path if isinstance(path, Path) else Path(str(path))
-    parts = path_obj.parts
-    base = root if root is not None and not path_obj.is_absolute() else Path()
+    candidate = Path(root) / path_obj if root is not None and not path_obj.is_absolute() else path_obj
+    boundary = Path(root) if root is not None else Path(candidate.anchor)
     # Only components before the leaf can be containing support directories.
-    return any(
-        part in SKILL_SUPPORT_DIRS and (base / Path(*parts[:idx]) / "SKILL.md").exists()
-        for idx, part in enumerate(parts[:-1])
-        if idx > 0
-    )
+    for support_dir in candidate.parents:
+        if support_dir.name not in SKILL_SUPPORT_DIRS:
+            continue
+        for owner in support_dir.parents:
+            if (owner / "SKILL.md").exists():
+                return True
+            if owner == boundary:
+                break
+    return False
 
 
 _yaml_load_fn = None
@@ -768,12 +776,15 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
     org_root = os.path.join(skills_dir_str, ORG_MIRROR_DIR_NAME)
     matches: list[str] = []
     for root, dirs, files in os.walk(skills_dir_str, followlinks=True):
-        has_skill_md = "SKILL.md" in files
         if root == skills_dir_str and ORG_MIRROR_DIR_NAME in dirs and active_org is None:
             dirs.remove(ORG_MIRROR_DIR_NAME)
         elif root == org_root:
             dirs[:] = [d for d in dirs if d == active_org]
-        dirs[:] = [d for d in dirs if d not in EXCLUDED_SKILL_DIRS and not (has_skill_md and d in SKILL_SUPPORT_DIRS)]
+        dirs[:] = [
+            d for d in dirs
+            if d not in EXCLUDED_SKILL_DIRS
+            and not is_skill_support_path(Path(root) / d / filename, root=skills_dir)
+        ]
         if filename in files:
             matches.append(os.path.join(root, filename))
     yield from map(Path, sorted(matches))

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -196,12 +196,19 @@ def test_iter_skill_index_files_prunes_skill_support_dirs(tmp_path):
     script_package.mkdir(parents=True)
     (script_package / "SKILL.md").write_text("---\nname: helper\n---\n", encoding="utf-8")
 
+    nested_package = real / "creative" / "design" / "references" / "nested-skill"
+    nested_package.mkdir(parents=True)
+    (nested_package / "SKILL.md").write_text(
+        "---\nname: nested\n---\n", encoding="utf-8"
+    )
+
     found = list(iter_skill_index_files(tmp_path, "SKILL.md"))
     desc_found = list(iter_skill_index_files(tmp_path, "DESCRIPTION.md"))
 
     assert found == [real / "SKILL.md"]
     assert desc_found == []
     assert is_skill_support_path(package / "SKILL.md") is True
+    assert is_skill_support_path(nested_package / "SKILL.md") is True
     assert is_excluded_skill_path(package / "SKILL.md") is True
 
 

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -947,6 +947,32 @@ class TestSkillViewCollisionDetection:
         assert result["path"] == "creative/sketch/SKILL.md"
         assert "REAL SKETCH SKILL" in result["content"]
 
+    def test_nested_support_markdown_is_only_available_via_file_path(self, tmp_path):
+        local_dir = tmp_path / "local"
+        local_dir.mkdir()
+        owner = _make_skill(local_dir, "illustrator")
+        support_file = owner / "creative-design" / "references" / "sketch.md"
+        support_file.parent.mkdir(parents=True)
+        support_file.write_text("REFERENCE ONLY")
+
+        p1, p2 = self._patch_dirs(local_dir, [])
+        with p1, p2:
+            missing = json.loads(skill_view("sketch"))
+            reference = json.loads(
+                skill_view(
+                    "illustrator",
+                    file_path="creative-design/references/sketch.md",
+                )
+            )
+            _make_skill(local_dir, "sketch", body="REAL SKETCH SKILL")
+            real = json.loads(skill_view("sketch"))
+
+        assert missing["success"] is False
+        assert reference["success"] is True
+        assert reference["content"] == "REFERENCE ONLY"
+        assert real["success"] is True
+        assert "REAL SKETCH SKILL" in real["content"]
+
 
     def test_two_externals_same_name_also_refuse(self, tmp_path):
         """Collision detection is symmetric — two external dirs with

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -333,16 +333,16 @@ def _collect_skill_candidates(name, local_category_name, all_dirs):
             seen_md.add(key)
             candidates.append((sd, smd))
 
-    def _record_direct(direct_path: Path) -> None:  # "mlops/axolotl" / "axolotl" or its flat .md sibling
+    def _record_direct(direct_path: Path, search_dir: Path) -> None:  # "mlops/axolotl" / "axolotl" or its flat .md sibling
         flat = direct_path.with_suffix(".md")
-        if not _is_skill_support_path(direct_path) and direct_path.is_dir() and (direct_path / "SKILL.md").exists():
+        if not _is_skill_support_path(direct_path, root=search_dir) and direct_path.is_dir() and (direct_path / "SKILL.md").exists():
             _record(direct_path, direct_path / "SKILL.md")
-        elif flat.exists() and not _is_skill_support_path(flat):
+        elif flat.exists() and not _is_skill_support_path(flat, root=search_dir):
             _record(None, flat)
 
     for search_dir in all_dirs:
         for direct in filter(None, (name, local_category_name)):  # "p:x" with no plugin p → "p/x"
-            _record_direct(search_dir / direct)
+            _record_direct(search_dir / direct, search_dir)
         # Recursive by directory name plus frontmatter `name:` — skills_list()
         # exposes the frontmatter name, so skill_view(name) must accept it too.
         for found_skill_md in iter_skill_index_files(search_dir, "SKILL.md"):
@@ -352,7 +352,7 @@ def _collect_skill_candidates(name, local_category_name, all_dirs):
         # Legacy flat <name>.md anywhere under the dir; support docs are excluded
         # (they load via file_path and must not shadow real skills sharing the basename).
         for found_md in search_dir.rglob(f"{name}.md"):
-            if found_md.name != "SKILL.md" and not _is_skill_support_path(found_md):
+            if found_md.name != "SKILL.md" and not _is_skill_support_path(found_md, root=search_dir):
                 _record(None, found_md)
     return candidates
 


### PR DESCRIPTION
## What does this PR do?

`skill_view("sketch")` can currently treat `illustrator/creative-design/references/sketch.md` as a standalone legacy skill. That either loads support material as instructions or makes a real `sketch/SKILL.md` ambiguous. This change classifies support directories relative to any ancestor skill root, while preserving support-named top-level categories and explicit linked-file access.

### Symptom

A nested reference Markdown file can be returned as a standalone skill or collide with a real skill that shares its basename.

### Impact

Agents can receive the wrong instructions or fail to load the intended skill when a skill package organizes support material below intermediate topic directories.

### Bug Cause

**Trigger:** `agent/skill_utils.py:78` / `is_skill_support_path`

**Causal chain:**
1. A skill package places a support directory below one or more topic directories.
2. `is_skill_support_path` checks only whether the support directory's immediate parent contains `SKILL.md`.
3. The legacy Markdown candidate scan accepts the nested support file, so `skill_view` loads it or reports a false collision.

**Why it is wrong:** Support ownership is determined by an ancestor skill root, not only by the support directory's immediate parent.

**Working sibling / contrast:** A direct `skill/references/file.md` path is already excluded because its support directory is immediately below the skill root.

**Ruled out:** This is not caused by frontmatter aliases; the bad candidate is collected by basename before frontmatter can distinguish it.

### Fix

Walk ancestors above each support directory up to the discovery root when determining ownership. Apply the shared predicate to recursive index scanning and every direct or legacy candidate path, with regression coverage for nested support packages, real same-name skills, explicit file access, and existing support-named category behavior.

## Related Issue

Closes #109564

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/skill_utils.py` - recognize nested support directories owned by ancestor skill roots and prune them from shared scans.
- `tools/skills_tool.py` - use discovery-root-bounded support classification for all candidate strategies.
- `tests/agent/test_skill_utils.py` - cover nested support package pruning.
- `tests/tools/test_skills_tool.py` - cover nested support Markdown lookup, explicit access, and a real same-name skill.

## How to Test

1. The new resolver regression fails on `main` because bare `skill_view("sketch")` succeeds with the reference document; it passes on this branch.
2. The focused scanner and resolver invariants pass (6 tests):

```bash
scripts/run_tests.sh tests/agent/test_skill_utils.py -q -k 'prunes_skill_support_dirs or keeps_support_named_categories or uses_explicit_discovery_root'
scripts/run_tests.sh tests/tools/test_skills_tool.py -q -k 'nested_support_markdown_is_only_available_via_file_path or legacy_flat_md_skill_preserves_frontmatter_metadata or view_reference_files'
```

The complete two-file run also reaches 63 passing tests but retains four pre-existing Windows path-separator failures in untouched assertions.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [x] I've added tests for my changes.
- [x] I've tested on my platform: Windows 11.

### Documentation & Housekeeping

- [x] Relevant documentation and docstrings are updated.
- [x] Config examples are N/A because no config keys changed.
- [x] Contributor workflow docs are N/A because no workflow changed.
- [x] Cross-platform impact was considered; the implementation uses `pathlib` and existing scanner primitives.
- [x] Tool schema updates are N/A because the public schema is unchanged.
