### PR TITLE
fix(gateway): finish proxy streams without waiting for another chunk

### DIFF
--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -2606,10 +2606,6 @@ class GatewayTurnMixin:
 
                     buffer = ""
                     async for chunk in resp.content.iter_any():
-                        if saw_done:
-                            # A buggy upstream that holds the connection open after [DONE]
-                            # would otherwise block us for up to sock_read seconds.
-                            break
                         if not _run_still_current():
                             return _stale_result("stream")
                         buffer += chunk.decode("utf-8", errors="replace")
@@ -2618,6 +2614,9 @@ class GatewayTurnMixin:
                             if _consume_sse_line(line):
                                 saw_done = True
                                 break
+                        # Exit before the iterator requests another network chunk.
+                        if saw_done:
+                            break
                         if len(buffer) > _GATEWAY_PROXY_SSE_BUFFER_MAX_CHARS:
                             raise ValueError("Proxy SSE stream exceeded max buffer size without a line boundary")
                     # The final SSE frame may not be newline-terminated: flush the residual

--- a/tests/gateway/test_proxy_mode.py
+++ b/tests/gateway/test_proxy_mode.py
@@ -44,12 +44,14 @@ class _FakeSSEResponse:
         self._sse_chunks = sse_chunks or []
         self._error_text = error_text
         self.content = self
+        self.chunks_requested = 0
 
     async def text(self):
         return self._error_text
 
     async def iter_any(self):
         for chunk in self._sse_chunks:
+            self.chunks_requested += 1
             if isinstance(chunk, str):
                 chunk = chunk.encode("utf-8")
             yield chunk
@@ -329,6 +331,10 @@ class TestStreamingResilience:
 
         assert result["final_response"] == "Hello"
 
+        # Fetching the next chunk already waits on the peer; dropping it after
+        # arrival is too late when the peer leaves the completed stream open.
+        assert resp.chunks_requested == 2
+
     @pytest.mark.asyncio
     async def test_residual_buffer_flushed_after_eof(self, monkeypatch):
         """A final SSE frame without a trailing newline must not be dropped.
@@ -485,4 +491,3 @@ class TestEnvVarRegistration:
         info = OPTIONAL_ENV_VARS["GATEWAY_PROXY_URL"]
         assert info["category"] == "messaging"
         assert info["password"] is False
-


### PR DESCRIPTION
## What does this PR do?

Finish a proxy reply as soon as its `[DONE]` marker arrives, without waiting for another network chunk.

Small follow-up to @0xbyt4's streaming fix carried in #106404. Its completed-stream check was at the top of the `async for` body: Python had already requested the next chunk before checking it. A peer that leaves the completed connection open could therefore keep the reply waiting for the read timeout.

Move that check immediately after line parsing. No request format, retry or outcome policy changes.

## Verification

The existing completion-marker test now also counts iterator reads. It requested a third chunk before this fix, despite the second containing `[DONE]`; afterward it requests only the first two and returns the same reply.

All 14 proxy tests pass on the main-based branch, plus scoped Ruff and whitespace checks. Tests use a deterministic fake transport, not a live service or model. No new dependencies.

## Checklist

- [x] Contribution guidelines and open/merged PR search checked.
- [x] Original source attribution preserved.
- [x] Only the loop boundary and its regression coverage changed.
- [x] Tested on macOS.
- [ ] Full repository suite and other-platform CI not run locally.

Related: #106404. The same fix is carried in the continuity preparation, but this PR has no dependency on that stack or #106742.
