### PR TITLE
fix(dashboard): block sensitive files from /api/fs/read-text

### DIFF
--- a/hermes_cli/web_routers/files.py
+++ b/hermes_cli/web_routers/files.py
@@ -630,6 +630,8 @@ async def fs_list(path: str):
 @router.get("/api/fs/read-text")
 async def fs_read_text(path: str):
     target, st = _fs_regular_file(_fs_path(path))
+    if _is_sensitive_path(target):
+        raise HTTPException(status_code=403, detail="Access to sensitive files is not allowed")
     if st.st_size > _FS_TEXT_SOURCE_MAX_BYTES:
         raise HTTPException(status_code=413, detail="File too large")
     data = _fs_read_bytes(target, min(st.st_size, _FS_TEXT_PREVIEW_MAX_BYTES))


### PR DESCRIPTION
## Problem

`/api/fs/read-text` returns file contents for the in-app text preview but never consults `_is_sensitive_path`. Every other read surface on the same data does:

- `/api/fs/download` → guarded (403)
- `/api/fs/read-data-url` → guarded
- `/api/files/read` (managed) → guarded
- `/api/files/list` → filtered

The guard docstring states it exists for the "list/read/download" exfil surface (#57505), but `fs_read_text` was missed. An authenticated dashboard user can read `.env`, `auth.json`, `config.yaml`, or anything under `mcp-tokens/` through read-text even though `/api/fs/download` correctly rejects the same path — an inconsistent policy that re-opens the #57505 exfiltration channel via a different endpoint.

## Fix

Add the same `_is_sensitive_path` check to `fs_read_text`, returning the identical 403 detail used by the other read endpoints.

## Verification

`pytest tests/hermes_cli/test_web_server_files.py`: 9 passed.