### PR TITLE
fix(chat): recover a caller-bound encrypted reasoning replay rejection

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -579,6 +579,15 @@ def _provider_special_cases(c: _Ctx) -> Optional[Verdict]:
     # ``codex_reasoning_items`` — a genuine block with nothing to strip behaves as before.
     if _is_codex_masked_replay_rejection(c):
         return _v(_R.invalid_encrypted_content, **_ABORT_FALLBACK)
+    # The opencode relay's Console upstream seals replayed reasoning to the caller
+    # that minted it; after its key-rotated free pool changes callers mid-session it
+    # answers ``[invalid_request_error] reasoning `encrypted_content` was not issued
+    # to this caller`` (#109572). That buckets as format_error, so the one-shot strip
+    # in turn_recovery never runs and every retry resends the same poisoned history.
+    # Route it to invalid_encrypted_content — format_error's terminal hints kept —
+    # so turn_recovery's reasoning_details strip can repair the turn.
+    if _is_caller_bound_reasoning_replay_rejection(status, msg):
+        return _v(_R.invalid_encrypted_content, **_ABORT_FALLBACK)
     # Anthropic thinking-block 400s (signature mismatch after transcript
     # mutation). Not gated on provider — OpenRouter proxies Anthropic errors.
     if status == 400 and "thinking" in msg and any(p in msg for p in _THINKING_MUTATION_WORDS):
@@ -894,6 +903,18 @@ def _is_codex_masked_replay_rejection(c: "_Ctx") -> bool:
     return (c.code == "invalid_prompt" and body_msg == _CODEX_MASKED_REPLAY_MESSAGE) or (
         c.msg.strip() == f"invalid_prompt: {_CODEX_MASKED_REPLAY_MESSAGE}"
     )
+
+
+_CALLER_BOUND_REPLAY_MARKERS = ("encrypted_content", "not issued to this caller")
+
+
+def _is_caller_bound_reasoning_replay_rejection(status: Optional[int], msg: str) -> bool:
+    """HTTP 400 naming the replayed ``reasoning.encrypted_content`` as "not issued to
+    this caller" — the opencode relay's key-rotated free pool rejects caller-bound
+    reasoning blobs this way (muse-spark on opencode-free, #109572). Not gated on
+    provider: the wording is the Console upstream's and any relay fronting it reports
+    it verbatim; both markers together are too specific for an unrelated 400."""
+    return status == 400 and all(marker in msg for marker in _CALLER_BOUND_REPLAY_MARKERS)
 
 
 def _error_obj(body: Any) -> dict:

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -415,6 +415,43 @@ def _recover_format_errors(
         )
         return True
 
+    # 400 ``reasoning `encrypted_content` was not issued to this caller`` on a
+    # chat-completions ``reasoning_details`` replay (#109572): the blob is sealed to
+    # a caller the provider's pool no longer routes to (opencode-free key rotation),
+    # so it is permanently un-replayable. Strip the poisoned carrier from the
+    # persisted history and the in-flight request, retry once.
+    if (
+        classified.reason == FailoverReason.invalid_encrypted_content
+        and not _retry.invalid_encrypted_content_retry_attempted
+        and agent.api_mode == "chat_completions"
+        and any(
+            isinstance(_m, dict)
+            and _m.get("role") == "assistant"
+            and isinstance(_m.get("reasoning_details"), list)
+            and _m.get("reasoning_details")
+            for _m in messages
+        )
+    ):
+        _retry.invalid_encrypted_content_retry_attempted = True
+        _stripped = 0
+        for _m in messages:
+            if isinstance(_m, dict) and _m.get("reasoning_details"):
+                _m.pop("reasoning_details", None)
+                _stripped += 1
+        for _m in api_messages:
+            if isinstance(_m, dict) and "reasoning_details" in _m:
+                _m.pop("reasoning_details", None)
+        _vlines(
+            agent,
+            f"⚠️  Encrypted reasoning replay was rejected by the provider — "
+            f"stripped reasoning_details from {_stripped} message(s), retrying...",
+        )
+        logger.warning(
+            "%sInvalid encrypted reasoning recovery: stripped reasoning_details from %d messages",
+            agent.log_prefix, _stripped,
+        )
+        return True
+
     # Structured 400 naming ``context_management``: disable native compaction for the
     # session, retry once; local compression takes over.
     if (

--- a/tests/agent/test_caller_bound_reasoning_replay_recovery.py
+++ b/tests/agent/test_caller_bound_reasoning_replay_recovery.py
@@ -1,0 +1,136 @@
+"""A caller-bound ``reasoning_details`` replay rejection reaches the one-shot
+strip-and-retry recovery on chat completions (#109572).
+
+The opencode relay's Console upstream seals replayed reasoning to the caller
+that minted it; after its key-rotated free pool changes callers mid-session it
+answers ``[invalid_request_error] reasoning `encrypted_content` was not issued
+to this caller``. classify_api_error bucketed that as format_error, so the
+one-shot repair never ran, every retry resent the same poisoned history, and a
+long Desktop session became permanently uncontinuable. The classifier now
+routes the exact envelope to invalid_encrypted_content, and this recovery
+strips the sealed carrier from the persisted history and the in-flight
+request."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from agent.error_classifier import FailoverReason, classify_api_error
+from agent.turn_recovery import _recover_format_errors
+from agent.turn_retry_state import TurnRetryState
+
+_MESSAGE = (
+    "Error from provider (Console): Upstream request failed: "
+    "[invalid_request_error] reasoning `encrypted_content` was not issued to this caller"
+)
+_BODY = {"error": {"message": _MESSAGE, "type": "invalid_request_error", "param": None,
+                   "code": "invalid_request_error"}}
+
+
+class MockAPIError(Exception):
+    """Simulates an OpenAI SDK APIStatusError."""
+
+    def __init__(self, message, status_code=None, body=None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.body = body or {}
+
+
+def _history():
+    return [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi",
+         "reasoning_details": [{"type": "reasoning.encrypted", "data": "opaque-caller-bound-blob"}]},
+    ]
+
+
+def _agent(api_mode="chat_completions"):
+    agent = MagicMock()
+    agent.api_mode = api_mode
+    agent.log_prefix = "[test] "
+    return agent
+
+
+def test_caller_bound_replay_envelope_is_invalid_encrypted_content():
+    e = MockAPIError(f"Error code: 400 - {_MESSAGE}", status_code=400, body=_BODY)
+    result = classify_api_error(e, provider="opencode-free", model="muse-spark-1.3-contributor-free")
+    assert result.reason == FailoverReason.invalid_encrypted_content
+    # format_error's terminal hints kept — the verdict only buys the replay strip.
+    assert result.retryable is False and result.should_fallback is True
+
+
+def test_caller_bound_replay_envelope_stays_narrow():
+    # Same wording on a 5xx is a server error, not a replay rejection.
+    e = MockAPIError(f"Error code: 500 - {_MESSAGE}", status_code=500, body=_BODY)
+    assert classify_api_error(e, provider="opencode-free", model="m").reason != (
+        FailoverReason.invalid_encrypted_content
+    )
+    # A 400 naming encrypted_content without the caller wording keeps its own bucket.
+    e = MockAPIError(
+        "Error code: 400 - Unknown parameter: encrypted_content",
+        status_code=400,
+        body={"error": {"code": "unknown_parameter", "message": "Unknown parameter: encrypted_content"}},
+    )
+    assert classify_api_error(e, provider="opencode-free", model="m").reason != (
+        FailoverReason.invalid_encrypted_content
+    )
+
+
+def test_chat_completions_recovery_strips_reasoning_details_and_retries():
+    agent = _agent()
+    messages = _history()
+    api_messages = [dict(_m) for _m in messages]
+    classified = SimpleNamespace(reason=FailoverReason.invalid_encrypted_content)
+    _retry = TurnRetryState()
+
+    repaired = _recover_format_errors(
+        agent, MockAPIError(_MESSAGE, status_code=400, body=_BODY), classified, _retry,
+        messages, api_messages,
+    )
+
+    assert repaired is True
+    assert _retry.invalid_encrypted_content_retry_attempted is True
+    # The poisoned carrier is gone from both the persisted history and the request.
+    assert all("reasoning_details" not in _m for _m in messages)
+    assert all("reasoning_details" not in _m for _m in api_messages)
+
+
+def test_recovery_is_one_shot():
+    agent = _agent()
+    messages = _history()
+    _retry = TurnRetryState()
+    _retry.invalid_encrypted_content_retry_attempted = True
+    classified = SimpleNamespace(reason=FailoverReason.invalid_encrypted_content)
+
+    assert _recover_format_errors(
+        agent, MockAPIError(_MESSAGE, status_code=400), classified, _retry, messages, [dict(_m) for _m in messages],
+    ) is False
+    assert messages[1]["reasoning_details"]  # nothing was stripped
+
+
+def test_no_reasoning_details_no_new_recovery_path():
+    agent = _agent()
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+    ]
+    classified = SimpleNamespace(reason=FailoverReason.invalid_encrypted_content)
+    _retry = TurnRetryState()
+
+    assert _recover_format_errors(
+        agent, MockAPIError(_MESSAGE, status_code=400), classified, _retry, messages, [dict(_m) for _m in messages],
+    ) is False
+
+
+def test_codex_responses_mode_is_unchanged():
+    # The codex_responses branch still requires codex_reasoning_items; a history
+    # carrying only reasoning_details must not enter either strip path.
+    agent = _agent(api_mode="codex_responses")
+    agent._codex_reasoning_replay_enabled = True
+    messages = _history()
+    classified = SimpleNamespace(reason=FailoverReason.invalid_encrypted_content)
+    _retry = TurnRetryState()
+
+    assert _recover_format_errors(
+        agent, MockAPIError(_MESSAGE, status_code=400), classified, _retry, messages, [dict(_m) for _m in messages],
+    ) is False
+    assert messages[1]["reasoning_details"]


### PR DESCRIPTION
## What does this PR do?

Fixes a session-bricking provider rejection: on chat completions, when a relay's key-rotated free pool changes callers mid-session (opencode-free / muse-spark), the next turn replays the persisted `reasoning_details` (which carry caller-sealed `encrypted_content`) and the provider answers a non-retryable HTTP 400 `[invalid_request_error] reasoning `encrypted_content` was not issued to this caller`. `classify_api_error` bucketed that envelope as `format_error`, so the existing one-shot repair never ran — every retry resent the same poisoned history and a long Desktop session became permanently uncontinuable (#109572).

Two changes, mirroring the masked `invalid_prompt: Request blocked.` fix for openai-codex:

- `agent/error_classifier.py`: route the exact envelope (HTTP 400 + both `encrypted_content` and `not issued to this caller` markers) to `invalid_encrypted_content`, keeping `format_error`'s abort-and-fallback hints. Not gated on provider — the wording is the Console upstream's and any relay fronting it reports it verbatim; both markers together are too specific for an unrelated 400.
- `agent/turn_recovery.py`: add the chat-completions counterpart to the existing `codex_responses` one-shot strip-and-retry. The caller-bound blob is permanently un-replayable, so strip `reasoning_details` from the persisted history and the in-flight request, then retry once. A request with nothing to strip aborts exactly as before.

## Related Issue

Fixes #109572

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py` — new `_is_caller_bound_reasoning_replay_rejection` helper + one branch in `_provider_special_cases` classifying the envelope as `invalid_encrypted_content`
- `agent/turn_recovery.py` — one-shot `chat_completions` recovery branch in `_recover_format_errors` stripping `reasoning_details` from `messages` and `api_messages`
- `tests/agent/test_caller_bound_reasoning_replay_recovery.py` — regression tests for the classification (positive + narrow negatives) and the recovery (strip-and-retry, one-shot, no-target no-op, `codex_responses` unchanged)

## How to Test

1. `python -m pytest tests/agent/test_caller_bound_reasoning_replay_recovery.py -q` — 6 passed on this branch; on base the two core tests fail (envelope classified `format_error`, recovery returns False), which is exactly the reported brick.
2. `python -m pytest tests/agent/test_error_classifier.py tests/agent/test_turn_retry_state.py tests/agent/test_turn_recovery_retry_notice.py tests/agent/test_caller_bound_reasoning_replay_recovery.py tests/agent/test_nonretryable_result_carries_verdict.py -q` — 164 passed, no regressions in the classifier/retry domains.
3. Manual check (offline): simulate a provider returning the exact 400 from the issue against a session whose assistant history carries `reasoning_details` — observed result: the turn logs the strip warning, retries once without the sealed carrier, and the session continues instead of aborting.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — no skill added.

## Screenshots / Logs

Not applicable — behavior change is covered by the new regression tests (red on base, green on this branch).
