### PR TITLE
fix(update): preserve Windows gateway cold-start during Desktop update hand-off (#109538)

### DIFF
--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -869,12 +869,35 @@ def _start_attestation_path() -> Path:
     return _hermes_home().joinpath(*_START_ATTESTATION_RELATIVE)
 
 
+# Default freshness window: 24 hours (86400 seconds) for handoff/attestation relevance.
+_DEFAULT_ATTESTATION_FRESHNESS_SECONDS = 86400.0
+
+
 def _write_start_attestation(pids: list[int], via: str) -> None:
-    """Persist the PIDs a ✓ vouched for. Best-effort, never raises."""
+    """Persist the PIDs a ✓ vouched for, bound to create_time and timestamp. Best-effort, never raises."""
     try:
         path = _start_attestation_path()
         path.parent.mkdir(parents=True, exist_ok=True)
-        payload = {"pids": [int(p) for p in pids], "via": via, "ts": datetime.now(timezone.utc).isoformat()}
+        now_utc = datetime.now(timezone.utc)
+        from gateway.status import get_process_start_time
+        create_times: dict[str, float] = {}
+        valid_pids: list[int] = []
+        for p in pids:
+            try:
+                pid_int = int(p)
+                valid_pids.append(pid_int)
+                st = get_process_start_time(pid_int)
+                if st is not None:
+                    create_times[str(pid_int)] = float(st)
+            except Exception:
+                pass
+        payload = {
+            "pids": valid_pids,
+            "create_times": create_times,
+            "via": via,
+            "ts": now_utc.isoformat(),
+            "timestamp": now_utc.timestamp(),
+        }
         tmp = path.with_suffix(".json.tmp")
         tmp.write_text(json.dumps(payload), encoding="utf-8")
         tmp.replace(path)
@@ -889,25 +912,128 @@ def _clear_start_attestation() -> None:
         pass
 
 
-def _attested_pid_exited_cleanly(pid: int) -> bool:
-    """True when the lifecycle ledger shows a clean exit for ``pid``."""
+def _read_start_attestation() -> dict | None:
+    """Parsed attestation payload dict, or None when absent/unreadable/invalid. Never raises."""
+    try:
+        data = json.loads(_start_attestation_path().read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else None
+    except (OSError, ValueError):
+        return None
+
+
+def _attested_pids_from(data: object) -> list[int]:
+    """PID list from an attestation payload; empty for anything malformed."""
+    if not isinstance(data, dict):
+        return []
+    pids = data.get("pids")
+    if not isinstance(pids, list):
+        return []
+    return [p for p in pids if isinstance(p, int)]
+
+
+def _is_attestation_fresh(data: dict, max_age_seconds: float = _DEFAULT_ATTESTATION_FRESHNESS_SECONDS) -> bool:
+    """True when the attestation was written within max_age_seconds. Malformed/missing ts reads False."""
+    if not isinstance(data, dict):
+        return False
+    ts_val = data.get("timestamp")
+    if isinstance(ts_val, (int, float)):
+        return (time.time() - float(ts_val)) <= max_age_seconds
+    ts_str = data.get("ts")
+    if isinstance(ts_str, str):
+        try:
+            dt = datetime.fromisoformat(ts_str)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return (datetime.now(timezone.utc) - dt).total_seconds() <= max_age_seconds
+        except Exception:
+            return False
+    return False
+
+
+def _attested_pid_exited_cleanly(pid: int, expected_create_time: float | None = None) -> bool:
+    """True when the lifecycle ledger shows a clean exit for ``pid`` matching expected_create_time."""
     try:
         from gateway.lifecycle_ledger import get_lifecycle_sentinel_path
 
         data = json.loads(get_lifecycle_sentinel_path(_hermes_home()).read_text(encoding="utf-8"))
     except Exception:
         return False
-    return isinstance(data, dict) and data.get("phase") == "exited" and data.get("pid") == pid
+    if not (isinstance(data, dict) and data.get("phase") == "exited" and data.get("pid") == pid):
+        return False
+    ledger_start = data.get("start_time")
+    if expected_create_time is not None and ledger_start is not None:
+        try:
+            if abs(float(ledger_start) - float(expected_create_time)) > 2.0:
+                return False
+        except (ValueError, TypeError):
+            pass
+    return True
+
+
+def attested_gateway_died(
+    current_pids: list[int] | None = None,
+    max_age_seconds: float = _DEFAULT_ATTESTATION_FRESHNESS_SECONDS,
+) -> bool:
+    """True when the start attestation vouches for fresh gateway PID(s) that are gone without a clean exit.
+
+    Read-only twin of :func:`check_start_attestation` for callers that must not consume the
+    one-shot marker — ``hermes update`` consults it to decide whether a Desktop-owned install
+    still owes a gateway cold-start (#109538).
+
+    Binds attestation to process create_time and freshness window. Returns ``False`` for anything
+    undecidable or invalid (no marker, stale marker > max_age_seconds, malformed payload, a gateway
+    running now, a clean ledger exit, or discovery failure): "unknown" must never read as "dead".
+    """
+    try:
+        data = _read_start_attestation()
+        if not isinstance(data, dict):
+            return False
+        attested = _attested_pids_from(data)
+        if not attested:
+            return False
+        if not _is_attestation_fresh(data, max_age_seconds=max_age_seconds):
+            return False
+
+        if current_pids is None:
+            try:
+                from hermes_cli.gateway import find_gateway_pids
+
+                current_pids = list(find_gateway_pids())
+            except Exception:
+                return False
+
+        create_times = data.get("create_times")
+        create_times_dict = create_times if isinstance(create_times, dict) else {}
+
+        from gateway.status import get_process_start_time
+        for pid in attested:
+            if pid in current_pids:
+                expected_st = create_times_dict.get(str(pid))
+                if expected_st is not None:
+                    try:
+                        actual_st = get_process_start_time(pid)
+                        if actual_st is not None and abs(float(actual_st) - float(expected_st)) <= 2.0:
+                            return False  # Same process is still running
+                    except Exception:
+                        return False
+                else:
+                    return False
+
+        if any(_attested_pid_exited_cleanly(pid, create_times_dict.get(str(pid))) for pid in attested):
+            return False
+
+        return True
+    except Exception:
+        return False
 
 
 def check_start_attestation(current_pids: list[int] | None = None) -> str | None:
     """Surface (once) a gateway that died after a ✓ was printed for it. Never raises. Gateway running
     or a clean-exit ledger record: clear silently; otherwise return a warning and consume the marker."""
-    try:
-        data = json.loads(_start_attestation_path().read_text(encoding="utf-8"))
-    except (OSError, ValueError):
+    data = _read_start_attestation()
+    if data is None:
         return None
-    attested = [p for p in data.get("pids", []) if isinstance(p, int)] if isinstance(data, dict) else []
+    attested = _attested_pids_from(data)
     if not attested:
         _clear_start_attestation()
         return None
@@ -921,9 +1047,15 @@ def check_start_attestation(current_pids: list[int] | None = None) -> str | None
             return None
 
     _clear_start_attestation()
-    if current_pids or any(_attested_pid_exited_cleanly(pid) for pid in attested):
+    create_times = data.get("create_times")
+    create_times_dict = create_times if isinstance(create_times, dict) else {}
+    if current_pids or any(_attested_pid_exited_cleanly(pid, create_times_dict.get(str(pid))) for pid in attested):
         return None
 
+    return _format_attestation_warning(attested, data)
+
+
+def _format_attestation_warning(attested: list[int], data: dict) -> str:
     via = data.get("via") or "direct spawn"
     ts = data.get("ts") or "unknown time"
     lines = [

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -937,17 +937,34 @@ def _is_attestation_fresh(data: dict, max_age_seconds: float = _DEFAULT_ATTESTAT
         return False
     ts_val = data.get("timestamp")
     if isinstance(ts_val, (int, float)):
-        return (time.time() - float(ts_val)) <= max_age_seconds
+        age = time.time() - float(ts_val)
+        return -60.0 <= age <= max_age_seconds
     ts_str = data.get("ts")
     if isinstance(ts_str, str):
         try:
             dt = datetime.fromisoformat(ts_str)
             if dt.tzinfo is None:
                 dt = dt.replace(tzinfo=timezone.utc)
-            return (datetime.now(timezone.utc) - dt).total_seconds() <= max_age_seconds
+            age = (datetime.now(timezone.utc) - dt).total_seconds()
+            return -60.0 <= age <= max_age_seconds
         except Exception:
             return False
     return False
+
+
+def _start_times_match(recorded: Any, current: Any) -> bool:
+    """Compare recorded and current process start times, supporting seconds and centiseconds."""
+    if recorded is None or current is None:
+        return True
+    try:
+        r, c = float(recorded), float(current)
+        if r > 1e10:
+            r = r / 100.0
+        if c > 1e10:
+            c = c / 100.0
+        return abs(r - c) <= 2.0
+    except (ValueError, TypeError):
+        return False
 
 
 def _attested_pid_exited_cleanly(pid: int, expected_create_time: float | None = None) -> bool:
@@ -962,11 +979,8 @@ def _attested_pid_exited_cleanly(pid: int, expected_create_time: float | None = 
         return False
     ledger_start = data.get("start_time")
     if expected_create_time is not None and ledger_start is not None:
-        try:
-            if abs(float(ledger_start) - float(expected_create_time)) > 2.0:
-                return False
-        except (ValueError, TypeError):
-            pass
+        if not _start_times_match(ledger_start, expected_create_time):
+            return False
     return True
 
 
@@ -1012,7 +1026,7 @@ def attested_gateway_died(
                 if expected_st is not None:
                     try:
                         actual_st = get_process_start_time(pid)
-                        if actual_st is not None and abs(float(actual_st) - float(expected_st)) <= 2.0:
+                        if actual_st is not None and _start_times_match(expected_st, actual_st):
                             return False  # Same process is still running
                     except Exception:
                         return False

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1294,7 +1294,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         "pre_update_backup", pre_update_snapshot_id is not None,
         f"snapshot={pre_update_snapshot_id}" if pre_update_snapshot_id else "disabled or failed")
 
-    _windows_gateway_resume = _m()._pause_windows_gateways_for_update()
+    _windows_gateway_resume = _m()._pause_windows_gateways_for_update(args)
     if _windows_gateway_resume:
         import atexit as _atexit
         _atexit.register(_m()._resume_windows_gateways_after_update, _windows_gateway_resume)

--- a/hermes_cli/update_cmd_windows.py
+++ b/hermes_cli/update_cmd_windows.py
@@ -734,22 +734,36 @@ def _restore_windows_gateway_service(name: str, *, timeout: float = 60.0) -> Non
         raise RuntimeError(f"Windows service {name} did not reach a restorable state within {timeout:.0f}s")
 
 
-def _windows_cold_start_plan() -> dict | None:
+def _windows_cold_start_plan(args=None) -> dict | None:
     """Pause token for the no-running-gateway case: cold-start after update when an autostart entry exists.
 
     An installed autostart entry is an explicit "I want a gateway" signal; a gateway that died between
     updates would otherwise stay down until next login (resume only relaunches what was running).
     Desktop-owned lifecycle -> ``None`` (spawning ``gateway run`` beside Desktop races ports/state);
-    the skip is ownership, not liveness."""
+    the skip is ownership, not liveness — except when the start attestation reports a vouched-for
+    gateway that died without a clean exit (#109538). The Desktop hand-off exits the app before the
+    updater starts and can kill the running gateway in those same seconds, so discovery finds no live
+    PID to pause — the dead attestation is the surviving "a gateway was up" evidence, and the Desktop
+    does not restart the messaging gateway itself. Keep the plan; the spawn-time re-check in
+    ``_cold_start_windows_gateway_after_update`` stays the ownership authority."""
     from hermes_cli.update_cmd import _desktop_owns_gateway_lifecycle
-    with _best_effort('Could not check Desktop gateway-lifecycle ownership before update: %s'):
-        if _desktop_owns_gateway_lifecycle():
-            logger.debug("Skipping Windows gateway cold-start plan: Desktop owns gateway lifecycle")
-            return None
+    from hermes_cli import gateway_windows
     with _best_effort('Could not check Windows gateway autostart state before update: %s'):
-        from hermes_cli import gateway_windows
-        if gateway_windows.is_installed():
-            return {"resume_needed": True, "profiles": {}, "unmapped_pids": [], "unmapped": [], "cold_start_if_installed": True}
+        if not gateway_windows.is_installed():
+            return None
+        desktop_owns = False
+        with _best_effort('Could not check Desktop gateway-lifecycle ownership before update: %s'):
+            desktop_owns = bool(_desktop_owns_gateway_lifecycle())
+        if desktop_owns:
+            attested_died = False
+            with _best_effort('Could not probe attested gateway death before update: %s'):
+                attested_died = bool(gateway_windows.attested_gateway_died())
+            if not attested_died:
+                logger.debug("Skipping Windows gateway cold-start plan: Desktop owns gateway lifecycle")
+                if bool(getattr(args, "gateway", False)):
+                    print("  ⚠ Gateway cold-start skipped: Desktop control plane active. Run 'hermes gateway start' if your bot is offline.")
+                return None
+        return {"resume_needed": True, "profiles": {}, "unmapped_pids": [], "unmapped": [], "cold_start_if_installed": True}
     return None
 
 
@@ -855,7 +869,7 @@ def _gateway_drain_timeout(socket_acks: list[dict]) -> float:
     return drain_timeout
 
 
-def _pause_windows_gateways_for_update() -> dict | None:
+def _pause_windows_gateways_for_update(args=None) -> dict | None:
     """Stop running Windows gateways before mutating the checkout or venv.
 
     Scheduled/startup gateways run via pythonw.exe, invisible to the hermes.exe instance guard, yet keep files
@@ -868,7 +882,7 @@ def _pause_windows_gateways_for_update() -> dict | None:
         from hermes_cli.gateway import _capture_gateway_argv
     profile_processes, service_gateways, service_gateway_pids, running_pids = _discover_windows_gateways()
     if not running_pids:
-        return _windows_cold_start_plan()
+        return _windows_cold_start_plan(args=args)
     profiles, mapped_pids, socket_acks = _request_socket_pauses(running_pids, profile_processes, service_gateway_pids)
     # Resolve venv-side launchers BEFORE draining: a dead worker's parent cannot be recovered (NoSuchProcess).
     # The launcher keeps ``.pyd`` mapped and would trip the venv-holder guard; it is killed with the survivors.
@@ -926,7 +940,8 @@ def _cold_start_windows_gateway_after_update() -> bool:
         if list(find_gateway_pids(all_profiles=True)):
             return True
     with _abort_on_error("Could not re-check Desktop gateway-lifecycle ownership before cold-start"):
-        if _desktop_owns_gateway_lifecycle():
+        from hermes_cli import gateway_windows
+        if _desktop_owns_gateway_lifecycle() and not gateway_windows.attested_gateway_died():
             logger.debug("Skipping Windows gateway cold-start: Desktop owns gateway lifecycle")
             return True
     with _abort_on_error("Could not cold-start Windows gateway after update"):

--- a/tests/hermes_cli/test_gateway_start_attestation.py
+++ b/tests/hermes_cli/test_gateway_start_attestation.py
@@ -332,3 +332,26 @@ def test_attested_probe_malformed_payload_fails_closed(attest_home):
     ]:
         marker.write_text(bad, encoding="utf-8")
         assert gateway_windows.attested_gateway_died(current_pids=[]) is False
+
+
+def test_attested_probe_clock_skew_and_start_time_units():
+    """Verify clock-skew tolerance and process start-time comparison across units."""
+    # Clock skew: minor negative age (-10s, NTP step) tolerated; future time (-70s) rejected
+    assert gateway_windows._is_attestation_fresh({"timestamp": time.time() + 10.0}) is True
+    assert gateway_windows._is_attestation_fresh({"timestamp": time.time() + 70.0}) is False
+
+    # Start times matching: None matches as wildcard
+    assert gateway_windows._start_times_match(None, 12345.0) is True
+    assert gateway_windows._start_times_match(12345.0, None) is True
+
+    # Seconds unit (e.g. float epoch ~ 1.7e9): within 2.0s is match
+    assert gateway_windows._start_times_match(1726000000.0, 1726000001.5) is True
+    assert gateway_windows._start_times_match(1726000000.0, 1726000005.0) is False
+
+    # Centiseconds unit (Windows psutil: ~ 1.7e11): within 200 centiseconds is match
+    assert gateway_windows._start_times_match(172600000000, 172600000150) is True
+    assert gateway_windows._start_times_match(172600000000, 172600000500) is False
+
+    # Non-numeric gracefully handled
+    assert gateway_windows._start_times_match("invalid", 123) is False
+

--- a/tests/hermes_cli/test_gateway_start_attestation.py
+++ b/tests/hermes_cli/test_gateway_start_attestation.py
@@ -15,6 +15,7 @@ All timing knobs are shrunk so no test sleeps longer than ~1s.
 """
 
 import json
+import time
 
 import pytest
 
@@ -189,3 +190,145 @@ def test_breakaway_fallback_warns_even_on_success(monkeypatch, attest_home, caps
     assert "✓" in out
     assert "could not break away" in out
     assert "schtasks /Run /TN Hermes_Gateway" in out
+
+
+# ---------------------------------------------------------------------------
+# #109538: Attested gateway death probe, freshness, PID reuse & identity
+# ---------------------------------------------------------------------------
+
+
+def test_attestation_records_create_time_and_timestamp(monkeypatch, attest_home):
+    import gateway.status as gst
+    monkeypatch.setattr(gst, "get_process_start_time", lambda pid: 12345.67 if pid == 777 else None)
+    gateway_windows._write_start_attestation([777], "direct spawn")
+    marker = attest_home / "state" / "gateway.start-attestation.json"
+    assert marker.exists()
+    data = json.loads(marker.read_text(encoding="utf-8"))
+    assert data.get("pids") == [777]
+    assert data.get("create_times") == {"777": 12345.67}
+    assert isinstance(data.get("timestamp"), (int, float))
+    assert isinstance(data.get("ts"), str)
+
+
+def test_attested_probe_is_read_only_and_never_consumes_marker(attest_home):
+    """The update path needs the death verdict without consuming the one-shot marker the
+    next CLI start still owes the user; and only a *detectable* death may read True.
+
+    ``hermes update`` consults this probe to keep the cold-start plan when Desktop owns
+    the lifecycle (#109538) — consuming the marker here would silence the CLI-start
+    warning that reports the same death to the user.
+    """
+    assert gateway_windows.attested_gateway_died(current_pids=[]) is False  # no marker yet
+
+    gateway_windows._write_start_attestation([555], "cold-start after update")
+
+    assert gateway_windows.attested_gateway_died(current_pids=[555]) is False  # alive
+    assert gateway_windows.attested_gateway_died(current_pids=[]) is True  # dead, unclean
+    marker = attest_home / "state" / "gateway.start-attestation.json"
+    assert marker.exists()  # unconsumed — the CLI start below still reports it
+    assert gateway_windows.check_start_attestation(current_pids=[]) is not None
+
+    state = attest_home / "state"
+    state.mkdir(exist_ok=True)
+    (state / "gateway.lifecycle.json").write_text(
+        json.dumps({"phase": "exited", "pid": 556, "exit_reason": "graceful_shutdown"}),
+        encoding="utf-8",
+    )
+    gateway_windows._write_start_attestation([556], "cold-start after update")
+    assert gateway_windows.attested_gateway_died(current_pids=[]) is False  # planned stop
+
+
+def test_attested_probe_enforces_freshness_window(attest_home):
+    """A stale crash marker from days ago must not authorize a competing gateway
+    when Desktop currently owns lifecycle. Freshness window must be enforced."""
+    state = attest_home / "state"
+    state.mkdir(exist_ok=True)
+    marker = state / "gateway.start-attestation.json"
+
+    # Stale marker: timestamp from 2 days ago (172800s ago)
+    two_days_ago = time.time() - 172800.0
+    stale_payload = {
+        "pids": [999],
+        "create_times": {"999": 1000.0},
+        "via": "test",
+        "timestamp": two_days_ago,
+        "ts": "2026-09-10T00:00:00+00:00",
+    }
+    marker.write_text(json.dumps(stale_payload), encoding="utf-8")
+    assert gateway_windows.attested_gateway_died(current_pids=[], max_age_seconds=86400.0) is False
+
+    # Fresh marker: timestamp from 10s ago
+    fresh_payload = {
+        "pids": [999],
+        "create_times": {"999": 1000.0},
+        "via": "test",
+        "timestamp": time.time() - 10.0,
+        "ts": "2026-09-13T00:00:00+00:00",
+    }
+    marker.write_text(json.dumps(fresh_payload), encoding="utf-8")
+    assert gateway_windows.attested_gateway_died(current_pids=[], max_age_seconds=86400.0) is True
+
+
+def test_attested_probe_pid_reuse_and_identity_validation(monkeypatch, attest_home):
+    """PID reuse validation:
+    1) If a running process shares the PID but has a different create_time, it is PID reuse.
+    2) If an unrelated clean exit ledger exists with a different start_time, it must not suppress recovery."""
+    import gateway.status as gst
+
+    state = attest_home / "state"
+    state.mkdir(exist_ok=True)
+    marker = state / "gateway.start-attestation.json"
+
+    payload = {
+        "pids": [888],
+        "create_times": {"888": 5000.0},
+        "via": "test",
+        "timestamp": time.time(),
+        "ts": "2026-09-13T00:00:00+00:00",
+    }
+    marker.write_text(json.dumps(payload), encoding="utf-8")
+
+    # Running process has PID 888, but its create_time is 9000.0 (PID reused by another process!)
+    monkeypatch.setattr(gst, "get_process_start_time", lambda pid: 9000.0 if pid == 888 else None)
+    # Even though 888 is in current_pids, it's not the attested process!
+    assert gateway_windows.attested_gateway_died(current_pids=[888]) is True
+
+    # Same PID with matching create_time (5000.0) is the genuine live process
+    monkeypatch.setattr(gst, "get_process_start_time", lambda pid: 5000.0 if pid == 888 else None)
+    assert gateway_windows.attested_gateway_died(current_pids=[888]) is False
+
+    # Unrelated clean exit in ledger with different start_time (2000.0 != 5000.0) does NOT suppress recovery
+    (state / "gateway.lifecycle.json").write_text(
+        json.dumps({"phase": "exited", "pid": 888, "start_time": 2000.0, "exit_reason": "graceful_shutdown"}),
+        encoding="utf-8",
+    )
+    assert gateway_windows.attested_gateway_died(current_pids=[]) is True
+
+    # Matching clean exit in ledger (start_time 5000.0 == 5000.0) proves legitimate clean exit
+    (state / "gateway.lifecycle.json").write_text(
+        json.dumps({"phase": "exited", "pid": 888, "start_time": 5000.0, "exit_reason": "graceful_shutdown"}),
+        encoding="utf-8",
+    )
+    assert gateway_windows.attested_gateway_died(current_pids=[]) is False
+
+
+def test_attested_probe_malformed_payload_fails_closed(attest_home):
+    """Malformed payloads must fail closed safely: 'unknown must never read as dead'."""
+    state = attest_home / "state"
+    state.mkdir(exist_ok=True)
+    marker = state / "gateway.start-attestation.json"
+
+    for bad in [
+        "not json",
+        json.dumps(None),
+        json.dumps("string"),
+        json.dumps([]),
+        json.dumps({}),
+        json.dumps({"pids": None}),
+        json.dumps({"pids": "not_a_list"}),
+        json.dumps({"pids": [None]}),
+        json.dumps({"pids": ["not_int"]}),
+        json.dumps({"pids": [123], "timestamp": "bad_ts", "ts": None}),
+    ]:
+        marker.write_text(bad, encoding="utf-8")
+        assert gateway_windows.attested_gateway_died(current_pids=[]) is False

--- a/tests/hermes_cli/test_windows_gateway_cold_start_desktop_lifecycle.py
+++ b/tests/hermes_cli/test_windows_gateway_cold_start_desktop_lifecycle.py
@@ -94,10 +94,34 @@ def test_pause_skips_cold_start_plan_when_desktop_owns_lifecycle(monkeypatch):
         hermes_gateway, "find_windows_gateway_services", lambda **_k: []
     )
     monkeypatch.setattr(gateway_windows, "is_installed", lambda: True)
+    monkeypatch.setattr(gateway_windows, "attested_gateway_died", lambda: False)
     monkeypatch.setattr(update_cmd, "_desktop_owns_gateway_lifecycle", lambda: True)
     monkeypatch.setattr(update_cmd_windows, "_desktop_owns_gateway_lifecycle", lambda: True)
 
     assert update_cmd._pause_windows_gateways_for_update() is None
+
+
+def test_pause_warns_when_desktop_owns_lifecycle_under_gateway_mode(monkeypatch, capsys):
+    """#109538 (Suggestion 2): when --gateway is requested and cold-start is skipped
+    because Desktop owns lifecycle, print an actionable warning instead of a silent debug log."""
+    import argparse
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: True)
+    monkeypatch.setattr(main_install_repair, "_is_windows", lambda: True)
+    monkeypatch.setattr(hermes_gateway, "find_gateway_pids", lambda **_k: [])
+    monkeypatch.setattr(
+        hermes_gateway, "find_windows_gateway_services", lambda **_k: []
+    )
+    monkeypatch.setattr(gateway_windows, "is_installed", lambda: True)
+    monkeypatch.setattr(gateway_windows, "attested_gateway_died", lambda: False)
+    monkeypatch.setattr(update_cmd, "_desktop_owns_gateway_lifecycle", lambda: True)
+    monkeypatch.setattr(update_cmd_windows, "_desktop_owns_gateway_lifecycle", lambda: True)
+
+    args = argparse.Namespace(gateway=True)
+    token = update_cmd._pause_windows_gateways_for_update(args)
+    assert token is None
+    out = capsys.readouterr().out
+    assert "Gateway cold-start skipped: Desktop control plane active" in out
+    assert "hermes gateway start" in out
 
 
 def test_pause_still_cold_starts_when_autostart_and_no_desktop_owner(monkeypatch):
@@ -122,11 +146,38 @@ def test_pause_still_cold_starts_when_autostart_and_no_desktop_owner(monkeypatch
     }
 
 
+def test_pause_keeps_cold_start_plan_when_desktop_owns_but_attested_gateway_died(monkeypatch):
+    """#109538: the Desktop hand-off can kill the running gateway moments before this
+    discovery runs, so a dead start attestation is the surviving 'a gateway was up'
+    evidence. The plan must keep the cold-start instead of silently leaving the bot down."""
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: True)
+    monkeypatch.setattr(main_install_repair, "_is_windows", lambda: True)
+    monkeypatch.setattr(hermes_gateway, "find_gateway_pids", lambda **_k: [])
+    monkeypatch.setattr(
+        hermes_gateway, "find_windows_gateway_services", lambda **_k: []
+    )
+    monkeypatch.setattr(gateway_windows, "is_installed", lambda: True)
+    monkeypatch.setattr(gateway_windows, "attested_gateway_died", lambda: True)
+    monkeypatch.setattr(update_cmd, "_desktop_owns_gateway_lifecycle", lambda: True)
+    monkeypatch.setattr(update_cmd_windows, "_desktop_owns_gateway_lifecycle", lambda: True)
+
+    token = update_cmd._pause_windows_gateways_for_update()
+
+    assert token == {
+        "resume_needed": True,
+        "profiles": {},
+        "unmapped_pids": [],
+        "unmapped": [],
+        "cold_start_if_installed": True,
+    }
+
+
 def test_cold_start_aborts_when_desktop_owns_lifecycle(monkeypatch):
     spawned = []
     monkeypatch.setattr(cli_main, "_is_windows", lambda: True)
     monkeypatch.setattr(main_install_repair, "_is_windows", lambda: True)
     monkeypatch.setattr(hermes_gateway, "find_gateway_pids", lambda **_k: [])
+    monkeypatch.setattr(gateway_windows, "attested_gateway_died", lambda: False)
     monkeypatch.setattr(update_cmd, "_desktop_owns_gateway_lifecycle", lambda: True)
     monkeypatch.setattr(update_cmd_windows, "_desktop_owns_gateway_lifecycle", lambda: True)
     monkeypatch.setattr(
@@ -136,3 +187,27 @@ def test_cold_start_aborts_when_desktop_owns_lifecycle(monkeypatch):
     update_cmd._cold_start_windows_gateway_after_update()
 
     assert spawned == []
+
+
+def test_cold_start_restores_attested_dead_gateway_despite_desktop_ownership(monkeypatch, capsys):
+    """#109538: the same dead attestation must also survive the spawn-time ownership
+    re-check — nothing else brings the messaging gateway back on this install."""
+    spawned = []
+    monkeypatch.setattr(cli_main, "_is_windows", lambda: True)
+    monkeypatch.setattr(main_install_repair, "_is_windows", lambda: True)
+    monkeypatch.setattr(hermes_gateway, "find_gateway_pids", lambda **_k: [])
+    monkeypatch.setattr(gateway_windows, "attested_gateway_died", lambda: True)
+    monkeypatch.setattr(update_cmd, "_desktop_owns_gateway_lifecycle", lambda: True)
+    monkeypatch.setattr(update_cmd_windows, "_desktop_owns_gateway_lifecycle", lambda: True)
+    monkeypatch.setattr(
+        gateway_windows, "_spawn_detached", lambda: spawned.append(1) or 4242
+    )
+    monkeypatch.setattr(gateway_windows, "_wait_for_gateway_ready", lambda *a, **k: [4242])
+    monkeypatch.setattr(gateway_windows, "_write_start_attestation", lambda *a, **k: None)
+
+    assert update_cmd._cold_start_windows_gateway_after_update() is True
+    assert spawned == [1]
+    assert (
+        "Gateway started via cold-start after update (PID: 4242)"
+        in capsys.readouterr().out
+    )


### PR DESCRIPTION
## What does this PR do?

Resolves the silent-outage bug reported in #109538 and provides a robust, canonical solution for Windows gateway update hand-off lifecycle management:
On Windows, when the Desktop self-update hand-off exits the Desktop app, running messaging gateways (e.g. Telegram / Discord) can die moments before the updater starts (due to pre-update stop or Job Object collateral teardown).
The subsequent `hermes update --gateway` found no running gateway PIDs, but skipped the cold-start plan via `_desktop_owns_gateway_lifecycle()`. Because Desktop only supervises its own internal control plane (`serve`) and never relaunches messaging gateways, the bot remained silently offline until manual intervention.

This PR provides a comprehensive fix that resolves the root causes and addresses the architectural constraints:
1. **Preserves the Cold-Start Plan on Attested Death**: In `_windows_cold_start_plan()`, Desktop lifecycle ownership does not suppress cold-start when an attested gateway process died.
2. **Double-Checked Spawn Protection**: In `_cold_start_windows_gateway_after_update()`, Desktop ownership allows cold-start recovery if an attested gateway was lost.
3. **Loud Warning for Skipped Gateway Updates (Suggestion 2 in #109538)**: Skipping a `--gateway` cold-start under active Desktop control plane now prints an explicit, visible warning with `hermes gateway start` guidance instead of hiding behind a `logger.debug` trace.
4. **Attestation Identity Binding & Freshness**:
   - `_write_start_attestation()` records `(pid, create_time)` and numeric UTC timestamp.
   - `attested_gateway_died()` enforces a 24-hour freshness window so stale crash markers from days ago cannot falsely steal lifecycle.
   - Validates process `create_time` against current PIDs and ledger exit records to protect against PID reuse.
5. **Fail-Closed Malformed Data Handling**:
   - `_read_start_attestation()` and `_attested_pids_from()` strictly validate payload types.
   - Any malformed payload (e.g. `{"pids": null}`, non-list, bad types) fails closed safely returning `False` ("unknown must never read as dead"), preserving Desktop ownership refusal.

## Related Issue

Fixes #109538

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway_windows.py`:
  - `_write_start_attestation()`: records process `create_times` via `get_process_start_time` and `timestamp`.
  - `_read_start_attestation()` / `_attested_pids_from()`: safe parsers with strict type validation.
  - `_is_attestation_fresh()`: validates marker age within 24h freshness window.
  - `_attested_pid_exited_cleanly()`: checks ledger exit record with `create_time` match.
  - `attested_gateway_died()`: read-only probe verifying attested dead processes without consuming marker.
- `hermes_cli/update_cmd_windows.py`:
  - `_windows_cold_start_plan(args=None)`: preserves cold-start plan when attested gateway died; prints actionable warning when `--gateway` is active and cold-start is skipped.
  - `_pause_windows_gateways_for_update(args=None)`: forwards args to `_windows_cold_start_plan`.
  - `_cold_start_windows_gateway_after_update()`: allows spawn when attested gateway died.
- `hermes_cli/update_cmd.py`:
  - Passes `args` into `_pause_windows_gateways_for_update(args)`.
- `tests/hermes_cli/test_windows_gateway_cold_start_desktop_lifecycle.py`:
  - Added tests for warning on skip with `--gateway`, keeping plan on attested death, and restoring attested dead gateway.
- `tests/hermes_cli/test_gateway_start_attestation.py`:
  - Added tests for `create_times` and `timestamp` persistence, read-only death probe, freshness window enforcement, PID reuse protection, and fail-closed malformed payload handling.

## How to Test

1. Run the targeted test suites:
   `python scripts/run_tests_parallel.py tests/hermes_cli/test_windows_gateway_cold_start_desktop_lifecycle.py tests/hermes_cli/test_gateway_start_attestation.py`
2. Run related Windows gateway/update suites:
   `python scripts/run_tests_parallel.py tests/hermes_cli/test_gateway_windows.py tests/hermes_cli/test_update_cold_start_gateway_liveness.py tests/hermes_cli/test_windows_update_restart_reconciliation.py tests/hermes_cli/test_update_handoff_backend_reap.py`
   (All tests pass with 0 failures).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(update): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] Focused test suites pass locally (all Windows gateway and update suites green)
- [x] I've added invariant tests covering the behavioral contract
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Docstrings updated with issue context (#109538)
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered: all modifications are Windows-specific under existing Windows platform guards.
