### PR TITLE
fix(dashboard): persist the WhatsApp allowlist outside QR onboarding

### DIFF
--- a/web/src/pages/ChannelsPage.test.tsx
+++ b/web/src/pages/ChannelsPage.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { MessagingPlatform } from "@/lib/api";
+
+const apiMocks = vi.hoisted(() => ({
+  updateMessagingPlatform: vi.fn(),
+  startWhatsAppOnboarding: vi.fn(),
+  getWhatsAppOnboardingStatus: vi.fn(),
+  applyWhatsAppOnboarding: vi.fn(),
+  cancelWhatsAppOnboarding: vi.fn(),
+  getActionStatus: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({ api: apiMocks }));
+
+let container: HTMLDivElement;
+let root: Root;
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const showToast = vi.fn();
+const onChanged = vi.fn(async () => undefined);
+const onRestartNeeded = vi.fn();
+const setRestartNeeded = vi.fn();
+
+function makePlatform(overrides: Partial<MessagingPlatform> = {}): MessagingPlatform {
+  return {
+    id: "whatsapp",
+    name: "WhatsApp",
+    description: "",
+    docs_url: null,
+    enabled: true,
+    configured: true,
+    gateway_running: true,
+    state: "running",
+    error_code: null,
+    error_message: null,
+    updated_at: null,
+    home_channel: null,
+    env_vars: [],
+    ingress_url: null,
+    whatsapp_setup: { mode: "bot", allowed_users_set: true, home_channel_set: false },
+    ...overrides,
+  } as MessagingPlatform;
+}
+
+async function renderPanel(platform: MessagingPlatform) {
+  const { WhatsAppOnboardingPanel } = await import("./ChannelsPage");
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () =>
+    root.render(
+      <WhatsAppOnboardingPanel
+        onChanged={onChanged}
+        onRestartNeeded={onRestartNeeded}
+        platform={platform}
+        setRestartNeeded={setRestartNeeded}
+        showToast={showToast}
+      />,
+    ),
+  );
+}
+
+function click(el: Element | null) {
+  if (!el) throw new Error("element not rendered");
+  el.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+}
+
+const saveButton = () =>
+  Array.from(document.querySelectorAll("button")).find((b) =>
+    b.textContent?.includes("Save allowlist"),
+  ) ?? null;
+
+async function typeAllowedUsers(value: string) {
+  const input = document.querySelector<HTMLInputElement>("#whatsapp-allowed-users");
+  if (!input) throw new Error("allowed-users input not rendered");
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+beforeEach(() => {
+  for (const fn of Object.values(apiMocks)) fn.mockReset();
+  apiMocks.updateMessagingPlatform.mockResolvedValue({ ok: true, platform: "whatsapp", hot_served: true });
+  vi.clearAllMocks();
+  vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, status: 500 })));
+  vi.stubGlobal("ResizeObserver", class { disconnect() {} observe() {} unobserve() {} });
+});
+
+afterEach(async () => {
+  await act(async () => root?.unmount());
+  container?.remove();
+  vi.unstubAllGlobals();
+});
+
+describe("WhatsAppOnboardingPanel idle allowlist save (#109776)", () => {
+  it("persists a non-empty allowlist through the messaging config endpoint without an onboarding session", async () => {
+    await renderPanel(makePlatform());
+    expect(saveButton()).not.toBeNull();
+
+    await typeAllowedUsers("15551234567,15557654321");
+    await act(async () => click(saveButton()));
+
+    expect(apiMocks.updateMessagingPlatform).toHaveBeenCalledWith("whatsapp", {
+      env: { WHATSAPP_ALLOWED_USERS: "15551234567,15557654321" },
+    });
+    expect(showToast).toHaveBeenCalledWith(
+      expect.stringContaining("allowlist saved"),
+      "success",
+    );
+    expect(onChanged).toHaveBeenCalled();
+  });
+
+  it("saving an empty field explicitly clears the saved allowlist and asks for a restart", async () => {
+    apiMocks.updateMessagingPlatform.mockResolvedValue({ ok: true, platform: "whatsapp", hot_served: false });
+    await renderPanel(makePlatform());
+
+    await typeAllowedUsers("   ");
+    await act(async () => click(saveButton()));
+
+    expect(apiMocks.updateMessagingPlatform).toHaveBeenCalledWith("whatsapp", {
+      clear_env: ["WHATSAPP_ALLOWED_USERS"],
+    });
+    expect(onRestartNeeded).toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith(expect.stringContaining("restart"), "success");
+  });
+
+  it("keeps the idle save action hidden while the channel is not configured yet", async () => {
+    await renderPanel(makePlatform({ configured: false }));
+    expect(saveButton()).toBeNull();
+    expect(apiMocks.updateMessagingPlatform).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a backend rejection as an error toast without touching the restart state", async () => {
+    apiMocks.updateMessagingPlatform.mockRejectedValue(new Error("400: WHATSAPP_ALLOWED_USERS is not configurable"));
+    await renderPanel(makePlatform());
+
+    await typeAllowedUsers("15551234567");
+    await act(async () => click(saveButton()));
+
+    expect(showToast).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to save allowlist"),
+      "error",
+    );
+    expect(onRestartNeeded).not.toHaveBeenCalled();
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/pages/ChannelsPage.tsx
+++ b/web/src/pages/ChannelsPage.tsx
@@ -650,7 +650,7 @@ export default function ChannelsPage() {
   );
 }
 
-function WhatsAppOnboardingPanel({
+export function WhatsAppOnboardingPanel({
   onChanged,
   onRestartNeeded,
   platform,
@@ -678,6 +678,7 @@ function WhatsAppOnboardingPanel({
     configuredMode ?? "bot",
   );
   const [allowedUsers, setAllowedUsers] = useState("");
+  const [savingAllowlist, setSavingAllowlist] = useState(false);
   const [error, setError] = useState("");
   const [tick, setTick] = useState(0);
 
@@ -846,6 +847,43 @@ function WhatsAppOnboardingPanel({
     }
   };
 
+  // #109776: while no onboarding session is running, the allowed-numbers field
+  // had no persistence path — it was editable but only lived in React state.
+  // Route idle edits through the normal messaging config endpoint (same one the
+  // Configure dialog uses): non-empty input replaces the allowlist, an empty
+  // input explicitly clears it (apply_whatsapp_onboarding keeps blanks as "keep").
+  const saveAllowedUsers = async () => {
+    setSavingAllowlist(true);
+    setError("");
+    try {
+      const trimmed = allowedUsers.trim();
+      const result = await api.updateMessagingPlatform(
+        platform.id,
+        trimmed
+          ? { env: { WHATSAPP_ALLOWED_USERS: trimmed } }
+          : { clear_env: ["WHATSAPP_ALLOWED_USERS"] },
+      );
+      if (result.hot_served) {
+        showToast(
+          "WhatsApp allowlist saved; the running gateway reloaded it",
+          "success",
+        );
+      } else {
+        onRestartNeeded();
+        showToast(
+          "WhatsApp allowlist saved — restart the gateway to apply it",
+          "success",
+        );
+      }
+      setAllowedUsers("");
+      await onChanged();
+    } catch (saveError) {
+      showToast(`Failed to save allowlist: ${saveError}`, "error");
+    } finally {
+      setSavingAllowlist(false);
+    }
+  };
+
   const expiresIn = useMemo(
     () => (setup ? formatExpiry(setup.expires_at) : ""),
     // tick keeps the memo fresh without recalculating on every render branch.
@@ -943,6 +981,24 @@ function WhatsAppOnboardingPanel({
               disabled={phase === "waiting" || phase === "applying"}
               placeholder="15551234567,15557654321"
             />
+            {!setup && platform.configured && (
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  size="sm"
+                  className="uppercase"
+                  onClick={() => void saveAllowedUsers()}
+                  disabled={savingAllowlist || phase !== "idle"}
+                  prefix={savingAllowlist ? <Spinner /> : <Save className="h-4 w-4" />}
+                >
+                  Save allowlist
+                </Button>
+                <span className="text-xs text-muted-foreground">
+                  {hasSavedAllowedUsers
+                    ? "A saved allowlist is active. Enter numbers to replace it, or save an empty field to remove it."
+                    : "No allowlist saved yet. Enter numbers to restrict who can message Hermes, then save."}
+                </span>
+              </div>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## What does this PR do?

While WhatsApp onboarding is idle, the Channels page rendered an editable "Allowed WhatsApp numbers" field with no persistence path: the value lived only in React state, and the "Save and restart" button only renders inside an active onboarding session that has reached `connected`/`applying`. A user who wanted to restrict an already-linked account had to re-enter the QR flow, and an access-control field that silently discards edits is unsafe — the user believes the channel is restricted while the runtime config is unchanged (#109776).

This wires idle allowlist edits to the existing per-platform config endpoint (`PUT /api/messaging/platforms/whatsapp`, the same path the Configure dialog uses) instead of adding a new one:

- a non-empty input replaces `WHATSAPP_ALLOWED_USERS` (backend re-validates via `_validate_messaging_env_value`);
- an empty input clears it explicitly via `clear_env` (the onboarding `apply` endpoint treats blank as "keep", so explicit clearing needs this path — matching the note in `apply_whatsapp_onboarding`);
- the `hot_served` result is surfaced the same way other channel saves do: hot-reload confirmation when a live multiplexer serves the profile, otherwise a restart-needed notice;
- the save action only appears when the panel is idle (no pairing session) and the channel is already configured, so it never interferes with QR onboarding.

## Related Issue

Fixes #109776

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `web/src/pages/ChannelsPage.tsx` — `WhatsAppOnboardingPanel`: added `saveAllowedUsers` (calls `api.updateMessagingPlatform`), a `savingAllowlist` busy state, and an idle-state "Save allowlist" button plus a hint describing the replace/clear semantics; exported the component so the behavior is unit-testable.
- `web/src/pages/ChannelsPage.test.tsx` — new: 4 tests covering non-empty save → `env` write, empty save → `clear_env` + restart notice, action hidden while unconfigured, and backend rejection → error toast without restart state change.

## How to Test

1. `cd web && ../node_modules/.bin/vitest run src/pages/ChannelsPage.test.tsx` — should pass 4/4 (persists via config endpoint, clears via `clear_env`, hides while unconfigured, surfaces backend errors).
2. `cd web && ../node_modules/.bin/vitest run` — full suite should pass: 305/305 passed.
3. `cd web && ../node_modules/.bin/tsc -p . --noEmit` — should pass with no errors; `eslint src/pages/ChannelsPage.tsx src/pages/ChannelsPage.test.tsx` — 0 errors.
4. Manual path (dashboard): link WhatsApp, then with onboarding idle edit the allowed-numbers field and press "Save allowlist"; Observed result: toast confirms the save and `WHATSAPP_ALLOWED_USERS` in `.env` reflects the new value without starting a QR session.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — web-only change; the vitest suite above is the equivalent (305/305 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A
