### PR TITLE
fix(computer_use): enable the session cursor when the overlay policy allows it

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -2324,6 +2324,73 @@ class TestSessionLifecycle:
         assert name == "start_session"
         assert args["session"] == backend._session_id
 
+    def _started_backend(self):
+        """A backend whose session handshake already flipped `_started`, ready
+        for post-handshake tuning assertions."""
+        from unittest.mock import MagicMock
+        from tools.computer_use.cua_backend import CuaDriverBackend
+
+        backend = CuaDriverBackend()
+        backend._session = MagicMock()
+        backend._session.start = MagicMock()
+        backend._session.call_tool = MagicMock(return_value={
+            "data": "", "images": [], "image_mime_types": [],
+            "structuredContent": None, "isError": False,
+        })
+        return backend
+
+    @staticmethod
+    def _cursor_call(backend):
+        """The set_agent_cursor_enabled call_tool a start() issued, if any."""
+        for call in backend._session.call_tool.call_args_list:
+            name, args = call.args
+            if name == "set_agent_cursor_enabled":
+                return args
+        return None
+
+    def test_start_enables_agent_cursor_when_policy_allows_it(self):
+        """#109690: the engine default-hides the per-session cursor, so a run
+        whose overlay policy allows it must explicitly enable the cursor —
+        the mirror of the disable branch. Without it the documented tinted
+        overlay cursor never appears for a Hermes run."""
+        from unittest.mock import patch
+
+        backend = self._started_backend()
+        with patch(
+            "tools.computer_use.cua_backend.cua_driver_runtime_contract_status",
+            return_value={"ready": True},
+        ), patch("tools.lazy_deps.ensure"), patch(
+            "tools.computer_use.cua_backend._cua_no_overlay",
+            return_value=False,
+        ):
+            backend.start()
+
+        args = self._cursor_call(backend)
+        assert args is not None, "policy allows overlay: cursor must be enabled"
+        assert args["enabled"] is True
+        assert args["cursor_id"] == backend._session_id
+        assert args["session"] == backend._session_id
+
+    def test_start_disables_agent_cursor_when_policy_forbids_it(self):
+        """The pre-#109690 behavior stays: a policy that forbids the overlay
+        still disables the session cursor (belt-and-suspenders for a daemon
+        started without --no-overlay support)."""
+        from unittest.mock import patch
+
+        backend = self._started_backend()
+        with patch(
+            "tools.computer_use.cua_backend.cua_driver_runtime_contract_status",
+            return_value={"ready": True},
+        ), patch("tools.lazy_deps.ensure"), patch(
+            "tools.computer_use.cua_backend._cua_no_overlay",
+            return_value=True,
+        ):
+            backend.start()
+
+        args = self._cursor_call(backend)
+        assert args is not None, "policy forbids overlay: cursor must be disabled"
+        assert args["enabled"] is False
+        assert args["cursor_id"] == backend._session_id
 
     def test_session_lifecycle_failures_are_non_fatal(self):
         """A lifecycle-label failure does not discard an otherwise valid runtime."""

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -274,9 +274,11 @@ class CuaDriverBackend(_CaptureMixin, _InputMixin, ComputerUseBackend):
             if max_dim:  # smaller screenshots cost less over the daemon socket and per turn
                 self._best_effort("set_config(max_image_dimension) failed",
                                   self.set_config, max_image_dimension=max_dim)
-            if _cua_no_overlay():  # belt-and-suspenders when --no-overlay is unsupported or ignored
-                self._best_effort("set_agent_cursor_enabled failed",
-                                  self.set_agent_cursor_enabled, False, cursor_id=self._session_id)
+            # The engine default-hides the per-session cursor: opt in when the policy allows the overlay,
+            # opt out when it doesn't (belt-and-suspenders for an unsupported or ignored --no-overlay).
+            self._best_effort("set_agent_cursor_enabled failed",
+                              self.set_agent_cursor_enabled, not _cua_no_overlay(),
+                              cursor_id=self._session_id)
 
     def stop(self) -> None:
         # Best-effort end_session so the driver cleans per-session state (cursor overlay, recording ownership,


### PR DESCRIPTION
## What does this PR do?

The wrapper's only agent-cursor call site was the *disable* branch in `CuaDriverBackend.start()` (`tools/computer_use/cua_backend.py`): when `_cua_no_overlay()` was true it sent `set_agent_cursor_enabled(False)`, but nothing ever sent `True`. The engine default-hides the per-session cursor, so for any run whose policy **allows** the overlay — an explicit `computer_use.no_overlay: false`, or the Windows / Linux-Wayland defaults — the documented tinted overlay cursor (website/docs/user-guide/features/computer-use.md: "you'll see a **tinted overlay cursor** glide across the screen") never appeared: the session stayed `cursor_visible: false` forever even though the daemon was started without `--no-overlay` and `agent_cursor.enabled` was `true` driver-side.

This makes the post-handshake toggle symmetric: opt in when the policy allows the overlay, opt out when it doesn't (the existing belt-and-suspenders path for a daemon whose `--no-overlay` flag is unsupported or ignored is preserved unchanged). macOS/X11/headless default-off behavior is untouched — `_cua_no_overlay()` itself is not modified.

## Related Issue

Fixes #109690

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/computer_use/cua_backend.py` — replaced the disable-only `if _cua_no_overlay():` branch in `start()` with a single symmetric call: `set_agent_cursor_enabled(not _cua_no_overlay(), cursor_id=self._session_id)`, still best-effort behind the existing `_started` handshake guard.
- `tests/tools/test_computer_use.py` — added `TestSessionLifecycle.test_start_enables_agent_cursor_when_policy_allows_it` (RED on the old code: no enable call exists) and `test_start_disables_agent_cursor_when_policy_forbids_it` (regression guard for the preserved disable path), plus small `_started_backend`/`_cursor_call` helpers.

## How to Test

1. `python -m pytest tests/tools/test_computer_use.py -k TestSessionLifecycle -q` — 4 passed (2 existing + 2 new). Observed result: passes with this change; the enable test fails with `AssertionError` on `main` (no `set_agent_cursor_enabled` call is issued).
2. `python -m pytest tests/tools/test_computer_use.py tests/computer_use/ tests/tools/test_computer_use_cua_*.py tests/tools/test_computer_use_delivery_ladder.py tests/tools/test_computer_use_placeholder_ids.py tests/tools/test_computer_use_fullscreen_capture.py tests/tools/test_computer_use_null_pid_windows.py tests/tools/test_computer_use_empty_discovery_diagnosis.py -q` — 240 passed, 8 skipped, 1 pre-existing env failure (`test_serve_process_disables_overlay_when_policy_requires_it` fails identically on a clean `main` checkout here: it requires a locally installed CudaDriver.app bundle).
3. `ruff check tools/computer_use/cua_backend.py tests/tools/test_computer_use.py` — All checks passed.
4. Manual (macOS, per the issue's repro): set `computer_use.no_overlay: false`, start a Hermes computer-use session, then `cua-driver sessions --json` — the session should now report `cursor_visible: true` after the first input action instead of permanently `false`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (code now matches the documented behavior)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — toggle is driven by the existing platform-aware `_cua_no_overlay()` policy; macOS/X11/headless defaults unchanged
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A