### PR TITLE
feat(mcp): Adding Apify MCP server

### DIFF
--- a/contributors/emails/drobnik.j@gmail.com
+++ b/contributors/emails/drobnik.j@gmail.com
@@ -1,0 +1,1 @@
+drobnikj

--- a/optional-mcps/apify/manifest.yaml
+++ b/optional-mcps/apify/manifest.yaml
@@ -1,0 +1,34 @@
+manifest_version: 1
+
+name: apify
+description: Discover and run Apify Actors for web scraping, data extraction, and automation, and search Apify documentation.
+source: https://docs.apify.com/platform/integrations/mcp
+
+# Hosted Streamable HTTP; disable optional tool/client telemetry by default.
+transport:
+  type: http
+  url: https://mcp.apify.com/?telemetry-enabled=false
+
+auth:
+  type: oauth
+
+# Keep the server's default tool surface and let users choose at install time.
+# Actor execution can consume Apify credits; no Actors are run during setup.
+suggest:
+  keywords:
+    - apify
+  hosts:
+    - apify.com
+
+post_install: |
+  Authenticate with your Apify account in the browser when prompted.
+  If authentication was not completed during installation, run:
+    hermes mcp login apify
+
+  Start a new Hermes session after authentication to load the tools.
+  You can change the enabled tools at any time with:
+    hermes mcp configure apify
+
+  Running Actors can consume Apify credits. Review Actor pricing and inputs
+  before starting a run. For a read-only first test, search Apify documentation
+  or discover Actors without running them.


### PR DESCRIPTION
## What does this PR do?

Adds [Apify's hosted MCP server](https://mcp.apify.com/) to the optional catalog, using existing MCP support—no new core tools or local server to manage.

## Related Issue

No linked issue.

## Type of Change

- [x] ✨ New feature (non-breaking)

## Changes Made

- Add `optional-mcps/apify/manifest.yaml` with hosted Streamable HTTP, browser OAuth, and optional tool/client telemetry disabled by default.
- Add Apify discovery hints and setup guidance for login, tool selection, and a new session.
- Explain Actor pricing: runs can consume Apify credits; setup does not run Actors.

## How to Test

1. Install Apify from the MCP catalog and authenticate in the browser. If needed, run `hermes mcp login apify`.
2. Start a new Hermes session and ask: “Find Apify Actors for extracting product data. Do not run them.” Verify discovery returns results.
3. Search Apify documentation, then use `hermes mcp configure apify` to verify tool selection works.

These are manual verification steps, not a claim of completed end-to-end testing. Actor execution is optional and should only be tested after reviewing pricing and inputs.

## Checklist

### Code

- [x] Contributing Guide reviewed.
- [x] Commit follows Conventional Commits (`feat: Adding Apify MCP server`).
- [x] Existing PRs searched; related approaches linked above.
- [x] Scope limited to the Apify catalog manifest.
- [ ] Full test suite passed — not confirmed; Python tests were still pending at review time. Local command: `scripts/run_tests.sh`.
- [ ] New tests added — none in this manifest-only PR.
- [x] Manual platform/E2E testing — not yet confirmed.

### Documentation & Housekeeping

- [x] Setup, authentication, tool configuration, and pricing guidance included in the manifest.
- [x] Config example changes: N/A; no new config keys.
- [x] Architecture/workflow documentation changes: N/A; existing MCP catalog path.
- [x] Cross-platform impact considered: hosted HTTP/OAuth; no local commands or platform-specific dependencies added.
- [x] Tool schema changes: N/A; tools supplied by the remote MCP server.

## Screenshots / Logs

No manual screenshots or logs supplied. [CI run](https://github.com/apify/hermes-agent/actions/runs/34228789047): Python lint, E2E, and macOS jobs passed at review time; Python and Windows tests were pending. Contributor attribution needs mapping, and the MCP catalog requires maintainer security review plus the `ci-reviewed` label.
