### PR TITLE
fix(state): fail closed on symlinked state.db paths and pin the chmod inode

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -7,6 +7,7 @@ splits sessions via parent_session_id chains; sessions are source-tagged
 
 import asyncio
 import atexit
+import errno
 import hashlib
 import json
 import logging
@@ -226,13 +227,15 @@ def _secure_state_db_files(db_path: Path, *, create_main: bool = False) -> None:
     the process umask (commonly 0644 under 0022). Read-only SessionDB
     attachments never call this helper and remain observational.
 
-    Existing files are tightened with ``chmod(2)`` on the path: opening the
+    Existing files are tightened without ever (re)opening them: opening the
     file and closing that descriptor would drop every POSIX ``fcntl`` lock the
     process holds on its inode — including the locks of an already-open SQLite
     connection to the same database. A lock-losing close in one process lets a
     sibling's connection take the shared-memory DMS exclusively at its own
     close, checkpoint, and unlink the sidecars while long-lived holders
     (gateway, desktop ``hermes serve``) keep using the deleted inodes.
+    Symlinked state paths fail closed with ``ELOOP`` before the caller's
+    ``sqlite3.connect()`` can follow them (#109857).
     """
     if os.name == "nt":
         return
@@ -271,11 +274,36 @@ def _secure_state_db_files(db_path: Path, *, create_main: bool = False) -> None:
         except FileNotFoundError:
             continue
         if stat.S_ISLNK(st.st_mode):
-            # Refuse a planted symlink exactly like O_NOFOLLOW would.
-            continue
+            # Fail closed exactly like the O_NOFOLLOW create above: silently
+            # skipping the link lets the caller's sqlite3.connect() follow it
+            # and operate on whatever it points at (#109857).
+            raise OSError(errno.ELOOP, os.strerror(errno.ELOOP), str(path))
         if not stat.S_ISREG(st.st_mode):
             continue
-        os.chmod(path, 0o600)
+        _chmod_pinned_inode(path, 0o600)
+
+
+def _chmod_pinned_inode(path: Path, mode: int) -> None:
+    """Tighten ``path`` without following a link swapped in after the lstat().
+
+    A bare chmod(2) on the path re-resolves the name, so a replacement symlink
+    racing between validation and chmod could change the mode of an unrelated
+    target (#109857). On Linux the validated inode is pinned with an O_PATH
+    descriptor and reached through ``/proc/self/fd/<fd>``; an O_PATH descriptor
+    holds no POSIX locks, so closing it stays lock-neutral for live SQLite
+    connections. Platforms without O_PATH (macOS/BSD) use the no-follow chmod,
+    which applies to the link itself, never to a swapped-in target.
+    """
+    if hasattr(os, "O_PATH"):
+        fd = os.open(path, os.O_PATH | os.O_NOFOLLOW | os.O_CLOEXEC)
+        try:
+            if not stat.S_ISREG(os.fstat(fd).st_mode):
+                return
+            os.chmod(f"/proc/self/fd/{fd}", mode)
+        finally:
+            os.close(fd)
+    else:
+        os.chmod(path, mode, follow_symlinks=False)
 
 
 # Openings of the background-review harness prompts (agent/background_review.py).

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1,6 +1,7 @@
 """Tests for hermes_state.py — SessionDB SQLite CRUD, FTS5 search, export."""
 
 import contextlib
+import errno
 import re
 import sqlite3
 import time
@@ -453,6 +454,84 @@ class TestConnectionLifecycle:
 
         # budget + 1 = the initial attempt plus `budget` retries.
         assert len(attempts) == budget + 1
+
+
+class TestSecureStateDbSymlinkFailClosed:
+    """A planted state.db/-wal/-shm symlink must stop the writable open (#109857)."""
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks and permission bits")
+    @pytest.mark.parametrize(
+        "planted_name", ["state.db", "state.db-wal", "state.db-shm"]
+    )
+    def test_planted_symlink_fails_closed(self, tmp_path, planted_name):
+        """Hardening raises ELOOP instead of skipping, so the caller's
+        sqlite3.connect() never follows the planted link."""
+        target = tmp_path / "target.db"
+        sqlite3.connect(target).close()
+        os.chmod(target, 0o666)
+        planted = tmp_path / planted_name
+        planted.symlink_to(target)
+
+        with pytest.raises(OSError) as exc_info:
+            hermes_state._secure_state_db_files(
+                tmp_path / "state.db", create_main=True
+            )
+
+        assert exc_info.value.errno == errno.ELOOP
+        assert stat.S_IMODE(target.stat().st_mode) == 0o666
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks and permission bits")
+    def test_swap_after_lstat_cannot_chmod_replacement_target(
+        self, tmp_path, monkeypatch
+    ):
+        """The chmod must never re-resolve the pathname to a swapped-in link.
+
+        lstat() validates one inode; a bare chmod(path) would follow a
+        replacement symlink planted after the check and change the mode of an
+        unrelated target (#109857).
+        """
+        db_path = tmp_path / "state.db"
+        db_path.write_bytes(b"regular")
+        target = tmp_path / "unrelated"
+        target.write_bytes(b"unrelated")
+        os.chmod(target, 0o666)
+
+        real_lstat = os.lstat
+
+        def swap_after_check(path):
+            st = real_lstat(path)
+            if Path(path) == db_path:
+                db_path.unlink()
+                db_path.symlink_to(target)
+            return st
+
+        monkeypatch.setattr(os, "lstat", swap_after_check)
+        try:
+            hermes_state._secure_state_db_files(db_path)
+        except OSError:
+            # Linux: the O_PATH|O_NOFOLLOW pin fails closed (ELOOP) on the
+            # swapped-in link; both outcomes leave the target untouched.
+            pass
+
+        assert stat.S_IMODE(target.stat().st_mode) == 0o666
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX symlinks and permission bits")
+    def test_session_db_open_refuses_planted_symlink(self, tmp_path):
+        """End to end: the writable SessionDB open fails before sqlite3
+        follows the planted link or the hardening touches its target."""
+        target = tmp_path / "target.db"
+        seed = sqlite3.connect(target)
+        seed.execute("CREATE TABLE marker (x)")
+        seed.commit()
+        seed.close()
+        os.chmod(target, 0o666)
+        planted = tmp_path / "state.db"
+        planted.symlink_to(target)
+
+        with pytest.raises(OSError):
+            SessionDB(db_path=planted)
+
+        assert stat.S_IMODE(target.stat().st_mode) == 0o666
 
 
 # =========================================================================


### PR DESCRIPTION
## What does this PR do?

Restores the fail-closed symlink invariant for writable state stores, which #109841 unintentionally weakened while fixing the POSIX-lock regression (#109728): ``_secure_state_db_files`` silently skipped an existing `state.db`/`-wal`/`-shm` symlink instead of refusing it, so the caller's `sqlite3.connect()` could follow the planted link. The bare `chmod(path)` also re-resolved the pathname, leaving a TOCTOU window where a symlink swapped in after the `lstat()` check could change the mode of an unrelated target.

Two changes, both keeping #109841's lock invariant (no open/close of an existing inode):

- A detected symlink now raises `ELOOP` — the same error `O_NOFOLLOW` produces on the create path — so the writable open fails closed instead of continuing to `sqlite3.connect()`.
- The mode change targets the inode `lstat()` validated: on Linux an `O_PATH | O_NOFOLLOW` descriptor pins it and is reached via `/proc/self/fd/<fd>` (an `O_PATH` descriptor holds no POSIX locks, so closing it cannot disturb a live SQLite connection); on macOS/BSD a `follow_symlinks=False` chmod applies to the link itself, never a swapped-in target. A symlink swapped into the race window either fails closed (`ELOOP`/`ENOTSUP`) or chmods the link itself — never the unrelated target.

## Related Issue

Fixes #109857

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `hermes_state.py`: `_secure_state_db_files`` symlink branch raises `OSError(ELOOP)` instead of `continue`; docstring updated. New `_chmod_pinned_inode()` helper applies the 0600 tightening without following a swapped-in link (Linux: `O_PATH`-pinned inode via `/proc/self/fd`; other POSIX: no-follow chmod). Added `import errno`.
- `tests/test_hermes_state.py`: new `TestSecureStateDbSymlinkFailClosed` — planted main/wal/shm symlinks raise `ELOOP` with the target untouched, a deterministic lstat→chmod swap cannot affect the replacement target, and an end-to-end `SessionDB` open on a planted link fails before sqlite3 follows it.

## How to Test

1. `python -m pytest tests/test_hermes_state.py -k SymlinkFailClosed -q` — Observed result: 5 passed (all 5 fail on unpatched `main`: the three planted-symlink cases and the swap case let the hardening proceed / chmod the unrelated target, and the SessionDB open follows the link).
2. `python -m pytest tests/test_hermes_state.py -q` — Observed result: 280 passed, 2 skipped.
3. Regression on the shared hardening path: `python -m pytest tests/hermes_state/test_named_profile_session_db.py tests/hermes_state/test_state_db_file_identity.py tests/hermes_state/test_live_db_isolation_guard.py tests/test_journal_mode_config.py -q` — Observed result: 49 passed, 1 skipped.
4. `ruff check hermes_state.py tests/test_hermes_state.py` — Observed result: all checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — targeted suites above pass in full; the full-tree run was not executed on this host
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64); the Linux `O_PATH` branch is exercised by CI

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (helper docstring included)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — helper early-returns on `nt` alongside the rest of the function
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A