### PR TITLE
fix(state): preserve SQLite locks during macOS permission hardening

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -229,6 +229,10 @@ def _secure_state_db_files(db_path: Path, *, create_main: bool = False) -> None:
     """
     if os.name == "nt":
         return
+    if sys.platform == "darwin":
+        from hermes_state_dbfile import secure_state_db_files_macos
+        secure_state_db_files_macos(db_path, create_main=create_main)
+        return
 
     for index, path in enumerate(
         (

--- a/hermes_state_dbfile.py
+++ b/hermes_state_dbfile.py
@@ -10,12 +10,14 @@ call time, so tests that monkeypatch ``hermes_state.<name>`` keep intercepting.
 from __future__ import annotations
 
 import contextlib
+import errno
 import hashlib
 import json
 import logging
 import os
 import shutil
 import sqlite3
+import stat
 import struct
 import sys
 import threading
@@ -29,6 +31,32 @@ from hermes_state_common import (
 
 # Log-record parity with the origin module (caplog tests pin "hermes_state").
 logger = logging.getLogger("hermes_state")
+
+
+def secure_state_db_files_macos(db_path: Path, *, create_main: bool = False) -> None:
+    """Closing even an O_EVTONLY fd cancels SQLite's POSIX locks on macOS.
+
+    Change existing files by pathname without following symlinks. Only an
+    exclusively created, not-yet-opened database gets a descriptor to close.
+    """
+    if create_main:
+        try:
+            fd = os.open(db_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC, 0o600)
+        except FileExistsError:
+            pass
+        else:
+            os.close(fd)
+    for path in (db_path, db_path.with_name(db_path.name + "-wal"), db_path.with_name(db_path.name + "-shm")):
+        try:
+            mode = path.lstat().st_mode
+            if stat.S_ISDIR(mode):
+                continue  # sqlite3.connect owns the canonical directory error.
+            if not stat.S_ISREG(mode):
+                code = errno.ELOOP if stat.S_ISLNK(mode) else errno.EINVAL
+                raise OSError(code, "Refusing a non-regular SQLite database file", str(path))
+            os.chmod(path, 0o600, follow_symlinks=False)
+        except FileNotFoundError:
+            continue
 
 
 def _prepare_connection_retirement():

--- a/tests/test_state_permission_locks_macos.py
+++ b/tests/test_state_permission_locks_macos.py
@@ -1,0 +1,81 @@
+"""Permission hardening must retain live SQLite locks on macOS."""
+
+import os
+from pathlib import Path
+import sqlite3
+import stat
+import subprocess
+import sys
+
+import pytest
+
+from hermes_state import _secure_state_db_files
+
+
+@pytest.mark.macos_only
+@pytest.mark.parametrize("journal_mode", ["wal", "delete"])
+def test_permission_hardening_preserves_live_sqlite_write_lock(tmp_path, journal_mode):
+    path = tmp_path / "state.db"
+    conn = sqlite3.connect(path)
+    conn.execute(f"PRAGMA journal_mode={journal_mode}")
+    conn.execute("CREATE TABLE evidence(value)")
+    conn.commit()
+    conn.execute("BEGIN IMMEDIATE")
+    probe = """
+import sqlite3, sys
+conn = sqlite3.connect(sys.argv[1], timeout=0)
+try:
+    conn.execute('BEGIN IMMEDIATE')
+except sqlite3.OperationalError as exc:
+    assert 'locked' in str(exc), str(exc)
+    print('blocked')
+else:
+    conn.rollback()
+    print('admitted')
+finally:
+    conn.close()
+"""
+
+    def competing_writer():
+        return subprocess.check_output(
+            [sys.executable, "-c", probe, str(path)], text=True, timeout=10).strip()
+
+    try:
+        assert competing_writer() == "blocked"
+        # Both constructor call sites can run while another handle holds locks.
+        _secure_state_db_files(path, create_main=True)
+        _secure_state_db_files(path)
+        assert competing_writer() == "blocked"
+    finally:
+        conn.rollback()
+        conn.close()
+
+
+@pytest.mark.macos_only
+def test_permission_hardening_keeps_private_creation_and_rejects_symlinks(tmp_path):
+    path = tmp_path / "state.db"
+    old_umask = os.umask(0)
+    try:
+        _secure_state_db_files(path, create_main=True)
+    finally:
+        os.umask(old_umask)
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    files = [path, Path(str(path) + "-wal"), Path(str(path) + "-shm")]
+    for file in files:
+        file.touch()
+        file.chmod(0o666)
+    _secure_state_db_files(path, create_main=True)
+    assert all(stat.S_IMODE(file.stat().st_mode) == 0o600 for file in files)
+
+    target = tmp_path / "unrelated"
+    target.write_text("unchanged", encoding="utf-8")
+    target.chmod(0o644)
+    for file in files:
+        file.unlink()
+        file.symlink_to(target)
+        with pytest.raises(OSError):
+            _secure_state_db_files(path, create_main=True)
+        assert target.read_text(encoding="utf-8") == "unchanged"
+        assert stat.S_IMODE(target.stat().st_mode) == 0o644
+        file.unlink()
+        file.touch(mode=0o600)


### PR DESCRIPTION
## What does this PR do?

Preserves SQLite locks when SessionDB hardens state.db and its sidecar permissions on macOS. After #109509, the open/fchmod/close sequence can release locks belonging to existing SQLite connections in the same process. A competing connection can then remove live WAL/SHM files, leaving running sessions with DeletedWalGenerationError.

The shared permission helper now uses macOS pathname chmod with follow_symlinks=False for existing regular files. Only a missing database is opened, with exclusive creation and mode 0600. Existing symlinks and other non-regular files remain rejected. This fixes all macOS SessionDB callers, including gateway and Dashboard clients, without a client-specific workaround or a new dependency. Linux and Windows behavior is unchanged.

## Related Issue

Related to #109728 and the macOS symptoms in #109641. Complements the Linux-only O_PATH implementation in #109734; macOS has no O_PATH, and an O_EVTONLY descriptor also releases these locks when closed. This does not implement the separate macOS preconnect deleted-sidecar detector requested in #109641.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Route macOS permission hardening to the existing hermes_state_dbfile.py module.
- Preserve private creation and permissions without opening/closing existing SQLite files.
- Add native macOS regression coverage using a real competing process in WAL and DELETE journal modes, plus private creation and symlink rejection checks.

## How to Test

```bash
scripts/run_tests.sh -j 3 --file-retries 0 tests/test_state_permission_locks_macos.py
```

On macOS 26.6, both lock tests fail on unmodified main at b6b53c69a6 and pass with this patch. The competing writer stays blocked after permission hardening in both journal modes. All three new cases pass.

Broader focused run:

```bash
scripts/run_tests.sh -j 3 --file-retries 0 tests/test_state_permission_locks_macos.py tests/test_hermes_state.py tests/tools/test_async_delegation.py tests/hermes_state/test_deleted_wal_generation_guard.py tests/hermes_state/test_deleted_wal_checkpoint_guard.py
```

Result: 318 passed, 14 skipped, 1 failed. The failure is TestPerformancePragmasEndToEnd::test_configured_pragmas_reach_all_connection_types (read pool is None). The same full-file failure reproduces in an isolated worktree at unmodified b6b53c69a6; that test passes alone on both revisions. It is an existing test-order problem, not resolved by this patch.

Also verified with the installed Python 3.11 / SQLite 3.53.1 runtime: two SessionDB handles, repeated external SQLite reads and closes, then a session write and cross-handle readback; WAL/SHM inodes stayed unchanged. Ruff and git diff --check pass.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing PRs; the overlapping Linux-only fix is linked above.
- [x] This PR contains only this fix and its regression tests.
- [ ] I've run the complete test suite and all tests pass (focused results and baseline failure documented above).
- [x] I've added tests for the change.
- [x] I've tested on macOS 26.6 (Apple Silicon).

### Documentation & Housekeeping

- [x] Relevant helper docstring updated; no user-facing configuration change.
- [x] Config example, architecture instructions, and tool schemas: N/A.
- [x] Cross-platform impact considered; the new implementation is macOS-only.
