### PR TITLE
fix(auxiliary): keep key_cmd credentials and extra_headers through the async rebuild

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4336,7 +4336,14 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     if _client_declares(sync_client, "HERMES_SKIP_ASYNC_WRAP"):
         return sync_client, model
     sync_base_url = str(sync_client.base_url)
-    async_kwargs = {"api_key": sync_client.api_key, "base_url": sync_base_url}
+    # key_cmd/Entra credentials live in the SDK's per-request provider slot — ``.api_key`` stays
+    # "" until the first request refreshes it. Rebuilding AsyncOpenAI from ``.api_key`` alone
+    # drops the provider and every async aux call goes out with no Authorization header (#109595).
+    _key_provider = getattr(sync_client, "_api_key_provider", None)
+    async_kwargs = {
+        "api_key": _key_provider if callable(_key_provider) else sync_client.api_key,
+        "base_url": sync_base_url,
+    }
     if base_url_host_matches(sync_base_url, "openrouter.ai"):
         headers = _apply_user_default_headers(build_or_headers())
     elif _is_official_codex_base_url(sync_base_url):
@@ -4349,6 +4356,14 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
         except Exception:
             inferred = ""
         headers = _endpoint_default_headers(sync_base_url, inferred, is_vision=is_vision, xai=True)
+    # Named-custom entries lift user extra_headers onto the sync client's default_headers; the
+    # rebuild would drop them — carry user-configured (non-SDK-generated) headers across (#109595).
+    _sdk_header_keys = {"accept", "content-type", "user-agent", "authorization"}
+    _sync_user_headers = {
+        k: v for k, v in dict(getattr(sync_client, "default_headers", None) or {}).items()
+        if str(k).lower() not in _sdk_header_keys and not str(k).lower().startswith(("x-stainless", "openai-"))
+    }
+    headers = {**_sync_user_headers, **(headers or {})}
     if headers:
         async_kwargs["default_headers"] = headers
     _apply_required_codex_headers(async_kwargs, access_token=sync_client.api_key, base_url=sync_base_url)
@@ -4711,11 +4726,14 @@ def _resolve_custom_branch(req: _ResolveRequest) -> _ResolveResult:
     return None, None
 
 
-def _named_custom_openai_wire_client(custom_base: str, custom_key: Any):
+def _named_custom_openai_wire_client(custom_base: str, custom_key: Any, extra_headers: Optional[Dict[str, str]] = None):
     """Plain OpenAI client on the /v1 equivalent of a named custom entry's base URL."""
     _clean_base, _dq = _extract_url_query_params(_to_openai_base_url(custom_base))
     _extra = {"default_query": _dq} if _dq else {}
     _headers = _apply_user_default_headers(None)
+    if isinstance(extra_headers, dict) and extra_headers:
+        # The entry's extra_headers (gateway routing tags etc.) must reach the wire (#109595).
+        _headers = {**(_headers or {}), **{str(k): str(v) for k, v in extra_headers.items()}}
     if _headers:
         _extra["default_headers"] = _headers
     return _create_openai_client(api_key=custom_key, base_url=_clean_base, **_extra)
@@ -4776,7 +4794,9 @@ def _resolve_named_custom_branch(req: _ResolveRequest) -> Optional[_ResolveResul
             return _route_client(req, _named_custom_openai_wire_client(custom_base, custom_key), final_model)
         return _route_client(
             req, AnthropicAuxiliaryClient(real_client, final_model, custom_key, custom_base, is_oauth=False), final_model)
-    client = _named_custom_openai_wire_client(custom_base, custom_key)
+    _entry_headers = custom_entry.get("extra_headers")
+    client = _named_custom_openai_wire_client(
+        custom_base, custom_key, extra_headers=_entry_headers if isinstance(_entry_headers, dict) else None)
     # codex_responses, or auto-detect via _wrap_transport (which reads the task-level api_mode).
     if entry_api_mode == "codex_responses":
         client = CodexAuxiliaryClient(client, final_model)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4365,13 +4365,23 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
             inferred = ""
         headers = _endpoint_default_headers(sync_base_url, inferred, is_vision=is_vision, xai=True)
     # Named-custom entries lift user extra_headers onto the sync client's default_headers; the
-    # rebuild would drop them — carry user-configured (non-SDK-generated) headers across (#109595).
-    _sdk_header_keys = {"accept", "content-type", "user-agent", "authorization"}
-    _sync_user_headers = {
-        k: v for k, v in dict(getattr(sync_client, "default_headers", None) or {}).items()
-        if str(k).lower() not in _sdk_header_keys and not str(k).lower().startswith(("x-stainless", "openai-"))
-    }
-    headers = {**_sync_user_headers, **(headers or {})}
+    # rebuild would drop them — carry the explicitly configured mapping across (#109595). The
+    # SDK's ``_custom_headers`` is exactly what the client was constructed with, so taking it
+    # whole (rather than inferring SDK ownership from header names) preserves configured
+    # Authorization/User-Agent/OpenAI-* credentials and routing values that named entries are
+    # allowed to set. The SDK merges custom headers last, so they keep precedence over both the
+    # endpoint defaults above and the bearer minted by the key provider.
+    _configured_headers = getattr(sync_client, "_custom_headers", None)
+    if _configured_headers is None:
+        # Non-SDK-shaped client: conservatively filter the merged default_headers view.
+        _sdk_owned_keys = {"accept", "content-type", "user-agent", "authorization"}
+        _sync_user_headers = {
+            k: v for k, v in dict(getattr(sync_client, "default_headers", None) or {}).items()
+            if str(k).lower() not in _sdk_owned_keys and not str(k).lower().startswith(("x-stainless", "openai-"))
+        }
+    else:
+        _sync_user_headers = dict(_configured_headers)
+    headers = {**(headers or {}), **_sync_user_headers}
     if headers:
         async_kwargs["default_headers"] = headers
     _apply_required_codex_headers(async_kwargs, access_token=sync_client.api_key, base_url=sync_base_url)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4339,11 +4339,19 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     # key_cmd/Entra credentials live in the SDK's per-request provider slot — ``.api_key`` stays
     # "" until the first request refreshes it. Rebuilding AsyncOpenAI from ``.api_key`` alone
     # drops the provider and every async aux call goes out with no Authorization header (#109595).
+    # The sync client's provider is ``Callable[[], str]`` while AsyncOpenAI awaits its provider
+    # (``Callable[[], Awaitable[str]]``) — forward it wrapped via asyncio.to_thread, otherwise the
+    # first async request crashes with "object str can't be used in 'await' expression".
     _key_provider = getattr(sync_client, "_api_key_provider", None)
-    async_kwargs = {
-        "api_key": _key_provider if callable(_key_provider) else sync_client.api_key,
-        "base_url": sync_base_url,
-    }
+    if callable(_key_provider):
+        import asyncio
+
+        def _async_key_provider(_sync_provider=_key_provider):
+            return asyncio.to_thread(_sync_provider)
+
+        async_kwargs = {"api_key": _async_key_provider, "base_url": sync_base_url}
+    else:
+        async_kwargs = {"api_key": sync_client.api_key, "base_url": sync_base_url}
     if base_url_host_matches(sync_base_url, "openrouter.ai"):
         headers = _apply_user_default_headers(build_or_headers())
     elif _is_official_codex_base_url(sync_base_url):

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -501,14 +501,21 @@ class TestBareNamedAuxCredentialChain:
     }
 
     def test_async_resolve_keeps_key_cmd_provider(self, tmp_path):
-        """async resolve must carry the key_cmd token provider, not the empty .api_key snapshot."""
+        """async resolve must carry the key_cmd token provider, not the empty .api_key snapshot.
+
+        AsyncOpenAI awaits its provider before every request, so the assertion runs the SDK's
+        real refresh: a dropped provider leaves ``api_key`` unset and an unwrapped sync
+        provider raises TypeError on await."""
+        import asyncio
+
         _write_config(tmp_path, self.CFG)
         from agent.auxiliary_client import resolve_vision_provider_client
         _prov, client, model = resolve_vision_provider_client(async_mode=True)
         assert client is not None
         provider = getattr(client, "_api_key_provider", None)
         assert callable(provider), "async client lost the key_cmd token provider (#109595)"
-        assert provider() == "vk-test-1234"
+        asyncio.run(client._refresh_api_key())
+        assert client.api_key == "vk-test-1234"
 
     def test_async_resolve_keeps_extra_headers(self, tmp_path):
         """The named entry's extra_headers must reach the async client's default headers."""
@@ -521,6 +528,8 @@ class TestBareNamedAuxCredentialChain:
 
     def test_text_task_async_chain_keeps_provider(self, tmp_path):
         """The generic text-task path (get_text_auxiliary_client) has the same rebuild."""
+        import asyncio
+
         _write_config(tmp_path, self.CFG)
         from agent.auxiliary_client import get_text_auxiliary_client
         client, model = get_text_auxiliary_client("compression")
@@ -528,4 +537,5 @@ class TestBareNamedAuxCredentialChain:
         async_client, _ = _to_async_client(client, model)
         provider = getattr(async_client, "_api_key_provider", None)
         assert callable(provider), "sync→async rebuild dropped the key_cmd provider (#109595)"
-        assert provider() == "vk-test-1234"
+        asyncio.run(async_client._refresh_api_key())
+        assert async_client.api_key == "vk-test-1234"

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -478,3 +478,54 @@ class TestResolveProviderClientMainRuntimeCustom:
         assert model == "explicit-model"
         assert "explicit.example.com" in str(client.base_url)
         assert client.api_key == "sk-explicit"
+
+
+class TestBareNamedAuxCredentialChain:
+    """#109595: a bare-named custom provider pinned by auxiliary.<task> must keep its
+    credential and extra_headers through the sync→async rebuild that async_call_llm uses."""
+
+    CFG = {
+        "model": {"provider": "hermes-bifrost", "default": "glm-5.3-flash"},
+        "providers": {
+            "hermes-bifrost": {
+                "base_url": "http://127.0.0.1:18088/openai/v1",
+                "api_mode": "chat_completions",
+                "key_cmd": "/bin/echo vk-test-1234",
+                "extra_headers": {"x-bf-eh-x-opencode-session": "hermes-opsman"},
+            },
+        },
+        "auxiliary": {
+            "vision": {"provider": "hermes-bifrost", "model": "qwen-3.8-flash"},
+            "compression": {"provider": "hermes-bifrost", "model": "qwen-3.8-flash"},
+        },
+    }
+
+    def test_async_resolve_keeps_key_cmd_provider(self, tmp_path):
+        """async resolve must carry the key_cmd token provider, not the empty .api_key snapshot."""
+        _write_config(tmp_path, self.CFG)
+        from agent.auxiliary_client import resolve_vision_provider_client
+        _prov, client, model = resolve_vision_provider_client(async_mode=True)
+        assert client is not None
+        provider = getattr(client, "_api_key_provider", None)
+        assert callable(provider), "async client lost the key_cmd token provider (#109595)"
+        assert provider() == "vk-test-1234"
+
+    def test_async_resolve_keeps_extra_headers(self, tmp_path):
+        """The named entry's extra_headers must reach the async client's default headers."""
+        _write_config(tmp_path, self.CFG)
+        from agent.auxiliary_client import resolve_vision_provider_client
+        _prov, client, _model = resolve_vision_provider_client(async_mode=True)
+        assert client is not None
+        headers = {str(k).lower(): str(v) for k, v in (client.default_headers or {}).items()}
+        assert headers.get("x-bf-eh-x-opencode-session") == "hermes-opsman"
+
+    def test_text_task_async_chain_keeps_provider(self, tmp_path):
+        """The generic text-task path (get_text_auxiliary_client) has the same rebuild."""
+        _write_config(tmp_path, self.CFG)
+        from agent.auxiliary_client import get_text_auxiliary_client
+        client, model = get_text_auxiliary_client("compression")
+        from agent.auxiliary_client import _to_async_client
+        async_client, _ = _to_async_client(client, model)
+        provider = getattr(async_client, "_api_key_provider", None)
+        assert callable(provider), "sync→async rebuild dropped the key_cmd provider (#109595)"
+        assert provider() == "vk-test-1234"

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -1,6 +1,7 @@
 """Tests for named custom provider and 'main' alias resolution in auxiliary_client."""
 
 import json
+import sys
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -490,8 +491,17 @@ class TestBareNamedAuxCredentialChain:
             "hermes-bifrost": {
                 "base_url": "http://127.0.0.1:18088/openai/v1",
                 "api_mode": "chat_completions",
-                "key_cmd": "/bin/echo vk-test-1234",
-                "extra_headers": {"x-bf-eh-x-opencode-session": "hermes-opsman"},
+                # sys.executable keeps the mint portable (the old "/bin/echo" form was POSIX-only);
+                # double quotes survive both POSIX sh and Windows cmd.
+                "key_cmd": f'"{sys.executable}" -c "print(\'vk-test-1234\')"',
+                # Exactly the names a naive name-based rebuild filter used to drop: a configured
+                # bearer, a custom agent string, and OpenAI routing values (#109595 review).
+                "extra_headers": {
+                    "Authorization": "Bearer vk-configured-auth",
+                    "User-Agent": "hermes-aux-test/1.0",
+                    "OpenAI-Organization": "org-aux-test",
+                    "x-bf-eh-x-opencode-session": "hermes-opsman",
+                },
             },
         },
         "auxiliary": {
@@ -499,6 +509,20 @@ class TestBareNamedAuxCredentialChain:
             "compression": {"provider": "hermes-bifrost", "model": "qwen-3.8-flash"},
         },
     }
+
+    def _assert_configured_headers_survive(self, client):
+        """Assert on the headers the SDK actually builds for a request (transport-level), not
+        just the client's default_headers mapping. The SDK merges ``_custom_headers`` last, so
+        these also prove precedence: the configured values override the SDK's own
+        Authorization/User-Agent even though a key_cmd provider is attached."""
+        from openai._models import FinalRequestOptions
+
+        built = client._build_headers(
+            FinalRequestOptions(method="post", url="/chat/completions", json_data={"stream": False}))
+        assert built["authorization"] == "Bearer vk-configured-auth"
+        assert built["user-agent"] == "hermes-aux-test/1.0"
+        assert built["openai-organization"] == "org-aux-test"
+        assert built["x-bf-eh-x-opencode-session"] == "hermes-opsman"
 
     def test_async_resolve_keeps_key_cmd_provider(self, tmp_path):
         """async resolve must carry the key_cmd token provider, not the empty .api_key snapshot.
@@ -517,14 +541,31 @@ class TestBareNamedAuxCredentialChain:
         asyncio.run(client._refresh_api_key())
         assert client.api_key == "vk-test-1234"
 
-    def test_async_resolve_keeps_extra_headers(self, tmp_path):
-        """The named entry's extra_headers must reach the async client's default headers."""
+    def test_initial_async_resolution_keeps_configured_headers(self, tmp_path):
+        """Initial async resolution must keep every configured header — including the
+        Authorization/User-Agent/OpenAI-* names a name-based filter wrongly dropped."""
         _write_config(tmp_path, self.CFG)
         from agent.auxiliary_client import resolve_vision_provider_client
         _prov, client, _model = resolve_vision_provider_client(async_mode=True)
         assert client is not None
-        headers = {str(k).lower(): str(v) for k, v in (client.default_headers or {}).items()}
-        assert headers.get("x-bf-eh-x-opencode-session") == "hermes-opsman"
+        self._assert_configured_headers_survive(client)
+
+    def test_same_provider_rebuild_keeps_configured_headers(self, tmp_path):
+        """The same-provider sync→async rebuild (transient-retry path) keeps the configured headers."""
+        _write_config(tmp_path, self.CFG)
+        from agent.auxiliary_client import resolve_vision_provider_client, _to_async_client
+        _prov, sync_client, model = resolve_vision_provider_client(async_mode=False)
+        async_client, _ = _to_async_client(sync_client, model, is_vision=True)
+        self._assert_configured_headers_survive(async_client)
+
+    def test_fallback_candidate_rebuild_keeps_configured_headers(self, tmp_path):
+        """The recovery-ladder fallback path rebuilds a sync candidate through the same
+        ``_to_async_client``; a text aux client stands in for the ladder's fb_client."""
+        _write_config(tmp_path, self.CFG)
+        from agent.auxiliary_client import get_text_auxiliary_client, _to_async_client
+        fb_client, fb_model = get_text_auxiliary_client("compression")
+        async_client, _ = _to_async_client(fb_client, fb_model or "")
+        self._assert_configured_headers_survive(async_client)
 
     def test_text_task_async_chain_keeps_provider(self, tmp_path):
         """The generic text-task path (get_text_auxiliary_client) has the same rebuild."""


### PR DESCRIPTION
## What does this PR do?

When `auxiliary.<task>` pins a bare-named custom provider (e.g. `provider: hermes-bifrost` with no `custom:` prefix), every async aux call (`async_call_llm`) goes out with **no Authorization header at all** — not an empty key, not the wrong key, not the `no-key-required` placeholder — and the entry's `extra_headers` are dropped too.

Root cause chain:

1. `_named_custom_api_key()` correctly resolves the entry's `key_cmd` into a callable token provider (`CommandTokenSource`).
2. The OpenAI SDK stores that callable in the per-request `_api_key_provider` slot; the public `.api_key` attribute stays `""` until the first sync request refreshes it. So far so good — sync calls work.
3. `_to_async_client()` rebuilds `AsyncOpenAI` from `sync_client.api_key` alone. The empty snapshot wins, the provider is gone, and every async request is sent credential-less. The main-model path never goes through this rebuild, which is why only auxiliary tasks fail.
4. Separately, the named entry's `extra_headers` were never lifted onto the named-custom wire client, and would have been lost again in the same async rebuild.

This is why the reporter's workaround (task-level `base_url` + `key_env`, both plain strings) works while the bare-name pin does not.

## Related Issue

Fixes #109595

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` — `_to_async_client`: forward `sync_client._api_key_provider` (when callable) instead of the empty `.api_key` snapshot when rebuilding `AsyncOpenAI`; carry user-configured (non-SDK-generated) default headers across the rebuild so named-entry `extra_headers` survive.
- `agent/auxiliary_client.py` — `_named_custom_openai_wire_client`: accept and lift the entry's `extra_headers` into `default_headers`; `_resolve_named_custom_branch` passes them through.
- `tests/agent/test_auxiliary_named_custom_providers.py` — three regressions: async vision resolve keeps the key_cmd provider, keeps the entry's extra_headers, and the generic text-task sync→async rebuild keeps the provider.

## How to Test

1. `pytest tests/agent/test_auxiliary_named_custom_providers.py -q` — all pass (3 new tests included).
2. Wider regression: `pytest tests/agent/test_auxiliary_client.py tests/agent/test_actual_auxiliary_routing.py tests/agent/test_auxiliary_anthropic_pool_fallback_regression.py tests/agent/test_auxiliary_client_azure_foundry.py tests/agent/test_auxiliary_user_default_headers.py tests/agent/test_auxiliary_client_proxy_env.py -q` — 357 passed.
3. Manual repro of the original shape: pin `auxiliary.vision.provider: <bare-named-entry>` whose entry uses `key_cmd` + `extra_headers`; before the fix `resolve_vision_provider_client(async_mode=True)` yields a client whose `_api_key_provider` is `None` (zero auth on the wire); after the fix the provider is present and `provider()` returns the key_cmd output, and `default_headers` carries the entry tags. Observed result: 3/3 new assertions pass after the fix, fail before.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before (bare-name pin, async resolve — zero auth on the wire):
```
client: {"type": "OpenAI", "api_key": "", "default_headers": {"x-bf-vk": "<MISSING>"}}
```
After:
```
client._api_key_provider() == "vk-test-1234"   # key_cmd output, refreshed per request
client.default_headers["x-bf-eh-x-opencode-session"] == "hermes-opsman"
```