### PR TITLE
fix(mcp): persist trust-gate session/always answers per (server, tool)

### DIFF
--- a/tests/tools/test_mcp_trust_gate_persistence.py
+++ b/tests/tools/test_mcp_trust_gate_persistence.py
@@ -1,0 +1,141 @@
+"""Persistence of MCP trust-gate approval scopes (#109818).
+
+A gateway ``session``/``always`` answer to a trust-gate prompt must be remembered
+under the per-(server, tool) key the gate consults on the next call; a permanent
+``always`` entry must skip the prompt entirely, including in a fresh session.
+Server-initiated elicitations (no ``persist_key``) keep the pre-existing per-call
+behaviour. All approval state is mocked or sandboxed; nothing touches real config.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from tools import approval as approval_mod
+from tools.approval_prompt import request_elicitation_consent
+
+
+@pytest.fixture
+def clean_approval_state(monkeypatch, tmp_path):
+    monkeypatch.setattr(approval_mod, "save_permanent_allowlist", lambda patterns: None)
+
+    def _reset():
+        approval_mod.load_permanent(set())
+        with approval_mod._lock:
+            approval_mod._session_approved.clear()
+
+    _reset()
+    yield
+    _reset()
+
+
+def _gateway(choice, captured=None):
+    """Patch the gateway surface so decisions resolve with *choice* without a real gateway."""
+    def _decision(session_key, notify_cb, data, *, surface="gateway"):
+        if captured is not None:
+            captured.update(data)
+        return {"resolved": True, "choice": choice}
+
+    return patch("tools.approval_gateway_wait._await_gateway_decision", side_effect=_decision)
+
+
+def _gateway_context():
+    return [
+        patch("tools.approval_context._is_gateway_approval_context", return_value=True),
+        patch("tools.approval._gateway_notify_cb", return_value=lambda **kw: None),
+    ]
+
+
+class TestGatewayChoicePersistence:
+    def test_always_persists_permanent_entry(self, clean_approval_state):
+        with _gateway_context()[0], _gateway_context()[1], _gateway("always"):
+            out = request_elicitation_consent("run tool?", "desc", persist_key="mcp:srv/tool")
+        assert out == "accept"
+        # A *fresh* session is approved: the entry survived as permanent.
+        assert approval_mod.is_approved("fresh-session", "mcp:srv/tool")
+
+    def test_session_choice_scoped_to_answering_session(self, clean_approval_state):
+        with _gateway_context()[0], _gateway_context()[1], _gateway("session"):
+            out = request_elicitation_consent("run tool?", "desc", persist_key="mcp:srv/tool")
+        assert out == "accept"
+        # The answering session ("default") remembers; a different one does not.
+        assert approval_mod.is_approved("default", "mcp:srv/tool")
+        assert not approval_mod.is_approved("other-session", "mcp:srv/tool")
+
+    def test_once_answer_persists_nothing(self, clean_approval_state):
+        with _gateway_context()[0], _gateway_context()[1], _gateway("once"):
+            out = request_elicitation_consent("run tool?", "desc", persist_key="mcp:srv/tool")
+        assert out == "accept"
+        assert not approval_mod.is_approved("default", "mcp:srv/tool")
+        assert not approval_mod.is_approved("fresh-session", "mcp:srv/tool")
+
+    def test_without_persist_key_always_stays_per_call(self, clean_approval_state):
+        """Server-initiated elicitations have no (server, tool) identity to key a standing
+        approval on, so they must keep the pre-existing per-call behaviour."""
+        with _gateway_context()[0], _gateway_context()[1], _gateway("always"):
+            out = request_elicitation_consent("confirm?", "desc")
+        assert out == "accept"
+        assert not approval_mod.is_approved("default", "mcp_elicitation")
+        assert not approval_mod.is_approved("fresh-session", "mcp:srv/tool")
+
+    def test_persistence_failure_never_downgrades_an_accepted_call(self, clean_approval_state, monkeypatch):
+        def _boom(patterns):
+            raise OSError("config unwritable")
+
+        monkeypatch.setattr(approval_mod, "save_permanent_allowlist", _boom)
+        with _gateway_context()[0], _gateway_context()[1], _gateway("always"):
+            out = request_elicitation_consent("run tool?", "desc", persist_key="mcp:srv/tool")
+        # The call was already approved; a persistence failure only means re-asking next time.
+        assert out == "accept"
+
+
+class TestCliChoicePersistence:
+    def test_cli_session_choice_remembered_when_keyed(self, clean_approval_state):
+        with patch("tools.approval_prompt.prompt_dangerous_approval", return_value="session"):
+            out = request_elicitation_consent("run tool?", "desc", persist_key="mcp:srv/tool")
+        assert out == "accept"
+        assert approval_mod.is_approved("default", "mcp:srv/tool")
+        assert not approval_mod.is_approved("other", "mcp:srv/tool")
+
+
+class TestTrustGateShortCircuit:
+    def test_permanent_entry_skips_the_prompt(self, clean_approval_state):
+        from tools import mcp_tool, mcp_tool_handlers
+        approval_mod.load_permanent({"mcp:srv/tool"})
+        with patch.dict(mcp_tool._server_trust_levels, {"srv": "untrusted"}), \
+             patch("tools.mcp_tool_scope._resolve_server_key", return_value="srv"), \
+             patch("tools.approval_prompt.request_elicitation_consent",
+                   side_effect=AssertionError("approved entry must not re-prompt")) as prompt:
+            out = mcp_tool_handlers._trust_gate_check("srv", "tool")
+        assert out is None
+        prompt.assert_not_called()
+
+    def test_prompt_passes_per_server_tool_key(self, clean_approval_state):
+        from tools import mcp_tool, mcp_tool_handlers
+        with patch.dict(mcp_tool._server_trust_levels, {"srv": "untrusted"}), \
+             patch("tools.mcp_tool_scope._resolve_server_key", return_value="srv"), \
+             patch("tools.approval_prompt.request_elicitation_consent", return_value="accept") as prompt:
+            out = mcp_tool_handlers._trust_gate_check("srv", "tool")
+        assert out is None
+        assert prompt.call_args.kwargs["persist_key"] == "mcp:srv/tool"
+
+    def test_sibling_tool_not_covered_by_another_tools_approval(self, clean_approval_state):
+        """The key is per (server, tool): approving one write-capable tool never widens
+        to the server's other tools."""
+        from tools import mcp_tool, mcp_tool_handlers
+        approval_mod.load_permanent({"mcp:srv/tool"})
+        with patch.dict(mcp_tool._server_trust_levels, {"srv": "untrusted"}), \
+             patch("tools.mcp_tool_scope._resolve_server_key", return_value="srv"), \
+             patch("tools.approval_prompt.request_elicitation_consent", return_value="decline") as prompt:
+            out = mcp_tool_handlers._trust_gate_check("srv", "other-tool")
+        assert out is not None
+        prompt.assert_called_once()
+
+    def test_allowlist_lookup_failure_falls_through_to_prompting(self, clean_approval_state):
+        from tools import mcp_tool, mcp_tool_handlers
+        with patch.dict(mcp_tool._server_trust_levels, {"srv": "untrusted"}), \
+             patch("tools.mcp_tool_scope._resolve_server_key", return_value="srv"), \
+             patch("tools.approval.is_approved", side_effect=RuntimeError("state unavailable")), \
+             patch("tools.approval_prompt.request_elicitation_consent", return_value="decline") as prompt:
+            out = mcp_tool_handlers._trust_gate_check("srv", "tool")
+        assert out is not None  # declined — but the user was asked, never silently waved through
+        prompt.assert_called_once()

--- a/tools/approval_prompt.py
+++ b/tools/approval_prompt.py
@@ -250,15 +250,34 @@ def _consent(choice, unresolved: str) -> str:
     return unresolved if choice == "timeout" else "decline"
 
 
+def _remember_elicitation_choice(session_key: str, choice: str, persist_key: str) -> None:
+    """Honour the scope the user picked for a keyed elicitation approval: ``session``
+    remembers it for this session, ``always`` also writes it to the permanent
+    allowlist. Persistence failures only downgrade to re-asking next time; they never
+    change the answer for the call already approved."""
+    from tools import approval as _a
+    try:
+        _a._persist_choice(session_key, choice, [(persist_key, None, False)])
+    except Exception:
+        logger.warning("Could not persist elicitation approval %r (%s)", persist_key, choice)
+
+
 def request_elicitation_consent(message: str, description: str, *,
                                 timeout_seconds: int | None = None,
-                                surface: str = "mcp-elicitation") -> str:
+                                surface: str = "mcp-elicitation",
+                                persist_key: str | None = None) -> str:
     """Route an MCP elicitation request to the surface owning the active session:
     gateway sessions through ``_await_gateway_decision``, CLI/TUI through
     ``prompt_dangerous_approval``. Always fails closed: a missing notify_cb in a
     gateway session, timeouts, and exceptions map to ``"decline"`` so a server
     treats them as "user did not approve" rather than retrying or hanging.
-    Returns ``"accept" | "decline" | "cancel"``."""
+    Returns ``"accept" | "decline" | "cancel"``.
+
+    ``persist_key``: approval key under which a ``session``/``always`` answer is
+    remembered (``tools.approval.is_approved``). Without it the answer is per-call
+    — the pre-existing behaviour for server-initiated elicitations, which have no
+    (server, tool) identity to key a standing approval on. Callers that pass a key
+    must consult ``is_approved`` first, or the remembered entry never skips a prompt."""
     from tools import approval as _a
     try:
         session_key = _ctx.get_current_session_key()
@@ -284,13 +303,19 @@ def request_elicitation_consent(message: str, description: str, *,
             return "decline"
         if not decision.get("resolved"):
             return "cancel"
-        return _consent(decision.get("choice"), "decline")
+        choice = decision.get("choice")
+        if persist_key and choice in ("session", "always"):
+            _remember_elicitation_choice(session_key, choice, persist_key)
+        return _consent(choice, "decline")
 
-    # allow_permanent=False: elicitation is a per-call confirmation — no pattern to remember.
+    # allow_permanent=False: elicitation never offers "always" at the CLI; a "session"
+    # answer still gets remembered when the caller keyed the approval.
     try:
         choice = prompt_dangerous_approval(message, description, timeout_seconds=timeout_seconds,
                                            allow_permanent=False)
     except Exception as exc:
         logger.error("Elicitation CLI prompt failed: %s", exc, exc_info=True)
         return "decline"
+    if persist_key and choice == "session":
+        _remember_elicitation_choice(session_key, choice, persist_key)
     return _consent(choice, "cancel")  # timeout mirrors the gateway's unresolved outcome

--- a/tools/mcp_tool_handlers.py
+++ b/tools/mcp_tool_handlers.py
@@ -46,6 +46,16 @@ def _trust_gate_check(server_name: str, tool_name: str) -> Optional[str]:
     if (_core._server_trust_levels.get(key, _core._TRUST_FULL) != _core._TRUST_UNTRUSTED
             or _core._tool_read_only_hints.get(key, {}).get(tool_name) is True):
         return None
+    # Keyed per (server, tool) so a "session"/"always" answer on one tool never widens to the
+    # server's other write-capable tools (#109818). is_approved consults the session and
+    # permanent allowlists; a lookup failure falls through to prompting (still fail-closed).
+    persist_key = f"mcp:{key}/{tool_name}"
+    try:
+        from tools import approval as _approval, approval_context as _actx
+        if _approval.is_approved(_actx.get_current_session_key(), persist_key):
+            return None
+    except Exception:
+        pass
     try:  # lazy: tools.approval routes the prompt to whichever surface owns the session
         from tools.approval_prompt import request_elicitation_consent
         answer = request_elicitation_consent(
@@ -53,7 +63,7 @@ def _trust_gate_check(server_name: str, tool_name: str) -> Optional[str]:
             f"(no readOnlyHint=true annotation) and may modify external state.",
             f"Server '{server_name}' is configured 'trust: untrusted'. "
             f"Approve to run '{tool_name}' once, or deny to block it.",
-            surface=f"mcp-trust/{server_name}")
+            surface=f"mcp-trust/{server_name}", persist_key=persist_key)
     except Exception as exc:
         logger.error("MCP trust gate: approval check failed for %s.%s: %s", server_name, tool_name, exc, exc_info=True)
         return tool_error(f"MCP tool '{tool_name}' on untrusted server '{server_name}' was blocked: the approval "


### PR DESCRIPTION
## What does this PR do?

Makes the MCP trust gate honour the approval scope the operator actually picked. Today `_trust_gate_check()` prompts on *every* call for a write-capable tool on a `trust: untrusted` server: `request_elicitation_consent()` maps `once`/`session`/`always` to a bare `accept` and persists nothing, and its `pattern_key` is the constant `"mcp_elicitation"`, so there is nothing per-(server, tool) to remember even if it were saved (#109818). After this PR:

- the gate consults `approval.is_approved(session_key, "mcp:<server>/<tool>")` before prompting — a remembered `always` (or in-session `session`) approval skips the prompt, across gateway restarts for `always`;
- a gateway `session`/`always` answer is persisted under that per-(server, tool) key via the existing `_persist_choice` machinery (`always` lands in `command_allowlist`, withdrawable by editing config, same as command approvals);
- the CLI path (which already hides "always" via `allow_permanent=False`) now honours a keyed `session` answer instead of discarding it;
- server-initiated elicitations (`mcp_tool_sampling`) keep per-call semantics: they have no (server, tool) identity to key a standing approval on, so no `persist_key` is passed and behaviour is unchanged.

Fail-closed properties are preserved: an allowlist lookup failure falls through to prompting (never silently waves a call through), and a persistence failure never downgrades an already-approved answer — it only means the user is asked again next time.

## Related Issue

Fixes #109818

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/approval_prompt.py` — added `persist_key` parameter to `request_elicitation_consent()` plus `_remember_elicitation_choice()` helper; gateway and CLI paths persist `session`/`always` choices through `tools.approval._persist_choice` (exceptions logged, never affect the current answer).
- `tools/mcp_tool_handlers.py` — `_trust_gate_check()` now short-circuits on `is_approved()` with the per-(server, tool) key `mcp:<server>/<tool>` and passes that key as `persist_key` to the consent prompt.
- `tests/tools/test_mcp_trust_gate_persistence.py` — new: 10 tests covering permanent/session/once semantics, per-tool scoping (a sibling tool still prompts), short-circuit, no-`persist_key` regression guard, and both fail-closed paths.

## How to Test

1. `python -m pytest tests/tools/test_mcp_trust_gate_persistence.py -q` — Observed result: `10 passed`.
2. Red/green check: with the two source changes stashed, the suite reports `7 failed` (KeyError `persist_key`, missing short-circuit); with them restored, `10 passed` — the tests capture the reported symptom.
3. Regression: `python -m pytest tests/tools/test_mcp_elicitation.py tests/tools/test_mcp_trust_gating.py tests/tools/test_approval.py tests/tools/test_approval_mode_parity.py tests/tools/test_approval_outcome_parity.py -q` — Observed result: `171 passed, 1 failed`; the single failure (`TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`) reproduces identically on a clean `upstream/main` checkout with this branch's changes stashed, i.e. pre-existing and unrelated.
4. `ruff check tools/approval_prompt.py tools/mcp_tool_handlers.py tests/tools/test_mcp_trust_gate_persistence.py` — Observed result: `All checks passed!`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (ran the affected suites instead — see How to Test; one pre-existing unrelated failure documented there)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (reuses the existing `command_allowlist` key)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
