### PR TITLE
fix(guardrails): reset re-read streak after real compaction (#109683)

### DIFF
--- a/agent/compression_facade.py
+++ b/agent/compression_facade.py
@@ -265,6 +265,10 @@ class CompressionFacadeMixin:
                     idle_timeout=idle_timeout, total_ceiling=total_ceiling,
                 )
             _mirror_result_onto_live_lists(self, result, messages, direct_path=direct_path)
+            guardrails = getattr(self, "_tool_guardrails", None)
+            if (isinstance(result, tuple) and result and isinstance(result[0], list)
+                    and result[0] is not messages and guardrails is not None):
+                guardrails.reset_no_progress_after_compaction()
             _rebind_caller_session_context(self)
             return result
         finally:

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -329,6 +329,20 @@ class ToolCallGuardrailController:
         self._turn_web_search_count = 0
         self._turn_subagent_count = 0
 
+    def reset_no_progress_after_compaction(self) -> None:
+        """Forget streaks whose evidence was removed by a real mid-turn compaction.
+
+        Compression changes the model-visible context, so an idempotent re-read used to
+        re-anchor after compaction is not a continuation of the pre-compaction loop. Failure
+        counters and caps deliberately survive: they track independent safety boundaries.
+        """
+        self._no_progress.clear()
+        self._identical_streak_sig = None
+        self._identical_streak_result_hash = ""
+        self._identical_streak_count = 0
+        self._identical_streak_first_call_id = ""
+        self._call_history.clear()
+
     @property
     def halt_decision(self) -> ToolGuardrailDecision | None:
         return self._halt_decision

--- a/tests/agent/test_compaction_guardrail_reanchor.py
+++ b/tests/agent/test_compaction_guardrail_reanchor.py
@@ -1,0 +1,94 @@
+"""Wiring regression for #109683.
+
+Mid-turn REAL compaction (``AIAgent._compress_context`` returning a genuinely new
+message list) replaces the visible history; a legitimate re-read afterward must not be
+counted against a no-progress streak warmed against the PRE-compaction transcript. A
+same-list no-op/aborted attempt must leave that streak untouched — the distinguishing
+signal is result-list identity at the ``compression_facade.py`` choke point, not any
+other side channel. Complements the cross-turn tracker in open PR #85352.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from hermes_state import SessionDB
+
+
+def _build_agent(tmp_path: Path, session_id: str):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(session_id, source="cli")
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._cached_system_prompt = "sys"
+    return agent
+
+
+def _warm_guardrail_streaks(agent):
+    """Warm an idempotent no-progress streak (read_file) plus an unrelated
+    exact-failure streak (terminal) that must never be touched by a compaction reset."""
+    guard = agent._tool_guardrails
+    read_args = {"path": "notes.md"}
+    guard.before_call("read_file", read_args)
+    guard.after_call("read_file", read_args, "same content", failed=False)
+    fail_args = {"command": "pytest -k thing"}
+    guard.before_call("terminal", fail_args)
+    guard.after_call("terminal", fail_args, "boom", failed=True)
+    return read_args, fail_args
+
+
+def test_real_compaction_resets_no_progress_streak_but_not_exact_failure_109683(tmp_path):
+    from agent.conversation_compression import CompressionCommitFence
+    from agent.tool_guardrails import ToolCallSignature
+
+    agent = _build_agent(tmp_path, "COMPACTION_REANCHOR_REAL")
+    read_args, fail_args = _warm_guardrail_streaks(agent)
+    messages = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hey"}]
+
+    def _fake_real_compaction(agent_arg, msgs, system_message, **kwargs):
+        # Real compaction: a brand-new list object, never the caller's own list.
+        return [{"role": "user", "content": "[CONTEXT COMPACTION] summary"}], "sys"
+
+    with patch("agent.conversation_compression.compress_context", side_effect=_fake_real_compaction):
+        agent._compress_context(messages, "sys", commit_fence=CompressionCommitFence())
+
+    read_sig = ToolCallSignature.from_call("read_file", read_args)
+    fail_sig = ToolCallSignature.from_call("terminal", fail_args)
+    guard = agent._tool_guardrails
+    assert read_sig not in guard._no_progress, "no-progress streak must reset after a real compaction"
+    assert guard._exact_failure_counts[fail_sig] == 1, "exact-failure counter must survive a real compaction"
+    assert guard._same_tool_failure_counts["terminal"] == 1, "same-tool-failure counter must survive"
+
+
+def test_noop_compaction_leaves_no_progress_streak_untouched_109683(tmp_path):
+    from agent.conversation_compression import CompressionCommitFence
+    from agent.tool_guardrails import ToolCallSignature
+
+    agent = _build_agent(tmp_path, "COMPACTION_REANCHOR_NOOP")
+    read_args, _fail_args = _warm_guardrail_streaks(agent)
+    messages = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hey"}]
+
+    def _fake_noop_compaction(agent_arg, msgs, system_message, **kwargs):
+        # Aborted/no-op attempt: hands back the caller's OWN list, unchanged.
+        return msgs, system_message
+
+    with patch("agent.conversation_compression.compress_context", side_effect=_fake_noop_compaction):
+        agent._compress_context(messages, "sys", commit_fence=CompressionCommitFence())
+
+    read_sig = ToolCallSignature.from_call("read_file", read_args)
+    guard = agent._tool_guardrails
+    assert read_sig in guard._no_progress, "a same-list no-op must not reset the no-progress streak"
+    assert guard._no_progress[read_sig][1] == 1

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -376,3 +376,41 @@ def test_supervised_task_platforms_keep_warning_only_default():
     for platform in ("telegram", "discord", "cron", "kanban"):
         cfg = ToolCallGuardrailConfig.from_mapping({}, platform=platform)
         assert cfg.hard_stop_enabled is True, platform
+
+
+def test_reset_no_progress_after_compaction_clears_only_the_idempotent_streak_109683():
+    """#109683: mid-turn REAL compaction rewrites the visible transcript, so a legitimate
+    re-read of content the model can no longer see must not inherit the no-progress streak
+    counted against the PRE-compaction context. Only the idempotent no-progress tracker may
+    be reset; exact-failure / same-tool-failure counters are unrelated to context visibility
+    and must survive untouched (complements the cross-turn tracker in open PR #85352)."""
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=True, no_progress_warn_after=2, no_progress_block_after=2,
+            exact_failure_block_after=5,
+        )
+    )
+    read_args = {"path": "notes.md"}
+    controller.before_call("read_file", read_args)
+    controller.after_call("read_file", read_args, "same content", failed=False)
+    controller.before_call("read_file", read_args)
+    controller.after_call("read_file", read_args, "same content", failed=False)
+    blocked = controller.before_call("read_file", read_args)
+    assert blocked.action == "block"
+    assert blocked.code == "idempotent_no_progress_block"
+
+    # Unrelated exact-failure streak, warmed on a different tool/signature.
+    fail_args = {"command": "pytest -k thing"}
+    controller.before_call("terminal", fail_args)
+    controller.after_call("terminal", fail_args, "boom", failed=True)
+    controller.before_call("terminal", fail_args)
+    second_fail = controller.after_call("terminal", fail_args, "boom", failed=True)
+    assert second_fail.count == 2
+
+    controller.reset_no_progress_after_compaction()
+
+    # The re-read is allowed again — the pre-compaction streak no longer blocks it.
+    assert controller.before_call("read_file", read_args).action == "allow"
+    # The exact-failure streak kept counting from where it left off, untouched by the reset.
+    third_fail = controller.after_call("terminal", fail_args, "boom", failed=True)
+    assert third_fail.count == 3


### PR DESCRIPTION
Closes #109683

## Summary

Resets only the guardrail state invalidated by a **real mid-turn context compaction**, so a legitimate re-read used to re-anchor after compaction is not blocked as a continuation of a pre-compaction idempotent-read loop.

## Root cause

`ToolCallGuardrailController` tracks identical idempotent results for the whole user turn. When compaction replaces the model-visible message list in the middle of that turn, the model may correctly re-read a file whose prior content was removed from context. That re-read can return identical content, but was counted against the old pre-compaction streak and eventually blocked.

## Fix

At the single `CompressionFacadeMixin._compress_context()` choke point, reset only compaction-invalidated tracking when compression returns a new message-list identity:

- idempotent no-progress records
- consecutive identical-call state
- identical-call cycle history

No-op compaction leaves all state intact. Exact-failure counts, same-tool failure counts, mutation progress markers, and web/subagent caps are deliberately preserved.

## Tests

- RED: the new unit and facade wiring tests failed on `main` because the reset method/hook did not exist and real compaction left the no-progress record populated.
- GREEN: `pytest -q tests/agent/test_tool_guardrails.py tests/agent/test_compaction_guardrail_reanchor.py` → `22 passed`.
- Adjacent compaction coverage: `pytest -q tests/agent/test_tool_guardrails.py tests/agent/test_compaction_guardrail_reanchor.py tests/run_agent/test_413_compression.py` → `54 passed`.
- `git diff --check` passed.

## Scope

This is complementary to open #85352, which addresses no-progress loops across turns. This patch handles the false-positive boundary inside one turn when compaction genuinely changes the visible context.
