### PR TITLE
fix(cli): replace the last-good config snapshot when a raw-cache hit is accepted

### DIFF
--- a/hermes_cli/config_effective.py
+++ b/hermes_cli/config_effective.py
@@ -48,6 +48,26 @@ def _recover_user_raw(config_path: Path, path_key: str, exc: Exception) -> Dict[
     return copy.deepcopy(raw) if raw is not None else {}
 
 
+def _backup_active_home_good(config_path: Path) -> None:
+    """Keep the active home's durable good copy in step with a snapshot the loader just accepted
+    (the same copy ``load_config`` keeps: a fresh process recovers from it — see
+    ``_recover_user_raw``). ``backup_config`` skips when the newest ``good`` copy already holds
+    identical bytes, so every accepted signature may publish through it.
+
+    Only for the ACTIVE home — a read of another profile's file (doctor, TUI cwd lookup) must
+    not create backups/ inside that profile. Identity is by inode (a symlinked or relativized
+    alias names the same file), not lexical Path equality, and the copy is written under the
+    active path's name so a fresh process recovering through the canonical path finds it."""
+    active = _config.get_config_path()
+    try:
+        same = config_path.samefile(active)
+    except OSError:  # samefile needs both files to exist; resolve instead
+        same = config_path.resolve() == active.resolve()
+    if same:
+        from hermes_cli.config_backups import backup_config
+        backup_config(active, "good")
+
+
 def load_user_config_effective(config_path: Optional[Path] = None, *, fail_closed: bool = False) -> Dict[str, Any]:
     """User ``config.yaml`` → ``${VAR}`` expansion → managed overlay → model-key canonicalization.
     NO ``DEFAULT_CONFIG`` merge: a key absent from the file (and from the managed layer) is absent
@@ -74,7 +94,12 @@ def load_user_config_effective(config_path: Optional[Path] = None, *, fail_close
         raw_hit = _config._RAW_CONFIG_CACHE.get(path_key)
         if user_sig is not None and raw_hit is not None and raw_hit[:2] == user_sig:
             raw = copy.deepcopy(raw_hit[2])  # one parse per process, shared with read_raw_config()
-            _LAST_GOOD_USER_RAW.setdefault(path_key, copy.deepcopy(raw))
+            # The snapshot accepted through the shared raw cache must also become the
+            # last-known-good (and the durable backup): setdefault would pin the first-ever
+            # snapshot, so a later torn write resurrects an older policy this process already
+            # served past (#109876).
+            _LAST_GOOD_USER_RAW[path_key] = copy.deepcopy(raw)
+            _backup_active_home_good(config_path)
         elif user_sig is not None:
             try:
                 with open(config_path, encoding="utf-8") as f:
@@ -87,12 +112,7 @@ def load_user_config_effective(config_path: Optional[Path] = None, *, fail_close
                 raw = loaded if isinstance(loaded, dict) else {}
                 _config._RAW_CONFIG_CACHE[path_key] = (*user_sig, copy.deepcopy(raw))
                 _LAST_GOOD_USER_RAW[path_key] = copy.deepcopy(raw)
-                # Same copy load_config keeps: a fresh process recovers from it (see _recover_user_raw).
-                # Only for the ACTIVE home — a read of another profile's file (doctor, TUI cwd lookup)
-                # must not create backups/ inside that profile.
-                if config_path == _config.get_config_path():
-                    from hermes_cli.config_backups import backup_config
-                    backup_config(config_path, "good")
+                _backup_active_home_good(config_path)
 
         env_snapshot = _config._env_ref_snapshot(raw)
         managed = managed_scope.load_managed_config()

--- a/tests/hermes_cli/test_config_effective.py
+++ b/tests/hermes_cli/test_config_effective.py
@@ -122,3 +122,49 @@ def _reset_caches_keep_last_good():
 
     cfg._RAW_CONFIG_CACHE.clear()
     config_effective._EFFECTIVE_CACHE.clear()
+
+
+def test_raw_cache_hit_replaces_last_good_and_backup(homes):
+    """Regression for #109876: a snapshot accepted through the shared raw cache (refreshed by
+    another raw-config caller such as ``read_raw_config()``) must become the last-known-good AND
+    the newest durable good backup — so a later torn write recovers the NEWER accepted policy,
+    never the first-ever snapshot (older ``approvals``, providers, routing)."""
+    import time
+
+    from hermes_cli import config
+    from hermes_cli.config_backups import load_newest_good_backup
+    from hermes_cli.config_effective import load_user_config_effective
+
+    home, _ = homes
+    cfg = home / "config.yaml"
+    _write(cfg, "approvals:\n  deny: [old]\n")
+    assert load_user_config_effective(cfg)["approvals"]["deny"] == ["old"]
+    assert load_newest_good_backup(cfg)["approvals"]["deny"] == ["old"]
+
+    time.sleep(1.1)  # good copies are named at second granularity; keep the v1 and v2 copies distinct
+    cfg.write_text("approvals:\n  deny: [new]\n", encoding="utf-8")  # the file moves on, caches stay
+    assert config.read_raw_config()["approvals"]["deny"] == ["new"]
+    assert load_user_config_effective(cfg)["approvals"]["deny"] == ["new"]  # served off the raw-cache hit
+    assert load_newest_good_backup(cfg)["approvals"]["deny"] == ["new"]
+
+    cfg.write_text("approvals: [unterminated\n", encoding="utf-8")
+    _reset_caches_keep_last_good()
+    assert load_user_config_effective(cfg)["approvals"]["deny"] == ["new"]
+
+
+def test_good_backup_matches_active_home_by_inode(homes):
+    """Regression for #109876: the active-home gate matches by inode, not lexical Path equality
+    — reading through a symlinked alias of the active config.yaml still publishes the good copy
+    UNDER THE ACTIVE NAME (a fresh process recovering through the canonical path finds it),
+    while another profile's file still never creates backups/ inside that profile."""
+    from hermes_cli.config_effective import load_user_config_effective
+
+    home, _ = homes
+    _write(home / "config.yaml", USER_YAML)
+    alias = home / "alias-config.yaml"
+    alias.symlink_to(home / "config.yaml")
+
+    load_user_config_effective(alias)
+
+    assert list((home / "backups" / "config").glob("config.yaml.good.*"))
+    assert not list((home / "backups" / "config").glob("alias-config.yaml.*"))


### PR DESCRIPTION
## What does this PR do?

Fixes a policy-resurrection regression from #109556: `load_user_config_effective()` could roll back to an OLDER accepted config after a newer one had already been served.

When another raw-config caller (e.g. `read_raw_config()`) refreshes the shared `_RAW_CONFIG_CACHE` to v2, the effective loader serves v2 off the cache hit — but the raw-cache-hit branch only `setdefault`-ed `_LAST_GOOD_USER_RAW`, so the first-ever v1 snapshot stayed pinned. A later torn/mid-edit write then recovered v1 (older `approvals.deny`, providers, routing) instead of v2. That branch also never published the active home's durable good backup for the newly accepted signature, so a fresh process recovered from a stale backup too.

Both accepted-config branches now:
- **assign** (not `setdefault`) the defensive copy to `_LAST_GOOD_USER_RAW`, and
- publish the good backup through one new helper, `_backup_active_home_good()`, which identifies the active home **by inode** (`samefile`, with a `resolve()` fallback) instead of lexical `Path` equality, and writes the copy **under the active path's name** so a fresh process recovering through the canonical path finds it. Another profile's file still never creates `backups/` inside that profile.

## Related Issue

Fixes #109876

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/config_effective.py`: raw-cache-hit branch now replaces `_LAST_GOOD_USER_RAW` and publishes the good backup for the accepted snapshot; extracted `_backup_active_home_good()` (inode-based active-home identity + backup under the active name) and reused it for the parsed-config branch, replacing the lexical `config_path == get_config_path()` gate.
- `tests/hermes_cli/test_config_effective.py`: added `test_raw_cache_hit_replaces_last_good_and_backup` (full v1 → raw refresh v2 → effective consumes v2 → corrupt → recover v2 lifecycle, including the durable backup) and `test_good_backup_matches_active_home_by_inode` (symlinked alias publishes under the active name; no `alias-*` copies).

## How to Test

1. Reproduce on `main` with the script from #109876 (isolated `HERMES_HOME`): it prints `['old'] ['new'] ['new'] ['old']` — the final line resurrects the older policy. With this PR it prints `['old'] ['new'] ['new'] ['new']`, and the newest `backups/config/config.yaml.good.*` holds the `['new']` snapshot (Observed result: verified on macOS, darwin 25.4.0 arm64).
2. `python3 -m pytest tests/hermes_cli/test_config_effective.py tests/hermes_cli/test_config_backups.py -q` → 7 passed (Observed result: 7 passed in 1.44s).
3. Wider config-surface regression: `python3 -m pytest tests/hermes_cli/test_config.py tests/hermes_cli/test_config_lkg_backup.py tests/hermes_cli/test_read_raw_config_readonly.py tests/hermes_cli/test_config_env_refs.py tests/hermes_cli/test_resolve_provider_corrupt_config.py tests/hermes_cli/test_config_loader_e2e.py -q` → 141 passed, 4 skipped.
4. Red/green check: with the production change stashed, both new tests fail (2 failed); with it restored, all 5 tests in the file pass. `ruff check` passes on both changed files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin 25.4.0, arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the new helper carries a docstring documenting the accepted-snapshot/active-name contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no OS-specific APIs; `samefile`/`resolve()` are POSIX+Windows-safe
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A