### PR TITLE
fix(cron): authenticate Chronos callbacks with the job profile

### DIFF
--- a/cron/chronos_fire_profiles.py
+++ b/cron/chronos_fire_profiles.py
@@ -1,72 +1,53 @@
 """Bounded job-to-profile hints for authenticated Chronos callbacks."""
 
-import os
-import uuid
+import hashlib
 from pathlib import Path
 from typing import Optional
 
-from cron.jobs import _job_output_dir
 from hermes_constants import get_default_hermes_root
-from utils import atomic_replace
-
-
-def _cron_fire_profile_index_dir() -> Path:
-    """Shared per-job profile hints for public Chronos fire callbacks."""
-    return get_default_hermes_root() / "cron" / "fire_profile_index"
+from utils import atomic_write_text
 
 
 def _cron_fire_profile_hint_path(job_id: str) -> Optional[Path]:
-    clean = str(job_id or "").strip()
-    if not clean:
+    if not isinstance(job_id, str) or not job_id or len(job_id) > 128:
         return None
     try:
-        _job_output_dir(clean)
-    except ValueError:
+        key = hashlib.sha256(job_id.encode("utf-8")).hexdigest()
+    except UnicodeError:
         return None
-    return _cron_fire_profile_index_dir() / f"{clean}.profile"
+    return get_default_hermes_root() / "cron" / "fire_profile_index" / f"{key}.profile"
 
 
 def resolve_cron_fire_profile_hint(job_id: str) -> Optional[str]:
-    """Return a bounded profile hint for a Chronos fire job, if known."""
-    path = _cron_fire_profile_hint_path(job_id)
-    if path is None or not path.is_file():
-        return None
-    try:
-        profile = path.read_text(encoding="utf-8").strip()
-    except Exception:
-        return None
-    return profile or None
+    """Read one bounded hint, never a profile/job scan or an authentication grant."""
+    from hermes_cli.profiles import validate_profile_name
 
-
-def record_cron_fire_profile_hint(job_id: str, profile: str) -> None:
-    """Persist a best-effort profile hint for a Chronos-armed job."""
-    clean_profile = str(profile or "").strip()
-    if not clean_profile or clean_profile == "custom":
-        return
     path = _cron_fire_profile_hint_path(job_id)
     if path is None:
+        return None
+    try:
+        with path.open(encoding="utf-8") as stream:
+            profile = stream.read(66).strip()  # profile ids are at most 64 characters
+        validate_profile_name(profile)
+    except (OSError, UnicodeError, ValueError):
+        return None
+    return profile
+
+
+def record_cron_fire_profile_hint(job_id: str, profile: Optional[str] = None) -> None:
+    """Persist routing before arming, retaining it for authenticated late callbacks.
+
+    A cancelled job still needs to authenticate to receive `gone`; a provision timeout
+    may also have armed NAS successfully. Existence and JWT checks remain with the receiver.
+    """
+    from hermes_cli.profiles import get_active_profile_name, validate_profile_name
+
+    profile = profile or get_active_profile_name()
+    if profile == "custom":
+        return
+    validate_profile_name(profile)
+    path = _cron_fire_profile_hint_path(job_id)
+    if path is None or resolve_cron_fire_profile_hint(job_id) == profile:
         return
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = path.with_name(f"{path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
-    try:
-        tmp_path.write_text(f"{clean_profile}\n", encoding="utf-8")
-        atomic_replace(tmp_path, path)
-    finally:
-        try:
-            if tmp_path.exists():
-                tmp_path.unlink()
-        except OSError:
-            pass
-
-
-def forget_cron_fire_profile_hint(job_id: str) -> None:
-    """Remove a Chronos fire profile hint when a job is cancelled or deleted."""
-    path = _cron_fire_profile_hint_path(job_id)
-    if path is None:
-        return
-    try:
-        path.unlink()
-    except FileNotFoundError:
-        pass
-
-
+    atomic_write_text(path, f"{profile}\n", create_mode=0o600)

--- a/cron/chronos_fire_profiles.py
+++ b/cron/chronos_fire_profiles.py
@@ -1,0 +1,72 @@
+"""Bounded job-to-profile hints for authenticated Chronos callbacks."""
+
+import os
+import uuid
+from pathlib import Path
+from typing import Optional
+
+from cron.jobs import _job_output_dir
+from hermes_constants import get_default_hermes_root
+from utils import atomic_replace
+
+
+def _cron_fire_profile_index_dir() -> Path:
+    """Shared per-job profile hints for public Chronos fire callbacks."""
+    return get_default_hermes_root() / "cron" / "fire_profile_index"
+
+
+def _cron_fire_profile_hint_path(job_id: str) -> Optional[Path]:
+    clean = str(job_id or "").strip()
+    if not clean:
+        return None
+    try:
+        _job_output_dir(clean)
+    except ValueError:
+        return None
+    return _cron_fire_profile_index_dir() / f"{clean}.profile"
+
+
+def resolve_cron_fire_profile_hint(job_id: str) -> Optional[str]:
+    """Return a bounded profile hint for a Chronos fire job, if known."""
+    path = _cron_fire_profile_hint_path(job_id)
+    if path is None or not path.is_file():
+        return None
+    try:
+        profile = path.read_text(encoding="utf-8").strip()
+    except Exception:
+        return None
+    return profile or None
+
+
+def record_cron_fire_profile_hint(job_id: str, profile: str) -> None:
+    """Persist a best-effort profile hint for a Chronos-armed job."""
+    clean_profile = str(profile or "").strip()
+    if not clean_profile or clean_profile == "custom":
+        return
+    path = _cron_fire_profile_hint_path(job_id)
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f"{path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}")
+    try:
+        tmp_path.write_text(f"{clean_profile}\n", encoding="utf-8")
+        atomic_replace(tmp_path, path)
+    finally:
+        try:
+            if tmp_path.exists():
+                tmp_path.unlink()
+        except OSError:
+            pass
+
+
+def forget_cron_fire_profile_hint(job_id: str) -> None:
+    """Remove a Chronos fire profile hint when a job is cancelled or deleted."""
+    path = _cron_fire_profile_hint_path(job_id)
+    if path is None:
+        return
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+

--- a/hermes_cli/web_routers/cron.py
+++ b/hermes_cli/web_routers/cron.py
@@ -7,6 +7,7 @@ late-binding seam so ``monkeypatch.setattr(web_server_cron, ...)`` keeps working
 
 import asyncio
 import functools
+import json
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -30,7 +31,7 @@ _forward_cron_fire_to_gateway = late("_forward_cron_fire_to_gateway", "hermes_cl
 _gateway_intentionally_stopped = late("_gateway_intentionally_stopped", "hermes_cli.web_server_cron")
 _notify_cron_provider_for_profile = late("_notify_cron_provider_for_profile", "hermes_cli.web_server_cron")
 _call_cron_for_profile = late("_call_cron_for_profile", "hermes_cli.web_server_cron")
-_load_cron_config_for_profile = late("_load_cron_config_for_profile", "hermes_cli.web_server_cron")
+_authenticate_cron_fire = late("_authenticate_cron_fire", "hermes_cli.web_server_cron")
 load_config = late("load_config", "hermes_cli.config")
 _cron_profile_dicts = late("_cron_profile_dicts", "hermes_cli.web_server_cron")
 _cron_profile_home = late("_cron_profile_home", "hermes_cli.web_server_cron")
@@ -208,6 +209,10 @@ def _delete_cron_job_sync(job_id: str, profile: Optional[str] = None):
 # next attempt past the outage instead of burning its retry budget in it.
 _CRON_FIRE_RETRY_AFTER_SECONDS = 60
 
+# Profile selection needs the job id before JWT verification; bound even chunked
+# requests before buffering/parsing this otherwise tiny callback payload.
+_CRON_FIRE_MAX_BODY_BYTES = 8 * 1024
+
 
 @router.get("/api/cron/jobs")
 async def list_cron_jobs(profile: str = "all"):
@@ -280,70 +285,29 @@ async def cron_fire_webhook(request: Request):
     and its response passed through (the gateway re-verifies the JWT). Gateway
     unreachable -> 503 so NAS retries; deliberately NO local-execution fallback.
     """
-    from plugins.cron_providers.chronos.verify import get_fire_verifier
-
     auth = request.headers.get("Authorization", "")
     token = auth[7:].strip() if auth.startswith("Bearer ") else ""
-
-    try:
-        body = await request.json()
-    except Exception:
-        body = {}
-    job_id = (body or {}).get("job_id") if isinstance(body, dict) else None
-    verifier = get_fire_verifier()
-
-    def _verify_with_config(cfg):
-        return verifier(
-            token=token,
-            expected_audience=cfg_get(
-                cfg, "cron", "chronos", "expected_audience", default=""
-            ),
-            jwks_or_key=cfg_get(
-                cfg, "cron", "chronos", "nas_jwks_url", default=""
-            )
-            or None,
-            issuer=cfg_get(cfg, "cron", "chronos", "portal_url", default="")
-            or None,
-        )
-
-    profile = None
-    if job_id:
-        try:
-            from cron.chronos_fire_profiles import resolve_cron_fire_profile_hint
-
-            profile = resolve_cron_fire_profile_hint(job_id)
-        except Exception:
-            profile = None
-
-    try:
-        cfg = _load_cron_config_for_profile(profile) if profile else load_config()
-    except Exception:
-        _log.exception("Ignoring stale Chronos fire profile hint for job %s", job_id)
-        profile = None
-        cfg = load_config()
-
-    claims = _verify_with_config(cfg)
-    if claims is None and profile:
-        # A persisted hint can go stale if a job is recreated or profiles are
-        # rearranged. Do not treat that hint as authoritative: fall back to the
-        # process Chronos verifier first, and only scan profiles after some
-        # configured verifier has accepted the bearer.
-        profile = None
-        claims = _verify_with_config(load_config())
-    if claims is None:
+    if not token:
         return JSONResponse({"error": "invalid fire token"}, status_code=401)
 
+    payload = bytearray()
+    async for chunk in request.stream():
+        if len(payload) + len(chunk) > _CRON_FIRE_MAX_BODY_BYTES:
+            return JSONResponse({"error": "fire payload is too large"}, status_code=413)
+        payload.extend(chunk)
+    try:
+        body = json.loads(payload)
+    except (ValueError, RecursionError):
+        body = {}
+    job_id = body.get("job_id") if isinstance(body, dict) else None
+    if not isinstance(job_id, str) or not job_id:
+        job_id = None
+    authenticated, profile = await _run_cron_dashboard_io(_authenticate_cron_fire, token, job_id)
+    if not authenticated:
+        return JSONResponse({"error": "invalid fire token"}, status_code=401)
     if not job_id:
         return JSONResponse({"error": "missing job_id"}, status_code=400)
-
-    if not profile:
-        # _find_cron_job_profile walks every profile and lists its jobs (file
-        # I/O per profile). Keep it behind the bearer verifier because this
-        # endpoint is otherwise deliberately public.
-        profile = await _run_cron_dashboard_io(_find_cron_job_profile, job_id)
-    if not profile:
-        # Job is gone (cancelled / completed) — nothing to fire. 200 so NAS
-        # does not retry a fire that is intentionally absent.
+    if not profile:  # authenticated late callback for a cancelled/completed job
         return JSONResponse({"status": "gone", "job_id": job_id}, status_code=200)
 
     forwarded = await _forward_cron_fire_to_gateway(profile, job_id, auth)

--- a/hermes_cli/web_routers/cron.py
+++ b/hermes_cli/web_routers/cron.py
@@ -308,7 +308,7 @@ async def cron_fire_webhook(request: Request):
     profile = None
     if job_id:
         try:
-            from cron.jobs import resolve_cron_fire_profile_hint
+            from cron.chronos_fire_profiles import resolve_cron_fire_profile_hint
 
             profile = resolve_cron_fire_profile_hint(job_id)
         except Exception:

--- a/hermes_cli/web_routers/cron.py
+++ b/hermes_cli/web_routers/cron.py
@@ -30,6 +30,7 @@ _forward_cron_fire_to_gateway = late("_forward_cron_fire_to_gateway", "hermes_cl
 _gateway_intentionally_stopped = late("_gateway_intentionally_stopped", "hermes_cli.web_server_cron")
 _notify_cron_provider_for_profile = late("_notify_cron_provider_for_profile", "hermes_cli.web_server_cron")
 _call_cron_for_profile = late("_call_cron_for_profile", "hermes_cli.web_server_cron")
+_load_cron_config_for_profile = late("_load_cron_config_for_profile", "hermes_cli.web_server_cron")
 load_config = late("load_config", "hermes_cli.config")
 _cron_profile_dicts = late("_cron_profile_dicts", "hermes_cli.web_server_cron")
 _cron_profile_home = late("_cron_profile_home", "hermes_cli.web_server_cron")
@@ -284,27 +285,64 @@ async def cron_fire_webhook(request: Request):
     auth = request.headers.get("Authorization", "")
     token = auth[7:].strip() if auth.startswith("Bearer ") else ""
 
-    cfg = await asyncio.to_thread(load_config)
-    claims = get_fire_verifier()(
-        token=token,
-        expected_audience=cfg_get(cfg, "cron", "chronos", "expected_audience", default=""),
-        jwks_or_key=cfg_get(cfg, "cron", "chronos", "nas_jwks_url", default="") or None,
-        issuer=cfg_get(cfg, "cron", "chronos", "portal_url", default="") or None,
-    )
-    if claims is None:
-        return JSONResponse({"error": "invalid fire token"}, status_code=401)
-
     try:
         body = await request.json()
     except Exception:
         body = {}
     job_id = (body or {}).get("job_id") if isinstance(body, dict) else None
+
+    def _verify_with_config(cfg):
+        return get_fire_verifier()(
+            token=token,
+            expected_audience=cfg_get(
+                cfg, "cron", "chronos", "expected_audience", default=""
+            ),
+            jwks_or_key=cfg_get(
+                cfg, "cron", "chronos", "nas_jwks_url", default=""
+            )
+            or None,
+            issuer=cfg_get(cfg, "cron", "chronos", "portal_url", default="")
+            or None,
+        )
+
+    profile = None
+    if job_id:
+        try:
+            from cron.jobs import resolve_cron_fire_profile_hint
+
+            profile = resolve_cron_fire_profile_hint(job_id)
+        except Exception:
+            profile = None
+
+    try:
+        cfg = _load_cron_config_for_profile(profile) if profile else load_config()
+    except Exception:
+        _log.exception("Ignoring stale Chronos fire profile hint for job %s", job_id)
+        profile = None
+        cfg = load_config()
+
+    claims = _verify_with_config(cfg)
+    if claims is None and profile:
+        # A persisted hint can go stale if a job is recreated or profiles are
+        # rearranged. Do not treat that hint as authoritative: fall back to the
+        # process Chronos verifier first, and only scan profiles after some
+        # configured verifier has accepted the bearer.
+        profile = None
+        claims = _verify_with_config(load_config())
+    if claims is None:
+        return JSONResponse({"error": "invalid fire token"}, status_code=401)
+
     if not job_id:
         return JSONResponse({"error": "missing job_id"}, status_code=400)
 
-    # Walks every profile's job list (file I/O) — off the event loop.
-    profile = await _run_cron_dashboard_io(_find_cron_job_profile, job_id)
-    if not profile:  # job is gone (cancelled / completed): 200 so NAS does not retry
+    if not profile:
+        # _find_cron_job_profile walks every profile and lists its jobs (file
+        # I/O per profile). Keep it behind the bearer verifier because this
+        # endpoint is otherwise deliberately public.
+        profile = await _run_cron_dashboard_io(_find_cron_job_profile, job_id)
+    if not profile:
+        # Job is gone (cancelled / completed) — nothing to fire. 200 so NAS
+        # does not retry a fire that is intentionally absent.
         return JSONResponse({"status": "gone", "job_id": job_id}, status_code=200)
 
     forwarded = await _forward_cron_fire_to_gateway(profile, job_id, auth)

--- a/hermes_cli/web_routers/cron.py
+++ b/hermes_cli/web_routers/cron.py
@@ -290,9 +290,10 @@ async def cron_fire_webhook(request: Request):
     except Exception:
         body = {}
     job_id = (body or {}).get("job_id") if isinstance(body, dict) else None
+    verifier = get_fire_verifier()
 
     def _verify_with_config(cfg):
-        return get_fire_verifier()(
+        return verifier(
             token=token,
             expected_audience=cfg_get(
                 cfg, "cron", "chronos", "expected_audience", default=""

--- a/hermes_cli/web_server_cron.py
+++ b/hermes_cli/web_server_cron.py
@@ -234,6 +234,46 @@ def _load_cron_config_for_profile(profile: Optional[str]) -> Dict[str, Any]:
         reset_hermes_home_override(token)
 
 
+def _authenticate_cron_fire(token: str, job_id: Optional[str]) -> Tuple[bool, Optional[str]]:
+    """Authenticate before scanning jobs, then require the actual owner's authority.
+
+    Hints can outlive jobs or name a stale profile. They select a verifier only;
+    the persisted job store selects the destination, which must verify the same JWT.
+    Run this worker off the event loop: config, store and JWKS reads can all block.
+    """
+    from cron.chronos_fire_profiles import resolve_cron_fire_profile_hint
+    from plugins.cron_providers.chronos.verify import get_fire_verifier
+
+    verifier = get_fire_verifier()
+
+    def verify_profile(profile):
+        try:
+            cfg = _load_cron_config_for_profile(profile)
+        except (HTTPException, OSError, ValueError):
+            return False
+        return verifier(
+            token=token,
+            expected_audience=cfg_get(cfg, "cron", "chronos", "expected_audience", default=""),
+            jwks_or_key=cfg_get(cfg, "cron", "chronos", "nas_jwks_url", default="") or None,
+            issuer=cfg_get(cfg, "cron", "chronos", "portal_url", default="") or None,
+        ) is not None
+
+    hinted_profile = resolve_cron_fire_profile_hint(job_id) if job_id else None
+    authenticated_profile = hinted_profile
+    if not verify_profile(hinted_profile):
+        if hinted_profile is None or not verify_profile(None):
+            return False, None
+        authenticated_profile = None
+    if not job_id:
+        return True, None
+    profile = _find_cron_job_profile(job_id)
+    if profile is None:
+        return True, None
+    if profile != authenticated_profile and not verify_profile(profile):
+        return False, None
+    return True, profile
+
+
 async def _run_cron_dashboard_io(func, *args, **kwargs):
     """Run cron dashboard profile/job I/O outside the FastAPI event loop."""
     from starlette.concurrency import run_in_threadpool

--- a/hermes_cli/web_server_cron.py
+++ b/hermes_cli/web_server_cron.py
@@ -214,6 +214,26 @@ def _find_cron_job_profile(job_id: str) -> Optional[str]:
     return None
 
 
+def _load_cron_config_for_profile(profile: Optional[str]) -> Dict[str, Any]:
+    """Load Chronos settings from the resolved cron profile home."""
+    from hermes_cli.config import load_config
+
+    if not profile:
+        return load_config()
+
+    _profile_name, home = _cron_profile_home(profile)
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    token = set_hermes_home_override(str(home))
+    try:
+        return load_config()
+    finally:
+        reset_hermes_home_override(token)
+
+
 async def _run_cron_dashboard_io(func, *args, **kwargs):
     """Run cron dashboard profile/job I/O outside the FastAPI event loop."""
     from starlette.concurrency import run_in_threadpool

--- a/plugins/cron_providers/chronos/__init__.py
+++ b/plugins/cron_providers/chronos/__init__.py
@@ -90,6 +90,13 @@ class ChronosCronScheduler(CronScheduler):
         self._get_client().provision(
             job_id=job_id, fire_at=fire_at, dedup_key=f"{job_id}:{fire_at}",
             agent_callback_url=str(_cfg("cron", "chronos", "callback_url") or ""))
+        try:
+            from cron.chronos_fire_profiles import record_cron_fire_profile_hint
+            from hermes_cli.profiles import get_active_profile_name
+
+            record_cron_fire_profile_hint(job_id, get_active_profile_name())
+        except Exception:
+            logger.debug("Chronos failed to record fire profile hint for %s", job_id, exc_info=True)
         with self._lock:
             self._armed[job_id] = fire_at
 
@@ -104,6 +111,12 @@ class ChronosCronScheduler(CronScheduler):
         try:
             self._get_client().cancel(job_id=job_id)
         finally:
+            try:
+                from cron.chronos_fire_profiles import forget_cron_fire_profile_hint
+
+                forget_cron_fire_profile_hint(job_id)
+            except Exception:
+                logger.debug("Chronos failed to clear fire profile hint for %s", job_id, exc_info=True)
             with self._lock:
                 self._armed.pop(job_id, None)
 

--- a/plugins/cron_providers/chronos/__init__.py
+++ b/plugins/cron_providers/chronos/__init__.py
@@ -14,6 +14,7 @@ import threading
 from typing import Any, Dict
 
 from cron.scheduler_provider import CronScheduler
+from cron.chronos_fire_profiles import record_cron_fire_profile_hint
 
 logger = logging.getLogger("cron.chronos")
 
@@ -87,16 +88,10 @@ class ChronosCronScheduler(CronScheduler):
         fire_at = job.get("next_run_at")
         if not fire_at:
             return
+        record_cron_fire_profile_hint(job_id)
         self._get_client().provision(
             job_id=job_id, fire_at=fire_at, dedup_key=f"{job_id}:{fire_at}",
             agent_callback_url=str(_cfg("cron", "chronos", "callback_url") or ""))
-        try:
-            from cron.chronos_fire_profiles import record_cron_fire_profile_hint
-            from hermes_cli.profiles import get_active_profile_name
-
-            record_cron_fire_profile_hint(job_id, get_active_profile_name())
-        except Exception:
-            logger.debug("Chronos failed to record fire profile hint for %s", job_id, exc_info=True)
         with self._lock:
             self._armed[job_id] = fire_at
 
@@ -111,12 +106,6 @@ class ChronosCronScheduler(CronScheduler):
         try:
             self._get_client().cancel(job_id=job_id)
         finally:
-            try:
-                from cron.chronos_fire_profiles import forget_cron_fire_profile_hint
-
-                forget_cron_fire_profile_hint(job_id)
-            except Exception:
-                logger.debug("Chronos failed to clear fire profile hint for %s", job_id, exc_info=True)
             with self._lock:
                 self._armed.pop(job_id, None)
 
@@ -144,7 +133,10 @@ class ChronosCronScheduler(CronScheduler):
             if j.get("enabled") and j.get("next_run_at") and j.get("state") != "paused"}
         observed = self._list_armed()
         for job_id, fire_at in desired.items():
-            if observed.get(job_id) != fire_at and (job := get_job(job_id)):
+            if observed.get(job_id) == fire_at:
+                # A cold upgrade must index one-shots that NAS already has armed.
+                record_cron_fire_profile_hint(job_id)
+            elif (job := get_job(job_id)):
                 self._arm_logged(job, f"arm job {job_id}")
         for job_id in observed.keys() - desired.keys():
             try:

--- a/tests/hermes_cli/test_chronos_profile_fire_auth.py
+++ b/tests/hermes_cli/test_chronos_profile_fire_auth.py
@@ -1,0 +1,216 @@
+"""Chronos callbacks keep profile authentication across the scheduler lifecycle."""
+
+import threading
+import time
+from pathlib import Path
+
+import httpx
+import jwt
+import pytest
+import yaml
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from starlette.testclient import TestClient
+
+from hermes_cli import web_server
+from hermes_cli import web_server_cron as cron_web
+from plugins.cron_providers.chronos import ChronosCronScheduler
+from plugins.cron_providers.chronos import verify as fire_verify
+
+
+@pytest.fixture
+def fire_profiles(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    root = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key = key.public_key().public_bytes(
+        serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    homes = {"default": root, "work": root / "profiles" / "work"}
+    for profile, home in homes.items():
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text(yaml.safe_dump({"cron": {"chronos": {
+            "expected_audience": f"agent:{profile}",
+            "portal_url": f"https://{profile}.example",
+            "nas_jwks_url": public_key,
+            "callback_url": "https://agent.example/api/cron/fire",
+        }}}), encoding="utf-8")
+
+    def token(profile="work", **overrides):
+        claims = {"aud": f"agent:{profile}", "iss": f"https://{profile}.example",
+                  "exp": int(time.time()) + 600, "purpose": "cron_fire"}
+        return jwt.encode({**claims, **overrides}, key, algorithm="RS256")
+
+    def create(profile="work"):
+        with cron_web._cron_store_scope(homes[profile]) as jobs:
+            return jobs.create_job(prompt="inspect status", schedule="every 1h")
+
+    forwarded = []
+
+    async def forward(profile, job_id, authorization):
+        forwarded.append((profile, job_id, authorization))
+        return 202, {"status": "accepted", "job_id": job_id}
+
+    monkeypatch.setattr(cron_web, "_forward_cron_fire_to_gateway", forward)
+    monkeypatch.setattr(web_server.app.state, "auth_required", True, raising=False)
+    monkeypatch.setattr(web_server.app.state, "bound_host", None, raising=False)
+    return homes, token, create, forwarded
+
+
+def test_profile_fire_auth_survives_arm_reconcile_and_cancel(fire_profiles):
+    homes, token, create, forwarded = fire_profiles
+    new_job, existing_job, failed_job = create(), create(), create()
+    provider = ChronosCronScheduler()
+    issued_token = token()
+
+    with TestClient(web_server.app) as client:
+        def fire(job_id):
+            # The public dashboard runs in its own default-profile context.
+            with cron_web._cron_store_scope(homes["default"]):
+                return client.post("/api/cron/fire", json={"job_id": job_id},
+                                   headers={"Authorization": f"Bearer {issued_token}"})
+
+        class NasClient:
+            def __init__(self):
+                self.armed = {existing_job["id"]: existing_job["next_run_at"]}
+                self.provisions = []
+
+            def provision(self, *, job_id, fire_at, **kwargs):
+                # NAS can call back before its provision response reaches Hermes.
+                self.provisions.append(job_id)
+                assert fire(job_id).status_code == 202
+                if job_id == failed_job["id"]:
+                    raise TimeoutError("provision response lost")
+                self.armed[job_id] = fire_at
+
+            def list_armed(self):
+                return [{"job_id": job_id, "fire_at": fire_at}
+                        for job_id, fire_at in self.armed.items()]
+
+            def cancel(self, *, job_id):
+                self.armed.pop(job_id, None)
+
+        nas = NasClient()
+        provider._client = nas
+        with cron_web._cron_store_scope(homes["work"]):
+            provider.register_job(new_job)
+            with pytest.raises(TimeoutError, match="provision response lost"):
+                provider.register_job(failed_job)
+        assert fire(failed_job["id"]).status_code == 202
+
+        # A cold upgrade discovers already-armed NAS jobs without provisioning again.
+        provider = ChronosCronScheduler()
+        provider._client = nas
+        with cron_web._cron_store_scope(homes["work"]):
+            provider.reconcile()
+        assert fire(existing_job["id"]).status_code == 202
+        assert existing_job["id"] not in nas.provisions
+
+        with cron_web._cron_store_scope(homes["work"]) as jobs:
+            jobs.remove_job(new_job["id"])
+            provider.reconcile()
+        before = list(forwarded)
+        response = fire(new_job["id"])
+        assert response.status_code == 200
+        assert response.json()["status"] == "gone"
+        assert new_job["id"] not in nas.armed
+        assert forwarded == before
+        assert {profile for profile, _, _ in forwarded} == {"work"}
+        assert all(auth == f"Bearer {issued_token}" for _, _, auth in forwarded)
+
+
+@pytest.mark.asyncio
+async def test_fire_verifies_owner_off_loop_and_rejects_invalid_tokens(fire_profiles, monkeypatch):
+    homes, token, create, forwarded = fire_profiles
+    job = create()
+    provider = ChronosCronScheduler()
+    provider._client = type("NasClient", (), {"provision": lambda self, **kwargs: None})()
+    with cron_web._cron_store_scope(homes["work"]):
+        provider.register_job(job)
+
+    loop_thread = threading.get_ident()
+    verification_threads = []
+    verified = []
+    scans = []
+    real_scan = cron_web._find_cron_job_profile
+
+    def verify(**kwargs):
+        verification_threads.append(threading.get_ident())
+        claims = fire_verify.verify_nas_fire_token(**kwargs)
+        if claims is not None:
+            verified.append(kwargs["token"])
+        return claims
+
+    def scan(job_id):
+        assert verified, "an unauthenticated callback must not scan profile job stores"
+        scans.append(job_id)
+        return real_scan(job_id)
+
+    monkeypatch.setattr(fire_verify, "get_fire_verifier", lambda: verify)
+    monkeypatch.setattr(cron_web, "_find_cron_job_profile", scan)
+    transport = httpx.ASGITransport(app=web_server.app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        consumed = []
+
+        async def oversized_stream():
+            for chunk in range(128):
+                consumed.append(chunk)
+                yield b" " * 1024
+
+        response = await client.post("/api/cron/fire", content=oversized_stream(),
+                                     headers={"Authorization": "Bearer forged"})
+        assert response.request.headers["transfer-encoding"] == "chunked"
+        assert response.status_code == 413
+        assert 0 < len(consumed) < 128
+        assert verification_threads == scans == forwarded == []
+        consumed.clear()
+        response = await client.post("/api/cron/fire", content=oversized_stream())
+        assert response.status_code == 401
+        assert consumed == verification_threads == scans == forwarded == []
+        for bearer, expected_status in (("forged", 401), (token("default"), 400)):
+            response = await client.post("/api/cron/fire", content=b"{",
+                                         headers={"Authorization": f"Bearer {bearer}"})
+            assert response.status_code == expected_status
+        verified.clear()
+
+        for bearer in ("forged", token(aud="agent:other"), token(iss="https://other.example")):
+            response = await client.post("/api/cron/fire", json={"job_id": job["id"]},
+                                         headers={"Authorization": f"Bearer {bearer}"})
+            assert response.status_code == 401
+            assert scans == []
+        for job_id in ("../work/config.yaml", "x" * 256, ["work"], {"profile": "work"}):
+            response = await client.post("/api/cron/fire", json={"job_id": job_id},
+                                         headers={"Authorization": "Bearer forged"})
+            assert response.status_code == 401
+            assert scans == []
+        assert forwarded == []
+        # A default-profile token cannot authorize a work-profile job via fallback.
+        response = await client.post("/api/cron/fire", json={"job_id": job["id"]},
+                                     headers={"Authorization": f"Bearer {token('default')}"})
+        assert response.status_code == 401
+        assert forwarded == []
+        response = await client.post("/api/cron/fire", json={"job_id": job["id"]},
+                                     headers={"Authorization": f"Bearer {token()}"})
+        assert response.status_code == 202
+
+        from cron.chronos_fire_profiles import record_cron_fire_profile_hint
+
+        default_job = create("default")
+        # A stale hint can recover only through another configured verifier accepting
+        # the token, followed by authentication against the actual job owner.
+        for stale_profile in ("work", "removed-profile"):
+            record_cron_fire_profile_hint(default_job["id"], stale_profile)
+            response = await client.post("/api/cron/fire", json={"job_id": default_job["id"]},
+                                         headers={"Authorization": f"Bearer {token('default')}"})
+            assert response.status_code == 202
+        before = list(forwarded)
+        (homes["work"] / "config.yaml").unlink()
+        response = await client.post("/api/cron/fire", json={"job_id": job["id"]},
+                                     headers={"Authorization": f"Bearer {token()}"})
+        assert response.status_code == 401
+        assert forwarded == before
+    assert verification_threads and loop_thread not in verification_threads
+    assert [(profile, job_id) for profile, job_id, _ in forwarded] == [
+        ("work", job["id"]), ("default", default_job["id"]), ("default", default_job["id"]),
+    ]


### PR DESCRIPTION
A Chronos callback for a named profile was verified with the dashboard profile configuration before the job owner was resolved. Valid callbacks therefore received 401 when the profile audience or issuer differed. Jobs already armed by an older gateway could also fail after a cold start before scheduler reconciliation.

Discover the current profiles’ configured verifiers in a shared background build. A first callback or required refresh receives 503 with Retry-After while discovery completes. Untrusted issuer and audience claims select only locally configured candidates; each candidate uses current configuration and full JWT verification. The actual job owner must accept the same token before it is forwarded unchanged to the gateway. The process profile retains its existing fast path.

The catalogue rechecks profile directories, configuration files and the loader’s referenced environment values before rejecting unknown selectors or failed candidates, including new profiles sharing an existing selector with a different key. A change during discovery causes a bounded rebuild instead of publishing an inconsistent snapshot. No per-job hints or cancelled-job history are retained, and authenticated late callbacks still receive gone. Configuration, JWT and job store work runs outside the event loop. Missing Bearer tokens are rejected before body consumption, and streamed bodies are capped at 8 KiB before parsing.

Fixes #69715.

Continues #69730 by @worlldz, preserving all three original commits and their authorship. The followup adapts authentication to the current gateway forwarding path and supports callbacks before scheduler warmup.

Validation: 96 tests passed across seven focused files on macOS with Python 3.13.12 and native Linux with Python 3.11.15, using locked dependencies in Linux. Two new behavior contracts exercise real RSA signatures, profile configuration, job stores and the ASGI endpoint in a temporary home. Coverage includes callback before reconciliation, mixed-version jobs, concurrent discovery, configuration changes during a build, key and issuer rotation, dotenv loaded after startup, managed overlays, ownership checks, cancellation and chunked body limits. The cold-start authentication failure and environment-only invalidation failure were reproduced before correction. The Linux source snapshot was verified identical to the published files. Ruff, compatibility pointer checks, whitespace checks and independent review passed.
