### PR TITLE
fix(desktop): label Settings "Applies to" chips with the bot title / display name

### DIFF
--- a/apps/desktop/src/app/settings/profile-scope.test.tsx
+++ b/apps/desktop/src/app/settings/profile-scope.test.tsx
@@ -24,8 +24,8 @@ const { $activeGatewayProfile, $profiles } = await import('@/store/profile')
 const { $settingsScopeOverride } = await import('@/store/settings-scope')
 const { SettingsProfileScope } = await import('./profile-scope')
 
-const profile = (name: string, isDefault = false): ProfileInfo =>
-  ({ has_env: false, is_default: isDefault, model: null, name }) as unknown as ProfileInfo
+const profile = (name: string, isDefault = false, extra: Partial<ProfileInfo> = {}): ProfileInfo =>
+  ({ has_env: false, is_default: isDefault, model: null, name, ...extra }) as ProfileInfo
 
 beforeEach(() => {
   $activeGatewayProfile.set('default')
@@ -64,5 +64,33 @@ describe('SettingsProfileScope', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'default' }))
     expect($settingsScopeOverride.get()).toBeNull()
+  })
+
+  it('labels chips with the bot title, else the display name, else the slug', () => {
+    $profiles.set([
+      profile('default', true, { bot_title: 'JordyV', display_name: 'JordieF' }),
+      profile('default-2', false, { display_name: 'Copy' }),
+      profile('weather-man')
+    ])
+
+    render(<SettingsProfileScope />)
+
+    // Bot Mode title wins over display_name and the slug — same identity the
+    // Bots roster shows.
+    expect(screen.getByRole('button', { name: 'JordyV' })).toBeTruthy()
+    // display_name (profile.yaml) when no Bot Mode title exists.
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeTruthy()
+    // Canonical slug when neither is set.
+    expect(screen.getByRole('button', { name: 'weather-man' })).toBeTruthy()
+  })
+
+  it('keeps selection keyed on the canonical name while showing the presentation label', () => {
+    $profiles.set([profile('default', true), profile('coder', false, { bot_title: 'JordyV' })])
+
+    render(<SettingsProfileScope />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'JordyV' }))
+    // The label changed, the identity did not: the override stores the slug.
+    expect($settingsScopeOverride.get()).toBe('coder')
   })
 })

--- a/apps/desktop/src/app/settings/profile-scope.tsx
+++ b/apps/desktop/src/app/settings/profile-scope.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react'
 
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
-import { $activeGatewayProfile, $profiles, normalizeProfileKey, refreshProfiles } from '@/store/profile'
+import { $activeGatewayProfile, $profiles, normalizeProfileKey, profileLabel, refreshProfiles } from '@/store/profile'
 import { $settingsScopeOverride, setSettingsScope } from '@/store/settings-scope'
 
 // The same chip affordance the Gateway page uses for its per-profile
@@ -62,7 +62,7 @@ export function SettingsProfileScope({ className }: { className?: string }) {
           <ScopeChip
             active={normalizeProfileKey(profile.name) === selected}
             key={profile.name}
-            label={profile.name}
+            label={profileLabel(profile)}
             onSelect={() => setSettingsScope(profile.name)}
           />
         ))}

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -41,11 +41,18 @@ export function normalizeProfileKey(name: string | null | undefined): string {
   return value || 'default'
 }
 
-// Presentation-only label: the display_name from profile.yaml when set (e.g. a
-// renamed default profile), else the canonical name. Never used for
+// Presentation-only label: the Bot Mode title the Bots roster shows when set
+// (ui_meta['hermes-bots'].title), else the display_name from profile.yaml
+// (e.g. a renamed default profile), else the canonical name. Never used for
 // comparison or routing — canonical `name` remains the identity everywhere.
-export function profileLabel(profile: Pick<ProfileInfo, 'display_name' | 'name'>): string {
-  return (profile.display_name ?? '').trim() || profile.name
+export function profileLabel(
+  profile: Pick<ProfileInfo, 'bot_title' | 'display_name' | 'name'>
+): string {
+  return (
+    (profile.bot_title ?? '').trim() ||
+    (profile.display_name ?? '').trim() ||
+    profile.name
+  )
 }
 
 // The profile the running local backend is actually scoped to (mirrors

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1050,6 +1050,9 @@ export interface ProfileCreatePayload {
 export interface ProfileInfo {
   /** Presentation-only label override (profile.yaml display_name). */
   display_name?: string
+  /** Bot Mode title (profile.yaml ui_meta['hermes-bots'].title) — the name the
+   *  Bots roster shows for this profile. Presentation-only. */
+  bot_title?: string
   has_env: boolean
   is_default: boolean
   model: null | string

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -469,6 +469,9 @@ class ProfileInfo:
     description_auto: bool = False
     # Presentation-only display name; resolution/comparison/spawn always use ``name``.
     display_name: str = ""
+    # Bot Mode title (``profile.yaml`` ``ui_meta['hermes-bots'].title``) — the name
+    # the Bots roster shows. Presentation-only, like ``display_name``.
+    bot_title: str = ""
 
 
 def _load_yaml_dict(path: Path) -> Optional[dict]:
@@ -614,10 +617,17 @@ def read_profile_meta(profile_dir: Path) -> dict:
     defaults when missing/unreadable). Never raises — a corrupt file on one profile must not
     break ``hermes profile list``."""
     data = _load_yaml_dict(profile_dir / "profile.yaml") or {}
+    ui_meta = data.get("ui_meta")
+    bot_title = ""
+    if isinstance(ui_meta, dict):
+        hermes_bots = ui_meta.get("hermes-bots")
+        if isinstance(hermes_bots, dict):
+            bot_title = str(hermes_bots.get("title") or "").strip()
     return {
         "description": str(data.get("description") or "").strip(),
         "description_auto": bool(data.get("description_auto", False)),
         "display_name": str(data.get("display_name") or "").strip(),
+        "bot_title": bot_title,
     }
 
 

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -83,6 +83,7 @@ def _profile_to_dict(info) -> Dict[str, Any]:
         "description": attr("description", "") or "",
         "description_auto": bool(attr("description_auto", False)),
         "display_name": attr("display_name", "") or "",
+        "bot_title": attr("bot_title", "") or "",
         "distribution_name": attr("distribution_name", None),
         "distribution_version": attr("distribution_version", None),
         "distribution_source": attr("distribution_source", None),

--- a/hermes_cli/web_server_profiles.py
+++ b/hermes_cli/web_server_profiles.py
@@ -109,6 +109,7 @@ def _fallback_profile_entry(profiles_mod, name: str, home: Path, *, is_default: 
         "skill_count": _safe(lambda: profiles_mod._count_skills(home), 0),
         "gateway_running": _safe(gateway_running, False),
         "description": meta("description", ""), "description_auto": meta("description_auto", False),
+        "bot_title": meta("bot_title", ""),
         "distribution_name": None, "distribution_version": None, "distribution_source": None,
         "has_alias": False}
 

--- a/tests/hermes_cli/test_profile_display_name.py
+++ b/tests/hermes_cli/test_profile_display_name.py
@@ -46,6 +46,24 @@ class TestMetaAndValidation:
     def test_missing_file_defaults_empty(self, profile_env):
         assert read_profile_meta(profile_env)["display_name"] == ""
 
+    def test_bot_title_read_from_hermes_bots_ui_meta(self, profile_env):
+        (profile_env / "profile.yaml").write_text(
+            "ui_meta:\n  hermes-bots:\n    title: JordyV\n", encoding="utf-8")
+        assert read_profile_meta(profile_env)["bot_title"] == "JordyV"
+
+    def test_bot_title_absent_when_no_bots_meta(self, profile_env):
+        (profile_env / "profile.yaml").write_text(
+            "display_name: JordieF\nui_meta:\n  user-sections: {}\n", encoding="utf-8")
+        assert read_profile_meta(profile_env)["bot_title"] == ""
+
+    def test_bot_title_never_raises_on_malformed_shapes(self, profile_env):
+        (profile_env / "profile.yaml").write_text(
+            "ui_meta: hermes-bots\n", encoding="utf-8")  # ui_meta is a scalar
+        assert read_profile_meta(profile_env)["bot_title"] == ""
+        (profile_env / "profile.yaml").write_text(
+            "ui_meta:\n  hermes-bots: 7\n", encoding="utf-8")  # not a mapping
+        assert read_profile_meta(profile_env)["bot_title"] == ""
+
     def test_empty_clears_key_from_file(self, profile_env):
         write_profile_meta(profile_env, display_name="Harumesu")
         write_profile_meta(profile_env, display_name="")


### PR DESCRIPTION
Closes #109686.

## What happens

The shared "Applies to" profile selector on the config-backed settings pages (Model, Workspace, Safety, Memory & Context, Voice, Tools & Keys) renders each profile's **canonical slug** (`default`, `default-2`, `weather-man`) while every sibling surface — the sidebar switcher, the profiles page, the Bots roster — shows the chosen identity. Two coupled causes, exactly as the issue's RCA lays out:

1. **The chip bypasses the label helper.** `profile-scope.tsx` rendered `label={profile.name}` directly; `chat/sidebar/profile-switcher.tsx` and `app/profiles/index.tsx` resolve through `profileLabel()` (`display_name || name`). The Settings chip was the last outlier of the #90305 / #103264 family.
2. **The Bot Mode title was unreachable from Settings.** The Settings shell reads profiles via REST `/api/profiles`, whose row builder `_profile_to_dict()` exposed `display_name` but not the Bot Mode title (`profile.yaml` `ui_meta['hermes-bots'].title`) that the roster prefers. The gateway RPC `profiles.list` already attaches it via `_profile_ui_meta_fields()`; the REST row just never got it.

## Fix

- `hermes_cli/profiles.py` — `read_profile_meta()` now also extracts `bot_title` from `ui_meta['hermes-bots'].title` (defensive against malformed shapes: scalar `ui_meta`, non-mapping `hermes-bots`, missing title — all read as `""`, never raise, consistent with the "one corrupt profile.yaml must not break the list" contract). `ProfileInfo` carries it; `_profile_info()` already splats `**meta`.
- `hermes_cli/web_routers/profiles.py` — the REST `/api/profiles` row exposes `bot_title`.
- `hermes_cli/web_server_profiles.py` — the directory-scan fallback row exposes it too (reads the same `read_profile_meta`).
- `apps/desktop/src/types/hermes.ts` — `ProfileInfo.bot_title`.
- `apps/desktop/src/store/profile.ts` — `profileLabel()` resolves the same precedence the Bots roster uses: **bot title → `display_name` → canonical slug**.
- `apps/desktop/src/app/settings/profile-scope.tsx` — the chip labels through `profileLabel(profile)`.

Presentation-only, as before: canonical `name` stays the identity — `key`, the `active` comparison, `setSettingsScope(profile.name)`, and the override store all keep keyed on the slug (pinned by a test: click the chip labelled `JordyV`, the override stores `coder`).

## With the reported profile set

| Profile | Before | After |
|---|---|---|
| `default` (`display_name: JordieF`, bot title `JordyV`) | `default` | `JordyV` |
| `default-2` (bot title `JordyV (copy)`) | `default-2` | `JordyV (copy)` |
| `weather-man` (bot title `Weather`) | `weather-man` | `Weather` |
| `coder` (nothing set) | `coder` | `coder` (unchanged) |

## Tests

- `tests/hermes_cli/test_profile_display_name.py` — 4 new cases: title read from `hermes-bots` ui_meta, absent when other/absent meta, never-raises on malformed shapes (`ui_meta` scalar, `hermes-bots` non-mapping).
- `apps/desktop/src/app/settings/profile-scope.test.tsx` — 2 new cases: the title → display_name → slug precedence on chip labels, and selection staying keyed on the canonical name under a presentation label.

Full local runs: `pytest tests/hermes_cli/test_profile_display_name.py` 15/15, `vitest run --project ui` on the profile/settings/bots suites 85/85, `tsc --noEmit` clean.

## Deliberately out of scope

Defect 2 of the issue (Bot Mode writing `display_name` on create/copy so core surfaces agree by construction) touches `profiles.create` / `duplicateBot` semantics and the rename flow; the roster-side fallback chain already prefers the title, so this PR makes Settings agree with what the roster shows *today*. The write-path change deserves its own PR — happy to follow up.
