### PR TITLE
fix(cron): pin the named custom identity in the provider creation snapshot

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1624,6 +1624,17 @@ def _compute_provider_model_snapshots(
                 runtime_kwargs["explicit_base_url"] = normalized_base_url
             snap = resolve_runtime_provider(**runtime_kwargs)
             provider_snapshot = str(snap.get("provider") or "").strip().lower() or None
+            if provider_snapshot == "custom":
+                # Bare "custom" is the billing class shared by every named entry — replaying it
+                # resolves to the OpenRouter fallback instead of this endpoint (#109765). Pin the
+                # durable identity, the same lookup session persistence heals with.
+                with contextlib.suppress(Exception):
+                    from hermes_cli.runtime_provider import canonical_custom_identity
+
+                    provider_snapshot = canonical_custom_identity(
+                        base_url=str(snap.get("base_url") or ""),
+                        config_provider=str(snap.get("requested_provider") or ""),
+                    ) or provider_snapshot
     if normalized_model is None:
         with contextlib.suppress(Exception):
             model_snapshot = _resolve_default_model_snapshot() or None

--- a/tests/cron/test_cron_snapshot_custom_identity.py
+++ b/tests/cron/test_cron_snapshot_custom_identity.py
@@ -1,0 +1,86 @@
+"""A cron creation snapshot must pin the durable provider identity, not the
+resolved billing class.
+
+``_compute_provider_model_snapshots`` stored the resolved runtime's provider
+tag. Every named custom entry resolves to the literal ``"custom"``, so a job
+created without an explicit provider pinned ``"custom"``; on replay the
+scheduler resolves that bare string through the OpenRouter fallback instead of
+the configured entry (#109765). The snapshot must heal bare ``custom`` to the
+``custom:<name>`` identity — the same lookup session persistence uses.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cron import jobs
+from hermes_cli import runtime_provider as rp
+
+PROVIDER_KEY = "omniroute"
+BASE_URL = "https://omniroute.invalid/v1"
+CANONICAL = f"custom:{PROVIDER_KEY}"
+
+
+@pytest.fixture
+def named_custom_config(monkeypatch):
+    config = {
+        "model": {"default": "hermes-smart-stack", "provider": CANONICAL},
+        "custom_providers": [
+            {
+                "name": PROVIDER_KEY,
+                "base_url": BASE_URL,
+                "api_key": "sk-test",
+                "model": "hermes-smart-stack",
+            },
+        ],
+    }
+    monkeypatch.setattr(rp, "load_config", lambda *a, **k: config)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda *a, **k: config)
+    monkeypatch.setattr(rp, "_get_model_config", lambda: config["model"])
+    return config
+
+
+def _snapshot(monkeypatch, runtime):
+    monkeypatch.setattr(rp, "resolve_runtime_provider", lambda **k: dict(runtime))
+    return jobs._compute_provider_model_snapshots(
+        provider=None, model=None, base_url=None, no_agent=False
+    )
+
+
+def test_bare_custom_snapshot_heals_to_named_identity(named_custom_config, monkeypatch):
+    """The regression (#109765): the resolved tag `custom` must not be pinned as-is."""
+    provider_snapshot, _ = _snapshot(
+        monkeypatch,
+        {"provider": "custom", "base_url": BASE_URL, "requested_provider": CANONICAL},
+    )
+    assert provider_snapshot == CANONICAL
+
+
+def test_unresolvable_bare_custom_keeps_current_behaviour(monkeypatch):
+    """No configured entry to heal to: keep the bare tag instead of inventing an identity."""
+    config = {"model": {}}
+    monkeypatch.setattr(rp, "load_config", lambda *a, **k: config)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda *a, **k: config)
+    monkeypatch.setattr(rp, "_get_model_config", lambda: config["model"])
+    provider_snapshot, _ = _snapshot(
+        monkeypatch,
+        {
+            "provider": "custom",
+            "base_url": "https://unconfigured.invalid/v1",
+            "requested_provider": "custom",
+        },
+    )
+    assert provider_snapshot == "custom"
+
+
+def test_non_custom_tag_is_stored_unchanged(monkeypatch):
+    """Providers that are their own identity (openrouter, anthropic, ...) need no healing."""
+    provider_snapshot, _ = _snapshot(
+        monkeypatch,
+        {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "requested_provider": "auto",
+        },
+    )
+    assert provider_snapshot == "openrouter"


### PR DESCRIPTION
## What does this PR do?

`_compute_provider_model_snapshots()` stored the resolved runtime's provider *tag*. Every named custom entry resolves to the literal `custom` (the shared billing class), so a cron job created without an explicit provider got `provider_snapshot: "custom"`. When the scheduler later replays that snapshot as the job's provider pin, the bare string `custom` matches no `custom_providers` entry and falls through `resolve_runtime_provider()` to the OpenRouter last-resort fallback — the job then fails with a non-retryable 401 (no OpenRouter key) or silently re-routes spend to OpenRouter.

The fix heals a bare `custom` snapshot to the durable `custom:<name>` identity at capture time, using `canonical_custom_identity()` — the same lookup every session persistence/restore path already uses (bare `custom` is documented in `is_routable_provider()` as "not a routable identity; restore paths must heal it"). On replay, `requested="custom:<name>"` is resolved directly to the configured entry by the named-custom rung, so the snapshot now round-trips. When no configured entry matches (nothing to heal to), the snapshot keeps the bare tag exactly as before.

## Related Issue

Fixes #109765

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/jobs.py`: in `_compute_provider_model_snapshots()`, when the resolved runtime's provider tag is the bare billing class `custom`, heal it via `canonical_custom_identity(base_url=..., config_provider=...)` before storing the snapshot (fail-open: on any error or when no configured entry matches, keep the previous bare-tag behaviour).
- `tests/cron/test_cron_snapshot_custom_identity.py`: new regression tests — bare `custom` heals to the named identity; an unresolvable bare `custom` keeps current behaviour; non-custom tags are stored unchanged.

## How to Test

1. `python -m pytest tests/cron/test_cron_snapshot_custom_identity.py -q` — 3 passed (the heal test fails with `assert 'custom' == 'custom:omniroute'` on `main`).
2. `python -m pytest tests/cron/ tests/hermes_cli/test_canonical_custom_identity.py -q` — 1267 passed, 6 skipped; the single failure (`test_file_permissions.py::test_ensure_hermes_home_sets_0700`) reproduces identically on a clean `main` checkout, so it is environmental, not introduced here.
3. `ruff check cron/jobs.py tests/cron/test_cron_snapshot_custom_identity.py` — all checks passed.

Observed result: with a `custom_providers` entry named `omniroute` as the configured default, the captured snapshot is `custom:omniroute` instead of `custom`, so replay resolves to the configured endpoint rather than the OpenRouter fallback.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (scope run: `tests/cron/` + `tests/hermes_cli/test_canonical_custom_identity.py`, see How to Test)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure-Python identity resolution, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable (no UI change).