### PR TITLE
fix(state): preserve SQLite locks during Linux permission hardening

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7,6 +7,7 @@ splits sessions via parent_session_id chains; sessions are source-tagged
 
 import asyncio
 import atexit
+import errno
 import hashlib
 import json
 import logging
@@ -15,6 +16,7 @@ import queue
 import random
 import re
 import sqlite3
+import stat
 import sys
 import threading
 import time
@@ -230,6 +232,7 @@ def _secure_state_db_files(db_path: Path, *, create_main: bool = False) -> None:
     if os.name == "nt":
         return
 
+    path_only = sys.platform.startswith("linux") and hasattr(os, "O_PATH")
     for index, path in enumerate(
         (
             db_path,
@@ -237,13 +240,26 @@ def _secure_state_db_files(db_path: Path, *, create_main: bool = False) -> None:
             db_path.with_name(db_path.name + "-shm"),
         )
     ):
-        flags = os.O_RDONLY
-        if index == 0 and create_main:
+        # A normal open/fchmod/close drops this process's SQLite POSIX locks.
+        # O_PATH pins the inode without participating in those locks.
+        flags = os.O_PATH if path_only else os.O_RDONLY
+        if index == 0 and create_main and not path_only:
             flags = os.O_WRONLY | os.O_CREAT
         if hasattr(os, "O_NOFOLLOW"):
             flags |= os.O_NOFOLLOW
         if hasattr(os, "O_CLOEXEC"):
             flags |= os.O_CLOEXEC
+        if path_only and index == 0 and create_main:
+            try:
+                created = os.open(
+                    path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC,
+                    0o600,
+                )
+            except FileExistsError:
+                pass
+            else:
+                # Only a newly created inode is closed, before SQLite opens it.
+                os.close(created)
         try:
             fd = os.open(path, flags, 0o600)
         except FileNotFoundError:
@@ -253,7 +269,18 @@ def _secure_state_db_files(db_path: Path, *, create_main: bool = False) -> None:
             # canonical error for this, and a directory leaks no row data.
             continue
         try:
-            os.fchmod(fd, 0o600)
+            if path_only:
+                mode = os.fstat(fd).st_mode
+                if stat.S_ISDIR(mode):
+                    continue
+                if stat.S_ISLNK(mode):
+                    raise OSError(errno.ELOOP, "Refusing a symlink database file", str(path))
+                if not stat.S_ISREG(mode):
+                    raise OSError(errno.EINVAL, "Database file is not regular", str(path))
+                # fchmod rejects O_PATH; procfs resolves this exact pinned inode.
+                os.chmod(f"/proc/self/fd/{fd}", 0o600)
+            else:
+                os.fchmod(fd, 0o600)
         finally:
             os.close(fd)
 

--- a/tests/test_state_permission_locks.py
+++ b/tests/test_state_permission_locks.py
@@ -1,0 +1,63 @@
+"""Permission hardening must preserve live SQLite locks and reject symlinks."""
+
+import errno
+import os
+import stat
+import subprocess
+import sys
+
+import pytest
+
+from hermes_state import SessionDB, _secure_state_db_files
+from hermes_state_dbfile import iter_deleted_sqlite_sidecar_holders
+
+
+@pytest.mark.linux_only
+def test_hardening_preserves_live_wal_generation_across_other_openers(tmp_path):
+    path = tmp_path / "state.db"
+    first = SessionDB(path)
+    second = SessionDB(path)
+    try:
+        for _ in range(3):
+            _secure_state_db_files(path, create_main=True)
+            subprocess.run(
+                [sys.executable, "-c",
+                 "import sqlite3,sys; c=sqlite3.connect(sys.argv[1]); "
+                 "c.execute('SELECT count(*) FROM sessions').fetchone(); c.close()",
+                 str(path)],
+                check=True, capture_output=True, text=True, timeout=10,
+            )
+            assert iter_deleted_sqlite_sidecar_holders(path) == []
+            first._raise_if_db_replaced()
+            first._conn.execute("BEGIN IMMEDIATE")
+            first._conn.rollback()
+    finally:
+        second.close()
+        first.close()
+    assert iter_deleted_sqlite_sidecar_holders(path) == []
+    reopened = SessionDB(path)
+    reopened.close()
+
+
+@pytest.mark.linux_only
+@pytest.mark.parametrize("suffix", ["", "-wal", "-shm"])
+def test_hardening_keeps_files_private_and_refuses_symlink_targets(tmp_path, suffix):
+    path = tmp_path / "state.db"
+    old_umask = os.umask(0)
+    try:
+        _secure_state_db_files(path, create_main=True)
+    finally:
+        os.umask(old_umask)
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    sidecar = path.with_name(path.name + suffix)
+    if sidecar.exists():
+        sidecar.unlink()
+    target = tmp_path / "unrelated-file"
+    target.write_text("keep this private test content unchanged")
+    target.chmod(0o644)
+    sidecar.symlink_to(target)
+    with pytest.raises(OSError) as error:
+        _secure_state_db_files(path, create_main=True)
+    assert error.value.errno == errno.ELOOP
+    assert stat.S_IMODE(target.stat().st_mode) == 0o644
+    assert target.read_text() == "keep this private test content unchanged"

--- a/tests/test_state_permission_locks.py
+++ b/tests/test_state_permission_locks.py
@@ -53,11 +53,11 @@ def test_hardening_keeps_files_private_and_refuses_symlink_targets(tmp_path, suf
     if sidecar.exists():
         sidecar.unlink()
     target = tmp_path / "unrelated-file"
-    target.write_text("keep this private test content unchanged")
+    target.write_text("keep this private test content unchanged", encoding="utf-8")
     target.chmod(0o644)
     sidecar.symlink_to(target)
     with pytest.raises(OSError) as error:
         _secure_state_db_files(path, create_main=True)
     assert error.value.errno == errno.ELOOP
     assert stat.S_IMODE(target.stat().st_mode) == 0o644
-    assert target.read_text() == "keep this private test content unchanged"
+    assert target.read_text(encoding="utf-8") == "keep this private test content unchanged"


### PR DESCRIPTION
## Summary

Fixes #109728. Regression follow-up to the permission hardening merged in #109509.

On Linux, `_secure_state_db_files` opens and closes ordinary descriptors for the database and its WAL/SHM files. Closing such a descriptor releases the process's POSIX locks on that inode, including locks held by SQLite through other descriptors. Opening a second `SessionDB` can therefore silently remove the first connection's locks. Another SQLite process may then unlink its sidecars, leaving live connections on deleted generations. The deleted-generation guard correctly refuses further access, but the result is a session outage.

This behavior is documented in [SQLite's corruption guidance](https://www.sqlite.org/howtocorrupt.html#posix_advisory_locks_canceled_by_a_separate_thread_doing_close). The regression reproduces with a throwaway database; no manual WAL deletion, update script, or session cleanup is required.

## Changes

- On Linux, pin existing files with `O_PATH | O_NOFOLLOW | O_CLOEXEC` and apply owner-only permissions through `/proc/self/fd/<fd>`. Closing an `O_PATH` descriptor does not cancel SQLite's POSIX locks.
- Create a missing main database exclusively with mode `0600` before SQLite opens it. If another opener creates it first, use the existing-file path.
- Preserve symlink rejection and reject non-regular files, while retaining SQLite's existing error path for directories.
- Keep the existing non-Linux implementation unchanged. This fix relies on Linux procfs and does not claim to solve the equivalent lock behavior on every POSIX platform.
- Add two Linux-only invariant test functions (four cases): repeated real SQLite openers must preserve the live WAL generation, and private creation/symlink rejection must remain intact.

The shared helper also covers callers in async delegation. No WAL guard is disabled, no journal-mode default changes, no sidecars are manually removed, and no permanent descriptor cache is introduced.

## Validation

Tested on Linux with Python 3.11, against main `b6b53c69a6ed49cb099cf1bfe76b5e6edd718e5a`, using `scripts/run_tests.sh` in an isolated test environment.

**Red on unmodified main:**

```sh
scripts/run_tests.sh -j 1 --file-retries 0 tests/test_state_permission_locks.py
```

Result: **1 failed, 3 passed**. The live-generation test finds three deleted sidecar holders where it expects none.

**With this fix:**

```sh
scripts/run_tests.sh -j 1 --file-retries 0 \
  tests/test_state_permission_locks.py \
  tests/test_hermes_state.py \
  tests/tools/test_async_delegation.py \
  tests/hermes_state/test_deleted_wal_generation_guard.py \
  tests/hermes_state/test_deleted_wal_checkpoint_guard.py
```

Result: **328 passed, 1 failed, 5 skipped**. All four new regression cases pass.

The one failure is `TestFTS5Search::test_search_projection_skips_context_enrichment_queries` (`context_query_count()` is 0 rather than 1). I independently reran that test on the unmodified base and obtained the same failure. It was also noted in #109509; this PR does not change the unrelated FTS behavior.

`ruff check hermes_state.py tests/test_state_permission_locks.py` and `git diff --check` pass.

The same fix was applied temporarily to the affected Linux installation. Gateway/dashboard operation resumed without a database restore or journal-mode change, and the user confirmed that existing sessions open and a new prompt receives a response. This contribution does not change that installation's official upstream remote or update workflow.
