### PR TITLE
fix(cli): stop flagging enabled MCP server names as unknown platform toolsets

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -604,7 +604,7 @@ def _get_platform_tools(config: dict, platform: str, *, include_default_mcp_serv
         enabled_toolsets = _prune_toolsets_stripped_by_disabled(enabled_toolsets, disabled_names)
 
     if explicitly_configured and toolset_names:
-        _warn_all_invalid_platform_toolsets(platform, platform_toolsets[platform])
+        _warn_all_invalid_platform_toolsets(platform, platform_toolsets[platform], config)
     return enabled_toolsets
 
 
@@ -666,12 +666,15 @@ def _merge_mcp_servers(
     return result | explicit_mcp_servers
 
 
-def _warn_all_invalid_platform_toolsets(platform: str, explicit: list) -> None:
+def _warn_all_invalid_platform_toolsets(platform: str, explicit: list, config: dict) -> None:
     """Warn once when an explicit platform list has only invalid names (``hermes`` for ``hermes-cli`` → no
-    native tools), at session tool resolution rather than only in update/doctor."""
+    native tools), at session tool resolution rather than only in update/doctor. Enabled MCP server names are
+    load-bearing passthrough entries (the platform's MCP allowlist, ``_merge_mcp_servers``), so they are not
+    "unknown" here and must not lure the user into reconfiguring (#109791)."""
     from toolsets import validate_toolset
 
-    named = [str(t) for t in explicit if isinstance(t, str) and t]
+    mcp_names = enabled_mcp_server_names(config)
+    named = [str(t) for t in explicit if isinstance(t, str) and t and t not in mcp_names]
     if named and not any(validate_toolset(t) for t in named) and platform not in _warned_invalid_platform_toolsets:
         _warned_invalid_platform_toolsets.add(platform)
         logger.warning(

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -74,6 +74,60 @@ def test_partially_valid_platform_toolsets_no_runtime_warning(caplog):
     assert not any("#38798" in r.getMessage() for r in caplog.records)
 
 
+def test_mcp_only_platform_toolsets_no_runtime_warning(caplog):
+    """#109791: an explicit list of enabled MCP server names is a load-bearing
+    passthrough (the platform's MCP allowlist), not an unknown-toolset config,
+    so the runtime zero-tools warning must not fire for it."""
+    import hermes_cli.tools_config as _tc
+    # The runtime warning fires once per platform per process; clear the guard
+    # so this test is deterministic regardless of prior resolutions.
+    _tc._warned_invalid_platform_toolsets.discard("telegram")
+    config = {
+        "mcp_servers": {"drawio": {"command": "mcp-proxy"}, "github": {"command": "mcp-proxy"}},
+        "platform_toolsets": {"telegram": ["drawio", "github"]},
+    }
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.tools_config"):
+        _get_platform_tools(config, "telegram")
+
+    assert not any("#38798" in r.getMessage() for r in caplog.records)
+
+
+def test_mcp_name_alongside_unknown_toolset_warns_without_mcp_name(caplog):
+    """A genuinely unknown name still warns, but an enabled MCP server name on
+    the same list is excluded from the reported unknown names (#109791)."""
+    import hermes_cli.tools_config as _tc
+    _tc._warned_invalid_platform_toolsets.discard("telegram")
+    config = {
+        "mcp_servers": {"drawio": {"command": "mcp-proxy"}},
+        "platform_toolsets": {"telegram": ["drawio", "bogus"]},
+    }
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.tools_config"):
+        _get_platform_tools(config, "telegram")
+
+    messages = [r.getMessage() for r in caplog.records if "#38798" in r.getMessage()]
+    assert messages, "expected the zero-valid warning for the unknown name"
+    assert "bogus" in messages[0] and "drawio" not in messages[0], messages
+
+
+def test_disabled_mcp_server_name_still_warns(caplog):
+    """A name matching a DISABLED MCP server merges no tools into the platform,
+    so it keeps the unknown-name warning (#109791)."""
+    import hermes_cli.tools_config as _tc
+    _tc._warned_invalid_platform_toolsets.discard("telegram")
+    config = {
+        "mcp_servers": {"drawio": {"command": "mcp-proxy", "enabled": False}},
+        "platform_toolsets": {"telegram": ["drawio"]},
+    }
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.tools_config"):
+        _get_platform_tools(config, "telegram")
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("#38798" in m and "drawio" in m for m in warnings), warnings
+
+
 def test_null_platform_toolsets_fall_back_to_platform_default():
     """A YAML ``platform:`` value is absent, not an explicit empty list."""
     config = {"platform_toolsets": {"cli": None}}


### PR DESCRIPTION
## What does this PR do?

`_warn_all_invalid_platform_toolsets` (the runtime-side warning at session tool resolution) only consulted `validate_toolset`, so an explicit `platform_toolsets` list made of enabled MCP server names was reported as "no valid toolsets configured (unknown name(s): ...) - tools will be unavailable. Run `hermes tools` to reconfigure." But those names are load-bearing passthrough entries — they form the platform's MCP allowlist and are merged by `_merge_mcp_servers` — so the MCP tools are in fact available, and following the "reconfigure" advice silently reshapes the platform's tool surface (#109791).

This PR excludes enabled MCP server names (`enabled_mcp_server_names`, the same source `_merge_mcp_servers` uses) from the unknown-name check:

- an MCP-only list no longer warns;
- a genuinely unknown name on the same list still warns, but no longer drags the MCP name into the unknown list;
- a name matching a **disabled** MCP server still warns, because it merges no tools.

The doctor/migration-side validator (`hermes_cli/toolset_validation.py`) already got the equivalent passthrough exemption in #90890; this closes the runtime path, which that PR does not touch.

## Related Issue

Fixes #109791

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/tools_config.py`: `_warn_all_invalid_platform_toolsets` now takes `config` and filters enabled MCP server names out of the unknown-name candidates before the "no valid toolsets" check; docstring updated.
- `tests/hermes_cli/test_tools_config.py`: three regression tests (MCP-only list silent, MCP name excluded from the unknown list while a real typo still warns, disabled server name still warns).

## How to Test

1. Configure `mcp_servers: {drawio: {command: mcp-proxy}}` and `platform_toolsets: {telegram: [drawio]}`.
2. Before the fix, resolving platform tools logs `WARNING hermes_cli.tools_config: platform 'telegram' has no valid toolsets configured (unknown name(s): drawio) ...` — Observed result: after the fix no warning is emitted and the MCP allowlist still resolves.
3. `pytest tests/hermes_cli/test_tools_config.py -q` — Observed result: 55 passed, 6 skipped (3 new tests included; verified red on the pre-fix behavior).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (docstring updated in place)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A