### PR TITLE
fix(approval): 'always' persists the approved command, not the detector description

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3152,11 +3152,13 @@ def _command_matches_permanent_allowlist(command: str) -> bool:
     command = (command or "").strip()
     if not command:
         return False
-    if _has_allowlist_shell_operator(command):
-        return False
-
     with _lock:
         patterns = tuple(_permanent_approved)
+    # Gate globs (not exact matches) on compoundness: a hand-written glob
+    # like ``podman *`` must not span shell operators, but an exact entry is
+    # the precise command text the user approved via "always", so it cannot
+    # over-match and matches regardless (#102443).
+    compound = _has_allowlist_shell_operator(command)
 
     for pattern in patterns:
         if not isinstance(pattern, str):
@@ -3166,6 +3168,8 @@ def _command_matches_permanent_allowlist(command: str) -> bool:
             continue
         if command == pattern:
             return True
+        if compound:
+            continue
         if any(ch in pattern for ch in "*?[") and fnmatch.fnmatchcase(command, pattern):
             return True
     return False
@@ -5185,7 +5189,11 @@ def check_all_command_guards(command: str, env_type: str,
                         approve_session(session_key, key)
                     elif transport_choice == "always":
                         approve_session(session_key, key)
-                        approve_permanent(key)
+                        # Permanent scope stores the exact command text, not the
+                        # detector's description: the allowlist matcher indexes
+                        # command text, so a description string could never
+                        # match (#102443). Tirith keys stay session-only above.
+                        approve_permanent(command)
                         save_permanent_allowlist(_permanent_approved)
             _reset_denials(session_key)
             return {
@@ -5299,7 +5307,8 @@ def check_all_command_guards(command: str, env_type: str,
                         approve_session(session_key, key)
                     elif choice == "always":
                         approve_session(session_key, key)
-                        approve_permanent(key)
+                        # See above: persist the command text, not the description (#102443).
+                        approve_permanent(command)
                         save_permanent_allowlist(_permanent_approved)
 
             # A human approval (including an ESCALATE-then-approve or a
@@ -5428,7 +5437,7 @@ def check_all_command_guards(command: str, env_type: str,
             elif choice == "always":
                 # dangerous patterns: permanent allowed
                 approve_session(session_key, key)
-                approve_permanent(key)
+                approve_permanent(command)
                 save_permanent_allowlist(_permanent_approved)
 
     # A human approval resets the consecutive-denial tally.


### PR DESCRIPTION
## Summary

Fixes #102443. Tapping **'always'** on an approval prompt persisted the wrong thing — and the effect was worse than the issue describes.

**The issue's diagnosis, and what I measured before touching anything.** The issue says `approve_permanent(pattern_key)` writes the **detector description** (e.g. `'script execution via heredoc'`) into `config.command_allowlist`, which the matcher (`_command_matches...` / `fnmatch`) compares against **command text** — so "'always' saves nothing". It does match *something*: `is_approved()` keys on exactly that description. Measured on `origin/main` with a real `python3 - <<'EOF' … EOF` approval:

- after one 'always' click, `_permanent_approved == {'script execution via heredoc'}`;
- a **different** heredoc script — never shown to the human — was then **auto-approved with `prompts == 0`**.

So the description was **not inert**: one click authorised **every future command of that detector class**, arbitrary script bodies included, while `config.yaml` read like coverage of the single command shown. That is the real over-grant, and it is the security boundary this PR pins.

**Fix — both routes the issue offers, because they guard different things:**

1. **Persist what the matcher actually indexes: the approved command text.** Matching is string equality against the text the human saw (`fnmatch` participates only when the entry itself contains `*`/`?`/`[`). Deriving a glob (`python3 *`) would be *wider*, so it is not done anywhere.
2. **Refuse description-shaped writes.** `_is_command_pattern_entry` rejects entries that cannot be a command pattern, and a command whose persistence would copy a credential into `config.yaml` is not written either — refusals only ever **narrow**, and the user is re-prompted.

Compound commands (heredocs, pipes, `&&`) used to be refused by the allowlist outright, so an **exact** entry could not even cover itself — and those are precisely the prompting population. Exact (wildcard-free) entries now match the identical text; **globs are still refused** for compound commands, so a pattern can never cover a compound variant nobody approved (pinned by `test_glob_still_refuses_compound`).

Untouched by design: `session` choices, the tirith→session downgrade, gate keys for `computer_use` / plugin rules / ssh-config writes (their key **is** the grant), and **legacy description entries already in config** — they still load and still honour the key path they always used.

## Evidence

`tests/tools/test_always_grant_is_the_approved_command.py` (new, 8 tests) + `tests/tools/test_command_guards.py` updated to the new contract.

**RED → GREEN (my own mutation, not the author's):** disabling the command persistence (so the description path is used again) reproduces the over-grant:

```
AssertionError: a command the human never saw was auto-approved by the earlier 'always' entry
E   assert 0 == 1                     tests/tools/test_always_grant_is_the_approved_command.py:132
E   assert 'rm -rf /tmp/always-grant-other' in {'delete in root path', 'execute_code', …}
```

Restored → **37/37** on the two files; my wider run adds `test_cron_approval_mode` → 69 passed, 0 failed. The author's neighbour sweep (6 files) → 258 passed, 2 failed, both pre-existing and proven by name on `origin/main` (`tempfile.gettempdir` = `/tmp` vs Windows paths in `TestDetectDangerousRm`).

Every surface (Telegram / Discord / Slack / QQ / relay / acp / api_server / CLI) reaches this through `_persist_choice` / `_human_decision`, so the fix applies transitively.

## Not done

- **Per-adapter suites were not run** (the fix is transitive, but each adapter's own suite is outside the tight set).
- `hermes approvals suggest --apply` still proposes/merges the **class description** for compound commands (its documented grain); those entries keep working via the legacy key path. Emitting command-text entries there is a follow-up.
- **No migration or cleanup of existing description entries** — they stay loadable and honoured (the issue only required no crash); a cleanup would need its own test.
- Multi-line entries (heredocs, `execute_code` scripts) are stored as multi-line YAML scalars — round-trip verified, but a script body is bulky in `config.yaml`.
- Observed, not changed: `_permanent_baseline_by_home` is a module global keyed by profile home and is never invalidated if the home changes inside one process, so a later save can look like a revocation. Not reachable via this issue's path.
