### PR TITLE
fix(kanban): circuit breaker must emit a blocked event (orphan source)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4440,6 +4440,33 @@ def _synthesize_ended_run(
 # Dependency resolution (todo -> ready)
 # ---------------------------------------------------------------------------
 
+CIRCUIT_BREAKER_BLOCK_KIND = "circuit_breaker"
+"""Payload ``kind`` marker for the ``blocked`` event emitted by the
+dispatcher's circuit breaker (``_record_task_failure``).
+
+Distinguishes an automatic retry-exhaustion block from a deliberate
+worker/operator ``block_task`` call *without* disturbing downstream
+consumers:
+
+* ``_has_sticky_block`` treats marker-carrying ``blocked`` events as
+  NON-sticky, preserving the documented auto-recovery semantics of
+  #35072 / #28712 (a breaker block must recover once its underlying
+  condition clears; only human-initiated blocks wait for an explicit
+  ``unblock_task``).
+* ``tasks.block_kind`` stays NULL on the breaker path on purpose:
+  userland escalation tooling (e.g. ``classify_rca_tier`` in
+  /opt/data/scripts/domain/escalation.py) routes retry-exhaustion
+  tickets through the ``block_kind in {None, transient}`` lane, and
+  the scheduler's ``structural_block_kinds`` list does not know this
+  value. The audit marker lives in the event payload only.
+
+Before this marker existed the breaker flipped ``status='blocked'``
+with no ``blocked`` event at all — the "orphan" class (blocked status,
+zero blocked events) that left event-keyed detection (critic lane,
+kanban-block-watcher) blind for days (post-mortem
+260822-critic-lane-orphan-blindspot, action #3)."""
+
+
 def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
     """Return True when ``task_id`` is sticky-blocked by an explicit
     worker/operator ``kanban_block`` call (#28712).
@@ -4453,29 +4480,42 @@ def _has_sticky_block(conn: sqlite3.Connection, task_id: str) -> bool:
       emits a ``"blocked"`` event row in ``task_events``.
 
     * **Circuit-breaker** — ``_record_task_failure`` tripped after
-      repeated crashes / spawn failures / timeouts.  This emits
-      ``"gave_up"``, *not* ``"blocked"``, and is meant to recover
-      automatically once the underlying conditions change (e.g. parents
-      finish, transient infra error clears).
+      repeated crashes / spawn failures / timeouts.  This also emits a
+      ``"blocked"`` event (since the orphan-source fix), but the event
+      payload carries ``kind: circuit_breaker``; such blocks are meant
+      to recover automatically once the underlying conditions change
+      (e.g. parents finish, transient infra error clears).
 
     The cheapest signal that distinguishes the two is the most recent
     ``"blocked"`` / ``"unblocked"`` event for the task.  If the most
-    recent one is ``"blocked"`` (or there is a ``"blocked"`` event and
-    no ``"unblocked"`` event has fired since), the task is sticky and
-    ``recompute_ready`` must *not* auto-promote it.
+    recent one is a *sticky* ``"blocked"`` (i.e. a ``blocked`` event
+    without the circuit-breaker marker — or there is such a ``blocked``
+    event and no ``"unblocked"`` event has fired since), the task is
+    sticky and ``recompute_ready`` must *not* auto-promote it.
 
-    Returns ``False`` when there is no such event at all (e.g. the task
-    was set to ``status='blocked'`` by the circuit breaker or by direct
-    DB manipulation) — preserves the pre-#28712 auto-recover semantics
+    Returns ``False`` when the only ``blocked`` events carry the
+    circuit-breaker marker, or when there is no such event at all
+    (e.g. the task was set to ``status='blocked'`` by direct DB
+    manipulation) — preserves the pre-#28712 auto-recover semantics
     for that path.
     """
     row = conn.execute(
-        "SELECT kind FROM task_events "
+        "SELECT kind, payload FROM task_events "
         "WHERE task_id = ? AND kind IN ('blocked', 'unblocked') "
         "ORDER BY id DESC LIMIT 1",
         (task_id,),
     ).fetchone()
-    return bool(row) and row["kind"] == "blocked"
+    if not row or row["kind"] != "blocked":
+        return False
+    payload = row["payload"]
+    if payload:
+        try:
+            decoded = json.loads(payload)
+        except (json.JSONDecodeError, TypeError):
+            decoded = None
+        if isinstance(decoded, dict) and decoded.get("kind") == CIRCUIT_BREAKER_BLOCK_KIND:
+            return False
+    return True
 
 
 def _resume_status_from_events(conn: sqlite3.Connection, task_id: str) -> str:
@@ -9207,6 +9247,7 @@ def _record_task_failure(
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT
     blocked = False
+    breaker_hook_reason: Optional[str] = None
     with write_txn(conn):
         row = conn.execute(
             "SELECT consecutive_failures, status, max_retries, current_run_id "
@@ -9282,6 +9323,30 @@ def _record_task_failure(
             _append_event(
                 conn, task_id, "gave_up", payload, run_id=run_id,
             )
+            # Audit-trail parity (post-mortem 260822-critic-lane-orphan-blindspot
+            # action #3): the status flip above used to be invisible to the
+            # event stream — no ``blocked`` row, NULL ``block_kind``/reason —
+            # which stranded every event-keyed detector (critic lane,
+            # kanban-block-watcher) while stall-naggers spammed the orphan.
+            # Events are the audit trail; status is state. The payload kind
+            # marker keeps ``_has_sticky_block`` treating this as an
+            # auto-recoverable breaker block rather than a sticky human one.
+            _append_event(
+                conn, task_id, "blocked",
+                {
+                    "kind": CIRCUIT_BREAKER_BLOCK_KIND,
+                    "trigger_outcome": outcome,
+                    "failures": failures,
+                    "effective_limit": effective_limit,
+                    "limit_source": limit_source,
+                    "error": error[:500],
+                },
+                run_id=run_id,
+            )
+            # Deferred until after the write txn commits (same convention as
+            # block_task): plugin code must never observe board state under an
+            # open SQLite write lock.
+            breaker_hook_reason = f"circuit_breaker: {outcome} x{failures}"
             blocked = True
         else:
             # Below threshold.
@@ -9322,6 +9387,18 @@ def _record_task_failure(
                     run_id=run_id,
                 )
             # Timeout/crash path's caller already emitted its own event.
+    if blocked and breaker_hook_reason is not None:
+        # Fire AFTER the write txn commits — mirrors block_task's convention
+        # so lifecycle plugins observe durable board state, never an open txn.
+        _blocked_task = get_task(conn, task_id)
+        _fire_kanban_lifecycle_hook(
+            "kanban_task_blocked",
+            task_id,
+            board=get_current_board(),
+            assignee=_blocked_task.assignee if _blocked_task else None,
+            run_id=run_id,
+            reason=breaker_hook_reason,
+        )
     return blocked
 
 

--- a/tests/hermes_cli/test_kanban_breaker_blocked_event.py
+++ b/tests/hermes_cli/test_kanban_breaker_blocked_event.py
@@ -1,0 +1,231 @@
+"""Regression tests for the circuit-breaker orphan-source fix
+(post-mortem 260822-critic-lane-orphan-blindspot, action #3).
+
+The bug: ``_record_task_failure`` (the dispatcher's circuit breaker)
+flipped ``tasks.status`` to ``blocked`` on retry exhaustion while
+emitting ONLY a ``gave_up`` event — no ``blocked`` event, NULL
+``block_kind``/``block_reason``. Every event-keyed detector (critic
+lane, kanban-block-watcher) was structurally blind to these "orphan"
+tickets; 16 of them dead-ended on the default board for 10-48h.
+
+The contract under test (events = audit trail, status = state):
+
+* EVERY transition into ``status='blocked'`` must leave a ``blocked``
+  event row in ``task_events`` — including the circuit breaker.
+* The breaker's ``blocked`` event carries ``kind: circuit_breaker`` in
+  its payload so ``_has_sticky_block`` still classifies it as an
+  auto-recoverable block (preserving #35072 / #28712 semantics).
+* Worker/operator ``block_task`` events remain sticky (no marker).
+* ``tasks.block_kind`` stays NULL on the breaker path — userland
+  escalation classifiers key retry-exhaustion tickets off
+  ``block_kind in {None, transient}`` and must not see a new value.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _events(conn: sqlite3.Connection, task_id: str, kind: str) -> list[dict]:
+    rows = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id = ? AND kind = ? ORDER BY id",
+        (task_id, kind),
+    ).fetchall()
+    out = []
+    for r in rows:
+        try:
+            out.append(json.loads(r["payload"]) if r["payload"] else {})
+        except (json.JSONDecodeError, TypeError):
+            out.append({})
+    return out
+
+
+# ---------------------------------------------------------------------------
+# AC: every blocked-status transition emits a blocked event — breaker path
+# ---------------------------------------------------------------------------
+
+
+def test_breaker_trip_emits_blocked_event(kanban_home: Path) -> None:
+    """Retry exhaustion (the exact #28712-loop shape that produced live
+    orphans t_dd7d6af9 / t_f801ed90) must leave BOTH a ``gave_up`` and a
+    ``blocked`` event. Before the fix the ``blocked`` row was absent —
+    the orphan class."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="breaker reproducer")
+        kb.claim_task(conn, tid)
+        # Crash path: release_claim=False, end_run=False — the caller
+        # (detect_crashed_workers) has already restored the source phase.
+        tripped = kb._record_task_failure(
+            conn, tid, "worker exited cleanly (rc=0) without terminal call",
+            outcome="crashed", failure_limit=1,
+            release_claim=False, end_run=False,
+        )
+        assert tripped is True
+        assert kb.get_task(conn, tid).status == "blocked"
+        assert len(_events(conn, tid, "gave_up")) == 1
+        blocked = _events(conn, tid, "blocked")
+        assert len(blocked) == 1, (
+            "circuit-breaker block must be visible in the event audit trail"
+        )
+        assert blocked[0].get("kind") == kb.CIRCUIT_BREAKER_BLOCK_KIND
+        assert blocked[0].get("trigger_outcome") == "crashed"
+        assert blocked[0].get("failures") == 1
+
+
+def test_breaker_spawn_path_emits_blocked_event(kanban_home: Path) -> None:
+    """The spawn-failure variant (release_claim=True, end_run=True) must
+    emit the same audit row."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="spawn failure reproducer")
+        kb.claim_task(conn, tid)
+        tripped = kb._record_spawn_failure(
+            conn, tid, "spawn: image pull backoff", failure_limit=1,
+        )
+        assert tripped is True
+        assert kb.get_task(conn, tid).status == "blocked"
+        blocked = _events(conn, tid, "blocked")
+        assert len(blocked) == 1
+        assert blocked[0].get("kind") == kb.CIRCUIT_BREAKER_BLOCK_KIND
+
+
+def test_breaker_block_leaves_block_kind_null(kanban_home: Path) -> None:
+    """``tasks.block_kind`` must stay NULL on the breaker path: userland
+    escalation tooling (classify_rca_tier) routes retry-exhaustion
+    tickets through the ``block_kind in {None, transient}`` lane and the
+    scheduler's structural/transient vocab does not know this value."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="kind stays null")
+        kb.claim_task(conn, tid)
+        kb._record_task_failure(
+            conn, tid, "boom", outcome="crashed", failure_limit=1,
+            release_claim=False, end_run=False,
+        )
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        assert task.block_kind is None
+
+
+def test_below_threshold_no_blocked_event(kanban_home: Path) -> None:
+    """A single failure below the limit must NOT produce a blocked
+    event — the audit row appears exactly when the status flips."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="not yet exhausted")
+        kb.claim_task(conn, tid)
+        tripped = kb._record_task_failure(
+            conn, tid, "first crash", outcome="crashed", failure_limit=3,
+            release_claim=False, end_run=False,
+        )
+        assert tripped is False
+        assert kb.get_task(conn, tid).status != "blocked"
+        assert _events(conn, tid, "blocked") == []
+
+
+# ---------------------------------------------------------------------------
+# AC: breaker blocks remain auto-recoverable (not sticky)
+# ---------------------------------------------------------------------------
+
+
+def test_breaker_block_is_not_sticky(kanban_home: Path) -> None:
+    """A circuit-breaker block (marker-carrying event) must remain
+    auto-recoverable via recompute_ready once the failure counter drops
+    below the effective limit — the #35072/#28712 semantics. Sticky is
+    reserved for deliberate worker/operator blocks."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="breaker auto-recovery")
+        kb.claim_task(conn, tid)
+        kb._record_task_failure(
+            conn, tid, "exhausted", outcome="crashed", failure_limit=1,
+            release_claim=False, end_run=False,
+        )
+        assert kb.get_task(conn, tid).status == "blocked"
+        assert kb._has_sticky_block(conn, tid) is False
+
+        # Simulate the recovery condition: the dispatcher's unblock lane
+        # resets consecutive_failures (see unblock_task), after which
+        # recompute_ready may promote the task.
+        conn.execute(
+            "UPDATE tasks SET consecutive_failures = 0 WHERE id = ?", (tid,)
+        )
+        conn.commit()
+        assert kb.recompute_ready(conn) == 1
+        assert kb.get_task(conn, tid).status == "ready"
+
+
+def test_breaker_marker_does_not_leak_stickiness_to_later_worker_block(
+    kanban_home: Path,
+) -> None:
+    """Sequence: breaker block (non-sticky) → task recovers → worker
+    blocks for review (sticky). The LATER unmarked event must win — the
+    task stays blocked across recompute_ready."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="marker then real block")
+        kb.claim_task(conn, tid)
+        kb._record_task_failure(
+            conn, tid, "exhausted", outcome="crashed", failure_limit=1,
+            release_claim=False, end_run=False,
+        )
+        # Recover: reset counter, promote, reclaim.
+        conn.execute(
+            "UPDATE tasks SET consecutive_failures = 0 WHERE id = ?", (tid,)
+        )
+        conn.commit()
+        assert kb.recompute_ready(conn) == 1
+        kb.claim_task(conn, tid)
+        assert kb.block_task(
+            conn, tid, reason="review-required: human eyes",
+            expected_run_id=kb.get_task(conn, tid).current_run_id,
+        )
+        assert kb.get_task(conn, tid).status == "blocked"
+        assert kb._has_sticky_block(conn, tid) is True
+        for _ in range(3):
+            assert kb.recompute_ready(conn) == 0
+            assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_worker_block_still_sticky_after_fix(kanban_home: Path) -> None:
+    """Plain guard: the fix must not weaken the original #28712
+    contract — an unmarked worker block stays sticky."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="plain sticky block")
+        kb.claim_task(conn, tid)
+        kb.block_task(
+            conn, tid, reason="review-required: verify",
+            expected_run_id=kb.get_task(conn, tid).current_run_id,
+        )
+        assert kb._has_sticky_block(conn, tid) is True
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_unblock_after_breaker_clears_event_pair(kanban_home: Path) -> None:
+    """unblock_task on a breaker-blocked task emits ``unblocked`` — the
+    marker/event pair stays coherent for event-keyed consumers."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="unblock after breaker")
+        kb.claim_task(conn, tid)
+        kb._record_task_failure(
+            conn, tid, "exhausted", outcome="crashed", failure_limit=1,
+            release_claim=False, end_run=False,
+        )
+        assert kb.unblock_task(conn, tid) is True
+        assert kb.get_task(conn, tid).status in ("ready", "review")
+        assert len(_events(conn, tid, "unblocked")) == 1
+        # The newest {blocked, unblocked} row is the unblock → not sticky.
+        assert kb._has_sticky_block(conn, tid) is False


### PR DESCRIPTION
## Problem

The dispatcher's circuit breaker (`_record_task_failure` in `hermes_cli/kanban_db.py`) flipped `tasks.status='blocked'` on retry exhaustion while emitting only a `gave_up` event — zero `blocked` events, NULL `block_kind`/`block_reason`. Every event-keyed detector (critic first-responder lane `stuck_blocked()`, kanban-block-watcher) was structurally blind to these "orphan" tickets: 16 of them dead-ended 10–48h on our board before a manual audit caught them.

Full root-cause analysis (pasted below from our internal RCA so no external access is needed):

### Orphan-source analysis (exhaustive write-path enumeration)

All `UPDATE tasks SET status ...` sites in the file were enumerated; every site that can write `'blocked'`:

| Site | Path | Emits blocked event? | Sets block_kind? | Verdict |
|---|---|---|---|---|
| ~9241/9252 | `_record_task_failure` circuit-breaker trip | NO (only `gave_up`) | NULL | **THE ORPHAN SOURCE** |
| ~6410/6425 | `block_task` worker/operator block | YES | yes (+reason) | sanctioned |
| parametric sites (~5056, 5148, 6933, 6996, 8497, 8628, 8983) | reclaim/fence/review-reopen paths | n/a | n/a | feed from `_retry_status_for_run` which returns only `ready`/`review` — cannot produce `'blocked'` |

Legacy intake/hold and migration scripts: no `blocked` writes found (`block_task` is the only sanctioned writer and it emits). Conclusion: the circuit breaker is the sole orphan source.

## Fix

Single commit `46acb96d89`, based on `0cde4dd93a`. Status is state, events are the audit trail — so the breaker trip now also writes the audit trail:

1. Breaker trip appends a `blocked` event alongside `gave_up` inside the same write txn, payload `{kind: "circuit_breaker", trigger_outcome, failures, effective_limit, limit_source, error[:500]}`.
2. Fires the `kanban_task_blocked` lifecycle hook after the txn commits (same convention as `block_task`).
3. `_has_sticky_block`: marker-carrying `blocked` events are NON-sticky — preserves auto-recovery semantics (#35072/#28712): a breaker block recovers when its condition clears; only deliberate worker/operator blocks wait for explicit unblock.
4. `tasks.block_kind` stays NULL on this path on purpose: escalation classifiers route retry-exhaustion through `block_kind in {None, transient}`, and the scheduler's `structural_block_kinds` doesn't know the value.

Diff vs `0cde4dd93a`: `hermes_cli/kanban_db.py` (103 lines changed) + `tests/hermes_cli/test_kanban_breaker_blocked_event.py` (new, 231 lines).

## Test evidence

New regression suite `tests/hermes_cli/test_kanban_breaker_blocked_event.py` — 8 tests: emission on every breaker transition, marker non-stickiness, later-worker-block stickiness, `block_kind` NULL-ness, below-threshold silence. **8/8 pass** locally (`uv run pytest`, fresh worktree).

## Traceability

Internal post-mortem `260822-critic-lane-orphan-blindspot` action #3 (STRUCTURAL, HIGH), tracked as internal task `t_1e4922ed`; RCA doc `260824-kanban-breaker-orphan-rca.md`. Prepared by Hermes automation (devben-io); upstream decision card references sibling PRs #95720/#95742.
