### PR TITLE
fix(state): demote legacy FTS shadows by exact whitelist, not unescaped LIKE prefix

### DIFF
--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -19,6 +19,8 @@ from hermes_state_common import (
     escape_like as _escape_like, fts_rebuild_admission, fts_trigram_session_sql, routed_sessions_setting,
 )
 
+from hermes_state_fts import _FTS5_SHADOW_SUFFIXES
+
 # Pre-split logger identity so log filtering/capture is unchanged.
 logger = logging.getLogger("hermes_state")
 
@@ -535,16 +537,26 @@ class SessionSearchMixin:
                     "AND name IN ('messages_fts', 'messages_fts_trigram') AND sql LIKE 'CREATE VIRTUAL TABLE%'"
                 )
                 conn.execute("PRAGMA writable_schema=RESET")
+                # Demote only the exact fts5 shadow names — never an unescaped LIKE
+                # prefix: ``_`` stays a single-character wildcard (``messagesXfts_probe``
+                # matches) and the prefix is wider than the shadow family
+                # (``messages_fts_other`` matches), so unrelated look-alike tables would
+                # be renamed into the trash family and dropped by the teardown drain
+                # (#109748). The exact set also keeps messages_fts_cjk* out: that family
+                # is an independent v23+ index, not part of the demoted legacy layout —
+                # fts5's xRename renames the entire shadow family in one step, so
+                # sweeping the cjk vtable here aborts the loop on the next cjk shadow
+                # entry and drags _config — needed by the vtable constructor — into the
+                # trash family (#103647).
+                demotable = [
+                    f"messages_fts_{suffix}" for suffix in _FTS5_SHADOW_SUFFIXES
+                ] + [
+                    f"messages_fts_trigram_{suffix}" for suffix in _FTS5_SHADOW_SUFFIXES
+                ]
                 for row in conn.execute(
                     "SELECT name FROM sqlite_master WHERE type = 'table' "
-                    "AND (name LIKE 'messages_fts_%' ESCAPE '\\' "
-                    "OR name LIKE 'messages_fts_trigram_%' ESCAPE '\\') "
-                    # messages_fts_cjk* is an independent v23+ index, not part of the
-                    # demoted legacy layout: fts5's xRename renames the entire shadow
-                    # family in one step, so sweeping the cjk vtable here aborts the
-                    # loop on the next cjk shadow entry and drags _config — needed by
-                    # the vtable constructor — into the trash family (#103647).
-                    "AND name NOT LIKE 'messages\\_fts\\_cjk%' ESCAPE '\\'"
+                    f"AND name IN ({','.join('?' for _ in demotable)})",
+                    demotable,
                 ).fetchall():
                     conn.execute(f"ALTER TABLE {row[0]} RENAME TO fts_v22_trash_{row[0]}")
             # Claim the backfill BEFORE the empty v23 tables exist so a crash before

--- a/tests/test_fts_demote_selection_whitelist.py
+++ b/tests/test_fts_demote_selection_whitelist.py
@@ -1,0 +1,89 @@
+"""Legacy-FTS demotion must select tables by the exact fts5 shadow whitelist.
+
+The demotion enumeration used an unescaped LIKE prefix: with ESCAPE declared
+but ``_`` left unescaped, the underscore stayed a single-character wildcard
+and the prefix was wider than the five fts5 shadow suffixes, so unrelated
+look-alike tables were renamed into the fts_v22_trash_* family and dropped by
+the teardown drain — silent data loss (#109748).
+"""
+
+import sqlite3
+import time
+
+from hermes_state import SessionDB
+from hermes_state_common import SCHEMA_SQL
+
+
+def _legacy_db_with_lookalikes(db_path):
+    """Hand-build a legacy inline-FTS layout that also carries two unrelated
+    look-alike tables the old LIKE prefix would sweep in."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.executescript(SCHEMA_SQL)
+        conn.executescript("""
+            DROP TABLE IF EXISTS messages_fts;
+            DROP TABLE IF EXISTS messages_fts_trigram;
+            DROP VIEW IF EXISTS messages_fts_trigram_src;
+            CREATE VIRTUAL TABLE messages_fts USING fts5(content);
+            CREATE TRIGGER messages_fts_insert AFTER INSERT ON messages BEGIN
+                INSERT INTO messages_fts(rowid, content) VALUES (new.id, COALESCE(new.content,''));
+            END;
+            -- Unrelated look-alikes: ``messagesXfts_probe`` only matches the old
+            -- pattern because the unescaped ``_`` acts as a wildcard; ``messages_fts_other``
+            -- matches because the prefix is wider than the five shadow suffixes.
+            CREATE TABLE messagesXfts_probe (id INTEGER PRIMARY KEY, note TEXT);
+            CREATE TABLE messages_fts_other (id INTEGER PRIMARY KEY, note TEXT);
+        """)
+        conn.execute("DELETE FROM schema_version")
+        conn.execute("INSERT INTO schema_version (version) VALUES (10)")
+        conn.execute(
+            "INSERT INTO sessions (id, source, started_at) VALUES ('s1', 'cli', ?)",
+            (time.time(),),
+        )
+        conn.execute(
+            "INSERT INTO messages (session_id, timestamp, role, content) "
+            "VALUES ('s1', ?, 'user', 'legacy inline message')",
+            (time.time(),),
+        )
+        conn.execute("INSERT INTO messagesXfts_probe (note) VALUES ('probe-data-keep')")
+        conn.execute("INSERT INTO messages_fts_other (note) VALUES ('other-data-keep')")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_optimize_demote_drops_only_exact_shadow_names(tmp_path):
+    db_path = tmp_path / "state.db"
+    _legacy_db_with_lookalikes(db_path)
+
+    db = SessionDB(db_path=db_path)
+    try:
+        assert db.fts_optimize_available(), "legacy inline layout must be eligible"
+        result = db.optimize_fts_storage(vacuum=False)
+        assert result["ok"]
+        # The real legacy shadow family is demoted and the v23 index serves search.
+        assert db.search_messages("legacy inline message")
+        # The unrelated look-alikes survive untouched, data intact.
+        with db._lock:
+            names = {
+                row[0] for row in db._conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table'"
+                )
+            }
+            assert "messagesXfts_probe" in names, "wildcard-match table must not be demoted"
+            assert "messages_fts_other" in names, "over-broad-prefix table must not be demoted"
+            assert [r[0] for r in db._conn.execute(
+                "SELECT note FROM messagesXfts_probe"
+            ).fetchall()] == ["probe-data-keep"]
+            assert [r[0] for r in db._conn.execute(
+                "SELECT note FROM messages_fts_other"
+            ).fetchall()] == ["other-data-keep"]
+            trash = [
+                row[0] for row in db._conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table' "
+                    "AND name LIKE 'fts\\_v22\\_trash\\_%' ESCAPE '\\'"
+                )
+            ]
+        assert not trash, f"unexpected tables left in the trash family: {trash}"
+    finally:
+        db.close()


### PR DESCRIPTION
## What does this PR do?

The legacy-FTS demotion path in `hermes_state_search.py` selected the tables it renames into the trash family with an **unescaped SQL `LIKE` prefix**: `ESCAPE '\'` was declared but the `_` in `messages_fts_%` was never escaped, so it stayed a single-character wildcard, and the prefix itself is broader than the fts5 shadow family. Two consequences:

- `messagesXfts_probe`-style tables match through the wildcard `_`;
- `messages_fts_other`-style tables match through the over-broad prefix.

Both shapes get renamed into `fts_v22_trash_*` and are then **dropped** by the teardown drain — silent data loss while `optimize_fts_storage` reports `ok=True` and search keeps working.

The fix selects the **exact shadow names** instead: the demotable set is built from `_FTS5_SHADOW_SUFFIXES` (`content/data/docsize/idx/config`) for both legacy families and matched via a parameterized `IN (...)` query — the same exact-match approach `_drop_orphan_fts_shadow_tables()` in `hermes_state_fts.py` already uses. The exact set also keeps `messages_fts_cjk*` out of the demotion, preserving the #103647 protection without its special-case `NOT LIKE`.

## Related Issue

Fixes #109748

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state_search.py`: `_demote_legacy_fts_to_trash()` now enumerates the exact fts5 shadow names (`messages_fts_{suffix}` + `messages_fts_trigram_{suffix}` from `_FTS5_SHADOW_SUFFIXES`) via a parameterized `IN (...)` query instead of the unescaped `LIKE` prefix; the `#103647` cjk exclusion is expressed by the whitelist itself.
- `hermes_state_search.py`: import `_FTS5_SHADOW_SUFFIXES` from `hermes_state_fts`.
- `tests/test_fts_demote_selection_whitelist.py` (new): regression test that seeds a legacy inline-FTS DB carrying two look-alike tables (`messagesXfts_probe`, `messages_fts_other`) with data, runs `optimize_fts_storage(vacuum=False)`, and asserts both tables survive untouched with their rows intact while the real shadow family still demotes and the v23 index serves search.

## How to Test

1. `python -m pytest tests/test_fts_demote_selection_whitelist.py -q` — 1 passed. Observed result pre-fix: FAILED at `assert "messagesXfts_probe" in names` (the wildcard-matched table had been renamed into the trash family); post-fix: passed, both look-alike tables keep their data.
2. `python -m pytest tests/test_fts_cjk_bigram.py tests/hermes_state -q` — 337 passed, 18 skipped (the #103647 cjk-during-demote scenario stays green through the whitelist).
3. `python -m pytest tests/test_hermes_state.py -q` — 274 passed, 2 skipped (demote crash-window / resume coverage unchanged).
4. `ruff check hermes_state_search.py tests/test_fts_demote_selection_whitelist.py` — All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — affected suites run locally: `test_fts_demote_selection_whitelist.py` (new), `test_fts_cjk_bigram.py`, `tests/hermes_state/` (337 passed / 18 skipped), `test_hermes_state.py` (274 passed / 2 skipped), all green
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behavior-preserving selection tightening; the inline comment documents the invariant)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure SQL selection change, no platform surface)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Pre-fix failure of the new regression test (clean `upstream/main`), showing the issue's reported behavior reproduced locally:

```
>   assert "messagesXfts_probe" in names, "wildcard-match table must not be demoted"
E   AssertionError: wildcard-match table must not be demoted
```
