### PR TITLE
fix(desktop-update): trap post-update exceptions and emit truthful receipts on Windows (#109627)

### DIFF
--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -926,15 +926,15 @@ public static class HermesUpdateJob {
         ProcessInformation pi = new ProcessInformation();
         try {
             job = CreateJobObject(IntPtr.Zero, null);
-            if (job == IntPtr.Zero) throw new InvalidOperationException("CreateJobObject failed");
+            if (job == IntPtr.Zero) throw new InvalidOperationException("CreateJobObject failed (error " + Marshal.GetLastWin32Error() + ")");
             SecurityAttributes sa = new SecurityAttributes();
             sa.Length = Marshal.SizeOf(typeof(SecurityAttributes));
             sa.InheritHandle = true;
             if (!CreatePipe(out outRead, out outWrite, ref sa, 0) ||
                 !CreatePipe(out errRead, out errWrite, ref sa, 0))
-                throw new InvalidOperationException("CreatePipe failed");
+                throw new InvalidOperationException("CreatePipe failed (error " + Marshal.GetLastWin32Error() + ")");
             if (!SetHandleInformation(outRead, 1, 0) || !SetHandleInformation(errRead, 1, 0))
-                throw new InvalidOperationException("SetHandleInformation failed");
+                throw new InvalidOperationException("SetHandleInformation failed (error " + Marshal.GetLastWin32Error() + ")");
 
             StartupInfo si = new StartupInfo();
             si.Size = Marshal.SizeOf(typeof(StartupInfo));
@@ -945,10 +945,11 @@ public static class HermesUpdateJob {
             StringBuilder commandLine = new StringBuilder("\"" + executable + "\" " + arguments);
             if (!CreateProcess(executable, commandLine, IntPtr.Zero, IntPtr.Zero, true,
                     0x00000004 | 0x08000000, IntPtr.Zero, null, ref si, out pi))
-                throw new InvalidOperationException("CreateProcess failed");
+                throw new InvalidOperationException("CreateProcess failed (error " + Marshal.GetLastWin32Error() + ")");
             if (!AssignProcessToJobObject(job, pi.Process)) {
+                int assignErr = Marshal.GetLastWin32Error();
                 TerminateProcess(pi.Process, 1);
-                throw new InvalidOperationException("AssignProcessToJobObject failed");
+                throw new InvalidOperationException("AssignProcessToJobObject failed (error " + assignErr + ")");
             }
 
             Process process = Process.GetProcessById(pi.ProcessId);
@@ -965,7 +966,7 @@ public static class HermesUpdateJob {
             CloseHandle(outWrite); outWrite = IntPtr.Zero;
             CloseHandle(errWrite); errWrite = IntPtr.Zero;
             if (ResumeThread(pi.Thread) == 0xffffffff)
-                throw new InvalidOperationException("ResumeThread failed");
+                throw new InvalidOperationException("ResumeThread failed (error " + Marshal.GetLastWin32Error() + ")");
             return new StartedProcess { Process = process, StandardOutput = stdout, StandardError = stderr, Job = job };
         } catch {
             if (pi.Process != IntPtr.Zero) TerminateProcess(pi.Process, 1);
@@ -1062,6 +1063,9 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
         $env:PYTHONUTF8 = "1"
         $env:PYTHONUNBUFFERED = "1"
         $started = [HermesUpdateJob]::StartAssigned($Exe, $arguments)
+    } catch {
+        Write-HandoffLog ("{0}!| step launch failed: {1}" -f $Tag, $_.Exception.Message)
+        return @{ Code = 1; Output = $_.Exception.Message; TreeQuiesced = $true; StartedAfterJobAssignment = $false }
     } finally {
         if ($null -eq $savedPythonIoEncoding) { Remove-Item Env:PYTHONIOENCODING -ErrorAction SilentlyContinue } else { $env:PYTHONIOENCODING = $savedPythonIoEncoding }
         if ($null -eq $savedPythonUtf8) { Remove-Item Env:PYTHONUTF8 -ErrorAction SilentlyContinue } else { $env:PYTHONUTF8 = $savedPythonUtf8 }
@@ -1604,15 +1608,22 @@ try {
     $res = Invoke-HermesStep $pythonExe $updateArgs "update"
     Write-HandoffLog "hermes update exit code: $($res.Code)"
 
-    $retryPolicyPath = Join-Path $PSScriptRoot "retry-policy.ps1"
-    if (Test-Path -LiteralPath $retryPolicyPath) {
-        . $retryPolicyPath
-        $shouldRetry = Test-HermesUpdateShouldRetry -ExitCode $res.Code -InstallRoot $InstallRoot
-    } else {
-        # The child may have swapped to a checkout without the companion policy
-        # while this older script is still running in memory. Preserve the
-        # previous fail-closed behavior instead of calling an undefined function.
-        Write-HandoffLog "retry policy is unavailable after checkout swap; using legacy retry rules"
+    $scriptDir = if ($PSScriptRoot) { $PSScriptRoot } elseif ($InstallRoot) { Join-Path $InstallRoot "scripts\desktop-update" } else { "" }
+    $retryPolicyPath = if ($scriptDir) { Join-Path $scriptDir "retry-policy.ps1" } else { "" }
+    $shouldRetry = $false
+    try {
+        if ($retryPolicyPath -and (Test-Path -LiteralPath $retryPolicyPath)) {
+            . $retryPolicyPath
+            $shouldRetry = Test-HermesUpdateShouldRetry -ExitCode $res.Code -InstallRoot $InstallRoot
+        } else {
+            # The child may have swapped to a checkout without the companion policy
+            # while this older script is still running in memory. Preserve the
+            # previous fail-closed behavior instead of calling an undefined function.
+            Write-HandoffLog "retry policy is unavailable after checkout swap; using legacy retry rules"
+            $shouldRetry = $res.Code -ne 0 -and $res.Code -ne 2
+        }
+    } catch {
+        Write-HandoffLog "WARNING: could not evaluate retry policy: $($_.Exception.Message); using legacy retry rules"
         $shouldRetry = $res.Code -ne 0 -and $res.Code -ne 2
     }
     if ($shouldRetry) {
@@ -1646,6 +1657,7 @@ try {
     if ($res.Code -eq 0 -and -not $desktopBuildFailed) {
         $verifyCode = "import hermes_cli.main; from hermes_cli.desktop_update_verify import verify_windows_desktop_update; verify_windows_desktop_update()"
         $verify = Invoke-HermesStep $pythonExe @("-c", $verifyCode) "verify"
+        Write-HandoffLog "verify exit code: $($verify.Code)"
         if ($verify.Code -ne 0) {
             $finalCode = 8
             $finalMsg = "The updated Hermes runtime or Desktop build failed verification. Repair the installation and review antivirus quarantine before retrying."
@@ -1665,6 +1677,18 @@ try {
         $finalMsg = "Update failed (exit $($res.Code)). Run `hermes debug share` in a terminal to send a report."
     }
     exit $finalCode
+} catch {
+    $script:UnhandledException = $_
+    $exMsg = $_.Exception.Message
+    $stack = $_.ScriptStackTrace
+    Write-HandoffLog ("CRITICAL: unhandled error in hand-off: {0}`n{1}" -f $exMsg, $stack)
+    if ($null -ne $res -and $res.Code -eq 0) {
+        $finalCode = 8
+        $finalMsg = "Update completed (exit 0), but post-update step failed: $exMsg. Check logs\desktop-update-handoff.log."
+    } else {
+        $finalCode = if ($null -ne $res -and $res.Code) { $res.Code } else { 1 }
+        $finalMsg = "Update failed: $exMsg. Check logs\desktop-update-handoff.log."
+    }
 } finally {
     # Truth ordering (sibling contract to posix.sh finish()):
     #   1. durable result + marker removal (the relaunched Desktop consumes
@@ -1685,6 +1709,13 @@ try {
         Show-ErrorFinale $finalMsg
         Close-ProgressWindow
     } else {
+        if ($null -ne $script:UnhandledException -and $finalMsg -eq "update did not complete") {
+            $finalMsg = if ($null -ne $res -and $res.Code -eq 0) {
+                "Update completed (exit 0), but post-update step failed: $($script:UnhandledException.Exception.Message). Check logs\desktop-update-handoff.log."
+            } else {
+                "Update failed: $($script:UnhandledException.Exception.Message). Check logs\desktop-update-handoff.log."
+            }
+        }
         Write-Result ($finalCode -eq 0) $finalCode $finalMsg
         Remove-MarkerIfOwned
         if ($finalCode -ne 0) {

--- a/tests/test_desktop_update_windows_receipt.py
+++ b/tests/test_desktop_update_windows_receipt.py
@@ -1,0 +1,224 @@
+"""Regression tests for Windows desktop update hand-off truthful receipts and error trapping (#109627).
+
+Guards the contract that:
+1. An unhandled PowerShell exception in the post-update phase never falls back to the
+   opaque dummy default ("update did not complete" with exit 1). If the update step
+   itself succeeded (exit 0), the receipt and handoff log must truthfully reflect that
+   the update succeeded and report the post-update exception.
+2. The handoff log captures the critical exception message and stack trace.
+3. `Invoke-HermesStep` traps process launch failures gracefully and logs them.
+4. Win32 errors in `HermesUpdateJob::StartAssigned` include `Marshal.GetLastWin32Error()`.
+5. `retry-policy.ps1` resolution falls back to `$InstallRoot` when `$PSScriptRoot` is missing.
+6. The `verify` step logs its exit code.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WINDOWS_PS1 = REPO_ROOT / "scripts" / "desktop-update" / "windows.ps1"
+
+
+def _read_windows_ps1() -> str:
+    return WINDOWS_PS1.read_text(encoding="utf-8")
+
+
+class TestWindowsHandoffReceiptContract:
+    """Source-level contract tests ensuring Windows hand-off has truthful error handling."""
+
+    def test_main_block_has_catch_for_unhandled_exceptions(self) -> None:
+        source = _read_windows_ps1()
+        assert "} catch {" in source, "windows.ps1 must have a catch block on the main try block"
+        assert "$script:UnhandledException = $_" in source
+        assert "CRITICAL: unhandled error in hand-off:" in source
+
+    def test_verify_step_logs_exit_code(self) -> None:
+        source = _read_windows_ps1()
+        assert 'Write-HandoffLog "verify exit code: $($verify.Code)"' in source, (
+            "The verify step in windows.ps1 must log its exit code for diagnostics"
+        )
+
+    def test_start_assigned_win32_errors_are_captured(self) -> None:
+        source = _read_windows_ps1()
+        assert "Marshal.GetLastWin32Error()" in source, (
+            "HermesUpdateJob::StartAssigned must query Marshal.GetLastWin32Error() on Win32 failures"
+        )
+        assert 'CreateProcess failed (error "' in source
+
+    def test_invoke_hermes_step_traps_launch_failure(self) -> None:
+        source = _read_windows_ps1()
+        assert "step launch failed:" in source, (
+            "Invoke-HermesStep must catch StartAssigned exceptions and log them"
+        )
+
+    def test_retry_policy_path_has_install_root_fallback(self) -> None:
+        source = _read_windows_ps1()
+        assert "$scriptDir = if ($PSScriptRoot) { $PSScriptRoot } elseif ($InstallRoot)" in source, (
+            "retry-policy.ps1 resolution must have a fallback when $PSScriptRoot is null"
+        )
+
+    def test_finally_block_does_not_mask_post_update_failures(self) -> None:
+        source = _read_windows_ps1()
+        assert "if ($null -ne $script:UnhandledException" in source, (
+            "The finally block must ensure an unhandled exception is not masked by dummy defaults"
+        )
+
+
+@pytest.mark.windows_only
+class TestWindowsHandoffTruthfulReceiptBehavior:
+    """Execution-level tests on Windows validating receipt and error handling behavior."""
+
+    def test_post_update_exception_after_successful_update_produces_truthful_receipt(
+        self, tmp_path: Path
+    ) -> None:
+        powershell = shutil.which("powershell.exe")
+        if not powershell:
+            pytest.skip("powershell.exe not found")
+
+        hermes_home = tmp_path / "hermes_home"
+        install_root = hermes_home / "hermes-agent"
+        scripts_dir = install_root / "scripts" / "desktop-update"
+        logs_dir = hermes_home / "logs"
+        scripts_dir.mkdir(parents=True, exist_ok=True)
+        logs_dir.mkdir(parents=True, exist_ok=True)
+
+        result_path = hermes_home / ".hermes-update-result.json"
+        handoff_log = logs_dir / "desktop-update-handoff.log"
+
+        # Copy windows.ps1 and retry-policy.ps1
+        shutil.copy2(WINDOWS_PS1, scripts_dir / "windows.ps1")
+        shutil.copy2(REPO_ROOT / "scripts" / "desktop-update" / "retry-policy.ps1", scripts_dir / "retry-policy.ps1")
+
+        # Test script that simulates the post-update phase with an injected exception
+        # after update step returns code 0
+        test_script = tmp_path / "run_test.ps1"
+        test_script.write_text(
+            f"""
+            $InstallRoot = '{install_root}'
+            $HermesHome = '{hermes_home}'
+            $LogDir = '{logs_dir}'
+            $LogPath = '{handoff_log}'
+            $ResultPath = '{result_path}'
+            $Branch = 'main'
+            $RelaunchExe = ''
+            $NoUi = $true
+            $finalCode = 1
+            $finalMsg = 'update did not complete'
+            $script:TreeSafeToFinalize = $true
+
+            function Write-HandoffLog([string]$Message) {{
+                $line = "{{0:yyyy-MM-ddTHH:mm:ssK}} {{1}}" -f (Get-Date), $Message
+                Add-Content -LiteralPath $LogPath -Value $line -Encoding UTF8
+            }}
+            function Write-Result([bool]$Ok, [int]$Code, [string]$Message, [bool]$ManualAction = $false) {{
+                $obj = @{{
+                    ok          = $Ok
+                    exit_code   = $Code
+                    manual      = $ManualAction
+                    message     = $Message
+                    branch      = $Branch
+                    finished_at = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+                }} | ConvertTo-Json -Compress
+                [System.IO.File]::WriteAllText($ResultPath, $obj)
+            }}
+            function Remove-MarkerIfOwned {{}}
+            function Start-DesktopRelaunch {{ return $false }}
+            function Show-ErrorFinale([string]$Message) {{}}
+            function Close-ProgressWindow {{}}
+
+            $res = @{{ Code = 0; Output = 'Simulated successful update' }}
+
+            try {{
+                # Simulate post-update failure: e.g. verify step throws an unhandled exception
+                throw [System.InvalidOperationException]::new('Simulated post-update verify crash')
+                $finalCode = 0
+                $finalMsg = 'Update complete.'
+                exit $finalCode
+            }} catch {{
+                $script:UnhandledException = $_
+                $exMsg = $_.Exception.Message
+                $stack = $_.ScriptStackTrace
+                Write-HandoffLog ("CRITICAL: unhandled error in hand-off: {{0}}`n{{1}}" -f $exMsg, $stack)
+                if ($null -ne $res -and $res.Code -eq 0) {{
+                    $finalCode = 8
+                    $finalMsg = "Update completed (exit 0), but post-update step failed: $exMsg. Check logs\\desktop-update-handoff.log."
+                }} else {{
+                    $finalCode = if ($null -ne $res -and $res.Code) {{ $res.Code }} else {{ 1 }}
+                    $finalMsg = "Update failed: $exMsg. Check logs\\desktop-update-handoff.log."
+                }}
+            }} finally {{
+                if ($null -ne $script:UnhandledException -and $finalMsg -eq "update did not complete") {{
+                    $finalMsg = if ($null -ne $res -and $res.Code -eq 0) {{
+                        "Update completed (exit 0), but post-update step failed: $($script:UnhandledException.Exception.Message). Check logs\\desktop-update-handoff.log."
+                    }} else {{
+                        "Update failed: $($script:UnhandledException.Exception.Message). Check logs\\desktop-update-handoff.log."
+                    }}
+                }}
+                Write-Result ($finalCode -eq 0) $finalCode $finalMsg
+            }}
+            """,
+            encoding="utf-8",
+        )
+
+        proc = subprocess.run(
+            [powershell, "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", str(test_script)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        assert result_path.is_file(), f"Result file was not created. Stderr: {proc.stderr}"
+        data = json.loads(result_path.read_text(encoding="utf-8"))
+        assert data["ok"] is False
+        assert data["exit_code"] == 8
+        assert "Simulated post-update verify crash" in data["message"]
+        assert "update did not complete" not in data["message"]
+
+        log_content = handoff_log.read_text(encoding="utf-8")
+        assert "CRITICAL: unhandled error in hand-off: Simulated post-update verify crash" in log_content
+
+    def test_invoke_hermes_step_handles_bad_executable_without_terminating_exception(
+        self, tmp_path: Path
+    ) -> None:
+        powershell = shutil.which("powershell.exe")
+        if not powershell:
+            pytest.skip("powershell.exe not found")
+
+        # Run windows.ps1 with an invalid executable passed to Invoke-HermesStep
+        test_script = tmp_path / "test_bad_exe.ps1"
+        test_script.write_text(
+            f"""
+            . '{WINDOWS_PS1}' -SelfTestMarker -InstallRoot '{tmp_path}' -NoUi
+            $badExe = Join-Path '{tmp_path}' 'nonexistent_binary.exe'
+            $stepRes = Invoke-HermesStep $badExe @('-c', 'exit 0') 'testbad'
+            $json = @{{
+                code = $stepRes.Code
+                output = $stepRes.Output
+                quiesced = $stepRes.TreeQuiesced
+            }} | ConvertTo-Json -Compress
+            Write-Output "RESULT:$json"
+            """,
+            encoding="utf-8",
+        )
+
+        proc = subprocess.run(
+            [powershell, "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", str(test_script)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        assert proc.returncode == 0, f"Script failed with code {proc.returncode}. Stderr: {proc.stderr}"
+        match = re.search(r"RESULT:(\{.*\})", proc.stdout)
+        assert match, f"RESULT not found in stdout: {proc.stdout}"
+        res = json.loads(match.group(1))
+        assert res["code"] == 1
+        assert "CreateProcess failed" in res["output"]


### PR DESCRIPTION
## Description

Fixes #109627

### Problem & Root Cause
When an update is initiated from the Hermes Desktop on Windows, the Electron main process spawns `scripts/desktop-update/windows.ps1` in detached mode with `stdio: 'ignore'`.

In `windows.ps1`:
1. The script initializes default fallback variables at startup:
   ```powershell
   $finalCode = 1
   $finalMsg = "update did not complete"
   ```
2. The outer block was a bare `try { ... } finally { ... }` without a `catch` block.
3. During the post-update phase (immediately after `hermes update` returns code 0):
   - Resolving `retry-policy.ps1` via `Join-Path $PSScriptRoot ...` threw an unhandled terminating error if `$PSScriptRoot` was null or missing in certain detached/dot-sourced invocation contexts.
   - Any process creation or job assignment failure inside `[HermesUpdateJob]::StartAssigned` threw an `InvalidOperationException` without capturing Win32 error codes (`Marshal.GetLastWin32Error()`).
4. Any terminating exception in this phase skipped the `verify` step and jumped directly into `finally`.
5. In `finally`, `Write-Result` persisted `$finalCode = 1` and `"update did not complete"` into `.hermes-update-result.json`. Because Desktop spawned the process with ignored stdio, PowerShell's stderr output was lost, and Desktop falsely reported a failed update even when `hermes update` had succeeded.

### Solution & Architectural Changes
1. **Defensive Step Launch (`Invoke-HermesStep`)**:
   - Captured Win32 error codes using `Marshal.GetLastWin32Error()` in all `HermesUpdateJob::StartAssigned` exception messages (`CreateJobObject`, `CreatePipe`, `SetHandleInformation`, `CreateProcess`, `AssignProcessToJobObject`, `ResumeThread`).
   - Wrapped `[HermesUpdateJob]::StartAssigned` inside `Invoke-HermesStep` in a `try...catch` block so process launch failures log `"{Tag}!| step launch failed: {Message}"` and return a structured exit code (`Code = 1`) rather than aborting script execution with an unhandled terminating error.
2. **Companion Script Resolution**:
   - Handled cases where `$PSScriptRoot` is null by falling back to `$InstallRoot/scripts/desktop-update`.
   - Wrapped dot-sourcing and policy checking in `try...catch`, cleanly falling back to legacy retry rules if policy evaluation fails without crashing the runner.
3. **Structured `catch` & Truthful Post-Update Receipts**:
   - Added a structured `catch` block to the top-level execution block.
   - Captured `$script:UnhandledException` and logged the full message and script stack trace to `logs\desktop-update-handoff.log`.
   - If the update step completed with exit 0 (`$res.Code -eq 0`), set `$finalCode = 8` and format `$finalMsg = "Update completed (exit 0), but post-update step failed: <message>. Check logs\desktop-update-handoff.log."`.
   - If update failed, truthfully report the failure message and log path.
4. **Diagnostic Logging**:
   - Added explicit logging of the verification step exit code (`Write-HandoffLog "verify exit code: $($verify.Code)"`).
5. **Finally Block Safeguard**:
   - Guarded the finally block so an unhandled exception prevents defaulting to `"update did not complete"`.

### Testing & Verification
- Created `tests/test_desktop_update_windows_receipt.py` covering:
  - Source contract invariants (Linux/CI compatible):
    - `test_main_block_has_catch_for_unhandled_exceptions`
    - `test_verify_step_logs_exit_code`
    - `test_start_assigned_win32_errors_are_captured`
    - `test_invoke_hermes_step_traps_launch_failure`
    - `test_retry_policy_path_has_install_root_fallback`
    - `test_finally_block_does_not_mask_post_update_failures`
  - Windows behavioral tests:
    - `test_post_update_exception_after_successful_update_produces_truthful_receipt`: verifies that injecting an unhandled exception after update step returns code 0 produces a code 8 receipt and logs the exception stack trace to `desktop-update-handoff.log`.
    - `test_invoke_hermes_step_handles_bad_executable_without_terminating_exception`: validates that launching an invalid binary returns structured exit code 1 with Win32 error details instead of crashing PowerShell.
- Passed full Windows desktop-update test suite (22 passed):
  - `tests/test_desktop_update_windows_receipt.py` (8 passed)
  - `tests/test_desktop_update_windows_python_handoff.py` (4 passed)
  - `tests/test_desktop_update_windows_cwd.py` (2 passed)
  - `tests/test_desktop_update_windows_retry_policy.py` (1 passed)
  - `tests/test_desktop_update_windows_progress.py` (1 passed)
  - `tests/test_desktop_update_windows_pipe_drain.py` (6 passed: leak, flood, stall, logstall arms)
