### PR TITLE
fix(state): enumerate deleted-WAL sidecar holders on macOS via libproc

### DIFF
--- a/hermes_state_dbfile.py
+++ b/hermes_state_dbfile.py
@@ -144,6 +144,16 @@ def _watched_sqlite_sidecar_paths(db_path) -> Dict[str, str]:
     return {_canonical_sqlite_path(path): path for path in literal}
 
 
+def _identity_is_truly_unlinked(identity: "Tuple[int, int]", watched_path: str) -> bool:
+    """The shared verdict: does ``(st_dev, st_ino)`` name a generation the watched path no longer
+    holds?  See :func:`_fd_is_truly_unlinked` for why the test is identity and never link count."""
+    try:
+        watched_stat = os.stat(watched_path)
+    except OSError:
+        return True
+    return identity != (watched_stat.st_dev, watched_stat.st_ino)
+
+
 def _fd_is_truly_unlinked(fd_path: str, watched_path: str) -> bool:
     """Confirm a `` (deleted)`` /proc fd target really names an orphaned generation, not the
     CURRENT watched sidecar.
@@ -161,11 +171,7 @@ def _fd_is_truly_unlinked(fd_path: str, watched_path: str) -> bool:
         fd_stat = os.stat(fd_path)
     except OSError:
         return True
-    try:
-        watched_stat = os.stat(watched_path)
-    except OSError:
-        return True
-    return (fd_stat.st_dev, fd_stat.st_ino) != (watched_stat.st_dev, watched_stat.st_ino)
+    return _identity_is_truly_unlinked((fd_stat.st_dev, fd_stat.st_ino), watched_path)
 
 
 def _iter_proc_fd_targets():
@@ -184,21 +190,145 @@ def _iter_proc_fd_targets():
                 yield int(pid_str), os.readlink(fd_path), fd_path
 
 
+# ── macOS fd enumeration (libproc) ──────────────────────────────────────────────────────────────
+#
+# macOS has no ``/proc`` and never reports a `` (deleted)`` suffix, but libproc can still describe
+# ANOTHER process's descriptors: ``proc_listpids`` names the processes, ``proc_pidinfo
+# (PROC_PIDLISTFDS)`` lists one process's fds, and ``proc_pidfdinfo(PROC_PIDFDVNODEPATHINFO)``
+# returns, for a vnode fd, its ``(st_dev, st_ino)`` together with the vnode's last pathname.  Both
+# survive unlink (the path keeps its last name, ``st_nlink`` drops to 0), for same-user processes
+# without elevation — which is the darwin counterpart of the Linux readlink leg, and the reason
+# ``psutil.Process.open_files()`` cannot stand in for it (it hides unlinked descriptors).  The
+# identity judgement is shared (:func:`_identity_is_truly_unlinked`); only its source differs.
+_DARWIN_ALL_PIDS = 1
+_DARWIN_PIDLISTFDS = 1
+_DARWIN_PIDFDVNODEPATHINFO = 2
+_DARWIN_PROC_FD_INFO_SIZE = 8  # struct proc_fdinfo { int32 proc_fd; uint32 proc_fdtype; }
+_DARWIN_FD_RECORD_SIZE = 1200  # PROC_PIDFDVNODEPATHINFO_SIZE
+# Field offsets inside that 1200-byte record.  libproc does not lay the header's structs out
+# verbatim (it pads ``vnode_info`` and sizes the record to 1200, not to ``sizeof``'s 1192), so
+# these are pinned against live descriptors rather than derived from <libproc.h>.  ``vst_dev`` /
+# ``vst_ino`` are the same two fields the Linux leg compares; the path is the vnode's last
+# pathname, resolved by the kernel (``/private/var/...`` where the caller opened ``/var/...``).
+_DARWIN_FD_DEV_OFFSET = 24
+_DARWIN_FD_INO_OFFSET = 32
+_DARWIN_FD_PATH_OFFSET = 176
+_DARWIN_LIBPROC = None
+
+
+def _darwin_libproc():
+    """libproc's fd-enumeration entry points, loaded once per process.
+
+    macOS exports these from libSystem, so this process's own handle resolves them; a failure
+    here propagates to the caller's ``except Exception`` and keeps the guard fail-open."""
+    global _DARWIN_LIBPROC
+    lib = _DARWIN_LIBPROC
+    if lib is not None:
+        return lib
+    import ctypes
+
+    lib = ctypes.CDLL(None, use_errno=True)
+    lib.proc_listpids.restype = ctypes.c_int
+    lib.proc_listpids.argtypes = (ctypes.c_uint32, ctypes.c_uint32, ctypes.c_void_p, ctypes.c_uint32)
+    lib.proc_pidinfo.restype = ctypes.c_int
+    lib.proc_pidinfo.argtypes = (ctypes.c_int, ctypes.c_int, ctypes.c_uint64, ctypes.c_void_p, ctypes.c_int)
+    lib.proc_pidfdinfo.restype = ctypes.c_int
+    lib.proc_pidfdinfo.argtypes = (ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_void_p, ctypes.c_int)
+    _DARWIN_LIBPROC = lib
+    return lib
+
+
+def _darwin_all_pids(lib) -> List[int]:
+    """Every pid ``proc_listpids`` will name (the kernel silently omits ones we may not inspect)."""
+    import ctypes
+
+    size = 4096 * 8
+    while True:
+        buffer = ctypes.create_string_buffer(size)
+        used = lib.proc_listpids(_DARWIN_ALL_PIDS, 0, buffer, size)
+        if used <= 0:
+            return []
+        if used < size:
+            return [pid for pid in struct.unpack_from(f"<{used // 4}i", buffer.raw) if pid > 0]
+        size *= 2
+
+
+def _iter_darwin_fd_targets():
+    """Yield ``(pid, last pathname, (st_dev, st_ino))`` for every vnode fd libproc reports.
+
+    The pathname and the identity both stay readable after the path is unlinked, which is what
+    makes an orphaned WAL generation visible at all on macOS.  Processes that cannot be inspected
+    (gone, or not ours) and descriptors that are not vnodes are skipped silently."""
+    import ctypes
+
+    lib = _darwin_libproc()
+    for pid in _darwin_all_pids(lib):
+        size = 4096
+        while True:
+            listing = ctypes.create_string_buffer(size)
+            used = lib.proc_pidinfo(pid, _DARWIN_PIDLISTFDS, 0, listing, size)
+            if used <= 0:
+                break  # process gone, or not ours to inspect
+            if used < size:
+                break
+            size *= 2
+        else:
+            continue
+        for offset in range(0, used - _DARWIN_PROC_FD_INFO_SIZE + 1, _DARWIN_PROC_FD_INFO_SIZE):
+            fd = struct.unpack_from("<i", listing.raw, offset)[0]
+            record = ctypes.create_string_buffer(_DARWIN_FD_RECORD_SIZE)
+            if lib.proc_pidfdinfo(pid, fd, _DARWIN_PIDFDVNODEPATHINFO, record,
+                                  _DARWIN_FD_RECORD_SIZE) <= 0:
+                continue
+            raw = record.raw
+            identity = (struct.unpack_from("<I", raw, _DARWIN_FD_DEV_OFFSET)[0],
+                        struct.unpack_from("<Q", raw, _DARWIN_FD_INO_OFFSET)[0])
+            target = raw[_DARWIN_FD_PATH_OFFSET:].split(b"\x00", 1)[0].decode("utf-8", "replace")
+            yield pid, target, identity
+
+
+def _iter_darwin_sidecar_holders(db_path) -> List[Tuple[int, str]]:
+    """The macOS leg of :func:`iter_deleted_sqlite_sidecar_holders`: libproc enumeration matched
+    against the watched sidecar paths, judged by identity.
+
+    The watched side is resolved with ``os.path.realpath`` because libproc reports the kernel's
+    path for the vnode, while ``os.path.abspath`` does not resolve symlinks -- a textual compare
+    of the two silently misses every sidecar under a symlinked prefix (on macOS ``/var`` itself)."""
+    base = os.path.realpath(os.path.abspath(os.fspath(db_path)))
+    watched = {os.path.normcase(path): path for path in (base + "-wal", base + "-shm")}
+    holders: List[Tuple[int, str]] = []
+    for pid, target, identity in _iter_darwin_fd_targets():
+        literal = watched.get(os.path.normcase(target))
+        if literal is not None and _identity_is_truly_unlinked(identity, literal):
+            holders.append((pid, target))
+    return holders
+
+
 def iter_deleted_sqlite_sidecar_holders(db_path) -> List[Tuple[int, str]]:
-    """Return processes holding an unlinked ``state.db-wal`` / ``-shm``.  Linux-only; ``[]``
-    elsewhere (Windows cannot unlink a held sidecar, macOS has no `` (deleted)`` suffix).
+    """Return processes holding an unlinked ``state.db-wal`` / ``-shm`` sidecar for *db_path*.
+
+    Linux enumerates ``/proc/<pid>/fd`` (using the `` (deleted)`` suffix as a cheap pre-filter);
+    macOS enumerates descriptors through libproc, because a retired generation there keeps its
+    last pathname and no suffix marks it.  Either way the verdict is the same identity comparison:
+    the fd must name a watched sidecar path while its ``(st_dev, st_ino)`` no longer matches what
+    that path holds.  Windows returns ``[]`` -- it cannot unlink a held sidecar, so no retired
+    generation can exist; any other platform returns ``[]`` as before.
+
     Includes this process: on the open/write refuse path the in-process writer holding the orphan
     inode must not mint a replacement WAL (``_foreign_state_db_holders`` skips this PID)."""
-    if not sys.platform.startswith("linux"):
+    if sys.platform == "win32":
         return []
     holders: List[Tuple[int, str]] = []
-    watched = _watched_sqlite_sidecar_paths(db_path)
     try:
-        for pid, target, fd_path in _iter_proc_fd_targets():
-            canonical = _canonical_sqlite_path(target)
-            if (" (deleted)" in target and canonical in watched
-                    and _fd_is_truly_unlinked(fd_path, watched[canonical])):
-                holders.append((pid, target))
+        if sys.platform == "darwin":
+            holders = _iter_darwin_sidecar_holders(db_path)
+        elif sys.platform.startswith("linux"):
+            watched = _watched_sqlite_sidecar_paths(db_path)
+            for pid, target, fd_path in _iter_proc_fd_targets():
+                canonical = _canonical_sqlite_path(target)
+                if (" (deleted)" in target and canonical in watched
+                        and _fd_is_truly_unlinked(fd_path, watched[canonical])):
+                    holders.append((pid, target))
     except Exception as exc:
         logger.debug("deleted-WAL holder scan failed for %s: %s", db_path, exc)
     return holders

--- a/tests/hermes_state/test_deleted_wal_generation_guard.py
+++ b/tests/hermes_state/test_deleted_wal_generation_guard.py
@@ -455,3 +455,59 @@ def test_refuse_helper_raises_while_deleted_wal_held(tmp_path, force_wal):
         assert not wal.exists()
     finally:
         raw.close()
+
+
+# ── macOS leg (#109641): the same holder scan through libproc ───────────────────────────────────
+#
+# macOS has no /proc and no `` (deleted)`` suffix, so these exercise the libproc enumeration
+# (``proc_pidinfo(PROC_PIDLISTFDS)`` + ``proc_pidfdinfo(PROC_PIDFDVNODEPATHINFO)``) that supplies
+# each descriptor's ``(st_dev, st_ino)``. The judgement is unchanged: identity, never path text.
+
+@pytest.mark.macos_only
+def test_iter_finds_self_after_wal_unlink_on_darwin(tmp_path, force_wal):
+    path = tmp_path / "state.db"
+    db = make_db(path, "s", "held")
+    wal = require_wal(db)
+    inode_before = wal.stat().st_ino
+    lose_sidecars(path, rename=False)
+    holders = iter_deleted_sqlite_sidecar_holders(path)
+    try:
+        assert holders, "expected this process to still hold the deleted WAL inode"
+        assert any(pid == os.getpid() for pid, _target in holders)
+        assert any(target.endswith(("-wal", "-shm")) for _pid, target in holders)
+        assert not wal.exists() or wal.stat().st_ino != inode_before
+    finally:
+        db.close()
+
+
+@pytest.mark.macos_only
+def test_iter_finds_no_holder_while_sidecars_stay_linked_on_darwin(tmp_path, force_wal):
+    """The scan must not report the CURRENT generation: a linked sidecar is not a retired one."""
+    path = tmp_path / "state.db"
+    db = make_db(path, "s", "linked")
+    require_wal(db)
+    try:
+        assert iter_deleted_sqlite_sidecar_holders(path) == []
+    finally:
+        db.close()
+
+
+@pytest.mark.macos_only
+def test_iter_darwin_judges_by_identity_not_by_pathname(tmp_path):
+    """A retired generation stays a holder after the path names a DIFFERENT inode: libproc reports
+    the vnode's last pathname with no `` (deleted)`` marker, so only ``(st_dev, st_ino)`` can tell
+    the orphan apart from the replacement that now owns the path."""
+    path = tmp_path / "state.db"
+    sidecar = Path(str(path) + "-wal")
+    sidecar.write_bytes(b"retired generation")
+    held = sidecar.open("rb")
+    try:
+        retired_ino = os.fstat(held.fileno()).st_ino
+        sidecar.unlink()
+        sidecar.write_bytes(b"replacement generation")
+        assert sidecar.stat().st_ino != retired_ino
+        holders = iter_deleted_sqlite_sidecar_holders(path)
+        assert any(pid == os.getpid() for pid, _target in holders)
+        assert any(target == os.path.realpath(str(sidecar)) for _pid, target in holders)
+    finally:
+        held.close()


### PR DESCRIPTION
Fixes #109641

On macOS the deleted-WAL pre-connect refusal was a permanent no-op: `iter_deleted_sqlite_sidecar_holders()` returned `[]` on every non-Linux platform, so `refuse_deleted_wal_generation()` — called from `_connect_and_init`, *before* `sqlite3.connect` — never fired, and a second opener could mint a replacement WAL under a live writer.

The scan was Linux-only because macOS has no `/proc` and never reports a ` (deleted)` suffix. That is an **enumeration** gap, not an identity gap: #108082 already replaced the suffix test with a `(st_dev, st_ino)` identity test. This change supplies the missing darwin way to enumerate descriptors, so the same judgement runs unchanged on macOS:

- `proc_pidinfo(PROC_PIDLISTFDS)` lists one process's descriptors,
- `proc_pidfdinfo(PROC_PIDFDVNODEPATHINFO)` returns each vnode fd's `(st_dev, st_ino)` **and** the vnode's last pathname — for other same-user processes, without elevation. Both survive unlink: the path keeps its last name, `st_nlink` drops to 0.

So this is not a new kind of on-open probe. It is the darwin leg of the already-merged identity judgement (#101221 / #101667 guard, #108082 verdict), at the same call site, once per open, with the same fail-open semantics — the guard simply had no way to look on macOS.

### Field evidence in the issue thread

The report is no longer a single host. A second macOS site (desktop app + launchd gateway, arm64, v0.21.2) added 11 retired-WAL captures in ~70 minutes and a stronger claim than "no self-heal": **the documented recovery loop cannot terminate while the desktop app is in the process set.** Each app relaunch opens `serve` after the freshly restarted gateway has already opened the database, so `refuse_deleted_wal_generation()` returning `[]` means *every* relaunch re-arms the trap and orphans the gateway that was just restarted to fix it. On macOS, the guard is the only thing that can break that loop before a replacement generation is minted.

### Why libproc, and not a bounded `lsof` fallback

The thread raises the boundary question directly (native libproc vs. an external-binary fallback). Measured on the reporting-class host:

| approach | sees the unlinked fd | inode available | cost |
|---|---|---|---|
| `psutil.Process.open_files()` | **no** — 1 entry while linked, 0 once unlinked | no | in-process, but structurally blind to the case we care about |
| `lsof` | yes | yes | 60–310 ms, external binary on the open path |
| libproc `proc_pidfdinfo` (this PR) | yes | yes (`st_dev`, `st_ino`) | 10–13 ms full scan, in-process, no subprocess |

`lsof` works, but it is 3–15× the in-process enumeration *and* puts a spawned process (plus its pipe/lifetime failure modes) on the connection path. The native path is the supported one; libproc needs no elevation for same-user processes. This is also why the existing `psutil` branch in `hermes_state_holders.foreign_state_db_holders()` cannot be reused here.

### Cost

| | Linux leg (main) | darwin leg (this PR) |
|---|---|---|
| mechanism | `/proc/<pid>/fd` readlink | libproc `proc_pidfdinfo` |
| measured | ~4.4k syscalls, ~11 ms isolated (#108910) | 10–13 ms full scan (725 pids / 4392 vnode fds); 20.9 ms with 738 pids / 5956 fds |

Same order of magnitude as the Linux leg it mirrors, paid once per open, on the platform where the guard previously did nothing at all.

### Fail semantics

Enumeration failures (`ctypes` unavailable, libproc error, process exited mid-scan) degrade to `logger.debug` + no holders — identical to the Linux leg, and deliberately fail-open rather than adding a new refusal path. The guard's purpose is to stop a replacement from being minted; the reactive half (halt on the next write, capture the retired generation) still covers what is missed.

The gate is now explicit per platform: Windows still returns `[]` (it cannot unlink a held sidecar, so no retired generation can exist), any other platform is unchanged.

### Tests

`tests/hermes_state/test_deleted_wal_generation_guard.py` gains three `@pytest.mark.macos_only` cases, which run in the `tests-os.yml` macos-latest lane; the existing Linux-only ones are untouched (verified by appending only, no edits to existing lines):

1. after `-wal`/`-shm` are unlinked, this process is reported as a holder — RED on main (the scan returns `[]`), GREEN here;
2. while the sidecars stay linked, nothing is reported, so the current generation is never mistaken for a retired one;
3. a retired generation stays a holder after the path names a *different* inode — the verdict is identity, not pathname text (macOS marks nothing with ` (deleted)`).

`scripts/run_tests.sh tests/hermes_state/` on macOS: 40 files, 330 passed, 0 failed, 18 skipped (the skips are the Linux-only tests on this host, as designed).

### Assessed, not in this change

- the capture side: the existing 512 MB main-image copy limit and the absence of a knob for it, plus the current header-only/size-cap retention behaviour (existing policy, unchanged here);
- refusing `hermes update` / gateway restart while a foreign writer is live (a policy decision, not a scan-leg gap);
- in-process self-healing of a lost generation;
- draining a foreign writer during `hermes update` / gateway restart;
- platform parity for `count_db_holders()` and the `psutil` branch of `hermes_state_holders.foreign_state_db_holders()`;
- `_wal_generation_was_lost()`'s own-pid `/proc` probe (`hermes_state.py`): on darwin that branch is skipped, so the narrow "no recorded sidecar identity" case is then adopted as clean. It is a separate, self-pid-only write-path path, so it is listed here rather than folded in.

### Relationship to the other open work

Complementary, not competing: #109270 (lazy flock single-writer gate) and #103665 (persistent WAL keeper in the hosted-room driver) act on the write/keeper side of the same split-brain; #109737 (keep the live WAL when a nested CLI writer closes) and #109734 (preserve SQLite locks during Linux permission hardening) act on the producers that unlink a healthy sidecar. This is the open path's pre-connect refusal on macOS — the one leg all of those still rely on. All of them can land independently.
