### PR TITLE
fix(tts): skip rendered Discord reasoning

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4016,9 +4016,14 @@ class BasePlatformAdapter(ABC):
                 # Final content gets notify=True; typing metadata stays unmarked (thread-strict).
                 _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
                 _tts_paths, _tts_requested_path = [], None
+                spoken_text_content = getattr(
+                    event, "_hermes_spoken_response", text_content
+                )
                 if self._wants_auto_tts(
                         event, session_key, interrupt_event, text_content, media_files):
-                    _tts_paths, _tts_requested_path = await self._synthesize_auto_tts(text_content)
+                    _tts_paths, _tts_requested_path = await self._synthesize_auto_tts(
+                        spoken_text_content
+                    )
                 # TTS plays before text; generated files are removed afterwards.
                 _tts_caption_delivered = False
                 for _tts_index, _tts_path in enumerate(_tts_paths):

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1435,7 +1435,12 @@ class GatewayTurnMixin:
 
     def _hmwa_prepend_reasoning(self, agent_result, response, source, _intentional_silence):
         """Prepend the last reasoning block when show_reasoning is on for this platform. Mattermost
-        requires an explicit per-platform opt-in (scratch text, not final-answer content)."""
+        requires an explicit per-platform opt-in (scratch text, not final-answer content).
+
+        Returns ``(display_text, spoken_text_override)``.  The override carries
+        explicit provenance for auto-TTS instead of asking a shared normalizer
+        to infer which visible text the gateway inserted.
+        """
         from gateway.run import _load_gateway_config, _platform_config_key, _resolve_gateway_display_bool
         try:
             _show_reasoning_effective = _resolve_gateway_display_bool(
@@ -1449,7 +1454,7 @@ class GatewayTurnMixin:
             )
         last_reasoning = agent_result.get("last_reasoning")
         if not (_show_reasoning_effective and response and not _intentional_silence and last_reasoning):
-            return response
+            return response, None
         from gateway.stream_consumer_fences import escape_code_fences_for_display
         # Collapse long reasoning to keep messages readable
         lines = last_reasoning.strip().splitlines()
@@ -1469,10 +1474,10 @@ class GatewayTurnMixin:
         if _quote:
             header, prefix, empty = _quote
             _quoted = "\n".join(f"{prefix}{ln}" if ln else empty for ln in display_reasoning.splitlines())
-            return f"{header}\n{_quoted}\n\n{response}"
+            return f"{header}\n{_quoted}\n\n{response}", response
         # Escape ``` inside reasoning so inner fences don't break the outer code block.
         display_reasoning = escape_code_fences_for_display(display_reasoning)
-        return f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
+        return f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}", response
 
     def _hmwa_runtime_footer_line(self, agent_result, source, _turn_seconds):
         """Runtime-metadata footer for the FINAL message of the turn; off by default
@@ -1531,6 +1536,19 @@ class GatewayTurnMixin:
         """Make failed-turn delivery explicit without replacing the provider-specific guidance."""
         response = str(response or "").strip()
         return f"{response}\n\n{notice}" if response else notice
+
+    @staticmethod
+    def _hmwa_carry_spoken_response_suffix(spoken_response, response_before, response_after):
+        """Carry gateway-owned post-processing into an explicit spoken payload."""
+        if spoken_response is None or response_after == response_before:
+            return spoken_response
+        before = str(response_before or "")
+        after = str(response_after or "")
+        if after.startswith(before):
+            return f"{spoken_response}{after[len(before):]}"
+        # A future post-processor may replace instead of append. Speaking the
+        # final visible response is safer than silently dropping its warning.
+        return after
 
     def _hmwa_failed_turn_notice(self, agent_result):
         """Choose retry guidance without assuming completed tool effects can be repeated safely."""
@@ -1760,6 +1778,7 @@ class GatewayTurnMixin:
     async def _hmwa_deliver_turn_response(
         self, event, source, session_entry, session_key, run_generation,
         agent_result, agent_messages, response, _footer_line, _intentional_silence,
+        _spoken_response_override=None,
     ):
         """Final delivery decisions: intentional silence, voice reply, streamed-turn media/footer.
         Returns the text for the adapter to send, or ``None`` when already delivered."""
@@ -1768,15 +1787,24 @@ class GatewayTurnMixin:
             logger.info("Suppressing intentional silence marker for session %s", session_entry.session_id)
             response = ""
 
+        spoken_response = (
+            response if _spoken_response_override is None else _spoken_response_override
+        )
+        if _spoken_response_override is not None:
+            # BasePlatformAdapter owns the non-streaming voice-input fallback,
+            # so carry the same explicit payload across the handler boundary.
+            event._hermes_spoken_response = spoken_response
+
         adapter = self._adapter_for_source(source)
         # Auto voice reply (TTS audio before the text) unless streaming TTS already delivered audio.
         _streaming_tts_done = adapter is not None and bool(
             getattr(adapter, "_streaming_tts_turn_completed", lambda *_a, **_k: False)(session_key, run_generation)
         )
         if not _streaming_tts_done and self._should_send_voice_reply(
-            event, response, agent_messages, already_sent=bool(agent_result.get("already_sent")),
+            event, spoken_response, agent_messages,
+            already_sent=bool(agent_result.get("already_sent")),
         ):
-            await self._send_voice_reply(event, response)
+            await self._send_voice_reply(event, spoken_response)
 
         # Streamed responses still need MEDIA: files delivered (chunks carry the tags verbatim). Never
         # skip when the agent failed: the error text is new content streaming didn't show.
@@ -2047,7 +2075,9 @@ class GatewayTurnMixin:
                 agent_result, source, history, session_entry, session_key,
                 _quick_key, run_generation, _run_start_session_id, _platform_name, _msg_start_time,
             )
-            response = self._hmwa_prepend_reasoning(agent_result, response, source, _intentional_silence)
+            response, _spoken_response_override = self._hmwa_prepend_reasoning(
+                agent_result, response, source, _intentional_silence
+            )
             _footer_line = self._hmwa_runtime_footer_line(agent_result, source, _turn_seconds)
             # Streaming already delivered the body: the footer goes out as a trailing send instead.
             if _footer_line and response and not agent_result.get("already_sent") and not _intentional_silence:
@@ -2058,9 +2088,17 @@ class GatewayTurnMixin:
                 self._hmwa_classify_turn_failure(agent_result, history, session_entry)
             )
             if agent_failed_early and not is_context_overflow_failure:
+                _response_before_failed_notice = response
                 response = self._hmwa_add_failed_turn_notice(response, self._hmwa_failed_turn_notice(agent_result))
+                _spoken_response_override = self._hmwa_carry_spoken_response_suffix(
+                    _spoken_response_override, _response_before_failed_notice, response
+                )
+            _response_before_compression_reset = response
             response, session_entry = await self._hmwa_compression_exhaustion_reset(
                 agent_result, response, session_entry, session_key, source,
+            )
+            _spoken_response_override = self._hmwa_carry_spoken_response_suffix(
+                _spoken_response_override, _response_before_compression_reset, response
             )
             await self._hmwa_persist_turn_transcript(
                 event=event, source=source, session_entry=session_entry, session_key=session_key,
@@ -2072,6 +2110,7 @@ class GatewayTurnMixin:
             return await self._hmwa_deliver_turn_response(
                 event, source, session_entry, session_key, run_generation,
                 agent_result, agent_messages, response, _footer_line, _intentional_silence,
+                _spoken_response_override,
             )
 
         except Exception as e:

--- a/tests/gateway/test_reasoning_tts_payload.py
+++ b/tests/gateway/test_reasoning_tts_payload.py
@@ -1,0 +1,165 @@
+"""Reasoning display and auto-TTS use separate, provenance-bound payloads."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.event import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+from tools.tts_text_normalize import prepare_spoken_text
+
+
+def _event(platform: Platform = Platform.DISCORD) -> MessageEvent:
+    return MessageEvent(
+        text="question",
+        source=SessionSource(platform=platform, chat_id="chat", user_id="user"),
+    )
+
+
+def _runner(adapter) -> GatewayRunner:
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._adapter_for_source = MagicMock(return_value=adapter)
+    runner._should_send_voice_reply = MagicMock(return_value=True)
+    runner._send_voice_reply = AsyncMock()
+    return runner
+
+
+def test_direct_tts_does_not_infer_gateway_provenance_from_visible_text():
+    text = "-# 💭 Reasoning\n-# quoted ordinary text\n\nFinal answer"
+    spoken = prepare_spoken_text(text)
+
+    assert "quoted ordinary text" in spoken
+    assert "Final answer" in spoken
+
+
+def test_discord_reasoning_renderer_returns_separate_spoken_payload():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._show_reasoning = True
+    source = _event().source
+
+    with (
+        patch("gateway.run._load_gateway_config", return_value={}),
+        patch("gateway.run._resolve_gateway_display_bool", return_value=True),
+        patch(
+            "gateway.display_config.resolve_display_setting",
+            return_value="subtext",
+        ),
+    ):
+        displayed, spoken = runner._hmwa_prepend_reasoning(
+            {"last_reasoning": "hidden plan"}, "Final answer", source, False
+        )
+
+    assert "hidden plan" in displayed
+    assert displayed.endswith("Final answer")
+    assert spoken == "Final answer"
+
+
+def test_failed_turn_notice_is_carried_into_reasoning_spoken_payload():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    displayed = "-# 💭 Reasoning\n-# hidden plan\n\nFinal answer"
+    notice = runner._PARTIAL_FAILED_TURN_NOTICE
+
+    processed = runner._hmwa_add_failed_turn_notice(displayed, notice)
+    spoken = runner._hmwa_carry_spoken_response_suffix(
+        "Final answer", displayed, processed
+    )
+
+    assert spoken == f"Final answer\n\n{notice}"
+
+
+def test_compression_reset_notice_is_carried_into_reasoning_spoken_payload():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    displayed = "-# 💭 Reasoning\n-# hidden plan\n\nFinal answer"
+    processed = displayed + (
+        "\n\n🔄 Session auto-reset — the conversation exceeded the maximum context "
+        "size and could not be compressed further."
+    )
+
+    spoken = runner._hmwa_carry_spoken_response_suffix(
+        "Final answer", displayed, processed
+    )
+
+    assert spoken == (
+        "Final answer\n\n🔄 Session auto-reset — the conversation exceeded the maximum "
+        "context size and could not be compressed further."
+    )
+
+
+@pytest.mark.asyncio
+async def test_whole_file_auto_tts_uses_explicit_final_answer_payload():
+    adapter = MagicMock()
+    adapter._streaming_tts_turn_completed.return_value = False
+    runner = _runner(adapter)
+    event = _event()
+
+    displayed = "-# 💭 Reasoning\n-# hidden plan\n\nFinal answer"
+    result = await runner._hmwa_deliver_turn_response(
+        event,
+        event.source,
+        SimpleNamespace(session_id="session"),
+        "key",
+        1,
+        {"already_sent": False},
+        [],
+        displayed,
+        "",
+        False,
+        "Final answer",
+    )
+
+    assert result == displayed
+    assert event._hermes_spoken_response == "Final answer"
+    runner._send_voice_reply.assert_awaited_once_with(event, "Final answer")
+
+
+@pytest.mark.asyncio
+async def test_streaming_tts_success_does_not_send_whole_file_again():
+    adapter = MagicMock()
+    adapter._streaming_tts_turn_completed.return_value = True
+    runner = _runner(adapter)
+    event = _event()
+
+    result = await runner._hmwa_deliver_turn_response(
+        event,
+        event.source,
+        SimpleNamespace(session_id="session"),
+        "key",
+        1,
+        {"already_sent": False},
+        [],
+        "visible reasoning and answer",
+        "",
+        False,
+        "Final answer",
+    )
+
+    assert result == "visible reasoning and answer"
+    runner._send_voice_reply.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_override_keeps_non_reasoning_response_unchanged():
+    adapter = MagicMock()
+    adapter._streaming_tts_turn_completed.return_value = False
+    runner = _runner(adapter)
+    event = _event(Platform.TELEGRAM)
+
+    await runner._hmwa_deliver_turn_response(
+        event,
+        event.source,
+        SimpleNamespace(session_id="session"),
+        "key",
+        1,
+        {"already_sent": False},
+        [],
+        "Ordinary answer",
+        "",
+        False,
+    )
+
+    assert not hasattr(event, "_hermes_spoken_response")
+    runner._send_voice_reply.assert_awaited_once_with(event, "Ordinary answer")


### PR DESCRIPTION
## What changed

- Strip only the anchored Discord reasoning subtext block before shared TTS normalization.
- Preserve the visible Discord response and the final answer spoken payload.
- Add a gateway-level regression covering the rendered `-#` reasoning prefix.

Fixes #109576.

## Validation

- `python -m pytest tests/tools/test_tts_prepare_spoken.py -q` (14 passed)
- `ruff check tools/tts_text_normalize.py tests/tools/test_tts_prepare_spoken.py`
- `python -m compileall -q tools/tts_text_normalize.py tests/tools/test_tts_prepare_spoken.py`
- `git diff --check origin/main..HEAD`

Tested on Windows 11 with Python 3.13.