### PR TITLE
fix(tools): stop advertising a capped terminal spill as full output

### DIFF
--- a/tests/tools/test_terminal_spill_capped_note.py
+++ b/tests/tools/test_terminal_spill_capped_note.py
@@ -1,0 +1,73 @@
+"""A capped terminal spill must be advertised as partial, not full output (#109757).
+
+The collector tees overflow to a spill file with a hard cap (``_SPILL_CAP_CHARS``).
+When the cap is hit — or a spill write/close fails — the saved file holds only a
+prefix of the stream, so the structured result and ``truncation_note`` must not
+claim complete recovery. These tests drive the real collector, native finalizer,
+and foreground result formatter; nothing is patched except the cap/close itself.
+"""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from tools.environments.base_output import (
+    _BoundedOutputCollector,
+    _finalize_wait_result,
+)
+from tools.terminal_tool_result import finalize_foreground_result
+
+
+def _finalize_collector_output(collector, tmp_path):
+    raw = _finalize_wait_result(collector, collector.render(), 0)
+    return json.loads(
+        finalize_foreground_result(
+            command="printf example",
+            result=raw,
+            env=SimpleNamespace(cwd=str(tmp_path)),
+            env_type="local",
+            effective_task_id="fixture",
+            task_id="fixture",
+            session_id=None,
+            session_key="fixture",
+            workdir=None,
+            command_cwd=str(tmp_path),
+            approval_note=None,
+        )
+    )
+
+
+def test_capped_spill_is_not_advertised_as_full_output(tmp_path):
+    collector = _BoundedOutputCollector(100, tmp_path / "capped.log")
+    collector._SPILL_CAP_CHARS = 500
+    source = "abc " * 1000
+    collector.append(source)
+    result = _finalize_collector_output(collector, tmp_path)
+
+    saved = Path(result["full_output_path"]).read_text()
+    assert saved != source and "[spill capped" in saved
+    assert result["full_output_capped"] is True
+    assert "full output" not in result["truncation_note"].lower()
+    assert "capped" in result["truncation_note"].lower()
+
+
+def test_uncapped_spill_still_advertises_full_output(tmp_path):
+    collector = _BoundedOutputCollector(100, tmp_path / "full.log")
+    source = "abc " * 100  # overflows the capture window, far below the spill cap
+    collector.append(source)
+    result = _finalize_collector_output(collector, tmp_path)
+
+    saved = Path(result["full_output_path"]).read_text()
+    assert saved == source  # the uncapped spill holds the full stream
+    assert "full_output_capped" not in result
+    assert "Full output" in result["truncation_note"]
+
+
+def test_failed_spill_close_is_not_advertised_as_full_output(tmp_path):
+    collector = _BoundedOutputCollector(100, tmp_path / "close-fail.log")
+    collector.append("abc " * 100)
+    collector._spill_fh.close = lambda: (_ for _ in ()).throw(OSError("disk gone"))
+    result = _finalize_collector_output(collector, tmp_path)
+
+    assert result["full_output_capped"] is True
+    assert "full output" not in result["truncation_note"].lower()

--- a/tools/environments/base_output.py
+++ b/tools/environments/base_output.py
@@ -83,9 +83,17 @@ class _BoundedOutputCollector:
             try:
                 self._spill_fh.close()
             except OSError:
-                pass
+                # A failed close can lose buffered tail bytes, so the file is
+                # no longer guaranteed to hold the complete stream (#109757).
+                self._spill_capped = True
             self._spill_fh = None
             return str(self._spill_path)
+
+    @property
+    def spill_capped(self) -> bool:
+        """Whether the spill file is only a prefix of the stream (cap hit or I/O failure)."""
+        with self._lock:
+            return self._spill_capped
 
     @property
     def buffered_chars(self) -> int:
@@ -205,6 +213,8 @@ def _finalize_wait_result(collector: _BoundedOutputCollector, rendered: str, ret
     if spill:
         result["output_total_chars"] = collector.total_chars
         result["full_output_path"] = spill
+        if collector.spill_capped:
+            result["full_output_capped"] = True
     return result
 
 

--- a/tools/terminal_tool_result.py
+++ b/tools/terminal_tool_result.py
@@ -170,7 +170,7 @@ def _failure_hint(command: str, returncode: int, output: str, exit_note) -> Opti
     return None
 
 
-def _redact_spill_file(path, total_chars, command) -> list[tuple[str, Any]]:
+def _redact_spill_file(path, total_chars, command, capped: bool = False) -> list[tuple[str, Any]]:
     """Spill handle so the model can read the omitted middle instead of
     re-running. The collector wrote it raw; redact it with the same pass so no
     secret persists unmasked on disk. On failure drop the handle (and file)."""
@@ -190,6 +190,15 @@ def _redact_spill_file(path, total_chars, command) -> list[tuple[str, Any]]:
         with _quiet("spill unlink"):
             Path(path).unlink()
         return []
+    if capped:
+        # The spill file hit its hard cap (or an I/O failure truncated it):
+        # it holds only a prefix of the stream, not the full output (#109757).
+        note = ("Output exceeded the capture window and the saved spill file hit its "
+                f"hard cap, so it holds only a capped prefix of the {total_chars:,}-char "
+                f"stream: {path} — treat it as partial output when searching it with "
+                "search_files or paging it with read_file.")
+        return [("output_total_chars", total_chars), ("full_output_path", path),
+                ("full_output_capped", True), ("truncation_note", note)]
     note = ("Output exceeded the capture window (head+tail shown). "
             f"Full output ({total_chars:,} chars) saved to {path} — search it with "
             "search_files or page it with read_file instead of re-running the command.")
@@ -264,7 +273,8 @@ def finalize_foreground_result(
     optional_fields: list[tuple[str, Any]] = [
         ("cwd", changed_cwd),
         ("environment_recreated", _ENV_RECREATED_NOTE if result.get("environment_recreated") else None),
-        *_redact_spill_file(result.get("full_output_path"), result.get("output_total_chars"), command),
+        *_redact_spill_file(result.get("full_output_path"), result.get("output_total_chars"), command,
+                            capped=bool(result.get("full_output_capped"))),
         ("verification_evidence", _verification_evidence(
             command, command_cwd, session_id or task_id or effective_task_id or "default",
             returncode, output)),


### PR DESCRIPTION
## What does this PR do?

A foreground terminal spill that hits the collector hard ceiling (`_SPILL_CAP_CHARS`), or that loses data to an I/O failure mid-tee/close, only holds a **prefix** of the captured stream. Yet the finalizer attached no cap state, and `_redact_spill_file()` unconditionally emitted a `Full output (N chars) saved to ...` note whose character count referred to the complete stream, not the capped file — so the model was told complete recovery was available when it was not.

This PR carries the cap state end to end and distinguishes partial/capped recovery from complete recovery in both the structured result and the user-facing note:

- `close_spill()` now marks the spill as capped when the file close fails (buffered tail bytes may be lost, so full recovery is not guaranteed)
- a `spill_capped` property is exposed and propagated through `_finalize_wait_result()` as `full_output_capped`
- `_redact_spill_file()` emits a partial/capped note plus a `full_output_capped: true` field instead of the misleading `Full output` claim; the below-cap path is unchanged

## Related Issue

Fixes #109757

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/base_output.py`: `close_spill()` sets `_spill_capped` on a failed close; new `spill_capped` property; `_finalize_wait_result()` attaches `full_output_capped: True` when the spill is capped
- `tools/terminal_tool_result.py`: `_redact_spill_file()` takes a `capped` flag, emits a partial-output note and `full_output_capped` field for capped spills (full-output note unchanged otherwise); caller passes the flag through
- `tests/tools/test_terminal_spill_capped_note.py`: regression tests for capped, uncapped, and failed-close spills through the real collector → finalizer → formatter chain

## How to Test

1. `pytest tests/tools/test_terminal_spill_capped_note.py -q` — should pass (3 tests)
2. `pytest tests/tools/test_base_environment.py tests/tools/test_terminal_environment_recreated_notice.py tests/tools/test_terminal_exit_semantics.py tests/tools/test_terminal_signal_exit.py tests/tools/test_terminal_hints.py tests/tools/test_threaded_process_handle.py tests/tools/test_file_write_surrogate_roundtrip.py -q` — Observed result: 130 passed, no regressions
3. `ruff check tools/environments/base_output.py tools/terminal_tool_result.py tests/tools/test_terminal_spill_capped_note.py` — All checks passed
4. Pre-fix: `test_capped_spill_is_not_advertised_as_full_output` fails with `KeyError: full_output_capped` and the note says `Full output (4,000 chars) saved ...` while the file holds a capped prefix (the issue reproduction). Post-fix: the note describes a capped prefix and the structured result carries `full_output_capped: true`.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run the relevant test suites listed above (module-scoped `pytest tests/ -q` subset: tools/terminal domain, 133 passed total)
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] N/A (behavior-preserving note/field addition; docstrings updated in place)
- [x] N/A (no config keys changed)
- [x] N/A (no architecture or workflow changes)
- [x] I have considered cross-platform impact — the change is platform-independent (pure Python state plumbing; no OS-specific paths touched)
- [x] N/A (no tool behavior/schema change)