### PR TITLE
fix(tools): stop one unreadable ticket from wedging bot live delivery

### DIFF
--- a/tests/tools/test_bot_live_owner_delivery.py
+++ b/tests/tools/test_bot_live_owner_delivery.py
@@ -106,3 +106,51 @@ def test_delivery_keeps_the_sender_and_refuses_a_different_one_under_the_same_id
     with pytest.raises(ValueError):
         mailbox.deliver_to_live_owner(tmp_path, owner, "hello", delivery_id="b" * 32, author={**author, "id": "bot:other"})
     assert "author" not in mailbox.deliver_to_live_owner(tmp_path, owner, "no sender", delivery_id="c" * 32)
+
+
+@pytest.mark.skipif(os.name == "nt" or getattr(os, "geteuid", lambda: 1)() == 0,
+                    reason="needs POSIX file permissions for an unreadable ticket")
+def test_unreadable_ticket_does_not_wedge_bulk_scans(tmp_path, caplog):
+    import logging
+
+    from tools import bot_live_delivery as mailbox
+
+    owner = dict(profile_home=str(tmp_path.resolve()), session_id="chat",
+                 lease_id="lease", live_session_id="live")
+    queued = mailbox.deliver_to_live_owner(tmp_path, owner, "readable", delivery_id="d" * 32)
+    root = tmp_path / "runtime" / mailbox.DELIVERY_DIR_NAME
+    unreadable = root / f"{'e' * 32}.json"
+    unreadable.write_text('{"status": "queued"}', encoding="utf-8")
+    unreadable.chmod(0)
+    corrupt = root / f"{'1' * 32}.json"
+    corrupt.write_text("{not json", encoding="utf-8")
+    with caplog.at_level(logging.WARNING, logger="tools.bot_live_delivery"):
+        # Sender side: admission of a fresh id must survive the sequence sweep.
+        admitted = mailbox.deliver_to_live_owner(tmp_path, owner, "second", delivery_id="f" * 32)
+        # Receiver side: every readable queued ticket must still be claimed, in order.
+        assert mailbox.claim_pending_delivery(tmp_path, owner)["delivery_id"] == queued["delivery_id"]
+        assert mailbox.claim_pending_delivery(tmp_path, owner)["delivery_id"] == admitted["delivery_id"]
+        assert mailbox.claim_pending_delivery(tmp_path, owner) is None
+    assert admitted["status"] == "queued"
+    assert any(record.message.startswith(f"bot_live_delivery: skipping unreadable ticket {'e' * 32}.json")
+               and "Permission denied" in record.message
+               for record in caplog.records)
+
+
+@pytest.mark.skipif(os.name == "nt" or getattr(os, "geteuid", lambda: 1)() == 0,
+                    reason="needs POSIX file permissions for an unreadable ticket")
+def test_unreadable_ticket_keeps_exact_id_reads_fail_closed(tmp_path):
+    from tools import bot_live_delivery as mailbox
+
+    owner = dict(profile_home=str(tmp_path.resolve()), session_id="chat",
+                 lease_id="lease", live_session_id="live")
+    unreadable = tmp_path / "runtime" / mailbox.DELIVERY_DIR_NAME / f"{'e' * 32}.json"
+    unreadable.parent.mkdir(parents=True, exist_ok=True)
+    unreadable.write_text('{"status": "queued"}', encoding="utf-8")
+    unreadable.chmod(0)
+    # Uninspectable is not absent: an exact-id retry must fail closed instead of
+    # minting a fresh receipt that overwrites the possibly-live one (#109820).
+    with pytest.raises(PermissionError):
+        mailbox.deliver_to_live_owner(tmp_path, owner, "same id", delivery_id="e" * 32)
+    with pytest.raises(PermissionError):
+        mailbox.read_delivery_result(tmp_path, "e" * 32)

--- a/tools/bot_live_delivery.py
+++ b/tools/bot_live_delivery.py
@@ -8,6 +8,7 @@ not permission to execute the same input again. Receipts are permanent.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import tempfile
@@ -18,6 +19,8 @@ from pathlib import Path
 from typing import Any
 
 from hermes_cli.active_sessions import _FileLock
+
+log = logging.getLogger(__name__)
 
 DELIVERY_DIR_NAME = "bot_live_delivery"
 _OWNER_KEYS = ("profile_home", "session_id", "lease_id", "live_session_id")
@@ -106,6 +109,23 @@ def _read(path: Path) -> dict[str, Any] | None:
         return None
 
 
+def _scan_read(path: Path) -> dict[str, Any] | None:
+    """Bulk-scan variant: one unreadable ticket must not wedge the whole dir.
+
+    Directory scans (sequence high-water mark, queued-claim sweep) may only
+    treat a file as absent when it is provably absent; an unreadable ticket
+    degrades to "that one delivery is uninspectable" with a loud warning.
+    Exact-id reads (admission idempotency, completion, result lookup) keep
+    using _read so a permission error still fails closed instead of
+    licensing an overwrite of a possibly-live receipt.
+    """
+    try:
+        return _read(path)
+    except (OSError, json.JSONDecodeError) as exc:
+        log.warning("bot_live_delivery: skipping unreadable ticket %s (%s)", path.name, exc)
+        return None
+
+
 def _write(path: Path, record: dict[str, Any]) -> None:
     fd, temporary = tempfile.mkstemp(dir=path.parent, prefix=".delivery-")
     try:
@@ -143,7 +163,7 @@ def deliver_to_live_owner(
         # high-water mark, allocated while holding the cross-process lock.
         sequence = max((record.get("sequence", record["created_at"])
                         for candidate in root.glob("*.json")
-                        if (record := _read(candidate)) is not None), default=0) + 1
+                        if (record := _scan_read(candidate)) is not None), default=0) + 1
         record = dict(delivery_id=key, id=key, owner=pinned, **pinned,
                       message=message, status="queued", created_at=time.time_ns(),
                       sequence=sequence, **({"author": dict(author)} if author else {}))
@@ -181,7 +201,7 @@ def claim_pending_delivery(
     with _locked(profile_home) as root:
         pending = []
         for path in root.glob("*.json"):
-            record = _read(path)
+            record = _scan_read(path)
             if record is not None and record["status"] == "queued" and _matches(profile_home, record, current):
                 pending.append(record)
         if not pending:


### PR DESCRIPTION
## What does this PR do?

One unreadable ticket file in `runtime/bot_live_delivery/` currently wedges the whole mailbox: both bulk directory scans read every `*.json` ticket with `_read`, which only tolerates `FileNotFoundError`. A single permission-denied or corrupt ticket therefore fails **every** sender admission (surfacing as `ambiguous`/`unverified` and inviting duplicate re-sends) and crashes the receiver's `claim_pending_delivery` poller each cycle (#109820).

This PR isolates the failure to the one bad file:

- Bulk scans (the admission sequence high-water mark in `deliver_to_live_owner` and the queued sweep in `claim_pending_delivery`) now use a `_scan_read` helper that skips-and-warns per file, so one unreadable/corrupt ticket degrades to "that one delivery is uninspectable" instead of wedging the directory.
- Exact-id reads (`_read`: admission idempotency, `complete_delivery`, `read_delivery_result`) intentionally keep failing closed. An unreadable receipt is unknown, not absent — treating it as absent would let an admission retry mint a fresh record and overwrite a possibly-live receipt, breaking the module's "receipts are permanent" guarantee.

## Related Issue

Fixes #109820

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/bot_live_delivery.py`: added `_scan_read()` (skip-and-warn on `OSError` / `json.JSONDecodeError`, with a module logger); switched the two `root.glob("*.json")` sweeps to it. `_read()` and all exact-id call sites are unchanged.
- `tests/tools/test_bot_live_owner_delivery.py`: added `test_unreadable_ticket_does_not_wedge_bulk_scans` (chmod-000 ticket + corrupt-JSON ticket present: fresh admission still succeeds, readable tickets are still claimed in sequence order, warning is logged) and `test_unreadable_ticket_keeps_exact_id_reads_fail_closed` (same-id retry and `read_delivery_result` raise `PermissionError` rather than treating the receipt as absent).

## How to Test

1. `pytest tests/tools/test_bot_live_owner_delivery.py tests/cron/test_cron_live_bot_delivery.py -q` — observed result: 11 passed.
2. Red/green check: stashing only the `tools/bot_live_delivery.py` change makes `test_unreadable_ticket_does_not_wedge_bulk_scans` fail with `JSONDecodeError` escaping the claim sweep (the wedge symptom from the issue); restoring the fix should pass all 9 tests in the file. Observed result: 1 failed before the fix, 9 passed after.
3. `ruff check tools/bot_live_delivery.py tests/tools/test_bot_live_owner_delivery.py` — observed result: All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (ARM64); the permission tests skip on Windows/root where chmod-000 stays readable

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the bug is Windows-origin (elevated-relaunch ACL drift) but the fix is platform-neutral skip-and-warn; POSIX-only tests skip on `nt`
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
