### PR TITLE
fix(dashboard): resolve the runtime provider before auto-detecting context length

### DIFF
--- a/hermes_cli/web_routers/models.py
+++ b/hermes_cli/web_routers/models.py
@@ -5,6 +5,7 @@ Extracted from ``hermes_cli.web_server``; helpers/state that tests monkeypatch o
 """
 
 import asyncio
+import contextlib
 import logging
 from typing import Optional
 
@@ -55,7 +56,8 @@ def get_model_info(profile: Optional[str] = None):
     context length (so the UI can show "Auto-detected: 200K" beside the
     override) plus models.dev capabilities when available."""
     try:
-        model_cfg = _load_config_scoped(profile).get("model", "")
+        cfg = _load_config_scoped(profile)
+        model_cfg = cfg.get("model", "")
         model_name, provider = _main_model_fields(model_cfg)
         base_url = model_cfg.get("base_url", "") if isinstance(model_cfg, dict) else ""
         config_ctx = model_cfg.get("context_length") if isinstance(model_cfg, dict) else None
@@ -65,9 +67,22 @@ def get_model_info(profile: Optional[str] = None):
 
         try:
             from agent.model_metadata import get_model_context_length
-            # config_context_length=None: ignore the override — we want the auto value
-            auto_ctx = get_model_context_length(model=model_name, base_url=base_url, provider=provider,
-                                                config_context_length=None)
+            # config_context_length=None: ignore the override — we want the auto value.
+            # Resolve the runtime provider inside the profile scope first, the way the
+            # agent's own client path does: when the endpoint lives in a custom_providers
+            # entry, model.base_url is empty (the normal shape for that setup) and every
+            # resolver route is gated on a non-empty base_url, so the resolver fell
+            # straight through to the 256K default — shown as "Auto-detected" (#86097).
+            with _profile_scope(profile):
+                api_key = ""
+                with contextlib.suppress(Exception):
+                    from hermes_cli.runtime_provider import resolve_runtime_provider
+                    rt = resolve_runtime_provider(requested=provider or None, target_model=model_name) or {}
+                    base_url = str(rt.get("base_url") or base_url or "").strip()
+                    api_key = str(rt.get("api_key") or "")
+                auto_ctx = get_model_context_length(model=model_name, base_url=base_url, api_key=api_key,
+                                                    provider=provider, config_context_length=None,
+                                                    custom_providers=cfg.get("custom_providers"))
         except Exception:
             auto_ctx = 0
 

--- a/tests/hermes_cli/test_model_info_custom_provider_context.py
+++ b/tests/hermes_cli/test_model_info_custom_provider_context.py
@@ -1,0 +1,115 @@
+"""Regression tests for ``/api/model/info`` custom-provider context-length resolution.
+
+Issue #86097: the route read ``model.base_url`` straight from the model config and
+never resolved the runtime provider nor forwarded ``custom_providers``. For installs
+whose endpoint lives in a ``custom_providers`` entry, ``model.base_url`` is empty
+(the normal shape for that setup), so every resolver route gated on a non-empty
+``base_url`` was skipped and the settings UI showed the 256K fallback as
+"Auto-detected" instead of the entry's real window.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from hermes_cli.web_routers.models import get_model_info
+
+ENTRY_URL = "http://127.0.0.1:8301/v1"
+
+
+def _make_cfg(entry=None):
+    model_cfg = {"default": "profile-main", "provider": "omlx-local", "base_url": ""}
+    custom_providers = [entry] if entry is not None else []
+    return {"model": model_cfg, "custom_providers": custom_providers}
+
+
+def _run(cfg, resolved=None, resolve_raises=False):
+    """Call ``get_model_info`` with config load, profile scope, and runtime
+    provider resolution patched; return (info, calls-seen)."""
+    seen = {}
+
+    def fake_resolve(*, requested=None, explicit_api_key=None, explicit_base_url=None, target_model=None):
+        if resolve_raises:
+            raise RuntimeError("resolution unavailable")
+        seen["requested"] = requested
+        seen["target_model"] = target_model
+        return dict(resolved or {})
+
+    with (
+        patch("hermes_cli.config.load_config", side_effect=lambda: cfg),
+        patch("hermes_cli.web_server_profiles._profile_scope"),
+        patch("hermes_cli.runtime_provider.resolve_runtime_provider", side_effect=fake_resolve),
+        patch("agent.models_dev.get_model_capabilities", return_value=None),
+    ):
+        info = get_model_info(profile=None)
+
+    return info, seen
+
+
+def _capture_resolver_call(monkeypatch):
+    """Record what the route hands to ``get_model_context_length``."""
+    from agent import model_metadata
+
+    captured = {}
+
+    def fake_ctx(model, base_url="", api_key="", config_context_length=None, provider="", custom_providers=None):
+        captured.update(model=model, base_url=base_url, api_key=api_key,
+                        provider=provider, custom_providers=custom_providers)
+        # Stand-in for the entry's real window (oMLX publishes 262144 via /v1/models).
+        if base_url == ENTRY_URL and custom_providers:
+            return 262144
+        return 256000
+
+    monkeypatch.setattr(model_metadata, "get_model_context_length", fake_ctx)
+    return captured
+
+
+def test_custom_provider_endpoint_reaches_the_resolver(monkeypatch):
+    """The resolver must receive the custom entry's base_url and the config's
+    custom_providers — not the empty model.base_url (#86097)."""
+    captured = _capture_resolver_call(monkeypatch)
+    entry = {"name": "omlx-local", "base_url": ENTRY_URL}
+
+    info, seen = _run(_make_cfg(entry), resolved={"base_url": ENTRY_URL, "api_key": ""})
+
+    assert seen["requested"] == "omlx-local"
+    assert seen["target_model"] == "profile-main"
+    assert captured["base_url"] == ENTRY_URL, "resolver got the empty model.base_url"
+    assert captured["custom_providers"] == [entry], "custom_providers were not forwarded"
+    assert info["auto_context_length"] == 262144
+    assert info["effective_context_length"] == 262144
+
+
+def test_resolver_key_forwarded_to_the_probe(monkeypatch):
+    """The resolved entry credential rides along, so a keyed local server does not
+    answer the context probe with 401s."""
+    captured = _capture_resolver_call(monkeypatch)
+
+    _run(_make_cfg({"name": "omlx-local", "base_url": ENTRY_URL}),
+         resolved={"base_url": ENTRY_URL, "api_key": "route" + "-entry-" + "credential"})
+
+    assert captured["api_key"] == "route" + "-entry-" + "credential"
+
+
+def test_resolution_failure_degrades_to_config_base_url(monkeypatch):
+    """A resolver error must not break the route: fall back to the (possibly
+    empty) config base_url — the pre-fix behaviour, not a 500."""
+    captured = _capture_resolver_call(monkeypatch)
+
+    info, _ = _run(_make_cfg(), resolve_raises=True)
+
+    assert captured["base_url"] == ""
+    assert info["auto_context_length"] == 256000
+    assert info["model"] == "profile-main"
+
+
+def test_cloud_runtime_without_base_url_keeps_configured_one(monkeypatch):
+    """A resolved cloud provider (no base_url of its own) leaves a configured
+    model.base_url untouched."""
+    captured = _capture_resolver_call(monkeypatch)
+    cfg = _make_cfg()
+    cfg["model"]["base_url"] = "https://proxy.example.internal/v1"
+
+    _run(cfg, resolved={"provider": "openai"})
+
+    assert captured["base_url"] == "https://proxy.example.internal/v1"


### PR DESCRIPTION
## What does this PR do?

`/api/model/info` read `base_url` straight from the model config and never resolved the runtime provider nor forwarded `custom_providers`. For installs whose endpoint lives in a `custom_providers` entry, `model.base_url` is empty — the normal shape for that setup — and every resolver route in `get_model_context_length` is gated on a non-empty `base_url`, so the resolver fell straight through to the 256K default and the settings UI displayed it as "Auto-detected" next to the override field.

The fix resolves the runtime provider inside the profile scope first (the same pattern the agent's own client path uses, e.g. `agent_runtime_helpers.py`), then forwards the resolved `base_url`/`api_key` plus the config's `custom_providers` to `get_model_context_length`, so the resolver reaches the per-model override (step 0c) and the endpoint probes (`/v1/models` `max_model_len`). A resolution failure degrades to the configured `base_url` — the previous behaviour, never a 500 on this display-only route.

## Related Issue

Fixes #86097

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_routers/models.py` — `get_model_info` now resolves the runtime provider (`requested=provider`, `target_model=model`) inside `_profile_scope(profile)` and overrides `base_url`/`api_key` from the resolved runtime; passes `cfg.get("custom_providers")` through to `get_model_context_length`.
- `tests/hermes_cli/test_model_info_custom_provider_context.py` — regression tests: entry endpoint + `custom_providers` reach the resolver, resolved credential rides along, resolver failure degrades to the configured `base_url`, cloud runtimes without their own `base_url` keep the configured one.

## How to Test

1. Configure a model whose endpoint lives in a `custom_providers` entry (empty `model.base_url`) served by a server that publishes `max_model_len` via `GET /v1/models` (e.g. oMLX).
2. Open the dashboard model settings — before: "Auto-detected: 256K"; after: the server's real window (262144 in the issue's report).
3. `.venv/bin/python -m pytest tests/hermes_cli/test_model_info_custom_provider_context.py -q` — Observed result: 4 passed. Full surface around the change (`test_moa_set_models_preserves_extra_keys`, `test_nous_policy_surfaces`, `test_code_skew`, `test_dashboard_auth_middleware`, `test_model_switch_custom_providers`, `test_model_cost_guard`, `test_inventory`, `test_web_routers_*`): 158 passed. `ruff check` on both files: All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #15060 fills `config_context_length` from per-model overrides but its helper returns 0 whenever `model.base_url` is empty, so it does not cover this install shape (and it targets the pre-split `web_server.py` layout); #83696 improves the oMLX probe *inside* the resolver, while this PR fixes the caller never reaching it. #86097 was re-triaged today as not a duplicate of #24640 (different failure point).
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — targeted suites listed above all pass on Python 3.11
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comment documents the constraint)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (no platform-specific code touched)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/hermes_cli/test_model_info_custom_provider_context.py -q
....                                                                     [100%]
4 passed in 0.40s
```
