### PR TITLE
fix(gateway): preserve code-fence whitespace when splitting long messages

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4264,10 +4264,15 @@ class BasePlatformAdapter(ABC):
                     if safe_split > _cp_limit // 4:
                         split_at = safe_split
             chunk_body = remaining[:split_at]
-            remaining = remaining[split_at:].lstrip()
-            full_chunk = prefix + chunk_body
-            # Walk only chunk_body (not the prepended prefix) for the fence state.
+            rest = remaining[split_at:]
+            # Walk only chunk_body (not the prepended prefix) for the fence state BEFORE trimming:
+            # inside a code fence the leading whitespace of ``rest`` is literal code content
+            # (blank lines, indentation), so only strip it for prose splits.
             in_code, lang = fence_state_after(chunk_body, carry_lang is not None, carry_lang or "")
+            if not in_code:
+                rest = rest.lstrip()
+            remaining = rest
+            full_chunk = prefix + chunk_body
             carry_lang = lang if in_code else None
             # Close the orphaned fence so the chunk stands alone.
             chunks.append(full_chunk + FENCE_CLOSE if in_code else full_chunk)


### PR DESCRIPTION
## Problem

`truncate_message` calls `.lstrip()` on the remainder after **every** chunk split. When the split point falls inside a code fence, that leading whitespace is literal code content:

- blank lines inside the fence are deleted
- indented lines lose their indentation (a Python snippet split across chunks becomes semantically wrong — an indented block body merges into the wrong level)

Runtime repro (chunk boundary between a blank line and an indented line inside a ` ```python ` fence):

```
input : ```python\na = 1 ...\n\n    indented_block()\nb = 2 ...```
chunk 1: ... `\n\n``` (1/2)`   <- fence closed, fine
chunk 2: ` ```python\nindented_block() `  <- 4-space indentation silently eaten
```

## Fix

Compute the fence state of the chunk body **before** trimming, and only `lstrip()` when the split is in prose. Fence content passes through verbatim; reopened fences still close/reopen with the same language tag and the `(i/n)` indicators are unchanged.

## Verification

- Runtime probe: `    indented_block()` now preserved verbatim in the continuation chunk
- Prose splits still strip leading whitespace (existing behavior)
- UTF-16 (`len_fn`) path used by Telegram unchanged
- `pytest tests/gateway -k "truncate or message_length or chunk"`: 147 passed, 3 skipped