### PR TITLE
docs(delegate): drop the nonexistent delegate_task(background=true) from docs

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/references/background-systems.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/background-systems.md
@@ -11,9 +11,11 @@ Spawn a subagent with an isolated context + terminal session.
 - **Single:** `delegate_task(goal, context)`.
 - **Batch:** `delegate_task(tasks=[{goal, ...}, ...])` runs children in
   parallel, capped by `delegation.max_concurrent_children` (default 3).
-- **Background:** `delegate_task(background=true)` returns a handle
-  immediately and keeps the parent loop going; the child's result
-  re-enters the conversation as a new turn when it finishes.
+- **Always background:** a top-level `delegate_task` returns a handle
+  immediately and keeps the parent loop going — there is no `background`
+  argument to pass. The child's result re-enters the conversation as a
+  new turn when it finishes. (An orchestrator child's own `delegate_task`
+  calls are the exception: they wait inline for its workers.)
 - **Roles:** `leaf` (default; cannot re-delegate) vs `orchestrator`
   (can spawn its own workers, bounded by `delegation.max_spawn_depth`).
 - **Not durable.** A backgrounded child is still process-local — if the

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -76,9 +76,10 @@ fixed at the mount, not by adding a tool.
 
 ## Delegation (`tools/delegate_tool.py`)
 
-Spawns a subagent with isolated context + terminal session; the parent waits for the summary unless
-`background=true`, which returns a delegation id and re-enters the result via the async-delegation
-completion queue. Shapes: single (`goal` + optional `context`, `toolsets`) or batch (`tasks: [...]`,
+Spawns a subagent with isolated context + terminal session; a top-level call always runs detached —
+it returns a delegation id immediately and the result re-enters via the async-delegation
+completion queue (there is no `background` argument; an orchestrator child's calls wait inline
+for its workers). Shapes: single (`goal` + optional `context`, `toolsets`) or batch (`tasks: [...]`,
 concurrency capped by `delegation.max_concurrent_children`, default 3). A background batch returns as ONE
 completion by default; with `delegation.independent_completions` it is split into completion **units**
 (`delegate_tool_dispatch._units_of`): tasks sharing a `group` join and report together; each ungrouped

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -369,7 +369,8 @@ With a hard cap configured, if a subagent times out having made **zero** API cal
 
 ## Stall Detection for Background Subagents
 
-Background delegations (`delegate_task(background=true)`) are watched by a
+Background delegations (every top-level `delegate_task` runs detached
+automatically — there is no `background` argument) are watched by a
 **progress-based stall monitor** — on by default, zero config. Unlike a
 wall-clock timeout, it never touches a child that is making progress, no
 matter how long it runs.


### PR DESCRIPTION
## What does this PR do?

Three texts told agents to call `delegate_task(background=true)`, but `DELEGATE_TASK_SCHEMA` (`tools/delegate_tool.py`) does not expose a `background` property — the code comment right at the schema marks it "Unadvertised; do not re-add", and `_model_background_value` states that top-level delegations always run in the background and the model does not choose. An agent taking the docs literally either passes an unknown key or invents a polling loop to compensate.

This PR rewrites the three spots to state the real contract on current `main`: a top-level `delegate_task` always runs detached, returns a handle immediately, and the result re-enters the conversation as a new message; an orchestrator child (depth > 0) is the exception that waits inline for its workers. Docs must describe the behavior that ships, so the wording intentionally avoids predicting whether that contract will ever change.

## Related Issue

Fixes #109730

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `skills/autonomous-ai-agents/hermes-agent/references/background-systems.md` — replaced the "**Background:** `delegate_task(background=true)`" bullet with an "**Always background**" bullet: top-level calls always return a handle, there is no `background` argument, orchestrator children wait inline.
- `website/docs/user-guide/features/delegation.md` — "Stall Detection" intro now says every top-level `delegate_task` runs detached automatically instead of showing a `background=true` call.
- `tools/AGENTS.md` — same root cause, third occurrence found while fixing the two above: the delegation section said "the parent waits for the summary unless `background=true`", which inverts the actual default. Rewritten to the same real contract.

## How to Test

1. `git grep -n "delegate_task(background" \` — should return no hits after this change (Observed result: zero hits across `skills/`, `website/`, `tools/AGENTS.md`, `docs/`).
2. `sed -n '598,665p' tools/delegate_tool.py` — `DELEGATE_TASK_SCHEMA` parameters are `tasks` / `action` / `subagent_id` / `message` only; the adjacent comment reads "`background` (bool) is also accepted — DEPRECATED, ignored: top-level delegations always run in the background. Unadvertised; do not re-add." The docs now match this.
3. Sanity: `.venv/bin/pytest tests/tools/test_delegate.py -q` — 80 passed; the 1 failure (`test_child_dedicated_db_follows_parents_db_path`) reproduces identically on a pristine `upstream/main` checkout (commit b6b53c69a6) in this environment, i.e. pre-existing and unrelated to a docs-only change. Observed result: docs-only diff, no code path touched.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (docs-only change; ran the delegation module `tests/tools/test_delegate.py` as sanity — 80 passed, 1 pre-existing failure reproduced identically on pristine `upstream/main`, see How to Test)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A, documentation-only
- [x] I've tested on my platform: macOS (darwin 25.4.0, arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (wording fix only, no workflow change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no behavior change)