### PR TITLE
fix(kanban): anchor shift-click range selection on plain card open

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -961,6 +961,10 @@
       setLastSelectedId(null);
       setFailedIds(new Set());
     }, []);
+    const openTask = useCallback(function (taskId) {
+      setLastSelectedId(taskId);
+      setSelectedTaskId(taskId);
+    }, []);
     const moveSelected = useCallback(function (newStatus) {
       if (selectedIds.size === 0) return;
       const count = selectedIds.size;
@@ -1283,7 +1287,7 @@
         h(OrchestrationPanel, null),
         h(AttentionStrip, {
           boardData,
-          onOpen: setSelectedTaskId,
+          onOpen: openTask,
         }),
         h(BoardToolbar, {
           board: boardData,
@@ -1328,7 +1332,7 @@
           onMoveSelected: moveSelected,
           onDelete: deleteTask,
           onDeleteSelected: deleteSelected,
-          onOpen: setSelectedTaskId,
+          onOpen: openTask,
           onCreate: createTask,
           allTasks: boardData.columns.reduce(function (acc, c) { return acc.concat(c.tasks); }, []),
         }),
@@ -1336,7 +1340,7 @@
           taskId: selectedTaskId,
           boardSlug: board,
           onClose: function () { setSelectedTaskId(null); },
-          onOpenTask: setSelectedTaskId,
+          onOpenTask: openTask,
           onRefresh: loadBoard,
           renderMarkdown: renderMd,
           allTasks: boardData.columns.reduce(function (acc, c) { return acc.concat(c.tasks); }, []),

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1232,3 +1232,38 @@ def test_specify_happy_path(client, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Plain card open anchors shift-click range selection
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_plain_card_open_anchors_shift_range_selection():
+    """A plain card open must record the shift-click range anchor.
+
+    ``toggleRange`` anchors on ``lastSelectedId``; before the anchoring
+    opener only ctrl/meta-click ever set it, so the natural click-first,
+    shift-click-second gesture degraded to a single-card selection. Every
+    open-card entry point must route through the anchoring opener instead
+    of setting the drawer task directly.
+    """
+
+    repo_root = Path(__file__).resolve().parents[2]
+    js = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text(
+        encoding="utf-8"
+    )
+
+    # The opener records the anchor before opening the drawer.
+    assert "const openTask = useCallback(function (taskId) {" in js
+
+    # No open-card site may bypass it straight to setSelectedTaskId.
+    assert "onOpen: setSelectedTaskId," not in js
+    assert "onOpenTask: setSelectedTaskId," not in js
+
+    # Board columns and the attention strip route through the anchoring opener.
+    assert js.count("onOpen: openTask,") == 2
+
+    # Drawer follow-up links re-anchor on the newly opened card.
+    assert "onOpenTask: openTask," in js
+
+    # toggleRange still reads the anchor it is now reliably given.
+    assert "const anchor = lastSelectedId;" in js


### PR DESCRIPTION
## Summary

Fixes #109652.

A plain click on a kanban card opened the task drawer without setting a selection anchor, so `toggleRange` degraded to selecting a single card and shift-click range selection was unreachable through the natural gesture (only ctrl/meta-click built a multi-card selection).

The range machinery itself was correct — it simply never received an anchor from the click users try first.

## Changes

Single file: `plugins/kanban/dashboard/dist/index.js` (the kanban dashboard plugin ships as a plain IIFE with no build step; this file is the source of truth, edited directly like previous kanban fixes).

- Add an `openTask` callback next to `clearSelected` that opens the drawer **and** records the opened card as the selection anchor:
  ```js
  const openTask = useCallback(function (taskId) {
    setLastSelectedId(taskId);
    setSelectedTaskId(taskId);
  }, []);
  ```
- Route the three open-card sites through it: `AttentionStrip.onOpen`, the board `onOpen`, and `TaskDrawer.onOpenTask` — so every way of opening a card anchors the selection consistently.

Plain-click behavior is otherwise unchanged: it still opens the drawer and does not alter the current selection. This is the "set the anchor on a plain click" option from the report.

## Verification

Behavioral harness running the **real** `toggleRange` (and new `openTask`) code extracted verbatim from the file, over a two-column board `[A, B | C, D]`:

| scenario | before (main) | after (fix) |
|---|---|---|
| click A, shift-click C | `{C}` — no range, the reported bug | `{A, B, C}` — full range across columns |
| click B, click D, shift-click B | `{B}` | `{B, C, D}` — re-anchors on the last opened card |
| ctrl-click A, shift-click C | `{A, B, C}` (worked before) | `{A, B, C}` (unchanged) |

Also verified: `node --check` on the modified file passes; selection semantics of `toggleSelected` / `selectAllVisible` / `selectAllInColumn` untouched.

The secondary "range can only grow" note from the report (shrink semantics à la `SessionsPage`) is deliberately not included — it changes existing selection behavior and deserves its own change.
