### PR TITLE
docs(configuration): the Ink TUI is launched with `hermes --tui`, not `hermes tui`

### DIFF
--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2124,7 +2124,7 @@ Notes:
 - Narrow terminals still drop wide-mode-only fields (`context_detail`, `cache_hit`, `latency`, `tps`, `prompt_elapsed`, `idle_since`) regardless of config (`cache_hit` also shows in the medium ≥52-col tier).
 - `latency`/`tps` stay hidden until API calls have been recorded (e.g. the Codex app-server backend reports no latency).
 - `battery` and `title` visibility here compose with their own toggles (`/battery`, `/title`) — both must be on for the segment to show.
-- The same key also filters the **Ink TUI** status rule (`hermes tui`), where `cache_hit`, `latency`, and `tps` render as width-budgeted tail segments (◎ / ◷ / ↑) on terminals ≥96/104/110 columns respectively.
+- The same key also filters the **Ink TUI** status rule (`hermes --tui`), where `cache_hit`, `latency`, and `tps` render as width-budgeted tail segments (◎ / ◷ / ↑) on terminals ≥96/104/110 columns respectively.
 - Display-only: no effect on prompt caching or request payloads. Changes take effect on the next session start.
 
 ### Runtime-metadata footer (gateway only)


### PR DESCRIPTION
## What does this PR do?

`website/docs/user-guide/configuration.md` (line 2127) tells readers the Ink TUI status rule applies to `hermes tui`. There is no such subcommand: `hermes tui` exits with `argument command: invalid choice: 'tui'`, and the TUI is launched with the root flag `hermes --tui`, which is what every other page uses (`user-guide/tui.md`, `user-guide/cli.md`, `user-guide/windows-native.md`). One backticked token changes; no zh-Hans mirror line exists for this sentence.

## Related Issue

No tracked issue (found while checking documented commands against `hermes --help`).

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `website/docs/user-guide/configuration.md:2127` — `` `hermes tui` `` → `` `hermes --tui` ``

## How to Test

1. `python -m hermes_cli.main tui --help` → `invalid choice: 'tui'`; `python -m hermes_cli.main --help` lists `--tui`.
2. `grep -rn '`hermes tui`' website/docs website/i18n` → no matches on this branch (one on `main`).

## Checklist

- [x] I've read the Contributing Guide; conventional-commit title; searched open PRs (none touch this line); docs-only, no tests apply; macOS 26, Python 3.12.
