### PR TITLE
fix(stt): refuse SIMD-baseline native wheels on pre-x86-64-v2 CPUs instead of SIGILL

### DIFF
--- a/tests/tools/test_cpu_baseline_gate.py
+++ b/tests/tools/test_cpu_baseline_gate.py
@@ -1,0 +1,133 @@
+"""CPU-baseline gate for the SIMD native wheels (numpy 2.4 / ctranslate2).
+
+NumPy 2.4 raised its x86-64 cpu-baseline to x86-64-v2 (SSE4.1/SSE4.2/POPCNT) and
+ctranslate2's wheels dispatch above that too, so on pre-v2 cores the first
+``import numpy`` (or ``WhisperModel`` load) raises SIGILL — a signal Python cannot
+catch, which takes the whole ``hermes serve`` process down (#109771). These tests
+pin the three gates that must refuse instead: lazy-install (before pip), the local
+whisper loader (before the import) and the transcribe entry point.
+"""
+
+import sys
+import types
+
+import pytest
+
+import tools.lazy_deps as ld
+import tools.transcription_local as tl
+import tools.transcription_tools as tt
+
+
+V2_FLAGS = "flags\t\t: fpu mmx sse sse2 sse3 ssse3 sse4_1 sse4_2 popcnt\n"
+PRE_V2_FLAGS = "flags\t\t: fpu mmx sse sse2 sse3 ssse3\n"  # AMD E2-2000-class: no SSE4/POPCNT
+
+
+def _pre_v2_linux(monkeypatch):
+    monkeypatch.setattr(ld.sys, "platform", "linux")
+    monkeypatch.setattr(ld.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(ld, "_read_cpuinfo_flags", lambda: PRE_V2_FLAGS)
+
+
+class TestCpuBaselineProbe:
+    def test_pre_v2_cpu_is_reported_unsupported(self, monkeypatch):
+        _pre_v2_linux(monkeypatch)
+        reason = ld._cpu_baseline_missing_reason()
+        assert reason is not None
+        assert "x86-64-v2" in reason
+
+    def test_v2_cpu_passes(self, monkeypatch):
+        monkeypatch.setattr(ld.sys, "platform", "linux")
+        monkeypatch.setattr(ld.platform, "machine", lambda: "x86_64")
+        monkeypatch.setattr(ld, "_read_cpuinfo_flags", lambda: V2_FLAGS)
+        assert ld._cpu_baseline_missing_reason() is None
+
+    def test_unreadable_cpuinfo_fails_open(self, monkeypatch):
+        _pre_v2_linux(monkeypatch)
+        monkeypatch.setattr(ld, "_read_cpuinfo_flags", lambda: "")
+        assert ld._cpu_baseline_missing_reason() is None
+
+    def test_non_x86_64_is_never_gated(self, monkeypatch):
+        monkeypatch.setattr(ld.sys, "platform", "linux")
+        monkeypatch.setattr(ld.platform, "machine", lambda: "aarch64")
+        assert ld._cpu_baseline_missing_reason() is None
+
+    def test_macos_is_never_gated(self, monkeypatch):
+        monkeypatch.setattr(ld.sys, "platform", "darwin")
+        assert ld._cpu_baseline_missing_reason() is None
+
+    def test_simd_features_are_gated_but_not_others(self, monkeypatch):
+        _pre_v2_linux(monkeypatch)
+        for feature in ("stt.faster_whisper", "wake.openwakeword", "wake.sherpa", "wake.porcupine"):
+            assert ld._unsupported_feature_reason(feature) is not None
+        assert ld._unsupported_feature_reason("platform.telegram") is None
+
+
+class TestLazyInstallGate:
+    def test_pre_v2_cpu_blocks_whisper_install_before_pip(self, monkeypatch):
+        _pre_v2_linux(monkeypatch)
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: False)
+        monkeypatch.setattr(ld, "_lazy_install_target", lambda: None)
+        monkeypatch.setattr(
+            ld, "_venv_pip_install",
+            lambda *a, **kw: pytest.fail("pip must not run for SIMD wheels on a pre-v2 CPU"),
+        )
+
+        with pytest.raises(ld.FeatureUnavailable) as excinfo:
+            ld.ensure("stt.faster_whisper", prompt=False)
+
+        assert "x86-64-v2" in str(excinfo.value)
+
+    def test_pre_v2_cpu_blocks_wake_engines_too(self, monkeypatch):
+        _pre_v2_linux(monkeypatch)
+        monkeypatch.setattr(ld, "_is_satisfied", lambda spec: False)
+        monkeypatch.setattr(ld, "_lazy_install_target", lambda: None)
+        monkeypatch.setattr(
+            ld, "_venv_pip_install",
+            lambda *a, **kw: pytest.fail("pip must not run for SIMD wheels on a pre-v2 CPU"),
+        )
+
+        for feature in ("wake.openwakeword", "wake.sherpa", "wake.porcupine"):
+            with pytest.raises(ld.FeatureUnavailable):
+                ld.ensure(feature, prompt=False)
+
+
+class TestLocalWhisperLoaderGate:
+    def test_pre_v2_cpu_refuses_before_the_native_import(self, monkeypatch):
+        _pre_v2_linux(monkeypatch)
+        monkeypatch.setattr(tl.platform, "system", lambda: "Linux")
+
+        def _boom():
+            raise AssertionError("faster_whisper must not be imported on a pre-v2 CPU")
+
+        fake_fw = types.ModuleType("faster_whisper")
+        setattr(fake_fw, "WhisperModel", _boom)
+        monkeypatch.setitem(sys.modules, "faster_whisper", fake_fw)
+
+        with pytest.raises(tl.CpuBaselineError, match="x86-64-v2"):
+            tl._load_local_whisper_model("base")
+
+    def test_v2_cpu_proceeds_to_the_loader(self, monkeypatch):
+        monkeypatch.setattr(ld.sys, "platform", "linux")
+        monkeypatch.setattr(ld.platform, "machine", lambda: "x86_64")
+        monkeypatch.setattr(ld, "_read_cpuinfo_flags", lambda: V2_FLAGS)
+        monkeypatch.setattr(tl.platform, "system", lambda: "Linux")
+
+        class _Model:
+            def __init__(self, *a, **kw):
+                pass
+
+        fake_fw = types.ModuleType("faster_whisper")
+        setattr(fake_fw, "WhisperModel", _Model)
+        monkeypatch.setitem(sys.modules, "faster_whisper", fake_fw)
+
+        assert tl._load_local_whisper_model("base") is not None
+
+
+class TestTranscribeLocalRefuses:
+    def test_error_envelope_instead_of_crash(self, monkeypatch):
+        _pre_v2_linux(monkeypatch)
+
+        result = tt._transcribe_local("/tmp/any.wav", "base")
+
+        assert result["success"] is False
+        assert "x86-64-v2" in result["error"]

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
+import platform
 import re
 import shutil
 import site
@@ -325,11 +326,60 @@ def _allow_lazy_installs() -> bool:
     return True
 
 
+def _read_cpuinfo_flags() -> str:
+    """The first ``flags`` line of /proc/cpuinfo, or "" when unavailable."""
+    try:
+        with open("/proc/cpuinfo", encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                if line.startswith("flags"):
+                    return line
+    except OSError:
+        pass
+    return ""
+
+
+def _cpu_baseline_missing_reason() -> Optional[str]:
+    """Why this CPU cannot run the prebuilt SIMD wheels some features install, or None.
+
+    NumPy 2.4 raised its x86-64 cpu-baseline to the x86-64-v2 microarchitecture
+    (SSE4.1/SSE4.2/POPCNT) and ctranslate2's wheels dispatch above that too, so on
+    pre-v2 cores the first ``import numpy`` (or the first ``WhisperModel`` load) raises
+    SIGILL — a signal, not an exception, which takes the whole process down. Only
+    x86-64 Linux is probed: every supported arm64 host and every Intel Mac (2009+,
+    SSE4.2 since Nehalem, and Rosetta advertises SSE4.2) satisfies v2, and Windows
+    has no portable flag source worth the false-positive risk.
+    """
+    if sys.platform != "linux" or (platform.machine().lower() not in {"x86_64", "amd64"}):
+        return None
+    flags = _read_cpuinfo_flags()
+    if not flags:
+        return None  # unreadable cpuinfo: don't guess, let the import speak for itself
+    missing = {"sse4_1", "sse4_2", "popcnt"} - set(flags.replace(",", " ").split())
+    if not missing:
+        return None
+    return (
+        "unsupported on this CPU: the bundled native wheels (numpy 2.4, ctranslate2) are "
+        "built for the x86-64-v2 baseline (SSE4.1/SSE4.2/POPCNT), which this processor "
+        "lacks, and importing them kills the process with SIGILL rather than raising an "
+        "exception. Use a cloud STT/TTS provider, a local whisper CLI "
+        "(HERMES_LOCAL_STT_COMMAND), or a v2-capable CPU."
+    )
+
+
+# Features whose wheels carry the x86-64-v2 SIMD baseline (numpy 2.4 / ctranslate2 /
+# onnxruntime native code). Gated before install so a doomed pip run never happens.
+_SIMD_BASELINE_FEATURES = frozenset({
+    "stt.faster_whisper", "wake.openwakeword", "wake.sherpa", "wake.porcupine",
+})
+
+
 def _unsupported_feature_reason(feature: str) -> Optional[str]:
     """Platform capability gate (not policy): why a feature cannot work on this host, or None."""
     if sys.platform == "win32" and feature == "platform.matrix":
         return ("unsupported on Windows: Matrix E2EE depends on python-olm, which has no Windows wheel and "
                 "requires make + libolm to build from sdist. Run Hermes under WSL to use Matrix on Windows.")
+    if feature in _SIMD_BASELINE_FEATURES:
+        return _cpu_baseline_missing_reason()
     return None
 
 

--- a/tools/transcription_local.py
+++ b/tools/transcription_local.py
@@ -115,6 +115,19 @@ def _should_force_faster_whisper_cpu() -> bool:
     return _sysctl_value("sysctl.proc_translated") == "1" or _sysctl_value("hw.optional.arm64") == "1"
 
 
+def _cpu_unsupported_reason() -> Optional[str]:
+    """Why faster-whisper cannot run on this host (SIGILL-class, not exception-class)."""
+    try:
+        from tools.lazy_deps import _cpu_baseline_missing_reason
+        return _cpu_baseline_missing_reason()
+    except Exception:
+        return None
+
+
+class CpuBaselineError(RuntimeError):
+    """Raised instead of letting numpy/ctranslate2 SIGILL the process on pre-x86-64-v2 CPUs."""
+
+
 def _get_idle_unload_seconds(local_cfg: Dict[str, Any]) -> int:
     """Resolve the idle unload timeout from config; 0 = never (default), negatives clamp to 0."""
     return max(_config_number(local_cfg, "unload_after_idle_seconds", 0, int), 0)
@@ -134,6 +147,10 @@ def _load_local_whisper_model(model_name: str, device: str = "auto", compute_typ
         # Importing ctranslate2 can itself abort on Apple Silicon/Rosetta when
         # multiple Intel OpenMP runtimes are loaded — set before the import.
         os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+    # SIGILL cannot be caught: a pre-x86-64-v2 core dies inside the native import
+    # before Python sees anything, so refuse before the import rather than restart-loop.
+    if unsupported := _cpu_unsupported_reason():
+        raise CpuBaselineError(unsupported)
     from faster_whisper import WhisperModel
     if force_cpu:
         logger.info("Apple Silicon/Rosetta detected — loading faster-whisper on CPU "

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -354,6 +354,12 @@ def _transcribe_local(
     file_path: str, model_name: str, *, language: Optional[str] = None, prompt: Optional[str] = None
 ) -> Dict[str, Any]:
     """Transcribe using faster-whisper (local, free)."""
+    # SIGILL-class CPU check first: lazy-install would either fetch wheels that
+    # crash the process on import (numpy on pre-x86-64-v2 cores) or install an
+    # unloadable ctranslate2 — refuse with the remediation hint up front.
+    from tools.transcription_local import _cpu_unsupported_reason
+    if unsupported := _cpu_unsupported_reason():
+        return _error_result(unsupported)
     if not _HAS_FASTER_WHISPER and not _try_lazy_install_stt():
         return _error_result("faster-whisper not installed")
     try:

--- a/tools/wake_word.py
+++ b/tools/wake_word.py
@@ -386,9 +386,16 @@ def check_wake_word_requirements(cfg: Optional[Dict[str, Any]] = None) -> Dict[s
     capture_mode = resolve_capture_mode(cfg)
     missing = " and ".join(n for n, ok in (("speech-to-text", stt_ok), ("text-to-speech", tts_ok)) if not ok)
 
+    # SIGILL-class: numpy/ctranslate2 wheels need x86-64-v2; refuse before the doomed install.
+    try:
+        cpu_unsupported = lazy_deps._cpu_baseline_missing_reason()
+    except Exception:
+        cpu_unsupported = None
+
     # Ordered remediation ladder: first true predicate wins.
     ladder = (
         (not key_ok, lambda: "Set PORCUPINE_ACCESS_KEY (free key at https://console.picovoice.ai)."),
+        (cpu_unsupported is not None, lambda: f"Wake word unavailable: {cpu_unsupported}"),
         (not deps_ok and not lazy_ok, lambda: lazy_deps.feature_install_command(feature) or ""),
         (not tflite_ok,
          lambda: "The wake word needs the tflite runtime on this Mac: pip install ai-edge-litert"),
@@ -410,7 +417,8 @@ def check_wake_word_requirements(cfg: Optional[Dict[str, Any]] = None) -> Dict[s
                     "build with client-capture wake support.")
 
     return {
-        "available": key_ok and stt_ok and tts_ok and tflite_ok and mic_ok, "provider": provider,
+        "available": cpu_unsupported is None and key_ok and stt_ok and tts_ok and tflite_ok and mic_ok,
+        "provider": provider,
         "deps_available": deps_ok, "audio_available": audio_ok,
         "local_input_available": _local_input_device_ready() if deps_ok else False,
         "capture": capture_mode, "access_key_set": key_ok, "stt_available": stt_ok, "tts_available": tts_ok,

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -106,6 +106,10 @@ You do **not** need to install Python, Node.js, ripgrep, or ffmpeg manually. The
 Nix is **no longer an explicitly supported install path** (best-effort only). If you already use Nix (on NixOS, macOS, or Linux), there's a dedicated setup path with a Nix flake, declarative NixOS module, and optional container mode. See the **[Nix & NixOS Setup](./nix-setup.md)** guide.
 :::
 
+:::info Older x86-64 CPUs (pre-2009 / no SSE4.2)
+Local voice features (local whisper transcription, wake-word detection) install native wheels — numpy 2.4 and ctranslate2 — whose prebuilt binaries require the **x86-64-v2** instruction set (SSE4.1/SSE4.2/POPCNT). On CPUs older than that (e.g. AMD E2/Bobcat, pre-Nehalem Intel), importing those libraries crashes the process with `SIGILL` instead of raising a Python error. Hermes detects this CPU class and disables local voice with a clear message instead; the rest of Hermes (including cloud STT/TTS providers and a local `whisper` CLI via `HERMES_LOCAL_STT_COMMAND`) keeps working. Check your CPU with `grep -o 'sse4_2' /proc/cpuinfo | head -1` — no output means local voice is unavailable on that machine.
+:::
+
 ---
 
 ## Manual / Developer Installation


### PR DESCRIPTION
## Summary

Fixes #109771.

`hermes serve` on a pre-x86-64-v2 CPU (AMD E2-2000 in the report: no SSE4.1/SSE4.2/AVX) crashes with `SIGILL` in two places, and neither can be caught with `try/except` because a signal, not an exception, kills the process:

1. `numpy==2.4.3` SIGILLs at import — NumPy 2.4 raised the x86-64 cpu-baseline to the x86-64-v2 microarchitecture (SSE4.1/SSE4.2/POPCNT); pre-v2 cores die inside `_multiarray_umath`.
2. `ctranslate2==4.8.2` SIGILLs when `WhisperModel` is constructed — its prebuilt binaries dispatch above the v2 baseline too (OpenNMT/CTranslate2#1224), taking the whole serve process down on first dictation.

This PR turns both into readable, actionable failures at the moment the feature is requested, instead of a systemd restart loop:

- `tools/lazy_deps.py` — `_cpu_baseline_missing_reason()` probes x86-64 Linux via `/proc/cpuinfo` flags for `sse4_1`/`sse4_2`/`popcnt` (fails open when cpuinfo is unreadable; never gates arm64/macOS/Windows). Wired into `_unsupported_feature_reason()` for the SIMD-wheel features (`stt.faster_whisper`, `wake.openwakeword`, `wake.sherpa`, `wake.porcupine`), so `ensure()` raises `FeatureUnavailable` with the remediation hint before pip installs doomed wheels (also covers the `hermes update` refresh path).
- `tools/transcription_local.py` — `_load_local_whisper_model()` raises `CpuBaselineError` before `from faster_whisper import WhisperModel`, covering hosts where the wheels are already installed (the reporter's exact state).
- `tools/transcription_tools.py` — `_transcribe_local()` returns the error envelope first, so a voice message produces a readable error instead of a dead gateway; the lazy-install attempt is skipped entirely.
- `tools/wake_word.py` — `check_wake_word_requirements()` gains the CPU predicate at the top of the remediation ladder and marks itself unavailable.
- docs — prerequisites note: which CPU class local voice needs, how to check (`grep -o 'sse4_2' /proc/cpuinfo`), and what still works on such machines (cloud STT/TTS, `HERMES_LOCAL_STT_COMMAND` whisper CLI).

## Testing

- new `tests/tools/test_cpu_baseline_gate.py` — 11 tests: probe true/false/unreadable/non-x86-64/macOS, install gate blocks pip for all four SIMD features without touching unrelated features, loader refuses before the native import / proceeds on v2, transcribe returns the error envelope. 11/11 passed on Python 3.11.
- Regression: `test_lazy_deps*.py` + `test_transcription*.py` + `test_wake_word.py` — the FAILED set is byte-identical to pristine `main` on this host (13 pre-existing macOS-env failures on both sides, 0 new; 99 passed), verified by running both sides and diffing the lists.
- `ruff check` clean on all changed files; `py_compile` clean.
