### PR TITLE
fix(local-runtime): stop recommending models with multi-minute prompt waits

### DIFF
--- a/apps/desktop/src/app/settings/local-models-settings.test.tsx
+++ b/apps/desktop/src/app/settings/local-models-settings.test.tsx
@@ -72,6 +72,10 @@ const FITTING_MODEL: LocalCatalogModel = {
   mtp: false,
   fits: true,
   fit_summary: 'runs at its full 256K context',
+  reference_prompt_tokens: 20000,
+  reference_output_tokens: 512,
+  estimated_ttft_seconds: 480,
+  estimated_turn_seconds: 520,
   start_window: 262144,
   start_window_label: '256K',
   spilled: false
@@ -210,7 +214,7 @@ describe('LocalModelsSettings', () => {
     expect(screen.getByText('Full 256K context').className).not.toContain('emerald')
   })
 
-  it('explains the Recommended pick on hover', async () => {
+  it('explains the Recommended pick and reference-turn cost on hover', async () => {
     // The tooltip is the resolver's own reason, and it must actually OPEN:
     // Tip works by asChild-cloning hover handlers onto the pill, so a Pill
     // that swallows its rest props kills the tooltip silently (the pill
@@ -220,6 +224,13 @@ describe('LocalModelsSettings', () => {
     })
     await renderFullPane()
     await screen.findByText('Qwen3.6 27B')
+
+    const ttft = screen.getByText('TTFT ≈ 8m')
+    fireEvent.pointerMove(ttft)
+    fireEvent.pointerEnter(ttft)
+    await waitFor(() =>
+      expect(screen.getAllByText(/20K prompt · first token ≈ 8m · 512 output tokens ≈ 9m total/).length).toBeGreaterThan(0)
+    )
 
     fireEvent.pointerMove(screen.getByText('Recommended'))
     fireEvent.pointerEnter(screen.getByText('Recommended'))

--- a/apps/desktop/src/app/settings/local-models-settings.tsx
+++ b/apps/desktop/src/app/settings/local-models-settings.tsx
@@ -70,6 +70,18 @@ function gbLabel(bytes: number | null | undefined): string {
   return `${(bytes / (1 << 30)).toFixed(1)} GB`
 }
 
+function durationLabel(seconds: number): string {
+  if (seconds < 60) {
+    return `${Math.max(1, Math.round(seconds))}s`
+  }
+
+  if (seconds < 3600) {
+    return `${Math.round(seconds / 60)}m`
+  }
+
+  return `${(seconds / 3600).toFixed(1)}h`
+}
+
 // Catalog display order: what runs well leads. Resident (all on GPU)
 // first, then spilled (works, slower), then doesn't-fit; catalog order
 // (recommended first) holds within each band.
@@ -734,6 +746,23 @@ export function LocalModelsSettings() {
                         ))}
 
                       {!model.fits && <Pill>{copy.pillUpTo(model.native_context_label)}</Pill>}
+
+                      {model.fits &&
+                        model.reference_prompt_tokens &&
+                        model.reference_output_tokens &&
+                        model.estimated_ttft_seconds &&
+                        model.estimated_turn_seconds && (
+                          <Tip
+                            label={copy.referenceTurnEstimate(
+                              `${Math.round(model.reference_prompt_tokens / 1000)}K`,
+                              durationLabel(model.estimated_ttft_seconds),
+                              `${model.reference_output_tokens}`,
+                              durationLabel(model.estimated_turn_seconds)
+                            )}
+                          >
+                            <Pill>TTFT ≈ {durationLabel(model.estimated_ttft_seconds)}</Pill>
+                          </Tip>
+                        )}
 
                       {model.vision && <Pill>{copy.pillVision}</Pill>}
                     </span>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1314,9 +1314,7 @@ export const en: Translations = {
       unifiedMemory: 'Unified memory',
       modelsTitle: 'Models',
       recommended: 'Recommended',
-      /* The Recommended badge's tooltip, keyed by the resolver branch that
-         made the pick. Qualitative on purpose: predictions order candidates,
-         they are not promises to print. */
+      /* The Recommended badge's tooltip, keyed by the resolver branch that made the pick. */
       recommendedReason: {
         'best-quality-resident':
           'The highest-quality model that runs entirely on your GPU at full speed. Picks weigh quality against predicted speed on this hardware.',
@@ -1325,6 +1323,8 @@ export const en: Translations = {
         'fastest-resident':
           'No model reaches full speed on this hardware; this one comes closest while running entirely in GPU memory.'
       } as Record<string, string>,
+      referenceTurnEstimate: (prompt, ttft, output, turn) =>
+        `${prompt} prompt · first token ≈ ${ttft} · ${output} output tokens ≈ ${turn} total. Hardware-class estimate, not a benchmark.`,
       noRecommendationTitle: 'No automatic recommendation for this machine',
       noRecommendationDetail:
         'Automatic setup requires a curated model that fits entirely in GPU or unified memory. You can still choose a model below or browse more models.',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1149,6 +1149,7 @@ export interface Translations {
       /** Recommended-badge tooltip by resolver branch; unknown keys (newer
        *  backend) simply show no tooltip. */
       recommendedReason: Record<string, string>
+      referenceTurnEstimate: (prompt: string, ttft: string, output: string, turn: string) => string
       noRecommendationTitle: string
       noRecommendationDetail: string
       noRecommendationAction: string

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1418,6 +1418,10 @@ export interface LocalCatalogModel {
   quant_reason?: string
   quant_validated?: boolean
   variant_count?: number
+  reference_prompt_tokens?: number
+  reference_output_tokens?: number
+  estimated_ttft_seconds?: number
+  estimated_turn_seconds?: number
   start_window?: number
   start_window_label?: string
   spilled?: boolean

--- a/hermes_cli/local_runtime/catalog.py
+++ b/hermes_cli/local_runtime/catalog.py
@@ -161,14 +161,21 @@ def select_variant(entry: CatalogEntry, budget: HardwareBudget) -> VariantChoice
 #
 # QUALITY is a judgment made once at authoring time (entry.quality). SPEED is physics per machine:
 # decode is memory-bound, so predicted tok/s ≈ bandwidth / bytes-read-per-token (build size scaled
-# by decode fraction). The bandwidth axis is the `uma` flag: every discrete card that matters is
-# 900+ GB/s GDDR while the unified-memory class measures ~1/5th of that. A measured per-machine
-# bandwidth could replace these class constants without touching the rule; predictions order
-# candidates and gate the floor — they are not display values.
+# by decode fraction). Batched prompt evaluation reuses each weight load across several tokens, so
+# prefill is faster than decode but still scales on the same active-weight and bandwidth axes. The
+# bandwidth axis is the `uma` flag: every discrete card that matters is 900+ GB/s GDDR while the
+# unified-memory class measures ~1/5th of that.
 
 _DISCRETE_BANDWIDTH_GB_S = 1000.0   # representative GDDR6X/GDDR7 class
 _UMA_BANDWIDTH_GB_S = 210.0         # measured on unified-memory NVIDIA
 _HOST_BANDWIDTH_GB_S = 80.0         # spilled weights stream over host DRAM
+_PREFILL_BATCH_REUSE = 3.0           # measured CPU/Vulkan prefill is roughly 3x decode
+
+# One representative agent turn. This matches the system prompt + tool schema scale users actually
+# send, instead of pricing only the answer stream after that prompt has already been evaluated.
+REFERENCE_PROMPT_TOKENS = 20_000
+REFERENCE_OUTPUT_TOKENS = 512
+PLEASANT_REFERENCE_TURN_S = 120.0
 
 # Below this predicted decode speed a model stops feeling pleasant for agentic use (roughly
 # reading speed with headroom for tool-call bursts). Distinct from the growth policy's 6 tok/s
@@ -186,6 +193,21 @@ def predicted_decode_tok_s(entry: CatalogEntry, variant: QuantVariant, budget: H
     return bandwidth * 1e9 / bytes_per_token
 
 
+def predicted_prefill_tok_s(entry: CatalogEntry, variant: QuantVariant, budget: HardwareBudget, *,
+                            spilled: bool = False) -> float:
+    """Reference-prompt throughput, including reuse from batched prompt evaluation."""
+    return predicted_decode_tok_s(entry, variant, budget, spilled=spilled) * _PREFILL_BATCH_REUSE
+
+
+def predicted_reference_turn_s(entry: CatalogEntry, variant: QuantVariant,
+                               budget: HardwareBudget, *, spilled: bool = False) -> tuple[float, float]:
+    """Return (time-to-first-token, total turn) for the representative agent turn."""
+    decode_tok_s = predicted_decode_tok_s(entry, variant, budget, spilled=spilled)
+    prefill_tok_s = predicted_prefill_tok_s(entry, variant, budget, spilled=spilled)
+    ttft_s = REFERENCE_PROMPT_TOKENS / prefill_tok_s
+    return ttft_s, ttft_s + REFERENCE_OUTPUT_TOKENS / decode_tok_s
+
+
 def recommended_entry(budget: HardwareBudget,
                       entries: "tuple[CatalogEntry, ...] | None" = None
                       ) -> "tuple[CatalogEntry, str] | None":
@@ -193,9 +215,10 @@ def recommended_entry(budget: HardwareBudget,
 
     Callers pass pre-filtered entries when some are ineligible for reasons the catalog can't know
     (engine too old). Reasons: best-quality-resident (quality won among resident entries clearing
-    the pleasant floor); speed-gated-quality (same, but the floor eliminated a HIGHER quality
-    candidate); fastest-resident (nothing resident clears the floor). Returns None when no
-    eligible entry runs resident; spilled models remain available for explicit selection.
+    both the decode and reference-turn floors); speed-gated-quality (same, but either floor
+    eliminated a HIGHER quality candidate); fastest-resident (nothing resident clears both
+    floors). Returns None when no eligible entry runs resident; spilled models remain available
+    for explicit selection.
     """
     pool = CATALOG if entries is None else entries
     fitting = [(e, c) for e in pool if (c := select_variant(e, budget)) is not None]
@@ -205,14 +228,19 @@ def recommended_entry(budget: HardwareBudget,
     def speed(t, spilled=False):
         return predicted_decode_tok_s(t[0], t[1].variant, budget, spilled=spilled)
 
+    def turn_s(t):
+        return predicted_reference_turn_s(t[0], t[1].variant, budget)[1]
+
     resident = [(e, c) for e, c in fitting if c.zero_spill]
-    pleasant = [t for t in resident if speed(t) >= PLEASANT_FLOOR_TOK_S]
+    pleasant = [t for t in resident
+                if speed(t) >= PLEASANT_FLOOR_TOK_S
+                and turn_s(t) <= PLEASANT_REFERENCE_TURN_S]
     if pleasant:
         pick = max(pleasant, key=lambda t: (t[0].quality, -t[1].variant.size_bytes))[0]
         floor_gated = any(e.quality > pick.quality for e, _ in resident)
         return (pick, "speed-gated-quality" if floor_gated else "best-quality-resident")
     if resident:
-        return (max(resident, key=speed)[0], "fastest-resident")
+        return (min(resident, key=lambda t: (turn_s(t), -t[0].quality))[0], "fastest-resident")
     # A spilled model may be usable, but it is not a recommendation. Keep it
     # discoverable through Browse so the user can opt in with the degradation visible.
     return None

--- a/hermes_cli/web_routers/local_models.py
+++ b/hermes_cli/web_routers/local_models.py
@@ -554,11 +554,16 @@ def _catalog_row(entry, budget, recommended, recommended_reason, staged_ids) -> 
     variant = choice.variant
     decision = entry.launch_plan(variant, budget).decision
     download_total = entry.download_bytes(variant)
+    ttft_s, turn_s = catalog.predicted_reference_turn_s(
+        entry, variant, budget, spilled=not choice.zero_spill)
     row.update({
         "fits": True, "model_id": variant.model_id, "quant": variant.quant,
         "quant_validated": variant.validated, "size_bytes": download_total,
         "size_label": _human_gb(download_total), "variant_count": len(entry.variants),
         "quant_reason": _QUANT_REASONS.get(choice.reason_key, _QUANT_REASON_COMPACT).format(quant=variant.quant),
+        "reference_prompt_tokens": catalog.REFERENCE_PROMPT_TOKENS,
+        "reference_output_tokens": catalog.REFERENCE_OUTPUT_TOKENS,
+        "estimated_ttft_seconds": round(ttft_s), "estimated_turn_seconds": round(turn_s),
     })
     if isinstance(decision, estimator.PhysicsRefusal):
         row["fit_summary"] = row["quant_reason"]

--- a/tests/hermes_cli/test_local_models_routes.py
+++ b/tests/hermes_cli/test_local_models_routes.py
@@ -147,6 +147,10 @@ def test_catalog_prices_every_entry_for_this_machine(client):
         if row["fits"]:
             assert row["start_window"] >= 1
             assert row["start_window_label"].endswith("K")
+            assert row["reference_prompt_tokens"] > 0
+            assert row["reference_output_tokens"] > 0
+            assert row["estimated_ttft_seconds"] > 0
+            assert row["estimated_turn_seconds"] >= row["estimated_ttft_seconds"]
         else:
             assert "memory" in row["fit_summary"].lower()
         assert isinstance(row["downloaded"], bool)

--- a/tests/hermes_cli/test_local_recommendation.py
+++ b/tests/hermes_cli/test_local_recommendation.py
@@ -24,7 +24,9 @@ import pytest
 from hermes_cli.local_runtime.catalog import (
     CATALOG,
     PLEASANT_FLOOR_TOK_S,
+    PLEASANT_REFERENCE_TURN_S,
     predicted_decode_tok_s,
+    predicted_reference_turn_s,
     recommended_entry,
     select_variant,
 )
@@ -151,6 +153,23 @@ def test_unified_never_recommends_a_below_floor_dense_model():
     ]
     if clears:
         assert predicted_decode_tok_s(entry, choice.variant, budget) >= PLEASANT_FLOOR_TOK_S
+
+
+def test_recommendation_prices_prefill_before_quality():
+    budget = _unified(128)
+    pick = recommended_entry(budget)[0]
+    choice = select_variant(pick, budget)
+    assert choice is not None
+    _, turn_s = predicted_reference_turn_s(pick, choice.variant, budget)
+    assert turn_s <= PLEASANT_REFERENCE_TURN_S
+
+    higher_quality = [entry for entry in CATALOG if entry.quality > pick.quality]
+    assert higher_quality
+    for entry in higher_quality:
+        candidate = select_variant(entry, budget)
+        if candidate is not None and candidate.zero_spill:
+            _, candidate_turn_s = predicted_reference_turn_s(entry, candidate.variant, budget)
+            assert candidate_turn_s > PLEASANT_REFERENCE_TURN_S
 
 
 def test_quality_decides_where_speed_permits():

--- a/tests/hermes_cli/test_local_recommendation.py
+++ b/tests/hermes_cli/test_local_recommendation.py
@@ -62,21 +62,20 @@ def _unified(size_gb: int) -> HardwareBudget:
 #    48  | qwen3.8-27b             | qwen3.6-35b-a3b
 #    96  | qwen3.8-27b             | qwen3.6-35b-a3b
 #   128  | qwen3.8-flash-next      | qwen3.6-35b-a3b
-#   256  | qwen3.8-flash-next      | qwen3.8-flash-next
-#   512  | qwen3.8-flash-next      | qwen3.8-flash-next
+#   256  | qwen3.8-flash-next      | qwen3.6-35b-a3b
+#   512  | qwen3.8-flash-next      | qwen3.6-35b-a3b
 #
 # Reading guide for reviewers:
 # - Discrete <=16 GB: nothing runs resident; no automatic recommendation.
 #   Browse remains available for explicit spill choices.
 # - Discrete 24-96 GB: the 27B is the flagship experience — dense reads
 #   at ~1 TB/s clear the floor easily, so quality decides.
-# - Discrete/unified where Flash Next fits resident (128 GB discrete,
-#   256+ GB unified): the frontier model is the pick — highest quality,
-#   and its sparse decode clears the floor even at UMA bandwidth
-#   (~24 tok/s predicted at 210 GB/s).
-# - Unified 32-128 GB — the Spark class, the reason this resolver
-#   exists: the dense 27B predicts ~13 tok/s at UMA bandwidth (below
-#   the pleasant floor), so the 35B-A3B (~60 tok/s) wins.
+# - Discrete 128+ GB: Flash Next is the highest-quality fitting model and
+#   its sparse decode plus prefill clear the reference-turn budget.
+# - Unified 32+ GB — the Spark class, the reason this resolver exists:
+#   Flash Next clears the decode floor once it fits, but its reference
+#   prompt does not clear the turn budget at UMA bandwidth. The 35B-A3B
+#   (~60 tok/s decode) wins on total turn latency.
 # - Unified <=24 GB: no entry passes the physics check inside the UMA
 #   budget (spilling is impossible on UMA by construction — the pool IS
 #   the RAM). The pane's browse flow is the path for those machines
@@ -97,9 +96,9 @@ DECISION_TABLE = [
     (128, "discrete", "qwen3.8-flash-next", "best-quality-resident"),
     (128, "unified", "qwen3.6-35b-a3b", "speed-gated-quality"),
     (256, "discrete", "qwen3.8-flash-next", "best-quality-resident"),
-    (256, "unified", "qwen3.8-flash-next", "best-quality-resident"),
+    (256, "unified", "qwen3.6-35b-a3b", "speed-gated-quality"),
     (512, "discrete", "qwen3.8-flash-next", "best-quality-resident"),
-    (512, "unified", "qwen3.8-flash-next", "best-quality-resident"),
+    (512, "unified", "qwen3.6-35b-a3b", "speed-gated-quality"),
 ]
 
 

--- a/tests/hermes_cli/test_local_recommendation.py
+++ b/tests/hermes_cli/test_local_recommendation.py
@@ -155,20 +155,24 @@ def test_unified_never_recommends_a_below_floor_dense_model():
 
 
 def test_recommendation_prices_prefill_before_quality():
-    budget = _unified(128)
+    budget = _unified(256)
     pick = recommended_entry(budget)[0]
     choice = select_variant(pick, budget)
     assert choice is not None
     _, turn_s = predicted_reference_turn_s(pick, choice.variant, budget)
     assert turn_s <= PLEASANT_REFERENCE_TURN_S
 
-    higher_quality = [entry for entry in CATALOG if entry.quality > pick.quality]
+    higher_quality = [
+        (entry, candidate)
+        for entry in CATALOG
+        if entry.quality > pick.quality
+        and (candidate := select_variant(entry, budget)) is not None
+        and candidate.zero_spill
+    ]
     assert higher_quality
-    for entry in higher_quality:
-        candidate = select_variant(entry, budget)
-        if candidate is not None and candidate.zero_spill:
-            _, candidate_turn_s = predicted_reference_turn_s(entry, candidate.variant, budget)
-            assert candidate_turn_s > PLEASANT_REFERENCE_TURN_S
+    for entry, candidate in higher_quality:
+        _, candidate_turn_s = predicted_reference_turn_s(entry, candidate.variant, budget)
+        assert candidate_turn_s > PLEASANT_REFERENCE_TURN_S
 
 
 def test_quality_decides_where_speed_permits():


### PR DESCRIPTION
## What does this PR do?

Local Models now prices the prompt prefill and the answer stream as one representative agent turn before recommending a model. The model list also shows an estimated time to first token for each fitting catalog entry, so a user can distinguish a responsive local model from one that may wait several minutes before producing output.

### Symptom

The recommendation could select a model based only on predicted decode throughput. On machines where a roughly 20K-token Hermes prompt takes minutes to prefill, the picker and its tooltip did not represent the dominant wait before the first output token.

### Impact

Integrated-GPU and CPU-class local runtimes could receive a recommendation that looked usable even though each uncached agent turn spent most of its wall time in prompt processing.

### Bug Cause

**Trigger:** `hermes_cli/local_runtime/catalog.py` / `recommended_entry()` comparing candidates only against `predicted_decode_tok_s()`.

**Causal chain:**
1. Local Models probes a machine budget and asks the catalog for its recommended entry.
2. The catalog gates candidates on answer decode throughput without pricing the prompt that must be processed first.
3. The desktop shows a qualitative recommendation reason, so materially different multi-minute waits are indistinguishable.

**Why it is wrong:** decode throughput describes streaming feel after generation starts, not time to first token or total turn latency. For Hermes agent prompts, prefill can dominate the turn.

**Working sibling / contrast:** runtime load progress can report prompt processing after a model is already running, but the pre-download catalog decision previously had no prefill estimate to compare candidates or inform the user.

**Ruled out:** this is not a memory-fit error. `select_variant()` correctly distinguishes resident, spilled, and refused models; the missing term is latency after a model fits.

### Fix

- Estimate prefill throughput from the same hardware-class bandwidth and active-weight axes used by decode, including measured batch reuse.
- Gate quality recommendations on both the decode floor and a 20K-prompt, 512-output reference-turn budget; when no candidate clears both, rank the fallback by total reference-turn latency.
- Return estimated TTFT and total-turn seconds in each fitting catalog row and render TTFT as a visible model pill with a detailed, explicitly non-benchmark tooltip.
- Cover the prefill-gated recommendation invariant and the desktop estimate display.

## Related Issue

Closes #109606

## Why this PR vs existing PR #109618

PR #109618 adds an optional `CatalogEntry.prefill_tok_s`, but no production catalog entry supplies that field and the production catalog route does not pass `input_tokens` to `recommended_entry()`. Its `use_latency` branch therefore never runs for real Local Models rows, leaving the reported decode-only recommendation unchanged. This PR closes that production path in `catalog.py`, `web_routers/local_models.py`, and the desktop model list: every fitting catalog candidate receives a hardware-class reference-turn estimate, the recommendation actually gates on it, and users can see the resulting TTFT estimate before downloading.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/local_runtime/catalog.py` - estimate prefill and reference-turn latency, then include it in recommendation gating and fallback ranking.
- `hermes_cli/web_routers/local_models.py` - expose reference workload, TTFT, and total-turn estimates for fitting catalog rows.
- `apps/desktop/src/app/settings/local-models-settings.tsx` - show the estimated TTFT and reference-turn details for each fitting model.
- `apps/desktop/src/types/hermes.ts`, `apps/desktop/src/i18n/` - type and describe the new estimate fields.
- `tests/hermes_cli/test_local_recommendation.py`, `apps/desktop/src/app/settings/local-models-settings.test.tsx` - cover the recommendation and presentation contracts.

## How to Test

1. Open Settings -> Local Models and inspect a fitting model row.
2. Confirm the row shows a TTFT estimate and its tooltip identifies the 20K prompt and 512-token output reference turn.
3. Run the focused Python recommendation tests and desktop component test listed below.

```bash
scripts/run_tests.sh tests/hermes_cli/test_local_recommendation.py tests/hermes_cli/test_catalog_variants.py
cd apps/desktop && npx vitest run src/app/settings/local-models-settings.test.tsx
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and compared this implementation with PR #109618
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've considered cross-platform impact; the estimate consumes the existing platform-neutral hardware budget

### Documentation & Housekeeping

- [x] Relevant policy and API behavior are documented in code; no user guide update is required
- [x] `cli-config.yaml.example` is N/A because no config key changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow changed
- [x] Tool descriptions and schemas are N/A because no model tool changed
