### PR TITLE
fix(update): stream the web UI install with an idle watchdog

### DIFF
--- a/hermes_cli/main_web_build.py
+++ b/hermes_cli/main_web_build.py
@@ -205,12 +205,22 @@ def _console_print(text: str) -> None:
         print(text.encode(encoding, errors="replace").decode(encoding, errors="replace"))
 
 
+# Idle watchdog for the web UI dependency install (``npm ci --silent`` emits almost no
+# output on a healthy run — deleting and re-linking node_modules can sit silent for
+# ~10 minutes on a slow disk, see the heartbeat discussion in #101850 — so the budget
+# is far looser than the streamed build's 180s): longer than this with zero streamed
+# output is a stall, not slowness, and the run is terminated instead of wedging
+# ``hermes update`` forever (issue #109794).
+_WEB_INSTALL_IDLE_TIMEOUT_SECONDS = 900
+
+
 def _run_with_idle_timeout(
     cmd: list[str], cwd: Path, *, idle_timeout_seconds: int = 180, indent: str = "    ",
-    env: dict[str, str] | None = None) -> subprocess.CompletedProcess:
+    env: dict[str, str] | None = None, step_label: str = "Build") -> subprocess.CompletedProcess:
     """Stream a subprocess, killing it after *idle_timeout_seconds* of silence (a silent captured
     Vite build on a low-memory host looks like a hang and users reboot mid-install). Returns merged
-    stdout, empty stderr, rc 124 if terminate raced a clean exit; never raises on idle timeout.
+    stdout, empty stderr, and rc 124 whenever the idle watchdog terminated the child; never raises
+    on idle timeout.
 
     Issue #33788: ``npm run build`` (Vite) was invoked with ``capture_output=True`` and no timeout. On
     low-memory hosts (notably WSL2 with the default 4 GB cap) the build can stall or sit silent for minutes;
@@ -270,12 +280,14 @@ def _run_with_idle_timeout(
     combined = "".join(merged_chunks)
     if idle_killed:
         combined += (
-            f"\n  ⚠ Build produced no output for {idle_timeout_seconds}s — terminated.\n"
+            f"\n  ⚠ {step_label} produced no output for {idle_timeout_seconds}s — terminated.\n"
             "    Common causes: out-of-memory on a low-RAM host (WSL/container),\n"
             "    a stuck Node process, or an antivirus scan stalling I/O.\n"
         )
-        if rc == 0:
-            rc = 124  # GNU `timeout` convention
+        # Always report the timeout as rc 124 (GNU `timeout` convention), whether the
+        # child exited 0 in a race with the terminate, or died from the signal itself
+        # (-15 / 1): callers treat "killed by the watchdog" as one outcome.
+        rc = 124
     return subprocess.CompletedProcess(cmd, rc, stdout=combined, stderr="")
 
 
@@ -312,7 +324,8 @@ def _nixos_build_env() -> dict[str, str] | None:
 
 def _run_npm_install_deterministic(
     npm: str, cwd: Path, *, extra_args: tuple[str, ...] = (), capture_output: bool = True,
-    env: dict[str, str] | None = None) -> subprocess.CompletedProcess:
+    env: dict[str, str] | None = None,
+    idle_timeout_seconds: int | None = None) -> subprocess.CompletedProcess:
     """Deterministic npm install that never mutates ``package-lock.json``.
 
     ``npm ci`` when a lockfile exists, else/on failure ``npm install --no-save``
@@ -325,23 +338,34 @@ def _run_npm_install_deterministic(
     ``package-lock.json``. Without it, an out-of-sync lockfile gets rewritten by the fallback, which drifts
     the committed lockfile and makes every future ``npm ci`` fail — a self-reinforcing cycle where web
     devDeps never install and a stale dist is served on every update (PR #65595).
+
+    ``idle_timeout_seconds`` routes the install through :func:`_run_with_idle_timeout` instead of a
+    captured ``subprocess.run``: under ``capture_output`` a silently stalled ``npm ci`` is
+    indistinguishable from a hang, and ``hermes update`` then wedges at "Building web UI..." with no
+    output, no receipt, and no recovery until something kills it (issue #109794). An idle kill (rc 124,
+    the ``timeout`` convention) skips both the ci→install fallback and the engine repair — a stalled npm
+    retried in the same environment stalls the same way.
     """
     # CI=1 no-ops unicode-animations' postinstall that animates to /dev/tty.
     run_env = _npm_lifecycle_env(env)
 
     def _attempt(npm_exe: str) -> subprocess.CompletedProcess:
         def _run(args: list[str]) -> subprocess.CompletedProcess:
-            return _run_npm_watching_for_engine_failure(
-                [npm_exe, *args, "--include=dev", *extra_args], cwd=cwd, env=run_env, capture_output=capture_output,
-            )
+            cmd = [npm_exe, *args, "--include=dev", *extra_args]
+            if idle_timeout_seconds is None:
+                return _run_npm_watching_for_engine_failure(
+                    cmd, cwd=cwd, env=run_env, capture_output=capture_output)
+            return _run_with_idle_timeout(
+                cmd, cwd=cwd, idle_timeout_seconds=idle_timeout_seconds, env=run_env,
+                step_label="npm install")
         if (cwd / "package-lock.json").exists():
             ci_result = _run(["ci"])
-            if ci_result.returncode == 0:
+            if ci_result.returncode in (0, 124):
                 return ci_result
         return _run(["install", "--no-save"])
 
     result = _attempt(npm)
-    if result.returncode == 0:
+    if result.returncode in (0, 124):
         return result
 
     from hermes_cli.npm_engine import maybe_repair_npm_engine
@@ -494,7 +518,9 @@ def _do_build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
 
     def _install_web_deps(*, silent: bool) -> subprocess.CompletedProcess:
         extra = (*npm_workspace_args, "--silent", "--prefer-offline") if silent else (*npm_workspace_args, "--prefer-offline")
-        return _run_npm_install_deterministic(npm, npm_cwd, extra_args=extra, env=build_env)
+        return _run_npm_install_deterministic(
+            npm, npm_cwd, extra_args=extra, env=build_env,
+            idle_timeout_seconds=_WEB_INSTALL_IDLE_TIMEOUT_SECONDS)
 
     def _build() -> subprocess.CompletedProcess:
         # Streamed + idle-killed (never capture_output on a long Vite build: it

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -12,6 +12,7 @@ freshness check is a no-op and the OOM rebuild always runs.
 """
 
 import os
+import sys
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -19,6 +20,7 @@ from unittest.mock import patch
 import pytest
 
 from hermes_cli.main_web_build import _build_web_ui, _run_npm_install_deterministic
+from hermes_cli.main_web_build import _WEB_INSTALL_IDLE_TIMEOUT_SECONDS
 from hermes_cli.main_web_build import _web_ui_build_needed, _compute_web_ui_content_hash, _missing_web_build_tool, _web_ui_stamp_path, _write_web_ui_build_stamp
 from hermes_cli.update_cmd import _web_build_toolchain_ready, _web_toolchain_roots
 
@@ -138,18 +140,19 @@ class TestBuildWebUISkipsWhenFresh:
         install_cp = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
         build_cp = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
         with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
-             patch("hermes_cli.main.subprocess.run", return_value=install_cp) as mock_run, \
-             patch("hermes_cli.main_web_build._run_with_idle_timeout", return_value=build_cp) as mock_build:
+             patch("hermes_cli.main.subprocess.run", return_value=install_cp), \
+             patch("hermes_cli.main_web_build._run_with_idle_timeout", return_value=build_cp) as mock_helper:
             result = _build_web_ui(web_dir)
 
         assert result is True
-        args, kwargs = mock_run.call_args
+        # The install command line is assembled on the idle-helper call (issue #109794).
+        args, kwargs = mock_helper.call_args_list[0]
         assert "--workspace" not in args[0]
         assert Path(args[0][0]).name in {"npm", "npm.cmd"}
         assert args[0][1:] == ["ci", "--include=dev", "--silent", "--prefer-offline"]
         assert kwargs["cwd"] == web_dir
         assert "ESBUILD_BINARY_PATH" not in kwargs["env"]
-        assert "ESBUILD_BINARY_PATH" not in mock_build.call_args.kwargs["env"]
+        assert "ESBUILD_BINARY_PATH" not in mock_helper.call_args_list[1].kwargs["env"]
 
     def test_workspace_root_install_names_update_closure(self, tmp_path, monkeypatch):
         """From the workspace root, _build_web_ui must install the SAME
@@ -171,12 +174,12 @@ class TestBuildWebUISkipsWhenFresh:
         install_cp = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
         build_cp = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
         with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
-             patch("hermes_cli.main.subprocess.run", return_value=install_cp) as mock_run, \
-             patch("hermes_cli.main_web_build._run_with_idle_timeout", return_value=build_cp):
+             patch("hermes_cli.main.subprocess.run", return_value=install_cp), \
+             patch("hermes_cli.main_web_build._run_with_idle_timeout", return_value=build_cp) as mock_helper:
             result = _build_web_ui(web_dir)
 
         assert result is True
-        args, kwargs = mock_run.call_args
+        args, kwargs = mock_helper.call_args_list[0]  # the install invocation
         cmd = args[0]
         assert "--include-workspace-root" in cmd
         assert cmd.count("--workspace") == 2
@@ -194,22 +197,21 @@ class TestBuildWebUISkipsWhenFresh:
         install_cp = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
         build_cp = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
         with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
-             patch("hermes_cli.main.subprocess.run", return_value=install_cp) as mock_run, \
-             patch("hermes_cli.main_web_build._run_with_idle_timeout", return_value=build_cp):
+             patch("hermes_cli.main.subprocess.run", return_value=install_cp), \
+             patch("hermes_cli.main_web_build._run_with_idle_timeout", return_value=build_cp) as mock_helper:
             result = _build_web_ui(web_dir)
 
         assert result is True
-        cmd = mock_run.call_args[0][0]
+        cmd = mock_helper.call_args_list[0][0][0]  # the install invocation
         assert "ui-tui" not in cmd
         assert "--include-workspace-root" in cmd
         assert "web" in cmd
 
     def test_web_build_uses_idle_timeout_helper(self, tmp_path):
-        """npm run build now goes through _run_with_idle_timeout (issue #33788).
-
-        The install step keeps its capture_output behavior (the existing
-        retry-on-EPERM contract depends on it); only the long-running build
-        step is streamed + idle-killed.
+        """npm run build goes through _run_with_idle_timeout (issue #33788), and the
+        install step does too with a wider budget (issue #109794): a silently
+        stalled `npm ci` under capture_output wedges `hermes update` at
+        "Building web UI..." forever. Both steps are now streamed + idle-killed.
         """
         web_dir, _ = _make_web_dir(tmp_path)
 
@@ -217,16 +219,22 @@ class TestBuildWebUISkipsWhenFresh:
         build_cp = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
         with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
              patch("hermes_cli.main.subprocess.run", return_value=install_cp), \
-             patch("hermes_cli.main_web_build._run_with_idle_timeout", return_value=build_cp) as mock_idle:
+             patch("hermes_cli.main_web_build._run_with_idle_timeout", side_effect=[install_cp, build_cp]) as mock_idle:
             result = _build_web_ui(web_dir)
 
         assert result is True
-        # Build was invoked through the idle-timeout helper, not subprocess.run.
-        mock_idle.assert_called_once()
-        args, kwargs = mock_idle.call_args
-        # Positional: [npm, "run", "build"]; cwd passed as kwarg.
-        assert args[0] == ["/usr/bin/npm", "run", "build"]
-        assert kwargs["cwd"] == web_dir
+        # Both the install and the build were invoked through the idle-timeout helper.
+        assert mock_idle.call_count == 2
+        install_args, install_kwargs = mock_idle.call_args_list[0]
+        build_args, build_kwargs = mock_idle.call_args_list[1]
+        # Install: [npm, <subcommand>, ...] with the wider 300s idle budget
+        # (no lockfile in this fixture, so the subcommand is `install --no-save`).
+        assert install_args[0][0] == "/usr/bin/npm"
+        assert install_kwargs["idle_timeout_seconds"] == _WEB_INSTALL_IDLE_TIMEOUT_SECONDS
+        assert install_kwargs["step_label"] == "npm install"
+        # Build: [npm, "run", "build"] on the streamed 180s default.
+        assert build_args[0] == ["/usr/bin/npm", "run", "build"]
+        assert build_kwargs["cwd"] == web_dir
 
 
 class TestBuildWebUIRetryAndStaleFallback:
@@ -243,11 +251,11 @@ class TestBuildWebUIRetryAndStaleFallback:
              patch("hermes_cli.main_web_build._time.sleep") as mock_sleep, \
              patch("hermes_cli.main.subprocess.run", return_value=install_ok), \
              patch("hermes_cli.main_web_build._run_with_idle_timeout",
-                   side_effect=[build_fail, build_ok]) as mock_idle:
+                   side_effect=[install_ok, build_fail, build_ok]) as mock_idle:
             result = _build_web_ui(web_dir)
 
         assert result is True
-        assert mock_idle.call_count == 2  # build + retry
+        assert mock_idle.call_count == 3  # install + build + retry
         mock_sleep.assert_called_once_with(3)
 
     def test_falls_back_to_stale_dist_when_retry_also_fails(self, tmp_path, capsys):
@@ -263,7 +271,7 @@ class TestBuildWebUIRetryAndStaleFallback:
              patch("hermes_cli.main_web_build._time.sleep"), \
              patch("hermes_cli.main.subprocess.run", return_value=install_ok), \
              patch("hermes_cli.main_web_build._run_with_idle_timeout",
-                   side_effect=[build_fail, build_fail]):
+                   side_effect=[install_ok, build_fail, build_fail]):
             result = _build_web_ui(web_dir, fatal=True)
 
         # MUST return True (serve stale) — issue #23817 — even with fatal=True,
@@ -272,6 +280,73 @@ class TestBuildWebUIRetryAndStaleFallback:
         out = capsys.readouterr().out
         assert "serving stale dist as fallback" in out
         assert "vite ENOMEM" in out  # combined output surfaced to user
+
+
+class TestNpmInstallIdleWatchdog:
+    """Issue #109794: a silently stalled ``npm ci`` under ``capture_output`` is
+    indistinguishable from a hang, so ``hermes update`` used to wedge at
+    "Building web UI..." with no output until something killed it from outside."""
+
+    def test_idle_killed_install_skips_fallback_and_engine_repair(self, tmp_path):
+        """rc 124 (idle kill) returns immediately — the ci→install fallback and the
+        engine repair would re-run the same stalled environment and stall again."""
+        (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
+        idle_killed = __import__("subprocess").CompletedProcess(
+            [], 124, stdout="\n  ⚠ npm install produced no output for 300s — terminated.\n", stderr="")
+        with patch("hermes_cli.main_web_build._run_with_idle_timeout", return_value=idle_killed) as mock_idle, \
+             patch("hermes_cli.main_web_build._run_npm_watching_for_engine_failure") as mock_captured, \
+             patch("hermes_cli.npm_engine.maybe_repair_npm_engine", return_value=None) as mock_repair:
+            result = _run_npm_install_deterministic("/usr/bin/npm", tmp_path, idle_timeout_seconds=300)
+
+        assert result.returncode == 124
+        assert "terminated" in result.stdout
+        mock_idle.assert_called_once()      # npm ci ran once and was idle-killed
+        mock_captured.assert_not_called()   # no captured re-run path was taken
+        mock_repair.assert_not_called()     # no engine repair on an idle kill
+
+    def test_idle_watchdog_opt_in_only(self, tmp_path):
+        """Default callers (e.g. the desktop npm install) keep the captured behavior."""
+        (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
+        ok = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+        with patch("hermes_cli.main_web_build._run_with_idle_timeout") as mock_idle, \
+             patch("hermes_cli.main_web_build._run_npm_watching_for_engine_failure", return_value=ok) as mock_captured:
+            result = _run_npm_install_deterministic("/usr/bin/npm", tmp_path)
+
+        assert result.returncode == 0
+        mock_idle.assert_not_called()
+        mock_captured.assert_called_once()
+
+    def test_web_build_install_failure_is_observable(self, tmp_path, capsys):
+        """An idle-killed install surfaces through the standard failure block
+        instead of printing nothing after '→ Building web UI...' (issue #109794)."""
+        web_dir, _ = _make_web_dir(tmp_path)
+        idle_killed = __import__("subprocess").CompletedProcess(
+            [], 124, stdout="  ⚠ npm install produced no output for 300s — terminated.\n", stderr="")
+        with patch("hermes_cli.main_install_repair._resolve_node_runtime_npm", return_value="/usr/bin/npm"), \
+             patch("hermes_cli.main_web_build._run_with_idle_timeout", return_value=idle_killed), \
+             patch("hermes_cli.main_web_build._web_ui_build_needed", return_value=True):
+            result = _build_web_ui(web_dir, fatal=True)
+
+        assert result is False
+        out = capsys.readouterr().out
+        assert "Web UI npm install failed" in out
+        assert "terminated" in out
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX shell script as the fake npm")
+    def test_stalled_install_process_is_killed(self, tmp_path):
+        """End-to-end: a real child that never outputs is terminated, not waited on."""
+        fake_npm = tmp_path / "fake-npm"
+        fake_npm.write_text("#!/bin/sh\nsleep 60\n", encoding="utf-8")
+        fake_npm.chmod(0o755)
+        (tmp_path / "package-lock.json").write_text("{}", encoding="utf-8")
+
+        started = time.monotonic()
+        result = _run_npm_install_deterministic(str(fake_npm), tmp_path, idle_timeout_seconds=1)
+        elapsed = time.monotonic() - started
+
+        assert elapsed < 30  # killed by the watchdog, not by the 60s sleep
+        assert result.returncode == 124
+        assert "npm install produced no output" in result.stdout
 
 
 class TestBuildWebUIFlock:


### PR DESCRIPTION
## What does this PR do?

`hermes update` can wedge forever at the `→ Building web UI...` step. The streamed build half of that step is already protected — `npm run build` goes through `_run_with_idle_timeout` (180s of silence kills it, #33788) — but the dependency install that runs **first** (`npm ci --silent`) is executed via `subprocess.run(capture_output=True)` with no timeout at all. A silently stalled npm under `capture_output` is indistinguishable from a hang: the parent waits forever, `update.log` shows nothing after `→ Building web UI...`, no receipt is written (receipts are only written when a run ends), and the run only ends when something kills it from outside.

Issue #109794 documents exactly this: run A sat at the web UI build step for 24 minutes (a healthy run of the same step completes in ≤4 minutes) and left no receipt; the follow-up run then overlapped it on the same checkout because the in-progress marker ages out by wall clock (tracked separately as #109795).

This PR routes the install through the same `_run_with_idle_timeout` helper, with a deliberately loose 900s idle budget, and makes the idle-kill return code unambiguous:

- **Loose budget**: a healthy `npm ci --silent` re-links `node_modules` and can sit with zero output for ~10 minutes on a slow disk — that healthy-silence case is exactly why #101850 adds a heartbeat around this step. 900s of zero *streamed* output therefore means a stall, not slowness. The budget is a module constant (`_WEB_INSTALL_IDLE_TIMEOUT_SECONDS`) so it is easy to tune.
- **rc 124 always on idle kill** (GNU `timeout` convention), whether the child died from the signal (`-15`/`1`) or raced a clean exit — callers treat "killed by the watchdog" as one outcome.
- **No blind retry on an idle kill**: rc 124 skips the `ci` → `install --no-save` fallback and the npm engine repair inside `_run_npm_install_deterministic`. A stalled npm retried in the same environment stalls the same way; without this, one wedge would turn into three back-to-back wedges.
- **Observability**: the install is now streamed (a silent `npm ci` no longer prints nothing after `→ Building web UI...`), and an idle kill surfaces through the existing `Web UI npm install failed` block with the watchdog diagnosis, instead of an eternal silent wait.

Default callers of `_run_npm_install_deterministic` (e.g. the desktop npm install) are unchanged: the watchdog is strictly opt-in via the new `idle_timeout_seconds` argument.

## Related Issue

Fixes #109794

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main_web_build.py`:
  - `_run_with_idle_timeout`: added `step_label` (the idle-kill message now names the step it terminated) and normalized an idle kill to rc 124 regardless of how the child died.
  - `_run_npm_install_deterministic`: new opt-in `idle_timeout_seconds` argument; when set, install commands stream through `_run_with_idle_timeout` instead of a captured `subprocess.run`; rc 124 returns immediately without the ci→install fallback or the engine-repair retry.
  - `_do_build_web_ui`: the web install now passes `idle_timeout_seconds=_WEB_INSTALL_IDLE_TIMEOUT_SECONDS` (900).
- `tests/hermes_cli/test_web_ui_build.py`: updated the three install-command-line assertions to read the assembled command off the idle-helper call (install no longer goes through `subprocess.run`), and added `TestNpmInstallIdleWatchdog` covering: idle kill skips fallback/engine repair, the watchdog is opt-in (default callers unchanged), an idle-killed install surfaces through the standard failure block, and an end-to-end real-child stall that is terminated rather than waited on.

## How to Test

1. `pytest tests/hermes_cli/test_web_ui_build.py -q` — 28 passed (includes the 4 new watchdog tests).
2. `pytest tests/hermes_cli/test_run_with_idle_timeout.py tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_desktop_exe_integrity.py tests/hermes_cli/test_dashboard_web_dist_validation.py tests/hermes_cli/test_update_current_node_repair.py -q` — 55 passed, 12 skipped.
3. `pytest tests/hermes_cli/test_cmd_update.py -q` — 47 passed.
4. End-to-end wedge simulation (covered by `test_stalled_install_process_is_killed`): a fake npm that sleeps 60s without output is terminated by the watchdog (rc 124) in ~1s with the `npm install produced no output` diagnosis, instead of blocking the parent indefinitely.

Observed result: all listed suites pass; the stall simulation returns in ~1s rather than hanging.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (the adjacent #101850 adds a heartbeat to keep *healthy* silent installs alive; this PR terminates genuinely *stalled* ones — the two are complementary)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (focused + affected suites listed above; the unrelated 4 pre-existing combination-order failures in `test_resource_limits.py`/`test_update_*` reproduce identically on a clean `upstream/main` checkout with the same file set)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior documented in docstrings)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) (`Popen.terminate`/`kill` cover Windows; the end-to-end real-child test skips on win32, the mocked tests run everywhere)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
