### PR TITLE
fix(tools): explain sudo auth failures caused by an empty SUDO_PASSWORD

### DIFF
--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -1,5 +1,7 @@
 """Regression tests for sudo detection and sudo password handling."""
 
+import os
+
 import tools.terminal_tool as terminal_tool
 import tools.terminal_tool_sudo as terminal_tool_sudo
 
@@ -146,3 +148,62 @@ def test_sudo_rewrite_preserves_env_operands_and_prose(monkeypatch):
 def test_count_real_sudo_invocations_ignores_mentions(monkeypatch):
     assert terminal_tool_sudo._count_real_sudo_invocations("grep sudo README.md") == 0
     assert terminal_tool_sudo._count_real_sudo_invocations("sudo a; sudo b") == 2
+
+
+def test_empty_configured_sudo_password_gets_explainer_note(monkeypatch):
+    """SUDO_PASSWORD="" still pipes a blank line (kept contract), but a sudo
+    rejection of that blank line must tell the operator the value is EMPTY,
+    not wrong."""
+    monkeypatch.setenv("SUDO_PASSWORD", "")
+    output = (
+        "[sudo] password for root: Sorry, try again.\n[sudo] password for root:\n"
+        "sudo: no password was provided\nsudo: 1 incorrect password attempt"
+    )
+    annotated = terminal_tool_sudo._annotate_empty_configured_sudo_password(
+        "sudo true", output
+    )
+    assert "SUDO_PASSWORD is set to an empty string" in annotated
+    assert "sudo: 1 incorrect password attempt" in annotated
+
+
+def test_counted_incorrect_password_attempts_count_as_auth_failure():
+    assert terminal_tool_sudo._sudo_wrong_password_failure(
+        "sudo: 2 incorrect password attempts"
+    )
+
+
+def test_wrong_password_note_absent_for_real_password():
+    monkeyback = os.environ.get("SUDO_PASSWORD")
+    os.environ["SUDO_PASSWORD"] = "realpw"
+    try:
+        output = "sudo: incorrect password attempt"
+        annotated = terminal_tool_sudo._annotate_empty_configured_sudo_password(
+            "sudo true", output
+        )
+        assert annotated == output
+    finally:
+        if monkeyback is None:
+            del os.environ["SUDO_PASSWORD"]
+        else:
+            os.environ["SUDO_PASSWORD"] = monkeyback
+
+
+def test_wrong_password_note_absent_when_no_sudo_in_command(monkeypatch):
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    output = "sudo: 1 incorrect password attempt"
+    annotated = terminal_tool_sudo._annotate_empty_configured_sudo_password(
+        "echo hi", output
+    )
+    assert annotated == output
+
+
+def test_sudo_annotations_surfaced_for_empty_configured_password(monkeypatch):
+    """The empty-password explainer must ride the same annotation seam the
+    terminal executor already uses, not just the helper in isolation."""
+    monkeypatch.setenv("SUDO_PASSWORD", "")
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "0")
+    from tools.terminal_tool_result import _sudo_annotations
+    output = "sudo: 1 incorrect password attempt"
+    annotated, auth_failed, _ = _sudo_annotations("sudo true", output, env_type="local")
+    assert auth_failed is True
+    assert "SUDO_PASSWORD is set to an empty string" in annotated

--- a/tools/terminal_tool_result.py
+++ b/tools/terminal_tool_result.py
@@ -117,12 +117,16 @@ def _sudo_annotations(command: str, output: str, env_type: str) -> tuple[str, bo
     """Sudo failure handling -> (output, auth_failed, cache_cleared)."""
     import tools.terminal_tool as tt
     from tools.terminal_tool_sudo import (
-        _handle_sudo_failure, _in_delegated_child_context, _invalidate_cached_sudo_on_auth_failure,
+        _annotate_empty_configured_sudo_password,
+        _handle_sudo_failure,
+        _in_delegated_child_context,
+        _invalidate_cached_sudo_on_auth_failure,
         _sudo_wrong_password_failure,
     )
     from utils import env_var_enabled
     output = _handle_sudo_failure(output, env_type)
     auth_failed = _sudo_wrong_password_failure(output)
+    output = _annotate_empty_configured_sudo_password(command, output)
     cache_cleared = _invalidate_cached_sudo_on_auth_failure(command, output)
     can_reprompt = cache_cleared and (
         tt._get_sudo_password_callback() is not None or env_var_enabled("HERMES_INTERACTIVE")

--- a/tools/terminal_tool_sudo.py
+++ b/tools/terminal_tool_sudo.py
@@ -106,12 +106,45 @@ _SUDO_WRONG_PASSWORD_MARKERS = (
     "sudo: maximum 3 incorrect authentication attempts",
     "sudo: 3 incorrect password attempts",
 )
+# sudo -S prints "sudo: N incorrect password attempt(s)" after exhausting its
+# N tries; the singular/plural marker pair above only catches the per-try echo.
+_SUDO_WRONG_PASSWORD_COUNT_RE = re.compile(r"sudo: \d+ incorrect password attempts?")
 
 
 def _sudo_wrong_password_failure(output: str) -> bool:
     """Return True when sudo rejected a piped password."""
     lowered = (output or "").lower()
+    if _SUDO_WRONG_PASSWORD_COUNT_RE.search(lowered):
+        return True
     return any(marker in lowered for marker in _SUDO_WRONG_PASSWORD_MARKERS)
+
+
+def _annotate_empty_configured_sudo_password(command: str | None, output: str) -> str:
+    """Explain that sudo failed on a piped EMPTY password.
+
+    ``SUDO_PASSWORD=""`` deliberately reaches ``sudo -S`` as a blank line (a
+    passwordless-sudo host accepts it), so this is not treated as
+    misconfiguration upstream. But when sudo then REJECTS that blank line, the
+    operator sees "incorrect password attempt" and hunts for a wrong password
+    that was never set. A one-line note closes that gap without changing the
+    rewrite contract."""
+    if (
+        not _sudo_wrong_password_failure(output)
+        or _count_real_sudo_invocations(command or "") == 0
+    ):
+        return output
+    try:
+        from agent.secret_scope import get_secret
+        configured = get_secret("SUDO_PASSWORD")
+    except Exception:
+        configured = os.environ.get("SUDO_PASSWORD")
+    if configured:
+        return output
+    return output + (
+        "\n\n⚠️ SUDO_PASSWORD is set to an empty string, so sudo was fed a blank "
+        "line. Either set a real password in your .env or remove the entry so sudo "
+        "fails with its plain no-password error instead."
+    )
 
 
 def _invalidate_cached_sudo_on_auth_failure(command: str | None, output: str) -> bool:


### PR DESCRIPTION
## Summary

`SUDO_PASSWORD=""` deliberately reaches `sudo -S` as a blank line (kept contract from e22416dd9b — a passwordless-sudo host accepts it, and `test_explicit_empty_sudo_password_tries_empty_without_prompt` still passes untouched). But when sudo then *rejects* that blank line, the output the operator sees is `Sorry, try again` / `sudo: 1 incorrect password attempt` — indistinguishable from a wrong password. The reporter hunted for a wrong password that was never set (#109612).

Two small additions, contract unchanged:

1. **Counted failure marker.** `_SUDO_WRONG_PASSWORD_MARKERS` catches `sudo: incorrect password attempt` and `sudo: 3 incorrect password attempts` but not `sudo: 1/2 incorrect password attempt(s)` — the summary line sudo actually prints after exhausting its tries. `_SUDO_WRONG_PASSWORD_COUNT_RE` closes that gap, so auth-failure detection (and cache invalidation) now fires on the counted form too.
2. **Empty-configured explainer.** `_annotate_empty_configured_sudo_password` appends one line when sudo rejected a piped password AND the configured `SUDO_PASSWORD` is empty: `⚠️ SUDO_PASSWORD is set to an empty string, so sudo was fed a blank line. …` Wired into the existing `_sudo_annotations` seam in `terminal_tool_result.py`, next to `_handle_sudo_failure`.

## Tests

- `test_empty_configured_sudo_password_gets_explainer_note` — the note fires on the report's exact output (`sudo: 1 incorrect password attempt`) with `SUDO_PASSWORD=""`.
- `test_counted_incorrect_password_attempts_count_as_auth_failure` — regex surface.
- `test_wrong_password_note_absent_for_real_password` / `..._when_no_sudo_in_command` — no false positives: real password → no note, no sudo in command → no note.
- `test_sudo_annotations_surfaced_for_empty_configured_password` — integration through the real `_sudo_annotations` seam (catches a lost wiring line, verified by mutation).
- Existing `test_explicit_empty_sudo_password_tries_empty_without_prompt` untouched and green.

Mutation checks performed locally: disabling the annotator, disabling the regex branch, and removing the wiring line each turn exactly the matching new test red; restore returns all 25 to green (`ruff check` clean, no new `ruff format` complaints on my lines).

Fixes #109612
