### PR TITLE
fix(desktop): stop a live renderer before the POSIX stage-and-swap rename

### DIFF
--- a/hermes_cli/main_desktop.py
+++ b/hermes_cli/main_desktop.py
@@ -207,8 +207,12 @@ def _swap_staged_desktop_app(desktop_dir: Path, staging_dir: Path) -> Optional[P
         shutil.rmtree(previous, ignore_errors=True)
         moved_aside = live_root.exists()
         if moved_aside:
-            # A Desktop may have reopened during the long packaging step.
-            stopped = _stop_desktop_processes_locking_build(desktop_dir)
+            # A Desktop may have reopened during the long packaging step (Windows lock) or
+            # never exited at all (a manual `hermes update`/`hermes desktop` run does not
+            # wait for it — only the update hand-offs do). Either way a renderer alive
+            # past the rename below keeps fetching its old hashed chunks from disk and
+            # dies on the next lazy import, so stop it on every platform (#109643).
+            stopped = _stop_desktop_processes_locking_build(desktop_dir, also_posix=True)
             if stopped:
                 logger.info("stopped desktop processes before staged app promotion: %s", stopped)
             os.rename(live_root, previous)
@@ -629,11 +633,15 @@ def _try_redownload_electron_dist(project_root: Path, env: dict) -> bool:
     return _redownload_electron_dist(project_root, env, mirror=_ELECTRON_FALLBACK_MIRROR)
 
 
-def _stop_desktop_processes_locking_build(desktop_dir: Path) -> list[int]:
-    """Terminate a running desktop app whose exe lives INSIDE this build's ``release`` tree (Windows
-    only — its lock makes the pack die with ``Access is denied``; POSIX can unlink a running
-    binary). Never raises; returns the PIDs asked to stop."""
-    if sys.platform != "win32":
+def _stop_desktop_processes_locking_build(desktop_dir: Path, *, also_posix: bool = False) -> list[int]:
+    """Terminate a running desktop app whose exe lives INSIDE this build's ``release`` tree.
+
+    Windows needs it everywhere: the exe lock makes the pack die with ``Access is denied``.
+    POSIX can rename a running app's files away, so the pack itself needs no stop — but a
+    renderer left alive through the stage-and-swap promotion keeps fetching its OLD hashed
+    chunks by path after the swap and dies on the next lazy import (#109643), so the swap
+    point passes ``also_posix=True``. Never raises; returns the PIDs asked to stop."""
+    if sys.platform != "win32" and not also_posix:
         return []
     try:
         import psutil

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -1408,6 +1408,64 @@ def test_swap_staged_desktop_app_rolls_back_when_second_rename_fails(tmp_path, m
     assert not (live_exe.parent.parent / (live_exe.parent.name + ".previous")).exists()
 
 
+def test_swap_staged_desktop_app_stops_live_renderer_before_rename(tmp_path):
+    """#109643: a renderer alive through the promotion rename keeps fetching its
+    old hashed chunks from disk and dies on the next lazy import — the swap must
+    ask for running desktop processes to stop on EVERY platform."""
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    live_exe = desktop_dir / "release" / _packaged_exe_rel()
+    live_exe.parent.mkdir(parents=True)
+    live_exe.write_text("old", encoding="utf-8")
+    staging = main_desktop._desktop_staging_dir(desktop_dir)
+    staged_exe = staging / _packaged_exe_rel()
+    staged_exe.parent.mkdir(parents=True)
+    staged_exe.write_text("new", encoding="utf-8")
+
+    with patch("hermes_cli.main_desktop._stop_desktop_processes_locking_build",
+               return_value=[4321]) as stop:
+        promoted = main_desktop._swap_staged_desktop_app(desktop_dir, staging)
+
+    assert promoted == live_exe
+    stop.assert_called_once_with(desktop_dir, also_posix=True)
+
+
+def test_stop_desktop_processes_locking_build_posix_swap_bypasses_early_return(tmp_path, monkeypatch):
+    """#109643: also_posix=True must run the scan on POSIX (the default pack-time
+    call stays Windows-only — the staging pack never touches the live tree)."""
+    monkeypatch.setattr(main_desktop.sys, "platform", "darwin")
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    live_exe = desktop_dir / "release" / _packaged_exe_rel()
+    live_exe.parent.mkdir(parents=True)
+    live_exe.write_text("old", encoding="utf-8")
+
+    class _FakeProc:
+        def __init__(self, pid, exe):
+            self.info = {"pid": pid, "exe": exe}
+            self.pid = pid
+
+        def terminate(self):
+            return None
+
+    target = _FakeProc(100, str(live_exe))
+    outsider = _FakeProc(200, "/usr/bin/unrelated")
+
+    class _FakePsutil:
+        @staticmethod
+        def process_iter(attrs):
+            return [target, outsider]
+
+        @staticmethod
+        def wait_procs(victims, timeout=5):
+            return [], []
+
+    monkeypatch.setitem(sys.modules, "psutil", _FakePsutil)
+
+    assert main_desktop._stop_desktop_processes_locking_build(desktop_dir) == []
+    assert main_desktop._stop_desktop_processes_locking_build(desktop_dir, also_posix=True) == [100]
+
+
 def test_gui_failed_pack_leaves_previous_app_untouched(tmp_path, monkeypatch, capsys):
     """Every pack attempt fails → the pre-existing app is exactly as it was,
     no staging dir remains, exit is non-zero."""


### PR DESCRIPTION
## What does this PR do?

On macOS/Linux, a desktop rebuild driven outside the update hand-offs (e.g. a manual `hermes update` or `hermes desktop --force-build` while the Desktop is running) promotes the staged app over `release/` while the running instance is still alive. POSIX happily renames a running app's files away, so the promotion completes — but the live renderer keeps its old Vite module graph in memory and fetches its OLD hashed chunks by path from the newly swapped tree, dying on the next lazy route with `Failed to fetch dynamically imported module` (#85868; also reported as #96375 and #109643, where the swapped-in bundle is verified complete — a relaunch fixes it, and the torn-bundle guard does not apply because there is nothing torn).

The promotion path (`_swap_staged_desktop_app`) already stops running desktop processes before the rename, but `_stop_desktop_processes_locking_build` returns early off Windows (where the motivation is the exe file lock). This PR adds an `also_posix=True` flag, passed only from the swap point, so a renderer alive at promotion time is terminated before the live tree is renamed aside. The pack-time calls stay Windows-only: the staging pack builds into a sibling directory and never touches the live tree, so there is nothing to protect there — stopping the user's app for the whole multi-minute pack would be pure downside.

After the swap, `hermes desktop` launches the new app right away, and the `--build-only`/hand-off paths relaunch it themselves (posix.sh `--relaunch-target`, the installer's detached launch), so a stopped instance always comes back.

## Related Issue

Fixes #85868

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main_desktop.py`: `_stop_desktop_processes_locking_build` gains `also_posix: bool = False`; when set, the Windows-only early return is bypassed so the psutil scan/terminate also runs on macOS/Linux. Docstring records both motivations (Windows file lock vs. stale-renderer correctness).
- `hermes_cli/main_desktop.py`: `_swap_staged_desktop_app` now calls it with `also_posix=True` before renaming the live app aside, with a comment explaining why a renderer must not survive the rename.
- `tests/hermes_cli/test_gui_command.py`: two regression tests — the swap asks for the stop with `also_posix=True` on every platform, and the function's early return is bypassed on POSIX only when the flag is passed (default pack-time call still returns `[]`).

## How to Test

1. `pytest tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_desktop_exe_integrity.py -q` → 51 passed, 12 skipped (platform-conditional skips, same as before the change). Observed result: 51 passed, 12 skipped in 0.94s.
2. `ruff check hermes_cli/main_desktop.py tests/hermes_cli/test_gui_command.py` → All checks passed.
3. New test `test_stop_desktop_processes_locking_build_posix_swap_bypasses_early_return` fakes psutil (a process whose exe lives under `release/`, plus an unrelated one) and asserts: default call on darwin returns `[]`, `also_posix=True` terminates exactly the in-tree process. Should pass.
4. Manual reproduction of the bug this fixes (before the change): run the Desktop, run `hermes desktop --force-build` in a terminal, then click through to a not-yet-visited lazy route in the still-running app → `Failed to fetch dynamically imported module` in `desktop.log`. After the change, the running instance is stopped before the swap and the fresh app opens on the new bundle. (Verified by the unit tests' call-contract; the live reproduction matches the #109643/#85868 reports.)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (\#96171 covers failed/incomplete-pack rollback and mac bundle verification — a complementary layer; it never touches the swap-time process stop this fix adds)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted: `tests/hermes_cli/test_gui_command.py`, `tests/hermes_cli/test_desktop_exe_integrity.py`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon, arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings updated in place
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-patibility) — Windows behavior unchanged (flag is a no-op superset); macOS/Linux gain the swap-time stop
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A — not a skill.

## Screenshots / Logs

None — CLI-side change; behavior is covered by the new unit tests.