### PR TITLE
fix(agent): restart tool-call slot when Gemini revises streamed arguments

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -568,6 +568,13 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
                 slot = tool_call_indices[call_key] = {"index": len(tool_call_indices), "id": _new_call_id(fc), "last_arguments": ""}
             # Gemini re-sends the full args each event; emit only the new suffix.
             last_arguments = str(slot.get("last_arguments") or "")
+            if last_arguments and not args_str.startswith(last_arguments):
+                # Revised (not extended) arguments: an OpenAI-style consumer CONCATENATES argument
+                # deltas, so re-emitting full args as one delta would append them to the stale prefix
+                # and yield unparseable JSON. Restart the slot with a fresh id/index instead — the
+                # accumulator treats a new id as a new call and replaces the arguments wholesale.
+                slot = tool_call_indices[call_key] = {"index": len(tool_call_indices), "id": _new_call_id(fc), "last_arguments": ""}
+                last_arguments = ""
             slot["last_arguments"] = args_str
             delta = {"index": slot["index"], "id": slot["id"], "name": name, "extra_content": _tool_call_extra_from_part(part),
                      "arguments": args_str[len(last_arguments):] if args_str.startswith(last_arguments) else args_str}


### PR DESCRIPTION
## Problem

Gemini re-sends the FULL `functionCall.args` on each streaming event. `translate_stream_event` emits only the new suffix when args **extend** the previous snapshot — but when the model **revises** arguments (new JSON that is not a prefix extension), it re-emitted the full args as one delta.

An OpenAI-style consumer **concatenates** argument deltas (`ToolCallAccumulator` joins parts), so the accumulated string became the stale prefix followed by the full revised JSON — unparseable, and the tool call fails.

**Repro:** two stream events with args `{"body": "hello"}` then `{"body": "hello world"}`:
- before: consumer concat = `{"body": "hello", "path": "a.txt"}{"body": "hello world", "path": "a.txt"}` → `json.loads` fails (`Extra data`)
- after: revision restarts the slot with a fresh id/index → two parseable slots, latest args correct

## Fix

On a non-prefix revision, restart the slot (new call id, next index). The accumulator's documented contract — *"a new id at an already-seen raw index is redirected to a fresh slot"* — makes the consumer replace the arguments wholesale.

## Verification

- Repro script red before / green after
- `tests/agent/test_gemini_native_adapter.py`: 31 passed